### PR TITLE
Async await dispatcher

### DIFF
--- a/documentation/wiki/FSharp API.md
+++ b/documentation/wiki/FSharp API.md
@@ -10,8 +10,10 @@ Unlike default (C#) actor system, F#-aware systems should be created using `Akka
 
 Example:
 
-    open Akka.FSharp
-    use system = System.create "my-system" (Configuration.load())
+```fsharp
+open Akka.FSharp
+use system = System.create "my-system" (Configuration.load())
+```
 
 F# also gives you it's own actor system Configuration module with support of following functions:
 

--- a/src/core/Akka.Cluster/ClusterSettings.cs
+++ b/src/core/Akka.Cluster/ClusterSettings.cs
@@ -79,7 +79,7 @@ namespace Akka.Cluster
             _metricsGossipInterval = cc.GetTimeSpan("metrics.gossip-interval");
             _metricsMovingAverageHalfLife = cc.GetTimeSpan("metrics.moving-average-half-life");
 
-            _minNrOfMembersOfRole = cc.GetConfig("role").Root.GetObject().AsEnumerable()
+            _minNrOfMembersOfRole = cc.GetConfig("role").Root.GetObject().Items
                 .ToImmutableDictionary(kv => kv.Key, kv => kv.Value.GetObject().GetKey("min-nr-of-members").GetInt());
         }
 

--- a/src/core/Akka.Remote/RemoteWatcher.cs
+++ b/src/core/Akka.Remote/RemoteWatcher.cs
@@ -413,7 +413,7 @@ namespace Akka.Remote
         protected void ProcessUnwatchRemote(ActorRef watchee, ActorRef watcher)
         {
             //TODO: What to do about this. Remote actors seem to get 0 uid
-            // as ActorPathSurrogate doesn't contain the uid
+            // as Surrogate doesn't contain the uid
             /*if (watchee.Path.Uid == ActorCell.UndefinedUid)
                 LogActorForDeprecationWarning(watchee);
             else*/

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -63,7 +63,7 @@ namespace Akka.Actor
                 _actorAwaitingResultSender = ActorCell.Current.Sender;
             }
             _result = result;
-            _sender = sender ?? NoSender;
+            _actorAwaitingResult = actorAwaitingResult ?? NoSender;
             _unregister = unregister;
             _path = path;
         }
