### PR TITLE
Adds TestFSMRef to TestKit

### DIFF
--- a/src/core/Akka.TestKit.Tests/Akka.TestKit.Tests.csproj
+++ b/src/core/Akka.TestKit.Tests/Akka.TestKit.Tests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="TestEventListenerTests\EventFilterTestBase.cs" />
     <Compile Include="TestEventListenerTests\ExceptionEventFilterTests.cs" />
     <Compile Include="TestEventListenerTests\ForwardAllEventsTestEventListener.cs" />
+    <Compile Include="TestFSMRefTests\TestFSMRefSpec.cs" />
     <Compile Include="TestKitBaseTests\AwaitAssertTests.cs" />
     <Compile Include="TestKitBaseTests\DilatedTests.cs" />
     <Compile Include="TestKitBaseTests\ExpectTests.cs" />

--- a/src/core/Akka.TestKit/Akka.TestKit.csproj
+++ b/src/core/Akka.TestKit/Akka.TestKit.csproj
@@ -111,6 +111,7 @@
     <Compile Include="TestActors\BlackHoleActor.cs" />
     <Compile Include="TestActors\EchoActor.cs" />
     <Compile Include="TestBarrier.cs" />
+    <Compile Include="TestFSMRef.cs" />
     <Compile Include="TestKitAssertions.cs" />
     <Compile Include="MessageEnvelope.cs" />
     <Compile Include="NullMessageEnvelope.cs" />

--- a/src/core/Akka.TestKit/TestActorRefBase.cs
+++ b/src/core/Akka.TestKit/TestActorRefBase.cs
@@ -35,6 +35,11 @@ namespace Akka.TestKit
             get { return _internalRef; }
         }
 
+        public InternalTestActorRef InternalRef
+        {
+            get { return _internalRef; }
+        }
+
         public TActor UnderlyingActor
         {
             get { return (TActor) _internalRef.UnderlyingActor; }

--- a/src/core/Akka.TestKit/TestFSMRef.cs
+++ b/src/core/Akka.TestKit/TestFSMRef.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Linq.Expressions;
+using Akka.Actor;
+using Akka.Actor.Internal;
+
+namespace Akka.TestKit
+{
+    /// <summary>
+    /// This is a specialized form of the <see cref="TestActorRef"/> with support for querying and
+    /// setting the state of a <see cref="FSM{TState,TData}"/>. 
+    /// </summary>
+    /// <typeparam name="TActor">The type of the actor.</typeparam>
+    /// <typeparam name="TState">The type of the state.</typeparam>
+    /// <typeparam name="TData">The type of the data.</typeparam>
+    public class TestFSMRef<TActor, TState, TData> : TestActorRefBase<TActor> where TActor : FSM<TState, TData>
+    {
+        public TestFSMRef(ActorSystem system, Props props, ActorRef supervisor = null, string name = null, bool activateLogging = false)
+            : base(system, props, supervisor, name)
+        {
+            if(activateLogging)
+                Tell(InternalActivateFsmLogging.Instance, this);
+        }
+
+        /// <summary>Get current state name of this FSM.</summary>
+        public TState StateName { get { return UnderlyingActor.StateName; } }
+
+        /// <summary>Get current state data of this FSM.</summary>
+        public TData StateData { get { return UnderlyingActor.StateData; } }
+
+
+        /// <summary>
+        /// Change FSM state data; but do not transition to a new state name. 
+        /// This method is directly equivalent to a transition initiated from within the FSM.
+        /// </summary>
+        public void SetStateData(TData stateData, TimeSpan? timeout = null)
+        {
+            SetState(UnderlyingActor.StateName, stateData, timeout);
+        }
+
+
+        /// <summary>
+        /// Change FSM state timeout. This method is directly equivalent to a
+        /// transition initiated from within the FSM using the current state name and data
+        /// but with the specified timeout.
+        /// </summary>
+        public void SetStateTimeout(TimeSpan timeout)
+        {
+            SetState(UnderlyingActor.StateName, UnderlyingActor.StateData, timeout);
+        }
+
+        /// <summary>
+        /// Change FSM state; but keeps the current state data. 
+        /// This method is directly equivalent to a  transition initiated from within the FSM.
+        /// </summary>
+        public void SetState(TState stateName, TimeSpan? timeout = null)
+        {
+            SetState(stateName, UnderlyingActor.StateData, timeout);
+        }
+
+        /// <summary>
+        /// Change FSM state. This method is directly equivalent to a
+        /// corresponding transition initiated from within the FSM, including timeout
+        /// and stop handling.
+        /// </summary>
+        public void SetState(TState stateName, TData stateData, TimeSpan? timeout = null, FSMBase.Reason stopReason = null)
+        {
+            var fsm = ((InternalSupportsTestFSMRef<TState, TData>)UnderlyingActor);
+            InternalRef.Cell.UseThreadContext(() => fsm.ApplyState(new FSMBase.State<TState, TData>(stateName, stateData, timeout, stopReason)));
+        }
+
+        /// <summary>
+        /// Proxy for <see cref="FSM{TState,TData}.SetTimer"/>
+        /// </summary>
+        public void SetTimer(string name, object msg, TimeSpan timeout, bool repeat = false)
+        {
+            InternalRef.Cell.UseThreadContext(() => UnderlyingActor.SetTimer(name, msg, timeout, repeat));
+        }
+
+        /// <summary>
+        /// Proxy for <see cref="FSM{TState,TData}.CancelTimer"/>
+        /// </summary>
+        public void CancelTimer(string name)
+        {
+            UnderlyingActor.CancelTimer(name);
+        }
+
+        /// <summary>
+        /// Proxy for <see cref="FSM{TState,TData}.IsTimerActive"/>
+        /// </summary>
+        public bool IsTimerActive(string name)
+        {
+            return UnderlyingActor.IsTimerActive(name);
+        }
+
+
+        /// <summary>
+        /// Determines whether the FSM has a active state timer active.
+        /// </summary>
+        /// <returns><c>true</c> if the FSM has a active state timer active; <c>false</c> otherwise</returns>
+        public bool IsStateTimerActive()
+        {
+            var fsm = ((InternalSupportsTestFSMRef<TState, TData>)UnderlyingActor);
+            return fsm.IsStateTimerActive;
+        }
+    }
+
+}

--- a/src/core/Akka.TestKit/TestKitBase_ActorOf.cs
+++ b/src/core/Akka.TestKit/TestKitBase_ActorOf.cs
@@ -130,5 +130,111 @@ namespace Akka.TestKit
             return new TestActorRef<TActor>(Sys, Props.Create<TActor>(), NoSupervisor, name);
         }
 
