### PR TITLE
Akka.Persistence: minor changes + F# plugin init

### DIFF
--- a/src/Akka.Persistence.FSharp/Akka.Persistence.FSharp.fsproj
+++ b/src/Akka.Persistence.FSharp/Akka.Persistence.FSharp.fsproj
@@ -1,0 +1,88 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>d22c316e-991e-432a-950c-29bc3c45c07b</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Akka.Persistence.FSharp</RootNamespace>
+    <AssemblyName>Akka.Persistence.FSharp</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
+    <Name>Akka.Persistence.FSharp</Name>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Debug\Akka.Persistence.FSharp.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Release\Akka.Persistence.FSharp.XML</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="FsApi.fs" />
+    <None Include="Script.fsx" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\core\Akka.FSharp\Akka.FSharp.fsproj">
+      <Name>Akka.FSharp</Name>
+      <Project>{81574240-bc31-4be4-b447-adf0d32f4246}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\core\Akka.Persistence\Akka.Persistence.csproj">
+      <Name>Akka.Persistence</Name>
+      <Project>{fca84dea-c118-424b-9eb8-34375dfef18a}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\core\Akka\Akka.csproj">
+      <Name>Akka</Name>
+      <Project>{5deddf90-37f0-48d3-a0b0-a5cbd8a7e377}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Akka.Persistence.FSharp/FsApi.fs
+++ b/src/Akka.Persistence.FSharp/FsApi.fs
@@ -1,0 +1,271 @@
+﻿module Akka.Persistence.FSharp
+
+open System
+open Akka.Actor
+open Akka.FSharp
+open Akka.Persistence
+
+type PersistenceId = string
+
+[<Interface>]
+type Snapshotter<'State> =
+    abstract LoadSnapshot: PersistenceId -> SnapshotSelectionCriteria -> int64 -> unit
+    abstract SaveSnapshot: 'State -> unit
+    abstract DeleteSnapshot: int64 -> DateTime -> unit
+    abstract DeleteSnapshots: SnapshotSelectionCriteria -> unit
+
+[<Interface>]
+type Eventsourced<'Command, 'Event, 'State> =
+    inherit ActorRefFactory
+    inherit ICanWatch
+    inherit Snapshotter<'State>
+        
+    /// <summary>
+    /// Gets <see cref="ActorRef" /> for the current actor.
+    /// </summary>
+    abstract Self : ActorRef
+    
+    /// <summary>
+    /// Gets the current actor context.
+    /// </summary>
+    abstract Context : IActorContext
+    
+    /// <summary>
+    /// Returns a sender of current message or <see cref="ActorRef.NoSender" />, if none could be determined.
+    /// </summary>
+    abstract Sender : unit -> ActorRef
+    
+    /// <summary>
+    /// Explicit signalization of unhandled message.
+    /// </summary>
+    abstract Unhandled : obj -> unit
+    
+    /// <summary>
+    /// Lazy logging adapter. It won't be initialized until logging function will be called. 
+    /// </summary>
+    abstract Log : Lazy<Akka.Event.LoggingAdapter>
+
+    /// <summary>
+    /// Persists sequence of events in the event journal. Use second argument to define 
+    /// function which will update state depending on events.
+    /// </summary>
+    abstract Persist: 'Event seq -> ('Event -> 'State) -> unit
+    
+    /// <summary>
+    /// Asynchronously persists sequence of events in the event journal. Use second argument 
+    /// to define function which will update state depending on events.
+    /// </summary>
+    abstract AsyncPersist: 'Event seq -> ('Event -> 'State) -> unit
+
+    /// <summary>
+    /// Defers a second argument (update state callback) to be called after persisting target
+    /// event will be confirmed.
+    /// </summary>
+    abstract Defer: 'Event seq -> ('Event -> 'State) -> unit
+
+    /// <summary>
+    /// Returns currently attached journal actor reference.
+    /// </summary>
+    abstract Journal: unit -> ActorRef
+    
+    /// <summary>
+    /// Returns currently attached snapshot store actor reference.
+    /// </summary>
+    abstract SnapshotStore: unit -> ActorRef
+    
+    /// <summary>
+    /// Returns value determining if current persistent actor is actually recovering.
+    /// </summary>
+    abstract IsRecovering: unit -> bool
+    
+    /// <summary>
+    /// Returns last sequence number attached to latest persisted event.
+    /// </summary>
+    abstract LastSequenceNr: unit -> int64
+
+    /// <summary>
+    /// Persistent actor's identifier that doesn't change across different actor incarnations.
+    /// </summary>
+    abstract PersistenceId: unit -> PersistenceId
+
+type Aggregate<'Command, 'Event, 'State> = {
+    state: 'State
+    apply: Eventsourced<'Command, 'Event, 'State> -> 'State -> 'Event -> 'State
+    exec: Eventsourced<'Command, 'Event, 'State> -> 'State -> 'Command -> 'State
+}
+
+type FunPersistentActor<'Command, 'Event, 'State>(aggregate: Aggregate<'Command, 'Event, 'State>, name: PersistenceId) as this =
+    inherit UntypedPersistentActor()
+
+    let mutable state: 'State = aggregate.state
+    let mailbox = 
+        let self' = this.Self
+        let context = UntypedPersistentActor.Context :> IActorContext
+        let updateState (updater: 'Event -> 'State) e : unit = 
+            state <- updater e
+            ()
+        { new Eventsourced<'Command, 'Event, 'State> with
+            member __.Self = self'
+            member __.Context = context
+            member __.Sender() = this.Sender()
+            member __.Unhandled msg = this.Unhandled msg
+            member __.ActorOf(props, name) = context.ActorOf(props, name)
+            member __.ActorSelection(path : string) = context.ActorSelection(path)
+            member __.ActorSelection(path : ActorPath) = context.ActorSelection(path)
+            member __.Watch(aref:ActorRef) = context.Watch aref
+            member __.Unwatch(aref:ActorRef) = context.Unwatch aref
+            member __.Log = lazy (Akka.Event.Logging.GetLogger(context)) 
+            member __.Persist events callback = this.Persist(events, Action<'Event>(updateState callback))
+            member __.AsyncPersist events callback  = this.PersistAsync(events, Action<'Event>(updateState callback)) 
+            member __.Defer events callback = this.Defer(events, Action<'Event>(updateState callback))
+            member __.Journal() = this.Journal
+            member __.SnapshotStore() = this.SnapshotStore
+            member __.PersistenceId() = this.PersistenceId
+            member __.IsRecovering() = this.IsRecovering
+            member __.LastSequenceNr() = this.LastSequenceNr
+            member __.LoadSnapshot pid criteria seqNr = this.LoadSnapshot(pid, criteria, seqNr)
+            member __.SaveSnapshot state = this.SaveSnapshot(state)
+            member __.DeleteSnapshot seqNr timestamp = this.DeleteSnapshot(seqNr, timestamp)
+            member __.DeleteSnapshots criteria = this.DeleteSnapshots(criteria) }
+      
+    member __.Sender() : ActorRef = base.Sender
+    member __.Unhandled msg = base.Unhandled msg
+    override x.OnCommand (msg: obj) = 
+        match msg with
+        | :? 'Command as cmd -> state <- aggregate.exec mailbox state cmd
+        | _ -> ()   // ignore?
+    override x.OnRecover (msg: obj) = 
+        match msg with
+        | :? 'Event as e -> state <- aggregate.apply mailbox state e
+        | _ -> ()   // ignore?        
+    default x.PersistenceId = name
+
+
+[<Interface>]
+type View<'Event, 'State> =
+    inherit ActorRefFactory
+    inherit ICanWatch
+    inherit Snapshotter<'State>
+
+    /// <summary>
+    /// Gets <see cref="ActorRef" /> for the current actor.
+    /// </summary>
+    abstract Self : ActorRef
+    
+    /// <summary>
+    /// Gets the current actor context.
+    /// </summary>
+    abstract Context : IActorContext
+    
+    /// <summary>
+    /// Returns a sender of current message or <see cref="ActorRef.NoSender" />, if none could be determined.
+    /// </summary>
+    abstract Sender : unit -> ActorRef
+    
+    /// <summary>
+    /// Explicit signalization of unhandled message.
+    /// </summary>
+    abstract Unhandled : obj -> unit
+    
+    /// <summary>
+    /// Lazy logging adapter. It won't be initialized until logging function will be called. 
+    /// </summary>
+    abstract Log : Lazy<Akka.Event.LoggingAdapter>
+    
+    /// <summary>
+    /// Returns currently attached journal actor reference.
+    /// </summary>
+    abstract Journal: unit -> ActorRef
+    
+    /// <summary>
+    /// Returns currently attached snapshot store actor reference.
+    /// </summary>
+    abstract SnapshotStore: unit -> ActorRef
+        
+    /// <summary>
+    /// Returns last sequence number attached to latest persisted event.
+    /// </summary>
+    abstract LastSequenceNr: unit -> int64
+
+    /// <summary>
+    /// Persistent actor's identifier that doesn't change across different actor incarnations.
+    /// </summary>
+    abstract PersistenceId: unit -> PersistenceId
+    
+    /// <summary>
+    /// View's identifier that doesn't change across different view incarnations.
+    /// </summary>
+    abstract ViewId: unit -> PersistenceId
+
+type Perspective<'Event, 'State> = {
+    state: 'State
+    apply: View<'Event, 'State> -> 'State -> 'Event -> 'State
+}
+
+type FunPersistentView<'Event, 'State>(perspective: Perspective<'Event, 'State>, name: PersistenceId, viewId: PersistenceId) as this =
+    inherit PersistentView()
+
+    let mutable state: 'State = perspective.state
+    let mailbox = 
+        let self' = this.Self
+        let context = PersistentView.Context :> IActorContext
+        let updateState (updater: 'Event -> 'State) e : unit = 
+            state <- updater e
+            ()
+        { new View<'Event, 'State> with
+            member __.Self = self'
+            member __.Context = context
+            member __.Sender() = this.Sender()
+            member __.Unhandled msg = this.Unhandled msg
+            member __.ActorOf(props, name) = context.ActorOf(props, name)
+            member __.ActorSelection(path : string) = context.ActorSelection(path)
+            member __.ActorSelection(path : ActorPath) = context.ActorSelection(path)
+            member __.Watch(aref:ActorRef) = context.Watch aref
+            member __.Unwatch(aref:ActorRef) = context.Unwatch aref
+            member __.Log = lazy (Akka.Event.Logging.GetLogger(context)) 
+            member __.Journal() = this.Journal
+            member __.SnapshotStore() = this.SnapshotStore
+            member __.PersistenceId() = this.PersistenceId
+            member __.ViewId() = this.ViewId
+            member __.LastSequenceNr() = this.LastSequenceNr
+            member __.LoadSnapshot pid criteria seqNr = this.LoadSnapshot(pid, criteria, seqNr)
+            member __.SaveSnapshot state = this.SaveSnapshot(state)
+            member __.DeleteSnapshot seqNr timestamp = this.DeleteSnapshot(seqNr, timestamp)
+            member __.DeleteSnapshots criteria = this.DeleteSnapshots(criteria) }
+      
+    member __.Sender() : ActorRef = base.Sender
+    member __.Unhandled msg = base.Unhandled msg
+    override x.Receive (msg: obj): bool = 
+        match msg with
+        | :? 'Event as e -> 
+            state <- perspective.apply mailbox state e
+            true
+        | _ -> false   // ignore?        
+    default x.PersistenceId = name
+    default x.ViewId = viewId
+    
+module Linq = 
+    open System.Linq.Expressions
+    open Akka.FSharp.Linq
+    
+    type PersistentExpression = 
+        static member ToExpression(f : System.Linq.Expressions.Expression<System.Func<FunPersistentActor<'Command, 'Event, 'State>>>) = 
+            match f with
+            | Lambda(_, Invoke(Call(null, Method "ToFSharpFunc", Ar [| Lambda(_, p) |]))) -> 
+                Expression.Lambda(p, [||]) :?> System.Linq.Expressions.Expression<System.Func<FunPersistentActor<'Command, 'Event, 'State>>>
+            | _ -> failwith "Doesn't match"
+        static member ToExpression(f : System.Linq.Expressions.Expression<System.Func<FunPersistentView<'Event, 'State>>>) = 
+            match f with
+            | Lambda(_, Invoke(Call(null, Method "ToFSharpFunc", Ar [| Lambda(_, p) |]))) -> 
+                Expression.Lambda(p, [||]) :?> System.Linq.Expressions.Expression<System.Func<FunPersistentView<'Event, 'State>>>
+            | _ -> failwith "Doesn't match"
+     
+let spawnPersist (actorFactory : ActorRefFactory) (name : string) (aggregate: Aggregate<'Command, 'Event, 'State>) (options : SpawnOption list) : ActorRef =
+    let e = Linq.PersistentExpression.ToExpression(fun () -> new FunPersistentActor<'Command, 'Event, 'State>(aggregate, name))
+    let props = applySpawnOptions (Props.Create e) options
+    actorFactory.ActorOf(props, name)
+    
+let spawnView (actorFactory : ActorRefFactory) (viewName: string) (name : string)  (perspective: Perspective<'Event, 'State>) (options : SpawnOption list) : ActorRef =
+    let e = Linq.PersistentExpression.ToExpression(fun () -> new FunPersistentView<'Event, 'State>(perspective, name, viewName))
+    let props = applySpawnOptions (Props.Create e) options
+    actorFactory.ActorOf(props, viewName)

--- a/src/Akka.Persistence.FSharp/Script.fsx
+++ b/src/Akka.Persistence.FSharp/Script.fsx
@@ -1,0 +1,8 @@
+﻿// Learn more about F# at http://fsharp.net. See the 'F# Tutorial' project
+// for more guidance on F# programming.
+
+#load "FsApi.fs"
+open Akka.Persistence.FSharp
+
+// Define your library scripting code here
+

--- a/src/Akka.sln
+++ b/src/Akka.sln
@@ -158,6 +158,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Persistence", "core\Ak
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Persistence.TestKit.Tests", "core\Akka.Persistence.TestKit.Tests\Akka.Persistence.TestKit.Tests.csproj", "{E6CDDAC1-BD68-4C7B-9E6D-569AC6D50793}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Akka.Persistence.FSharp", "Akka.Persistence.FSharp\Akka.Persistence.FSharp.fsproj", "{D22C316E-991E-432A-950C-29BC3C45C07B}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "PersistenceExample.FsApi", "PersistenceExample.FsApi\PersistenceExample.FsApi.fsproj", "{8C261CA2-3CAD-42FF-B21C-C32E7D718F95}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug Mono|Any CPU = Debug Mono|Any CPU
@@ -547,6 +551,22 @@ Global
 		{E6CDDAC1-BD68-4C7B-9E6D-569AC6D50793}.Release Mono|Any CPU.Build.0 = Release|Any CPU
 		{E6CDDAC1-BD68-4C7B-9E6D-569AC6D50793}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E6CDDAC1-BD68-4C7B-9E6D-569AC6D50793}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D22C316E-991E-432A-950C-29BC3C45C07B}.Debug Mono|Any CPU.ActiveCfg = Debug|Any CPU
+		{D22C316E-991E-432A-950C-29BC3C45C07B}.Debug Mono|Any CPU.Build.0 = Debug|Any CPU
+		{D22C316E-991E-432A-950C-29BC3C45C07B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D22C316E-991E-432A-950C-29BC3C45C07B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D22C316E-991E-432A-950C-29BC3C45C07B}.Release Mono|Any CPU.ActiveCfg = Release|Any CPU
+		{D22C316E-991E-432A-950C-29BC3C45C07B}.Release Mono|Any CPU.Build.0 = Release|Any CPU
+		{D22C316E-991E-432A-950C-29BC3C45C07B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D22C316E-991E-432A-950C-29BC3C45C07B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8C261CA2-3CAD-42FF-B21C-C32E7D718F95}.Debug Mono|Any CPU.ActiveCfg = Debug|Any CPU
+		{8C261CA2-3CAD-42FF-B21C-C32E7D718F95}.Debug Mono|Any CPU.Build.0 = Debug|Any CPU
+		{8C261CA2-3CAD-42FF-B21C-C32E7D718F95}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8C261CA2-3CAD-42FF-B21C-C32E7D718F95}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8C261CA2-3CAD-42FF-B21C-C32E7D718F95}.Release Mono|Any CPU.ActiveCfg = Release|Any CPU
+		{8C261CA2-3CAD-42FF-B21C-C32E7D718F95}.Release Mono|Any CPU.Build.0 = Release|Any CPU
+		{8C261CA2-3CAD-42FF-B21C-C32E7D718F95}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8C261CA2-3CAD-42FF-B21C-C32E7D718F95}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -615,5 +635,7 @@ Global
 		{AD9418B6-C452-4169-94FB-D43DE0BFA966} = {01167D3C-49C4-4CDE-9787-C176D139ACDD}
 		{FCA84DEA-C118-424B-9EB8-34375DFEF18A} = {01167D3C-49C4-4CDE-9787-C176D139ACDD}
 		{E6CDDAC1-BD68-4C7B-9E6D-569AC6D50793} = {01167D3C-49C4-4CDE-9787-C176D139ACDD}
+		{D22C316E-991E-432A-950C-29BC3C45C07B} = {01167D3C-49C4-4CDE-9787-C176D139ACDD}
+		{8C261CA2-3CAD-42FF-B21C-C32E7D718F95} = {B17C5E75-B5F7-4492-9A97-A0C8DF66EF02}
 	EndGlobalSection
 EndGlobal

--- a/src/PersistenceExample.FsApi/App.config
+++ b/src/PersistenceExample.FsApi/App.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/PersistenceExample.FsApi/PersistenceExample.FsApi.fsproj
+++ b/src/PersistenceExample.FsApi/PersistenceExample.FsApi.fsproj
@@ -5,15 +5,15 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>19993c0b-8f9d-4fe4-b047-45965ea66ba2</ProjectGuid>
+    <ProjectGuid>8c261ca2-3cad-42ff-b21c-c32e7d718f95</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <RootNamespace>Pigeon.FSharp.Api</RootNamespace>
-    <AssemblyName>FSharp.Api</AssemblyName>
+    <RootNamespace>PersistenceExample.FsApi</RootNamespace>
+    <AssemblyName>PersistenceExample.FsApi</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
-    <Name>FSharp.Api</Name>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <Name>PersistenceExample.FsApi</Name>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -25,7 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DocumentationFile>bin\Debug\Pigeon.FSharp.Api.XML</DocumentationFile>
+    <DocumentationFile>bin\Debug\PersistenceExample.FsApi.XML</DocumentationFile>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -36,34 +36,11 @@
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DocumentationFile>bin\Release\Pigeon.FSharp.Api.XML</DocumentationFile>
+    <DocumentationFile>bin\Release\PersistenceExample.FsApi.XML</DocumentationFile>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release Mono|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <Tailcalls>true</Tailcalls>
-    <DefineConstants>TRACE</DefineConstants>
-    <WarningLevel>3</WarningLevel>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DocumentationFile>bin\Release\Pigeon.FSharp.Api.XML</DocumentationFile>
-    <Prefer32Bit>true</Prefer32Bit>
-    <OutputPath>bin\Release Mono\</OutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug Mono|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <Tailcalls>false</Tailcalls>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <WarningLevel>3</WarningLevel>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DocumentationFile>bin\Debug\FSharp.Api.XML</DocumentationFile>
-    <Prefer32Bit>true</Prefer32Bit>
-    <OutputPath>bin\Debug Mono\</OutputPath>
   </PropertyGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '11.0'">
@@ -86,9 +63,6 @@
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
   <ItemGroup>
-    <Compile Include="MapReduce.fs" />
-    <Compile Include="Greeter.fs" />
-    <Compile Include="Supervisioning.fs" />
     <Compile Include="Program.fs" />
     <None Include="App.config" />
     <Content Include="packages.config" />
@@ -99,18 +73,28 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
-    <ProjectReference Include="..\..\core\Akka.FSharp\Akka.FSharp.fsproj">
+    <ProjectReference Include="..\Akka.Persistence.FSharp\Akka.Persistence.FSharp.fsproj">
+      <Name>Akka.Persistence.FSharp</Name>
+      <Project>{d22c316e-991e-432a-950c-29bc3c45c07b}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\core\Akka.FSharp\Akka.FSharp.fsproj">
       <Name>Akka.FSharp</Name>
       <Project>{81574240-bc31-4be4-b447-adf0d32f4246}</Project>
       <Private>True</Private>
     </ProjectReference>
-    <ProjectReference Include="..\..\core\Akka\Akka.csproj">
+    <ProjectReference Include="..\core\Akka.Persistence\Akka.Persistence.csproj">
+      <Name>Akka.Persistence</Name>
+      <Project>{fca84dea-c118-424b-9eb8-34375dfef18a}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\core\Akka\Akka.csproj">
       <Name>Akka</Name>
       <Project>{5deddf90-37f0-48d3-a0b0-a5cbd8a7e377}</Project>
       <Private>True</Private>

--- a/src/PersistenceExample.FsApi/Program.fs
+++ b/src/PersistenceExample.FsApi/Program.fs
@@ -1,0 +1,98 @@
+﻿open System
+open Akka.FSharp
+open Akka.Persistence
+open Akka.Persistence.FSharp
+
+    
+let system = System.create "sys" (Configuration.load())
+
+// Scenario 0: basic statefull persistent actor
+module Scenario0 =
+
+    let update state e = e::state
+    let apply _ = update
+    let exec (mailbox: Eventsourced<_,_,_>) state cmd = 
+        match cmd with
+        | "print" -> printf "State is: %A\n" state
+        | s       -> mailbox.Persist [s] (update state)
+        state
+
+    let run() =
+        printfn "--- SCENARIO 0 ---\n"
+        let s0 = 
+            spawnPersist system "s0" {
+                state = []
+                apply = apply
+                exec = exec
+            } []
+
+        s0 <! "foo"
+        s0 <! "bar"
+        s0 <! "baz"
+
+        s0 <! "print"
+
+// Scenario 1: statefull actor recovering from snapshot
+module Scenario1 =
+
+    type Command =
+        | Update of string
+        | TakeSnapshot
+        | Print
+        | Crash
+
+    let update state e = (e.ToString())::state
+    let apply (mailbox: Eventsourced<Command,obj,string list>) state (event:obj) = 
+        match event with
+        | :? string as e -> update state e
+        | :? SnapshotOffer as o -> o.Snapshot :?> string list
+        | x -> 
+            mailbox.Unhandled x
+            state
+    let exec (mailbox: Eventsourced<Command,obj,string list>) state cmd =
+        match cmd with
+        | Update s -> mailbox.Persist [s] (update state)
+        | TakeSnapshot -> mailbox.SaveSnapshot state
+        | Print -> printf "State is: %A\n" state
+        | Crash -> failwith "planned crash"
+        state
+
+    let run() =
+    
+        printfn "--- SCENARIO 1 ---\n"
+        let s1 = 
+            spawnPersist system "s1" {
+                state = []
+                apply = apply
+                exec = exec
+            } []
+
+        s1 <! Update "a"
+        s1 <! Print
+        // restart
+        s1 <! Crash
+        s1 <! Print
+        s1 <! Update "b"
+        s1 <! Print
+        s1 <! TakeSnapshot
+        s1 <! Update "c"
+        s1 <! Print
+
+        // expected output at the first run:
+        // State is: [a]
+        // Error crash report
+        // State is: [a]
+        // State is: [b;a]
+        // State is: [c;b;a]
+        
+        // expected output at the second run:
+        // State is: [a;b;a]
+        // Error crash report
+        // State is: [a;b;a]
+        // State is: [b;a;b;a]
+        // State is: [c;b;a;b;a]
+
+    
+Scenario1.run()
+
+Console.ReadLine()

--- a/src/PersistenceExample.FsApi/packages.config
+++ b/src/PersistenceExample.FsApi/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+</packages>

--- a/src/core/Akka.FSharp/FsApi.fs
+++ b/src/core/Akka.FSharp/FsApi.fs
@@ -359,7 +359,7 @@ type SpawnOption =
     | Dispatcher of string
     | Mailbox of string
 
-let rec private applySpawnOptions (props : Props) (opt : SpawnOption list) : Props = 
+let rec applySpawnOptions (props : Props) (opt : SpawnOption list) : Props = 
     match opt with
     | [] -> props
     | h :: t -> 

--- a/src/core/Akka.Persistence/Eventsourced.cs
+++ b/src/core/Akka.Persistence/Eventsourced.cs
@@ -86,12 +86,12 @@ namespace Akka.Persistence
 
         public IStash Stash { get; set; }
 
-        protected ActorRef Journal
+        public ActorRef Journal
         {
             get { return _journal ?? (_journal = Extension.JournalFor(SnapshotterId)); }
         }
 
-        protected ActorRef SnapshotStore
+        public ActorRef SnapshotStore
         {
             get { return _snapshotStore ?? (_snapshotStore = Extension.SnapshotStoreFor(SnapshotterId)); }
         }
@@ -122,22 +122,22 @@ namespace Akka.Persistence
         /// </summary>
         public long SnapshotSequenceNr { get { return LastSequenceNr; } }
         
-        protected void LoadSnapshot(string persistenceId, SnapshotSelectionCriteria criteria, long toSequenceNr)
+        public void LoadSnapshot(string persistenceId, SnapshotSelectionCriteria criteria, long toSequenceNr)
         {
             SnapshotStore.Tell(new LoadSnapshot(persistenceId, criteria, toSequenceNr));
         }
 
-        protected void SaveSnapshot(object snapshot)
+        public void SaveSnapshot(object snapshot)
         {
             SnapshotStore.Tell(new SaveSnapshot(new SnapshotMetadata(SnapshotterId, SnapshotSequenceNr), snapshot));
         }
 
-        protected void DeleteSnapshot(long sequenceNr, DateTime timestamp)
+        public void DeleteSnapshot(long sequenceNr, DateTime timestamp)
         {
             SnapshotStore.Tell(new DeleteSnapshot(new SnapshotMetadata(SnapshotterId, sequenceNr, timestamp)));
         }
 
-        protected void DeleteSnapshots(SnapshotSelectionCriteria criteria)
+        public void DeleteSnapshots(SnapshotSelectionCriteria criteria)
         {
             SnapshotStore.Tell(new DeleteSnapshots(SnapshotterId, criteria));
         }
@@ -177,7 +177,7 @@ namespace Akka.Persistence
         /// If persistence of an event fails, the persistent actor will be stopped. 
         /// This can be customized by handling <see cref="PersistenceFailure"/> in <see cref="ReceiveCommand"/> method. 
         /// </summary>
-        protected void Persist<TEvent>(TEvent @event, Action<TEvent> handler)
+        public void Persist<TEvent>(TEvent @event, Action<TEvent> handler)
         {
             _pendingStashingPersistInvocations++;
             _pendingInvocations.AddLast(new StashingHandlerInvocation(@event, o => handler((TEvent)o)));
@@ -188,7 +188,7 @@ namespace Akka.Persistence
         /// Asynchronously persists series of <paramref name="events"/> in specified order.
         /// This is equivalent of multiple calls of <see cref="Persist{TEvent}(TEvent,System.Action{TEvent})"/> calls.
         /// </summary>
-        protected void Persist<TEvent>(IEnumerable<TEvent> events, Action<TEvent> handler)
+        public void Persist<TEvent>(IEnumerable<TEvent> events, Action<TEvent> handler)
         {
             Action<object> inv = o => handler((TEvent)o);
             foreach (var @event in events)
@@ -220,7 +220,7 @@ namespace Akka.Persistence
         /// If persistence of an event fails, the persistent actor will be stopped. 
         /// This can be customized by handling <see cref="PersistenceFailure"/> in <see cref="ReceiveCommand"/> method. 
         /// </summary>
-        protected void PersistAsync<TEvent>(TEvent @event, Action<TEvent> handler)
+        public void PersistAsync<TEvent>(TEvent @event, Action<TEvent> handler)
         {
             _pendingInvocations.AddLast(new AsyncHandlerInvocation(@event, o => handler((TEvent)o)));
             _eventBatch.AddFirst(new Persistent(@event));
@@ -230,7 +230,7 @@ namespace Akka.Persistence
         /// Asynchronously persists series of <paramref name="events"/> in specified order.
         /// This is equivalent of multiple calls of <see cref="PersistAsync{TEvent}(TEvent,System.Action{TEvent})"/> calls.
         /// </summary>
-        protected void PersistAsync<TEvent>(IEnumerable<TEvent> events, Action<TEvent> handler)
+        public void PersistAsync<TEvent>(IEnumerable<TEvent> events, Action<TEvent> handler)
         {
             Action<object> inv = o => handler((TEvent)o);
             foreach (var @event in events)
@@ -251,7 +251,7 @@ namespace Akka.Persistence
         /// If there are not awaiting persist handler calls, the <paramref name="handler"/> will be invoced immediately.
         /// 
         /// </summary>
-        protected void Defer<TEvent>(TEvent evt, Action<TEvent> handler)
+        public void Defer<TEvent>(TEvent evt, Action<TEvent> handler)
         {
             if (_pendingInvocations.Count == 0)
             {
@@ -264,7 +264,7 @@ namespace Akka.Persistence
             }
         }
 
-        protected void Defer<TEvent>(IEnumerable<TEvent> events, Action<TEvent> handler)
+        public void Defer<TEvent>(IEnumerable<TEvent> events, Action<TEvent> handler)
         {
             foreach (var @event in events)
             {
@@ -272,7 +272,7 @@ namespace Akka.Persistence
             }
         }
 
-        protected void DeleteMessages(long toSequenceNr, bool permanent)
+        public void DeleteMessages(long toSequenceNr, bool permanent)
         {
             Journal.Tell(new DeleteMessagesTo(PersistenceId, toSequenceNr, permanent));
         }

--- a/src/core/Akka.Persistence/Persistence.cs
+++ b/src/core/Akka.Persistence/Persistence.cs
@@ -20,7 +20,8 @@ namespace Akka.Persistence
         public PersistenceExtension(ExtendedActorSystem system)
         {
             _system = system;
-            _config = system.Settings.Config.WithFallback(Persistence.DefaultConfig()).GetConfig("akka.persistence");
+            _system.Settings.InjectTopLevelFallback(Persistence.DefaultConfig());
+            _config = system.Settings.Config.GetConfig("akka.persistence");
             _journal = CreatePlugin("journal", type => typeof (AsyncWriteJournal).IsAssignableFrom(type)
                 ? Dispatchers.DefaultDispatcherId
                 : DefaultPluginDispatcherId);

--- a/src/core/Akka.Persistence/PersistentView.cs
+++ b/src/core/Akka.Persistence/PersistentView.cs
@@ -74,7 +74,7 @@ namespace Akka.Persistence
             _currentState = RecoveryPending();
         }
 
-        private ActorRef SnapshotStore
+        public ActorRef SnapshotStore
         {
             get { return _snapshotStore ?? (_snapshotStore = Extension.SnapshotStoreFor(SnapshotterId)); }
         }
@@ -131,7 +131,7 @@ namespace Akka.Persistence
         /// </summary>
         public long SnapshotSequenceNr { get { return LastSequenceNr; } }
 
-        private ActorRef Journal
+        public ActorRef Journal
         {
             get { return _journal ?? (_journal = Extension.JournalFor(PersistenceId)); }
         }

--- a/src/examples/FSharp.Api/packages.config
+++ b/src/examples/FSharp.Api/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+</packages>

--- a/src/packages/repositories.config
+++ b/src/packages/repositories.config
@@ -30,6 +30,8 @@
   <repository path="..\examples\Cluster\Roles\Samples.Cluster.Transformation\packages.config" />
   <repository path="..\examples\Cluster\Routing\Samples.Cluster.ConsistentHashRouting\packages.config" />
   <repository path="..\examples\Cluster\Samples.Cluster.Simple\packages.config" />
+  <repository path="..\examples\FSharp.Api\packages.config" />
   <repository path="..\examples\Stocks\SymbolLookup\packages.config" />
   <repository path="..\examples\TimeServer\TimeClient\packages.config" />
+  <repository path="..\PersistenceExample.FsApi\packages.config" />
 </repositories>


### PR DESCRIPTION
I've just initialized a new F# plugin for Akka.Persistence. At the present moment it introduces basic concepts for persistent actors and views (guaranteed delivery still not covered). It's still a proof of concept - definitely not for releasing purposes. Sample project showing API features is available under `/Examples/Persistence/PersistenceExample.FsApi` path.

### Changes for Akka.Persistence

- `Persistence.DefaultConfig()` included as default fallback for plugin-related configuration (no need to call it explicitly on `ActorSystem.Create`).
- Changed encapsulation for particular fields to make them available for F# plugin perspective.