### PR TITLE
.NET Configuration section containing Hocon CDATA

### DIFF
--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -60,6 +60,7 @@
       <HintPath>..\..\packages\fastJSON.2.0.27.1\lib\net40\fastjson.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="xunit">
       <HintPath>..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>
@@ -88,6 +89,7 @@
     <Compile Include="Actor\FSMTransitionSpec.cs" />
     <Compile Include="Actor\PatternSpec.cs" />
     <Compile Include="Actor\RootGuardianActorRef_Tests.cs" />
+    <Compile Include="Configuration\ConfigurationSpec.cs" />
     <Compile Include="Event\EventBusSpec.cs" />
     <Compile Include="Event\EventStreamSpec.cs" />
     <Compile Include="HoconTests.cs" />
@@ -110,6 +112,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Content Include="App.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
   </ItemGroup>
   <Choose>

--- a/src/core/Akka.Tests/App.config
+++ b/src/core/Akka.Tests/App.config
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <section name="akka" type="Akka.Configuration.Hocon.AkkaConfigurationSection, Akka" />
+  </configSections>
+
+  <akka>
+    <hocon>
+      <![CDATA[
+          akka {
+            log-config-on-start = off
+            stdout-loglevel = INFO
+            loglevel = ERROR
+            actor {
+              provider = ""Akka.Remote.RemoteActorRefProvider, Akka.Remote""
+              debug {
+                  receive = on
+                  autoreceive = on
+                  lifecycle = on
+                  event-stream = on
+                  unhandled = on
+              }
+            }
+            remote {
+              #this is the new upcoming remoting support, which enables multiple transports
+              helios.tcp {
+                  transport-class = ""Akka.Remote.Transport.Helios.HeliosTcpTransport, Akka.Remote""
+                  #applied-adapters = []
+                  transport-protocol = tcp
+                  port = 8091
+                  hostname = ""127.0.0.1""
+              }
+            log-remote-lifecycle-events = INFO
+          }
+      ]]>
+    </hocon>
+  </akka>
+</configuration>

--- a/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
+++ b/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
@@ -1,0 +1,19 @@
+﻿using Akka.Configuration.Hocon;
+using System.Configuration;
+using Xunit;
+
+namespace Akka.Tests.Configuration
+{
+    public class ConfigurationSpec : AkkaSpec
+    {
+        [Fact]
+        public void DeserializesHoconConfigurationFromNetConfigFile()
+        {
+            var section = (AkkaConfigurationSection)ConfigurationManager.GetSection("akka");
+            Assert.NotNull(section);
+            Assert.False(string.IsNullOrEmpty(section.Hocon.Content));
+            var akkaConfig = section.AkkaConfig;
+            Assert.NotNull(akkaConfig);
+        }
+    }
+}

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -56,6 +56,7 @@
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -107,7 +108,10 @@
     <Compile Include="Configuration\ConfigurationException.cs" />
     <Compile Include="Configuration\ConfigurationFactory.cs" />
     <Compile Include="Configuration\Config.cs" />
+    <Compile Include="Configuration\Hocon\AkkaConfigurationSection.cs" />
+    <Compile Include="Configuration\Hocon\CDataConfigurationElement.cs" />
     <Compile Include="Configuration\Hocon\HoconArray.cs" />
+    <Compile Include="Configuration\Hocon\HoconConfigurationElement.cs" />
     <Compile Include="Configuration\Hocon\HoconLiteral.cs" />
     <Compile Include="Configuration\Hocon\HoconObject.cs" />
     <Compile Include="Configuration\Hocon\HoconParser.cs" />

--- a/src/core/Akka/Configuration/Hocon/AkkaConfigurationSection.cs
+++ b/src/core/Akka/Configuration/Hocon/AkkaConfigurationSection.cs
@@ -1,0 +1,22 @@
+﻿using System.Configuration;
+
+namespace Akka.Configuration.Hocon
+{
+    public class AkkaConfigurationSection : ConfigurationSection
+    {
+        private const string ConfigurationPropertyName = "hocon";
+        private Config _akkaConfig;
+
+        public Config AkkaConfig
+        {
+            get { return _akkaConfig ?? (_akkaConfig = ConfigurationFactory.ParseString(Hocon.Content)); }
+        }
+
+        [ConfigurationProperty(ConfigurationPropertyName, IsRequired = true)]
+        public HoconConfigurationElement Hocon
+        {
+            get { return (HoconConfigurationElement)base[ConfigurationPropertyName]; }
+            set { base[ConfigurationPropertyName] = value; }
+        }
+    }
+}

--- a/src/core/Akka/Configuration/Hocon/CDataConfigurationElement.cs
+++ b/src/core/Akka/Configuration/Hocon/CDataConfigurationElement.cs
@@ -1,0 +1,29 @@
+﻿using System.Configuration;
+using System.Xml;
+
+namespace Akka.Configuration.Hocon
+{
+    public abstract class CDataConfigurationElement : ConfigurationElement
+    {
+        protected const string ContentPropertyName = "content";
+
+        protected override void DeserializeElement(XmlReader reader, bool serializeCollectionKey)
+        {
+            foreach (ConfigurationProperty configurationProperty in Properties)
+            {
+                var name = configurationProperty.Name;
+                if (name == ContentPropertyName)
+                {
+                    var contentString = reader.ReadString();
+                    base[name] = contentString.Trim();
+                }
+                else
+                {
+                    var attributeValue = reader.GetAttribute(name);
+                    base[name] = attributeValue;
+                }
+            }
+            reader.ReadEndElement();
+        }
+    }
+}

--- a/src/core/Akka/Configuration/Hocon/HoconConfigurationElement.cs
+++ b/src/core/Akka/Configuration/Hocon/HoconConfigurationElement.cs
@@ -1,0 +1,14 @@
+﻿using System.Configuration;
+
+namespace Akka.Configuration.Hocon
+{
+    public class HoconConfigurationElement : CDataConfigurationElement
+    {
+        [ConfigurationProperty(ContentPropertyName, IsRequired = true, IsKey = true)]
+        public string Content
+        {
+            get { return (string)base[ContentPropertyName]; }
+            set { base[ContentPropertyName] = value; }
+        }
+    }
+}


### PR DESCRIPTION
- This PR introduces 3 new classes in Akka.Configuration.Hocon providing the functionality to parse a simple configuration section containing pure Hocon CDATA. I've intentionally decided to place the CFG section in that namespace, in case I attempt to come up with a pure .NET configuration (which I'd put in Akka.Configuration)
- The configuration section exposes a parsed Akka configuration via lazy loading
- Simple parsing test and example usage of the configuration section added to Akka.Tests
