### PR TITLE
Fixes two problems with how mailboxes are created

### DIFF
--- a/src/core/Akka.Tests/Actor/StashMailboxSpec.cs
+++ b/src/core/Akka.Tests/Actor/StashMailboxSpec.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using Akka.Actor;
+using Akka.Dispatch;
+using Akka.TestKit;
+using Akka.TestKit.TestActors;
+using Xunit;
+
+namespace Akka.Tests.Actor
+{
+    public class StashMailboxSpec : AkkaSpec
+    {
+        [Fact]
+        public void When_creating_normal_actor_Then_a_normal_mailbox_is_created()
+        {
+            var actorRef = ActorOf<BlackHoleActor>();
+            var intRef = (LocalActorRef)actorRef;
+            intRef.Cell.Mailbox.GetType().ShouldBe(typeof(UnboundedMailbox));
+        }
+
+        [Fact]
+        public void When_creating_actor_marked_with_WithUnboundedStash_a_mailbox_which_supports_unbounded_stash_is_created()
+        {
+            var actorRef = ActorOf<UnboundedStashActor>();
+            var intRef = (LocalActorRef)actorRef;
+            intRef.Cell.Mailbox.GetType().ShouldBe(typeof(UnboundedDequeBasedMailbox));
+        }
+
+        [Fact(Skip = "We do not have a BoundedDequeBasedMailbox yet")] //TODO: Remove Skip when we have a BoundedDequeBasedMailbox
+        public void When_creating_actor_marked_with_WithBoundedStash_a_mailbox_which_supports_unbounded_stash_is_created()
+        {
+            var actorRef = ActorOf<BoundedStashActor>();
+            var intRef = (LocalActorRef)actorRef;
+            //intRef.Cell.Mailbox.GetType().ShouldBe(typeof(BoundedDequeBasedMailbox));
+            throw new Exception("Incomplete. Remove the comment on the line above this, and remove this line, when we have BoundedDequeBasedMailbox");
+        }
+
+        private class UnboundedStashActor : BlackHoleActor, WithUnboundedStash
+        {
+            public IStash CurrentStash { get; set; }
+        }
+        private class BoundedStashActor : BlackHoleActor, WithBoundedStash
+        {
+            public IStash CurrentStash { get; set; }
+        }
+    }
+}

--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Actor\PatternSpec.cs" />
     <Compile Include="Actor\ReceiveTimeoutSpec.cs" />
     <Compile Include="Actor\RootGuardianActorRef_Tests.cs" />
+    <Compile Include="Actor\StashMailboxSpec.cs" />
     <Compile Include="Configuration\ConfigurationSpec.cs" />
     <Compile Include="Actor\ReceiveActorTests_Become.cs" />
     <Compile Include="Actor\ReceiveActorTests_LifeCycle.cs" />

--- a/src/core/Akka/Actor/Props.cs
+++ b/src/core/Akka/Actor/Props.cs
@@ -116,8 +116,7 @@ namespace Akka.Actor
         {
             get
             {
-                var mailbox = Deploy.Mailbox;
-                return mailbox == Deploy.NoMailboxGiven ? Mailboxes.DefaultMailboxId: mailbox;
+                return Deploy.Mailbox;
             }
         }
 

--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -283,7 +283,7 @@ akka {
       # FQCN of the MailboxType. The Class of the FQCN must have a public
       # constructor with
       # (akka.actor.ActorSystem.Settings, com.typesafe.config.Config) parameters.
-      mailbox-type = "Akka.Dispatch.ConcurrentQueueMailbox"
+      mailbox-type = "Akka.Dispatch.UnboundedMailbox"
  
       # If the mailbox is bounded then it uses this setting to determine its
       # capacity. The provided value must be positive.

--- a/src/core/Akka/Dispatch/Mailboxes.cs
+++ b/src/core/Akka/Dispatch/Mailboxes.cs
@@ -86,7 +86,7 @@ namespace Akka.Dispatch
             }
 
 
-            return FromConfig("");
+            return FromConfig(DefaultMailboxId);
         }
 
         /// <summary>


### PR DESCRIPTION
- If no mailbox has been specified, and stashing IS requested by the actor then a mailbox that supports bounded/unbounded stashing should be created.
- If no mailbox has been specified, and stashing is NOT requested by the actor, then the default mailbox as specified in the config should be used. The default mailbox in default config should be UnboundedMailbox.

This is what has changed
- In Mailboxes.GetMailboxType fallback to the default mailbox as defined in config, instead of "" (which defaults to UnboundedMailbox).
- Allow Props.Mailbox to return an empty string
- Default mailbox in pigeon.conf should be UnboundedMailbox and not ConcurrentQueueMailbox. Since UnboundedMailbox inherits ConcurrentQueueMailbox this will not have any effect on existing code.

Discussed in #429
