### PR TITLE
MultiNodeTestRunner fixes for #593 and #594

### DIFF
--- a/src/core/Akka.Cluster.Tests/MultiNode/ConvergenceSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MultiNode/ConvergenceSpec.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Linq;
 using System.Threading;
-using Akka.Actor;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
 using Akka.TestKit;
-using TCP;
 using Xunit;
 using Address = Akka.Actor.Address;
 

--- a/src/core/Akka.MultiNodeTestRunner.Shared.Tests/Akka.MultiNodeTestRunner.Shared.Tests.csproj
+++ b/src/core/Akka.MultiNodeTestRunner.Shared.Tests/Akka.MultiNodeTestRunner.Shared.Tests.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SpecRunCoordinatorSpec.cs" />
     <Compile Include="TestRunCoordinatorSpec.cs" />
+    <Compile Include="TestRunShutdownSpec.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\contrib\testkits\Akka.TestKit.Xunit\Akka.TestKit.Xunit.csproj">

--- a/src/core/Akka.MultiNodeTestRunner.Shared.Tests/TestRunShutdownSpec.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared.Tests/TestRunShutdownSpec.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Linq;
+using Akka.Actor;
+using Akka.MultiNodeTestRunner.Shared.Reporting;
+using Akka.MultiNodeTestRunner.Shared.Sinks;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.MultiNodeTestRunner.Shared.Tests
+{
+    /// <summary>
+    /// Used to validate that we can get final reporting on shutdown
+    /// </summary>
+    public class TestRunShutdownSpec : AkkaSpec
+    {
+        [Fact]
+        public void TestCoordinatorEnabledMessageSink_should_receive_TestRunTree_when_EndTestRun_is_received()
+        {
+            var consoleMessageSink = Sys.ActorOf(Props.Create(() => new ConsoleMessageSinkActor(true)));
+            var nodeIndexes = Enumerable.Range(1, 4).ToArray();
+            var nodeTests = NodeMessageHelpers.BuildNodeTests(nodeIndexes);
+
+            var beginSpec = new BeginNewSpec(nodeTests.First().TypeName, nodeTests.First().MethodName, nodeTests);
+            consoleMessageSink.Tell(beginSpec);
+
+            // create some messages for each node, the test runner, and some result messages
+            // just like a real MultiNodeSpec
+            var allMessages = NodeMessageHelpers.GenerateMessageSequence(nodeIndexes, 300);
+            var runnerMessages = NodeMessageHelpers.GenerateTestRunnerMessageSequence(20);
+            var passMessages = NodeMessageHelpers.GenerateResultMessage(nodeIndexes, true);
+            allMessages.UnionWith(runnerMessages);
+            allMessages.UnionWith(passMessages);
+
+            foreach (var message in allMessages)
+                consoleMessageSink.Tell(message);
+
+            //end the spec
+            consoleMessageSink.Tell(new EndSpec());
+
+            //end the test run...
+            var sinkReadyToTerminate =
+                consoleMessageSink.AskAndWait<MessageSinkActor.SinkCanBeTerminated>(new EndTestRun(),
+                    TimeSpan.FromSeconds(3));
+            Assert.NotNull(sinkReadyToTerminate);
+
+        }
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/FileSystemMessageSinkActor.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/FileSystemMessageSinkActor.cs
@@ -57,11 +57,10 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
 
         protected override void AdditionalReceives()
         {
-            Receive<TestRunTree>(tree => WriteToFile(tree));
             Receive<FactData>(data => ReceiveFactData(data));
         }
 
-        private void WriteToFile(TestRunTree tree)
+        protected override void HandleTestRunTree(TestRunTree tree)
         {
             Console.WriteLine("Writing test state to: {0}", Path.GetFullPath(FileName));
             FileStore.SaveTestRun(FileName, tree);

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/MessageSink.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/MessageSink.cs
@@ -56,10 +56,9 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
             IsClosed = true;
 
             //Signal that the test run has ended
-            MessageSinkActorRef.Tell(new EndTestRun());
-
-            //Give the TestCoordinatorRef 10 seconds to shut down
-            return await MessageSinkActorRef.GracefulStop(TimeSpan.FromSeconds(10));
+            return await MessageSinkActorRef.Ask<MessageSinkActor.SinkCanBeTerminated>(new EndTestRun())
+                .ContinueWith(tr => MessageSinkActorRef.GracefulStop(TimeSpan.FromSeconds(2)), 
+                TaskContinuationOptions.AttachedToParent & TaskContinuationOptions.ExecuteSynchronously).Unwrap();
         }
 
         #endregion
@@ -97,10 +96,10 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
         /*
          * Regular expressions - go big or go home. [Aaronontheweb]
          */
-        private const string NodeLogMessageRegexString = @"\[(\w){4}(?<node>[0-9]{1,2})\]\[(?<level>(\w)*)\]\[(?<time>\d{1,2}[- /.]\d{1,2}[- /.]\d{1,4}\s\d{1,2}:\d{1,2}:\d{1,2}\s(AM|PM))\](?<thread>\[(\w|\s)*\])\[(?<logsource>(\[|\w|:|/|\(|\)|\]|\.|-|\$|%|\+|\^)*)\]\s(?<message>(\w|\s|:|<|\.|\+|>|,|\[|/|-|]|%|\$|\+|\^)*)";
+        private const string NodeLogMessageRegexString = @"\[(\w){4}(?<node>[0-9]{1,2})\]\[(?<level>(\w)*)\]\[(?<time>\d{1,2}[- /.]\d{1,2}[- /.]\d{1,4}\s\d{1,2}:\d{1,2}:\d{1,2}\s(AM|PM))\](?<thread>\[(\w|\s)*\])\[(?<logsource>(\[|\w|:|/|\(|\)|\]|\.|-|\$|%|\+|\^|@)*)\]\s(?<message>(\w|\s|:|<|\.|\+|>|,|\[|/|-|]|%|\$|\+|\^|@)*)";
         protected static readonly Regex NodeLogMessageRegex = new Regex(NodeLogMessageRegexString);
 
-        private const string RunnerLogMessageRegexString = @"\[(?<level>(\w)*)\]\[(?<time>\d{1,2}[- /.]\d{1,2}[- /.]\d{1,4}\s\d{1,2}:\d{1,2}:\d{1,2}\s(AM|PM))\](?<thread>\[(\w|\s)*\])\[(?<logsource>(\[|\w|:|/|\(|\)|\]|\.|-|\$|%|\+|\^)*)\]\s(?<message>(\w|\s|:|<|\.|\+|>|,|\[|/|-|]|%|\$|\+|\^)*)";
+        private const string RunnerLogMessageRegexString = @"\[(?<level>(\w)*)\]\[(?<time>\d{1,2}[- /.]\d{1,2}[- /.]\d{1,4}\s\d{1,2}:\d{1,2}:\d{1,2}\s(AM|PM))\](?<thread>\[(\w|\s)*\])\[(?<logsource>(\[|\w|:|/|\(|\)|\]|\.|-|\$|%|\+|\^|@)*)\]\s(?<message>(\w|\s|:|<|\.|\+|>|,|\[|/|-|]|%|\$|\+|\^|@)*)";
         protected static readonly Regex RunnerLogMessageRegex = new Regex(RunnerLogMessageRegexString);
 
         private const string NodeLogFragmentRegexString = @"\[(\w){4}(?<node>[0-9]{1,2})\](?<message>(.)*)";

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/MessageSinkActor.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/MessageSinkActor.cs
@@ -1,4 +1,5 @@
 ﻿using Akka.Actor;
+using Akka.MultiNodeTestRunner.Shared.Reporting;
 
 namespace Akka.MultiNodeTestRunner.Shared.Sinks
 {
@@ -7,6 +8,34 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
     /// </summary>
     public abstract class MessageSinkActor : ReceiveActor
     {
+        #region Message classes
+
+        /// <summary>
+        /// Used to signal that the underlying  <see cref="MessageSinkActor"/> 
+        /// must collect and report its final test run results.
+        /// 
+        /// Shut down process is ready to begin.
+        /// </summary>
+        public class BeginSinkTerminate
+        {
+            public BeginSinkTerminate(TestRunTree testRun, ActorRef subscriber)
+            {
+                Subscriber = subscriber;
+                TestRun = testRun;
+            }
+
+            public TestRunTree TestRun { get; private set; }
+            public ActorRef Subscriber { get; private set; }
+        }
+
+        /// <summary>
+        /// Signals to <see cref="MessageSink"/> that the <see cref="MessageSinkActor"/> is ready to be
+        /// shut down.
+        /// </summary>
+        public class SinkCanBeTerminated { }
+
+        #endregion
+
         protected MessageSinkActor()
         {
             SetReceive();
@@ -26,6 +55,8 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
             Receive<NodeCompletedSpecWithSuccess>(success => HandleNodeSpecPass(success));
             Receive<NodeCompletedSpecWithFail>(fail => HandleNodeSpecFail(fail));
             Receive<EndTestRun>(end => HandleTestRunEnd(end));
+            Receive<TestRunTree>(tree => HandleTestRunTree(tree));
+            Receive<BeginSinkTerminate>(terminate => HandleSinkTerminate(terminate));
             AdditionalReceives();
         }
 
@@ -53,7 +84,17 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
 
         protected abstract void HandleNodeSpecFail(NodeCompletedSpecWithFail nodeFail);
 
-        protected abstract void HandleTestRunEnd(EndTestRun endTestRun);
+        protected virtual void HandleTestRunEnd(EndTestRun endTestRun)
+        {
+            Self.Tell(new BeginSinkTerminate(null, Sender));
+        }
+
+        protected virtual void HandleSinkTerminate(BeginSinkTerminate terminate)
+        {
+            terminate.Subscriber.Tell(new SinkCanBeTerminated());
+        }
+
+        protected abstract void HandleTestRunTree(TestRunTree tree);
 
         #endregion
     }

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/Messages.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/Messages.cs
@@ -79,6 +79,11 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
         public DateTime When { get; private set; }
 
         public string Message { get; private set; }
+
+        public override string ToString()
+        {
+            return string.Format("[NODE{1}][{0}]: {2}", When, NodeIndex, Message);
+        }
     }
 
     /// <summary>
@@ -104,6 +109,13 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
         public string LogSource { get; private set; }
 
         public LogLevel Level { get; private set; }
+
+        public override string ToString()
+        {
+            return string.Format("[NODE{1}][{0}][{2}][{3}]: {4}", When, NodeIndex,
+                Level.ToString().Replace("Level", "").ToUpperInvariant(), LogSource,
+                Message);
+        }
     }
 
     /// <summary>
@@ -126,6 +138,13 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
         public string LogSource { get; private set; }
 
         public LogLevel Level { get; private set; }
+
+        public override string ToString()
+        {
+            return string.Format("[RUNNER][{0}][{1}][{2}]: {3}", When,
+                Level.ToString().Replace("Level", "").ToUpperInvariant(), LogSource,
+                Message);
+        }
     }
 
 

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/SinkCoordinator.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/SinkCoordinator.cs
@@ -163,7 +163,7 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
             var test = tests.First();
 
             foreach (var sink in Sinks)
