### PR TITLE
ConsistentHashRouter rewrite with Virtual Nodes, Cluster support for pool routers, and ActorRefProvider Updates

### DIFF
--- a/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
+++ b/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
@@ -88,6 +88,8 @@
     <Compile Include="MultiNode\MultiNodeClusterSpec.cs" />
     <Compile Include="MultiNode\MultiNodeFact.cs" />
     <Compile Include="MultiNode\MultiNodeLoggingConfig.cs" />
+    <Compile Include="MultiNode\Routing\ClusterConsistentHashingGroupSpec.cs" />
+    <Compile Include="MultiNode\Routing\ClusterConsistentHashingRouterSpec.cs" />
     <Compile Include="NodeMetricsSpec.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Proto\ClusterMessageSerializerSpec.cs" />

--- a/src/core/Akka.Cluster.Tests/MultiNode/JoinSeedNodeSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MultiNode/JoinSeedNodeSpec.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Immutable;
 using System.Threading;
 using Akka.Actor;
+using Akka.Configuration;
 using Akka.Remote.TestKit;
 
 namespace Akka.Cluster.Tests.MultiNode
@@ -31,6 +32,7 @@ namespace Akka.Cluster.Tests.MultiNode
             _ordinary2 = Role("ordinary2");
 
             CommonConfig = MultiNodeLoggingConfig.LoggingConfig.WithFallback(DebugConfig(true))
+                .WithFallback(ConfigurationFactory.ParseString(@"akka.cluster.publish-stats-interval = 25s"))
                 .WithFallback(MultiNodeClusterSpec.ClusterConfig());
         }
     }

--- a/src/core/Akka.Cluster.Tests/MultiNode/Routing/ClusterConsistentHashingGroupSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MultiNode/Routing/ClusterConsistentHashingGroupSpec.cs
@@ -73,12 +73,14 @@ namespace Akka.Cluster.Tests.MultiNode.Routing
     {
         private readonly ClusterConsistentHashingGroupSpecConfig _config;
 
-        protected ClusterConsistentHashingGroupSpec() : this(new ClusterConsistentHashingGroupSpecConfig())
+        protected ClusterConsistentHashingGroupSpec()
+            : this(new ClusterConsistentHashingGroupSpecConfig())
         {
-            
+
         }
 
-        protected ClusterConsistentHashingGroupSpec(ClusterConsistentHashingGroupSpecConfig config) : base(config)
+        protected ClusterConsistentHashingGroupSpec(ClusterConsistentHashingGroupSpecConfig config)
+            : base(config)
         {
             _config = config;
         }
@@ -86,7 +88,6 @@ namespace Akka.Cluster.Tests.MultiNode.Routing
         protected Routees CurrentRoutees(ActorRef router)
         {
             var routerAsk = router.Ask<Routees>(new GetRoutees(), GetTimeoutOrDefault(null));
-            routerAsk.Wait();
             return routerAsk.Result;
         }
 
@@ -101,28 +102,19 @@ namespace Akka.Cluster.Tests.MultiNode.Routing
         }
 
         [MultiNodeFact]
-        public void ClusterConsistentHashingGroupSpecs()
-        {
-            AClusterRouterWithConsitentHashingGroupMustStartClusterWith3Nodes();
-            AClusterRouterWithConsistentHashingGroupMustSendToSameDestinationsFromDifferentNodes();
-        }
-
-        protected void AClusterRouterWithConsitentHashingGroupMustStartClusterWith3Nodes()
+        public void AClusterRouterWithConsistentHashingGroupMustSendToSameDestinationsFromDifferentNodes()
         {
             Sys.ActorOf(Props.Create<ClusterConsistentHashingGroupSpecConfig.Destination>(), "dest");
             AwaitClusterUp(_config.First, _config.Second, _config.Third);
             EnterBarrier("after-1");
-        }
 
