### PR TITLE
Send Terminated when trying to watch already terminated actors

### DIFF
--- a/src/core/Akka.TestKit/AkkaSpec.cs
+++ b/src/core/Akka.TestKit/AkkaSpec.cs
@@ -227,6 +227,18 @@ namespace Akka.Tests
             Xunit.Assert.True(Math.Abs(actual - expected) <= epsilon, string.Format("Expected {0} but received {1}", expected, actual));
         }
 
+        protected TMessage ExpectMsgPF<TMessage>(TimeSpan timeout, Predicate<TMessage> isMessage, string hint = "")
+        {
+            object actual;
+            bool success = queue.TryTake(out actual, timeout);
+
+            Xunit.Assert.True(success, string.Format("expected message of type {0} but timed out after {1}", typeof(TMessage), timeout));
+            Xunit.Assert.True(actual is TMessage, string.Format("expected message of type {0} but received {1} instead", typeof(TMessage), actual.GetType()));
+            var message = (TMessage)actual;
+            Xunit.Assert.True(isMessage(message), string.Format("expected {0} but got {1} instead", hint, message));
+            return message;
+        }
+
         protected T expectMsgPF<T>(TimeSpan duration, string hint, Func<object, T> pf)
         {
             object t;

--- a/src/core/Akka.Tests/Actor/DeathWatchSpec.cs
+++ b/src/core/Akka.Tests/Actor/DeathWatchSpec.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using Akka.Actor;
+using Xunit;
+
+namespace Akka.Tests.Actor
+{
+    public class DeathWatchSpec : AkkaSpec
+    {
+        private readonly InternalActorRef _supervisor;
+
+        public DeathWatchSpec()
+        {
+            _supervisor = sys.ActorOf(Props.Create(() => new Supervisor(SupervisorStrategy.DefaultStrategy)), "watchers");
+        }
+
+        [Fact]
+        public void Given_terminated_actor_When_watching_Then_should_receive_Terminated_message()
+        {
+            var terminal = sys.ActorOf(Props.Empty, "killed-actor");
+            terminal.Tell(new PoisonPill(),testActor);
+            StartWatching(terminal);
+            ExpectTerminationOf(terminal);
+        }
+
+//        protected override string GetConfig()
+//        {
+//            return @"
+//                akka.log-dead-letters-during-shutdown = true
+//                akka.actor.debug.autoreceive = true
+//                akka.actor.debug.lifecycle = true
+//                akka.actor.debug.event-stream = true
+//                akka.actor.debug.unhandled = true
+//                akka.log-dead-letters = true
+//                akka.loglevel = DEBUG
+//                akka.stdout-loglevel = DEBUG
+//            ";
+//        }
+
+        private void ExpectTerminationOf(ActorRef actorRef)
+        {
+            ExpectMsgPF<WrappedTerminated>(TimeSpan.FromSeconds(5), w => ReferenceEquals(w.Terminated.ActorRef, actorRef));
+        }
+
+        private void StartWatching(ActorRef target)
+        {
+            _supervisor.Ask(CreateWatchAndForwarderProps(target, testActor), TimeSpan.FromSeconds(3));
+        }
+
+        private Props CreateWatchAndForwarderProps(ActorRef target, ActorRef forwardToActor)
+        {
+            return Props.Create(() => new WatchAndForwardActor(target, forwardToActor));
+        }
+
+        public class WatchAndForwardActor : ActorBase
+        {
+            private readonly ActorRef _forwardToActor;
+
+            public WatchAndForwardActor(ActorRef watchedActor, ActorRef forwardToActor)
+            {
+                _forwardToActor = forwardToActor;
+                Context.Watch(watchedActor);
+            }
+
+            protected override bool Receive(object message)
+            {
+                var terminated = message as Terminated;
+                if(terminated != null)
+                    _forwardToActor.Tell(new WrappedTerminated(terminated), Sender);
+                else
+                    _forwardToActor.Tell(message, Sender);
+                return true;
+            }
+        }
+
+        public class WrappedTerminated
+        {
+            private readonly Terminated _terminated;
+
+            public WrappedTerminated(Terminated terminated)
+            {
+                _terminated = terminated;
+            }
+
+            public Terminated Terminated { get { return _terminated; } }
+        }
+    }
+}

--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Actor\AskSpec.cs" />
     <Compile Include="Actor\DeadLettersSpec.cs" />
     <Compile Include="Actor\ActorSystemSpec.cs" />
+    <Compile Include="Actor\DeathWatchSpec.cs" />
     <Compile Include="Actor\DeployerSpec.cs" />
     <Compile Include="Actor\FSMTimingSpec.cs" />
     <Compile Include="Actor\FSMTransitionSpec.cs" />

--- a/src/core/Akka/Actor/ActorBase.cs
+++ b/src/core/Akka/Actor/ActorBase.cs
@@ -57,7 +57,10 @@ namespace Akka.Actor
     ///     Class ActorBase.
     /// </summary>
     public abstract partial class ActorBase
-    {    
+    {
+        private ActorRef _clearedSelf;
+        private bool _hasBeenCleared;
+
         /// <summary>
         ///     Initializes a new instance of the <see cref="ActorBase" /> class.
         /// </summary>
@@ -82,7 +85,7 @@ namespace Akka.Actor
         ///     Gets the self ActorRef
         /// </summary>
         /// <value>Self ActorRef</value>
-        protected ActorRef Self { get { return Context.Self; } }
+        protected ActorRef Self { get { return _hasBeenCleared?  _clearedSelf : Context.Self; } }
 
         /// <summary>
         ///     Gets the context.
@@ -95,13 +98,13 @@ namespace Akka.Actor
         protected static IActorContext Context
         {
             get
-            {
-                ActorCell context = ActorCell.Current;
+            {                
+                var context = ActorCell.Current;
                 if (context == null)
                     throw new NotSupportedException(
                         "There is no active ActorContext, this is most likely due to use of async operations from within this actor.");
 
-                return context;
+                return context.ActorHasBeenCleared ? null : context;
             }
         }
 
@@ -167,6 +170,12 @@ namespace Akka.Actor
         protected void Unbecome()
         {
             Context.Unbecome();
+        }
+
+        internal void Clear(ActorRef self)
+        {
+            _hasBeenCleared = true;
+            _clearedSelf = self;
         }
     }
 }

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -13,9 +13,11 @@ namespace Akka.Actor
 {
     public partial class ActorCell : IActorContext, IUntypedActorContext, Cell 
     {
+        /// <summary>NOTE! Only constructor and ClearActorFields is allowed to update this</summary>
+        private InternalActorRef _self;
         public const int UndefinedUid = 0;
-        private readonly InternalActorRef _self;
-        private readonly Props _props;
+        private Props _props;
+        private static Props _terminatedProps=new TerminatedProps();
         [ThreadStatic] private static ActorCell current;
 
         protected ConcurrentDictionary<string, InternalActorRef> children =
@@ -25,6 +27,7 @@ namespace Akka.Actor
         protected Stack<Receive> behaviorStack = new Stack<Receive>();
         private long uid;
         private ActorBase _actor;
+        private bool _actorHasBeenCleared;
 
 
         public ActorCell(ActorSystem system, InternalActorRef self, Props props, MessageDispatcher dispatcher, InternalActorRef parent)
@@ -54,6 +57,7 @@ namespace Akka.Actor
         public ActorRef Sender { get; private set; }
         public bool HasMessages { get { return Mailbox.HasUnscheduledMessages; } }
         public int NumberOfMessages { get { return Mailbox.NumberOfMessages; } }
+        internal bool ActorHasBeenCleared { get { return _actorHasBeenCleared; } }
 
         public void Init(bool sendSupervise, Func<Mailbox> createMailbox /*, MailboxType mailboxType*/) //TODO: switch from  Func<Mailbox> createMailbox to MailboxType mailboxType
         {
@@ -174,6 +178,11 @@ namespace Akka.Actor
         {
             watchees.Add(watchee);
             watchee.Tell(new Watch(watchee, Self),Self);
+            //If watchee is terminated, its mailbox have been replaced by 
+            //DeadLetterMailbox, which will forward the Watch message as a
+            //DeadLetter to DeadLetterActorRef. It inspects the message inside
+            //the DeadLetter, sees it is a Watch and sends watcher, i.e. us
+            //a DeathWatchNotification(watchee)
         }
 
         /// <summary>
@@ -310,6 +319,23 @@ namespace Akka.Actor
             };
 
             Mailbox.Post(m);
+        }
+
+        protected void ClearActorCell()
+        {
+            //TODO: UnstashAll();
+            _props = _terminatedProps;
+        }
+
+        protected void ClearActor()
+        {
+            if(_actor != null)
+            {
+                _actor.Clear(System.DeadLetters);
+            }
+            _actorHasBeenCleared = true;
+            CurrentMessage = null;
+            behaviorStack = null;
         }
 
         public static NameAndUid SplitNameAndUid(string name)

--- a/src/core/Akka/Actor/ActorSystem.cs
+++ b/src/core/Akka/Actor/ActorSystem.cs
@@ -66,9 +66,10 @@ namespace Akka.Actor
             ConfigureSettings(config);
             ConfigureEventStream();
             ConfigureSerialization();
+            ConfigureProvider();
             ConfigureMailboxes();
             ConfigureDispatchers();
-            ConfigureProvider();
+            InitProvider();
             ConfigureLoggers();
             LoadExtensions();
             Start();
@@ -375,6 +376,10 @@ namespace Akka.Actor
             Debug.Assert(providerType != null, "providerType != null");
             var provider = (ActorRefProvider)Activator.CreateInstance(providerType,Name,Settings,EventStream);
             Provider = provider;
+        }
+
+        private void InitProvider()
+        {
             Provider.Init(this);
         }
 

--- a/src/core/Akka/Actor/BroadcastActorRef.cs
+++ b/src/core/Akka/Actor/BroadcastActorRef.cs
@@ -15,9 +15,9 @@ namespace Akka.Actor
                 this.actors.TryAdd(a, a);
         }
 
-        public void Add(ActorRef actor)
+        public bool TryAdd(ActorRef actor)
         {
-            actors.TryAdd(actor, actor);
+            return actors.TryAdd(actor, actor);
         }
 
         internal void Remove(ActorRef actor)

--- a/src/core/Akka/Actor/DeadLetterMailbox.cs
+++ b/src/core/Akka/Actor/DeadLetterMailbox.cs
@@ -1,0 +1,56 @@
+﻿using Akka.Dispatch;
+using Akka.Dispatch.SysMsg;
+using Akka.Event;
+
+namespace Akka.Actor
+{
+    public class DeadLetterMailbox : Mailbox
+    {
+        private readonly ActorRef _deadLetters;
+
+        public DeadLetterMailbox(ActorRef deadLetters)
+        {
+            _deadLetters = deadLetters;
+        }
+
+        public override void Post(Envelope envelope)
+        {
+            var message = envelope.Message;
+            if(message is SystemMessage)
+            {
+                Mailbox.DebugPrint("DeadLetterMailbox forwarded system message " + envelope+ " as a DeadLetter");
+                _deadLetters.Tell(new DeadLetter(message, _deadLetters, _deadLetters), _deadLetters);//TODO: When we have refactored Post to SystemEnqueue(ActorRef receiver, Envelope envelope), replace _deadLetters with receiver               
+            }
+            else if(message is DeadLetter)
+            {
+                //Just drop it like it's hot
+                Mailbox.DebugPrint("DeadLetterMailbox dropped DeadLetter " + envelope);
+            }
+            else
+            {
+                Mailbox.DebugPrint("DeadLetterMailbox forwarded message " + envelope + " as a DeadLetter");
+                var sender = envelope.Sender;
+                _deadLetters.Tell(new DeadLetter(message,sender,_deadLetters),sender);//TODO: When we have refactored Post to Enqueue(ActorRef receiver, Envelope envelope), replace _deadLetters with receiver
+            }
+        }
+
+        public override void Dispose()
+        {            
+        }
+
+        public override void Stop()
+        {
+            
+        }
+
+        protected override int GetNumberOfMessages()
+        {
+            return 0;
+        }
+
+        protected override void Schedule()
+        {
+            //Intentionally left blank
+        }
+    }
+}

--- a/src/core/Akka/Actor/Props.cs
+++ b/src/core/Akka/Actor/Props.cs
@@ -325,6 +325,14 @@ namespace Akka.Actor
         #endregion
     }
 
