### PR TITLE
Fixes ParseSpec for non-US cultures 

### DIFF
--- a/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
+++ b/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
@@ -83,6 +83,7 @@
     <Compile Include="MultiNode\ConvergenceSpec.cs" />
     <Compile Include="MultiNode\InitialHeartbeatSpec.cs" />
     <Compile Include="MultiNode\JoinInProgressSpec.cs" />
+    <Compile Include="MultiNode\JoinSeedNodeSpec.cs" />
     <Compile Include="MultiNode\LeaderLeavingSpec.cs" />
     <Compile Include="MultiNode\MultiNodeClusterSpec.cs" />
     <Compile Include="MultiNode\MultiNodeFact.cs" />

--- a/src/core/Akka.Cluster.Tests/MultiNode/JoinSeedNodeSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MultiNode/JoinSeedNodeSpec.cs
@@ -1,0 +1,101 @@
+﻿using System.Collections.Immutable;
+using System.Threading;
+using Akka.Actor;
+using Akka.Remote.TestKit;
+
+namespace Akka.Cluster.Tests.MultiNode
+{
+    public class JoinSeedNodeConfig : MultiNodeConfig
+    {
+        private readonly RoleName _seed1;
+        public RoleName Seed1 { get { return _seed1; } }
+
+        private readonly RoleName _seed2;
+        public RoleName Seed2 { get { return _seed2; } }
+
+        private readonly RoleName _seed3;
+        public RoleName Seed3 { get { return _seed3; } }
+
+        private readonly RoleName _ordinary1;
+        public RoleName Ordinary1 { get { return _ordinary1; } }
+
+        private readonly RoleName _ordinary2;
+        public RoleName Ordinary2 { get { return _ordinary2; } }
+
+        public JoinSeedNodeConfig()
+        {
+            _seed1 = Role("seed1");
+            _seed2 = Role("seed2");
+            _seed3 = Role("seed3");
+            _ordinary1 = Role("ordinary1");
+            _ordinary2 = Role("ordinary2");
+
+            CommonConfig = MultiNodeLoggingConfig.LoggingConfig.WithFallback(DebugConfig(true))
+                .WithFallback(MultiNodeClusterSpec.ClusterConfig());
+        }
+    }
+
+    public class JoinSeedNodeMultiNode1 : JoinSeedNodeSpec { }
+    public class JoinSeedNodeMultiNode2 : JoinSeedNodeSpec { }
+    public class JoinSeedNodeMultiNode3 : JoinSeedNodeSpec { }
+    public class JoinSeedNodeMultiNode4 : JoinSeedNodeSpec { }
+    public class JoinSeedNodeMultiNode5 : JoinSeedNodeSpec { }
+
+    public abstract class JoinSeedNodeSpec : MultiNodeClusterSpec
+    {
+        private readonly JoinSeedNodeConfig _config;
+
+        protected JoinSeedNodeSpec() : this(new JoinSeedNodeConfig()) { }
+
+        protected JoinSeedNodeSpec(JoinSeedNodeConfig config) : base(config)
+        {
+            _config = config;
+        }
+
+        private ImmutableList<Address> _seedNodes;
+            
+        [MultiNodeFact]
+        public void JoinSeedNodeSpecs()
+        {
+            _seedNodes = ImmutableList.Create(GetAddress(_config.Seed1), GetAddress(_config.Seed2),
+                GetAddress(_config.Seed3));
+            AClusterWithSeedNodesMustBeAbleToStartTheSeedNodesConcurrently();
+            AClusterWithSeedNodesMustBeAbleToJoinTheSeedNodes();
+        }
+
+        public void AClusterWithSeedNodesMustBeAbleToStartTheSeedNodesConcurrently()
+        {
+            
+
+            RunOn(() =>
+            {
+                // test that first seed doesn't have to be started first
+                Thread.Sleep(3000);
+            }, _config.Seed1);
+
+            RunOn(() =>
+            {
+                Cluster.JoinSeedNodes(_seedNodes);
+                RunOn(() =>
+                {
+                    //verify that we can call this multiple times with no issue                    
+                    Cluster.JoinSeedNodes(_seedNodes);
+                }, _config.Seed3);
+                AwaitMembersUp(3);
+            }, _config.Seed1, _config.Seed2, _config.Seed3);
+
+            EnterBarrier("after-1");
+        }
+
+        public void AClusterWithSeedNodesMustBeAbleToJoinTheSeedNodes()
+        {
+            RunOn(() =>
+            {
+                Cluster.JoinSeedNodes(_seedNodes);
+            }, _config.Ordinary1, _config.Ordinary2);
+
+            AwaitMembersUp(Roles.Count);
+            EnterBarrier("after-2");
+        }
+    }
+}

--- a/src/core/Akka.Cluster.Tests/MultiNode/MultiNodeClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MultiNode/MultiNodeClusterSpec.cs
@@ -351,14 +351,14 @@ namespace Akka.Cluster.Tests.MultiNode
                     AwaitAssert(() =>
                     {
                         foreach (var a in canNotBePartOfMemberRing)
-                            _assertions.AssertFalse(ClusterView.Members.Select(m => m.Address).Contains(a));
+                            ClusterView.Members.Select(m => m.Address).Contains(a).ShouldBeFalse();
                     });
