### PR TITLE
Implement and use SystemGuardianActor instead of GuardianActor

### DIFF
--- a/src/core/Akka/Actor/ActorRefProvider.cs
+++ b/src/core/Akka/Actor/ActorRefProvider.cs
@@ -123,7 +123,7 @@ namespace Akka.Actor
         private ActorSystemImpl _system;
         private readonly Dictionary<string, InternalActorRef> _extraNames = new Dictionary<string, InternalActorRef>();
         private readonly TaskCompletionSource<Status> _terminationPromise = new TaskCompletionSource<Status>();
-        private SupervisorStrategy _systemGuardianStrategy;
+        private readonly SupervisorStrategy _systemGuardianStrategy;
         private VirtualPathContainer _tempContainer;
         private RootGuardianActorRef _rootGuardian;
         private LocalActorRef _userGuardian;    //This is called guardian in Akka
@@ -230,15 +230,13 @@ namespace Akka.Actor
 
         private LocalActorRef CreateSystemGuardian(LocalActorRef rootGuardian, string name, LocalActorRef userGuardian)     //Corresponds to Akka's: override lazy val guardian: systemGuardian
         {
-            //TODO: When SystemGuardianActor has been implemented switch to this:
-            //return CreateRootGuardianChild(rootGuardian, name, () =>
-            //{
-            //    var props = Props.Create(() => new SystemGuardianActor(userGuardian), _systemGuardianStrategy);
+            return CreateRootGuardianChild(rootGuardian, name, () =>
+            {
+                var props = Props.Create(() => new SystemGuardianActor(userGuardian), _systemGuardianStrategy);
 
-            //    var systemGuardian = new LocalActorRef(_system, props, DefaultDispatcher, _defaultMailbox, rootGuardian, RootPath / name);
-            //    return systemGuardian;
-            //});   
-            return (LocalActorRef)rootGuardian.Cell.ActorOf<GuardianActor>(name);           
+                var systemGuardian = new LocalActorRef(_system, props, DefaultDispatcher, _defaultMailbox, rootGuardian, RootPath/name);
+                return systemGuardian;
+            });
         }
 
         private LocalActorRef CreateRootGuardianChild(LocalActorRef rootGuardian, string name, Func<LocalActorRef> childCreator)

--- a/src/core/Akka/Actor/BuiltInActors.cs
+++ b/src/core/Akka/Actor/BuiltInActors.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using Akka.Dispatch.SysMsg;
 using Akka.Event;
 
@@ -31,7 +32,7 @@ namespace Akka.Actor
             else if(message is StopChild)
                 Context.Stop(((StopChild)message).Child);
             else
-                Context.System.DeadLetters.Tell(new DeadLetter(message,Sender,Self),Sender);
+                Context.System.DeadLetters.Tell(new DeadLetter(message, Sender, Self), Sender);
             return true;
         }
     }
