### PR TITLE
Rename GetMillisDuration to GetTimeSpan and provide Obsolete-marked fallback

### DIFF
--- a/src/core/Akka.Cluster.Tests/ClusterConfigSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterConfigSpec.cs
@@ -20,8 +20,8 @@ namespace Akka.Cluster.Tests
             Assert.True(settings.LogInfo);
             Assert.Equal(8, settings.FailureDetectorConfig.GetDouble("threshold"));
             Assert.Equal(1000, settings.FailureDetectorConfig.GetInt("max-sample-size"));
-            Assert.Equal(TimeSpan.FromMilliseconds(100), settings.FailureDetectorConfig.GetMillisDuration("min-std-deviation"));
-            Assert.Equal(TimeSpan.FromSeconds(3), settings.FailureDetectorConfig.GetMillisDuration("acceptable-heartbeat-pause"));
+            Assert.Equal(TimeSpan.FromMilliseconds(100), settings.FailureDetectorConfig.GetTimeSpan("min-std-deviation"));
+            Assert.Equal(TimeSpan.FromSeconds(3), settings.FailureDetectorConfig.GetTimeSpan("acceptable-heartbeat-pause"));
             Assert.Equal(typeof(PhiAccrualFailureDetector), Type.GetType(settings.FailureDetectorImplementationClass));
             Assert.Equal(ImmutableList.Create<Address>(), settings.SeedNodes);
             Assert.Equal(TimeSpan.FromSeconds(5), settings.SeedNodeTimeout);

--- a/src/core/Akka.Cluster/ClusterSettings.cs
+++ b/src/core/Akka.Cluster/ClusterSettings.cs
@@ -46,21 +46,21 @@ namespace Akka.Cluster
             _logInfo = cc.GetBoolean("log-info");
             _failureDetectorConfig = cc.GetConfig("failure-detector");
             _failureDetectorImplementationClass = _failureDetectorConfig.GetString("implementation-class");
-            _heartbeatInterval = _failureDetectorConfig.GetMillisDuration("heartbeat-interval");
-            _heartbeatExpectedResponseAfter = _failureDetectorConfig.GetMillisDuration("expected-response-after");
+            _heartbeatInterval = _failureDetectorConfig.GetTimeSpan("heartbeat-interval");
+            _heartbeatExpectedResponseAfter = _failureDetectorConfig.GetTimeSpan("expected-response-after");
             _monitoredByNrOfMembers = _failureDetectorConfig.GetInt("monitored-by-nr-of-members");
 
             _seedNodes = cc.GetStringList("seed-nodes").Select(Address.Parse).ToImmutableList();
-            _seedNodeTimeout = cc.GetMillisDuration("seed-node-timeout");
-            _retryUnsuccessfulJoinAfter = cc.GetMillisDurationWithOffSwitch("retry-unsuccessful-join-after");
-            _periodicTasksInitialDelay = cc.GetMillisDuration("periodic-tasks-initial-delay");
-            _gossipInterval = cc.GetMillisDuration("gossip-interval");
-            _gossipTimeToLive = cc.GetMillisDuration("gossip-time-to-live");
-            _leaderActionsInterval = cc.GetMillisDuration("leader-actions-interval");
-            _unreachableNodesReaperInterval = cc.GetMillisDuration("unreachable-nodes-reaper-interval");
-            _publishStatsInterval = cc.GetMillisDurationWithOffSwitch("publish-stats-interval");
+            _seedNodeTimeout = cc.GetTimeSpan("seed-node-timeout");
+            _retryUnsuccessfulJoinAfter = cc.GetTimeSpanWithOffSwitch("retry-unsuccessful-join-after");
+            _periodicTasksInitialDelay = cc.GetTimeSpan("periodic-tasks-initial-delay");
+            _gossipInterval = cc.GetTimeSpan("gossip-interval");
+            _gossipTimeToLive = cc.GetTimeSpan("gossip-time-to-live");
+            _leaderActionsInterval = cc.GetTimeSpan("leader-actions-interval");
+            _unreachableNodesReaperInterval = cc.GetTimeSpan("unreachable-nodes-reaper-interval");
+            _publishStatsInterval = cc.GetTimeSpanWithOffSwitch("publish-stats-interval");
 
