### PR TITLE
Allow EventFilter to match paths without system name for source

### DIFF
--- a/src/core/Akka.TestKit/Akka.TestKit.csproj
+++ b/src/core/Akka.TestKit/Akka.TestKit.csproj
@@ -89,6 +89,7 @@
     </Compile>
     <Compile Include="EventFilter\EventFilterFactory.cs" />
     <Compile Include="EventFilter\Internal\InfoFilter.cs" />
+    <Compile Include="EventFilter\Internal\StringMatcher\EqualsStringAndPathMatcher.cs" />
     <Compile Include="EventFilter\Internal\StringMatcher\IStringMatcher.cs" />
     <Compile Include="EventFilter\Internal\StringMatcher\MatchesAll.cs" />
     <Compile Include="EventFilter\Internal\StringMatcher\PredicateMatcher.cs" />

--- a/src/core/Akka.TestKit/EventFilter/EventFilterFactory.cs
+++ b/src/core/Akka.TestKit/EventFilter/EventFilterFactory.cs
@@ -59,7 +59,7 @@ namespace Akka.TestKit
         /// <returns>The new filter</returns>
         public EventFilterApplier Exception(Type exceptionType, Regex pattern, string source = null, bool checkInnerExceptions=false)
         {
-            var sourceMatcher = source == null ? null : new EqualsString(source);
+            var sourceMatcher = source == null ? null : new EqualsStringAndPathMatcher(source);
             return Exception(exceptionType, new RegexMatcher(pattern), sourceMatcher, checkInnerExceptions);
         }
 
@@ -117,7 +117,7 @@ namespace Akka.TestKit
         public EventFilterApplier Exception(Type exceptionType, string message = null, string start = null, string contains = null, string source = null, bool checkInnerExceptions=false)
         {
             var messageMatcher = CreateMessageMatcher(message, start, contains);
-            var sourceMatcher = source == null ? null : new EqualsString(source);
+            var sourceMatcher = source == null ? null : new EqualsStringAndPathMatcher(source);
             return Exception(exceptionType, messageMatcher, sourceMatcher, checkInnerExceptions);
         }
 
@@ -249,7 +249,7 @@ namespace Akka.TestKit
 
         private EventFilterApplier DeadLetter(Predicate<DeadLetter> isMatch, string source = null)
         {
-            var sourceMatcher = source == null ? null : new EqualsString(source);
+            var sourceMatcher = source == null ? null : new EqualsStringAndPathMatcher(source);
             var filter = new DeadLettersFilter(null, sourceMatcher, isMatch);
             return CreateApplier(filter);
         }

--- a/src/core/Akka.TestKit/EventFilter/EventFilterFactory_Generated.cs
+++ b/src/core/Akka.TestKit/EventFilter/EventFilterFactory_Generated.cs
@@ -46,7 +46,7 @@ namespace Akka.TestKit
         public EventFilterApplier Error(string message = null, string start = null, string contains = null, string source = null)
         {				    
             var messageMatcher = CreateMessageMatcher(message, start, contains);   //This file has been auto generated. Do NOT modify this file directly
-            var sourceMatcher = source == null ? null : new EqualsString(source);
+            var sourceMatcher = source == null ? null : new EqualsStringAndPathMatcher(source);
             var filter = new ErrorFilter(messageMatcher, sourceMatcher);
             return CreateApplier(filter);
         }
@@ -66,7 +66,7 @@ namespace Akka.TestKit
         /// <returns>The new filter</returns>
         public EventFilterApplier Error(Regex pattern, string source = null)
         {
-            var sourceMatcher = source == null ? null : new EqualsString(source);
+            var sourceMatcher = source == null ? null : new EqualsStringAndPathMatcher(source);
             var filter = new ErrorFilter(new RegexMatcher(pattern), sourceMatcher);
             return CreateApplier(filter);
         }
@@ -103,7 +103,7 @@ namespace Akka.TestKit
         public EventFilterApplier Warning(string message = null, string start = null, string contains = null, string source = null)
         {				    
             var messageMatcher = CreateMessageMatcher(message, start, contains);   //This file has been auto generated. Do NOT modify this file directly
-            var sourceMatcher = source == null ? null : new EqualsString(source);
+            var sourceMatcher = source == null ? null : new EqualsStringAndPathMatcher(source);
             var filter = new WarningFilter(messageMatcher, sourceMatcher);
             return CreateApplier(filter);
         }
@@ -123,7 +123,7 @@ namespace Akka.TestKit
         /// <returns>The new filter</returns>
         public EventFilterApplier Warning(Regex pattern, string source = null)
         {
-            var sourceMatcher = source == null ? null : new EqualsString(source);
+            var sourceMatcher = source == null ? null : new EqualsStringAndPathMatcher(source);
             var filter = new WarningFilter(new RegexMatcher(pattern), sourceMatcher);
             return CreateApplier(filter);
         }
