### PR TITLE
Removed a bunch of redundant type checks

### DIFF
--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -742,17 +742,17 @@ namespace Akka.Cluster
             }
             else if (message is ClusterUserAction.JoinTo)
             {
-                var jt = message as ClusterUserAction.JoinTo;
+                var jt = (ClusterUserAction.JoinTo)message;
                 Join(jt.Address);
             }
             else if (message is InternalClusterAction.JoinSeedNodes)
             {
-                var js = message as InternalClusterAction.JoinSeedNodes;
+                var js = (InternalClusterAction.JoinSeedNodes)message;
                 JoinSeedNodes(js.SeedNodes);
             }
             else if (message is InternalClusterAction.ISubscriptionMessage)
             {
-                var isub = message as InternalClusterAction.ISubscriptionMessage;
+                var isub = (InternalClusterAction.ISubscriptionMessage)message;
                 _publisher.Forward(isub);
             }
             else
@@ -765,7 +765,7 @@ namespace Akka.Cluster
         {
             if (message is InternalClusterAction.Welcome)
             {
-                var w = message as InternalClusterAction.Welcome;
+                var w = (InternalClusterAction.Welcome)message;
                 Welcome(joinWith, w.From, w.Gossip);
             }
             else if (message is InternalClusterAction.InitJoin)
@@ -774,13 +774,13 @@ namespace Akka.Cluster
             }
             else if (message is ClusterUserAction.JoinTo)
             {
-                var jt = message as ClusterUserAction.JoinTo;
+                var jt = (ClusterUserAction.JoinTo)message;
                 BecomeUninitialized();
                 Join(jt.Address);
             }
             else if (message is InternalClusterAction.ISubscriptionMessage)
             {
-                var isub = message as InternalClusterAction.ISubscriptionMessage;
+                var isub = (InternalClusterAction.ISubscriptionMessage)message;
                 _publisher.Forward(isub);
             }
             else if (message is InternalClusterAction.ITick)
@@ -820,12 +820,12 @@ namespace Akka.Cluster
         {
             if (message is GossipEnvelope)
             {
-                var ge = message as GossipEnvelope;
+                var ge = (GossipEnvelope)message;
                 ReceiveGossip(ge);
             }
             else if (message is GossipStatus)
             {
-                var gs = message as GossipStatus;
+                var gs = (GossipStatus)message;
                 ReceiveGossipStatus(gs);
             }
             else if (message is InternalClusterAction.GossipTick)
@@ -854,17 +854,17 @@ namespace Akka.Cluster
             }
             else if (message is InternalClusterAction.Join)
             {
-                var join = message as InternalClusterAction.Join;
+                var join = (InternalClusterAction.Join)message;
                 Joining(join.Node, join.Roles);
             }
             else if (message is ClusterUserAction.Down)
             {
-                var down = message as ClusterUserAction.Down;
+                var down = (ClusterUserAction.Down)message;
                 Downing(down.Address);
             }
             else if (message is ClusterUserAction.Leave)
             {
-                var leave = message as ClusterUserAction.Leave;
+                var leave = (ClusterUserAction.Leave)message;
                 Leaving(leave.Address);
             }
             else if (message is InternalClusterAction.ISubscriptionMessage)
@@ -873,17 +873,17 @@ namespace Akka.Cluster
             }
             else if (message is QuarantinedEvent)
             {
-                var q = message as QuarantinedEvent;
+                var q = (QuarantinedEvent)message;
                 Quarantined(new UniqueAddress(q.Address, q.Uid));
             }
             else if (message is ClusterUserAction.JoinTo)
             {
-                var jt = message as ClusterUserAction.JoinTo;
+                var jt = (ClusterUserAction.JoinTo)message;
                 _log.Info("Trying to join [{0}] when already part of a cluster, ignoring", jt.Address);
             }
             else if (message is InternalClusterAction.JoinSeedNodes)
             {
-                var joinSeedNodes = message as InternalClusterAction.JoinSeedNodes;
+                var joinSeedNodes = (InternalClusterAction.JoinSeedNodes)message;
                 _log.Info("Trying to join seed nodes [{0}] when already part of a cluster, ignoring",
                     joinSeedNodes.SeedNodes.Select(a => a.ToString()).Aggregate((a, b) => a + ", " + b));
             }

