### PR TITLE
Change Receive to work like Akka

### DIFF
--- a/src/Akka.FSharp/FsApi.fs
+++ b/src/Akka.FSharp/FsApi.fs
@@ -140,7 +140,7 @@ open Microsoft.FSharp.Quotations
 open Microsoft.FSharp.Linq.QuotationEvaluation
 
 type FunActor<'m,'v>(actor: Actor<'m> -> Cont<'m,'v>) as self =
-    inherit ActorBase()
+    inherit UntypedActor()
 
     let mutable state = 
         let self' = self.Self

--- a/src/Akka.Remote/Endpoint.cs
+++ b/src/Akka.Remote/Endpoint.cs
@@ -238,7 +238,7 @@ namespace Akka.Remote
     /// forming any outbound associations.
     /// </remarks>
     /// </summary>
-    internal class ReliableDeliverySupervisor : ActorBase, IActorLogging
+    internal class ReliableDeliverySupervisor : UntypedActor, IActorLogging
     {
         private LoggingAdapter _log = Logging.GetLogger(Context);
         public LoggingAdapter Log { get { return _log; } }

--- a/src/Akka.Remote/Remoting.cs
+++ b/src/Akka.Remote/Remoting.cs
@@ -260,7 +260,7 @@ namespace Akka.Remote
         public string Name { get; private set; }
     }
 
-    internal class TransportSupervisor : ActorBase
+    internal class TransportSupervisor : UntypedActor
     {
         private readonly SupervisorStrategy _strategy = new OneForOneStrategy(3, TimeSpan.FromMinutes(1), exception => Directive.Restart);
         protected override SupervisorStrategy SupervisorStrategy()

--- a/src/Akka.Remote/Transport/TransportAdapters.cs
+++ b/src/Akka.Remote/Transport/TransportAdapters.cs
@@ -316,7 +316,7 @@ namespace Akka.Remote.Transport
         }
     }
 
-    internal abstract class ActorTransportAdapterManager : ActorBase
+    internal abstract class ActorTransportAdapterManager : UntypedActor
     {
         /// <summary>
         /// Lightweight Stash implementation

--- a/src/Akka/Actor/Exceptions.cs
+++ b/src/Akka/Actor/Exceptions.cs
@@ -64,10 +64,23 @@ namespace Akka.Actor
     }
 
     /// <summary>
-    ///     Class DeathPactException.
+    /// A DeathPactException is thrown by an Actor that receives a Terminated(someActor) message
+    /// that it doesn't handle itself, effectively crashing the Actor and escalating to the supervisor.
     /// </summary>
     public class DeathPactException : AkkaException
     {
+        private readonly ActorRef _deadActor;
+
+        public DeathPactException(ActorRef deadActor)
+            : base("Monitored actor [" + deadActor + "] terminated")
+        {
+            _deadActor = deadActor;
+        }
+
+        public ActorRef DeadActor
+        {
+            get { return _deadActor; }
+        }
     }
 
     /// <summary>

--- a/src/Akka/Actor/FSM.cs
+++ b/src/Akka/Actor/FSM.cs
@@ -673,9 +673,9 @@ namespace Akka.Actor
         /// Main actor receive method
         /// </summary>
         /// <param name="message"></param>
-        protected override void OnReceive(object message)
+        protected override bool Receive(object message)
         {
-            PatternMatch.Match(message)
+            var match = PatternMatch.Match(message)
                 .With<TimeoutMarker>(marker =>
                 {
                     if (generation == marker.Generation)
@@ -734,6 +734,7 @@ namespace Akka.Actor
                     generation++;
                     ProcessMsg(msg, Sender);
                 });
+            return match.WasHandled;
         }
 
         private void ProcessMsg(object any, object source)

--- a/src/Akka/Actor/IUntypedActorContext.cs
+++ b/src/Akka/Actor/IUntypedActorContext.cs
@@ -1,0 +1,7 @@
+﻿namespace Akka.Actor
+{
+    public interface IUntypedActorContext : IActorContext
+    {
+        void Become(UntypedReceive receive, bool discardOld = true);
+    }
+}

--- a/src/Akka/Actor/Receive.cs
+++ b/src/Akka/Actor/Receive.cs
@@ -1,0 +1,8 @@
+﻿namespace Akka.Actor
+{
+    /// <summary>
+    ///     Delegate Receive
+    /// </summary>
+    /// <param name="message">The message.</param>
+    public delegate bool Receive(object message);
+}

--- a/src/Akka/Actor/TypedActor.cs
+++ b/src/Akka/Actor/TypedActor.cs
@@ -24,16 +24,16 @@ namespace Akka.Actor
         ///     Processor for user defined messages.
         /// </summary>
         /// <param name="message">The message.</param>
-        protected override sealed void OnReceive(object message)
+        protected override sealed bool Receive(object message)
         {
             MethodInfo method = GetType().GetMethod("Handle", new[] {message.GetType()});
             if (method == null)
             {
-                Unhandled(message);
-                return;
+                return false;
             }
 
             method.Invoke(this, new[] {message});
+            return true;
         }
     }
 }

