### PR TITLE
added nuget update self to build cmd, so nuget is always up to date

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,5 +1,7 @@
 @echo off
 
+.nuget\nuget.exe update -self
+
 .nuget\nuget.exe install FAKE -OutputDirectory packages -ExcludeVersion -Version 2.10.24
 
 if not exist packages\SourceLink.Fake\tools\SourceLink.fsx ( 


### PR DESCRIPTION
I updated the build.cmd file, so that it checks for new versions of nuget and updates it to the new version is found.
