### PR TITLE
Async Await support w/o performance hit and TypedActor/UntypedActor support

### DIFF
--- a/src/core/Akka.MultiNodeTestRunner.Shared/Reporting/SpecRunCoordinator.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Reporting/SpecRunCoordinator.cs
@@ -80,7 +80,7 @@ namespace Akka.MultiNodeTestRunner.Shared.Reporting
         /// and report their results
         /// </summary>
         /// <returns>An awaitable task, since this operation uses the <see cref="Futures.Ask"/> pattern</returns>
-        private Task HandleEndSpec(EndSpec endSpec)
+        private void HandleEndSpec(EndSpec endSpec)
         {
             var futures = new Task<NodeData>[Nodes.Count];
 
@@ -94,7 +94,7 @@ namespace Akka.MultiNodeTestRunner.Shared.Reporting
             var sender = Context.Sender;
 
             //wait for all Ask operations to complete and pipe the result back to ourselves, including the ref for the original sender
-            return Task.WhenAll(futures)
+            Task.WhenAll(futures)
                 .PipeTo(Self, sender);
         }
 

--- a/src/core/Akka.Tests/Dispatch/AsyncAwaitSpec.cs
+++ b/src/core/Akka.Tests/Dispatch/AsyncAwaitSpec.cs
@@ -20,7 +20,7 @@ namespace Akka.Tests.Dispatch
             {
                 Self.Tell("change");
                 await Task.Delay(TimeSpan.FromSeconds(1));
-                //we expect that state should have changed due to an incoming message
+                //we expect that state should not have changed due to an incoming message
                 Sender.Tell(state);
             });
         }

--- a/src/core/Akka.Tests/Dispatch/AsyncAwaitSpec.cs
+++ b/src/core/Akka.Tests/Dispatch/AsyncAwaitSpec.cs
@@ -1,11 +1,45 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Dispatch;
 using Akka.TestKit;
 using Xunit;
 
 namespace Akka.Tests.Dispatch
 {
+    public class SuspendActor : ReceiveActor
+    {
+        public SuspendActor()
+        {
+            var state = 0;
+            Receive<string>(s => s == "change", _ =>
+            {
+                state = 1;
+            });
+            Receive<string>(AsyncBehavior.Suspend, async _ =>
+            {
+                Self.Tell("change");
+                await Task.Delay(TimeSpan.FromSeconds(1));
+                //we expect that state should have changed due to an incoming message
+                Sender.Tell(state);
+            });
+        }
+    }
+    public class ReentrantActor : ReceiveActor
+    {
+        public ReentrantActor()
+        {
+            var state = 0;
+            Receive<string>(s => s == "change", _ => state = 1);
+            Receive<string>(AsyncBehavior.Reentrant, async _ =>
+            {
+                Self.Tell("change");
+                await Task.Delay(TimeSpan.FromSeconds(1));
+                //we expect that state should have changed due to an incoming message
+                Sender.Tell(state);
+            });
+        }
+    }
     public class AsyncAwaitActor : ReceiveActor
     {
         public AsyncAwaitActor()
@@ -16,10 +50,30 @@ namespace Akka.Tests.Dispatch
                 var self = Self;
                 await Task.Yield();
                 await Task.Delay(TimeSpan.FromSeconds(1));
-                Assert.Same(sender,Sender);
+                Assert.Same(sender, Sender);
                 Assert.Same(self, Self);
                 Sender.Tell("done");
             });
+        }
+    }
+
+    public class UntypedAsyncAwaitActor : UntypedActor
+    {
+        protected override void OnReceive(object message)
+        {
+            if (message is string)
+            {
+                RunTask(AsyncBehavior.Suspend,  async () =>
+                {
+                    var sender = Sender;
+                    var self = Self;
+                    await Task.Yield();
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+                    Assert.Same(sender, Sender);
+                    Assert.Same(self, Self);
+                    Sender.Tell("done");
+                });
+            }
         }
     }
 
@@ -39,11 +93,37 @@ namespace Akka.Tests.Dispatch
         }
     }
 
