### PR TITLE
F# API changes

### DIFF
--- a/src/core/Akka.FSharp/FsApi.fs
+++ b/src/core/Akka.FSharp/FsApi.fs
@@ -18,15 +18,11 @@ type Actor<'msg> =
 type Actor() = 
     inherit Akka.Actor.UntypedActor()
 
-let inline select (path : string) : ActorSelection = ActorSelection(ActorCell.GetCurrentSelfOrNoSender(), path)
+let inline select (selector: ActorRefFactory) (path : string) : ActorSelection = selector.ActorSelection path
 let inline (<!) (actorRef : #ICanTell) (msg : obj) = actorRef.Tell(msg, ActorCell.GetCurrentSelfOrNoSender())
 let inline (!>) (msg : obj) (actorRef : #ICanTell) = actorRef <! msg
 let inline (<?) (tell : #ICanTell) (msg : obj) = tell.Ask msg |> Async.AwaitTask
 let inline (?>) (msg : obj) (actorRef : #ICanTell) = actorRef <? msg
-
-module ActorSelection = 
-    let inline (<!) (actorPath : string) (msg : obj) = (select actorPath) <! msg
-    let inline (<?) (actorPath : string) (msg : obj) = (select actorPath) <? msg
 
 type ActorPath with
     


### PR DESCRIPTION
### New F# helper functions

While working with F# and Akka.NET I've often implemented a helper functions, which wrapped actor receiver logic into F#-specific actor loop. My proposition is to to use include them into standard FsApi. 

Example:

``` fsharp
let receiver = function
    | Some x -> printfn "%A" x
    | None -> ()

let receiverWithMailbox (mailbox: Actor<'a>) = function
    | Some x -> 
        printfn "%A" x
        mailbox.Sender() <! x
    | None -> ()

let system = System.create "sys" (Configuration.defaultConfig())
let r1 = spawn system "receiver" (actorOf receiver)
let r2 = spawn system "receiver2" (actorOf2 receiverWithMailbox)
```
### Breaking changes in existing F# API
1. `Strategy.allForOne'` and `Strategy.oneForOne'` renamed to `Strategy.allForOne2` and `Strategy.oneForOne2` - change inspired by standard F# collections library. Since F# won't allow duplicate function names, all functions with same functionality but different argument lists are recognized by digits at the end of the function names.
2. `select` function - it was broken before, since it couldn't be used out of the actor context. Therefore it now will require two parameters instead of one: ActorRefFactory instance and path. It's basically a wrapper over `ActorRefFactory.ActorSelection` method.

Example:

``` fsharp
let system = System.create "sys" (Configuration.defaultConfig())
let selection = select system "akka.tcp://sys@localhost/user/test"
selection <! "test message"
```
1. Removed `<!` and `<?` operators using implicit conversion of string &rarr; ActorSelection. Implicit conversion is now impossible since select method require an `ActorRefFactory` instance.