-                AwaitAssert(() => _assertions.AssertEqual(numbersOfMembers, ClusterView.Members.Count));
-                AwaitAssert(() => _assertions.AssertTrue(ClusterView.Members.All(m => m.Status == MemberStatus.Up)));
+                AwaitAssert(() => ClusterView.Members.Count.ShouldBe(numbersOfMembers));
+                AwaitAssert(() => ClusterView.Members.All(m => m.Status == MemberStatus.Up).ShouldBeTrue("All members should be up"));
                 // clusterView.leader is updated by LeaderChanged, await that to be updated also
                 var firstMember = ClusterView.Members.FirstOrDefault();
                 var expectedLeader = firstMember == null ? null : firstMember.Address;
-                AwaitAssert(() => _assertions.AssertEqual(expectedLeader, ClusterView.Leader));
+                AwaitAssert(() => ClusterView.Leader.ShouldBe(expectedLeader));
             });
         }
 

--- a/src/core/Akka.MultiNodeTestRunner.Shared.Tests/ParsingSpec.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared.Tests/ParsingSpec.cs
@@ -52,8 +52,22 @@ namespace Akka.MultiNodeTestRunner.Shared.Tests
             LogMessageForNode nodeMessage;
             MessageSink.TryParseLogMessage(foundMessageStr, out nodeMessage).ShouldBeTrue("should have been able to parse log message");
 
+            Assert.NotNull(nodeMessage);
             Assert.Equal(foundMessage.LogLevel(), nodeMessage.Level);
             Assert.Equal(foundMessage.LogSource, nodeMessage.LogSource);
+        }
+
+        [Fact]
+        public void MessageSink_should_parse_NonUS_culture_Node_log_message_correctly()
+        {
+            //format the string as it would appear when reported by multinode test runner
+            var foundMessageStr = "[NODE1][DEBUG][2015-02-09 23:05:08][Thread 0008][[akka://ParsingSpec-1/user/$b]] Received message LOG ME!";
+            LogMessageForNode nodeMessage;
+            MessageSink.TryParseLogMessage(foundMessageStr, out nodeMessage).ShouldBeTrue("should have been able to parse log message");
+
+            Assert.NotNull(nodeMessage);
+            Assert.Equal(LogLevel.DebugLevel, nodeMessage.Level);
+            Assert.Equal("[akka://ParsingSpec-1/user/$b]", nodeMessage.LogSource);
         }
 
         [Fact]

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Reporting/TestRunCoordinator.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Reporting/TestRunCoordinator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Akka.Actor;
 using Akka.MultiNodeTestRunner.Shared.Persistence;
 using Akka.MultiNodeTestRunner.Shared.Sinks;
@@ -106,7 +107,7 @@ namespace Akka.MultiNodeTestRunner.Shared.Reporting
             });
             Receive<BeginNewSpec>(spec => ReceiveBeginSpecRun(spec));
             Receive<EndSpec>(spec => ReceiveEndSpecRun(spec));
-            Receive<RequestTestRunState>(state => Sender.Tell(TestRunData.Copy()));
+            Receive<RequestTestRunState>(state => Sender.Tell(TestRunData.Copy(TestRunPassed(TestRunData))));
             Receive<SubscribeFactCompletionMessages>(messages => AddSubscriber(messages));
             Receive<UnsubscribeFactCompletionMessages>(messages => RemoveSubscriber(messages));
             Receive<EndTestRun>(run =>
@@ -168,6 +169,11 @@ namespace Akka.MultiNodeTestRunner.Shared.Reporting
 
             //Ready to begin the next spec
             _currentSpecRunActor = null;
+        }
+
+        private static bool TestRunPassed(TestRunTree tree)
+        {
+            return tree.Specs.All(x => x.Passed.HasValue && x.Passed.Value);
         }
 
         #endregion

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Reporting/TestRunTree.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Reporting/TestRunTree.cs
@@ -73,12 +73,12 @@ namespace Akka.MultiNodeTestRunner.Shared.Reporting
         /// <summary>
         /// Returns a deep copy of the current tree.
         /// </summary>
-        public TestRunTree Copy()
+        public TestRunTree Copy(bool? passed = null)
         {
             var specs = new FactData[_specs.Count];
             _specs.CopyTo(specs);
 
-            return new TestRunTree(StartTime, specs.ToList(), EndTime, Passed);
+            return new TestRunTree(StartTime, specs.ToList(), EndTime, passed ?? Passed);
         }
 
         #region Equality

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/MessageSink.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/MessageSink.cs
@@ -96,10 +96,10 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
         /*
          * Regular expressions - go big or go home. [Aaronontheweb]
          */
