### PR TITLE
Translate surrogate types back to original type after deserialization. prep for #556

### DIFF
--- a/src/core/Akka.Remote.Tests/RemoteRouterSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteRouterSpec.cs
@@ -105,10 +105,8 @@ namespace Akka.Remote.Tests
             for (var i = 0; i < 5; i++)
             {
                 router.Tell("", probe.Ref);
-                var strPath = probe.ExpectMsg<ActorRefSurrogate>().Path;
-                ActorPath path;
-                Assert.True(ActorPath.TryParse(strPath, out path));
-                replies.Add(path);
+                var expected = probe.ExpectMsg<ActorRef>();
+                replies.Add(expected.Path);
             }
 
             Assert.Equal(2, replies.Count);
@@ -127,10 +125,8 @@ namespace Akka.Remote.Tests
             for (var i = 0; i < 5; i++)
             {
                 router.Tell("", probe.Ref);
-                var strPath = probe.ExpectMsg<ActorRefSurrogate>().Path;
-                ActorPath path;
-                Assert.True(ActorPath.TryParse(strPath, out path));
-                replies.Add(path);
+                var expected = probe.ExpectMsg<ActorRef>();
+                replies.Add(expected.Path);
             }
 
             Assert.Equal(2, replies.Count);
@@ -149,10 +145,8 @@ namespace Akka.Remote.Tests
             for (var i = 0; i < 5000; i++)
             {
                 router.Tell("", probe.Ref);
-                var strPath = probe.ExpectMsg<ActorRefSurrogate>().Path;
-                ActorPath path;
-                Assert.True(ActorPath.TryParse(strPath, out path));
-                replies.Add(path);
+                var expected = probe.ExpectMsg<ActorRef>();
+                replies.Add(expected.Path);
             }
 
             Assert.True(replies.Count >= 2);
@@ -172,10 +166,8 @@ namespace Akka.Remote.Tests
             for (var i = 0; i < 5; i++)
             {
                 router.Tell("", probe.Ref);
-                var strPath = probe.ExpectMsg<ActorRefSurrogate>().Path;
-                ActorPath path;
-                Assert.True(ActorPath.TryParse(strPath, out path));
-                replies.Add(path);
+                var expected = probe.ExpectMsg<ActorRef>();
+                replies.Add(expected.Path);
             }
 
             Assert.Equal(2, replies.Count);
@@ -200,10 +192,8 @@ namespace Akka.Remote.Tests
             for (var i = 0; i < 5; i++)
             {
                 router.Tell("", probe.Ref);
-                var strPath = probe.ExpectMsg<ActorRefSurrogate>().Path;
-                ActorPath path;
-                Assert.True(ActorPath.TryParse(strPath, out path));
-                replies.Add(path);
+                var expected = probe.ExpectMsg<ActorRef>();
+                replies.Add(expected.Path);
             }
 
             Assert.Equal(2, replies.Count);
@@ -227,10 +217,8 @@ namespace Akka.Remote.Tests
             for (var i = 0; i < 5; i++)
             {
                 router.Tell("", probe.Ref);
-                var strPath = probe.ExpectMsg<ActorRefSurrogate>().Path;
-                ActorPath path;
-                Assert.True(ActorPath.TryParse(strPath, out path));
-                replies.Add(path);
+                var expected = probe.ExpectMsg<ActorRef>();
+                replies.Add(expected.Path);
             }
 
             Assert.Equal(2, replies.Count);
@@ -256,10 +244,8 @@ namespace Akka.Remote.Tests
             for (var i = 0; i < 5; i++)
             {
                 router.Tell("", probe.Ref);
-                var strPath = probe.ExpectMsg<ActorRefSurrogate>().Path;
-                ActorPath path;
-                Assert.True(ActorPath.TryParse(strPath, out path));
-                replies.Add(path);
+                var expected = probe.ExpectMsg<ActorRef>();
+                replies.Add(expected.Path);
             }
 
             Assert.Equal(4, replies.Count);
