### PR TITLE
Fix releasenotes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 0.7.1 NEXTVERSION
+_This is a placeholder for the next released version. Add new stuff that will go into the next version below. It might be 0.7.1 or 0.8._
+
+
 #### 0.7.0 Oct 16 2014
 Major new changes and additions in this release, including some breaking changes...
 


### PR DESCRIPTION
I created a 0.6.5 to act as a placeholder for 0.7 but forgot to tell @Aaronontheweb about it, so this PR moves things from 0.6.5 to 0.7.

It also creates a placeholder for next version. Currently this is called 0.7.1, but could just as well be 0.8.
