### PR TITLE
Working async await ftw

### DIFF
--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="FAKE" version="3.17.0" />
+</packages>

--- a/src/core/Akka.Persistence/Akka.Persistence.csproj
+++ b/src/core/Akka.Persistence/Akka.Persistence.csproj
@@ -40,7 +40,7 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
@@ -76,6 +76,7 @@ namespace Akka.Persistence.Journal
 
         private void HandleReplayMessages(ReplayMessages message)
         {
+            var context = Context;
             // Send replayed messages and replay result to persistentActor directly. No need
             // to resequence replayed messages relative to written and looped messages.
             ReplayMessagesAsync(message.PersistenceId, message.FromSequenceNr, message.ToSequenceNr, message.Max, p =>
@@ -85,7 +86,7 @@ namespace Akka.Persistence.Journal
             .NotifyAboutReplayCompletion(message.PersistentActor)
             .ContinueWith(t =>
             {
-                if(!t.IsFaulted && CanPublish) Context.System.EventStream.Publish(message);
+                if (!t.IsFaulted && CanPublish) context.System.EventStream.Publish(message);
             }, _continuationOptions);
         }
 

--- a/src/core/Akka.Persistence/packages.config
+++ b/src/core/Akka.Persistence/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Google.ProtocolBuffers" version="2.4.1.521" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
 </packages>

--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.0.0-rc1-build1030\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.0.0-rc1-build1030\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -18,6 +19,7 @@
     <TestProjectType>UnitTest</TestProjectType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>86a30492</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -112,6 +114,7 @@
     <Compile Include="Actor\ReceiveActorTests_Become.cs" />
     <Compile Include="Actor\ReceiveActorTests_LifeCycle.cs" />
     <Compile Include="Configuration\HoconTests.cs" />
+    <Compile Include="Dispatch\AsyncAwaitSpec.cs" />
     <Compile Include="Dispatch\MailboxesSpec.cs" />
     <Compile Include="Event\EventBusSpec.cs" />
     <Compile Include="Event\EventStreamSpec.cs" />
@@ -190,6 +193,12 @@
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.0.0-rc1-build1030\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.0.0-rc1-build1030\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/core/Akka.Tests/Dispatch/AsyncAwaitSpec.cs
+++ b/src/core/Akka.Tests/Dispatch/AsyncAwaitSpec.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Tests.Dispatch
+{
+    public class AsyncAwaitActor : ReceiveActor
+    {
+        public AsyncAwaitActor()
+        {
+            Receive<string>(async _ =>
+            {
+                var sender = Sender;                
+                await Task.Yield();
+                await Task.Delay(TimeSpan.FromSeconds(1));
+                Assert.Same(sender,Sender);
+                Sender.Tell("done");
+            });
+        }
+    }
+
+    public class Asker : ReceiveActor
+    {
+        public Asker(ActorRef other)
+        {
+            Receive<string>(async _ =>
+            {
+                var res = await other.Ask("start");
+                Sender.Tell(res);
+            });
+        }
+    }
+
+    public class BlockingAsker : ReceiveActor
+    {
+        public BlockingAsker(ActorRef other)
+        {
+            Receive<string>( _ =>
+            {
+                var res = other.Ask("start").Result;
+                Sender.Tell(res);
+            });
+        }
+    }
+
+    public class BlockingAskSelf : ReceiveActor
+    {
+        public BlockingAskSelf()
+        {
+            Receive<int>(_ =>
+            {
+                //since this actor is blocking in the handler below, it will never
+                //be able to execute this section
+                Sender.Tell("done");
+            });
+            Receive<string>(_ =>
+            {
+                //ask and block
+                var res = Self.Ask(123).Result;
+                Sender.Tell(res);
+            });
+        }
+    }
+
+    public class ActorAsyncAwaitSpec : AkkaSpec
+    {
+        [Fact]
+        public async Task Actors_should_be_able_to_async_await_in_message_loop()
+        {
+            var actor = Sys.ActorOf(Props.Create<AsyncAwaitActor>().WithDispatcher("akka.actor.task-dispatcher"));
+            var task = actor.Ask<string>("start", TimeSpan.FromSeconds(55));
+            actor.Tell(123, ActorRef.NoSender);
+            var res = await task;
+            Assert.Equal("done", res);
+        }
+
+        [Fact]
+        public async Task Actors_should_be_able_to_async_await_ask_message_loop()
+        {
+            var actor = Sys.ActorOf(Props.Create<AsyncAwaitActor>().WithDispatcher("akka.actor.task-dispatcher"),
+                "Worker");
+            var asker = Sys.ActorOf(Props.Create(() => new Asker(actor)).WithDispatcher("akka.actor.task-dispatcher"),
+                "Asker");
+            var task = asker.Ask("start", TimeSpan.FromSeconds(55));
+            actor.Tell(123, ActorRef.NoSender);
+            var res = await task;
+            Assert.Equal("done", res);
+        }
+
+        [Fact]
+        public async Task Actors_should_be_able_to_block_ask_message_loop()
+        {
+            var actor = Sys.ActorOf(Props.Create<AsyncAwaitActor>().WithDispatcher("akka.actor.task-dispatcher"),
+                "Worker");
+            var asker = Sys.ActorOf(Props.Create(() => new BlockingAsker(actor)).WithDispatcher("akka.actor.task-dispatcher"),
+                "Asker");
+            var task = asker.Ask("start", TimeSpan.FromSeconds(55));
+            actor.Tell(123, ActorRef.NoSender);
+            var res = await task;
+            Assert.Equal("done", res);
+        }
+
+        [Fact(Skip = "Maybe not possible to solve")]
+        public async Task Actors_should_be_able_to_block_ask_self_message_loop()
+        {
+            var asker = Sys.ActorOf(Props.Create(() => new BlockingAskSelf()).WithDispatcher("akka.actor.task-dispatcher"),
+                "Asker");
+            var task = asker.Ask("start", TimeSpan.FromSeconds(55));
+            var res = await task;
+            Assert.Equal("done", res);
+        }
+    }
+}

--- a/src/core/Akka.Tests/packages.config
+++ b/src/core/Akka.Tests/packages.config
@@ -3,4 +3,5 @@
   <package id="fastJSON" version="2.0.27.1" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.0.0-rc1-build1030" targetFramework="net45" />
 </packages>

--- a/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
+++ b/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
@@ -151,6 +151,7 @@ namespace Akka.Actor
                     .Message
                     .Match()
                     .With<CompleteFuture>(HandleCompleteFuture)
+                    .With<CompleteTask>(HandleCompleteTask)
                     .With<Failed>(HandleFailed)
                     .With<DeathWatchNotification>(m => WatchedActorTerminated(m.Actor, m.ExistenceConfirmed, m.AddressTerminated))
                     .With<Create>(m => HandleCreate(m.Failure))
@@ -171,7 +172,12 @@ namespace Akka.Actor
             }
         }
 
