### PR TITLE
Added compilable expression based PatternBuilder.

### DIFF
--- a/src/core/Akka.Tests/Util/PatternSpec.cs
+++ b/src/core/Akka.Tests/Util/PatternSpec.cs
@@ -1,10 +1,15 @@
-﻿using Xunit;
+﻿using Akka.Util;
+using Xunit;
 
 namespace Akka.Tests.Util
 {
-    
     public class PatternSpec
     {
+
+        class A { }
+
+        class B : A { }
+
         [Fact]
         public void PatternMatch_should_not_throw_NullReferenceException()
         {
@@ -12,6 +17,82 @@ namespace Akka.Tests.Util
             nullObj.Match()
                 .With<string>(str => { })
                 .Default(m => {});
+        }
+
+        [Fact]
+        public void PatternBuilder_should_not_throw_NullReferenceException()
+        {
+            object nullObj = null;
+            var pattern = PatternBuilder.Match()
+                .With<string>(str => { })
+                .Default(m => { })
+                .Compile();
+            var matched = pattern(nullObj);
+        }
+
+        [Fact]
+        public void PatternBuilder_should_match_correct_type()
+        {
+            string message = "Message";
+            bool matched = false;
+
+            var pattern = PatternBuilder.Match()
+                .With<string>(s => matched = true)
+                .Compile();
+
+            var handled = pattern(message);
+            Assert.True(matched);
+            Assert.True(handled);
+        }
+
+        [Fact]
+        public void PatternBuilder_should_not_match_incorrect_type()
+        {
+            string message = "Message";
+            bool matched = false;
+
+            var pattern = PatternBuilder.Match()
+                .With<int>(i => matched = true)
+                .Compile();
+
+            var handled = pattern(message);
+            Assert.False(matched);
+            Assert.False(handled);
+        }
+
+        [Fact]
+        public void PatternBuilder_should_handle_default()
+        {
+            string message = "Message";
+            bool matched = false;
+
+            var pattern = PatternBuilder.Match()
+                .With<int>(i => matched = true)
+                .Default(m => { })
+                .Compile();
+
+            var handled = pattern(message);
+            Assert.True(handled);
+            Assert.False(matched);
+        }
+
+        [Fact]
+        public void PatternBuilder_should_match_multiple_matched_patterns()
+        {
+            var testObjectB = new B();
+            bool matchedA = false;
+            bool matchedB = false;
+
+            var pattern = PatternBuilder.Match()
+                .With<A>(m => matchedA = true)
+                .With<B>(m => matchedB = true)
+                .Compile();
+
+            var handled = pattern(testObjectB);
+
+            Assert.True(matchedA);
+            Assert.True(matchedB);
+            Assert.True(handled);
         }
     }
 }

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -206,8 +206,10 @@
     <Compile Include="Util\AtomicReference.cs" />
     <Compile Include="Util\AtomicBoolean.cs" />
     <Compile Include="Util\ConcurrentSet.cs" />
+    <Compile Include="Util\Matcher.cs" />
     <Compile Include="Util\MonoConcurrentQueue.cs" />
     <Compile Include="Util\MurmurHash.cs" />
+    <Compile Include="Util\PatternBuilder.cs" />
     <Compile Include="Util\Reflection\ExpressionExtensions.cs" />
     <Compile Include="PatternMatch.cs" />
     <Compile Include="Util\ThreadLocalRandom.cs" />

--- a/src/core/Akka/Util/Matcher.cs
+++ b/src/core/Akka/Util/Matcher.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Akka.Util
+{
+    /// <summary>
+    /// A delegate that matches an incoming message with a pattern and optionally
+    /// handles the message. Returns whether or not any pattern matched the
+    /// message type.
+    /// </summary>
+    /// <param name="message">The message to match to the pattern.</param>
+    /// <returns>Whether or not the message was handled.</returns>
+    public delegate bool Matcher(object message);
+}

