### PR TITLE
added all TestKit projects to SandCastle

### DIFF
--- a/documentation/akkadoc.shfbproj
+++ b/documentation/akkadoc.shfbproj
@@ -80,6 +80,12 @@
 <DocumentationSource sourceFile="..\src\core\Akka.Remote.TestKit\bin\Release\Akka.Remote.TestKit.dll" />
 <DocumentationSource sourceFile="..\src\core\Akka.Remote.TestKit\bin\Release\Akka.Remote.TestKit.xml" />
 <DocumentationSource sourceFile="..\src\core\Akka.Remote\bin\Release\Akka.Remote.xml" />
+<DocumentationSource sourceFile="..\src\core\Akka.TestKit\bin\Release\Akka.TestKit.dll" />
+<DocumentationSource sourceFile="..\src\contrib\testkits\Akka.TestKit.VsTest\bin\Release\Akka.TestKit.VsTest.dll" />
+<DocumentationSource sourceFile="..\src\contrib\testkits\Akka.TestKit.VsTest\bin\Release\Akka.TestKit.VsTest.xml" />
+<DocumentationSource sourceFile="..\src\core\Akka.TestKit\bin\Release\Akka.TestKit.xml" />
+<DocumentationSource sourceFile="..\src\contrib\testkits\Akka.TestKit.Xunit\bin\Release\Akka.TestKit.Xunit.dll" />
+<DocumentationSource sourceFile="..\src\contrib\testkits\Akka.TestKit.Xunit\bin\Release\Akka.TestKit.Xunit.xml" />
 <DocumentationSource sourceFile="..\src\core\Akka\bin\Release\Akka.xml" /></DocumentationSources>
   </PropertyGroup>
   <!-- There are no properties for these groups.  AnyCPU needs to appear in order for Visual Studio to perform


### PR DESCRIPTION
Going to close this one pretty much right away - @sean-gilliam fixed the issue with SandCastle and Akka.TestKit. This just adds those binaries to the SandCastle build file.