-            _autoDownUnreachableAfter = cc.GetMillisDurationWithOffSwitch("auto-down-unreachable-after");
+            _autoDownUnreachableAfter = cc.GetTimeSpanWithOffSwitch("auto-down-unreachable-after");
 
             _roles = cc.GetStringList("roles").ToImmutableHashSet();
             _minNrOfMembers = cc.GetInt("min-nr-of-members");
@@ -71,13 +71,13 @@ namespace Akka.Cluster
             if (String.IsNullOrEmpty(_useDispatcher)) _useDispatcher = Dispatchers.DefaultDispatcherId;
             _gossipDifferentViewProbability = cc.GetDouble("gossip-different-view-probability");
             _reduceGossipDifferentViewProbability = cc.GetInt("reduce-gossip-different-view-probability");
-            _schedulerTickDuration = cc.GetMillisDuration("scheduler.tick-duration");
+            _schedulerTickDuration = cc.GetTimeSpan("scheduler.tick-duration");
             _schedulerTicksPerWheel = cc.GetInt("scheduler.ticks-per-wheel");
             _metricsEnabled = cc.GetBoolean("metrics.enabled");
             _metricsCollectorClass = cc.GetString("metrics.collector-class");
-            _metricsInterval = cc.GetMillisDuration("metrics.collect-interval");
-            _metricsGossipInterval = cc.GetMillisDuration("metrics.gossip-interval");
-            _metricsMovingAverageHalfLife = cc.GetMillisDuration("metrics.moving-average-half-life");
+            _metricsInterval = cc.GetTimeSpan("metrics.collect-interval");
+            _metricsGossipInterval = cc.GetTimeSpan("metrics.gossip-interval");
+            _metricsMovingAverageHalfLife = cc.GetTimeSpan("metrics.moving-average-half-life");
 
             _minNrOfMembersOfRole = cc.GetConfig("role").Root.GetObject().AsEnumerable()
                 .ToImmutableDictionary(kv => kv.Key, kv => kv.Value.GetObject().GetKey("min-nr-of-members").GetInt());

--- a/src/core/Akka.Cluster/Util.cs
+++ b/src/core/Akka.Cluster/Util.cs
@@ -68,10 +68,17 @@ namespace Akka.Cluster
             }
         }
 
+
+        [Obsolete("Use GetTimeSpanWithOffSwitch instead")]
         public static TimeSpan? GetMillisDurationWithOffSwitch(this Config @this, string key)
         {
+            return GetTimeSpanWithOffSwitch(@this, key);
+        }
+
+        public static TimeSpan? GetTimeSpanWithOffSwitch(this Config @this, string key)
+        {
             TimeSpan? ret = null;
-            if (@this.GetString(key).ToLower() != "off") ret = @this.GetMillisDuration(key);
+            if (@this.GetString(key).ToLower() != "off") ret = @this.GetTimeSpan(key);
             return ret;
         }
 

--- a/src/core/Akka.Remote.TestKit/Extension.cs
+++ b/src/core/Akka.Remote.TestKit/Extension.cs
@@ -101,12 +101,12 @@ namespace Akka.Remote.TestKit
 
         public TestConductorSettings(Config config)
         {
-            _connectTimeout = config.GetMillisDuration("connect-timeout");
+            _connectTimeout = config.GetTimeSpan("connect-timeout");
             _clientReconnects = config.GetInt("client-reconnects");
-            _reconnectBackoff = config.GetMillisDuration("reconnect-backoff");
-            _barrierTimeout = config.GetMillisDuration("barrier-timeout");
-            _queryTimeout = config.GetMillisDuration("query-timeout");
-            _packetSplitThreshold = config.GetMillisDuration("packet-split-threshold");
+            _reconnectBackoff = config.GetTimeSpan("reconnect-backoff");
+            _barrierTimeout = config.GetTimeSpan("barrier-timeout");
+            _queryTimeout = config.GetTimeSpan("query-timeout");
+            _packetSplitThreshold = config.GetTimeSpan("packet-split-threshold");
             //_serverSocketWorkerPoolSize = ComputeWps(config.GetConfig("helios.tcp.server-socket-worker-pool"));
             //_clientSocketWorkerPoolSize = ComputeWps(config.GetConfig("helios.tcp.client-socket-worker-pool"));
         }

