### PR TITLE
Fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Submit only relevant commits. We don't mind many commits in a pull request, but 
 If you have commits that looks like this _"Merge branch 'my-branch' into dev"_ or _"Merge branch 'dev' of github .com/akkadotnet/akka.net into dev"_ you're probaly using merge instead of [rebase](https://help.github.com/articles/about-git-rebase) locally. See below on _Handling updates from upstream_. 
 - __Squash commits__ Often we create temporary commits like _"Started implementing feature x"_ and then _"Did a bit more on feature x"_. Squash these commits together using [interactive rebase](https://help.github.com/articles/about-git-rebase). Also see [Squashing commits with rebase](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html).
 - __Descriptive commit messages__ If a commit's message isn't descriptive, change it using [interactive rebase](https://help.github.com/articles/about-git-rebase). Refer to issues using `#issue`. Example of a bad message ~~"Small cleanup"~~. Example of good message: _"Removed Security.Claims header from FSM, which broke Mono build per #62"_. Don't be afraid to write long messages, if needed. Try to explain _why_ you've done the changes. The Erlang repo has some info on [writing good commit messages](https://github.com/erlang/otp/wiki/Writing-good-commit-messages).
-- __No one-commit-to-rule-them-all__ Large commits that changes too many things at the same time are very hard to review. Split large commits into smaller. See this [StackOverflow question](http://stackoverflow.com/questions/6217156/break-a-previous-commit-into-multiple-commits) for informatin on how to do this.
+- __No one-commit-to-rule-them-all__ Large commits that changes too many things at the same time are very hard to review. Split large commits into smaller. See this [StackOverflow question](http://stackoverflow.com/questions/6217156/break-a-previous-commit-into-multiple-commits) for information on how to do this.
 - __Tests__ Add relevant tests and make sure all existing ones still passes. Tests can be run using the command
 - __No Warnings__ Make sure your code do not produce any build warnings.
 
@@ -97,8 +97,8 @@ This ensures that your history is "clean" i.e. you have one branch off from _dev
 If you're working on a long running feature then you may want to do this quite often, rather than run the risk of potential merge issues further down the line.
 
 ### Making changes to a Pull request
-If you realize you've missed something after submitting a Pull request, just commit to your local branch and push the branch just like you did the first time. This commit wil automatically be included in the Pull request.
-If we ask you to change already published commits using interactive reabse (like squashing or splitting commits or  rewriting commit messages) you need to force push using `-f`:
+If you realize you've missed something after submitting a Pull request, just commit to your local branch and push the branch just like you did the first time. This commit will automatically be included in the Pull request.
+If we ask you to change already published commits using interactive rebase (like squashing or splitting commits or  rewriting commit messages) you need to force push using `-f`:
 ```
 git push -f origin my-new-branch-123
 ```

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -180,9 +180,9 @@ __Breaking Change to the internal api: The `Next` property on `IAtomicCounter<T>
 __Akka.Serilog__ `SerilogLogMessageFormatter` has been moved to the namespace `Akka.Logger.Serilog` (it used to be in `Akka.Serilog.Event.Serilog`).
 Update your `using` statements from `using Akka.Serilog.Event.Serilog;` to `using Akka.Logger.Serilog;`.
 
-__Breaking Change to the internal api: Changed signatures in the abstract class `SupervisorStrategy`__. The following methods has new signatures: `HandleFailure`, `ProcessFailure`. If you've inherited from `SupervisorStrategy`, `OneForOneStrategy` or `AllForOneStrategy` and overriden the aforementioned methods you need to update their signatures.
+__Breaking Change to the internal api: Changed signatures in the abstract class `SupervisorStrategy`__. The following methods has new signatures: `HandleFailure`, `ProcessFailure`. If you've inherited from `SupervisorStrategy`, `OneForOneStrategy` or `AllForOneStrategy` and overridden the aforementioned methods you need to update their signatures.
 
-__TestProbe can be implicitly casted to ActorRef__. New feature. Tests requring the `ActorRef` of a `TestProbe` can now be simplified:
+__TestProbe can be implicitly casted to ActorRef__. New feature. Tests requiring the `ActorRef` of a `TestProbe` can now be simplified:
 ``` C#
 var probe = CreateTestProbe();
 var sut = ActorOf<GreeterActor>();
@@ -292,7 +292,7 @@ If you need to print to stdout directly use `Akka.Util.StandardOutWriter.Write()
 
 #### 0.6.4 Sep 9 2014
 * Introduced `TailChoppingRouter`
-* All `ActorSystem` extensions now take an `ExtendedActorSystem` as a dependency - all thirdy party actor system extensions will need to update accordingly.
+* All `ActorSystem` extensions now take an `ExtendedActorSystem` as a dependency - all third party actor system extensions will need to update accordingly.
 * Fixed numerous bugs with remote deployment of actors.
 * Fixed a live-lock issue for high-traffic connections on Akka.Remote and introduced softer heartbeat failure deadlines.
 * Changed the configuration chaining process.

--- a/documentation/wiki/Async Await.md
+++ b/documentation/wiki/Async Await.md
@@ -5,7 +5,7 @@ title: Async Await
 
 # Akka.NET and Async Await
 
-To enable Async Await support in an Akka.NET actor, you will need to configure your arctor to use the `task-dispatcher`.
+To enable Async Await support in an Akka.NET actor, you will need to configure your actor to use the `task-dispatcher`.
 This can be accomplished like this:
 
 ```csharp

--- a/documentation/wiki/Configuration.md
+++ b/documentation/wiki/Configuration.md
@@ -125,7 +125,7 @@ var fluentConfig = FluentConfig.Begin()
 var system = ActorSystem.Create("MyServer", fluentConfig);
 ```
 
-The fluent configuration support is a simple builder ontop of the HOCON configuration.
+The fluent configuration support is a simple builder on top of the HOCON configuration.
 This is because Akka.NET uses HOCON internally inside most of it's modules, such as routers and remoting.
 
 Fluent configuration is based on extension methods on the `FluentConfig` class, this makes it possible to supply new config methods for different modules w/o altering the configuration API.

--- a/documentation/wiki/FSharp API.md
+++ b/documentation/wiki/FSharp API.md
@@ -70,7 +70,7 @@ All of these functions may be used with either actor system or actor itself. In 
 
 ### Actor spawning options
 
-To be able to specifiy more precise actor creation behavior, you may use `spawnOpt` and `spawne` methods, both taking a list of `SpawnOption` values. Each specific option should be present only once in the collection. When a conflict occurs (more than one option of specified type has been found), the latest value found inside the list will be chosen.
+To be able to specify more precise actor creation behavior, you may use `spawnOpt` and `spawne` methods, both taking a list of `SpawnOption` values. Each specific option should be present only once in the collection. When a conflict occurs (more than one option of specified type has been found), the latest value found inside the list will be chosen.
 
 -   `SpawnOption.Deploy(Akka.Actor.Deploy)` - defines deployment strategy for created actors (see: Deploy). This option may be used along with `spawne` function to enable remote actors deployment.
 -   `SpawnOption.Router(Akka.Routing.RouterConfig)` - defines an actor to be a router as well as it's routing specifics (see: [Routing](http://akkadotnet.github.io/wiki/Routing)).
@@ -215,7 +215,7 @@ F# API provides following scheduling functions:
 
 ### Logging
 
-F# API supports two groups of logging functions - one that operates directly on strings and second (which may be recognized by *f* suffix in function names) which operates using F# string formating features. Major difference is performance - first one is less powerful, but it's also faster than the second one.
+F# API supports two groups of logging functions - one that operates directly on strings and second (which may be recognized by *f* suffix in function names) which operates using F# string formatting features. Major difference is performance - first one is less powerful, but it's also faster than the second one.
 
 Both groups support logging on various levels (DEBUG, &lt;default&gt; INFO, WARNING and ERROR). Actor system's logging level may be managed through configuration, i.e.:
 

--- a/documentation/wiki/Fault tolerance.md
+++ b/documentation/wiki/Fault tolerance.md
@@ -95,7 +95,7 @@ by overriding the `logFailure` method.
 
 ## Supervision of Top-Level Actors
 
-Toplevel actors means those which are created using `system.ActorOf()`, and
+Top-level actors means those which are created using `system.ActorOf()`, and
 they are children of the [User Guardian](User guardian). There are no
 special rules applied in this case, the guardian simply applies the configured
 strategy.

--- a/documentation/wiki/Persistence.md
+++ b/documentation/wiki/Persistence.md
@@ -4,7 +4,7 @@ title: Persistence
 ---
 ## Persistence
 
-Akka.Persistence plugin enables to create a statefull actors, which internal state may be stored inside persistent data storage and used for recovery in case of restart, migration or VM crash. Core concept behind Akka persistence lays in storing not only actor state directly (in form of the snapshots) but also history of all of the changes of that actor's state. This is quite useful solution common in patterns such as eventsourcing. Changes are immutable by nature, as they describe facts already reported in the history, and can be stored inside event journal in append-only mode. While recovering, actor restores it's state from the latests snapshot available - which can reduce recovery time - and then recreates it further by replaying events stored inside journal. Among other features provided by persistence plugin is support for command query segregation model and point-to-point communication with at-least-once delivery semantics.
+Akka.Persistence plugin enables to create a stateful actors, which internal state may be stored inside persistent data storage and used for recovery in case of restart, migration or VM crash. Core concept behind Akka persistence lays in storing not only actor state directly (in form of the snapshots) but also history of all of the changes of that actor's state. This is quite useful solution common in patterns such as eventsourcing. Changes are immutable by nature, as they describe facts already reported in the history, and can be stored inside event journal in append-only mode. While recovering, actor restores it's state from the latests snapshot available - which can reduce recovery time - and then recreates it further by replaying events stored inside journal. Among other features provided by persistence plugin is support for command query segregation model and point-to-point communication with at-least-once delivery semantics.
 
 ### Architecture
 
@@ -13,15 +13,15 @@ Akka.Persistence features are available through new set of actor base classes:
 - `PersistentActor` is a persistent, stateful equivalent of *ActorBase* class. It's able to persist event inside the journal, creating snapshots in snapshot stores and recover from them in thread-safe manner. It can be used for both changing and reading state of the actor.
 - `PersistentView` is used to recreate internal state of other persistent actor based on journaled messages. It works in read-only manner - it cannot journal any event by itself.
 - `GuaranteedDeliveryActor` may be used to ensure at-least-once delivery semantics between communicating actors, even in case when either sender or receiver VM crashes.
-- `Journal` stores a sequence of events send by the persistent actor. The storage backend of the journal is plugable. By default it uses in-memory message stream and is NOT a persistent storage.
-- `Snapshot store` is used to persist snapshots of either persistent actor's or view's internal state. They can be used to reduce recovery times in case when a lot of events needs to be replayed for specific persistent actor. Storage backend of the snapshot store is plugable. By default it uses local file system.
+- `Journal` stores a sequence of events send by the persistent actor. The storage backend of the journal is pluggable. By default it uses in-memory message stream and is NOT a persistent storage.
+- `Snapshot store` is used to persist snapshots of either persistent actor's or view's internal state. They can be used to reduce recovery times in case when a lot of events needs to be replayed for specific persistent actor. Storage backend of the snapshot store is pluggable. By default it uses local file system.
 
 ### Persistent actors
 
 Unlike default `ActorBase` class `PersistentActor` and it's derivatives requires to setup a few more additional members:
 
 - `PersistenceId` is a persistent actor's identifier that doesn't change across different actor incarnations. It's used to retrieve an event stream required by the persistent actor to recover it's internal state.
-- `ReceiveRecover` is a method invoked during actor's recovery cycle. Incomming objects may be user-defined events as well as system messages, for example `SnapshotOffer` which is used to deliver latest actor state saved in the snapshot store.
+- `ReceiveRecover` is a method invoked during actor's recovery cycle. Incoming objects may be user-defined events as well as system messages, for example `SnapshotOffer` which is used to deliver latest actor state saved in the snapshot store.
 - `ReceiveCommand` is an equivalent of basic `Receive` method of default Akka.NET actors.
 
 Persistent actors also offer a set of specialized members:
@@ -62,8 +62,8 @@ Members:
 - `Deliver` method is used to send message to another actor in at-least-once delivery semantics. Message sent this way must be confirmed by the other endpoint with `ConfirmDelivery` method. Otherwise it will be resend again and again until the redelivery limit will be reached.
 - `GetDeliverySnapshot` and `SetDeliverySnapshot` methods are used as part of delivery snapshotting strategy. They return/reset state of the current guaranteed delivery actor unconfirmed messages. In order to save custom deliverer state inside snapshot, a returned delivery snapshot should be included into that snapshot and reset in *ReceiveRecovery* method, when `SnapshotOffer` arrives.
 - `RedeliveryBurstLimit` is a virtual property which determines maximum number of unconfirmed messages to be send in each redelivery attempt. It may be usefull to prevent message overflow scenarios. It may be overriden or configured inside HOCON configuration under *akka.persistence.at-least-once-delivery.redelivery-burst-limit* path (10 000 by default).
-- `UnconfirmedDeliveryAttemptsToWarn` is a virtual property which determines, how many unconfirmed deliveries may be sent before guranteed delivery actor will send an `UnconfirmedWarning` message to itself. Count is reset after actor's restart. It may be overriden or configured inside HOCON configuration under *akka.persistence.at-least-once-delivery.warn-after-number-of-unconfirmed-attempts* path (5 by default).
-- `MaxUnconfirmedMessages` is a virtual property which determines maximum of unconfirmed deliveries hold in memory. After this threshold is exceeded any `Deliver` method will raise `MaxUnconfirmedMessagesExceededException`. It may be overriden or configured inside HOCON configuration under *akka.persistence.at-least-once-delivery.max-unconfirmed-messages* path (100 000 by default).
+- `UnconfirmedDeliveryAttemptsToWarn` is a virtual property which determines, how many unconfirmed deliveries may be sent before guaranteed delivery actor will send an `UnconfirmedWarning` message to itself. Count is reset after actor's restart. It may be overriden or configured inside HOCON configuration under *akka.persistence.at-least-once-delivery.warn-after-number-of-unconfirmed-attempts* path (5 by default).
+- `MaxUnconfirmedMessages` is a virtual property which determines maximum of unconfirmed deliveries hold in memory. After this threshold is exceeded any `Deliver` method will raise `MaxUnconfirmedMessagesExceededException`. It may be overridden or configured inside HOCON configuration under *akka.persistence.at-least-once-delivery.max-unconfirmed-messages* path (100 000 by default).
 - `UnconfirmedCount` property shows a number of the unconfirmed messages.
 
 ### Journals

--- a/documentation/wiki/ReceiveActor.md
+++ b/documentation/wiki/ReceiveActor.md
@@ -20,7 +20,7 @@ private class MyActor : ReceiveActor
 }
 ```
 
-Whenever a message of typ `string` is sent to **MyActor** the first handler is invoked and for messages of type `int` the second handler is used.
+Whenever a message of type `string` is sent to **MyActor** the first handler is invoked and for messages of type `int` the second handler is used.
 
 ## Handler priority
 If more than one handler matches, the one that appears first is used, and the others are not called.

--- a/documentation/wiki/Stash.md
+++ b/documentation/wiki/Stash.md
@@ -13,7 +13,7 @@ In Akka.NET, this functionality is provided by two interfaces:
 
 When an actor implements one of these interfaces, it will automatically get a deque-based mailbox.
 
-These interfaces require you to provide a Stash property on your actor. The proerty will be automatically populated with an appropriated implementation during the actor's creation:
+These interfaces require you to provide a Stash property on your actor. The property will be automatically populated with an appropriated implementation during the actor's creation:
 
 ```csharp
 public class MyActorWithStash : UntypedActor, WithUnboundedStash

--- a/src/contrib/dependencyInjection/Akka.DI.AutoFac/AutoFacDependencyResolver.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.AutoFac/AutoFacDependencyResolver.cs
@@ -51,7 +51,7 @@ namespace Akka.DI.AutoFac
                        Registrations.
                        Where(registration => registration.Activator.LimitType.
                                  Name.Equals(actorName, StringComparison.InvariantCultureIgnoreCase)).
-                        Select(regisration => regisration.Activator.LimitType).
+                        Select(registration => registration.Activator.LimitType).
                         FirstOrDefault());
 
             return typeCache[actorName];

--- a/src/core/Akka.Cluster.Tests/AutoDownSpec.cs
+++ b/src/core/Akka.Cluster.Tests/AutoDownSpec.cs
@@ -122,7 +122,7 @@ namespace Akka.Cluster.Tests
         }
 
         [Fact]
-        public void AutoDownMustNotDownUnreachableWhenLoosingLeadershipInbetweenDetectionAndSpecfiedDuration()
+        public void AutoDownMustNotDownUnreachableWhenLoosingLeadershipInbetweenDetectionAndSpecifiedDuration()
         {
             var a = AutoDownActor(TimeSpan.FromSeconds(2));
             a.Tell(new ClusterEvent.LeaderChanged(MemberA.Address));

--- a/src/core/Akka.Cluster.Tests/ClusterConfigSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterConfigSpec.cs
@@ -14,7 +14,7 @@ namespace Akka.Cluster.Tests
         public ClusterConfigSpec() : base(@"akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""") { }
 
         [Fact]
-        public void ClusteringMustBeAbleToPareseGenericClusterConfigElements()
+        public void ClusteringMustBeAbleToParseGenericClusterConfigElements()
         {
             var settings = new ClusterSettings(Sys.Settings.Config, Sys.Name);
             Assert.True(settings.LogInfo);

--- a/src/core/Akka.Cluster.Tests/EWMASpec.cs
+++ b/src/core/Akka.Cluster.Tests/EWMASpec.cs
@@ -74,7 +74,7 @@ namespace Akka.Cluster.Tests
         }
 
         [Fact]
-        public void DataStream_must_calcualte_sane_alpha_from_short_halflife()
+        public void DataStream_must_calculate_sane_alpha_from_short_halflife()
         {
             var alpha = EWMA.CalculateAlpha(TimeSpan.FromMilliseconds(1), TimeSpan.FromSeconds(3));
             Assert.True(alpha <= 1.0d);
@@ -83,7 +83,7 @@ namespace Akka.Cluster.Tests
         }
 
         [Fact]
-        public void DataStream_must_calcualte_sane_alpha_from_long_halflife()
+        public void DataStream_must_calculate_sane_alpha_from_long_halflife()
         {
             var alpha = EWMA.CalculateAlpha(TimeSpan.FromDays(1), TimeSpan.FromSeconds(3));
             Assert.True(alpha <= 1.0d);

--- a/src/core/Akka.Cluster.Tests/MemberOrderingSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MemberOrderingSpec.cs
@@ -67,7 +67,7 @@ namespace Akka.Cluster.Tests
         }
 
         [Fact]
-        public void MemberOrderingMustConsitentOrderingAndEquals()
+        public void MemberOrderingMustConsistentOrderingAndEquals()
         {
             var address1 = new Address("akka.tcp", "sys1", "host1", 9001);
             var address2 = address1.Copy(port: 9002);

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -775,7 +775,7 @@ namespace Akka.Cluster
             else if (message is ClusterUserAction.JoinTo)
             {
                 var jt = message as ClusterUserAction.JoinTo;
-                BecomeUnitialized();
+                BecomeUninitialized();
                 Join(jt.Address);
             }
             else if (message is InternalClusterAction.ISubscriptionMessage)
@@ -787,7 +787,7 @@ namespace Akka.Cluster
             {
                 if (deadline != null && deadline.IsOverdue)
                 {
-                    BecomeUnitialized();
+                    BecomeUninitialized();
                     if (_cluster.Settings.SeedNodes.Any()) JoinSeedNodes(_cluster.Settings.SeedNodes);
                     else Join(joinWith);
                 }
@@ -798,7 +798,7 @@ namespace Akka.Cluster
             }
         }
 
-        private void BecomeUnitialized()
+        private void BecomeUninitialized()
         {
             // make sure that join process is stopped
             StopSeedNodeProcess();

--- a/src/core/Akka.MultiNodeTestRunner.Shared.Tests/Persistence/JsonPersistentTestRunStoreSpec.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared.Tests/Persistence/JsonPersistentTestRunStoreSpec.cs
@@ -61,10 +61,10 @@ namespace Akka.MultiNodeTestRunner.Shared.Tests.Persistence
             var allMessages = NodeMessageHelpers.GenerateMessageSequence(nodeIndexes, 300);
             var runnerMessages = NodeMessageHelpers.GenerateTestRunnerMessageSequence(20);
             var successMessages = NodeMessageHelpers.GenerateResultMessage(nodeIndexes, true);
-            var messsageFragments = NodeMessageHelpers.GenerateMessageFragmentSequence(nodeIndexes, 100);
+            var messageFragments = NodeMessageHelpers.GenerateMessageFragmentSequence(nodeIndexes, 100);
             allMessages.UnionWith(runnerMessages);
             allMessages.UnionWith(successMessages);
-            allMessages.UnionWith(messsageFragments);
+            allMessages.UnionWith(messageFragments);
 
             foreach (var message in allMessages)
                 testRunCoordinator.Tell(message);
@@ -78,9 +78,9 @@ namespace Akka.MultiNodeTestRunner.Shared.Tests.Persistence
             testRunStore.SaveTestRun(file, testRunData).ShouldBeTrue("Should have been able to save test run");
 
             //retrieve the test run from file
-            var retreivedFile = testRunStore.FetchTestRun(file);
-            Assert.NotNull(retreivedFile);
-            Assert.True(testRunData.Equals(retreivedFile));
+            var retrievedFile = testRunStore.FetchTestRun(file);
+            Assert.NotNull(retrievedFile);
+            Assert.True(testRunData.Equals(retrievedFile));
         }
     }
 }

--- a/src/core/Akka.Persistence.TestKit/Journal/JournalSpec.cs
+++ b/src/core/Akka.Persistence.TestKit/Journal/JournalSpec.cs
@@ -42,7 +42,7 @@ namespace Akka.Persistence.TestKit.Journal
 
             Journal.Tell(new WriteMessages(messages, probe.Ref, ActorInstanceId));
 
-            probe.ExpectMsg<WriteMessagesSuccessull>();
+            probe.ExpectMsg<WriteMessagesSuccessful>();
             for (int i = from; i <= to; i++)
             {
                 var n = i;

--- a/src/core/Akka.Persistence.Tests/PersistentActorSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorSpec.cs
@@ -172,7 +172,7 @@ namespace Akka.Persistence.Tests
         }
 
         [Fact(Skip = "not implemented yet")]
-        public void PersistentActor_should_support_user_stash_operations_with_serveral_stashed_messages()
+        public void PersistentActor_should_support_user_stash_operations_with_several_stashed_messages()
         {
             var pref = ActorOf(Props.Create(() => new UserStashManyActor(Name)));
             var n = 10;
@@ -360,7 +360,7 @@ namespace Akka.Persistence.Tests
         }
 
         [Fact]
-        public void PersistentActor_should_invoke_deffered_handlers_in_presence_of_mixed_a_long_series_Persist_and_PersistAsync_calls()
+        public void PersistentActor_should_invoke_deferred_handlers_in_presence_of_mixed_a_long_series_Persist_and_PersistAsync_calls()
         {
             var pref = ActorOf(Props.Create(() => new DeferringMixedCallsPPADDPADPersistActor(Name)));
             var p1 = CreateTestProbe();
@@ -386,7 +386,7 @@ namespace Akka.Persistence.Tests
         }
 
         [Fact]
-        public void PersistentActor_should_invoke_deffered_handlers_right_away_if_there_are_no_persist_handlers_registered()
+        public void PersistentActor_should_invoke_deferred_handlers_right_away_if_there_are_no_persist_handlers_registered()
         {
             var pref = ActorOf(Props.Create(() => new DeferringWithNoPersistCallsPersistActor(Name)));
             pref.Tell(new Cmd("a"));
@@ -399,7 +399,7 @@ namespace Akka.Persistence.Tests
         }
 
         [Fact]
-        public void PersistentActor_should_invoke_deffered_handlers_preserving_the_original_sender_reference()
+        public void PersistentActor_should_invoke_deferred_handlers_preserving_the_original_sender_reference()
         {
             var pref = ActorOf(Props.Create(() => new DeferringWithAsyncPersistActor(Name)));
             var p1 = CreateTestProbe();

--- a/src/core/Akka.Persistence/Eventsourced.Recovery.cs
+++ b/src/core/Akka.Persistence/Eventsourced.Recovery.cs
@@ -318,7 +318,7 @@ namespace Akka.Persistence
                     TryFirstInvocationHandler(m.Message, onWriteMessageComplete);
                 }
             }
-            else if (message is WriteMessagesSuccessull || message is WriteMessagesFailed)
+            else if (message is WriteMessagesSuccessful || message is WriteMessagesFailed)
             {
                 if (_journalBatch.Count == 0) _isWriteInProgress = false;
                 else FlushJournalBatch();

--- a/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
@@ -117,7 +117,7 @@ namespace Akka.Persistence.Journal
             {
                 if (!t.IsFaulted)
                 {
-                    _resequencer.Tell(new Desequenced(WriteMessagesSuccessull.Instance, counter, message.PersistentActor, Self));
+                    _resequencer.Tell(new Desequenced(WriteMessagesSuccessful.Instance, counter, message.PersistentActor, Self));
                     resequence(x => new WriteMessageSuccess(x, message.ActorInstanceId));
                 }
                 else

--- a/src/core/Akka.Persistence/Journal/SyncWriteJournal.cs
+++ b/src/core/Akka.Persistence/Journal/SyncWriteJournal.cs
@@ -88,7 +88,7 @@ namespace Akka.Persistence.Journal
                 var batch = CreatePersistentBatch(msg.Messages);
                 WriteMessages(batch);
 
-                msg.PersistentActor.Tell(WriteMessagesSuccessull.Instance);
+                msg.PersistentActor.Tell(WriteMessagesSuccessful.Instance);
                 foreach (var message in msg.Messages)
                 {
                     if (message is IPersistentRepresentation)

--- a/src/core/Akka.Persistence/JournalProtocol.cs
+++ b/src/core/Akka.Persistence/JournalProtocol.cs
@@ -107,13 +107,13 @@ namespace Akka.Persistence
     /// to the requestor before all subsequent <see cref="WriteMessageSuccess"/> replies.
     /// </summary>
     [Serializable]
-    public class WriteMessagesSuccessull : IEquatable<WriteMessagesSuccessull>
+    public class WriteMessagesSuccessful : IEquatable<WriteMessagesSuccessful>
     {
-        public static readonly WriteMessagesSuccessull Instance = new WriteMessagesSuccessull();
+        public static readonly WriteMessagesSuccessful Instance = new WriteMessagesSuccessful();
 
-        private WriteMessagesSuccessull() { }
+        private WriteMessagesSuccessful() { }
 
-        public bool Equals(WriteMessagesSuccessull other)
+        public bool Equals(WriteMessagesSuccessful other)
         {
             return true;
         }

--- a/src/core/Akka.Persistence/PersistentView.Lifecycle.cs
+++ b/src/core/Akka.Persistence/PersistentView.Lifecycle.cs
@@ -25,7 +25,7 @@ namespace Akka.Persistence
 
         protected override void PostStop()
         {
-            if (_scheduleCancelation != null) _scheduleCancelation.Cancel();
+            if (_scheduleCancellation != null) _scheduleCancellation.Cancel();
             base.PostStop();
         }
 

--- a/src/core/Akka.Persistence/PersistentView.Recovery.cs
+++ b/src/core/Akka.Persistence/PersistentView.Recovery.cs
@@ -143,8 +143,8 @@ namespace Akka.Persistence
             ChangeState(Idle());
             if (IsAutoUpdate)
             {
-                _scheduleCancelation = new CancellationTokenSource();
-                Context.System.Scheduler.ScheduleOnce(AutoUpdateInterval, Self, new Update(false, AutoUpdateReplayMax), _scheduleCancelation.Token);
+                _scheduleCancellation = new CancellationTokenSource();
+                Context.System.Scheduler.ScheduleOnce(AutoUpdateInterval, Self, new Update(false, AutoUpdateReplayMax), _scheduleCancellation.Token);
             }
             if (shouldAwait)
             {

--- a/src/core/Akka.Persistence/PersistentView.cs
+++ b/src/core/Akka.Persistence/PersistentView.cs
@@ -74,7 +74,7 @@ namespace Akka.Persistence
         private ActorRef _snapshotStore;
         private ActorRef _journal;
 
-        private CancellationTokenSource _scheduleCancelation;
+        private CancellationTokenSource _scheduleCancellation;
 
         private IStash _internalStash;
         private ViewState _currentState;

--- a/src/core/Akka.Remote.Tests/RemoteRouterSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteRouterSpec.cs
@@ -121,7 +121,7 @@ namespace Akka.Remote.Tests
         }
 
         [Fact]
-        public void RemoteRouter_must_deploy_its_children_on_remote_host_driven_by_programatic_definition()
+        public void RemoteRouter_must_deploy_its_children_on_remote_host_driven_by_programmatic_definition()
         {
             var probe = CreateTestProbe(masterActorSystem);
             var router = masterActorSystem.ActorOf(new RemoteRouterConfig(new RoundRobinPool(2), new[] { new Address("akka.tcp", sysName, "localhost", port) })
@@ -210,7 +210,7 @@ namespace Akka.Remote.Tests
         }
 
         [Fact]
-        public void RemoteRouter_must_let_remote_deployment_be_overriden_by_local_configuration()
+        public void RemoteRouter_must_let_remote_deployment_be_overridden_by_local_configuration()
         {
             var probe = CreateTestProbe(masterActorSystem);
             var router = masterActorSystem.ActorOf(new RoundRobinPool(2).Props(Props.Create<Echo>())
@@ -235,7 +235,7 @@ namespace Akka.Remote.Tests
         }
 
         [Fact]
-        public void RemoteRouter_must_let_remote_deployment_router_be_overriden_by_local_configuration()
+        public void RemoteRouter_must_let_remote_deployment_router_be_overridden_by_local_configuration()
         {
             var probe = CreateTestProbe(masterActorSystem);
             var router = masterActorSystem.ActorOf(new RoundRobinPool(2).Props(Props.Create<Echo>())
@@ -262,7 +262,7 @@ namespace Akka.Remote.Tests
         }
 
         [Fact]
-        public void RemoteRouter_must_let_remote_deployment_be_overriden_by_remote_configuration()
+        public void RemoteRouter_must_let_remote_deployment_be_overridden_by_remote_configuration()
         {
             var probe = CreateTestProbe(masterActorSystem);
             var router = masterActorSystem.ActorOf(new RoundRobinPool(2).Props(Props.Create<Echo>())

--- a/src/core/Akka.Remote.Tests/RemoteWatcherSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteWatcherSpec.cs
@@ -332,7 +332,7 @@ namespace Akka.Remote.Tests
 
         [Fact]
         public void
-            ARemoteWatcherMustGenerateAddressTerminatedForNewWatchAfterBrokenConnectionWasRestablishedAndBrokenAgain()
+            ARemoteWatcherMustGenerateAddressTerminatedForNewWatchAfterBrokenConnectionWasReestablishedAndBrokenAgain()
         {
             var p = CreateTestProbe();
             var q = CreateTestProbe();

--- a/src/core/Akka.Remote.Tests/Transport/ThrottleModeSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/ThrottleModeSpec.cs
@@ -91,7 +91,7 @@ namespace Akka.Remote.Tests.Transport
         }
 
         [Fact]
-        public void ThrottleMode_must_allow_oversized_packets_throuh_by_loaning()
+        public void ThrottleMode_must_allow_oversized_packets_through_by_loaning()
         {
             var bucket = new TokenBucket(100, 100, 0L, 20);
             var bucket1 = bucket.TryConsumeTokens(0L, 30);

--- a/src/core/Akka.Remote/AckedDelivery.cs
+++ b/src/core/Akka.Remote/AckedDelivery.cs
@@ -330,12 +330,12 @@ namespace Akka.Remote
         /// <summary>
         /// Constructor
         /// </summary>
-        /// <param name="lastDelviered">Sequence number of the last message that has been delivered.</param>
+        /// <param name="lastDelivered">Sequence number of the last message that has been delivered.</param>
         /// <param name="cumulativeAck">The highest sequence number received so far</param>
         /// <param name="buffer">Buffer of messages that are waiting for delivery.</param>
-        public AckedReceiveBuffer(SeqNo lastDelviered, SeqNo cumulativeAck, SortedSet<T> buffer)
+        public AckedReceiveBuffer(SeqNo lastDelivered, SeqNo cumulativeAck, SortedSet<T> buffer)
         {
-            LastDelivered = lastDelviered ?? new SeqNo(-1);
+            LastDelivered = lastDelivered ?? new SeqNo(-1);
             CumulativeAck = cumulativeAck ?? new SeqNo(-1);
             Buf = buffer;
         }
@@ -406,7 +406,7 @@ namespace Akka.Remote
                 }
 
                 Buf.ExceptWith(deliver);
-                return new AckReceiveDeliverable<T>(Copy(lastDelviered: updatedLastDelivered, buffer: Buf), deliver, ack);
+                return new AckReceiveDeliverable<T>(Copy(lastDelivered: updatedLastDelivered, buffer: Buf), deliver, ack);
             }
             
         }
@@ -427,9 +427,9 @@ namespace Akka.Remote
 
         #region Copy methods
 
-        public AckedReceiveBuffer<T> Copy(SeqNo lastDelviered = null, SeqNo cumulativeAck = null, SortedSet<T> buffer = null)
+        public AckedReceiveBuffer<T> Copy(SeqNo lastDelivered = null, SeqNo cumulativeAck = null, SortedSet<T> buffer = null)
         {
-            return new AckedReceiveBuffer<T>(lastDelviered ?? LastDelivered, cumulativeAck ?? CumulativeAck, buffer ?? new SortedSet<T>(Buf, Comparer));
+            return new AckedReceiveBuffer<T>(lastDelivered ?? LastDelivered, cumulativeAck ?? CumulativeAck, buffer ?? new SortedSet<T>(Buf, Comparer));
         }
 
         #endregion

--- a/src/core/Akka.TestKit.Tests/TestKitBaseTests/ExpectTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestKitBaseTests/ExpectTests.cs
@@ -17,7 +17,7 @@ namespace Akka.Testkit.Tests.TestKitBaseTests
         }
 
         [Fact]
-        public void ExpectMsgAllOf_should_fail_when_receiveing_unexpected()
+        public void ExpectMsgAllOf_should_fail_when_receiving_unexpected()
         {
             TestActor.Tell("1");
             TestActor.Tell("2");

--- a/src/core/Akka.Tests/Actor/ActorDslSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorDslSpec.cs
@@ -10,7 +10,7 @@ namespace Akka.Tests.Actor
     public class ActorDslSpec : AkkaSpec
     {
         [Fact]
-        public void A_ligthweight_creator_must_support_creating_regular_actors()
+        public void A_lightweight_creator_must_support_creating_regular_actors()
         {
             var a = Sys.ActorOf(Props.Create(() => new Act(c =>
                 c.Receive<string>(msg => msg == "hello", (msg, ctx) => TestActor.Tell("hi")))));
@@ -51,7 +51,7 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
-        public void A_ligthweight_creator_must_support_actor_setup_and_teardown()
+        public void A_lightweight_creator_must_support_actor_setup_and_teardown()
         {
             const string started = "started";
             const string stopped = "stopped";
@@ -68,19 +68,19 @@ namespace Akka.Tests.Actor
         }
 
         [Fact(Skip = "TODO: requires event filters")]
-        public void A_ligthweight_creator_must_support_restart()
+        public void A_lightweight_creator_must_support_restart()
         {
             //TODO: requires event filters
         }
 
         [Fact(Skip = "TODO: requires event filters")]
-        public void A_ligthweight_creator_must_support_supervising()
+        public void A_lightweight_creator_must_support_supervising()
         {
             //TODO: requires event filters
         }
 
         [Fact]
-        public void A_ligthweight_creator_must_support_nested_declarations()
+        public void A_lightweight_creator_must_support_nested_declarations()
         {
             var a = Sys.ActorOf(act =>
             {
@@ -96,7 +96,7 @@ namespace Akka.Tests.Actor
         }
 
         [Fact(Skip = "TODO: requires proven and tested stash implementation")]
-        public void A_ligthweight_creator_must_support_stash()
+        public void A_lightweight_creator_must_support_stash()
         {
             //TODO: requires proven and tested stash implementation
         }

--- a/src/core/Akka.Tests/Actor/ActorPathSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorPathSpec.cs
@@ -87,7 +87,7 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
-        public void ReturnFalsUponMalformedPath()
+        public void ReturnFalseUponMalformedPath()
         {
             ActorPath ignored;
             ActorPath.TryParse("", out ignored).ShouldBe(false);

--- a/src/core/Akka.Tests/Actor/ActorRefSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorRefSpec.cs
@@ -160,7 +160,7 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
-        public void An_ActorRef_should_suppport_reply_via_Sender()
+        public void An_ActorRef_should_support_reply_via_Sender()
         {
             var latch = new TestLatch(Sys, 4);
             var serverRef = Sys.ActorOf(Props.Create<ReplyActor>());

--- a/src/core/Akka.Tests/Actor/ActorSelectionSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorSelectionSpec.cs
@@ -57,7 +57,7 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
-        public void CanResolveWildcardQuestionmark()
+        public void CanResolveWildcardQuestionMark()
         {
             Sys.ActorSelection("user/t?st").Tell("hello2");
             ExpectMsg("hello2");

--- a/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
@@ -74,7 +74,7 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
-        public void AnActorSystem_Must_Support_Dynamically_Regsitered_Extensions()
+        public void AnActorSystem_Must_Support_Dynamically_Registered_Extensions()
         {
             Assert.False(Sys.HasExtension<OtherTestExtensionImpl>());
             var otherTestExtension = Sys.WithExtension<OtherTestExtensionImpl>(typeof(OtherTestExtension));

--- a/src/core/Akka.Tests/Actor/ReceiveActorTests.cs
+++ b/src/core/Akka.Tests/Actor/ReceiveActorTests.cs
@@ -43,7 +43,7 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
-        public void Given_an_EchoActor_When_receiveing_messages_Then_messages_should_be_sent_back()
+        public void Given_an_EchoActor_When_receiving_messages_Then_messages_should_be_sent_back()
         {
             //Given
             var system = ActorSystem.Create("test");

--- a/src/core/Akka.Tests/Actor/SupervisorHierarchySpec.cs
+++ b/src/core/Akka.Tests/Actor/SupervisorHierarchySpec.cs
@@ -232,7 +232,7 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
-        public void A_supervisor_hierarchy_must_handle_failure_in_creation_when_supervision_startegy_returns_Resume_and_Restart()
+        public void A_supervisor_hierarchy_must_handle_failure_in_creation_when_supervision_strategy_returns_Resume_and_Restart()
         {
             var createAttempt = new AtomicCounter(0);
             var preStartCalled = new AtomicCounter(0);

--- a/src/core/Akka.Tests/Configuration/HoconTests.cs
+++ b/src/core/Akka.Tests/Configuration/HoconTests.cs
@@ -76,7 +76,7 @@ namespace Akka.Tests.Configuration
 
 
         [Fact]
-        public void CanConcatinateSubstitutedUnquotedString()
+        public void CanConcatenateSubstitutedUnquotedString()
         {
             var hocon = @"a {
   name = Roger
@@ -86,7 +86,7 @@ namespace Akka.Tests.Configuration
         }
 
         [Fact]
-        public void CanConcatinateSubstitutedArray()
+        public void CanConcatenateSubstitutedArray()
         {
             var hocon = @"a {
   b = [1,2,3]
@@ -372,7 +372,7 @@ a.b.e.f=3
         }
 
         [Fact]
-        public void CanAssignTrippleQuotedStringToField()
+        public void CanAssignTripleQuotedStringToField()
         {
             var hocon = @"a=""""""hello""""""";
             Assert.Equal("hello", ConfigurationFactory.ParseString(hocon).GetString("a"));

--- a/src/core/Akka.Tests/MatchHandler/MatchBuilderSignatureTests.cs
+++ b/src/core/Akka.Tests/MatchHandler/MatchBuilderSignatureTests.cs
@@ -133,7 +133,7 @@ namespace Akka.Tests.MatchHandler
             Assert.True(signature2.Equals(signature1));
         }
         [Fact]
-        public void Equals_with_same_elements_in_signature_but_feweer_in_one_should_be_false()
+        public void Equals_with_same_elements_in_signature_but_fewer_in_one_should_be_false()
         {
             var signature1 = new MatchBuilderSignature(new object[] { 4711, "42", new object() });
             var signature2 = new MatchBuilderSignature(new object[] { 4711, "42" });

--- a/src/core/Akka/Actor/ICanTell.cs
+++ b/src/core/Akka/Actor/ICanTell.cs
@@ -8,6 +8,6 @@ namespace Akka.Actor
 {
     public interface ICanTell
     {
-        void Tell(object mssage, ActorRef sender);
+        void Tell(object message, ActorRef sender);
     }
 }

--- a/src/core/Akka/Configuration/Hocon/HoconTokenizer.cs
+++ b/src/core/Akka/Configuration/Hocon/HoconTokenizer.cs
@@ -389,7 +389,7 @@ namespace Akka.Configuration.Hocon
         ///     Determines whether [is start of triple quoted text].
         /// </summary>
         /// <returns><c>true</c> if [is start of triple quoted text]; otherwise, <c>false</c>.</returns>
-        public bool IsStartOfTrippleQuotedText()
+        public bool IsStartOfTripleQuotedText()
         {
             return Matches("\"\"\"");
         }
@@ -450,7 +450,7 @@ namespace Akka.Configuration.Hocon
         ///     Pulls the triple quoted text.
         /// </summary>
         /// <returns>Token.</returns>
-        public Token PullTrippleQuotedText()
+        public Token PullTripleQuotedText()
         {
             var sb = new StringBuilder();
             Take(3);
@@ -578,9 +578,9 @@ namespace Akka.Configuration.Hocon
                 return PullStartOfObject();
             }
 
-            if (IsStartOfTrippleQuotedText())
+            if (IsStartOfTripleQuotedText())
             {
-                return PullTrippleQuotedText();
+                return PullTripleQuotedText();
             }
 
             if (IsStartOfQuotedText())
@@ -732,7 +732,7 @@ namespace Akka.Configuration.Hocon
                 return true;
             if (IsObjectStart())
                 return true;
-            if (IsStartOfTrippleQuotedText())
+            if (IsStartOfTripleQuotedText())
                 return true;
             if (IsSubstitutionStart())
                 return true;

--- a/src/core/Akka/Util/MatchHandler/MatchExpressionBuilder.cs
+++ b/src/core/Akka/Util/MatchHandler/MatchExpressionBuilder.cs
@@ -166,7 +166,7 @@ namespace Akka.Tools.MatchHandler
                 var parameter = Expression.Parameter(argumentValue.GetType(), "arg" + iPlus1);
                 parameters[iPlus1] = parameter;
                 if(argument.ValueIsActionOrFunc)
-                    argument.PredicateAndHandler.ActionOrFuncExpresssion = parameter;
+                    argument.PredicateAndHandler.ActionOrFuncExpression = parameter;
                 else
                     argument.PredicateAndHandler.PredicateExpression = parameter;
             }
@@ -180,7 +180,7 @@ namespace Akka.Tools.MatchHandler
                     extraArgsValues[i] = argumentValue;
                     var expression = Expression.Convert(Expression.ArrayIndex(_extraArgsArrayParameter, Expression.Constant(i)), argumentValue.GetType());
                     if(argument.ValueIsActionOrFunc)
-                        argument.PredicateAndHandler.ActionOrFuncExpresssion = expression;
+                        argument.PredicateAndHandler.ActionOrFuncExpression = expression;
                     else
                         argument.PredicateAndHandler.PredicateExpression = expression;
                 }
@@ -261,7 +261,7 @@ namespace Akka.Tools.MatchHandler
             //Adds this code to the body:
             //    action(arg);
             //    return true;
-            body.Add(Expression.Invoke(handler.ActionOrFuncExpresssion, argumentExpression));
+            body.Add(Expression.Invoke(handler.ActionOrFuncExpression, argumentExpression));
             body.Add(Expression.Return(returnTarget, Expression.Constant(true)));
         }
 
@@ -278,7 +278,7 @@ namespace Akka.Tools.MatchHandler
                 Expression.IfThen(
                     Expression.Invoke(handler.PredicateExpression, argumentExpression),
                     Expression.Block(
-                        Expression.Invoke(handler.ActionOrFuncExpresssion, argumentExpression),
+                        Expression.Invoke(handler.ActionOrFuncExpression, argumentExpression),
                         Expression.Return(returnTarget, Expression.Constant(true))
                         )));
         }
@@ -292,7 +292,7 @@ namespace Akka.Tools.MatchHandler
             //    }
             body.Add(
                 Expression.IfThen(
-                    Expression.Invoke(handler.ActionOrFuncExpresssion, argumentExpression),
+                    Expression.Invoke(handler.ActionOrFuncExpression, argumentExpression),
                         Expression.Return(returnTarget, Expression.Constant(true))
                         ));
         }

--- a/src/core/Akka/Util/MatchHandler/PredicateAndHandler.cs
+++ b/src/core/Akka/Util/MatchHandler/PredicateAndHandler.cs
@@ -20,7 +20,7 @@ namespace Akka.Tools.MatchHandler
         public IReadOnlyList<Argument> Arguments { get; private set; }
         public bool HandlerFirstArgumentShouldBeBaseType { get { return _handlerFirstArgumentShouldBeBaseType; } }
 
-        public Expression ActionOrFuncExpresssion { get; set; }
+        public Expression ActionOrFuncExpression { get; set; }
         public Expression PredicateExpression { get; set; }        
         public static PredicateAndHandler CreateAction(object action, object predicate = null, bool handlerFirstArgumentShouldBeBaseType=false)
         {


### PR DESCRIPTION
I think I got all (or at least most) of them now. 

Split it into three commits since some of the typos were in a class name and some methods.
