### PR TITLE
F# API modifications + more examples

### DIFF
--- a/src/core/Akka.FSharp/FsApi.fs
+++ b/src/core/Akka.FSharp/FsApi.fs
@@ -8,6 +8,7 @@ type IO<'msg> = | Input
 type Actor<'msg> =
     abstract Receive : unit -> IO<'msg>
     abstract Self : ActorRef
+    abstract Context: IActorContext
     abstract Sender : unit -> ActorRef
     abstract Unhandled: 'msg -> unit
 
@@ -138,28 +139,33 @@ type ActorBuilder() =
 open Microsoft.FSharp.Quotations
 open Microsoft.FSharp.Linq.QuotationEvaluation
 
-type FunActor<'m,'v>(actor: Actor<'m> -> Cont<'m,'v>, strategy: unit -> SupervisorStrategy) as self =
+type FunActor<'m,'v>(actor: Actor<'m> -> Cont<'m,'v>, strategy: SupervisorStrategy) as self =
     inherit UntypedActor()
-
 
     let mutable state = 
         let self' = self.Self 
+        let context' = UntypedActor.Context :> IActorContext
         actor { new Actor<'m> with
                                 member this.Receive() = Input
                                 member this.Self = self'
+                                member this.Context = context'
                                 member this.Sender() = self.Sender()
                                 member this.Unhandled msg = self.Unhandled msg } 
-
+    
     new (actor: Expr<Actor<'m> -> Cont<'m,'v>>) = FunActor(actor.Compile() ())
-    new(actor: Actor<'m> -> Cont<'m,'v>) = FunActor(actor, fun() -> Actor.SupervisorStrategy.DefaultStrategy) 
-
-    override x.SupervisorStrategy() = strategy()
+    new(actor: Actor<'m> -> Cont<'m,'v>) = FunActor(actor, null) 
 
     member x.Sender() =
         base.Sender
 
     member x.Unhandled(msg:'m) =
         base.Unhandled msg
+
+    override x.SupervisorStrategy() =
+        if strategy <> null then
+            strategy
+        else 
+            base.SupervisorStrategy()
 
     override x.OnReceive(msg) =
         let message = msg :?> 'm
@@ -224,6 +230,39 @@ module Serialization =
 module Configuration =
     let parse = Akka.Configuration.ConfigurationFactory.ParseString
 
+module Strategy =
+    /// <summary>
+    /// Returns a builder function returning OneForOneStrategy supervisor based on provided decider func.
+    /// </summary>
+    /// <param name="decider">Supervisor strategy behavior decider function.</param>
+    let oneForOne (decider: Exception -> Directive) = 
+        OneForOneStrategy(System.Func<_,_>(decider)) :> SupervisorStrategy
+
+    /// <summary>
+    /// Returns a builder function returning OneForOneStrategy supervisor based on provided decider func.
+    /// </summary>
+    /// <param name="retries">Number of times, actor could be restarted. If negative, there is not limit.</param>
+    /// <param name="timeout">Time window for number of retries to occur.</param>
+    /// <param name="decider">Supervisor strategy behavior decider function.</param>
+    let oneForOne' retries timeout (decider: Exception -> Directive) = 
+        OneForOneStrategy(retries, timeout, System.Func<_,_>(decider)) :> SupervisorStrategy
+
+    /// <summary>
+    /// Returns a builder function returning AllForOneStrategy supervisor based on provided decider func.
+    /// </summary>
+    /// <param name="decider">Supervisor strategy behavior decider function.</param>
+    let allForOne (decider: Exception -> Directive) = 
+        AllForOneStrategy(System.Func<_,_>(decider)) :> SupervisorStrategy
+
+    /// <summary>
+    /// Returns a builder function returning AllForOneStrategy supervisor based on provided decider func.
+    /// </summary>
+    /// <param name="retries">Number of times, actor could be restarted. If negative, there is not limit.</param>
+    /// <param name="timeout">Time window for number of retries to occur.</param>
+    /// <param name="decider">Supervisor strategy behavior decider function.</param>
+    let allForOne' retries timeout (decider: Exception -> Directive) () = 
+        AllForOneStrategy(retries, timeout, System.Func<_,_>(decider)) :> SupervisorStrategy
+
 module System =
     /// <summary>
     /// Creates an actor system with remote deployment serialization enabled.
@@ -245,8 +284,8 @@ module System =
 /// <param name="name">The actor instance nane</param>
 /// <param name="f">the actor's message handling function.</param>
 let spawne (system:ActorSystem) name (f: Expr<Actor<'m> -> Cont<'m,'v>>)  =
-   let e = Linq.Expression.ToExpression(fun () -> new FunActor<'m,'v>(f))
-   system.ActorOf(Props.Create(e), name)
+    let e = Linq.Expression.ToExpression(fun () -> new FunActor<'m,'v>(f))
+    system.ActorOf(Props.Create(e), name)
    
 /// <summary>
 /// Spawns an actor using specified actor computation expression, with strategy supervisor factory.
@@ -256,9 +295,9 @@ let spawne (system:ActorSystem) name (f: Expr<Actor<'m> -> Cont<'m,'v>>)  =
 /// <param name="name">The actor instance name</param>
 /// <param name="strategy">Function used to generate supervisor strategy</param>
 /// <param name="f">the actor's message handling function.</param>
-let spawns (system:ActorSystem) name (strategy: unit -> SupervisorStrategy) (f: Actor<'m> -> Cont<'m,'v>)  =
-   let e = Linq.Expression.ToExpression(fun () -> new FunActor<'m,'v>(f, strategy))
-   system.ActorOf(Props.Create(e), name)
+let spawns (system:ActorSystem) name (strategy: SupervisorStrategy) (f: Actor<'m> -> Cont<'m,'v>)  =
+    let e = Linq.Expression.ToExpression(fun () -> new FunActor<'m,'v>(f, strategy))
+    system.ActorOf(Props.Create(e), name)
 
 /// <summary>
 /// Spawns an actor using specified actor computation expression.
@@ -268,4 +307,18 @@ let spawns (system:ActorSystem) name (strategy: unit -> SupervisorStrategy) (f: 
 /// <param name="name">The actor instance nane</param>
 /// <param name="f">the actor's message handling function.</param>
 let spawn (system:ActorSystem) name (f: Actor<'m> -> Cont<'m,'v>)  =
-   spawns system name (fun () -> Actor.SupervisorStrategy.DefaultStrategy) f
+    spawns system name null f
+
+[<AutoOpen>]
+module Actors =
+    // declare extension methods for Actor interface
+    type Actor<'msg> with
+        /// <summary>
+        /// Implementation of spawn method using actor-local context.
+        /// Actor refs returned this way are considered children of current actor.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="f"></param>
+        member this.spawn name (f: Actor<'m> -> Cont<'m,'v>) =
+            let e = Linq.Expression.ToExpression(fun () -> new FunActor<'m,'v>(f))
+            this.Context.ActorOf(Props.Create(e), name)

--- a/src/examples/FSharp.Api/FSharp.Api.fsproj
+++ b/src/examples/FSharp.Api/FSharp.Api.fsproj
@@ -47,6 +47,9 @@
     <Reference Include="System.Numerics" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MapReduce.fs" />
+    <Compile Include="Greeter.fs" />
+    <Compile Include="Supervisioning.fs" />
     <Compile Include="Program.fs" />
     <None Include="App.config" />
   </ItemGroup>

--- a/src/examples/FSharp.Api/Greeter.fs
+++ b/src/examples/FSharp.Api/Greeter.fs
@@ -1,0 +1,60 @@
+﻿module Greeter
+
+open Akka.Actor
+open Akka.FSharp
+open Akka.Configuration
+open System
+
+type SomeActorMessages =
+    | Greet of string
+    | Hi
+
+type SomeActor() =    
+    inherit Actor()
+
+    override x.OnReceive message =
+        match message with
+        | :? SomeActorMessages as m ->  
+            match m with
+            | Greet(name) -> Console.WriteLine("Hello {0}",name)
+            | Hi -> Console.WriteLine("Hello from F#!")
+        | _ -> failwith "unknown message"
+
+let main() =
+    printf "Greeter example:\n"
+    let system = ConfigurationFactory.Default() |> System.create "FSharpActors"
+    let actor = 
+        spawn system "MyActor"
+        <| fun mailbox ->
+            let rec again name =
+                actor {
+                    let! message = mailbox.Receive()
+                    match message with
+                    | Greet(n) when n = name ->
+                        printfn "Hello again, %s" name
+                        return! again name
+                    | Greet(n) -> 
+                        printfn "Hello %s" n
+                        return! again n
+                    | Hi -> 
+                        printfn "Hello from F#!"
+                        return! again name }
+            and loop() =
+                actor {
+                    let! message = mailbox.Receive()
+                    match message with
+                    | Greet(name) -> 
+                        printfn "Hello %s" name
+                        return! again name
+                    | Hi ->
+                        printfn "Hello from F#!"
+                        return! loop() } 
+            loop()
+
+    actor <! Greet "roger"
+    actor <! Hi
+    actor <! Greet "roger"
+    actor <! Hi
+    actor <! Greet "jeremie"
+    actor <! Hi
+    actor <! Greet "jeremie"

--- a/src/examples/FSharp.Api/MapReduce.fs
+++ b/src/examples/FSharp.Api/MapReduce.fs
@@ -1,0 +1,72 @@
+﻿module MapReduce
+
+open System
+open System.Collections.Concurrent
+open Akka.Actor
+open Akka.Configuration
+open Akka.Routing
+open Akka.FSharp
+
+/// Collection of messages used for map-reduce implementation
+type MRMsg =
+    | Collect                           // collect all reduced data so far
+    | Reduce of (string * int) list     // reduce mapped data
+    | Map of string                     // map chunk of data
+
+/// Helper function used to wrap message handler functions into Akka.NET actor API
+let actorFor func' = fun (mailbox:Actor<MRMsg>) ->
+    let rec loop() = actor {
+        let! msg = mailbox.Receive()
+        func' mailbox msg
+        return! loop() }
+    loop()
+
+let mapWords (line:string) = seq { for word in line.Split() -> (word.ToLower(), 1) }
+
+/// Mapper actor function used for mapping chunk of data onto 
+/// specialized data structure and forwarding it to the reducer
+let map reducer (mailbox:Actor<MRMsg>) = function
+    | Map line  -> reducer <! Reduce (mapWords line |> List.ofSeq)
+    | m         -> mailbox.Unhandled m
+
+let reduceWords (dict:ConcurrentDictionary<string,int>) iter = 
+    iter
+    |> List.iter (fun (k, v) -> dict.AddOrUpdate(k, v, System.Func<_,_,_>(fun key old -> old + v)) |> ignore)
+
+/// Reducer actor function, which either reduces mapped data into shared dictionary
+/// or returns all reduced data on demand
+let reduce (dict:ConcurrentDictionary<string,int>) (mailbox:Actor<MRMsg>) = function
+    | Reduce l  -> reduceWords dict l |> ignore
+    | Collect   -> mailbox.Sender() <! seq { for e in dict -> (e.Key, e.Value) }
+    | m         -> mailbox.Unhandled m
+
+/// Master actor function, used as proxy between system user and internal Map/Reduce implementation
+/// Can either forward data chunk to mappers or forward a request of returning all reduced data
+let master mapper (reducer:InternalActorRef) (mailbox:Actor<MRMsg>) = function
+    | Map line  -> mapper <! Map line
+    | Collect   -> reducer.Tell(Collect, mailbox.Sender())
+    | m         -> mailbox.Unhandled m
+
+let main() =
+    let system = System.create "MapReduceSystem" <| ConfigurationFactory.Default()
+
+    let dict = ConcurrentDictionary<string,int>()
+
+    // initialize system actors
+    let reducer = spawn system "reduce" <| actorFor (reduce dict)
+    let mapper =  spawn system "map"    <| actorFor (map reducer)
+    let master =  spawn system "master" <| actorFor (master mapper reducer)
+
+    // send input data
+    master <! Map "Orange orange apple"
+    master <! Map "cherry apple orange"
+
+    Threading.Thread.Sleep 500
+
+    // return processed data and display it
+    async {
+        let! res = master.Ask(Collect) |> Async.AwaitTask
+        for (k, v) in res :?> (string*int) seq do
+            printfn "%s\t%d" k v
+        system.Shutdown()
+    } |> Async.RunSynchronously

--- a/src/examples/FSharp.Api/Program.fs
+++ b/src/examples/FSharp.Api/Program.fs
@@ -1,61 +1,7 @@
-﻿open Akka.Actor
-open Akka.FSharp
-open Akka.Configuration
-open System
+﻿open System
 
-type SomeActorMessages =
-    | Greet of string
-    | Hi
-
-type SomeActor() =    
-    inherit Actor()
-
-    override x.OnReceive message =
-        match message with
-        | :? SomeActorMessages as m ->  
-            match m with
-            | Greet(name) -> Console.WriteLine("Hello {0}",name)
-            | Hi -> Console.WriteLine("Hello from F#!")
-        | _ -> failwith "unknown message"
-
-let system =  
-    ConfigurationFactory.Default() 
-    |> System.create "FSharpActors"
-
-let actor = 
-    spawn system "MyActor"
-    <| fun mailbox ->
-        let rec again name =
-            actor {
-                let! message = mailbox.Receive()
-                match message with
-                | Greet(n) when n = name ->
-                    printfn "Hello again, %s" name
-                    return! again name
-                | Greet(n) -> 
-                    printfn "Hello %s" n
-                    return! again n
-                | Hi -> 
-                    printfn "Hello from F#!"
-                    return! again name }
-        and loop() =
-            actor {
-                let! message = mailbox.Receive()
-                match message with
-                | Greet(name) -> 
-                    printfn "Hello %s" name
-                    return! again name
-                | Hi ->
-                    printfn "Hello from F#!"
-                    return! loop() } 
-        loop()
-
-actor <! Greet "roger"
-actor <! Hi
-actor <! Greet "roger"
-actor <! Hi
-actor <! Greet "jeremie"
-actor <! Hi
-actor <! Greet "jeremie"
-
-System.Console.ReadKey() |> ignore
+[<EntryPoint>]
+let main args =
+    Supervisioning.main()
+    Console.ReadLine()
+    0

--- a/src/examples/FSharp.Api/Supervisioning.fs
+++ b/src/examples/FSharp.Api/Supervisioning.fs
@@ -1,0 +1,61 @@
+﻿module Supervisioning
+
+open System
+open Akka.Actor
+open Akka.Configuration
+open Akka.FSharp
+
+/// Define message type for immediate value return
+type Respond = Respond
+
+/// worker function
+let workerFun (mailbox:Actor<'msg>) =
+    let state = ref 0   // we store value in a reference cell
+    let rec loop() = actor {
+        let! msg = mailbox.Receive()
+        // worker should save state only for positive integers, and respond on demand, all other options causes exceptions
+        match msg :> obj with
+        | :? int as num -> if num > 0 then state := num else raise (ArithmeticException "values equal or less than 0")
+        | :? Respond    -> mailbox.Sender() <! !state
+        | _             -> raise (ArgumentException "Unsupported argument")
+        return! loop() }
+    loop()
+
+let main() =
+    let system = System.create "SypervisorSystem" <| ConfigurationFactory.Default()
+
+    // create a supervisor actor
+    let supervisor = 
+        spawns system "master"
+        // below we define OneForOneStrategy to handle specific exceptions incoming from child actors
+        <| (Strategy.oneForOne <| fun e -> 
+            match e with
+            | :? ArithmeticException -> Directive.Resume
+            | :? ArgumentException   -> Directive.Stop
+            | _                      -> Directive.Escalate)
+        <| fun mailbox ->
+            // by using mailbox.spawn we may create a child actors without exiting a F# functional API
+            let worker = mailbox.spawn "worker" <| workerFun
+            let rec loop() = actor {
+                let! msg = mailbox.Receive()
+                match msg :> obj with
+                | :? Respond -> worker.Tell(msg, mailbox.Sender())
+                | _          -> worker <! msg
+                return! loop() }
+            loop()
+    async {
+        // this one should be handled gently
+        supervisor <! 5
+        System.Threading.Thread.Sleep 500
+        let! r = supervisor <? Respond
+        printfn "value received %d" (r :?> int)
+    } |> Async.RunSynchronously
+    async {
+        // this one should cause ArithmeticException in worker actor, handled by it's parent (supervisor)
+        // according to SupervisorStrategy, it should resume system work
+        supervisor <! -11
+        System.Threading.Thread.Sleep 500
+        // since -11 thrown an exception and didn't saved a state, a previous value (5) should be returned
+        let! r = supervisor <? Respond      
+        printfn "value received %d" (r :?> int)
+    } |> Async.RunSynchronously 


### PR DESCRIPTION
I've created some new F# API modifications:
- Extended default F# Actor interface with Context property (to access ActorContext) and spawn extension method (to enable use `spawn`-like creation of child actors)
- Modified previous SupervisorStrategy-aware function parameters according to the @thinkbeforecoding comments.
- Added `Strategy` module with functions allowing creation of OneForOne and AllForOne supervisor strategies in way enhancing F# syntax (function currying, using F# lambdas).

Additionally I've created an examples (Supervisioning.fs) to show possible usage of new API functions. Furthermore I've attached example of MapReduce algorithm using F# functional API (as I've described on my blog in details - http://bartoszsypytkowski.com/blog/2014/07/09/fsharp-akka-map-reduce/).
