### PR TITLE
[F# API] More idiomatic API and more ActorSelection methods

### DIFF
--- a/src/core/Akka.FSharp/FsApi.fs
+++ b/src/core/Akka.FSharp/FsApi.fs
@@ -1,173 +1,168 @@
 ﻿module Akka.FSharp
+
 open Akka.Actor
 open System
 
-type IO<'msg> = | Input
+type IO<'msg> = 
+    | Input
 
 [<Interface>]
-type Actor<'msg> =
+type Actor<'msg> = 
     abstract Receive : unit -> IO<'msg>
     abstract Self : ActorRef
-    abstract Context: IActorContext
+    abstract Context : IActorContext
     abstract Sender : unit -> ActorRef
-    abstract Unhandled: 'msg -> unit
+    abstract Unhandled : 'msg -> unit
 
 [<AbstractClass>]
-type Actor()=
+type Actor() = 
     inherit Akka.Actor.UntypedActor()
 
+let inline select (path : string) : ActorSelection = ActorSelection(ActorCell.GetCurrentSelfOrNoSender(), path)
+let inline (<!) (actorRef : #ICanTell) (msg : obj) = actorRef.Tell(msg, ActorCell.GetCurrentSelfOrNoSender())
+let inline (!>) (msg : obj) (actorRef : #ICanTell) = actorRef <! msg
+let inline (<?) (tell : #ICanTell) (msg : obj) = tell.Ask msg |> Async.AwaitTask
+let inline (?>) (msg : obj) (actorRef : #ICanTell) = actorRef <? msg
 
+module ActorSelection = 
+    let inline (<!) (actorPath : string) (msg : obj) = (select actorPath) <! msg
+    let inline (<?) (actorPath : string) (msg : obj) = (select actorPath) <? msg
 
-
-
-
-let inline (<!) (actorRef: #ICanTell) (msg: obj) =
-    actorRef.Tell(msg, ActorCell.GetCurrentSelfOrNoSender())
-    ignore()
-
-let (<?) (tell:#ICanTell) (msg: obj) =
-    tell.Ask msg
-    |> Async.AwaitTask
+type ActorPath with
+    
+    static member TryParse(path : string) = 
+        let mutable actorPath : ActorPath = null
+        if ActorPath.TryParse(path, &actorPath) then Some actorPath
+        else None
+    
+    static member TryParseAddress(path : string) = 
+        let mutable address : Address = null
+        if ActorPath.TryParseAddress(path, &address) then Some address
+        else None
 
 /// <summary>
 /// Gives access to the next message throu let! binding in
 /// actor computation expression.
 /// </summary>
-
-
-type Cont<'m,'v> =
-    | Func of ('m -> Cont<'m,'v>)
+type Cont<'m, 'v> = 
+    | Func of ('m -> Cont<'m, 'v>)
     | Return of 'v
 
 /// <summary>
 /// The builder for actor computation expression<
 /// </summary>
-type ActorBuilder() =
-
+type ActorBuilder() = 
     // binds the next message
-    member this.Bind(m : IO<'msg>, f :'msg -> _) =
-        Func (fun m -> f m)
-
+    member this.Bind(m : IO<'msg>, f : 'msg -> _) = Func(fun m -> f m)
+    
     // binds the result of another actor computation expression
-    member this.Bind(x : Cont<'m,'a>, f :'a -> Cont<'m,'b>) : Cont<'m,'b> =
+    member this.Bind(x : Cont<'m, 'a>, f : 'a -> Cont<'m, 'b>) : Cont<'m, 'b> = 
         match x with
         | Func fx -> Func(fun m -> this.Bind(fx m, f))
         | Return v -> f v
     
     member this.ReturnFrom(x) = x
-
     member this.Return x = Return x
-
-    member this.Zero() = Return ()
-
-    member this.TryWith(f:unit -> Cont<'m,'a>,c: exn -> Cont<'m,'a>): Cont<'m,'a> =
-        try
+    member this.Zero() = Return()
+    
+    member this.TryWith(f : unit -> Cont<'m, 'a>, c : exn -> Cont<'m, 'a>) : Cont<'m, 'a> = 
+        try 
             true, f()
-        with
-        | ex -> false, c ex
-        |> function
-           | true, Func fn -> Func(fun m -> this.TryWith((fun () -> fn m), c) )
-           | _, v -> v
-
-    member this.TryFinally(f: unit -> Cont<'m,'a>, fnl: unit -> unit) : Cont<'m,'a> =
-        try
+        with ex -> false, c ex
+        |> function 
+        | true, Func fn -> Func(fun m -> this.TryWith((fun () -> fn m), c))
+        | _, v -> v
+    
+    member this.TryFinally(f : unit -> Cont<'m, 'a>, fnl : unit -> unit) : Cont<'m, 'a> = 
+        try 
             match f() with
-            | Func fn -> Func(fun m -> this.TryFinally((fun() -> fn m), fnl))
-            | r ->
+            | Func fn -> Func(fun m -> this.TryFinally((fun () -> fn m), fnl))
+            | r -> 
                 fnl()
                 r
-        with
-        | ex ->
+        with ex -> 
             fnl()
             reraise()
-
-    member this.Using(d: #IDisposable, f:  _-> Cont<'m,'v>) : Cont<'m,'v> =
-        this.TryFinally((fun () -> f d), fun() -> if d <> null then d.Dispose())
-
-    member this.While(condition: unit -> bool, f: unit -> Cont<'m,unit>) : Cont<'m, unit> =
-        if condition() then
-            match f() with
-            | Func fn -> Func(fun m -> 
-                            fn m |> ignore
-                            this.While(condition, f))
-            | v -> this.While(condition, f)
-        else
-            Return ()
     
-    member this.For(source: 's seq, f: 's -> Cont<'m, unit>) : Cont<'m, unit> =
+    member this.Using(d : #IDisposable, f : _ -> Cont<'m, 'v>) : Cont<'m, 'v> = 
+        this.TryFinally((fun () -> f d), 
+                        fun () -> 
+                            if d <> null then d.Dispose())
+    
+    member this.While(condition : unit -> bool, f : unit -> Cont<'m, unit>) : Cont<'m, unit> = 
+        if condition() then 
+            match f() with
+            | Func fn -> 
+                Func(fun m -> 
+                    fn m |> ignore
+                    this.While(condition, f))
+            | v -> this.While(condition, f)
+        else Return()
+    
+    member this.For(source : 's seq, f : 's -> Cont<'m, unit>) : Cont<'m, unit> = 
         use e = source.GetEnumerator()
-        let rec loop() =
-            if e.MoveNext() then
+        
+        let rec loop() = 
+            if e.MoveNext() then 
                 match f e.Current with
-                | Func fn -> Func(fun m -> 
-                         fn m |> ignore
-                         loop())
+                | Func fn -> 
+                    Func(fun m -> 
+                        fn m |> ignore
+                        loop())
                 | r -> loop()
-            else
-                Return ()
+            else Return()
         loop()
-
-
-    member this.Delay(f: unit -> Cont<_,_>) = 
-        f
-
-    member this.Run(f: unit -> Cont<_,_>) = f()
-    member this.Run(f: Cont<_,_>) = f
-
-    member this.Combine(f: unit -> Cont<'m, _>,g: unit -> Cont<'m,'v>) : Cont<'m,'v> =
+    
+    member this.Delay(f : unit -> Cont<_, _>) = f
+    member this.Run(f : unit -> Cont<_, _>) = f()
+    member this.Run(f : Cont<_, _>) = f
+    
+    member this.Combine(f : unit -> Cont<'m, _>, g : unit -> Cont<'m, 'v>) : Cont<'m, 'v> = 
         match f() with
-        | Func fx -> Func(fun m -> this.Combine((fun() -> fx m), g))
+        | Func fx -> Func(fun m -> this.Combine((fun () -> fx m), g))
         | Return _ -> g()
-
-    member this.Combine(f: Cont<'m, _>,g: unit -> Cont<'m,'v>) : Cont<'m,'v> =
+    
+    member this.Combine(f : Cont<'m, _>, g : unit -> Cont<'m, 'v>) : Cont<'m, 'v> = 
         match f with
         | Func fx -> Func(fun m -> this.Combine(fx m, g))
         | Return _ -> g()
-
-    member this.Combine(f: unit -> Cont<'m, _>,g: Cont<'m,'v>) : Cont<'m,'v> =
+    
+    member this.Combine(f : unit -> Cont<'m, _>, g : Cont<'m, 'v>) : Cont<'m, 'v> = 
         match f() with
-        | Func fx -> Func(fun m -> this.Combine((fun() -> fx m), g))
+        | Func fx -> Func(fun m -> this.Combine((fun () -> fx m), g))
         | Return _ -> g
-
-    member this.Combine(f: Cont<'m, _>,g: Cont<'m,'v>) : Cont<'m,'v> =
+    
+    member this.Combine(f : Cont<'m, _>, g : Cont<'m, 'v>) : Cont<'m, 'v> = 
         match f with
         | Func fx -> Func(fun m -> this.Combine(fx m, g))
         | Return _ -> g
-
-
 
 open Microsoft.FSharp.Quotations
 open Microsoft.FSharp.Linq.QuotationEvaluation
 
-type FunActor<'m,'v>(actor: Actor<'m> -> Cont<'m,'v>, strategy: SupervisorStrategy) as self =
+type FunActor<'m, 'v>(actor : Actor<'m> -> Cont<'m, 'v>, strategy : SupervisorStrategy) as self = 
     inherit UntypedActor()
-
+    
     let mutable state = 
-        let self' = self.Self 
+        let self' = self.Self
         let context' = UntypedActor.Context :> IActorContext
         actor { new Actor<'m> with
-                                member this.Receive() = Input
-                                member this.Self = self'
-                                member this.Context = context'
-                                member this.Sender() = self.Sender()
-                                member this.Unhandled msg = self.Unhandled msg } 
+                    member this.Receive() = Input
+                    member this.Self = self'
+                    member this.Context = context'
+                    member this.Sender() = self.Sender()
+                    member this.Unhandled msg = self.Unhandled msg }
     
-    new (actor: Expr<Actor<'m> -> Cont<'m,'v>>) = FunActor(actor.Compile() ())
-    new(actor: Actor<'m> -> Cont<'m,'v>) = FunActor(actor, null) 
-
-    member x.Sender() =
-        base.Sender
-
-    member x.Unhandled(msg:'m) =
-        base.Unhandled msg
-
-    override x.SupervisorStrategy() =
-        if strategy <> null then
-            strategy
-        else 
-            base.SupervisorStrategy()
-
-    override x.OnReceive(msg) =
+    new(actor : Expr<Actor<'m> -> Cont<'m, 'v>>) = FunActor(actor.Compile () ())
+    new(actor : Actor<'m> -> Cont<'m, 'v>) = FunActor(actor, null)
+    member x.Sender() = base.Sender
+    member x.Unhandled(msg : 'm) = base.Unhandled msg
+    
+    override x.SupervisorStrategy() = 
+        if strategy <> null then strategy
+        else base.SupervisorStrategy()
+    
+    override x.OnReceive(msg) = 
         let message = msg :?> 'm
         match state with
         | Func f -> state <- f message
@@ -178,98 +173,99 @@ type FunActor<'m,'v>(actor: Actor<'m> -> Cont<'m,'v>, strategy: SupervisorStrate
 /// </summary>
 let actor = ActorBuilder()
 
-module Linq =
+module Linq = 
     open System.Linq.Expressions
-
-    let (|Lambda|_|) (e:Expression) =
+    
+    let (|Lambda|_|) (e : Expression) = 
         match e with
         | :? LambdaExpression as l -> Some(l.Parameters, l.Body)
         | _ -> None
-    let (|Call|_|) (e:Expression) =
+    
+    let (|Call|_|) (e : Expression) = 
         match e with
-        | :? MethodCallExpression as c -> Some(c.Object,c.Method,c.Arguments)
+        | :? MethodCallExpression as c -> Some(c.Object, c.Method, c.Arguments)
         | _ -> None
-
-    let (|Method|) (e:System.Reflection.MethodInfo) = e.Name
-    let (|Invoke|_|) =
-        function
-        | Call(o,Method("Invoke"),_) -> Some o
+    
+    let (|Method|) (e : System.Reflection.MethodInfo) = e.Name
+    
+    let (|Invoke|_|) = 
+        function 
+        | Call(o, Method("Invoke"), _) -> Some o
         | _ -> None
-    let (|Ar|) (p:System.Collections.ObjectModel.ReadOnlyCollection<Expression>) = Array.ofSeq p
-    type Expression =
-        static member ToExpression (f:System.Linq.Expressions.Expression<System.Func<FunActor<'m,'v>>>) =
+    
+    let (|Ar|) (p : System.Collections.ObjectModel.ReadOnlyCollection<Expression>) = Array.ofSeq p
+    
+    type Expression = 
+        static member ToExpression(f : System.Linq.Expressions.Expression<System.Func<FunActor<'m, 'v>>>) = 
             match f with
-            | Lambda(_,Invoke(Call(null, Method "ToFSharpFunc", Ar [|Lambda(_,p)|]))) ->
-                Expression.Lambda(p,[||]) :?> System.Linq.Expressions.Expression<System.Func<FunActor<'m,'v>>>
+            | Lambda(_, Invoke(Call(null, Method "ToFSharpFunc", Ar [| Lambda(_, p) |]))) -> 
+                Expression.Lambda(p, [||]) :?> System.Linq.Expressions.Expression<System.Func<FunActor<'m, 'v>>>
             | _ -> failwith "Doesn't match"
 
-module Serialization =
+module Serialization = 
     open Nessos.FsPickler
-
     open Akka.Serialization
     open Quotations.Patterns
-
-    type ExprSerializer(system) =
-        
+    
+    type ExprSerializer(system) = 
         inherit Serializer(system)
-        
-
         let fsp = FsPickler.CreateBinary()
         override x.Identifier = 9
         override x.IncludeManifest = true
-
-        override x.ToBinary(o) =
+        
+        override x.ToBinary(o) = 
             use stream = new System.IO.MemoryStream()
-            fsp.Serialize(o.GetType(),stream, o)
-            stream.ToArray()           
-         
-        override x.FromBinary(bytes, t) =
+            fsp.Serialize(o.GetType(), stream, o)
+            stream.ToArray()
+        
+        override x.FromBinary(bytes, t) = 
             use stream = new System.IO.MemoryStream(bytes)
             fsp.Deserialize(t, stream)
-          
-module Configuration =
+
+module Configuration = 
     let parse = Akka.Configuration.ConfigurationFactory.ParseString
+    let defaultConfig = Akka.Configuration.ConfigurationFactory.Default
 
-module Strategy =
+module Strategy = 
     /// <summary>
     /// Returns a builder function returning OneForOneStrategy supervisor based on provided decider func.
     /// </summary>
     /// <param name="decider">Supervisor strategy behavior decider function.</param>
-    let oneForOne (decider: Exception -> Directive) = 
-        OneForOneStrategy(System.Func<_,_>(decider)) :> SupervisorStrategy
-
+    let oneForOne (decider : Exception -> Directive) = 
+        OneForOneStrategy(System.Func<_, _>(decider)) :> SupervisorStrategy
+    
     /// <summary>
     /// Returns a builder function returning OneForOneStrategy supervisor based on provided decider func.
     /// </summary>
     /// <param name="retries">Number of times, actor could be restarted. If negative, there is not limit.</param>
     /// <param name="timeout">Time window for number of retries to occur.</param>
     /// <param name="decider">Supervisor strategy behavior decider function.</param>
-    let oneForOne' retries timeout (decider: Exception -> Directive) = 
-        OneForOneStrategy(retries, timeout, System.Func<_,_>(decider)) :> SupervisorStrategy
-
+    let oneForOne' retries timeout (decider : Exception -> Directive) = 
+        OneForOneStrategy(retries, timeout, System.Func<_, _>(decider)) :> SupervisorStrategy
+    
     /// <summary>
     /// Returns a builder function returning AllForOneStrategy supervisor based on provided decider func.
     /// </summary>
     /// <param name="decider">Supervisor strategy behavior decider function.</param>
-    let allForOne (decider: Exception -> Directive) = 
-        AllForOneStrategy(System.Func<_,_>(decider)) :> SupervisorStrategy
-
+    let allForOne (decider : Exception -> Directive) = 
+        AllForOneStrategy(System.Func<_, _>(decider)) :> SupervisorStrategy
+    
     /// <summary>
     /// Returns a builder function returning AllForOneStrategy supervisor based on provided decider func.
     /// </summary>
     /// <param name="retries">Number of times, actor could be restarted. If negative, there is not limit.</param>
     /// <param name="timeout">Time window for number of retries to occur.</param>
     /// <param name="decider">Supervisor strategy behavior decider function.</param>
-    let allForOne' retries timeout (decider: Exception -> Directive) () = 
-        AllForOneStrategy(retries, timeout, System.Func<_,_>(decider)) :> SupervisorStrategy
+    let allForOne' retries timeout (decider : Exception -> Directive) () = 
+        AllForOneStrategy(retries, timeout, System.Func<_, _>(decider)) :> SupervisorStrategy
 
-module System =
+module System = 
     /// <summary>
     /// Creates an actor system with remote deployment serialization enabled.
     /// </summary>
     /// <param name="name">The system name.</param>
     /// <param name="configStr">The configuration</param>
-    let create name (config: Configuration.Config) =
+    let create name (config : Configuration.Config) = 
         let system = ActorSystem.Create(name, config)
         let serializer = new Serialization.ExprSerializer(system :?> ExtendedActorSystem)
         system.Serialization.AddSerializer(serializer)
@@ -283,10 +279,10 @@ module System =
 /// <param name="system">The system used to spawn the actor</param>
 /// <param name="name">The actor instance nane</param>
 /// <param name="f">the actor's message handling function.</param>
-let spawne (system:ActorSystem) name (f: Expr<Actor<'m> -> Cont<'m,'v>>)  =
-    let e = Linq.Expression.ToExpression(fun () -> new FunActor<'m,'v>(f))
+let spawne (system : ActorSystem) name (f : Expr<Actor<'m> -> Cont<'m, 'v>>) = 
+    let e = Linq.Expression.ToExpression(fun () -> new FunActor<'m, 'v>(f))
     system.ActorOf(Props.Create(e), name)
-   
+
 /// <summary>
 /// Spawns an actor using specified actor computation expression, with strategy supervisor factory.
 /// The actor can only be used locally. 
@@ -295,8 +291,8 @@ let spawne (system:ActorSystem) name (f: Expr<Actor<'m> -> Cont<'m,'v>>)  =
 /// <param name="name">The actor instance name</param>
 /// <param name="strategy">Function used to generate supervisor strategy</param>
 /// <param name="f">the actor's message handling function.</param>
-let spawns (system:ActorSystem) name (strategy: SupervisorStrategy) (f: Actor<'m> -> Cont<'m,'v>)  =
-    let e = Linq.Expression.ToExpression(fun () -> new FunActor<'m,'v>(f, strategy))
+let spawns (system : ActorSystem) name (strategy : SupervisorStrategy) (f : Actor<'m> -> Cont<'m, 'v>) = 
+    let e = Linq.Expression.ToExpression(fun () -> new FunActor<'m, 'v>(f, strategy))
     system.ActorOf(Props.Create(e), name)
 
 /// <summary>
@@ -306,20 +302,21 @@ let spawns (system:ActorSystem) name (strategy: SupervisorStrategy) (f: Actor<'m
 /// <param name="system">The system used to spawn the actor</param>
 /// <param name="name">The actor instance nane</param>
 /// <param name="f">the actor's message handling function.</param>
-let spawn (system:ActorSystem) name (f: Actor<'m> -> Cont<'m,'v>)  =
-    spawns system name null f
+let spawn (system : ActorSystem) name (f : Actor<'m> -> Cont<'m, 'v>) = spawns system name null f
 
 [<AutoOpen>]
-module Actors =
+module Actors = 
     // declare extension methods for Actor interface
     type Actor<'msg> with
+        
         /// <summary>
         /// Implementation of spawne method using actor-local context.
         /// Actor refs returned this way are considered children of current actor.
         /// </summary>
-        member this.spawne (system:ActorSystem) name (f: Expr<Actor<'m> -> Cont<'m,'v>>)  =
-            let e = Linq.Expression.ToExpression(fun () -> new FunActor<'m,'v>(f))
+        member this.spawne (system : ActorSystem) name (f : Expr<Actor<'m> -> Cont<'m, 'v>>) = 
+            let e = Linq.Expression.ToExpression(fun () -> new FunActor<'m, 'v>(f))
             this.Context.ActorOf(Props.Create(e), name)
+        
         /// <summary>
         /// Implementation of spawns method using actor-local context.
         /// Actor refs returned this way are considered children of current actor. 
@@ -327,12 +324,12 @@ module Actors =
         /// <param name="name">The actor instance name to be created as child of current actor</param>
         /// <param name="strategy">Function used to generate supervisor strategy</param>
         /// <param name="f">the actor's message handling function.</param>
-        member this.spawns name (strategy: SupervisorStrategy) (f: Actor<'m> -> Cont<'m,'v>)  =
-            let e = Linq.Expression.ToExpression(fun () -> new FunActor<'m,'v>(f, strategy))
+        member this.spawns name (strategy : SupervisorStrategy) (f : Actor<'m> -> Cont<'m, 'v>) = 
+            let e = Linq.Expression.ToExpression(fun () -> new FunActor<'m, 'v>(f, strategy))
             this.Context.ActorOf(Props.Create(e), name)
+        
         /// <summary>
         /// Implementation of spawn method using actor-local context.
         /// Actor refs returned this way are considered children of current actor.
         /// </summary>
-        member this.spawn name (f: Actor<'m> -> Cont<'m,'v>) =
-            this.spawns name null f
+        member this.spawn name (f : Actor<'m> -> Cont<'m, 'v>) = this.spawns name null f


### PR DESCRIPTION
I've done few changes for F# API. Most push diffs consider fixing code formatting, so I've decided to enumerate major changes:
### ActorPath parsing

`ActorPath` now has `TryParse` and `TryParseAddress` methods, which are more idiomatic with standard F# API - instead of using ref parameters they return Option type, which may be of type `Some<ActorPath>` / `Some<Address>`, if parsing has succeeded or `None` otherwise.
### ActorSelection

I've created a `select` function, which takes actor path string and returns ActorSelection with anchor set on current ActorCell self. 

Also inspired by [canopy API](http://lefthandedgoat.github.io/canopy/), I've created a tell and ask operators (`<!` and `<?`) overrides, which may operate directly on actor path string instead of actor refs. Since this may cause and operators conflicts and be a controversial feature it requires opening Akka.FSharp.ActorSelection module in order to use.

Examples:

``` fsharp
let s: ActorSelection = select "akka://system/user/actor"

open Akka.FSharp.ActorSelection
"akka://system/user/actor" <! Message("hello")
```
### Default Configuration

Since a `Configuration` module already exists, I've decided to add missing `defaultConfig` method, which returns a default Akka actor system configuration.