-
+        private void HandleCompleteTask(CompleteTask task)
+        {
+            CurrentMessage = task.State.Message;
+            Sender = task.State.Sender;
+            task.SetResult();
+        }
         public void SwapMailbox(DeadLetterMailbox mailbox)
         {
             Mailbox.DebugPrint("{0} Swapping mailbox to DeadLetterMailbox",Self);

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -3,10 +3,13 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Remoting.Messaging;
 using System.Threading.Tasks;
 using Akka.Actor.Internals;
 using Akka.Dispatch.SysMsg;
 using System.Threading;
+using Akka.Actor.Internal;
+using Akka.Dispatch;
 using Akka.Event;
 using Akka.Util;
 using Akka.Util.Internal;
@@ -51,12 +54,16 @@ namespace Akka.Actor
         private readonly TaskCompletionSource<object> _result;
         private readonly Action _unregister;
         private readonly ActorPath _path;
-        private ActorRef _sender;
+        private readonly ActorRef _actorAwaitingResult;
 
-        public FutureActorRef(TaskCompletionSource<object> result, ActorRef sender, Action unregister, ActorPath path)
+        public FutureActorRef(TaskCompletionSource<object> result, ActorRef actorAwaitingResult, Action unregister, ActorPath path)
         {
+            if (ActorCell.Current != null)
+            {
+                _actorAwaitingResultSender = ActorCell.Current.Sender;
+            }
             _result = result;
-            _sender = sender ?? NoSender;
+            _actorAwaitingResult = actorAwaitingResult ?? NoSender;
             _unregister = unregister;
             _path = path;
         }
@@ -75,8 +82,11 @@ namespace Akka.Actor
         private const int INITIATED = 0;
         private const int COMPLETED = 1;
         private int status = INITIATED;
+        private readonly ActorRef _actorAwaitingResultSender;
+
         protected override void TellInternal(object message, ActorRef sender)
         {
+
             if (message is SystemMessage) //we have special handling for system messages
             {
                 SendSystemMessage(message.AsInstanceOf<SystemMessage>(), sender);
@@ -86,13 +96,31 @@ namespace Akka.Actor
                 if (Interlocked.Exchange(ref status, COMPLETED) == INITIATED)
                 {
                     _unregister();
-                    if (_sender == NoSender || message is Terminated)
+                    if (_actorAwaitingResult == NoSender || message is Terminated)
                     {
                         _result.TrySetResult(message);
                     }
                     else
                     {
-                        _sender.Tell(new CompleteFuture(() => _result.TrySetResult(message)));
+                        if (TaskScheduler.Current is ActorTaskScheduler)
+                        {
+                            var tmp = InternalCurrentActorCellKeeper.Current;
+                            InternalCurrentActorCellKeeper.Current = null;
+                            try
+                            {
+                                ActorTaskScheduler.SetCurrentState(_actorAwaitingResult, _actorAwaitingResultSender, "");
+
+                                _result.TrySetResult(message);
+                            }
+                            finally
+                            {
+                                InternalCurrentActorCellKeeper.Current = tmp;
+                            }
+                        }
+                        else
+                        {
+                            _actorAwaitingResult.Tell(new CompleteFuture(() => _result.TrySetResult(message)));
+                        }
                     }
                 }
             }
@@ -112,7 +140,7 @@ namespace Akka.Actor
         }
     }
 
