### PR TITLE
ClusterDeatchWatchSpecs now pass

### DIFF
--- a/src/core/Akka.Cluster.Tests/FailureDetectorPuppet.cs
+++ b/src/core/Akka.Cluster.Tests/FailureDetectorPuppet.cs
@@ -25,12 +25,23 @@ namespace Akka.Cluster.Tests
 
         public void MarkNodeAsUnavailable()
         {
-            _status.Value = Status.Down;
+            var oldStatus = _status.Value;
+            bool set;
+            do
+            {
+                set = _status.CompareAndSet(oldStatus, Status.Down);
+            } while (!set);
+
         }
 
         public void MarkNodeAsAvailable()
         {
-            _status.Value = Status.Up;
+            var oldStatus = _status.Value;
+            bool set;
+            do
+            {
+                set = _status.CompareAndSet(oldStatus, Status.Up);
+            } while (!set);
         }
 
         public override bool IsAvailable

--- a/src/core/Akka.Cluster.Tests/MultiNode/ClusterDeathWatchSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MultiNode/ClusterDeathWatchSpec.cs
@@ -1,7 +1,16 @@
-﻿using Akka.Actor;
+﻿using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Akka.Actor;
 using Akka.Configuration;
+using Akka.Event;
+using Akka.Remote;
 using Akka.Remote.TestKit;
 using Akka.TestKit;
+using Akka.TestKit.TestActors;
+using Akka.Util.Internal;
+using Xunit;
 
 namespace Akka.Cluster.Tests.MultiNode
 {
@@ -25,7 +34,7 @@ namespace Akka.Cluster.Tests.MultiNode
             _third = Role("third");
             _fourth = Role("fourth");
             _fifth = Role("fifth");
-
+            DeployOn(_fourth, @"/hello.remote = ""@first@""");
             CommonConfig = ConfigurationFactory.ParseString(@"akka.cluster.publish-stats-interval = 25s")
                 .WithFallback(MultiNodeLoggingConfig.LoggingConfig)
                 .WithFallback(DebugConfig(true))
@@ -68,55 +77,314 @@ namespace Akka.Cluster.Tests.MultiNode
             _config = config;
         }
 
+        private ActorRef _remoteWatcher;
+
+        protected ActorRef RemoteWatcher
+        {
+            get
+            {
+                if (_remoteWatcher == null)
+                {
+                    Sys.ActorSelection("/system/remote-watcher").Tell(new Identify(null), TestActor);
+                    _remoteWatcher = ExpectMsg<ActorIdentity>().Subject;
+                }
+                return _remoteWatcher;
+            }
+        }
+
         protected override void AtStartup()
         {
-            //TODO: Mute
+            if (!Log.IsDebugEnabled)
+            {
+                MuteMarkingAsUnreachable();
+            }
+            base.AtStartup();
         }
+
+
 
         [MultiNodeFact]
         public void ClusterDeathWatchSpecTests()
         {
+            AnActorWatchingARemoteActorInTheClusterMustReceiveTerminatedWhenWatchedNodeBecomesDownRemoved();
+            //AnActorWatchingARemoteActorInTheClusterMustReceiveTerminatedWhenWatchedPathDoesNotExist();
+            AnActorWatchingARemoteActorInTheClusterMustBeAbleToWatchActorBeforeNodeJoinsClusterAndClusterRemoteWatcherTakesOverFromRemoteWatcher();
+            AnActorWatchingARemoteActorInTheClusterMustBeAbleToShutdownSystemWhenUsingRemoteDeployedActorOnNodeThatCrashed();
         }
 
