### PR TITLE
Fixed the DequeWrapperMessageQueue so it correctly calls EnqueueFirst (#482)

### DIFF
--- a/src/core/Akka/Actor/Stash/Internal/AbstractStash.cs
+++ b/src/core/Akka/Actor/Stash/Internal/AbstractStash.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Akka.Dispatch;
+using Akka.Dispatch.MessageQueues;
 using Akka.Util.Internal;
 
 namespace Akka.Actor.Internal
@@ -23,7 +24,7 @@ namespace Akka.Actor.Internal
         protected AbstractStash(IActorContext context, int capacity = 100)
         {
             var actorCell = (ActorCell)context;
-            var mailbox = actorCell.Mailbox as DequeBasedMailbox;
+            var mailbox = actorCell.Mailbox as IDequeBasedMailbox;
             if(mailbox == null)
             {
                 string message = @"DequeBasedMailbox required, got: " + actorCell.Mailbox.GetType().Name + @"
@@ -41,8 +42,14 @@ An (unbounded) deque-based mailbox can be configured as follows:
             _capacity = capacity;
         }
 
-        private DequeBasedMailbox Mailbox { get { return (DequeBasedMailbox)_actorCell.Mailbox; } }
+        private IDequeBasedMailbox Mailbox { get { return (IDequeBasedMailbox)_actorCell.Mailbox; } }
 
+        /// <summary>
+        /// Stashes the current message in the actor's state.
+        /// </summary>
+        /// <exception cref="IllegalActorStateException">Thrown if we attempt to stash the same message more than once.</exception>
+        /// <exception cref="StashOverflowException">Thrown in the event that we're using a <see cref="BoundedMessageQueue"/> 
+        /// for the <see cref="IStash"/> and we've exceeded capacity.</exception>
         public void Stash()
         {
             var currMsg = _actorCell.CurrentMessage;
@@ -58,6 +65,9 @@ An (unbounded) deque-based mailbox can be configured as follows:
             else throw new StashOverflowException(string.Format("Couldn't enqueue message {0} to stash of {1}", currMsg, _actorCell.Self));
         }
 
+        /// <summary>
+        /// Unstash the most recently stashed message (top of the message stack.)
+        /// </summary>
         public void Unstash()
         {
             if(_theStash.Count > 0)
@@ -73,18 +83,25 @@ An (unbounded) deque-based mailbox can be configured as follows:
             }
         }
 
+        /// <summary>
+        /// Unstash all of the <see cref="Envelope"/>s in the Stash.
+        /// </summary>
         public void UnstashAll()
         {
             UnstashAll(envelope => true);
         }
 
+        /// <summary>
+        /// Unstash all of the <see cref="Envelope"/>s in the Stash.
+        /// </summary>
+        /// <param name="predicate">A predicate function to determine which messages to select.</param>
         public void UnstashAll(Func<Envelope, bool> predicate)
         {
             if(_theStash.Count > 0)
             {
                 try
                 {
-                    foreach(var item in _theStash.Where(predicate))
+                    foreach(var item in _theStash.Reverse().Where(predicate))
                     {
                         EnqueueFirst(item);
                     }
@@ -96,6 +113,11 @@ An (unbounded) deque-based mailbox can be configured as follows:
             }
         }
      
+        /// <summary>
+        /// Eliminates the contents of the <see cref="IStash"/>, and returns
+        /// the previous contents of the messages.
+        /// </summary>
+        /// <returns>Previously stashed messages.</returns>
         public IEnumerable<Envelope> ClearStash()
         {
             if(_theStash.Count == 0)

--- a/src/core/Akka/Dispatch/BoundedDequeBasedMailbox.cs
+++ b/src/core/Akka/Dispatch/BoundedDequeBasedMailbox.cs
@@ -5,7 +5,7 @@ namespace Akka.Dispatch
     /// <summary>
     /// Mailbox with support for EnqueueFirst
     /// </summary>
-    public class BoundedDequeBasedMailbox : Mailbox<BoundedMessageQueue, BoundedDequeMessageQueue>, DequeBasedMailbox
+    public class BoundedDequeBasedMailbox : Mailbox<BoundedMessageQueue, BoundedDequeMessageQueue>, IDequeBasedMailbox
     {
         protected override BoundedMessageQueue CreateSystemMessagesQueue()
         {

--- a/src/core/Akka/Dispatch/DequeBasedMailbox.cs
+++ b/src/core/Akka/Dispatch/DequeBasedMailbox.cs
@@ -1,11 +1,26 @@
 ﻿using Akka.Actor;
+using Akka.Dispatch.MessageQueues;
 
 namespace Akka.Dispatch
 {
-    public interface DequeBasedMailbox
+    /// <summary>
+    /// Used for <see cref="MessageQueue"/> instances that support double-ended queues.
+    /// </summary>
+    public interface IDequeBasedMailbox
     {
+        /// <summary>
+        /// Enqueues an <see cref="Envelope"/> to the front of
+        /// the <see cref="MessageQueue"/>. Typically called during
+        /// a <see cref="IStash.Unstash"/> or <see cref="IStash.UnstashAll()"/>operation.
+        /// </summary>
+        /// <param name="envelope">The message that will be prepended to the queue.</param>
         void EnqueueFirst(Envelope envelope);
 
+        /// <summary>
+        /// Posts a message to the back of the <see cref="MessageQueue"/>
+        /// </summary>
+        /// <param name="receiver">The intended recipient of the message.</param>
+        /// <param name="envelope">The message that will be appended to the queue.</param>
         void Post(ActorRef receiver, Envelope envelope);
     }
 }

--- a/src/core/Akka/Dispatch/MessageQueues/DequeWrapperMessageQueue.cs
+++ b/src/core/Akka/Dispatch/MessageQueues/DequeWrapperMessageQueue.cs
@@ -3,44 +3,77 @@ using Akka.Actor;
 
 namespace Akka.Dispatch.MessageQueues
 {
+    /// <summary>
+    /// Message queue for supporting <see cref="DequeBasedMessageQueueSemantics"/> within <see cref="Mailbox"/> instances.
+    /// 
+    /// Uses a <see cref="Stack{Envelope}"/> internally - each individual <see cref="EnqueueFirst"/>
+    /// </summary>
     public class DequeWrapperMessageQueue : MessageQueue, DequeBasedMessageQueueSemantics
     {
-        private readonly Queue<Envelope> _prependBuffer = new Queue<Envelope>();
+        private readonly Stack<Envelope> _prependBuffer = new Stack<Envelope>();
         private readonly MessageQueue _messageQueue;
+        /// <summary>
+        /// Takes another <see cref="MessageQueue"/> as an argument - wraps <see cref="messageQueue"/>
+        /// in order to provide it with prepend (<see cref="EnqueueFirst"/>) semantics.
+        /// </summary>
+        /// <param name="messageQueue"></param>
         public DequeWrapperMessageQueue(MessageQueue messageQueue)
         {
             _messageQueue = messageQueue;
         }
 
+        /// <summary>
+        /// Returns true if there are any messages inside the queue.
+        /// </summary>
         public bool HasMessages
         {
             get { return Count > 0; }
         }
 
+        /// <summary>
+        /// Returns the number of messages in both the internal message queue
+        /// and the prepend buffer.
+        /// </summary>
         public int Count
         {
             get { return _messageQueue.Count + _prependBuffer.Count; }
         }
 
+        /// <summary>
+        /// Enqueue a message to the back of the <see cref="MessageQueue"/>
+        /// </summary>
+        /// <param name="envelope"></param>
         public void Enqueue(Envelope envelope)
         {
             _messageQueue.Enqueue(envelope);
         }
 
+        /// <summary>
+        /// Attempt to dequeue a message from the front of the prepend buffer.
+        /// 
+        /// If the prepend buffer is empty, dequeue a message from the normal
+        /// <see cref="MessageQueue"/> wrapped but this wrapper.
+        /// </summary>
+        /// <param name="envelope">The message to return, if any</param>
+        /// <returns><c>true</c> if a message was available, <c>false</c> otherwise.</returns>
         public bool TryDequeue(out Envelope envelope)
         {
             if (_prependBuffer.Count > 0)
             {
-                envelope = _prependBuffer.Dequeue();
+                envelope = _prependBuffer.Pop();
                 return true;
             }
 
             return _messageQueue.TryDequeue(out envelope);
         }
 
+        /// <summary>
+        /// Add a message to the front of the queue via the prepend buffer.
+        /// </summary>
+        /// <param name="envelope">The message we wish to append to the front of the queue.</param>
         public void EnqueueFirst(Envelope envelope)
         {
-            _prependBuffer.Enqueue(envelope);
+            _prependBuffer.Push(envelope);
         }
     }
 }

--- a/src/core/Akka/Dispatch/UnboundedDequeBasedMailbox.cs
+++ b/src/core/Akka/Dispatch/UnboundedDequeBasedMailbox.cs
@@ -1,17 +1,27 @@
-﻿using Akka.Dispatch.MessageQueues;
+﻿using Akka.Actor;
+using Akka.Dispatch.MessageQueues;
 
 namespace Akka.Dispatch
 {
     /// <summary>
-    /// Mailbox with support for EnqueueFirst
+    /// Mailbox with support for EnqueueFirst. Used primarily for <see cref="IStash"/> support.
     /// </summary>
-    public class UnboundedDequeBasedMailbox : Mailbox<UnboundedMessageQueue, UnboundedDequeMessageQueue>, DequeBasedMailbox
+    public class UnboundedDequeBasedMailbox : Mailbox<UnboundedMessageQueue, UnboundedDequeMessageQueue>, IDequeBasedMailbox
     {
+        /// <summary>
+        /// Intended for system messages, creates an <see cref="UnboundedMessageQueue"/> to be used 
+        /// inside the <see cref="Mailbox"/>.
+        /// </summary>
         protected override UnboundedMessageQueue CreateSystemMessagesQueue()
         {
             return new UnboundedMessageQueue();
         }
 
+        /// <summary>
+        /// Used for user-defined messages within a <see cref="Mailbox"/>; creates a new <see cref="UnboundedDequeMessageQueue"/>
+        /// which means that any actor with a <see cref="IStash"/> can unstash messages to the front of the queue.
+        /// </summary>
+        /// <returns></returns>
         protected override UnboundedDequeMessageQueue CreateUserMessagesQueue()
         {
             return new UnboundedDequeMessageQueue();


### PR DESCRIPTION
Fixed the DequeWrapperMessageQueue so it correctly calls EnqueueFirst per issue #482

CC @HCanber @rogeralsing could you take a look at the changes I made to `AbstractStash` and `DequeWrapperMessageQueue` and verify that the behavior is correct?

I reverse the contents of the `Stack` when we call `UnstashAll` and as a result none of the Remoting or Clustering tests were affected. Ran the MultiNodeTest suite on my local machine and got the same results as  before, so I think we're set.