### PR TITLE
Add preliminary build support on Mono for #62.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 # Auto detect text files and perform LF normalization
 * text=auto
 
+
 # Custom for Visual Studio
 *.cs     diff=csharp
 *.sln    merge=union
@@ -20,3 +21,6 @@
 *.PDF    diff=astextplain
 *.rtf    diff=astextplain
 *.RTF    diff=astextplain
+
+# Needed for Mono build shell script
+*.sh	-text eol=lf

--- a/build.cmd
+++ b/build.cmd
@@ -1,8 +1,10 @@
 @echo off
 
-src\.nuget\nuget.exe update -self
+src\.nuget\NuGet.exe update -self
 
-src\.nuget\nuget.exe install FAKE -OutputDirectory src\packages -ExcludeVersion -Version 2.10.24
+src\.nuget\NuGet.exe install FAKE -OutputDirectory src\packages -ExcludeVersion -Version 2.10.24
+
+src\.nuget\NuGet.exe install xunit.runners -OutputDirectory src\packages\FAKE -ExcludeVersion -Version 1.9.2
 
 if not exist src\packages\SourceLink.Fake\tools\SourceLink.fsx ( 
   src\.nuget\nuget.exe install SourceLink.Fake -OutputDirectory src\packages -ExcludeVersion
@@ -10,7 +12,6 @@ if not exist src\packages\SourceLink.Fake\tools\SourceLink.fsx (
 cls
 
 set encoding=utf-8
-src\packages\FAKE\tools\FAKE.exe boot conf
 src\packages\FAKE\tools\FAKE.exe build.fsx %*
 
 

--- a/build.fsx
+++ b/build.fsx
@@ -1,5 +1,4 @@
-﻿#load "src/.build/boot.fsx"
-#I @"src\packages\fake\tools\"
+﻿#I @"src/packages/FAKE/tools"
 #r "FakeLib.dll"
 #r "System.Xml.Linq"
 
@@ -103,7 +102,7 @@ Target "Build" <| fun _ ->
 Target "CopyOutput" <| fun _ ->
     
     let copyOutput project =
-        let src = "src" @@ project @@ @"bin\release\"
+        let src = "src" @@ project @@ @"bin/Release/"
         let dst = binDir @@ project
         CopyDir dst src allFiles
     [ "core/Akka"
@@ -134,8 +133,8 @@ Target "CleanTests" <| fun _ ->
 
 open XUnitHelper
 Target "RunTests" <| fun _ ->  
-    let msTestAssemblies = !! "src/**/bin/release/Akka.TestKit.VsTest.Tests.dll"
-    let xunitTestAssemblies = !! "src/**/bin/release/*.Tests.dll" -- "src/**/bin/release/Akka.TestKit.VsTest.Tests.dll"
+    let msTestAssemblies = !! "src/**/bin/Release/Akka.TestKit.VsTest.Tests.dll"
+    let xunitTestAssemblies = !! "src/**/bin/Release/*.Tests.dll" -- "src/**/bin/Release/Akka.TestKit.VsTest.Tests.dll"
 
     mkdir testOutput
 
@@ -225,7 +224,7 @@ Target "Nuget" <| fun _ ->
         !! (releaseDir @@ project + ".pdb")
         |> CopyFiles libDir
 
-        let nugetSrcDir = workingDir @@ @"src\"
+        let nugetSrcDir = workingDir @@ @"src/"
         CreateDir nugetSrcDir
 
         let isCs = hasExt ".cs"

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+SCRIPT_PATH="${BASH_SOURCE[0]}";
+if ([ -h "${SCRIPT_PATH}" ]) then
+  while([ -h "${SCRIPT_PATH}" ]) do SCRIPT_PATH=`readlink "${SCRIPT_PATH}"`; done
+fi
+pushd . > /dev/null
+cd `dirname ${SCRIPT_PATH}` > /dev/null
+SCRIPT_PATH=`pwd`;
+popd  > /dev/null
+
+mono $SCRIPT_PATH/src/.nuget/NuGet.exe update -self
+
+mono $SCRIPT_PATH/src/.nuget/NuGet.exe install FAKE -OutputDirectory $SCRIPT_PATH/src/packages -ExcludeVersion -Version 2.10.24
+
+mono $SCRIPT_PATH/src/.nuget/NuGet.exe install xunit.runners -OutputDirectory $SCRIPT_PATH/src/packages/FAKE -ExcludeVersion -Version 1.9.2
+
+if ! [ -e $SCRIPT_PATH/src/packages/SourceLink.Fake/tools/SourceLink.fsx ] ; then
+	mono $SCRIPT_PATH/src/.nuget/NuGet.exe install SourceLink.Fake -OutputDirectory $SCRIPT_PATH/src/packages -ExcludeVersion
+
+fi
+
+export encoding=utf-8
+
+mono $SCRIPT_PATH/src/packages/FAKE/tools/FAKE.exe build.fsx "$@"

--- a/conf.fsx
+++ b/conf.fsx
@@ -1,6 +1,0 @@
-open Fake
-module FB = Fake.Boot
-FB.Prepare {
-    FB.Config.Default "src" with
-        NuGetDependencies = [{ PackageId = "xunit.runners"; Version = FB.SemanticVersion "1.9.2" }]
-}

--- a/src/.nuget/NuGet.targets
+++ b/src/.nuget/NuGet.targets
@@ -36,21 +36,14 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <PackagesProjectConfig>packages.$(MSBuildProjectName.Replace(' ', '_')).config</PackagesProjectConfig>
+        <PackagesProjectConfig Condition=" '$(OS)' == 'Windows_NT'">$(MSBuildProjectDirectory)\packages.$(MSBuildProjectName.Replace(' ', '_')).config</PackagesProjectConfig>
+        <PackagesProjectConfig Condition=" '$(OS)' != 'Windows_NT'">$(MSBuildProjectDirectory)\packages.$(MSBuildProjectName).config</PackagesProjectConfig>
     </PropertyGroup>
 
-    <Choose>
-        <When Condition="Exists('$(PackagesProjectConfig)')">
-            <PropertyGroup>
-                <PackagesConfig>$(PackagesProjectConfig)</PackagesConfig>
-            </PropertyGroup>
-        </When>
-        <When Condition="Exists('packages.config')">
-            <PropertyGroup>
-                <PackagesConfig>packages.config</PackagesConfig>
-            </PropertyGroup>
-        </When>
-    </Choose>
+    <PropertyGroup>
+      <PackagesConfig Condition="Exists('$(MSBuildProjectDirectory)\packages.config')">$(MSBuildProjectDirectory)\packages.config</PackagesConfig>
+      <PackagesConfig Condition="Exists('$(PackagesProjectConfig)')">$(PackagesProjectConfig)</PackagesConfig>
+    </PropertyGroup>
     
     <PropertyGroup>
         <!-- NuGet command -->
@@ -58,7 +51,7 @@
         <PackageSources Condition=" $(PackageSources) == '' ">@(PackageSource)</PackageSources>
 
         <NuGetCommand Condition=" '$(OS)' == 'Windows_NT'">"$(NuGetExePath)"</NuGetCommand>
-        <NuGetCommand Condition=" '$(OS)' != 'Windows_NT' ">mono --runtime=v4.0.30319 $(NuGetExePath)</NuGetCommand>
+        <NuGetCommand Condition=" '$(OS)' != 'Windows_NT' ">mono --runtime=v4.0.30319 "$(NuGetExePath)"</NuGetCommand>
 
         <PackageOutputDir Condition="$(PackageOutputDir) == ''">$(TargetDir.Trim('\\'))</PackageOutputDir>
 


### PR DESCRIPTION
This should allow the build scripts themselves to begin working under linux/mono in a rudimentary form. The test target is not fully exercised yet and may require some additional adjustments.
