### PR TITLE
removed obselete attributes from PatternMatch and UntypedActor

### DIFF
--- a/src/core/Akka/Actor/UntypedActor.cs
+++ b/src/core/Akka/Actor/UntypedActor.cs
@@ -5,7 +5,6 @@ namespace Akka.Actor
     /// <summary>
     /// Class UntypedActor.
     /// </summary>
-    [Obsolete("Use ReceiveActor or TypedActor instead",false)]
     public abstract class UntypedActor : ActorBase
     {
         protected sealed override bool Receive(object message)

--- a/src/core/Akka/PatternMatch.cs
+++ b/src/core/Akka/PatternMatch.cs
@@ -13,7 +13,6 @@ namespace Akka
         /// </summary>
         /// <param name="target">The target.</param>
         /// <returns>Case.</returns>
-        [Obsolete("Use is/as checks or replace actor with ReceiveActor/TypedActor",false)]
         public static Case Match(this object target)
         {
             return new Case(target);


### PR DESCRIPTION
Based on the discussions we've had over the past week, it looks like we're keeping these.
