### PR TITLE
Plugable actor creation pipeline + IDisposable action handling

### DIFF
--- a/src/core/Akka.Tests/Actor/ActorProducerPipelineTests.cs
+++ b/src/core/Akka.Tests/Actor/ActorProducerPipelineTests.cs
@@ -1,0 +1,197 @@
+﻿using System;
+using System.Collections.Generic;
+using Akka.Actor;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Tests.Actor
+{
+    public class ActorProducerPipelineTests : AkkaSpec
+    {
+        #region internal test classes
+
+        internal class TestException : Exception
+        {
+            public TestException(string message)
+                : base(message)
+            {
+            }
+        }
+
+        internal class PlugActor : ActorBase
+        {
+            public List<string> PluginMessages { get; private set; }
+            public PlugActor()
+            {
+                PluginMessages = new List<string>();
+            }
+
+            protected override bool Receive(object message)
+            {
+                Sender.Tell(PluginMessages.ToArray());
+                return true;
+            }
+        }
+
+        internal class PlugActorA : PlugActor { }
+        internal class PlugActorB : PlugActor { }
+
+        internal class GenericPlugin<T> : ActorProducerPluginBase<T> where T : PlugActor
+        {
+            public override void AfterActorCreated(T actor, IActorContext context)
+            {
+                actor.PluginMessages.Add(typeof(T).ToString());
+            }
+        }
+
+        internal class WorkingPlugin : ActorProducerPluginBase<PlugActor>
+        {
+            public override void AfterActorCreated(PlugActor actor, IActorContext context)
+            {
+                actor.PluginMessages.Add("working plugin");
+            }
+        }
+
+        internal class FailingPlugin : ActorProducerPluginBase<PlugActor>
+        {
+            public override void AfterActorCreated(PlugActor actor, IActorContext context)
+            {
+                actor.PluginMessages.Add("failing plugin");
+                throw new TestException("plugin failed");
+            }
+        }
+
+        internal class OrderedPlugin : ActorProducerPluginBase<PlugActor>
+        {
+            private readonly int _index;
+
+            public OrderedPlugin(int index)
+            {
+                _index = index;
+            }
+
+            public override void AfterActorCreated(PlugActor actor, IActorContext context)
+            {
+                actor.PluginMessages.Add("plugin-" + _index);
+            }
+        }
+
+        internal class OrderedPlugin1 : OrderedPlugin
+        {
+            public OrderedPlugin1() : base(1) { }
+        }
+
+        internal class OrderedPlugin2 : OrderedPlugin
+        {
+            public OrderedPlugin2() : base(2) { }
+        }
+
+        internal class OrderedPlugin3 : OrderedPlugin
+        {
+            public OrderedPlugin3() : base(3) { }
+        }
+
+        internal sealed class StashStatus
+        {
+            public static readonly StashStatus Instance = new StashStatus();
+            private StashStatus() { }
+        }
+
+        internal class StashingActor: ReceiveActor, WithUnboundedStash
+        {
+            public StashingActor()
+            {
+                Receive<StashStatus>(status => Sender.Tell("actor stash is " + (Stash != null ? "initialized" : "uninitialized")));
+                ReceiveAny(_ => Stash.Stash());
+            }
+
+            public IStash Stash { get; set; }
+        }
+
+        #endregion
+
+        private ActorProducerPipeline _pipeline;
+
+        public ActorProducerPipelineTests()
+        {
+            var extendedSystem = (ExtendedActorSystem)Sys;
+            _pipeline = extendedSystem.ActorProducerPipeline;
+        }
+
+        [Fact]
+        public void Pipeline_application_should_survive_internal_plugin_exceptions()
+        {
+            _pipeline.Register(new FailingPlugin());
+            _pipeline.Register(new WorkingPlugin());
+
+            EventFilter.Exception<TestException>("plugin failed").ExpectOne(() =>
+            {
+                var actor = ActorOf<PlugActor>();
+                var ask = actor.Ask<string[]>("plugins", TimeSpan.FromSeconds(1));
+
+                ask.Result.ShouldOnlyContainInOrder("failing plugin", "working plugin");
+            });
+        }
+
+        [Fact]
+        public void Pipeline_should_not_allow_to_register_the_same_plugin_twice()
+        {
+            var pluginCount = _pipeline.Count;
+
+            _pipeline.Register(new WorkingPlugin()).ShouldBeTrue();
+            _pipeline.Register(new WorkingPlugin()).ShouldBeFalse();
+
+            Assert.Equal(pluginCount + 1, _pipeline.Count);
+        }
+
+        [Fact]
+        public void Pipeline_should_allow_to_register_multiple_generic_plugins_with_different_generic_types()
+        {
+            _pipeline.Register(new WorkingPlugin()).ShouldBeTrue();
+            _pipeline.Register(new GenericPlugin<PlugActorA>()).ShouldBeTrue();
+            _pipeline.Register(new GenericPlugin<PlugActorB>()).ShouldBeTrue();
+
+            var plugA = ActorOf<PlugActorA>();
+            var plugB = ActorOf<PlugActorB>();
+
+            plugA.Ask<string[]>("plugins", TimeSpan.FromSeconds(3)).Result.ShouldOnlyContainInOrder("working plugin", typeof(PlugActorA).ToString());
+            plugB.Ask<string[]>("plugins", TimeSpan.FromSeconds(3)).Result.ShouldOnlyContainInOrder("working plugin", typeof(PlugActorB).ToString());
+        }
+
+        [Fact]
+        public void Pipeline_application_should_apply_plugins_in_specified_order()
+        {
+            _pipeline.Insert(0, new OrderedPlugin1()).ShouldBeTrue();
+            _pipeline.Insert(2, new OrderedPlugin3()).ShouldBeTrue();
+            _pipeline.Insert(1, new OrderedPlugin2()).ShouldBeTrue();
+
+            var actor = ActorOf<PlugActor>();
+            actor.Ask<string[]>("plugins", TimeSpan.FromSeconds(3)).Result.ShouldOnlyContainInOrder("plugin-1", "plugin-2", "plugin-3");
+        }
+
+        [Fact]
+        public void DefaultPipeline_should_apply_stashing_to_actors_implementing_it()
+        {
+            var actor = ActorOf<StashingActor>();
+            actor.Ask<string>(StashStatus.Instance, TimeSpan.FromSeconds(3)).Result.ShouldBe("actor stash is initialized");
+        }
+
+        [Fact]
+        public void DefaultPipeline_should_unstash_all_terminated_actors_stashed_messages_on_stop()
+        {
+            // we'll send 3 int messages to stash by the actor and then stop it,
+            // all stashed messages should then be unstashed back and sent to dead letters
+            EventFilter.DeadLetter<int>().Expect(3, () =>
+            {
+                var actor = ActorOf<StashingActor>();
+                // send some messages to stash
+                actor.Tell(1);
+                actor.Tell(2);
+                actor.Tell(3);
+                
+                // stop actor
+                actor.Tell(PoisonPill.Instance);
+            });
+        }
+    }
+}