@@ -284,10 +270,8 @@ namespace Akka.Remote.Tests
             for (var i = 0; i < 5; i++)
             {
                 router.Tell("", probe.Ref);
-                var strPath = probe.ExpectMsg<ActorRefSurrogate>().Path;
-                ActorPath path;
-                Assert.True(ActorPath.TryParse(strPath, out path));
-                replies.Add(path);
+                var expected = probe.ExpectMsg<ActorRef>();
+                replies.Add(expected.Path);
             }
 
             Assert.Equal(4, replies.Count);

--- a/src/core/Akka.Tests/Serialization/SerializationSpec.cs
+++ b/src/core/Akka.Tests/Serialization/SerializationSpec.cs
@@ -1,5 +1,6 @@
 ﻿using Akka.Serialization;
 using Akka.TestKit;
+using Akka.TestKit.TestActors;
 using Xunit;
 using System;
 using System.Collections.Generic;
@@ -51,6 +52,16 @@ namespace Akka.Tests.Serialization
             var deserialized = (Terminate)serializer.FromBinary(serialized, typeof(Terminate));
 
             Assert.NotNull(deserialized);
+        }
+
+        [Fact]
+        public void CanTranslateActorRefFromSurrogateType()
+        {
+            var aref = ActorOf<BlackHoleActor>();
+            var serializer = Sys.Serialization.FindSerializerFor(aref);
+            var bytes = serializer.ToBinary(aref);
+            var sref = (ActorRef)serializer.FromBinary(bytes, typeof(ActorRef));
+            Assert.NotNull(sref);
         }
 
         //TODO: find out why this fails on build server

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -8,6 +8,7 @@ using Akka.Actor.Internals;
 using Akka.Dispatch.SysMsg;
 using System.Threading;
 using Akka.Event;
+using Akka.Util;
 using Akka.Util.Internal;
 
 namespace Akka.Actor
@@ -111,7 +112,7 @@ namespace Akka.Actor
         }
     }
 
-    public class ActorRefSurrogate
+    public class ActorRefSurrogate : ISurrogate
     {
         public ActorRefSurrogate(string path)
         {
@@ -119,6 +120,11 @@ namespace Akka.Actor
         }
 
         public string Path { get; private set; }
+
+        public object Translate()
+        {
+            return (ActorRef) this;
+        }
     }
 
     internal static class ActorRefSender

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -220,6 +220,7 @@
     <Compile Include="Util\Internal\Collections\ImmutableAvlTreeMap.cs" />
     <Compile Include="Util\Internal\Collections\ImmutableTreeSet.cs" />
     <Compile Include="Util\Internal\StringBuilderExtensions.cs" />
+    <Compile Include="Util\ISurrogate.cs" />
     <Compile Include="Util\StandardOutWriter.cs" />
     <Compile Include="Event\Subscription.cs" />
     <Compile Include="Event\TraceLogger.cs" />

--- a/src/core/Akka/Serialization/NewtonSoftJsonSerializer.cs
+++ b/src/core/Akka/Serialization/NewtonSoftJsonSerializer.cs
@@ -1,5 +1,6 @@
 ﻿using Akka.Actor;
 using Akka.Actor.Internals;
+using Akka.Util;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -83,7 +84,13 @@ namespace Akka.Serialization
             Serialization.CurrentSystem = system;
             string data = Encoding.Default.GetString(bytes);
 
-            return JsonConvert.DeserializeObject(data, JsonSerializerSettings);
+            var res = JsonConvert.DeserializeObject(data, JsonSerializerSettings);
+            var surrogate = res as ISurrogate;
+            if (surrogate != null)
+            {
+                return surrogate.Translate();
+            }
+            return res;
         }
 
         /// <summary>

--- a/src/core/Akka/Util/ISurrogate.cs
+++ b/src/core/Akka/Util/ISurrogate.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Akka.Util
+{
+    public interface ISurrogate
+    {
+        object Translate();
+    }
+}


### PR DESCRIPTION
Made it possible to translate surrogate types back to the original type in the default json serializer.
This is a suggestion to solve the problems @Horusiath described in the gitter channel.

Any surrogate type implementing `ISurrogate` will be auto converted back after deserialization.
This could be useful for #556 