--- a/src/Akka/Actor/UntypedActor.cs
+++ b/src/Akka/Actor/UntypedActor.cs
@@ -5,5 +5,36 @@
     /// </summary>
     public abstract class UntypedActor : ActorBase
     {
+        protected sealed override bool Receive(object message)
+        {
+            OnReceive(message);
+            return true;
+        }
+
+        /// <summary>
+        /// To be implemented by concrete UntypedActor, this defines the behavior of the UntypedActor.
+        /// This method is called for every message received by the actor.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        protected abstract void OnReceive(object message);
+
+        /// <summary>
+        /// Changes the Actor's behavior to become the new <see cref="Receive"/> handler.
+        /// This method acts upon the behavior stack as follows:
+        /// <para>if <paramref name="discardOld"/>==<c>true</c> it will replace the current behavior (i.e. the top element)</para>
+        /// <para>if <paramref name="discardOld"/>==<c>false</c> it will keep the current behavior and push the given one atop</para>
+        /// The default of replacing the current behavior on the stack has been chosen to avoid memory
+        /// leaks in case client code is written without consulting this documentation first (i.e.
+        /// always pushing new behaviors and never issuing an <see cref="ActorBase.Unbecome"/>)
+        /// </summary>
+        /// <param name="receive">The receive delegate.</param>
+        /// <param name="discardOld">If <c>true</c> it will replace the current behavior; 
+        /// otherwise it will keep the current behavior and it can be reverted using <see cref="ActorBase.Unbecome"/></param>
+        protected void Become(UntypedReceive receive, bool discardOld = true)
+        {
+            Context.Become(receive, discardOld);
+        }
+
+        protected static new IUntypedActorContext Context { get { return (IUntypedActorContext) ActorBase.Context; } }
     }
 }

--- a/src/Akka/Actor/UntypedReceive.cs
+++ b/src/Akka/Actor/UntypedReceive.cs
@@ -1,8 +1,8 @@
 ﻿namespace Akka.Actor
 {
     /// <summary>
-    ///     Delegate Receive
+    ///     Delegate UntypedReceive
     /// </summary>
     /// <param name="message">The message.</param>
-    public delegate void Receive(object message);
+    public delegate void UntypedReceive(object message);
 }

--- a/src/Akka/Akka.csproj
+++ b/src/Akka/Akka.csproj
@@ -85,8 +85,10 @@
     <Compile Include="Actor\ExtendedActorSystem.cs" />
     <Compile Include="Actor\FSM.cs" />
     <Compile Include="Actor\GracefulStopSupport.cs" />
+    <Compile Include="Actor\IUntypedActorContext.cs" />
     <Compile Include="Actor\NoSerializationVerificationNeeded.cs" />
     <Compile Include="Actor\PipeToSupport.cs" />
+    <Compile Include="Actor\Receive.cs" />
     <Compile Include="Actor\Scheduler.cs" />
     <Compile Include="Actor\Settings.cs" />
     <Compile Include="Actor\Stash.cs" />
@@ -112,7 +114,7 @@
     <Compile Include="Actor\UntypedActor.cs" />
     <Compile Include="Actor\LocalActorRef.cs" />
     <Compile Include="Actor\Message.cs" />
-    <Compile Include="Actor\MessageHandler.cs" />
+    <Compile Include="Actor\UntypedReceive.cs" />
     <Compile Include="Dispatch\Mailboxes.cs" />
     <Compile Include="Dispatch\SysMsg\SystemMessage.cs" />
     <Compile Include="Dispatch\ThreadPoolBuilder.cs" />

--- a/src/Akka/Dispatch/FutureActor.cs
+++ b/src/Akka/Dispatch/FutureActor.cs
@@ -41,7 +41,7 @@ namespace Akka.Dispatch
         ///     Processor for user defined messages.
         /// </summary>
         /// <param name="message">The message.</param>
-        protected override void OnReceive(object message)
+        protected override bool Receive(object message)
         {
             if (message is SetRespondTo)
             {
@@ -54,18 +54,19 @@ namespace Akka.Dispatch
                 {
                     Self.Stop();
                     respondTo.Tell(new CompleteFuture(() => result.SetResult(message)));
-                    Become(_ => { });
+                    Become(EmptyReceive);
                 }
                 else
                 {
                     //if there is no listening actor asking,
                     //just eval the result directly
                     Self.Stop();
-                    Become(_ => { });
+                    Become(EmptyReceive);
 
                     result.SetResult(message);
                 }
             }
+            return true;
         }
     }
 

--- a/src/Akka/Routing/Listeners.cs
+++ b/src/Akka/Routing/Listeners.cs
@@ -64,7 +64,7 @@ namespace Akka.Routing
         {
             get{ return message =>
             {
-                PatternMatch.Match(message)
+                var match=PatternMatch.Match(message)
                     .With<Listen>(m => Add(m.Listener))
                     .With<Deafen>(d => Remove(d.Listener))
                     .With<WithListeners>(f =>
@@ -74,6 +74,7 @@ namespace Akka.Routing
                             f.ListenerFunction(listener);
                         }
                     });
+                return match.WasHandled;
             };}
         }
 

