### PR TITLE
Revert "Refactor childStats requestRestartPermission algorithm"

### DIFF
--- a/src/core/Akka/Actor/ChildrenContainer/Internal/ChildStats.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/ChildStats.cs
@@ -47,12 +47,18 @@ namespace Akka.Actor.Internal
         public bool RequestRestartPermission(int maxNrOfRetries, int withinTimeMilliseconds)
         {
             if (maxNrOfRetries == 0) return false;
-            if (withinTimeMilliseconds == 0)
+            var retriesIsDefined = maxNrOfRetries > 0;
+            var windowIsDefined = withinTimeMilliseconds > 0;
+            if (retriesIsDefined && !windowIsDefined)
             {
                 _maxNrOfRetriesCount++;
                 return _maxNrOfRetriesCount <= maxNrOfRetries;
             }
-            return RetriesInWindowOkay(maxNrOfRetries, withinTimeMilliseconds);
+            if (windowIsDefined)
+            {
+                return RetriesInWindowOkay(retriesIsDefined ? maxNrOfRetries : 1, withinTimeMilliseconds);
+            }
+            return true;
             //retriesWindow match {
             //  case (Some(retries), _) if retries < 1 ⇒ false
             //  case (Some(retries), None)             ⇒ { maxNrOfRetriesCount += 1; maxNrOfRetriesCount <= retries }
@@ -78,7 +84,7 @@ namespace Akka.Actor.Internal
             {
                 windowStart = _restartTimeWindowStartTicks;
             }
-            var windowInTicks = windowInMilliseconds*TimeSpan.TicksPerMillisecond;
+            var windowInTicks = windowInMilliseconds * TimeSpan.TicksPerMillisecond;
             var insideWindow = (now - windowStart) <= windowInTicks;
 
             if (insideWindow)
@@ -90,5 +96,7 @@ namespace Akka.Actor.Internal
             _restartTimeWindowStartTicks = now;
             return true;
         }
+
+
     }
 }


### PR DESCRIPTION
Reverts akkadotnet/akka.net#689

PR #689 has altered the algorithm. Unfortunately it introduced several bugs, and needs to be reverted, as support for negative values have been completely removed. 

The values for `maxNrOfRetries` and `withinTimeMilliseconds` are specified when creating `AllForOneStrategy` and `OneForOneStrategy`. From the docs for these constructors:
-- `maxNrOfRetries`: the number of times a child actor is allowed to be restarted, negative value means no limit, if the limit is exceeded the child actor is stopped.
-- `withinTimeMilliseconds`: duration in milliseconds of the time window for maxNrOfRetries, negative values means no window.

#689 made these calls do the incorrect thing:
``` C#
RequestRestartPermission(-1,-1)
RequestRestartPermission(10,-1)
RequestRestartPermission(-1, 10)
```
