### PR TITLE
ActorIdentity isn't handled by AutoReceiveMessage

### DIFF
--- a/src/core/Akka/Actor/AutoReceivedMessage.cs
+++ b/src/core/Akka/Actor/AutoReceivedMessage.cs
@@ -41,7 +41,7 @@ namespace Akka.Actor
     }
 
     //response to the Identity message, get identity by Sender
-    public sealed class ActorIdentity : AutoReceivedMessage
+    public sealed class ActorIdentity
     {
         public ActorIdentity(object messageId, ActorRef subject)
         {


### PR DESCRIPTION
ActorIdentity isn't handled by AutoReceiveMessage and shouldn't extend AutoReceivedMessage.

Should AutoReceiveMessage have a default case that throws an exception?