--- a/src/Akka/Tools/Pattern.cs
+++ b/src/Akka/Tools/Pattern.cs
@@ -11,10 +11,16 @@ namespace Akka
         }
     }
 
-    public class Case
+    public interface IMatchResult
+    {
+        bool WasHandled { get; }
+    }
+
+    public class Case : IMatchResult
     {
         private readonly object _message;
         private bool _handled;
+        public bool WasHandled { get { return _handled; } }
 
         public Case(object message)
         {
@@ -43,13 +49,21 @@ namespace Akka
             return this;
         }
 
-        public void Default(Action<object> action)
+        public IMatchResult Default(Action<object> action)
         {
             if (!_handled)
             {
                 action(_message);
                 _handled = true;
             }
+            return AlwaysHandled.Instance;
+        }
+
+        private class AlwaysHandled : IMatchResult
+        {
+            public static readonly AlwaysHandled Instance = new AlwaysHandled();
+            private AlwaysHandled() { }
+            public bool WasHandled { get { return true; } }
         }
     }
 }


### PR DESCRIPTION
## TL;DR

Akka and Akka.Net differs when it comes to Receive. This PR changes Akka.Net to be like Akka. 
Breaking change for inheritors of  `ActorBase`. 
No breaking change for inheritors of `UntypedActor`.
Since breaking changes are introduced I choose to be detailed about what I´ve done.
### Akka

Akka uses a [PartialFunction](http://www.scala-lang.org/api/current/index.html#scala.PartialFunction) for its receive function. If the partial function isn't defined for a message, the `unhandled` function is invoked. By default `unhandled` publishes a `UnhandledMessage` on the EventStream. If the user don't like the default behavior, `unhandled` can be overriden.

Akka´s `Receive` type is declared as: 

``` scala
type Receive = PartialFunction[Any, Unit]
```

with the functions:

```
apply(Any message) : Unit
isDefinedAt(Any message) : Boolean
```

Pseudo code for handling a message is:

``` c#
if(receive.isDefinedAt(message))
  receive.apply(message)
else
  unhandled(message)
```
### Akka.Net

In the current implementation of Akka.Net `OnReceive` has the signature `void OnReceive(object message)` and if the message is unhandled the user must manually call `Unhandled(message)` (which publishes to the EventStream) to signal that the message was unhandled. The user cannot override `Unhandled`.

Instead of having our own way of doing this, I would like Akka.Net to be like Akka and in order to do that we need to mimic the [PartialFunction](http://www.scala-lang.org/api/current/index.html#scala.PartialFunction) used in Akka. 

In Akka.Net the Receive is basically an `Action<object>`.
By changing it to `Func<object, bool>` we can mimic the functionality of Akka's Receive by combining `apply` and `isDefinedAt` into one function. This allows to have this type of handling in Akka.Net:

``` c#
if(!receive(message))
  unhandled(message)
```
## Changes

The changes made are in line with how Akka works.
- Existing `Receive` was renamed to `UntypedReceive` (since it's only used in `UntypedActor`)
- Introduce new `Receive` delegate that mimics the Akka's partial function. A return value of `true` indicates that the message was handled, while `false` indicates it was unhandled.

``` c#
public delegate bool PartialReceive(object message);
```
- In `ActorCell`:
  - Move functionality from `AutoReceiveMessage()` to `Invoke()` and introduce `ReceiveMessage()` to handle things previously handled by `AutoReceiveMessage()`
- In `ActorBase`: 
  - Refactor `protected abstract void OnReceive(object message)` to `protected abstract bool Receive(object message)`
  - Introduce `AroundReceive()` that is called from `ActorCell.ReceiveMessage()` and implements the pseudo code above.
  - Make `Unhandled()` virtual.
  - Remove obsolete code: `GetUnhandled()`, `IsUnhandled()`, `GetUnhandled()`, `lastMessageIsUnhandled`
- `UntypedActor` is still backwards compatible by these changes:
  - Reintroduce `void OnReceive(object message)`
  - Introduce `Become(UntypedReceive receive, bool discardOld = true)` to mimic the old one
  - Introduce `IUntypedActorContext Context` property.
- Introduce `IUntypedActorContext` (corresponding to Akka's `UntypedActorContext` trait):

``` c#
public interface IUntypedActorContext : IActorContext
{
  void Become(UntypedReceive receive, bool discardOld = true);
}
```

`ActorCell` implements both `IActorContext` and `IUntypedActorContext` just like Akka's.
## Consequences
- **Breaking change**: The changes means a breaking change to inheritors of `ActorBase` and these needs to be modified (inheritors of `UntypedActor` do not need to be modified)
- Existing actors in `Akka.Remote` (`ReliableDeliverySupervisor`, `TransportSupervisor`, `ActorTransportAdapterManager`) and `Akka.FSharp.FunActor` now inherits `UntypedActor` instead of `ActorBase`. Someone with more knowledge of the code, should go through these and change to ActorBase (for guidance, see what was changed in `FSMBase`).
