### PR TITLE
Update FsPickler version

### DIFF
--- a/src/core/Akka.FSharp/Akka.FSharp.fsproj
+++ b/src/core/Akka.FSharp/Akka.FSharp.fsproj
@@ -92,7 +92,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="FsPickler">
-      <HintPath>..\..\packages\FsPickler.0.8.6\lib\net45\FsPickler.dll</HintPath>
+      <HintPath>..\..\packages\FsPickler.0.9.11\lib\net45\FsPickler.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib" />
@@ -102,8 +102,6 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\Akka\Akka.csproj">
       <Name>Akka</Name>
       <Project>{5deddf90-37f0-48d3-a0b0-a5cbd8a7e377}</Project>

--- a/src/core/Akka.FSharp/FsApi.fs
+++ b/src/core/Akka.FSharp/FsApi.fs
@@ -214,7 +214,7 @@ module Serialization =
         inherit Serializer(system)
         
 
-        let fsp = new FsPickler()
+        let fsp = FsPickler.CreateBinary()
         override x.Identifier = 9
         override x.IncludeManifest = true
 

--- a/src/core/Akka.FSharp/packages.config
+++ b/src/core/Akka.FSharp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FsPickler" version="0.8.6" targetFramework="net45" />
+  <package id="FsPickler" version="0.9.11" targetFramework="net45" />
   <package id="FSPowerPack.Core.Community" version="3.0.0.0" targetFramework="net45" />
   <package id="FSPowerPack.Linq.Community" version="3.0.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The currently used version (0.8.6) contains certain bugs related to quotation serialization. This PR updates to the latest version which fixes these.
