### PR TITLE
Fix Become & Unbecome

### DIFF
--- a/src/Akka/Actor/ActorBase.cs
+++ b/src/Akka/Actor/ActorBase.cs
@@ -152,16 +152,24 @@ namespace Akka.Actor
 
 
         /// <summary>
-        ///     Becomes the specified receive function.
+        /// Changes the Actor's behavior to become the new <see cref="Receive"/> handler.
+        /// This method acts upon the behavior stack as follows:
+        /// <para>if <paramref name="discardOld"/>==<c>true</c> it will replace the current behavior (i.e. the top element)</para>
+        /// <para>if <paramref name="discardOld"/>==<c>false</c> it will keep the current behavior and push the given one atop</para>
+        /// The default of replacing the current behavior on the stack has been chosen to avoid memory
+        /// leaks in case client code is written without consulting this documentation first (i.e.
+        /// always pushing new behaviors and never issuing an <see cref="Unbecome"/>)
         /// </summary>
-        /// <param name="receive">The receive.</param>
-        protected void Become(Receive receive)
+        /// <param name="receive">The receive delegate.</param>
+        /// <param name="discardOld">If <c>true</c> it will replace the current behavior; 
+        /// otherwise it will keep the current behavior and it can be reverted using <see cref="Unbecome"/></param>
+        protected void Become(Receive receive, bool discardOld = true)
         {
-            Context.Become(receive);
+            Context.Become(receive, discardOld);
         }
 
         /// <summary>
