### PR TITLE
Spec tests for DeathWatchSpec

### DIFF
--- a/src/core/Akka.TestKit/Akka.TestKit.csproj
+++ b/src/core/Akka.TestKit/Akka.TestKit.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Supervisor.cs" />
     <Compile Include="TestActorRef.cs" />
+    <Compile Include="TestEvents.cs" />
     <Compile Include="TestKitExtension.cs" />
     <Compile Include="TestKitSettings.cs" />
     <Compile Include="TestLatch.cs" />

--- a/src/core/Akka.TestKit/AkkaSpec.cs
+++ b/src/core/Akka.TestKit/AkkaSpec.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Xunit.Sdk;
 
 namespace Akka.Tests
 {
@@ -238,6 +239,12 @@ namespace Akka.Tests
             Xunit.Assert.True(actual is TMessage, string.Format("expected message of type {0} but received {1} instead", typeof(TMessage), actual.GetType()));
 
             return default(TMessage);
+        }
+
+        protected T AwaitResult<T>(Task<object> ask, TimeSpan timeout)
+        {
+            ask.Wait(timeout);
+            return (T)ask.Result;
         }
 
         /// <summary>
@@ -501,6 +508,30 @@ namespace Akka.Tests
                 }
             }
             Xunit.Assert.True(false, "Expected exception of type " + typeof(T).Name);
+        }
+
+        protected void FilterEvents(ActorSystem system, EventFilter[] eventFilters, Action action)
+        {
+            sys.EventStream.Publish(new Mute(eventFilters));
+            try
+            {
+                action();
+
+                var leeway = TestKitSettings.TestEventFilterLeeway;
+                var failed = eventFilters
+                    .Where(x => !x.AwaitDone(leeway))
+                    .Select(x => string.Format("Timeout {0} waiting for {1}", leeway, x))
+                    .ToArray();
+
+                if (failed.Any())
+                {
+                    throw new AssertException("Filter completion error: " + string.Join("\n", failed));
+                }
+            }
+            finally
+            {
+                sys.EventStream.Publish(new Unmute(eventFilters));
+            }
         }
 
         protected void EventFilter<T>(string message, int occurances, Action intercept) where T : Exception

