### PR TITLE
v0.6.2 release (dev)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 * Improved F# API
 * Resizeable Router support
 * Inbox support - an actor-like object that can be subscribed to by external objects
+* Web.config and App.config support for Akka HOCON configuration
 
 #### 0.6.1 Jul 09 2014
 * Upgraded Helios dependency


### PR DESCRIPTION
Syncing the development branch first for our Akka v0.6.2 release, bound for NuGet later this afternoon.

Going to let AppVeyor do its thing and tell me if any of us have committed an act of evil against the codebase before I push to NuGet. All of the tests worked properly when I ran them locally moments ago.
