### PR TITLE
Add links to Apache license and explainer

### DIFF
--- a/documentation/wiki/What is Akka.md
+++ b/documentation/wiki/What is Akka.md
@@ -14,7 +14,7 @@ By using the Actor Model, we raise the abstraction level and provide a better pl
 
 For fault-tolerance we adopt the "let it crash" model which the telecom industry has used with great success to build applications that self-heal and systems that never stop. Actors also provide the abstraction for transparent distribution and the basis for truly scalable and fault-tolerant applications.
 
-Akka.NET is Open Source and available under the Apache 2 License.
+Akka.NET is Open Source and available under the [Apache 2 License](http://www.apache.org/licenses/LICENSE-2.0) -- [explained in plain english here](https://www.tldrlegal.com/l/apache2).
 
 Download from https://github.com/akkadotnet/akka.net.
 


### PR DESCRIPTION
Closes #653. Added both the Apache 2 and explainer link.