### PR TITLE
Stop multi-node tests running as unit tests

### DIFF
--- a/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
+++ b/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
@@ -82,6 +82,7 @@
     <Compile Include="MultiNode\InitialHeartbeatSpec.cs" />
     <Compile Include="MultiNode\JoinInProgressSpec.cs" />
     <Compile Include="MultiNode\MultiNodeClusterSpec.cs" />
+    <Compile Include="MultiNode\MultiNodeFact.cs" />
     <Compile Include="NodeMetricsSpec.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Proto\ClusterMessageSerializerSpec.cs" />

--- a/src/core/Akka.Cluster.Tests/MultiNode/JoinInProgressSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MultiNode/JoinInProgressSpec.cs
@@ -54,7 +54,7 @@ namespace Akka.Cluster.Tests.MultiNode
             _config = spec;
         }
 
-        [Fact]
+        [MultiNodeFact]
         public void AClusterNodeMustSendHeartbeatsImmediatelyWhenJoiningToAvoidFalseFailureDetectionDueToDelayedGossip()
         {
             RunOn(StartClusterNode, _config.First);

--- a/src/core/Akka.Cluster.Tests/MultiNode/MultiNodeFact.cs
+++ b/src/core/Akka.Cluster.Tests/MultiNode/MultiNodeFact.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Xunit;
+
+namespace Akka.Cluster.Tests.MultiNode
+{
+    public class MultiNodeFactAttribute : FactAttribute
+    {
+        public static Lazy<bool> ExecutedByMultiNodeRunner =
+            new Lazy<bool>(() =>
+            {
+                var args = Environment.GetCommandLineArgs();
+                if (args.Length == 0) return false;
+                var firstArg = args[0];
+                return firstArg.Contains("Akka.MultiNodeTestRunner") 
+                    || firstArg.Contains("Akka.NodeTestRunner");
+            });
+
+        public override string Skip
+        {
+            get
+            {
+                return ExecutedByMultiNodeRunner.Value
+                    ? null
+                    : "Must be executed by multi-node test runner";
+            }
+            set { base.Skip = value; }
+        }
+    }
+}


### PR DESCRIPTION
Test runners will ignore the multi-node tests unless they are run from the multi-node test runner.
