### PR TITLE
#701 add serialization constructor to exceptions

### DIFF
--- a/src/core/Akka.Persistence/GuaranteedDelivery.cs
+++ b/src/core/Akka.Persistence/GuaranteedDelivery.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using Akka.Actor;
 using Akka.Actor.Internals;
 using Akka.Persistence.Serialization;
+using System.Runtime.Serialization;
 
 namespace Akka.Persistence
 {
@@ -105,6 +106,11 @@ namespace Akka.Persistence
     {
         public MaxUnconfirmedMessagesExceededException(string message, Exception cause = null)
             : base(message, cause)
+        {
+        }
+
+        protected MaxUnconfirmedMessagesExceededException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/core/Akka.Persistence/Journal/AsyncWriteProxy.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteProxy.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Akka.Actor;
+using System.Runtime.Serialization;
 
 namespace Akka.Persistence.Journal
 {
@@ -15,6 +16,11 @@ namespace Akka.Persistence.Journal
 
         public AsyncReplayTimeoutException(string msg)
             : base(msg)
+        {
+        }
+
+        protected AsyncReplayTimeoutException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/core/Akka.Remote.TestKit/Controller.cs
+++ b/src/core/Akka.Remote.TestKit/Controller.cs
@@ -4,6 +4,7 @@ using Akka.Actor;
 using Akka.Event;
 using Helios.Net;
 using Helios.Topology;
+using System.Runtime.Serialization;
 
 namespace Akka.Remote.TestKit
 {
@@ -61,6 +62,10 @@ namespace Akka.Remote.TestKit
         public class ClientDisconnectedException : AkkaException
         {
             public ClientDisconnectedException(string msg) : base(msg){}
+
+            protected ClientDisconnectedException(SerializationInfo info, StreamingContext context) : base(info, context)
+            {
+            }
         }
 
         public class GetNodes

--- a/src/core/Akka.Remote/AckedDelivery.cs
+++ b/src/core/Akka.Remote/AckedDelivery.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Security.Policy;
 using Akka.Actor;
+using System.Runtime.Serialization;
 
 namespace Akka.Remote
 {
@@ -219,6 +220,10 @@ namespace Akka.Remote
         {
         }
 
+        protected ResendBufferCapacityReachedException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
     }
 
     class ResendUnfulfillableException : AkkaException

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -140,6 +140,11 @@ namespace Akka.Remote
     internal class EndpointException : AkkaException
     {
         public EndpointException(string msg, Exception cause = null) : base(msg, cause) { }
+
+        protected EndpointException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
     }
 
     /// <summary>

--- a/src/core/Akka.Remote/RemoteTransport.cs
+++ b/src/core/Akka.Remote/RemoteTransport.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
+using System.Runtime.Serialization;
 
 namespace Akka.Remote
 {
@@ -97,6 +98,11 @@ namespace Akka.Remote
     {
         public RemoteTransportException(string message, Exception cause = null)
             : base(message, cause)
+        {
+        }
+
+        protected RemoteTransportException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
+++ b/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Akka.Actor;
 using Google.ProtocolBuffers;
+using System.Runtime.Serialization;
 
 namespace Akka.Remote.Transport
 {
@@ -11,6 +12,11 @@ namespace Akka.Remote.Transport
     internal class PduCodecException : AkkaException
     {
         public PduCodecException(string msg, Exception cause = null) : base(msg, cause) { }
+
+        protected PduCodecException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
     }
 
     /*

--- a/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
+++ b/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
@@ -8,6 +8,7 @@ using Akka.Util;
 using Google.ProtocolBuffers;
 using Akka.Util.Internal;
 using Akka.Event;
+using System.Runtime.Serialization;
 
 namespace Akka.Remote.Transport
 {
@@ -27,6 +28,11 @@ namespace Akka.Remote.Transport
     public class AkkaProtocolException : AkkaException
     {
         public AkkaProtocolException(string message, Exception cause = null) : base(message, cause) { }
+
+        protected AkkaProtocolException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
     }
 
     /// <summary>

--- a/src/core/Akka.Remote/Transport/FailureInjectorTransportAdapter.cs
+++ b/src/core/Akka.Remote/Transport/FailureInjectorTransportAdapter.cs
@@ -6,6 +6,7 @@ using Akka.Event;
 using Akka.Util;
 using Akka.Util.Internal;
 using Google.ProtocolBuffers;
+using System.Runtime.Serialization;
 
 namespace Akka.Remote.Transport
 {
@@ -28,6 +29,11 @@ namespace Akka.Remote.Transport
         public FailureInjectorException(string msg)
         {
             Msg = msg;
+        }
+
+        protected FailureInjectorException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
         }
 
         public string Msg { get; private set; }

--- a/src/core/Akka.Remote/Transport/Transport.cs
+++ b/src/core/Akka.Remote/Transport/Transport.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Google.ProtocolBuffers;
+using System.Runtime.Serialization;
 
 namespace Akka.Remote.Transport
 {
@@ -57,6 +58,11 @@ namespace Akka.Remote.Transport
     {
         public InvalidAssociationException(string message, Exception cause = null)
             : base(message, cause)
+        {
+        }
+
+        protected InvalidAssociationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/core/Akka/Actor/Exceptions.cs
+++ b/src/core/Akka/Actor/Exceptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace Akka.Actor
 {
@@ -23,6 +24,12 @@ namespace Akka.Actor
             : base(message, cause)
         {
         }
+
+        protected AkkaException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+
         protected Exception Cause { get { return InnerException; } }
     }
 
@@ -42,6 +49,11 @@ namespace Akka.Actor
         {
             //Intentionally left blank
         }
+
+        protected InvalidActorNameException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
     }
 
     /// <summary>
@@ -53,6 +65,11 @@ namespace Akka.Actor
             : base(message)
         {
             //Intentionally left blank
+        }
+
+        protected AskTimeoutException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
         }
     }
 
@@ -69,6 +86,11 @@ namespace Akka.Actor
         public ActorInitializationException(ActorRef actor, string message, Exception cause = null) : base(message, cause)
         {
             _actor = actor;
+        }
+
+        protected ActorInitializationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
         }
 
         public ActorRef Actor { get { return _actor; } }
@@ -90,6 +112,11 @@ namespace Akka.Actor
         public LoggerInitializationException(string message) : base(message) { }
 
         public LoggerInitializationException(string message, Exception cause = null) : base(message, cause) { }
+
+        protected LoggerInitializationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
     }
 
 
@@ -106,6 +133,11 @@ namespace Akka.Actor
         public ActorKilledException(string message) : base(message)
         {
         }
+
+        protected ActorKilledException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
     }
 
     /// <summary>
@@ -115,6 +147,11 @@ namespace Akka.Actor
     public class IllegalActorStateException : AkkaException
     {
         public IllegalActorStateException(string msg) : base(msg) { }
+
+        protected IllegalActorStateException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
     }
 
     /// <summary>
@@ -123,6 +160,11 @@ namespace Akka.Actor
     public class IllegalActorNameException : AkkaException
     {
         public IllegalActorNameException(string msg) : base(msg) { }
+
+        protected IllegalActorNameException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
     }
 
     /// <summary>
@@ -137,6 +179,11 @@ namespace Akka.Actor
             : base("Monitored actor [" + deadActor + "] terminated")
         {
             _deadActor = deadActor;
+        }
+
+        protected DeathPactException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
         }
 
         public ActorRef DeadActor
@@ -163,6 +210,11 @@ namespace Akka.Actor
             exception = cause;
             this.optionalMessage = optionalMessage;
         }
+
+        protected PreRestartException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
     }
 
     /// <summary>
@@ -188,6 +240,11 @@ namespace Akka.Actor
             _originalCause = originalCause;
         }
 
+        protected PostRestartException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+
         public Exception OriginalCause { get { return _originalCause; } }
     }
 
@@ -197,20 +254,31 @@ namespace Akka.Actor
     /// </summary>
     public class ActorNotFoundException : AkkaException
     {
+        public ActorNotFoundException() : base() { }
+        
+        protected ActorNotFoundException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
     }
 
     /// <summary>
     /// InvalidMessageException is thrown when an invalid message is sent to an Actor.
     /// Currently only <c>null</c> is an invalid message.
     /// </summary>
-    public class InvalidMessageException:AkkaException
+    public class InvalidMessageException : AkkaException
     {
         public InvalidMessageException() : this("Message is null")
         {
         }
 
         public InvalidMessageException(string message):base(message)
-        {            
+        {
+        }
+
+        protected InvalidMessageException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
         }
     }
 }

--- a/src/core/Akka/Actor/Stash/StashOverflowException.cs
+++ b/src/core/Akka/Actor/Stash/StashOverflowException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Serialization;
 
 namespace Akka.Actor
 {
@@ -8,5 +9,10 @@ namespace Akka.Actor
     public class StashOverflowException : AkkaException
     {
         public StashOverflowException(string message, Exception cause = null) : base(message, cause) { }
+
+        protected StashOverflowException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
     }
 }

--- a/src/core/Akka/Configuration/ConfigurationException.cs
+++ b/src/core/Akka/Configuration/ConfigurationException.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Akka.Actor;
+using System.Runtime.Serialization;
 
 namespace Akka.Configuration
 {
@@ -11,7 +12,11 @@ namespace Akka.Configuration
 
         public ConfigurationException(string message, Exception exception): base(message, exception)
         {
-            
+        }
+
+        protected ConfigurationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
         }
     }
 }

--- a/src/core/Akka/Pattern/IllegalStateException.cs
+++ b/src/core/Akka/Pattern/IllegalStateException.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Text;
 
 namespace Akka.Pattern
@@ -12,6 +13,11 @@ namespace Akka.Pattern
         public IllegalStateException(string message) : base(message)
         {
 
+        }
+
+        protected IllegalStateException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
         }
     }
 }


### PR DESCRIPTION
Hi, please review this pull request. 
Now exceptions derived from ```AkkaException``` have serialization constructor. This should resolve issue #701
 