-    
+
 
     internal static class ActorRefSender
     {
@@ -147,7 +175,7 @@ namespace Akka.Actor
 
         public void Tell(object message, ActorRef sender)
         {
-            if (sender == null) throw new ArgumentNullException("sender", "A sender must be specified");
+            if (sender == null) throw new ArgumentNullException("sender", "A actorAwaitingResult must be specified");
 
             TellInternal(message, sender);
         }

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -175,7 +175,7 @@ namespace Akka.Actor
 
         public void Tell(object message, ActorRef sender)
         {
-            if (sender == null) throw new ArgumentNullException("sender", "A actorAwaitingResult must be specified");
+            if (sender == null) throw new ArgumentNullException("sender", "A sender must be specified");
 
             TellInternal(message, sender);
         }

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -32,7 +32,10 @@ namespace Akka.Actor
 
             ActorRef replyTo = ResolveReplyTo();
 
-            return Ask(self, replyTo, message, provider, timeout).ContinueWith(t => (T) t.Result);
+            var task = Ask(self, replyTo, message, provider, timeout).ContinueWith(t => (T) t.Result);
+            task.ConfigureAwait(true);
+
+            return task;
         }
 
         internal static ActorRef ResolveReplyTo()
@@ -60,7 +63,7 @@ namespace Akka.Actor
         private static Task<object> Ask(ICanTell self, ActorRef replyTo, object message, ActorRefProvider provider,
             TimeSpan? timeout)
         {
-            var result = new TaskCompletionSource<object>();
+            var result = new TaskCompletionSource<object>(TaskContinuationOptions.AttachedToParent);
             if (timeout.HasValue)
             {
                 var cancellationSource = new CancellationTokenSource();

--- a/src/core/Akka/Actor/Scheduler.cs
+++ b/src/core/Akka/Actor/Scheduler.cs
@@ -88,8 +88,7 @@ namespace Akka.Actor
         public Task Schedule(TimeSpan initialDelay, TimeSpan interval, Action action,
             CancellationToken cancellationToken)
         {
-            Action wrapped = WrapActionInActorSafeAction(action);
-            return InternalSchedule(initialDelay, interval, wrapped, cancellationToken);
+            return InternalSchedule(initialDelay, interval, action, cancellationToken);
         }
 
         /// <summary>
@@ -112,8 +111,7 @@ namespace Akka.Actor
         /// <returns>Task.</returns>
         public Task ScheduleOnce(TimeSpan initialDelay, Action action, CancellationToken cancellationToken)
         {
-            Action wrapped = WrapActionInActorSafeAction(action);
-            return InternalScheduleOnce(initialDelay, wrapped, cancellationToken);
+            return InternalScheduleOnce(initialDelay, action, cancellationToken);
         }
 
         /// <summary>
@@ -130,7 +128,7 @@ namespace Akka.Actor
                 await Task.Delay(initialDelay, token);
             }
             catch (OperationCanceledException) { }
-            if(!token.IsCancellationRequested)
+            if (!token.IsCancellationRequested)
                 action();
         }
 
