### PR TITLE
Hocon Value parse fixes #535 and Hocon ToString fix #534

### DIFF
--- a/src/core/Akka.Tests/Configuration/HoconTests.cs
+++ b/src/core/Akka.Tests/Configuration/HoconTests.cs
@@ -580,5 +580,18 @@ akka.actor {
             serializersConfig.Select(kvp => kvp.Value).First().GetString().ShouldBe("Akka.Remote.Serialization.MessageContainerSerializer, Akka.Remote");
             serializerBindingConfig.Select(kvp => kvp.Key).Last().ShouldBe("Akka.Remote.DaemonMsgCreate, Akka.Remote");
         }
+
+        [Fact]
+        public void CanOverwriteValue()
+        {
+            var hocon = @"
+test {
+  value  = 123
+}
+test.value = 456
+";
+            var config = ConfigurationFactory.ParseString(hocon);
+            config.GetInt("test.value").ShouldBe(456);
+        }
     }
 }

--- a/src/core/Akka/Configuration/Hocon/HoconParser.cs
+++ b/src/core/Akka/Configuration/Hocon/HoconParser.cs
@@ -112,6 +112,13 @@ namespace Akka.Configuration.Hocon
                         ParseObject(value, false);
                         return;
                     case TokenType.Assign:
+                        
+                        if (!value.IsObject())
+                        {
+                            //if not an object, then replace the value.
+                            //if object. value should be merged
+                            value.Clear();
+                        }
                         ParseValue(value);
                         return;
                     case TokenType.ObjectStart:
@@ -131,7 +138,6 @@ namespace Akka.Configuration.Hocon
             if (_reader.EoF)
                 throw new Exception("End of file reached while trying to read a value");
 
-            bool isObject = owner.IsObject();
             _reader.PullWhitespaceAndComments();
             while (_reader.IsValue())
             {
@@ -142,10 +148,9 @@ namespace Akka.Configuration.Hocon
                     case TokenType.EoF:
                         break;
                     case TokenType.LiteralValue:
-                        if (isObject)
+                        if (owner.IsObject())
                         {
                             //needed to allow for override objects
-                            isObject = false;
                             owner.Clear();
                         }
                         var lit = new HoconLiteral

--- a/src/core/Akka/Configuration/Hocon/HoconValue.cs
+++ b/src/core/Akka/Configuration/Hocon/HoconValue.cs
@@ -262,9 +262,9 @@ namespace Akka.Configuration.Hocon
             }
             if (IsArray())
             {
-                return string.Format("[{0}]", string.Join(",", GetArray().Select(e => e.ToString())));
+                return string.Format("[{0}]", string.Join(",", GetArray().Select(e => e.ToString(indent + 1))));
             }
-            return "aa";
+            return "<<unknown value>>";
         }
 
         private string QuoteIfNeeded(string text)


### PR DESCRIPTION
#### Hocon values was not replaced when assigning a new value to the same path.

```
a.b.c = 123
a.b.c = 456
```

Result was 123456
#535
#### Hocon Arrays string representation was incorrectly indented.

Minor cosmetic fix for hocon `ToString`, now indenting array contents properly. 
#534