+
+
+
+
+
+        /// <summary>
+        /// Create a new <see cref="FSM{TState,TData}"/> as child of the specified supervisor
+        /// and returns it as <see cref="TestFSMRef{TActor,TState,TData}"/> to enable inspecting and modifying the FSM directly.
+        /// </summary>
+        /// <typeparam name="TFsmActor">The type of the actor. It must be a <see cref="FSM{TState,TData}"/></typeparam>
+        /// <typeparam name="TState">The type of state name</typeparam>
+        /// <typeparam name="TData">The type of state data</typeparam>
+        /// <param name="props">The <see cref="Props"/> object</param>
+        /// <param name="supervisor">The supervisor</param>
+        /// <param name="name">Optional: The name.</param>
+        /// <param name="withLogging">Optional: If set to <c>true</c> logs state changes of the FSM as Debug messages. Default is <c>false</c>.</param>
+        public TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(Props props, ActorRef supervisor, string name = null, bool withLogging = false)
+            where TFsmActor : FSM<TState, TData>
+        {
+            return new TestFSMRef<TFsmActor, TState, TData>(Sys, props, supervisor, name, withLogging);
+        }
+
+        /// <summary>
+        /// Create a new <see cref="FSM{TState,TData}"/> as child of <see cref="Sys"/>
+        /// and returns it as <see cref="TestFSMRef{TActor,TState,TData}"/> to enable inspecting and modifying the FSM directly.
+        /// </summary>
+        /// <typeparam name="TFsmActor">The type of the actor. It must be a <see cref="FSM{TState,TData}"/> and have a public parameterless constructor</typeparam>
+        /// <typeparam name="TState">The type of state name</typeparam>
+        /// <typeparam name="TData">The type of state data</typeparam>
+        /// <param name="props">The <see cref="Props"/> object</param>
+        /// <param name="name">Optional: The name.</param>
+        /// <param name="withLogging">Optional: If set to <c>true</c> logs state changes of the FSM as Debug messages. Default is <c>false</c>.</param>
+        public TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(Props props, string name = null, bool withLogging = false)
+            where TFsmActor : FSM<TState, TData>
+        {
+            return new TestFSMRef<TFsmActor, TState, TData>(Sys, props,NoSupervisor, name, withLogging);
+        }
+
+
+        /// <summary>
+        /// Create a new <see cref="FSM{TState,TData}"/> as child of the specified supervisor
+        /// and returns it as <see cref="TestFSMRef{TActor,TState,TData}"/> to enable inspecting and modifying the FSM directly.
+        /// <typeparamref name="TFsmActor"/> must have a public parameterless constructor.
+        /// </summary>
+        /// <typeparam name="TFsmActor">The type of the actor. It must have a parameterless public constructor</typeparam>
+        /// <typeparam name="TState">The type of state name</typeparam>
+        /// <typeparam name="TData">The type of state data</typeparam>
+        /// <param name="supervisor">The supervisor</param>
+        /// <param name="name">Optional: The name.</param>
+        /// <param name="withLogging">Optional: If set to <c>true</c> logs state changes of the FSM as Debug messages. Default is <c>false</c>.</param>
+        public TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(ActorRef supervisor, string name = null, bool withLogging = false)
+            where TFsmActor : FSM<TState, TData>, new()
+        {
+            return new TestFSMRef<TFsmActor, TState, TData>(Sys,Props.Create<TFsmActor>(), supervisor, name, withLogging);
+        }
+
+        /// <summary>
+        /// Create a new <see cref="FSM{TState,TData}"/> as child of <see cref="Sys"/>
+        /// and returns it as <see cref="TestFSMRef{TActor,TState,TData}"/> to enable inspecting and modifying the FSM directly.
+        /// <typeparamref name="TFsmActor"/> must have a public parameterless constructor.
+        /// </summary>
+        /// <typeparam name="TFsmActor">The type of the actor. It must have a parameterless public constructor</typeparam>
+        /// <typeparam name="TState">The type of state name</typeparam>
+        /// <typeparam name="TData">The type of state data</typeparam>
+        /// <param name="name">Optional: The name.</param>
+        /// <param name="withLogging">Optional: If set to <c>true</c> logs state changes of the FSM as Debug messages. Default is <c>false</c>.</param>
+        public TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(string name = null, bool withLogging = false)
+            where TFsmActor : FSM<TState, TData>, new()
+        {
+            return new TestFSMRef<TFsmActor, TState, TData>(Sys, Props.Create<TFsmActor>(), NoSupervisor, name, withLogging);
+        }
+
+        /// <summary>
+        /// Create a new <see cref="FSM{TState,TData}"/> as child of the specified supervisor
+        /// and returns it as <see cref="TestFSMRef{TActor,TState,TData}"/> to enable inspecting and modifying the FSM directly.
+        /// Uses an expression that calls the constructor of <typeparamref name="TFsmActor"/>.
+        /// </summary>
+        /// <typeparam name="TFsmActor">The type of the actor.</typeparam>
+        /// <typeparam name="TState">The type of state name</typeparam>
+        /// <typeparam name="TData">The type of state data</typeparam>
+        /// <param name="factory">An expression that calls the constructor of <typeparamref name="TFsmActor"/></param>
+        /// <param name="supervisor">The supervisor</param>
+        /// <param name="name">Optional: The name.</param>
+        /// <param name="withLogging">Optional: If set to <c>true</c> logs state changes of the FSM as Debug messages. Default is <c>false</c>.</param>
+        public TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(Expression<Func<TFsmActor>> factory, ActorRef supervisor, string name = null, bool withLogging = false)
+            where TFsmActor : FSM<TState, TData>
+        {
+            return new TestFSMRef<TFsmActor, TState, TData>(Sys, Props.Create(factory), supervisor, name, withLogging);
+        }
+
+        /// <summary>
+        /// Create a new <see cref="FSM{TState,TData}"/> as child of <see cref="Sys"/>
+        /// and returns it as <see cref="TestFSMRef{TActor,TState,TData}"/> to enable inspecting and modifying the FSM directly.
+        /// Uses an expression that calls the constructor of <typeparamref name="TFsmActor"/>.
+        /// </summary>
+        /// <typeparam name="TFsmActor">The type of the actor.</typeparam>
+        /// <typeparam name="TState">The type of state name</typeparam>
+        /// <typeparam name="TData">The type of state data</typeparam>
+        /// <param name="factory">An expression that calls the constructor of <typeparamref name="TFsmActor"/></param>
+        /// <param name="name">Optional: The name.</param>
+        /// <param name="withLogging">Optional: If set to <c>true</c> logs state changes of the FSM as Debug messages. Default is <c>false</c>.</param>
+        public TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(Expression<Func<TFsmActor>> factory, string name = null, bool withLogging = false)
+            where TFsmActor : FSM<TState, TData>
+        {
+            return new TestFSMRef<TFsmActor, TState, TData>(Sys, Props.Create(factory), NoSupervisor, name, withLogging);
+        }
     }
 }

