### PR TITLE
Add ReSharper external annotations to log methods in the Akka assembly

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -249,6 +249,7 @@ let createNugetPackages _ =
         !! (releaseDir @@ project + ".dll")
         ++ (releaseDir @@ project + ".pdb")
         ++ (releaseDir @@ project + ".xml")
+        ++ (releaseDir @@ project + ".ExternalAnnotations.xml")
         |> CopyFiles libDir
 
         // Copy all src-files (.cs and .fs files) to workingDir/src

--- a/src/core/Akka/Akka.ExternalAnnotations.xml
+++ b/src/core/Akka/Akka.ExternalAnnotations.xml
@@ -1,0 +1,53 @@
+
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly name="Akka">
+  <!-- LoggingAdapter -->
+  <member name="M:Akka.Event.LoggingAdapter.Debug(System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
+  </member>
+  <member name="M:Akka.Event.LoggingAdapter.Info(System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
+  </member>
+  <member name="M:Akka.Event.LoggingAdapter.Warning(System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
+  </member>
+  <member name="M:Akka.Event.LoggingAdapter.Error(System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
+  </member>
+  <member name="M:Akka.Event.LoggingAdapter.Error(System.Exception,System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
+  </member>
+  <member name="M:Akka.Event.LoggingAdapter.Log(Akka.Event.LogLevel,System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
+  </member>
+
+  <!-- LoggingAdapterBase -->
+  <member name="M:Akka.Event.LoggingAdapterBase.Debug(System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
+  </member>
+  <member name="M:Akka.Event.LoggingAdapterBase.Info(System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
+  </member>
+  <member name="M:Akka.Event.LoggingAdapterBase.Warning(System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
+  </member>
+  <member name="M:Akka.Event.LoggingAdapterBase.Error(System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
+  </member>
+  <member name="M:Akka.Event.LoggingAdapterBase.Error(System.Exception,System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
+  </member>
+  <member name="M:Akka.Event.LoggingAdapterBase.Log(Akka.Event.LogLevel,System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
+  </member>
+    
+  <!-- ILogMessageFormatter -->
+  <member name="M:Akka.Event.ILogMessageFormatter.Format(System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
+  </member>
+  
+  <!-- DefaultLogMessageFormatter -->
+  <member name="M:Akka.Event.DefaultLogMessageFormatter.Format(System.String,System.Object[])">
+    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
+  </member>
+</assembly>

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -284,7 +284,11 @@
     <None Include="packages.config" />
     <None Include="Util\MatchHandler\README.md" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Content Include="Akka.ExternalAnnotations.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
This makes ReSharper understand that for example log.Error's first parameter is a format string and that the method behaves just like `string.Format()`

There are two ways to annotate code so ReSharper understands it. One is to include the Resharper Annotations nuget package (which adds a c# source file to the project), but there seems to be [a lot of problems](http://stackoverflow.com/questions/24805040/how-to-ignore-reference-to-jetbrains-annotations-dll-in-nodatime-nuget-package-x) with that approach, so I decided to use the second approach: an external xml-file. It will end up in the nuget package next to the dll, and Resharper will pick it up automatically.

For more info, see
https://www.jetbrains.com/resharper/webhelp/Code_Analysis__External_Annotations.html
https://www.jetbrains.com/resharper/webhelp/Code_Analysis__String_Formatting_Methods.html