--- a/src/core/Akka/Util/PatternBuilder.cs
+++ b/src/core/Akka/Util/PatternBuilder.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Akka.Util
+{
+    /// <summary>
+    /// Builds a pattern matching delegate used for matching incoming actor
+    /// messages to a specified functional pattern.
+    /// </summary>
+    public class PatternBuilder
+    {
+        /// <summary>
+        /// A list of pattern matching handlers.
+        /// </summary>
+        private List<Expression> handlers = new List<Expression>();
+
+        /// <summary>
+        /// The default matching handler, if any.
+        /// </summary>
+        private Expression defaultHandler;
+
+        /// <summary>
+        /// The expression variable that determines if the matcher handled the pattern or not.
+        /// </summary>
+        private ParameterExpression isHandled = Expression.Parameter(typeof(bool), "isHandled");
+
+        /// <summary>
+        /// The expression parameter that holds the input to match against.
+        /// </summary>
+        private ParameterExpression inputMessage = Expression.Parameter(typeof(object), "inputMessage");
+
+        private PatternBuilder() { }
+
+        /// <summary>
+        /// Adds a pattern to match against.
+        /// </summary>
+        /// <typeparam name="TMessage">The type of message that the pattern handler will respond to.</typeparam>
+        /// <param name="handler">The action to be performed when this pattern is matched.</param>
+        /// <returns>The pattern builder.</returns>
+        public PatternBuilder With<TMessage>(Action<TMessage> handler)
+        {
+            Expression<Action<TMessage>> handlerBinder = (x) => handler(x);
+
+            var ifIsThenHandleExpression = Expression.IfThen(
+                Expression.TypeIs(inputMessage, typeof(TMessage)),
+                Expression.Block(new Expression[] {
+                    Expression.Invoke(handlerBinder, Expression.Convert(inputMessage, typeof(TMessage))),
+                    Expression.Assign(isHandled, Expression.Constant(true))
+                })
+            );
+
+            handlers.Add(ifIsThenHandleExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a default pattern to match if no other patterns have handled the
+        /// message.
+        /// </summary>
+        /// <param name="handler">The action to be performed when the default patter is matched.</param>
+        /// <returns>The pattern builder.</returns>
+        public PatternBuilder Default(Action<object> handler)
+        {
+            Expression<Action<object>> handlerBinder = (x) => handler(x);
+
+            defaultHandler = Expression.IfThen(
+                Expression.Not(isHandled),
+                Expression.Block(new Expression[] 
+                {
+                    Expression.Invoke(handlerBinder, inputMessage),
+                    Expression.Assign(isHandled, Expression.Constant(true))
+                })
+            );
+            return this;
+        }
+
+        /// <summary>
+        /// Compiles the pattern into a function delegate.
+        /// </summary>
+        /// <returns>The compiled pattern matching delegate.</returns>
+        public Matcher Compile()
+        {
+            var allHandlers = handlers.ToList();
+            if(defaultHandler != null)
+            {
+                allHandlers.Add(defaultHandler);
+            }
+
+            allHandlers.Add(isHandled);
+            var block = Expression.Block(new ParameterExpression[] { isHandled }, allHandlers);
+
+            return Expression.Lambda<Matcher>(block, new ParameterExpression[] { inputMessage }).Compile();
+        }
+
+        /// <summary>
+        /// Starts the creation of a new functional pattern matcher.
+        /// </summary>
+        /// <returns>A new pattern.</returns>
+        public static PatternBuilder Match()
+        {
+            return new PatternBuilder();
+        }
+    }
+}


### PR DESCRIPTION
So, as opposed to reopening the PatternMatch issue specifically, I thought I'd throw in my idea for a performance oriented pattern matcher. Some tradeoffs and notes:
- It's not quite as idiomatically functional. You need to build the pattern and store it somewhere, but after that it is a compiled delegate that lives for as long as the actor lives.
- Compilation of the delegate is slow (well, relatively speaking, it's still quite fast), but matching is the same performance as hand writing all the if/else is/as statements.
- It does retain a nice friendly fluent interface.

Usage is like so:

```
private Matcher messageHandler;
public SomeActor()
{
    messageHandler = PatternBuilder.Match()
        .With<string>(s => Console.WriteLine(s))
        .With<int>(i => DoSomethingElse(i))
        .Default(obj => DoDefault(obj))
        .Compile();
}

protected override void OnReceive(object message)
{
    var handled = messageHandler(message);
}
```

Feedback?