--- a/src/core/Akka.TestKit/TestEvents.cs
+++ b/src/core/Akka.TestKit/TestEvents.cs
@@ -1,0 +1,235 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Event;
+using Xunit.Sdk;
+
+namespace Akka.TestKit
+{
+    public abstract class EventFilter
+    {
+        protected int Occurrences;
+        protected string Source;
+        protected string Message;
+        protected bool Complete;
+
+        protected EventFilter(int occurrences)
+        {
+            Occurrences = occurrences;
+            Message = string.Empty;
+            Complete = false;
+        }
+
+        protected EventFilter(int occurrences, string message, string source, bool complete)
+        {
+            Occurrences = occurrences;
+            Message = message;
+            Source = source;
+            Complete = complete;
+        }
+
+        protected EventFilter() : this(int.MaxValue)
+        {
+        }
+
+        protected abstract bool IsMatch(LogEvent evt);
+
+        public bool Apply(LogEvent evt)
+        {
+            if (IsMatch(evt))
+            {
+                if(Occurrences != int.MaxValue) Interlocked.Decrement(ref Occurrences);
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool AwaitDone(TimeSpan timeout)
+        {
+            if (Occurrences != int.MaxValue && Occurrences > 0)
+            {
+                var t = Task.Factory.StartNew(() =>
+                {
+                    while (Occurrences > 0) ;
+                });
+                t.Wait(timeout);
+            }
+
+            return Occurrences == int.MaxValue || Occurrences == 0;
+        }
+
+        public T Intercept<T>(ActorSystem system, Func<T> func)
+        {
+            system.EventStream.Publish(new Mute(this));
+            var leeway = TestKitExtension.For(system).TestEventFilterLeeway;
+            try
+            {
+                var result = func();
+
+                if (!AwaitDone(leeway))
+                {
+                    var msg = Occurrences > 0
+                        ? string.Format("Timeout ({0}) waiting for {1} messages on {2}", leeway, Occurrences, this)
+                        : string.Format("Received -{0} messages too many on {1}", Occurrences, this);
+
+                    throw new AssertException(msg);
+                }
+                return result;
+            }
+            finally
+            {
+                system.EventStream.Publish(new Unmute(this));
+            }
+        }
+
+        protected bool DoMatch(string src, object msg)
+        {
+            var msgstr = msg == null ? "null" : msg.ToString();
+            return (Source == src && !string.IsNullOrEmpty(Source) || string.IsNullOrEmpty(Source))
+                   && (Complete ? msgstr == Message : msgstr.Contains(Message));
+        }
+    }
+
+    /// <summary>
+    /// Implementation to <see cref="EventFilter"/> facitilites. 
+    /// To install a filter use Mute, and to uninstall - Unmute.
+    /// </summary>
+    public abstract class TestEvent
+    {
+    }
+
+    public sealed class Mute : TestEvent, NoSerializationVerificationNeeded
+    {
+        public Mute(params EventFilter[] filters)
+        {
+            Filters = filters;
+        }
+
+        public EventFilter[] Filters { get; private set; }
+    }
+
+    public sealed class Unmute : TestEvent, NoSerializationVerificationNeeded
+    {
+        public Unmute(params EventFilter[] filters)
+        {
+            Filters = filters;
+        }
+
+        public EventFilter[] Filters { get; private set; }
+    }
+    
+    public class ErrorFilter<TError> : EventFilter where TError: Exception
+    {
+        public ErrorFilter() 
+            : this(int.MaxValue, null, null, false)
+        {
+        }
+
+        public ErrorFilter(int occurrences, string message, string source, bool complete)
+            : base(occurrences, message, source, complete)
+        {
+        }
+
+        protected override bool IsMatch(LogEvent evt)
+        {
+            if (evt is Error)
+            {
+                var err = evt as Error;
+                if (err.Cause is TError)
+                {
+                    return (err.Message == null && string.IsNullOrEmpty(err.Cause.Message) && string.IsNullOrEmpty(err.Cause.StackTrace))
+                        || DoMatch(err.LogSource, err.Message)
+                        || DoMatch(err.LogSource, err.Cause.Message);
+                }
+            }
+
+            return false;
+        }
+    }
+
+    public class WarningFIlter : EventFilter
+    {
+        public WarningFIlter() 
+            : this(int.MaxValue, null, null, false)
+        {
+        }
+
+        public WarningFIlter(int occurrences, string message, string source, bool complete)
+            : base(occurrences, message, source, complete)
+        {
+        }
+        protected override bool IsMatch(LogEvent evt)
+        {
+            if (evt is Warning)
+            {
+                var warn = evt as Warning;
+                return DoMatch(warn.LogSource, warn.Message);
+            }
+
+            return false;
+        }
+    }
+
+    public class InfoFIlter : EventFilter
+    {
+        public InfoFIlter()
+            : this(int.MaxValue, null, null, false)
+        {
+        }
+
+        public InfoFIlter(int occurrences, string message, string source, bool complete)
+            : base(occurrences, message, source, complete)
+        {
+        }
+        protected override bool IsMatch(LogEvent evt)
+        {
+            if (evt is Info)
+            {
+                var info = evt as Info;
+                return DoMatch(info.LogSource, info.Message);
+            }
+
+            return false;
+        }
+    }
+
+    public class DebugFIlter : EventFilter
+    {
+        public DebugFIlter()
+            : this(int.MaxValue, null, null, false)
+        {
+        }
+
+        public DebugFIlter(int occurrences, string message, string source, bool complete)
+            : base(occurrences, message, source, complete)
+        {
+        }
+        protected override bool IsMatch(LogEvent evt)
+        {
+            if (evt is Debug)
+            {
+                var dbg = evt as Debug;
+                return DoMatch(dbg.LogSource, dbg.Message);
+            }
+
+            return false;
+        }
+    }
+
+    public class CustomEventFilter : EventFilter
+    {
+        private readonly Predicate<LogEvent> _predicate;
+
+        public CustomEventFilter(int occurrences, Predicate<LogEvent> predicate) : base(occurrences)
+        {
+            _predicate = predicate;
+        }
+
+        protected override bool IsMatch(LogEvent evt)
+        {
+            return _predicate(evt);
+        }
+    }
+}

--- a/src/core/Akka.TestKit/TestKitSettings.cs
+++ b/src/core/Akka.TestKit/TestKitSettings.cs
@@ -29,11 +29,34 @@ namespace Akka.TestKit
             }
         }
 
