### PR TITLE
Fixes #459. ImplicitSender should not change when creating TestProbes

### DIFF
--- a/src/core/Akka.TestKit.Tests/NoImplicitSenderSpec.cs
+++ b/src/core/Akka.TestKit.Tests/NoImplicitSenderSpec.cs
@@ -15,6 +15,7 @@ namespace Akka.Testkit.Tests
             echoActor.Tell("message");
             ExpectMsg<ActorRef>(actorRef => actorRef == DeadLetterActorRef.NoSender);
         }
+
     }
 
     public class ImplicitSenderSpec : AkkaSpec
@@ -33,6 +34,24 @@ namespace Akka.Testkit.Tests
         }
 
 
+        [Fact]
+        public void ImplicitSender_should_not_change_when_creating_Testprobes()
+        {
+            //Verifies that bug #459 has been fixed
+            var testProbe = CreateTestProbe();
+            TestActor.Tell("message");
+            ReceiveOne();
+            LastSender.ShouldBe(TestActor);
+        }
+
+        [Fact]
+        public void ImplicitSender_should_not_change_when_creating_TestActors()
+        {
+            var testActor2 = CreateTestActor("test2");
+            TestActor.Tell("message");
+            ReceiveOne();
+            LastSender.ShouldBe(TestActor);
+        }
     }
 
 }

--- a/src/core/Akka.TestKit/TestProbe.cs
+++ b/src/core/Akka.TestKit/TestProbe.cs
@@ -8,15 +8,11 @@ namespace Akka.TestKit
 {
     /// <summary>
     /// TestKit-based probe which allows sending, reception and reply.
+    /// User <see cref="TestKitBase.CreateTestProbe">CreateTestProbe()</see> inside your test 
+    /// to create new instances.
     /// </summary>
-    public class TestProbe : TestKitBase
-    {
-        [Obsolete("Use TestKit.CreateTestProbe() instead!", true)]
-        public TestProbe():base(assertions: null, system: null)
-        {
-            throw new NotSupportedException("TestProbes must be created via Testkit.CreateTestProbe()");    
-        }
-
+    public class TestProbe : TestKitBase, NoImplicitSender
+    {      
         public TestProbe(ActorSystem system, TestKitAssertions assertions)
             : base(assertions, system)
         {


### PR DESCRIPTION
Fixes bug #459
- Added `NoImplicitSender` to `TestProbe` class to make it not set its ´TestActor´ as implicit sender
- Removed deprecated constructor from `TestProbe` to prepare for v0.7
- Added test that verifies that the bug has been fixed, and a test that creating new `TestActor`s do not change implicit sender.
