### PR TITLE
close #619 (fixes FAKE NuGet publish)

### DIFF
--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -1010,7 +1010,6 @@ namespace Akka.Cluster
                         : Deadline.Now + _cluster.Settings.RetryUnsuccessfulJoinAfter;
 
                     Context.Become(m => TryingToJoin(m, address, joinDeadline));
-                    Self.Tell("testing"); //TODO: remove when done debugging
                     ClusterCore(address).Tell(new InternalClusterAction.Join(_cluster.SelfUniqueAddress, _cluster.SelfRoles));
                 }
             }


### PR DESCRIPTION
Fixed FAKE such that it passes arguments to NuGet.exe in the correct order now.

Also have a random fix that removes a debug statement I forgot to strip earlier when debugging my previous PR :\ 