### PR TITLE
added ClusterDeployer and relevant specs per #486

### DIFF
--- a/src/Akka.sln
+++ b/src/Akka.sln
@@ -117,6 +117,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Roles", "Roles", "{D23C0D51
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.Cluster.Transformation", "examples\Cluster\Roles\Samples.Cluster.Transformation\Samples.Cluster.Transformation.csproj", "{E5EB3DF5-D017-4B50-B5AA-2B0440DB773D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Routing", "Routing", "{0BA8B1E8-11DD-4A32-8BB4-99F7AB3E27BB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.Cluster.ConsistentHashRouting", "examples\Cluster\Routing\Samples.Cluster.ConsistentHashRouting\Samples.Cluster.ConsistentHashRouting.csproj", "{29A08A09-83F6-48D4-A9AE-B4AE314069C4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug Mono|Any CPU = Debug Mono|Any CPU
@@ -386,6 +390,14 @@ Global
 		{E5EB3DF5-D017-4B50-B5AA-2B0440DB773D}.Release Mono|Any CPU.Build.0 = Release|Any CPU
 		{E5EB3DF5-D017-4B50-B5AA-2B0440DB773D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E5EB3DF5-D017-4B50-B5AA-2B0440DB773D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{29A08A09-83F6-48D4-A9AE-B4AE314069C4}.Debug Mono|Any CPU.ActiveCfg = Debug|Any CPU
+		{29A08A09-83F6-48D4-A9AE-B4AE314069C4}.Debug Mono|Any CPU.Build.0 = Debug|Any CPU
+		{29A08A09-83F6-48D4-A9AE-B4AE314069C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{29A08A09-83F6-48D4-A9AE-B4AE314069C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{29A08A09-83F6-48D4-A9AE-B4AE314069C4}.Release Mono|Any CPU.ActiveCfg = Release|Any CPU
+		{29A08A09-83F6-48D4-A9AE-B4AE314069C4}.Release Mono|Any CPU.Build.0 = Release|Any CPU
+		{29A08A09-83F6-48D4-A9AE-B4AE314069C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{29A08A09-83F6-48D4-A9AE-B4AE314069C4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -434,5 +446,7 @@ Global
 		{B428311F-AD87-461D-9573-9004A2596ABA} = {DCE4B11E-6A5F-4AC8-A089-037F0B14BFAB}
 		{D23C0D51-7E21-454B-9C3E-1154A744FF81} = {DCE4B11E-6A5F-4AC8-A089-037F0B14BFAB}
 		{E5EB3DF5-D017-4B50-B5AA-2B0440DB773D} = {D23C0D51-7E21-454B-9C3E-1154A744FF81}
+		{0BA8B1E8-11DD-4A32-8BB4-99F7AB3E27BB} = {DCE4B11E-6A5F-4AC8-A089-037F0B14BFAB}
+		{29A08A09-83F6-48D4-A9AE-B4AE314069C4} = {0BA8B1E8-11DD-4A32-8BB4-99F7AB3E27BB}
 	EndGlobalSection
 EndGlobal

--- a/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
+++ b/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
@@ -65,6 +65,7 @@
   <ItemGroup>
     <Compile Include="AutoDownSpec.cs" />
     <Compile Include="ClusterConfigSpec.cs" />
+    <Compile Include="ClusterDeployerSpec.cs" />
     <Compile Include="ClusterDomainEventPublisherSpec.cs" />
     <Compile Include="ClusterDomainEventSpec.cs" />
     <Compile Include="ClusterHeartBeatSenderStateSpec.cs" />

--- a/src/core/Akka.Cluster.Tests/ClusterDeployerSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterDeployerSpec.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Actor.Internals;
+using Akka.Cluster.Routing;
+using Akka.Configuration;
+using Akka.Routing;
+using Akka.TestKit;
+using Akka.Util.Internal;
+using Xunit;
+
+namespace Akka.Cluster.Tests
+{
+    public class ClusterDeployerSpec : AkkaSpec
+    {
+        public static readonly Config deployConf = ConfigurationFactory.ParseString(@"
+        akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""
+      akka.actor.deployment {
+        /user/service1 {
+          router = round-robin-pool
+          nr-of-instances = 20
+          cluster.enabled = on
+          cluster.max-nr-of-instances-per-node = 3
+          cluster.allow-local-routees = off
+        }
+        /user/service2 {
+          dispatcher = mydispatcher
+          mailbox = mymailbox
+          router = round-robin-group
+          nr-of-instances = 20
+          routees.paths = [""/user/myservice""]
+          cluster.enabled = on
+          cluster.allow-local-routees = off
+          cluster.use-role = backend
+        }
+      }
+      akka.remote.helios.tcp.port = 0
+
+");
+
+        public ClusterDeployerSpec() : base(deployConf) { }
+
+        [Fact]
+        public void RemoteDeployer_must_be_able_to_parse_akka_actor_deployment_with_specified_cluster_pool()
+        {
+            var service = "/user/service1";
+            var deployment = Sys.AsInstanceOf<ActorSystemImpl>().Provider.Deployer.Lookup(service.Split('/').Drop(1));
+            deployment.ShouldNotBe(null);
+
+            deployment.Path.ShouldBe(service);
+            deployment.RouterConfig.GetType().ShouldBe(typeof(ClusterRouterPool));
+            deployment.RouterConfig.AsInstanceOf<ClusterRouterPool>().Local.GetType().ShouldBe(typeof(RoundRobinPool));
+            deployment.RouterConfig.AsInstanceOf<ClusterRouterPool>().Local.AsInstanceOf<RoundRobinPool>().NrOfInstances.ShouldBe(20);
+            deployment.RouterConfig.AsInstanceOf<ClusterRouterPool>().Settings.TotalInstances.ShouldBe(20);
+            deployment.RouterConfig.AsInstanceOf<ClusterRouterPool>().Settings.AllowLocalRoutees.ShouldBe(false);
+            deployment.RouterConfig.AsInstanceOf<ClusterRouterPool>().Settings.UseRole.ShouldBe(string.Empty);
+            deployment.RouterConfig.AsInstanceOf<ClusterRouterPool>().Settings.AsInstanceOf<ClusterRouterPoolSettings>().MaxInstancesPerNode.ShouldBe(3);
+            deployment.Scope.ShouldBe(ClusterScope.Instance);
+            deployment.Mailbox.ShouldBe(Deploy.NoMailboxGiven);
+            deployment.Dispatcher.ShouldBe(Deploy.NoDispatcherGiven);
+        }
+
+        [Fact]
+        public void RemoteDeployer_must_be_able_to_parse_akka_actor_deployment_with_specified_cluster_group()
+        {
+            var service = "/user/service2";
+            var deployment = Sys.AsInstanceOf<ActorSystemImpl>().Provider.Deployer.Lookup(service.Split('/').Drop(1));
+            deployment.ShouldNotBe(null);
+
+            deployment.Path.ShouldBe(service);
+            deployment.RouterConfig.GetType().ShouldBe(typeof(ClusterRouterGroup));
+            deployment.RouterConfig.AsInstanceOf<ClusterRouterGroup>().Local.GetType().ShouldBe(typeof(RoundRobinGroup));
+            deployment.RouterConfig.AsInstanceOf<ClusterRouterGroup>().Local.AsInstanceOf<RoundRobinGroup>().Paths.ShouldBe(new[]{ "/user/myservice" });
+            deployment.RouterConfig.AsInstanceOf<ClusterRouterGroup>().Settings.TotalInstances.ShouldBe(20);
+            deployment.RouterConfig.AsInstanceOf<ClusterRouterGroup>().Settings.AllowLocalRoutees.ShouldBe(false);
+            deployment.RouterConfig.AsInstanceOf<ClusterRouterGroup>().Settings.UseRole.ShouldBe("backend");
+            deployment.RouterConfig.AsInstanceOf<ClusterRouterGroup>().Settings.AsInstanceOf<ClusterRouterGroupSettings>().RouteesPaths.ShouldBe(new[] { "/user/myservice" });
+            deployment.Scope.ShouldBe(ClusterScope.Instance);
+            deployment.Mailbox.ShouldBe("mymailbox");
+            deployment.Dispatcher.ShouldBe("mydispatcher");
+        }
+
+        //todo: implement "have correct router mappings" test for adapative load-balancing routers (not yet implemented)
+    }
+}

--- a/src/core/Akka.Cluster.Tests/ClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterSpec.cs
@@ -17,7 +17,7 @@ namespace Akka.Cluster.Tests
             failure-detector.implementation-class = ""Akka.Cluster.Tests.FailureDetectorPuppet, Akka.Cluster.Tests""
         }
         akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""
-        akka.remote.netty.tcp.port = 0";
+        akka.remote.helios.tcp.port = 0";
 
         public ActorRef Self { get { return TestActor; } }
 

--- a/src/core/Akka.Cluster/ClusterActorRefProvider.cs
+++ b/src/core/Akka.Cluster/ClusterActorRefProvider.cs
@@ -1,8 +1,12 @@
-﻿using Akka.Actor;
+﻿using System;
+using Akka.Actor;
 using Akka.Actor.Internals;
 using Akka.Cluster.Configuration;
+using Akka.Cluster.Routing;
+using Akka.Configuration;
 using Akka.Event;
 using Akka.Remote;
+using Akka.Routing;
 
 namespace Akka.Cluster
 {
@@ -15,10 +19,12 @@ namespace Akka.Cluster
     /// </summary>
     public class ClusterActorRefProvider : RemoteActorRefProvider
     {
-        public ClusterActorRefProvider(string systemName, Settings settings, EventStream eventStream /*DynamicAcccess*/) : base(systemName, settings, eventStream)
+        public ClusterActorRefProvider(string systemName, Settings settings, EventStream eventStream /*DynamicAcccess*/)
+            : base(systemName, settings, eventStream)
         {
             var clusterConfig = ClusterConfigFactory.Default();
             settings.InjectTopLevelFallback(clusterConfig);
+            Deployer = new ClusterDeployer(settings);
         }
 
         public override void Init(ActorSystemImpl system)
@@ -43,6 +49,65 @@ namespace Akka.Cluster
                 RemoteSettings.WatchHeartbeatExpectedResponseAfter), "remote-watcher");
         }
 
-        //TODO: Deployment stuff
+        
+    }
+
+    /// <summary>
+    /// Cluster-aware scope of a <see cref="Deploy"/>
+    /// </summary>
+    public class ClusterScope : Scope
+    {
+        private ClusterScope() { }
+
+        public static readonly ClusterScope Instance = new ClusterScope();
+    }
+
+    /// <summary>
+    /// INTERNAL API
+    /// 
+    /// Deployer of cluster-aware routers
+    /// </summary>
+    internal class ClusterDeployer : RemoteDeployer
+    {
+        public ClusterDeployer(Settings settings)
+            : base(settings)
+        {
+        }
+
+        public override Deploy ParseConfig(string key, Config config)
+        {
+            var deploy = base.ParseConfig(key, config);
+            if (deploy == null) return null;
+
+            if (deploy.Config.GetBoolean("cluster.enabled"))
+            {
+                if(deploy.Scope != Deploy.NoScopeGiven)
+                    throw new ConfigurationException(string.Format("Cluster deployment can't be combined with scope [{0}]", deploy.Scope));
+                //TODO: add handling for RemoteRouterConfig
+
+                if (deploy.RouterConfig is Pool)
+                {
+                    return
+                        deploy.Copy(scope: ClusterScope.Instance)
+                            .WithRouterConfig(new ClusterRouterPool(deploy.RouterConfig as Pool,
+                                ClusterRouterPoolSettings.FromConfig(deploy.Config)));
+                }
+                else if (deploy.RouterConfig is Group)
+                {
+                    return
+                        deploy.Copy(scope: ClusterScope.Instance)
+                            .WithRouterConfig(new ClusterRouterGroup(deploy.RouterConfig as Group,
+                                ClusterRouterGroupSettings.FromConfig(deploy.Config)));
+                }
+                else
+                {
+                    throw new ArgumentException(string.Format("Cluster-aware router can only wrap Pool or Group, got [{0}]", deploy.RouterConfig.GetType()));
+                }
+            }
+            else
+            {
+                return deploy;
+            }
+        }
     }
 }

--- a/src/core/Akka.Cluster/Routing/ClusterRoutingConfig.cs
+++ b/src/core/Akka.Cluster/Routing/ClusterRoutingConfig.cs
@@ -112,7 +112,7 @@ namespace Akka.Cluster.Routing
 
         public override bool IsManagementMessage(object message)
         {
-            return message is IClusterMessage || message is ClusterEvent.CurrentClusterState || base.IsManagementMessage(message);
+            return message is ClusterEvent.IClusterDomainEvent || message is ClusterEvent.CurrentClusterState || base.IsManagementMessage(message);
         }
 
         public override RouterConfig WithFallback(RouterConfig routerConfig)
@@ -207,6 +207,11 @@ namespace Akka.Cluster.Routing
         ClusterRouterSettingsBase Settings { get; }
     }
 
+    /// <summary>
+    /// INTERNAL API
+    /// The router actor, subscribes to cluster events and
+    /// adjusts the routees.
+    /// </summary>
     internal abstract class ClusterRouterActor : RouterActor
     {
         protected ClusterRouterActor(ClusterRouterSettingsBase settings)
@@ -331,7 +336,10 @@ namespace Akka.Cluster.Routing
                 {
                     if (IsAvailable(member.Member)) AddMember(member.Member);
                 })
-                .Default(msg => base.OnReceive(msg));
+                .Default(msg =>
+                {
+                    base.OnReceive(msg);
+                });
         }
     }
 
@@ -342,6 +350,7 @@ namespace Akka.Cluster.Routing
     {
         public ClusterRouterGroupActor(ClusterRouterGroupSettings settings) : base(settings)
         {
+            Settings = settings;
             var groupConfig = Cell.RouterConfig as Group;
             if (groupConfig != null)
             {
@@ -355,7 +364,6 @@ namespace Akka.Cluster.Routing
                 ? ImmutableDictionary<Address, ImmutableHashSet<string>>.Empty.Add(Cluster.SelfAddress,
                     settings.RouteesPaths)
                 : ImmutableDictionary<Address, ImmutableHashSet<string>>.Empty;
-            Settings = settings;
         }
 
         public new ClusterRouterGroupSettings Settings { get; private set; }
@@ -407,8 +415,8 @@ namespace Akka.Cluster.Routing
                                 : curMin);
 
                 // pick next of unused paths
-                var minPath = Settings.RouteesPaths.First(p => !minNode.Value.Contains(p));
-                return new Tuple<Address, string>(minNode.Key, minPath);
+                var minPath = Settings.RouteesPaths.FirstOrDefault(p => !minNode.Value.Contains(p));
+                return minPath == null ? null : new Tuple<Address, string>(minNode.Key, minPath);
             }
         }
 

--- a/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
+++ b/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
@@ -117,7 +117,7 @@ namespace Akka.Remote.TestKit
             {
                 //TODO: Equivalent in Helios?
                 var transportConfig = _testTransport ? 
-                    ConfigurationFactory.ParseString("akka.remote.netty.tcp.applied-adapters = [trttl, gremlin]")
+                    ConfigurationFactory.ParseString("akka.remote.helios.tcp.applied-adapters = [trttl, gremlin]")
                         :  ConfigurationFactory.Empty;
 
                 var configs = ImmutableList.Create(_nodeConf[Myself], _commonConf, transportConfig,

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -66,7 +66,7 @@ namespace Akka.Remote
         public LocalActorRef SystemGuardian { get { return _local.SystemGuardian; } }
         public InternalActorRef TempContainer { get { return _local.TempContainer; } }
         public ActorRef DeadLetters { get { return _local.DeadLetters; } }
-        public Deployer Deployer { get; private set; }
+        public Deployer Deployer { get; protected set; }
         public Address DefaultAddress { get { return Transport.DefaultAddress; } }
         public Settings Settings { get { return _local.Settings; } }
         public Task TerminationTask { get { return _local.TerminationTask; } }

--- a/src/core/Akka.Remote/RemoteDeployer.cs
+++ b/src/core/Akka.Remote/RemoteDeployer.cs
@@ -5,7 +5,12 @@ using Akka.Routing;
 
 namespace Akka.Remote
 {
-    public class RemoteDeployer : Deployer
+    /// <summary>
+    /// INTERNAL API
+    /// 
+    /// Used for deployment of actors on remote systems
+    /// </summary>
+    internal class RemoteDeployer : Deployer
     {
         public RemoteDeployer(Settings settings) : base(settings)
         {

--- a/src/core/Akka/Routing/RouterConfig.cs
+++ b/src/core/Akka/Routing/RouterConfig.cs
@@ -101,6 +101,7 @@ namespace Akka.Routing
 
         public override IEnumerable<Routee> GetRoutees(RoutedActorCell routedActorCell)
         {
+            if (paths == null) return new Routee[0];
             return paths.Select(((ActorSystemImpl) routedActorCell.System).ActorSelection).Select(actor => new ActorSelectionRoutee(actor));
         }
     }

--- a/src/examples/Cluster/Routing/Samples.Cluster.ConsistentHashRouting/App.config
+++ b/src/examples/Cluster/Routing/Samples.Cluster.ConsistentHashRouting/App.config
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <section name="akka" type="Akka.Configuration.Hocon.AkkaConfigurationSection, Akka" />
+  </configSections>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+  </startup>
+  <akka>
+    <hocon>
+      <![CDATA[
+          akka {
+            actor {
+              provider = "Akka.Cluster.ClusterActorRefProvider, Akka.Cluster"
+            }
+            
+            remote {
+              log-remote-lifecycle-events = DEBUG
+              helios.tcp {
+                hostname = "127.0.0.1"
+                port = 0
+              }
+            }
+
+            cluster {
+              seed-nodes = [
+                "akka.tcp://ClusterSystem@127.0.0.1:2551",
+                "akka.tcp://ClusterSystem@127.0.0.1:2552"]
+
+              auto-down-unreachable-after = 10s
+              min-nr-of-members = 4 #both front-ends and at least 2 back-ends
+            }
+          }
+      ]]>
+    </hocon>
+  </akka>
+</configuration>

--- a/src/examples/Cluster/Routing/Samples.Cluster.ConsistentHashRouting/BackendActor.cs
+++ b/src/examples/Cluster/Routing/Samples.Cluster.ConsistentHashRouting/BackendActor.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Akka.Actor;
+using Akka.Event;
+
+namespace Samples.Cluster.ConsistentHashRouting
+{
+    public class BackendActor : UntypedActor
+    {
+        protected Akka.Cluster.Cluster Cluster = Akka.Cluster.Cluster.Get(Context.System);
+
+        protected override void OnReceive(object message)
+        {
+            if (message is FrontendCommand)
+            {
+                var command = message as FrontendCommand;
+                Console.WriteLine("Backend [{0}]: Received command {1} for job {2} from {3}", Cluster.SelfAddress, command.Message, command.JobId, Sender);
+                Sender.Tell(new CommandComplete());
+            }
+            else
+            {
+                Unhandled(message);
+            }
+        }
+    }
+}

--- a/src/examples/Cluster/Routing/Samples.Cluster.ConsistentHashRouting/FrontendActor.cs
+++ b/src/examples/Cluster/Routing/Samples.Cluster.ConsistentHashRouting/FrontendActor.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using Akka.Actor;
+using Akka.Cluster;
+
+namespace Samples.Cluster.ConsistentHashRouting
+{
+    public class FrontendActor : UntypedActor, WithUnboundedStash
+    {
+        protected readonly ActorRef BackendRouter;
+        protected int jobCount = 0;
+
+        public FrontendActor(ActorRef backendRouter)
+        {
+            BackendRouter = backendRouter;
+        }
+
+        protected Akka.Cluster.Cluster Cluster = Akka.Cluster.Cluster.Get(Context.System);
+
+        /// <summary>
+        /// Need to subscribe to cluster changes
+        /// </summary>
+        protected override void PreStart()
+        {
+            Cluster.Subscribe(Self, new[] { typeof(ClusterEvent.MemberUp) });
+        }
+
+        /// <summary>
+        /// Re-subscribe on restart
+        /// </summary>
+        protected override void PostStop()
+        {
+            Cluster.Unsubscribe(Self);
+        }
+
+        protected override void OnReceive(object message)
+        {
+            if (message is ClusterEvent.MemberUp)
+            {
+                Console.WriteLine("Frontend [{0}]: Cluster is ready. Able to begin jobs.");
+                //ready to begin routing messages to back-end
+                Become(ReadyToProcess);
+                Stash.UnstashAll();
+            }
+            else
+            {
+                Stash.Stash();
+            }
+        }
+
+        protected void ReadyToProcess(object message)
+        {
+            if (message is StartCommand)
+            {
+                var sc = message as StartCommand;
+                BackendRouter.Tell(new FrontendCommand()
+                {
+                    Message = string.Format("message {0}", jobCount++),
+                    JobId = sc.CommandText
+                });
+                BackendRouter.Tell(new FrontendCommand()
+                {
+                    Message = string.Format("message {0}", jobCount++),
+                    JobId = sc.CommandText
+                });
+            }
+            else if(message is CommandComplete)
+            {
+                Console.WriteLine("Frontend [{0}]: Received CommandComplete from {1}", Cluster.SelfAddress, Sender);
+            }
+        }
+
+        public IStash Stash { get; set; }
+    }
+}

--- a/src/examples/Cluster/Routing/Samples.Cluster.ConsistentHashRouting/Messages.cs
+++ b/src/examples/Cluster/Routing/Samples.Cluster.ConsistentHashRouting/Messages.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Akka.Routing;
+
+namespace Samples.Cluster.ConsistentHashRouting
+{
+    public class FrontendCommand : ConsistentHashable {
+        public string Message { get; set; }
+
+        public string JobId { get; set; }
+
+        public object ConsistentHashKey { get { return JobId; } }
+    }
+
+    public class StartCommand
+    {
+        public StartCommand(string commandText)
+        {
+            CommandText = commandText;
+        }
+
+        public string CommandText { get; private set; }
+
+        public override string ToString()
+        {
+            return CommandText;
+        }
+    }
+
+    public class CommandComplete
+    {
+    }
+}

--- a/src/examples/Cluster/Routing/Samples.Cluster.ConsistentHashRouting/Program.cs
+++ b/src/examples/Cluster/Routing/Samples.Cluster.ConsistentHashRouting/Program.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Cluster.Routing;
+using Akka.Configuration;
+using Akka.Configuration.Hocon;
+using Akka.Routing;
+using Akka.Util.Internal;
+
+namespace Samples.Cluster.ConsistentHashRouting
+{
+    class Program
+    {
+        private static Config _clusterConfig;
+
+        static void Main(string[] args)
+        {
+            var section = (AkkaConfigurationSection)ConfigurationManager.GetSection("akka");
+            _clusterConfig = section.AkkaConfig;
+            LaunchBackend(new[] { "2551" });
+            LaunchBackend(new[] { "2552" });
+            LaunchBackend(new string[0]);
+            LaunchFrontend(new string[0]);
+            LaunchFrontend(new string[0]);
+            Console.WriteLine("Press any key to exit.");
+            Console.ReadKey();
+        }
+
+        static void LaunchBackend(string[] args)
+        {
+            var port = args.Length > 0 ? args[0] : "0";
+            var config =
+                    ConfigurationFactory.ParseString("akka.remote.helios.tcp.port=" + port)
+                    .WithFallback(ConfigurationFactory.ParseString("akka.cluster.roles = [backend]"))
+                        .WithFallback(_clusterConfig);
+
+            var system = ActorSystem.Create("ClusterSystem", config);
+            system.ActorOf(Props.Create<BackendActor>(), "backend");
+        }
+
+        static void LaunchFrontend(string[] args)
+        {
+            var port = args.Length > 0 ? args[0] : "0";
+            var config =
+                    ConfigurationFactory.ParseString("akka.remote.helios.tcp.port=" + port)
+                    .WithFallback(ConfigurationFactory.ParseString("akka.cluster.roles = [frontend]"))
+                        .WithFallback(_clusterConfig);
+
+            var system = ActorSystem.Create("ClusterSystem", config);
+            var backendRouter =
+                system.ActorOf(
+                    Props.Empty.WithRouter(new ClusterRouterGroup(new ConsistentHashingGroup("/user/backend"),
+                        new ClusterRouterGroupSettings(10, false, "backend", ImmutableHashSet.Create("/user/backend")))));
+            var frontend = system.ActorOf(Props.Create(() => new FrontendActor(backendRouter)), "frontend");
+            var interval = TimeSpan.FromSeconds(12);
+            var counter = new AtomicCounter();
+            system.Scheduler.Schedule(interval, interval,() => frontend.Tell(new StartCommand("hello-" + counter.GetAndIncrement())));
+        }
+    }
+}

--- a/src/examples/Cluster/Routing/Samples.Cluster.ConsistentHashRouting/Properties/AssemblyInfo.cs
+++ b/src/examples/Cluster/Routing/Samples.Cluster.ConsistentHashRouting/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Samples.Cluster.ConsistentHashRouting")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Samples.Cluster.ConsistentHashRouting")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e35b7192-12f6-4a56-b916-44946384cb4f")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/examples/Cluster/Routing/Samples.Cluster.ConsistentHashRouting/Samples.Cluster.ConsistentHashRouting.csproj
+++ b/src/examples/Cluster/Routing/Samples.Cluster.ConsistentHashRouting/Samples.Cluster.ConsistentHashRouting.csproj
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{29A08A09-83F6-48D4-A9AE-B4AE314069C4}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Samples.Cluster.ConsistentHashRouting</RootNamespace>
+    <AssemblyName>Samples.Cluster.ConsistentHashRouting</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>..\..\..\..\packages\Microsoft.Bcl.Immutable.1.0.34\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="BackendActor.cs" />
+    <Compile Include="FrontendActor.cs" />
+    <Compile Include="Messages.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\core\Akka.Cluster\Akka.Cluster.csproj">
+      <Project>{6ab00f61-269a-4501-b06a-026707f000a7}</Project>
+      <Name>Akka.Cluster</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\core\Akka.Remote\Akka.Remote.csproj">
+      <Project>{ea4ff8fd-7c53-49c8-b9aa-02e458b3e6a7}</Project>
+      <Name>Akka.Remote</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\core\Akka\Akka.csproj">
+      <Project>{5deddf90-37f0-48d3-a0b0-a5cbd8a7e377}</Project>
+      <Name>Akka</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/examples/Cluster/Routing/Samples.Cluster.ConsistentHashRouting/packages.config
+++ b/src/examples/Cluster/Routing/Samples.Cluster.ConsistentHashRouting/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Bcl.Immutable" version="1.0.34" targetFramework="net45" />
+</packages>

--- a/src/packages/repositories.config
+++ b/src/packages/repositories.config
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <repositories>
   <repository path="..\benchmark\PingPong\packages.config" />
+  <repository path="..\contrib\loggers\Akka.Logger.NLog\packages.config" />
+  <repository path="..\contrib\loggers\Akka.Logger.Serilog\packages.config" />
+  <repository path="..\contrib\loggers\Akka.Logger.slf4net\packages.config" />
   <repository path="..\contrib\loggers\Akka.NLog\packages.config" />
   <repository path="..\contrib\loggers\Akka.Serilog\packages.config" />
   <repository path="..\contrib\loggers\Akka.slf4net\packages.config" />
@@ -19,6 +22,7 @@
   <repository path="..\core\Akka\packages.config" />
   <repository path="..\examples\Chat\ChatMessages\packages.config" />
   <repository path="..\examples\Cluster\Roles\Samples.Cluster.Transformation\packages.config" />
+  <repository path="..\examples\Cluster\Routing\Samples.Cluster.ConsistentHashRouting\packages.config" />
   <repository path="..\examples\Cluster\Samples.Cluster.Simple\packages.config" />
   <repository path="..\examples\Stocks\SymbolLookup\packages.config" />
   <repository path="..\examples\TimeServer\TimeClient\packages.config" />


### PR DESCRIPTION
Also changed a bunch of Akka.Cluster test configurations to use
akka.remote.helios instead of akka.remote.netty

fixing bugs related to cluster router deployments

fixed a critical bug with cluster router management messages; added an example

fixed divide by zero error with consistent hash routers

Made ConsistentHashableEnvelope a subclass of RouterEnvelope

Ensures that the correct message is sent to its intended destination
without changing the signature of the ConsistentHashableEnvelope class
itself.

fixed a cluster group router deployment bug

In this case, routers attempting to add routees from additional
deployments where none are available resulted in an invalid operation
error that could crash the router. Made this call safe instead.