--- a/src/core/Akka.Cluster/ClusterEvent.cs
+++ b/src/core/Akka.Cluster/ClusterEvent.cs
@@ -663,32 +663,32 @@ namespace Akka.Cluster
         {
             if (message is InternalClusterAction.PublishChanges)
             {
-                var p = message as InternalClusterAction.PublishChanges;
+                var p = (InternalClusterAction.PublishChanges)message;
                 PublishChanges(p.NewGossip);
             }
             else if (message is ClusterEvent.CurrentInternalStats)
             {
-                var i = message as ClusterEvent.CurrentInternalStats;
+                var i = (ClusterEvent.CurrentInternalStats)message;
                 PublishInternalStats(i);
             }
             else if (message is InternalClusterAction.SendCurrentClusterState)
             {
-                var sc = message as InternalClusterAction.SendCurrentClusterState;
+                var sc = (InternalClusterAction.SendCurrentClusterState)message;
                 SendCurrentClusterState(sc.Receiver);
             }
             else if (message is InternalClusterAction.Subscribe)
             {
-                var sub = message as InternalClusterAction.Subscribe;
+                var sub = (InternalClusterAction.Subscribe)message;
                 Subscribe(sub.Subscriber, sub.InitialStateMode, sub.To);
             }
             else if (message is InternalClusterAction.PublishEvent)
             {
-                var pub = message as InternalClusterAction.PublishEvent;
+                var pub = (InternalClusterAction.PublishEvent)message;
                 Publish(pub);
             }
             else if (message is InternalClusterAction.Unsubscribe)
             {
-                var unsub = message as InternalClusterAction.Unsubscribe;
+                var unsub = (InternalClusterAction.Unsubscribe)message;
                 Unsubscribe(unsub.Subscriber, unsub.To);
             }
             else

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Reporting/TestRunTree.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Reporting/TestRunTree.cs
@@ -346,9 +346,9 @@ namespace Akka.MultiNodeTestRunner.Shared.Reporting
         public void Put(MultiNodeMessage message)
         {
             //Check for passed messages
-            if (!Passed.HasValue && message is MultiNodeResultMessage)
+            var resultMessage = message as MultiNodeResultMessage;
+            if (!Passed.HasValue && resultMessage != null)
             {
-                var resultMessage = message as MultiNodeResultMessage;
                 Passed = resultMessage.Passed;
                 EndTime = DateTime.UtcNow.Ticks;
             }

--- a/src/core/Akka.Persistence.Tests/GuaranteedDeliveryCrashSpec.cs
+++ b/src/core/Akka.Persistence.Tests/GuaranteedDeliveryCrashSpec.cs
@@ -97,8 +97,8 @@ namespace Akka.Persistence.Tests
 
             protected override bool ReceiveCommand(object message)
             {
-                if (message is Message) Persist(message as Message, _ => Send());
-                else if (message is CrashMessage) Persist(message as CrashMessage, _ => { });
+                if (message is Message) Persist((Message)message, _ => Send());
+                else if (message is CrashMessage) Persist((CrashMessage)message, _ => { });
                 else return false;
                 return true;
             }

--- a/src/core/Akka.Persistence.Tests/PersistentActorFailureSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorFailureSpec.cs
@@ -28,9 +28,9 @@ namespace Akka.Persistence.Tests
         {
             private bool FailingReceive(object message)
             {
-                if (message is AsyncWriteTarget.ReplayMessages)
+                var replay = message as AsyncWriteTarget.ReplayMessages;
+                if (replay != null)
                 {
-                    var replay = message as AsyncWriteTarget.ReplayMessages;
                     var readFromStore = Read(replay.PersistenceId, replay.FromSequenceNr, replay.ToSequenceNr, replay.Max).ToArray();
 
                     if (readFromStore.Length == 0) Sender.Tell(AsyncWriteTarget.ReplaySuccess.Instance);

--- a/src/core/Akka.Persistence.Tests/PersistentActorSpec.Actors.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorSpec.Actors.cs
@@ -19,9 +19,9 @@ namespace Akka.Persistence.Tests
 
         protected bool Receiver(object message)
         {
-            if (message is Cmd)
+            var cmd = message as Cmd;
+            if (cmd != null)
             {
-                var cmd = message as Cmd;
                 Persist(new[] { new Evt(cmd.Data + "-1"), new Evt(cmd.Data + "-2") }, UpdateStateHandler);
                 return true;
             }
@@ -93,9 +93,10 @@ namespace Akka.Persistence.Tests
 
             protected bool UpdateState(object message)
             {
-                if (message is Evt)
+                var evt = message as Evt;
+                if (evt != null)
                 {
-                    Events.AddFirst((message as Evt).Data);
+                    Events.AddFirst(evt.Data);
                     return true;
                 }
 
@@ -123,9 +124,9 @@ namespace Akka.Persistence.Tests
 
             protected bool Receiver(object message)
             {
-                if (message is Cmd)
+                var cmd = message as Cmd;
+                if (cmd != null)
                 {
-                    var cmd = message as Cmd;
                     Persist(new[] { new Evt(cmd.Data + "-1"), new Evt(cmd.Data + "-2") }, UpdateStateHandler);
                     Persist(new[] { new Evt(cmd.Data + "-3"), new Evt(cmd.Data + "-4") }, UpdateStateHandler);
                     return true;
@@ -144,9 +145,9 @@ namespace Akka.Persistence.Tests
 
             protected bool Receiver(object message)
             {
-                if (message is Cmd)
+                var cmd = message as Cmd;
+                if (cmd != null)
                 {
-                    var cmd = message as Cmd;
                     Persist(new[] { new Evt(cmd.Data + "-11"), new Evt(cmd.Data + "-12") }, UpdateStateHandler);
                     UpdateState(new Evt(cmd.Data + "-10"));
                     return true;
@@ -163,9 +164,9 @@ namespace Akka.Persistence.Tests
             {
                 if (CommonBehavior(message)) return true;
 
-                if (message is Cmd)
+                var cmd = message as Cmd;
+                if (cmd != null)
                 {
-                    var cmd = message as Cmd;
                     Persist(new Evt(cmd.Data + "-0"), evt =>
                     {
                         UpdateState(evt);
@@ -178,10 +179,9 @@ namespace Akka.Persistence.Tests
 
             protected bool NewBehavior(object message)
             {
-                if (message is Cmd)
+                var cmd = message as Cmd;
+                if (cmd != null)
                 {
-                    var cmd = message as Cmd;
-
                     Persist(new Evt(cmd.Data + "-21"), UpdateStateHandler);
                     Persist(new Evt(cmd.Data + "-22"), evt =>
                     {
@@ -202,9 +202,9 @@ namespace Akka.Persistence.Tests
             {
                 if (CommonBehavior(message)) return true;
 
-                if (message is Cmd)
+                var cmd = message as Cmd;
+                if (cmd != null)
                 {
-                    var cmd = message as Cmd;
                     Persist(new Evt(cmd.Data + "-0"), evt =>
                     {
                         UpdateState(evt);
@@ -217,10 +217,9 @@ namespace Akka.Persistence.Tests
 
             protected bool NewBehavior(object message)
             {
-                if (message is Cmd)
+                var cmd = message as Cmd;
+                if (cmd != null)
                 {
-                    var cmd = message as Cmd;
-
                     Persist(new Evt(cmd.Data + "-21"), evt =>
                     {
                         UpdateState(evt);
@@ -239,10 +238,10 @@ namespace Akka.Persistence.Tests
             protected override bool ReceiveCommand(object message)
             {
                 if (CommonBehavior(message)) return true;
-                
-                if (message is Cmd)
+
+                var cmd = message as Cmd;
+                if (cmd != null)
                 {
-                    var cmd = message as Cmd;
                     Context.Become(NewBehavior);
                     Persist(new Evt(cmd.Data + "-0"), UpdateStateHandler);
                     return true;
@@ -271,10 +270,10 @@ namespace Akka.Persistence.Tests
             protected override bool ReceiveCommand(object message)
             {
                 if (CommonBehavior(message)) return true;
-                
-                if (message is Cmd)
+
+                var cmd = message as Cmd;
+                if (cmd != null)
                 {
-                    var cmd = message as Cmd;
                     Persist(new Evt(cmd.Data + "-0"), UpdateStateHandler);
                     Context.Become(NewBehavior);
                     return true;
@@ -284,9 +283,9 @@ namespace Akka.Persistence.Tests
 
             protected bool NewBehavior(object message)
             {
-                if (message is Cmd)
+                var cmd = message as Cmd;
+                if (cmd != null)
                 {
-                    var cmd = message as Cmd;
                     Persist(new[] { new Evt(cmd.Data + "-31"), new Evt(cmd.Data + "-32") }, UpdateStateHandler);
                     UpdateState(new Evt(cmd.Data + "-30"));
                     Context.Unbecome();
@@ -309,10 +308,11 @@ namespace Akka.Persistence.Tests
             {
                 if (!base.ReceiveRecover(message))
                 {
-                    if (message is SnapshotOffer)
+                    var snapshotOffer = message as SnapshotOffer;
+                    if (snapshotOffer != null)
                     {
                         Probe.Tell("offered");
-                        Events = (message as SnapshotOffer).Snapshot as LinkedList<object>;
+                        Events = snapshotOffer.Snapshot as LinkedList<object>;
                     }
                     else return false;
                 }
@@ -322,7 +322,7 @@ namespace Akka.Persistence.Tests
             protected override bool ReceiveCommand(object message)
             {
                 if (CommonBehavior(message)) ;
-                else if (message is Cmd) HandleCmd(message as Cmd);
+                else if (message is Cmd) HandleCmd((Cmd)message);
                 else if (message is SaveSnapshotSuccess) Probe.Tell("saved");
                 else if (message.ToString() == "snap") SaveSnapshot(Events);
                 else return false;
@@ -387,9 +387,9 @@ namespace Akka.Persistence.Tests
 
             protected override bool ReceiveCommand(object message)
             {
-                if (message is Cmd)
+                var cmd = message as Cmd;
+                if (cmd != null)
                 {
-                    var cmd = message as Cmd;
                     if (cmd.Data.ToString() == "a")
                     {
                         if (!_stashed)
@@ -857,14 +857,14 @@ namespace Akka.Persistence.Tests
             {
                 if (message is LatchCmd)
                 {
-                    var latchCmd = message as LatchCmd;
+                    var latchCmd = (LatchCmd)message;
                     Sender.Tell(latchCmd.Data);
                     latchCmd.Latch.Ready(TimeSpan.FromSeconds(5));
                     PersistAsync(latchCmd.Data, _ => { });
                 }
                 else if (message is Cmd)
                 {
-                    var cmd = message as Cmd;
+                    var cmd = (Cmd)message;
                     Sender.Tell(cmd.Data);
                     PersistAsync(cmd.Data, _ => { });
                 }

--- a/src/core/Akka.Persistence.Tests/PersistentViewSpec.Actors.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentViewSpec.Actors.cs
@@ -238,7 +238,7 @@ namespace Akka.Persistence.Tests
                     _probe.Tell("snapped");
                 else if (message is SnapshotOffer)
                 {
-                    var offer = message as SnapshotOffer;
+                    var offer = (SnapshotOffer)message;
                     _last = offer.Snapshot.ToString();
                     _probe.Tell(_last);
                 }

--- a/src/core/Akka.Persistence/Eventsourced.Lifecycle.cs
+++ b/src/core/Akka.Persistence/Eventsourced.Lifecycle.cs
@@ -38,9 +38,9 @@ namespace Akka.Persistence
             finally
             {
                 object inner;
-                if (message is WriteMessageSuccess) inner = (message as WriteMessageSuccess).Persistent;
-                else if (message is LoopMessageSuccess) inner = (message as LoopMessageSuccess).Message;
-                else if (message is ReplayedMessage) inner = (message as ReplayedMessage).Persistent;
+                if (message is WriteMessageSuccess) inner = ((WriteMessageSuccess)message).Persistent;
+                else if (message is LoopMessageSuccess) inner = ((LoopMessageSuccess)message).Message;
+                else if (message is ReplayedMessage) inner = ((ReplayedMessage)message).Persistent;
                 else inner = null;
 
                 FlushJournalBatch();
@@ -67,13 +67,13 @@ namespace Akka.Persistence
             else if (message is RecoveryFailure)
             {
                 var msg = string.Format("{0} was killed after recovery failure (persistence id = {1}). To avoid killing persistent actors on recovery failure, a PersistentActor must handle RecoveryFailure messages. Recovery failure was caused by: {2}", 
-                    GetType().Name, PersistenceId, (message as RecoveryFailure).Cause.Message);
+                    GetType().Name, PersistenceId, ((RecoveryFailure)message).Cause.Message);
 
                 throw new ActorKilledException(msg);
             }
             else if (message is PersistenceFailure)
             {
-                var fail = message as PersistenceFailure;
+                var fail = (PersistenceFailure)message;
                 var msg = string.Format("{0} was killed after persistence failure (persistence id = {1}, sequence nr: {2}, payload type: {3}). To avoid killing persistent actors on recovery failure, a PersistentActor must handle RecoveryFailure messages. Persistence failure was caused by: {4}",
                     GetType().Name, PersistenceId, fail.SequenceNr, fail.Payload.GetType().Name, fail.Cause.Message);
                 throw new ActorKilledException(msg);

--- a/src/core/Akka.Persistence/Eventsourced.Recovery.cs
+++ b/src/core/Akka.Persistence/Eventsourced.Recovery.cs
@@ -61,7 +61,7 @@ namespace Akka.Persistence
             {
                 Receive receiveRecover = ReceiveRecover;
                 if (message is IPersistentRepresentation && IsRecovering)
-                    return receiveRecover((message as IPersistentRepresentation).Payload);
+                    return receiveRecover(((IPersistentRepresentation)message).Payload);
                 else if (message is SnapshotOffer)
                     return receiveRecover((SnapshotOffer)message);
                 else if (message is RecoveryFailure)

--- a/src/core/Akka.Persistence/Journal/AsyncWriteProxy.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteProxy.cs
@@ -162,9 +162,9 @@ namespace Akka.Persistence.Journal
 
         protected override bool Receive(object message)
         {
-            if (message is SetStore)
+            var setStore = message as SetStore;
+            if (setStore != null)
             {
-                var setStore = message as SetStore;
                 _store = setStore.Store;
                 Stash.UnstashAll();
                 Context.Become(_initialized);
@@ -218,7 +218,7 @@ namespace Akka.Persistence.Journal
 
         protected override bool Receive(object message)
         {
-            if (message is IPersistentRepresentation) _replayCallback(message as IPersistentRepresentation);
+            if (message is IPersistentRepresentation) _replayCallback((IPersistentRepresentation)message);
             else if (message is AsyncWriteTarget.ReplaySuccess)
             {
                 _replayCompletionPromise.SetResult(new object());
@@ -226,7 +226,7 @@ namespace Akka.Persistence.Journal
             }
             else if (message is AsyncWriteTarget.ReplayFailure)
             {
-                var failure = message as AsyncWriteTarget.ReplayFailure;
+                var failure = (AsyncWriteTarget.ReplayFailure)message;
                 _replayCompletionPromise.SetException(failure.Cause);
                 Context.Stop(Self);
             }

--- a/src/core/Akka.Persistence/Journal/MemoryJournal.cs
+++ b/src/core/Akka.Persistence/Journal/MemoryJournal.cs
@@ -37,10 +37,10 @@ namespace Akka.Persistence.Journal
 
         protected override bool Receive(object message)
         {
-            if (message is AsyncWriteTarget.WriteMessages) Add(message as AsyncWriteTarget.WriteMessages);
-            else if (message is AsyncWriteTarget.DeleteMessagesTo) Delete(message as AsyncWriteTarget.DeleteMessagesTo);
-            else if (message is AsyncWriteTarget.ReplayMessages) Read(message as AsyncWriteTarget.ReplayMessages);
-            else if (message is AsyncWriteTarget.ReadHighestSequenceNr) GetHighestSequenceNumber(message as AsyncWriteTarget.ReadHighestSequenceNr);
+            if (message is AsyncWriteTarget.WriteMessages) Add((AsyncWriteTarget.WriteMessages)message);
+            else if (message is AsyncWriteTarget.DeleteMessagesTo) Delete((AsyncWriteTarget.DeleteMessagesTo)message);
+            else if (message is AsyncWriteTarget.ReplayMessages) Read((AsyncWriteTarget.ReplayMessages)message);
+            else if (message is AsyncWriteTarget.ReadHighestSequenceNr) GetHighestSequenceNumber((AsyncWriteTarget.ReadHighestSequenceNr)message);
             else return false;
             return true;
         }

--- a/src/core/Akka.Persistence/Journal/SyncWriteJournal.cs
+++ b/src/core/Akka.Persistence/Journal/SyncWriteJournal.cs
@@ -40,10 +40,10 @@ namespace Akka.Persistence.Journal
 
         protected override bool Receive(object message)
         {
-            if (message is WriteMessages) HandleWriteMessages(message as WriteMessages);
-            else if (message is ReplayMessages) HandleReplayMessages(message as ReplayMessages);
-            else if (message is ReadHighestSequenceNr) HandleReadHighestSequenceNr(message as ReadHighestSequenceNr);
-            else if (message is DeleteMessagesTo) HandleDeleteMessagesTo(message as DeleteMessagesTo);
+            if (message is WriteMessages) HandleWriteMessages((WriteMessages)message);
+            else if (message is ReplayMessages) HandleReplayMessages((ReplayMessages)message);
+            else if (message is ReadHighestSequenceNr) HandleReadHighestSequenceNr((ReadHighestSequenceNr)message);
+            else if (message is DeleteMessagesTo) HandleDeleteMessagesTo((DeleteMessagesTo)message);
             else return false;
             return true;
         }

--- a/src/core/Akka.Persistence/Journal/WriteJournal.cs
+++ b/src/core/Akka.Persistence/Journal/WriteJournal.cs
@@ -13,9 +13,9 @@ namespace Akka.Persistence.Journal
 
         protected bool PreparePersistentWrite(IPersistentEnvelope persistentEnvelope)
         {
-            if (persistentEnvelope is IPersistentRepresentation)
+            var repr = persistentEnvelope as IPersistentRepresentation;
+            if (repr != null)
             {
-                var repr = persistentEnvelope as IPersistentRepresentation;
                 repr.PrepareWrite(Context);
                 return true;
             }

--- a/src/core/Akka.Persistence/Serialization/MessageSerializer.cs
+++ b/src/core/Akka.Persistence/Serialization/MessageSerializer.cs
@@ -37,8 +37,8 @@ namespace Akka.Persistence.Serialization
 
         public override byte[] ToBinary(object obj)
         {
-            if (obj is IPersistentRepresentation) return PersistentToProto(obj as IPersistentRepresentation).Build().ToByteArray();
-            if (obj is GuaranteedDeliverySnapshot) return SnapshotToProto(obj as GuaranteedDeliverySnapshot).Build().ToByteArray();
+            if (obj is IPersistentRepresentation) return PersistentToProto((IPersistentRepresentation)obj).Build().ToByteArray();
+            if (obj is GuaranteedDeliverySnapshot) return SnapshotToProto((GuaranteedDeliverySnapshot)obj).Build().ToByteArray();
 
             throw new ArgumentException(typeof(MessageSerializer) + " cannot serialize object of type " + obj.GetType());
         }

--- a/src/core/Akka.Persistence/Serialization/SnapshotSerializer.cs
+++ b/src/core/Akka.Persistence/Serialization/SnapshotSerializer.cs
@@ -60,7 +60,8 @@ namespace Akka.Persistence.Serialization
 
         public override byte[] ToBinary(object obj)
         {
-            if (obj is Snapshot) return SnapshotToBinary((obj as Snapshot).Data);
+            var snapshot = obj as Snapshot;
+            if (snapshot != null) return SnapshotToBinary(snapshot.Data);
 
             throw new ArgumentException(typeof(SnapshotSerializer) + "cannot serialize object of type " + obj.GetType(), "obj");
         }

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -867,7 +867,7 @@ namespace Akka.Remote
             }
             else if (message is Status.Failure)
             {
-                var failure = message as Status.Failure;
+                var failure = (Status.Failure)message;
                 if (failure.Cause is InvalidAssociationException)
                 {
                     PublishAndThrow(new InvalidAssociation(LocalAddress, RemoteAddress, failure.Cause),
@@ -882,7 +882,7 @@ namespace Akka.Remote
             }
             else if (message is Handle)
             {
-                var inboundHandle = message as Handle;
+                var inboundHandle = (Handle)message;
                 Context.Parent.Tell(
                     new ReliableDeliverySupervisor.GotUid((int)inboundHandle.ProtocolHandle.HandshakeInfo.Uid));
                 _handle = inboundHandle.ProtocolHandle;
@@ -925,7 +925,7 @@ namespace Akka.Remote
         {
             if (message is EndpointManager.Send)
             {
-                var s = message as EndpointManager.Send;
+                var s = (EndpointManager.Send)message;
                 if (!WriteSend(s))
                 {
                     if (s.Seq == null) EnqueueInBuffer(s);
@@ -971,7 +971,7 @@ namespace Akka.Remote
         {
             if (message is Terminated)
             {
-                var t = message as Terminated;
+                var t = (Terminated)message;
                 if (_reader == null || t.ActorRef.Equals(_reader))
                 {
                     PublishAndThrow(new EndpointDisassociatedException("Disassociated"), LogLevel.DebugLevel);
@@ -979,7 +979,7 @@ namespace Akka.Remote
             }
             else if (message is StopReading)
             {
-                var stop = message as StopReading;
+                var stop = (StopReading)message;
                 if (_reader != null)
                 {
                     _reader.Tell(stop, stop.ReplyTo);
@@ -992,7 +992,7 @@ namespace Akka.Remote
             }
             else if (message is TakeOver)
             {
-                var takeover = message as TakeOver;
+                var takeover = (TakeOver)message;
 
                 // Shutdown old reader
                 _handle.Disassociate();
@@ -1007,7 +1007,7 @@ namespace Akka.Remote
             }
             else if (message is OutboundAck)
             {
-                var ack = message as OutboundAck;
+                var ack = (OutboundAck)message;
                 _lastAck = ack.Ack;
                 if (_ackDeadline.IsOverdue)
                     TrySendPureAck();
@@ -1229,7 +1229,7 @@ namespace Akka.Remote
             {
                 if (msg is EndpointManager.Send)
                 {
-                    return WriteSend(msg as EndpointManager.Send);
+                    return WriteSend((EndpointManager.Send)msg);
                 }
                 else if (msg is FlushAndStop)
                 {
@@ -1238,7 +1238,7 @@ namespace Akka.Remote
                 }
                 else if (msg is StopReading)
                 {
-                    var s = msg as StopReading;
+                    var s = (StopReading)msg;
                     if (_reader != null) _reader.Tell(s, s.ReplyTo);
                 }
                 return true;
@@ -1499,11 +1499,11 @@ namespace Akka.Remote
         {
             if (message is Disassociated)
             {
-                HandleDisassociated((message as Disassociated).Info);
+                HandleDisassociated(((Disassociated)message).Info);
             }
             else if (message is InboundPayload)
             {
-                var payload = message as InboundPayload;
+                var payload = (InboundPayload)message;
                 var ackAndMessage = TryDecodeMessageAndAck(payload.Payload);
                 if (ackAndMessage.AckOption != null && _reliableDeliverySupervisor != null)
                     _reliableDeliverySupervisor.Tell(ackAndMessage.AckOption);
@@ -1525,7 +1525,7 @@ namespace Akka.Remote
             }
             else if (message is EndpointWriter.StopReading)
             {
-                var stop = message as EndpointWriter.StopReading;
+                var stop = (EndpointWriter.StopReading)message;
                 SaveState();
                 Context.Become(NotReading);
                 stop.ReplyTo.Tell(new EndpointWriter.StoppedReading(stop.Writer));
@@ -1540,15 +1540,15 @@ namespace Akka.Remote
         {
             if (message is Disassociated)
             {
-                HandleDisassociated((message as Disassociated).Info);
+                HandleDisassociated(((Disassociated)message).Info);
             }
             else if (message is EndpointWriter.StopReading)
             {
-                var stop = message as EndpointWriter.StopReading;
+                var stop = (EndpointWriter.StopReading)message;
                 Sender.Tell(new EndpointWriter.StoppedReading(stop.Writer));
             } else if (message is InboundPayload)
             {
-                var payload = message as InboundPayload;
+                var payload = (InboundPayload)message;
                 var ackAndMessage = TryDecodeMessageAndAck(payload.Payload);
                 if (ackAndMessage.AckOption != null && _reliableDeliverySupervisor != null)
                     _reliableDeliverySupervisor.Tell(ackAndMessage.AckOption);

--- a/src/core/Akka.Remote/Transport/FailureInjectorTransportAdapter.cs
+++ b/src/core/Akka.Remote/Transport/FailureInjectorTransportAdapter.cs
@@ -128,14 +128,14 @@ namespace Akka.Remote.Transport
         {
             if (message is All)
             {
-                var all = message as All;
+                var all = (All)message;
                 _allMode = all.Mode;
                 return Task.FromResult(true);
             }
             
             if (message is One)
             {
-                var one = message as One;
+                var one = (One)message;
                 //  don't care about the protocol part - we are injected in the stack anyway!
                 addressChaosTable.AddOrUpdate(NakedAddress(one.RemoteAddress), address => one.Mode, (address, mode) => one.Mode);
                 return Task.FromResult(true);

--- a/src/core/Akka.Remote/Transport/ThrottleTransportAdapter.cs
+++ b/src/core/Akka.Remote/Transport/ThrottleTransportAdapter.cs
@@ -220,13 +220,13 @@ namespace Akka.Remote.Transport
         {
             if (message is InboundAssociation)
             {
-                var ia = message as InboundAssociation;
+                var ia = (InboundAssociation)message;
                 var wrappedHandle = WrapHandle(ia.Association, associationListener, true);
                 wrappedHandle.ThrottlerActor.Tell(new Handle(wrappedHandle));
             }
             else if (message is AssociateUnderlying)
             {
-                var ua = message as AssociateUnderlying;
+                var ua = (AssociateUnderlying)message;
 
                 // Slight modification of PipeTo, only success is sent, failure is propagated to a separate Task
                 var associateTask = WrappedTransport.Associate(ua.RemoteAddress);
@@ -248,7 +248,7 @@ namespace Akka.Remote.Transport
             }
             else if (message is AssociateResult) // Finished outbound association and got back the handle
             {
-                var ar = message as AssociateResult;
+                var ar = (AssociateResult)message;
                 var wrappedHandle = WrapHandle(ar.AssociationHandle, associationListener, false);
                 var naked = NakedAddress(ar.AssociationHandle.RemoteAddress);
                 var inMode = GetInboundMode(naked);
@@ -260,7 +260,7 @@ namespace Akka.Remote.Transport
             }
             else if (message is SetThrottle)
             {
-                var st = message as SetThrottle;
+                var st = (SetThrottle)message;
                 var naked = NakedAddress(st.Address);
                 _throttlingModes[naked] = new Tuple<ThrottleMode, ThrottleTransportAdapter.Direction>(st.Mode, st.Direction);
                 var ok = Task.FromResult(SetThrottleAck.Instance);
@@ -281,7 +281,7 @@ namespace Akka.Remote.Transport
             }
             else if (message is ForceDisassociate)
             {
-                var fd = message as ForceDisassociate;
+                var fd = (ForceDisassociate)message;
                 var naked = NakedAddress(fd.Address);
                 foreach (var handle in _handleTable)
                 {
@@ -310,7 +310,7 @@ namespace Akka.Remote.Transport
             }
             else if (message is ForceDisassociateExplicitly)
             {
-                var fde = message as ForceDisassociateExplicitly;
+                var fde = (ForceDisassociateExplicitly)message;
                 var naked = NakedAddress(fde.Address);
                 foreach (var handle in _handleTable)
                 {
@@ -339,7 +339,7 @@ namespace Akka.Remote.Transport
             }
             else if (message is Checkin)
             {
-                var chkin = message as Checkin;
+                var chkin = (Checkin)message;
                 var naked = NakedAddress(chkin.Origin);
                 _handleTable.Add(new Tuple<Address, ThrottlerHandle>(naked, chkin.ThrottlerHandle));
                 SetMode(naked, chkin.ThrottlerHandle);

--- a/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
+++ b/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
@@ -87,12 +87,12 @@ namespace Akka.Actor
                 Publish(new Debug(Self.Path.ToString(), actorType, "received AutoReceiveMessage " + message));
 
             var m = envelope.Message;
-            if (m is Terminated) ReceivedTerminated(m as Terminated);
-            else if (m is AddressTerminated) AddressTerminated((m as AddressTerminated).Address);
+            if (m is Terminated) ReceivedTerminated((Terminated)m);
+            else if (m is AddressTerminated) AddressTerminated(((AddressTerminated)m).Address);
             else if (m is Kill) Kill();
             else if (m is PoisonPill) HandlePoisonPill();
-            else if (m is ActorSelectionMessage) ReceiveSelection(m as ActorSelectionMessage);
-            else if (m is Identify) HandleIdentity(m as Identify);
+            else if (m is ActorSelectionMessage) ReceiveSelection((ActorSelectionMessage)m);
+            else if (m is Identify) HandleIdentity((Identify)m);
         }
 
         /// <summary>
@@ -148,17 +148,17 @@ namespace Akka.Actor
             {
                 var m = envelope.Message;
 
-                if (m is CompleteTask) HandleCompleteTask(m as CompleteTask);
-                else if (m is Failed) HandleFailed(m as Failed);
+                if (m is CompleteTask) HandleCompleteTask((CompleteTask)m);
+                else if (m is Failed) HandleFailed((Failed)m);
                 else if (m is DeathWatchNotification)
                 {
-                    var msg = m as DeathWatchNotification;
+                    var msg = (DeathWatchNotification)m;
                     WatchedActorTerminated(msg.Actor, msg.ExistenceConfirmed, msg.AddressTerminated);
                 }
-                else if (m is Create) HandleCreate((m as Create).Failure);
+                else if (m is Create) HandleCreate(((Create)m).Failure);
                 else if (m is Watch)
                 {
-                    var watch = m as Watch;
+                    var watch = (Watch)m;
                     AddWatcher(watch.Watchee, watch.Watcher);
                 }
                 else if (m is Unwatch)
@@ -166,13 +166,13 @@ namespace Akka.Actor
                     var unwatch = m as Unwatch;
                     RemWatcher(unwatch.Watchee, unwatch.Watcher);
                 }
-                else if (m is Recreate) FaultRecreate((m as Recreate).Cause);
+                else if (m is Recreate) FaultRecreate(((Recreate)m).Cause);
                 else if (m is Suspend) FaultSuspend();
-                else if (m is Resume) FaultResume((m as Resume).CausedByFailure);
+                else if (m is Resume) FaultResume(((Resume)m).CausedByFailure);
                 else if (m is Terminate) Terminate();
                 else if (m is Supervise)
                 {
-                    var supervise = m as Supervise;
+                    var supervise = (Supervise)m;
                     Supervise(supervise.Child, supervise.Async);
                 }
                 else

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -301,7 +301,7 @@ namespace Akka.Actor
                 }
 
                 if (State is ActorPath)
-                    return State as ActorPath;
+                    return (ActorPath)State;
                 if (State is StoppedWithPath)
                     return State.AsInstanceOf<StoppedWithPath>().Path;
                 if (State is Stopped)
@@ -319,7 +319,7 @@ namespace Akka.Actor
         {
             if (message is SystemMessage)
             {
-                SendSystemMessage(message as SystemMessage); 
+                SendSystemMessage((SystemMessage)message);
                 return;
             }
 
@@ -343,12 +343,12 @@ namespace Akka.Actor
             if(message is Terminate) Stop();
             else if (message is DeathWatchNotification)
             {
-                var dw = message as DeathWatchNotification;
+                var dw = (DeathWatchNotification)message;
                 Tell(new Terminated(dw.Actor, dw.ExistenceConfirmed, dw.AddressTerminated));
             }
             else if (message is Watch)
             {
-                var watch = message as Watch;
+                var watch = (Watch)message;
                 if (watch.Watchee == this)
                 {
                     if (!AddWatcher(watch.Watcher))
@@ -366,7 +366,7 @@ namespace Akka.Actor
             }
             else if (message is Unwatch)
             {
-                var unwatch = message as Unwatch;
+                var unwatch = (Unwatch)message;
                 if(unwatch.Watchee == this && unwatch.Watcher != this) RemoveWatcher(unwatch.Watcher);
                 else Console.WriteLine("BUG: illegal Unwatch({0},{1}) for {2}", unwatch.Watchee, unwatch.Watcher, this);
             }
@@ -398,7 +398,7 @@ namespace Akka.Actor
             }
             else if (state is ActorPath)
             {
-                var p = state as ActorPath;
+                var p = (ActorPath)state;
                 if (UpdateState(p, new StoppedWithPath(p)))
                 {
                     try

--- a/src/core/Akka/Routing/RouterActor.cs
+++ b/src/core/Akka/Routing/RouterActor.cs
@@ -36,12 +36,12 @@ namespace Akka.Routing
             }
             else if (message is AddRoutee)
             {
-                var addRoutee = message as AddRoutee;
+                var addRoutee = (AddRoutee)message;
                 Cell.AddRoutee(addRoutee.Routee);
             }
             else if (message is RemoveRoutee)
             {
-                var removeRoutee = message as RemoveRoutee;
+                var removeRoutee = (RemoveRoutee)message;
                 Cell.RemoveRoutee(removeRoutee.Routee, true);
                 StopIfAllRouteesRemoved();
             }

--- a/src/core/Akka/Routing/RouterPoolActor.cs
+++ b/src/core/Akka/Routing/RouterPoolActor.cs
@@ -20,7 +20,7 @@ namespace Akka.Routing
             {
                 if (Cell.RouterConfig is Pool)
                 {
-                    return Cell.RouterConfig as Pool;
+                    return (Pool)Cell.RouterConfig;
                 }
                 else
                 {
@@ -54,7 +54,7 @@ namespace Akka.Routing
             }
             else if (message is AdjustPoolSize)
             {
-                var poolSize = message as AdjustPoolSize;
+                var poolSize = (AdjustPoolSize)message;
                 if (poolSize.Change > 0)
                 {
                     var newRoutees = Enumerable.Repeat(Pool.NewRoutee(Cell.RouteeProps, Context), poolSize.Change).ToArray();

--- a/src/examples/Cluster/Routing/Samples.Cluster.ConsistentHashRouting/BackendActor.cs
+++ b/src/examples/Cluster/Routing/Samples.Cluster.ConsistentHashRouting/BackendActor.cs
@@ -10,9 +10,9 @@ namespace Samples.Cluster.ConsistentHashRouting
 
         protected override void OnReceive(object message)
         {
-            if (message is FrontendCommand)
+            var command = message as FrontendCommand;
+            if (command != null)
             {
-                var command = message as FrontendCommand;
                 Console.WriteLine("Backend [{0}]: Received command {1} for job {2} from {3}", Cluster.SelfAddress, command.Message, command.JobId, Sender);
                 Sender.Tell(new CommandComplete());
             }

--- a/src/examples/Cluster/Routing/Samples.Cluster.ConsistentHashRouting/FrontendActor.cs
+++ b/src/examples/Cluster/Routing/Samples.Cluster.ConsistentHashRouting/FrontendActor.cs
@@ -51,7 +51,7 @@ namespace Samples.Cluster.ConsistentHashRouting
         {
             if (message is StartCommand)
             {
-                var sc = message as StartCommand;
+                var sc = (StartCommand)message;
                 BackendRouter.Tell(new FrontendCommand()
                 {
                     Message = string.Format("message {0}", jobCount++),

--- a/src/examples/Cluster/Samples.Cluster.Simple/SimpleClusterListener2.cs
+++ b/src/examples/Cluster/Samples.Cluster.Simple/SimpleClusterListener2.cs
@@ -29,12 +29,12 @@ namespace Samples.Cluster.Simple
         {
             if (message is ClusterEvent.CurrentClusterState)
             {
-                var state = (ClusterEvent.CurrentClusterState) message;
+                var state = (ClusterEvent.CurrentClusterState)message;
                 Log.Info("Current members: {0}", state.Members);
             }
             else if (message is ClusterEvent.MemberUp)
             {
-                var up = message as ClusterEvent.MemberUp;
+                var up = (ClusterEvent.MemberUp)message;
                 var mem = up;
                 Log.Info("Member is Up: {0}", mem.Member);
             }

--- a/src/examples/PersistenceExample/ExamplePersistentActor.cs
+++ b/src/examples/PersistenceExample/ExamplePersistentActor.cs
@@ -78,7 +78,7 @@ namespace PersistenceExample
         {
             ExampleState state;
             if (message is Event)
-                UpdateState(message as Event);
+                UpdateState((Event)message);
             else if (message is SnapshotOffer && (state = ((SnapshotOffer) message).Snapshot as ExampleState) != null)
                 State = state;
             else return false;
@@ -89,7 +89,7 @@ namespace PersistenceExample
         {
             if (message is Command)
             {
-                var cmd = message as Command;
+                var cmd = (Command)message;
                 Persist(new Event(cmd.Data + "-" + EventsCount), UpdateState);
             }
             else if (message == "snap")


### PR DESCRIPTION
Most of these are in the form of the following:

if (message is ClusterUserAction.JoinTo)
{
    var jt = message as ClusterUserAction.JoinTo;
    ...
}

Here message is being checked twice for being of type
ClusterUserAction.JoinTo

So instead I replaced the 'as' cast to a direct cast.

if (message is ClusterUserAction.JoinTo)
{
    var jt = (ClusterUserAction.JoinTo)message;
    ...
}

I would have done the more familiar 'as' cast/check for
null convention but most of these are part of a long
if/else chain that doesn't make sense to break apart.