### PR TITLE
Added message ordering, persistence, and reporting for the MultiNodeTestRunner

### DIFF
--- a/src/Akka.sln
+++ b/src/Akka.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+VisualStudioVersion = 12.0.30723.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChatMessages", "examples\Chat\ChatMessages\ChatMessages.csproj", "{819221CB-82B7-43D3-A4DE-E00AF17F2FDF}"
 EndProject
@@ -73,7 +73,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PingPong", "benchmark\PingP
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{10C5B1E8-15B5-4EB3-81AE-1FC054FE1305}"
 	ProjectSection(SolutionItems) = preProject
-		build.fsx = build.fsx
+		..\build.fsx = ..\build.fsx
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TimeServer", "TimeServer", "{E17B704F-3DF0-4723-8E83-43DC8D33997A}"
@@ -163,6 +163,11 @@ EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "PersistenceExample.FsApi", "PersistenceExample.FsApi\PersistenceExample.FsApi.fsproj", "{8C261CA2-3CAD-42FF-B21C-C32E7D718F95}"
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharp.HelloAkka", "examples\HelloWorld\FSharp.HelloAkka\FSharp.HelloAkka.fsproj", "{59CC70F9-9F8D-495D-89CC-16DE732F6BA6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.MultiNodeTestRunner.Shared.Tests", "core\Akka.MultiNodeTestRunner.Shared.Tests\Akka.MultiNodeTestRunner.Shared.Tests.csproj", "{91746A3F-21C6-4614-B0AB-A59310D75C51}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.MultiNodeTestRunner.Shared", "core\Akka.MultiNodeTestRunner.Shared\Akka.MultiNodeTestRunner.Shared.csproj", "{964F0EC5-FBE6-47C5-8AE6-145114D5DB8C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug Mono|Any CPU = Debug Mono|Any CPU
@@ -576,6 +581,22 @@ Global
 		{59CC70F9-9F8D-495D-89CC-16DE732F6BA6}.Release Mono|Any CPU.Build.0 = Release|Any CPU
 		{59CC70F9-9F8D-495D-89CC-16DE732F6BA6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{59CC70F9-9F8D-495D-89CC-16DE732F6BA6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{91746A3F-21C6-4614-B0AB-A59310D75C51}.Debug Mono|Any CPU.ActiveCfg = Debug|Any CPU
+		{91746A3F-21C6-4614-B0AB-A59310D75C51}.Debug Mono|Any CPU.Build.0 = Debug|Any CPU
+		{91746A3F-21C6-4614-B0AB-A59310D75C51}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{91746A3F-21C6-4614-B0AB-A59310D75C51}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{91746A3F-21C6-4614-B0AB-A59310D75C51}.Release Mono|Any CPU.ActiveCfg = Release|Any CPU
+		{91746A3F-21C6-4614-B0AB-A59310D75C51}.Release Mono|Any CPU.Build.0 = Release|Any CPU
+		{91746A3F-21C6-4614-B0AB-A59310D75C51}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{91746A3F-21C6-4614-B0AB-A59310D75C51}.Release|Any CPU.Build.0 = Release|Any CPU
+		{964F0EC5-FBE6-47C5-8AE6-145114D5DB8C}.Debug Mono|Any CPU.ActiveCfg = Debug|Any CPU
+		{964F0EC5-FBE6-47C5-8AE6-145114D5DB8C}.Debug Mono|Any CPU.Build.0 = Debug|Any CPU
+		{964F0EC5-FBE6-47C5-8AE6-145114D5DB8C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{964F0EC5-FBE6-47C5-8AE6-145114D5DB8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{964F0EC5-FBE6-47C5-8AE6-145114D5DB8C}.Release Mono|Any CPU.ActiveCfg = Release|Any CPU
+		{964F0EC5-FBE6-47C5-8AE6-145114D5DB8C}.Release Mono|Any CPU.Build.0 = Release|Any CPU
+		{964F0EC5-FBE6-47C5-8AE6-145114D5DB8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{964F0EC5-FBE6-47C5-8AE6-145114D5DB8C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -647,5 +668,7 @@ Global
 		{D22C316E-991E-432A-950C-29BC3C45C07B} = {01167D3C-49C4-4CDE-9787-C176D139ACDD}
 		{8C261CA2-3CAD-42FF-B21C-C32E7D718F95} = {B17C5E75-B5F7-4492-9A97-A0C8DF66EF02}
 		{59CC70F9-9F8D-495D-89CC-16DE732F6BA6} = {19FD9F6D-7ED2-4DF6-98EE-348027F8D5DA}
+		{91746A3F-21C6-4614-B0AB-A59310D75C51} = {01167D3C-49C4-4CDE-9787-C176D139ACDD}
+		{964F0EC5-FBE6-47C5-8AE6-145114D5DB8C} = {01167D3C-49C4-4CDE-9787-C176D139ACDD}
 	EndGlobalSection
 EndGlobal

--- a/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
+++ b/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
@@ -86,6 +86,7 @@
     <Compile Include="MultiNode\LeaderLeavingSpec.cs" />
     <Compile Include="MultiNode\MultiNodeClusterSpec.cs" />
     <Compile Include="MultiNode\MultiNodeFact.cs" />
+    <Compile Include="MultiNode\MultiNodeLoggingConfig.cs" />
     <Compile Include="NodeMetricsSpec.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Proto\ClusterMessageSerializerSpec.cs" />

--- a/src/core/Akka.Cluster.Tests/MultiNode/ClusterDeathWatchSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MultiNode/ClusterDeathWatchSpec.cs
@@ -26,9 +26,9 @@ namespace Akka.Cluster.Tests.MultiNode
             _fourth = Role("fourth");
             _fifth = Role("fifth");
 
-            CommonConfig = ConfigurationFactory.ParseString(@"
-                akka.loggers = [""Akka.Logger.NLog.NLogLogger, Akka.Logger.NLog""]
-                akka.cluster.publish-stats-interval = 25s").WithFallback(DebugConfig(true))
+            CommonConfig = ConfigurationFactory.ParseString(@"akka.cluster.publish-stats-interval = 25s")
+                .WithFallback(MultiNodeLoggingConfig.LoggingConfig)
+                .WithFallback(DebugConfig(true))
                 .WithFallback(MultiNodeClusterSpec.ClusterConfigWithFailureDetectorPuppet());
         }
     }

--- a/src/core/Akka.Cluster.Tests/MultiNode/ConvergenceSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MultiNode/ConvergenceSpec.cs
@@ -29,9 +29,9 @@ namespace Akka.Cluster.Tests.MultiNode
             _third = Role("third");
             _fourth = Role("fourth");
 
-            CommonConfig = ConfigurationFactory.ParseString(@"
-                akka.loggers = [""Akka.Logger.NLog.NLogLogger, Akka.Logger.NLog""]
-                akka.cluster.publish-stats-interval = 25s").WithFallback(DebugConfig(true))
+            CommonConfig = ConfigurationFactory.ParseString(@"akka.cluster.publish-stats-interval = 25s")
+                .WithFallback(MultiNodeLoggingConfig.LoggingConfig)
+                .WithFallback(DebugConfig(true))
                 .WithFallback(@"akka.cluster.failure-detector.threshold = 4")
                 .WithFallback(MultiNodeClusterSpec.ClusterConfig(failureDetectorPuppet));
         }

--- a/src/core/Akka.Cluster.Tests/MultiNode/InitialHeartbeatSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MultiNode/InitialHeartbeatSpec.cs
@@ -36,7 +36,9 @@ namespace Akka.Cluster.Tests.MultiNode
             _first = Role("first");
             _second = Role("second");
 
-            CommonConfig = DebugConfig(false).WithFallback(
+            CommonConfig = DebugConfig(false)
+                .WithFallback(MultiNodeLoggingConfig.LoggingConfig)
+                .WithFallback(
                 ConfigurationFactory.ParseString(@"
                     akka.testconductor.barrier-timeout = 60 s
                     akka.stdout-loglevel = DEBUG

--- a/src/core/Akka.Cluster.Tests/MultiNode/JoinInProgressSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MultiNode/JoinInProgressSpec.cs
@@ -19,7 +19,7 @@ namespace Akka.Cluster.Tests.MultiNode
             _first = Role("first");
             _second = Role("second");
 
-            CommonConfig = ConfigurationFactory.ParseString(@"akka.loggers = [""Akka.Logger.NLog.NLogLogger, Akka.Logger.NLog""]").WithFallback(DebugConfig(true)).WithFallback(
+            CommonConfig = MultiNodeLoggingConfig.LoggingConfig.WithFallback(DebugConfig(true)).WithFallback(
                 ConfigurationFactory.ParseString(@"
                     akka.stdout-loglevel = DEBUG
                     akka.cluster {

--- a/src/core/Akka.Cluster.Tests/MultiNode/LeaderLeavingSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MultiNode/LeaderLeavingSpec.cs
@@ -36,8 +36,8 @@ namespace Akka.Cluster.Tests.MultiNode
             _second = Role("second");
             _third = Role("third");
 
-            CommonConfig = ConfigurationFactory.ParseString(
-                @"akka.loggers = [""Akka.Logger.NLog.NLogLogger, Akka.Logger.NLog""]").WithFallback(DebugConfig(true))
+            CommonConfig = MultiNodeLoggingConfig.LoggingConfig
+                .WithFallback(DebugConfig(true))
                 .WithFallback(@"akka.cluster.auto-down-unreachable-after = 0s
 akka.cluster.publish-stats-interval = 25 s")
                 .WithFallback(MultiNodeClusterSpec.ClusterConfigWithFailureDetectorPuppet());

--- a/src/core/Akka.Cluster.Tests/MultiNode/MultiNodeLoggingConfig.cs
+++ b/src/core/Akka.Cluster.Tests/MultiNode/MultiNodeLoggingConfig.cs
@@ -1,0 +1,25 @@
+﻿using Akka.Configuration;
+using Akka.Remote.TestKit;
+
+namespace Akka.Cluster.Tests.MultiNode
+{
+    /// <summary>
+    /// Static <see cref="Config"/> provider that allows toggleable logging
+    /// for <see cref="MultiNodeSpec"/> instances within the Akka.Cluster.Tests assembly
+    /// </summary>
+    public static class MultiNodeLoggingConfig
+    {
+// ReSharper disable once InconsistentNaming
+        private static readonly Config _loggingConfig =
+            ConfigurationFactory.ParseString(@"
+                akka.loggers = [""Akka.Event.DefaultLogger""]");
+
+        /// <summary>
+        /// Used to specify which loggers to enable for the <see cref="MultiNodeClusterSpec"/> instances
+        /// </summary>
+        public static Config LoggingConfig
+        {
+            get { return _loggingConfig; }
+        }
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared.Tests/Akka.MultiNodeTestRunner.Shared.Tests.csproj
+++ b/src/core/Akka.MultiNodeTestRunner.Shared.Tests/Akka.MultiNodeTestRunner.Shared.Tests.csproj
@@ -4,18 +4,17 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{C1113300-74F1-446A-9914-3020C842EDF1}</ProjectGuid>
-    <OutputType>Exe</OutputType>
+    <ProjectGuid>{91746A3F-21C6-4614-B0AB-A59310D75C51}</ProjectGuid>
+    <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Akka.MultiNodeTestRunner</RootNamespace>
-    <AssemblyName>Akka.MultiNodeTestRunner</AssemblyName>
+    <RootNamespace>Akka.MultiNodeTestRunner.Shared.Tests</RootNamespace>
+    <AssemblyName>Akka.MultiNodeTestRunner.Shared.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -25,7 +24,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
@@ -34,35 +32,36 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Faker">
+      <HintPath>..\..\packages\faker-csharp.1.2.0\lib\net4\Faker.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="xunit.abstractions">
-      <HintPath>..\..\packages\xunit.abstractions.2.0.0-beta4-build2738\lib\net35\xunit.abstractions.dll</HintPath>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit">
+      <HintPath>..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.runner.utility">
-      <HintPath>..\..\packages\xunit.runner.utility.2.0.0-beta4-build2738\lib\net35\xunit.runner.utility.dll</HintPath>
+    <Reference Include="xunit.extensions">
+      <HintPath>..\..\packages\xunit.extensions.1.9.2\lib\net20\xunit.extensions.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\Akka.Remote.TestKit\CommandLine.cs">
-      <Link>CommandLine.cs</Link>
-    </Compile>
-    <Compile Include="Discovery.cs" />
-    <Compile Include="Program.cs" />
+    <Compile Include="NodeDataActorSpec.cs" />
+    <Compile Include="NodeMessageHelpers.cs" />
+    <Compile Include="ParsingSpec.cs" />
+    <Compile Include="Persistence\JsonPersistentTestRunStoreSpec.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SpecRunCoordinatorSpec.cs" />
+    <Compile Include="TestRunCoordinatorSpec.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\contrib\loggers\Akka.Logger.NLog\Akka.Logger.NLog.csproj">
-      <Project>{a8aa2d7e-3d35-44df-af92-80a2c39c1f4d}</Project>
-      <Name>Akka.Logger.NLog</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Akka.Cluster.Tests\Akka.Cluster.Tests.csproj">
-      <Project>{c8d6a95c-50bf-4416-a212-86b18b87220d}</Project>
-      <Name>Akka.Cluster.Tests</Name>
+    <ProjectReference Include="..\..\contrib\testkits\Akka.TestKit.Xunit\Akka.TestKit.Xunit.csproj">
+      <Project>{11f4d4b8-7e07-4457-abf2-609b3e7b2649}</Project>
+      <Name>Akka.TestKit.Xunit</Name>
     </ProjectReference>
     <ProjectReference Include="..\Akka.MultiNodeTestRunner.Shared\Akka.MultiNodeTestRunner.Shared.csproj">
       <Project>{964f0ec5-fbe6-47c5-8ae6-145114d5db8c}</Project>
@@ -72,14 +71,24 @@
       <Project>{28520f30-2868-4bd3-9cae-ac27226c24e3}</Project>
       <Name>Akka.NodeTestRunner</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Akka.Remote\Akka.Remote.csproj">
-      <Project>{ea4ff8fd-7c53-49c8-b9aa-02e458b3e6a7}</Project>
-      <Name>Akka.Remote</Name>
+    <ProjectReference Include="..\Akka.TestKit\Akka.TestKit.csproj">
+      <Project>{0d3cbad0-bbdb-43e5-afc4-ed1d3ecdc224}</Project>
+      <Name>Akka.TestKit</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj">
+      <Project>{e636d23c-3432-4aa9-9a5d-5f29d33d3399}</Project>
+      <Name>Akka.Tests.Shared.Internals</Name>
     </ProjectReference>
     <ProjectReference Include="..\Akka\Akka.csproj">
       <Project>{5deddf90-37f0-48d3-a0b0-a5cbd8a7e377}</Project>
       <Name>Akka</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/core/Akka.MultiNodeTestRunner.Shared.Tests/NodeDataActorSpec.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared.Tests/NodeDataActorSpec.cs
@@ -1,0 +1,114 @@
+﻿using Akka.Actor;
+using Akka.MultiNodeTestRunner.Shared.Persistence;
+using Akka.MultiNodeTestRunner.Shared.Reporting;
+using Akka.MultiNodeTestRunner.Shared.Sinks;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.MultiNodeTestRunner.Shared.Tests
+{
+    public class NodeDataActorSpec : AkkaSpec
+    {
+        [Fact]
+        public void NodeData_should_maintain_events_in_time_order()
+        {
+            var nodeIndex = 1;
+            var nodeDataActor = Sys.ActorOf(Props.Create(() => new NodeDataActor(nodeIndex)));
+            var m1 = NodeMessageHelpers.GenerateMessageSequence(nodeIndex, 3);
+
+            foreach(var m in m1)
+                nodeDataActor.Tell(m);
+
+            var m2 = NodeMessageHelpers.GenerateMessageSequence(nodeIndex, 4);
+            foreach(var m in m2)
+                nodeDataActor.Tell(m);
+
+            //union the two sets together
+            m1.UnionWith(m2);
+
+            //Kill the node data actor and have it deliver its payload to TestActor
+            nodeDataActor.Tell(new EndSpec(), TestActor);
+
+            var nodeData = ExpectMsg<NodeData>();
+
+            Assert.True(m1.SetEquals(nodeData.EventStream));
+            Assert.Equal(nodeIndex, nodeData.NodeIndex);
+            Assert.False(nodeData.EndTime.HasValue);
+            Assert.False(nodeData.Passed.HasValue);
+        }
+
+        [Fact]
+        public void NodeData_should_mark_as_complete_when_MultiNodeResultMessage_received()
+        {
+            var nodeIndex = 1;
+            var nodeDataActor = Sys.ActorOf(Props.Create(() => new NodeDataActor(nodeIndex)));
+
+            var m1 = NodeMessageHelpers.GenerateMessageSequence(nodeIndex, 3);
+            m1.UnionWith(NodeMessageHelpers.GenerateResultMessage(nodeIndex, true));
+
+            foreach (var m in m1)
+                nodeDataActor.Tell(m);
+
+            //Kill the node data actor and have it deliver its payload to TestActor
+            nodeDataActor.Tell(new EndSpec(), TestActor);
+
+            var nodeData = ExpectMsg<NodeData>();
+
+            Assert.True(m1.SetEquals(nodeData.EventStream));
+            Assert.True(nodeData.Passed.Value);
+            Assert.True(nodeData.EndTime.HasValue);
+            Assert.True(nodeData.EndTime.Value >= nodeData.StartTime);
+        }
+
+        [Fact]
+        public void NodeData_should_mark_as_failed_when_MultiNodeResultMessage_received()
+        {
+            var nodeIndex = 1;
+            var nodeDataActor = Sys.ActorOf(Props.Create(() => new NodeDataActor(nodeIndex)));
+
+            var m1 = NodeMessageHelpers.GenerateMessageSequence(nodeIndex, 3);
+            m1.UnionWith(NodeMessageHelpers.GenerateResultMessage(nodeIndex, false));
+
+            foreach (var m in m1)
+                nodeDataActor.Tell(m);
+
+            //Kill the node data actor and have it deliver its payload to TestActor
+            nodeDataActor.Tell(new EndSpec(), TestActor);
+
+            var nodeData = ExpectMsg<NodeData>();
+
+            Assert.True(m1.SetEquals(nodeData.EventStream));
+            Assert.False(nodeData.Passed.Value);
+            Assert.True(nodeData.EndTime.HasValue);
+            Assert.True(nodeData.EndTime.Value >= nodeData.StartTime);
+        }
+
+        [Fact]
+        public void NodeData_should_process_LogMessageFragments_into_timeline()
+        {
+            var nodeIndex = 1;
+            var nodeDataActor = Sys.ActorOf(Props.Create(() => new NodeDataActor(nodeIndex)));
+            var m1 = NodeMessageHelpers.GenerateMessageSequence(nodeIndex, 3);
+
+            foreach (var m in m1)
+                nodeDataActor.Tell(m);
+
+            var m2 = NodeMessageHelpers.GenerateMessageFragmentSequence(nodeIndex, 4);
+            foreach (var m in m2)
+                nodeDataActor.Tell(m);
+
+            //union the two sets together
+            m1.UnionWith(m2);
+
+            //Kill the node data actor and have it deliver its payload to TestActor
+            nodeDataActor.Tell(new EndSpec(), TestActor);
+
+            var nodeData = ExpectMsg<NodeData>();
+
+            Assert.True(m1.SetEquals(nodeData.EventStream));
+            Assert.Equal(nodeIndex, nodeData.NodeIndex);
+            Assert.False(nodeData.EndTime.HasValue);
+            Assert.False(nodeData.Passed.HasValue);
+        }
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared.Tests/NodeMessageHelpers.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared.Tests/NodeMessageHelpers.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Akka.Event;
+using Akka.MultiNodeTestRunner.Shared.Persistence;
+using Akka.MultiNodeTestRunner.Shared.Reporting;
+using Akka.Util;
+
+namespace Akka.MultiNodeTestRunner.Shared.Tests
+{
+    /// <summary>
+    /// Helper class for creating <see cref="MultiNodeMessage"/>
+    /// </summary>
+    public static class NodeMessageHelpers
+    {
+        public static IList<NodeTest> BuildNodeTests(IEnumerable<int> nodeIndicies)
+        {
+            var methodName = Faker.Generators.Strings.GenerateAlphaNumericString();
+            var className = Faker.Generators.Strings.GenerateAlphaNumericString();
+            var testName = Faker.Generators.Strings.GenerateAlphaNumericString();
+
+            return nodeIndicies.Select(i => new NodeTest() {MethodName = methodName, Node = i, TestName = testName, TypeName = className}).ToList();
+        }
+
+        /// <summary>
+        /// Meta-function for generating a distribution of messages across multiple nodes
+        /// </summary>
+        private static SortedSet<MultiNodeMessage> GenerateMessageDistributionForNodes(IEnumerable<int> nodeIndices,
+            int count, Func<int, int, SortedSet<MultiNodeMessage>> messageGenerator)
+        {
+            var nodes = nodeIndices.ToList();
+            var messages = new SortedSet<MultiNodeMessage>();
+
+            //special case for 1:1 distribution
+            if (nodes.Count == count)
+            {
+                foreach (var node in nodes)
+                {
+                    messages.UnionWith(messageGenerator(node, node));
+                }
+                return messages;
+            }
+
+            // Key = nodeIndex, Value = # of allocated messages
+            var messageDistribution = new Dictionary<int, int>();
+            foreach (var node in nodes)
+            {
+                messageDistribution[node] = 0;
+            }
+
+            var remainingMessages = count;
+            var nodeIterator = nodes.GetContinuousEnumerator();
+
+            while (remainingMessages > 0)
+            {
+                nodeIterator.MoveNext();
+                var node = nodeIterator.Current;
+                var added = Faker.Generators.Numbers.Int(1, Math.Max(1, remainingMessages / 2));
+
+                //Don't go over the message count
+                if (added > remainingMessages)
+                    added = remainingMessages;
+
+                messageDistribution[node] += added;
+                remainingMessages -= added;
+            }
+
+            //generate the assigned sequence for each node
+            foreach (var node in messageDistribution)
+                messages.UnionWith(messageGenerator(node.Key, node.Value));
+
+            return messages;
+        }
+
+        public static SortedSet<MultiNodeMessage> GenerateMessageSequence(IEnumerable<int> nodeIndices, int count)
+        {
+            return GenerateMessageDistributionForNodes(nodeIndices, count, GenerateMessageSequence);
+        }
+
+        public static SortedSet<MultiNodeMessage> GenerateMessageSequence(int nodeIndex, int count)
+        {
+            var messages = new SortedSet<MultiNodeMessage>();
+            var startTime = DateTime.UtcNow;
+            foreach (var i in Enumerable.Range(0, count))
+            {
+                messages.Add(new MultiNodeLogMessage(Faker.Generators.DateTimes.GetTimeStamp(startTime, startTime + TimeSpan.FromSeconds(20)), String.Format("Message {0}", i), nodeIndex,
+                    "/foo", LogLevel.InfoLevel));
+            }
+            return messages;
+        }
+
+        public static SortedSet<MultiNodeMessage> GenerateMessageFragmentSequence(IEnumerable<int> nodeIndices, int count)
+        {
+            return GenerateMessageDistributionForNodes(nodeIndices, count, GenerateMessageFragmentSequence);
+        }
+
+        public static SortedSet<MultiNodeMessage> GenerateMessageFragmentSequence(int nodeIndex, int count)
+        {
+            var messages = new SortedSet<MultiNodeMessage>();
+            var startTime = DateTime.UtcNow;
+            foreach (var i in Enumerable.Range(0, count))
+            {
+                messages.Add(new MultiNodeLogMessageFragment(Faker.Generators.DateTimes.GetTimeStamp(startTime, startTime + TimeSpan.FromSeconds(20)), String.Format("Message {0}", i), nodeIndex));
+            }
+            return messages;
+        }
+
+        public static SortedSet<MultiNodeMessage> GenerateTestRunnerMessageSequence(int count)
+        {
+            var messages = new SortedSet<MultiNodeMessage>();
+            var startTime = DateTime.UtcNow;
+            foreach (var i in Enumerable.Range(0, count))
+            {
+                messages.Add(new MultiNodeTestRunnerMessage(Faker.Generators.DateTimes.GetTimeStamp(startTime, startTime + TimeSpan.FromSeconds(20)), String.Format("Message {0}", i),
+                    "/foo", LogLevel.InfoLevel));
+            }
+            return messages;
+        }
+
+        public static SortedSet<MultiNodeMessage> GenerateResultMessage(IEnumerable<int> nodeIndices, bool pass)
+        {
+            var messages = new SortedSet<MultiNodeMessage>();
+            var enumerable = nodeIndices as int[] ?? nodeIndices.ToArray();
+            return GenerateMessageDistributionForNodes(enumerable, enumerable.Count(),
+                (i, i1) => GenerateResultMessage(i, pass));
+        }
+
+        public static SortedSet<MultiNodeMessage> GenerateResultMessage(int nodeIndex, bool pass)
+        {
+            var messages = new SortedSet<MultiNodeMessage>();
+            var startTime = DateTime.UtcNow;
+            messages.Add(
+                new MultiNodeResultMessage(
+                    Faker.Generators.DateTimes.GetTimeStamp(startTime, startTime + TimeSpan.FromSeconds(30)),
+                    String.Format("Test passed? {0}", pass), nodeIndex, pass));
+            return messages;
+        }
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared.Tests/ParsingSpec.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared.Tests/ParsingSpec.cs
@@ -1,0 +1,140 @@
+﻿using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.MultiNodeTestRunner.Shared.Reporting;
+using Akka.MultiNodeTestRunner.Shared.Sinks;
+using Akka.NodeTestRunner;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.MultiNodeTestRunner.Shared.Tests
+{
+    /// <summary>
+    /// Used to test the <see cref="MessageSink"/>'s ability to parse 
+    /// </summary>
+    public class ParsingSpec : AkkaSpec
+    {
+        public ParsingSpec()
+            : base(ConfigurationFactory.ParseString(@"
+        akka {
+                loglevel = DEBUG
+                stdout-loglevel = DEBUG
+            }
+            "))
+        {
+
+        }
+
+        #region Actor definitions
+
+        public class LoggingActor : UntypedActor
+        {
+            protected override void OnReceive(object message)
+            {
+                Context.GetLogger().Debug("Received message {0}", message);
+            }
+        }
+
+        #endregion
+
+        [Fact]
+        public void MessageSink_should_parse_Node_log_message_correctly()
+        {
+            var loggingActor = Sys.ActorOf<LoggingActor>();
+            Sys.EventStream.Subscribe(TestActor, typeof(Debug));
+            loggingActor.Tell("LOG ME!");
+
+            //capture the logged message
+            var foundMessage = ExpectMsg<Debug>();
+
+            //format the string as it would appear when reported by multinode test runner
+            var foundMessageStr = "[NODE1]" + foundMessage; 
+            LogMessageForNode nodeMessage;
+            MessageSink.TryParseLogMessage(foundMessageStr, out nodeMessage).ShouldBeTrue("should have been able to parse log message");
+
+            Assert.Equal(foundMessage.LogLevel(), nodeMessage.Level);
+            Assert.Equal(foundMessage.LogSource, nodeMessage.LogSource);
+        }
+
+        [Fact]
+        public void MessageSink_should_parse_Node_log_message_fragment_correctly()
+        {
+           //format the a log fragment as would be recorded by the test runner
+            var message = "this is some message";
+            var foundMessageStr = "[NODE1]" + message;
+            LogMessageFragmentForNode nodeMessage;
+            MessageSink.TryParseLogMessage(foundMessageStr, out nodeMessage).ShouldBeTrue("should have been able to parse log message");
+
+            Assert.Equal(1, nodeMessage.NodeIndex);
+            Assert.Equal(message, nodeMessage.Message);
+        }
+
+        [Fact]
+        public void MessageSink_should_parse_Runner_log_message_correctly()
+        {
+            var loggingActor = Sys.ActorOf<LoggingActor>();
+            Sys.EventStream.Subscribe(TestActor, typeof(Debug));
+            loggingActor.Tell("LOG ME... but like the test runner this time!");
+
+            //capture the logged message
+            var foundMessage = ExpectMsg<Debug>();
+
+            //format the string as it would appear when reported by multinode test runner
+            var foundMessageStr = foundMessage.ToString();
+            LogMessageForTestRunner runnerMessage;
+            MessageSink.TryParseLogMessage(foundMessageStr, out runnerMessage).ShouldBeTrue("should have been able to parse log message");
+
+            Assert.Equal(foundMessage.LogLevel(), runnerMessage.Level);
+            Assert.Equal(foundMessage.LogSource, runnerMessage.LogSource);
+        }
+
+        [Fact]
+        public void MessageSink_should_parse_Node_SpecPass_message_correctly()
+        {
+            var specPass = new SpecPass(1, GetType().Assembly.GetName().Name);
+            NodeCompletedSpecWithSuccess nodeCompletedSpecWithSuccess;
+            MessageSink.TryParseSuccessMessage(specPass.ToString(), out nodeCompletedSpecWithSuccess)
+                .ShouldBeTrue("should have been able to parse node success message");
+
+            Assert.Equal(specPass.NodeIndex, nodeCompletedSpecWithSuccess.NodeIndex);
+        }
+
+        [Fact]
+        public void MessageSink_should_parse_Node_SpecFail_message_correctly()
+        {
+            var specFail = new SpecFail(1, GetType().Assembly.GetName().Name);
+            NodeCompletedSpecWithFail nodeCompletedSpecWithFail;
+            MessageSink.TryParseFailureMessage(specFail.ToString(), out nodeCompletedSpecWithFail)
+                .ShouldBeTrue("should have been able to parse node failure message");
+
+            Assert.Equal(specFail.NodeIndex, nodeCompletedSpecWithFail.NodeIndex);
+        }
+
+        [Fact]
+        public void MessageSink_should_be_able_to_infer_message_type()
+        {
+            var specPass = new SpecPass(1, GetType().Assembly.GetName().Name);
+            var specFail = new SpecFail(1, GetType().Assembly.GetName().Name);
+
+            var loggingActor = Sys.ActorOf<LoggingActor>();
+            Sys.EventStream.Subscribe(TestActor, typeof(Debug));
+            loggingActor.Tell("LOG ME!");
+
+            //capture the logged message
+            var foundMessage = ExpectMsg<Debug>();
+
+            //format the string as it would appear when reported by multinode test runner
+            var nodeMessageStr = "[NODE1]" + foundMessage;
+            var nodeMessageFragment = "[NODE1]      Only part of a message!";
+            var runnerMessageStr = foundMessage.ToString();
+
+            MessageSink.DetermineMessageType(nodeMessageStr).ShouldBe(MessageSink.MultiNodeTestRunnerMessageType.NodeLogMessage);
+            MessageSink.DetermineMessageType(runnerMessageStr).ShouldBe(MessageSink.MultiNodeTestRunnerMessageType.RunnerLogMessage);
+            MessageSink.DetermineMessageType(specPass.ToString()).ShouldBe(MessageSink.MultiNodeTestRunnerMessageType.NodePassMessage);
+            MessageSink.DetermineMessageType(specFail.ToString()).ShouldBe(MessageSink.MultiNodeTestRunnerMessageType.NodeFailMessage);
+            MessageSink.DetermineMessageType("[Node2][FAIL-EXCEPTION] Type: Xunit.Sdk.TrueException").ShouldBe(MessageSink.MultiNodeTestRunnerMessageType.NodeFailureException);
+            MessageSink.DetermineMessageType(nodeMessageFragment).ShouldBe(MessageSink.MultiNodeTestRunnerMessageType.NodeLogFragment);
+            MessageSink.DetermineMessageType("foo!").ShouldBe(MessageSink.MultiNodeTestRunnerMessageType.Unknown);
+        }
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared.Tests/Persistence/JsonPersistentTestRunStoreSpec.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared.Tests/Persistence/JsonPersistentTestRunStoreSpec.cs
@@ -1,0 +1,86 @@
+﻿using System.IO;
+using System.Linq;
+using System.Reflection;
+using Akka.Actor;
+using Akka.MultiNodeTestRunner.Shared.Persistence;
+using Akka.MultiNodeTestRunner.Shared.Reporting;
+using Akka.MultiNodeTestRunner.Shared.Sinks;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.MultiNodeTestRunner.Shared.Tests.Persistence
+{
+    public class JsonPersistentTestRunStoreSpec : AkkaSpec
+    {
+        [Fact]
+        public void Should_save_TestRunTree_as_JSON()
+        {
+            var testRunStore = new JsonPersistentTestRunStore();
+            var testRunCoordinator = Sys.ActorOf(Props.Create<TestRunCoordinator>());
+            var nodeIndexes = Enumerable.Range(1, 4).ToArray();
+            var nodeTests = NodeMessageHelpers.BuildNodeTests(nodeIndexes);
+
+            var beginSpec = new BeginNewSpec(nodeTests.First().TypeName, nodeTests.First().MethodName, nodeTests);
+
+            //begin a new spec
+            testRunCoordinator.Tell(beginSpec);
+
+            // create some messages for each node, the test runner, and some result messages
+            // just like a real MultiNodeSpec
+            var allMessages = NodeMessageHelpers.GenerateMessageSequence(nodeIndexes, 300);
+            var runnerMessages = NodeMessageHelpers.GenerateTestRunnerMessageSequence(20);
+            allMessages.UnionWith(runnerMessages);
+
+            foreach (var message in allMessages)
+                testRunCoordinator.Tell(message);
+
+            //end the spec
+            testRunCoordinator.Tell(new EndTestRun(), TestActor);
+            var testRunData = ExpectMsg<TestRunTree>();
+
+            //save the test run
+            var file = Path.GetTempFileName();
+            testRunStore.SaveTestRun(file, testRunData).ShouldBeTrue("Should have been able to save test run");
+        }
+
+        [Fact]
+        public void Should_load_saved_JSON_TestRunTree()
+        {
+            var testRunStore = new JsonPersistentTestRunStore();
+            var testRunCoordinator = Sys.ActorOf(Props.Create<TestRunCoordinator>());
+            var nodeIndexes = Enumerable.Range(1, 4).ToArray();
+            var nodeTests = NodeMessageHelpers.BuildNodeTests(nodeIndexes);
+
+            var beginSpec = new BeginNewSpec(nodeTests.First().TypeName, nodeTests.First().MethodName, nodeTests);
+
+            //begin a new spec
+            testRunCoordinator.Tell(beginSpec);
+
+            // create some messages for each node, the test runner, and some result messages
+            // just like a real MultiNodeSpec
+            var allMessages = NodeMessageHelpers.GenerateMessageSequence(nodeIndexes, 300);
+            var runnerMessages = NodeMessageHelpers.GenerateTestRunnerMessageSequence(20);
+            var successMessages = NodeMessageHelpers.GenerateResultMessage(nodeIndexes, true);
+            var messsageFragments = NodeMessageHelpers.GenerateMessageFragmentSequence(nodeIndexes, 100);
+            allMessages.UnionWith(runnerMessages);
+            allMessages.UnionWith(successMessages);
+            allMessages.UnionWith(messsageFragments);
+
+            foreach (var message in allMessages)
+                testRunCoordinator.Tell(message);
+
+            //end the spec
+            testRunCoordinator.Tell(new EndTestRun(), TestActor);
+            var testRunData = ExpectMsg<TestRunTree>();
+
+            //save the test run
+            var file = Path.GetTempFileName();
+            testRunStore.SaveTestRun(file, testRunData).ShouldBeTrue("Should have been able to save test run");
+
+            //retrieve the test run from file
+            var retreivedFile = testRunStore.FetchTestRun(file);
+            Assert.NotNull(retreivedFile);
+            Assert.True(testRunData.Equals(retreivedFile));
+        }
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared.Tests/Properties/AssemblyInfo.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Akka.MultiNodeTestRunner.Shared.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Akka.MultiNodeTestRunner.Shared.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("6e54ffe4-7a6a-4891-b457-c4dc4779b51a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/core/Akka.MultiNodeTestRunner.Shared.Tests/SpecRunCoordinatorSpec.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared.Tests/SpecRunCoordinatorSpec.cs
@@ -1,0 +1,154 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Akka.Actor;
+using Akka.MultiNodeTestRunner.Shared.Persistence;
+using Akka.MultiNodeTestRunner.Shared.Reporting;
+using Akka.MultiNodeTestRunner.Shared.Sinks;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.MultiNodeTestRunner.Shared.Tests
+{
+    public class SpecRunCoordinatorSpec : AkkaSpec
+    {
+        [Fact]
+        public void SpecRunCoordinator_should_log_TestRunner_messages()
+        {
+            var nodeIndexes = Enumerable.Range(1, 3).ToArray();
+            var nodeTests = NodeMessageHelpers.BuildNodeTests(nodeIndexes);
+
+            var specRunCoordinator = Sys.ActorOf(Props.Create(() => new SpecRunCoordinator(nodeTests.First()
+                .TypeName, nodeTests.First().MethodName, nodeTests)));
+
+            var runnerMessages = NodeMessageHelpers.GenerateTestRunnerMessageSequence(100);
+            foreach (var multiNodeMessage in runnerMessages)
+            {
+                specRunCoordinator.Tell(multiNodeMessage);
+            }
+
+            //End the test
+            specRunCoordinator.Tell(new EndSpec(), TestActor);
+            var factData = ExpectMsg<FactData>();
+
+            Assert.True(factData.RunnerMessages.Any());
+            Assert.True(runnerMessages.SetEquals(factData.RunnerMessages));
+        }
+
+        [Fact]
+        public void SpecRunCoordinator_should_route_messages_correctly_to_child_NodeDataActors()
+        {
+            var nodeIndexes = Enumerable.Range(1, 3).ToArray();
+            var nodeTests = NodeMessageHelpers.BuildNodeTests(nodeIndexes);
+
+            var specRunCoordinator = Sys.ActorOf(Props.Create(() => new SpecRunCoordinator(nodeTests.First()
+                .TypeName, nodeTests.First().MethodName, nodeTests)));
+
+            var messages = NodeMessageHelpers.GenerateMessageSequence(nodeIndexes, 100);
+            foreach (var multiNodeMessage in messages)
+            {
+                specRunCoordinator.Tell(multiNodeMessage);
+            }
+
+            //End the test
+            specRunCoordinator.Tell(new EndSpec(), TestActor);
+            var factData = ExpectMsg<FactData>();
+
+            // Combine the messages from each individual NodeData back into a unioned set. 
+            // Should match what we sent (messages.)
+            var combinedTimeline = new SortedSet<MultiNodeMessage>();
+            foreach(var nodeData in factData.NodeFacts)
+                combinedTimeline.UnionWith(nodeData.Value.EventStream);
+
+            Assert.Equal(nodeIndexes.Length, factData.NodeFacts.Count);
+            Assert.True(messages.SetEquals(combinedTimeline));
+        }
+
+        [Fact]
+        public void SpecRunCoordinator_should_mark_spec_as_passed_if_all_nodes_pass()
+        {
+            var nodeIndexes = Enumerable.Range(1, 3).ToArray();
+            var nodeTests = NodeMessageHelpers.BuildNodeTests(nodeIndexes);
+
+            var specRunCoordinator = Sys.ActorOf(Props.Create(() => new SpecRunCoordinator(nodeTests.First()
+                .TypeName, nodeTests.First().MethodName, nodeTests)));
+
+            var messages = NodeMessageHelpers.GenerateMessageSequence(nodeIndexes, 100);
+
+            //Add some result (PASS) messages
+            messages.UnionWith(NodeMessageHelpers.GenerateResultMessage(nodeIndexes, true));
+
+            foreach (var multiNodeMessage in messages)
+            {
+                specRunCoordinator.Tell(multiNodeMessage);
+            }
+
+            //End the test
+            specRunCoordinator.Tell(new EndSpec(), TestActor);
+            var factData = ExpectMsg<FactData>();
+
+            Assert.Equal(nodeIndexes.Length, factData.NodeFacts.Count);
+            Assert.True(factData.NodeFacts.All(x => x.Value.Passed.Value), "each individual node should have marked their test as passed");
+            Assert.True(factData.Passed.Value, "SpecCoordinator should have marked spec as passed");
+        }
+
+        [Fact]
+        public void SpecRunCoordinator_should_mark_spec_as_failed_if_all_nodes_fail()
+        {
+            var nodeIndexes = Enumerable.Range(1, 3).ToArray();
+            var nodeTests = NodeMessageHelpers.BuildNodeTests(nodeIndexes);
+
+            var specRunCoordinator = Sys.ActorOf(Props.Create(() => new SpecRunCoordinator(nodeTests.First()
+                .TypeName, nodeTests.First().MethodName, nodeTests)));
+
+            var messages = NodeMessageHelpers.GenerateMessageSequence(nodeIndexes, 100);
+
+            //Add some result (FAIL) messages
+            messages.UnionWith(NodeMessageHelpers.GenerateResultMessage(nodeIndexes, false));
+
+            foreach (var multiNodeMessage in messages)
+            {
+                specRunCoordinator.Tell(multiNodeMessage);
+            }
+
+            //End the test
+            specRunCoordinator.Tell(new EndSpec(), TestActor);
+            var factData = ExpectMsg<FactData>();
+
+            Assert.Equal(nodeIndexes.Length, factData.NodeFacts.Count);
+            Assert.True(factData.NodeFacts.All(x => !x.Value.Passed.Value), "each individual node should have marked their test as failed");
+            Assert.False(factData.Passed.Value, "SpecCoordinator should have marked spec as failed");
+        }
+
+        [Fact]
+        public void SpecRunCoordinator_should_mark_spec_as_failed_if_one_node_fails()
+        {
+            var nodeIndexes = Enumerable.Range(1, 3).ToArray();
+            var nodeTests = NodeMessageHelpers.BuildNodeTests(nodeIndexes);
+
+            var specRunCoordinator = Sys.ActorOf(Props.Create(() => new SpecRunCoordinator(nodeTests.First()
+                .TypeName, nodeTests.First().MethodName, nodeTests)));
+
+            var messages = NodeMessageHelpers.GenerateMessageSequence(nodeIndexes, 100);
+
+            //Add some result (1 FAIL, 2 PASS) messages
+            var front = nodeIndexes.First();
+            var nodesMinusFront = nodeIndexes.Where(x => x != front);
+            messages.UnionWith(NodeMessageHelpers.GenerateResultMessage(nodesMinusFront, true)); //PASS messages
+            messages.UnionWith(NodeMessageHelpers.GenerateResultMessage(front, false)); //one FAIL message
+
+            foreach (var multiNodeMessage in messages)
+            {
+                specRunCoordinator.Tell(multiNodeMessage);
+            }
+
+            //End the test
+            specRunCoordinator.Tell(new EndSpec(), TestActor);
+            var factData = ExpectMsg<FactData>();
+
+            Assert.Equal(nodeIndexes.Length, factData.NodeFacts.Count);
+            Assert.True(factData.NodeFacts.Count(x => !x.Value.Passed.Value) == 1, "one node should have marked their test as failed");
+            Assert.True(factData.NodeFacts.Count(x => x.Value.Passed.Value) == nodeIndexes.Length - 1, "rest of nodes should have marked their test as passed");
+            Assert.False(factData.Passed.Value, "SpecCoordinator should have marked spec as failed");
+        }
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared.Tests/TestRunCoordinatorSpec.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared.Tests/TestRunCoordinatorSpec.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Akka.Actor;
+using Akka.MultiNodeTestRunner.Shared.Persistence;
+using Akka.MultiNodeTestRunner.Shared.Reporting;
+using Akka.MultiNodeTestRunner.Shared.Sinks;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.MultiNodeTestRunner.Shared.Tests
+{
+    public class TestRunCoordinatorSpec : AkkaSpec
+    {
+        [Fact]
+        public void TestRunCoordinator_should_start_and_route_messages_to_SpecRunCoordinator()
+        {
+            var testRunCoordinator = Sys.ActorOf(Props.Create<TestRunCoordinator>());
+            var nodeIndexes = Enumerable.Range(1, 4).ToArray();
+            var nodeTests = NodeMessageHelpers.BuildNodeTests(nodeIndexes);
+
+            var beginSpec = new BeginNewSpec(nodeTests.First().TypeName, nodeTests.First().MethodName, nodeTests);
+
+            //begin a new spec
+            testRunCoordinator.Tell(beginSpec);
+
+            // create some messages for each node, the test runner, and some result messages
+            // just like a real MultiNodeSpec
+            var allMessages = NodeMessageHelpers.GenerateMessageSequence(nodeIndexes, 300);
+            var runnerMessages = NodeMessageHelpers.GenerateTestRunnerMessageSequence(20);
+            allMessages.UnionWith(runnerMessages);
+
+            foreach(var message in allMessages)
+                testRunCoordinator.Tell(message);
+
+            //end the spec
+            testRunCoordinator.Tell(new EndTestRun(), TestActor);
+            var testRunData = ExpectMsg<TestRunTree>();
+
+            Assert.Equal(1, testRunData.Specs.Count());
+
+            var specMessages = new SortedSet<MultiNodeMessage>();
+            foreach (var spec in testRunData.Specs)
+            {
+                specMessages.UnionWith(spec.RunnerMessages);
+                foreach(var fact in spec.NodeFacts)
+                    specMessages.UnionWith(fact.Value.EventStream);
+            }
+
+            Assert.True(allMessages.SetEquals(specMessages));
+               
+        }
+
+        [Fact]
+        public void TestRunCoordinator_should_publish_FactData_to_Subscribers_when_Specs_complete()
+        {
+            var testRunCoordinator = Sys.ActorOf(Props.Create<TestRunCoordinator>());
+            var nodeIndexes = Enumerable.Range(1, 4).ToArray();
+            var nodeTests = NodeMessageHelpers.BuildNodeTests(nodeIndexes);
+
+            var beginSpec = new BeginNewSpec(nodeTests.First().TypeName, nodeTests.First().MethodName, nodeTests);
+
+            //register the TestActor as a subscriber for FactData announcements
+            testRunCoordinator.Tell(new TestRunCoordinator.SubscribeFactCompletionMessages(TestActor));
+
+            //begin a new spec
+            testRunCoordinator.Tell(beginSpec);
+
+            // create some messages for each node, the test runner, and some result messages
+            // just like a real MultiNodeSpec
+            var allMessages = NodeMessageHelpers.GenerateMessageSequence(nodeIndexes, 300);
+            var runnerMessages = NodeMessageHelpers.GenerateTestRunnerMessageSequence(20);
+            var passMessages = NodeMessageHelpers.GenerateResultMessage(nodeIndexes, true);
+            allMessages.UnionWith(runnerMessages);
+            allMessages.UnionWith(passMessages);
+
+            foreach (var message in allMessages)
+                testRunCoordinator.Tell(message);
+
+            //end the spec
+            testRunCoordinator.Tell(new EndSpec());
+
+            var factData = ExpectMsg<FactData>();
+            Assert.True(factData.Passed.Value, "Spec should have passed");
+            Assert.True(factData.NodeFacts.All(x => x.Value.Passed.Value), "All individual nodes should have reported test pass");
+        }
+
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared.Tests/packages.config
+++ b/src/core/Akka.MultiNodeTestRunner.Shared.Tests/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="faker-csharp" version="1.2.0" targetFramework="net45" />
+  <package id="xunit" version="1.9.2" targetFramework="net45" />
+  <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
+</packages>

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Akka.MultiNodeTestRunner.Shared.csproj
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Akka.MultiNodeTestRunner.Shared.csproj
@@ -4,18 +4,17 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{C1113300-74F1-446A-9914-3020C842EDF1}</ProjectGuid>
-    <OutputType>Exe</OutputType>
+    <ProjectGuid>{964F0EC5-FBE6-47C5-8AE6-145114D5DB8C}</ProjectGuid>
+    <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Akka.MultiNodeTestRunner</RootNamespace>
-    <AssemblyName>Akka.MultiNodeTestRunner</AssemblyName>
+    <RootNamespace>Akka.MultiNodeTestRunner.Shared</RootNamespace>
+    <AssemblyName>Akka.MultiNodeTestRunner.Shared</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -25,7 +24,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
@@ -34,54 +32,47 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="xunit.abstractions">
-      <HintPath>..\..\packages\xunit.abstractions.2.0.0-beta4-build2738\lib\net35\xunit.abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="xunit.runner.utility">
-      <HintPath>..\..\packages\xunit.runner.utility.2.0.0-beta4-build2738\lib\net35\xunit.runner.utility.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\Akka.Remote.TestKit\CommandLine.cs">
-      <Link>CommandLine.cs</Link>
-    </Compile>
-    <Compile Include="Discovery.cs" />
-    <Compile Include="Program.cs" />
+    <Compile Include="ExitCodeContainer.cs" />
+    <Compile Include="NodeTest.cs" />
+    <Compile Include="Persistence\IPersistentTestRunStore.cs" />
+    <Compile Include="Persistence\JsonPersistentTestRunStore.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Sinks\ConsoleMessageSinkActor.cs" />
+    <Compile Include="Sinks\FileSystemMessageSinkActor.cs" />
+    <Compile Include="Sinks\IMessageSink.cs" />
+    <Compile Include="Reporting\MultiNodeMessage.cs" />
+    <Compile Include="Reporting\TestRunTree.cs" />
+    <Compile Include="Sinks\Messages.cs" />
+    <Compile Include="Sinks\MessageSink.cs" />
+    <Compile Include="Sinks\MessageSinkActor.cs" />
+    <Compile Include="Reporting\NodeDataActor.cs" />
+    <Compile Include="Reporting\SpecRunCoordinator.cs" />
+    <Compile Include="Sinks\SinkCoordinator.cs" />
+    <Compile Include="Sinks\TestCoordinatorEnabledMessageSink.cs" />
+    <Compile Include="Reporting\TestRunCoordinator.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\contrib\loggers\Akka.Logger.NLog\Akka.Logger.NLog.csproj">
-      <Project>{a8aa2d7e-3d35-44df-af92-80a2c39c1f4d}</Project>
-      <Name>Akka.Logger.NLog</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Akka.Cluster.Tests\Akka.Cluster.Tests.csproj">
-      <Project>{c8d6a95c-50bf-4416-a212-86b18b87220d}</Project>
-      <Name>Akka.Cluster.Tests</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Akka.MultiNodeTestRunner.Shared\Akka.MultiNodeTestRunner.Shared.csproj">
-      <Project>{964f0ec5-fbe6-47c5-8ae6-145114d5db8c}</Project>
-      <Name>Akka.MultiNodeTestRunner.Shared</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Akka.NodeTestRunner\Akka.NodeTestRunner.csproj">
-      <Project>{28520f30-2868-4bd3-9cae-ac27226c24e3}</Project>
-      <Name>Akka.NodeTestRunner</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Akka.Remote\Akka.Remote.csproj">
-      <Project>{ea4ff8fd-7c53-49c8-b9aa-02e458b3e6a7}</Project>
-      <Name>Akka.Remote</Name>
-    </ProjectReference>
     <ProjectReference Include="..\Akka\Akka.csproj">
       <Project>{5deddf90-37f0-48d3-a0b0-a5cbd8a7e377}</Project>
       <Name>Akka</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/core/Akka.MultiNodeTestRunner.Shared/ExitCodeContainer.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/ExitCodeContainer.cs
@@ -1,0 +1,14 @@
+﻿using Akka.MultiNodeTestRunner.Shared.Sinks;
+
+namespace Akka.MultiNodeTestRunner.Shared
+{
+    /// <summary>
+    /// Global state for hanging onto the exit code used by the process.
+    /// 
+    /// The <see cref="SinkCoordinator"/> sets this value once during shutdown.
+    /// </summary>
+    public static class ExitCodeContainer
+    {
+        public static int ExitCode = 0;
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared/NodeTest.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/NodeTest.cs
@@ -1,6 +1,6 @@
-﻿namespace Akka.MultiNodeTestRunner
+﻿namespace Akka.MultiNodeTestRunner.Shared
 {
-    class NodeTest
+    public class NodeTest
     {
         public int Node { get; set; }
         public string TestName { get; set; }

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Persistence/IPersistentTestRunStore.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Persistence/IPersistentTestRunStore.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading.Tasks;
+using Akka.MultiNodeTestRunner.Shared.Reporting;
+
+namespace Akka.MultiNodeTestRunner.Shared.Persistence
+{
+    /// <summary>
+    /// Persistent store for saving and retrieving <see cref="TestRunTree"/> instances
+    /// from disk.
+    /// </summary>
+    public interface IPersistentTestRunStore
+    {
+        bool SaveTestRun(string filePath, TestRunTree data);
+
+        bool TestRunExists(string filePath);
+
+        TestRunTree FetchTestRun(string filePath);
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Persistence/JsonPersistentTestRunStore.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Persistence/JsonPersistentTestRunStore.cs
@@ -1,0 +1,88 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Xml.Serialization;
+using Akka.MultiNodeTestRunner.Shared.Reporting;
+using Akka.Serialization;
+using Akka.Util;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Akka.MultiNodeTestRunner.Shared.Persistence
+{
+    /// <summary>
+    /// XML (omg not XML!) implementation of the <see cref="IPersistentTestRunStore"/>
+    /// </summary>
+    public class JsonPersistentTestRunStore : IPersistentTestRunStore
+    {
+        //Internal version of the contract resolver
+        private class AkkaContractResolver : DefaultContractResolver
+        {
+            protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+            {
+                var prop = base.CreateProperty(member, memberSerialization);
+
+                if (!prop.Writable)
+                {
+                    var property = member as PropertyInfo;
+                    if (property != null)
+                    {
+                        var hasPrivateSetter = property.GetSetMethod(true) != null;
+                        prop.Writable = hasPrivateSetter;
+                    }
+                }
+
+                return prop;
+            }
+        }
+
+        public static JsonSerializerSettings Settings = new JsonSerializerSettings
+        {
+            PreserveReferencesHandling = PreserveReferencesHandling.Objects,
+            DefaultValueHandling = DefaultValueHandling.Ignore,
+            MissingMemberHandling = MissingMemberHandling.Ignore,
+            ObjectCreationHandling = ObjectCreationHandling.Replace,
+            //important: if reuse, the serializer will overwrite properties in default references, e.g. Props.DefaultDeploy or Props.noArgs
+            ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
+            TypeNameHandling = TypeNameHandling.All,
+            ContractResolver = new AkkaContractResolver()
+            {
+                //SerializeCompilerGeneratedMembers = true,
+                //IgnoreSerializableAttribute = true,
+                //IgnoreSerializableInterface = true,
+            }
+        };
+
+        public bool SaveTestRun(string filePath, TestRunTree data)
+        {
+            Guard.Assert(data != null, "TestRunTree must not be null.");
+            Guard.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
+
+
+// ReSharper disable once AssignNullToNotNullAttribute //already made this null check with Guard
+            var finalPath = Path.GetFullPath(filePath);
+            var serializedObj = JsonConvert.SerializeObject(data, Formatting.Indented, Settings);
+
+// ReSharper disable once AssignNullToNotNullAttribute
+            File.WriteAllText(finalPath, serializedObj, Encoding.UTF8);
+
+            return true;
+        }
+
+        public bool TestRunExists(string filePath)
+        {
+            return !string.IsNullOrEmpty(filePath) && File.Exists(Path.GetFullPath(filePath));
+        }
+
+        public TestRunTree FetchTestRun(string filePath)
+        {
+            Guard.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
+            // ReSharper disable once AssignNullToNotNullAttribute //already made this null check with Guard
+            var finalPath = Path.GetFullPath(filePath);
+            var fileText = File.ReadAllText(finalPath, Encoding.UTF8);
+            if (string.IsNullOrEmpty(fileText)) return null;
+            return JsonConvert.DeserializeObject<TestRunTree>(fileText, Settings);
+        }
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Properties/AssemblyInfo.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Akka.MultiNodeTestRunner.Shared")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Akka.MultiNodeTestRunner.Shared")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("3830bade-088e-4cdb-828f-68f194b6458f")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Reporting/MultiNodeMessage.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Reporting/MultiNodeMessage.cs
@@ -1,0 +1,230 @@
+﻿using System;
+using Akka.Event;
+
+namespace Akka.MultiNodeTestRunner.Shared.Reporting
+{
+    /// <summary>
+    /// Message from an individual node
+    /// </summary>
+    public abstract class MultiNodeMessage : IComparable<MultiNodeMessage>, IEquatable<MultiNodeMessage>
+    {
+        protected MultiNodeMessage(long timeStamp, string message, int nodeIndex)
+        {
+            NodeIndex = nodeIndex;
+            Message = message;
+            TimeStamp = timeStamp;
+        }
+
+        /// <summary>
+        /// The absolute time this message occurred represented as <see cref="DateTime.Ticks"/>
+        /// </summary>
+        public long TimeStamp { get; private set; }
+
+        /// <summary>
+        /// The contents of the log message.
+        /// </summary>
+        public string Message { get; private set; }
+
+        /// <summary>
+        /// The index of the node in question.
+        /// </summary>
+        public int NodeIndex { get; private set; }
+
+        #region Comparisons
+
+        public virtual int CompareTo(MultiNodeMessage other)
+        {
+            var tc = TimeStamp.CompareTo(other.TimeStamp);
+            if(tc != 0) return tc;
+            var m = String.Compare(Message, other.Message, StringComparison.Ordinal);
+            if (m != 0) return m;
+            var ni = NodeIndex.CompareTo(other.NodeIndex);
+            if (ni != 0) return ni;
+            return 0;
+        }
+
+        #endregion
+
+        #region Equality
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = 13;
+                hashCode = (hashCode * 397) ^ TimeStamp.GetHashCode();
+                hashCode = (hashCode * 397) ^ NodeIndex;
+                hashCode = (hashCode * 397) ^ Message.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            var msg = obj as MultiNodeMessage;
+            return msg != null && Equals(msg);
+        }
+
+        public virtual bool Equals(MultiNodeMessage other)
+        {
+            return other != null &&
+                   NodeIndex == other.NodeIndex &&
+                   TimeStamp == other.TimeStamp &&
+                   string.Equals(Message, other.Message);
+
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Message used to contain the PASS / FAIL results for a specific test
+    /// </summary>
+    public class MultiNodeResultMessage : MultiNodeMessage
+    {
+        public MultiNodeResultMessage(long timeStamp, string message, int nodeIndex, bool passed)
+            : base(timeStamp, message, nodeIndex)
+        {
+            Passed = passed;
+        }
+
+        /// <summary>
+        /// Flag to determine whether or not this <see cref="MultiNodeMessage.NodeIndex"/> passed its test or not.
+        /// </summary>
+        public bool Passed { get; private set; }
+
+        #region Equality
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = base.GetHashCode();
+                hashCode = (hashCode * 397) ^ Passed.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        public override bool Equals(MultiNodeMessage other)
+        {
+            var otherResultMessage = other as MultiNodeResultMessage;
+            return otherResultMessage != null &&
+                   base.Equals(other) &&
+                   Passed == otherResultMessage.Passed;
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Messages emitted directly by the test runner itself for an individual spec
+    /// </summary>
+    public class MultiNodeTestRunnerMessage : MultiNodeMessage
+    {
+        public MultiNodeTestRunnerMessage(long timeStamp, string message, string actorPath, LogLevel logLevel)
+            : base(timeStamp, message, -1)
+        {
+            ActorPath = actorPath;
+            LogLevel = logLevel;
+        }
+
+        /// <summary>
+        /// The path of the actor on the remote node who generated this message.
+        /// 
+        /// CAN BE NULL.
+        /// </summary>
+        public string ActorPath { get; private set; }
+
+        /// <summary>
+        /// The log level for this message.
+        /// </summary>
+        public LogLevel LogLevel { get; private set; }
+
+        #region Equality
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = base.GetHashCode();
+                hashCode = (hashCode * 397) ^ (int)LogLevel;
+                hashCode = (hashCode * 397) ^ ActorPath.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        public override bool Equals(MultiNodeMessage other)
+        {
+            var otherLogMessage = other as MultiNodeTestRunnerMessage;
+            return otherLogMessage != null &&
+                    base.Equals(other) &&
+                    LogLevel == otherLogMessage.LogLevel &&
+                    string.Equals(ActorPath, otherLogMessage.ActorPath);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Used in cases where a log message was broken up across multiple lines and this fragment has to be appended
+    /// to a previous message in the timeline
+    /// </summary>
+    public class MultiNodeLogMessageFragment : MultiNodeMessage
+    {
+        public MultiNodeLogMessageFragment(long timeStamp, string message, int nodeIndex) : base(timeStamp, message, nodeIndex)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Message from a node containing log information
+    /// </summary>
+    public class MultiNodeLogMessage : MultiNodeMessage
+    {
+        public MultiNodeLogMessage(long timeStamp, string message, int nodeIndex, string actorPath, LogLevel logLevel)
+            : base(timeStamp, message, nodeIndex)
+        {
+            ActorPath = actorPath;
+            LogLevel = logLevel;
+        }
+
+        /// <summary>
+        /// The path of the actor on the remote node who generated this message.
+        /// 
+        /// CAN BE NULL.
+        /// </summary>
+        public string ActorPath { get; private set; }
+
+        /// <summary>
+        /// The log level for this message.
+        /// </summary>
+        public LogLevel LogLevel { get; private set; }
+
+        #region Equality
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = base.GetHashCode();
+                hashCode = (hashCode * 397) ^ (int)LogLevel;
+                hashCode = (hashCode * 397) ^ ActorPath.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        public override bool Equals(MultiNodeMessage other)
+        {
+            var otherLogMessage = other as MultiNodeLogMessage;
+            return otherLogMessage != null &&
+                    base.Equals(other) &&
+                    LogLevel == otherLogMessage.LogLevel &&
+                    string.Equals(ActorPath, otherLogMessage.ActorPath);
+        }
+
+        #endregion
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Reporting/NodeDataActor.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Reporting/NodeDataActor.cs
@@ -1,0 +1,51 @@
+using System;
+using Akka.Actor;
+using Akka.MultiNodeTestRunner.Shared.Persistence;
+using Akka.MultiNodeTestRunner.Shared.Sinks;
+
+namespace Akka.MultiNodeTestRunner.Shared.Reporting
+{
+    /// <summary>
+    /// Actor responsible for processing test messages for an individual node within a multi-node test
+    /// </summary>
+    public class NodeDataActor : ReceiveActor
+    {
+        /// <summary>
+        /// Data that will be processed and aggregated for an individual node
+        /// </summary>
+        protected NodeData NodeData;
+
+        /// <summary>
+        /// The ID of this node in the 0-N index of all nodes for this test.
+        /// </summary>
+        protected readonly int NodeIndex;
+
+        public NodeDataActor(int nodeIndex)
+        {
+            NodeIndex = nodeIndex;
+            NodeData = new NodeData(nodeIndex);
+            SetReceive();
+        }
+
+        #region Message-handling
+
+        private void SetReceive()
+        {
+            Receive<MultiNodeMessage>(message => NodeData.Put(message));
+
+
+            Receive<EndSpec>(spec =>
+            {
+                
+
+                //Send NodeData to parent for aggregation purposes
+                Sender.Tell(NodeData.Copy());
+
+                //Begin shutdown
+                Context.Self.GracefulStop(TimeSpan.FromSeconds(1));
+            });
+        }
+
+        #endregion
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Reporting/SpecRunCoordinator.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Reporting/SpecRunCoordinator.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.MultiNodeTestRunner.Shared.Persistence;
+using Akka.MultiNodeTestRunner.Shared.Sinks;
+
+namespace Akka.MultiNodeTestRunner.Shared.Reporting
+{
+    /// <summary>
+    /// Actor responsible for organizing the results of an individual spec
+    /// </summary>
+    public class SpecRunCoordinator : ReceiveActor
+    {
+        public SpecRunCoordinator(string className, string methodName, IList<NodeTest> nodes)
+        {
+            Nodes = nodes;
+            MethodName = methodName;
+            ClassName = className;
+            FactData = new FactData(string.Format("{0}.{1}", className, methodName));
+            _nodeActors = new Dictionary<int, ActorRef>();
+            SetReceive();
+        }
+
+        public string ClassName { get; private set; }
+
+        public string MethodName { get; private set; }
+
+        public IList<NodeTest> Nodes { get; private set; }
+
+        /// <summary>
+        /// All of the data for this individual spec
+        /// </summary>
+        protected FactData FactData;
+
+        /// <summary>
+        /// Internal dictionary used to route messages to their discrete nodes
+        /// </summary>
+        private readonly Dictionary<int, ActorRef> _nodeActors;
+
+        #region Actor Lifecycle
+
+        protected override void PreStart()
+        {
+            //create all of the NodeFactActor instances
+            foreach (var node in Nodes)
+            {
+                var index = node.Node;
+                _nodeActors.Add(index, Context.ActorOf(Props.Create(() => new NodeDataActor(index))));
+            }
+        }
+
+        #endregion
+
+        #region Message-handling
+
+        private void SetReceive()
+        {
+            Receive<MultiNodeTestRunnerMessage>(message =>
+            {
+                FactData.Put(message);
+            });
+            Receive<MultiNodeMessage>(message => RouteToNodeActor(message));
+            Receive<EndSpec>(spec => HandleEndSpec(spec));
+            Receive<NodeData[]>(datum => HandleNodeDatum(datum));
+        }
+
+        /// <summary>
+        /// Send a <see cref="MultiNodeMessage"/> to the correct <see cref="NodeDataActor"/> based on the 
+        /// <see cref="MultiNodeMessage.NodeIndex"/> property.
+        /// </summary>
+        private void RouteToNodeActor(MultiNodeMessage message)
+        {
+            var actor = _nodeActors[message.NodeIndex];
+            actor.Tell(message);
+        }
+
+        /// <summary>
+        /// Wait for all child <see cref="NodeDataActor"/> instances to finish processing
+        /// and report their results
+        /// </summary>
+        /// <returns>An awaitable task, since this operation uses the <see cref="Futures.Ask"/> pattern</returns>
+        private Task HandleEndSpec(EndSpec endSpec)
+        {
+            var futures = new Task<NodeData>[Nodes.Count];
+
+            var i = 0;
+            foreach (var node in _nodeActors)
+            {
+                futures[i] = node.Value.Ask<NodeData>(endSpec, TimeSpan.FromSeconds(1));
+                i++;
+            }
+
+            var sender = Context.Sender;
+
+            //wait for all Ask operations to complete and pipe the result back to ourselves, including the ref for the original sender
+            return Task.WhenAll(futures)
+                .PipeTo(Self, sender);
+        }
+
+        /// <summary>
+        /// When the result of a <see cref="HandleEndSpec"/> finally gets finished...
+        /// </summary>
+        /// <param name="nodeDatum">An evenlope with all of the <see cref="NodeData"/> messages we processed from earilier</param>
+        private void HandleNodeDatum(NodeData[] nodeDatum)
+        {
+            FactData.AddNodes(nodeDatum);
+
+            //mark this test as complete
+            FactData.Complete();
+
+            //Send our FactData back to the sender
+            Sender.Tell(FactData.Copy());
+
+            //Shut ourselves down
+            Self.GracefulStop(TimeSpan.FromSeconds(1));
+        }
+
+        #endregion
+
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Reporting/TestRunCoordinator.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Reporting/TestRunCoordinator.cs
@@ -1,0 +1,175 @@
+﻿using System;
+using System.Collections.Generic;
+using Akka.Actor;
+using Akka.MultiNodeTestRunner.Shared.Persistence;
+using Akka.MultiNodeTestRunner.Shared.Sinks;
+using Akka.Util;
+
+namespace Akka.MultiNodeTestRunner.Shared.Reporting
+{
+    /// <summary>
+    /// Actor responsible for organizing all of the data for each test run
+    /// </summary>
+    public class TestRunCoordinator : ReceiveActor
+    {
+        #region Internal message classes
+
+        /// <summary>
+        /// Message used to request the current <see cref="TestRunData"/> value.
+        /// </summary>
+        public class RequestTestRunState { }
+
+        /// <summary>
+        /// Signals that we need to publish all <see cref="FactData"/> messages to the <see cref="Subscriber"/>
+        /// </summary>
+        public class SubscribeFactCompletionMessages
+        {
+            public SubscribeFactCompletionMessages(ActorRef subscriber)
+            {
+                Subscriber = subscriber;
+            }
+
+            public ActorRef Subscriber { get; private set; }
+        }
+
+        /// <summary>
+        /// Signals that <see cref="Subscriber"/> no longer wants to receive <see cref="FactData"/> messages
+        /// </summary>
+        public class UnsubscribeFactCompletionMessages
+        {
+            public UnsubscribeFactCompletionMessages(ActorRef subscriber)
+            {
+                Subscriber = subscriber;
+            }
+
+
+            public ActorRef Subscriber { get; private set; }
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Default constructor which uses <see cref="DateTime.UtcNow"/> as the time for <see cref="TestRunStarted"/>.
+        /// </summary>
+        public TestRunCoordinator() : this(DateTime.UtcNow) { }
+
+        public TestRunCoordinator(DateTime testRunStarted)
+        {
+            TestRunStarted = testRunStarted;
+            TestRunData = new TestRunTree(testRunStarted.Ticks);
+            Subscribers = new List<ActorRef>();
+            SetReceive();
+        }
+
+        #region Internal fields and Properties
+
+        protected readonly DateTime TestRunStarted;
+
+        protected ActorRef _currentSpecRunActor;
+
+        /// <summary>
+        /// Automatically set when <see cref="EndTestRun"/> is sent to this actor.
+        /// </summary>
+        protected DateTime? TestRunCompleted { get; private set; }
+
+        /// <summary>
+        /// The amount of time elapsed for this test run
+        /// </summary>
+        protected TimeSpan TestRunElapsed
+        {
+            get
+            {
+                return TestRunStarted - (TestRunCompleted.HasValue ? TestRunCompleted.Value : DateTime.UtcNow);
+            }
+        }
+
+        /// <summary>
+        /// Contains the entire tree of information needed to process results of a full test run.
+        /// </summary>
+        protected TestRunTree TestRunData;
+
+        /// <summary>
+        /// All of the subscribers who wish to receive <see cref="FactData"/> notifications
+        /// </summary>
+        protected List<ActorRef> Subscribers;
+
+        #endregion
+
+        #region Message-handling
+
+        private void SetReceive()
+        {
+            Receive<MultiNodeMessage>(message =>
+            {
+                if (_currentSpecRunActor == null) return;
+                _currentSpecRunActor.Forward(message);
+            });
+            Receive<BeginNewSpec>(spec => ReceiveBeginSpecRun(spec));
+            Receive<EndSpec>(spec => ReceiveEndSpecRun(spec));
+            Receive<RequestTestRunState>(state => Sender.Tell(TestRunData.Copy()));
+            Receive<SubscribeFactCompletionMessages>(messages => AddSubscriber(messages));
+            Receive<UnsubscribeFactCompletionMessages>(messages => RemoveSubscriber(messages));
+            Receive<EndTestRun>(run =>
+            {
+                //clean up the current spec, if it hasn't been done already
+                if (_currentSpecRunActor != null)
+                {
+                    ReceiveEndSpecRun(new EndSpec());
+                }
+
+                //Mark the test run as finished
+                TestRunData.Complete();
+
+                //Deliver the final copy of the TestRunData
+                Sender.Tell(TestRunData.Copy());
+
+                //shutdown
+                Context.Stop(Self);
+            });
+        }
+
+        private void RemoveSubscriber(UnsubscribeFactCompletionMessages unsubscribe)
+        {
+            Subscribers.Remove(unsubscribe.Subscriber);
+        }
+
+        private void AddSubscriber(SubscribeFactCompletionMessages subscription)
+        {
+            Subscribers.Add(subscription.Subscriber);
+        }
+
+        private void ReceiveBeginSpecRun(BeginNewSpec spec)
+        {
+            Guard.Assert(_currentSpecRunActor == null, "EndSpec has not been called for previous run yet. Cannot begin next run.");
+
+            //Create the new spec run actor
+            _currentSpecRunActor =
+                Context.ActorOf(
+                    Props.Create(() => new SpecRunCoordinator(spec.ClassName, spec.MethodName, spec.Nodes)));
+        }
+
+        private void ReceiveEndSpecRun(EndSpec spec)
+        {
+            //Should receive a FactData in return
+            var specCompleteTask = _currentSpecRunActor.Ask<FactData>(spec, TimeSpan.FromSeconds(2));
+
+            //Going to block so we can't accidentally start processing  messages for a new spec yet..
+            specCompleteTask.Wait();
+
+            //Got the result we needed
+            var factData = specCompleteTask.Result;
+            TestRunData.AddSpec(factData);
+
+            //Publish the FactData back to any subscribers who wanted it
+            foreach (var subscriber in Subscribers)
+            {
+                subscriber.Tell(factData);
+            }
+
+            //Ready to begin the next spec
+            _currentSpecRunActor = null;
+        }
+
+        #endregion
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Reporting/TestRunTree.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Reporting/TestRunTree.cs
@@ -1,0 +1,403 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace Akka.MultiNodeTestRunner.Shared.Reporting
+{
+    /// <summary>
+    /// The top of the tree - represents an entire test run.
+    /// </summary>
+    public class TestRunTree : IEquatable<TestRunTree>
+    {
+        private readonly List<FactData> _specs;
+
+        public TestRunTree(long startTime) : this(startTime, new List<FactData>())
+        {
+        }
+
+        public TestRunTree(long startTime, List<FactData> specs) : this(startTime, specs, null, null)
+        {
+    
+        }
+
+        [JsonConstructor]
+        public TestRunTree(long startTime, List<FactData> specs, long? endTime, bool? passed)
+        {
+            StartTime = startTime;
+            _specs = specs;
+            EndTime = endTime;
+            Passed = passed;
+        }
+
+        /// <summary>
+        /// The absolute time tests began for this individual node
+        /// </summary>
+        public long StartTime { get; private set; }
+
+        /// <summary>
+        /// The absolute time tests ended for this individual node
+        /// </summary>
+        public long? EndTime { get; set; }
+
+        /// <summary>
+        /// Whether or not this test has acquired a result yet
+        /// </summary>
+        public bool? Passed { get; set; }
+
+        public IEnumerable<FactData> Specs { get { return _specs; } }
+
+        public TimeSpan Elapsed
+        {
+            get
+            {
+                return ((EndTime.HasValue ? new DateTime(EndTime.Value) : DateTime.UtcNow) - new DateTime(StartTime));
+            }
+        }
+
+        public void AddSpec(FactData spec)
+        {
+            _specs.Add(spec);
+        }
+
+        public void Complete()
+        {
+            var passes = _specs.Select(x => x.Passed);
+            if (passes.All(x => x.HasValue))
+            {
+                Passed = passes.All(x => x.Value);
+                EndTime = DateTime.UtcNow.Ticks;
+            }
+        }
+
+        /// <summary>
+        /// Returns a deep copy of the current tree.
+        /// </summary>
+        public TestRunTree Copy()
+        {
+            var specs = new FactData[_specs.Count];
+            _specs.CopyTo(specs);
+
+            return new TestRunTree(StartTime, specs.ToList(), EndTime, Passed);
+        }
+
+        #region Equality
+
+        public bool Equals(TestRunTree other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return 
+                _specs.SequenceEqual(other._specs) 
+                && StartTime == other.StartTime 
+                && EndTime == other.EndTime 
+                && Passed.Equals(other.Passed);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((TestRunTree) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (_specs != null ? _specs.GetHashCode() : 0);
+                hashCode = (hashCode*397) ^ StartTime.GetHashCode();
+                hashCode = (hashCode*397) ^ EndTime.GetHashCode();
+                hashCode = (hashCode*397) ^ Passed.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// A collection of data about a particular test
+    /// </summary>
+    public class FactData : IEquatable<FactData>
+    {
+        private readonly Dictionary<int, NodeData> _nodes;
+
+        /// <summary>
+        /// Messages sent by the test runner for this spec, rather than any individual nodes
+        /// </summary>
+        private readonly SortedSet<MultiNodeMessage> _testRunnerTimeLine;
+
+        public FactData(string factName) 
+            : this(factName, DateTime.UtcNow.Ticks, new Dictionary<int, NodeData>(), new  List<MultiNodeMessage>()) { }
+
+        public FactData(string factName, long startTime, Dictionary<int, NodeData> nodes, IEnumerable<MultiNodeMessage> testRunnerTimeLine)
+            : this(factName, startTime, nodes, testRunnerTimeLine, null, null)
+        {
+         
+        }
+
+        public FactData(string factName, long startTime, Dictionary<int, NodeData> nodes, IEnumerable<MultiNodeMessage> testRunnerTimeLine, long? endTime, bool? passed)
+        {
+            _nodes = nodes;
+            _testRunnerTimeLine = new SortedSet<MultiNodeMessage>(testRunnerTimeLine ?? new List<MultiNodeMessage>());
+            StartTime = startTime;
+            FactName = factName;
+            EndTime = endTime;
+            Passed = passed;
+        }
+
+        [JsonConstructor]
+        public FactData(string factName, long startTime, IEnumerable<NodeData> nodes, IEnumerable<MultiNodeMessage> testRunnerTimeLine, long? endTime, bool? passed)
+            : this(factName, startTime, 
+            nodes == null ? new Dictionary<int, NodeData>() : 
+            nodes.ToDictionary(key => key.NodeIndex, data => data), 
+            testRunnerTimeLine, endTime, passed)
+        {
+        }
+
+
+        public string FactName { get; private set; }
+
+        public IEnumerable<MultiNodeMessage> RunnerMessages { get { return _testRunnerTimeLine; } }
+
+        public Dictionary<int, NodeData> NodeFacts { get { return _nodes; } }
+
+        /// <summary>
+        /// The absolute time tests began for this individual node
+        /// </summary>
+        public long StartTime { get; private set; }
+
+        /// <summary>
+        /// The absolute time tests ended for this individual node
+        /// </summary>
+        public long? EndTime { get; set; }
+
+        /// <summary>
+        /// Whether or not this test has acquired a result yet
+        /// </summary>
+        public bool? Passed { get; set; }
+
+        public TimeSpan Elapsed
+        {
+            get
+            {
+                return ((EndTime.HasValue ? new DateTime(EndTime.Value) : DateTime.UtcNow) - new DateTime(StartTime));
+            }
+        }
+
+        public void Complete()
+        {
+            var passes = _nodes.Select(x => x.Value.Passed);
+            if (passes.All(x => x.HasValue))
+            {
+                Passed = passes.All(x => x.Value);
+                EndTime = DateTime.UtcNow.Ticks;
+            }
+        }
+
+        public void AddNodes(NodeData[] nodeDatum)
+        {
+            foreach(var node in nodeDatum)
+                AddNode(node);
+        }
+
+        public void AddNode(NodeData nodeData)
+        {
+            _nodes[nodeData.NodeIndex] = nodeData;
+        }
+
+        public void Put(MultiNodeMessage message)
+        {
+            _testRunnerTimeLine.Add(message);
+        }
+
+        /// <summary>
+        /// Creates a deep copy of the current <see cref="FactData"/> object.
+        /// </summary>
+        public FactData Copy()
+        {
+            var nodeData = new Dictionary<int, NodeData>(_nodes.Count);
+            foreach (var node in _nodes)
+            {
+                //make a copy of the NodeData too
+                nodeData[node.Key] = node.Value.Copy();
+            }
+
+            var messageTimeline = new MultiNodeMessage[_testRunnerTimeLine.Count];
+            _testRunnerTimeLine.CopyTo(messageTimeline);
+
+            return new FactData(FactName, StartTime, nodeData, messageTimeline, EndTime, Passed);
+        }
+
+        #region Equality
+
+        public bool Equals(FactData other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return _nodes.SequenceEqual(other._nodes)
+                && _testRunnerTimeLine.SetEquals(other._testRunnerTimeLine)
+                && string.Equals(FactName, other.FactName) 
+                && StartTime == other.StartTime 
+                && EndTime == other.EndTime 
+                && Passed.Equals(other.Passed);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((FactData) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (FactName.GetHashCode() * 397) ^ StartTime.GetHashCode();
+            }
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// A collection of data about the status of a particular node
+    /// </summary>
+    public class NodeData : IEquatable<NodeData>
+    {
+        private readonly SortedSet<MultiNodeMessage> _eventTimeLine;
+
+        public NodeData(int nodeIndex) : this(nodeIndex, DateTime.UtcNow.Ticks, new List<MultiNodeMessage>()) { }
+
+        public NodeData(int nodeIndex, long startTime, IEnumerable<MultiNodeMessage> eventTimeLine) 
+            : this(nodeIndex, startTime, eventTimeLine, null, null)
+        {
+          
+        }
+
+        /// <summary>
+        /// Copy constructor
+        /// </summary>
+        [JsonConstructor]
+        public NodeData(int nodeIndex, long startTime, IEnumerable<MultiNodeMessage> eventTimeLine, long? endTime,
+            bool? passed)
+        {
+            NodeIndex = nodeIndex;
+            StartTime = startTime;
+            _eventTimeLine = new SortedSet<MultiNodeMessage>(eventTimeLine ?? new List<MultiNodeMessage>());
+            EndTime = endTime;
+            Passed = passed;
+        }
+
+        /// <summary>
+        /// The position of this node in the 0...N index of all nodes in the set.
+        /// </summary>
+        public int NodeIndex { get; private set; }
+
+        /// <summary>
+        /// The absolute time tests began for this individual node
+        /// </summary>
+        public long StartTime { get; private set; }
+
+        /// <summary>
+        /// The absolute time tests ended for this individual node
+        /// </summary>
+        public long? EndTime { get; set; }
+
+        /// <summary>
+        /// Whether or not this test has acquired a result yet
+        /// </summary>
+        public bool? Passed { get; set; }
+
+        /// <summary>
+        /// Filter all of the result messages to the top
+        /// </summary>
+        public SortedSet<MultiNodeResultMessage> ResultMessages
+        {
+            get
+            {
+                return new SortedSet<MultiNodeResultMessage>(_eventTimeLine.Where(x => x.GetType() == typeof(MultiNodeResultMessage)).Cast<MultiNodeResultMessage>());
+            }
+        }
+
+        public TimeSpan Elapsed
+        {
+            get
+            {
+                return ((EndTime.HasValue ? new DateTime(EndTime.Value) : DateTime.UtcNow) - new DateTime(StartTime));
+            }
+        }
+
+        /// <summary>
+        /// All of the events that occurred for this node - time sequenced.
+        /// </summary>
+        public IEnumerable<MultiNodeMessage> EventStream
+        {
+            get { return _eventTimeLine; }
+        }
+
+        /// <summary>
+        /// Push a new message onto the <see cref="EventStream"/> for this node.
+        /// </summary>
+        public void Put(MultiNodeMessage message)
+        {
+            //Check for passed messages
+            if (!Passed.HasValue && message is MultiNodeResultMessage)
+            {
+                var resultMessage = message as MultiNodeResultMessage;
+                Passed = resultMessage.Passed;
+                EndTime = DateTime.UtcNow.Ticks;
+            }
+
+            _eventTimeLine.Add(message);
+        }
+
+        /// <summary>
+        /// Does a deep copy of the current <see cref="NodeData"/> object
+        /// </summary>
+        public NodeData Copy()
+        {
+            var events = new MultiNodeMessage[_eventTimeLine.Count];
+            _eventTimeLine.CopyTo(events);
+
+            return new NodeData(NodeIndex, StartTime, events, EndTime, Passed);
+        }
+
+        #region Equality
+
+        public bool Equals(NodeData other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return _eventTimeLine.SetEquals(other._eventTimeLine)
+                && NodeIndex == other.NodeIndex 
+                && StartTime == other.StartTime 
+                && EndTime == other.EndTime 
+                && Passed.Equals(other.Passed);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((NodeData) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (NodeIndex * 397) ^ StartTime.GetHashCode();
+            }
+        }
+
+        #endregion
+
+   
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/ConsoleMessageSinkActor.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/ConsoleMessageSinkActor.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Linq;
+using Akka.Actor;
+using Akka.Event;
+using Akka.MultiNodeTestRunner.Shared.Reporting;
+
+namespace Akka.MultiNodeTestRunner.Shared.Sinks
+{
+    /// <summary>
+    /// <see cref="MessageSinkActor"/> implementation that logs all of its output directly to the <see cref="Console"/>.
+    /// 
+    /// Has no persitence capabilities. Can optionally use a <see cref="TestRunCoordinator"/> to provide total "end of test" reporting.
+    /// </summary>
+    public class ConsoleMessageSinkActor : TestCoordinatorEnabledMessageSink
+    {
+        public ConsoleMessageSinkActor(bool useTestCoordinator) : base(useTestCoordinator)
+        {
+        }
+
+        #region Message handling
+
+        protected override void AdditionalReceives()
+        {
+            Receive<FactData>(data => ReceiveFactData(data));
+            Receive<TestRunTree>(tree => ReceiveTestRunTree(tree));
+        }
+
+        private void ReceiveTestRunTree(TestRunTree tree)
+        {
+            var passedSpecs = tree.Specs.Count(x => x.Passed.GetValueOrDefault(false));
+            WriteSpecMessage(string.Format("Test run completed in [{0}] with {1}/{2} specs passed.", tree.Elapsed, passedSpecs, tree.Specs.Count()));
+            
+        }
+
+        protected override void ReceiveFactData(FactData data)
+        {
+            PrintSpecRunResults(data);
+        }
+
+        private void PrintSpecRunResults(FactData data)
+        {
+            WriteSpecMessage(string.Format("Results for {0}", data.FactName));
+            WriteSpecMessage(string.Format("Start time: {0}", new DateTime(data.StartTime, DateTimeKind.Utc)));
+            foreach (var node in data.NodeFacts)
+            {
+                WriteSpecMessage(string.Format(" --> Node {0}: {1} [{2} elapsed]", node.Value.NodeIndex,
+                    node.Value.Passed.GetValueOrDefault(false) ? "PASS" : "FAIL", node.Value.Elapsed));
+            }
+            WriteSpecMessage(string.Format("End time: {0}",
+                new DateTime(data.EndTime.GetValueOrDefault(DateTime.UtcNow.Ticks), DateTimeKind.Utc)));
+            WriteSpecMessage(string.Format("FINAL RESULT: {0} after {1}.",
+                data.Passed.GetValueOrDefault(false) ? "PASS" : "FAIL", data.Elapsed));
+
+            //If we had a failure
+            if (data.Passed.GetValueOrDefault(false) == false)
+            {
+                WriteSpecMessage("Failure messages by Node");
+                foreach (var node in data.NodeFacts)
+                {
+                    if (node.Value.Passed.GetValueOrDefault(false) == false)
+                    {
+                        WriteSpecMessage(string.Format("<----------- BEGIN NODE {0} ----------->", node.Key));
+                        foreach (var resultMessage in node.Value.ResultMessages)
+                        {
+                            WriteSpecMessage(String.Format(" --> {0}", resultMessage.Message));
+                        }
+                        WriteSpecMessage(string.Format("<----------- END NODE {0} ----------->", node.Key));
+                    }
+                }
+            }
+        }
+
+        protected override void HandleNodeSpecFail(NodeCompletedSpecWithFail nodeFail)
+        {
+            WriteSpecFail(nodeFail.NodeIndex, nodeFail.Message);
+
+            base.HandleNodeSpecFail(nodeFail);
+        }
+
+        protected override void HandleTestRunEnd(EndTestRun endTestRun)
+        {
+            WriteSpecMessage("Test run complete.");
+            
+            base.HandleTestRunEnd(endTestRun);
+        }
+
+        protected override void HandleNewSpec(BeginNewSpec newSpec)
+        {
+            WriteSpecMessage(string.Format("Beginning spec {0}.{1} on {2} nodes", newSpec.ClassName, newSpec.MethodName, newSpec.Nodes.Count));
+
+            base.HandleNewSpec(newSpec);
+        }
+
+        protected override void HandleEndSpec(EndSpec endSpec)
+        {
+            WriteSpecMessage("Spec completed.");
+
+            base.HandleEndSpec(endSpec);
+        }
+
+        protected override void HandleNodeMessage(LogMessageForNode logMessage)
+        {
+            WriteNodeMessage(logMessage);
+
+            base.HandleNodeMessage(logMessage);
+        }
+
+        protected override void HandleNodeMessageFragment(LogMessageFragmentForNode logMessage)
+        {
+            WriteNodeMessage(logMessage);
+
+            base.HandleNodeMessageFragment(logMessage);
+        }
+
+        protected override void HandleRunnerMessage(LogMessageForTestRunner node)
+        {
+            WriteRunnerMessage(node);
+            
+            base.HandleRunnerMessage(node);
+        }
+
+        protected override void HandleNodeSpecPass(NodeCompletedSpecWithSuccess nodeSuccess)
+        {
+            WriteSpecPass(nodeSuccess.NodeIndex, nodeSuccess.Message);
+
+            base.HandleNodeSpecPass(nodeSuccess);
+        }
+
+        #endregion
+
+        #region Console output methods
+
+        /// <summary>
+        /// Used to print a spec status message (spec starting, finishing, failed, etc...)
+        /// </summary>
+        private void WriteSpecMessage(string message)
+        {
+            Console.ForegroundColor = ConsoleColor.DarkYellow;
+            Console.WriteLine("[RUNNER][{0}]: {1}", DateTime.UtcNow.ToShortTimeString(), message);
+            Console.ResetColor();
+        }
+
+        private void WriteSpecPass(int nodeIndex, string message)
+        {
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine("[NODE{0}][{1}]: SPEC PASSED: {2}", nodeIndex, DateTime.UtcNow.ToShortTimeString(), message);
+            Console.ResetColor();
+        }
+
+        private void WriteSpecFail(int nodeIndex, string message)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine("[NODE{0}][{1}]: SPEC FAILED: {2}", nodeIndex, DateTime.UtcNow.ToShortTimeString(), message);
+            Console.ResetColor();
+        }
+
+        private void WriteRunnerMessage(LogMessageForTestRunner nodeMessage)
+        {
+            Console.ForegroundColor = ColorForLogLevel(nodeMessage.Level);
+            Console.WriteLine("[RUNNER][{0}][{1}][{2}]: {3}", nodeMessage.When, nodeMessage.Level.ToString().Replace("Level", "").ToUpperInvariant(), nodeMessage.LogSource, nodeMessage.Message);
+            Console.ResetColor();
+        }
+
+        private void WriteNodeMessage(LogMessageForNode nodeMessage)
+        {
+            Console.ForegroundColor = ColorForLogLevel(nodeMessage.Level);
+            Console.WriteLine("[NODE{1}][{0}][{2}][{3}]: {4}", nodeMessage.When, nodeMessage.NodeIndex, nodeMessage.Level.ToString().Replace("Level", "").ToUpperInvariant(), nodeMessage.LogSource, nodeMessage.Message);
+            Console.ResetColor();
+        }
+
+        private void WriteNodeMessage(LogMessageFragmentForNode nodeMessage)
+        {
+            Console.WriteLine("[NODE{1}][{0}]: {2}", nodeMessage.When, nodeMessage.NodeIndex, nodeMessage.Message);
+        }
+
+        private static ConsoleColor ColorForLogLevel(LogLevel level)
+        {
+            var color = ConsoleColor.DarkGray;
+            switch (level)
+            {
+                case LogLevel.DebugLevel:
+                    color = ConsoleColor.Gray;
+                    break;
+                case LogLevel.InfoLevel:
+                    color = ConsoleColor.White;
+                    break;
+                case LogLevel.WarningLevel:
+                    color = ConsoleColor.Yellow;
+                    break;
+                case LogLevel.ErrorLevel:
+                    color = ConsoleColor.Red;
+                    break;
+            }
+
+            return color;
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// <see cref="IMessageSink"/> implementation that writes directly to the console.
+    /// </summary>
+    public class ConsoleMessageSink : MessageSink
+    {
+        public ConsoleMessageSink()
+            : base(Props.Create(() => new ConsoleMessageSinkActor(true)))
+        {
+        }
+
+        protected override void HandleUnknownMessageType(string message)
+        {
+            Console.ForegroundColor = ConsoleColor.DarkYellow;
+            Console.WriteLine("Unknown message: {0}", message);
+            Console.ResetColor();
+        }
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/FileSystemMessageSinkActor.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/FileSystemMessageSinkActor.cs
@@ -1,0 +1,76 @@
+using System;
+using System.IO;
+using Akka.Actor;
+using Akka.MultiNodeTestRunner.Shared.Persistence;
+using Akka.MultiNodeTestRunner.Shared.Reporting;
+
+namespace Akka.MultiNodeTestRunner.Shared.Sinks
+{
+    /// <summary>
+    /// A file system <see cref="MessageSink"/> implementation
+    /// </summary>
+    public class FileSystemMessageSink : MessageSink
+    {
+        public FileSystemMessageSink(string assemblyName)
+            : this(
+                Props.Create(
+                    () =>
+                        new FileSystemMessageSinkActor(new JsonPersistentTestRunStore(), GenerateFileName(assemblyName),
+                            true)))
+        {
+            
+        }
+
+        public FileSystemMessageSink(Props messageSinkActorProps) : base(messageSinkActorProps)
+        {
+        }
+
+        protected override void HandleUnknownMessageType(string message)
+        {
+            //do nothing
+        }
+
+        #region Static methods
+
+        public static string GenerateFileName(string assemblyName)
+        {
+            return string.Format("{0}-{1}.json", assemblyName.Replace(".dll", ""), DateTime.UtcNow.Ticks);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// <see cref="MessageSink"/> responsible for writing to the file system.
+    /// </summary>
+    public class FileSystemMessageSinkActor : TestCoordinatorEnabledMessageSink
+    {
+        protected IPersistentTestRunStore FileStore;
+        protected string FileName;
+
+        public FileSystemMessageSinkActor(IPersistentTestRunStore store, string fileName, bool useTestCoordinator)
+            : base(useTestCoordinator)
+        {
+            FileStore = store;
+            FileName = fileName;
+        }
+
+        protected override void AdditionalReceives()
+        {
+            Receive<TestRunTree>(tree => WriteToFile(tree));
+            Receive<FactData>(data => ReceiveFactData(data));
+        }
+
+        private void WriteToFile(TestRunTree tree)
+        {
+            Console.WriteLine("Writing test state to: {0}", Path.GetFullPath(FileName));
+            FileStore.SaveTestRun(FileName, tree);
+        }
+
+        protected override void ReceiveFactData(FactData data)
+        {
+            //Ask the TestRunCoordinator to give us the latest state
+            Sender.Tell(new TestRunCoordinator.RequestTestRunState());
+        }
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/IMessageSink.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/IMessageSink.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Event;
+
+namespace Akka.MultiNodeTestRunner.Shared.Sinks
+{
+    /// <summary>
+    /// Interface used to define destinations for MultiNodeTest messages
+    /// </summary>
+    public interface IMessageSink
+    {
+
+        #region Flow Control
+
+        /// <summary>
+        /// Make this <see cref="IMessageSink"/> ready for business.
+        /// 
+        /// Typically called at the beginning of a test run.
+        /// </summary>
+        void Open(ActorSystem context);
+
+        /// <summary>
+        /// Flag that determines if <see cref="Open"/> has been successfully called or not.
+        /// </summary>
+        bool IsOpen { get; }
+
+        /// <summary>
+        /// Flag that determines if <see cref="Close"/> has been successfully called or not.
+        /// </summary>
+        bool IsClosed { get; }
+
+        /// <summary>
+        /// Shut down the <see cref="IMessageSink"/> instance. 
+        /// 
+        /// Typically called at the end of a test run.
+        /// 
+        /// During instances of when a test run has been successfully started, this method
+        /// will wait up to 10 seconds for any <see cref="Actor"/> instances included as part of this
+        /// <see cref="IMessageSink"/> to shutdown, via the <see cref="GracefulStopSupport.GracefulStop(ActorRef, TimeSpan)"/> method.
+        /// </summary>
+        Task<bool> Close(ActorSystem context);
+
+        #endregion
+
+        #region Message Handling
+
+        /// <summary>
+        /// Report that the test runner is moving onto the next test in the testsuite.
+        /// </summary>
+        /// <param name="className">The name of the class containing the spec.</param>
+        /// <param name="methodName">The name of the individual test method.</param>
+        /// <param name="nodes">The number of nodes who will be participating in this test.</param>
+        void BeginTest(string className, string methodName, IList<NodeTest> nodes);
+
+        /// <summary>
+        /// Report that the test runner is terminating the current test in the suite.
+        /// </summary>
+        void EndTest();
+
+        /// <summary>
+        /// Report that an individual node has passed its test.
+        /// </summary>
+        /// <param name="nodeIndex">The Id of the node in the 0-N index.</param>
+        void Success(int nodeIndex);
+
+        /// <summary>
+        /// Report that an individual node has passed its test.
+        /// </summary>
+        /// <param name="nodeIndex">The Id of the node in the 0-N index.</param>
+        /// <param name="message">A string message included with the notification.</param>
+        void Success(int nodeIndex, string message);
+
+        /// <summary>
+        /// Report that an individual node has failed its test.
+        /// </summary>
+        /// <param name="nodeIndex">The Id of the node in the 0-N index.</param>
+        void Fail(int nodeIndex);
+
+        /// <summary>
+        /// Report that an individual node has failed its test.
+        /// </summary>
+        /// <param name="nodeIndex">The Id of the node in the 0-N index.</param>
+        /// <param name="message">A string message included with the notification.</param>
+        void Fail(int nodeIndex, string message);
+
+        /// <summary>
+        /// Report a log message for an individual node.
+        /// </summary>
+        /// <param name="nodeIndex">The Id of the node in the 0-N index.</param>
+        /// <param name="message">A string message included with the notification.</param>
+        /// <param name="logSource">The source of a log message.</param>
+        /// <param name="level">The <see cref="LogLevel"/> of this message.</param>
+        void Log(int nodeIndex, string message,  string logSource, LogLevel level);
+
+        /// <summary>
+        /// Report a log message from the MultiNodeTestRunner itself.
+        /// </summary>
+        /// <param name="message">A string message included with the notification.</param>
+        /// <param name="logSource">The source of a log message.</param>
+        /// <param name="level">The <see cref="LogLevel"/> of this message.</param>
+        void LogRunnerMessage(string message, string logSource, LogLevel level);
+
+        /// <summary>
+        /// Offer a raw message to the message sink. <see cref="MessageSink"/> will attempt to parse it
+        /// and turn it into one of the below parsing calls.
+        /// </summary>
+        /// <param name="messageStr">A raw log message</param>
+        void Offer(string messageStr);
+
+        #endregion
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/MessageSink.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/MessageSink.cs
@@ -1,0 +1,319 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Util;
+
+namespace Akka.MultiNodeTestRunner.Shared.Sinks
+{
+    /// <summary>
+    /// Abstract base class for all <see cref="IMessageSink"/> implementations. Includes some methods
+    /// for parsing log messages into structured formats.
+    /// </summary>
+    public abstract class MessageSink : IMessageSink
+    {
+        /// <summary>
+        /// ActorRef for the actor who coordinates all of reporting for each test run
+        /// </summary>
+        protected ActorRef MessageSinkActorRef;
+
+        protected readonly Props MessageSinkActorProps;
+
+        protected MessageSink(Props messageSinkActorProps)
+        {
+            MessageSinkActorProps = messageSinkActorProps;
+        }
+
+        #region Flow Control
+
+        public void Open(ActorSystem context)
+        {
+            //Do nothing
+            if(IsClosed || IsOpen) return;
+
+            IsOpen = true;
+
+            //Start the TestCoordinatorActor
+            MessageSinkActorRef = context.ActorOf(MessageSinkActorProps);
+        }
+
+        public bool IsOpen { get; private set; }
+        public bool IsClosed { get; private set; }
+
+        internal void RequestExitCode(ActorRef sender)
+        {
+            MessageSinkActorRef.Tell(new SinkCoordinator.RequestExitCode(), sender);
+        }
+
+        public async Task<bool> Close(ActorSystem context)
+        {
+            //Test run has already been closed or hasn't started
+            if (!IsOpen || IsClosed) return await Task.FromResult(false);
+
+            IsOpen = false;
+            IsClosed = true;
+
+            //Signal that the test run has ended
+            MessageSinkActorRef.Tell(new EndTestRun());
+
+            //Give the TestCoordinatorRef 10 seconds to shut down
+            return await MessageSinkActorRef.GracefulStop(TimeSpan.FromSeconds(10));
+        }
+
+        #endregion
+
+        #region Static methods and constants
+
+        /// <summary>
+        /// Constant used on calls where no message is procided by the caller.
+        /// </summary>
+        public const string NoMessage = "[no message given.]";
+
+        public enum MultiNodeTestRunnerMessageType
+        {
+            RunnerLogMessage,
+            NodeLogFragment, //for messages that had line breaks (such as stack traces)
+            NodeLogMessage,
+            NodePassMessage,
+            NodeFailMessage,
+            NodeFailureException,
+            Unknown
+        };
+
+        private const string NodePassStatusRegexString =
+            @"\[(\w){4}(?<node>[0-9]{1,2})\]\[(?<status>(PASS|FAIL))\]{1}\s(?<test>.*)";
+        protected static readonly Regex NodePassStatusRegex = new Regex(NodePassStatusRegexString);
+
+        private const string NodePassed = "PASS";
+
+        private const string NodeFailed = "FAIL";
+
+        private const string NodeFailureReasonRegexString =
+            @"\[(\w){4}(?<node>[0-9]{1,2})\]\[(?<status>(FAIL-EXCEPTION))\]{1}\s(?<message>.*)";
+        protected static readonly Regex NodeFailureReasonRegex = new Regex(NodeFailureReasonRegexString);
+
+        /*
+         * Regular expressions - go big or go home. [Aaronontheweb]
+         */
+        private const string NodeLogMessageRegexString = @"\[(\w){4}(?<node>[0-9]{1,2})\]\[(?<level>(\w)*)\]\[(?<time>\d{1,2}[- /.]\d{1,2}[- /.]\d{1,4}\s\d{1,2}:\d{1,2}:\d{1,2}\s(AM|PM))\](?<thread>\[(\w|\s)*\])\[(?<logsource>(\[|\w|:|/|\(|\)|\]|\.|-|\$|%|\+|\^)*)\]\s(?<message>(\w|\s|:|<|\.|\+|>|,|\[|/|-|]|%|\$|\+|\^)*)";
+        protected static readonly Regex NodeLogMessageRegex = new Regex(NodeLogMessageRegexString);
+
+        private const string RunnerLogMessageRegexString = @"\[(?<level>(\w)*)\]\[(?<time>\d{1,2}[- /.]\d{1,2}[- /.]\d{1,4}\s\d{1,2}:\d{1,2}:\d{1,2}\s(AM|PM))\](?<thread>\[(\w|\s)*\])\[(?<logsource>(\[|\w|:|/|\(|\)|\]|\.|-|\$|%|\+|\^)*)\]\s(?<message>(\w|\s|:|<|\.|\+|>|,|\[|/|-|]|%|\$|\+|\^)*)";
+        protected static readonly Regex RunnerLogMessageRegex = new Regex(RunnerLogMessageRegexString);
+
+        private const string NodeLogFragmentRegexString = @"\[(\w){4}(?<node>[0-9]{1,2})\](?<message>(.)*)";
+        protected static readonly Regex NodeLogFragmentRegex = new Regex(NodeLogFragmentRegexString);
+
+        public static MultiNodeTestRunnerMessageType DetermineMessageType(string messageStr)
+        {
+            var matchLog = NodeLogMessageRegex.Match(messageStr);
+            if(matchLog.Success) return MultiNodeTestRunnerMessageType.NodeLogMessage;
+
+            var matchRunnerLog = RunnerLogMessageRegex.Match(messageStr);
+            if (matchRunnerLog.Success) return MultiNodeTestRunnerMessageType.RunnerLogMessage;
+
+            var matchStatus = NodePassStatusRegex.Match(messageStr);
+            if (matchStatus.Success)
+            {
+                return matchStatus.Groups["status"].Value.Equals(NodePassed) ? MultiNodeTestRunnerMessageType.NodePassMessage : MultiNodeTestRunnerMessageType.NodeFailMessage;
+            }
+
+            var matchFailureReason = NodeFailureReasonRegex.Match(messageStr);
+            if(matchFailureReason.Success) return MultiNodeTestRunnerMessageType.NodeFailureException;
+
+            var nodeLogFragmentStatus = NodeLogFragmentRegex.Match(messageStr);
+            if(nodeLogFragmentStatus.Success) return MultiNodeTestRunnerMessageType.NodeLogFragment;
+
+            return MultiNodeTestRunnerMessageType.Unknown;
+        }
+
+        public static bool TryParseLogMessage(string messageStr, out LogMessageForNode logMessage)
+        {
+            var matchLog = NodeLogMessageRegex.Match(messageStr);
+            if (!matchLog.Success)
+            {
+                logMessage = null;
+                return false;
+            }
+            
+            LogLevel logLevel;
+            Enum.TryParse(matchLog.Groups["level"].Value, true, out logLevel);
+
+            var logSource = matchLog.Groups["logsource"].Value;
+            var message = matchLog.Groups["message"].Value;
+            var nodeIndex = Int32.Parse(matchLog.Groups["node"].Value);
+            logMessage = new LogMessageForNode(nodeIndex, message, logLevel, DateTime.UtcNow, logSource);
+
+            return true;
+        }
+
+        public static bool TryParseLogMessage(string messageStr, out LogMessageFragmentForNode logMessage)
+        {
+            var matchLog = NodeLogFragmentRegex.Match(messageStr);
+            if (!matchLog.Success)
+            {
+                logMessage = null;
+                return false;
+            }
+
+            var message = matchLog.Groups["message"].Value;
+            var nodeIndex = Int32.Parse(matchLog.Groups["node"].Value);
+            logMessage = new LogMessageFragmentForNode(nodeIndex, message, DateTime.UtcNow);
+
+            return true;
+        }
+
+        public static bool TryParseLogMessage(string messageStr, out LogMessageForTestRunner logMessage)
+        {
+            var matchLog = RunnerLogMessageRegex.Match(messageStr);
+            if (!matchLog.Success)
+            {
+                logMessage = null;
+                return false;
+            }
+
+            LogLevel logLevel;
+            Enum.TryParse(matchLog.Groups["level"].Value, true, out logLevel);
+
+            var logSource = matchLog.Groups["logsource"].Value;
+            var message = matchLog.Groups["message"].Value;
+            logMessage = new LogMessageForTestRunner(message, logLevel, DateTime.UtcNow, logSource);
+
+            return true;
+        }
+
+        public static bool TryParseSuccessMessage(string messageStr, out NodeCompletedSpecWithSuccess message)
+        {
+            var matchStatus = NodePassStatusRegex.Match(messageStr);
+            message = null;
+            if (!matchStatus.Success) return false;
+            if (!matchStatus.Groups["status"].Value.Equals(NodePassed)) return false;
+
+            var nodeIndex = Int32.Parse(matchStatus.Groups["node"].Value);
+            var passMessage = matchStatus.Groups["test"].Value + " " + matchStatus.Groups["status"].Value;
+            message = new NodeCompletedSpecWithSuccess(nodeIndex, passMessage);
+
+            return true;
+        }
+
+        public static bool TryParseFailureMessage(string messageStr, out NodeCompletedSpecWithFail message)
+        {
+            var matchStatus = NodePassStatusRegex.Match(messageStr);
+            message = null;
+            if (!matchStatus.Success) return false;
+            if (!matchStatus.Groups["status"].Value.Equals(NodeFailed)) return false;
+
+            var nodeIndex = Int32.Parse(matchStatus.Groups["node"].Value);
+            var passMessage = matchStatus.Groups["test"].Value + " " + matchStatus.Groups["status"].Value;
+            message = new NodeCompletedSpecWithFail(nodeIndex, passMessage);
+
+            return true;
+        }
+
+        public static bool TryParseFailureExceptionMessage(string messageStr, out NodeCompletedSpecWithFail message)
+        {
+            var matchStatus = NodeFailureReasonRegex.Match(messageStr);
+            message = null;
+            if (!matchStatus.Success) return false;
+
+            var nodeIndex = Int32.Parse(matchStatus.Groups["node"].Value);
+            var failureMessage = matchStatus.Groups["message"].Value;
+            message = new NodeCompletedSpecWithFail(nodeIndex, failureMessage);
+
+            return true;
+        }
+
+        #endregion
+
+        #region Message Handling
+
+        public void BeginTest(string className, string methodName, IList<NodeTest> nodes)
+        {
+            //begin the next spec
+            MessageSinkActorRef.Tell(new BeginNewSpec(className, methodName, nodes));
+        }
+
+        public void EndTest()
+        {
+            //end the current spec
+            MessageSinkActorRef.Tell(new EndSpec());
+        }
+
+        public void Success(int nodeIndex)
+        {
+            Success(nodeIndex, NoMessage);
+        }
+
+        public void Success(int nodeIndex, string message)
+        {
+            MessageSinkActorRef.Tell(new NodeCompletedSpecWithSuccess(nodeIndex, message ?? NoMessage));
+        }
+
+        public void Fail(int nodeIndex)
+        {
+            Fail(nodeIndex, NoMessage);
+        }
+
+        public void Fail(int nodeIndex, string message)
+        {
+            MessageSinkActorRef.Tell(new NodeCompletedSpecWithFail(nodeIndex, message ?? NoMessage));
+        }
+
+        public void Log(int nodeIndex, string message, string logSource, LogLevel level)
+        {
+            MessageSinkActorRef.Tell(new LogMessageForNode(nodeIndex, message, level, DateTime.UtcNow, logSource));
+        }
+
+        public void LogRunnerMessage(string message, string logSource, LogLevel level)
+        {
+            MessageSinkActorRef.Tell(new LogMessageForTestRunner(message, level, DateTime.UtcNow, logSource));
+        }
+
+        public void Offer(string messageStr)
+        {
+            var messageType = DetermineMessageType(messageStr);
+            if (messageType == MultiNodeTestRunnerMessageType.Unknown)
+            {
+                HandleUnknownMessageType(messageStr);
+                return;
+            }
+
+            if (messageType == MultiNodeTestRunnerMessageType.NodeLogMessage)
+            {
+                LogMessageForNode log;
+                Guard.Assert(TryParseLogMessage(messageStr, out log), "could not parse log message: " + messageStr);
+                MessageSinkActorRef.Tell(log);
+            }
+            else if (messageType == MultiNodeTestRunnerMessageType.RunnerLogMessage)
+            {
+                LogMessageForTestRunner runnerLog;
+                Guard.Assert(TryParseLogMessage(messageStr, out runnerLog), "could not parse test runner log message: " + messageStr);
+                MessageSinkActorRef.Tell(runnerLog);
+            }
+            else if (messageType == MultiNodeTestRunnerMessageType.NodePassMessage)
+            {
+                NodeCompletedSpecWithSuccess nodePass;
+                Guard.Assert(TryParseSuccessMessage(messageStr, out nodePass), "could not parse node spec pass message: " + messageStr);
+                MessageSinkActorRef.Tell(nodePass);
+            }
+            else if (messageType == MultiNodeTestRunnerMessageType.NodeFailMessage)
+            {
+                NodeCompletedSpecWithFail nodeFail;
+                Guard.Assert(TryParseFailureMessage(messageStr, out nodeFail), "could not parse node spec fail message: " + messageStr);
+                MessageSinkActorRef.Tell(nodeFail);
+            }
+            else if (messageType == MultiNodeTestRunnerMessageType.NodeFailureException)
+            {
+                NodeCompletedSpecWithFail nodeFail;
+                Guard.Assert(TryParseFailureExceptionMessage(messageStr, out nodeFail), "could not parse node spec failure + EXCEPTION message: " + messageStr);
+                MessageSinkActorRef.Tell(nodeFail);
+            }
+        }
+
+        protected abstract void HandleUnknownMessageType(string message);
+
+        #endregion
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/MessageSinkActor.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/MessageSinkActor.cs
@@ -1,0 +1,60 @@
+﻿using Akka.Actor;
+
+namespace Akka.MultiNodeTestRunner.Shared.Sinks
+{
+    /// <summary>
+    /// Actor responsible for directing the flow of all messages for each test run.
+    /// </summary>
+    public abstract class MessageSinkActor : ReceiveActor
+    {
+        protected MessageSinkActor()
+        {
+            SetReceive();
+        }
+
+        /// <summary>
+        /// Use the template method pattern here to force child actors to fill in
+        /// all handlers for these classes
+        /// </summary>
+        private void SetReceive()
+        {
+            Receive<BeginNewSpec>(spec => HandleNewSpec(spec));
+            Receive<EndSpec>(endspec => HandleEndSpec(endspec));
+            Receive<LogMessageForNode>(node => HandleNodeMessage(node));
+            Receive<LogMessageFragmentForNode>(node => HandleNodeMessageFragment(node));
+            Receive<LogMessageForTestRunner>(node => HandleRunnerMessage(node));
+            Receive<NodeCompletedSpecWithSuccess>(success => HandleNodeSpecPass(success));
+            Receive<NodeCompletedSpecWithFail>(fail => HandleNodeSpecFail(fail));
+            Receive<EndTestRun>(end => HandleTestRunEnd(end));
+            AdditionalReceives();
+        }
+
+        #region Abstract message-handling methods
+
+        /// <summary>
+        /// Used to hook additional <see cref="Receive"/> methods into the <see cref="MessageSinkActor"/>
+        /// </summary>
+        protected abstract void AdditionalReceives();
+
+        protected abstract void HandleNewSpec(BeginNewSpec newSpec);
+
+        protected abstract void HandleEndSpec(EndSpec endSpec);
+
+        protected abstract void HandleNodeMessage(LogMessageForNode logMessage);
+
+        /// <summary>
+        /// Used for truncated messages (happens when there's a line break during standard I/O redirection from child nodes)
+        /// </summary>
+        protected abstract void HandleNodeMessageFragment(LogMessageFragmentForNode logMessageFragment);
+
+        protected abstract void HandleRunnerMessage(LogMessageForTestRunner node);
+
+        protected abstract void HandleNodeSpecPass(NodeCompletedSpecWithSuccess nodeSuccess);
+
+        protected abstract void HandleNodeSpecFail(NodeCompletedSpecWithFail nodeFail);
+
+        protected abstract void HandleTestRunEnd(EndTestRun endTestRun);
+
+        #endregion
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/Messages.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/Messages.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using Akka.Event;
+
+namespace Akka.MultiNodeTestRunner.Shared.Sinks
+{
+    #region Message types
+
+    /// <summary>
+    /// Message type for signaling that a new spec is ready to be run
+    /// </summary>
+    public class BeginNewSpec
+    {
+        public BeginNewSpec(string className, string methodName, IList<NodeTest> nodes)
+        {
+            Nodes = nodes;
+            MethodName = methodName;
+            ClassName = className;
+        }
+
+        public string ClassName { get; private set; }
+
+        public string MethodName { get; private set; }
+
+        public IList<NodeTest> Nodes { get; private set; }
+    }
+
+    /// <summary>
+    /// Message type for indiciating that the current spec has ended.
+    /// </summary>
+    public class EndSpec { }
+
+    /// <summary>
+    /// Message type for signaling that a node has completed a spec successfully
+    /// </summary>
+    public class NodeCompletedSpecWithSuccess
+    {
+        public NodeCompletedSpecWithSuccess(int nodeIndex, string message)
+        {
+            Message = message;
+            NodeIndex = nodeIndex;
+        }
+
+        public int NodeIndex { get; private set; }
+
+        public string Message { get; private set; }
+    }
+
+    /// <summary>
+    /// Message type for signaling that a node has completed a spec unsuccessfully
+    /// </summary>
+    public class NodeCompletedSpecWithFail
+    {
+        public NodeCompletedSpecWithFail(int nodeIndex, string message)
+        {
+            Message = message;
+            NodeIndex = nodeIndex;
+        }
+
+        public int NodeIndex { get; private set; }
+
+        public string Message { get; private set; }
+    }
+
+    /// <summary>
+    /// Truncated message - cut off from it's parent due to line break in I/O redirection
+    /// </summary>
+    public class LogMessageFragmentForNode
+    {
+        public LogMessageFragmentForNode(int nodeIndex, string message, DateTime when)
+        {
+            NodeIndex = nodeIndex;
+            Message = message;
+            When = when;
+        }
+
+        public int NodeIndex { get; private set; }
+
+        public DateTime When { get; private set; }
+
+        public string Message { get; private set; }
+    }
+
+    /// <summary>
+    /// Message for an individual node participating in a spec
+    /// </summary>
+    public class LogMessageForNode
+    {
+        public LogMessageForNode(int nodeIndex, string message, LogLevel level, DateTime when, string logSource)
+        {
+            LogSource = logSource;
+            When = when;
+            Level = level;
+            Message = message;
+            NodeIndex = nodeIndex;
+        }
+
+        public int NodeIndex { get; private set; }
+
+        public DateTime When { get; private set; }
+
+        public string Message { get; private set; }
+
+        public string LogSource { get; private set; }
+
+        public LogLevel Level { get; private set; }
+    }
+
+    /// <summary>
+    /// Message for an individual node participating in a spec
+    /// </summary>
+    public class LogMessageForTestRunner
+    {
+        public LogMessageForTestRunner(string message, LogLevel level, DateTime when, string logSource)
+        {
+            LogSource = logSource;
+            When = when;
+            Level = level;
+            Message = message;
+        }
+
+        public DateTime When { get; private set; }
+
+        public string Message { get; private set; }
+
+        public string LogSource { get; private set; }
+
+        public LogLevel Level { get; private set; }
+    }
+
+
+    /// <summary>
+    /// Message used to signal the end of the test run.
+    /// </summary>
+    public class EndTestRun
+    {
+        
+    }
+
+    #endregion
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/SinkCoordinator.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/SinkCoordinator.cs
@@ -1,0 +1,186 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Event;
+
+namespace Akka.MultiNodeTestRunner.Shared.Sinks
+{
+    /// <summary>
+    /// Top-level actor responsible for managing all <see cref="MessageSink"/> instances.
+    /// </summary>
+    public class SinkCoordinator : ReceiveActor
+    {
+        #region Message classes
+
+        /// <summary>
+        /// Used to signal that we need to enable a given <see cref="MessageSink"/> instance
+        /// </summary>
+        public class EnableSink
+        {
+            public EnableSink(MessageSink sink)
+            {
+                Sink = sink;
+            }
+
+            public MessageSink Sink { get; private set; }
+        }
+
+        /// <summary>
+        /// Test run is complete. Shut down all sinks.
+        /// 
+        /// NOTE: Sending this message also means that the <see cref="ActorSystem"/> will be shut down.
+        /// </summary>
+        public class CloseAllSinks { }
+
+        /// <summary>
+        /// Confirms that a <see cref="MessageSink"/> has been closed
+        /// </summary>
+        public class SinkClosed { }
+
+        /// <summary>
+        /// Case class for distinguishing runner messages
+        /// </summary>
+        public class RunnerMessage
+        {
+            public RunnerMessage(string message)
+            {
+                Message = message;
+            }
+
+            public string Message { get; private set; }
+        }
+
+        /// <summary>
+        /// Message that the <see cref="SinkCoordinator"/> will pass onto a <see cref="MessageSinkActor"/>
+        /// </summary>
+        public class RequestExitCode { }
+
+        /// <summary>
+        /// Response sent to <see cref="SinkCoordinator"/>
+        /// </summary>
+        public class RecommendedExitCode
+        {
+            public RecommendedExitCode(int code)
+            {
+                Code = code;
+            }
+
+            public int Code { get; private set; }
+        }
+
+        #endregion
+
+        protected List<MessageSink> DefaultSinks;
+        protected List<MessageSink> Sinks = new List<MessageSink>();
+
+        protected int TotalReceiveClosedConfirmations = 0;
+        protected int ReceivedSinkCloseConfirmations = 0;
+
+        /// <summary>
+        /// Leave the console message sink enabled by default
+        /// </summary>
+        public SinkCoordinator()
+            : this(new[] { new ConsoleMessageSink() })
+        {
+
+        }
+
+        public SinkCoordinator(IEnumerable<MessageSink> defaultSinks)
+        {
+            DefaultSinks = defaultSinks.ToList();
+            InitializeReceives();
+        }
+
+        #region Actor lifecycle
+
+        protected override void PreStart()
+        {
+            foreach(var sink in DefaultSinks)
+                Self.Tell(new EnableSink(sink));
+        }
+
+        #endregion
+
+        #region Message-handling
+
+        private void InitializeReceives()
+        {
+            Receive<EnableSink>(sink =>
+            {
+                Sinks.Add(sink.Sink);
+                sink.Sink.Open(Context.System);
+            });
+
+            Receive<SinkClosed>(closed =>
+            {
+                ReceivedSinkCloseConfirmations++;
+
+                //Shut down the ActorSystem if all confirmations have been received
+                if (ReceivedSinkCloseConfirmations >= TotalReceiveClosedConfirmations)
+                    Context.System.Shutdown();
+            });
+
+            Receive<RecommendedExitCode>(code =>
+            {
+                ExitCodeContainer.ExitCode = code.Code;
+            });
+
+            Receive<CloseAllSinks>(sinks =>
+            {
+                //Ignore duplicate CloseAllSinks calls
+                if (TotalReceiveClosedConfirmations > 0) return;
+
+                TotalReceiveClosedConfirmations = Sinks.Count;
+                ReceivedSinkCloseConfirmations = 0;
+
+                foreach (var sink in Sinks)
+                {
+                    sink.RequestExitCode(Self);
+                    sink.Close(Context.System)
+                        .ContinueWith(r => new SinkClosed(),
+                        TaskContinuationOptions.ExecuteSynchronously & TaskContinuationOptions.AttachedToParent)
+                        .PipeTo(Self);
+                }
+            });
+            Receive<string>(s => PublishToChildren(s));
+            Receive<IList<NodeTest>>(tests => BeginSpec(tests));
+            Receive<EndSpec>(spec => EndSpec());
+            Receive<RunnerMessage>(runner => PublishToChildren(runner));
+        }
+
+
+        private void EndSpec()
+        {
+            foreach (var sink in Sinks)
+                sink.EndTest();
+        }
+
+        private void BeginSpec(IList<NodeTest> tests)
+        {
+            var test = tests.First();
+
+            foreach (var sink in Sinks)
+                sink.BeginTest(test.TypeName, test.MethodName, tests);
+        }
+
+        private void PublishToChildren(RunnerMessage message)
+        {
+            foreach (var sink in Sinks)
+                sink.LogRunnerMessage(message.Message, Assembly.GetExecutingAssembly().GetName().Name, LogLevel.InfoLevel);
+        }
+
+        /// <summary>
+        /// Publish a message to all <see cref="MessageSink"/> instances.
+        /// </summary>
+        private void PublishToChildren(string message)
+        {
+            foreach (var sink in Sinks)
+                sink.Offer(message);
+        }
+
+        #endregion
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/TestCoordinatorEnabledMessageSink.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/TestCoordinatorEnabledMessageSink.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.MultiNodeTestRunner.Shared.Reporting;
+
+namespace Akka.MultiNodeTestRunner.Shared.Sinks
+{
+    /// <summary>
+    /// A <see cref="MessageSinkActor"/> implementation that is capable of using a <see cref="TestRunCoordinator"/> for 
+    /// test run summaries and other purposes.
+    /// </summary>
+    public abstract class TestCoordinatorEnabledMessageSink : MessageSinkActor
+    {
+        protected ActorRef TestCoordinatorActorRef;
+        protected bool UseTestCoordinator;
+
+        protected TestCoordinatorEnabledMessageSink(bool useTestCoordinator)
+        {
+            UseTestCoordinator = useTestCoordinator;
+            Receive<SinkCoordinator.RequestExitCode>(code =>
+            {
+                if (UseTestCoordinator)
+                {
+                    TestCoordinatorActorRef.Ask<TestRunTree>(new TestRunCoordinator.RequestTestRunState())
+                        .ContinueWith(task => new SinkCoordinator.RecommendedExitCode(task.Result.Passed.GetValueOrDefault(false)
+                            ? 0
+                            : 1), TaskContinuationOptions.ExecuteSynchronously & TaskContinuationOptions.AttachedToParent)
+                            .PipeTo(Sender, Self);
+                }
+            });
+        }
+
+        protected override void PreStart()
+        {
+            //Fire up a TestRunCoordinator instance and subscribe to FactData messages when they arrive
+            if (UseTestCoordinator)
+            {
+                TestCoordinatorActorRef = Context.ActorOf<TestRunCoordinator>();
+                TestCoordinatorActorRef.Tell(new TestRunCoordinator.SubscribeFactCompletionMessages(Self));
+            }
+        }
+
+        protected abstract void ReceiveFactData(FactData data);
+
+        protected override void HandleNewSpec(BeginNewSpec newSpec)
+        {
+            if (UseTestCoordinator)
+            {
+                TestCoordinatorActorRef.Tell(newSpec);
+            }
+        }
+
+        protected override void HandleEndSpec(EndSpec endSpec)
+        {
+            if (UseTestCoordinator)
+            {
+                TestCoordinatorActorRef.Tell(endSpec);
+            }
+        }
+
+        protected override void HandleNodeMessageFragment(LogMessageFragmentForNode logMessage)
+        {
+            if (UseTestCoordinator)
+            {
+                var nodeMessage = new MultiNodeLogMessageFragment(logMessage.When.Ticks, logMessage.Message,
+                   logMessage.NodeIndex);
+
+                TestCoordinatorActorRef.Tell(nodeMessage);
+            }
+        }
+
+        protected override void HandleNodeMessage(LogMessageForNode logMessage)
+        {
+            if (UseTestCoordinator)
+            {
+                var nodeMessage = new MultiNodeLogMessage(logMessage.When.Ticks, logMessage.Message,
+                logMessage.NodeIndex, logMessage.LogSource, logMessage.Level);
+
+                TestCoordinatorActorRef.Tell(nodeMessage);
+            }
+        }
+
+        protected override void HandleRunnerMessage(LogMessageForTestRunner node)
+        {
+            if (UseTestCoordinator)
+            {
+                var runnerMessage = new MultiNodeTestRunnerMessage(node.When.Ticks, node.Message, node.LogSource,
+                    node.Level);
+
+                TestCoordinatorActorRef.Tell(runnerMessage);
+            }
+        }
+
+        protected override void HandleNodeSpecPass(NodeCompletedSpecWithSuccess nodeSuccess)
+        {
+            if (UseTestCoordinator)
+            {
+                var nodeMessage = new MultiNodeResultMessage(DateTime.UtcNow.Ticks, nodeSuccess.Message,
+                    nodeSuccess.NodeIndex, true);
+
+                TestCoordinatorActorRef.Tell(nodeMessage);
+            }
+        }
+
+        protected override void HandleNodeSpecFail(NodeCompletedSpecWithFail nodeFail)
+        {
+            if (UseTestCoordinator)
+            {
+                var nodeMessage = new MultiNodeResultMessage(DateTime.UtcNow.Ticks, nodeFail.Message,
+                    nodeFail.NodeIndex, false);
+
+                TestCoordinatorActorRef.Tell(nodeMessage);
+            }
+        }
+
+        protected override void HandleTestRunEnd(EndTestRun endTestRun)
+        {
+            if (UseTestCoordinator)
+            {
+                //Ask the TestRunCoordinator to give us the latest state
+                TestCoordinatorActorRef.Tell(new TestRunCoordinator.RequestTestRunState());
+
+                TestCoordinatorActorRef.Tell(endTestRun);
+                
+            }
+        }
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared/packages.config
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net45" />
+</packages>

--- a/src/core/Akka.MultiNodeTestRunner/Discovery.cs
+++ b/src/core/Akka.MultiNodeTestRunner/Discovery.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading;
+using Akka.MultiNodeTestRunner.Shared;
 using Xunit.Abstractions;
 
 namespace Akka.MultiNodeTestRunner

--- a/src/core/Akka.MultiNodeTestRunner/Program.cs
+++ b/src/core/Akka.MultiNodeTestRunner/Program.cs
@@ -1,7 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
+using System.Threading;
+using Akka.Actor;
+using Akka.MultiNodeTestRunner.Shared;
+using Akka.MultiNodeTestRunner.Shared.Reporting;
+using Akka.MultiNodeTestRunner.Shared.Sinks;
+using Akka.Remote.TestKit;
 using Xunit;
 
 namespace Akka.MultiNodeTestRunner
@@ -11,10 +18,16 @@ namespace Akka.MultiNodeTestRunner
     /// </summary>
     class Program
     {
+        protected static ActorSystem TestRunSystem;
+
+        protected static ActorRef SinkCoordinator;
+
+        
+
         /// <summary>
         /// MultiNodeTestRunner takes the following <see cref="args"/>:
         /// 
-        /// C:\> Akka.MultiNodeTestRunner.exe [assembly name]
+        /// C:\> Akka.MultiNodeTestRunner.exe [assembly name] [-Dmultinode.enable-filesink=on]
         /// 
         /// <list type="number">
         /// <listheader>
@@ -30,11 +43,22 @@ namespace Akka.MultiNodeTestRunner
         ///              "C:\akka.net\src\Akka.Cluster.Tests\bin\Debug\Akka.Cluster.Tests.dll"
         ///     </description>
         /// </item>
+        /// <item>
+        ///     <term>-Dmultinode.enable-filesink</term>
+        ///     <description>Having this flag set means that the contents of this test run will be saved in the
+        ///                 current working directory as a .JSON file.
+        ///     </description>
+        /// </item>
         /// </list>
         /// </summary>
         static void Main(string[] args)
         {
+            TestRunSystem = ActorSystem.Create("TestRunnerLogging");
+            SinkCoordinator = TestRunSystem.ActorOf(Props.Create<SinkCoordinator>());
+
             var assemblyName = args[0];
+
+            EnableAllSinks(assemblyName);
 
             using (var controller = new XunitFrontController(assemblyName))
             {
@@ -45,9 +69,11 @@ namespace Akka.MultiNodeTestRunner
 
                     foreach (var test in discovery.Tests)
                     {
-                        Console.WriteLine("Starting test {0}", test.Value.First().MethodName);
+                        PublishRunnerMessage(string.Format("Starting test {0}", test.Value.First().MethodName));
 
                         var processes = new List<Process>();
+
+                        StartNewSpec(test.Value);
 
                         foreach (var nodeTest in test.Value)
                         {
@@ -55,14 +81,27 @@ namespace Akka.MultiNodeTestRunner
                             var process = new Process();
                             processes.Add(process);
                             process.StartInfo.UseShellExecute = false;
+                            process.StartInfo.RedirectStandardOutput = true;
                             process.StartInfo.FileName = "Akka.NodeTestRunner.exe";
                             process.StartInfo.Arguments = String.Format(@"-Dmultinode.test-assembly=""{0}"" -Dmultinode.test-class=""{1}"" -Dmultinode.test-method=""{2}"" -Dmultinode.max-nodes={3} -Dmultinode.server-host=""{4}"" -Dmultinode.host=""{5}"" -Dmultinode.index={6}",
                                 assemblyName, nodeTest.TypeName, nodeTest.MethodName, test.Value.Count, "localhost", "localhost", nodeTest.Node - 1);
                             var nodeIndex = nodeTest.Node;
                             process.OutputDataReceived +=
-                                (sender, line) => Console.WriteLine("[Node{0}]{1}", nodeIndex, line.Data);
+                                (sender, line) =>
+                                {
+                                    //ignore any trailing whitespace
+                                    if (string.IsNullOrEmpty(line.Data) || string.IsNullOrWhiteSpace(line.Data)) return;
+                                    string message = line.Data;
+                                    if (!message.StartsWith("[NODE", true, CultureInfo.InvariantCulture))
+                                    {
+                                        message = "[NODE" + nodeIndex + "]" + message;
+                                    }
+                                    PublishToAllSinks(message);
+                                };
                             process.Start();
-                            Console.WriteLine("Started node {0} on pid {1}", nodeTest.Node, process.Id);
+
+                            process.BeginOutputReadLine();
+                            PublishRunnerMessage(string.Format("Started node {0} on pid {1}", nodeTest.Node, process.Id));
                         }
 
                         foreach (var process in processes)
@@ -70,11 +109,55 @@ namespace Akka.MultiNodeTestRunner
                             process.WaitForExit();
                             process.Close();
                         }
+
+                        PublishRunnerMessage("Waiting 3 seconds for all messages from all processes to be collected.");
+                        Thread.Sleep(TimeSpan.FromSeconds(3));
+                        FinishSpec();
                     }
                 }
             }
             Console.WriteLine("Complete");
-            Console.ReadLine();
+            PublishRunnerMessage("Waiting 5 seconds for all messages from all processes to be collected.");
+            Thread.Sleep(TimeSpan.FromSeconds(5));
+            CloseAllSinks();
+            
+            //Block until all Sinks have been terminated.
+            TestRunSystem.AwaitTermination(TimeSpan.FromMinutes(1));
+
+            //Return the proper exit code
+            Environment.Exit(ExitCodeContainer.ExitCode);
+        }
+
+        static void EnableAllSinks(string assemblyName)
+        {
+            var fileSystemSink = CommandLine.GetProperty("multinode.enable-filesink");
+            if (!string.IsNullOrEmpty(fileSystemSink))
+                SinkCoordinator.Tell(new SinkCoordinator.EnableSink(new FileSystemMessageSink(assemblyName)));
+        }
+
+        static void CloseAllSinks()
+        {
+            SinkCoordinator.Tell(new SinkCoordinator.CloseAllSinks());
+        }
+
+        static void StartNewSpec(IList<NodeTest> tests)
+        {
+            SinkCoordinator.Tell(tests);
+        }
+
+        static void FinishSpec()
+        {
+           SinkCoordinator.Tell(new EndSpec());
+        }
+
+        static void PublishRunnerMessage(string message)
+        {
+            SinkCoordinator.Tell(new SinkCoordinator.RunnerMessage(message));
+        }
+
+        static void PublishToAllSinks(string message)
+        {
+            SinkCoordinator.Tell(message);
         }
     }
 }

--- a/src/core/Akka.NodeTestRunner/App.config
+++ b/src/core/Akka.NodeTestRunner/App.config
@@ -6,6 +6,7 @@
   <nlog>
     <targets>
       <target name="UdpOutlet" type="NLogViewer" address="udp://localhost:7071" />
+      <target name="StdOut" type="Console" layout="${longdate}|${level:uppercase=true}|${logger}|${message}" />
     </targets>
     <rules>
       <logger name="*" minLevel="Trace" writeTo="UdpOutlet" />

--- a/src/core/Akka.NodeTestRunner/Sink.cs
+++ b/src/core/Akka.NodeTestRunner/Sink.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
@@ -27,24 +30,31 @@ namespace Akka.NodeTestRunner
             var testPassed = message as ITestPassed;
             if (testPassed != null)
             {
-                Console.WriteLine("[Node{0}] {1} passed.", _nodeIndex, testPassed.TestCase.DisplayName);
+                //the MultiNodeTestRuner uses 1-based indexing, which is why we have to add 1 to the index.
+                var specPass = new SpecPass(_nodeIndex + 1, testPassed.TestCase.DisplayName);
+                Console.WriteLine(specPass);
                 Passed = true;
                 return true;
             }
             var testFailed = message as ITestFailed;
             if (testFailed != null)
             {
-                Console.WriteLine("[Node{0}] {1} failed.", _nodeIndex, testFailed.TestDisplayName);
-                foreach(var failedMessage in testFailed.Messages) Console.WriteLine(failedMessage);
-                foreach (var stackTrace in testFailed.StackTraces) Console.WriteLine(stackTrace);
+                //the MultiNodeTestRuner uses 1-based indexing, which is why we have to add 1 to the index.
+                var specFail = new SpecFail(_nodeIndex + 1, testFailed.TestCase.DisplayName);
+                foreach (var failedMessage in testFailed.Messages) specFail.FailureMessages.Add(failedMessage);
+                foreach (var stackTrace in testFailed.StackTraces) specFail.FailureStackTraces.Add(stackTrace);
+                foreach(var exceptionType in testFailed.ExceptionTypes) specFail.FailureExceptionTypes.Add(exceptionType);
+                Console.Write(specFail);
                 return true;
             }
             var errorMessage = message as ErrorMessage;
             if (errorMessage != null)
             {
-                Console.WriteLine("[Node{0}] errored", _nodeIndex);
-                foreach (var errorText in errorMessage.Messages) Console.WriteLine(errorText);
-                foreach (var stackTrace in errorMessage.StackTraces) Console.WriteLine(stackTrace);
+                var specFail = new SpecFail(_nodeIndex + 1, "ERRORED");
+                foreach (var failedMessage in errorMessage.Messages) specFail.FailureMessages.Add(failedMessage);
+                foreach (var stackTrace in errorMessage.StackTraces) specFail.FailureStackTraces.Add(stackTrace);
+                foreach (var exceptionType in errorMessage.ExceptionTypes) specFail.FailureExceptionTypes.Add(exceptionType);
+                Console.Write(specFail);
             }
             if (message is ITestAssemblyFinished)
             {
@@ -57,6 +67,76 @@ namespace Akka.NodeTestRunner
         public void Dispose()
         {
             Finished.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Message class used for reporting a test pass.
+    /// 
+    /// <remarks>
+    /// The Akka.MultiNodeTestRunner.Shared.MessageSink depends on the format string
+    /// that this class produces, so do not remove or refactor it.
+    /// </remarks>
+    /// </summary>
+    public class SpecPass
+    {
+        public SpecPass(int nodeIndex, string testDisplayName)
+        {
+            TestDisplayName = testDisplayName;
+            NodeIndex = nodeIndex;
+        }
+
+        public int NodeIndex { get; private set; }
+
+        public string TestDisplayName { get; private set; }
+
+        public override string ToString()
+        {
+            return string.Format("[Node{0}][PASS] {1}", NodeIndex, TestDisplayName);
+        }
+    }
+
+    /// <summary>
+    /// Message class used for reporting a test fail.
+    /// 
+    /// <remarks>
+    /// The Akka.MultiNodeTestRunner.Shared.MessageSink depends on the format string
+    /// that this class produces, so do not remove or refactor it.
+    /// </remarks>
+    /// </summary>
+    public class SpecFail : SpecPass
+    {
+        public SpecFail(int nodeIndex, string testDisplayName) : base(nodeIndex, testDisplayName)
+        {
+            FailureMessages = new List<string>();
+            FailureStackTraces = new List<string>();
+            FailureExceptionTypes = new List<string>();
+        }
+
+        public IList<string> FailureMessages { get; private set; }
+        public IList<string> FailureStackTraces { get; private set; }
+        public IList<string> FailureExceptionTypes { get; private set; }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine(string.Format("[Node{0}][FAIL] {1}", NodeIndex, TestDisplayName));
+            foreach (var exception in FailureExceptionTypes)
+            {
+                sb.AppendFormat("[Node{0}][FAIL-EXCEPTION] Type: {1}", NodeIndex, exception);
+                sb.AppendLine();
+            }
+            foreach (var exception in FailureMessages)
+            {
+                sb.AppendFormat("--> [Node{0}][FAIL-EXCEPTION] Message: {1}", NodeIndex, exception);
+                sb.AppendLine();
+            }
+            foreach (var exception in FailureStackTraces)
+            {
+                sb.AppendFormat("--> [Node{0}][FAIL-EXCEPTION] StackTrace: {1}", NodeIndex, exception);
+                sb.AppendLine();
+            }
+            return sb.ToString();
         }
     }
 }

--- a/src/core/Akka/Properties/AssemblyInfo.cs
+++ b/src/core/Akka/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("Akka.Remote.Tests")]
 [assembly: InternalsVisibleTo("Akka.Cluster")]
 [assembly: InternalsVisibleTo("Akka.Cluster.Tests")]
+[assembly: InternalsVisibleTo("Akka.MultiNodeTestRunner.Shared.Tests")]

--- a/src/packages/repositories.config
+++ b/src/packages/repositories.config
@@ -12,6 +12,8 @@
   <repository path="..\core\Akka.Cluster\packages.config" />
   <repository path="..\core\Akka.FSharp.Tests\packages.config" />
   <repository path="..\core\Akka.FSharp\packages.config" />
+  <repository path="..\core\Akka.MultiNodeTestRunner.Shared.Tests\packages.config" />
+  <repository path="..\core\Akka.MultiNodeTestRunner.Shared\packages.config" />
   <repository path="..\core\Akka.MultiNodeTestRunner\packages.config" />
   <repository path="..\core\Akka.NodeTestRunner\packages.config" />
   <repository path="..\core\Akka.Persistence.TestKit.Tests\packages.config" />


### PR DESCRIPTION
close #568
close #567
close #566
close #564
close #562

## Change Summary

This pull request makes the following changes:

1. Adds the Akka.MultiNodeTestRunner.Shared and Akka.MultiNodeTestRunner.Shared.Tests projects to the  Solution file under `/core/`
2. Creates a small `ActorSystem` within the `MultiNodeTestRunner` for coalescing and organizing all of the raw data from each node (process) participating in a `MultiNodeSpec`. These actors parse data arriving via standard out redirection into discrete messages and help build a `TestRunTree` structure that can be used to do reporting. All messages are sorted in an event history based on their arrival time.
3. Provides summary reporting to the console for each spec - indicating which nodes failed and why they failed for every individual spec.
4. Provides the ability to save and load previous test runs as JSON files, which we can use to compare historical test runs in the future.
5. Adds configurable toggles for enabling different flavors of `MessageSinks` via the commandline arguments to the `MultiNodeTestRunner` - right now only console and file system are enabled.
6. Added build system support for running the `MultiNodeTestRunner` directly from our FAKE script. Just use the following command

````
C:\akkadotnet> .\build.cmd MultiNodeTests
````

This will automatically launch all `MultiNodeSpec` instances found inside `Akka.Cluster.Tests`. We'll need to make this more flexible to be able to run other assemblies that require multinode tests in the future.

These tests are not enabled by default in normal build runs, but they will at some point in the future.

Here's a sample of the output from the console, to give you a sense of what the reporting looks like:

![image](https://cloud.githubusercontent.com/assets/326939/6075685/5f7c56b2-ad8c-11e4-9d93-8216a8cbabaf.png)

## Outstanding Issues

### Silent Node Failures

Some failing nodes never report a result, successful or failure. When the MultiNodeTestRunner hears nothing it assumes failure. Here's an example:

[RUNNER][7:08 AM]: Results for Akka.Cluster.Tests.MultiNode.ConvergenceWithFailureDetectorPuppetMultiNode1.ConvergenceSp
ecTests
[RUNNER][7:08 AM]: Start time: 2/6/2015 7:08:18 AM
[RUNNER][7:08 AM]:  --> Node 1: PASS [00:00:32.4358987 elapsed]
Writing test state to: D:\Repositories\olympus\akka.net\bin\core\Akka.MultiNodeTestRunner\Akka.Cluster.Tests-63558803268
3391418.json
[RUNNER][7:08 AM]:  --> Node 2: PASS [00:00:32.2008843 elapsed]
[RUNNER][7:08 AM]:  --> Node 3: FAIL [00:00:34.9400449 elapsed]
[RUNNER][7:08 AM]:  --> Node 4: PASS [00:00:32.0848777 elapsed]
[RUNNER][7:08 AM]: End time: 2/6/2015 7:08:53 AM
[RUNNER][7:08 AM]: FINAL RESULT: FAIL after 00:00:34.9420446.
[RUNNER][7:08 AM]: Failure messages by Node
**[RUNNER][7:08 AM]: <----------- BEGIN NODE 3 ----------->
[RUNNER][7:08 AM]: <----------- END NODE 3 ----------->**

The section I've bolded should contain a message explaining why this node failed. Need to investigate the missing messages.

### Missing Test Run Summary

And for some reason, I have a piece of code that's supposed to provide a total test run summary on the console at the end of the run but that doesn't appear to be printing at the moment. Need to fix that too.

### Truncated Log Messages

I've seen a number of truncated log messages which fit the following pattern:

> [NODE1][2/6/2015 7:11:35 AM][DEBUG][[akka://MultiNodeClusterSpec/user/controller/127.0.0.1:27327:27327-server1]]: proces
sing Event: <Akka.Remote.TestKit.ToClient

OR

>  [NODE1][2/6/2015 7:11:35 AM][DEBUG] Remoting now listens on addresses: [akka.tcp://MultiNodeClusterSpec

I suspect this is an issue with the regular expressions I used to parse this information out of standard out.