### PR TITLE
Error when building Akka.FSharp.Tests

### DIFF
--- a/test/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
+++ b/test/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
@@ -32,8 +32,19 @@
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Release\Pigeon.FSharp.Tests.XML</DocumentationFile>
   </PropertyGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="mscorlib" />
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>True</Private>


### PR DESCRIPTION
Error when building Akka.FSharp.Tests if you don't have version 10.1.0.0 of Microsoft.VisualStudio.QualityTools.UnitTestFramework installed on your machine.

Adding same choose condition from Akka.Tests.csproj to Akka.FSharp.Tests.fsproj for the reference of the Microsoft.VisualStudio.QualityTools.UnitTestFramework.