--- a/src/core/Akka.Testkit.Tests/TestFSMRefTests/TestFSMRefSpec.cs
+++ b/src/core/Akka.Testkit.Tests/TestFSMRefTests/TestFSMRefSpec.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using Akka.Actor;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Testkit.Tests.TestFSMRefTests
+{
+    public class TestFSMRefSpec : AkkaSpec
+    {
+        [Fact]
+        public void A_TestFSMRef_must_allow_access_to_internal_state()
+        {
+            var fsm = ActorOfAsTestFSMRef<StateTestFsm, int, string>("test-fsm-ref-1");
+
+            fsm.StateName.ShouldBe(1);
+            fsm.StateData.ShouldBe("");
+
+            fsm.Tell("go");
+            fsm.StateName.ShouldBe(2);
+            fsm.StateData.ShouldBe("go");
+
+            fsm.SetState(1);
+            fsm.StateName.ShouldBe(1);
+            fsm.StateData.ShouldBe("go");
+
+            fsm.SetStateData("buh");
+            fsm.StateName.ShouldBe(1);
+            fsm.StateData.ShouldBe("buh");
+
+            fsm.SetStateTimeout(TimeSpan.FromMilliseconds(100));
+            Within(TimeSpan.FromMilliseconds(80), TimeSpan.FromMilliseconds(500), () =>
+                AwaitCondition(() => fsm.StateName == 2 && fsm.StateData == "timeout")
+                );
+        }
+
+        [Fact]
+        public void A_TestFSMRef_must_allow_access_to_timers()
+        {
+            var fsm = ActorOfAsTestFSMRef<TimerTestFsm, int, object>("test-fsm-ref-2");
+            fsm.IsTimerActive("test").ShouldBe(false);
+            fsm.SetTimer("test", 12, TimeSpan.FromMilliseconds(10), true);
+            fsm.IsTimerActive("test").ShouldBe(true);
+            fsm.CancelTimer("test");
+            fsm.IsTimerActive("test").ShouldBe(false);
+        }
+
+        private class StateTestFsm : FSM<int, string>
+        {
+            public StateTestFsm()
+            {
+                StartWith(1, "");
+                When(1, e =>
+                {
+                    var fsmEvent = e.FsmEvent;
+                    if(Equals(fsmEvent, "go"))
+                        return GoTo(2, "go");
+                    if(fsmEvent is StateTimeout)
+                        return GoTo(2, "timeout");
+                    return null;
+                });
+                When(2, e =>
+                {
+                    var fsmEvent = e.FsmEvent;
+                    if(Equals(fsmEvent, "back"))
+                        return GoTo(1, "back");
+                    return null;
+                });
+            }
+        }
+        private class TimerTestFsm : FSM<int, object>
+        {
+            public TimerTestFsm()
+            {
+                StartWith(1, null);
+                When(1, e => Stay());
+            }
+        }
+    }
+}

