### PR TITLE
Serializable actor path

### DIFF
--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -344,7 +344,6 @@ namespace Akka.Actor
     /// <summary>
     /// Class RootActorPath.
     /// </summary>
-    [Serializable]
     public class RootActorPath : ActorPath
     {
         /// <summary>
@@ -357,13 +356,11 @@ namespace Akka.Actor
         {
         }
 
-        [JsonIgnore]
         public override ActorPath Parent
         {
             get { return null; }
         }
 
-        [JsonIgnore]
         public override ActorPath Root
         {
             get { return this; }
@@ -392,7 +389,6 @@ namespace Akka.Actor
     /// <summary>
     /// Class ChildActorPath.
     /// </summary>
-    [Serializable]
     public class ChildActorPath : ActorPath
     {
         private readonly string _name;

--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Newtonsoft.Json;
 
 namespace Akka.Actor
 {
@@ -343,6 +344,7 @@ namespace Akka.Actor
     /// <summary>
     /// Class RootActorPath.
     /// </summary>
+    [Serializable]
     public class RootActorPath : ActorPath
     {
         /// <summary>
@@ -355,11 +357,13 @@ namespace Akka.Actor
         {
         }
 
+        [JsonIgnore]
         public override ActorPath Parent
         {
             get { return null; }
         }
 
+        [JsonIgnore]
         public override ActorPath Root
         {
             get { return this; }
@@ -388,6 +392,7 @@ namespace Akka.Actor
     /// <summary>
     /// Class ChildActorPath.
     /// </summary>
+    [Serializable]
     public class ChildActorPath : ActorPath
     {
         private readonly string _name;

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -208,6 +208,7 @@
     <Compile Include="Event\LogLevel.cs" />
     <Compile Include="Event\LogMessage.cs" />
     <Compile Include="Event\StandardOutLogger.cs" />
+    <Compile Include="Serialization\ActorPathSerializer.cs" />
     <Compile Include="Util\Internal\InterlockedSpin.cs" />
     <Compile Include="Util\Internal\Collections\EmptyReadOnlyCollections.cs" />
     <Compile Include="Util\Internal\Collections\IBinaryTreeNode.cs" />

--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -380,6 +380,7 @@ akka {
 		json = "Akka.Serialization.NewtonSoftJsonSerializer"
 		java = "Akka.Serialization.JavaSerializer"				# not used, reserves java serializer identifier
 		bytes = "Akka.Serialization.ByteArraySerializer"
+		actorPath = "Akka.Serialization.ActorPathSerializer"
 	}
  
     # Class to Serializer binding. You only need to specify the name of an
@@ -392,6 +393,7 @@ akka {
     serialization-bindings {
       "System.Byte[]" = bytes
       "System.Object" = json
+	  "Akka.Actor.ActorPath" = actorPath
     }
   }
  

--- a/src/core/Akka/Serialization/ActorPathSerializer.cs
+++ b/src/core/Akka/Serialization/ActorPathSerializer.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Text;
+using Akka.Actor;
+
+namespace Akka.Serialization
+{
+    public class ActorPathSerializer : Serializer
+    {
+        public ActorPathSerializer(ExtendedActorSystem system) : base(system)
+        {
+        }
+
+        public override int Identifier
+        {
+            get { return -4;}
+        }
+
+        public override bool IncludeManifest
+        {
+            get { return false; }
+        }
+
+        public override byte[] ToBinary(object obj)
+        {
+            if (obj == null) return null;
+            ActorPath path;
+            if ((path = obj as ActorPath) != null)
+            {
+                var serialized = path.ToSerializationFormat();
+                return Encoding.UTF8.GetBytes(serialized);
+            }
+
+            throw new NotSupportedException();
+        }
+
+        public override object FromBinary(byte[] bytes, Type type)
+        {
+            if (typeof (ActorPath).IsAssignableFrom(type))
+            {
+                var serialized = Encoding.UTF8.GetString(bytes);
+                ActorPath path;
+                if (ActorPath.TryParse(serialized, out path)) 
+                    return path;
+                
+                throw new FormatException("ActorPathSerializer couldn't deserialize provided string into ActorPath: " + serialized);
+            }
+
+            throw new NotSupportedException();
+        }
+    }
+}


### PR DESCRIPTION
This one will allow to properly serialize/deserialize `ActorPath` instances. It uses standard serialization to actor path's format string with address and deserializes it using TryParse method.

cc #553