### PR TITLE
UnwatchWatchedActors should check _watching and not _watchedBy

### DIFF
--- a/src/core/Akka/Actor/ActorCell.DeathWatch.cs
+++ b/src/core/Akka/Actor/ActorCell.DeathWatch.cs
@@ -100,7 +100,7 @@ namespace Akka.Actor
 
         protected void TellWatchersWeDied()
         {
-            if (!_watchedBy.Any()) return;
+            if (_watchedBy.Count==0) return;
             try
             {
                 // Don't need to send to parent parent since it receives a DWN by default
@@ -137,7 +137,7 @@ namespace Akka.Actor
 
         protected void UnwatchWatchedActors(ActorBase actor)
         {
-            if (!_watchedBy.Any()) return;
+            if(_watching.Count==0) return;
             MaintainAddressTerminatedSubscription(() =>
             {
                 try


### PR DESCRIPTION
This bug caused DeadLetters to be sent in this case:
A watches B
A terminates, and replaces its mailbox with Deadletters
After a while B terminates, so it sends DeathWatchNotification to A which is forwarded to DeadLetters

This fixes it to work like this:
A watches B
A terminates, Sends Unwatch to B and A replaces its mailbox with Deadletters
B Receives Unwatch and removes A from the list of watchers
After a while B terminates. No message sent to A

Also replaced a call to Any() with using Count instead.
