### PR TITLE
Akka.NET v0.7.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,25 @@
-#### 0.7.1 NEXTVERSION
-_This is a placeholder for the next released version. Add new stuff that will go into the next version below. It might be 0.7.1 or 0.8. __REMOVE THIS TEXT BEFORE RELEASING!___
+#### 0.7.1 Dec 13 2014
+__Brand New F# API__. The entire F# API has been updated to give it a more native F# feel while still holding true to the Erlang / Scala conventions used in actor systems. [Read more about the F# API changes](https://github.com/akkadotnet/akka.net/pull/526).
+
+__Multi-Node TestKit (Alpha)__. Not available yet as a NuGet package, but the first pass at the Akka.Remote.TestKit is now available from source, which allow you to test your actor systems running on multiple machines or processes.
+
+A multi-node test looks like this
+
+    public class InitialHeartbeatMultiNode1 : InitialHeartbeatSpec
+    {
+    }
+    
+    public class InitialHeartbeatMultiNode2 : InitialHeartbeatSpec
+    {
+    }
+    
+    public class InitialHeartbeatMultiNode3 : InitialHeartbeatSpec
+    {
+    }
+    
+    public abstract class InitialHeartbeatSpec : MultiNodeClusterSpec
+The MultiNodeTestRunner looks at this, works out that it needs to create 3 processes to run 3 nodes for the test.
+It executes NodeTestRunner in each process to do this passing parameters on the command line. [Read more about the multi-node testkit here](https://github.com/akkadotnet/akka.net/pull/497).
 
 __Breaking Change to the internal api: The `Next` property on `IAtomicCounter<T>` has been changed into the function `Next()`__ This was done as it had side effects, i.e. the value was increased when the getter was called. This makes it very hard to debug as the debugger kept calling the property and causing the value to be increased.
 
@@ -16,6 +36,9 @@ sut.Tell("Akka", probe); // previously probe.Ref was required
 probe.ExpectMsg("Hi Akka!");
 ```
 
+__Bugfix for ConsistentHashableEvenlope__. When using `ConsistentHashableEvenlope` in conjunction with `ConsistentHashRouter`s, `ConsistentHashableEvenlope` now correctly extracts its inner message instead of sending the entire `ConsistentHashableEvenlope` directly to the intended routee.
+
+__Akka.Cluster group routers now work as expected__. New update of Akka.Cluster - group routers now work as expected on cluster deployments. Still working on pool routers. [Read more about Akka.Cluster routers here](https://github.com/akkadotnet/akka.net/pull/489).
 
 #### 0.7.0 Oct 16 2014
 Major new changes and additions in this release, including some breaking changes...

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -4,5 +4,5 @@ using System.Reflection;
 [assembly: AssemblyCompanyAttribute("Akka.NET Team")]
 [assembly: AssemblyCopyrightAttribute("Copyright © 2013-2014 Akka.NET Team")]
 [assembly: AssemblyTrademarkAttribute("")]
-[assembly: AssemblyVersionAttribute("0.7.0.0")]
-[assembly: AssemblyFileVersionAttribute("0.7.0.0")]
+[assembly: AssemblyVersionAttribute("0.7.1.0")]
+[assembly: AssemblyFileVersionAttribute("0.7.1.0")]

--- a/src/contrib/loggers/Akka.Logger.NLog/Akka.Logger.NLog.nuspec
+++ b/src/contrib/loggers/Akka.Logger.NLog/Akka.Logger.NLog.nuspec
@@ -9,7 +9,7 @@
     <description>NLog logging adapter for Akka.NET</description>
     <licenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/akkadotnet/akka.net</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon-32x32.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes>@releaseNotes@</releaseNotes>
     <copyright>@copyright@</copyright>

--- a/src/contrib/loggers/Akka.Logger.Serilog/Akka.Logger.Serilog.nuspec
+++ b/src/contrib/loggers/Akka.Logger.Serilog/Akka.Logger.Serilog.nuspec
@@ -9,7 +9,7 @@
     <description>Serilog logging adapter for Akka.NET</description>
     <licenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/akkadotnet/akka.net</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon-32x32.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes>@releaseNotes@</releaseNotes>
     <copyright>@copyright@</copyright>

--- a/src/contrib/loggers/Akka.Logger.slf4net/Akka.Logger.slf4net.nuspec
+++ b/src/contrib/loggers/Akka.Logger.slf4net/Akka.Logger.slf4net.nuspec
@@ -9,7 +9,7 @@
     <description>slf4net logging adapter for Akka.NET</description>
     <licenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/akkadotnet/akka.net</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon-32x32.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes>@releaseNotes@</releaseNotes>
     <copyright>@copyright@</copyright>

--- a/src/contrib/testkits/Akka.TestKit.VsTest/Akka.TestKit.VsTest.nuspec
+++ b/src/contrib/testkits/Akka.TestKit.VsTest/Akka.TestKit.VsTest.nuspec
@@ -9,7 +9,7 @@
     <description>TestKit for writing tests for Akka.NET using Visual Studio Unit Testing Framework.</description>
     <licenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/akkadotnet/akka.net</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon-32x32.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes>@releaseNotes@</releaseNotes>
     <copyright>@copyright@</copyright>

--- a/src/contrib/testkits/Akka.TestKit.Xunit/Akka.TestKit.Xunit.nuspec
+++ b/src/contrib/testkits/Akka.TestKit.Xunit/Akka.TestKit.Xunit.nuspec
@@ -9,7 +9,7 @@
     <description>TestKit for writing tests for Akka.NET using xUnit.</description>
     <licenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/akkadotnet/akka.net</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon-32x32.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes>@releaseNotes@</releaseNotes>
     <copyright>@copyright@</copyright>

--- a/src/core/Akka.Cluster/Akka.Cluster.nuspec
+++ b/src/core/Akka.Cluster/Akka.Cluster.nuspec
@@ -9,7 +9,7 @@
     <description>Cluster support for Akka.NET</description>
     <licenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/akkadotnet/akka.net</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon-32x32.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes>@releaseNotes@</releaseNotes>
     <copyright>@copyright@</copyright>

--- a/src/core/Akka.FSharp/Akka.FSharp.nuspec
+++ b/src/core/Akka.FSharp/Akka.FSharp.nuspec
@@ -9,7 +9,7 @@
     <description>F# API support for Akka.NET</description>
     <licenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/akkadotnet/akka.net</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon-32x32.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes>@releaseNotes@</releaseNotes>
     <copyright>@copyright@</copyright>

--- a/src/core/Akka.Remote/Akka.Remote.nuspec
+++ b/src/core/Akka.Remote/Akka.Remote.nuspec
@@ -9,7 +9,7 @@
     <description>Remote actor support for Akka.NET</description>
     <licenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/akkadotnet/akka.net</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon-32x32.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes>@releaseNotes@</releaseNotes>
     <copyright>@copyright@</copyright>

--- a/src/core/Akka.TestKit/Akka.TestKit.nuspec
+++ b/src/core/Akka.TestKit/Akka.TestKit.nuspec
@@ -10,7 +10,7 @@
     <summary>This only contains base functionality. You need a Akka.TestKit.* package!</summary>
     <licenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/akkadotnet/akka.net</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon-32x32.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes>@releaseNotes@</releaseNotes>
     <copyright>@copyright@</copyright>

--- a/src/core/Akka/Akka.nuspec
+++ b/src/core/Akka/Akka.nuspec
@@ -9,7 +9,7 @@
     <description>Akka.NET is a port of the popular Java/Scala framework Akka to .NET</description>
     <licenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/akkadotnet/akka.net</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon-32x32.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes>@releaseNotes@</releaseNotes>
     <copyright>@copyright@</copyright>


### PR DESCRIPTION
**Brand New F# API**. The entire F# API has been updated to give it a
more native F# feel while still holding true to the Erlang / Scala
conventions used in actor systems. [Read more about the F# API
changes](https://github.com/akkadotnet/akka.net/pull/526).

**Multi-Node TestKit (Alpha)**. Not available yet as a NuGet package,
but the first pass at the Akka.Remote.TestKit is now available from
source, which allow you to test your actor systems running on multiple
machines or processes.

A multi-node test looks like this

public class InitialHeartbeatMultiNode1 : InitialHeartbeatSpec
{
}

public class InitialHeartbeatMultiNode2 : InitialHeartbeatSpec
{
}

public class InitialHeartbeatMultiNode3 : InitialHeartbeatSpec
{
}

public abstract class InitialHeartbeatSpec : MultiNodeClusterSpec
The MultiNodeTestRunner looks at this, works out that it needs to create
3 processes to run 3 nodes for the test.
It executes NodeTestRunner in each process to do this passing parameters
on the command line. [Read more about the multi-node testkit
here](https://github.com/akkadotnet/akka.net/pull/497).

**Breaking Change to the internal api: The `Next` property on
`IAtomicCounter<T>` has been changed into the function `Next()`** This
was done as it had side effects, i.e. the value was increased when the
getter was called. This makes it very hard to debug as the debugger kept
calling the property and causing the value to be increased.

**Akka.Serilog** `SerilogLogMessageFormatter` has been moved to the
namespace `Akka.Logger.Serilog` (it used to be in
`Akka.Serilog.Event.Serilog`).
Update your `using` statements from `using Akka.Serilog.Event.Serilog;`
to `using Akka.Logger.Serilog;`.

**Breaking Change to the internal api: Changed signatures in the
abstract class `SupervisorStrategy`**. The following methods has new
signatures: `HandleFailure`, `ProcessFailure`. If you've inherited from
`SupervisorStrategy`, `OneForOneStrategy` or `AllForOneStrategy` and
overriden the aforementioned methods you need to update their
signatures.

**TestProbe can be implicitly casted to ActorRef**. New feature. Tests
requring the `ActorRef` of a `TestProbe` can now be simplified:

``` C#
var probe = CreateTestProbe();
var sut = ActorOf<GreeterActor>();
sut.Tell("Akka", probe); // previously probe.Ref was required
probe.ExpectMsg("Hi Akka!");
```

**Bugfix for ConsistentHashableEvenlope**. When using
`ConsistentHashableEvenlope` in conjunction with
`ConsistentHashRouter`s, `ConsistentHashableEvenlope` now correctly
extracts its inner message instead of sending the entire
`ConsistentHashableEvenlope` directly to the intended routee.

**Akka.Cluster group routers now work as expected**. New update of
Akka.Cluster - group routers now work as expected on cluster
deployments. Still working on pool routers. [Read more about
Akka.Cluster routers
here](https://github.com/akkadotnet/akka.net/pull/489).
