### PR TITLE
Fix issue with PhiAccrualFailureDetector

### DIFF
--- a/src/core/Akka.Remote/FailureDetector.cs
+++ b/src/core/Akka.Remote/FailureDetector.cs
@@ -29,7 +29,7 @@ namespace Akka.Remote
 
         #region Static members
 
-        public static readonly Clock DefaultClock = () => Environment.TickCount / TimeSpan.TicksPerMillisecond;
+        public static readonly Clock DefaultClock = () => Environment.TickCount;
 
         #endregion
     }


### PR DESCRIPTION
Environment.TickCount is already in milliseconds (which is confusing).
There are potentially issues here when the sign of TickCount flips, as it's an int, depending on how this is used further up the stack.
Keeping that in mind for further changes