@@ -154,24 +152,8 @@ namespace Akka.Actor
                     await Task.Delay(interval, token);
                 }
                 catch (TaskCanceledException) { }
-                catch (OperationCanceledException) {}
+                catch (OperationCanceledException) { }
             }
-        }
-
-        /// <summary>
-        /// Wraps the action in an actor safe action.
-        /// </summary>
-        /// <param name="action">The action.</param>
-        /// <returns>Action.</returns>
-        private static Action WrapActionInActorSafeAction(Action action)
-        {
-            Action wrapped = action;
-            if (ActorCell.Current != null)
-            {
-                var self = ActorCell.Current.Self;
-                wrapped = () => self.Tell(new CompleteFuture(action));
-            }
-            return wrapped;
         }
     }
 }

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -181,6 +181,7 @@
     <Compile Include="Dispatch\Mailboxes.cs" />
     <Compile Include="Dispatch\MessageQueues\MessageQueue.cs" />
     <Compile Include="Dispatch\SysMsg\SystemMessage.cs" />
+    <Compile Include="Dispatch\TaskDispatcher.cs" />
     <Compile Include="Dispatch\ThreadPoolBuilder.cs" />
     <Compile Include="Dispatch\UnboundedDequeBasedMailbox.cs" />
     <Compile Include="Dispatch\UnboundedMailbox.cs" />

--- a/src/core/Akka/Dispatch/ConcurrentQueueMailbox.cs
+++ b/src/core/Akka/Dispatch/ConcurrentQueueMailbox.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+﻿﻿using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Threading;
 using Akka.Actor;
@@ -57,7 +57,7 @@ namespace Akka.Dispatch
                 {
                     Mailbox.DebugPrint(ActorCell.Self + " processing system message " + envelope);
                     // TODO: Add + " with " + ActorCell.GetChildren());
-                    ActorCell.SystemInvoke(envelope);
+                    dispatcher.SystemDispatch(ActorCell, envelope);
                 }
 
                 //we should process x messages in this run
@@ -69,7 +69,7 @@ namespace Akka.Dispatch
                     Mailbox.DebugPrint(ActorCell.Self + " processing message " + envelope);
 
                     //run the receive handler
-                    ActorCell.Invoke(envelope);
+                    dispatcher.Dispatch(ActorCell, envelope);
 
                     //check if any system message have arrived while processing user messages
                     if (_systemMessages.TryDequeue(out envelope))
@@ -77,7 +77,7 @@ namespace Akka.Dispatch
                         //handle system message
                         Mailbox.DebugPrint(ActorCell.Self + " processing system message " + envelope);
                         // TODO: Add + " with " + ActorCell.GetChildren());
-                        ActorCell.SystemInvoke(envelope);
+                        dispatcher.SystemDispatch(ActorCell, envelope);
                         break;
                     }
                     left--;
@@ -116,7 +116,7 @@ namespace Akka.Dispatch
                     //that wasn't scheduled due to dispatcher throughput beeing reached
                     //or system messages arriving during user message processing
                     Schedule();
-                }                
+                }
             });
         }
 

--- a/src/core/Akka/Dispatch/Dispatchers.cs
+++ b/src/core/Akka/Dispatch/Dispatchers.cs
@@ -57,6 +57,16 @@ namespace Akka.Dispatch
         /// </summary>
         /// <param name="run">The run.</param>
         public abstract void Schedule(Action run);
+
+        public virtual void Dispatch(ActorCell cell, Envelope envelope)
+        {
+            cell.Invoke(envelope);
+        }
+
+        public virtual void SystemDispatch(ActorCell cell, Envelope envelope)
+        {
+            cell.SystemInvoke(envelope);
+        }
     }
 
     /// <summary>
@@ -72,17 +82,7 @@ namespace Akka.Dispatch
         {
             var wc = new WaitCallback(_ => run());
             ThreadPool.UnsafeQueueUserWorkItem(wc, null);
-        }
-    }
-
-    /// <summary>
-    ///     Task based dispatcher
-    /// </summary>
-    public class TaskDispatcher : MessageDispatcher
-    {
-        public override void Schedule(Action run)
-        {
-            Task.Factory.StartNew(run, TaskCreationOptions.PreferFairness);
+            //ThreadPool.QueueUserWorkItem(wc, null);
         }
     }
 
