### PR TITLE
Add logging to TestKit. Set "akka.test.testkit.debug = true"

### DIFF
--- a/src/core/Akka.TestKit/Internal/BlockingQueue.cs
+++ b/src/core/Akka.TestKit/Internal/BlockingQueue.cs
@@ -58,6 +58,12 @@ namespace Akka.TestKit.Internal
             return false;
         }
 
+        /// <summary>
+        /// Removes an item from the collection.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token that can be used to cancel the operation..</param>
+        /// <returns>The item removed from the collection.</returns>
+        /// <exception cref="OperationCanceledException">Thrown if the operation was cancelled</exception>
         public T Take(CancellationToken cancellationToken)
         {
             var p = _collection.Take(cancellationToken);

--- a/src/core/Akka.TestKit/TestKitBase_AwaitConditions.cs
+++ b/src/core/Akka.TestKit/TestKitBase_AwaitConditions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reflection;
 using System.Threading;
+using Akka.Event;
 using Akka.TestKit.Internal;
 
 namespace Akka.TestKit
@@ -28,7 +29,8 @@ namespace Akka.TestKit
         {
             var maxDur = RemainingOrDefault;
             var interval = new TimeSpan(maxDur.Ticks / 10);
-            InternalAwaitCondition(conditionIsFulfilled, maxDur, interval, (format, args) => _assertions.Fail(format, args));
+            var logger = _testKitSettings.LogTestKitCalls ? _log : null;
+            InternalAwaitCondition(conditionIsFulfilled, maxDur, interval, (format, args) => _assertions.Fail(format, args), logger);
         }
 
         /// <summary>
@@ -53,7 +55,8 @@ namespace Akka.TestKit
         {
             var maxDur = RemainingOrDilated(max);
             var interval = new TimeSpan(maxDur.Ticks / 10);
-            InternalAwaitCondition(conditionIsFulfilled, maxDur, interval, (format, args) => _assertions.Fail(format, args));
+            var logger = _testKitSettings.LogTestKitCalls ? _log : null;
+            InternalAwaitCondition(conditionIsFulfilled, maxDur, interval, (format, args) => _assertions.Fail(format, args), logger);
         }
 
         /// <summary>
@@ -79,7 +82,8 @@ namespace Akka.TestKit
         {
             var maxDur = RemainingOrDilated(max);
             var interval = new TimeSpan(maxDur.Ticks / 10);
-            InternalAwaitCondition(conditionIsFulfilled, maxDur, interval, (format, args) => AssertionsFail(format, args, message));
+            var logger = _testKitSettings.LogTestKitCalls ? _log : null;
+            InternalAwaitCondition(conditionIsFulfilled, maxDur, interval, (format, args) => AssertionsFail(format, args, message), logger);
         }
 
         /// <summary>
@@ -112,12 +116,13 @@ namespace Akka.TestKit
         public void AwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan? max, TimeSpan? interval, string message = null)
         {
             var maxDur = RemainingOrDilated(max);
-            InternalAwaitCondition(conditionIsFulfilled, maxDur, interval, (format, args) => AssertionsFail(format, args, message));
+            var logger = _testKitSettings.LogTestKitCalls ? _log : null;
+            InternalAwaitCondition(conditionIsFulfilled, maxDur, interval, (format, args) => AssertionsFail(format, args, message), logger);
         }
 
-        private void AssertionsFail(string format, object[] args, string message=null)
+        private void AssertionsFail(string format, object[] args, string message = null)
         {
-            _assertions.Fail(format+(message ??""), args);
+            _assertions.Fail(format + (message ?? ""), args);
         }
 
 
@@ -132,10 +137,10 @@ namespace Akka.TestKit
         /// <param name="interval">Optional. The time between calls to <paramref name="conditionIsFulfilled"/> to check
         /// if the condition is fulfilled. Between calls the thread sleeps. If undefined, 100 ms is used
         /// </param>
-        public bool AwaitConditionNoThrow(Func<bool> conditionIsFulfilled, TimeSpan max, TimeSpan? interval=null)
+        public bool AwaitConditionNoThrow(Func<bool> conditionIsFulfilled, TimeSpan max, TimeSpan? interval = null)
         {
-            var intervalDur=interval.GetValueOrDefault(TimeSpan.FromMilliseconds(100));
-            return InternalAwaitCondition(conditionIsFulfilled, max, intervalDur,(f,a)=>{});
+            var intervalDur = interval.GetValueOrDefault(TimeSpan.FromMilliseconds(100));
+            return InternalAwaitCondition(conditionIsFulfilled, max, intervalDur, (f, a) => { });
         }
 
 
@@ -165,24 +170,68 @@ namespace Akka.TestKit
         /// </param>
         /// <param name="fail">Action that is called when the timeout expired. 
         /// The parameters conforms to <see cref="string.Format(string,object[])"/></param>