--- a/src/core/Akka/Actor/FSM.cs
+++ b/src/core/Akka/Actor/FSM.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using Akka.Actor.Internal;
 using Akka.Dispatch.SysMsg;
 using Akka.Event;
 using Akka.Routing;
-using Akka.Util;
 using Akka.Util.Internal;
 
 namespace Akka.Actor
@@ -370,7 +370,7 @@ namespace Akka.Actor
     /// </summary>
     /// <typeparam name="TState">The state name type</typeparam>
     /// <typeparam name="TData">The state data type</typeparam>
-    public abstract class FSM<TState, TData> : FSMBase, IActorLogging, IListeners
+    public abstract class FSM<TState, TData> : FSMBase, IActorLogging, IListeners, InternalSupportsTestFSMRef<TState,TData>
     {
         private readonly LoggingAdapter _logAdapter = Logging.GetLogger(Context);
         protected FSM()
@@ -378,6 +378,7 @@ namespace Akka.Actor
             if(this is LoggingFSM)
                 DebugEvent = Context.System.Settings.FsmDebugEvent;
         }
+        
         public delegate State<TState, TData> StateFunction(Event<TData> fsmEvent);
 
         public delegate void TransitionHandler(TState initialState, TState nextState);
@@ -424,6 +425,18 @@ namespace Akka.Actor
         public State<TState, TData> GoTo(TState nextStateName)
         {
             return new State<TState, TData>(nextStateName, _currentState.StateData);
+        }
+
+        /// <summary>
+        /// Produce transition to other state. Return this from a state function
+        /// in order to effect the transition.
+        /// </summary>
+        /// <param name="nextStateName">State designator for the next state</param>
+        /// <param name="stateData">Data for next state</param>
+        /// <returns>State transition descriptor</returns>
+        public State<TState, TData> GoTo(TState nextStateName, TData stateData)
+        {
+            return new State<TState, TData>(nextStateName, stateData);
         }
 
         /// <summary>
