### PR TITLE
Fixes ConsistentHashingRoutingLogic index calculation

### DIFF
--- a/src/core/Akka/Routing/ConsistentHash.cs
+++ b/src/core/Akka/Routing/ConsistentHash.cs
@@ -46,13 +46,13 @@ namespace Akka.Routing
                     return NoRoutee.NoRoutee;
 
                 var hash = Murmur3.Hash(key);
-                return routees[hash % routees.Length];
+                return routees[Math.Abs(hash) % routees.Length]; //The hash might be negative, so we have to make sure it's positive
             }
             else if (message is ConsistentHashable)
             {
                 var hashable = (ConsistentHashable) message;
                 int hash = Murmur3.Hash(hashable.ConsistentHashKey);
-                return routees[hash%routees.Length];
+                return routees[Math.Abs(hash) % routees.Length]; //The hash might be negative, so we have to make sure it's positive
             }
             else
             {


### PR DESCRIPTION
The hash value can be negative, and % in C# preserves the 
negative sign if the first operand (i.e. the hash value) is negative.
e.g. -5 % 2 --> -1
So we need to make sure it's always positive
