### PR TITLE
Fsharp api parse fix

### DIFF
--- a/src/core/Akka.FSharp/FsApi.fs
+++ b/src/core/Akka.FSharp/FsApi.fs
@@ -39,16 +39,6 @@ type ActorPath with
         let mutable address : Address = null
         if ActorPath.TryParseAddress(path, &address) then (true, address)
         else (false, address)
-    
-    static member Parse(path : string) = 
-        let mutable actorPath : ActorPath = null
-        if ActorPath.TryParse(path, &actorPath) then Some actorPath
-        else None
-    
-    static member ParseAddress(path : string) = 
-        let mutable address : Address = null
-        if ActorPath.TryParseAddress(path, &address) then Some address
-        else None
 
 /// <summary>
 /// Gives access to the next message throu let! binding in


### PR DESCRIPTION
Fixed TryParse method signatures. Accordingly to F# convention TryParse returns tuple of boolean and parsed value.