@@ -537,10 +550,8 @@ namespace Akka.Actor
                 _stateTimeouts[state] = timeout;
         }
 
-        /// <summary>
-        /// INTERNAL API. Used for testing.
-        /// </summary>
-        internal bool IsStateTimerActive
+        //Internal API
+        bool InternalSupportsTestFSMRef<TState, TData>.IsStateTimerActive
         {
             get
             {
@@ -567,7 +578,7 @@ namespace Akka.Actor
         }
 
         /// <summary>
-        /// Set handler which i called upon reception of unhandled FSM messages. Calling
+        /// Set handler which is called upon reception of unhandled FSM messages. Calling
         /// this method again will overwrite the previous contents.
         /// </summary>
         /// <param name="stateFunction"></param>
@@ -783,6 +794,7 @@ namespace Akka.Actor
                     Context.Unwatch(d.Listener);
                     Listeners.Remove(d.Listener);
                 })
+                .With<InternalActivateFsmLogging>(_=> { DebugEvent = true; })
                 .Default(msg =>
                 {
                     if (_timeoutFuture != null)
@@ -839,6 +851,12 @@ namespace Akka.Actor
             var actorRef = source as ActorRef;
             if(actorRef != null) return actorRef.ToString();
             return "unknown";
+        }
+
+        //Internal API
+        void InternalSupportsTestFSMRef<TState, TData>.ApplyState(State<TState, TData> upcomingState)
+        {
+            ApplyState(upcomingState);
         }
 
         private void ApplyState(State<TState, TData> upcomingState)

--- a/src/core/Akka/Actor/Internals/InternalSupportsTestFSMRef.cs
+++ b/src/core/Akka/Actor/Internals/InternalSupportsTestFSMRef.cs
@@ -1,0 +1,39 @@
+namespace Akka.Actor.Internal
+{
+    /// <summary>
+    /// INTERNAL API. Used for testing.
+    /// This is used to let TestFSMRef in TestKit access to internal methods.
+    /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public interface InternalSupportsTestFSMRef<TState, TData>
+    {
+        /// <summary>
+        /// INTERNAL API. Used for testing.
+        /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
+        /// </summary>
+        void ApplyState(FSMBase.State<TState, TData> upcomingState);
+
+        /// <summary>
+        /// INTERNAL API. Used for testing.
+        /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
+        /// </summary>
+        bool IsStateTimerActive { get; }
+    }
+
+    /// <summary>
+    /// INTERNAL API. Used for testing.
+    /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
+    /// </summary>
+    public class InternalActivateFsmLogging
+    {
+        private static readonly InternalActivateFsmLogging _instance=new InternalActivateFsmLogging();
+
+        private InternalActivateFsmLogging(){}
+        /// <summary>
+        /// INTERNAL API. Used for testing.
+        /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
+        /// </summary>
+        public static InternalActivateFsmLogging Instance { get { return _instance; } }
+    }
+}

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Actor\Dsl\Act.cs" />
     <Compile Include="Actor\Inbox.Actor.cs" />
     <Compile Include="Actor\Internals\InternalCurrentActorCellKeeper.cs" />
+    <Compile Include="Actor\Internals\InternalSupportsTestFSMRef.cs" />
     <Compile Include="Actor\Internals\InitializableActor.cs" />
     <Compile Include="Actor\ReceiveActor.cs" />
     <Compile Include="Actor\ActorBase.cs" />


### PR DESCRIPTION
Fixes #312

`TestFSMRef` is used to unit test `FSM`s.
Instead of creating it with `ActorOf` use `ActorOfAsTestFSMRef`
This will give access to some of the internals of the FSM.

This builds upon PR #406. But I wanted to submit this as reviewing seems to be very slow right now, so instead of waiting for #406 to be accepted this can be reviewed now.

Only the last two commits are relevant (the rest are reviewed in #406)
https://github.com/HCanber/akka.net/commit/4fa2686ef34bc3d511150f88756f8836abf5a8d2 **FSM: Add nongeneric getters in Event**
https://github.com/HCanber/akka.net/commit/1ac43ba25515ff3b088b73e6b3347dee9fad4ff4 __  Implement TestFSMRef__

Nothing controversial in this PR.

FSM has some members that TestFSMRef needed access to. This was done by
having FSM implement InternalSupportsTestFSMRef (that contains those members)
explicitly.

**DO NOT merge this before #406**
