### PR TITLE
Use preReleaseVersion for Akka.Cluster

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -36,7 +36,9 @@ let parsedRelease =
 //This means we cannot append the full date yyyMMddHHmmss to prerelease. 
 //See https://github.com/fsharp/FAKE/issues/522
 //TODO: When this has been fixed, switch to DateTime.UtcNow.ToString("yyyyMMddHHmmss")
-let release = if hasBuildParam "nugetprerelease" then ReleaseNotesHelper.ReleaseNotes.New(parsedRelease.AssemblyVersion, parsedRelease.AssemblyVersion + "-" + (getBuildParam "nugetprerelease") + DateTime.UtcNow.ToString("yyMMddHHmm"), parsedRelease.Notes) else parsedRelease
+let preReleaseVersion = parsedRelease.AssemblyVersion + "-" + (getBuildParamOrDefault "nugetprerelease" "pre") + DateTime.UtcNow.ToString("yyMMddHHmm")
+let isPreRelease = hasBuildParam "nugetprerelease"
+let release = if isPreRelease then ReleaseNotesHelper.ReleaseNotes.New(parsedRelease.AssemblyVersion, preReleaseVersion, parsedRelease.Notes) else parsedRelease
 
 printfn "Assembly version: %s\nNuget version; %s\n" release.AssemblyVersion release.NugetVersion
 //--------------------------------------------------------------------------------
@@ -185,7 +187,7 @@ module Nuget =
     // used to add -pre suffix to pre-release packages
     let getProjectVersion project =
       match project with
-      | "Akka.Cluster" -> release.NugetVersion + "-pre"
+      | "Akka.Cluster" -> preReleaseVersion
       | _ -> release.NugetVersion
 
 open Nuget


### PR DESCRIPTION
ping @Aaronontheweb 
This is what we talked about in #476 

When building:
    build.cmd Nuget
the package name for cluster will be like this:
   Akka.Cluster.0.6.5-pre1410160612

The numbers after pre are the UTC date and time on the format "yyMMddHHmm" to get an increasing version number of the prerelease package (as long as you build the next version the minute after).

This commit also makes sure that when building pre-release versions of all packages using
    build.cmd Nuget nugetprerelease=dev
the name of Akka.Cluster package use the specified prefix. In this example the name will be:
   Akka.Cluster.0.6.5-dev1410160612
