### PR TITLE
Implementation of the Inbox feature

### DIFF
--- a/src/core/Akka.TestKit/AkkaSpec.cs
+++ b/src/core/Akka.TestKit/AkkaSpec.cs
@@ -516,6 +516,20 @@ namespace Akka.Tests
             }
         }
 
+        protected void EventFilterLog<T>(string message, int occurences, Action intercept) where T : LogEvent
+        {
+            sys.EventStream.Subscribe(testActor, typeof(T));
+            intercept();
+            for (int i = 0; i < occurences; i++)
+            {
+                var res = queue.Take();
+                var error = (LogEvent)res;
+
+                Xunit.Assert.Equal(typeof(T), error.GetType());
+                var match = -1 != error.Message.ToString().IndexOf(message, StringComparison.CurrentCultureIgnoreCase);
+                Xunit.Assert.True(match);
+            }
+        }
 
         protected TestProbe TestProbe()
         {

--- a/src/core/Akka.Tests/Actor/InboxSpec.cs
+++ b/src/core/Akka.Tests/Actor/InboxSpec.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Event;
+using Xunit;
+
+namespace Akka.Tests.Actor
+{
+    public class InboxSpec : AkkaSpec
+    {
+        private Inbox _inbox;
+        public InboxSpec()
+        {
+            _inbox = Inbox.Create(sys);
+        }
+
+        [Fact]
+        public void Inbox_support_watch()
+        {
+            _inbox.Watch(testActor);
+
+            // check watch
+            testActor.Tell(PoisonPill.Instance);
+            var received = _inbox.Receive(TimeSpan.FromSeconds(1));
+
+            received.GetType().ShouldBe(typeof(Terminated));
+            var terminated = (Terminated)received;
+            terminated.ActorRef.ShouldBe(testActor);
+        }
+
+        [Fact]
+        public void Inbox_support_queueing_multiple_queries()
+        {
+            var tasks = new[]
+                {
+                    Task.Factory.StartNew(() => _inbox.Receive()),
+                    Task.Factory.StartNew(() =>
+                    {
+                        Thread.Sleep(100);
+                        return _inbox.ReceiveWhere(x => x.ToString() == "world"); 
+                    }), 
+                    Task.Factory.StartNew(() =>
+                    {
+                        Thread.Sleep(200);
+                        return _inbox.ReceiveWhere(x => x.ToString() == "hello"); 
+                    }) 
+                };
+
+            _inbox.Receiver.Tell(42);
+            _inbox.Receiver.Tell("hello");
+            _inbox.Receiver.Tell("world");
+
+            Task.WaitAll(tasks);
+
+            tasks[0].Result.ShouldBe(42);
+            tasks[1].Result.ShouldBe("world");
+            tasks[2].Result.ShouldBe("hello");
+        }
+
+        [Fact]
+        public void Inbox_support_selective_receives()
+        {
+            _inbox.Receiver.Tell("hello");
+            _inbox.Receiver.Tell("world");
+
+            var selection = _inbox.ReceiveWhere(x => x.ToString() == "world");       
+            selection.ShouldBe("world");
+            _inbox.Receive().ShouldBe("hello");
+        }
+
+        [Fact]
+        public void Inbox_have_maximum_queue_size()
+        {
+            sys.EventStream.Subscribe(testActor, typeof(Warning));
+            try
+            {
+                foreach (var zero in Enumerable.Repeat(0, 1000))
+                    _inbox.Receiver.Tell(zero);
+
+                expectNoMsg(TimeSpan.FromSeconds(1));
+                EventFilterLog<Warning>("dropping message", 1, () => _inbox.Receiver.Tell(42));
+                _inbox.Receiver.Tell(42);
+                expectNoMsg(TimeSpan.FromSeconds(1));
+
+                var gotit = Enumerable.Repeat(0, 1000).Select(_ => _inbox.Receive());
+                foreach (var o in gotit)
+                {
+                    o.ShouldBe(0);
+                }
+
+                intercept<TimeoutException>(() => _inbox.Receive(TimeSpan.FromSeconds(1)));
+            }
+            finally
+            {
+                sys.EventStream.Unsubscribe(testActor, typeof(Warning));
+            }
+        }
+
+
+        [Fact]
+        public void Inbox_have_a_default_and_custom_timeouts()
+        {
+            Within(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(6), () =>
+            {
+                intercept<TimeoutException>(() => _inbox.Receive());
+                return true;
+            });
+            Within(TimeSpan.FromSeconds(1), () =>
+            {
+                intercept<TimeoutException>(() => _inbox.Receive(TimeSpan.FromMilliseconds(100)));
+                return true;
+            });
+        }
+    }
+}

--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Actor\ActorCellTests.cs" />
     <Compile Include="Actor\ActorLifeCycleSpec.cs" />
     <Compile Include="Actor\ActorPathSpec.cs" />
+    <Compile Include="Actor\InboxSpec.cs" />
     <Compile Include="Actor\ReceiveActorTests.cs" />
     <Compile Include="Actor\ActorRefProviderSpec.cs" />
     <Compile Include="Actor\ActorSelectionSpec.cs" />

--- a/src/core/Akka/Actor/Inbox.Actor.cs
+++ b/src/core/Akka/Actor/Inbox.Actor.cs
@@ -1,0 +1,173 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Akka.Event;
+
+namespace Akka.Actor
+{
+    internal class InboxActor : ActorBase, IActorLogging
+    {
+        private readonly InboxQueue<object> _messages = new InboxQueue<object>();
+        private readonly InboxQueue<IQuery> _clients = new InboxQueue<IQuery>();
+
+        private readonly ISet<IQuery> _clientsByTimeout = new SortedSet<IQuery>(DeadlineComparer.Instance);
+        private bool _printedWarning;
+
+        private object _currentMessage;
+        private Select? _currentSelect;
+        private Tuple<DateTime, CancellationTokenSource> _currentDeadline;
+
+        private int size;
+        private LoggingAdapter log = Logging.GetLogger(Context);
+        public LoggingAdapter Log { get { return log; } }
+
+        public InboxActor(int size)
+        {
+            this.size = size;
+        }
+
+        public void EnqueueQuery(IQuery q)
+        {
+            var query = q.WithClient(Sender);
+            _clients.Enqueue(query);
+            _clientsByTimeout.Add(query);
+        }
+
+        public void EnqueueMessage(object msg)
+        {
+            if (_messages.Count < size)
+            {
+                _messages.Enqueue(msg);
+            }
+            else
+            {
+                if (!_printedWarning)
+                {
+                    Log.Warn("Dropping message: Inbox size has been exceeded, use akka.actor.inbox.inbox-size to increase maximum allowed inbox size. Current is " + size);
+                    _printedWarning = true;
+                }
+            }
+        }
+
+        public bool ClientPredicate(IQuery query)
+        {
+            if (query is Get)
+            {
+                return true;
+            }
+            else if (query is Select)
+            {
+                return ((Select)query).Predicate(_currentMessage);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public bool MessagePredicate(object msg)
+        {
+            if (!_currentSelect.HasValue)
+            {
+                return false;
+            }
+
+            return _currentSelect.Value.Predicate(msg);
+        }
+
+        protected override bool Receive(object message)
+        {
+            PatternMatch.Match(message)
+                .With<Get>(get =>
+                {
+                    if (_messages.Count == 0)
+                    {
+                        EnqueueQuery(get);
+                    }
+                    else
+                    {
+                        Sender.Tell(_messages.Dequeue());
+                    }
+                })
+                .With<Select>(select =>
+                {
+                    if (_messages.Count == 0)
+                    {
+                        EnqueueQuery(select);
+                    }
+                    else
+                    {
+                        _currentSelect = select;
+                        var firstMatch = _messages.DequeueFirstOrDefault(MessagePredicate);
+                        if (firstMatch == null)
+                        {
+                            EnqueueQuery(select);
+                        }
+                        else
+                        {
+                            Sender.Tell(firstMatch);
+                        }
+                        _currentSelect = null;
+                    }
+                })
+                .With<StartWatch>(sw => Context.Watch(sw.Target))
+                .With<Kick>(() =>
+                {
+                    var now = DateTime.Now;
+                    var overdue = _clientsByTimeout.TakeWhile(q => q.Deadline < now);
+                    foreach (var query in overdue)
+                    {
+                        query.Client.Tell(new Status.Failure(new TimeoutException("Deadline passed")));
+                    }
+                    _clients.RemoveAll(q => q.Deadline < now);
+                    _clientsByTimeout.IntersectWith(_clientsByTimeout.Where(q => q.Deadline >= now));
+                }).Default(msg =>
+                {
+                    if (_clients.Count == 0)
+                    {
+                        EnqueueMessage(msg);
+                    }
+                    else
+                    {
+                        _currentMessage = msg;
+                        var firstMatch = _clients.DequeueFirstOrDefault(ClientPredicate); //TODO: this should work as DequeueFirstOrDefault
+                        if (firstMatch != null)
+                        {
+                            _clientsByTimeout.ExceptWith(new[] { firstMatch });
+                            firstMatch.Client.Tell(msg);
+                        }
+                        else
+                        {
+                            EnqueueMessage(msg);
+                        }
+                        _currentMessage = null;
+                    }
+                });
+
+            if (_clients.Count == 0)
+            {
+                if (_currentDeadline != null)
+                {
+                    _currentDeadline.Item2.Cancel();
+                    _currentDeadline = null;
+                }
+            }
+            else
+            {
+                var next = _clientsByTimeout.Head().Deadline;
+                if (_currentDeadline != null)
+                {
+                    _currentDeadline.Item2.Cancel();
+                }
+                var cancellationTokenSource = new CancellationTokenSource();
+                Context.System.Scheduler.ScheduleOnce(next - DateTime.Now, Self, new Kick(), cancellationTokenSource.Token);
+
+                _currentDeadline = Tuple.Create(next, cancellationTokenSource);
+            }
+
+            return true;
+        }
+    }
+
+}

--- a/src/core/Akka/Actor/Inbox.cs
+++ b/src/core/Akka/Actor/Inbox.cs
@@ -1,0 +1,335 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Util;
+
+namespace Akka.Actor
+{
+    internal interface IQuery
+    {
+        DateTime Deadline { get; }
+        ActorRef Client { get; }
+        IQuery WithClient(ActorRef client);
+    }
+
+    internal struct Get : IQuery
+    {
+        public Get(DateTime deadline, ActorRef client = null)
+            : this()
+        {
+            Deadline = deadline;
+            Client = client;
+        }
+
+        public DateTime Deadline { get; private set; }
+        public ActorRef Client { get; private set; }
+        public IQuery WithClient(ActorRef client)
+        {
+            return new Get(Deadline, client);
+        }
+    }
+
+    internal struct Select : IQuery
+    {
+        public Select(DateTime deadline, Predicate<object> predicate, ActorRef client = null)
+            : this()
+        {
+            Deadline = deadline;
+            Predicate = predicate;
+            Client = client;
+        }
+
+        public DateTime Deadline { get; private set; }
+        public Predicate<object> Predicate { get; set; }
+        public ActorRef Client { get; private set; }
+        public IQuery WithClient(ActorRef client)
+        {
+            return new Select();
+        }
+    }
+
+    internal struct StartWatch
+    {
+        public StartWatch(ActorRef target)
+            : this()
+        {
+            Target = target;
+        }
+
+        public ActorRef Target { get; private set; }
+    }
+
+    internal struct Kick { }
+
+    // LinkedList wrapper instead of Queue? While it's used for queueing, however I expect a lot of churn around 
+    // adding-removing elements. Additionally we have to get a functionality of dequeueing element meeting
+    // a specific predicate (even if it's in middle of queue), and current queue implementation won't provide that in easy way.
+    [Serializable]
+    internal class InboxQueue<T> : ICollection<T>
+    {
+        private readonly LinkedList<T> _inner = new LinkedList<T>();
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return _inner.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public void Add(T item)
+        {
+            _inner.AddLast(item);
+        }
+
+        public void Clear()
+        {
+            _inner.Clear();
+        }
+
+        public bool Contains(T item)
+        {
+            return _inner.Contains(item);
+        }
+
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            _inner.CopyTo(array, arrayIndex);
+        }
+
+        public bool Remove(T item)
+        {
+            return _inner.Remove(item);
+        }
+
+        public int RemoveAll(Predicate<T> predicate)
+        {
+            var i = 0;
+            var node = _inner.First;
+            while (!(node == null || predicate(node.Value)))
+            {
+                var n = node;
+                node = node.Next;
+                _inner.Remove(n);
+                i++;
+            }
+
+            return i;
+        }
+
+        public void Enqueue(T item)
+        {
+            _inner.AddLast(item);
+        }
+
+        public T Dequeue()
+        {
+            var item = _inner.First.Value;
+            _inner.RemoveFirst();
+            return item;
+        }
+
+        public T DequeueFirstOrDefault(Predicate<T> predicate)
+        {
+            var node = _inner.First;
+            while (!(node == null || predicate(node.Value)))
+            {
+                node = node.Next;
+            }
+
+            if (node != null)
+            {
+                var item = node.Value;
+                _inner.Remove(node);
+                return item;
+            }
+
+            return default(T);
+        }
+
+        public int Count { get { return _inner.Count; } }
+        public bool IsReadOnly { get { return false; } }
+    }
+
+    internal class DeadlineComparer : IComparer<IQuery>
+    {
+        private static readonly DeadlineComparer _instance = new DeadlineComparer();
+
+        public static DeadlineComparer Instance { get { return _instance; } }
+
+        private DeadlineComparer()
+        {
+        }
+
+        public int Compare(IQuery x, IQuery y)
+        {
+            return x.Deadline.CompareTo(y.Deadline);
+        }
+    }
+
+    /// <summary>
+    /// <see cref="Inboxable"/> is an actor-like object to be listened by external objects.
+    /// It can watch other actors lifecycle and contains inner actor, which could be passed
+    /// as reference to other actors.
+    /// </summary>
+    public interface Inboxable
+    {
+        /// <summary>
+        /// Get a reference to internal actor. It may be for example registered in event stream.
+        /// </summary>
+        ActorRef Receiver { get; }
+
+        /// <summary>
+        /// Receive a next message from current <see cref="Inboxable"/> with default timeout. This call will return immediately,
+        /// if the internal actor previously received a message, or will block until it'll receive a message.
+        /// </summary>
+        object Receive();
+
+        /// <summary>
+        /// Receive a next message from current <see cref="Inboxable"/>. This call will return immediately,
+        /// if the internal actor previously received a message, or will block for time specified by 
+        /// <paramref name="timeout"/> until it'll receive a message.
+        /// </summary>
+        object Receive(TimeSpan timeout);
+
+        Task<object> ReceiveAsync();
+
+        Task<object> ReceiveAsync(TimeSpan timeout);
+
+        /// <summary>
+        /// Receive a next message satisfying specified <paramref name="predicate"/> under default timeout.
+        /// </summary>
+        object ReceiveWhere(Predicate<object> predicate);
+
+        /// <summary>
+        /// Receive a next message satisfying specified <paramref name="predicate"/> under provided <paramref name="timeout"/>.
+        /// </summary>
+        object ReceiveWhere(Predicate<object> predicate, TimeSpan timeout);
+
+        /// <summary>
+        /// Makes internal actor watch a provided <paramref name="target"/> actor. 
+        /// If it terminates a <see cref="Terminated"/> message will be received.
+        /// </summary>
+        void Watch(ActorRef target);
+
+        /// <summary>
+        /// Makes an internal actor act as a proxy of given <paramref name="message"/>, 
+        /// which will be send to given <paramref cref="target"/> actor. It means, 
+        /// that all <paramref name="target"/>'s replies will be sent to current inbox instead.
+        /// </summary>
+        void Send(ActorRef target, object message);
+    }
+
+    public class Inbox : Inboxable, IDisposable
+    {
+        private static int inboxNr = 0;
+        private readonly ISet<IObserver<object>> _subscribers;
+        private readonly ActorSystem _system;
+        private readonly TimeSpan _defaultTimeout;
+
+        public static Inbox Create(ActorSystem system)
+        {
+            var config = system.Settings.Config.GetConfig("akka").GetConfig("actor").GetConfig("inbox");
+            var inboxSize = config.GetInt("inbox-size");
+            var timeout = config.GetMillisDuration("default-timeout");
+
+            var receiver = system.SystemActorOf(Props.Create(() => new InboxActor(inboxSize)), "inbox-" + Interlocked.Increment(ref inboxNr));
+
+            var inbox = new Inbox(timeout, receiver, system);
+            return inbox;
+        }
+
+        private Inbox(TimeSpan defaultTimeout, ActorRef receiver, ActorSystem system)
+        {
+            _subscribers = new HashSet<IObserver<object>>();
+            _defaultTimeout = defaultTimeout;
+            _system = system;
+            Receiver = receiver;
+        }
+
+        public ActorRef Receiver { get; private set; }
+
+        /// <summary>
+        /// Make the inbox’s actor watch the <paramref name="target"/> actor such that 
+        /// reception of the <see cref="Terminated"/> message can then be awaited.
+        /// </summary>
+        public void Watch(ActorRef target)
+        {
+            Receiver.Tell(new StartWatch(target));
+        }
+
+        public void Send(ActorRef actorRef, object msg)
+        {
+            actorRef.Tell(msg, Receiver);
+        }
+
+        /// <summary>
+        /// Recive a single message from <see cref="Receiver"/> actor with default timeout. 
+        /// NOTE: Timeout resolution depends on system's scheduler.
+        /// </summary>
+        /// <remarks>
+        /// Don't use this method within actors, since it block current thread until a message is received.
+        /// </remarks>
+        public object Receive()
+        {
+            return Receive(_defaultTimeout);
+        }
+
+        /// <summary>
+        /// Recive a single message from <see cref="Receiver"/> actor. 
+        /// Provided <paramref name="timeout"/> is used for cleanup purposes.
+        /// NOTE: <paramref name="timeout"/> resolution depends on system's scheduler.
+        /// </summary>
+        /// <remarks>
+        /// Don't use this method within actors, since it block current thread until a message is received.
+        /// </remarks>
+        public object Receive(TimeSpan timeout)
+        {
+            var task = ReceiveAsync(timeout);
+            return AwaitResult(task, timeout);
+        }
+
+        public object ReceiveWhere(Predicate<object> predicate)
+        {
+            return ReceiveWhere(predicate, _defaultTimeout);
+        }
+
+        public object ReceiveWhere(Predicate<object> predicate, TimeSpan timeout)
+        {
+            var task = Receiver.Ask(new Select(DateTime.Now + timeout, predicate), Timeout.InfiniteTimeSpan);
+            return AwaitResult(task, timeout);
+        }
+
+        public Task<object> ReceiveAsync()
+        {
+            return ReceiveAsync(_defaultTimeout);
+        }
+
+        public Task<object> ReceiveAsync(TimeSpan timeout)
+        {
+            return Receiver.Ask(new Get(DateTime.Now + timeout), Timeout.InfiniteTimeSpan);
+        }
+
+        public void Dispose()
+        {
+            _system.Stop(Receiver);
+        }
+
+        private object AwaitResult(Task<object> task, TimeSpan timeout)
+        {
+            if (task.Wait(timeout))
+            {
+                return task.Result;
+            }
+            else
+            {
+                var fmt = string.Format("Inbox {0} didn't received a response message in specified timeout {1}", Receiver.Path, timeout);
+                throw new TimeoutException(fmt);
+            }
+        }
+    }
+}

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -68,6 +68,7 @@
     <Compile Include="..\..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Actor\Inbox.Actor.cs" />
     <Compile Include="Actor\ReceiveActor.cs" />
     <Compile Include="Actor\ActorBase.cs" />
     <Compile Include="Actor\ActorCell.cs" />
@@ -89,6 +90,7 @@
     <Compile Include="Actor\ChildrenContainer.cs" />
     <Compile Include="Actor\EmptyLocalActorRef.cs" />
     <Compile Include="Actor\ICanTell.cs" />
+    <Compile Include="Actor\Inbox.cs" />
     <Compile Include="Actor\LocalScope.cs" />
     <Compile Include="Actor\NameAndUid.cs" />
     <Compile Include="Actor\ReceiveTimeout.cs" />

--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -100,6 +100,11 @@ akka {
       # Default timeout for typed actor methods with non-void return type
       timeout = 5
     }
+
+	inbox {
+		inbox-size = 1000,
+		default-timeout = 5s
+	}
     
     # Mapping between ´deployment.router' short names to fully qualified class names
     router.type-mapping {


### PR DESCRIPTION
Linked to issue #200.

I've decided to do some changes comparing to original implementation:
- Original `Inbox.Select` now is called `Inbox.ReceiveWhere` and uses standard .NET Predicate<object> instead of Scala'ish predicates (which are able to handle both condition checking AND object-to-object mapping of values). I've decided to change name to reflect current meaning of the method, since Select is a popular LINQ method which works in different way.
- Inbox doesn't use ActorDSL (which is probably not implemented yet in Akka.NET). This also reflects in configuration node - _akka.actor.inbox.*_ instead of original _akka.actor.dsl.*_ (see: Pidgeon.conf changes).
- Inbox queue has it's own custom implementation, based on LinkedList instead of arrays (like original .NET queues). This is because of necessity to implement `DequeueFirstOrDefault` method (which dequeues element meeting provided predicate, even if that element is not the at the beginning of the queue) required to implement selective inbox receives.

I've also tried to implement an `IObservable` interface, but since Inbox works in request-response manner and not a push-notification, it would require more significant modifications.
