### PR TITLE
Fix coupling between async await support and the rest of the framework

### DIFF
--- a/src/core/Akka.Tests/Dispatch/AsyncAwaitSpec.cs
+++ b/src/core/Akka.Tests/Dispatch/AsyncAwaitSpec.cs
@@ -12,10 +12,12 @@ namespace Akka.Tests.Dispatch
         {
             Receive<string>(async _ =>
             {
-                var sender = Sender;                
+                var sender = Sender;
+                var self = Self;
                 await Task.Yield();
                 await Task.Delay(TimeSpan.FromSeconds(1));
                 Assert.Same(sender,Sender);
+                Assert.Same(self, Self);
                 Sender.Tell("done");
             });
         }
@@ -27,7 +29,11 @@ namespace Akka.Tests.Dispatch
         {
             Receive<string>(async _ =>
             {
+                var sender = Sender;
+                var self = Self;
                 var res = await other.Ask("start");
+                Assert.Same(sender, Sender);
+                Assert.Same(self, Self);
                 Sender.Tell(res);
             });
         }

--- a/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
+++ b/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
@@ -150,7 +150,6 @@ namespace Akka.Actor
                 envelope
                     .Message
                     .Match()
-                    .With<CompleteFuture>(HandleCompleteFuture)
                     .With<CompleteTask>(HandleCompleteTask)
                     .With<Failed>(HandleFailed)
                     .With<DeathWatchNotification>(m => WatchedActorTerminated(m.Actor, m.ExistenceConfirmed, m.AddressTerminated))
@@ -345,15 +344,6 @@ namespace Akka.Actor
         private void Kill()
         {
             throw new ActorKilledException("Kill");
-        }
-
-        /// <summary>
-        ///     Handles the complete future.
-        /// </summary>
-        /// <param name="m">The m.</param>
-        private void HandleCompleteFuture(CompleteFuture m)
-        {
-            m.SetResult();
         }
     }
 }

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -227,16 +227,7 @@ namespace Akka.Actor
                 object deserialized = _systemImpl.Serialization.Deserialize(serialized, serializer.Identifier,
                     message.GetType());
                 message = deserialized;
-            }
-            
-            //Execute CompleteFuture objects inline - if the Actor is waiting on the result of an Ask operation inside
-            //its receive method, then the mailbox will never schedule the CompleteFuture.
-            //Thus - we execute it inline, outside of the mailbox.
-            if (message is CompleteFuture)
-            {
-                HandleCompleteFuture(message.AsInstanceOf<CompleteFuture>());
-                return;
-            }
+            }           
 
             var m = new Envelope
             {

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -15,27 +15,18 @@ namespace Akka.Actor
         //when asking from outside of an actor, we need to pass a system, so the FutureActor can register itself there and be resolvable for local and remote calls
         public static Task<object> Ask(this ICanTell self, object message, TimeSpan? timeout = null)
         {
-            ActorRefProvider provider = ResolveProvider(self);
-            if (provider == null)
-                throw new NotSupportedException("Unable to resolve the target Provider");
-
-            ActorRef replyTo = ResolveReplyTo();
-
-            return Ask(self, replyTo, message, provider, timeout);
+            return self.Ask<object>(message, timeout);
         }
 
-        public static Task<T> Ask<T>(this ICanTell self, object message, TimeSpan? timeout = null)
+        public static async Task<T> Ask<T>(this ICanTell self, object message, TimeSpan? timeout = null)
         {
             ActorRefProvider provider = ResolveProvider(self);
             if (provider == null)
                 throw new NotSupportedException("Unable to resolve the target Provider");
 
-            ActorRef replyTo = ResolveReplyTo();
-
-            var task = Ask(self, replyTo, message, provider, timeout).ContinueWith(t => (T) t.Result);
-            task.ConfigureAwait(true);
-
-            return task;
+            ResolveReplyTo();
+            var result = (T)await Ask(self, message, provider, timeout);
+            return result;
         }
 
         internal static ActorRef ResolveReplyTo()
@@ -60,7 +51,7 @@ namespace Akka.Actor
             return null;
         }
 
