### PR TITLE
Move SerilogLogMessageFormatter to correct namespace.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,8 @@
 #### 0.7.1 NEXTVERSION
 _This is a placeholder for the next released version. Add new stuff that will go into the next version below. It might be 0.7.1 or 0.8._
 
+__Akka.Serilog__ `SerilogLogMessageFormatter` has been moved to the namespace `Akka.Logger.Serilog` (it used to be in `Akka.Serilog.Event.Serilog`).
+Update your `using` statements from `using Akka.Serilog.Event.Serilog;` to `using Akka.Logger.Serilog;`.
 
 #### 0.7.0 Oct 16 2014
 Major new changes and additions in this release, including some breaking changes...
@@ -11,7 +13,7 @@ __Akka.Cluster__ Support (pre-release) - Akka.Cluster is now available on NuGet 
         actor {
           provider = "Akka.Cluster.ClusterActorRefProvider, Akka.Cluster"
         }
-        
+
         remote {
           log-remote-lifecycle-events = DEBUG
           helios.tcp {
@@ -19,12 +21,12 @@ __Akka.Cluster__ Support (pre-release) - Akka.Cluster is now available on NuGet 
         port = 0
           }
         }
-        
+
         cluster {
           seed-nodes = [
         "akka.tcp://ClusterSystem@127.0.0.1:2551",
         "akka.tcp://ClusterSystem@127.0.0.1:2552"]
-        
+
           auto-down-unreachable-after = 10s
         }
       }
@@ -55,7 +57,7 @@ __Breaking Changes: Renamed Logger Namespaces__ - The namespaces, DLL names, and
 
 __Serilog Support__ - Akka.NET now has an official [Serilog](http://serilog.net/) logger that you can install via the `Akka.Logger.Serilog` package. You can register the serilog logger via your HOCON configuration like this:
 
-     loggers=["Akka.Logger.Serilog.SerilogLogger, Akka.Logger.Serilog"]
+     akka.loggers=["Akka.Logger.Serilog.SerilogLogger, Akka.Logger.Serilog"]
 
 __New Feature: Priority Mailbox__ - The `PriorityMailbox` allows you to define the priority of messages handled by your actors, and this is done by creating your own subclass of either the `UnboundedPriorityMailbox` or `BoundedPriorityMailbox` class and implementing the `PriorityGenerator` method like so:
 

--- a/src/contrib/loggers/Akka.Logger.Serilog/Akka.Logger.Serilog.csproj
+++ b/src/contrib/loggers/Akka.Logger.Serilog/Akka.Logger.Serilog.csproj
@@ -51,8 +51,9 @@
     <Compile Include="..\..\..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="Event\Serilog\MessageTemplateCache.cs" />
     <Compile Include="Event\Serilog\SerilogLogMessageFormatter.cs" />
+    <Compile Include="MessageTemplateCache.cs" />
+    <Compile Include="SerilogLogMessageFormatter.cs" />
     <Compile Include="SerilogLogger.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/contrib/loggers/Akka.Logger.Serilog/Event/Serilog/SerilogLogMessageFormatter.cs
+++ b/src/contrib/loggers/Akka.Logger.Serilog/Event/Serilog/SerilogLogMessageFormatter.cs
@@ -1,37 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Akka.Event;
-using Serilog.Events;
-using Serilog.Parsing;
+using System.Text;
+using System.Threading.Tasks;
 
+// ReSharper disable once CheckNamespace
 namespace Akka.Serilog.Event.Serilog
-{
-    public class SerilogLogMessageFormatter : ILogMessageFormatter
-    {
-        private readonly MessageTemplateCache _templateCache;
-            
-        public SerilogLogMessageFormatter()
-        {
-            _templateCache = new MessageTemplateCache(new MessageTemplateParser());
-        }
-
-        public string Format(string format, params object[] args)
-        {
-            var template = _templateCache.Parse(format);
-            var propertyTokens = template.Tokens.OfType<PropertyToken>().ToArray();
-            var properties = new Dictionary<string, LogEventPropertyValue>();
-
-            for (var i = 0; i < args.Length; i++)
-            {
-                var propertyToken = propertyTokens.ElementAtOrDefault(i);
-                if (propertyToken == null)
-                    break;
-
-                properties.Add(propertyToken.PropertyName, new ScalarValue(args[i]));
-            }
-
-            return template.Render(properties);
-        }
-    }
+{    
+	[Obsolete("Use Akka.Logger.Serilog.SerilogLogMessageFormatter instead. This class will be removed in a future version.")]
+	public class SerilogLogMessageFormatter : global::Akka.Logger.Serilog.SerilogLogMessageFormatter
+	{
+	}
 }

--- a/src/contrib/loggers/Akka.Logger.Serilog/MessageTemplateCache.cs
+++ b/src/contrib/loggers/Akka.Logger.Serilog/MessageTemplateCache.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using Serilog.Events;
 using Serilog.Parsing;
 
-namespace Akka.Serilog.Event.Serilog
+namespace Akka.Logger.Serilog
 {
     /// <summary>
     /// Taken directly from Serilog as the cache was internal.

--- a/src/contrib/loggers/Akka.Logger.Serilog/SerilogLogMessageFormatter.cs
+++ b/src/contrib/loggers/Akka.Logger.Serilog/SerilogLogMessageFormatter.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Akka.Event;
+using Serilog.Events;
+using Serilog.Parsing;
+
+namespace Akka.Logger.Serilog
+{
+    public class SerilogLogMessageFormatter : ILogMessageFormatter
+    {
+        private readonly MessageTemplateCache _templateCache;
+            
+        public SerilogLogMessageFormatter()
+        {
+            _templateCache = new MessageTemplateCache(new MessageTemplateParser());
+        }
+
+        public string Format(string format, params object[] args)
+        {
+            var template = _templateCache.Parse(format);
+            var propertyTokens = template.Tokens.OfType<PropertyToken>().ToArray();
+            var properties = new Dictionary<string, LogEventPropertyValue>();
+
+            for (var i = 0; i < args.Length; i++)
+            {
+                var propertyToken = propertyTokens.ElementAtOrDefault(i);
+                if (propertyToken == null)
+                    break;
+
+                properties.Add(propertyToken.PropertyName, new ScalarValue(args[i]));
+            }
+
+            return template.Render(properties);
+        }
+    }
+}


### PR DESCRIPTION
This should have been made in #292 but we missed that.
`SerilogLogMessageFormatter` is in the old namespace.

This should be backwards compatible, sort of . As long as no

``` C#
using Akka.Logger.Serilog;
```

statement exists in files where `SerilogLogMessageFormatter`  is used everything should compile (with a warning that `SerilogLogMessageFormatter` in the old namespace is obsolete).

If a both namespacese are used in a file where `SerilogLogMessageFormatter` is used

``` C#
using Akka.Logger.Serilog;
using Akka.Serilog.Event.Serilog;
```

... the user will get a compile error. The resolution is to remove the second using statement.
