### PR TITLE
Revert parts of #691 "refactor suspend children"

### DIFF
--- a/src/core/Akka/Actor/ActorCell.Children.cs
+++ b/src/core/Akka/Actor/ActorCell.Children.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using Akka.Actor.Internal;
 using Akka.Util;
@@ -198,12 +197,23 @@ namespace Akka.Actor
         /// </summary>
         private void SuspendChildren(List<ActorRef> exceptFor = null)
         {
-            var except = exceptFor ?? Enumerable.Empty<ActorRef>();
-            (from s in ChildrenContainer.Stats
-             where !except.Contains(s.Child)
-             select s.Child)
-            .ToList()
-            .ForEach(c => c.Suspend());
+            if (exceptFor == null)
+            {
+                foreach (var stats in ChildrenContainer.Stats)
+                {
+                    var child = stats.Child;
+                    child.Suspend();
+                }
+            }
+            else
+            {
+                foreach (var stats in ChildrenContainer.Stats)
+                {
+                    var child = stats.Child;
+                    if (!exceptFor.Contains(child))
+                        child.Suspend();
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This reverts parts of commit a43580322ec573e9e5259ef6e885e45fd601ad1e.

The previous version was optimized for the most common scenario, when `exceptFor == null`.
The LINQ expression introduced in #691 is creating a list every time and uses more enumerators. It also makes a call to `List<T>.Contains()` when we know it's not necessary.

Normally LINQ expression can make loops more readable, bu in this case, and it might come down to a matter of taste, I don't think the LINQ version was more readable.