### PR TITLE
Integer, Float and Decimal serialization fix

### DIFF
--- a/src/core/Akka.Tests/Serialization/SerializationSpec.cs
+++ b/src/core/Akka.Tests/Serialization/SerializationSpec.cs
@@ -14,6 +14,10 @@ namespace Akka.Tests.Serialization
     
     public class SerializationSpec : AkkaSpec
     {
+        public class UntypedContainerMessage
+        {
+            public object Contents { get; set; }
+        }
         public class ContainerMessage<T>
         {
             public ContainerMessage(T contents)
@@ -107,6 +111,41 @@ namespace Akka.Tests.Serialization
         public class SomeMessage
         {
             public ActorRef ActorRef { get; set; }
+        }
+
+        [Fact]
+        public void CanSerializeDecimal()
+        {
+            var message = 123.456m;
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeLong()
+        {
+            var message = 123l;
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeDouble()
+        {
+            var message = 123.456d;
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeInt()
+        {
+            var message = 123;
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeFloat()
+        {
+            var message = 123.456f;
+            AssertEqual(message);
         }
 
         [Fact]

--- a/src/core/Akka.Tests/Serialization/SerializationSpec.cs
+++ b/src/core/Akka.Tests/Serialization/SerializationSpec.cs
@@ -149,6 +149,13 @@ namespace Akka.Tests.Serialization
         }
 
         [Fact]
+        public void CanSerializeAddressMessage()
+        {
+            var message = new UntypedContainerMessage { Contents = new Address("abc","def") };
+            AssertEqual(message);
+        }
+
+        [Fact]
         public void CanSerializeDecimal()
         {
             var message = 123.456m;

--- a/src/core/Akka.Tests/Serialization/SerializationSpec.cs
+++ b/src/core/Akka.Tests/Serialization/SerializationSpec.cs
@@ -14,9 +14,44 @@ namespace Akka.Tests.Serialization
     
     public class SerializationSpec : AkkaSpec
     {
-        public class UntypedContainerMessage
+        public class UntypedContainerMessage : IEquatable<UntypedContainerMessage>
         {
+            public bool Equals(UntypedContainerMessage other)
+            {
+                if (ReferenceEquals(null, other)) return false;
+                if (ReferenceEquals(this, other)) return true;
+                return Equals(Contents, other.Contents);
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(null, obj)) return false;
+                if (ReferenceEquals(this, obj)) return true;
+                if (obj.GetType() != this.GetType()) return false;
+                return Equals((UntypedContainerMessage) obj);
+            }
+
+            public override int GetHashCode()
+            {
+                return (Contents != null ? Contents.GetHashCode() : 0);
+            }
+
+            public static bool operator ==(UntypedContainerMessage left, UntypedContainerMessage right)
+            {
+                return Equals(left, right);
+            }
+
+            public static bool operator !=(UntypedContainerMessage left, UntypedContainerMessage right)
+            {
+                return !Equals(left, right);
+            }
+
             public object Contents { get; set; }
+
+            public override string ToString()
+            {
+                return string.Format("<UntypedContainerMessage {0}>", Contents);
+            }
         }
         public class ContainerMessage<T>
         {
@@ -117,6 +152,41 @@ namespace Akka.Tests.Serialization
         public void CanSerializeDecimal()
         {
             var message = 123.456m;
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeDecimalMessage()
+        {
+            var message = new UntypedContainerMessage { Contents = 123.456m };
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeFloatMessage()
+        {
+            var message = new UntypedContainerMessage {Contents = 123.456f};
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeLongMessage()
+        {
+            var message = new UntypedContainerMessage { Contents = 123L };
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeDoubleMessage()
+        {
+            var message = new UntypedContainerMessage { Contents = 123.456d };
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeIntMessage()
+        {
+            var message = new UntypedContainerMessage { Contents = 123};
             AssertEqual(message);
         }
 
@@ -267,6 +337,7 @@ namespace Akka.Tests.Serialization
             var serialized = serializer.ToBinary(message);
             var deserialized = (T)serializer.FromBinary(serialized, typeof(T));
 
+       //     Assert.True(message.Equals(deserialized));
             Assert.Equal(message, deserialized);
         }
 

--- a/src/core/Akka/Serialization/NewtonSoftJsonSerializer.cs
+++ b/src/core/Akka/Serialization/NewtonSoftJsonSerializer.cs
@@ -26,7 +26,7 @@ namespace Akka.Serialization
             _settings = new JsonSerializerSettings
             {
                 PreserveReferencesHandling = PreserveReferencesHandling.Objects,
-                Converters = new List<JsonConverter> {new SurrogateConverter(system), new PrimitiveTypeConverter()},
+                Converters = new List<JsonConverter> {new PrimitiveTypeConverter(),new SurrogateConverter(system)},
                 NullValueHandling = NullValueHandling.Ignore,
                 DefaultValueHandling = DefaultValueHandling.Ignore,
                 MissingMemberHandling = MissingMemberHandling.Ignore,
@@ -135,6 +135,11 @@ namespace Akka.Serialization
             {
                 var surrogate = serializer.Deserialize<PrimitiveSurrogate>(reader);
                 return surrogate.GetValue();
+            }
+
+            public override bool CanRead
+            {
+                get { return true; }
             }
 
             public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/core/Akka/Util/ISurrogate.cs
+++ b/src/core/Akka/Util/ISurrogate.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace Akka.Util
 {
@@ -14,7 +17,44 @@ namespace Akka.Util
 
     public interface ISurrogated
     {
-
         ISurrogate ToSurrogate(ActorSystem system);
     }
+
+    public  class PrimitiveSurrogate
+    {
+        public string V { get; set; }
+        public long T { get; set; }
+
+        public PrimitiveSurrogate()
+        {
+            
+        } 
+
+        public PrimitiveSurrogate(int value)
+        {
+            V = value.ToString(NumberFormatInfo.InvariantInfo);
+            T = 1L;
+        }
+        public PrimitiveSurrogate(float value)
+        {
+            V = value.ToString(NumberFormatInfo.InvariantInfo);
+            T = 2L;
+        }
+        public PrimitiveSurrogate(decimal value)
+        {
+            V = value.ToString(NumberFormatInfo.InvariantInfo);
+            T = 3L;
+        }
+        public object GetValue()
+        {
+            if (T == 1L)
+                return int.Parse(V, NumberFormatInfo.InvariantInfo);
+            if (T == 2L)
+                return float.Parse(V, NumberFormatInfo.InvariantInfo);
+            if (T == 3L)
+                return decimal.Parse(V, NumberFormatInfo.InvariantInfo);
+
+            throw new NotSupportedException();
+        }
+    }  
 }

--- a/src/core/Akka/Util/ISurrogate.cs
+++ b/src/core/Akka/Util/ISurrogate.cs
@@ -56,5 +56,10 @@ namespace Akka.Util
 
             throw new NotSupportedException();
         }
+
+        public override string ToString()
+        {
+            return string.Format("<PrimitiveSurrogate {0}>", GetValue());
+        }
     }  
 }


### PR DESCRIPTION
This PR fixes a few issues with serialization:

Integers, Floats and Decimals serialized into fields of type Object, now works as expected.
This also applies to other surrogated types that are contained within Object containers.