### PR TITLE
Inbox.ReceiveWhere() throws a NullReferenceException #427

### DIFF
--- a/src/core/Akka/Actor/Inbox.cs
+++ b/src/core/Akka/Actor/Inbox.cs
@@ -47,7 +47,7 @@ namespace Akka.Actor
         public ActorRef Client { get; private set; }
         public IQuery WithClient(ActorRef client)
         {
-            return new Select();
+            return new Select(Deadline, Predicate, client);
         }
     }
 


### PR DESCRIPTION
Other modules should not be affected by this change.