+    public class TerminatedProps : Props
+    {
+        public override ActorBase NewActor()
+        {
+            throw new InvalidOperationException("This actor has been terminated");
+        }
+    }
+
     /// <summary>
     ///     Props instance that uses dynamic invocation to create new Actor instances,
     ///     rather than a traditional Activator.

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -44,7 +44,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug Mono|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\Debug Mono\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
@@ -77,6 +77,7 @@
     <Compile Include="Actor\ActorSelection.cs" />
     <Compile Include="Actor\ActorSystem.cs" />
     <Compile Include="Actor\Address.cs" />
+    <Compile Include="Actor\DeadLetterMailbox.cs" />
     <Compile Include="Actor\Deploy.cs" />
     <Compile Include="Actor\Futures.cs" />
     <Compile Include="Actor\AutoReceivedMessage.cs" />

--- a/src/core/Akka/Dispatch/Mailbox.cs
+++ b/src/core/Akka/Dispatch/Mailbox.cs
@@ -21,7 +21,10 @@ namespace Akka.Dispatch
         [Conditional("MAILBOXDEBUG")]
         public static void DebugPrint(string message, params object[] args)
         {
-            Console.WriteLine(message, args);
+            if(args.Length == 0)
+                Console.WriteLine("{0}", message);
+            else
+                Console.WriteLine(message, args);
         }
 
         private volatile ActorCell _actorCell;
