### PR TITLE
Log ActorInitializationException instead of underlying exception

### DIFF
--- a/src/core/Akka/Actor/Exceptions.cs
+++ b/src/core/Akka/Actor/Exceptions.cs
@@ -54,13 +54,19 @@ namespace Akka.Actor
 
         public ActorInitializationException(string message) : base(message) { }
 
-        public ActorInitializationException(string message, Exception cause = null) : base(message, cause) { }
+        public ActorInitializationException(string message, Exception cause) : base(message, cause) { }
         public ActorInitializationException(ActorRef actor, string message, Exception cause = null) : base(message, cause)
         {
             _actor = actor;
         }
 
         public ActorRef Actor { get { return _actor; } }
+
+        public override string ToString()
+        {
+            if (_actor == null) return base.ToString();
+            return _actor + ": " + base.ToString();
+        }
     }
 
     /// <summary>

--- a/src/core/Akka/Actor/SupervisorStrategy.cs
+++ b/src/core/Akka/Actor/SupervisorStrategy.cs
@@ -132,14 +132,15 @@ namespace Akka.Actor
             if(LoggingEnabled)
             {
                 var actorInitializationException = cause as ActorInitializationException;
-                if (actorInitializationException != null && actorInitializationException.InnerException!=null)
-                {
-                    cause = actorInitializationException.InnerException;
-                }
+                string message;
+                if(actorInitializationException != null && actorInitializationException.InnerException != null)
+                    message = actorInitializationException.InnerException.Message;
+                else
+                    message = cause.Message;
                 switch (directive)
                 {
                     case Directive.Resume:
-                        Publish(context, new Warning(child.Path.ToString(), GetType(), cause.Message));
+                        Publish(context, new Warning(child.Path.ToString(), GetType(), message));
                         break;
                     case Directive.Escalate:
                         //Don't log here
@@ -147,7 +148,7 @@ namespace Akka.Actor
                     default:
                         //case Directive.Restart:
                         //case Directive.Stop:
-                        Publish(context, new Error(cause, child.Path.ToString(), GetType(), cause.Message));
+                        Publish(context, new Error(cause, child.Path.ToString(), GetType(), message));
                         break;
                 }
             }


### PR DESCRIPTION
We currently log the underlying exception of an `ActorInitializationException` since I screwed up porting this from AKKA JVM a week back. :)
We should only use the message from the underlying exception, and still log the entire `ActorInitializationException`.

This is important since it's otherwise impossible to test that `ActorInitializationException` is thrown.