@@ -160,7 +160,7 @@ namespace Akka.TestKit
         public EventFilterApplier Info(string message = null, string start = null, string contains = null, string source = null)
         {				    
             var messageMatcher = CreateMessageMatcher(message, start, contains);   //This file has been auto generated. Do NOT modify this file directly
-            var sourceMatcher = source == null ? null : new EqualsString(source);
+            var sourceMatcher = source == null ? null : new EqualsStringAndPathMatcher(source);
             var filter = new InfoFilter(messageMatcher, sourceMatcher);
             return CreateApplier(filter);
         }
@@ -180,7 +180,7 @@ namespace Akka.TestKit
         /// <returns>The new filter</returns>
         public EventFilterApplier Info(Regex pattern, string source = null)
         {
-            var sourceMatcher = source == null ? null : new EqualsString(source);
+            var sourceMatcher = source == null ? null : new EqualsStringAndPathMatcher(source);
             var filter = new InfoFilter(new RegexMatcher(pattern), sourceMatcher);
             return CreateApplier(filter);
         }
@@ -217,7 +217,7 @@ namespace Akka.TestKit
         public EventFilterApplier Debug(string message = null, string start = null, string contains = null, string source = null)
         {				    
             var messageMatcher = CreateMessageMatcher(message, start, contains);   //This file has been auto generated. Do NOT modify this file directly
-            var sourceMatcher = source == null ? null : new EqualsString(source);
+            var sourceMatcher = source == null ? null : new EqualsStringAndPathMatcher(source);
             var filter = new DebugFilter(messageMatcher, sourceMatcher);
             return CreateApplier(filter);
         }
@@ -237,7 +237,7 @@ namespace Akka.TestKit
         /// <returns>The new filter</returns>
         public EventFilterApplier Debug(Regex pattern, string source = null)
         {
-            var sourceMatcher = source == null ? null : new EqualsString(source);
+            var sourceMatcher = source == null ? null : new EqualsStringAndPathMatcher(source);
             var filter = new DebugFilter(new RegexMatcher(pattern), sourceMatcher);
             return CreateApplier(filter);
         }

--- a/src/core/Akka.TestKit/EventFilter/EventFilterFactory_Generated.tt
+++ b/src/core/Akka.TestKit/EventFilter/EventFilterFactory_Generated.tt
@@ -65,7 +65,7 @@ private void Generate(string name)
         public EventFilterApplier <#= name #>(string message = null, string start = null, string contains = null, string source = null)
         {				    
             var messageMatcher = CreateMessageMatcher(message, start, contains);   //This file has been auto generated. Do NOT modify this file directly
-            var sourceMatcher = source == null ? null : new EqualsString(source);
+            var sourceMatcher = source == null ? null : new EqualsStringAndPathMatcher(source);
             var filter = new <#= name #>Filter(messageMatcher, sourceMatcher);
             return CreateApplier(filter);
         }
@@ -85,7 +85,7 @@ private void Generate(string name)
         /// <returns>The new filter</returns>
         public EventFilterApplier <#= name #>(Regex pattern, string source = null)
         {
-            var sourceMatcher = source == null ? null : new EqualsString(source);
+            var sourceMatcher = source == null ? null : new EqualsStringAndPathMatcher(source);
             var filter = new <#= name #>Filter(new RegexMatcher(pattern), sourceMatcher);
             return CreateApplier(filter);
         }

--- a/src/core/Akka.TestKit/EventFilter/Internal/StringMatcher/EqualsStringAndPathMatcher.cs
+++ b/src/core/Akka.TestKit/EventFilter/Internal/StringMatcher/EqualsStringAndPathMatcher.cs
@@ -1,0 +1,36 @@
+using System;
+using Akka.Actor;
+
+namespace Akka.TestKit.Internal.StringMatcher
+{
+    /// <summary>
+    /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
+    /// </summary>
+    public class EqualsStringAndPathMatcher : IStringMatcher
+    {
+        private readonly string _path;
+        private readonly bool _canBeRelative;
+
+        public EqualsStringAndPathMatcher(string path, bool canBeRelative=true)
+        {
+            _path = path;
+            _canBeRelative = canBeRelative;
+        }
+
+        public bool IsMatch(string path)
+        {
+            if (String.Equals(_path, path, StringComparison.OrdinalIgnoreCase)) return true;
+            if(!_canBeRelative)return false;
+
+            ActorPath actorPath;
+            if (!ActorPath.TryParse(path, out actorPath)) return false;
+            var pathWithoutAddress = actorPath.ToStringWithoutAddress();
+            return String.Equals(_path, pathWithoutAddress, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override string ToString()
+        {
+            return "== \"" + _path + "\"";
+        }
+    }
+}


### PR DESCRIPTION
Previously the full path was needed when specifying the source, including the actor system name.

This PR makes it possible to use paths without system name (paths with system name are still allowed):

```
EventFilter.Exception<ActorInitializationException>(source:"/user/failing-actor").ExpectOne(()=>
  ActorOf(Props.Create<FailsOnInstantiationActor>, "failing-actor")
);
```