@@ -46,7 +49,7 @@ namespace Akka.Dispatch
         ///     Posts the specified envelope to the mailbox.
         /// </summary>
         /// <param name="envelope">The envelope.</param>
-        public abstract void Post(Envelope envelope);
+        public abstract void Post(Envelope envelope);   //TODO: Refactor to Enqueue(ActorRef receiver, Envelope envelope)
 
         /// <summary>
         ///     Stops this instance.

--- a/src/core/Akka/Dispatch/Mailboxes.cs
+++ b/src/core/Akka/Dispatch/Mailboxes.cs
@@ -15,6 +15,7 @@ namespace Akka.Dispatch
         /// </summary>
         private readonly ActorSystem system;
 
+        private readonly DeadLetterMailbox _deadLetterMailbox;
         /// <summary>
         ///     Initializes a new instance of the <see cref="Mailboxes" /> class.
         /// </summary>
@@ -22,7 +23,10 @@ namespace Akka.Dispatch
         public Mailboxes(ActorSystem system)
         {
             this.system = system;
+            _deadLetterMailbox = new DeadLetterMailbox(system.DeadLetters);
         }
+
+        public DeadLetterMailbox DeadLetterMailbox { get { return _deadLetterMailbox; } }
 
         /// <summary>
         ///     Creates a mailbox from a configuration path.

--- a/src/examples/Chat/ChatServer/Program.cs
+++ b/src/examples/Chat/ChatServer/Program.cs
@@ -85,7 +85,7 @@ akka {
         public void Handle(ConnectRequest message)
         {
          //   Console.WriteLine("User {0} has connected", message.Username);
-            clients.Add(this.Sender);
+            clients.TryAdd(this.Sender);
             Sender.Tell(new ConnectResponse
             {
                 Message = "Hello and welcome to Akka .NET chat example",


### PR DESCRIPTION
Basically what this does, is when an actor terminates, it swaps the mailbox to `DeadLetterMailbox` (new class).

When the terminated actor receives  the `Watch` message `DeadLetterMailbox` will forward it as a `DeadLetter` to `DeadLetterActorRef`. It inspects the message inside the `DeadLetter`, sees it is a `Watch` and sends watcher a `DeathWatchNotification` message.