-        ///     Unbecomes the current receive function.
+        /// Reverts the Actor behavior to the previous one on the behavior stack.
         /// </summary>
         protected void Unbecome()
         {

--- a/src/Akka/Actor/ActorCell.cs
+++ b/src/Akka/Actor/ActorCell.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using Akka.Dispatch;
 using Akka.Dispatch.SysMsg;
 using Akka.Serialization;
+using Akka.Tools;
 
 namespace Akka.Actor
 {
@@ -121,15 +122,19 @@ namespace Akka.Actor
             return children.Values.ToArray();
         }
 
-        public void Become(Receive receive)
+        public void Become(Receive receive, bool discardOld = true)
         {
+            if(discardOld && behaviorStack.Count > 1) //We should never pop off the initial receiver
+                behaviorStack.Pop();
             behaviorStack.Push(receive);
             ReceiveMessage = receive;
         }
 
         public void Unbecome()
         {
-            ReceiveMessage = behaviorStack.Pop();
+            if(behaviorStack.Count>1)   //We should never pop off the initial receiver
+                behaviorStack.Pop();
+            ReceiveMessage = behaviorStack.Peek();
         }
 
         /// <summary>

--- a/src/Akka/Actor/IActorContext.cs
+++ b/src/Akka/Actor/IActorContext.cs
@@ -9,7 +9,7 @@ namespace Akka.Actor
         ActorRef Sender { get; }
         ActorSystem System { get; }
         InternalActorRef Parent { get; }
-        void Become(Receive receive);
+        void Become(Receive receive, bool discardOld = true);
         void Unbecome();
         InternalActorRef Child(string name);
         IEnumerable<InternalActorRef> GetChildren();

--- a/test/Akka.Tests/Actor/ActorBecomeTests.cs
+++ b/test/Akka.Tests/Actor/ActorBecomeTests.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using Akka.Actor;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Akka.Tests.Actor
+{
+    [TestClass]
+    public class ActorBecomeTests : AkkaSpec
+    {
+        private static readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(2);
+
+        [TestMethod]
+        public void When_calling_become_Then_the_new_handler_is_used()
+        {
+            //Given
+            var system = ActorSystem.Create("test");
+            var actor = system.ActorOf<BecomeActor>("become");
+
+            //When
+            actor.Tell("DEFAULTBECOME", testActor);
+            actor.Tell("hello", testActor);
+
+            //Then
+            expectMsg("2:hello", _defaultTimeout);
+        }
+
+
+        [TestMethod]
+        public void Given_actor_that_has_called_default_Become_twice_When_calling_unbecome_Then_the_default_handler_is_used_and_not_the_last_handler()
+        {
+            //Calling Become() does not persist the current handler, it just overwrites it, so when we call Unbecome(),
+            //no matter how many times, there is no persisted handler to revert to, so we'll end up with the default one
+
+            //Given
+            var system = ActorSystem.Create("test");
+            var actor = system.ActorOf<Become2Actor>("become"); 
+            //Now OnReceive is used
+            actor.Tell("DEFAULTBECOME", testActor);
+            //Now OnReceive2 is used
+            actor.Tell("DEFAULTBECOME", testActor);
+            //Now OnReceive3 is used
+
+            //When
+            actor.Tell("UNBECOME", testActor);
+            //Since we used the default Become(receive) above, i.e. Become(receive, discardOld:true)
+            //the OnReceive2 was overwritten, so the actor will revert to the default one, ie OnReceive
+            actor.Tell("hello", testActor);
+
+            //Then
+            expectMsg("1:hello", _defaultTimeout);
+        }
+
+
+        [TestMethod]
+        public void Given_actor_that_has_called_default_Become_without_overwriting_previous_handler_When_calling_unbecome_Then_the_previous_handler_is_used()
+        {
+            //Calling Become() does not persist the current handler, it just overwrites it, so when we call Unbecome(),
+            //no matter how many times, there is no persisted handler to revert to, so we'll end up with the default one
+
+            //Given
+            var system = ActorSystem.Create("test");
+            var actor = system.ActorOf<Become2Actor>("become");
+            //Now OnReceive is used
+            actor.Tell("BECOMESTACKED", testActor);
+            //Now OnReceive2 is used
+            actor.Tell("BECOMESTACKED", testActor);
+            //Now OnReceive3 is used, and OnReceive2 was persisted
+
+            //When
+            actor.Tell("UNBECOME", testActor);
+            //Since we used Become(receive, discardOld:true) the actor will revert to OnReceive2
+            actor.Tell("hello", testActor);
+
+            //Then
+            expectMsg("2:hello", _defaultTimeout);
+        }
+
+        private class BecomeActor : UntypedActor
+        {
+            protected override void OnReceive(object message)
+            {
+                var s = (string)message;
+                switch(s)
+                {
+                    case "DEFAULTBECOME":
+                        Become(OnReceive2);
+                        break;
+                    case "BECOMESTACKED":
+                        Become(OnReceive2,discardOld: false);
+                        break;
+                    default:
+                        Sender.Tell("1:" + s, Self);
+                        break;
+                }                
+            }
+
+            private void OnReceive2(object message)
+            {
+                var s = (string)message;
+                switch(s)
+                {
+                    case "UNBECOME":
+                        Unbecome();
+                        break;
+                    default:
+                        Sender.Tell("2:" + s, Self);
+                        break;
+                }
+            }
+        }
+
+        private class Become2Actor : UntypedActor
+        {
+            protected override void OnReceive(object message)
+            {
+                var s = (string)message;
+                switch(s)
+                {
+                    case "DEFAULTBECOME":
+                        Become(OnReceive2);
+                        break;
+                    case "BECOMESTACKED":
+                        Become(OnReceive2, discardOld: false);
+                        break;
+                    default:
+                        Sender.Tell("1:" + s, Self);
+                        break;
+                }
+            }
+
+            private void OnReceive2(object message)
+            {
+                var s = (string)message;
+                switch(s)
+                {
+                    case "DEFAULTBECOME":
+                        Become(OnReceive3);
+                        break;
+                    case "BECOMESTACKED":
+                        Become(OnReceive3, discardOld: false);
+                        break;
+                    case "UNBECOME":
+                        Unbecome();
+                        break;
+                    default:
+                        Sender.Tell("2:" + s, Self);
+                        break;
+                }
+            }
+
+            private void OnReceive3(object message)
+            {
+                var s = (string)message;
+                switch(s)
+                {
+                    case "UNBECOME":
+                        Unbecome();
+                        break;
+                    default:
+                        Sender.Tell("3:" + s, Self);
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/test/Akka.Tests/Akka.Tests.csproj
+++ b/test/Akka.Tests/Akka.Tests.csproj
@@ -74,6 +74,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="Actor\ActorBecomeTests.cs" />
     <Compile Include="Actor\ActorCellTests.cs" />
     <Compile Include="Actor\ActorLifeCycleSpec.cs" />
     <Compile Include="Actor\ActorPathSpec.cs" />


### PR DESCRIPTION
The current implementation of `Become()` and `Unbecome()` is incorrect. This PR fixes the behavior to the one Akka has.

Calling `Become(receive, discardOld: true)` means that the current receive delegate is replaced by the specified delegate.
Calling `Become(receive, discardOld: false)` means that the current receive delegate is persisted before the specified delegate is put in place. To revert to previously persisted delegates `Unbecome()` may be called.

`discardOld` is an optional parameter which defaults to `true`.
