### PR TITLE
Installs Akka.TestKit.TestEventListener as default logger for TestKit

### DIFF
--- a/src/core/Akka.TestKit.Tests/Akka.TestKit.Tests.csproj
+++ b/src/core/Akka.TestKit.Tests/Akka.TestKit.Tests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="TestActorRefTests\WrappedTerminated.cs" />
     <Compile Include="TestEventListenerTests\AllTestForEventFilterBase.cs" />
     <Compile Include="TestEventListenerTests\AllTestForEventFilterBase_Instances.cs" />
+    <Compile Include="TestEventListenerTests\ConfigTests.cs" />
     <Compile Include="TestEventListenerTests\CustomEventFilterTests.cs" />
     <Compile Include="TestEventListenerTests\DeadLettersEventFilterTests.cs" />
     <Compile Include="TestEventListenerTests\EventFilterTestBase.cs" />

--- a/src/core/Akka.TestKit.Tests/TestEventListenerTests/ConfigTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestEventListenerTests/ConfigTests.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Linq;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Testkit.Tests.TestEventListenerTests
+{
+    public class ConfigTests : TestKit.Xunit.TestKit
+    {
+        [Fact]
+        public void TestEventListener_is_in_config_by_default()
+        {
+            var configLoggers = Sys.Settings.Config.GetStringList("akka.loggers");
+            configLoggers.Any(logger => logger.Contains("Akka.TestKit.TestEventListener")).ShouldBeTrue();
+            configLoggers.Any(logger => logger.Contains("Akka.Event.DefaultLogger")).ShouldBeFalse();
+        }
+    }
+}

--- a/src/core/Akka.TestKit/EventFilter/TestEventListener.cs
+++ b/src/core/Akka.TestKit/EventFilter/TestEventListener.cs
@@ -11,7 +11,7 @@ namespace Akka.TestKit
     /// EventListener for running tests, which allows selectively filtering out
     /// expected messages. To use it, include something like this in
     /// the configuration:
-    /// <pre><code>akka.loggers = ["akka.testkit.TestEventListener"]</code></pre>
+    /// <pre><code>akka.loggers = ["akka.testkit.TestEventListener, Akka.TestKit"]</code></pre>
     /// </summary>
     public class TestEventListener : DefaultLogger
     {

--- a/src/core/Akka.TestKit/Internals/Reference.conf
+++ b/src/core/Akka.TestKit/Internals/Reference.conf
@@ -5,6 +5,12 @@
 # This is the reference config file that contains all the default settings.
 
 akka {
+	# Replace the default value, ["Akka.Event.DefaultLogger"], with TestEventListener
+	# This logger behaves exactly like DefaultLogger, but makes it possible
+	# to use EventFiltering. If no filter is specified it logs to StdOut just like
+	# DefaultLogger.
+  loggers = ["Akka.TestKit.TestEventListener, Akka.TestKit"]
+
   test {
     # factor by which to scale timeouts during tests, e.g. to account for shared
     # build system load

--- a/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
@@ -18,7 +18,6 @@ namespace Akka.TestKit
         private static Regex _nameReplaceRegex = new Regex("[^a-zA-Z0-9]", RegexOptions.Compiled);
         private static readonly Config _akkaSpecConfig = ConfigurationFactory.ParseString(@"
           akka {
-            #loggers = [""akka.testkit.TestEventListener""]
             loglevel = WARNING
             stdout-loglevel = WARNING
             serialize-messages = on


### PR DESCRIPTION
The default `Akka.Event.DefaultLogger` is replaced by `Akka.TestKit.TestEventListener` as the default logger for the system created by TestKit.

This logger behaves exactly like `DefaultLogger`, but makes it possible to use EventFiltering. If no filter is specified it logs to StdOut just like `DefaultLogger`.

Discussed in issue #323
