### PR TITLE
Fixes supervision spam bug for remote-deployed actors #348

### DIFF
--- a/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
+++ b/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
@@ -215,7 +215,15 @@ namespace Akka.Remote.Transport
                     {
                         senderOption = provider.ResolveActorRefWithLocalAddress(envelopeContainer.Sender.Path, localAddress);
                     }
-                    messageOption = new Message(recipient, recipientAddress, serializedMessage, senderOption);
+                    SeqNo seqOption = null;
+                    if (envelopeContainer.HasSeq)
+                    {
+                        unchecked
+                        {
+                            seqOption = new SeqNo((long)envelopeContainer.Seq); //proto takes a ulong
+                        }
+                    }
+                    messageOption = new Message(recipient, recipientAddress, serializedMessage, senderOption, seqOption);
                 }
             }
             


### PR DESCRIPTION
close #348

So, this is embarrassing  - `AckedDelivery` has never worked at all in production, because _I never decoded the SeqNo on the receiving end of the application_. I don't have an explanation for why this was never included in the `AkkaPduCodec` - just an oversight on my part.
