### PR TITLE
Implicitly cast a TestProbe to an ActorRef

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,14 @@ Update your `using` statements from `using Akka.Serilog.Event.Serilog;` to `usin
 
 __Breaking Change to the internal api: Changed signatures in the abstract class `SupervisorStrategy`__. The following methods has new signatures: `HandleFailure`, `ProcessFailure`. If you've inherited from `SupervisorStrategy`, `OneForOneStrategy` or `AllForOneStrategy` and overriden the aforementioned methods you need to update their signatures.
 
+__TestProbe can be implicitly casted to ActorRef__. New feature. Tests requring the `ActorRef` of a `TestProbe` can now be simplified:
+``` C#
+var probe = CreateTestProbe();
+var sut = ActorOf<GreeterActor>();
+sut.Tell("Akka", probe); // previously probe.Ref was required
+probe.ExpectMsg("Hi Akka!");
+```
+
 
 #### 0.7.0 Oct 16 2014
 Major new changes and additions in this release, including some breaking changes...

--- a/src/core/Akka.TestKit/TestProbe.cs
+++ b/src/core/Akka.TestKit/TestProbe.cs
@@ -72,5 +72,10 @@ namespace Akka.TestKit
         {
             throw new NotSupportedException("Cannot create a TestProbe from a TestProbe");
         }
+
+        public static implicit operator ActorRef(TestProbe probe)
+        {
+            return probe.Ref;
+        }
     }
 }


### PR DESCRIPTION
This PR makes `TestProbe` implicitly castable to `ActorRef`.

Tests requiring the `ActorRef` of a `TestProbe` can now be simplified:

``` C#
var probe = CreateTestProbe();
var sut = ActorOf<GreeterActor>();
sut.Tell("Akka", probe); // previously probe.Ref was required
probe.ExpectMsg("Hi Akka!");
```