+        /// <param name="logger">Optional: If a <see cref="LoggingAdapter"/> is specified, debug messages will be logged using it</param>
         protected static bool InternalAwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan max, TimeSpan? interval, Action<string, object[]> fail)
         {
+            return InternalAwaitCondition(conditionIsFulfilled, max, interval, fail, null);
+        }
+
+        /// <summary>
+        /// <para>Await until the given condition evaluates to <c>true</c> or the timeout
+        /// expires, whichever comes first.</para>
+        /// <para>If no timeout is given, take it from the innermost enclosing `within`
+        /// block.</para>
+        /// <para>Note that the timeout is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
+        /// specified in config value "akka.test.timefactor".</para>
+        /// <para>The parameter <paramref name="interval"/> specifies the time between calls to <paramref name="conditionIsFulfilled"/>
+        /// Between calls the thread sleeps. If <paramref name="interval"/> is undefined the thread only sleeps 
+        /// one time, using the <paramref name="max"/> as duration, and then rechecks the condition and ultimately 
+        /// succeeds or fails.</para>
+        /// <para>To make sure that tests run as fast as possible, make sure you do not leave this value as undefined,
+        /// instead set it to a relatively small value.</para>
+        /// </summary>
+        /// <param name="conditionIsFulfilled">The condition that must be fulfilled within the duration.</param>
+        /// <param name="max">The maximum duration. The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. 
+        /// scaled by the factor specified in config value "akka.test.timefactor".</param>
+        /// <param name="interval">The time between calls to <paramref name="conditionIsFulfilled"/> to check
+        /// if the condition is fulfilled. Between calls the thread sleeps. If undefined the thread only sleeps 
+        /// one time, using the <paramref name="max"/>, and then rechecks the condition and ultimately 
+        /// succeeds or fails.
+        /// <para>To make sure that tests run as fast as possible, make sure you do not set this value as undefined,
+        /// instead set it to a relatively small value.</para>
+        /// </param>
+        /// <param name="fail">Action that is called when the timeout expired. 
+        /// The parameters conforms to <see cref="string.Format(string,object[])"/></param>
+        /// <param name="logger">If a <see cref="LoggingAdapter"/> is specified, debug messages will be logged using it. If <c>null</c> nothing will be logged</param>
+        protected static bool InternalAwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan max, TimeSpan? interval, Action<string, object[]> fail, LoggingAdapter logger)
+        {
             max.EnsureIsPositiveFinite("max");
-            var stop = Now + max;
-            while(!conditionIsFulfilled())
+            var start = Now;
+            var stop = start + max;
+            ConditionalLog(logger, "Awaiting condition for {0}.{1}", max, interval.HasValue ? " Will sleep " + interval.Value + " between checks" : "");
+
+            while (!conditionIsFulfilled())
             {
                 var now = Now;
 
-                if(now > stop)
+                if (now > stop)
                 {
-                    fail("Timeout {0} expired. ", new object[] { max });
+                    const string message = "Timeout {0} expired while waiting for condition.";
+                    ConditionalLog(logger, message, max);
+                    fail(message, new object[] { max });
                     return false;
                 }
                 var sleepDuration = (stop - now).Min(interval);
                 Thread.Sleep(sleepDuration);
             }
+            ConditionalLog(logger, "Condition fulfilled after {0}", Now-start);
             return true;
         }
 
+        private static void ConditionalLog(LoggingAdapter logger, string format, params object[] args)
+        {
+            if (logger != null)
+                logger.Debug(format, args);
+        }
     }
 }

--- a/src/core/Akka.TestKit/TestKitBase_Within.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Within.cs
@@ -76,11 +76,23 @@ namespace Akka.TestKit
                 _end = prevEnd;
             }
 
-            var diff = Now - start;
-            _assertions.AssertTrue(min <= diff, "block took {0}, should have at least been {1}. {2}", diff, min, hint ?? "");
+            var elapsed = Now - start;
+            var wasTooFast = elapsed < min;
+            if(wasTooFast)
+            {
+                const string failMessage = "Failed: Block took {0}, should have at least been {1}. {2}";
+                ConditionalLog(failMessage, elapsed, min, hint ?? "");
+                _assertions.Fail(failMessage, elapsed, min, hint ?? "");
+            }
             if(!_lastWasNoMsg)
             {
-                _assertions.AssertTrue(diff <= maxDiff, "block took {0}, exceeding {1}. {2}", diff, maxDiff, hint ?? "");
+                var tookTooLong = elapsed > maxDiff;
+                if(tookTooLong)
+                {
+                    const string failMessage = "Failed: Block took {0}, exceeding {1}. {2}";
+                    ConditionalLog(failMessage, elapsed, maxDiff, hint ?? "");
+                    _assertions.Fail(failMessage, elapsed, maxDiff, hint ?? "");
+                }
             }
 
             return ret;

--- a/src/core/Akka.TestKit/TestKitSettings.cs
+++ b/src/core/Akka.TestKit/TestKitSettings.cs
@@ -13,6 +13,7 @@ namespace Akka.TestKit
         private readonly TimeSpan _singleExpectDefault;
         private readonly TimeSpan _testEventFilterLeeway;
         private readonly double _timefactor;
+        private readonly bool _logTestKitCalls;
 
         public TestKitSettings(Config config)
         {
@@ -20,6 +21,8 @@ namespace Akka.TestKit
             _singleExpectDefault = config.GetTimeSpan("akka.test.single-expect-default", allowInfinite: false);
             _testEventFilterLeeway = config.GetTimeSpan("akka.test.filter-leeway", allowInfinite: false);
             _timefactor = config.GetDouble("akka.test.timefactor");
+            _logTestKitCalls = config.GetBoolean("akka.test.testkit.debug");
+
             if(_timefactor <= 0)
                 throw new Exception(@"Expected a positive value for ""akka.test.timefactor"" but found "+_timefactor);
         }
@@ -51,5 +54,11 @@ namespace Akka.TestKit
         /// </para>
         /// </summary>
         public double TestTimeFactor { get { return _timefactor; } }
+
+        /// <summary>
+        /// If set to <c>true</c> calls to testkit will be logged.
+        /// This is enabled by seting configuration "akka.test.testkit.debug" value to a true.
+        /// </summary>
+        public bool LogTestKitCalls { get { return _logTestKitCalls; } }
     }
 }


### PR DESCRIPTION
Adds logging to TestKit that can be switched on by setting the config value  `akka.test.testkit.debug = true` which can be useful when debugging why a test fails. 

For example failures are logged in the normal event stream, which can be used to determine what happened before the test failed and what happened after, during system shutdown.