@@ -243,14 +243,14 @@ namespace Akka.Dispatch
                     dispatcher = new CurrentSynchronizationContextDispatcher();
                     break;
                 case null:
-                    throw new NotSupportedException("Could not resolve dispatcher for path " + path+". type is null");
+                    throw new NotSupportedException("Could not resolve dispatcher for path " + path + ". type is null");
                 default:
                     Type dispatcherType = Type.GetType(type);
                     if (dispatcherType == null)
                     {
-                        throw new NotSupportedException("Could not resolve dispatcher type " + type+" for path "+ path);
+                        throw new NotSupportedException("Could not resolve dispatcher type " + type + " for path " + path);
                     }
-                    dispatcher = (MessageDispatcher) Activator.CreateInstance(dispatcherType);
+                    dispatcher = (MessageDispatcher)Activator.CreateInstance(dispatcherType);
                     break;
             }
 

--- a/src/core/Akka/Dispatch/GenericMailbox.cs
+++ b/src/core/Akka/Dispatch/GenericMailbox.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+﻿﻿using System.Diagnostics;
 using System.Threading;
 using Akka.Actor;
 using Akka.Dispatch.MessageQueues;
@@ -9,9 +9,9 @@ namespace Akka.Dispatch
     /// <summary>
     /// Class Mailbox of TSys,TUser.
     /// </summary>
-    public abstract class Mailbox<TSys,TUser> : MessageQueueMailbox 
-        where TSys:MessageQueue
-        where TUser:MessageQueue
+    public abstract class Mailbox<TSys, TUser> : MessageQueueMailbox
+        where TSys : MessageQueue
+        where TUser : MessageQueue
     {
         private Stopwatch _deadLineTimer;
         private volatile bool _isClosed;
@@ -76,7 +76,7 @@ namespace Akka.Dispatch
                 {
                     Mailbox.DebugPrint(ActorCell.Self + " processing system message " + envelope);
                     // TODO: Add + " with " + ActorCell.GetChildren());
-                    ActorCell.SystemInvoke(envelope);
+                    dispatcher.SystemDispatch(ActorCell, envelope);
                 }
 
                 //we should process x messages in this run
@@ -88,7 +88,7 @@ namespace Akka.Dispatch
                     Mailbox.DebugPrint(ActorCell.Self + " processing message " + envelope);
 
                     //run the receive handler
-                    ActorCell.Invoke(envelope);
+                    dispatcher.Dispatch(ActorCell, envelope);
 
                     //check if any system message have arrived while processing user messages
                     if (_systemMessages.TryDequeue(out envelope))
@@ -96,7 +96,7 @@ namespace Akka.Dispatch
                         //handle system message
                         Mailbox.DebugPrint(ActorCell.Self + " processing system message " + envelope);
                         // TODO: Add + " with " + ActorCell.GetChildren());
-                        ActorCell.SystemInvoke(envelope);
+                        dispatcher.SystemDispatch(ActorCell, envelope);
                         break;
                     }
                     left--;
@@ -135,7 +135,7 @@ namespace Akka.Dispatch
                     //that wasn't scheduled due to dispatcher throughput beeing reached
                     //or system messages arriving during user message processing
                     Schedule();
-                }             
+                }
             });
         }
 

--- a/src/core/Akka/Dispatch/SysMsg/SystemMessage.cs
+++ b/src/core/Akka/Dispatch/SysMsg/SystemMessage.cs
@@ -7,8 +7,8 @@ namespace Akka.Dispatch.SysMsg
     /**
  * public API
  */
-//@SerialVersionUID(1L)
-//private[akka] case class Create(failure: Option[ActorInitializationException]) extends SystemMessage // sent to self from Dispatcher.register
+    //@SerialVersionUID(1L)
+    //private[akka] case class Create(failure: Option[ActorInitializationException]) extends SystemMessage // sent to self from Dispatcher.register
     /// <summary>
     ///     Class SystemMessage.
     /// </summary>
@@ -104,7 +104,7 @@ namespace Akka.Dispatch.SysMsg
 
         public override string ToString()
         {
-            return "<Failed>: " + _child + " (" + _uid + ") " + (_cause!=null ? ", Cause=" + _cause : "");
+            return "<Failed>: " + _child + " (" + _uid + ") " + (_cause != null ? ", Cause=" + _cause : "");
         }
     }
 
@@ -233,9 +233,6 @@ namespace Akka.Dispatch.SysMsg
         public Task Task { get; private set; }
     }
 