-        private const string NodeLogMessageRegexString = @"\[(\w){4}(?<node>[0-9]{1,2})\]\[(?<level>(\w)*)\]\[(?<time>\d{1,2}[- /.]\d{1,2}[- /.]\d{1,4}\s\d{1,2}:\d{1,2}:\d{1,2}\s(AM|PM))\](?<thread>\[(\w|\s)*\])\[(?<logsource>(\[|\w|:|/|\(|\)|\]|\.|-|\$|%|\+|\^|@)*)\]\s(?<message>(\w|\s|:|<|\.|\+|>|,|\[|/|-|]|%|\$|\+|\^|@)*)";
+        private const string NodeLogMessageRegexString = @"\[(\w){4}(?<node>[0-9]{1,2})\]\[(?<level>(\w)*)\]\[(?<time>\d{1,4}[- /.]\d{1,4}[- /.]\d{1,4}\s\d{1,2}:\d{1,2}:\d{1,2}(\s(AM|PM)){0,1})\](?<thread>\[(\w|\s)*\])\[(?<logsource>(\[|\w|:|/|\(|\)|\]|\.|-|\$|%|\+|\^|@)*)\]\s(?<message>(\w|\s|:|<|\.|\+|>|,|\[|/|-|]|%|\$|\+|\^|@)*)";
         protected static readonly Regex NodeLogMessageRegex = new Regex(NodeLogMessageRegexString);
 
-        private const string RunnerLogMessageRegexString = @"\[(?<level>(\w)*)\]\[(?<time>\d{1,2}[- /.]\d{1,2}[- /.]\d{1,4}\s\d{1,2}:\d{1,2}:\d{1,2}\s(AM|PM))\](?<thread>\[(\w|\s)*\])\[(?<logsource>(\[|\w|:|/|\(|\)|\]|\.|-|\$|%|\+|\^|@)*)\]\s(?<message>(\w|\s|:|<|\.|\+|>|,|\[|/|-|]|%|\$|\+|\^|@)*)";
+        private const string RunnerLogMessageRegexString = @"\[(?<level>(\w)*)\]\[(?<time>\d{1,4}[- /.]\d{1,4}[- /.]\d{1,4}\s\d{1,2}:\d{1,2}:\d{1,2}(\s(AM|PM)){0,1})\](?<thread>\[(\w|\s)*\])\[(?<logsource>(\[|\w|:|/|\(|\)|\]|\.|-|\$|%|\+|\^|@)*)\]\s(?<message>(\w|\s|:|<|\.|\+|>|,|\[|/|-|]|%|\$|\+|\^|@)*)";
         protected static readonly Regex RunnerLogMessageRegex = new Regex(RunnerLogMessageRegexString);
 
         private const string NodeLogFragmentRegexString = @"\[(\w){4}(?<node>[0-9]{1,2})\](?<message>(.)*)";

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/SinkCoordinator.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/SinkCoordinator.cs
@@ -145,7 +145,10 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
                         .PipeTo(Self);
                 }
             });
-            Receive<string>(s => PublishToChildren(s));
+            Receive<string>(s =>
+            {
+                PublishToChildren(s);
+            });
             Receive<NodeCompletedSpecWithSuccess>(s => PublishToChildren(s));
             Receive<IList<NodeTest>>(tests => BeginSpec(tests));
             Receive<EndSpec>(spec => EndSpec());

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/TestCoordinatorEnabledMessageSink.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/TestCoordinatorEnabledMessageSink.cs
@@ -22,9 +22,12 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
                 if (UseTestCoordinator)
                 {
                     TestCoordinatorActorRef.Ask<TestRunTree>(new TestRunCoordinator.RequestTestRunState())
-                        .ContinueWith(task => new SinkCoordinator.RecommendedExitCode(task.Result.Passed.GetValueOrDefault(false)
-                            ? 0
-                            : 1), TaskContinuationOptions.ExecuteSynchronously & TaskContinuationOptions.AttachedToParent)
+                        .ContinueWith(task =>
+                        {
+                            return new SinkCoordinator.RecommendedExitCode(task.Result.Passed.GetValueOrDefault(false)
+                                ? 0
+                                : 1);
+                        }, TaskContinuationOptions.ExecuteSynchronously & TaskContinuationOptions.AttachedToParent)
                             .PipeTo(Sender, Self);
                 }
             });

--- a/src/core/Akka.MultiNodeTestRunner/Program.cs
+++ b/src/core/Akka.MultiNodeTestRunner/Program.cs
@@ -54,7 +54,7 @@ namespace Akka.MultiNodeTestRunner
         static void Main(string[] args)
         {
             TestRunSystem = ActorSystem.Create("TestRunnerLogging");
-            SinkCoordinator = TestRunSystem.ActorOf(Props.Create<SinkCoordinator>());
+            SinkCoordinator = TestRunSystem.ActorOf(Props.Create<SinkCoordinator>(), "sinkCoordinator");
 
             var assemblyName = args[0];
 
@@ -172,7 +172,7 @@ namespace Akka.MultiNodeTestRunner
 
         static void PublishToAllSinks(string message)
         {
-            SinkCoordinator.Tell(message);
+            SinkCoordinator.Tell(message, ActorRef.NoSender);
         }
     }
 }


### PR DESCRIPTION
close #610

close #635

Also adds the `JoinSeedNodeSpec` to the Akka.Cluster MultiNodeSpecs.