--- a/src/core/Akka.Remote.Tests/RemoteConfigSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteConfigSpec.cs
@@ -47,8 +47,8 @@ namespace Akka.Remote.Tests
             Assert.Equal(TimeSpan.FromSeconds(1), remoteSettings.WatchUnreachableReaperInterval);
             Assert.Equal(10, remoteSettings.WatchFailureDetectorConfig.GetDouble("threshold"));
             Assert.Equal(200, remoteSettings.WatchFailureDetectorConfig.GetDouble("max-sample-size"));
-            Assert.Equal(TimeSpan.FromSeconds(10), remoteSettings.WatchFailureDetectorConfig.GetMillisDuration("acceptable-heartbeat-pause"));
-            Assert.Equal(TimeSpan.FromMilliseconds(100), remoteSettings.WatchFailureDetectorConfig.GetMillisDuration("min-std-deviation"));
+            Assert.Equal(TimeSpan.FromSeconds(10), remoteSettings.WatchFailureDetectorConfig.GetTimeSpan("acceptable-heartbeat-pause"));
+            Assert.Equal(TimeSpan.FromMilliseconds(100), remoteSettings.WatchFailureDetectorConfig.GetTimeSpan("min-std-deviation"));
 
             //TODO add adapter support
         }
@@ -61,7 +61,7 @@ namespace Akka.Remote.Tests
             //TODO fill this in when we add secure cookie support
             Assert.Equal(typeof(DeadlineFailureDetector), Type.GetType(settings.TransportFailureDetectorImplementationClass));
             Assert.Equal(TimeSpan.FromSeconds(4), settings.TransportHeartBeatInterval);
-            Assert.Equal(TimeSpan.FromSeconds(20), settings.TransportFailureDetectorConfig.GetMillisDuration("acceptable-heartbeat-pause"));
+            Assert.Equal(TimeSpan.FromSeconds(20), settings.TransportFailureDetectorConfig.GetTimeSpan("acceptable-heartbeat-pause"));
         }
 
         [Fact]

--- a/src/core/Akka.Remote/AkkaProtocolSettings.cs
+++ b/src/core/Akka.Remote/AkkaProtocolSettings.cs
@@ -15,7 +15,7 @@ namespace Akka.Remote
         {
             TransportFailureDetectorConfig = config.GetConfig("akka.remote.transport-failure-detector");
             TransportFailureDetectorImplementationClass = TransportFailureDetectorConfig.GetString("implementation-class");
-            TransportHeartBeatInterval = TransportFailureDetectorConfig.GetMillisDuration("heartbeat-interval");
+            TransportHeartBeatInterval = TransportFailureDetectorConfig.GetTimeSpan("heartbeat-interval");
         }
     }
 }

--- a/src/core/Akka.Remote/DeadlineFailureDetector.cs
+++ b/src/core/Akka.Remote/DeadlineFailureDetector.cs
@@ -39,7 +39,7 @@ namespace Akka.Remote
         /// </summary>
         /// <param name="config"></param>
         /// <param name="ev"></param>