-        protected void AClusterRouterWithConsistentHashingGroupMustSendToSameDestinationsFromDifferentNodes()
-        {
             ConsistentHashMapping hashMapping = msg =>
             {
                 if (msg is string) return msg;
                 return null;
             };
 
-            var paths = new List<string>() {"/user/dest"};
+            var paths = new List<string>() { "/user/dest" };
             var router =
                 Sys.ActorOf(
                     new ClusterRouterGroup(new ConsistentHashingGroup(paths).WithHashMapping(hashMapping),
@@ -135,7 +127,7 @@ namespace Akka.Cluster.Tests.MultiNode.Routing
                 var members = CurrentRoutees(router).Members;
                 members.Count().ShouldBe(3);
             });
-            var keys = new[] {"A", "B", "C", "D", "E", "F", "G"};
+            var keys = new[] { "A", "B", "C", "D", "E", "F", "G" };
             foreach (var key in Enumerable.Range(1, 10).SelectMany(i => keys))
             {
                 router.Tell(key, TestActor);

--- a/src/core/Akka.Cluster.Tests/MultiNode/Routing/ClusterConsistentHashingGroupSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MultiNode/Routing/ClusterConsistentHashingGroupSpec.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Akka.Actor;
+using Akka.Cluster.Routing;
+using Akka.Configuration;
+using Akka.Remote.TestKit;
+using Akka.Routing;
+using Akka.TestKit;
+
+namespace Akka.Cluster.Tests.MultiNode.Routing
+{
+    public class ClusterConsistentHashingGroupSpecConfig : MultiNodeConfig
+    {
+        #region Test classes
+        public sealed class Get { }
+        public sealed class Collected
+        {
+            public Collected(HashSet<object> messages)
+            {
+                Messages = messages;
+            }
+
+            public HashSet<object> Messages { get; private set; }
+        }
+
+        public class Destination : UntypedActor
+        {
+            private readonly HashSet<object> _receivedMessages = new HashSet<object>();
+            protected override void OnReceive(object message)
+            {
+                if (message is Get) Sender.Tell(new Collected(_receivedMessages));
+                else
+                {
+                    _receivedMessages.Add(message);
+                }
+            }
+        }
+
+        #endregion
+
+        private readonly RoleName _first;
+        public RoleName First { get { return _first; } }
+
+        private readonly RoleName _second;
+        public RoleName Second { get { return _second; } }
+
+        private readonly RoleName _third;
+
+        public RoleName Third { get { return _third; } }
+
+        public ClusterConsistentHashingGroupSpecConfig()
+        {
+            _first = Role("first");
+            _second = Role("second");
+            _third = Role("third");
+
+            CommonConfig = MultiNodeLoggingConfig.LoggingConfig.WithFallback(DebugConfig(false))
+                .WithFallback(ConfigurationFactory.ParseString(@"
+                    akka.cluster.publish-stats-interval = 5s
+                "))
+                .WithFallback(MultiNodeClusterSpec.ClusterConfig());
+        }
+    }
+
+    public class ClusterConsistentHashingGroupMultiNode1 : ClusterConsistentHashingGroupSpec { }
+    public class ClusterConsistentHashingGroupMultiNode2 : ClusterConsistentHashingGroupSpec { }
+    public class ClusterConsistentHashingGroupMultiNode3 : ClusterConsistentHashingGroupSpec { }
+
+
+    public abstract class ClusterConsistentHashingGroupSpec : MultiNodeClusterSpec
+    {
+        private readonly ClusterConsistentHashingGroupSpecConfig _config;
+
+        protected ClusterConsistentHashingGroupSpec() : this(new ClusterConsistentHashingGroupSpecConfig())
+        {
+            
+        }
+
+        protected ClusterConsistentHashingGroupSpec(ClusterConsistentHashingGroupSpecConfig config) : base(config)
+        {
+            _config = config;
+        }
+
+        protected Routees CurrentRoutees(ActorRef router)
+        {
+            var routerAsk = router.Ask<Routees>(new GetRoutees(), GetTimeoutOrDefault(null));
+            routerAsk.Wait();
+            return routerAsk.Result;
+        }
+
+        /// <summary>
+        /// Fills in the self address for local ActorRef
+        /// </summary>
+        protected Address FullAddress(ActorRef actorRef)
+        {
+            if (string.IsNullOrEmpty(actorRef.Path.Address.Host) || !actorRef.Path.Address.Port.HasValue)
+                return Cluster.SelfAddress;
+            return actorRef.Path.Address;
+        }
+
+        [MultiNodeFact]
+        public void ClusterConsistentHashingGroupSpecs()
+        {
+            AClusterRouterWithConsitentHashingGroupMustStartClusterWith3Nodes();
+            AClusterRouterWithConsistentHashingGroupMustSendToSameDestinationsFromDifferentNodes();
+        }
+
+        protected void AClusterRouterWithConsitentHashingGroupMustStartClusterWith3Nodes()
+        {
+            Sys.ActorOf(Props.Create<ClusterConsistentHashingGroupSpecConfig.Destination>(), "dest");
+            AwaitClusterUp(_config.First, _config.Second, _config.Third);
+            EnterBarrier("after-1");
+        }
+
+        protected void AClusterRouterWithConsistentHashingGroupMustSendToSameDestinationsFromDifferentNodes()
+        {
+            ConsistentHashMapping hashMapping = msg =>
+            {
+                if (msg is string) return msg;
+                return null;
+            };
+
+            var paths = new List<string>() {"/user/dest"};
+            var router =
+                Sys.ActorOf(
+                    new ClusterRouterGroup(new ConsistentHashingGroup(paths).WithHashMapping(hashMapping),
+                        new ClusterRouterGroupSettings(10, true, null, ImmutableHashSet.Create<string>(paths.ToArray())))
+                        .Props(), "router");
+
+            // it may take some time until router receives cluster member events
+            AwaitAssert(() =>
+            {
+                var members = CurrentRoutees(router).Members;
+                members.Count().ShouldBe(3);
+            });
+            var keys = new[] {"A", "B", "C", "D", "E", "F", "G"};
+            foreach (var key in Enumerable.Range(1, 10).SelectMany(i => keys))
+            {
+                router.Tell(key, TestActor);
+            }
+            EnterBarrier("messages-sent");
+            router.Tell(new Broadcast(new Get()));
+            var a = ExpectMsg<ClusterConsistentHashingGroupSpecConfig.Collected>().Messages;
+            var b = ExpectMsg<ClusterConsistentHashingGroupSpecConfig.Collected>().Messages;
+            var c = ExpectMsg<ClusterConsistentHashingGroupSpecConfig.Collected>().Messages;
+
+            a.Intersect(b).Count().ShouldBe(0);
+            a.Intersect(c).Count().ShouldBe(0);
+            b.Intersect(c).Count().ShouldBe(0);
+
+            (a.Count + b.Count + c.Count).ShouldBe(keys.Length);
+            EnterBarrier("after-2");
+        }
+    }
+}

--- a/src/core/Akka.Cluster.Tests/MultiNode/Routing/ClusterConsistentHashingRouterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MultiNode/Routing/ClusterConsistentHashingRouterSpec.cs
@@ -90,7 +90,6 @@ namespace Akka.Cluster.Tests.MultiNode.Routing
         protected Routees CurrentRoutees(ActorRef router)
         {
             var routerAsk = router.Ask<Routees>(new GetRoutees(), GetTimeoutOrDefault(null));
-            routerAsk.Wait();
             return routerAsk.Result;
         }
 
@@ -263,8 +262,6 @@ namespace Akka.Cluster.Tests.MultiNode.Routing
         /// </summary>
         protected void AClusterRouterWithConsistentHashingPoolMustRemoveRouteesFromDownedNode()
         {
-            
-
             RunOn(() =>
             {
                 Cluster.Down(GetAddress(_config.Third));

--- a/src/core/Akka.Cluster.Tests/MultiNode/Routing/ClusterConsistentHashingRouterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MultiNode/Routing/ClusterConsistentHashingRouterSpec.cs
@@ -1,0 +1,289 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Akka.Actor;
+using Akka.Cluster.Routing;
+using Akka.Configuration;
+using Akka.Remote.TestKit;
+using Akka.Routing;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Cluster.Tests.MultiNode.Routing
+{
+    public class ConsistentHashingRouterMultiNodeConfig : MultiNodeConfig
+    {
+        public class Echo : UntypedActor
+        {
+            protected override void OnReceive(object message)
+            {
+                Sender.Tell(Self);
+            }
+        }
+
+        private readonly RoleName _first;
+        public RoleName First { get { return _first; } }
+
+        private readonly RoleName _second;
+        public RoleName Second { get { return _second; } }
+
+        private readonly RoleName _third;
+
+        public RoleName Third { get { return _third; } }
+
+        public ConsistentHashingRouterMultiNodeConfig()
+        {
+            _first = Role("first");
+            _second = Role("second");
+            _third = Role("third");
+
+            CommonConfig = MultiNodeLoggingConfig.LoggingConfig.WithFallback(DebugConfig(true))
+                .WithFallback(ConfigurationFactory.ParseString(@"
+                    common-router-settings = {
+                        router = consistent-hashing-pool
+                        nr-of-instances = 10
+                        cluster {
+                            enabled = on
+                            max-nr-of-instances-per-node = 2
+                        }
+                    }
+                    akka.actor.deployment {
+                    /router1 = ${common-router-settings}
+                    /router3 = ${common-router-settings}
+                    /router4 = ${common-router-settings}
+                    }
+                    akka.cluster.publish-stats-interval = 5s
+                "))
+                .WithFallback(MultiNodeClusterSpec.ClusterConfig());
+        }
+    }
+
+    public class ClusterConsistentHashingRouterMultiNode1 : ClusterConsistentHashingRouterSpec { }
+    public class ClusterConsistentHashingRouterMultiNode2 : ClusterConsistentHashingRouterSpec { }
+    public class ClusterConsistentHashingRouterMultiNode3 : ClusterConsistentHashingRouterSpec { }
+
+    public abstract class ClusterConsistentHashingRouterSpec : MultiNodeClusterSpec
+    {
+        private readonly ConsistentHashingRouterMultiNodeConfig _config;
+
+        protected ClusterConsistentHashingRouterSpec() : this(new ConsistentHashingRouterMultiNodeConfig()) { }
+
+        protected ClusterConsistentHashingRouterSpec(ConsistentHashingRouterMultiNodeConfig config) : base(config)
+        {
+            _config = config;
+        }
+
+        private ActorRef _router1 = null;
+
+        protected ActorRef Router1
+        {
+            get { return _router1 ?? (_router1 = CreateRouter1()); }
+        }
+
+        private ActorRef CreateRouter1()
+        {
+            return
+                Sys.ActorOf(
+                    Props.Create<ConsistentHashingRouterMultiNodeConfig.Echo>().WithRouter(FromConfig.Instance),
+                    "router1");
+        }
+
+        protected Routees CurrentRoutees(ActorRef router)
+        {
+            var routerAsk = router.Ask<Routees>(new GetRoutees(), GetTimeoutOrDefault(null));
+            routerAsk.Wait();
+            return routerAsk.Result;
+        }
+
+        /// <summary>
+        /// Fills in the self address for local ActorRef
+        /// </summary>
+        protected Address FullAddress(ActorRef actorRef)
+        {
+            if (string.IsNullOrEmpty(actorRef.Path.Address.Host) || !actorRef.Path.Address.Port.HasValue)
+                return Cluster.SelfAddress;
+            return actorRef.Path.Address;
+        }
+
+        protected void AssertHashMapping(ActorRef router)
+        {
+            // it may take some time until router receives cluster member events
+            AwaitAssert(() =>
+            {
+                CurrentRoutees(router).Members.Count().ShouldBe(6);
+            });
+            var routees = CurrentRoutees(router);
+            var routerMembers = routees.Members.Select(x => FullAddress(((ActorRefRoutee)x).Actor)).Distinct().ToList();
+            routerMembers.ShouldBe(Roles.Select(GetAddress).ToList());
+
+            router.Tell("a", TestActor);
+            var destinationA = ExpectMsg<ActorRef>();
+            router.Tell("a", TestActor);
+            ExpectMsg(destinationA);
+        }
+
+        [MultiNodeFact]
+        public void ClusterConsistentHashingRouterSpecs()
+        {
+            AClusterRouterWithConsistentHashingPoolMustStartClusterWith2Nodes();
+            AClusterRouterWithConsistentHashingPoolMustCreateRouteesFromConfiguration();
+            AClusterRouterWithConsistentHashingPoolMustSelectDestinationBasedOnHashKey();
+            AClusterRouterWithConsistentHashingPoolMustDeployRouteesToNewMemberNodesInTheCluster();
+            AClusterRouterWithConsistentHashingPoolMustDeployProgramaticallyDefinedRouteesToTheMemberNodesInTheCluster();
+            AClusterRouterWithConsistentHashingPoolMustHandleCombinationOfConfiguredRouterAndProgramaticallyDefinedHashMapping();
+            AClusterRouterWithConsistentHashingPoolMustHandleCombinationOfConfiguredRouterAndProgramaticallyDefinedHashMappingAndClusterConfig
+                ();
+            AClusterRouterWithConsistentHashingPoolMustRemoveRouteesFromDownedNode();
+        }
+
+        protected void AClusterRouterWithConsistentHashingPoolMustStartClusterWith2Nodes()
+        {
+            AwaitClusterUp(_config.First, _config.Second);
+            EnterBarrier("after-1");
+        }
+
+        protected void AClusterRouterWithConsistentHashingPoolMustCreateRouteesFromConfiguration()
+        {
+            RunOn(() =>
+            {
+                // it may take some time until router receives cluster member events
+                AwaitAssert(() =>
+                {
+                    CurrentRoutees(Router1).Members.Count().ShouldBe(4);
+                });
+                var routees = CurrentRoutees(Router1);
+                var routerMembers = routees.Members.Select(x => FullAddress(((ActorRefRoutee)x).Actor)).Distinct().ToList();
+                routerMembers.ShouldBe(new List<Address>(){ GetAddress(_config.First), GetAddress(_config.Second) });
+            }, _config.First);
+
+            EnterBarrier("after-2");
+        }
+
+        protected void AClusterRouterWithConsistentHashingPoolMustSelectDestinationBasedOnHashKey()
+        {
+            RunOn(() =>
+            {
+                Router1.Tell(new ConsistentHashableEnvelope("A", "a"));
+                var destinationA = ExpectMsg<ActorRef>();
+                Router1.Tell(new ConsistentHashableEnvelope("AA", "a"));
+                ExpectMsg(destinationA);
+            }, _config.First);
+
+            EnterBarrier("after-3");
+        }
+
+        protected void AClusterRouterWithConsistentHashingPoolMustDeployRouteesToNewMemberNodesInTheCluster()
+        {
+            AwaitClusterUp(_config.First, _config.Second, _config.Third);
+
+            RunOn(() =>
+            {
+                //it may take some time until router receives cluster member events
+                AwaitAssert(() =>
+                {
+                    CurrentRoutees(Router1).Members.Count().ShouldBe(6);
+                });
+                var routees = CurrentRoutees(Router1);
+                var routerMembers = routees.Members.Select(x => FullAddress(((ActorRefRoutee)x).Actor)).Distinct().ToList();
+                routerMembers.ShouldBe(Roles.Select(GetAddress).ToList());
+            }, _config.First);
+
+            EnterBarrier("after-4");
+        }
+
+        protected void
+            AClusterRouterWithConsistentHashingPoolMustDeployProgramaticallyDefinedRouteesToTheMemberNodesInTheCluster()
+        {
+            RunOn(() =>
+            {
+                var router2 =
+                    Sys.ActorOf(
+                        new ClusterRouterPool(local: new ConsistentHashingPool(0),
+                            settings: new ClusterRouterPoolSettings(totalInstances: 10, maxInstancesPerNode: 2,
+                                allowLocalRoutees: true, useRole: null)).Props(Props.Create<ConsistentHashingRouterMultiNodeConfig.Echo>()), "router2");
+
+                //it may take some time until router receives cluster member events
+                AwaitAssert(() =>
+                {
+                    var members = CurrentRoutees(router2).Members.Count();
+                    members.ShouldBe(6);
+                });
+                var routees = CurrentRoutees(router2);
+                var routerMembers = routees.Members.Select(x => FullAddress(((ActorRefRoutee)x).Actor)).Distinct().ToList();
+                routerMembers.ShouldBe(Roles.Select(GetAddress).ToList());
+            }, _config.First);
+
+            EnterBarrier("after-5");
+        }
+
+        protected void
+            AClusterRouterWithConsistentHashingPoolMustHandleCombinationOfConfiguredRouterAndProgramaticallyDefinedHashMapping()
+        {
+            RunOn(() =>
+            {
+                ConsistentHashMapping hashMapping = msg =>
+                {
+                    if (msg is string) return msg;
+                    return null;
+                };
+                var router3 =
+                    Sys.ActorOf(new ConsistentHashingPool(0).WithHashMapping(hashMapping).Props(Props.Create<ConsistentHashingRouterMultiNodeConfig.Echo>()), "router3");
+                
+                AssertHashMapping(router3);
+            }, _config.First);
+
+            EnterBarrier("after-6");
+        }
+
+        protected void
+            AClusterRouterWithConsistentHashingPoolMustHandleCombinationOfConfiguredRouterAndProgramaticallyDefinedHashMappingAndClusterConfig
+            ()
+        {
+            RunOn(() =>
+            {
+                ConsistentHashMapping hashMapping = msg =>
+                {
+                    if (msg is string) return msg;
+                    return null;
+                };
+
+                var router4 =
+                    Sys.ActorOf(
+                        new ClusterRouterPool(local: new ConsistentHashingPool(0).WithHashMapping(hashMapping),
+                            settings: new ClusterRouterPoolSettings(totalInstances: 10, maxInstancesPerNode: 2,
+                                allowLocalRoutees: true, useRole: null)).Props(Props.Create<ConsistentHashingRouterMultiNodeConfig.Echo>()), "router4");
+
+                AssertHashMapping(router4);
+            }, _config.First);
+
+            EnterBarrier("after-7");
+        }
+
+        /// <summary>
+        /// An explicit check to ensure that our routers can adjust to unreachable member events as well
+        /// </summary>
+        protected void AClusterRouterWithConsistentHashingPoolMustRemoveRouteesFromDownedNode()
+        {
+            
+
+            RunOn(() =>
+            {
+                Cluster.Down(GetAddress(_config.Third));
+                //removed
+                AwaitAssert(() => Assert.False(ClusterView.UnreachableMembers.Select(x => x.Address).Contains(GetAddress(_config.Third))));
+                AwaitAssert(() => Assert.False(ClusterView.Members.Select(x => x.Address).Contains(GetAddress(_config.Third))));
+
+                // it may take some time until router receives cluster member events
+                AwaitAssert(() =>
+                {
+                    CurrentRoutees(Router1).Members.Count().ShouldBe(4);
+                });
+                var routees = CurrentRoutees(Router1);
+                var routerMembers = routees.Members.Select(x => FullAddress(((ActorRefRoutee)x).Actor)).Distinct().ToList();
+                routerMembers.ShouldBe(new List<Address>() { GetAddress(_config.First), GetAddress(_config.Second) });
+
+            }, _config.First);
+
+            EnterBarrier("after-8");
+        }
+    }
+}

--- a/src/core/Akka.Cluster/ClusterActorRefProvider.cs
+++ b/src/core/Akka.Cluster/ClusterActorRefProvider.cs
@@ -6,6 +6,7 @@ using Akka.Cluster.Routing;
 using Akka.Configuration;
 using Akka.Event;
 using Akka.Remote;
+using Akka.Remote.Routing;
 using Akka.Routing;
 
 namespace Akka.Cluster
@@ -60,6 +61,15 @@ namespace Akka.Cluster
         private ClusterScope() { }
 
         public static readonly ClusterScope Instance = new ClusterScope();
+        public override Scope WithFallback(Scope other)
+        {
+            return Instance;
+        }
+
+        public override Scope Copy()
+        {
+            return Instance;
+        }
     }
 
     /// <summary>
@@ -83,7 +93,8 @@ namespace Akka.Cluster
             {
                 if(deploy.Scope != Deploy.NoScopeGiven)
                     throw new ConfigurationException(string.Format("Cluster deployment can't be combined with scope [{0}]", deploy.Scope));
-                //TODO: add handling for RemoteRouterConfig
+                if(deploy.RouterConfig is RemoteRouterConfig)
+                    throw new ConfigurationException(string.Format("Cluster deployment can't be combined with [{0}]", deploy.Config));
 
                 if (deploy.RouterConfig is Pool)
                 {

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -125,6 +125,12 @@ namespace Akka.Cluster
                     return (_node.GetHashCode() * 397) ^ _roles.GetHashCode();
                 }
             }
+
+            public override string ToString()
+            {
+                return string.Format("{0}: {1} wants to join on Roles [{2}]", GetType(), Node,
+                    string.Join(",", Roles ?? ImmutableHashSet<string>.Empty));
+            }
         }
 
         /// <summary>
@@ -640,6 +646,7 @@ namespace Akka.Cluster
         GossipStats _gossipStats = new GossipStats();
         ActorRef _seedNodeProcess;
         int _seedNodeProcessCounter = 0; //for unique names
+        private bool _logInfo;
 
         readonly ActorRef _publisher;
 
@@ -648,9 +655,13 @@ namespace Akka.Cluster
             _publisher = publisher;
             SelfUniqueAddress = _cluster.SelfUniqueAddress;
             _vclockNode = new VectorClock.Node(VclockName(SelfUniqueAddress));
-            //TODO: _statsEnabled = PublishStatsInternal.IsFinite;
+            
             var settings = _cluster.Settings;
             var scheduler = _cluster.Scheduler;
+
+            _statsEnabled = settings.PublishStatsInterval.HasValue
+                            && settings.PublishStatsInterval >= TimeSpan.Zero
+                            && settings.PublishStatsInterval != TimeSpan.MaxValue;
 
             _gossipTaskCancellable = new CancellationTokenSource();
             _gossipTask =
@@ -679,7 +690,7 @@ namespace Akka.Cluster
                     InternalClusterAction.LeaderActionsTick.Instance,
                     _leaderActionsTaskCancellable.Token);
 
-            if (settings.PublishStatsInterval != null)
+            if (settings.PublishStatsInterval != null && settings.PublishStatsInterval > TimeSpan.Zero && settings.PublishStatsInterval != TimeSpan.MaxValue)
             {
                 _publishStatsTaskTaskCancellable = new CancellationTokenSource();
                 _publishStatsTask =
@@ -690,6 +701,8 @@ namespace Akka.Cluster
                                 InternalClusterAction.PublishStatsTick.Instance,
                                 _publishStatsTaskTaskCancellable.Token);
             }
+
+            _logInfo = settings.LogInfo;
         }
 
         ActorSelection ClusterCore(Address address)
@@ -736,6 +749,11 @@ namespace Akka.Cluster
 
         private void Uninitialized(object message)
         {
+            if (_logInfo && !(message is InternalClusterAction.ITick))
+            {
+                _log.Debug("[Uninitialized] Received {0}", message);
+            }
+
             if (message is InternalClusterAction.InitJoin)
             {
                 Sender.Tell(new InternalClusterAction.InitJoinNack(_cluster.SelfAddress));
@@ -763,6 +781,11 @@ namespace Akka.Cluster
 
         private void TryingToJoin(object message, Address joinWith, Deadline deadline)
         {
+            if (_logInfo && !(message is InternalClusterAction.ITick))
+            {
+                _log.Debug("[TryingToJoin] Received {0}", message);
+            }
+
             if (message is InternalClusterAction.Welcome)
             {
                 var w = message as InternalClusterAction.Welcome;
@@ -818,6 +841,11 @@ namespace Akka.Cluster
 
         private void Initialized(object message)
         {
+            if (_logInfo && !(message is InternalClusterAction.ITick))
+            {
+                _log.Debug("[Initialized] Received {0}", message);
+            }
+
             if (message is GossipEnvelope)
             {
                 var ge = message as GossipEnvelope;
@@ -906,6 +934,10 @@ namespace Akka.Cluster
             }
             else
             {
+                if (_logInfo)
+                {
+                    _log.Debug("[Unhandled] Received {0}", message);
+                }
                 base.Unhandled(message);
             }
         }
@@ -978,6 +1010,7 @@ namespace Akka.Cluster
                         : Deadline.Now + _cluster.Settings.RetryUnsuccessfulJoinAfter;
 
                     Context.Become(m => TryingToJoin(m, address, joinDeadline));
+                    Self.Tell("testing"); //TODO: remove when done debugging
                     ClusterCore(address).Tell(new InternalClusterAction.Join(_cluster.SelfUniqueAddress, _cluster.SelfRoles));
                 }
             }
@@ -1147,7 +1180,7 @@ namespace Akka.Cluster
                 var newOverview = localGossip.Overview.Copy(reachability: newReachability);
                 var newGossip = localGossip.Copy(overview: newOverview);
                 UpdateLatestGossip(newGossip);
-                _log.Warn("Cluster Node [{0}] - Marking node as TERMINATED [{1}], due to quarantine",
+                _log.Warning("Cluster Node [{0}] - Marking node as TERMINATED [{1}], due to quarantine",
                     Self, node.Address);
                 Publish(_latestGossip);
                 Downing(node.Address);
@@ -1482,7 +1515,7 @@ namespace Akka.Cluster
                     return m.CopyUp(upNumber);
                 }
 
-                if (m.Status == MemberStatus.Leaving && hasPartionHandoffCompletedSuccessfully)
+                if (m.Status == MemberStatus.Leaving)
                 {
                     // Move LEAVING => EXITING (once we have a convergence on LEAVING
                     // *and* if we have a successful partition handoff)
@@ -1514,6 +1547,13 @@ namespace Akka.Cluster
                 // log status changes
                 foreach (var m in changedMembers)
                     _log.Info("Leader is moving node [{0}] to [{1}]", m.Address, m.Status);
+
+                //log the removal of unreachable nodes
+                foreach (var m in removedUnreachable)
+                {
+                    var status = m.Status == MemberStatus.Exiting ? "exiting" : "unreachable";
+                    _log.Info("Leader is removing {0} node [{1}]", status, m.Address);
+                }
 
                 Publish(_latestGossip);
 

--- a/src/core/Akka.Cluster/Routing/ClusterRoutingConfig.cs
+++ b/src/core/Akka.Cluster/Routing/ClusterRoutingConfig.cs
@@ -5,12 +5,13 @@ using System.Linq;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Routing;
+using Akka.Util;
 using Akka.Util.Internal;
 
 namespace Akka.Cluster.Routing
 {
     /// <summary>
-    /// `TotalInstances` of cluster router must be > 0
+    /// <see cref="ClusterRouterSettingsBase.TotalInstances"/> of cluster router must be > 0
     /// </summary>
     public sealed class ClusterRouterGroupSettings : ClusterRouterSettingsBase
     {
@@ -23,7 +24,12 @@ namespace Akka.Cluster.Routing
             RouteesPaths = routeesPaths;
             if(routeesPaths == null || routeesPaths.IsEmpty || string.IsNullOrEmpty(routeesPaths.First())) throw new ArgumentException("routeesPaths must be defined", "routeesPaths");
 
-            //todo add relative actor path validation
+            //validate that all routeesPaths are relative
+            foreach (var path in routeesPaths)
+            {
+                if(RelativeActorPath.Unapply(path) == null)
+                    throw new ArgumentException(string.Format("routeesPaths [{0}] is not a valid relative actor path.", path), "routeesPaths");
+            }
         }
 
         public ImmutableHashSet<string> RouteesPaths { get; private set; }
@@ -35,9 +41,9 @@ namespace Akka.Cluster.Routing
     }
 
     /// <summary>
-    /// `totalInstances` of cluster router must be > 0
-    /// `maxInstancesPerNode` of cluster router must be > 0
-    /// `maxInstancesPerNode` of cluster router must be 1 when routeesPath is defined
+    /// <see cref="ClusterRouterSettingsBase.TotalInstances"/> of cluster router must be > 0
+    /// <see cref="MaxInstancesPerNode"/> of cluster router must be > 0
+    /// <see cref="MaxInstancesPerNode"/> of cluster router must be 1 when routeesPath is defined
     /// </summary>
     public sealed class ClusterRouterPoolSettings : ClusterRouterSettingsBase
     {
@@ -59,6 +65,9 @@ namespace Akka.Cluster.Routing
         }
     }
 
+    /// <summary>
+    /// Base class for defining <see cref="ClusterRouterGroupSettings"/> and <see cref="ClusterRouterPoolSettings"/>
+    /// </summary>
     public abstract class ClusterRouterSettingsBase
     {
         protected ClusterRouterSettingsBase(int totalInstances, bool allowLocalRoutees) : this(totalInstances, allowLocalRoutees, null)
@@ -87,7 +96,7 @@ namespace Akka.Cluster.Routing
     /// possible to mix this with built-in routers such as <see cref="RoundRobinGroup"/> or
     /// custom routers.
     /// </summary>
-    public sealed class ClusterRouterGroup : Group, IClusterRouterConfigBase
+    public sealed class ClusterRouterGroup : Group, IClusterRouterConfigBase<Group, ClusterRouterGroupSettings>
     {
         public ClusterRouterGroup(Group local, ClusterRouterGroupSettings settings)
         {
@@ -97,8 +106,8 @@ namespace Akka.Cluster.Routing
             RouterDispatcher = local.RouterDispatcher;
         }
 
-        public RouterConfig Local { get; private set; }
-        public ClusterRouterSettingsBase Settings { get; private set; }
+        public Group Local { get; private set; }
+        public ClusterRouterGroupSettings Settings { get; private set; }
 
         public override Router CreateRouter(ActorSystem system)
         {
@@ -117,7 +126,7 @@ namespace Akka.Cluster.Routing
 
         public override RouterConfig WithFallback(RouterConfig routerConfig)
         {
-            var localFallback = (ClusterRouterGroup) routerConfig;
+            var localFallback = routerConfig as ClusterRouterGroup;
             if (localFallback != null && (localFallback.Local is ClusterRouterGroup)) throw new ConfigurationException("ClusterRouterGroup is not allowed to wrap a ClusterRouterGroup");
             if (localFallback != null) return Copy(Local.WithFallback(localFallback.Local).AsInstanceOf<Group>());
             return Copy(Local.WithFallback(routerConfig).AsInstanceOf<Group>());
@@ -135,24 +144,65 @@ namespace Akka.Cluster.Routing
     /// possible to mix this with built-in routers such as <see cref="RoundRobinGroup"/> or
     /// custom routers.
     /// </summary>
-    public sealed class ClusterRouterPool : Pool, IClusterRouterConfigBase
+    public sealed class ClusterRouterPool : Pool, IClusterRouterConfigBase<Pool, ClusterRouterPoolSettings>
     {
         public ClusterRouterPool(Pool local, ClusterRouterPoolSettings settings)
         {
             Settings = settings;
             Local = local;
-            RouterDispatcher = local.RouterDispatcher;
-
-            if(local.Resizer != null) throw new ConfigurationException("Resizer can't be used together with cluster router.");
-            NrOfInstances = Settings.AllowLocalRoutees ? settings.MaxInstancesPerNode : 0;
-            Resizer = local.Resizer;
-            SupervisorStrategy = local.SupervisorStrategy;
+            Guard.Assert(local.Resizer == null, "Resizer can't be used together with cluster router.");
         }
 
         private readonly AtomicCounter _childNameCounter = new AtomicCounter(0);
 
-        public RouterConfig Local { get; private set; }
-        public ClusterRouterSettingsBase Settings { get; private set; }
+        public Pool Local { get; private set; }
+
+        public ClusterRouterPoolSettings Settings { get; private set; }
+
+        public override SupervisorStrategy SupervisorStrategy
+        {
+            get { return Local.SupervisorStrategy; }
+            set
+            {
+                Local.SupervisorStrategy = value;
+            }
+        }
+
+        public override Resizer Resizer { get { return Local.Resizer; } }
+
+
+        public override int GetNrOfInstances(ActorSystem system)
+        {
+            if (Settings.AllowLocalRoutees && !string.IsNullOrEmpty(Settings.UseRole))
+            {
+                return Cluster.Get(system).SelfRoles.Contains(Settings.UseRole) ? Settings.MaxInstancesPerNode : 0;
+            }
+            else if (Settings.AllowLocalRoutees && string.IsNullOrEmpty(Settings.UseRole))
+            {
+                return Settings.MaxInstancesPerNode;
+            }
+            else
+            {
+                return 0;
+            }
+        }
+
+        public override int NrOfInstances
+        {
+            get
+            {
+                return Local.NrOfInstances;
+            }
+            set
+            {
+                Local.NrOfInstances = value;
+            }
+        }
+
+        public override string RouterDispatcher
+        {
+            get { return Local.RouterDispatcher; }
+        }
 
         public override Router CreateRouter(ActorSystem system)
         {
@@ -164,10 +214,22 @@ namespace Akka.Cluster.Routing
             return new ClusterRouterPoolActor(((Pool) Local).SupervisorStrategy, (ClusterRouterPoolSettings) Settings);
         }
 
+        
+
+        public override Pool WithSupervisorStrategy(SupervisorStrategy strategy)
+        {
+            return new ClusterRouterPool(Local.WithSupervisorStrategy(strategy), Settings);
+        }
+
+        public override Pool WithResizer(Resizer resizer)
+        {
+            return new ClusterRouterPool(Local.WithResizer(resizer), Settings);
+        }
+
 
         public override bool IsManagementMessage(object message)
         {
-            return message is IClusterMessage || message is ClusterEvent.CurrentClusterState || base.IsManagementMessage(message);
+            return message is ClusterEvent.IClusterDomainEvent || message is ClusterEvent.CurrentClusterState || base.IsManagementMessage(message);
         }
 
         public override Routee NewRoutee(Props routeeProps, IActorContext context)
@@ -179,7 +241,7 @@ namespace Akka.Cluster.Routing
 
         public override RouterConfig WithFallback(RouterConfig routerConfig)
         {
-            var otherClusterRouterPool = (ClusterRouterPool) routerConfig;
+            var otherClusterRouterPool = routerConfig as ClusterRouterPool;
             if(otherClusterRouterPool != null && otherClusterRouterPool.Local is ClusterRouterPool) throw new ConfigurationException("ClusterRouterPool is not allowed to wrap a ClusterRouterPool");
             if (otherClusterRouterPool != null)
                 return Copy(Local.WithFallback(otherClusterRouterPool.Local).AsInstanceOf<Pool>());
@@ -200,11 +262,12 @@ namespace Akka.Cluster.Routing
     /// Have to implement this as an interface rather than a base class, so we can continue to inherit from <see cref="Group"/> and <see cref="Pool"/>
     /// on the concrete cluster router implementations.
     /// </summary>
-    public interface IClusterRouterConfigBase
+    public interface IClusterRouterConfigBase<out TR, out TC> where TR:RouterConfig
+                                                        where TC:ClusterRouterSettingsBase
     {
-        RouterConfig Local { get; }
+        TR Local { get; }
 
-        ClusterRouterSettingsBase Settings { get; }
+        TC Settings { get; }
     }
 
     /// <summary>
@@ -313,33 +376,39 @@ namespace Akka.Cluster.Routing
 
         protected override void OnReceive(object message)
         {
-            message.Match()
-                .With<ClusterEvent.CurrentClusterState>(state =>
+            if (message is ClusterEvent.CurrentClusterState)
+            {
+                var state = message as ClusterEvent.CurrentClusterState;
+                Nodes = ImmutableSortedSet.Create(Member.AddressOrdering,
+                      state.Members.Where(IsAvailable).Select(x => x.Address).ToArray());
+                AddRoutees();
+            }
+            else if (message is ClusterEvent.IMemberEvent)
+            {
+                var @event = message as ClusterEvent.IMemberEvent;
+                if (IsAvailable(@event.Member))
+                    AddMember(@event.Member);
+                else
                 {
-                    Nodes = ImmutableSortedSet.Create(Member.AddressOrdering,
-                        state.Members.Where(IsAvailable).Select(x => x.Address).ToArray());
-                    AddRoutees();
-                })
-                .With<ClusterEvent.IMemberEvent>(@event =>
-                {
-                    if (IsAvailable(@event.Member))
-                        AddMember(@event.Member);
-                    else
-                    {
-                        // other events means that it is no onger interesting, such as
-                        // MemberExited, MemberRemoved
-                        RemoveMember(@event.Member);
-                    }
-                })
-                .With<ClusterEvent.UnreachableMember>(member => RemoveMember(member.Member))
-                .With<ClusterEvent.ReachableMember>(member =>
-                {
-                    if (IsAvailable(member.Member)) AddMember(member.Member);
-                })
-                .Default(msg =>
-                {
-                    base.OnReceive(msg);
-                });
+                    // other events means that it is no onger interesting, such as
+                    // MemberExited, MemberRemoved
+                    RemoveMember(@event.Member);
+                }
+            }
+            else if (message is ClusterEvent.UnreachableMember)
+            {
+                var member = message as ClusterEvent.UnreachableMember;
+                RemoveMember(member.Member);
+            }
+            else if (message is ClusterEvent.ReachableMember)
+            {
+                var member = message as ClusterEvent.ReachableMember;
+                if (IsAvailable(member.Member)) AddMember(member.Member);
+            }
+            else
+            {
+                base.OnReceive(message);
+            }
         }
     }
 
@@ -377,20 +446,30 @@ namespace Akka.Cluster.Routing
         /// </summary>
         public override void AddRoutees()
         {
-            var deploymentTarget = SelectDeploymentTarget();
-            while (deploymentTarget != null)
+
+            Action doAddRoutees = null;
+            doAddRoutees = () =>
             {
-                var address = deploymentTarget.Item1;
-                var path = deploymentTarget.Item2;
-                var routee = _group.RouteeFor(address + path, Context);
-                UsedRouteePaths = UsedRouteePaths.SetItem(address,
-                    UsedRouteePaths.GetOrElse(address, ImmutableHashSet<string>.Empty).Add(path));
+                var deploymentTarget = SelectDeploymentTarget();
+                if (deploymentTarget != null)
+                {
+                    var address = deploymentTarget.Item1;
+                    var path = deploymentTarget.Item2;
+                    var routee = _group.RouteeFor(address + path, Context);
+                    UsedRouteePaths = UsedRouteePaths.SetItem(address,
+                        UsedRouteePaths.GetOrElse(address, ImmutableHashSet<string>.Empty).Add(path));
 
-                //must register each one, since registered routees are used in SelectDeploymentTarget
-                Cell.AddRoutee(routee);
+                    var currentRoutees = Cell.Router.Routees.ToList();
 
-                deploymentTarget = SelectDeploymentTarget();
-            }
+                    //must register each one, since registered routees are used in SelectDeploymentTarget
+                    Cell.AddRoutee(routee);
+
+                    doAddRoutees();
+                }
+            };
+
+            doAddRoutees();
+           
         }
 
         public Tuple<Address, string> SelectDeploymentTarget()
@@ -407,16 +486,13 @@ namespace Akka.Cluster.Routing
             }
             else
             {
+                //find the node with the fewest routees
                 var minNode =
-                    UsedRouteePaths.Aggregate(
-                        (curMin, x) =>
-                            (curMin.Value == ImmutableHashSet<string>.Empty || x.Value.Count < curMin.Value.Count)
-                                ? x
-                                : curMin);
+                    UsedRouteePaths.Select(x => new{ Address = x.Key, Used = x.Value }).OrderBy(x => x.Used.Count).First();
 
                 // pick next of unused paths
-                var minPath = Settings.RouteesPaths.FirstOrDefault(p => !minNode.Value.Contains(p));
-                return minPath == null ? null : new Tuple<Address, string>(minNode.Key, minPath);
+                var minPath = Settings.RouteesPaths.FirstOrDefault(p => !minNode.Used.Contains(p));
+                return minPath == null ? null : new Tuple<Address, string>(minNode.Address, minPath);
             }
         }
 
@@ -474,8 +550,8 @@ namespace Akka.Cluster.Routing
             if (currentNodes.IsEmpty || currentRoutees.Count >= Settings.TotalInstances) return null;
 
             //find the node with the least routees
-            var numberOfRouteesPerNode = currentRoutees.ToDictionary(FullAddress,
-                routee => currentNodes.Count(y => y == FullAddress(routee)));
+            var numberOfRouteesPerNode = currentNodes.ToDictionary(x => x,
+                routee => currentRoutees.Count(y => routee == FullAddress(y)));
 
             var target = numberOfRouteesPerNode.Aggregate(
                         (curMin, x) =>

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/MessageSink.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/MessageSink.cs
@@ -96,7 +96,7 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
         /*
          * Regular expressions - go big or go home. [Aaronontheweb]
          */
-        private const string NodeLogMessageRegexString = @"\[(\w){4}(?<node>[0-9]{1,2})\]\[(?<level>(\w)*)\]\[(?<time>\d{1,4}[- /.]\d{1,4}[- /.]\d{1,4}\s\d{1,2}:\d{1,2}:\d{1,2}(\s(AM|PM)){0,1})\](?<thread>\[(\w|\s)*\])\[(?<logsource>(\[|\w|:|/|\(|\)|\]|\.|-|\$|%|\+|\^|@)*)\]\s(?<message>(\w|\s|:|<|\.|\+|>|,|\[|/|-|]|%|\$|\+|\^|@)*)";
+        private const string NodeLogMessageRegexString = @"\[(\w){4}(?<node>[0-9]{1,2})\]\[(?<level>(\w)*)\]\[(?<time>\d{1,4}[- /.]\d{1,4}[- /.]\d{1,4}\s\d{1,2}:\d{1,2}:\d{1,2}(\s(AM|PM)){0,1})\](?<thread>\[(\w|\s)*\])\[(?<logsource>(\[|\w|:|/|\(|\)|\]|\.|-|\$|%|\+|\^|@)*)\]\s(?<message>(\w|\s|:|<|\.|\+|>|,|\[|/|-|]|%|\$|\+|\^|@|\(|\))*)";
         protected static readonly Regex NodeLogMessageRegex = new Regex(NodeLogMessageRegexString);
 
         private const string RunnerLogMessageRegexString = @"\[(?<level>(\w)*)\]\[(?<time>\d{1,4}[- /.]\d{1,4}[- /.]\d{1,4}\s\d{1,2}:\d{1,2}:\d{1,2}(\s(AM|PM)){0,1})\](?<thread>\[(\w|\s)*\])\[(?<logsource>(\[|\w|:|/|\(|\)|\]|\.|-|\$|%|\+|\^|@)*)\]\s(?<message>(\w|\s|:|<|\.|\+|>|,|\[|/|-|]|%|\$|\+|\^|@)*)";

--- a/src/core/Akka.MultiNodeTestRunner/Program.cs
+++ b/src/core/Akka.MultiNodeTestRunner/Program.cs
@@ -67,7 +67,7 @@ namespace Akka.MultiNodeTestRunner
                     controller.Find(false, discovery, new TestFrameworkOptions());
                     discovery.Finished.WaitOne();
 
-                    foreach (var test in discovery.Tests)
+                    foreach (var test in discovery.Tests.Reverse())
                     {
                         PublishRunnerMessage(string.Format("Starting test {0}", test.Value.First().MethodName));
 

--- a/src/core/Akka.Remote.TestKit/Controller.cs
+++ b/src/core/Akka.Remote.TestKit/Controller.cs
@@ -56,6 +56,11 @@ namespace Akka.Remote.TestKit
             {
                 return !Equals(left, right);
             }
+
+            public override string ToString()
+            {
+                return string.Format("{0}: {1}", GetType(), Name);
+            }
         }
 
         public class ClientDisconnectedException : AkkaException

--- a/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
+++ b/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
@@ -64,6 +64,7 @@ namespace Akka.Remote.TestKit
                         fsm = on
                     }
                     akka.remote.log-remote-lifecycle-events = on
+                    akka.log-dead-letters = on
                 ");
             return ConfigurationFactory.Empty;
         }

--- a/src/core/Akka.Remote.Tests/RemoteRouterSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteRouterSpec.cs
@@ -244,8 +244,7 @@ namespace Akka.Remote.Tests
                 .WithDeploy(
                 new Deploy(new RemoteScope(intendedRemoteAddress.Copy()))), "local-blub2");
 
-            // This line was subject to a bug in the original Akka - this router should be locally-deployed.
-            router.Path.Address.ToString().ShouldBe(string.Format("akka://{0}", masterActorSystem.Name));
+            router.Path.Address.ShouldBe(intendedRemoteAddress);
 
             var replies = new HashSet<ActorPath>();
             for (var i = 0; i < 5; i++)

--- a/src/core/Akka.Remote/RemoteDeployer.cs
+++ b/src/core/Akka.Remote/RemoteDeployer.cs
@@ -55,7 +55,7 @@ namespace Akka.Remote
             else
             {
                 //TODO: return deploy;
-                return deploy.Copy(scope: Deploy.NoScopeGiven);
+                return deploy;
             }
         }
     }

--- a/src/core/Akka.Remote/Routing/RemoteRouterConfig.cs
+++ b/src/core/Akka.Remote/Routing/RemoteRouterConfig.cs
@@ -19,8 +19,8 @@ namespace Akka.Remote.Routing
     /// </summary>
     public sealed class RemoteRouterConfig : Pool
     {
-        internal readonly Pool Local;
-        internal readonly IList<Address> Nodes;
+        public readonly Pool Local;
+        public readonly IList<Address> Nodes;
 
         /// <summary>
         /// Used for distributing routees to <see cref="Nodes"/>. Needs to be an instance variable since <see cref="Resizer"/> may call <see cref="RoutedActorCell.AddRoutees"/> several times.
@@ -58,10 +58,21 @@ namespace Akka.Remote.Routing
             set { Local.Resizer = value; }
         }
 
+        public override int GetNrOfInstances(ActorSystem system)
+        {
+            return Local.GetNrOfInstances(system);
+        }
+
         public override int NrOfInstances
         {
-            get { return Local.NrOfInstances; }
-            set { Local.NrOfInstances = value; }
+            get
+            {
+                return Local.NrOfInstances;
+            }
+            set
+            {
+                Local.NrOfInstances = value;
+            }
         }
 
         public override string RouterDispatcher
@@ -76,6 +87,16 @@ namespace Akka.Remote.Routing
         internal override RouterActor CreateRouterActor()
         {
             return Local.CreateRouterActor();
+        }
+
+        public override Pool WithSupervisorStrategy(SupervisorStrategy strategy)
+        {
+            return new RemoteRouterConfig(Local.WithSupervisorStrategy(strategy), Nodes);
+        }
+
+        public override Pool WithResizer(Resizer resizer)
+        {
+            return new RemoteRouterConfig(Local.WithResizer(resizer), Nodes);
         }
 
         public override Router CreateRouter(ActorSystem system)

--- a/src/core/Akka.Tests/Actor/RelativeActorPathSpec.cs
+++ b/src/core/Akka.Tests/Actor/RelativeActorPathSpec.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using Akka.Actor;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Tests.Actor
+{
+    public class RelativeActorPathSpec
+    {
+        protected IEnumerable<string> Elements(string path)
+        {
+            return RelativeActorPath.Unapply(path) ?? new List<string>();
+        }
+
+        [Fact]
+        public void RelativeActorPath_must_match_single_name()
+        {
+            Elements("foo").ShouldBe(new List<string>(){"foo"});
+        }
+
+        [Fact]
+        public void RelativeActorPath_must_match_path_separated_names()
+        {
+            Elements("foo/bar/baz").ShouldBe(new List<string>() { "foo", "bar", "baz" });
+        }
+
+        [Fact]
+        public void RelativeActorPath_must_match_url_encoded_name()
+        {
+            var name = WebUtility.UrlEncode("akka://ClusterSystem@127.0.0.1:2552");
+            Elements(name).ShouldBe(new List<string>() { name });
+        }
+
+        [Fact]
+        public void RelativeActorPath_must_match_path_with_uid_fragment()
+        {
+            Elements("foo/bar/baz#1234").ShouldBe(new List<string>() { "foo", "bar", "baz#1234" });
+        }
+    }
+}

--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Actor\FSMTransitionSpec.cs" />
     <Compile Include="Actor\PatternSpec.cs" />
     <Compile Include="Actor\ReceiveTimeoutSpec.cs" />
+    <Compile Include="Actor\RelativeActorPathSpec.cs" />
     <Compile Include="Actor\RootGuardianActorRef_Tests.cs" />
     <Compile Include="Actor\StashMailboxSpec.cs" />
     <Compile Include="Actor\Stash\ActorWithStashSpec.cs" />
@@ -126,6 +127,7 @@
     <Compile Include="MatchHandler\PartialActionBuilderTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Routing\BroadcastSpec.cs" />
+    <Compile Include="Routing\ConsistentHashingRouterSpec.cs" />
     <Compile Include="Routing\ListenerSpec.cs" />
     <Compile Include="Routing\RandomSpec.cs" />
     <Compile Include="Routing\ResizerSpec.cs" />

--- a/src/core/Akka.Tests/Routing/ConsistentHashingRouterSpec.cs
+++ b/src/core/Akka.Tests/Routing/ConsistentHashingRouterSpec.cs
@@ -1,0 +1,250 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Routing;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Tests.Routing
+{
+    public class ConsistentHashingRouterSpec : AkkaSpec
+    {
+        #region Actors & Message Classes
+
+        public class Echo : UntypedActor
+        {
+            protected override void OnReceive(object message)
+            {
+                if (message is ConsistentHashableEnvelope)
+                {
+                    Sender.Tell(string.Format("Unexpected envelope: {0}", message));
+                }
+                else
+                {
+                    Sender.Tell(Self);
+                }
+            }
+        }
+
+        public sealed class Msg : IConsistentHashable
+        {
+            public Msg(object consistentHashKey, string data)
+            {
+                ConsistentHashKey = consistentHashKey;
+                Data = data;
+            }
+
+            public string Data { get; private set; }
+
+            public object Key { get { return ConsistentHashKey; } }
+
+            public object ConsistentHashKey { get; private set; }
+        }
+
+        public sealed class MsgKey
+        {
+            public MsgKey(string name)
+            {
+                Name = name;
+            }
+
+            public string Name { get; private set; }
+        }
+
+        public sealed class Msg2
+        {
+            public Msg2(object key, string data)
+            {
+                Data = data;
+                Key = key;
+            }
+
+            public string Data { get; private set; }
+
+            public object Key { get; private set; }
+        }
+
+        #endregion
+
+        private ActorRef router1;
+        private ActorRef router3;
+        private ActorRef a, b, c;
+
+        public ConsistentHashingRouterSpec()
+            : base(@"
+            akka.actor.deployment {
+              /router1 {
+                router = consistent-hashing-pool
+                nr-of-instances = 3
+                virtual-nodes-factor = 17
+              }
+              /router2 {
+                router = consistent-hashing-pool
+                nr-of-instances = 5
+              }
+              /router3 {
+                router = consistent-hashing-group
+                virtual-nodes-factor = 17
+                routees.paths = [""user/A"",""user/B"",""user/C""]
+              }
+              /router4 {
+                router = consistent-hashing-group
+                routees.paths = [""user/A"",""user/B"",""user/C"", ]
+              }
+        ")
+        {
+            router1 = Sys.ActorOf(Props.Create<Echo>().WithRouter(FromConfig.Instance), "router1");
+            a = Sys.ActorOf(Props.Create<Echo>(), "A");
+            b = Sys.ActorOf(Props.Create<Echo>(), "B");
+            c = Sys.ActorOf(Props.Create<Echo>(), "C");
+            router3 = Sys.ActorOf(Props.Create<Echo>().WithRouter(FromConfig.Instance), "router3");
+        }
+
+        [Fact]
+        public async Task ConsistentHashingRouterMustCreateRouteesFromConfiguration()
+        {
+            var currentRoutees = await router1.Ask<Routees>(new GetRoutees(), GetTimeoutOrDefault(null));
+            currentRoutees.Members.Count().ShouldBe(3);
+        }
+
+        [Fact]
+        public void ConsistentHashingRouterMustSelectDestinationBasedOnConsistentHashKeyOfMessage()
+        {
+            router1.Tell(new Msg("a", "A"));
+            var destinationA = ExpectMsg<ActorRef>();
+            router1.Tell(new ConsistentHashableEnvelope("AA", "a"));
+            ExpectMsg(destinationA);
+
+            router1.Tell(new Msg(17, "A"));
+            var destinationB = ExpectMsg<ActorRef>();
+            router1.Tell(new ConsistentHashableEnvelope("BB", 17));
+            ExpectMsg(destinationB);
+
+            router1.Tell(new Msg(new MsgKey("c"), "C"));
+            var destinationC = ExpectMsg<ActorRef>();
+            router1.Tell(new ConsistentHashableEnvelope("CC", new MsgKey("c")));
+            ExpectMsg(destinationC);
+        }
+
+        [Fact]
+        public void ConsistentHashingRouterMustSelectDestinationWithDefinedHashMapping()
+        {
+            ConsistentHashMapping hashMapping = msg =>
+            {
+                if (msg is Msg2)
+                {
+                    var m2 = msg as Msg2;
+                    return m2.Key;
+                }
+
+                return null;
+            };
+            var router2 =
+                Sys.ActorOf(new ConsistentHashingPool(1, null, null, null, hashMapping: hashMapping).Props(Props.Create<Echo>()), "router2");
+
+            router2.Tell(new Msg2("a", "A"));
+            var destinationA = ExpectMsg<ActorRef>();
+            router2.Tell(new ConsistentHashableEnvelope("AA", "a"));
+            ExpectMsg(destinationA);
+
+            router2.Tell(new Msg2(17, "A"));
+            var destinationB = ExpectMsg<ActorRef>();
+            router2.Tell(new ConsistentHashableEnvelope("BB", 17));
+            ExpectMsg(destinationB);
+
+            router2.Tell(new Msg2(new MsgKey("c"), "C"));
+            var destinationC = ExpectMsg<ActorRef>();
+            router2.Tell(new ConsistentHashableEnvelope("CC", new MsgKey("c")));
+            ExpectMsg(destinationC);
+        }
+
+        [Fact]
+        public async Task ConsistentHashingGroupRouterMustCreateRouteesFromConfiguration()
+        {
+            var currentRoutees = await router3.Ask<Routees>(new GetRoutees(), GetTimeoutOrDefault(null));
+            currentRoutees.Members.Count().ShouldBe(3);
+        }
+
+        [Fact]
+        public void ConsistentHashingGroupRouterMustSelectDestinationBasedOnConsistentHashKeyOfMessage()
+        {
+            router3.Tell(new Msg("a", "A"));
+            var destinationA = ExpectMsg<ActorRef>();
+            router3.Tell(new ConsistentHashableEnvelope("AA", "a"));
+            ExpectMsg(destinationA);
+
+            router3.Tell(new Msg(17, "A"));
+            var destinationB = ExpectMsg<ActorRef>();
+            router3.Tell(new ConsistentHashableEnvelope("BB", 17));
+            ExpectMsg(destinationB);
+
+            router3.Tell(new Msg(new MsgKey("c"), "C"));
+            var destinationC = ExpectMsg<ActorRef>();
+            router3.Tell(new ConsistentHashableEnvelope("CC", new MsgKey("c")));
+            ExpectMsg(destinationC);
+        }
+
+        [Fact]
+        public void ConsistentHashingGroupRouterMustSelectDestinationWithDefinedHashMapping()
+        {
+            ConsistentHashMapping hashMapping = msg =>
+            {
+                if (msg is Msg2)
+                {
+                    var m2 = msg as Msg2;
+                    return m2.Key;
+                }
+
+                return null;
+            };
+            var router4 =
+                Sys.ActorOf(Props.Empty.WithRouter(new ConsistentHashingGroup(new[]{c},hashMapping: hashMapping)), "router4");
+
+            router4.Tell(new Msg2("a", "A"));
+            var destinationA = ExpectMsg<ActorRef>();
+            router4.Tell(new ConsistentHashableEnvelope("AA", "a"));
+            ExpectMsg(destinationA);
+
+            router4.Tell(new Msg2(17, "A"));
+            var destinationB = ExpectMsg<ActorRef>();
+            router4.Tell(new ConsistentHashableEnvelope("BB", 17));
+            ExpectMsg(destinationB);
+
+            router4.Tell(new Msg2(new MsgKey("c"), "C"));
+            var destinationC = ExpectMsg<ActorRef>();
+            router4.Tell(new ConsistentHashableEnvelope("CC", new MsgKey("c")));
+            ExpectMsg(destinationC);
+        }
+
+        [Fact]
+        public async Task ConsistentHashingRouterMustAdjustNodeRingWhenRouteeDies()
+        {
+            //create pool router with two routees
+            var router5 =
+                Sys.ActorOf(Props.Create<Echo>().WithRouter(new ConsistentHashingPool(2, null, null, null)), "router5");
+
+            //verify that we have at least 2 routees
+            var currentRoutees = await router5.Ask<Routees>(new GetRoutees(), GetTimeoutOrDefault(null));
+            currentRoutees.Members.Count().ShouldBe(2);
+
+            router5.Tell(new Msg("a", "A"), TestActor);
+            var actorWhoDies = ExpectMsg<ActorRef>();
+
+            //kill off the actor
+            actorWhoDies.Tell(PoisonPill.Instance);
+
+            //might take some time for the deathwatch to get processed
+            AwaitAssert(() =>
+            {
+                router5.Tell(new Msg("a", "A"), TestActor);
+                //verify that a different actor now owns this hash range
+                var actorWhoDidntDie = ExpectMsg<ActorRef>(TimeSpan.FromMilliseconds(50));
+                actorWhoDidntDie.ShouldNotBe(actorWhoDies);
+            }, TimeSpan.FromSeconds(5));
+
+            
+        }
+    }
+}

--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -585,5 +585,4 @@ namespace Akka.Actor
             return InternalCompareTo(left.Parent, right.Parent);
         }
     }
-
 }

--- a/src/core/Akka/Actor/ActorRefProvider.cs
+++ b/src/core/Akka/Actor/ActorRefProvider.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Akka.Actor.Internals;
+using Akka.Configuration;
 using Akka.Dispatch;
 using Akka.Dispatch.SysMsg;
 using Akka.Event;
@@ -341,67 +343,96 @@ namespace Akka.Actor
 
         public InternalActorRef ActorOf(ActorSystemImpl system, Props props, InternalActorRef supervisor, ActorPath path, bool systemService, Deploy deploy, bool lookupDeploy, bool async)
         {
-            //TODO: This does not match Akka's ActorOf at all
-
-            Deploy configDeploy = _system.Provider.Deployer.Lookup(path);
-            deploy = configDeploy ?? props.Deploy ?? Deploy.None;
-            if(deploy.Mailbox != Deploy.NoMailboxGiven)
-                props = props.WithMailbox(deploy.Mailbox);
-            if(deploy.Dispatcher != Deploy.NoDispatcherGiven)
-                props = props.WithDispatcher(deploy.Dispatcher);
-
-            //TODO: how should this be dealt with?
-            //akka simply passes the "deploy" var from remote daemon to ActorOf
-            //so it atleast seems like they ignore if remote scope is provided here.
-            //leaving this for now since it does work
-
-            if(props.RouterConfig.NoRouter())
+            if (props.Deploy.RouterConfig.NoRouter())
             {
-                return CreateNoRouter(system, props, supervisor, path, deploy, async);
+                if (Settings.DebugRouterMisconfiguration)
+                {
+                    var d = Deployer.Lookup(path);
+                    if (d != null && d.RouterConfig != RouterConfig.NoRouter)
+                        Log.Warning(
+                            string.Format(
+                                "Configuration says that [{0}] should be a router, but code disagrees. Remove the config or add a RouterConfig to its Props.",
+                                path));
+                }
+
+                var props2 = props;
+
+                // mailbox and dispatcher defined in deploy should override props
+                var propsDeploy = lookupDeploy ? Deployer.Lookup(path) : deploy;
+                if (propsDeploy != null)
+                {
+                    if (propsDeploy.Mailbox != Deploy.NoMailboxGiven)
+                        props2 = props2.WithMailbox(propsDeploy.Mailbox);
+                    if (propsDeploy.Dispatcher != Deploy.NoDispatcherGiven)
+                        props2 = props2.WithDispatcher(propsDeploy.Dispatcher);
+                }
+
+                //TODO: implement Dispatchers and uncomment
+                //if (!system.Dispatchers.HasDispatcher(props2.Dispatcher))
+                //{
+                //    throw new ConfigurationException(string.Format("Dispatcher [{0}] not configured for path {1}", props2.Dispatcher, path));
+                //}
+
+                try
+                {
+                    // for consistency we check configuration of dispatcher and mailbox locally
+                    var dispatcher = _system.Dispatchers.Lookup(props2.Dispatcher);
+                    var mailboxType = _system.Mailboxes.GetMailboxType(props2, ConfigurationFactory.Empty);
+                    var mailbox = _system.Mailboxes.CreateMailbox(props2, ConfigurationFactory.Empty);
+                    //TODO: dispatcher need configurators
+
+                    if (async)
+                        return
+                            new RepointableActorRef(system, props2, dispatcher,
+                                () => _system.Mailboxes.CreateMailbox(props2, ConfigurationFactory.Empty), supervisor,
+                                path).Initialize(async);
+                    return new LocalActorRef(system, props2, dispatcher,
+                        () => _system.Mailboxes.CreateMailbox(props2, ConfigurationFactory.Empty), supervisor, path);
+                }
+                catch (Exception ex)
+                {
+                    throw new ConfigurationException(
+                        string.Format(
+                            "Configuration problem while creating {0} with dispatcher [{1}] and mailbox [{2}]", path,
+                            props.Dispatcher, props.Mailbox), ex);
+                }
             }
-
-            return CreateWithRouter(system, props, supervisor, path, deploy, async);
-        }
-
-        private InternalActorRef CreateWithRouter(ActorSystemImpl system, Props props, InternalActorRef supervisor,
-            ActorPath path, Deploy deploy, bool async)
-        {
-            //if no Router config value was specified, override with procedural input
-            if (deploy.RouterConfig.NoRouter())
+            else //routers!!!
             {
-                deploy = deploy.WithRouterConfig(props.RouterConfig);
+                var lookup = (lookupDeploy ? Deployer.Lookup(path) : null) ?? Deploy.None;
+                var fromProps = new List<Deploy>() { props.Deploy.WithRouterConfig(props.Deploy.RouterConfig.WithFallback(props.Deploy.RouterConfig)), deploy, lookup };
+                var d = fromProps.Where(x => x != null).Aggregate((deploy1, deploy2) => deploy2.WithFallback(deploy1));
+                var p = props.WithRouter(d.RouterConfig);
+
+                //TODO: implement Dispatchers and uncomment
+                //if (!system.Dispatchers.HasDispatcher(p.Dispatcher))
+                //    throw new ConfigurationException(string.Format("Dispatcher [{0}] not configured for routees of path {1}", p.Dispatcher, path));
+                //if (!system.Dispatchers.HasDispatcher(d.RouterConfig.d))
+                //    throw new ConfigurationException(string.Format("Dispatcher [{0}] not configured for router of path {1}", p.RouterConfig.RouterDispatcher, path));
+
+                var routerProps = Props.Empty.WithRouter(p.Deploy.Copy().RouterConfig).WithDispatcher(p.RouterConfig.RouterDispatcher);
+                var routeeProps = props.WithRouter(RouterConfig.NoRouter);
+
+                try
+                {
+                    // routers use context.actorOf() to create the routees, which does not allow us to pass
+                    // these through, but obtain them here for early verification
+                    var routerDispatcher = system.Dispatchers.FromConfig(props.RouterConfig.RouterDispatcher);
+                    var routerMailbox = _system.Mailboxes.CreateMailbox(props, null);
+
+                    var routedActorRef = new RoutedActorRef(system, routerProps, routerDispatcher, () => routerMailbox, routeeProps,
+                        supervisor, path);
+                    routedActorRef.Initialize(async);
+                    return routedActorRef;
+                }
+                catch (Exception ex)
+                {
+                    throw new ConfigurationException(string.Format("Configuration problem while creating [{0}] with router dispatcher [{1}] and mailbox {2}" +
+                                                                   " and routee dispatcher [{3}] and mailbox [{4}].", path, routerProps.Dispatcher, routerProps.Mailbox,
+                                                                   routeeProps.Dispatcher, routeeProps.Mailbox));
+                }
+
             }
-
-            var routerDispatcher = system.Dispatchers.FromConfig(props.RouterConfig.RouterDispatcher);
-            var routerMailbox = _system.Mailboxes.CreateMailbox(props, null);
-            //TODO: Should be val routerMailbox = system.mailboxes.getMailboxType(routerProps, routerDispatcher.configurator.config)
-
-            // routers use context.actorOf() to create the routees, which does not allow us to pass
-            // these through, but obtain them here for early verification
-            var routerProps = Props.Empty.WithDeploy(deploy);
-            var routeeProps = props.WithRouter(RouterConfig.NoRouter);
-
-            var routedActorRef = new RoutedActorRef(system, routerProps, routerDispatcher, () => routerMailbox, routeeProps,
-                supervisor, path);
-            routedActorRef.Initialize(async);
-            return routedActorRef;
-        }
-
-        private InternalActorRef CreateNoRouter(ActorSystemImpl system, Props props, InternalActorRef supervisor, ActorPath path,
-            Deploy deploy, bool async)
-        {
-            if(props.Deploy != deploy)
-                props = props.WithDeploy(deploy);
-            var dispatcher = system.Dispatchers.FromConfig(props.Dispatcher);
-            var mailbox = _system.Mailboxes.CreateMailbox(props, null /*dispatcher.Configurator.Config*/);
-            //TODO: Should be: system.mailboxes.getMailboxType(props2, dispatcher.configurator.config)
-            if (async)
-            {
-                var reActorRef = new RepointableActorRef(system, props, dispatcher, () => mailbox, supervisor, path);
-                reActorRef.Initialize(async: true);
-                return reActorRef;
-            }
-            return new LocalActorRef(system, props, dispatcher, () => mailbox, supervisor, path);
         }
 
         public Address GetExternalAddressFor(Address address)

--- a/src/core/Akka/Actor/ActorRefProvider.cs
+++ b/src/core/Akka/Actor/ActorRefProvider.cs
@@ -378,7 +378,6 @@ namespace Akka.Actor
                     // for consistency we check configuration of dispatcher and mailbox locally
                     var dispatcher = _system.Dispatchers.Lookup(props2.Dispatcher);
                     var mailboxType = _system.Mailboxes.GetMailboxType(props2, ConfigurationFactory.Empty);
-                    var mailbox = _system.Mailboxes.CreateMailbox(props2, ConfigurationFactory.Empty);
                     //TODO: dispatcher need configurators
 
                     if (async)
@@ -400,7 +399,7 @@ namespace Akka.Actor
             else //routers!!!
             {
                 var lookup = (lookupDeploy ? Deployer.Lookup(path) : null) ?? Deploy.None;
-                var fromProps = new List<Deploy>() { props.Deploy.WithRouterConfig(props.Deploy.RouterConfig.WithFallback(props.Deploy.RouterConfig)), deploy, lookup };
+                var fromProps = new List<Deploy>() { props.Deploy.Copy(), deploy, lookup };
                 var d = fromProps.Where(x => x != null).Aggregate((deploy1, deploy2) => deploy2.WithFallback(deploy1));
                 var p = props.WithRouter(d.RouterConfig);
 

--- a/src/core/Akka/Actor/ActorSelection.cs
+++ b/src/core/Akka/Actor/ActorSelection.cs
@@ -72,6 +72,11 @@ namespace Akka.Actor
         public SelectionPathElement[] Elements { get; set; }
 
         /// <summary>
+        /// <see cref="string"/> representation of all of the elements in the <see cref="ActorSelection"/> path.
+        /// </summary>
+        public string PathString { get { return string.Join("/", Elements.Select(x => x.ToString())); } }
+
+        /// <summary>
         ///     Posts a message to this ActorSelection.
         /// </summary>
         /// <param name="message">The message.</param>

--- a/src/core/Akka/Actor/Deploy.cs
+++ b/src/core/Akka/Actor/Deploy.cs
@@ -1,11 +1,6 @@
 ﻿using Akka.Configuration;
-using Akka.Dispatch;
 using Akka.Routing;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Akka.Actor
 {
@@ -15,8 +10,8 @@ namespace Akka.Actor
 
         public static readonly string NoDispatcherGiven = string.Empty;
         public static readonly string NoMailboxGiven = string.Empty;
-        public static readonly Scope NoScopeGiven = null;
-        public static readonly Deploy None = null;
+        public static readonly Scope NoScopeGiven = Actor.NoScopeGiven.Instance;
+        public static readonly Deploy None = new Deploy();
         /*
          path: String = "",
   config: Config = ConfigFactory.empty,
@@ -92,7 +87,7 @@ namespace Akka.Actor
             return new Deploy
             {
                 Path = Path,
-                Config = Config.WithFallback(other.Config),
+                Config = Config == other.Config ? Config : Config.WithFallback(other.Config),
                 RouterConfig = RouterConfig.WithFallback(other.RouterConfig),
                 Scope = Scope.WithFallback(other.Scope),
                 Dispatcher = Dispatcher == NoDispatcherGiven ? other.Dispatcher : Dispatcher,

--- a/src/core/Akka/Actor/LocalScope.cs
+++ b/src/core/Akka/Actor/LocalScope.cs
@@ -1,12 +1,26 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Akka.Actor
+﻿namespace Akka.Actor
 {
+    /// <summary>
+    /// Used to deploy actors in local scope
+    /// </summary>
     public class LocalScope : Scope
     {
+        private LocalScope() { }
+        private static readonly LocalScope _instance = new LocalScope();
+
+        public static LocalScope Instance
+        {
+            get { return _instance; }
+        }
+
+        public override Scope WithFallback(Scope other)
+        {
+            return Instance;
+        }
+
+        public override Scope Copy()
+        {
+            return Instance;
+        }
     }
 }

--- a/src/core/Akka/Actor/Props.cs
+++ b/src/core/Akka/Actor/Props.cs
@@ -415,14 +415,23 @@ namespace Akka.Actor
             // TODO: this is a hack designed to preserve explicit router deployments https://github.com/akkadotnet/akka.net/issues/546
             // in reality, we should be able to do copy.Deploy = deploy.WithFallback(copy.Deploy); but that blows up at the moment
             // - Aaron Stannard
-            if (!(original.RouterConfig is NoRouter || original.RouterConfig is FromConfig) && deploy.RouterConfig is NoRouter)
-            {
-                copy.Deploy = deploy.WithRouterConfig(original.RouterConfig);
-            }
-            else
-            {
-                copy.Deploy = deploy;
-            }
+            copy.Deploy = deploy.WithFallback(copy.Deploy);
+            //if (!(original.RouterConfig is NoRouter || original.RouterConfig is FromConfig) && deploy.RouterConfig is NoRouter)
+            //{
+            //    copy.Deploy = deploy.WithFallback(copy.Deploy);
+            //    copy.Deploy = deploy.WithRouterConfig(original.RouterConfig);
+            //}
+            ////both configs describe valid, programmatically defined routers (usually clustered routers)
+            //else if (!(original.RouterConfig is NoRouter || original.RouterConfig is FromConfig) &&
+            //         !(deploy.RouterConfig is FromConfig))
+            //{
+            //    var deployedRouter = deploy.RouterConfig.WithFallback(original.RouterConfig);
+            //    copy.Deploy = copy.Deploy.WithRouterConfig(deployedRouter);
+            //}
+            //else
+            //{
+            //    copy.Deploy = deploy;
+            //}
             
             return copy;
         }

--- a/src/core/Akka/Actor/RemoteScope.cs
+++ b/src/core/Akka/Actor/RemoteScope.cs
@@ -3,6 +3,9 @@ using Akka.Util.Internal;
 
 namespace Akka.Actor
 {
+    /// <summary>
+    /// Used to deploy actors on remote nodes at the specified <see cref="Address"/>.
+    /// </summary>
     public class RemoteScope : Scope, IEquatable<RemoteScope>
     {
         protected RemoteScope()
@@ -34,6 +37,16 @@ namespace Akka.Actor
         public override int GetHashCode()
         {
             return (Address != null ? Address.GetHashCode() : 0);
+        }
+
+        public override Scope WithFallback(Scope other)
+        {
+            return this;
+        }
+
+        public override Scope Copy()
+        {
+            return new RemoteScope(Address.Copy());
         }
     }
 }

--- a/src/core/Akka/Actor/RepointableActorRef.cs
+++ b/src/core/Akka/Actor/RepointableActorRef.cs
@@ -65,7 +65,7 @@ namespace Akka.Actor
         ///Call twice on your own peril!
         ///This is protected so that others can have different initialization.
         /// </summary>
-        public void Initialize(bool async)
+        public RepointableActorRef Initialize(bool async)
         {
             var underlying = Underlying;
             if(underlying == null)
@@ -76,6 +76,8 @@ namespace Akka.Actor
                 _supervisor.Tell(new Supervise(this, async));
                 if(!async)
                     Point();
+
+                return this;
             }
             else
             {

--- a/src/core/Akka/Actor/Scope.cs
+++ b/src/core/Akka/Actor/Scope.cs
@@ -2,25 +2,22 @@
 
 namespace Akka.Actor
 {
-    public class Scope : IEquatable<Scope>
+    /// <summary>
+    /// Defines the scope of a <see cref="Deploy"/>
+    /// 
+    /// Valid values are:
+    /// 
+    /// * Local - this actor will be deployed locally in this process
+    /// * Remote - this actor will be deployed remotely on another system
+    /// * Cluster - this actor will be deployed into a cluster of remote processes
+    /// </summary>
+    public abstract class Scope : IEquatable<Scope>
     {
-        public static readonly LocalScope Local = new LocalScope();
-        private Scope _fallback;
+        public static readonly LocalScope Local = LocalScope.Instance;
 
-        public Scope WithFallback(Scope other)
-        {
-            Scope copy = Copy();
-            copy._fallback = other;
-            return copy;
-        }
+        public abstract Scope WithFallback(Scope other);
 
-        private Scope Copy()
-        {
-            return new Scope
-            {
-                _fallback = _fallback,
-            };
-        }
+        public abstract Scope Copy();
 
         public virtual bool Equals(Scope other)
         {
@@ -28,6 +25,31 @@ namespace Akka.Actor
 
             //we don't do equality checks on fallbacks
             return GetType() == other.GetType();
+        }
+    }
+
+    /// <summary>
+    /// Place-holder for when a scope of this deployment has not been specified yet
+    /// </summary>
+    internal class NoScopeGiven : Scope
+    {
+        private NoScopeGiven() { }
+
+        private static readonly NoScopeGiven _instance = new NoScopeGiven();
+
+        public static NoScopeGiven Instance
+        {
+            get { return _instance; }
+        }
+
+        public override Scope WithFallback(Scope other)
+        {
+            return other;
+        }
+
+        public override Scope Copy()
+        {
+            return Instance;
         }
     }
 }

--- a/src/core/Akka/Actor/Settings.cs
+++ b/src/core/Akka/Actor/Settings.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Akka.Configuration;
+using Akka.Routing;
 
 namespace Akka.Actor
 {
@@ -91,9 +92,9 @@ namespace Akka.Actor
             FsmDebugEvent = Config.GetBoolean("akka.actor.debug.fsm");
             DebugEventStream = Config.GetBoolean("akka.actor.debug.event-stream");
             DebugUnhandledMessage = Config.GetBoolean("akka.actor.debug.unhandled");
-            DebugRouterMisConfiguration = Config.GetBoolean("akka.actor.debug.router-misconfiguration");
+            DebugRouterMisconfiguration = Config.GetBoolean("akka.actor.debug.router-misconfiguration");
             Home = Config.GetString("akka.home") ?? "";
-
+            DefaultVirtualNodesFactor = Config.GetInt("akka.actor.deployment.default.virtual-nodes-factor");
             //TODO: dunno.. we dont have FiniteStateMachines, dont know what the rest is
             /*              
                 final val SchedulerClass: String = getString("akka.scheduler.implementation")
@@ -235,18 +236,17 @@ namespace Akka.Actor
         public string Home { get; private set; }
 
         /// <summary>
-        ///     Gets a value indicating whether [debug router mis configuration].
-        /// </summary>
-        /// <value><c>true</c> if [debug router mis configuration]; otherwise, <c>false</c>.</value>
-        public bool DebugRouterMisConfiguration { get; private set; }
-
-        /// <summary>
         ///     Gets a value indicating whether [debug lifecycle].
         /// </summary>
         /// <value><c>true</c> if [debug lifecycle]; otherwise, <c>false</c>.</value>
         public bool DebugLifecycle { get; private set; }
 
         public bool FsmDebugEvent { get; private set; }
+
+        /// <summary>
+        /// The number of default virtual nodes to use with <see cref="ConsistentHashingRoutingLogic"/>.
+        /// </summary>
+        public int DefaultVirtualNodesFactor { get; private set; }
 
         /// <summary>
         ///     Returns a <see cref="string" /> that represents this instance.

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -209,6 +209,7 @@
     <Compile Include="Event\LogLevel.cs" />
     <Compile Include="Event\LogMessage.cs" />
     <Compile Include="Event\StandardOutLogger.cs" />
+    <Compile Include="Routing\ConsistentHashRouter.cs" />
     <Compile Include="Util\Guard.cs" />
     <Compile Include="Util\ContinuousEnumerator.cs" />
     <Compile Include="Util\Internal\ImmutabilityUtils.cs" />

--- a/src/core/Akka/Dispatch/Dispatchers.cs
+++ b/src/core/Akka/Dispatch/Dispatchers.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;

--- a/src/core/Akka/Routing/Broadcast.cs
+++ b/src/core/Akka/Routing/Broadcast.cs
@@ -64,6 +64,20 @@ namespace Akka.Routing
         {
             return new Router(new BroadcastRoutingLogic());
         }
+
+        public override Pool WithSupervisorStrategy(SupervisorStrategy strategy)
+        {
+            return new BroadcastPool(NrOfInstances, Resizer, strategy, RouterDispatcher, UsePoolDispatcher);
+        }
+
+        public override Pool WithResizer(Resizer resizer)
+        {
+            return new BroadcastPool(NrOfInstances, resizer, SupervisorStrategy, RouterDispatcher, UsePoolDispatcher);
+        }
+        public override RouterConfig WithFallback(RouterConfig routerConfig)
+        {
+            return OverrideUnsetConfig(routerConfig);
+        }
     }
 
     public class BroadcastGroup : Group

--- a/src/core/Akka/Routing/ConsistentHash.cs
+++ b/src/core/Akka/Routing/ConsistentHash.cs
@@ -1,163 +1,247 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Akka.Actor;
-using Akka.Configuration;
-using Akka.Event;
+using System.Text;
 using Akka.Util;
+using Akka.Util.Internal;
 
 namespace Akka.Routing
 {
     /// <summary>
-    /// Marks a given class as consistently hashable, for use with <see cref="ConsistentHashingGroup"/>
-    /// or <see cref="ConsistentHashingPool"/> routers.
+    /// Consistent Hashing node ring implementaiton.
+    /// 
+    ///  A good explanation of Consistent Hashing:
+    /// http://weblogs.java.net/blog/tomwhite/archive/2007/11/consistent_hash.html
+    /// 
+    /// Note that toString of the ring nodes are used for the node
+    /// hash, i.e. make sure it is different for different nodes.
     /// </summary>
-    public interface ConsistentHashable
+    public class ConsistentHash<T>
     {
-        object ConsistentHashKey { get; }
+        private readonly SortedDictionary<int, T> _nodes;
+        private readonly int _virtualNodesFactor;
+
+        internal ConsistentHash(SortedDictionary<int, T> nodes, int virtualNodesFactor)
+        {
+            _nodes = nodes;
+
+            Guard.Assert(virtualNodesFactor >= 1, "virtualNodesFactor must be >= 1");
+
+            _virtualNodesFactor = virtualNodesFactor;
+        }
+
+        /// <summary>
+        /// arrays for fast binary search access
+        /// </summary>
+        private Tuple<int[], T[]> _ring = null;
+        private Tuple<int[], T[]> RingTuple
+        {
+            get { return _ring ?? (_ring = Tuple.Create(_nodes.Keys.ToArray(), _nodes.Values.ToArray())); }
+        }
+
+        /// <summary>
+        /// Sorted hash values of the nodes
+        /// </summary>
+        private int[] NodeHashRing
+        {
+            get { return RingTuple.Item1; }
+        }
+
+        /// <summary>
+        /// NodeRing is the nodes sorted in the same order as <see cref="NodeHashRing"/>, i.e. same index
+        /// </summary>
+        private T[] NodeRing
+        {
+            get { return RingTuple.Item2; }
+        }
+
+        /// <summary>
+        /// Add a node to the hash ring.
+        /// 
+        /// Note that <see cref="ConsistentHash{T}"/> is immutable and
+        /// this operation returns a new instance.
+        /// </summary>
+        public ConsistentHash<T> Add(T node)
+        {
+            return this + node;
+        }
+
+        /// <summary>
+        /// Removes a node from the hash ring.
+        /// 
+        /// Note that <see cref="ConsistentHash{T}"/> is immutable and
+        /// this operation returns a new instance.
+        /// </summary>
+        public ConsistentHash<T> Remove(T node)
+        {
+            return this - node;
+        }
+
+        /// <summary>
+        /// Converts the result of <see cref="Array.BinarySearch(T[], T)"/> into an index in the 
+        /// <see cref="RingTuple"/> array.
+        /// </summary>
+        /// <param name="i"></param>
+        /// <returns></returns>
+        private int Idx(int i)
+        {
+            if (i >= 0) return i; //exact match
+            else
+            {
+                var j = Math.Abs(i + 1);
+                if (j >= NodeHashRing.Length) return 0; //after last, use first
+                else return j; //next node clockwise
+            }
+        }
+
+        /// <summary>
+        /// Get the node responsible for the data key.
+        /// Can only be used if nodes exist in the node ring.
+        /// Otherwise throws <see cref="ArgumentException"/>.
+        /// </summary>
+        public T NodeFor(byte[] key)
+        {
+            Guard.Assert(!IsEmpty, string.Format("Can't get node for [{0}] from an empty node ring", key));
+
+            return NodeRing[Idx(Array.BinarySearch(NodeHashRing, ConsistentHash.HashFor(key)))];
+        }
+
+        /// <summary>
+        /// Get the node responsible for the data key.
+        /// Can only be used if nodes exist in the node ring.
+        /// Otherwise throws <see cref="ArgumentException"/>.
+        /// </summary>
+        public T NodeFor(string key)
+        {
+            Guard.Assert(!IsEmpty, string.Format("Can't get node for [{0}] from an empty node ring", key));
+
+            return NodeRing[Idx(Array.BinarySearch(NodeHashRing, ConsistentHash.HashFor(key)))];
+        }
+
+        /// <summary>
+        /// Is the node ring empty? i.e. no nodes added or all removed
+        /// </summary>
+        public bool IsEmpty
+        {
+            get { return !_nodes.Any(); }
+        }
+
+        #region Operator overloads
+
+        /// <summary>
+        /// Add a node to the hash ring.
+        /// 
+        /// Note that <see cref="ConsistentHash{T}"/> is immutable and
+        /// this operation returns a new instance.
+        /// </summary>s
+        public static ConsistentHash<T> operator +(ConsistentHash<T> hash, T node)
+        {
+            var nodeHash = ConsistentHash.HashFor(node.ToString());
+            return new ConsistentHash<T>(hash._nodes.CopyAndAdd(Enumerable.Range(1, hash._virtualNodesFactor).Select(r => new KeyValuePair<int, T>(ConsistentHash.ConcatenateNodeHash(nodeHash, r), node))),
+                hash._virtualNodesFactor);
+        }
+
+        /// <summary>
+        /// Removes a node from the hash ring.
+        /// 
+        /// Note that <see cref="ConsistentHash{T}"/> is immutable and
+        /// this operation returns a new instance.
+        /// </summary>
+        public static ConsistentHash<T> operator -(ConsistentHash<T> hash, T node)
+        {
+            var nodeHash = ConsistentHash.HashFor(node.ToString());
+            return new ConsistentHash<T>(hash._nodes.CopyAndRemove(Enumerable.Range(1, hash._virtualNodesFactor).Select(r => new KeyValuePair<int, T>(ConsistentHash.ConcatenateNodeHash(nodeHash, r), node))),
+                hash._virtualNodesFactor);
+        }
+
+        #endregion
     }
 
     /// <summary>
-    /// Envelope you can wrap around a message in order to make it hashable for use with <see cref="ConsistentHashingGroup"/>
-    /// or <see cref="ConsistentHashingPool"/> routers.
+    /// Static helper class for creating <see cref="ConsistentHash{T}"/> instances.
     /// </summary>
-    public class ConsistentHashableEnvelope : RouterEnvelope,  ConsistentHashable
+    public static class ConsistentHash
     {
-        public ConsistentHashableEnvelope(object message,object hashKey) : base(message)
+        /// <summary>
+        /// Factory method to create a <see cref="ConsistentHash{T}"/> instance.
+        /// </summary>
+        public static ConsistentHash<T> Create<T>(IEnumerable<T> nodes, int virtualNodesFactor)
         {
-            HashKey = hashKey;
-        }
-        public object HashKey { get;private set; }
-
-        public object ConsistentHashKey
-        {
-            get { return HashKey; }
-        }
-    }
-
-    public class ConsistentHashingRoutingLogic : RoutingLogic
-    {
-        private readonly Lazy<LoggingAdapter> _log;
-        private Dictionary<Type, Func<object, object>> _hashMapping;
-        private ActorSystem _system;
-        public override Routee Select(object message, Routee[] routees)
-        {
-            if (message == null || routees == null || routees.Length == 0)
-                return NoRoutee.NoRoutee;
-
-            if (_hashMapping.ContainsKey(message.GetType()))
+            var sortedDict = new SortedDictionary<int, T>();
+            foreach (var node in nodes)
             {
-                var key = _hashMapping[message.GetType()](message);
-                if (key == null)
-                    return NoRoutee.NoRoutee;
-
-                var hash = Murmur3.Hash(key);
-                return routees[Math.Abs(hash) % routees.Length]; //The hash might be negative, so we have to make sure it's positive
+                var nodeHash = HashFor(node.ToString());
+                var vnodes = Enumerable.Range(1, virtualNodesFactor)
+                    .Select(x => ConcatenateNodeHash(nodeHash, x)).ToList();
+                foreach(var vnode in vnodes)
+                    sortedDict.Add(vnode, node);
             }
-            else if (message is ConsistentHashable)
+
+            return new ConsistentHash<T>(sortedDict, virtualNodesFactor);
+        }
+
+        #region Hashing methods
+
+        internal static int ConcatenateNodeHash(int nodeHash, int vnode)
+        {
+            unchecked
             {
-                var hashable = (ConsistentHashable) message;
-                int hash = Murmur3.Hash(hashable.ConsistentHashKey);
-                return routees[Math.Abs(hash) % routees.Length]; //The hash might be negative, so we have to make sure it's positive
-            }
-            else
-            {
-                _log.Value.Warning("Message [{0}] must be handled by hashMapping, or implement [{1}] or be wrapped in [{2}]", message.GetType().Name, typeof(ConsistentHashable).Name, typeof(ConsistentHashableEnvelope).Name);
-                return Routee.NoRoutee;
+                var h = MurmurHash.StartHash((uint)nodeHash);
+                h = MurmurHash.ExtendHash(h, (uint)vnode, MurmurHash.StartMagicA, MurmurHash.StartMagicB);
+                return (int)MurmurHash.FinalizeHash(h);
             }
         }
 
-        public ConsistentHashingRoutingLogic(ActorSystem system) : this(system,new Dictionary<Type,Func<object,object>>())
-        {
-        }
-
-        private ConsistentHashingRoutingLogic(ActorSystem system, Dictionary<Type, Func<object, object>> hashMapping)
-        {            
-            _system = system;
-            _log = new Lazy<LoggingAdapter>(() => Logging.GetLogger(_system, this), true);
-            _hashMapping = hashMapping;
-        }
-   
-
-        public ConsistentHashingRoutingLogic WithHashMapping<T>(Func<T,object> mapping)
-        {
-            if (mapping == null)
-                throw new ArgumentNullException("mapping");
-
-            var copy = new Dictionary<Type, Func<object, object>>(_hashMapping);
-            copy.Add(typeof(T), o => mapping((T)o));
-            return new ConsistentHashingRoutingLogic(_system,copy);
-        }
-    }
-
-    public class ConsistentHashingGroup : Group
-    {        
-        protected ConsistentHashingGroup()
-        {
-        }
-
-        public ConsistentHashingGroup(Config config)
-            : base(config.GetStringList("routees.paths"))
-        {
-        }
-
-        public ConsistentHashingGroup(params string[] paths)
-            : base(paths)
-        {
-        }
-
-        public ConsistentHashingGroup(IEnumerable<string> paths)
-            : base(paths)
-        {
-        }
-
-        public ConsistentHashingGroup(IEnumerable<ActorRef> routees) : base(routees)
-        {
-        }
-
-        public override Router CreateRouter(ActorSystem system)
-        {
-            return new Router(new ConsistentHashingRoutingLogic(system));
-        }
-    }
-
-    public class ConsistentHashingPool : Pool
-    {
-        protected ConsistentHashingPool()
-        {            
-        }
-
         /// <summary>
-        /// Initializes a new instance of the <see cref="ConsistentHashingPool"/> class.
+        /// Translate the offered object into a byte array, or returns the original object
+        /// if it needs to be serialized first.
         /// </summary>
-        /// <param name="config">The configuration.</param>
-        public ConsistentHashingPool(Config config) : base(config)
+        /// <param name="obj">An arbitrary .NET object</param>
+        /// <returns>The object encoded into bytes - in the case of custom classes, the hashcode may be used.</returns>
+        internal static object ToBytesOrObject(object obj)
         {
-            
-        }
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ConsistentHashingPool"/> class.
-        /// </summary>
-        /// <param name="nrOfInstances">The nr of instances.</param>
-        /// <param name="resizer">The resizer.</param>
-        /// <param name="supervisorStrategy">The supervisor strategy.</param>
-        /// <param name="routerDispatcher">The router dispatcher.</param>
-        /// <param name="usePoolDispatcher">if set to <c>true</c> [use pool dispatcher].</param>
-        public ConsistentHashingPool(int nrOfInstances, Resizer resizer,SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = false)
-            : base(nrOfInstances, resizer, supervisorStrategy, routerDispatcher, usePoolDispatcher)
-        {
-            
+                if (obj == null)
+                    return new byte[] { 0 };
+                if (obj is byte[])
+                    return (byte[])obj;
+                if (obj is int)
+                    return BitConverter.GetBytes((int)obj);
+                if (obj is uint)
+                    return BitConverter.GetBytes((uint)obj);
+                if (obj is short)
+                    return BitConverter.GetBytes((short)obj);
+                if (obj is ushort)
+                    return BitConverter.GetBytes((ushort)obj);
+                if (obj is bool)
+                    return BitConverter.GetBytes((bool)obj);
+                if (obj is long)
+                    return BitConverter.GetBytes((long)obj);
+                if (obj is ulong)
+                    return BitConverter.GetBytes((ulong)obj);
+                if (obj is char)
+                    return BitConverter.GetBytes((char)obj);
+                if (obj is float)
+                    return BitConverter.GetBytes((float)obj);
+                if (obj is double)
+                    return BitConverter.GetBytes((double)obj);
+                if (obj is decimal)
+                    return new BitArray(decimal.GetBits((decimal)obj)).ToBytes();
+                if (obj is Guid)
+                    return ((Guid)obj).ToByteArray();
+            return obj;
         }
 
-        /// <summary>
-        /// Simple form of ConsistentHashingPool constructor
-        /// </summary>
-        /// <param name="nrOfInstances">The nr of instances.</param>
-        public ConsistentHashingPool(int nrOfInstances) : base(nrOfInstances, null, Pool.DefaultStrategy, null) { }
-
-        public override Router CreateRouter(ActorSystem system)
+        internal static int HashFor(byte[] bytes)
         {
-            return new Router(new ConsistentHashingRoutingLogic(system));
+            return MurmurHash.ByteHash(bytes);
         }
+
+        internal static int HashFor(string hashKey)
+        {
+            return MurmurHash.StringHash(hashKey);
+        }
+
+        #endregion
     }
 }

--- a/src/core/Akka/Routing/ConsistentHashRouter.cs
+++ b/src/core/Akka/Routing/ConsistentHashRouter.cs
@@ -1,0 +1,424 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.Serialization;
+using Akka.Util;
+using Akka.Util.Internal;
+
+namespace Akka.Routing
+{
+    /// <summary>
+    /// Static class for assisting with <see cref="ConsistentHashMapping"/> instances
+    /// </summary>
+    internal static class ConsistentHashingRouter
+    {
+        /// <summary>
+        /// Default empty <see cref="ConsistentHashMapping"/> implementation
+        /// </summary>
+        public static readonly ConsistentHashMapping EmptyConsistentHashMapping = key => null;
+    }
+
+    /// <summary>
+    /// Marks a given class as consistently hashable, for use with <see cref="ConsistentHashingGroup"/>
+    /// or <see cref="ConsistentHashingPool"/> routers.
+    /// </summary>
+    public interface IConsistentHashable
+    {
+        object ConsistentHashKey { get; }
+    }
+
+
+    /// <summary>
+    /// Envelope you can wrap around a message in order to make it hashable for use with <see cref="ConsistentHashingGroup"/>
+    /// or <see cref="ConsistentHashingPool"/> routers.
+    /// </summary>
+    public class ConsistentHashableEnvelope : RouterEnvelope, IConsistentHashable
+    {
+        public ConsistentHashableEnvelope(object message, object hashKey)
+            : base(message)
+        {
+            HashKey = hashKey;
+        }
+        public object HashKey { get; private set; }
+
+        public object ConsistentHashKey
+        {
+            get { return HashKey; }
+        }
+    }
+
+    /// <summary>
+    /// Delegate for computing the hashkey from any given
+    /// type of message. Extracts the property / data that is going
+    /// to be used for a given hash, but doesn't actually return
+    /// the hash values themselves.
+    /// 
+    /// If returning an byte[] or string it will be used as is,
+    /// otherwise the configured <see cref="Serializer"/> will be applied
+    /// to the returned data."/>
+    /// </summary>
+    public delegate object ConsistentHashMapping(object msg);
+
+    /// <summary>
+    /// Uses consistent hashing to select a <see cref="Routee"/> based on the sent message.
+    /// 
+    /// There are 3 ways to define what data to use for the consistent hash key.
+    /// 
+    /// 1. You can define a <see cref="ConsistentHashMapping"/> or use <see cref="WithHashMapper"/>
+    /// of the router to map incoming messages to their consistent hash key.
+    /// This makes the decision transparent for the sender.
+    /// 
+    /// 2. Messages may implement <see cref="IConsistentHashable"/>. The hash key is part
+    /// of the message and it's convenient to define it together with the message
+    /// definition.
+    /// 
+    /// 3. The message can be wrapped in a <see cref="ConsistentHashableEnvelope"/> to
+    /// define what data to use for the consistent hash key. The sender knows what key
+    /// to use.
+    /// 
+    /// These ways to define the consistent hash key can be used together and at the
+    /// same time for one router. The <see cref="ConsistentHashMapping"/> is tried first.
+    /// </summary>
+    public class ConsistentHashingRoutingLogic : RoutingLogic
+    {
+        private readonly Lazy<LoggingAdapter> _log;
+        private ConsistentHashMapping _hashMapping;
+        private readonly ActorSystem _system;
+
+        private readonly AtomicReference<Tuple<Routee[], ConsistentHash<ConsistentRoutee>>> _consistentHashRef = new AtomicReference<Tuple<Routee[], ConsistentHash<ConsistentRoutee>>>(Tuple.Create<Routee[], ConsistentHash<ConsistentRoutee>>(null, null));
+
+        private readonly Address _selfAddress;
+        private readonly int _vnodes;
+
+        public ConsistentHashingRoutingLogic(ActorSystem system)
+            : this(system, 0, ConsistentHashingRouter.EmptyConsistentHashMapping)
+        {
+        }
+
+        public ConsistentHashingRoutingLogic(ActorSystem system, int virtualNodesFactor, ConsistentHashMapping hashMapping)
+        {
+            _system = system;
+            _log = new Lazy<LoggingAdapter>(() => Logging.GetLogger(_system, this), true);
+            _hashMapping = hashMapping;
+            _selfAddress = system.AsInstanceOf<ExtendedActorSystem>().Provider.DefaultAddress;
+            _vnodes = virtualNodesFactor == 0 ? system.Settings.DefaultVirtualNodesFactor : virtualNodesFactor;
+        }
+
+
+        public override Routee Select(object message, Routee[] routees)
+        {
+            if (message == null || routees == null || routees.Length == 0)
+                return Routee.NoRoutee;
+
+            Func<ConsistentHash<ConsistentRoutee>> updateConsistentHash = () =>
+            {
+                // update consistentHash when routees are changed
+                // changes to routees are rare when no changes this is a quick operation
+                var oldConsistHashTuple = _consistentHashRef.Value;
+                var oldRoutees = oldConsistHashTuple.Item1;
+                var oldConsistentHash = oldConsistHashTuple.Item2;
+
+                if (oldRoutees == null || !routees.SequenceEqual(oldRoutees))
+                {
+                    // when other instance, same content, no need to re-hash, but try to set routees
+                    var consistentHash = routees == oldRoutees
+                        ? oldConsistentHash
+                        : ConsistentHash.Create(routees.Select(x => new ConsistentRoutee(x, _selfAddress)), _vnodes);
+                    //ignore, don't update, in case of CAS failure
+                    _consistentHashRef.CompareAndSet(oldConsistHashTuple, Tuple.Create(routees, consistentHash));
+                    return consistentHash;
+                }
+                return oldConsistentHash;
+            };
+
+            Func<object, Routee> target = hashData =>
+            {
+                try
+                {
+                    var currentConsistentHash = updateConsistentHash();
+                    if (currentConsistentHash.IsEmpty) return Routee.NoRoutee;
+                    else
+                    {
+                        if (hashData is byte[])
+                            return currentConsistentHash.NodeFor(hashData as byte[]).Routee;
+                        if (hashData is string)
+                            return currentConsistentHash.NodeFor(hashData as string).Routee;
+                        return
+                            currentConsistentHash.NodeFor(
+                                _system.Serialization.FindSerializerFor(hashData).ToBinary(hashData)).Routee;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    //serializationfailed
+                    _log.Value.Warning("Couldn't route message with consistent hash key [{0}] due to [{1}]", hashData, ex.Message);
+                    return Routee.NoRoutee;
+                }
+            };
+
+            if (_hashMapping(message) != null)
+            {
+                return target(ConsistentHash.ToBytesOrObject(_hashMapping(message)));
+            }
+            else if (message is IConsistentHashable)
+            {
+                var hashable = (IConsistentHashable)message;
+                return target(ConsistentHash.ToBytesOrObject(hashable.ConsistentHashKey));
+            }
+            else
+            {
+                _log.Value.Warning("Message [{0}] must be handled by hashMapping, or implement [{1}] or be wrapped in [{2}]", message.GetType().Name, typeof(IConsistentHashable).Name, typeof(ConsistentHashableEnvelope).Name);
+                return Routee.NoRoutee;
+            }
+        }
+
+        public ConsistentHashingRoutingLogic WithHashMapping(ConsistentHashMapping mapping)
+        {
+            if (mapping == null)
+                throw new ArgumentNullException("mapping");
+           
+            return new ConsistentHashingRoutingLogic(_system, _vnodes, mapping);
+        }
+
+    }
+
+    /// <summary>
+    /// INTERNAL API
+    /// 
+    /// Important to use ActorRef with full address, with host and port, in the hash ring,
+    /// so that same ring is produced on different nodes.
+    /// The ConsistentHash uses toString of the ring nodes, and the ActorRef itself
+    /// isn't a good representation, because LocalActorRef doesn't include the
+    /// host and port.
+    /// </summary>
+    internal sealed class ConsistentRoutee
+    {
+        public ConsistentRoutee(Routee routee, Address selfAddress)
+        {
+            SelfAddress = selfAddress;
+            Routee = routee;
+        }
+
+        public Routee Routee { get; private set; }
+
+        public Address SelfAddress { get; private set; }
+
+        public override string ToString()
+        {
+            if (Routee is ActorRefRoutee)
+            {
+                var actorRef = Routee as ActorRefRoutee;
+                return ToStringWithFullAddress(actorRef.Actor.Path);
+            }
+            else if (Routee is ActorSelectionRoutee)
+            {
+                var selection = Routee as ActorSelectionRoutee;
+                return ToStringWithFullAddress(selection.Selection.Anchor.Path) + selection.Selection.PathString;
+            }
+            else
+            {
+                return Routee.ToString();
+            }
+        }
+
+        private string ToStringWithFullAddress(ActorPath path)
+        {
+            if (string.IsNullOrEmpty(path.Address.Host) || !path.Address.Port.HasValue)
+                return path.ToStringWithAddress(SelfAddress);
+            return path.ToString();
+        }
+    }
+
+    /// <summary>
+    /// <see cref="Group"/> implementation of the consistent hashing router.
+    /// </summary>
+    public class ConsistentHashingGroup : Group
+    {
+        /// <summary>
+        /// Virtual nodes used in the <see cref="ConsistentHash{T}"/>.
+        /// </summary>
+        public int VirtualNodesFactor { get; private set; }
+
+        protected ConsistentHashMapping HashMapping;
+
+        protected ConsistentHashingGroup()
+        {
+        }
+
+        public ConsistentHashingGroup(Config config)
+            : base(config.GetStringList("routees.paths"))
+        {
+            VirtualNodesFactor = config.GetInt("virtual-nodes-factor", 0);
+        }
+
+        public ConsistentHashingGroup(params string[] paths)
+            : base(paths)
+        {
+        }
+
+        public ConsistentHashingGroup(IEnumerable<string> paths, int virtualNodesFactor = 0, ConsistentHashMapping hashMapping = null)
+            : base(paths)
+        {
+            VirtualNodesFactor = virtualNodesFactor;
+            HashMapping = hashMapping;
+        }
+
+        public ConsistentHashingGroup(IEnumerable<ActorRef> routees, int virtualNodesFactor = 0, ConsistentHashMapping hashMapping = null)
+            : base(routees)
+        {
+            VirtualNodesFactor = virtualNodesFactor;
+            HashMapping = hashMapping;
+        }
+
+        /// <summary>
+        /// Apply a <see cref="VirtualNodesFactor"/> to the <see cref="ConsistentHashingGroup"/>
+        /// 
+        /// Note: this method is immutable and will return a new instance.
+        /// </summary>
+        public ConsistentHashingGroup WithVirtualNodesFactor(int vnodes)
+        {
+            return new ConsistentHashingGroup(Paths, vnodes, HashMapping);
+        }
+
+        /// <summary>
+        /// Apply a <see cref="ConsistentHashMapping"/> to the <see cref="ConsistentHashingGroup"/>.
+        /// 
+        /// Note: this method is immutable and will return a new instance.
+        /// </summary>
+        public ConsistentHashingGroup WithHashMapping(ConsistentHashMapping mapping)
+        {
+            return new ConsistentHashingGroup(Paths, VirtualNodesFactor, mapping);
+        }
+
+        public override Router CreateRouter(ActorSystem system)
+        {
+            return new Router(new ConsistentHashingRoutingLogic(system, VirtualNodesFactor, HashMapping ?? ConsistentHashingRouter.EmptyConsistentHashMapping));
+        }
+
+        public override RouterConfig WithFallback(RouterConfig routerConfig)
+        {
+            if (routerConfig is FromConfig || routerConfig is NoRouter)
+            {
+                return base.WithFallback(routerConfig);
+            }
+            else if (routerConfig is ConsistentHashingGroup)
+            {
+                var other = routerConfig as ConsistentHashingGroup;
+                return WithHashMapping(other.HashMapping);
+            }
+            else
+            {
+                throw new ArgumentException(string.Format("Expected ConsistentHashingGroup, got {0}", routerConfig), "routerConfig");
+            }
+        }
+    }
+
+    /// <summary>
+    /// <see cref="Pool"/> implementation of a consistent hash router.
+    /// 
+    /// NOTE: Using <see cref="Resizer"/> with <see cref="ConsistentHashingPool"/> is potentially harmful, as hash ranges
+    /// might change radically during live message processing. This router works best with fixed-sized pools or fixed
+    /// number of routees per node in the event of clustered deployments.
+    /// </summary>
+    public class ConsistentHashingPool : Pool
+    {
+        /// <summary>
+        /// Virtual nodes used in the <see cref="ConsistentHash{T}"/>.
+        /// </summary>
+        public int VirtualNodesFactor { get; private set; }
+
+        private ConsistentHashMapping HashMapping;
+
+        protected ConsistentHashingPool()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConsistentHashingPool"/> class.
+        /// </summary>
+        /// <param name="config">The configuration.</param>
+        public ConsistentHashingPool(Config config)
+            : base(config)
+        {
+            VirtualNodesFactor = config.GetInt("virtual-nodes-factor", 0);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConsistentHashingPool"/> class.
+        /// </summary>
+        /// <param name="nrOfInstances">The nr of instances.</param>
+        /// <param name="resizer">The resizer.</param>
+        /// <param name="supervisorStrategy">The supervisor strategy.</param>
+        /// <param name="routerDispatcher">The router dispatcher.</param>
+        /// <param name="usePoolDispatcher">if set to <c>true</c> [use pool dispatcher].</param>
+        /// <param name="virtualNodesFactor">The number of virtual nodes to use on the hash ring</param>
+        /// <param name="hashMapping">The consistent hash mapping function to use on incoming messages</param>
+        public ConsistentHashingPool(int nrOfInstances, Resizer resizer, SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = false, int virtualNodesFactor = 0, ConsistentHashMapping hashMapping = null)
+            : base(nrOfInstances, resizer, supervisorStrategy, routerDispatcher, usePoolDispatcher)
+        {
+            VirtualNodesFactor = virtualNodesFactor;
+            HashMapping = hashMapping;
+        }
+
+        /// <summary>
+        /// Apply a <see cref="VirtualNodesFactor"/> to the <see cref="ConsistentHashingPool"/>
+        /// 
+        /// Note: this method is immutable and will return a new instance.
+        /// </summary>
+        public ConsistentHashingPool WithVirtualNodesFactor(int vnodes)
+        {
+            return new ConsistentHashingPool(NrOfInstances, Resizer, SupervisorStrategy, RouterDispatcher, UsePoolDispatcher, vnodes, HashMapping);
+        }
+
+        /// <summary>
+        /// Apply a <see cref="ConsistentHashMapping"/> to the <see cref="ConsistentHashingPool"/>.
+        /// 
+        /// Note: this method is immutable and will return a new instance.
+        /// </summary>
+        public ConsistentHashingPool WithHashMapping(ConsistentHashMapping mapping)
+        {
+            return new ConsistentHashingPool(NrOfInstances, Resizer, SupervisorStrategy, RouterDispatcher, UsePoolDispatcher, VirtualNodesFactor, mapping);
+        }
+
+        /// <summary>
+        /// Simple form of ConsistentHashingPool constructor
+        /// </summary>
+        /// <param name="nrOfInstances">The nr of instances.</param>
+        public ConsistentHashingPool(int nrOfInstances) : base(nrOfInstances, null, Pool.DefaultStrategy, null) { }
+
+        public override Router CreateRouter(ActorSystem system)
+        {
+            return new Router(new ConsistentHashingRoutingLogic(system, VirtualNodesFactor, HashMapping ?? ConsistentHashingRouter.EmptyConsistentHashMapping));
+        }
+
+        public override Pool WithSupervisorStrategy(SupervisorStrategy strategy)
+        {
+            return new ConsistentHashingPool(NrOfInstances, Resizer, strategy, RouterDispatcher, UsePoolDispatcher, VirtualNodesFactor, HashMapping);
+        }
+
+        public override Pool WithResizer(Resizer resizer)
+        {
+            return new ConsistentHashingPool(NrOfInstances, resizer, SupervisorStrategy, RouterDispatcher, UsePoolDispatcher, VirtualNodesFactor, HashMapping);
+        }
+
+        public override RouterConfig WithFallback(RouterConfig routerConfig)
+        {
+            if (routerConfig is FromConfig || routerConfig is NoRouter)
+            {
+                return OverrideUnsetConfig(routerConfig);
+            }
+            else if (routerConfig is ConsistentHashingPool)
+            {
+                var other = routerConfig as ConsistentHashingPool;
+                return WithHashMapping(other.HashMapping).OverrideUnsetConfig(other);
+            }
+            else
+            {
+                throw new ArgumentException(string.Format("Expected ConsistentHashingPool, got {0}", routerConfig), "routerConfig");
+            }
+        }
+    }
+}

--- a/src/core/Akka/Routing/Random.cs
+++ b/src/core/Akka/Routing/Random.cs
@@ -119,5 +119,20 @@ namespace Akka.Routing
         {
             return new Router(new RoundRobinRoutingLogic());
         }
+
+        public override Pool WithSupervisorStrategy(SupervisorStrategy strategy)
+        {
+            return new RandomPool(NrOfInstances, Resizer, strategy, RouterDispatcher, UsePoolDispatcher);
+        }
+
+        public override Pool WithResizer(Resizer resizer)
+        {
+            return new RandomPool(NrOfInstances, resizer, SupervisorStrategy, RouterDispatcher, UsePoolDispatcher);
+        }
+
+        public override RouterConfig WithFallback(RouterConfig routerConfig)
+        {
+            return OverrideUnsetConfig(routerConfig);
+        }
     }
 }

--- a/src/core/Akka/Routing/RoundRobin.cs
+++ b/src/core/Akka/Routing/RoundRobin.cs
@@ -141,5 +141,20 @@ namespace Akka.Routing
         {
             return new Router(new RoundRobinRoutingLogic());
         }
+
+        public override Pool WithSupervisorStrategy(SupervisorStrategy strategy)
+        {
+            return new RoundRobinPool(NrOfInstances, Resizer, strategy, RouterDispatcher, UsePoolDispatcher);
+        }
+
+        public override Pool WithResizer(Resizer resizer)
+        {
+            return new RoundRobinPool(NrOfInstances, resizer, SupervisorStrategy, RouterDispatcher, UsePoolDispatcher);
+        }
+
+        public override RouterConfig WithFallback(RouterConfig routerConfig)
+        {
+            return OverrideUnsetConfig(routerConfig);
+        }
     }
 }

--- a/src/core/Akka/Routing/RoutedActorCell.cs
+++ b/src/core/Akka/Routing/RoutedActorCell.cs
@@ -122,7 +122,7 @@ namespace Akka.Routing
                 .With<Pool>(r =>
                 {
                     var routees = new List<Routee>();
-                    for (var i = 0; i < r.NrOfInstances; i++)
+                    for (var i = 0; i < r.GetNrOfInstances(System); i++)
                     {
                         var routee = r.NewRoutee(_routeeProps, this);
                         routees.Add(routee);

--- a/src/core/Akka/Routing/ScatterGatherFirstCompleted.cs
+++ b/src/core/Akka/Routing/ScatterGatherFirstCompleted.cs
@@ -148,5 +148,20 @@ namespace Akka.Routing
         {
             return new Router(new ScatterGatherFirstCompletedRoutingLogic(_within));
         }
+
+        public override Pool WithSupervisorStrategy(SupervisorStrategy strategy)
+        {
+            return new ScatterGatherFirstCompletedPool(NrOfInstances, Resizer, strategy, RouterDispatcher, _within, UsePoolDispatcher);
+        }
+
+        public override Pool WithResizer(Resizer resizer)
+        {
+            return new ScatterGatherFirstCompletedPool(NrOfInstances, resizer, SupervisorStrategy, RouterDispatcher, _within, UsePoolDispatcher);
+        }
+
+        public override RouterConfig WithFallback(RouterConfig routerConfig)
+        {
+            return OverrideUnsetConfig(routerConfig);
+        }
     }
 }

--- a/src/core/Akka/Routing/SmallestMailbox.cs
+++ b/src/core/Akka/Routing/SmallestMailbox.cs
@@ -101,5 +101,20 @@ namespace Akka.Routing
         {
             return new Router(new SmallestMailboxRoutingLogic());
         }
+
+        public override Pool WithSupervisorStrategy(SupervisorStrategy strategy)
+        {
+            return new SmallestMailboxPool(NrOfInstances, Resizer, strategy, RouterDispatcher, UsePoolDispatcher);
+        }
+
+        public override Pool WithResizer(Resizer resizer)
+        {
+            return new SmallestMailboxPool(NrOfInstances, resizer, SupervisorStrategy, RouterDispatcher, UsePoolDispatcher);
+        }
+
+        public override RouterConfig WithFallback(RouterConfig routerConfig)
+        {
+            return OverrideUnsetConfig(routerConfig);
+        }
     }
 }

--- a/src/core/Akka/Routing/TailChoppingRoutingLogic.cs
+++ b/src/core/Akka/Routing/TailChoppingRoutingLogic.cs
@@ -204,10 +204,9 @@ namespace Akka.Routing
         /// </summary>
         /// <param name="strategy">The strategy to use.</param>
         /// <returns>The tail chopping pool.</returns>
-        public TailChoppingPool WithSupervisorStrategy(SupervisorStrategy strategy)
+        public override Pool WithSupervisorStrategy(SupervisorStrategy strategy)
         {
-            SupervisorStrategy = strategy;
-            return this;
+            return new TailChoppingPool(NrOfInstances, Resizer, strategy, RouterDispatcher, _within, _interval, UsePoolDispatcher);
         }
 
         /// <summary>
@@ -215,10 +214,9 @@ namespace Akka.Routing
         /// </summary>
         /// <param name="resizer">The resizer to use.</param>
         /// <returns>The tail chopping pool.</returns>
-        public TailChoppingPool WithResizer(Resizer resizer)
+        public override Pool WithResizer(Resizer resizer)
         {
-            Resizer = resizer;
-            return this;
+            return new TailChoppingPool(NrOfInstances, resizer, SupervisorStrategy, RouterDispatcher, _within, _interval, UsePoolDispatcher);
         }
 
         /// <summary>
@@ -240,6 +238,11 @@ namespace Akka.Routing
         public override Router CreateRouter(ActorSystem system)
         {
             return new Router(new TailChoppingRoutingLogic(_within, _interval, system.Scheduler));
+        }
+
+        public override RouterConfig WithFallback(RouterConfig routerConfig)
+        {
+            return OverrideUnsetConfig(routerConfig);
         }
     }
 

--- a/src/core/Akka/Util/Internal/ImmutabilityUtils.cs
+++ b/src/core/Akka/Util/Internal/ImmutabilityUtils.cs
@@ -12,6 +12,8 @@ namespace Akka.Util.Internal
     /// </summary>
     internal static class ImmutabilityUtils
     {
+        #region HashSet<T>
+
         public static HashSet<T> CopyAndAdd<T>(this HashSet<T> set, T item)
         {
             Guard.Assert(set != null, "set cannot be null");
@@ -32,5 +34,29 @@ namespace Akka.Util.Internal
             copyList.Remove(item);
             return new HashSet<T>(copyList);
         }
+
+        #endregion
+
+        #region IDictionary<T>
+
+        public static SortedDictionary<TKey, TValue> CopyAndAdd<TKey, TValue>(this SortedDictionary<TKey, TValue> dict,
+            IEnumerable<KeyValuePair<TKey, TValue>> values)
+        {
+            var newDict = new SortedDictionary<TKey, TValue>();
+            foreach(var item in dict.Concat(values))
+                newDict.Add(item.Key, item.Value);
+            return newDict;
+        }
+
+        public static SortedDictionary<TKey, TValue> CopyAndRemove<TKey, TValue>(this SortedDictionary<TKey, TValue> dict,
+            IEnumerable<KeyValuePair<TKey, TValue>> values)
+        {
+            var newDict = new SortedDictionary<TKey, TValue>();
+            foreach (var item in dict.Except(values))
+                newDict.Add(item.Key, item.Value);
+            return newDict;
+        }
+
+        #endregion
     }
 }

--- a/src/core/Akka/Util/MurmurHash.cs
+++ b/src/core/Akka/Util/MurmurHash.cs
@@ -1,37 +1,120 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Akka.Util
 {
     /// <summary>
-    /// A Murmur3 implementation in .NET that doesn't suck. Imported from https://github.com/markedup-mobi/openmetrics
-    /// 
-    /// This is a C# port of the canonical algorithm in C++, with some helper functions
-    /// designed to make it easier to work with POCOs and .NET primitives.
+    /// Murmur3 Hash implementation
     /// </summary>
-    public static class Murmur3
+    public static class MurmurHash
     {
+        // Magic values used for MurmurHash's 32 bit hash.
+        // Don't change these without consulting a hashing expert!
+        private const uint VisibleMagic = 0x971e137b;
+        private const uint HiddenMagicA = 0x95543787;
+        private const uint HiddenMagicB = 0x2ad7eb25;
+        private const uint VisibleMixer = 0x52dce729;
+        private const uint HiddenMixerA = 0x7b7d159c;
+        private const uint HiddenMixerB = 0x6bce6396;
+        private const uint FinalMixer1 = 0x85ebca6b;
+        private const uint FinalMixer2 = 0xc2b2ae35;
 
-        #region Constants
+        // Arbitrary values used for hashing certain classes
 
-        private const uint ObjectSeed = 0xef91da3;
-        private const uint BytesSeed = 0x1a7d9dfe;
         private const uint StringSeed = 0x331df49;
+        private const uint ArraySeed = 0x3c074a61;
 
-        /* Constants for 32-bit hashing */
+        /** The first 23 magic integers from the first stream are stored here */
+        private static readonly uint[] StoredMagicA;
 
-        private const uint X86_32_C1 = 0xcc9e2d51;
+        /** The first 23 magic integers from the second stream are stored here */
+        private static readonly uint[] StoredMagicB;
 
-        private const uint X86_32_C2 = 0x1b873593;
+        /// <summary>
+        /// The initial magic integer in the first stream.
+        /// </summary>
+        public const uint StartMagicA = HiddenMagicA;
 
-        /* Constants for 64-bit hashing */
+        /// <summary>
+        /// The initial magic integer in the second stream.
+        /// </summary>
+        public const uint StartMagicB = HiddenMagicB;
 
-        private const ulong X64_128_C1 = 0x87c37b91114253d5L;
+        static MurmurHash()
+        {
+            //compute range of values for StoredMagicA
+            var storedMagicA = new List<uint>();
+            var nextMagicA = HiddenMagicA;
+            foreach (var i in Enumerable.Repeat(0, 23))
+            {
+                nextMagicA = NextMagicA(nextMagicA);
+                storedMagicA.Add(nextMagicA);
+            }
+            StoredMagicA = storedMagicA.ToArray();
 
-        private const ulong X64_128_C2 = 0x4cf5ad432745937fL;
+            //compute range of values for StoredMagicB
+            var storedMagicB = new List<uint>();
+            var nextMagicB = HiddenMagicB;
+            foreach (var i in Enumerable.Repeat(0, 23))
+            {
+                nextMagicB = NextMagicB(nextMagicB);
+                storedMagicB.Add(nextMagicB);
+            }
+            StoredMagicB = storedMagicB.ToArray();
+        }
 
-        #endregion
+        /// <summary>
+        /// Begin a new hash with a seed value.
+        /// </summary>
+        public static uint StartHash(uint seed)
+        {
+            return seed ^ VisibleMagic;
+        }
+
+        /// <summary>
+        /// Given a magic integer from the first stream, compute the next
+        /// </summary>
+        public static uint NextMagicA(uint magicA)
+        {
+            return magicA * 5 + HiddenMixerA;
+        }
+
+        /// <summary>
+        /// Given a magic integer from the second stream, compute the next
+        /// </summary>
+        public static uint NextMagicB(uint magicB)
+        {
+            return magicB * 5 + HiddenMixerB;
+        }
+
+        /// <summary>
+        /// Incorporates a new value into an existing hash
+        /// </summary>
+        /// <param name="hash">The prior hash value</param>
+        /// <param name="value">The new value to incorporate</param>
+        /// <param name="magicA">A magic integer from the left of the stream</param>
+        /// <param name="magicB">A magic integer froma different stream</param>
+        /// <returns>The updated hash value</returns>
+        public static uint ExtendHash(uint hash, uint value, uint magicA, uint magicB)
+        {
+            return (hash ^ RotateLeft32(value * magicA, 11) * magicB) * 3 + VisibleMixer;
+        }
+
+        /// <summary>
+        /// Once all hashes have been incorporated, this performs a final mixing.
+        /// </summary>
+        public static uint FinalizeHash(uint hash)
+        {
+            var h = (hash ^ (hash >> 16));
+            h *= FinalMixer1;
+            h ^= h >> 13;
+            h *= FinalMixer2;
+            h ^= h >> 16;
+            return h;
+        }
 
         #region Internal 32-bit hashing helpers
 
@@ -57,306 +140,91 @@ namespace Akka.Util
             return (original << shift) | (original >> (64 - shift));
         }
 
-
-
-        private static uint Mix32(uint hash, uint data)
-        {
-            var h1 = MixLast32(hash, data);
-            h1 = RotateLeft32(h1, 13);
-            h1 = h1 + (5 + 0xe6546b64);
-            return h1;
-        }
-
-        private static uint MixLast32(uint hash, uint data)
-        {
-            var k1 = data;
-
-            k1 *= X86_32_C1;
-            k1 = RotateLeft32(k1, 15);
-            k1 *= X86_32_C2;
-
-            hash ^= k1;
-            return hash;
-        }
-
-        /// <summary>
-        /// Finalization mix - force all bits of a hash block to avalanche.
-        /// 
-        /// I have no idea what that means but it sound awesome.
-        /// </summary>
-        private static uint Avalanche32(uint h)
-        {
-            h ^= h >> 16;
-            h *= 0x85ebca6b;
-            h ^= h >> 13;
-            h *= 0xc2b2ae35;
-            h ^= h >> 16;
-
-            return h;
-        }
-
         #endregion
 
         /// <summary>
-        /// Pass a .NET object to the function and get a 32-bit Murmur3 hash in return.
+        /// Compute a high-quality hash of a byte array
         /// </summary>
-        /// <param name="obj">the object to hash.</param>
-        /// <returns>A hash value, expressed as a 32 bit integer.</returns>
-        public static int Hash(object obj)
+        public static int ByteHash(byte[] b)
         {
-            var objbytes = GetObjBytes(obj);
-            if (obj == null) return 0; //short-circuit the hash if the value is null
-            var hash = Hash_X86_32(objbytes, objbytes.Length, ObjectSeed);
-            return hash;
+            return ArrayHash(b);
         }
 
         /// <summary>
-        /// Pass a .NET object to the function and get a 32-bit Murmur3 hash in return.
+        /// Compute a high-quality hash of an array
         /// </summary>
-        /// <param name="bytes">An array of bytes to hash</param>
-        /// <returns>A hash value, expressed as a 32 bit integer.</returns>
-        public static int HashBytes(byte[] bytes)
+        public static int ArrayHash<T>(T[] a)
         {
-            return Hash_X86_32(bytes, bytes.Length, BytesSeed);
-        }
-
-        /// <summary>
-        /// Pass a .NET <see cref="string"/> to the function and get a 32-bit Murmur3 hash in return.
-        /// </summary>
-        /// <param name="str">A string to hash</param>
-        /// <returns>A hash value, expressed as a 32 bit integer.</returns>
-        public static int HashString(string str)
-        {
-            var bytes = GetObjBytes(str);
-            return Hash_X86_32(bytes, bytes.Length, StringSeed);
-        }
-
-        /// <summary>
-        /// Translate the offered object into a byte array.
-        /// </summary>
-        /// <param name="obj">An arbitrary .NET object</param>
-        /// <returns>The object encoded into bytes - in the case of custom classes, the hashcode may be used.</returns>
-        private static byte[] GetObjBytes(object obj)
-        {
-            while (true)
+            unchecked
             {
-                if (obj == null)
-                    return new byte[] { 0 };
-                if (obj is byte[])
-                    return (byte[])obj;
-                if (obj is int)
-                    return BitConverter.GetBytes((int)obj);
-                if (obj is uint)
-                    return BitConverter.GetBytes((uint)obj);
-                if (obj is short)
-                    return BitConverter.GetBytes((short)obj);
-                if (obj is ushort)
-                    return BitConverter.GetBytes((ushort)obj);
-                if (obj is bool)
-                    return BitConverter.GetBytes((bool)obj);
-                if (obj is long)
-                    return BitConverter.GetBytes((long)obj);
-                if (obj is ulong)
-                    return BitConverter.GetBytes((ulong)obj);
-                if (obj is char)
-                    return BitConverter.GetBytes((char)obj);
-                if (obj is float)
-                    return BitConverter.GetBytes((float)obj);
-                if (obj is double)
-                    return BitConverter.GetBytes((double)obj);
-                if (obj is decimal)
-                    return new BitArray(decimal.GetBits((decimal)obj)).ToBytes();
-                if (obj is Guid)
-                    return ((Guid)obj).ToByteArray();
-                if (obj is string)
-                    return Encoding.Unicode.GetBytes((string)obj);
-                obj = obj.ToString();
+                var h = StartHash((uint)a.Length * ArraySeed);
+                var c = HiddenMagicA;
+                var k = HiddenMagicB;
+                var j = 0;
+                while (j < a.Length)
+                {
+                    h = ExtendHash(h, (uint)a[j].GetHashCode(), c, k);
+                    c = NextMagicA(c);
+                    k = NextMagicB(k);
+                    j += 1;
+                }
+                return (int)FinalizeHash(h);
             }
         }
 
         /// <summary>
-        /// Compute a 32-bit Murmur3 hash for an X86 system.
+        /// Compute high-quality hash of a string
         /// </summary>
-        /// <param name="data">The data that needs to be hashed</param>
-        /// <param name="length">The length of the data being hashed</param>
-        /// <param name="seed">A seed value used to compute the hash</param>
-        /// <returns>A computed hash value, as a signed integer.</returns>
-        public static int Hash_X86_32(byte[] data, int length, uint seed)
+        public static int StringHash(string s)
         {
-
-            var nblocks = length;
-            var h1 = seed;
-            uint k1 = 0;
-
-            var i = 0;
-            while (nblocks >= 4)
+            unchecked
             {
-                var k = data[i + 0] & 0xFF;
-                k |= (data[i + 1] & 0xFF) << 8;
-                k |= (data[i + 2] & 0xFF) << 16;
-                k |= (data[i + 3] & 0xFF) << 24;
-
-                unchecked
+                var sChar = s.ToCharArray();
+                var h = StartHash((uint)s.Length * StringSeed);
+                var c = HiddenMagicA;
+                var k = HiddenMagicB;
+                var j = 0;
+                while (j + 1 < s.Length)
                 {
-                    h1 = Mix32(h1, (uint)k);
+                    var i = (uint)((sChar[j] << 16) + sChar[j + 1]);
+                    h = ExtendHash(h, i, c, k);
+                    c = NextMagicA(c);
+                    k = NextMagicB(k);
+                    j += 2;
+                }
+                if (j < s.Length) h = ExtendHash(h, sChar[j], c, k);
+                return (int)FinalizeHash(h);
+            }
+        }
+
+        /// <summary>
+        /// Compute a hash that is symmetric in its arguments--that is,
+        /// where the order of appearance of elements does not matter.
+        /// This is useful for hashing sets, for example.
+        /// </summary>
+        public static int SymmetricHash<T>(IEnumerable<T> xs, uint seed)
+        {
+            unchecked
+            {
+                uint a = 0, b = 0, n = 0;
+                uint c = 1;
+                foreach (var i in xs)
+                {
+                    var u = (uint)i.GetHashCode();
+                    a += u;
+                    b ^= u;
+                    if (u != 0) c *= u;
+                    n += 1;
                 }
 
-                i += 4;
-                nblocks -= 4;
-            }
-
-            //tail - there's an unprocessed tail of data that we need to hash
-            switch (length)
-            {
-                case 3:
-                    k1 ^= (((uint)data[i + 2] & 0xFF) << 16);
-                    goto case 2; //thanks for the code smell, C#!
-                case 2:
-                    k1 ^= (((uint)data[i + 1] & 0xFF) << 8);
-                    goto case 1;
-                case 1:
-                    k1 ^= ((uint)data[i] & 0xFF);
-                    h1 = MixLast32(h1, k1);
-                    break;
-            }
-
-            //finalization
-            h1 ^= (uint)length;
-            h1 = Avalanche32(h1);
-            unchecked
-            {
-                return (int)h1;
+                var h = StartHash(seed*n);
+                h = ExtendHash(h, a, StoredMagicA[0], StoredMagicB[0]);
+                h = ExtendHash(h, b, StoredMagicA[1], StoredMagicB[1]);
+                h = ExtendHash(h, c, StoredMagicA[2], StoredMagicB[2]);
+                return (int)FinalizeHash(h);
             }
         }
-
-
-        #region 64-bit hash functions
-
-        /// <summary>
-        /// Compute a 128-bit Murmur3 hash for an X64 system.
-        /// </summary>
-        /// <param name="data">The data that needs to be hashed</param>
-        /// <param name="length">The length of the data being hashed</param>
-        /// <param name="seed">A seed value used to compute the hash</param>
-        /// <returns>A computed hash value, as an array consisting of two unsigned long integers.</returns>
-        public static ulong[] Hash_X64_128(byte[] data, int length, uint seed)
-        {
-            ulong h1 = seed;
-            ulong h2 = seed;
-            ulong k1, k2 = 0;
-            var nblocks = length >> 4; // /16
-
-            for (var i = 0; i < nblocks; i++)
-            {
-                k1 = GetBlock64(data, i << 3);
-                k2 = GetBlock64(data, (i + 1) << 3);
-
-                k1 *= X64_128_C1;
-                k1 = RotateLeft64(k1, 31);
-                k1 *= X64_128_C2;
-                h1 ^= k1;
-
-                h1 = RotateLeft64(h1, 27);
-                h1 += h2;
-                h1 += h2; h1 = h1 * 5 + 0x52dce729;
-
-                k2 *= X64_128_C2;
-                k2 = RotateLeft64(k2, 33);
-                k2 *= X64_128_C1;
-                h2 ^= k2;
-                h2 = RotateLeft64(h2, 31);
-                h2 += h1; h2 = h2 * 5 + 0x38495ab5;
-            }
-
-            //tail - there's an unprocessed tail of data that we need to hash
-            var offset = (nblocks << 4); // nblocks * 16
-            k1 = 0; k2 = 0;
-            switch (length & 15)
-            {
-                case 15: k2 ^= ((ulong)data[offset + 14]) << 48;
-                    goto case 14;
-                case 14: k2 ^= ((ulong)data[offset + 13]) << 40;
-                    goto case 13;
-                case 13: k2 ^= ((ulong)data[offset + 12]) << 32;
-                    goto case 12;
-                case 12: k2 ^= ((ulong)data[offset + 11]) << 24;
-                    goto case 11;
-                case 11: k2 ^= ((ulong)data[offset + 10]) << 16;
-                    goto case 10;
-                case 10: k2 ^= ((ulong)data[offset + 9]) << 8;
-                    goto case 9;
-                case 9: k2 ^= ((ulong)data[offset + 8]) << 0;
-                    k2 *= X64_128_C2; k2 = RotateLeft64(k2, 33); k2 *= X64_128_C1; h2 ^= k2;
-                    goto case 8;
-                case 8: k1 ^= ((ulong)data[offset + 7]) << 56;
-                    goto case 7;
-                case 7: k1 ^= ((ulong)data[offset + 6]) << 48;
-                    goto case 6;
-                case 6: k1 ^= ((ulong)data[offset + 5]) << 40;
-                    goto case 5;
-                case 5: k1 ^= ((ulong)data[offset + 4]) << 32;
-                    goto case 4;
-                case 4: k1 ^= ((ulong)data[offset + 3]) << 24;
-                    goto case 3;
-                case 3: k1 ^= ((ulong)data[offset + 2]) << 16;
-                    goto case 2;
-                case 2: k1 ^= ((ulong)data[offset + 1]) << 8;
-                    goto case 1;
-                case 1: k1 ^= ((ulong)data[offset + 0]) << 0;
-                    k1 *= X64_128_C1; k1 = RotateLeft64(k1, 31); k1 *= X64_128_C2; h1 ^= k1;
-                    break;
-            }
-
-            //finalization
-            h1 ^= (ulong)length; h2 ^= (ulong)length;
-
-            h1 += h2;
-            h2 += h1;
-
-            h1 = ForceMix64(h1);
-            h2 = ForceMix64(h2);
-
-            h1 += h2;
-            h2 += h1;
-
-            return new[] { h1, h2 };
-        }
-
-
-
-        /// <summary>
-        /// Read the next 8-byte block (int64) from a block number
-        /// </summary>
-        /// <param name="blocks">the original byte array</param>
-        /// <param name="i">the current block count</param>
-        /// <returns>An unsigned 64-bit integer</returns>
-        private static ulong GetBlock64(byte[] blocks, int i)
-        {
-            unchecked
-            {
-                return (ulong)BitConverter.ToInt64(blocks, i);
-            }
-        }
-
-        /// <summary>
-        /// Finalization mix - force all bits of a hash block to avalanche.
-        /// 
-        /// I have no idea what that means but it sound awesome.
-        /// </summary>
-        private static ulong ForceMix64(ulong k)
-        {
-            k ^= k >> 33;
-            k *= 0xff51afd7ed558ccd;
-            k ^= k >> 33;
-            k *= 0xc4ceb9fe1a85ec53;
-            k ^= k >> 33;
-
-            return k;
-        }
-
-
-        #endregion
-    }
+    } 
 
     /// <summary>
     /// Extension method class to make it easier to work with <see cref="BitArray"/> instances

--- a/src/examples/Cluster/Routing/Samples.Cluster.ConsistentHashRouting/Messages.cs
+++ b/src/examples/Cluster/Routing/Samples.Cluster.ConsistentHashRouting/Messages.cs
@@ -3,7 +3,7 @@ using Akka.Routing;
 
 namespace Samples.Cluster.ConsistentHashRouting
 {
-    public class FrontendCommand : ConsistentHashable {
+    public class FrontendCommand : IConsistentHashable {
         public string Message { get; set; }
 
         public string JobId { get; set; }

--- a/src/examples/Routing/Program.cs
+++ b/src/examples/Routing/Program.cs
@@ -6,7 +6,7 @@ using Akka.Routing;
 
 namespace Routing
 {
-    public class HashableMessage : ConsistentHashable
+    public class HashableMessage : IConsistentHashable
     {
         public string Name { get; set; }
         public int Id { get; set; }


### PR DESCRIPTION
From the original commit message

---
close #550
helps resolve #673

Reimplemented Murmur3, ConsistentHashRouting to use virtual nodes
Added deploy and routerconfig fallback support
Rewrote ActorOf method to LocalActorRefProvider to match Akka
Rewrote ActorOf method to RemoteActorRefProvider to match Akka
Breaking change - renamed ConsistentHashable interface to IConsistentHashable (per #633)
Added MultiNodeTests for ClusterConsistentHashRouting
Implemented Pool routers for Akka.Cluster

Updates
---
This is a major update of three systems:

1. *Props, Deploy, RouterConfig, and ActorRefProvider* - this code now matches what's inside Akka. Deploy and RouterConfig fallbacks now work as expected. This was necessary in order to support `ClusterPoolRouters` in combination with `ConsistentHashingPool`, which relies on a combination of configured routing behavior and programmatically defined routing behavior (`ConsistentHashMapping`.)
2. *ConsistentHashRouter, MurmurHash, and ConsistentHashMapping* - the entire infrastructure for consistent hash routing has been updated to support virtual nodes and the latest Akka API. More on this in a moment.
3. *ClusterGroupRouter and ClusterPoolRouter* - pool routing is now supported in Akka.Cluster and is covered by multi-node tests, which pass.

### ConsistentHashRouting

The APIs are largely the same, but with two major exceptions:
#### `ConsistentHashMapping` Delegate
There are three ways to instruct a router to hash a message:
1. Wrap the message in a `ConsistentHashableEnvelope`;
2. Implement the `IConsistentHashable` interface on your message types; or
3. Or, write a `ConsistentHashMapper` delegate and pass it to a `ConsistentHashingGroup` or a `ConsistentHashingPool` programmatically at create time.

Here's an example, taken from the `ConsistentHashSpecs`:

```csharp
ConsistentHashMapping hashMapping = msg =>
{
    if (msg is Msg2)
    {
        var m2 = msg as Msg2;
        return m2.Key;
    }

    return null;
};
var router2 =
    Sys.ActorOf(new ConsistentHashingPool(1, null, null, null, hashMapping: hashMapping)
    .Props(Props.Create<Echo>()), "router2");
```

Alternatively, you don't have to pass the `ConsistentHashMapping` into the constructor - you can use the `WithHashMapping` fluent interface built on top of both `ConsistentHashingGroup` and `ConsistentHashingPool`:

```csharp
var router2 =
    Sys.ActorOf(new ConsistentHashingPool(1).WithHashMapping(hashMapping)
    .Props(Props.Create<Echo>()), "router2");
```

### `ActorOf` changes

Now you might be wondering, what the hell does `ConsistentHashRouting` have to do with `ActorRefProvider`? The answer is - in order to support `ConsistentHashMapper`, there are many situations where half of the router will be defined in configuration and the other half programmatically.

In order to support this, *especially* with ClusterPoolRouter wrapping a `ConsistentHashingPool`, we needed to follow the Akka conventions to have Deploy and RouterConfig properly fall back.

I had to shave a couple of large, hairy, and kind of angry yaks in order to do that but it's done and all tests pass. Both the `RemoteActorRefProvider` and `LocalActorRefProvider`'s ActorOf method matches what's in Akka now.

### Breaking Changes
Per #633, `ConsistentHashable` interface has been renamed to `IConsistentHashable` - this will break any existing user-defined message types which implement the `ConsistentHashable` interface.