-        public void AnActorWatchingARemoteActorInTheClusterReceiveTerminatedWhenWatchedNodeBecomesDownRemoved()
+        public void AnActorWatchingARemoteActorInTheClusterMustReceiveTerminatedWhenWatchedNodeBecomesDownRemoved()
         {
-            AwaitClusterUp(_config.First, _config.Second, _config.Third, _config.Fourth);
-            EnterBarrier("cluster-up");
-
-            RunOn(() =>
+            Within(TimeSpan.FromSeconds(20), () =>
             {
+                AwaitClusterUp(_config.First, _config.Second, _config.Third, _config.Fourth);
+                EnterBarrier("cluster-up");
+
+                RunOn(() =>
+                {
+                    EnterBarrier("subjected-started");
+
+                    var path2 = new RootActorPath(GetAddress(_config.Second)) / "user" / "subject";
+                    var path3 = new RootActorPath(GetAddress(_config.Third)) / "user" / "subject";
+                    var watchEstablished = new TestLatch(Sys, 2);
+                    Sys.ActorOf(Props.Create(() => new Observer(path2, path3, watchEstablished, TestActor))
+                        .WithDeploy(Deploy.Local), "observer1");
+
+                    watchEstablished.Ready();
+                    EnterBarrier("watch-established");
+                    ExpectMsg(path2);
+                    ExpectNoMsg(TimeSpan.FromSeconds(2));
+                    EnterBarrier("second-terminated");
+                    MarkNodeAsUnavailable(GetAddress(_config.Third));
+                    AwaitAssert(() => Assert.True(ClusterView.UnreachableMembers.Select(x => x.Address).Contains(GetAddress(_config.Third))));
+                    Cluster.Down(GetAddress(_config.Third));
+                    //removed
+                    AwaitAssert(() => Assert.False(ClusterView.Members.Select(x => x.Address).Contains(GetAddress(_config.Third))));
+                    AwaitAssert(() => Assert.False(ClusterView.UnreachableMembers.Select(x => x.Address).Contains(GetAddress(_config.Third))));
+                    ExpectMsg(path3);
+                    EnterBarrier("third-terminated");
+                }, _config.First);
+
+                RunOn(() =>
+                {
+                    Sys.ActorOf(BlackHoleActor.Props, "subject");
+                    EnterBarrier("subjected-started");
+                    EnterBarrier("watch-established");
+                    RunOn(() =>
+                    {
+                        MarkNodeAsUnavailable(GetAddress(_config.Second));
+                        AwaitAssert(() => Assert.True(ClusterView.UnreachableMembers.Select(x => x.Address).Contains(GetAddress(_config.Second))));
+                        Cluster.Down(GetAddress(_config.Second));
+                        //removed
+                        AwaitAssert(() => Assert.False(ClusterView.Members.Select(x => x.Address).Contains(GetAddress(_config.Second))));
+                        AwaitAssert(() => Assert.False(ClusterView.UnreachableMembers.Select(x => x.Address).Contains(GetAddress(_config.Second))));
+                    }, _config.Third);
+                    EnterBarrier("second-terminated");
+                    EnterBarrier("third-terminated");
+                }, _config.Second, _config.Third, _config.Fourth);
+
+                RunOn(() =>
+                {
+                    EnterBarrier("subjected-started");
+                    EnterBarrier("watch-established");
+                    EnterBarrier("second-terminated");
+                    EnterBarrier("third-terminated");
+                }, _config.Fifth);
+
+                EnterBarrier("after-1");
+            });
+        }
+
+        /* 
+         * NOTE: it's not possible to watch a path that doesn't exist in Akka.NET
+         * REASON: in order to do this, you fist need an ActorRef. Can't get one for
+         * a path that doesn't exist at the time of creation. In Scala Akka they have to use
+         * System.ActorFor for this, which has been deprecated for a long time and has never been
+         * supported in Akka.NET.
+        */
+        //public void AnActorWatchingARemoteActorInTheClusterMustReceiveTerminatedWhenWatchedPathDoesNotExist()
+        //{
+        //    Thread.Sleep(5000);
+        //    RunOn(() =>
+        //    {
+        //        var path2 = new RootActorPath(GetAddress(_config.Second)) / "user" / "non-existing";
+        //        Sys.ActorOf(Props.Create(() => new DumbObserver(path2, TestActor)).WithDeploy(Deploy.Local), "observer3");
+        //        ExpectMsg(path2);
+        //    }, _config.First);
+
+        //    EnterBarrier("after-2");
+        //}
+
+        public void AnActorWatchingARemoteActorInTheClusterMustBeAbleToWatchActorBeforeNodeJoinsClusterAndClusterRemoteWatcherTakesOverFromRemoteWatcher()
+        {
+            Within(TimeSpan.FromSeconds(20), () =>
+            {
+                RunOn(() => Sys.ActorOf(BlackHoleActor.Props.WithDeploy(Deploy.Local), "subject5"), _config.Fifth);
                 EnterBarrier("subjected-started");
 
-                var path2 = new RootActorPath(GetAddress(_config.Second)) / "user" / "subject";
-                var path3 = new RootActorPath(GetAddress(_config.Third)) / "user" / "subject";
-                var watchEstablished = new TestLatch(Sys, 2);
+                RunOn(() =>
+                {
+                    Sys.ActorSelection(new RootActorPath(GetAddress(_config.Fifth)) / "user" / "subject5").Tell(new Identify("subject5"), TestActor);
+                    var subject5 = ExpectMsg<ActorIdentity>().Subject;
+                    Watch(subject5);
+
+                    //fifth is not a cluster member, so the watch is handled by the RemoteWatcher
+                    AwaitAssert(() =>
+                    {
+                        RemoteWatcher.Tell(Remote.RemoteWatcher.Stats.Empty);
+                        ExpectMsg<Remote.RemoteWatcher.Stats>().WatchingRefs.Contains(new Tuple<ActorRef, ActorRef>(subject5, TestActor)).ShouldBeTrue();
+                    });
+                }, _config.First);
+                EnterBarrier("remote-watch");
+
+                // second and third are already removed
+                AwaitClusterUp(_config.First, _config.Fourth, _config.Fifth);
+
+                RunOn(() =>
+                {
+                    // fifth is member, so the watch is handled by the ClusterRemoteWatcher,
+                    // and cleaned up from RemoteWatcher
+                    AwaitAssert(() =>
+                    {
+                        RemoteWatcher.Tell(Remote.RemoteWatcher.Stats.Empty);
+                        ExpectMsg<Remote.RemoteWatcher.Stats>().WatchingRefs.Select(x => x.Item1.Path.Name).Contains("subject5").ShouldBeFalse();
+                    });
+                }, _config.First);
+
+                EnterBarrier("cluster-watch");
+
+                RunOn(() =>
+                {
+                    MarkNodeAsUnavailable(GetAddress(_config.Fifth));
+                    AwaitAssert(() => ClusterView.UnreachableMembers.Select(x => x.Address).Contains(GetAddress(_config.Fifth)).ShouldBeTrue());
+                    Cluster.Down(GetAddress(_config.Fifth));
+                    // removed
+                    AwaitAssert(() => Assert.False(ClusterView.UnreachableMembers.Select(x => x.Address).Contains(GetAddress(_config.Fifth))));
+                    AwaitAssert(() => Assert.False(ClusterView.Members.Select(x => x.Address).Contains(GetAddress(_config.Fifth))));
+                }, _config.Fourth);
+
+                EnterBarrier("fifth-terminated");
+                RunOn(() =>
+                {
+                    ExpectMsg<Terminated>().ActorRef.Path.Name.ShouldBe("subject5");
+                }, _config.First);
+
+                EnterBarrier("after-3");
+            });
+
+        }
+
+        public void AnActorWatchingARemoteActorInTheClusterMustBeAbleToShutdownSystemWhenUsingRemoteDeployedActorOnNodeThatCrashed()
+        {
+            Within(TimeSpan.FromSeconds(20), () =>
+            {
+                // fourth actor system will be shutdown, not part of testConductor any more
+                // so we can't use barriers to synchronize with it
+                var firstAddress = GetAddress(_config.First);
+                RunOn(() =>
+                {
+                    Sys.ActorOf(Props.Create(() => new EndActor(TestActor, null)), "end");
+                }, _config.First);
+                EnterBarrier("end-actor-created");
+
+                RunOn(() =>
+                {
+                    var hello = Sys.ActorOf(BlackHoleActor.Props, "hello");
+                    Assert.IsType<RemoteActorRef>(hello);
+                    hello.Path.Address.ShouldBe(GetAddress(_config.First));
+                    Watch(hello);
+                    EnterBarrier("hello-deployed");
+                    MarkNodeAsUnavailable(GetAddress(_config.First));
+                    AwaitAssert(() => ClusterView.UnreachableMembers.Select(x => x.Address).Contains(GetAddress(_config.First)).ShouldBeTrue());
+                    Cluster.Down(GetAddress(_config.First));
+                    // removed
+                    AwaitAssert(() => Assert.False(ClusterView.UnreachableMembers.Select(x => x.Address).Contains(GetAddress(_config.First))));
+                    AwaitAssert(() => Assert.False(ClusterView.Members.Select(x => x.Address).Contains(GetAddress(_config.First))));
+
+                    ExpectTerminated(hello);
+                    EnterBarrier("first-unavailable");
+
+                    var timeout = RemainingOrDefault;
+                    try
+                    {
+                        Sys.AwaitTermination(timeout);
+                    }
+                    catch (TimeoutException ex)
+                    {
+                        Assert.True(false, String.Format("Failed to stop [{0}] within [{1}]", Sys.Name, timeout));
+                    }
+
+                    
+                    // signal to the first node that the fourth nodeis done
+                    var endSystem = ActorSystem.Create("EndSystem", Sys.Settings.Config);
+                    try
+                    {
+                        var endProbe = CreateTestProbe(endSystem);
+                        var endActor = endSystem.ActorOf(Props.Create(() => new EndActor(endProbe.Ref, firstAddress)),
+                            "end");
+                        endActor.Tell(EndActor.SendEnd.Instance);
+                        endProbe.ExpectMsg<EndActor.EndAck>();
+                    }
+                    finally
+                    {
+                        Shutdown(endSystem, TimeSpan.FromSeconds(10));
+                    }
+
+                    // no barrier here, because it is not part of TestConductor roles any more
+
+                }, _config.Fourth);
+
+                RunOn(() =>
+                {
+                    EnterBarrier("hello-deployed");
+                    EnterBarrier("first-unavailable");
+
+                    // don't end the test until fourth is done
+                    RunOn(() =>
+                    {
+                        // fourth system will be shutdown, remove to not participate in barriers any more
+                        TestConductor.Shutdown(_config.Fourth).Wait();
+                        ExpectMsg<EndActor.End>();
+                    }, _config.First);
+                }, _config.First, _config.Second, _config.Third, _config.Fifth);
 
             });
         }
 
-        class Observer : UntypedActor
+        /// <summary>
+        /// Used to report <see cref="Terminated"/> events to the <see cref="TestActor"/>
+        /// </summary>
+        class Observer : ReceiveActor
         {
-            readonly Address _oldLeaderAddress;
-            readonly TestLatch _latch;
+            private readonly ActorRef _testActorRef;
+            readonly TestLatch _watchEstablished;
 
-            public Observer(ActorPath path2, ActorPath path3)
+            public Observer(ActorPath path2, ActorPath path3, TestLatch watchEstablished, ActorRef testActorRef)
             {
+                _watchEstablished = watchEstablished;
+                _testActorRef = testActorRef;
+
+                Receive<ActorIdentity>(identity => identity.MessageId.Equals(path2), identity =>
+                {
+                    Context.Watch(identity.Subject);
+                    _watchEstablished.CountDown();
+                });
+
+                Receive<ActorIdentity>(identity => identity.MessageId.Equals(path3), identity =>
+                {
+                    Context.Watch(identity.Subject);
+                    _watchEstablished.CountDown();
+                });
+
+                Receive<Terminated>(terminated =>
+                {
+                    _testActorRef.Tell(terminated.ActorRef.Path);
+                });
+
                 Context.ActorSelection(path2).Tell(new Identify(path2));
                 Context.ActorSelection(path3).Tell(new Identify(path3));
+
             }
+        }
 
-            protected override void OnReceive(object message)
+        class DumbObserver : ReceiveActor
+        {
+            private readonly ActorRef _testActorRef;
+
+            public DumbObserver(ActorPath path2, ActorRef testActorRef)
             {
-                var actorIdentity = message as ActorIdentity;
-                if (actorIdentity != null)
-                {
-                    if (actorIdentity.MessageId == "path2")
-                        Context.Watch(actorIdentity.Subject);
+                _testActorRef = testActorRef;
 
-                }
-                var memberExited = message as ClusterEvent.MemberExited;
-                if (memberExited != null && memberExited.Member.Address == _oldLeaderAddress)
-                    _latch.CountDown();
+                Receive<ActorIdentity>(identity =>
+                {
+                    Context.Watch(identity.Subject);
+                });
+
+                Receive<Terminated>(terminated =>
+                {
+                    _testActorRef.Tell(terminated.ActorRef.Path);
+                });
+
+                Context.ActorSelection(path2).Tell(new Identify(path2));
             }
         }
     }

