### PR TITLE
Replace the unclear MakeDecider with clearer versions

### DIFF
--- a/src/core/Akka.Tests/Actor/ActorRefSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorRefSpec.cs
@@ -110,7 +110,7 @@ namespace Akka.Tests.Actor
                             c.DefaultPostRestart(reason);
                         };
                     });
-                    a.Strategy = new OneForOneStrategy(2, TimeSpan.FromSeconds(1), SupervisorStrategy.MakeDecider(typeof(Exception)));
+                    a.Strategy = new OneForOneStrategy(2, TimeSpan.FromSeconds(1), r=> Directive.Restart);
                     a.Receive<string>((_, ctx) => child.Tell(Kill.Instance));
                 });
 

--- a/src/core/Akka.Tests/Actor/DeathWatchSpec.cs
+++ b/src/core/Akka.Tests/Actor/DeathWatchSpec.cs
@@ -127,7 +127,7 @@ namespace Akka.Tests.Actor
             {
                 var timeout = TimeSpan.FromSeconds(5);
                 var supervisor = Sys.ActorOf(Props.Create(() => new Supervisor(
-                    new OneForOneStrategy(2, TimeSpan.FromSeconds(1), SupervisorStrategy.MakeDecider(typeof(Exception))))));
+                    new OneForOneStrategy(2, TimeSpan.FromSeconds(1), r => Directive.Restart))));
 
                 var t1 = supervisor.Ask(Props.Create(() => new EchoTestActor()));
                 t1.Wait(timeout);

--- a/src/core/Akka/Actor/SupervisorStrategy.cs
+++ b/src/core/Akka/Actor/SupervisorStrategy.cs
@@ -185,18 +185,6 @@ namespace Akka.Actor
         /// </summary>
         public abstract void HandleChildTerminated(IActorContext actorContext, ActorRef child, IEnumerable<InternalActorRef> children);
 
-        public static Func<Exception, Directive> MakeDecider(params Type[] trapExit)
-        {
-            var baseException = typeof (Exception);
-            // all types in [trapExit] have to inherit from System.Exception
-            if (!trapExit.Any(baseException.IsAssignableFrom))
-            {
-                throw new ArgumentException("SupervisorStrategy.MakeDecider requires all provided types to inherit from System.Exception class", "trapExit");
-            }
-
-            return reason => trapExit.Any(e => e.IsInstanceOfType(reason)) ? Directive.Restart : Directive.Escalate;
-        }
-
     }
 
     /// <summary>


### PR DESCRIPTION
Akka JVM has `SupervisorStrategy.makeDecider` functions of which one has been ported to our code.

```
SupervisorStrategy.MakeDecider(exceptions)
```

When you see the line above in the code it is very unclear, just by looking at the name, what it does.
It returns _Restart_ if the reason to why an actor failed is one of the specified exceptions; otherwise _Escalate_ .

A more suitable name would probably have been something like

```
SupervisorStrategy.MakeRestartDeciderFor(exceptions).
```

However in our code base it's only used twice, and the usage looks like this:

```
SupervisorStrategy.MakeDecider(typeof(Exception))
```

Which means, always Restart. This commit replaces those calls with the much clearer

```
reason => Directive.Restart
```

And also removes `MakeDecider`.

If we want to introduce helper functions for making deciders we should not port Akka JVMs way, but introduce our own.

Thoughts?
