### PR TITLE
validate-type-resolution-233

### DIFF
--- a/src/core/Akka.Cluster/ClusterMetricsCollector.cs
+++ b/src/core/Akka.Cluster/ClusterMetricsCollector.cs
@@ -832,11 +832,7 @@ namespace Akka.Cluster
             var fqcn = settings.MetricsCollectorClass;
             if (fqcn == typeof (PerformanceCounterMetricsCollector).AssemblyQualifiedName) return new PerformanceCounterMetricsCollector(system);
             
-            var metricsCollectorClass = Type.GetType(fqcn);
-            if (metricsCollectorClass == null)
-            {
-                throw new ConfigurationException(string.Format("Could not create custom metrics collector {0}", fqcn));
-            }
+            var metricsCollectorClass = TypeExtensions.ResolveConfiguredType(fqcn);
 
             try
             {

--- a/src/core/Akka.Remote/EndpointManager.cs
+++ b/src/core/Akka.Remote/EndpointManager.cs
@@ -663,12 +663,7 @@ namespace Akka.Remote
                         Transport.Transport driver;
                         try
                         {
-                            var driverType = Type.GetType(transportSettings.TransportClass);
-                            if(driverType==null)
-                                throw new Exception(string.Format("Cannot instantiate transport [{0}]. Cannot find the type.",transportSettings.TransportClass));
-
-                            if(!typeof(Transport.Transport).IsAssignableFrom(driverType))
-                                throw new Exception(string.Format("Cannot instantiate transport [{0}]. It does not implement [{1}].",transportSettings.TransportClass,typeof(Transport.Transport).FullName));
+                            var driverType = TypeExtensions.ResolveType(transportSettings.TransportClass, typeof(Transport.Transport));
 
                             var constructorInfo = driverType.GetConstructor(new []{typeof(ActorSystem),typeof(Config)});
                             if(constructorInfo==null)

--- a/src/core/Akka.Remote/FailureDetectorRegistry.cs
+++ b/src/core/Akka.Remote/FailureDetectorRegistry.cs
@@ -2,6 +2,7 @@
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Event;
+using Akka.Util;
 
 namespace Akka.Remote
 {
@@ -58,11 +59,7 @@ namespace Akka.Remote
         /// <returns>A configured instance of the given <see cref="FailureDetector"/> implementation.</returns>
         public static FailureDetector Load(string fqcn, Config config, ActorSystem system)
         {
-            var failureDetectorClass = Type.GetType(fqcn);
-            if (failureDetectorClass == null)
-            {
-                throw new ConfigurationException(string.Format("Could not create custom FailureDetector {0}", fqcn));
-            }
+            var failureDetectorClass = TypeExtensions.ResolveConfiguredType(fqcn);
             var failureDetector = (FailureDetector) Activator.CreateInstance(failureDetectorClass, config, system.EventStream);
             return failureDetector;
         }

--- a/src/core/Akka.Remote/MessageSerializer.cs
+++ b/src/core/Akka.Remote/MessageSerializer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Akka.Actor;
 using Akka.Serialization;
+using Akka.Util;
 using Google.ProtocolBuffers;
 
 namespace Akka.Remote
@@ -19,7 +20,7 @@ namespace Akka.Remote
         public static object Deserialize(ActorSystem system, SerializedMessage messageProtocol)
         {
             Type type = messageProtocol.HasMessageManifest
-                ? Type.GetType(messageProtocol.MessageManifest.ToStringUtf8())
+                ? TypeExtensions.ResolveType(messageProtocol.MessageManifest.ToStringUtf8())
                 : null;
             var message = system.Serialization.Deserialize(messageProtocol.Message.ToByteArray(),
                 messageProtocol.SerializerId, type);

--- a/src/core/Akka.Remote/Serialization/DaemonMsgCreateSerializer.cs
+++ b/src/core/Akka.Remote/Serialization/DaemonMsgCreateSerializer.cs
@@ -4,6 +4,7 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.Routing;
 using Akka.Serialization;
+using Akka.Util;
 using Google.ProtocolBuffers;
 
 namespace Akka.Remote.Serialization
@@ -106,7 +107,7 @@ namespace Akka.Remote.Serialization
         public override object FromBinary(byte[] bytes, Type type)
         {
             var proto = DaemonMsgCreateData.ParseFrom(bytes);
-            var clazz = Type.GetType(proto.Props.Clazz);
+            var clazz = TypeExtensions.ResolveType(proto.Props.Clazz);
             var args = GetArgs(proto);
             var props = new Props(GetDeploy(proto.Props.Deploy), clazz, args);
             return new DaemonMsgCreate(
@@ -161,7 +162,7 @@ namespace Akka.Remote.Serialization
                 {
                     Type t = null;
                     if (typeName != null)
-                        t = Type.GetType(typeName);
+                        t = TypeExtensions.ResolveType(typeName);
                     args[i] = Deserialize(arg, t);
                 }
             }

--- a/src/core/Akka.Remote/Serialization/MessageContainerSerializer.cs
+++ b/src/core/Akka.Remote/Serialization/MessageContainerSerializer.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Akka.Actor;
 using Akka.Serialization;
+using Akka.Util;
 using Google.ProtocolBuffers;
 
 namespace Akka.Remote.Serialization
@@ -83,7 +84,7 @@ namespace Akka.Remote.Serialization
             Type msgType = null;
             if (selectionEnvelope.HasMessageManifest)
             {
-                msgType = Type.GetType(selectionEnvelope.MessageManifest.ToStringUtf8());
+                msgType = TypeExtensions.ResolveType(selectionEnvelope.MessageManifest.ToStringUtf8());
             }
             int serializerId = selectionEnvelope.SerializerId;
             object msg = Deserialize(selectionEnvelope.EnclosedMessage, msgType, serializerId);

--- a/src/core/Akka.Remote/Transport/TransportAdapters.cs
+++ b/src/core/Akka.Remote/Transport/TransportAdapters.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Internals;
+using Akka.Util;
 
 namespace Akka.Remote.Transport
 {
@@ -59,8 +60,7 @@ namespace Akka.Remote.Transport
             {
                 try
                 {
-                    var adapterTypeName = Type.GetType(adapter.Value);
-                    // ReSharper disable once AssignNullToNotNullAttribute
+                    var adapterTypeName = TypeExtensions.ResolveType(adapter.Value, typeof(ITransportAdapterProvider));
                     var newAdapter = (ITransportAdapterProvider)Activator.CreateInstance(adapterTypeName);
                     _adaptersTable.Add(adapter.Key, newAdapter);
                 }

--- a/src/core/Akka/Actor/Deployer.cs
+++ b/src/core/Akka/Actor/Deployer.cs
@@ -92,8 +92,7 @@ namespace Akka.Actor
 
             var path = string.Format("akka.actor.router.type-mapping.{0}", routerTypeAlias);
             var routerTypeName = _settings.Config.GetString(path);
-            var routerType = Type.GetType(routerTypeName);
-            Debug.Assert(routerType != null, "routerType != null");
+            var routerType = TypeExtensions.ResolveType(routerTypeName, typeof(RouterConfig));
             var routerConfig = (RouterConfig)Activator.CreateInstance(routerType, deployment);
 
             return routerConfig;

--- a/src/core/Akka/Actor/Internals/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internals/ActorSystemImpl.cs
@@ -8,6 +8,7 @@ using Akka.Configuration;
 using Akka.Dispatch;
 using Akka.Dispatch.SysMsg;
 using Akka.Event;
+using Akka.Util;
 
 
 namespace Akka.Actor.Internals
@@ -249,8 +250,7 @@ namespace Akka.Actor.Internals
         /// </summary>
         private void ConfigureProvider()
         {
-            Type providerType = Type.GetType(_settings.ProviderClass);
-            global::System.Diagnostics.Debug.Assert(providerType != null, "providerType != null");
+            Type providerType = TypeExtensions.ResolveType(_settings.ProviderClass, typeof(ActorRefProvider));
             var provider = (ActorRefProvider)Activator.CreateInstance(providerType, _name, _settings, _eventStream);
             _provider = provider;
         }

--- a/src/core/Akka/Actor/Settings.cs
+++ b/src/core/Akka/Actor/Settings.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Akka.Configuration;
+using Akka.Util;
 
 namespace Akka.Actor
 {
@@ -47,12 +48,9 @@ namespace Akka.Actor
             
             ConfigVersion = Config.GetString("akka.version");
             ProviderClass = Config.GetString("akka.actor.provider");
-            var providerType = Type.GetType(ProviderClass);
-            if (providerType == null)
-                throw new ConfigurationException(string.Format("'akka.actor.provider' is not a valid type name : '{0}'", ProviderClass));
-            if (!typeof(ActorRefProvider).IsAssignableFrom(providerType))
-                throw new ConfigurationException(string.Format("'akka.actor.provider' is not a valid actor ref provider: '{0}'", ProviderClass));
-            
+            var providerType = TypeExtensions.ResolveConfiguredType(ProviderClass, typeof(ActorRefProvider));
+            //TODO: why is providerType not used?
+
             SupervisorStrategyClass = Config.GetString("akka.actor.guardian-supervisor-strategy");
 
             CreationTimeout = Config.GetTimeSpan("akka.actor.creation-timeout");

--- a/src/core/Akka/Dispatch/Dispatchers.cs
+++ b/src/core/Akka/Dispatch/Dispatchers.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
+using Akka.Util;
 
 namespace Akka.Dispatch
 {
@@ -245,11 +246,7 @@ namespace Akka.Dispatch
                 case null:
                     throw new NotSupportedException("Could not resolve dispatcher for path " + path+". type is null");
                 default:
-                    Type dispatcherType = Type.GetType(type);
-                    if (dispatcherType == null)
-                    {
-                        throw new NotSupportedException("Could not resolve dispatcher type " + type+" for path "+ path);
-                    }
+                    Type dispatcherType = TypeExtensions.ResolveConfiguredType(type,typeof(MessageDispatcher));
                     dispatcher = (MessageDispatcher) Activator.CreateInstance(dispatcherType);
                     break;
             }

--- a/src/core/Akka/Dispatch/Mailboxes.cs
+++ b/src/core/Akka/Dispatch/Mailboxes.cs
@@ -35,6 +35,7 @@ namespace Akka.Dispatch
             foreach (var kvp in requirements)
             {
                 var type = Type.GetType(kvp.Key);
+                //TODO: should this throw?
                 if (type == null)
                 {
                     //TODO: can't log here, logger not created yet

--- a/src/core/Akka/Event/LoggingBus.cs
+++ b/src/core/Akka/Event/LoggingBus.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Akka.Configuration;
+using Akka.Util;
 
 namespace Akka.Event
 {
@@ -83,12 +84,7 @@ namespace Akka.Event
             var shouldRemoveStandardOutLogger = true;
             foreach (var strLoggerType in loggerTypes)
             {
-                var loggerType = Type.GetType(strLoggerType);
-
-                if (loggerType == null)
-                {
-                    throw new ConfigurationException("Logger specified in config cannot be found: \"" + strLoggerType + "\"");
-                }
+                var loggerType = TypeExtensions.ResolveConfiguredType(strLoggerType);
                 if (loggerType == typeof(StandardOutLogger))
                 {
                     shouldRemoveStandardOutLogger = false;

--- a/src/core/Akka/Serialization/Serialization.cs
+++ b/src/core/Akka/Serialization/Serialization.cs
@@ -40,6 +40,7 @@ namespace Akka.Serialization
                 var serializerType = Type.GetType(serializerTypeName);
                 if (serializerType == null)
                 {
+                    //TODO: why does this log when mailbox type resolution does not?
                     system.Log.Warning(string.Format("The type name for serializer '{0}' did not resolve to an actual Type: '{1}'",
                             kvp.Key, serializerTypeName));
                     continue;
@@ -55,7 +56,7 @@ namespace Akka.Serialization
                 var typename = kvp.Key;
                 var serializerName = kvp.Value.GetString();
                 var messageType = Type.GetType(typename);
-
+                //TODO: should this throw?
                 if (messageType == null)
                 {
 

--- a/src/core/Akka/Util/TypeExtensions.cs
+++ b/src/core/Akka/Util/TypeExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Akka.Configuration;
 
 namespace Akka.Util
 {
@@ -29,6 +30,83 @@ namespace Akka.Util
         public static bool Implements(this Type type, Type moreGeneralType)
         {
             return moreGeneralType.IsAssignableFrom(type);
+        }
+
+        /// <summary>
+        /// Resolvesa Type from typeName, throws ArgumentException if typeName is not a valid type.
+        /// </summary>
+        /// <param name="typeName">Name of the type to resolve</param>
+        /// <returns>A resolved type</returns>
+        public static Type ResolveType(string typeName)
+        {
+            var type = Type.GetType(typeName);
+            if (type == null)
+            {
+                throw new ArgumentException("Provided type name did not resolve an actual type", "typeName");
+            }
+            return type;
+        }
+
+        /// <summary>
+        /// Resolvesa Type from typeName.
+        /// Throws ArgumentException if typeName is not a valid type.
+        /// </summary>
+        /// <param name="typeName"></param>
+        /// <param name="implementsType"></param>
+        /// <returns></returns>
+        public static Type ResolveType(string typeName, Type implementsType)
+        {
+            var type = ResolveType(typeName);
+            if (implementsType == null) 
+                return type;
+
+            if (!implementsType.IsAssignableFrom(type))
+            {
+                throw new ArgumentException(
+                    string.Format("Provided type name '{0}' is not assignable to type '{1}'", typeName,
+                        implementsType.Name));
+            }
+            return type;
+        }
+
+        /// <summary>
+        /// Resolves a Type from typeName.
+        /// Throws ConfigurationException if typeName is not a valid type.
+        /// </summary>
+        /// <param name="typeName"></param>
+        /// <returns></returns>
+        public static Type ResolveConfiguredType(string typeName)
+        {
+            var type = Type.GetType(typeName);
+            if (type == null)
+            {
+                throw new ConfigurationException(string.Format("Provided type name '{0}' did not resolve an actual type", typeName));
+            }
+
+            return type;
+        }
+
+        /// <summary>
+        /// Resolves a Type from typeName.
+        /// Throws ConfigurationException if typeName is not a valid type.
+        /// Throws ConfigurationException if resolved type is not compatible with implementsType.
+        /// </summary>
+        /// <param name="typeName"></param>
+        /// <param name="implementsType"></param>
+        /// <returns></returns>
+        public static Type ResolveConfiguredType(string typeName,Type implementsType)
+        {
+            var type = ResolveConfiguredType(typeName);
+            if (implementsType == null) 
+                return type;
+
+            if (!implementsType.IsAssignableFrom(type))
+            {
+                throw new ConfigurationException(
+                    string.Format("Provided type name '{0}' is not assignable to type '{1}'", typeName,
+                        implementsType.Name));
+            }
+            return type;
         }
     }
 }


### PR DESCRIPTION
Related to #233 
- Added better typeresolution for config and serialization.
  instead of checking `Type.GetType` for `null` result, that is now handled in a helper method with a consistent error message.

Questions:
- What should the errormessages be?
- Where should the helper methods live? currently located in `TypeExtensions` but these are not extension methods, 
- there is some inconsistent behavior on failed resolution, throw, log, ignore, see todo's