-    /// <summary>
-    ///     Class CompleteFuture.
-    /// </summary>
     public sealed class CompleteFuture : SystemMessage
     {
         /// <summary>
@@ -246,6 +243,28 @@ namespace Akka.Dispatch.SysMsg
         {
             SetResult = action;
         }
+
+        /// <summary>
+        ///     Gets the set result.
+        /// </summary>
+        /// <value>The set result.</value>
+        public Action SetResult { get; private set; }
+    }
+
+    public sealed class CompleteTask : SystemMessage
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="CompleteTask" /> class.
+        /// </summary>
+        /// <param name="ambientState"></param>
+        /// <param name="action">The action.</param>
+        public CompleteTask(AmbientState state, Action action)
+        {
+            State = state;
+            SetResult = action;
+        }
+
+        public AmbientState State { get; private set; }
 
         /// <summary>
         ///     Gets the set result.
@@ -292,7 +311,7 @@ namespace Akka.Dispatch.SysMsg
 
         public override string ToString()
         {
-            return "<Recreate>" + (Cause==null? "":" Cause: " + Cause);
+            return "<Recreate>" + (Cause == null ? "" : " Cause: " + Cause);
         }
     }
 
@@ -429,7 +448,7 @@ namespace Akka.Dispatch.SysMsg
     {
         private readonly ActorInitializationException _failure;
 
-        public Create(ActorInitializationException failure=null)
+        public Create(ActorInitializationException failure = null)
         {
             _failure = failure;
         }

--- a/src/core/Akka/Dispatch/TaskDispatcher.cs
+++ b/src/core/Akka/Dispatch/TaskDispatcher.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Remoting.Messaging;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Dispatch.SysMsg;
+
+namespace Akka.Dispatch
+{
+    /// <summary>
+    /// Task based dispatcher with async await support
+    /// </summary>
+    public class TaskDispatcher : MessageDispatcher
+    {
+        public override void Dispatch(ActorCell cell, Envelope envelope)
+        {
+            ActorTaskScheduler.SetCurrentState(cell.Self, envelope.Sender, envelope.Message);
+            base.Dispatch(cell, envelope);
+        }
+
+        public override void Schedule(Action run)
+        {
+            ActorTaskScheduler.Schedule(run);        
+        }
+    }
+
+    public class AmbientState
+    {
+        public ActorRef Self { get; set; }
+        public ActorRef Sender { get; set; }
+        public object Message { get; set; }
+    }
+
+    public class ActorTaskScheduler : TaskScheduler
+    {
+        public static readonly TaskScheduler Instance = new ActorTaskScheduler();
+        public static readonly TaskFactory TaskFactory = new TaskFactory(Instance);
+        public static readonly object RootScheduler = new object();
+        public static readonly string StateKey = "akka.state";
+
+        public static void SetCurrentState(ActorRef self,ActorRef sender,object message)
+        {
+            CallContext.LogicalSetData(StateKey, new AmbientState
+            {
+                Sender = sender,
+                Self = self,
+                Message = message
+            });
+        }
+
+        public static void Schedule(Action run)
+        {
+            TaskFactory.StartNew(_ => run(), RootScheduler);
+        }
+
+        protected override IEnumerable<Task> GetScheduledTasks()
+        {
+            return null;
+        }
+
+        protected override void QueueTask(Task task)
+        {
+
+            if (task.AsyncState == RootScheduler)
+            {
+                ThreadPool.UnsafeQueueUserWorkItem(_ => { TryExecuteTask(task); }, null);
+            }
+            else
+            {
+                var s = CallContext.LogicalGetData(StateKey) as AmbientState;
+
+                if (s == null)
+                {
+                    TryExecuteTask(task);
+                    return;
+                }
+
+                s.Self.Tell(new CompleteTask(s, () => { TryExecuteTask(task); }), ActorRef.NoSender);
+            }
+        }
+
+        protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
+        {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Finally got the testrunners and fixed some broken Nuget references.

This PR gives us the ability to use async await for both Ask and other async operations when using the `TaskDispatcher`
It is completely separate from all other infrastructure so it does not affect other usecases.

How it works.
If an actor is configured with `.WithDispatcher("akka.actor.task-dispatcher"),`
It will dispatch all messages through the task dispatcher, which in turn places all relevant continuation state into the `LogicalCallContext` which makes it possible for state to flow async.
It also executes the mailbox using Tasks and applies an `ActorTaskScheduler` to manage all task execution within the current context.
