### PR TITLE
Log to stdout in colors

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,7 @@
 #### 0.6.5
+* Logging to Standard Out is now done in color. To disable it set `StandardOutLogger.UseColors = false;`.
+Colors can be customized: `StandardOutLogger.DebugColor = ConsoleColor.Green;`.
+If you need to print to stdout use `Akka.Util.StandardOutWriter.Write()` instead of `Console.WriteLine`, otherwise your messages might get printed in the wrong color.
 
 #### 0.6.4 Sep 9 2014
 * Introduced `TailChoppingRouter`

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -197,6 +197,7 @@
     <Compile Include="Event\LogLevel.cs" />
     <Compile Include="Event\LogMessage.cs" />
     <Compile Include="Event\StandardOutLogger.cs" />
+    <Compile Include="Util\StandardOutWriter.cs" />
     <Compile Include="Event\Subscription.cs" />
     <Compile Include="Event\TraceLogger.cs" />
     <Compile Include="Event\UnhandledMessage.cs" />

--- a/src/core/Akka/Event/DefaultLogger.cs
+++ b/src/core/Akka/Event/DefaultLogger.cs
@@ -33,9 +33,9 @@ namespace Akka.Event
             return false;            
         }
 
-        protected virtual void Print(LogEvent m)
+        protected virtual void Print(LogEvent logEvent)
         {
-            Console.WriteLine(m);
+            StandardOutLogger.PrintLogEvent(logEvent);
         }
     }
 }

--- a/src/core/Akka/Event/StandardOutLogger.cs
+++ b/src/core/Akka/Event/StandardOutLogger.cs
@@ -1,9 +1,11 @@
-﻿using Akka.Actor;
+﻿using System.Reflection;
+using Akka.Actor;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Akka.Util;
 
 namespace Akka.Event
 {
@@ -12,14 +14,18 @@ namespace Akka.Event
     /// </summary>
     public class StandardOutLogger : MinimalActorRef
     {
-        private ActorPath _path = new RootActorPath(Address.AllSystems, "/StandardOutLogger");
+        private readonly ActorPath _path = new RootActorPath(Address.AllSystems, "/StandardOutLogger");
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="StandardOutLogger" /> class.
-        /// </summary>
-        public StandardOutLogger()
+        static StandardOutLogger()
         {
+            DebugColor = ConsoleColor.Gray;
+            InfoColor = ConsoleColor.White;
+            WarningColor = ConsoleColor.Yellow;
+            ErrorColor = ConsoleColor.Red;
+            UseColors = true;
         }
+
+
 
         /// <summary>
         ///     Gets the provider.
@@ -44,9 +50,47 @@ namespace Akka.Event
         /// <exception cref="System.ArgumentNullException">message</exception>
         protected override void TellInternal(object message, ActorRef sender)
         {
-            if (message == null)
+            if(message == null)
                 throw new ArgumentNullException("message");
-            Console.WriteLine(message);
+            var logEvent = message as LogEvent;
+            if(logEvent != null)
+                PrintLogEvent(logEvent);
+            else
+                Console.WriteLine(message);
+        }
+
+
+
+
+        public static ConsoleColor DebugColor { get; set; }
+        public static ConsoleColor InfoColor { get; set; }
+        public static ConsoleColor WarningColor { get; set; }
+        public static ConsoleColor ErrorColor { get; set; }
+        public static bool UseColors { get; set; }
+
+        public static void PrintLogEvent(LogEvent logEvent)
+        {
+            ConsoleColor? color = null;
+            if(UseColors)
+            {
+                var logLevel = logEvent.LogLevel();
+                switch(logLevel)
+                {
+                    case LogLevel.DebugLevel:
+                        color = DebugColor;
+                        break;
+                    case LogLevel.InfoLevel:
+                        color = InfoColor;
+                        break;
+                    case LogLevel.WarningLevel:
+                        color = WarningColor;
+                        break;
+                    case LogLevel.ErrorLevel:
+                        color = ErrorColor;
+                        break;
+                }
+            }
+            StandardOutWriter.WriteLine(logEvent.ToString(), color);
         }
     }
 }

--- a/src/core/Akka/Util/StandardOutWriter.cs
+++ b/src/core/Akka/Util/StandardOutWriter.cs
@@ -1,0 +1,66 @@
+using System;
+
+namespace Akka.Util
+{
+
+    /// <summary>
+    /// This class contains methods for thread safe writing to the standard output stream.
+    ///  </summary>
+    public static class StandardOutWriter
+    {
+        private static readonly object _lock = new object();
+
+        /// <summary>
+        /// Writes the specified <see cref="string"/> value to the standard output stream. Optionally 
+        /// you may specify which colors should be used.
+        /// </summary>
+        /// <param name="message">The <see cref="string"/> value to write</param>
+        /// <param name="foregroundColor">Optional: The foreground color</param>
+        /// <param name="backgroundColor">Optional: The background color</param>
+        public static void Write(string message, ConsoleColor? foregroundColor = null, ConsoleColor? backgroundColor = null)
+        {
+            WriteToConsole(() => Console.Write(message), foregroundColor, backgroundColor);
+        }
+
+        /// <summary>
+        /// Writes the specified <see cref="string"/> value, followed by the current line terminator,
+        /// to the standard output stream. Optionally you may specify which colors should be used.
+        /// </summary>
+        /// <param name="message">The <see cref="string"/> value to write</param>
+        /// <param name="foregroundColor">Optional: The foreground color</param>
+        /// <param name="backgroundColor">Optional: The background color</param>
+
+        public static void WriteLine(string message, ConsoleColor? foregroundColor = null, ConsoleColor? backgroundColor = null)
+        {
+            WriteToConsole(() => Console.WriteLine(message), foregroundColor, backgroundColor);
+        }
+
+        private static void WriteToConsole(Action write, ConsoleColor? foregroundColor = null, ConsoleColor? backgroundColor = null)
+        {
+            lock(_lock)
+            {
+                ConsoleColor? fg = null;
+                if(foregroundColor.HasValue)
+                {
+                    fg = Console.ForegroundColor;
+                    Console.ForegroundColor = foregroundColor.Value;
+                }
+                ConsoleColor? bg = null;
+                if(backgroundColor.HasValue)
+                {
+                    bg = Console.BackgroundColor;
+                    Console.BackgroundColor = backgroundColor.Value;
+                }
+                write();
+                if(fg.HasValue)
+                {
+                    Console.ForegroundColor = fg.Value;
+                }
+                if(bg.HasValue)
+                {
+                    Console.BackgroundColor = bg.Value;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves #461
- Added `StandardOutWriter` that implements change-color-write-change-back-color helper functions
- `StandardOutLogger` and `DefaultLogger` logs in color, se #461 for an example.
- Updated Release_Notes (I think we should do that directly when we introduce or change things that's important to know)

`StandardOutLogger.UseColors = false;` turns it off.
Colors can be customized using: `StandardOutLogger.DebugColor = ConsoleColor.Green;`
