### PR TITLE
A closed mailbox shouldn't process usermsgs. Fixes #209

### DIFF
--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -28,6 +28,7 @@ namespace Akka.Actor
         private long uid;
         private ActorBase _actor;
         private bool _actorHasBeenCleared;
+        private Mailbox _mailbox;
 
 
         public ActorCell(ActorSystem system, InternalActorRef self, Props props, MessageDispatcher dispatcher, InternalActorRef parent)
@@ -40,7 +41,8 @@ namespace Akka.Actor
         }
 
         public object CurrentMessage { get; private set; }
-        public Mailbox Mailbox { get; protected set; }
+        public Mailbox Mailbox { get { return _mailbox; } }
+
         public MessageDispatcher Dispatcher { get; private set; }
         public bool IsLocal { get{return true;} }
         protected ActorBase Actor { get { return _actor; } }
@@ -65,7 +67,7 @@ namespace Akka.Actor
             var mailbox = createMailbox(); //Akka: dispatcher.createMailbox(this, mailboxType)
             mailbox.Setup(Dispatcher);
             mailbox.SetActor(this);
-            Mailbox = mailbox;
+            _mailbox = mailbox;
 
             var createMessage = new Create();
             // AKKA:

--- a/src/core/Akka/Actor/DeadLetterMailbox.cs
+++ b/src/core/Akka/Actor/DeadLetterMailbox.cs
@@ -38,7 +38,7 @@ namespace Akka.Actor
         {            
         }
 
-        public override void Stop()
+        public override void BecomeClosed()
         {
             
         }
@@ -49,6 +49,11 @@ namespace Akka.Actor
         }
 
         protected override void Schedule()
+        {
+            //Intentionally left blank
+        }
+
+        public override void CleanUp()
         {
             //Intentionally left blank
         }

--- a/src/core/Akka/Dispatch/ConcurrentQueueMailbox.cs
+++ b/src/core/Akka/Dispatch/ConcurrentQueueMailbox.cs
@@ -58,7 +58,7 @@ namespace Akka.Dispatch
                 int left = dispatcher.Throughput;
 
                 //try dequeue a user message
-                while (!_isSuspended && _userMessages.TryDequeue(out envelope))
+                while (!_isSuspended && !_isClosed && _userMessages.TryDequeue(out envelope))
                 {
                     Mailbox.DebugPrint(ActorCell.Self + " processing message " + envelope);
 
@@ -149,7 +149,7 @@ namespace Akka.Dispatch
         /// <summary>
         ///     Stops this instance.
         /// </summary>
-        public override void Stop()
+        public override void BecomeClosed()
         {
             _isClosed = true;
         }
@@ -168,5 +168,38 @@ namespace Akka.Dispatch
             return _userMessages.Count;
         }
 
+        public override void CleanUp()
+        {
+            var actorCell = ActorCell;
+            if(actorCell != null) // actor is null for the deadLetterMailbox
+            {
+                var deadLetterMailbox = actorCell.System.Mailboxes.DeadLetterMailbox;
+                Envelope envelope   ;
+                while(_systemMessages.TryDequeue(out envelope))
+                {
+                    deadLetterMailbox.Post(envelope);
+                }
+                while(_userMessages.TryDequeue(out envelope))
+                {
+                    deadLetterMailbox.Post(envelope);
+                }
+            }
+
+            //Akka JVM code:
+            //   if (actor ne null) { // actor is null for the deadLetterMailbox
+            //     val dlm = actor.dispatcher.mailboxes.deadLetterMailbox
+            //     var messageList = systemDrain(new LatestFirstSystemMessageList(NoMessage))
+            //     while (messageList.nonEmpty) {
+            //       // message must be “virgin” before being able to systemEnqueue again
+            //       val msg = messageList.head
+            //       messageList = messageList.tail
+            //       msg.unlink()
+            //       dlm.systemEnqueue(actor.self, msg)
+            //     }
+
+            //     if (messageQueue ne null) // needed for CallingThreadDispatcher, which never calls Mailbox.run()
+            //       messageQueue.cleanUp(actor.self, actor.dispatcher.mailboxes.deadLetterMailbox.messageQueue)
+            //   }
+        }
     }   
 }

--- a/src/core/Akka/Dispatch/Mailbox.cs
+++ b/src/core/Akka/Dispatch/Mailbox.cs
@@ -54,7 +54,7 @@ namespace Akka.Dispatch
         /// <summary>
         ///     Stops this instance.
         /// </summary>
-        public abstract void Stop();
+        public abstract void BecomeClosed();
 
         /// <summary>
         ///     Attaches a MessageDispatcher to the Mailbox.
@@ -142,5 +142,6 @@ namespace Akka.Dispatch
         protected abstract void Schedule();
 
 
+        public abstract void CleanUp();
     }   
 }


### PR DESCRIPTION
A terminated actor should also drain all messages to DeadLetterMailbox.
Fixes #209