--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Actor\ActorDslSpec.cs" />
     <Compile Include="Actor\ActorLifeCycleSpec.cs" />
     <Compile Include="Actor\ActorPathSpec.cs" />
+    <Compile Include="Actor\ActorProducerPipelineTests.cs" />
     <Compile Include="Actor\ActorRefSpec.cs" />
     <Compile Include="Actor\InboxSpec.cs" />
     <Compile Include="Actor\LocalActorRefProviderSpec.cs" />

--- a/src/core/Akka/Actor/ActorCell.FaultHandling.cs
+++ b/src/core/Akka/Actor/ActorCell.FaultHandling.cs
@@ -58,10 +58,8 @@ namespace Akka.Actor
                         // if the actor fails in preRestart, we can do nothing but log it: it’s best-effort
                         failedActor.AroundPreRestart(cause, optionalMessage);
 
-                        //if the actor uses a stash Unstash all messages. 
-                        //If the user do not want this behavior, the stash should be cleared in PreRestart
-                        //either by calling ClearStash or by calling UnstashAll.
-                        UnstashAllActorMessages(failedActor);
+                        // run actor termination plugin pipeline
+                        _systemImpl.ActorProducerPipeline.BeforeActorTerminated(failedActor, this);
                     }
                     catch (Exception e)
                     {
@@ -87,15 +85,6 @@ namespace Akka.Actor
             {
                 // need to keep that suspend counter balanced
                 FaultResume(null);
-            }
-        }
-
-        private static void UnstashAllActorMessages(ActorBase actor)
-        {
-            var actorStash = actor as IActorStash;
-            if (actorStash != null)
-            {
-                actorStash.Stash.UnstashAll();
             }
         }
 