-        //TODO: Implement:
-        //  val TestTimeFactor = config.getDouble("akka.test.timefactor").
-        //       requiring(tf ⇒ !tf.isInfinite && tf > 0, "akka.test.timefactor must be positive finite double")
-        // val SingleExpectDefaultTimeout: FiniteDuration = config.getMillisDuration("akka.test.single-expect-default")
-        // val TestEventFilterLeeway: FiniteDuration = config.getMillisDuration("akka.test.filter-leeway")
+        public double TestTimeFactor
+        {
+            get
+            {
+                var factor = _config.GetDouble("akka.test.timefactor");
+                if (double.IsInfinity(factor) || factor > 0.0)
+                {
+                    throw new Exception("akka.test.timefactor must be positive finite double");
+                }
 
+                return factor;
+            }
+        }
+
+        public TimeSpan SingleExpectDefaultTimeout
+        {
+            get
+            {
+                return _config.GetMillisDuration("akka.test.single-expect-default", TimeSpan.FromSeconds(5));
+            }
+        }
+
+        public TimeSpan TestEventFilterLeeway
+        {
+            get
+            {
+                return _config.GetMillisDuration("akka.test.filter-leeway", TimeSpan.FromSeconds(5));
+            }
+        }
     }
 }

--- a/src/core/Akka.TestKit/TestProbe.cs
+++ b/src/core/Akka.TestKit/TestProbe.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using System.Threading;
+using Xunit;
 using Akka.Actor;
 using System;
 using System.Collections.Concurrent;
@@ -55,6 +56,16 @@ namespace Akka.Tests
             {
                 Assert.True(false, "Did not expect a message during the duration " + duration.ToString());
             }
