### PR TITLE
Be able to create prerelease packages and publish to custom feeds

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+#### 0.6.4
+
 #### 0.6.3 Aug 13 2014
 * Made it so HOCON config sections chain properly
 * Optimized actor memory footprint

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 [assembly: AssemblyCompanyAttribute("Akka")]
 [assembly: AssemblyCopyrightAttribute("Copyright © 2013-2014 Akka.NET Team")]
 [assembly: AssemblyTrademarkAttribute("")]
-[assembly: AssemblyVersionAttribute("0.6.3.0")]
-[assembly: AssemblyFileVersionAttribute("0.6.3.0")]
+[assembly: AssemblyVersionAttribute("0.6.4.0")]
+[assembly: AssemblyFileVersionAttribute("0.6.4.0")]
 namespace System {
 }

--- a/src/core/Akka.FSharp/Properties/AssemblyInfo.fs
+++ b/src/core/Akka.FSharp/Properties/AssemblyInfo.fs
@@ -10,9 +10,9 @@ open System.Runtime.InteropServices
 [<assembly: AssemblyCompanyAttribute("Akka.NET Team")>]
 [<assembly: ComVisibleAttribute(false)>]
 [<assembly: CLSCompliantAttribute(true)>]
-[<assembly: AssemblyVersionAttribute("0.6.3.0")>]
-[<assembly: AssemblyFileVersionAttribute("0.6.3.0")>]
+[<assembly: AssemblyVersionAttribute("0.6.4.0")>]
+[<assembly: AssemblyFileVersionAttribute("0.6.4.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "0.6.3.0"
+    let [<Literal>] Version = "0.6.4.0"


### PR DESCRIPTION
New build parameters:
- nugetpublishurl: The feed to publish too. Uses default if not specified
- nugetprerelease: Prerelease prefix.

Example: If "-nugetprerelease=dev" is used as parameter when executing
build.cmd a prerelease package will be created with a version on the format:
version + "-dev" + DateTime.UtcNow (unfortunately seconds had to be left
   out as Fake only supports an int)
For example: 1.6.4-dev14081911
