### PR TITLE
bugfix: absolute ActorSelections fail inside any ActorContext

### DIFF
--- a/src/Pigeon/Actor/ActorCell.cs
+++ b/src/Pigeon/Actor/ActorCell.cs
@@ -69,7 +69,7 @@ namespace Pigeon.Actor
                    //absolute path
                    if (path.Split('/').First() == "")
                    {
-                       return new ActorSelection(this.System.Provider.RootCell.Self, path);
+                       return new ActorSelection(this.System.Provider.RootCell.Self, path.TrimStart('/'));
                    }                    
                    else // relative path
                    {

--- a/test/Pigeon.Tests/Actor/ActorSelectionSpec.cs
+++ b/test/Pigeon.Tests/Actor/ActorSelectionSpec.cs
@@ -36,5 +36,37 @@ namespace Pigeon.Tests.Actor
             task.Wait();
             Assert.AreEqual("hello", task.Result);
         }
+
+        #region Tests for verifying that ActorSelections made within an ActorContext can be resolved
+
+        /// <summary>
+        /// Accepts a Tuple containing a string representation of an ActorPath and a message, respectively
+        /// </summary>
+        public class ActorContextSelectionActor : TypedActor, IHandle<Tuple<string, string>>
+        {
+            public void Handle(Tuple<string, string> message)
+            {
+                var testActorSelection = Context.ActorSelection(message.Item1);
+                testActorSelection.Tell(message.Item2);
+            }
+        }
+
+        [TestMethod()]
+        public void CanResolveAbsoluteActorPathInActorContext()
+        {
+            var contextActor = sys.ActorOf<ActorContextSelectionActor>();
+            contextActor.Tell(new Tuple<string,string>("/user/test", "hello"));
+            expectMsg("hello");
+        }
+
+        [TestMethod()]
+        public void CanResolveRelativeActorPathInActorContext()
+        {
+            var contextActor = sys.ActorOf<ActorContextSelectionActor>();
+            contextActor.Tell(new Tuple<string, string>("../test/../../user/test", "hello"));
+            expectMsg("hello");
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Turns out a leading slash was the culprit (`/`user/actor1)!

Added unit tests to `ActorSelectionSpec` to help verify `ActorSelection` behavior from inside `ActorContext`s as well as from the `ActorSystem` itself.
