### PR TITLE
ReceiveTimeoutSpec

### DIFF
--- a/src/core/Akka.Tests/Actor/ReceiveTimeoutSpec.cs
+++ b/src/core/Akka.Tests/Actor/ReceiveTimeoutSpec.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Xunit;
+using Akka.TestKit;
+using Akka.Tests;
+
+
+namespace Akka.Actor
+{
+    public class ReceiveTimeoutSpec : AkkaSpec
+    {
+        private static readonly object Tick = new object();
+
+        public class TimeoutActor : ActorBase
+        {
+            private TestLatch _timeoutLatch;
+
+            public TimeoutActor(TestLatch timeoutLatch)
+            {
+                _timeoutLatch = timeoutLatch;
+                Context.SetReceiveTimeout(TimeSpan.FromMilliseconds(500));
+            }
+            protected override bool Receive(object message)
+            {                
+                if (message is ReceiveTimeout)
+                {
+                    _timeoutLatch.Open();
+                    return true;
+                }
+                if (message == Tick)
+                {
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        public class NoTimeoutActor : ActorBase
+        {
+            private TestLatch _timeoutLatch;
+
+            public NoTimeoutActor(TestLatch timeoutLatch)
+            {
+                _timeoutLatch = timeoutLatch;
+            }
+            protected override bool Receive(object message)
+            {
+                if (message is ReceiveTimeout)
+                {
+                    _timeoutLatch.Open();
+                    return true;
+                }
+                if (message == Tick)
+                {
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        [Fact(DisplayName="An actor with receive timeout must get timeout")]
+        public void GetTimeout()
+        {
+            var timeoutLatch = new TestLatch(sys);
+            var timeoutActor = sys.ActorOf(Props.Create(() => new TimeoutActor(timeoutLatch)));
+
+            timeoutLatch.Ready(TestLatch.DefaultTimeout);
+            sys.Stop(timeoutActor);
+        }
+
+        //TODO: how does this prove that there was a reschedule?? see ReceiveTimeoutSpec.scala 
+        [Fact(DisplayName = "An actor with receive timeout must reschedule timeout after regular receive")]
+        public void RescheduleTimeout()
+        {
+            var timeoutLatch = new TestLatch(sys);
+            var timeoutActor = sys.ActorOf(Props.Create(() => new TimeoutActor(timeoutLatch)));
+            timeoutActor.Tell(Tick);
+            timeoutLatch.Ready(TestLatch.DefaultTimeout);
+            sys.Stop(timeoutActor);
+        }
+
+        [Fact(DisplayName = "An actor with receive timeout must not receive timeout message when not specified")]
+        public void NotGetTimeout()
+        {
+            var timeoutLatch = new TestLatch(sys);
+            var timeoutActor = sys.ActorOf(Props.Create(() => new NoTimeoutActor(timeoutLatch)));
+            intercept<TimeoutException>(() => timeoutLatch.Ready(TestLatch.DefaultTimeout));            
+            sys.Stop(timeoutActor);
+        }
+    }
+}

--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Actor\FSMTimingSpec.cs" />
     <Compile Include="Actor\FSMTransitionSpec.cs" />
     <Compile Include="Actor\PatternSpec.cs" />
+    <Compile Include="Actor\ReceiveTimeoutSpec.cs" />
     <Compile Include="Actor\RootGuardianActorRef_Tests.cs" />
     <Compile Include="Configuration\ConfigurationSpec.cs" />
     <Compile Include="Actor\ReceiveActorTests_Become.cs" />

--- a/src/examples/FSharp.Api/Program.fs
+++ b/src/examples/FSharp.Api/Program.fs
@@ -3,5 +3,5 @@
 [<EntryPoint>]
 let main args =
     Supervisioning.main()
-    Console.ReadLine()
+    Console.ReadLine() |> ignore
     0


### PR DESCRIPTION
Completed the spec for `ReceiveTimeout`

Actors can now get a `ReceiveTimeout` message if they call the `SetReceiveTimeout` method.
This enables you to for example klill off idle actors, or close expensive resources if they have not been used for a while.

``` csharp
public class MyActor : ReceiveActor
{
    public MyActor()
    {
          SetReceiveTimeout(Timespan.FromSeconds(3));
          Receive<MyMessage>(message => ...);
          Receive<ReceiveTimeout>(timeout => ... actor is idle... );
    }
}
```
