### PR TITLE
F# MapReduce uses InternalActorRef. It should be using ActorRef. Breaking change

### DIFF
--- a/src/examples/FSharp.Api/MapReduce.fs
+++ b/src/examples/FSharp.Api/MapReduce.fs
@@ -42,7 +42,7 @@ let reduce (dict:ConcurrentDictionary<string,int>) (mailbox:Actor<MRMsg>) = func
 
 /// Master actor function, used as proxy between system user and internal Map/Reduce implementation
 /// Can either forward data chunk to mappers or forward a request of returning all reduced data
-let master mapper (reducer:InternalActorRef) (mailbox:Actor<MRMsg>) = function
+let master mapper (reducer:ActorRef) (mailbox:Actor<MRMsg>) = function
     | Map line  -> mapper <! Map line
     | Collect   -> reducer.Tell(Collect, mailbox.Sender())
     | m         -> mailbox.Unhandled m


### PR DESCRIPTION
`InternalActorRef` is only meant to be used internally by Akka, and not exposed externally, so I changed it to `ActorRef`.
Upcoming PR for #182 will change `ActorOf` to return an `ActorRef` (which will change the signature of `spawns`). This is to prepare for that commit.

@Horusiath Can you verify this PR is OK (tests working, but my F# skills could be better :)