--- a/src/core/Akka.Cluster.Tests/MultiNode/MultiNodeClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MultiNode/MultiNodeClusterSpec.cs
@@ -58,48 +58,50 @@ namespace Akka.Cluster.Tests.MultiNode
             ");
         }
 
-        // sometimes we need to coordinate test shutdown with messages instead of barriers
-        sealed class SendEnd
-        {
-            private SendEnd() { }
-            private static readonly SendEnd _instance = new SendEnd();
-            public static SendEnd Instance
-            {
-                get
-                {
-                    return _instance;
-                }
-            }
-        }
-
-        sealed class End
-        {
-            private End() { }
-            private static readonly End _instance = new End();
-            public static End Instance
-            {
-                get
-                {
-                    return _instance;
-                }
-            }
-        }
-
-        sealed class EndAck
-        {
-            private EndAck() { }
-            private static readonly EndAck _instance = new EndAck();
-            public static EndAck Instance
-            {
-                get
-                {
-                    return _instance;
-                }
-            }
-        }
 
         public class EndActor : UntypedActor
         {
+
+            // sometimes we need to coordinate test shutdown with messages instead of barriers
+            public sealed class SendEnd
+            {
+                private SendEnd() { }
+                private static readonly SendEnd _instance = new SendEnd();
+                public static SendEnd Instance
+                {
+                    get
+                    {
+                        return _instance;
+                    }
+                }
+            }
+
+            public sealed class End
+            {
+                private End() { }
+                private static readonly End _instance = new End();
+                public static End Instance
+                {
+                    get
+                    {
+                        return _instance;
+                    }
+                }
+            }
+
+            public sealed class EndAck
+            {
+                private EndAck() { }
+                private static readonly EndAck _instance = new EndAck();
+                public static EndAck Instance
+                {
+                    get
+                    {
+                        return _instance;
+                    }
+                }
+            }
+
             readonly ActorRef _testActor;
             readonly Address _target;
 
@@ -237,6 +239,12 @@ namespace Akka.Cluster.Tests.MultiNode
             }
         }
 