@@ -285,10 +274,8 @@ namespace Akka.Actor
                 {
                     a.AroundPostStop();
 
-                    //if the actor uses a stash, we must Unstash all messages. 
-                    //If the user do not want this behavior, the stash should be cleared in PostStop
-                    //either by calling ClearStash or by calling UnstashAll.
-                    UnstashAllActorMessages(a);
+                    // run actor termination plugin pipeline
+                    _systemImpl.ActorProducerPipeline.BeforeActorTerminated(a, this);
                 }
             }
             catch (Exception x)

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -263,9 +263,13 @@ namespace Akka.Actor
                     {
                         disposable.Dispose();
                     }
-                    catch (Exception)
+                    catch (Exception e)
                     {
-                        //TODO: what if user defined Dispose method will fail?
+                        if (_systemImpl.Log != null)
+                        {
+                            _systemImpl.Log.Error(e, "An error occurred while disposing {0} actor. Reason: {1}", 
+                                actor.GetType(), e.Message);
+                        }
                     }
                 }
 

--- a/src/core/Akka/Actor/ActorProducerPipeline.cs
+++ b/src/core/Akka/Actor/ActorProducerPipeline.cs
@@ -1,0 +1,251 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Akka.Event;
+
+namespace Akka.Actor
+{
+    /// <summary>
+    /// Plugin interface used to define
+    /// </summary>
+    public interface IActorProducerPlugin
+    {
+        /// <summary>
+        /// Determines if current plugin can be applied to provided <paramref name="actor"/> instance.
+        /// </summary>
+        bool CanBeAppliedTo(ActorBase actor);
+
+        /// <summary>
+        /// Plugin behavior applied to <paramref name="actor"/> instance when the new one is being created.
+        /// </summary>
+        void AfterActorCreated(ActorBase actor, IActorContext context);
+
+        /// <summary>
+        /// Plugin behavior applied to <paramref name="actor"/> instance before the actor is being recycled.
+        /// </summary>
+        void BeforeActorTerminated(ActorBase actor, IActorContext context);
+    }
+
+    /// <summary>
+    /// Base actor producer pipeline plugin class.
+    /// </summary>
+    public abstract class ActorProducerPluginBase : IActorProducerPlugin
+    {
+        /// <summary>
+        /// By default derivatives of this plugin will be applied to all actors.
+        /// </summary>
+        public virtual bool CanBeAppliedTo(ActorBase actor)
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// Plugin behavior applied to <paramref name="actor"/> instance when the new one is being created.
+        /// </summary>
+        public virtual void AfterActorCreated(ActorBase actor, IActorContext context) { }
+
+        /// <summary>
+        /// Plugin behavior applied to <paramref name="actor"/> instance before the actor is being recycled.
+        /// </summary>
+        public virtual void BeforeActorTerminated(ActorBase actor, IActorContext context) { }
+    }
+
+    /// <summary>
+    /// Base generic actor producer pipeline plugin class.
+    /// </summary>
+    public abstract class ActorProducerPluginBase<TActor> : IActorProducerPlugin where TActor : ActorBase
+    {
+        /// <summary>
+        /// By default derivatives of this plugin will be applied to all actors inheriting from <typeparam name="TActor">actor generic type</typeparam>.
+        /// </summary>
+        public virtual bool CanBeAppliedTo(ActorBase actor)
+        {
+            return actor is TActor;
+        }
+
+        void IActorProducerPlugin.AfterActorCreated(ActorBase actor, IActorContext context)
+        {
+            AfterActorCreated(actor as TActor, context);
+        }
+
+        void IActorProducerPlugin.BeforeActorTerminated(ActorBase actor, IActorContext context)
+        {
+            BeforeActorDestroyed(actor as TActor, context);
+        }
+
+        /// <summary>
+        /// Plugin behavior applied to <paramref name="actor"/> instance when the new one is being created.
+        /// </summary>
+        public virtual void AfterActorCreated(TActor actor, IActorContext context) { }
+
+        /// <summary>
+        /// Plugin behavior applied to <paramref name="actor"/> instance before the actor is being recycled.
+        /// </summary>
+        public virtual void BeforeActorDestroyed(TActor actor, IActorContext context) { }
+    }
+
+    internal class DefaultProducerPipeline : ActorProducerPipeline
+    {
+        public DefaultProducerPipeline(Func<LoggingAdapter> logBuilder)
+            : base(logBuilder, new ActorStashPlugin())
+        {
+        }
+    }
+
+    public class ActorProducerPipeline : IEnumerable<IActorProducerPlugin>
+    {
+        private LoggingAdapter _log;
+        private readonly Func<LoggingAdapter> _logBuilder;
+        private readonly List<IActorProducerPlugin> _plugins;
+
+        public ActorProducerPipeline(Func<LoggingAdapter> logBuilder, params IActorProducerPlugin[] defaultPlugins)
+        {
+            _logBuilder = logBuilder;
+            _plugins = defaultPlugins != null && defaultPlugins.Length > 0
+                ? new List<IActorProducerPlugin>(defaultPlugins)
+                : new List<IActorProducerPlugin>();
+        }
+
+        public LoggingAdapter Log { get { return _log ?? (_log = _logBuilder()); } }
+
+        public int Count { get { return _plugins.Count; } }
+
+        public IEnumerator<IActorProducerPlugin> GetEnumerator()
+        {
+            return _plugins.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        /// <summary>
+        /// Register target <paramref name="plugin"/> at the end of producer pipeline.
+        /// </summary>
+        /// <returns>True if plugin was registered (it has not been found in pipeline already). False otherwise. </returns>
+        public bool Register(IActorProducerPlugin plugin)
+        {
+            if (!AlreadyExists(plugin))
+            {
+                _plugins.Add(plugin);
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Register target <paramref name="plugin"/> inside producer pipeline at specified <paramref name="index"/>.
+        /// </summary>
+        /// <returns>True if plugin was registered (it has not been found in pipeline already). False otherwise. </returns>
+        public bool Insert(int index, IActorProducerPlugin plugin)
+        {
+            if (!AlreadyExists(plugin))
+            {
+                _plugins.Insert(index, plugin);
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Unregisters plugin from producer pipeline, returning false if plugin was not found.
+        /// </summary>
+        public bool Unregister(IActorProducerPlugin plugin)
+        {
+            return _plugins.Remove(plugin);
+        }
+
+        /// <summary>
+        /// Returns true if current actor producer pipeline already has registered provided plugin type.
+        /// </summary>
+        public bool IsRegistered(IActorProducerPlugin plugin)
+        {
+            return _plugins.Any(p => p.GetType() == plugin.GetType());
+        }
+
+        /// <summary>
+        /// Resolves and applies all plugins valid to specified <paramref name="actor"/> 
+        /// registered in current producer pipeline to newly created actor.
+        /// </summary>
+        internal void AfterActorCreated(ActorBase actor, IActorContext context)
+        {
+            var pipeline = ResolvePipelineFor(actor).ToArray();
+
+            LogDebugPipeline(actor.GetType(), pipeline);
+
+            foreach (var plugin in pipeline)
+            {
+                try
+                {
+                    plugin.AfterActorCreated(actor, context);
+                }
+                catch (Exception cause)
+                {
+                    const string fmt = "An exception occured while trying to apply plugin of type {0} to the newly created actor (Type = {1}, Path = {2})";
+                    LogException(actor, cause, fmt, plugin);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Resolves and applies all plugins valid to specified <paramref name="actor"/> 
+        /// registered in current producer pipeline before old actor would be recycled.
+        /// </summary>
+        internal void BeforeActorTerminated(ActorBase actor, IActorContext context)
+        {
+            var pipeline = ResolvePipelineFor(actor).ToArray();
+
+            LogDebugPipeline(actor.GetType(), pipeline);
+
+            foreach (var plugin in pipeline)
+            {
+                try
+                {
+                    plugin.BeforeActorTerminated(actor, context);
+                }
+                catch (Exception cause)
+                {
+                    const string fmt = "An exception occured while trying to apply plugin of type {0} to the actor before it's destruction (Type = {1}, Path = {2})";
+                    LogException(actor, cause, fmt, plugin);
+                }
+            }
+        }
+
+        private IEnumerable<IActorProducerPlugin> ResolvePipelineFor(ActorBase actor)
+        {
+            return _plugins.Where(plugin => plugin.CanBeAppliedTo(actor));
+        }
+
+        private void LogDebugPipeline(Type actorType, IActorProducerPlugin[] pipeline)
+        {
+            if (pipeline.Length > 0 && Log != null && Log.IsDebugEnabled)
+            {
+                var debugMessage = string.Format("Resolved plugin pipeline for {0} actor: [{1}]", actorType,
+                    string.Join(", ", pipeline.Select(plug => plug.GetType())));
+
+                Log.Debug(debugMessage);
+            }
+        }
+
+        private void LogException(ActorBase actor, Exception e, string errorMessageFormat, IActorProducerPlugin plugin)
+        {
+            var internalActor = (actor as IInternalActor);
+            var actorPath = internalActor != null && internalActor.ActorContext != null
+                ? internalActor.ActorContext.Self.Path.ToString()
+                : string.Empty;
+
+            Log.Error(e, errorMessageFormat, plugin.GetType(), actor.GetType(), actorPath);
+        }
+
+        private bool AlreadyExists(IActorProducerPlugin plugin)
+        {
+            var pluginType = plugin.GetType();
+            var alreadyExists = _plugins.Any(p => p.GetType() == pluginType);
+            return alreadyExists;
+        }
+    }
+}

--- a/src/core/Akka/Actor/ActorProducerPipeline.cs
+++ b/src/core/Akka/Actor/ActorProducerPipeline.cs
@@ -71,7 +71,7 @@ namespace Akka.Actor
 
         void IActorProducerPlugin.BeforeActorTerminated(ActorBase actor, IActorContext context)
         {
-            BeforeActorDestroyed(actor as TActor, context);
+            BeforeActorTerminated(actor as TActor, context);
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace Akka.Actor
         /// <summary>
         /// Plugin behavior applied to <paramref name="actor"/> instance before the actor is being recycled.
         /// </summary>
-        public virtual void BeforeActorDestroyed(TActor actor, IActorContext context) { }
+        public virtual void BeforeActorTerminated(TActor actor, IActorContext context) { }
     }
 
     internal class DefaultProducerPipeline : ActorProducerPipeline

--- a/src/core/Akka/Actor/ExtendedActorSystem.cs
+++ b/src/core/Akka/Actor/ExtendedActorSystem.cs
@@ -26,6 +26,12 @@
         /// </summary>
         public abstract InternalActorRef SystemGuardian { get; }
 
+        /// <summary>
+        /// Gets the actor producer pipeline for current actor system. It may be used by
+        /// Akka plugins to inject custom behavior directly into actor creation chain.
+        /// </summary>
+        public abstract ActorProducerPipeline ActorProducerPipeline { get; }
+
         /// <summary>Creates a new system actor in the "/system" namespace. This actor 
         /// will be shut down during system shutdown only after all user actors have
         /// terminated.</summary>
@@ -35,7 +41,6 @@
         /// will be shut down during system shutdown only after all user actors have
         /// terminated.</summary>
         public abstract ActorRef SystemActorOf<TActor>(string name = null) where TActor : ActorBase, new();
-
 
         //TODO: Missing threadFactory, dynamicAccess, printTree
         //  /**

--- a/src/core/Akka/Actor/Internals/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internals/ActorSystemImpl.cs
@@ -29,6 +29,7 @@ namespace Akka.Actor.Internals
         private Dispatchers _dispatchers;
         private Mailboxes _mailboxes;
         private Scheduler _scheduler;
+        private ActorProducerPipeline _actorProducerPipeline;
 
         public ActorSystemImpl(string name)
             : this(name, ConfigurationFactory.Load())
@@ -42,6 +43,7 @@ namespace Akka.Actor.Internals
                     "], must contain only word characters (i.e. [a-zA-Z0-9] plus non-leading '-')");
             if(config == null)
                 throw new ArgumentNullException("config");
+
             _name = name;
             ConfigureScheduler();
             ConfigureSettings(config);
@@ -50,6 +52,7 @@ namespace Akka.Actor.Internals
             ConfigureSerialization();
             ConfigureMailboxes();
             ConfigureDispatchers();
+            ConfigureActorProducerPipeline();
         }
 
         public override ActorRefProvider Provider { get { return _provider; } }
@@ -62,10 +65,12 @@ namespace Akka.Actor.Internals
         public override Mailboxes Mailboxes { get { return _mailboxes; } }
         public override Scheduler Scheduler { get { return _scheduler; } }
         public override LoggingAdapter Log { get { return _log; } }
+        public override ActorProducerPipeline ActorProducerPipeline { get { return _actorProducerPipeline; } }
 
 
         public override InternalActorRef Guardian { get { return _provider.Guardian; } }
         public override InternalActorRef SystemGuardian { get { return _provider.SystemGuardian; } }
+
 
         /// <summary>Creates a new system actor.</summary>
         public override ActorRef SystemActorOf(Props props, string name = null)
@@ -272,6 +277,15 @@ namespace Akka.Actor.Internals
         }
 
         /// <summary>
+        /// Configures the actor producer pipeline.
+        /// </summary>
+        private void ConfigureActorProducerPipeline()
+        {
+            // we push Log in lazy manner since it may not be configured at point of pipeline initialization
+            _actorProducerPipeline = new DefaultProducerPipeline(() => Log);
+        }
+
+        /// <summary>
         ///     Stop this actor system. This will stop the guardian actor, which in turn
         ///     will recursively stop all its child actors, then the system guardian
         ///     (below which the logging actors reside) and the execute all registered
@@ -282,7 +296,6 @@ namespace Akka.Actor.Internals
             Log.Debug("System shutdown initiated");
             _provider.Guardian.Stop();
         }
-
 
         public override Task TerminationTask { get { return _provider.TerminationTask; } }
 

--- a/src/core/Akka/Actor/Stash/IActorStash.cs
+++ b/src/core/Akka/Actor/Stash/IActorStash.cs
@@ -15,4 +15,39 @@ namespace Akka.Actor
         /// </value>
         IStash Stash { get; set; }
     }
+
+    public class ActorStashPlugin : ActorProducerPluginBase
+    {
+        /// <summary>
+        /// Stash plugin is applied to all actors implementing <see cref="IActorStash"/> interface.
+        /// </summary>
+        public override bool CanBeAppliedTo(ActorBase actor)
+        {
+            return actor is IActorStash;
+        }
+
+        /// <summary>
+        /// Creates a new stash for specified <paramref name="actor"/> if it has not been initialized already.
+        /// </summary>
+        public override void AfterActorCreated(ActorBase actor, IActorContext context)
+        {
+            var stashed = actor as IActorStash;
+            if (stashed != null && stashed.Stash == null)
+            {
+                stashed.Stash = context.CreateStash(actor.GetType());
+            }
+        }
+
+        /// <summary>
+        /// Ensures, that all stashed messages inside <paramref name="actor"/> stash have been unstashed.
+        /// </summary>
+        public override void BeforeActorTerminated(ActorBase actor, IActorContext context)
+        {
+            var actorStash = actor as IActorStash;
+            if (actorStash != null)
+            {
+                actorStash.Stash.UnstashAll();
+            }
+        }
+    }
 }

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -69,6 +69,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Actor\ActorCell.DeathWatch.cs" />
+    <Compile Include="Actor\ActorProducerPipeline.cs" />
     <Compile Include="Actor\ChildrenContainer\Internal\ChildrenContainer.cs" />
     <Compile Include="Actor\ChildrenContainer\Internal\ChildrenContainerBase.cs" />
     <Compile Include="Actor\ChildrenContainer\Internal\ChildStats.cs" />

--- a/src/core/Akka/Event/Logging.cs
+++ b/src/core/Akka/Event/Logging.cs
@@ -13,7 +13,7 @@ namespace Akka.Event
     /// <see cref="LogEvent"/> when the string representation was supplied directly.
     /// </summary>
     public class DummyClassForStringSources { }
-
+    
     /// <summary>
     ///     Class Logging.
     /// </summary>


### PR DESCRIPTION
cc #533

I've created `ActorProducerPipeline`, which accessible from `ExtendedActorSystem` (to be able to configure by plugins) and allows to inject custom hooks satisfying following interface:
```csharp
interface IActorProducerPlugin {
    bool CanBeAppliedTo(ActorBase actor);
    void AfterActorCreated(ActorBase actor, IActorContext context);
    void BeforeActorTerminated(ActorBase actor, IActorContext context);
}
```

- **CanBeAppliedTo** determines if plugin can be applied to specific actor instance.
- **AfterActorCreated** is applied to actor after it has been instantiated by an `ActorCell` and before `InitializableActor.Init` method will (optionally) be invoked.
- **BeforeActorTerminated** is applied before actor terminates and before `IDisposable.Dispose` method will be invoked (for disposable actors) - **auto handling disposable actors is second feature of this commit**.

For common use it's better to create custom classes inheriting from `ActorProducerPluginBase` and `ActorProducerPluginBase<TActor>` classes.

Pipeline itself provides following interface:

```csharp
class ActorProducerPipeline : IEnumerable<IActorProducerPlugin> {
    int Count { get; } // current plugins count - 1 by default (ActorStashPlugin)
    bool Register(IActorProducerPlugin plugin)
    bool Unregister(IActorProducerPlugin plugin)
    bool IsRegistered(IActorProducerPlugin plugin)
    bool Insert(int index, IActorProducerPlugin plugin)
}
```

- **Register** - registers a plugin if no other plugin of the same type has been registered already (plugins with generic types are counted separately). Returns true if plugin has been registered.
- **Insert** - same as register, but plugin will be placed in specific place inside the pipeline - useful if any plugins precedence is required.
- **Unregister** - unregisters specified plugin if it has been found. Returns true if plugin was found and unregistered.
- **IsRegistered** - checks if plugin has been already registered.

By default pipeline is filled with one already used plugin - `ActorStashPlugin`, which replaces stash initialization/unstashing mechanism used up to this moment.