### PR TITLE
RemoteDepoy.ParseScope if deployment\default\remote configuration item is set to string.empty treat as if null

### DIFF
--- a/src/core/Akka.Remote/RemoteDeployer.cs
+++ b/src/core/Akka.Remote/RemoteDeployer.cs
@@ -18,7 +18,9 @@ namespace Akka.Remote
         protected override Scope ParseScope(Config config)
         {
             var remote = config.GetString("remote");
-            if (remote == null)
+			//valid case for remote to be missing == null or for 
+			//remote to be nothing remote = ""
+            if (string.IsNullOrWhiteSpace(remote))
                 return Deploy.NoScopeGiven;
 
             ActorPath actorPath;


### PR DESCRIPTION
in fallback remote.config  deployment\default\remote ="" which is a valid case, but ActorPath.TryParse is not happy with an empty string, treat the empty string case the same way as if the deployment\default\remote configuration element was missing
