### PR TITLE
Type validation for configs

### DIFF
--- a/src/core/Akka/Actor/Settings.cs
+++ b/src/core/Akka/Actor/Settings.cs
@@ -27,6 +27,12 @@ namespace Akka.Actor
 
             ConfigVersion = Config.GetString("akka.version");
             ProviderClass = Config.GetString("akka.actor.provider");
+            var providerType = Type.GetType(ProviderClass);
+            if (providerType == null)
+                throw new ConfigurationException(string.Format("'akka.actor.provider' is not a valid type name : '{0}'", ProviderClass));
+            if (!typeof(ActorRefProvider).IsAssignableFrom(providerType))
+                throw new ConfigurationException(string.Format("'akka.actor.provider' is not a valid actor ref provider: '{0}'", ProviderClass));
+            
             SupervisorStrategyClass = Config.GetString("akka.actor.guardian-supervisor-strategy");
 
             CreationTimeout = Config.GetMillisDuration("akka.actor.creation-timeout");

--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -238,6 +238,11 @@ akka {
 		type = "SynchronizedDispatcher"
 		throughput = 10
 	}
+
+	task-dispatcher {
+		type = "Akka.Dispatch.TaskDispatcher"
+		throughput = 100
+	}
     
     default-dispatcher {
       # Must be one of the following


### PR DESCRIPTION
Changes in this PR:
- When resolving `ActorRefProvider` from the HOCON config, we now validate that the type exist and is a  `ActorRefProvider` sub type

Issue found here https://twitter.com/kot_2010/status/492228000411561984/photo/1 .. double `"` is parsed as `""` + `Akka.Remote.RemoteActorRefProvider` + `,` //<- json terminate line
So "" is not a syntax error, it just means empty string and then HOCON unquoted string literal parsing kicks in.. so not a parser error but a malformed config.
- Added task-dispatcher to default config
  > `TaskDispatcher` is slightly slower than our default dispatcher, but works under medium trust.