-        public DeadlineFailureDetector(Config config, EventStream ev) : this(config.GetMillisDuration("acceptable-heartbeat-pause")) { }
+        public DeadlineFailureDetector(Config config, EventStream ev) : this(config.GetTimeSpan("acceptable-heartbeat-pause")) { }
 
         protected DeadlineFailureDetector(Clock clock)
         {

--- a/src/core/Akka.Remote/PhiAccrualFailureDetector.cs
+++ b/src/core/Akka.Remote/PhiAccrualFailureDetector.cs
@@ -73,9 +73,9 @@ namespace Akka.Remote
         {
             _threshold = config.GetDouble("threshold");
             _maxSampleSize = config.GetInt("max-sample-size");
-            _minStdDeviation = config.GetMillisDuration("min-std-deviation");
-            _acceptableHeartbeatPause = config.GetMillisDuration("acceptable-heartbeat-pause");
-            _firstHeartbeatEstimate = config.GetMillisDuration("heartbeat-interval");
+            _minStdDeviation = config.GetTimeSpan("min-std-deviation");
+            _acceptableHeartbeatPause = config.GetTimeSpan("acceptable-heartbeat-pause");
+            _firstHeartbeatEstimate = config.GetTimeSpan("heartbeat-interval");
             state = new State(FirstHeartBeat, null);
         }
 

--- a/src/core/Akka.Remote/RemoteSettings.cs
+++ b/src/core/Akka.Remote/RemoteSettings.cs
@@ -31,29 +31,29 @@ namespace Akka.Remote
             RemoteLifecycleEventsLogLevel = config.GetString("akka.remote.log-remote-lifecycle-events") ?? "DEBUG";
             Dispatcher = config.GetString("akka.remote.use-dispatcher");
             if (RemoteLifecycleEventsLogLevel.Equals("on")) RemoteLifecycleEventsLogLevel = "DEBUG";
-            FlushWait = config.GetMillisDuration("akka.remote.flush-wait-on-shutdown");
-            ShutdownTimeout = config.GetMillisDuration("akka.remote.shutdown-timeout");
+            FlushWait = config.GetTimeSpan("akka.remote.flush-wait-on-shutdown");
+            ShutdownTimeout = config.GetTimeSpan("akka.remote.shutdown-timeout");
             TransportNames = config.GetStringList("akka.remote.enabled-transports");
             Transports = (from transportName in TransportNames
                 let transportConfig = TransportConfigFor(transportName)
                 select new TransportSettings(transportConfig)).ToArray();
             Adapters = ConfigToMap(config.GetConfig("akka.remote.adapters"));
-            BackoffPeriod = config.GetMillisDuration("akka.remote.backoff-interval");
-            RetryGateClosedFor = config.GetMillisDuration("akka.remote.retry-gate-closed-for", TimeSpan.Zero);
+            BackoffPeriod = config.GetTimeSpan("akka.remote.backoff-interval");
+            RetryGateClosedFor = config.GetTimeSpan("akka.remote.retry-gate-closed-for", TimeSpan.Zero);
             UsePassiveConnections = config.GetBoolean("akka.remote.use-passive-connections");
             SysMsgBufferSize = config.GetInt("akka.remote.system-message-buffer-size");
-            SysResendTimeout = config.GetMillisDuration("akka.remote.resend-interval");
-            InitialSysMsgDeliveryTimeout = config.GetMillisDuration("akka.remote.initial-system-message-delivery-timeout");
-            SysMsgAckTimeout = config.GetMillisDuration("akka.remote.system-message-ack-piggyback-timeout");
-            QuarantineDuration = config.GetMillisDuration("akka.remote.prune-quarantine-marker-after");
-            StartupTimeout = config.GetMillisDuration("akka.remote.startup-timeout");
-            CommandAckTimeout = config.GetMillisDuration("akka.remote.command-ack-timeout");
+            SysResendTimeout = config.GetTimeSpan("akka.remote.resend-interval");
+            InitialSysMsgDeliveryTimeout = config.GetTimeSpan("akka.remote.initial-system-message-delivery-timeout");
+            SysMsgAckTimeout = config.GetTimeSpan("akka.remote.system-message-ack-piggyback-timeout");
+            QuarantineDuration = config.GetTimeSpan("akka.remote.prune-quarantine-marker-after");
+            StartupTimeout = config.GetTimeSpan("akka.remote.startup-timeout");
+            CommandAckTimeout = config.GetTimeSpan("akka.remote.command-ack-timeout");
 
             WatchFailureDetectorConfig = config.GetConfig("akka.remote.watch-failure-detector");
             WatchFailureDetectorImplementationClass = WatchFailureDetectorConfig.GetString("implementation-class");
-            WatchHeartBeatInterval = WatchFailureDetectorConfig.GetMillisDuration("heartbeat-interval");
-            WatchUnreachableReaperInterval = WatchFailureDetectorConfig.GetMillisDuration("unreachable-nodes-reaper-interval");
-            WatchHeartbeatExpectedResponseAfter = WatchFailureDetectorConfig.GetMillisDuration("expected-response-after");
+            WatchHeartBeatInterval = WatchFailureDetectorConfig.GetTimeSpan("heartbeat-interval");
+            WatchUnreachableReaperInterval = WatchFailureDetectorConfig.GetTimeSpan("unreachable-nodes-reaper-interval");
+            WatchHeartbeatExpectedResponseAfter = WatchFailureDetectorConfig.GetTimeSpan("expected-response-after");
         }
 
         /// <summary>

