### PR TITLE
Add info on Title and Description for a PR in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,12 @@ If you have commits that looks like this _"Merge branch 'my-branch' into dev"_ o
 
 After reviewing a Pull request, we might ask you to fix some commits. After you've done that you need to force push to update your branch in your local fork.
 
+####Title and Description for the Pull Request####
+Give the PR a descriptive title and in the description field describe what you have done in general terms and why. This will help the reviewers greatly, and provide a history for the future.
+
+Especially if you modify something existing, be very clear! Have you changed any algorithms, or did you just intend to reorder the code? Justify why the changes are needed.
+
+
 ---
 
 ### Getting started


### PR DESCRIPTION
A PR should always be justified. 
As a few PR lately have slipped through without any description at all, except a title saying "Refactor Xyz" I thought it could be useful to have a paragraph we could point contributors to.

Maybe a native English speaker could have a look at what I've written. :) 