-        private static Task<object> Ask(ICanTell self, ActorRef replyTo, object message, ActorRefProvider provider,
+        private static Task<object> Ask(ICanTell self, object message, ActorRefProvider provider,
             TimeSpan? timeout)
         {
             var result = new TaskCompletionSource<object>(TaskContinuationOptions.AttachedToParent);
@@ -75,7 +66,7 @@ namespace Akka.Actor
             ActorPath path = provider.TempPath();
             //callback to unregister from tempcontainer
             Action unregister = () => provider.UnregisterTempActor(path);
-            var future = new FutureActorRef(result, replyTo, unregister, path);
+            var future = new FutureActorRef(result, unregister, path);
             //The future actor needs to be registered in the temp container
             provider.RegisterTempActor(future, path);
             self.Tell(message, future);

--- a/src/core/Akka/Actor/GracefulStopSupport.cs
+++ b/src/core/Akka/Actor/GracefulStopSupport.cs
@@ -50,7 +50,7 @@ namespace Akka.Actor
             //callback to unregister from tempcontainer
             Action unregister = () => provider.UnregisterTempActor(path);
 
-            var fref = new FutureActorRef(promise, ActorRef.NoSender, unregister, path);
+            var fref = new FutureActorRef(promise, unregister, path);
             internalTarget.Tell(new Watch(internalTarget, fref));
             target.Tell(stopMessage, ActorRef.NoSender);
             return promise.Task.ContinueWith(t =>

--- a/src/core/Akka/Dispatch/FutureActor.cs
+++ b/src/core/Akka/Dispatch/FutureActor.cs
@@ -36,21 +36,12 @@ namespace Akka.Dispatch
         /// <param name="message">The message.</param>
         protected override bool Receive(object message)
         {
-            if (respondTo != ActorRef.NoSender)
-            {
-                ((InternalActorRef)Self).Stop();
-                respondTo.Tell(new CompleteFuture(() => result.SetResult(message)));
-                Become(EmptyReceive);
-            }
-            else
-            {
-                //if there is no listening actor asking,
-                //just eval the result directly
-                ((InternalActorRef)Self).Stop();
-                Become(EmptyReceive);
+            //if there is no listening actor asking,
+            //just eval the result directly
+            ((InternalActorRef)Self).Stop();
+            Become(EmptyReceive);
 
-                result.SetResult(message);
-            }
+            result.SetResult(message);
 
             return true;
         }

--- a/src/core/Akka/Dispatch/SysMsg/SystemMessage.cs
+++ b/src/core/Akka/Dispatch/SysMsg/SystemMessage.cs
@@ -233,30 +233,12 @@ namespace Akka.Dispatch.SysMsg
         public Task Task { get; private set; }
     }
 
-    public sealed class CompleteFuture : SystemMessage
-    {
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="CompleteFuture" /> class.
-        /// </summary>
-        /// <param name="action">The action.</param>
-        public CompleteFuture(Action action)
-        {
-            SetResult = action;
-        }
-
-        /// <summary>
-        ///     Gets the set result.
-        /// </summary>
-        /// <value>The set result.</value>
-        public Action SetResult { get; private set; }
-    }
-
     public sealed class CompleteTask : SystemMessage
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="CompleteTask" /> class.
         /// </summary>
-        /// <param name="ambientState"></param>
+        /// <param name="state"></param>
         /// <param name="action">The action.</param>
         public CompleteTask(AmbientState state, Action action)
         {


### PR DESCRIPTION
This PR fixes some hard coupling between `FutureActorRef` and the new Async Await support.
`CompleteFuture` have been removed in favor for completing `TaskCompletionSource`'s inline.
Ask support have also been cleaned up to utilize more idiomatic handling of tasks.