### PR TITLE
Fixed issue #447

### DIFF
--- a/src/contrib/loggers/Akka.NLog/NLogLogger.cs
+++ b/src/contrib/loggers/Akka.NLog/NLogLogger.cs
@@ -2,6 +2,7 @@
 using Akka.Event;
 using NLog;
 using System;
+using NLogger = global::NLog.Logger;
 
 namespace Akka.Logger.NLog
 {
@@ -9,18 +10,18 @@ namespace Akka.Logger.NLog
     {
         private readonly LoggingAdapter _log = Logging.GetLogger(Context);
 
-        private static void WithNLog(Action<global::NLog.Logger> logStatement)
+        private static void Log(LogEvent logEvent, Action<NLogger> logStatement)
         {
-            var logger = LogManager.GetCurrentClassLogger();
+            var logger = LogManager.GetLogger(logEvent.LogClass.FullName);
             logStatement(logger);
         }
 
         public NLogLogger()
         {
-            Receive<Error>(m => WithNLog(logger => logger.Error("{0}", m.Message)));
-            Receive<Warning>(m => WithNLog(logger => logger.Warn("{0}", m.Message)));
-            Receive<Info>(m => WithNLog(logger => logger.Info("{0}", m.Message)));
-            Receive<Debug>(m => WithNLog(logger => logger.Debug("{0}", m.Message)));
+            Receive<Error>(m => Log(m, logger => logger.Error("{0}", m.Message)));
+            Receive<Warning>(m => Log(m, logger => logger.Warn("{0}", m.Message)));
+            Receive<Info>(m => Log(m, logger => logger.Info("{0}", m.Message)));
+            Receive<Debug>(m => Log(m, logger => logger.Debug("{0}", m.Message)));
             Receive<InitializeLogger>(m =>
             {
                 _log.Info("NLogLogger started");


### PR DESCRIPTION
NLog's loggers are now created using logEvent's LogClass. This enables the programmer to fully utilize NLog's configuration in order to separate class-specific logs into separate logging targets.
