### PR TITLE
FSM: Make _log obsolete and do some cosmetic changes

### DIFF
--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -711,7 +711,7 @@ namespace Akka.Remote
             }
             catch (Exception ex)
             {
-                _log.Error(ex, "Unable to publish error event to EventStream");
+                Log.Error(ex, "Unable to publish error event to EventStream");
             }
         }
 

--- a/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
+++ b/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
@@ -557,7 +557,7 @@ namespace Akka.Remote.Transport
                                     })
                                     .Default(d =>
                                     {
-                                        _log.Debug(string.Format("Exepcted message of type Associate; instead received {0}", d));
+                                        Log.Debug(string.Format("Exepcted message of type Associate; instead received {0}", d));
                                         //Expect handshake to be finished, dropping connection
                                         SendDisassociate(wrappedHandle, DisassociateInfo.Unknown);
                                         nextState = Stop();
@@ -880,7 +880,7 @@ namespace Akka.Remote.Transport
         /// </summary>
         private void PublishError(UnderlyingTransportError transportError)
         {
-            _log.Error(transportError.Cause, transportError.Message);
+            Log.Error(transportError.Cause, transportError.Message);
         }
 
         #endregion


### PR DESCRIPTION
- Made _log obsolete, use Log property instead. _log will be removed prior to v1.
- Renamed the generic type params to TState and TData
- Switched to use log-field internally
- Fixed spelling errors
