### PR TITLE
fixed  a NullReferenceException issue with TypedActors

### DIFF
--- a/src/Pigeon/Actor/TypedActor.cs
+++ b/src/Pigeon/Actor/TypedActor.cs
@@ -17,7 +17,10 @@ namespace Pigeon.Actor
         {
             var method = this.GetType().GetMethod("Handle", new[] { message.GetType() });
             if (method == null)
+            {
                 Unhandled(message);
+                return;
+            }
 
             method.Invoke(this, new[] { message });
         }


### PR DESCRIPTION
In the event of an unhandled message, TypedActors just route it to the `Unhandled` method and no longer throw a NullReferenceException
