### PR TITLE
Akka.NET v0.8 Stable Release (dev)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,157 @@
+#### 0.8.0 Feb 11 2015
+
+__Dependency Injection support for Ninject, Castle Windsor, and AutoFac__. Thanks to some amazing effort from individual contributor (**[@jcwrequests](https://github.com/jcwrequests "@jcwrequests")**), Akka.NET now has direct dependency injection support for [Ninject](http://www.ninject.org/), [Castle Windsor](http://docs.castleproject.org/Default.aspx?Page=MainPage&NS=Windsor&AspxAutoDetectCookieSupport=1), and [AutoFac](https://github.com/autofac/Autofac).
+
+Here's an example using Ninject, for instance:
+
+    // Create and build your container 
+    var container = new Ninject.StandardKernel(); 
+	container.Bind().To(typeof(TypedWorker)); 
+	container.Bind().To(typeof(WorkerService));
+    
+    // Create the ActorSystem and Dependency Resolver 
+	var system = ActorSystem.Create("MySystem"); 
+	var propsResolver = new NinjectDependencyResolver(container,system);
+
+	//Create some actors who need Ninject
+	var worker1 = system.ActorOf(propsResolver.Create<TypedWorker>(), "Worker1");
+	var worker2 = system.ActorOf(propsResolver.Create<TypedWorker>(), "Worker2");
+
+	//send them messages
+	worker1.Tell("hi!");
+
+You can install these DI plugins for Akka.NET via NuGet - here's how:
+
+* **Ninject** - `install-package Akka.DI.Ninject`
+* **Castle Windsor** - `install-package Akka.DI.CastleWindsor`
+* **AutoFac** - `install-package Akka.DI.AutoFac`
+
+**Read the [full Dependency Injection with Akka.NET documentation](http://getakka.net/wiki/Dependency%20injection "Dependency Injection with Akka.NET") here.**
+
+__Persistent Actors with Akka.Persistence (Alpha)__. Core contributor **[@Horusiath](https://github.com/Horusiath)** ported the majority of Akka's Akka.Persistence and Akka.Persistence.TestKit modules. 
+
+> Even in the core Akka project these modules are considered to be "experimental," but the goal is to provide actors with a way of automatically saving and recovering their internal state to a configurable durable store - such as a database or filesystem.
+
+Akka.Persistence also introduces the notion of *reliable delivery* of messages, achieved through the `GuaranteedDeliveryActor`.
+
+Akka.Persistence also ships with an FSharp API out of the box, so while this package is in beta you can start playing with it either F# or C# from day one.
+
+If you want to play with Akka.Persistence, please install any one of the following packages:
+
+* **Akka.Persistence** - `install-package Akka.Persistence -pre`
+* **Akka.Persistence.FSharp** - `install-package Akka.Persistence.FSharp -pre`
+* **Akka.Persistence.TestKit** - `install-package Akka.Persistence.TestKit -pre`
+
+**Read the [full Persistent Actors with Akka.NET documentation](http://getakka.net/wiki/Persistence "Persistent Actors with Akka.NET") here.**
+
+__Remote Deployment of Routers and Routees__. You can now remotely deploy routers and routees via configuration, like so:
+
+**Deploying _routees_ remotely via `Config`**:
+
+	actor.deployment {
+	    /blub {
+	      router = round-robin-pool
+	      nr-of-instances = 2
+	      target.nodes = [""akka.tcp://${sysName}@localhost:${port}""]
+	    }
+	}
+
+	var router = masterActorSystem.ActorOf(new RoundRobinPool(2).Props(Props.Create<Echo>()), "blub");
+
+When deploying a router via configuration, just specify the `target.nodes` property with a list of `Address` instances for each node you want to deploy your routees.
+
+> NOTE: Remote deployment of routees only works for `Pool` routers.
+
+**Deploying _routers_ remotely via `Config`**:
+
+	actor.deployment {
+	    /blub {
+	      router = round-robin-pool
+	      nr-of-instances = 2
+	      remote = ""akka.tcp://${sysName}@localhost:${port}""
+	    }
+	}
+
+	var router = masterActorSystem.ActorOf(Props.Create<Echo>().WithRouter(FromConfig.Instance), "blub");
+
+Works just like remote deployment of actors.
+
+If you want to deploy a router remotely via explicit configuration, you can do it in code like this via the `RemoteScope` and `RemoteRouterConfig`:
+
+**Deploying _routees_ remotely via explicit configuration**:
+
+    var intendedRemoteAddress = Address.Parse("akka.tcp://${sysName}@localhost:${port}"
+    .Replace("${sysName}", sysName)
+    .Replace("${port}", port.ToString()));
+    
+     var router = myActorSystem.ActorOf(new RoundRobinPool(2).Props(Props.Create<Echo>())
+    .WithDeploy(new Deploy(
+		new RemoteScope(intendedRemoteAddress.Copy()))), "myRemoteRouter");
+
+**Deploying _routers_ remotely via explicit configuration**:
+
+    var intendedRemoteAddress = Address.Parse("akka.tcp://${sysName}@localhost:${port}"
+    .Replace("${sysName}", sysName)
+    .Replace("${port}", port.ToString()));
+    
+     var router = myActorSystem.ActorOf(
+		new RemoteRouterConfig(
+		new RoundRobinPool(2), new[] { new Address("akka.tcp", sysName, "localhost", port) })
+        .Props(Props.Create<Echo>()), "blub2");
+
+**Improved Serialization and Remote Deployment Support**. All internals related to serialization and remote deployment have undergone vast improvements in order to support the other work that went into this release.
+
+**Pluggable Actor Creation Pipeline**. We reworked the plumbing that's used to provide automatic `Stash` support and exposed it as a pluggable actor creation pipeline for local actors.
+
+This release adds the `ActorProducerPipeline`, which is accessible from `ExtendedActorSystem` (to be able to configure by plugins) and allows you to inject custom hooks satisfying following interface:
+
+
+    interface IActorProducerPlugin {
+	    bool CanBeAppliedTo(ActorBase actor);
+	    void AfterActorCreated(ActorBase actor, IActorContext context);
+	    void BeforeActorTerminated(ActorBase actor, IActorContext context);
+    }
+
+- **CanBeAppliedTo** determines if plugin can be applied to specific actor instance.
+- **AfterActorCreated** is applied to actor after it has been instantiated by an `ActorCell` and before `InitializableActor.Init` method will (optionally) be invoked.
+- **BeforeActorTerminated** is applied before actor terminates and before `IDisposable.Dispose` method will be invoked (for disposable actors) - **auto handling disposable actors is second feature of this commit**.
+
+For common use it's better to create custom classes inheriting from `ActorProducerPluginBase` and `ActorProducerPluginBase<TActor>` classes.
+
+Pipeline itself provides following interface:
+
+    class ActorProducerPipeline : IEnumerable<IActorProducerPlugin> {
+	    int Count { get; } // current plugins count - 1 by default (ActorStashPlugin)
+	    bool Register(IActorProducerPlugin plugin)
+	    bool Unregister(IActorProducerPlugin plugin)
+	    bool IsRegistered(IActorProducerPlugin plugin)
+	    bool Insert(int index, IActorProducerPlugin plugin)
+    }
+
+- **Register** - registers a plugin if no other plugin of the same type has been registered already (plugins with generic types are counted separately). Returns true if plugin has been registered.
+- **Insert** - same as register, but plugin will be placed in specific place inside the pipeline - useful if any plugins precedence is required.
+- **Unregister** - unregisters specified plugin if it has been found. Returns true if plugin was found and unregistered.
+- **IsRegistered** - checks if plugin has been already registered.
+
+By default pipeline is filled with one already used plugin - `ActorStashPlugin`, which replaces stash initialization/unstashing mechanism used up to this moment.
+
+**MultiNodeTestRunner and Akka.Remote.TestKit**. The MultiNodeTestRunner and the Multi Node TestKit (Akka.Remote.TestKit) underwent some drastic changes in this update. They're still not quite ready for public use yet, but if you want to see what the experience is like you can [clone the Akka.NET Github repository](https://github.com/akkadotnet/akka.net) and run the following command:
+
+````
+C:\akkadotnet> .\build.cmd MultiNodeTests
+````
+
+This will automatically launch all `MultiNodeSpec` instances found inside `Akka.Cluster.Tests`. We'll need to make this more flexible to be able to run other assemblies that require multinode tests in the future.
+
+These tests are not enabled by default in normal build runs, but they will at some point in the future.
+
+Here's a sample of the output from the console, to give you a sense of what the reporting looks like:
+
+![image](https://cloud.githubusercontent.com/assets/326939/6075685/5f7c56b2-ad8c-11e4-9d93-8216a8cbabaf.png)
+
+The MultiNodeTestRunner uses XUnit internally and will dynamically deploy as many processes are needed to satisfy any individual test. Has been tested with up to 6 processes.
+
+
 #### 0.7.1 Dec 13 2014
 __Brand New F# API__. The entire F# API has been updated to give it a more native F# feel while still holding true to the Erlang / Scala conventions used in actor systems. [Read more about the F# API changes](https://github.com/akkadotnet/akka.net/pull/526).
 

--- a/build.fsx
+++ b/build.fsx
@@ -19,7 +19,7 @@ cd __SOURCE_DIRECTORY__
 
 let product = "Akka.NET"
 let authors = [ "Akka.NET Team" ]
-let copyright = "Copyright © 2013-2014 Akka.NET Team"
+let copyright = "Copyright © 2013-2015 Akka.NET Team"
 let company = "Akka.NET Team"
 let description = "Akka.NET is a port of the popular Java/Scala framework Akka to .NET"
 let tags = ["akka";"actors";"actor";"model";"Akka";"concurrency"]
@@ -124,9 +124,16 @@ Target "CopyOutput" <| fun _ ->
       "core/Akka.Remote.TestKit"
       "core/Akka.Cluster"
       "core/Akka.MultiNodeTestRunner"
+      "core/Akka.Persistence"
+      "core/Akka.Persistence.FSharp"
+      "core/Akka.Persistence.TestKit"
       "contrib/loggers/Akka.Logger.slf4net"
       "contrib/loggers/Akka.Logger.NLog" 
       "contrib/loggers/Akka.Logger.Serilog" 
+      "contrib/dependencyinjection/Akka.DI.Core"
+      "contrib/dependencyinjection/Akka.DI.AutoFac"
+      "contrib/dependencyinjection/Akka.DI.CastleWindsor"
+      "contrib/dependencyinjection/Akka.DI.Ninject"
       "contrib/testkits/Akka.TestKit.Xunit" 
       ]
     |> List.iter copyOutput
@@ -195,6 +202,9 @@ module Nuget =
         match project with
         | "Akka" -> []
         | "Akka.Cluster" -> ["Akka.Remote", release.NugetVersion]
+        | "Akka.Persistence.TestKit" -> ["Akka.Persistence", preReleaseVersion]
+        | "Akka.Persistence.FSharp" -> ["Akka.Persistence", preReleaseVersion]
+        | di when (di.StartsWith("Akka.DI.") && not (di.EndsWith("Core"))) -> ["Akka.DI.Core", release.NugetVersion]
         | testkit when testkit.StartsWith("Akka.TestKit.") -> ["Akka.TestKit", release.NugetVersion]
         | _ -> ["Akka", release.NugetVersion]
 
@@ -202,6 +212,7 @@ module Nuget =
     let getProjectVersion project =
       match project with
       | "Akka.Cluster" -> preReleaseVersion
+      | persistence when persistence.StartsWith("Akka.Persistence") -> preReleaseVersion
       | _ -> release.NugetVersion
 
 open Nuget

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -2,7 +2,7 @@
 using System.Reflection;
 
 [assembly: AssemblyCompanyAttribute("Akka.NET Team")]
-[assembly: AssemblyCopyrightAttribute("Copyright © 2013-2014 Akka.NET Team")]
+[assembly: AssemblyCopyrightAttribute("Copyright © 2013-2015 Akka.NET Team")]
 [assembly: AssemblyTrademarkAttribute("")]
-[assembly: AssemblyVersionAttribute("0.7.1.0")]
-[assembly: AssemblyFileVersionAttribute("0.7.1.0")]
+[assembly: AssemblyVersionAttribute("0.8.0.0")]
+[assembly: AssemblyFileVersionAttribute("0.8.0.0")]

--- a/src/contrib/dependencyInjection/Akka.DI.AutoFac/Akka.DI.AutoFac.csproj
+++ b/src/contrib/dependencyInjection/Akka.DI.AutoFac/Akka.DI.AutoFac.csproj
@@ -47,6 +47,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="AutoFacDependencyResolver.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -61,6 +64,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="Akka.DI.AutoFac.nuspec" />
     <None Include="packages.config" />
     <None Include="Readme.md" />
   </ItemGroup>

--- a/src/contrib/dependencyInjection/Akka.DI.AutoFac/Akka.DI.AutoFac.nuspec
+++ b/src/contrib/dependencyInjection/Akka.DI.AutoFac/Akka.DI.AutoFac.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <id>@project@</id>
+    <title>@project@@title@</title>
+    <version>@build.number@</version>
+    <authors>@authors@</authors>
+    <owners>@authors@</owners>
+    <description>AutoFac Dependency Injection (DI) support for Akka.NET</description>
+    <licenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/akkadotnet/akka.net</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon-32x32.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes>@releaseNotes@</releaseNotes>
+    <copyright>@copyright@</copyright>
+    <tags>@tags@ DI AutoFac</tags>
+    @dependencies@
+    @references@
+  </metadata>
+</package>

--- a/src/contrib/dependencyInjection/Akka.DI.AutoFac/Properties/AssemblyInfo.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.AutoFac/Properties/AssemblyInfo.cs
@@ -8,10 +8,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Akka.DI.AutoFac")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Akka.DI.AutoFac")]
-[assembly: AssemblyCopyright("Copyright ©  2014")]
-[assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -21,16 +18,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("c93451c6-5471-4ce7-8459-aeeb82835ab1")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/contrib/dependencyInjection/Akka.DI.CastleWindsor/Akka.DI.CastleWindsor.csproj
+++ b/src/contrib/dependencyInjection/Akka.DI.CastleWindsor/Akka.DI.CastleWindsor.csproj
@@ -50,6 +50,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="WindsorDependencyResolver.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -64,6 +67,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="Akka.DI.CastleWindsor.nuspec" />
     <None Include="packages.config" />
     <None Include="Readme.md" />
   </ItemGroup>

--- a/src/contrib/dependencyInjection/Akka.DI.CastleWindsor/Akka.DI.CastleWindsor.nuspec
+++ b/src/contrib/dependencyInjection/Akka.DI.CastleWindsor/Akka.DI.CastleWindsor.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <id>@project@</id>
+    <title>@project@@title@</title>
+    <version>@build.number@</version>
+    <authors>@authors@</authors>
+    <owners>@authors@</owners>
+    <description>CastleWindsor Dependency Injection (DI) support for Akka.NET</description>
+    <licenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/akkadotnet/akka.net</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon-32x32.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes>@releaseNotes@</releaseNotes>
+    <copyright>@copyright@</copyright>
+    <tags>@tags@ DI CastleWindsor</tags>
+    @dependencies@
+    @references@
+  </metadata>
+</package>

--- a/src/contrib/dependencyInjection/Akka.DI.CastleWindsor/Properties/AssemblyInfo.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.CastleWindsor/Properties/AssemblyInfo.cs
@@ -8,10 +8,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Akka.DI.CastleWindsor")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Akka.DI.CastleWindsor")]
-[assembly: AssemblyCopyright("Copyright ©  2014")]
-[assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -21,16 +18,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("d162ecd4-6360-4df6-8832-cba665a1f02b")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/contrib/dependencyInjection/Akka.DI.Core/Akka.DI.Core.csproj
+++ b/src/contrib/dependencyInjection/Akka.DI.Core/Akka.DI.Core.csproj
@@ -42,6 +42,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="DIActorProducer.cs" />
     <Compile Include="DIExt.cs" />
     <Compile Include="DIExtension.cs" />
@@ -56,6 +59,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="Akka.DI.Core.nuspec" />
     <None Include="Readme.md" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/contrib/dependencyInjection/Akka.DI.Core/Akka.DI.Core.nuspec
+++ b/src/contrib/dependencyInjection/Akka.DI.Core/Akka.DI.Core.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <id>@project@</id>
+    <title>@project@@title@</title>
+    <version>@build.number@</version>
+    <authors>@authors@</authors>
+    <owners>@authors@</owners>
+    <description>Dependency injection support for Akka.NET</description>
+    <licenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/akkadotnet/akka.net</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon-32x32.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes>@releaseNotes@</releaseNotes>
+    <copyright>@copyright@</copyright>
+    <tags>@tags@ DI Ninject Autofac CastleWindsor</tags>
+    @dependencies@
+    @references@
+  </metadata>
+</package>

--- a/src/contrib/dependencyInjection/Akka.DI.Core/Properties/AssemblyInfo.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.Core/Properties/AssemblyInfo.cs
@@ -8,10 +8,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Akka.DI.Core")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Akka.DI.Core")]
-[assembly: AssemblyCopyright("Copyright ©  2014")]
-[assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -21,16 +18,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("58efce02-ae94-4ce2-a9b0-1b2fda47f203")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/contrib/dependencyInjection/Akka.DI.Ninject/Akka.DI.Ninject.csproj
+++ b/src/contrib/dependencyInjection/Akka.DI.Ninject/Akka.DI.Ninject.csproj
@@ -47,6 +47,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="NinjectDependencyResolver.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -61,6 +64,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="Akka.DI.Ninject.nuspec" />
     <None Include="packages.config" />
     <None Include="Readme.md" />
   </ItemGroup>

--- a/src/contrib/dependencyInjection/Akka.DI.Ninject/Akka.DI.Ninject.nuspec
+++ b/src/contrib/dependencyInjection/Akka.DI.Ninject/Akka.DI.Ninject.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <id>@project@</id>
+    <title>@project@@title@</title>
+    <version>@build.number@</version>
+    <authors>@authors@</authors>
+    <owners>@authors@</owners>
+    <description>Ninject Dependency Injection (DI) support for Akka.NET</description>
+    <licenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/akkadotnet/akka.net</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon-32x32.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes>@releaseNotes@</releaseNotes>
+    <copyright>@copyright@</copyright>
+    <tags>@tags@ DI Ninject</tags>
+    @dependencies@
+    @references@
+  </metadata>
+</package>

--- a/src/contrib/dependencyInjection/Akka.DI.Ninject/Properties/AssemblyInfo.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.Ninject/Properties/AssemblyInfo.cs
@@ -8,10 +8,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Akka.DI.Ninject")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Akka.DI.Ninject")]
-[assembly: AssemblyCopyright("Copyright ©  2014")]
-[assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -21,16 +18,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e8ad7ddb-58d4-4db4-8696-cfadea8a49ca")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/core/Akka.FSharp/Properties/AssemblyInfo.fs
+++ b/src/core/Akka.FSharp/Properties/AssemblyInfo.fs
@@ -6,13 +6,13 @@ open System.Runtime.InteropServices
 [<assembly: AssemblyTitleAttribute("Akka.FSharp")>]
 [<assembly: AssemblyProductAttribute("Akka.NET")>]
 [<assembly: AssemblyDescriptionAttribute("Akka.NET is a port of the popular Java/Scala framework Akka to .NET")>]
-[<assembly: AssemblyCopyrightAttribute("Copyright © 2013-2014 Akka.NET Team")>]
+[<assembly: AssemblyCopyrightAttribute("Copyright © 2013-2015 Akka.NET Team")>]
 [<assembly: AssemblyCompanyAttribute("Akka.NET Team")>]
 [<assembly: ComVisibleAttribute(false)>]
 [<assembly: CLSCompliantAttribute(true)>]
-[<assembly: AssemblyVersionAttribute("0.7.1.0")>]
-[<assembly: AssemblyFileVersionAttribute("0.7.1.0")>]
+[<assembly: AssemblyVersionAttribute("0.8.0.0")>]
+[<assembly: AssemblyFileVersionAttribute("0.8.0.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "0.7.1.0"
+    let [<Literal>] Version = "0.8.0.0"

--- a/src/core/Akka.Persistence.FSharp/Akka.Persistence.FSharp.fsproj
+++ b/src/core/Akka.Persistence.FSharp/Akka.Persistence.FSharp.fsproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <Compile Include="FsApi.fs" />
     <None Include="Script.fsx" />
+    <None Include="Akka.Persistence.FSharp.nuspec" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Akka.FSharp\Akka.FSharp.fsproj">

--- a/src/core/Akka.Persistence.FSharp/Akka.Persistence.FSharp.nuspec
+++ b/src/core/Akka.Persistence.FSharp/Akka.Persistence.FSharp.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <id>@project@</id>
+    <title>@project@@title@</title>
+    <version>@build.number@</version>
+    <authors>@authors@</authors>
+    <owners>@authors@</owners>
+    <description>F# API for persistence actors in Akka.NET</description>
+    <licenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/akkadotnet/akka.net</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon-32x32.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes>@releaseNotes@</releaseNotes>
+    <copyright>@copyright@</copyright>
+    <tags>@tags@ F# FSharp persistence eventsource</tags>
+    @dependencies@
+    @references@
+  </metadata>
+</package>

--- a/src/core/Akka.Persistence.TestKit/Akka.Persistence.TestKit.csproj
+++ b/src/core/Akka.Persistence.TestKit/Akka.Persistence.TestKit.csproj
@@ -45,6 +45,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Journal\JournalSpec.cs" />
     <Compile Include="PluginSpec.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -69,6 +72,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="Akka.Persistence.TestKit.nuspec" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/core/Akka.Persistence.TestKit/Akka.Persistence.TestKit.nuspec
+++ b/src/core/Akka.Persistence.TestKit/Akka.Persistence.TestKit.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <id>@project@</id>
+    <title>@project@@title@</title>
+    <version>@build.number@</version>
+    <authors>@authors@</authors>
+    <owners>@authors@</owners>
+    <description>Testkit for Persistence actor support for Akka.NET</description>
+    <licenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/akkadotnet/akka.net</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon-32x32.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes>@releaseNotes@</releaseNotes>
+    <copyright>@copyright@</copyright>
+    <tags>@tags@ persistence eventsource teskit</tags>
+    @dependencies@
+    @references@
+  </metadata>
+</package>

--- a/src/core/Akka.Persistence.TestKit/Properties/AssemblyInfo.cs
+++ b/src/core/Akka.Persistence.TestKit/Properties/AssemblyInfo.cs
@@ -8,10 +8,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Akka.Persistence.TestKit")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Akka.Persistence.TestKit")]
-[assembly: AssemblyCopyright("Copyright ©  2014")]
-[assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -21,16 +18,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("f850ec56-04f4-4212-960d-2300210aca57")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/core/Akka.Persistence/Akka.Persistence.csproj
+++ b/src/core/Akka.Persistence/Akka.Persistence.csproj
@@ -52,6 +52,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Eventsourced.Lifecycle.cs" />
     <Compile Include="GuaranteedDelivery.cs" />
     <Compile Include="Eventsourced.cs" />
@@ -86,6 +89,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="Akka.Persistence.nuspec" />
     <None Include="packages.config" />
     <EmbeddedResource Include="persistence.conf" />
     <None Include="README.md" />

--- a/src/core/Akka.Persistence/Akka.Persistence.nuspec
+++ b/src/core/Akka.Persistence/Akka.Persistence.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <id>@project@</id>
+    <title>@project@@title@</title>
+    <version>@build.number@</version>
+    <authors>@authors@</authors>
+    <owners>@authors@</owners>
+    <description>Persistence actor support for Akka.NET</description>
+    <licenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/akkadotnet/akka.net</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon-32x32.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes>@releaseNotes@</releaseNotes>
+    <copyright>@copyright@</copyright>
+    <tags>@tags@ persistence eventsource</tags>
+    @dependencies@
+    @references@
+  </metadata>
+</package>

--- a/src/core/Akka.Persistence/Properties/AssemblyInfo.cs
+++ b/src/core/Akka.Persistence/Properties/AssemblyInfo.cs
@@ -8,10 +8,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Akka.PersistenceExtension")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Akka.PersistenceExtension")]
-[assembly: AssemblyCopyright("Copyright ©  2014")]
-[assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -21,16 +18,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e3bcba88-003c-4cda-8a60-f0c2553fe3c8")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/core/Akka/Actor/Props.cs
+++ b/src/core/Akka/Actor/Props.cs
@@ -44,7 +44,7 @@ namespace Akka.Actor
 
         private bool CompareSupervisorStrategy(Props other)
         {
-            return true;
+            return true; //TODO: fix https://github.com/akkadotnet/akka.net/issues/599
             return Equals(SupervisorStrategy, other.SupervisorStrategy);
         }
 


### PR DESCRIPTION
#### 0.8.0 Feb 11 2015

__Dependency Injection support for Ninject, Castle Windsor, and AutoFac__. Thanks to some amazing effort from individual contributor (**[@jcwrequests](https://github.com/jcwrequests "@jcwrequests")**), Akka.NET now has direct dependency injection support for [Ninject](http://www.ninject.org/), [Castle Windsor](http://docs.castleproject.org/Default.aspx?Page=MainPage&NS=Windsor&AspxAutoDetectCookieSupport=1), and [AutoFac](https://github.com/autofac/Autofac).

Here's an example using Ninject, for instance:

    // Create and build your container 
    var container = new Ninject.StandardKernel(); 
	container.Bind().To(typeof(TypedWorker)); 
	container.Bind().To(typeof(WorkerService));
    
    // Create the ActorSystem and Dependency Resolver 
	var system = ActorSystem.Create("MySystem"); 
	var propsResolver = new NinjectDependencyResolver(container,system);

	//Create some actors who need Ninject
	var worker1 = system.ActorOf(propsResolver.Create<TypedWorker>(), "Worker1");
	var worker2 = system.ActorOf(propsResolver.Create<TypedWorker>(), "Worker2");

	//send them messages
	worker1.Tell("hi!");

You can install these DI plugins for Akka.NET via NuGet - here's how:

* **Ninject** - `install-package Akka.DI.Ninject`
* **Castle Windsor** - `install-package Akka.DI.CastleWindsor`
* **AutoFac** - `install-package Akka.DI.AutoFac`

**Read the [full Dependency Injection with Akka.NET documentation](http://getakka.net/wiki/Dependency%20injection "Dependency Injection with Akka.NET") here.**

__Persistent Actors with Akka.Persistence (Alpha)__. Core contributor **[@Horusiath](https://github.com/Horusiath)** ported the majority of Akka's Akka.Persistence and Akka.Persistence.TestKit modules. 

> Even in the core Akka project these modules are considered to be "experimental," but the goal is to provide actors with a way of automatically saving and recovering their internal state to a configurable durable store - such as a database or filesystem.

Akka.Persistence also introduces the notion of *reliable delivery* of messages, achieved through the `GuaranteedDeliveryActor`.

Akka.Persistence also ships with an FSharp API out of the box, so while this package is in beta you can start playing with it either F# or C# from day one.

If you want to play with Akka.Persistence, please install any one of the following packages:

* **Akka.Persistence** - `install-package Akka.Persistence -pre`
* **Akka.Persistence.FSharp** - `install-package Akka.Persistence.FSharp -pre`
* **Akka.Persistence.TestKit** - `install-package Akka.Persistence.TestKit -pre`

**Read the [full Persistent Actors with Akka.NET documentation](http://getakka.net/wiki/Persistence "Persistent Actors with Akka.NET") here.**

__Remote Deployment of Routers and Routees__. You can now remotely deploy routers and routees via configuration, like so:

**Deploying _routees_ remotely via `Config`**:

	actor.deployment {
	    /blub {
	      router = round-robin-pool
	      nr-of-instances = 2
	      target.nodes = [""akka.tcp://${sysName}@localhost:${port}""]
	    }
	}

	var router = masterActorSystem.ActorOf(new RoundRobinPool(2).Props(Props.Create<Echo>()), "blub");

When deploying a router via configuration, just specify the `target.nodes` property with a list of `Address` instances for each node you want to deploy your routees.

> NOTE: Remote deployment of routees only works for `Pool` routers.

**Deploying _routers_ remotely via `Config`**:

	actor.deployment {
	    /blub {
	      router = round-robin-pool
	      nr-of-instances = 2
	      remote = ""akka.tcp://${sysName}@localhost:${port}""
	    }
	}

	var router = masterActorSystem.ActorOf(Props.Create<Echo>().WithRouter(FromConfig.Instance), "blub");

Works just like remote deployment of actors.

If you want to deploy a router remotely via explicit configuration, you can do it in code like this via the `RemoteScope` and `RemoteRouterConfig`:

**Deploying _routees_ remotely via explicit configuration**:

    var intendedRemoteAddress = Address.Parse("akka.tcp://${sysName}@localhost:${port}"
    .Replace("${sysName}", sysName)
    .Replace("${port}", port.ToString()));
    
     var router = myActorSystem.ActorOf(new RoundRobinPool(2).Props(Props.Create<Echo>())
    .WithDeploy(new Deploy(
		new RemoteScope(intendedRemoteAddress.Copy()))), "myRemoteRouter");

**Deploying _routers_ remotely via explicit configuration**:

    var intendedRemoteAddress = Address.Parse("akka.tcp://${sysName}@localhost:${port}"
    .Replace("${sysName}", sysName)
    .Replace("${port}", port.ToString()));
    
     var router = myActorSystem.ActorOf(
		new RemoteRouterConfig(
		new RoundRobinPool(2), new[] { new Address("akka.tcp", sysName, "localhost", port) })
        .Props(Props.Create<Echo>()), "blub2");

**Improved Serialization and Remote Deployment Support**. All internals related to serialization and remote deployment have undergone vast improvements in order to support the other work that went into this release.

**Pluggable Actor Creation Pipeline**. We reworked the plumbing that's used to provide automatic `Stash` support and exposed it as a pluggable actor creation pipeline for local actors.

This release adds the `ActorProducerPipeline`, which is accessible from `ExtendedActorSystem` (to be able to configure by plugins) and allows you to inject custom hooks satisfying following interface:


    interface IActorProducerPlugin {
	    bool CanBeAppliedTo(ActorBase actor);
	    void AfterActorCreated(ActorBase actor, IActorContext context);
	    void BeforeActorTerminated(ActorBase actor, IActorContext context);
    }

- **CanBeAppliedTo** determines if plugin can be applied to specific actor instance.
- **AfterActorCreated** is applied to actor after it has been instantiated by an `ActorCell` and before `InitializableActor.Init` method will (optionally) be invoked.
- **BeforeActorTerminated** is applied before actor terminates and before `IDisposable.Dispose` method will be invoked (for disposable actors) - **auto handling disposable actors is second feature of this commit**.

For common use it's better to create custom classes inheriting from `ActorProducerPluginBase` and `ActorProducerPluginBase<TActor>` classes.

Pipeline itself provides following interface:

    class ActorProducerPipeline : IEnumerable<IActorProducerPlugin> {
	    int Count { get; } // current plugins count - 1 by default (ActorStashPlugin)
	    bool Register(IActorProducerPlugin plugin)
	    bool Unregister(IActorProducerPlugin plugin)
	    bool IsRegistered(IActorProducerPlugin plugin)
	    bool Insert(int index, IActorProducerPlugin plugin)
    }

- **Register** - registers a plugin if no other plugin of the same type has been registered already (plugins with generic types are counted separately). Returns true if plugin has been registered.
- **Insert** - same as register, but plugin will be placed in specific place inside the pipeline - useful if any plugins precedence is required.
- **Unregister** - unregisters specified plugin if it has been found. Returns true if plugin was found and unregistered.
- **IsRegistered** - checks if plugin has been already registered.

By default pipeline is filled with one already used plugin - `ActorStashPlugin`, which replaces stash initialization/unstashing mechanism used up to this moment.

**MultiNodeTestRunner and Akka.Remote.TestKit**. The MultiNodeTestRunner and the Multi Node TestKit (Akka.Remote.TestKit) underwent some drastic changes in this update. They're still not quite ready for public use yet, but if you want to see what the experience is like you can [clone the Akka.NET Github repository](https://github.com/akkadotnet/akka.net) and run the following command:

````
C:\akkadotnet> .\build.cmd MultiNodeTests
````

This will automatically launch all `MultiNodeSpec` instances found inside `Akka.Cluster.Tests`. We'll need to make this more flexible to be able to run other assemblies that require multinode tests in the future.

These tests are not enabled by default in normal build runs, but they will at some point in the future.

Here's a sample of the output from the console, to give you a sense of what the reporting looks like:

![image](https://cloud.githubusercontent.com/assets/326939/6075685/5f7c56b2-ad8c-11e4-9d93-8216a8cbabaf.png)

The MultiNodeTestRunner uses XUnit internally and will dynamically deploy as many processes are needed to satisfy any individual test. Has been tested with up to 6 processes.