### PR TITLE
Remove StandardOutLogger if other loggers are used

### DIFF
--- a/src/core/Akka/Event/LoggingBus.cs
+++ b/src/core/Akka/Event/LoggingBus.cs
@@ -16,18 +16,20 @@ namespace Akka.Event
         /// <summary>
         ///     All log levels
         /// </summary>
-        private static readonly LogLevel[] allLogLevels = Enum.GetValues(typeof(LogLevel)).Cast<LogLevel>().ToArray();
+        private static readonly LogLevel[] _allLogLevels = Enum.GetValues(typeof(LogLevel)).Cast<LogLevel>().ToArray();
 
         /// <summary>
         ///     The loggers
         /// </summary>
-        private readonly List<ActorRef> loggers = new List<ActorRef>();
+        private readonly List<ActorRef> _loggers = new List<ActorRef>();
+
+        private LogLevel _logLevel;
 
         /// <summary>
         ///     Gets the log level.
         /// </summary>
         /// <value>The log level.</value>
-        public LogLevel LogLevel { get; private set; }
+        public LogLevel LogLevel { get { return _logLevel; }}
 
         /// <summary>
         ///     Determines whether [is sub classification] [the specified parent].
@@ -79,30 +81,48 @@ namespace Akka.Event
         public async void StartDefaultLoggers(ActorSystemImpl system)
         {
             //TODO: find out why we have logName and in AddLogger, "name"
-            string logName = SimpleName(this) + "(" + system.Name + ")";
-            LogLevel logLevel = Logging.LogLevelFor(system.Settings.LogLevel);
-            IList<string> loggerTypes = system.Settings.Loggers;
-            foreach (string loggerType in loggerTypes)
+            var logName = SimpleName(this) + "(" + system.Name + ")";
+            var logLevel = Logging.LogLevelFor(system.Settings.LogLevel);
+            var loggerTypes = system.Settings.Loggers;
+            var timeout = system.Settings.LoggerStartTimeout;
+            var shouldRemoveStandardOutLogger = true;
+            foreach (var strLoggerType in loggerTypes)
             {
-                Type actorClass = Type.GetType(loggerType);
-                if (actorClass == null)
+                var loggerType = Type.GetType(strLoggerType);
+
+                if (loggerType == null)
                 {
                     //TODO: create real exceptions and refine error messages
-                    throw new Exception("Can not use logger of type:" + loggerType);
+                    throw new Exception("Logger specified in config cannot be found: \"" + strLoggerType+"\"");
                 }
-                TimeSpan timeout = system.Settings.LoggerStartTimeout;
-                Task task = AddLogger(system, actorClass, logLevel, logName);
-                if (await Task.WhenAny(task, Task.Delay(timeout)) == task)
+                if(loggerType == typeof(StandardOutLogger))
                 {
+                    shouldRemoveStandardOutLogger = false;
+                    continue;
                 }
-                else
+                var addLoggerTask = AddLogger(system, loggerType, logLevel, logName);
+
+                if(!addLoggerTask.Wait(timeout))
                 {
                     Publish(new Warning(logName, GetType(),
                         "Logger " + logName + " did not respond within " + timeout + " to InitializeLogger(bus)"));
                 }
+                else
+                {
+                    var actorRef = addLoggerTask.Result;
+                    _loggers.Add(actorRef);
+                    SubscribeLogLevelAndAbove(logLevel, actorRef);
+                    Publish(new Debug(logName, GetType(), "Logger " + actorRef.Path.Name + " started"));
+                }
+            }
+            _logLevel = logLevel;
+            if(shouldRemoveStandardOutLogger)
+            {
+                Publish(new Debug(logName, GetType(), "StandardOutLogger being removed"));
+                Unsubscribe(Logging.StandardOutLogger);
             }
             Publish(new Debug(logName, GetType(), "Default Loggers started"));
-            SetLogLevel(logLevel);
+
         }
 
         /// <summary>
@@ -113,7 +133,7 @@ namespace Akka.Event
         /// <param name="logLevel">The log level.</param>
         /// <param name="logName">Name of the log.</param>
         /// <returns>Task.</returns>
-        private async Task AddLogger(ActorSystemImpl system, Type actorClass, LogLevel logLevel, string logName)
+        private async Task<ActorRef> AddLogger(ActorSystemImpl system, Type actorClass, LogLevel logLevel, string logName)
         {
             //TODO: remove the newguid stuff
             string name = "log" + system.Name + "-" + SimpleName(actorClass);
@@ -130,8 +150,8 @@ namespace Akka.Event
                 name = name + Guid.NewGuid();
                 actor = system.SystemActorOf(Props.Create(actorClass), name);
             }
-            loggers.Add(actor);
             await actor.Ask(new InitializeLogger(this));
+            return actor;
         }
 
         /// <summary>
@@ -150,11 +170,8 @@ namespace Akka.Event
         /// <param name="config">The configuration.</param>
         private void SetUpStdoutLogger(Settings config)
         {
-            LogLevel logLevel = Logging.LogLevelFor(config.StdoutLogLevel);
-            foreach (LogLevel level in allLogLevels.Where(l => l >= logLevel))
-            {
-                Subscribe(Logging.StandardOutLogger, Logging.ClassFor(level));
-            }
+            var logLevel = Logging.LogLevelFor(config.StdoutLogLevel);
+            SubscribeLogLevelAndAbove(logLevel, Logging.StandardOutLogger);
         }
 
         /// <summary>
@@ -163,19 +180,26 @@ namespace Akka.Event
         /// <param name="logLevel">The log level.</param>
         public void SetLogLevel(LogLevel logLevel)
         {
-            LogLevel = LogLevel;
-            foreach (ActorRef logger in loggers)
+            _logLevel = logLevel;
+            foreach (ActorRef logger in _loggers)
             {
                 //subscribe to given log level and above
-                foreach (LogLevel level in allLogLevels.Where(l => l >= logLevel))
-                {
-                    Subscribe(logger, Logging.ClassFor(level));
-                }
+                SubscribeLogLevelAndAbove(logLevel, logger);
+
                 //unsubscribe to all levels below loglevel
-                foreach (LogLevel level in allLogLevels.Where(l => l < logLevel))
+                foreach (LogLevel level in _allLogLevels.Where(l => l < logLevel))
                 {
                     Unsubscribe(logger, Logging.ClassFor(level));
                 }
+            }
+        }
+
+        private void SubscribeLogLevelAndAbove(LogLevel logLevel, ActorRef logger)
+        {
+            //subscribe to given log level and above
+            foreach(LogLevel level in _allLogLevels.Where(l => l >= logLevel))
+            {
+                Subscribe(logger, Logging.ClassFor(level));
             }
         }
     }


### PR DESCRIPTION
Fixes #356 
- If StandardOutLogger isn't among those specified in config `akka.loggers` it is removed after the others have been started
- Only add a logger to _loggers if it responded within the timeout. Then subscribe it to LogLevel. 
