### PR TITLE
Serializable supervisor

### DIFF
--- a/src/core/Akka.TestKit.Tests/TestActorRefTests/BossActor.cs
+++ b/src/core/Akka.TestKit.Tests/TestActorRefTests/BossActor.cs
@@ -14,7 +14,7 @@ namespace Akka.TestKit.Tests.TestActorRefTests
 
         protected override SupervisorStrategy SupervisorStrategy()
         {
-            return new OneForOneStrategy(maxNrOfRetries: 5, withinTimeRange: TimeSpan.FromSeconds(1), decider: ex => ex is ActorKilledException ? Directive.Restart : Directive.Escalate);
+            return new OneForOneStrategy(maxNrOfRetries: 5, withinTimeRange: TimeSpan.FromSeconds(1), localOnlyDecider: ex => ex is ActorKilledException ? Directive.Restart : Directive.Escalate);
         }
 
         protected override bool ReceiveMessage(object message)

--- a/src/core/Akka/Actor/SupervisorStrategy.cs
+++ b/src/core/Akka/Actor/SupervisorStrategy.cs
@@ -535,6 +535,11 @@ namespace Akka.Actor
             return new DeployableDecider(defaultDirective,pairs);
         }
 
+        public static DeployableDecider From(Directive defaultDirective, IEnumerable<KeyValuePair<Type, Directive>> pairs)
+        {
+            return From(defaultDirective, pairs.ToArray());
+        }
+
         public static LocalOnlyDecider From(Func<Exception, Directive> localOnlyDecider)
         {
             return new LocalOnlyDecider(localOnlyDecider);

--- a/src/core/Akka/Actor/SupervisorStrategy.cs
+++ b/src/core/Akka/Actor/SupervisorStrategy.cs
@@ -532,12 +532,12 @@ namespace Akka.Actor
     {
         public static DeployableDecider From(Directive defaultDirective, params KeyValuePair<Type, Directive>[] pairs)
         {
-            return new DeployableDecider(defaultDirective,pairs);
+            return new DeployableDecider(defaultDirective, pairs);     
         }
 
         public static DeployableDecider From(Directive defaultDirective, IEnumerable<KeyValuePair<Type, Directive>> pairs)
         {
-            return From(defaultDirective, pairs.ToArray());
+            return new DeployableDecider(defaultDirective, pairs);
         }
 
         public static LocalOnlyDecider From(Func<Exception, Directive> localOnlyDecider)
@@ -562,7 +562,17 @@ namespace Akka.Actor
 
     public class DeployableDecider : IDecider
     {
-        public DeployableDecider(Directive defaultDirective, params KeyValuePair<Type, Directive>[] pairs)
+        //Json .net can not decide which of the other ctors are the correct one to use
+        //so we fall back to default ctor and property injection for deserializer
+        protected DeployableDecider()
+        {            
+        }
+
+        public DeployableDecider(Directive defaultDirective, IEnumerable<KeyValuePair<Type, Directive>> pairs) : this(defaultDirective,pairs.ToArray())
+        {
+        }
+
+        public DeployableDecider(Directive defaultDirective,params KeyValuePair<Type, Directive>[] pairs)
         {
             DefaultDirective = defaultDirective;
             Pairs = pairs;


### PR DESCRIPTION
Added decider type that replaces the decider lambda
Added Decider serialization spec
Added SupervisorStrategy Serialization spec
Added Decider DSL

PR for #665 

Serializable Deciders can now be created like this:
```csharp
   var decider = Decider.From(
                Directive.Restart,
                Directive.Stop.When<ArgumentException>(),
                Directive.Stop.When<NullReferenceException>());
```

Old lambda support is still valid but not serializable.
