### PR TITLE
Serializable ActorPath using ISurrogate interface

### DIFF
--- a/src/core/Akka.Tests/Serialization/SerializationSpec.cs
+++ b/src/core/Akka.Tests/Serialization/SerializationSpec.cs
@@ -43,6 +43,19 @@ namespace Akka.Tests.Serialization
         }
 
         [Fact]
+        public void CanSerializeActorPath()
+        {
+            var uri = "akka.tcp://sys@localhost:9000/user/actor";
+            var actorPath = ActorPath.Parse(uri);
+
+            var serializer = Sys.Serialization.FindSerializerFor(actorPath);
+            var serialized = serializer.ToBinary(actorPath);
+            var deserialized = (ActorPath) serializer.FromBinary(serialized, typeof (ActorPath));
+
+            Assert.Equal(actorPath, deserialized);
+        }
+
+        [Fact]
         public void CanSerializeSingletonMessages()
         {
             var message = Terminate.Instance;

--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Akka.Util;
 using Newtonsoft.Json;
 
 namespace Akka.Actor
@@ -348,6 +349,27 @@ namespace Akka.Actor
         {
             return String.Join("/", pathElements);
         }
+
+        public static implicit operator ActorPathSurrogate(ActorPath path)
+        {
+            if (path != null)
+            {
+                return new ActorPathSurrogate(path.ToSerializationFormat());
+            }
+
+            return null;
+        }
+
+        public static implicit operator ActorPath(ActorPathSurrogate surrogate)
+        {
+            ActorPath path;
+            if (TryParse(surrogate.Path, out path))
+            {
+                return path;
+            }
+
+            return null;
+        }
     }
 
     /// <summary>
@@ -465,6 +487,20 @@ namespace Akka.Actor
             if (nameCompareResult != 0)
                 return nameCompareResult;
             return InternalCompareTo(left.Parent, right.Parent);
+        }
+    }
+    public class ActorPathSurrogate : ISurrogate
+    {
+        public ActorPathSurrogate(string path)
+        {
+            Path = path;
+        }
+
+        public string Path { get; private set; }
+
+        public object Translate()
+        {
+            return (ActorPath)this;
         }
     }
 }

--- a/src/core/Akka/Serialization/NewtonSoftJsonSerializer.cs
+++ b/src/core/Akka/Serialization/NewtonSoftJsonSerializer.cs
@@ -34,7 +34,7 @@ namespace Akka.Serialization
             JsonConvert.DefaultSettings = () => new JsonSerializerSettings
             {
                 PreserveReferencesHandling = PreserveReferencesHandling.Objects,
-                Converters = new List<JsonConverter> { new ActorRefConverter() }
+                Converters = new List<JsonConverter> { new ActorRefConverter(), new ActorPathConverter() }
             };
         }
 
@@ -92,6 +92,27 @@ namespace Akka.Serialization
                 return surrogate.Translate();
             }
             return res;
+        }
+
+        public class ActorPathConverter : JsonConverter
+        {
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                var path = (ActorPath)value;
+                var surrogate = new ActorPathSurrogate(path.ToSerializationFormat());
+                serializer.Serialize(writer, surrogate);
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            {
+                var surrogate = serializer.Deserialize<ActorPathSurrogate>(reader);
+                return (ActorPath) surrogate;
+            }
+
+            public override bool CanConvert(Type objectType)
+            {
+                return (typeof(ActorPath).IsAssignableFrom(objectType));
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
cc #553

This implementation uses new `ISurrogate` interface for object serialization with custom JsonConverter dedicated for the `ActorPath` class and it's derivatives. Unit test attached.