--- a/src/core/Akka.Remote/Transport/Helios/HeliosTransport.cs
+++ b/src/core/Akka.Remote/Transport/Helios/HeliosTransport.cs
@@ -62,7 +62,7 @@ namespace Akka.Remote.Transport.Helios
             else if (protocolString.Equals("udp")) TransportMode = new Udp();
             else throw new ConfigurationException(string.Format("Unknown transport transport-protocol='{0}'", protocolString));
             EnableSsl = Config.GetBoolean("enable-ssl");
-            ConnectTimeout = Config.GetMillisDuration("connection-timeout");
+            ConnectTimeout = Config.GetTimeSpan("connection-timeout");
             WriteBufferHighWaterMark = OptionSize("write-buffer-high-water-mark");
             WriteBufferLowWaterMark = OptionSize("write-buffer-low-water-mark");
             SendBufferSize = OptionSize("send-buffer-size");

--- a/src/core/Akka.TestKit/TestKitSettings.cs
+++ b/src/core/Akka.TestKit/TestKitSettings.cs
@@ -16,9 +16,9 @@ namespace Akka.TestKit
 
         public TestKitSettings(Config config)
         {
-            _defaultTimeout = config.GetMillisDuration("akka.test.default-timeout", allowInfinite:false);
-            _singleExpectDefault = config.GetMillisDuration("akka.test.single-expect-default", allowInfinite: false);
-            _testEventFilterLeeway = config.GetMillisDuration("akka.test.filter-leeway", allowInfinite: false);
+            _defaultTimeout = config.GetTimeSpan("akka.test.default-timeout", allowInfinite:false);
+            _singleExpectDefault = config.GetTimeSpan("akka.test.single-expect-default", allowInfinite: false);
+            _testEventFilterLeeway = config.GetTimeSpan("akka.test.filter-leeway", allowInfinite: false);
             _timefactor = config.GetDouble("akka.test.timefactor");
             if(_timefactor <= 0)
                 throw new Exception(@"Expected a positive value for ""akka.test.timefactor"" but found "+_timefactor);

--- a/src/core/Akka/Actor/Inbox.cs
+++ b/src/core/Akka/Actor/Inbox.cs
@@ -236,7 +236,7 @@ namespace Akka.Actor
         {
             var config = system.Settings.Config.GetConfig("akka").GetConfig("actor").GetConfig("inbox");
             var inboxSize = config.GetInt("inbox-size");
-            var timeout = config.GetMillisDuration("default-timeout");
+            var timeout = config.GetTimeSpan("default-timeout");
 
             var receiver =((ActorSystemImpl) system).SystemActorOf(Props.Create(() => new InboxActor(inboxSize)), "inbox-" + Interlocked.Increment(ref inboxNr));
 

--- a/src/core/Akka/Actor/Settings.cs
+++ b/src/core/Akka/Actor/Settings.cs
@@ -55,8 +55,8 @@ namespace Akka.Actor
             
             SupervisorStrategyClass = Config.GetString("akka.actor.guardian-supervisor-strategy");
 
-            CreationTimeout = Config.GetMillisDuration("akka.actor.creation-timeout");
-            UnstartedPushTimeout = Config.GetMillisDuration("akka.actor.unstarted-push-timeout");
+            CreationTimeout = Config.GetTimeSpan("akka.actor.creation-timeout");
+            UnstartedPushTimeout = Config.GetTimeSpan("akka.actor.unstarted-push-timeout");
 
             SerializeAllMessages = Config.GetBoolean("akka.actor.serialize-messages");
             SerializeAllCreators = Config.GetBoolean("akka.actor.serialize-creators");
@@ -65,7 +65,7 @@ namespace Akka.Actor
             StdoutLogLevel = Config.GetString("akka.stdout-loglevel");
             Loggers = Config.GetStringList("akka.loggers");
 
-            LoggerStartTimeout = Config.GetMillisDuration("akka.logger-startup-timeout");
+            LoggerStartTimeout = Config.GetTimeSpan("akka.logger-startup-timeout");
 
             //handled
             LogConfigOnStart = Config.GetBoolean("akka.log-config-on-start");

--- a/src/core/Akka/Configuration/Config.cs
+++ b/src/core/Akka/Configuration/Config.cs
@@ -227,13 +227,19 @@ namespace Akka.Configuration
             return value;
         }
 
+        [Obsolete("Use GetTimeSpan instead")]
         public TimeSpan GetMillisDuration(string path, TimeSpan? @default = null, bool allowInfinite = true)
+        {
+            return GetTimeSpan(path, @default, allowInfinite);
+        }
+
+        public TimeSpan GetTimeSpan(string path, TimeSpan? @default = null, bool allowInfinite = true)
         {
             HoconValue value = GetNode(path);
             if (value == null)
                 return @default.GetValueOrDefault();
 
-            return value.GetMillisDuration(allowInfinite);
+            return value.GetTimeSpan(allowInfinite);
         }
 
         public override string ToString()

--- a/src/core/Akka/Configuration/Hocon/HoconValue.cs
+++ b/src/core/Akka/Configuration/Hocon/HoconValue.cs
@@ -179,7 +179,14 @@ namespace Akka.Configuration.Hocon
             return GetArray() != null;
         }
 