+        }
+
+        public Terminated ExpectTerminated(TimeSpan timeout)
+        {
+            var cancellationTokenSource = new CancellationTokenSource((int)timeout.TotalMilliseconds);
+            var actual = queue.Take(cancellationTokenSource.Token);
+
+            Assert.True(actual is Terminated);
+
+            return (Terminated)actual;
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/DeathWatchSpec.cs
+++ b/src/core/Akka.Tests/Actor/DeathWatchSpec.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using System.Runtime.Remoting.Contexts;
 using Akka.Actor;
 using Akka.Dispatch;
 using Akka.Dispatch.SysMsg;
 using Akka.Event;
+using Akka.TestKit;
 using Xunit;
 
 namespace Akka.Tests.Actor
@@ -11,34 +11,36 @@ namespace Akka.Tests.Actor
     public class DeathWatchSpec : AkkaSpec
     {
         private readonly InternalActorRef _supervisor;
+        private ActorRef _terminal;
 
         public DeathWatchSpec()
         {
-            _supervisor = System.ActorOf(Props.Create<Supervisor>(() => new Supervisor(SupervisorStrategy.DefaultStrategy)), "watchers");
+            _supervisor = System.ActorOf(Props.Create(() => new Supervisor(SupervisorStrategy.DefaultStrategy)), "watchers");
+            _terminal = sys.ActorOf(Props.Empty);
         }
 
         [Fact]
-        public void Given_terminated_actor_When_watching_Then_should_receive_Terminated_message()
+        public void DeathWatch_must_notify_with_one_Terminated_message_when_an_Actor_is_already_terminated()
         {
-            var terminal=System.ActorOf(Props.Empty,"killed-actor");
-            terminal.Tell(PoisonPill.Instance,testActor);
+            var terminal = System.ActorOf(Props.Empty, "killed-actor");
+            terminal.Tell(PoisonPill.Instance, testActor);
             StartWatching(terminal);
             ExpectTerminationOf(terminal);
         }
 
-//        protected override string GetConfig()
-//        {
-//            return @"
-//                akka.log-dead-letters-during-shutdown = true
-//                akka.actor.debug.autoreceive = true
-//                akka.actor.debug.lifecycle = true
-//                akka.actor.debug.event-stream = true
-//                akka.actor.debug.unhandled = true
-//                akka.log-dead-letters = true
-//                akka.loglevel = DEBUG
-//                akka.stdout-loglevel = DEBUG
-//            ";
-//        }
+        //        protected override string GetConfig()
+        //        {
+        //            return @"
+        //                akka.log-dead-letters-during-shutdown = true
+        //                akka.actor.debug.autoreceive = true
+        //                akka.actor.debug.lifecycle = true
+        //                akka.actor.debug.event-stream = true
+        //                akka.actor.debug.unhandled = true
+        //                akka.log-dead-letters = true
+        //                akka.loglevel = DEBUG
+        //                akka.stdout-loglevel = DEBUG
+        //            ";
+        //        }
         [Fact]
         public void Bug209_any_user_messages_following_a_Terminate_message_should_be_forwarded_to_DeadLetterMailbox()
         {
@@ -62,19 +64,178 @@ namespace Akka.Tests.Actor
             mailbox.Resume();
 
             //The actor should Terminate, exchange the mailbox to a DeadLetterMailbox and forward the user message to the DeadLetterMailbox
-            ExpectMsgPF<DeadLetter>(TimeSpan.FromSeconds(1),d=>(string) d.Message=="SomeUserMessage");
-            actor.Cell.Mailbox.ShouldBe(System.Mailboxes.DeadLetterMailbox);            
+            ExpectMsgPF<DeadLetter>(TimeSpan.FromSeconds(1), d => (string)d.Message == "SomeUserMessage");
+            actor.Cell.Mailbox.ShouldBe(System.Mailboxes.DeadLetterMailbox);
         }
 
+        [Fact]
+        public void DeathWatch_must_notify_with_one_Terminated_message_when_actor_is_stopped()
+        {
+            const string msg = "hello";
+            StartWatching(_terminal).Tell(msg);
+            expectMsg(msg);
+            _terminal.Tell(PoisonPill.Instance);
+            ExpectTerminationOf(_terminal);
+        }
+
+        [Fact]
+        public void DeathWatch_must_notify_with_all_monitors_with_one_Terminated_message_when_Actor_is_stopped()
+        {
+            var monitor1 = StartWatching(_terminal);
+            var monitor2 = StartWatching(_terminal);
+            var monitor3 = StartWatching(_terminal);
+
+            _terminal.Tell(PoisonPill.Instance);
+
+            ExpectTerminationOf(_terminal);
+            ExpectTerminationOf(_terminal);
+            ExpectTerminationOf(_terminal);
+
+            sys.Stop(monitor1);
+            sys.Stop(monitor2);
+            sys.Stop(monitor3);
+        }
+
+        [Fact]
+        public void DeathWatch_must_notify_with_current_monitors_with_one_Terminated_message_when_Actor_is_stopped()
+        {
+            var monitor1 = StartWatching(_terminal);
+            var monitor2 = sys.ActorOf(Props.Create(() => new WatchAndUnwatchMonitor(_terminal, testActor)).WithDeploy(Deploy.Local));
+            var monitor3 = StartWatching(_terminal);
+
+            monitor2.Tell("ping");
+            expectMsg("pong");      // since Watch and Unwatch are asynchronous, we need some sync
+
+            _terminal.Tell(PoisonPill.Instance);
+
+            ExpectTerminationOf(_terminal);
+            ExpectTerminationOf(_terminal);
+
+            sys.Stop(monitor1);
+            sys.Stop(monitor2);
+            sys.Stop(monitor3);
+        }
+
+        //[Fact]
+        //public void DeathWatch_must_notify_with_a_Terminated_message_once_when_Actor_is_stopped_but_not_when_restarted()
+        //{
+        //    EventFilter<ActorKilledException>(null, 1, () =>
+        //    {
+        //        var supervisor = sys.ActorOf(Props.Create(() => new Supervisor(
+        //            new OneForOneStrategy(2, TimeSpan.FromSeconds(1), SupervisorStrategy.DefaultDecider))));    // DefaultDecider will cause Restart directive
+
+        //        var terminal = AwaitResult<InternalActorRef>(supervisor.Ask(Props.Create(() => new EchoTestActor())), DefaultTimeout);
+        //        var monitor = AwaitResult<ActorRef>(supervisor.Ask(CreateWatchAndForwarderProps(terminal, testActor), DefaultTimeout), DefaultTimeout);
+
+        //        terminal.Tell(Kill.Instance);
+        //        terminal.Tell(Kill.Instance);
+
+        //        var foo = AwaitResult<string>(terminal.Ask("foo", DefaultTimeout), DefaultTimeout);
+        //        foo.ShouldBe("foo");
+
+        //        terminal.Tell(Kill.Instance);
+
+        //        ExpectTerminationOf(terminal);
+        //        terminal.IsTerminated.ShouldBe(true);
+
+        //        sys.Stop(supervisor);
+        //    });
+        //}
+
+        //// See issue: #61
+        //[Fact]
+        //public void DeathWatch_must_fail_a_monitor_which_doesnt_handle_Terminated()
+        //{
+        //    FilterEvents(sys, new EventFilter[] { new ErrorFilter<ActorKilledException>(), new ErrorFilter<DeathPactException>() }, () =>
+        //    {
+        //        // Strategy has to be a custom derivative of OneForOneStrategy which implements custom ProcessFailure method in following manner:
+        //        //
+        //        //  override def handleFailure(context: ActorContext, child: ActorRef, cause: Throwable, stats: ChildRestartStats, children: Iterable[ChildRestartStats]) = {
+        //        //      testActor.tell(FF(Failed(child, cause, 0)), child)
+        //        //      super.handleFailure(context, child, cause, stats, children)
+        //        //  }
+        //        var strategy = new OneForOneStrategy(SupervisorStrategy.DefaultDecider);
+        //        var supervisior = sys.ActorOf(Props.Create(() => new Supervisor(strategy)).WithDeploy(Deploy.Local));
+
+        //        var failed = AwaitResult<ActorRef>(supervisior.Ask(Props.Empty), DefaultTimeout);
+        //        var brother = AwaitResult<ActorRef>(supervisior.Ask(Props.Create(() => new BrotherActor(failed))), DefaultTimeout);
+
+        //        StartWatching(brother);
+
+        //        failed.Tell(Kill.Instance);
+        //        var result = receiveWhile(TimeSpan.FromSeconds(3), msg =>
+        //        {
+        //            var res = 0;
+        //            msg.Match()
+        //                .With<FF>(ff =>
+        //                {
+        //                    if (ff.Fail.Cause is ActorKilledException && ff.Fail.Child == failed) res = 1;
+        //                    if (ff.Fail.Cause is DeathPactException && ff.Fail.Child == brother) res = 2;
+        //                })
+        //                .With<WrappedTerminated>(x => res = x.Terminated.ActorRef == brother ? 3 : 0);
+        //            return res;
+        //        }, 3);
+
+        //        ((InternalActorRef)testActor).IsTerminated.ShouldBe(false);
+        //        result[0].ShouldBe(1);
+        //        result[1].ShouldBe(2);
+        //        result[2].ShouldBe(3);
+        //    });
+        //}
+
+        [Fact]
+        public void DeathWatch_must_be_able_to_watch_child_with_the_same_name_after_the_old_one_died()
+        {
+            var parent = sys.ActorOf(Props.Create(() => new KnobActor(testActor)).WithDeploy(Deploy.Local));
+
+            parent.Tell(Knob);
+            expectMsg(Bonk);
+            parent.Tell(Knob);
+            expectMsg(Bonk);
+        }
+
+        [Fact]
+        public void DeathWatch_must_notify_only_when_watching()
+        {
+            var subject = sys.ActorOf(Props.Create(() => new EchoActor(_terminal)));
+            testActor.Tell(new DeathWatchNotification(subject, true, false));
+            expectNoMsg(TimeSpan.FromSeconds(3));
+        }
+
+        //// See issue: #61
+        //[Fact]
+        //public void DeathWatch_must_discard_Terminated_when_unwatched_between_sysmsg_and_processing()
+        //{
+        //    var t1 = new TestLatch(sys, 1);
+        //    var t2 = new TestLatch(sys, 1);
+        //    var p = new TestProbe();
+        //    var w = sys.ActorOf(Props.Create(() => new Watcher()).WithDeploy(Deploy.Local), "testWatcher");
+
+        //    w.Tell(new W(p.Ref));
+        //    w.Tell(new Latches(t1, t2));
+        //    t1.Ready(TimeSpan.FromSeconds(3));
+        //    watch(testActor);
+        //    p.Tell(Stop.Instance, testActor);
+        //    p.ExpectTerminated(DefaultTimeout);
+        //    w.Tell(new U(p.Ref));
+        //    t2.CountDown();
+
+        //    w.Tell(new Identify(null));
+        //    expectMsg(new ActorIdentity(null, w), DefaultTimeout);
+        //    w.Tell(new Identify(null));
+        //    expectMsg(new ActorIdentity(null, w), DefaultTimeout);
+        //}
 
         private void ExpectTerminationOf(ActorRef actorRef)
         {
             ExpectMsgPF<WrappedTerminated>(TimeSpan.FromSeconds(5), w => ReferenceEquals(w.Terminated.ActorRef, actorRef));
         }
 
-        private void StartWatching(ActorRef target)
+        private ActorRef StartWatching(ActorRef target)
         {
-            _supervisor.Ask(CreateWatchAndForwarderProps(target, testActor), TimeSpan.FromSeconds(3));
+            var task = _supervisor.Ask(CreateWatchAndForwarderProps(target, testActor), TimeSpan.FromSeconds(3));
+            task.Wait(TimeSpan.FromSeconds(3));
+            return (ActorRef)task.Result;
         }
 
         private Props CreateWatchAndForwarderProps(ActorRef target, ActorRef forwardToActor)
@@ -82,7 +243,114 @@ namespace Akka.Tests.Actor
             return Props.Create(() => new WatchAndForwardActor(target, forwardToActor));
         }
 
-        public class WatchAndForwardActor : ActorBase
+        internal class BrotherActor : ActorBase
+        {
+            public BrotherActor(ActorRef failed)
+            {
+                Context.Watch(failed);
+            }
+
+            protected override bool Receive(object message)
+            {
+                return true;
+            }
+        }
+
+        internal const string Knob = "KNOB";
+        internal const string Bonk = "BONK";
+        internal class KnobKidActor : ActorBase
+        {
+            protected override bool Receive(object message)
+            {
+                message.Match().With<string>(x =>
+                {
+                    if (x == Knob)
+                    {
+                        Context.Stop(Self);
+                    }
+                });
+                return true;
+            }
+        }
+        internal class KnobActor : ActorBase
+        {
+            private readonly ActorRef _testActor;
+
+            public KnobActor(ActorRef testActor)
+            {
+                _testActor = testActor;
+            }
+
+            protected override bool Receive(object message)
+            {
+                message.Match().With<string>(x =>
+                {
+                    if (x == Knob)
+                    {
+                        var kid = Context.ActorOf(Props.Create(() => new KnobKidActor()), "kid");
+                        Context.Watch(kid);
+                        kid.Forward(Knob);
+                        Context.Become(msg =>
+                        {
+                            msg.Match().With<Terminated>(y =>
+                            {
+                                if (y.ActorRef == kid)
+                                {
+                                    _testActor.Tell(Bonk);
+                                    Context.Unbecome();
+                                }
+                            });
+                            return true;
+                        });
+                    }
+                });
+                return true;
+            }
+        }
+
+        internal class WatchAndUnwatchMonitor : ActorBase
+        {
+            private readonly ActorRef _testActor;
+
+            public WatchAndUnwatchMonitor(ActorRef terminal, ActorRef testActor)
+            {
+                _testActor = testActor;
+                Context.Watch(terminal);
+                Context.Unwatch(terminal);
+            }
+
+            protected override bool Receive(object message)
+            {
+                message.Match()
+                    .With<string>(x =>
+                    {
+                        if (x == "ping")
+                        {
+                            _testActor.Tell("pong");
+                        }
+                    })
+                    .With<Terminated>(x => _testActor.Tell(new WrappedTerminated(x)));
+                return true;
+            }
+        }
+
+        internal class Watcher : ActorBase
+        {
+            protected override bool Receive(object message)
+            {
+                message.Match()
+                    .With<W>(w => Context.Watch(w.Ref))
+                    .With<W>(w => Context.Unwatch(w.Ref))
+                    .With<Latches>(x =>
+                    {
+                        x.T1.CountDown();
+                        x.T2.Ready(TimeSpan.FromSeconds(3));
+                    });
+                return true;
+            }
+        }
+
+        internal class WatchAndForwardActor : ActorBase
         {
             private readonly ActorRef _forwardToActor;
 
@@ -95,10 +363,19 @@ namespace Akka.Tests.Actor
             protected override bool Receive(object message)
             {
                 var terminated = message as Terminated;
-                if(terminated != null)
+                if (terminated != null)
                     _forwardToActor.Forward(new WrappedTerminated(terminated));
                 else
                     _forwardToActor.Forward(message);
+                return true;
+            }
+        }
+
+        internal class EchoTestActor : ActorBase
+        {
+            protected override bool Receive(object message)
+            {
+                Sender.Tell(message);
                 return true;
             }
         }
@@ -114,5 +391,51 @@ namespace Akka.Tests.Actor
 
             public Terminated Terminated { get { return _terminated; } }
         }
+
+        internal struct W
+        {
+            public W(ActorRef @ref)
+                : this()
+            {
+                Ref = @ref;
+            }
+
+            public ActorRef Ref { get; private set; }
+        }
+
+        internal struct U
+        {
+            public U(ActorRef @ref)
+                : this()
+            {
+                Ref = @ref;
+            }
+
+            public ActorRef Ref { get; private set; }
+        }
+        internal struct FF
+        {
+            public FF(Failed fail)
+                : this()
+            {
+                Fail = fail;
+            }
+
+            public Failed Fail { get; private set; }
+        }
+
+        internal struct Latches : NoSerializationVerificationNeeded
+        {
+
+            public Latches(TestLatch t1, TestLatch t2)
+                : this()
+            {
+                T1 = t1;
+                T2 = t2;
+            }
+            public TestLatch T1 { get; set; }
+            public TestLatch T2 { get; set; }
+        }
+
     }
 }


### PR DESCRIPTION
See #61

I've filled DeathWatchSpec with tests based on original Akka implementation. I've created a TestEvent (required FilterEvents method), but haven't tested them yet. I've also have to comment out 3 of the tests, reasons will be described in linked issue.