@@ -99,7 +99,7 @@ namespace Akka.Actor
                     InternalCurrentActorCellKeeper.Current = null;
                     try
                     {
-                        CallContext.LogicalSetData("akka.state", new AmbientState()
+                        CallContext.LogicalSetData(TaskDispatcher.CallContextKey, new AmbientState()
                         {
                             Self = _actorAwaitingResult,
                             Message = "",

--- a/src/core/Akka/Actor/Deploy.cs
+++ b/src/core/Akka/Actor/Deploy.cs
@@ -55,11 +55,12 @@ namespace Akka.Actor
             Scope = scope ?? NoScopeGiven;
         }
 
-        public Deploy(RouterConfig routerConfig)
+        public Deploy(RouterConfig routerConfig) : this()
         {
             RouterConfig = routerConfig;
         }
         public Deploy(string path, Config config, RouterConfig routerConfig, Scope scope, string dispatcher)
+            : this()
         {
             Path = path;
             Config = config;
@@ -69,6 +70,7 @@ namespace Akka.Actor
         }
 
         public Deploy(string path, Config config, RouterConfig routerConfig, Scope scope, string dispatcher, string mailbox)
+            : this()
         {
             Path = path;
             Config = config;
@@ -139,8 +141,7 @@ namespace Akka.Actor
                    string.Equals(Dispatcher, other.Dispatcher) &&
                    string.Equals(Path, other.Path) &&
                    RouterConfig.Equals(other.RouterConfig) &&
-                   // todo: need test for configuration equality
-                   //((Config.IsNullOrEmpty() && other.Config.IsNullOrEmpty()) || Config.ToString().Equals(other.Config.ToString())) &&
+                   ((Config.IsNullOrEmpty() && other.Config.IsNullOrEmpty()) || Config.ToString().Equals(other.Config.ToString())) &&
                    (Scope == null && other.Scope == null || (Scope != null && Scope.Equals(other.Scope)));
         }
     }

--- a/src/core/Akka/Actor/RemoteScope.cs
+++ b/src/core/Akka/Actor/RemoteScope.cs
@@ -3,10 +3,9 @@ using Akka.Util.Internal;
 
 namespace Akka.Actor
 {
-    public class RemoteScope : Scope
+    public class RemoteScope : Scope, IEquatable<RemoteScope>
     {
-        [Obsolete("For Serialization only", true)]
-        public RemoteScope()
+        protected RemoteScope()
         {
         }
 
@@ -17,9 +16,24 @@ namespace Akka.Actor
 
         public Address Address { get; set; }
 
-        public override bool Equals(Scope other)
+        public bool Equals(RemoteScope other)
         {
-            return base.Equals(other) && Address.Equals(other.AsInstanceOf<RemoteScope>().Address);
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Equals(Address, other.Address);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((RemoteScope) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return (Address != null ? Address.GetHashCode() : 0);
         }
     }
 }

--- a/src/core/Akka/Actor/SupervisorStrategy.cs
+++ b/src/core/Akka/Actor/SupervisorStrategy.cs
@@ -245,8 +245,7 @@ namespace Akka.Actor
         /// <summary>
         /// Serialization-friendly constructor
         /// </summary>
-        [Obsolete("For serialization purposes only!")]
-        public OneForOneStrategy() : this(DefaultDecider) { }
+        protected OneForOneStrategy() : this(DefaultDecider) { }
 
         protected override bool LoggingEnabled { get { return _loggingEnabled; } }
 
@@ -333,9 +332,8 @@ namespace Akka.Actor
       
         /// <summary>
         /// Serialization-friendly constructor
-        /// </summary>
-        [Obsolete("For serialization purposes only!")]
-        public AllForOneStrategy() : this(DefaultDecider) { }
+        /// </summary>]
+        protected AllForOneStrategy() : this(DefaultDecider) { }
 
         protected override bool LoggingEnabled { get { return _loggingEnabled; } }
 

--- a/src/core/Akka/Configuration/Config.cs
+++ b/src/core/Akka/Configuration/Config.cs
@@ -6,11 +6,6 @@ namespace Akka.Configuration
 {
     public class Config
     {
-        private Config _fallback;
-        private HoconValue _node;
-        private IEnumerable<HoconSubstitution> _substitutions;
-
-
         public Config()
         {
         }
@@ -20,8 +15,8 @@ namespace Akka.Configuration
             if (root.Value == null)
                 throw new ArgumentNullException("root.Value");
 
-            _node = root.Value;
-            _substitutions = root.Substitutions;
+            Root = root.Value;
+            Substitutions = root.Substitutions;
         }
 
         public Config(Config source, Config fallback)
@@ -29,41 +24,42 @@ namespace Akka.Configuration
             if (source == null)
                 throw new ArgumentNullException("source");
 
-            _node = source._node;
-            _fallback = fallback;
+            Root = source.Root;
+            Fallback = fallback;
         }
+
+        public Config Fallback { get; private set; }
 
         /// <summary>
         ///     Lets the caller know if this root node contains any values
         /// </summary>
         public bool IsEmpty
         {
-            get { return _node == null || _node.IsEmpty; }
+            get { return Root == null || Root.IsEmpty; }
         }
 
         /// <summary>
         ///     Returns the root node of this configuration section
         /// </summary>
-        public HoconValue Root
-        {
-            get { return _node; }
-        }
+        public HoconValue Root { get; private set; }
+
+        public IEnumerable<HoconSubstitution> Substitutions { get; set; }
 
         protected Config Copy()
         {
             //deep clone
             return new Config
             {
-                _fallback = _fallback != null ? _fallback.Copy() : null,
-                _node = _node,
-                _substitutions = _substitutions
+                Fallback = Fallback != null ? Fallback.Copy() : null,
+                Root = Root,
+                Substitutions = Substitutions
             };
         }
 
         private HoconValue GetNode(string path)
         {
             string[] elements = path.Split('.');
-            HoconValue currentNode = _node;
+            HoconValue currentNode = Root;
             if (currentNode == null)
             {
                 throw new Exception("Current node should not be null");
@@ -73,8 +69,8 @@ namespace Akka.Configuration
                 currentNode = currentNode.GetChildObject(key);
                 if (currentNode == null)
                 {
-                    if (_fallback != null)
-                        return _fallback.GetNode(path);
+                    if (Fallback != null)
+                        return Fallback.GetNode(path);
 
                     return null;
                 }
@@ -204,9 +200,9 @@ namespace Akka.Configuration
         public Config GetConfig(string path)
         {
             HoconValue value = GetNode(path);
-            if (_fallback != null)
+            if (Fallback != null)
             {
-                Config f = _fallback.GetConfig(path);
+                Config f = Fallback.GetConfig(path);
                 if (value == null && f == null)
                     return null;
                 if (value == null)
@@ -244,10 +240,10 @@ namespace Akka.Configuration
 
         public override string ToString()
         {
-            if (_node == null)
+            if (Root == null)
                 return "";
 
-            return _node.ToString();
+            return Root.ToString();
         }
 
         public Config WithFallback(Config fallback)
@@ -258,11 +254,11 @@ namespace Akka.Configuration
             Config clone = Copy();
 
             Config current = clone;
-            while (current._fallback != null)
+            while (current.Fallback != null)
             {
-                current = current._fallback;
+                current = current.Fallback;
             }
-            current._fallback = fallback;
+            current.Fallback = fallback;
 
             return clone;
         }
@@ -276,29 +272,29 @@ namespace Akka.Configuration
 
         public static Config operator +(Config config, string fallback)
         {
-            var fallbackConfig = ConfigurationFactory.ParseString(fallback);
+            Config fallbackConfig = ConfigurationFactory.ParseString(fallback);
             return config.WithFallback(fallbackConfig);
         }
 
         public static Config operator +(string configHocon, Config fallbackConfig)
         {
-            var config = ConfigurationFactory.ParseString(configHocon);
+            Config config = ConfigurationFactory.ParseString(configHocon);
             return config.WithFallback(fallbackConfig);
         }
 
         public static implicit operator Config(string str)
         {
-            var config = ConfigurationFactory.ParseString(str);
+            Config config = ConfigurationFactory.ParseString(str);
             return config;
         }
 
         public IEnumerable<KeyValuePair<string, HoconValue>> AsEnumerable()
         {
             var used = new HashSet<string>();
-            var current = this;
+            Config current = this;
             while (current != null)
             {
-                foreach (var kvp in current.Root.GetObject().AsEnumerable())
+                foreach (var kvp in current.Root.GetObject().Items)
                 {
                     if (!used.Contains(kvp.Key))
                     {
@@ -306,7 +302,7 @@ namespace Akka.Configuration
                         used.Add(kvp.Key);
                     }
                 }
-                current = current._fallback;
+                current = current.Fallback;
             }
         }
     }
@@ -315,15 +311,17 @@ namespace Akka.Configuration
     {
         public static Config SafeWithFallback(this Config config, Config fallback)
         {
-            return config == null ? fallback 
-                : ReferenceEquals(config,fallback) ? config 
-                : config.WithFallback(fallback);
+            return config == null
+                ? fallback
+                : ReferenceEquals(config, fallback)
+                    ? config
+                    : config.WithFallback(fallback);
         }
 
         /// <summary>
-        /// Convenience method for determining if <see cref="Config"/> has any usable content period.
+        ///     Convenience method for determining if <see cref="Config" /> has any usable content period.
         /// </summary>
-        /// <returns>true if the <see cref="Config"/> is null or <see cref="Config.IsEmpty"/> return true; false otherwise.</returns>
+        /// <returns>true if the <see cref="Config" /> is null or <see cref="Config.IsEmpty" /> return true; false otherwise.</returns>
         public static bool IsNullOrEmpty(this Config config)
         {
             return config == null || config.IsEmpty;

--- a/src/core/Akka/Configuration/Hocon/HoconObject.cs
+++ b/src/core/Akka/Configuration/Hocon/HoconObject.cs
@@ -3,31 +3,23 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using Newtonsoft.Json;
 
 namespace Akka.Configuration.Hocon
 {
     public class HoconObject : IHoconElement
     {
-        private readonly Dictionary<string, HoconValue> _children = new Dictionary<string, HoconValue>();
-
-        public IEnumerable<HoconValue> Children
+        public HoconObject()
         {
-            get { return _children.Values; }
+            Items = new Dictionary<string, HoconValue>();
         }
 
-        public IEnumerable<KeyValuePair<string, HoconValue>> AsEnumerable()
-        {
-            foreach (var item in _children)
-            {
-                yield return item;
-            }
-        }
-
+        [JsonIgnore]
         public IDictionary<string, object> Unwrapped
         {
             get
             {
-                return _children.ToDictionary(k => k.Key, v =>
+                return Items.ToDictionary(k => k.Key, v =>
                 {
                     HoconObject obj = v.Value.GetObject();
                     if (obj != null)
@@ -36,6 +28,8 @@ namespace Akka.Configuration.Hocon
                 });
             }
         }
+
+        public Dictionary<string, HoconValue> Items { get; private set; }
 
         public bool IsString()
         {
@@ -59,21 +53,21 @@ namespace Akka.Configuration.Hocon
 
         public HoconValue GetKey(string key)
         {
-            if (_children.ContainsKey(key))
+            if (Items.ContainsKey(key))
             {
-                return _children[key];
+                return Items[key];
             }
             return null;
         }
 
         public HoconValue GetOrCreateKey(string key)
         {
-            if (_children.ContainsKey(key))
+            if (Items.ContainsKey(key))
             {
-                return _children[key];
+                return Items[key];
             }
             var child = new HoconValue();
-            _children.Add(key, child);
+            Items.Add(key, child);
             return child;
         }
 
@@ -86,7 +80,7 @@ namespace Akka.Configuration.Hocon
         {
             var i = new string(' ', indent*2);
             var sb = new StringBuilder();
-            foreach (var kvp in _children)
+            foreach (var kvp in Items)
             {
                 string key = QuoteIfNeeded(kvp.Key);
                 sb.AppendFormat("{0}{1} : {2}\r\n", i, key, kvp.Value.ToString(indent));

--- a/src/core/Akka/Configuration/Hocon/HoconRoot.cs
+++ b/src/core/Akka/Configuration/Hocon/HoconRoot.cs
@@ -5,6 +5,10 @@ namespace Akka.Configuration.Hocon
 {
     public class HoconRoot
     {
+        protected HoconRoot()
+        {            
+        }
+
         public HoconRoot(HoconValue value, IEnumerable<HoconSubstitution> substitutions)
         {
             Value = value;

--- a/src/core/Akka/Configuration/Hocon/HoconSubstitution.cs
+++ b/src/core/Akka/Configuration/Hocon/HoconSubstitution.cs
@@ -7,6 +7,10 @@ namespace Akka.Configuration.Hocon
     /// </summary>
     public class HoconSubstitution : IHoconElement, IMightBeAHoconObject
     {
+        protected HoconSubstitution()
+        {            
+        }
+
         /// <summary>
         ///     Initializes a new instance of the <see cref="HoconSubstitution" /> class.
         /// </summary>

--- a/src/core/Akka/Configuration/Hocon/HoconValue.cs
+++ b/src/core/Akka/Configuration/Hocon/HoconValue.cs
@@ -8,17 +8,22 @@ namespace Akka.Configuration.Hocon
 {
     public class HoconValue : IMightBeAHoconObject
     {
-        private readonly List<IHoconElement> _values = new List<IHoconElement>();
+        public HoconValue()
+        {
+            Values = new List<IHoconElement>();
+        }
 
         public bool IsEmpty
         {
-            get { return _values.Count == 0; }
+            get { return Values.Count == 0; }
         }
+
+        public List<IHoconElement> Values { get; private set; }
 
         public HoconObject GetObject()
         {
             //TODO: merge objects?
-            IHoconElement raw = _values.FirstOrDefault();
+            IHoconElement raw = Values.FirstOrDefault();
             var o = raw as HoconObject;
             var sub = raw as IMightBeAHoconObject;
             if (o != null) return o;
@@ -33,28 +38,28 @@ namespace Akka.Configuration.Hocon
 
         public void AppendValue(IHoconElement value)
         {
-            _values.Add(value);
+            Values.Add(value);
         }
 
         public void Clear()
         {
-            _values.Clear();
+            Values.Clear();
         }
 
         public void NewValue(IHoconElement value)
         {
-            _values.Clear();
-            _values.Add(value);
+            Values.Clear();
+            Values.Add(value);
         }
 
         public bool IsString()
         {
-            return _values.Any() && _values.All(v => v.IsString());
+            return Values.Any() && Values.All(v => v.IsString());
         }
 
         private string ConcatString()
         {
-            string concat = string.Join("", _values.Select(l => l.GetString())).Trim();
+            string concat = string.Join("", Values.Select(l => l.GetString())).Trim();
 
             if (concat == "null")
                 return null;
@@ -166,7 +171,7 @@ namespace Akka.Configuration.Hocon
 
         public IList<HoconValue> GetArray()
         {
-            IEnumerable<HoconValue> x = from arr in _values
+            IEnumerable<HoconValue> x = from arr in Values
                 where arr.IsArray()
                 from e in arr.GetArray()
                 select e;

--- a/src/core/Akka/Dispatch/ConcurrentQueueMailbox.cs
+++ b/src/core/Akka/Dispatch/ConcurrentQueueMailbox.cs
@@ -69,7 +69,7 @@ namespace Akka.Dispatch
                     Mailbox.DebugPrint(ActorCell.Self + " processing message " + envelope);
 
                     //run the receive handler
-                    ActorCell.Invoke(envelope);
+                    ActorCell.Dispatcher.Dispatch(ActorCell,envelope);
 
                     //check if any system message have arrived while processing user messages
                     if (_systemMessages.TryDequeue(out envelope))
@@ -77,7 +77,7 @@ namespace Akka.Dispatch
                         //handle system message
                         Mailbox.DebugPrint(ActorCell.Self + " processing system message " + envelope);
                         // TODO: Add + " with " + ActorCell.GetChildren());
-                        ActorCell.SystemInvoke(envelope);
+                        ActorCell.Dispatcher.SystemDispatch(ActorCell,envelope);
                         break;
                     }
                     left--;

--- a/src/core/Akka/Dispatch/Dispatchers.cs
+++ b/src/core/Akka/Dispatch/Dispatchers.cs
@@ -41,13 +41,13 @@ namespace Akka.Dispatch
         }
 
         /// <summary>
-        ///     Gets or sets the throughput deadline time.
+        /// Gets or sets the deadline time for a mailbox run, if the execution time exceeds this, the mailbox run will stop and reschedule.
         /// </summary>
         /// <value>The throughput deadline time.</value>
         public long? ThroughputDeadlineTime { get; set; }
 
         /// <summary>
-        ///     Gets or sets the throughput.
+        /// Gets or sets the maximum number of messages to process in a single mailbox run.
         /// </summary>
         /// <value>The throughput.</value>
         public int Throughput { get; set; }
@@ -57,6 +57,16 @@ namespace Akka.Dispatch
         /// </summary>
         /// <param name="run">The run.</param>
         public abstract void Schedule(Action run);
+
+        public virtual void Dispatch(ActorCell cell, Envelope envelope)
+        {
+            cell.Invoke(envelope);
+        }
+
+        public virtual void SystemDispatch(ActorCell cell, Envelope envelope)
+        {
+            cell.SystemInvoke(envelope);
+        }
     }
 
     /// <summary>

--- a/src/core/Akka/Dispatch/GenericMailbox.cs
+++ b/src/core/Akka/Dispatch/GenericMailbox.cs
@@ -88,7 +88,7 @@ namespace Akka.Dispatch
                     Mailbox.DebugPrint(ActorCell.Self + " processing message " + envelope);
 
                     //run the receive handler
-                    ActorCell.Invoke(envelope);
+                    ActorCell.Dispatcher.Dispatch(ActorCell, envelope);
 
                     //check if any system message have arrived while processing user messages
                     if (_systemMessages.TryDequeue(out envelope))
@@ -96,7 +96,7 @@ namespace Akka.Dispatch
                         //handle system message
                         Mailbox.DebugPrint(ActorCell.Self + " processing system message " + envelope);
                         // TODO: Add + " with " + ActorCell.GetChildren());
-                        ActorCell.SystemInvoke(envelope);
+                        ActorCell.Dispatcher.SystemDispatch(ActorCell, envelope);
                         break;
                     }
                     left--;

--- a/src/core/Akka/Routing/Broadcast.cs
+++ b/src/core/Akka/Routing/Broadcast.cs
@@ -23,6 +23,10 @@ namespace Akka.Routing
     /// </summary>
     public class BroadcastPool : Pool
     {
+        protected BroadcastPool()
+        {           
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="BroadcastPool"/> class.
         /// </summary>
@@ -63,9 +67,8 @@ namespace Akka.Routing
     }
 
     public class BroadcastGroup : Group
-    {
-        [Obsolete("For serialization only",true)]
-        public BroadcastGroup()
+    {        
+        protected BroadcastGroup()
         {
             
         }

--- a/src/core/Akka/Routing/ConsistentHash.cs
+++ b/src/core/Akka/Routing/ConsistentHash.cs
@@ -91,9 +91,8 @@ namespace Akka.Routing
     }
 
     public class ConsistentHashingGroup : Group
-    {
-        [Obsolete("For serialization only",true)]
-        public ConsistentHashingGroup()
+    {        
+        protected ConsistentHashingGroup()
         {
         }
 
@@ -124,8 +123,11 @@ namespace Akka.Routing
 
     public class ConsistentHashingPool : Pool
     {
+        protected ConsistentHashingPool()
+        {            
+        }
 
-                /// <summary>
+        /// <summary>
         /// Initializes a new instance of the <see cref="ConsistentHashingPool"/> class.
         /// </summary>
         /// <param name="config">The configuration.</param>

--- a/src/core/Akka/Routing/Resizer.cs
+++ b/src/core/Akka/Routing/Resizer.cs
@@ -45,74 +45,47 @@ namespace Akka.Routing
     /// <summary>
     /// Implementation of [[Resizer]] that adjust the [[Pool]] based on specified thresholds.
     /// </summary>
-    public class DefaultResizer : Resizer
+    public class DefaultResizer : Resizer, IEquatable<DefaultResizer>
     {
-        /// <summary>
-        /// The fewest number of routees the router should ever have.
-        /// </summary>
-        public readonly int LowerBound = 1;
+        public bool Equals(DefaultResizer other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return MessagesPerResize == other.MessagesPerResize && BackoffRate.Equals(other.BackoffRate) && RampupRate.Equals(other.RampupRate) && BackoffThreshold.Equals(other.BackoffThreshold) && UpperBound == other.UpperBound && PressureThreshold == other.PressureThreshold && LowerBound == other.LowerBound;
+        }
 
-        /// <summary>
-        /// The most number of routees the router should ever have. 
-        /// Must be greater than or equal to `lowerBound`.
-        /// </summary>
-        public readonly int UpperBound = 10;
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((DefaultResizer) obj);
+        }
 
-        /// <summary>
-        /// * Threshold to evaluate if routee is considered to be busy (under pressure).
-        /// Implementation depends on this value (default is 1).
-        /// <ul>
-        /// <li> 0:   number of routees currently processing a message.</li>
-        /// <li> 1:   number of routees currently processing a message has
-        ///           some messages in mailbox.</li>
-        /// <li> > 1: number of routees with at least the configured `pressureThreshold`
-        ///           messages in their mailbox. Note that estimating mailbox size of
-        ///           default UnboundedMailbox is O(N) operation.</li>
-        /// </ul>
-        /// </summary>
-        private readonly int _pressureThreshold = 1;
-
-        /// <summary>
-        /// Percentage to increase capacity whenever all routees are busy.
-        /// For example, 0.2 would increase 20% (rounded up), i.e. if current
-        /// capacity is 6 it will request an increase of 2 more routees.
-        /// </summary>
-        private readonly double _rampupRate = 0.2;
-
-        /// <summary>
-        /// Minimum fraction of busy routees before backing off.
-        /// For example, if this is 0.3, then we'll remove some routees only when
-        /// less than 30% of routees are busy, i.e. if current capacity is 10 and
-        /// 3 are busy then the capacity is unchanged, but if 2 or less are busy
-        /// the capacity is decreased.
-        ///
-        /// Use 0.0 or negative to avoid removal of routees.
-        /// </summary>
-        private readonly double _backoffThreshold = 0.3;
-
-        /// <summary>
-        /// Fraction of routees to be removed when the resizer reaches the
-        /// backoffThreshold.
-        /// For example, 0.1 would decrease 10% (rounded up), i.e. if current
-        /// capacity is 9 it will request an decrease of 1 routee.
-        /// </summary>
-        private readonly double _backoffRate = 0.1;
-
-        /// <summary>
-        /// Number of messages between resize operation.
-        /// Use 1 to resize before each message.
-        /// </summary>
-        private readonly int _messagesPerResize = 10;
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = MessagesPerResize;
+                hashCode = (hashCode*397) ^ BackoffRate.GetHashCode();
+                hashCode = (hashCode*397) ^ RampupRate.GetHashCode();
+                hashCode = (hashCode*397) ^ BackoffThreshold.GetHashCode();
+                hashCode = (hashCode*397) ^ UpperBound;
+                hashCode = (hashCode*397) ^ PressureThreshold;
+                hashCode = (hashCode*397) ^ LowerBound;
+                return hashCode;
+            }
+        }
 
         public DefaultResizer(int lower, int upper, int pressureThreshold = 1, double rampupRate = 0.2d, double backoffThreshold = 0.3d, double backoffRate = 0.1d, int messagesPerResize = 10)
         {
             LowerBound = lower;
             UpperBound = upper;
-            _pressureThreshold = pressureThreshold;
-            _rampupRate = rampupRate;
-            _backoffThreshold = backoffThreshold;
-            _backoffRate = backoffRate;
-            _messagesPerResize = messagesPerResize;
+            PressureThreshold = pressureThreshold;
+            RampupRate = rampupRate;
+            BackoffThreshold = backoffThreshold;
+            BackoffRate = backoffRate;
+            MessagesPerResize = messagesPerResize;
         }
 
         /// <summary>
@@ -123,11 +96,11 @@ namespace Akka.Routing
         {
             LowerBound = resizerConfig.GetInt("lower-bound");
             UpperBound = resizerConfig.GetInt("upper-bound");
-            _pressureThreshold = resizerConfig.GetInt("pressure-threshold");
-            _rampupRate = resizerConfig.GetDouble("rampup-rate");
-            _backoffThreshold = resizerConfig.GetDouble("backoff-threshold");
-            _backoffRate = resizerConfig.GetDouble("backoff-rate");
-            _messagesPerResize = resizerConfig.GetInt("messages-per-resize");
+            PressureThreshold = resizerConfig.GetInt("pressure-threshold");
+            RampupRate = resizerConfig.GetDouble("rampup-rate");
+            BackoffThreshold = resizerConfig.GetDouble("backoff-threshold");
+            BackoffRate = resizerConfig.GetDouble("backoff-rate");
+            MessagesPerResize = resizerConfig.GetInt("messages-per-resize");
 
             Validate();
         }
@@ -142,14 +115,14 @@ namespace Akka.Routing
             if (UpperBound < LowerBound)
                 throw new ArgumentException(string.Format("upperBound must be >= lowerBound, was: {0} < {1}",
                     UpperBound, LowerBound));
-            if (_rampupRate < 0.0)
-                throw new ArgumentException(string.Format("rampupRate must be >= 0.0, was {0}", _rampupRate));
-            if (_backoffThreshold > 1.0)
-                throw new ArgumentException(string.Format("backoffThreshold must be <= 1.0, was {0}", _backoffThreshold));
-            if (_backoffRate < 0.0)
-                throw new ArgumentException(string.Format("backoffRate must be >= 0.0, was {0}", _backoffRate));
-            if (_messagesPerResize <= 0)
-                throw new ArgumentException(string.Format("messagesPerResize must be > 0, was {0}", _messagesPerResize));
+            if (RampupRate < 0.0)
+                throw new ArgumentException(string.Format("rampupRate must be >= 0.0, was {0}", RampupRate));
+            if (BackoffThreshold > 1.0)
+                throw new ArgumentException(string.Format("backoffThreshold must be <= 1.0, was {0}", BackoffThreshold));
+            if (BackoffRate < 0.0)
+                throw new ArgumentException(string.Format("backoffRate must be >= 0.0, was {0}", BackoffRate));
+            if (MessagesPerResize <= 0)
+                throw new ArgumentException(string.Format("messagesPerResize must be > 0, was {0}", MessagesPerResize));
         }
 
         public static DefaultResizer FromConfig(Config resizerConfig)
@@ -159,7 +132,7 @@ namespace Akka.Routing
 
         public override bool IsTimeForResize(long messageCounter)
         {
-            return messageCounter%_messagesPerResize == 0;
+            return messageCounter%MessagesPerResize == 0;
         }
 
         public override int Resize(IEnumerable<Routee> currentRoutees)
@@ -210,9 +183,9 @@ namespace Akka.Routing
         /// <returns>proposed decrease in capacity (as a negative number)</returns>
         public int Backoff(int pressure, int capacity)
         {
-            if (_backoffThreshold > 0.0 && _backoffRate > 0.0 && capacity > 0 && (Convert.ToDouble(pressure)/Convert.ToDouble(capacity)) < _backoffThreshold)
+            if (BackoffThreshold > 0.0 && BackoffRate > 0.0 && capacity > 0 && (Convert.ToDouble(pressure)/Convert.ToDouble(capacity)) < BackoffThreshold)
             {
-                return Convert.ToInt32(Math.Floor(-1.0*_backoffRate*capacity));
+                return Convert.ToInt32(Math.Floor(-1.0*BackoffRate*capacity));
             }
             return 0;
         }
@@ -226,7 +199,7 @@ namespace Akka.Routing
         /// <returns>proposed increase in capacity</returns>
         public int Rampup(int pressure, int capacity)
         {
-            return (pressure < capacity) ? 0 : Convert.ToInt32(Math.Ceiling(_rampupRate*capacity));
+            return (pressure < capacity) ? 0 : Convert.ToInt32(Math.Ceiling(RampupRate*capacity));
         }
 
         /// <summary>
@@ -261,27 +234,84 @@ namespace Akka.Routing
                             if(cell != null)
                             {
                                 return
-                                    _pressureThreshold == 1
+                                    PressureThreshold == 1
                                         ? cell.Mailbox.Status == Mailbox.MailboxStatus.Busy &&
                                           cell.Mailbox.HasUnscheduledMessages
-                                        : (_pressureThreshold < 1
+                                        : (PressureThreshold < 1
                                             ? cell.Mailbox.Status == Mailbox.MailboxStatus.Busy &&
                                               cell.CurrentMessage != null
-                                            : cell.Mailbox.NumberOfMessages >= _pressureThreshold);
+                                            : cell.Mailbox.NumberOfMessages >= PressureThreshold);
                             }
                             else
                             {
                                 return
-                                    _pressureThreshold == 1
+                                    PressureThreshold == 1
                                         ? underlying.HasMessages
-                                        : (_pressureThreshold < 1
+                                        : (PressureThreshold < 1
                                             ? true // unstarted cells are always busy, for example
-                                            : underlying.NumberOfMessages >= _pressureThreshold);
+                                            : underlying.NumberOfMessages >= PressureThreshold);
                             }
                         }
                     }
                     return false;
                 });
         }
+
+        /// <summary>
+        /// The fewest number of routees the router should ever have.
+        /// </summary>
+        public int LowerBound { get; set; }
+
+        /// <summary>
+        /// The most number of routees the router should ever have. 
+        /// Must be greater than or equal to `lowerBound`.
+        /// </summary>
+        public int UpperBound { get; set; }
+
+        /// <summary>
+        /// * Threshold to evaluate if routee is considered to be busy (under pressure).
+        /// Implementation depends on this value (default is 1).
+        /// <ul>
+        /// <li> 0:   number of routees currently processing a message.</li>
+        /// <li> 1:   number of routees currently processing a message has
+        ///           some messages in mailbox.</li>
+        /// <li> > 1: number of routees with at least the configured `pressureThreshold`
+        ///           messages in their mailbox. Note that estimating mailbox size of
+        ///           default UnboundedMailbox is O(N) operation.</li>
+        /// </ul>
+        /// </summary>
+        public int PressureThreshold { get;private set; }
+
+        /// <summary>
+        /// Percentage to increase capacity whenever all routees are busy.
+        /// For example, 0.2 would increase 20% (rounded up), i.e. if current
+        /// capacity is 6 it will request an increase of 2 more routees.
+        /// </summary>
+        public double RampupRate { get; private set; }
+
+        /// <summary>
+        /// Minimum fraction of busy routees before backing off.
+        /// For example, if this is 0.3, then we'll remove some routees only when
+        /// less than 30% of routees are busy, i.e. if current capacity is 10 and
+        /// 3 are busy then the capacity is unchanged, but if 2 or less are busy
+        /// the capacity is decreased.
+        ///
+        /// Use 0.0 or negative to avoid removal of routees.
+        /// </summary>
+        public double BackoffThreshold { get; private set; }
+
+        /// <summary>
+        /// Fraction of routees to be removed when the resizer reaches the
+        /// backoffThreshold.
+        /// For example, 0.1 would decrease 10% (rounded up), i.e. if current
+        /// capacity is 9 it will request an decrease of 1 routee.
+        /// </summary>
+        public double BackoffRate { get; private set; }
+
+        /// <summary>
+        /// Number of messages between resize operation.
+        /// Use 1 to resize before each message.
+        /// </summary>
+        public int MessagesPerResize { get; private set; }
     }
 }

--- a/src/core/Akka/Routing/RoundRobin.cs
+++ b/src/core/Akka/Routing/RoundRobin.cs
@@ -43,8 +43,7 @@ namespace Akka.Routing
     /// </summary>
     public class RoundRobinGroup : Group
     {
-        [Obsolete("For serialization only",true)]
-        public RoundRobinGroup()
+        protected RoundRobinGroup()
         {
             
         }
@@ -116,8 +115,7 @@ namespace Akka.Routing
             
         }
 
-        [Obsolete("for serialization only",true)]
-        public RoundRobinPool()
+        protected RoundRobinPool()
         {
             
         }

--- a/src/core/Akka/Routing/RouterConfig.cs
+++ b/src/core/Akka/Routing/RouterConfig.cs
@@ -129,9 +129,37 @@ namespace Akka.Routing
     }
 
 
-    //TODO: ensure this can be serialized/deserialized fully
-    public abstract class Pool : RouterConfig
+    //TODO: ensure this can be serialized/deserialized fully    
+    public abstract class Pool : RouterConfig, IEquatable<Pool>
     {
+        //TODO: add supervisor strategy to the equality compare
+        public bool Equals(Pool other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Equals(Resizer, other.Resizer) && UsePoolDispatcher.Equals(other.UsePoolDispatcher) && NrOfInstances == other.NrOfInstances;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((Pool) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = (Resizer != null ? Resizer.GetHashCode() : 0);
+                hashCode = (hashCode*397) ^ UsePoolDispatcher.GetHashCode();
+                hashCode = (hashCode*397) ^ NrOfInstances;
+                return hashCode;
+            }
+        }
+
+
         protected Pool() //for serialization
         {
         }
@@ -157,6 +185,8 @@ namespace Akka.Routing
             UsePoolDispatcher = config.HasPath("pool-dispatcher");
             // ReSharper restore DoNotCallOverridableMethodsInConstructor
         }
+
+        //TODO: do we want mutable props here ???
 
         /// <summary>
         /// The number of instances in the pool.
@@ -236,16 +266,16 @@ namespace Akka.Routing
 
         #region Overrides
 
-        public override bool Equals(RouterConfig other)
-        {
-            if (!base.Equals(other)) return false;
-            var otherPool = other as Pool;
-            if (otherPool == null) return false; //should never be true due to the previous check
-            return NrOfInstances == otherPool.NrOfInstances &&
-                   UsePoolDispatcher == otherPool.UsePoolDispatcher &&
-                   (Resizer == null && otherPool.Resizer == null || Resizer != null && otherPool.Resizer != null) &&
-                   SupervisorStrategy.GetType() == otherPool.SupervisorStrategy.GetType();
-        }
+        //public override bool Equals(RouterConfig other)
+        //{
+        //    if (!base.Equals(other)) return false;
+        //    var otherPool = other as Pool;
+        //    if (otherPool == null) return false; //should never be true due to the previous check
+        //    return NrOfInstances == otherPool.NrOfInstances &&
+        //           UsePoolDispatcher == otherPool.UsePoolDispatcher &&
+        //           (Resizer == null && otherPool.Resizer == null || Resizer != null && otherPool.Resizer != null) &&
+        //           SupervisorStrategy.GetType() == otherPool.SupervisorStrategy.GetType();
+        //}
 
         #endregion
     }

--- a/src/core/Akka/Routing/ScatterGatherFirstCompleted.cs
+++ b/src/core/Akka/Routing/ScatterGatherFirstCompleted.cs
@@ -50,9 +50,7 @@ namespace Akka.Routing
 
     public class ScatterGatherFirstCompletedGroup : Group
     {
-        private TimeSpan _within;
-        [Obsolete("For serialization only",true)]
-        public ScatterGatherFirstCompletedGroup()
+        protected ScatterGatherFirstCompletedGroup()
         {
             
         }
@@ -63,7 +61,7 @@ namespace Akka.Routing
         public ScatterGatherFirstCompletedGroup(Config config)
             : base(config.GetStringList("routees.paths"))
         {
-            _within = config.GetTimeSpan("within");
+            Within = config.GetTimeSpan("within");
         }
 
         /// <summary>
@@ -73,7 +71,7 @@ namespace Akka.Routing
         public ScatterGatherFirstCompletedGroup(TimeSpan within,params string[] paths)
             : base(paths)
         {
-            _within = within;
+            Within = within;
         }
 
         /// <summary>
@@ -82,7 +80,7 @@ namespace Akka.Routing
         /// <param name="paths">The paths.</param>
         public ScatterGatherFirstCompletedGroup(IEnumerable<string> paths,TimeSpan within) : base(paths)
         {
-            _within = within;
+            Within = within;
         }
 
         /// <summary>
@@ -91,8 +89,10 @@ namespace Akka.Routing
         /// <param name="routees">The routees.</param>
         public ScatterGatherFirstCompletedGroup(IEnumerable<ActorRef> routees,TimeSpan within) : base(routees)
         {
-            _within = within;
+            Within = within;
         }
+
+        public TimeSpan Within { get;private set; }
 
         /// <summary>
         ///     Creates the router.
@@ -100,7 +100,7 @@ namespace Akka.Routing
         /// <returns>Router.</returns>
         public override Router CreateRouter(ActorSystem system)
         {
-            return new Router(new ScatterGatherFirstCompletedRoutingLogic(_within));
+            return new Router(new ScatterGatherFirstCompletedRoutingLogic(Within));
         }
     }
 
@@ -129,8 +129,7 @@ namespace Akka.Routing
             _within = config.GetTimeSpan("within");
         }
 
-        [Obsolete("for serialization only",true)]
-        public ScatterGatherFirstCompletedPool()
+        protected ScatterGatherFirstCompletedPool()
         {
             
         }

--- a/src/core/Akka/Routing/SmallestMailbox.cs
+++ b/src/core/Akka/Routing/SmallestMailbox.cs
@@ -91,10 +91,8 @@ namespace Akka.Routing
             
         }
 
-        [Obsolete("for serialization only",true)]
-        public SmallestMailboxPool()
-        {
-            
+        protected SmallestMailboxPool()
+        {            
         }
 
         public SmallestMailboxPool(int nrOfInstances) : base(nrOfInstances, null, Pool.DefaultStrategy, null) { }

--- a/src/core/Akka/Util/ISurrogate.cs
+++ b/src/core/Akka/Util/ISurrogate.cs
@@ -3,11 +3,18 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Akka.Actor;
 
 namespace Akka.Util
 {
     public interface ISurrogate
     {
-        object Translate();
+        object FromSurrogate(ActorSystem system);
+    }
+
+    public interface ISurrogated
+    {
+
+        ISurrogate ToSurrogate(ActorSystem system);
     }
 }


### PR DESCRIPTION
Added Async Await support for `TaskDispatcher`.
This means that any actor running under the `TaskDispatcher` can now safely use async await inside actors.

The behavior used here is what Orleans call a Reentrant actor, that is, while the actor awaits an async task, it can still process other messages.
Once the async task completes, the TaskDispatcher will marshall execution back into the actors context and re-apply ambient properties such as Sender, CurrentMessage etc.

This does come with a cost, setting state that can flow with async operations is costly, so the pingpong benchmark suffers a 50% throughput loss when this is enabled.
However, this will have little to no effect on real world implementations where there are real work being performed in the actors.

This PR also contains references to the updated xUnit 2.0 vs.net runner.
I dont know if that is good or bad, should they be removed?  
It looks like this is the default way to run xUnit in vs now adays (it is a nuget ref that makes the tests discoverable from the test explorer, so no need to install a vs.net plugin)