+        /// <summary>
+        /// Initialize the cluster of the specified member nodes (<see cref="roles"/>)
+        /// and wait until all joined and <see cref="MemberStatus.Up"/>.
+        /// 
+        /// First node will be started firat and others will join the first.
+        /// </summary>
         public void AwaitClusterUp(params RoleName[] roles)
         {
             // make sure that the node-to-join is started before other join

--- a/src/core/Akka.Cluster/ClusterActorRefProvider.cs
+++ b/src/core/Akka.Cluster/ClusterActorRefProvider.cs
@@ -36,13 +36,13 @@ namespace Akka.Cluster
             Cluster.Get(system);
         }
 
-        protected override ActorRef CreateRemoteWatcher(ActorSystem system)
+        protected override ActorRef CreateRemoteWatcher(ActorSystemImpl system)
         {
             // make sure Cluster extension is initialized/loaded from init thread
             Cluster.Get(system);
 
             var failureDetector = CreateRemoteWatcherFailureDetector(system);
-            return system.ActorOf(ClusterRemoteWatcher.Props(
+            return system.SystemActorOf(ClusterRemoteWatcher.Props(
                 failureDetector,
                 RemoteSettings.WatchHeartBeatInterval,
                 RemoteSettings.WatchUnreachableReaperInterval,

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -592,7 +592,7 @@ namespace Akka.Cluster
         {
             _publisher =
                 Context.ActorOf(Props.Create<ClusterDomainEventPublisher>().WithDispatcher(Context.Props.Dispatcher), "publisher");
-            _coreDaemon = Context.ActorOf(new Props(typeof(ClusterCoreDaemon), new object[]{_publisher}).WithDispatcher(Context.Props.Dispatcher), "daemon");
+            _coreDaemon = Context.ActorOf(Props.Create(() => new ClusterCoreDaemon(_publisher)).WithDispatcher(Context.Props.Dispatcher), "daemon");
             Context.Watch(_coreDaemon);
 
             Context.Parent.Tell(new InternalClusterAction.PublisherCreated(_publisher));

--- a/src/core/Akka.NodeTestRunner/Program.cs
+++ b/src/core/Akka.NodeTestRunner/Program.cs
@@ -22,7 +22,39 @@ namespace Akka.NodeTestRunner
                 using (var sink = new Sink(nodeIndex))
                 {
                     Thread.Sleep(10000);
-                    controller.RunTests(new[] { new Xunit1TestCase(assemblyName, null, typeName, testName, displayName, null, "MultiNodeTest") }, sink, new TestFrameworkOptions());
+                    try
+                    {
+                        controller.RunTests(
+                            new[]
+                            {
+                                new Xunit1TestCase(assemblyName, null, typeName, testName, displayName, null,
+                                    "MultiNodeTest")
+                            }, sink, new TestFrameworkOptions());
+                    }
+                    catch (AggregateException ex)
+                    {
+                        var specFail = new SpecFail(nodeIndex, displayName);
+                        specFail.FailureExceptionTypes.Add(ex.GetType().ToString());
+                        specFail.FailureMessages.Add(ex.Message);
+                        specFail.FailureStackTraces.Add(ex.StackTrace);
+                        foreach (var innerEx in ex.Flatten().InnerExceptions)
+                        {
+                            specFail.FailureExceptionTypes.Add(innerEx.GetType().ToString());
+                            specFail.FailureMessages.Add(innerEx.Message);
+                            specFail.FailureStackTraces.Add(innerEx.StackTrace);
+                        }
+                        Console.WriteLine(specFail);
+                        Environment.Exit(1); //signal failure
+                    }
+                    catch (Exception ex)
+                    {
+                        var specFail = new SpecFail(nodeIndex, displayName);
+                        specFail.FailureExceptionTypes.Add(ex.GetType().ToString());
+                        specFail.FailureMessages.Add(ex.Message);
+                        specFail.FailureStackTraces.Add(ex.StackTrace);
+                        Console.WriteLine(specFail);
+                        Environment.Exit(1); //signal failure
+                    }
                     sink.Finished.WaitOne();
                     Environment.Exit(sink.Passed ? 0 : 1);
                 }

--- a/src/core/Akka.Remote.TestKit.Tests/Akka.Remote.TestKit.Tests.csproj
+++ b/src/core/Akka.Remote.TestKit.Tests/Akka.Remote.TestKit.Tests.csproj
@@ -32,9 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Helios, Version=1.3.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Helios.1.3.5.0\lib\net45\Helios.dll</HintPath>
+    <Reference Include="Helios">
+      <HintPath>..\..\packages\Helios.1.3.6.0\lib\net45\Helios.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.0.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/core/Akka.Remote.TestKit.Tests/packages.config
+++ b/src/core/Akka.Remote.TestKit.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Helios" version="1.3.5.0" targetFramework="net45" />
+  <package id="Helios" version="1.3.6.0" targetFramework="net45" />
   <package id="Microsoft.Bcl.Immutable" version="1.0.34" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/core/Akka.Remote.TestKit/Akka.Remote.TestKit.csproj
+++ b/src/core/Akka.Remote.TestKit/Akka.Remote.TestKit.csproj
@@ -40,7 +40,7 @@
   <ItemGroup>
     <Reference Include="Helios, Version=1.3.5.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Helios.1.3.5.0\lib\net45\Helios.dll</HintPath>
+      <HintPath>..\..\packages\Helios.1.3.6.0\lib\net45\Helios.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable">

--- a/src/core/Akka.Remote.TestKit/Conductor.cs
+++ b/src/core/Akka.Remote.TestKit/Conductor.cs
@@ -264,10 +264,13 @@ namespace Akka.Remote.TestKit
         public void OnDisconnect(HeliosConnectionException cause, IConnection closedChannel)
         {
             _log.Debug("disconnect from {0}", closedChannel.RemoteHost);
-            var fsm = _clients[closedChannel];
-            fsm.Tell(new Controller.ClientDisconnected(new RoleName(null)));
-            ActorRef removedActor;
-            _clients.TryRemove(closedChannel, out removedActor);
+            ActorRef fsm;
+            if (_clients.TryGetValue(closedChannel, out fsm))
+            {
+                fsm.Tell(new Controller.ClientDisconnected(new RoleName(null)));
+                ActorRef removedActor;
+                _clients.TryRemove(closedChannel, out removedActor);
+            }
         }
 
         public void OnMessage(object message, IConnection responseChannel)

--- a/src/core/Akka.Remote.TestKit/Player.cs
+++ b/src/core/Akka.Remote.TestKit/Player.cs
@@ -515,6 +515,7 @@ namespace Akka.Remote.TestKit
         readonly ActorRef _fsm;
         readonly LoggingAdapter _log;
         readonly Scheduler _scheduler;
+        private bool _loggedDisconnect = false;
         
         Deadline _nextAttempt;
         
@@ -558,7 +559,12 @@ namespace Akka.Remote.TestKit
 
         public void OnDisconnect(HeliosConnectionException cause, IConnection closedChannel)
         {
-            _log.Debug("disconnected from {0}", closedChannel.RemoteHost);
+            if (!_loggedDisconnect) //added this to help mute log messages
+            {
+                _loggedDisconnect = true;
+                _log.Debug("disconnected from {0}", closedChannel.RemoteHost);
+                
+            }
             _fsm.Tell(PoisonPill.Instance);
             //TODO: Some logic here in JVM version to execute this on a different pool to the Netty IO pool
             RemoteConnection.Shutdown(closedChannel);

--- a/src/core/Akka.Remote.TestKit/packages.config
+++ b/src/core/Akka.Remote.TestKit/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Google.ProtocolBuffers" version="2.4.1.521" targetFramework="net45" />
-  <package id="Helios" version="1.3.5.0" targetFramework="net45" />
+  <package id="Helios" version="1.3.6.0" targetFramework="net45" />
   <package id="Microsoft.Bcl.Immutable" version="1.0.34" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net45" />
 </packages>

--- a/src/core/Akka.Remote/Akka.Remote.csproj
+++ b/src/core/Akka.Remote/Akka.Remote.csproj
@@ -59,7 +59,7 @@
     </Reference>
     <Reference Include="Helios, Version=1.3.5.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Helios.1.3.5.0\lib\net45\Helios.dll</HintPath>
+      <HintPath>..\..\packages\Helios.1.3.6.0\lib\net45\Helios.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -103,17 +103,15 @@ namespace Akka.Remote
             _remoteWatcher = CreateRemoteWatcher(system);
         }
 
-        protected virtual ActorRef CreateRemoteWatcher(ActorSystem system)
+        protected virtual ActorRef CreateRemoteWatcher(ActorSystemImpl system)
         {
             var failureDetector = CreateRemoteWatcherFailureDetector(system);
-            return
-                system.ActorOf(
-                    RemoteSettings.ConfigureDispatcher(
-                        RemoteWatcher.Props(
-                            failureDetector,
-                            RemoteSettings.WatchHeartBeatInterval,
-                            RemoteSettings.WatchUnreachableReaperInterval,
-                            RemoteSettings.WatchHeartbeatExpectedResponseAfter)), "remote-watcher");
+            return system.SystemActorOf(RemoteSettings.ConfigureDispatcher(
+                RemoteWatcher.Props(
+                    failureDetector,
+                    RemoteSettings.WatchHeartBeatInterval,
+                    RemoteSettings.WatchUnreachableReaperInterval,
+                    RemoteSettings.WatchHeartbeatExpectedResponseAfter)), "remote-watcher");
         }
 
         protected DefaultFailureDetectorRegistry<Address> CreateRemoteWatcherFailureDetector(ActorSystem system)

--- a/src/core/Akka.Remote/Remoting.cs
+++ b/src/core/Akka.Remote/Remoting.cs
@@ -26,6 +26,15 @@ namespace Akka.Remote
         }
     }
 
+    //TODO: needs to be implemented in Endpoint
+    /// <summary>
+    /// INTERNAL API
+    /// Messages marked with this interface will be sent before other messages when buffering is active.
+    /// This means that these messages don't obey normal message ordering.
+    /// It is used for failure detector heartbeat messages.
+    /// </summary>
+    internal interface IPriorityMessage { }
+
     /// <summary>
     /// INTERNAL API
     /// </summary>

--- a/src/core/Akka.Remote/packages.config
+++ b/src/core/Akka.Remote/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Google.ProtocolBuffers" version="2.4.1.521" targetFramework="net45" />
-  <package id="Helios" version="1.3.5.0" targetFramework="net45" />
+  <package id="Helios" version="1.3.6.0" targetFramework="net45" />
 </packages>

--- a/src/core/Akka.TestKit/TestLatch.cs
+++ b/src/core/Akka.TestKit/TestLatch.cs
@@ -54,6 +54,14 @@ namespace Akka.TestKit
                 string.Format("Timeout of {0}", atMost));
         }
 
+        /// <summary>
+        /// Uses the <see cref="DefaultTimeout"/>
+        /// </summary>
+        public void Ready()
+        {
+            Ready(DefaultTimeout);
+        }
+
         public void Result(TimeSpan atMost)
         {
             Ready(atMost);

--- a/src/examples/FSharp.Deploy.Local/App.config
+++ b/src/examples/FSharp.Deploy.Local/App.config
@@ -1,6 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/src/examples/FSharp.Deploy.Remote/App.config
+++ b/src/examples/FSharp.Deploy.Remote/App.config
@@ -1,6 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/src/examples/TimeServer/TimeClient/TimeClient.csproj
+++ b/src/examples/TimeServer/TimeClient/TimeClient.csproj
@@ -34,9 +34,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Helios, Version=1.3.5.1, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Helios.1.3.5.0\lib\net45\Helios.dll</HintPath>
+    <Reference Include="Helios">
+      <HintPath>..\..\..\packages\Helios.1.3.6.0\lib\net45\Helios.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/examples/TimeServer/TimeClient/packages.config
+++ b/src/examples/TimeServer/TimeClient/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Helios" version="1.3.5.0" targetFramework="net45" />
+  <package id="Helios" version="1.3.6.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
close #602 

`ClusterRemoteWatcher` is now fully covered per the original `ClusterDeathWatchSpec`.

Unearthed some bugs as part of this unit test and fixed them accordingly:
* Found a race condition that resulted in unhandled errors within Helios during periods of rapid successive calls to `Disconnect`. Pushed a new version of Helios, v1.3.6, with fixes for this and referenced it throughout Akka.NET.
* `RemoteWatcher` was incorrectly deployed under the `/user/` actor hierarchy. It now lives happily under `/system/`
* `AddressTerminated` did not correctly fire within `RemoteWatcher`
* Fixed a couple sources of exceptions within `Conductor` inside the Akka.Remote.TestKit
* Added some equality members and implicit case operators to `ActorPath.Surrogate` so it can be used inside `ReceiveActor.Receive<>` predicates that expect an ActorPath.

This is one of the more important multi-node tests because cluster deployment is pretty useless without reliable deathwatch, so that this passes makes me feel pretty optimistic about the state of the plumbing inside Akka.Cluster. Many more `MultiNodeSpec`s yet to go though.