+
+        [Obsolete("Use GetTimeSpan instead")]
         public TimeSpan GetMillisDuration(bool allowInfinite = true)
+        {
+            return GetTimeSpan(allowInfinite);
+        }
+
+        public TimeSpan GetTimeSpan(bool allowInfinite = true)
         {
             string res = GetString();
             if (res.EndsWith("ms"))

--- a/src/core/Akka/Dispatch/Dispatchers.cs
+++ b/src/core/Akka/Dispatch/Dispatchers.cs
@@ -221,7 +221,7 @@ namespace Akka.Dispatch
             Config config = _system.Settings.Config.GetConfig(path);
             string type = config.GetString("type");
             int throughput = config.GetInt("throughput");
-            long throughputDeadlineTime = config.GetMillisDuration("throughput-deadline-time").Ticks;
+            long throughputDeadlineTime = config.GetTimeSpan("throughput-deadline-time").Ticks;
             //shutdown-timeout
             //throughput-deadline-time
             //attempt-teamwork

--- a/src/core/Akka/Routing/ScatterGatherFirstCompleted.cs
+++ b/src/core/Akka/Routing/ScatterGatherFirstCompleted.cs
@@ -63,7 +63,7 @@ namespace Akka.Routing
         public ScatterGatherFirstCompletedGroup(Config config)
             : base(config.GetStringList("routees.paths"))
         {
-            _within = config.GetMillisDuration("within");
+            _within = config.GetTimeSpan("within");
         }
 
         /// <summary>
@@ -126,7 +126,7 @@ namespace Akka.Routing
 
         public ScatterGatherFirstCompletedPool(Config config) : base(config)
         {
-            _within = config.GetMillisDuration("within");
+            _within = config.GetTimeSpan("within");
         }
 
         [Obsolete("for serialization only",true)]

--- a/src/core/Akka/Routing/TailChoppingRoutingLogic.cs
+++ b/src/core/Akka/Routing/TailChoppingRoutingLogic.cs
@@ -179,8 +179,8 @@ namespace Akka.Routing
         public TailChoppingPool(Config config)
         {
             NrOfInstances = config.GetInt("nr-of-instances");
-            within = config.GetMillisDuration("within");
-            interval = config.GetMillisDuration("tail-chopping-router.interval");
+            within = config.GetTimeSpan("within");
+            interval = config.GetTimeSpan("tail-chopping-router.interval");
             Resizer = DefaultResizer.FromConfig(config);
             UsePoolDispatcher = config.HasPath("pool-dispatcher");
         }
@@ -265,8 +265,8 @@ namespace Akka.Routing
         public TailChoppingGroup(Config config)
         {
             Paths = config.GetStringList("routees.paths").ToArray();
-            within = config.GetMillisDuration("within");
-            interval = config.GetMillisDuration("tail-chopping-router.interval");
+            within = config.GetTimeSpan("within");
+            interval = config.GetTimeSpan("tail-chopping-router.interval");
         }
 
         /// <summary>


### PR DESCRIPTION
This is a non breaking change. GetMillisDuration still exists but has been marked as Obsolete.
Fixes #332
