### PR TITLE
WIP: Prefix Interfaces with "I"

### DIFF
--- a/src/core/Akka.TestKit/Akka.TestKit.csproj
+++ b/src/core/Akka.TestKit/Akka.TestKit.csproj
@@ -98,7 +98,7 @@
     <Compile Include="EventFilter\Internal\WarningFilter.cs" />
     <Compile Include="EventFilter\TestEvent\Mute.cs" />
     <Compile Include="EventFilter\TestEvent\Unmute.cs" />
-    <Compile Include="EventFilter\UnmutableFilter.cs" />
+    <Compile Include="EventFilter\IUnmutableFilter.cs" />
     <Compile Include="FSMSpecHelpers.cs" />
     <Compile Include="AutoPilots.cs" />
     <Compile Include="NoImplicitSender.cs" />

--- a/src/core/Akka.TestKit/EventFilter/IUnmutableFilter.cs
+++ b/src/core/Akka.TestKit/EventFilter/IUnmutableFilter.cs
@@ -3,7 +3,7 @@ using System;
 namespace Akka.TestKit
 {
     // ReSharper disable once InconsistentNaming
-    public interface UnmutableFilter : IDisposable
+    public interface IUnmutableFilter : IDisposable
     {
         /// <summary>
         /// Call this to let events that previously have been muted to be logged again.


### PR DESCRIPTION
In support of #652, the purpose of this branch will be to prefix all interfaces in all assemblies with an `I` to match the .NET convention.

Do not merge this PR until the "WIP" is removed and it is ready to be considered.

Thanks!