+    public class UntypedAsker : UntypedActor
+    {
+        private readonly ActorRef _other;
+
+        public UntypedAsker(ActorRef other)
+        {
+            _other = other;
+        }
+
+        protected override void OnReceive(object message)
+        {
+            if (message is string)
+            {
+                RunTask(AsyncBehavior.Suspend, async () =>
+                {
+                    var sender = Sender;
+                    var self = Self;
+                    var res = await _other.Ask("start");
+                    Assert.Same(sender, Sender);
+                    Assert.Same(self, Self);
+                    Sender.Tell(res);
+                });
+            }
+        }
+    }
+
     public class BlockingAsker : ReceiveActor
     {
         public BlockingAsker(ActorRef other)
         {
-            Receive<string>( _ =>
+            Receive<string>(_ =>
             {
                 //not async, blocking wait
                 var res = other.Ask("start").Result;
@@ -75,12 +155,6 @@ namespace Akka.Tests.Dispatch
     {
         private readonly ActorRef _callback;
 
-        protected override void PostRestart(Exception reason)
-        {
-            _callback.Tell("done");
-            base.PostRestart(reason);
-        }
-
         public AsyncExceptionActor(ActorRef callback)
         {
             _callback = callback;
@@ -89,6 +163,12 @@ namespace Akka.Tests.Dispatch
                 await Task.Yield();
                 ThrowException();
             });
+        }
+
+        protected override void PostRestart(Exception reason)
+        {
+            _callback.Tell("done");
+            base.PostRestart(reason);
         }
 
         private static void ThrowException()
@@ -104,11 +184,11 @@ namespace Akka.Tests.Dispatch
             Receive<string>(m =>
             {
                 //this is also safe, all tasks complete in the actor context
-                Task.Delay(TimeSpan.FromSeconds(1))
-                    .ContinueWith(t =>
-                    {
-                        Sender.Tell("done");
-                    });
+                RunTask(AsyncBehavior.Suspend, () =>
+                {
+                    Task.Delay(TimeSpan.FromSeconds(1))
+                        .ContinueWith(t => { Sender.Tell("done"); });
+                });
             });
         }
     }
@@ -116,33 +196,45 @@ namespace Akka.Tests.Dispatch
     public class AsyncTplExceptionActor : ReceiveActor
     {
         private readonly ActorRef _callback;
-        protected override void PostRestart(Exception reason)
-        {
-            _callback.Tell("done");
-            base.PostRestart(reason);
-        }
 
         public AsyncTplExceptionActor(ActorRef callback)
         {
             _callback = callback;
             Receive<string>(m =>
             {
-                Task.Delay(TimeSpan.FromSeconds(1))
-                    .ContinueWith(t =>
-                    {
-                        throw new Exception("foo");
-                    });
+                RunTask(AsyncBehavior.Suspend, () =>
+                {
+                    Task.Delay(TimeSpan.FromSeconds(1))
+                   .ContinueWith(t => { throw new Exception("foo"); });
+                });               
             });
+        }
+
+        protected override void PostRestart(Exception reason)
+        {
+            _callback.Tell("done");
+            base.PostRestart(reason);
         }
     }
 
     public class ActorAsyncAwaitSpec : AkkaSpec
     {
         [Fact]
+        public async Task UntypedActors_should_be_able_to_async_await_ask_message_loop()
+        {
+            var actor = Sys.ActorOf(Props.Create<UntypedAsyncAwaitActor>(), "Worker");
+            var asker = Sys.ActorOf(Props.Create(() => new UntypedAsker(actor)), "Asker");
+            var task = asker.Ask("start", TimeSpan.FromSeconds(5));
+            actor.Tell(123, ActorRef.NoSender);
+            var res = await task;
+            Assert.Equal("done", res);
+        }
+
+        [Fact]
         public async Task Actors_should_be_able_to_async_await_in_message_loop()
         {
-            var actor = Sys.ActorOf(Props.Create<AsyncAwaitActor>().WithDispatcher("akka.actor.task-dispatcher"));
-            var task = actor.Ask<string>("start", TimeSpan.FromSeconds(55));
+            var actor = Sys.ActorOf(Props.Create<AsyncAwaitActor>());
+            var task = actor.Ask<string>("start", TimeSpan.FromSeconds(5));
             actor.Tell(123, ActorRef.NoSender);
             var res = await task;
             Assert.Equal("done", res);
@@ -151,11 +243,9 @@ namespace Akka.Tests.Dispatch
         [Fact]
         public async Task Actors_should_be_able_to_async_await_ask_message_loop()
         {
-            var actor = Sys.ActorOf(Props.Create<AsyncAwaitActor>().WithDispatcher("akka.actor.task-dispatcher"),
-                "Worker");
-            var asker = Sys.ActorOf(Props.Create(() => new Asker(actor)).WithDispatcher("akka.actor.task-dispatcher"),
-                "Asker");
-            var task = asker.Ask("start", TimeSpan.FromSeconds(55));
+            var actor = Sys.ActorOf(Props.Create<AsyncAwaitActor>(), "Worker");
+            var asker = Sys.ActorOf(Props.Create(() => new Asker(actor)), "Asker");
+            var task = asker.Ask("start", TimeSpan.FromSeconds(5));
             actor.Tell(123, ActorRef.NoSender);
             var res = await task;
             Assert.Equal("done", res);
@@ -164,11 +254,9 @@ namespace Akka.Tests.Dispatch
         [Fact]
         public async Task Actors_should_be_able_to_block_ask_message_loop()
         {
-            var actor = Sys.ActorOf(Props.Create<AsyncAwaitActor>().WithDispatcher("akka.actor.task-dispatcher"),
-                "Worker");
-            var asker = Sys.ActorOf(Props.Create(() => new BlockingAsker(actor)).WithDispatcher("akka.actor.task-dispatcher"),
-                "Asker");
-            var task = asker.Ask("start", TimeSpan.FromSeconds(55));
+            var actor = Sys.ActorOf(Props.Create<AsyncAwaitActor>().WithDispatcher("akka.actor.task-dispatcher"),"Worker");
+            var asker =Sys.ActorOf(Props.Create(() => new BlockingAsker(actor)).WithDispatcher("akka.actor.task-dispatcher"),"Asker");
+            var task = asker.Ask("start", TimeSpan.FromSeconds(5));
             actor.Tell(123, ActorRef.NoSender);
             var res = await task;
             Assert.Equal("done", res);
@@ -177,9 +265,8 @@ namespace Akka.Tests.Dispatch
         [Fact(Skip = "Maybe not possible to solve")]
         public async Task Actors_should_be_able_to_block_ask_self_message_loop()
         {
-            var asker = Sys.ActorOf(Props.Create(() => new BlockingAskSelf()).WithDispatcher("akka.actor.task-dispatcher"),
-                "Asker");
-            var task = asker.Ask("start", TimeSpan.FromSeconds(55));
+            var asker = Sys.ActorOf(Props.Create(() => new BlockingAskSelf()),"Asker");
+            var task = asker.Ask("start", TimeSpan.FromSeconds(5));
             var res = await task;
             Assert.Equal("done", res);
         }
@@ -187,7 +274,7 @@ namespace Akka.Tests.Dispatch
         [Fact]
         public void Actors_should_be_able_to_supervise_async_exceptions()
         {
-            var asker = Sys.ActorOf(Props.Create(() => new AsyncExceptionActor(TestActor)).WithDispatcher("akka.actor.task-dispatcher"));
+            var asker = Sys.ActorOf(Props.Create(() => new AsyncExceptionActor(TestActor)));
             asker.Tell("start");
             ExpectMsg("done", TimeSpan.FromSeconds(5));
         }
@@ -195,17 +282,32 @@ namespace Akka.Tests.Dispatch
         [Fact]
         public async Task Actors_should_be_able_to_use_ContinueWith()
         {
-            var asker = Sys.ActorOf(Props.Create<AsyncTplActor>().WithDispatcher("akka.actor.task-dispatcher"));
-            var res = await asker.Ask("start",TimeSpan.FromSeconds(5));
+            var asker = Sys.ActorOf(Props.Create<AsyncTplActor>());
+            var res = await asker.Ask("start", TimeSpan.FromSeconds(5));
             Assert.Equal("done", res);
         }
 
         [Fact]
         public void Actors_should_be_able_to_supervise_exception_ContinueWith()
         {
-            var asker = Sys.ActorOf(Props.Create(() => new AsyncTplExceptionActor(TestActor)).WithDispatcher("akka.actor.task-dispatcher"));
+            var asker = Sys.ActorOf(Props.Create(() => new AsyncTplExceptionActor(TestActor)));
             asker.Tell("start");
-            ExpectMsg( "done", TimeSpan.FromSeconds(5));
+            ExpectMsg("done", TimeSpan.FromSeconds(5));
+        }
+        [Fact]
+        public async Task Actors_should_be_able_to_reenter()
+        {
+            var asker = Sys.ActorOf(Props.Create(() => new ReentrantActor()));
+            var res = await asker.Ask<int>("start",TimeSpan.FromSeconds(5));
+            res.ShouldBe(1);
+        }
+
+        [Fact]
+        public async Task Actors_should_be_able_to_suspend_reentrancy()
+        {
+            var asker = Sys.ActorOf(Props.Create(() => new SuspendActor()));
+            var res = await asker.Ask<int>("start", TimeSpan.FromSeconds(555));
+            res.ShouldBe(0);
         }
     }
 }

--- a/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
+++ b/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
@@ -169,6 +169,8 @@ namespace Akka.Actor
                 else if (m is Recreate) FaultRecreate((m as Recreate).Cause);
                 else if (m is Suspend) FaultSuspend();
                 else if (m is Resume) FaultResume((m as Resume).CausedByFailure);
+                else if (m is SuspendReentrancy) HandleSuspendReentrancy();
+                else if (m is ResumeReentrancy) HandleResumeReentrancy();
                 else if (m is Terminate) Terminate();
                 else if (m is Supervise)
                 {
@@ -184,6 +186,16 @@ namespace Akka.Actor
             {
                 HandleInvokeFailure(cause);
             }
+        }
+
+        private void HandleSuspendReentrancy()
+        {
+            Mailbox.Suspend(MailboxSuspendStatus.AwaitingTask);
+        }
+
+        private void HandleResumeReentrancy()
+        {
+            Mailbox.Resume(MailboxSuspendStatus.AwaitingTask);
         }
 
         private void HandleCompleteTask(CompleteTask task)
@@ -338,6 +350,16 @@ namespace Akka.Actor
         public void Suspend()
         {
             SendSystemMessage(Dispatch.SysMsg.Suspend.Instance);
+        }
+
+        public void SuspendReentrancy()
+        {
+            SendSystemMessage(Dispatch.SysMsg.SuspendReentrancy.Instance);
+        }
+
+        public void ResumeReentrancy()
+        {
+            SendSystemMessage(Dispatch.SysMsg.ResumeReentrancy.Instance);
         }
 
         private void SendSystemMessage(SystemMessage systemMessage)

--- a/src/core/Akka/Actor/UntypedActor.cs
+++ b/src/core/Akka/Actor/UntypedActor.cs
@@ -1,4 +1,9 @@
 ﻿using System;
+using System.Runtime.ExceptionServices;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Dispatch;
 
 namespace Akka.Actor
 {
@@ -11,6 +16,16 @@ namespace Akka.Actor
         {
             OnReceive(message);
             return true;
+        }
+
+        protected void RunTask(AsyncBehavior behavior, Action action)
+        {
+            ActorTaskScheduler.RunTask(behavior,action);
+        }
+
+        protected void RunTask(AsyncBehavior behavior, Func<Task> action)
+        {
+            ActorTaskScheduler.RunTask(behavior,action);
         }
 
         /// <summary>

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -168,6 +168,7 @@
     <Compile Include="Configuration\Hocon\HoconTokenizer.cs" />
     <Compile Include="Configuration\Hocon\HoconValue.cs" />
     <Compile Include="Configuration\Hocon\IHoconElement.cs" />
+    <Compile Include="Dispatch\ActorTaskScheduler.cs" />
     <Compile Include="Dispatch\BoundedDequeBasedMailbox.cs" />
     <Compile Include="Dispatch\ConcurrentQueueMailbox.cs" />
     <Compile Include="Dispatch\DequeBasedMailbox.cs" />

--- a/src/core/Akka/Dispatch/ActorTaskScheduler.cs
+++ b/src/core/Akka/Dispatch/ActorTaskScheduler.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Remoting.Messaging;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Dispatch.SysMsg;
+
+namespace Akka.Dispatch
+{
+    public enum AsyncBehavior
+    {
+        Reentrant,
+        Suspend
+    }
+
+    public class AmbientState
+    {
+        public ActorRef Self { get; set; }
+        public ActorRef Sender { get; set; }
+        public object Message { get; set; }
+    }
+
+    public class ActorTaskScheduler : TaskScheduler
+    {
+        public static readonly TaskScheduler Instance = new ActorTaskScheduler();
+        public static readonly TaskFactory TaskFactory = new TaskFactory(Instance);
+        public static readonly string StateKey = "akka.state";
+        private const string Faulted = "faulted";
+        private static readonly object Outer = new object();
+
+        public static void SetCurrentState(ActorRef self, ActorRef sender, object message)
+        {
+            CallContext.LogicalSetData(StateKey, new AmbientState
+            {
+                Sender = sender,
+                Self = self,
+                Message = message
+            });
+        }
+
+        protected override IEnumerable<Task> GetScheduledTasks()
+        {
+            return null;
+        }
+
+        protected override void QueueTask(Task task)
+        {
+            if (task.AsyncState == Outer)
+            {
+                TryExecuteTask(task);
+                return;
+            }
+
+            //we get here if the task needs to be marshalled back to the mailbox
+            //e.g. if previous task was an IO completion
+            var s = CallContext.LogicalGetData(StateKey) as AmbientState;
+
+            s.Self.Tell(new CompleteTask(s, () =>
+            {
+                TryExecuteTask(task);
+                if (task.IsFaulted)
+                    Rethrow(task, null);
+
+            }), ActorRef.NoSender);
+        }
+
+        protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
+        {
+            if (taskWasPreviouslyQueued)
+                return false;
+
+            var s = CallContext.LogicalGetData(StateKey) as AmbientState;
+            var cell = ActorCell.Current;
+
+            //Is the current cell and the current state the same?
+            if (cell != null &&
+                s != null &&
+                cell.Self == s.Self &&
+                cell.Sender == s.Sender &&
+                cell.CurrentMessage == s.Message)
+            {
+                var res = TryExecuteTask(task);
+                return res;
+            }
+
+            return false;
+        }
+
+        public static void RunTask(AsyncBehavior behavior, Action action)
+        {
+            RunTask(behavior, () =>
+            {
+                action();
+                return Task.FromResult(0);
+            });
+        }
+
+        public static void RunTask(AsyncBehavior behavior, Func<Task> action)
+        {
+            var context = ActorCell.Current;
+
+            //if reentrancy is not allowed, suspend user message processing
+            if (behavior == AsyncBehavior.Suspend)
+            {
+                context.SuspendReentrancy();
+            }
+
+            SetCurrentState(context.Self, context.Sender, null);
+
+            //wrap our action inside a task, so that everything executing 
+            //directly or indirectly from the action is executed on our task scheduler
+
+            Task.Factory.StartNew(async _ =>
+            {
+
+                //start executing our action and potential promise style
+                //tasks
+                await action()
+                    //we need to use ContinueWith so that any exception is
+                    //thrown inside the actor context.
+                    //this is needed for IO completion tasks that execute out of context                    
+                    .ContinueWith(
+                        Rethrow,
+                        Faulted,
+                        TaskContinuationOptions.OnlyOnFaulted);
+
+                //if reentrancy was suspended, make sure we re-enable messageprocessing again
+                if (behavior == AsyncBehavior.Suspend)
+                {
+                    context.ResumeReentrancy();
+                }
+            },
+                Outer,
+                CancellationToken.None,
+                TaskCreationOptions.None,
+                Instance);
+        }
+
+        private static void Rethrow(Task x, object s)
+        {
+            //this just rethrows the exception the task contains
+            x.Wait();
+        }
+    }
+}

--- a/src/core/Akka/Dispatch/ConcurrentQueueMailbox.cs
+++ b/src/core/Akka/Dispatch/ConcurrentQueueMailbox.cs
@@ -64,7 +64,7 @@ namespace Akka.Dispatch
                 var left = dispatcher.Throughput;
 
                 //try dequeue a user message
-                while (!_isSuspended && !_isClosed && _userMessages.TryDequeue(out envelope))
+                while (!IsSuspended && !_isClosed && _userMessages.TryDequeue(out envelope))
                 {
                     Mailbox.DebugPrint(ActorCell.Self + " processing message " + envelope);
 
@@ -102,7 +102,7 @@ namespace Akka.Dispatch
                 Interlocked.Exchange(ref status, MailboxStatus.Idle);
 
                 //there are still messages that needs to be processed
-                if (_systemMessages.Count > 0 || (!_isSuspended && _userMessages.Count > 0))
+                if (_systemMessages.Count > 0 || (!IsSuspended && _userMessages.Count > 0))
                 {
                     //we still need has unscheduled messages for external info.
                     //e.g. repointable actor ref uses it

--- a/src/core/Akka/Dispatch/GenericMailbox.cs
+++ b/src/core/Akka/Dispatch/GenericMailbox.cs
@@ -83,7 +83,7 @@ namespace Akka.Dispatch
                 var left = dispatcher.Throughput;
 
                 //try dequeue a user message
-                while (!_isSuspended && !_isClosed && _userMessages.TryDequeue(out envelope))
+                while (!IsSuspended && !_isClosed && _userMessages.TryDequeue(out envelope))
                 {
                     Mailbox.DebugPrint(ActorCell.Self + " processing message " + envelope);
 
@@ -121,7 +121,7 @@ namespace Akka.Dispatch
                 Interlocked.Exchange(ref status, MailboxStatus.Idle);
 
                 //there are still messages that needs to be processed
-                if (_systemMessages.Count > 0 || (!_isSuspended && _userMessages.Count > 0))
+                if (_systemMessages.Count > 0 || (!IsSuspended && _userMessages.Count > 0))
                 {
                     //we still need has unscheduled messages for external info.
                     //e.g. repointable actor ref uses it

--- a/src/core/Akka/Dispatch/SysMsg/SystemMessage.cs
+++ b/src/core/Akka/Dispatch/SysMsg/SystemMessage.cs
@@ -354,6 +354,38 @@ namespace Akka.Dispatch.SysMsg
     }
 
     /// <summary>
+    ///     Class SuspendReentrancy.
+    /// </summary>
+    public sealed class SuspendReentrancy : SystemMessage
+    {
+        private SuspendReentrancy() { }
+        private static readonly SuspendReentrancy _instance = new SuspendReentrancy();
+        public static SuspendReentrancy Instance
+        {
+            get
+            {
+                return _instance;
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Class ResumeReentrancy.
+    /// </summary>
+    public sealed class ResumeReentrancy : SystemMessage
+    {
+        private ResumeReentrancy() { }
+        private static readonly ResumeReentrancy _instance = new ResumeReentrancy();
+        public static ResumeReentrancy Instance
+        {
+            get
+            {
+                return _instance;
+            }
+        }
+    }
+
+    /// <summary>
     ///     Class Stop.
     /// </summary>
     public sealed class Stop : SystemMessage

--- a/src/core/Akka/Dispatch/TaskDispatcher.cs
+++ b/src/core/Akka/Dispatch/TaskDispatcher.cs
@@ -13,9 +13,4 @@ namespace Akka.Dispatch
             Task.Run(run);
         }
     }    
-
-        public override string ToString()
-        {
-            return string.Format("(Sender: {0}, Self: {1}, Message: {2})", Sender, Self, Message);
-        }
 }

--- a/src/core/Akka/Dispatch/TaskDispatcher.cs
+++ b/src/core/Akka/Dispatch/TaskDispatcher.cs
@@ -1,97 +1,21 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Runtime.ExceptionServices;
-using System.Runtime.Remoting.Messaging;
-using System.Threading;
 using System.Threading.Tasks;
-using Akka.Actor;
-using Akka.Dispatch.SysMsg;
 
 namespace Akka.Dispatch
 {
     /// <summary>
-    /// Task based dispatcher with async await support
+    /// Task based dispatcher
     /// </summary>
     public class TaskDispatcher : MessageDispatcher
     {
-        public override void Dispatch(ActorCell cell, Envelope envelope)
-        {
-            ActorTaskScheduler.SetCurrentState(cell.Self, envelope.Sender, envelope.Message);
-            base.Dispatch(cell, envelope);
-        }
-
         public override void Schedule(Action run)
         {
-            
-            ActorTaskScheduler.Schedule(run);        
+            Task.Run(run);
         }
-    }
-
-
-
-    public class AmbientState
-    {
-        public ActorRef Self { get; set; }
-        public ActorRef Sender { get; set; }
-        public object Message { get; set; }
+    }    
 
         public override string ToString()
         {
             return string.Format("(Sender: {0}, Self: {1}, Message: {2})", Sender, Self, Message);
         }
-    }
-
-    public class ActorTaskScheduler : TaskScheduler
-    {
-        public static readonly TaskScheduler Instance = new ActorTaskScheduler();
-        public static readonly TaskFactory TaskFactory = new TaskFactory(Instance);
-        public static readonly object ScheduleMailboxRun = new object();
-        public static readonly string StateKey = "akka.state";
-
-        public static void SetCurrentState(ActorRef self,ActorRef sender,object message)
-        {
-            CallContext.LogicalSetData(StateKey, new AmbientState
-            {
-                Sender = sender,
-                Self = self,
-                Message = message
-            });
-        }
-
-        public static void Schedule(Action run)
-        {
-            TaskFactory.StartNew(_ => run(), ScheduleMailboxRun);
-        }
-
-        protected override IEnumerable<Task> GetScheduledTasks()
-        {
-            return null;
-        }
-
-        protected override void QueueTask(Task task)
-        {
-
-            if (task.AsyncState == ScheduleMailboxRun)
-            {
-                ThreadPool.UnsafeQueueUserWorkItem(_ => { TryExecuteTask(task); }, null);
-            }
-            else
-            {
-                var s = CallContext.LogicalGetData(StateKey) as AmbientState;
-
-                s.Self.Tell(new CompleteTask(s, () => 
-                { 
-                    TryExecuteTask(task);
-                    if (task.IsFaulted)
-                        ExceptionDispatchInfo.Capture(task.Exception.InnerException).Throw();
-
-                }), ActorRef.NoSender);
-            }
-        }
-
-        protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
-        {
-            return false;
-        }
-    }
 }


### PR DESCRIPTION

This PR removes the need to use the special "task-dispatcher" for async await inside ReceiveActor.
If the receive handler is an async method, it will apply the correct scheduling mechanics for that handler only.

This PR also introduces the `RunTask` method inside `UntypedActor` (possibly it should be in `ActorBase`)
This method lets you run tasks within the ActorTaskScheduler.

This does however not address "reentrancy", messages can still be processed during await periods (but never in parallell)
But this could easily be handled by extending how RunActor behaves, e.g. an argument for if reentrancy is allowed or not, and if not, suspend the mailbox.

The idea behind `RunTask` is that it allows you to run any task, or multiple tasks, within the safety of the ActorTaskScheduler. this means that reading and writing state is safe both using async/await and continueWith.

cc. @nvivo 