### PR TITLE
added nuget build support for Akka.Cluster

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -119,6 +119,7 @@ Target "CopyOutput" <| fun _ ->
       "core/Akka.FSharp"
       "core/Akka.TestKit"
       "core/Akka.Remote"
+      "core/Akka.Cluster"
       "contrib/loggers/Akka.Logger.slf4net"
       "contrib/loggers/Akka.Logger.NLog" 
       "contrib/loggers/Akka.Logger.Serilog" 
@@ -181,6 +182,12 @@ module Nuget =
         | testkit when testkit.StartsWith("Akka.TestKit.") -> ["Akka.TestKit", release.NugetVersion]
         | _ -> ["Akka", release.NugetVersion]
 
+    // used to add -pre suffix to pre-release packages
+    let getProjectVersion project =
+      match project with
+      | "Akka.Cluster" -> release.NugetVersion + "-pre"
+      | _ -> release.NugetVersion
+
 open Nuget
 
 //--------------------------------------------------------------------------------
@@ -213,6 +220,7 @@ let createNugetPackages _ =
         let packages = projectDir @@ "packages.config"        
         let packageDependencies = if (fileExists packages) then (getDependencies packages) else []
         let dependencies = packageDependencies @ getAkkaDependency project
+        let releaseVersion = getProjectVersion project
 
         let pack outputDir symbolPackage =
             NuGetHelper.NuGet
@@ -224,7 +232,7 @@ let createNugetPackages _ =
                         Project =  project
                         Properties = ["Configuration", "Release"]
                         ReleaseNotes = release.Notes |> String.concat "\n"
-                        Version = release.NugetVersion
+                        Version = releaseVersion
                         Tags = tags |> String.concat " "
                         Title = nugetTitleSuffix
                         OutputPath = outputDir

--- a/src/core/Akka.Cluster/Akka.Cluster.csproj
+++ b/src/core/Akka.Cluster/Akka.Cluster.csproj
@@ -85,6 +85,7 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Configuration\Cluster.conf" />
+    <None Include="Akka.Cluster.nuspec" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup />

--- a/src/core/Akka.Cluster/Akka.Cluster.nuspec
+++ b/src/core/Akka.Cluster/Akka.Cluster.nuspec
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <id>@project@</id>
+    <title>@project@@title@</title>
+    <version>@build.number@</version>
+    <authors>@authors@</authors>
+    <owners>@authors@</owners>
+    <description>Cluster support for Akka.NET</description>
+    <licenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/akkadotnet/akka.net</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes>@releaseNotes@</releaseNotes>
+    <copyright>@copyright@</copyright>
+    <tags>@tags@</tags>
+    @dependencies@
+    @references@
+  </metadata>
+</package>

--- a/src/core/Akka.Cluster/VectorClock.cs
+++ b/src/core/Akka.Cluster/VectorClock.cs
@@ -53,7 +53,6 @@ namespace Akka.Cluster
                 return new Node(hash);
             }
 
-            //TODO: Use murmur here?
             private static Node Hash(string name)
             {
                 var md5 = System.Security.Cryptography.MD5.Create();


### PR DESCRIPTION
Modified the `build.fsx` file to use a function for selecting the NuGet version number - all it really does is make sure that a -pre suffix is used on specifically named pre-release packages.

At present, here is what the output from `build NuGet` looks like:

![image](https://cloud.githubusercontent.com/assets/326939/4656153/ecd1f9aa-54d0-11e4-8a75-12f1209456f3.png)

@HCanber @rogeralsing do the names of the logging packages look correct? These changes were applied after PR #465 was merged in.

CC @smalldave removed the TODO regarding MD5 for the VectorClock - your original code is inline with the original Akka source and is fine as-is. No need for Murmur3.