-                sink.BeginTest(test.TypeName, test.MethodName, tests);
+                sink.BeginTest(test.TestName, test.MethodName, tests);
         }
 
         private void PublishToChildren(RunnerMessage message)


### PR DESCRIPTION
Fixed both issues. Now we get reporting like this at the end of the test run:

[RUNNER][11:17 PM]: Test run completed in [00:09:05.5357386] with 3/6 specs passed.
[RUNNER][11:17 PM]: Results for Akka.Cluster.Tests.MultiNode.ClusterDeathWatchMultiNode.ConvergenceSpecTests
[RUNNER][11:17 PM]: Start time: 2/6/2015 11:08:33 PM
[RUNNER][11:17 PM]:  --> Node 1: PASS [00:00:23.6013804 elapsed]
[RUNNER][11:17 PM]:  --> Node 2: PASS [00:00:23.6613864 elapsed]
[RUNNER][11:17 PM]:  --> Node 3: PASS [00:00:23.6613864 elapsed]
[RUNNER][11:17 PM]:  --> Node 4: PASS [00:00:23.5403777 elapsed]
[RUNNER][11:17 PM]:  --> Node 5: PASS [00:00:23.6343846 elapsed]
[RUNNER][11:17 PM]: End time: 2/6/2015 11:09:00 PM
[RUNNER][11:17 PM]: FINAL RESULT: PASS after 00:00:26.5915572.
[RUNNER][11:17 PM]: Results for Akka.Cluster.Tests.MultiNode.ConvergenceWithFailureDetectorPuppetMultiNode.ConvergenceSp
ecTests
[RUNNER][11:17 PM]: Start time: 2/6/2015 11:09:00 PM
[RUNNER][11:17 PM]:  --> Node 1: PASS [00:05:12.7689035 elapsed]
[RUNNER][11:17 PM]:  --> Node 2: PASS [00:05:12.5078879 elapsed]
[RUNNER][11:17 PM]:  --> Node 3: FAIL [00:08:38.1538760 elapsed]
[RUNNER][11:17 PM]:  --> Node 4: PASS [00:05:12.4648879 elapsed]
[RUNNER][11:17 PM]: End time: 2/6/2015 11:17:38 PM
[RUNNER][11:17 PM]: FINAL RESULT: FAIL after 00:08:38.1558739.
[RUNNER][11:17 PM]: Failure messages by Node
[RUNNER][11:17 PM]: <----------- BEGIN NODE 3 ----------->
[RUNNER][11:17 PM]: [received no messages - SILENT FAILURE].
[RUNNER][11:17 PM]: <----------- END NODE 3 ----------->
[RUNNER][11:17 PM]: Results for Akka.Cluster.Tests.MultiNode.ConvergenceWithAccrualFailureDetectorMultiNode.ConvergenceS
pecTests
[RUNNER][11:17 PM]: Start time: 2/6/2015 11:14:13 PM
[RUNNER][11:17 PM]:  --> Node 1: PASS [00:00:35.7570845 elapsed]
[RUNNER][11:17 PM]:  --> Node 2: PASS [00:00:35.4680725 elapsed]
[RUNNER][11:17 PM]:  --> Node 3: FAIL [00:03:25.3839697 elapsed]
[RUNNER][11:17 PM]:  --> Node 4: PASS [00:00:35.2020561 elapsed]
[RUNNER][11:17 PM]: End time: 2/6/2015 11:17:38 PM
[RUNNER][11:17 PM]: FINAL RESULT: FAIL after 00:03:25.3849656.
[RUNNER][11:17 PM]: Failure messages by Node
[RUNNER][11:17 PM]: <----------- BEGIN NODE 3 ----------->
[RUNNER][11:17 PM]: [received no messages - SILENT FAILURE].
[RUNNER][11:17 PM]: <----------- END NODE 3 ----------->
[RUNNER][11:17 PM]: Results for Akka.Cluster.Tests.MultiNode.InitialHeartbeatMultiNodeConfig+InitialHeartbeatMultiNode.A
MemberMustDetectFailureEvenThoughNoHeartbeatsHaveBeenReceived
[RUNNER][11:17 PM]: Start time: 2/6/2015 11:14:51 PM
[RUNNER][11:17 PM]:  --> Node 1: PASS [00:00:49.8699168 elapsed]
[RUNNER][11:17 PM]:  --> Node 2: FAIL [00:00:49.2528811 elapsed]
[RUNNER][11:17 PM]:  --> Node 3: FAIL [00:00:49.1058734 elapsed]
[RUNNER][11:17 PM]: End time: 2/6/2015 11:16:23 PM
[RUNNER][11:17 PM]: FINAL RESULT: FAIL after 00:01:32.5064554.
[RUNNER][11:17 PM]: Failure messages by Node
[RUNNER][11:17 PM]: <----------- BEGIN NODE 2 ----------->
[RUNNER][11:17 PM]:  --> AMemberMustDetectFailureEvenThoughNoHeartbeatsHaveBeenReceived FAIL
[RUNNER][11:17 PM]:  --> Message: Failed: Timeout 00:00:00.0500000 while waiting for a message of type Akka.Cluster.Clus
terEvent+CurrentClusterState
[RUNNER][11:17 PM]:  --> Type: Xunit.Sdk.TrueException
[RUNNER][11:17 PM]:  --> StackTrace:    at Akka.TestKit.Xunit.XunitAssertions.Fail(String format, Object[] args) in d:\R
epositories\olympus\akka.net\src\contrib\testkits\Akka.TestKit.Xunit\XunitAssertions.cs:line 16
[RUNNER][11:17 PM]: <----------- END NODE 2 ----------->
[RUNNER][11:17 PM]: <----------- BEGIN NODE 3 ----------->
[RUNNER][11:17 PM]:  --> AMemberMustDetectFailureEvenThoughNoHeartbeatsHaveBeenReceived FAIL
[RUNNER][11:17 PM]:  --> Type: Xunit.Sdk.TrueException
[RUNNER][11:17 PM]:  --> Message: Failed: Timeout 00:00:00.0500000 while waiting for a message of type Akka.Cluster.Clus
terEvent+CurrentClusterState
[RUNNER][11:17 PM]:  --> StackTrace:    at Akka.TestKit.Xunit.XunitAssertions.Fail(String format, Object[] args) in d:\R
epositories\olympus\akka.net\src\contrib\testkits\Akka.TestKit.Xunit\XunitAssertions.cs:line 16
[RUNNER][11:17 PM]: <----------- END NODE 3 ----------->
[RUNNER][11:17 PM]: Results for Akka.Cluster.Tests.MultiNode.JoinInProgressMultiNode.AClusterNodeMustSendHeartbeatsImmed
iatelyWhenJoiningToAvoidFalseFailureDetectionDueToDelayedGossip
[RUNNER][11:17 PM]: Start time: 2/6/2015 11:16:23 PM
[RUNNER][11:17 PM]:  --> Node 1: PASS [00:00:34.5570209 elapsed]
[RUNNER][11:17 PM]:  --> Node 2: PASS [00:00:34.5060188 elapsed]
[RUNNER][11:17 PM]: End time: 2/6/2015 11:17:01 PM
[RUNNER][11:17 PM]: FINAL RESULT: PASS after 00:00:38.1412308.
[RUNNER][11:17 PM]: Results for Akka.Cluster.Tests.MultiNode.LeaderLeavingSpecConfig+ALeaderLeavingMultiNode.ALeaderThat
IsLeavingMustBeMovedToLeavingThenExitingThenRemovedThenBeShutDownAndThenANewLeaderShouldBeElected
[RUNNER][11:17 PM]: Start time: 2/6/2015 11:17:01 PM
[RUNNER][11:17 PM]:  --> Node 1: PASS [00:00:29.4407260 elapsed]
[RUNNER][11:17 PM]:  --> Node 2: PASS [00:00:29.5067269 elapsed]
[RUNNER][11:17 PM]:  --> Node 3: PASS [00:00:29.5067269 elapsed]
[RUNNER][11:17 PM]: End time: 2/6/2015 11:17:33 PM
[RUNNER][11:17 PM]: FINAL RESULT: PASS after 00:00:31.5999080.