@@ -52,10 +53,95 @@ namespace Akka.Actor
         protected override bool Receive(object message)
         {
             //TODO need to add termination hook support
-            if(message is StopChild) Context.Stop(((StopChild)message).Child);
-            else
-                Context.System.DeadLetters.Tell(new DeadLetter(message, Sender, Self), Sender);
+            var terminated = message as Terminated;
+            if(terminated != null)
+            {
+                var terminatedActor = terminated.ActorRef;
+                if(_userGuardian.Equals(terminatedActor))
+                {
+                    // time for the systemGuardian to stop, but first notify all the
+                    // termination hooks, they will reply with TerminationHookDone
+                    // and when all are done the systemGuardian is stopped
+                    Context.Become(Terminating);
+                    //TODO: Send TerminationHook to all registered termination hooks
+                    //foreach(var terminationHook in _terminationHooks)
+                    //{
+                    //    terminationHook.Tell(terminationHook.Instance);
+                    //}
+                    StopWhenAllTerminationHooksDone();
+                }
+                else
+                {
+                    // a registered, and watched termination hook terminated before
+                    // termination process of guardian has started
+                    //TODO: Implement termination hook support
+                    //_terminationHooks.Remove(terminatedActor)
+                }
+                return true;
+            }
+
+
+            var stopChild = message as StopChild;
+            if(stopChild != null)
+            {
+                Context.Stop(stopChild.Child);
+                return true;
+            }
+            var sender = Sender;
+            //TODO: Implement termination hook support
+            //var registerTerminationHook = message as RegisterTerminationHook;
+            //if(registerTerminationHook != null && !ReferenceEquals(sender, Context.System.DeadLetters))
+            //{
+            //    _terminationHooks.Add(sender);
+            //    Context.Watch(sender);
+            //    return true;
+            //}
+            Context.System.DeadLetters.Tell(new DeadLetter(message, sender, Self), sender);
             return true;
+        }
+
+        private bool Terminating(object message)
+        {
+            var terminated = message as Terminated;
+            if(terminated != null)
+            {
+                StopWhenAllTerminationHooksDone(terminated.ActorRef);
+                return true;
+            }
+            var sender = Sender;
+            //TODO: Implement termination hook support
+            //var terminationHookDone = message as TerminationHookDone;
+            //if(terminationHookDone != null)
+            //{
+            //    StopWhenAllTerminationHooksDone(sender);
+            //    return true;
+            //}
+            Context.System.DeadLetters.Tell(new DeadLetter(message, sender, Self), sender);
+            return true;
+        }
+
+        private void StopWhenAllTerminationHooksDone(ActorRef remove)
+        {
+            //TODO: Implement termination hook support
+            //_terminationHooks.Remove(terminatedActor)
+            StopWhenAllTerminationHooksDone();
+        }
+
+        private void StopWhenAllTerminationHooksDone()
+        {
+            //TODO: Implement termination hook support
+            //if(_terminationHooks.Count == 0)
+            {
+                var actorSystem = Context.System;
+                actorSystem.EventStream.StopDefaultLoggers(actorSystem);
+                Context.Stop(Self);
+            }
+        }
+
+        protected override void PreRestart(Exception reason, object message)
+        {
+            //Guardian MUST NOT lose its children during restart
+            //Intentionally left blank
         }
     }
 
@@ -66,7 +152,8 @@ namespace Akka.Actor
     {
         private readonly EventStream _eventStream;
 
-        public DeadLetterActorRef(ActorRefProvider provider, ActorPath path, EventStream eventStream) : base(provider,path,eventStream)
+        public DeadLetterActorRef(ActorRefProvider provider, ActorPath path, EventStream eventStream)
+            : base(provider, path, eventStream)
         {
             _eventStream = eventStream;
         }
@@ -75,7 +162,7 @@ namespace Akka.Actor
 
         protected override void HandleDeadLetter(DeadLetter deadLetter)
         {
-            if(!SpecialHandle(deadLetter.Message,deadLetter.Sender))
+            if(!SpecialHandle(deadLetter.Message, deadLetter.Sender))
                 _eventStream.Publish(deadLetter);
         }
 

--- a/src/core/Akka/Event/LoggingBus.cs
+++ b/src/core/Akka/Event/LoggingBus.cs
@@ -74,7 +74,7 @@ namespace Akka.Event
         /// </summary>
         /// <param name="system">The system.</param>
         /// <exception cref="System.Exception">Can not use logger of type: + loggerType</exception>
-        public void StartDefaultLoggers(ActorSystemImpl system)
+        public void StartDefaultLoggers(ActorSystemImpl system) //TODO: Should be internal
         {
             var logName = SimpleName(this) + "(" + system.Name + ")";
             var logLevel = Logging.LogLevelFor(system.Settings.LogLevel);
@@ -117,6 +117,11 @@ namespace Akka.Event
                 Unsubscribe(Logging.StandardOutLogger);
             }
             Publish(new Debug(logName, GetType(), "Default Loggers started"));
+        }
+
+        internal void StopDefaultLoggers(ActorSystem system)
+        {
+            //TODO: Implement stopping loggers
         }
 
         private void AddLogger(ActorSystemImpl system, Type loggerType, LogLevel logLevel, string loggingBusName, TimeSpan timeout)


### PR DESCRIPTION
System Guardian, the one called **"system"** previously was a `GuardianActor`

This PR implements `SystemGuardianActor` and uses it instead.
Note that termination hooks are not implemented yet.
