### PR TITLE
changed build.fsx to add Akka.Remote NuGet dependency to Akka.Cluster

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -181,6 +181,7 @@ module Nuget =
     let getAkkaDependency project =
         match project with
         | "Akka" -> []
+        | "Akka.Cluster" -> ["Akka.Remote", release.NugetVersion]
         | testkit when testkit.StartsWith("Akka.TestKit.") -> ["Akka.TestKit", release.NugetVersion]
         | _ -> ["Akka", release.NugetVersion]
 


### PR DESCRIPTION
Really minor change - Akka.Cluster needs to depend on Akka.Remote, not just Akka. Updated `build.fsx` to reflect this (although I already pushed a NuGet package with this fix)
