### PR TITLE
Fix regex for ActorPath so it can handle escaped characters correctly

### DIFF
--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -63,6 +63,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
+    <Reference Include="System.Web" />
     <Reference Include="xunit">
       <HintPath>..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>

--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -22,9 +22,11 @@ namespace Akka.Actor
     /// </summary>
     public abstract class ActorPath : IEquatable<ActorPath>, IComparable<ActorPath>
     {
-        /// <summary> The regex that actor names must conform to </summary>
+        /// <summary> The regex that actor names must conform to RFC 2396, http://www.ietf.org/rfc/rfc2396.txt </summary>
+        //Note that AKKA JVM does not allow parenthesis ( ) but, according to RFC 2396 those are allowed, and 
+        //since we use URL Encode to create valid actor names, we must allow them
         public static readonly Regex ElementRegex =
-            new Regex(@"^(?:[-a-zA-Z0-9:@&=+,.!~*'_;]|%\\p{N}{2})(?:[-a-zA-Z0-9:@&=+,.!~*'\$_;]|%\\p{N}{2})*$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+            new Regex(@"^(?:[-a-zA-Z0-9:@&=+,.!~*'_;\(\)]|%[0-9a-fA-F]{2})(?:[-a-zA-Z0-9:@&=+,.!~*'\$_;\(\)]|%[0-9a-fA-F]{2})*$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
         private readonly string _name;
 

--- a/src/core/Akka/Actor/Exceptions.cs
+++ b/src/core/Akka/Actor/Exceptions.cs
@@ -27,8 +27,7 @@ namespace Akka.Actor
     }
 
     /// <summary>
-    /// An ActorInitializationException is thrown when the the initialization logic for an Actor fails.
-    /// which doesn't validate.
+    /// An InvalidActorNameException is thrown when the actor name is invalid
     /// </summary>
     public class InvalidActorNameException : AkkaException
     {


### PR DESCRIPTION
This PR fixes errors introduced in PR #517 which caused the tests in `RemoteWatcherSpec` to fail.

**Escaped characters**
Escaped characters, i.e. % hex hex, for example `%2a` should be matched by the regex, but the regex used the named Unicode character class _N_. Like this

```
%\p{N}{2}
```

i.e. percent followed by exactly two characters from the named Unicode character class _N, All Numbers_.

The problem with that character class is that it also contains other number characters, such as Ⅷ⅓, so `%Ⅷ⅓` was incorrectly matched by the regex.
Also, the character class do not contain the hexadecimal letters `a-f` so `%2a` was not matched.

Changed

```
%\p{N}{2}
```

to:

```
%[0-9a-fA-F]{2}
```

**Parenthesis**
Allow usage of parenthesis ().
Note that AKKA JVM does not allow parenthesis ( ) but, according to RFC 2396, those are allowed and since we use URL Encode (see Akka.Remoting.AddressUrlEncoder) to create valid actor names, we must allow them too.
