### PR TITLE
Akka persistence bugfixes

### DIFF
--- a/src/core/Akka.Persistence.TestKit.Tests/Cleanup.cs
+++ b/src/core/Akka.Persistence.TestKit.Tests/Cleanup.cs
@@ -5,27 +5,19 @@ namespace Akka.Persistence.TestKit.Tests
 {
     public static class Cleanup
     {
-        public static void CreateStorageLocations(this ActorSystem system, params string[] config)
+        public static void CreateStorageLocations(this ActorSystem system, string path)
         {
-            foreach (var locationConfig in config)
+            if (!Directory.Exists(path))
             {
-                var path = system.Settings.Config.GetString(locationConfig);
-                if (!Directory.Exists(path))
-                {
-                    Directory.CreateDirectory(path);
-                }
+                Directory.CreateDirectory(path);
             }
         }
 
-        public static void DeleteStorageLocations(this ActorSystem system, params string[] config)
+        public static void DeleteStorageLocations(this ActorSystem system, string path)
         {
-            foreach (var locationConfig in config)
+            if (Directory.Exists(path))
             {
-                var path = system.Settings.Config.GetString(locationConfig);
-                if (Directory.Exists(path))
-                {
-                    Directory.Delete(path, true);
-                }
+                Directory.Delete(path, true);
             }
         }
     }

--- a/src/core/Akka.Persistence.TestKit.Tests/LocalSnapshotStoreSpec.cs
+++ b/src/core/Akka.Persistence.TestKit.Tests/LocalSnapshotStoreSpec.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Akka.Configuration;
 using Akka.Persistence.TestKit.Snapshot;
 
@@ -6,17 +7,24 @@ namespace Akka.Persistence.TestKit.Tests
 {
     public class LocalSnapshotStoreSpec : SnapshotStoreSpec
     {
+        private readonly string _path;
         public LocalSnapshotStoreSpec() 
             : base(ConfigurationFactory.ParseString(
                 @"akka.test.timefactor = 3
                   akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.local""
-                  akka.persistence.snapshot-store.local.dir = ""target/snapshots"""), 
+                  akka.persistence.snapshot-store.local.dir = ""target/snapshots-" + Guid.NewGuid() + @""""), 
             "LocalSnapshotStoreSpec")
         {
-            Sys.DeleteStorageLocations("akka.persistence.snapshot-store.local.dir");
-            Sys.CreateStorageLocations("akka.persistence.snapshot-store.local.dir");
+            _path = Sys.Settings.Config.GetString("akka.persistence.snapshot-store.local.dir");
+            Sys.CreateStorageLocations(_path);
+
             Metadata = WriteSnapshots().ToList();
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            Sys.DeleteStorageLocations(_path);
+        }
     }
 }

--- a/src/core/Akka.Persistence.TestKit/Journal/JournalSpec.cs
+++ b/src/core/Akka.Persistence.TestKit/Journal/JournalSpec.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
@@ -11,18 +13,42 @@ namespace Akka.Persistence.TestKit.Journal
         protected static readonly Config Config =
             ConfigurationFactory.ParseString("akka.persistence.publish-plugin-commands = on");
 
+        private static readonly string _specConfigTemplate = @"
+            akka.persistence {{
+                publish-plugin-commands = on
+                journal {{
+                    plugin = ""akka.persistence.journal.testspec""
+                    testspec {{
+                        class = ""{0}""
+                        plugin-dispatcher = ""akka.actor.default-dispatcher""
+                    }}
+                }}
+            }}
+        ";
+
         private readonly TestProbe _senderProbe;
         private readonly TestProbe _receiverProbe;
 
         protected JournalSpec(Config config = null, string actorSystemName = null, string testActorName = null)
-            : base(config ?? Config, actorSystemName ?? "JournalSpec", testActorName)
+            : base(FromConfig(config).WithFallback(Config), actorSystemName ?? "JournalSpec", testActorName)
         {
             _senderProbe = CreateTestProbe();
             _receiverProbe = CreateTestProbe();
             WriteMessages(1, 5, Pid, _senderProbe.Ref);
         }
 
+        protected JournalSpec(Type journalType, string actorSystemName = null)
+            : base(ConfigFromTemplate(journalType), actorSystemName)
+        {
+        }
+
         protected ActorRef Journal { get { return Extension.JournalFor(null); } }
+
+        private static Config ConfigFromTemplate(Type journalType)
+        {
+            var config = string.Format(_specConfigTemplate, journalType.AssemblyQualifiedName);
+            return ConfigurationFactory.ParseString(config);
+        }
 
         protected bool IsReplayedMessage(ReplayedMessage message, long seqNr, bool isDeleted = false)
         {

--- a/src/core/Akka.Persistence.TestKit/Snapshot/SnapshotStoreSpec.cs
+++ b/src/core/Akka.Persistence.TestKit/Snapshot/SnapshotStoreSpec.cs
@@ -16,6 +16,15 @@ namespace Akka.Persistence.TestKit.Snapshot
         protected static readonly Config Config =
             ConfigurationFactory.ParseString("akka.persistence.publish-plugin-commands = on");
 
+        private static readonly string _specConfigTemplate = @"
+            akka.persistence.snapshot-store {
+                plugin = ""akka.persistence.snapshot-store.my""
+                my {
+                    class = ""TestPersistencePlugin.MySnapshotStore, TestPersistencePlugin""
+                    plugin-dispatcher = ""akka.persistence.dispatchers.default-plugin-dispatcher""
+                }
+            }";
+
         private readonly TestProbe _senderProbe;
         protected List<SnapshotMetadata> Metadata;
         
@@ -25,7 +34,17 @@ namespace Akka.Persistence.TestKit.Snapshot
             _senderProbe = CreateTestProbe();
         }
 
+        protected SnapshotStoreSpec(Type snapshotStoreType, string actorSystemName = null)
+            : base(ConfigFromTemplate(snapshotStoreType), actorSystemName)
+        {
+        }
+
         protected ActorRef SnapshotStore { get { return Extension.SnapshotStoreFor(null); } }
+
+        private static Config ConfigFromTemplate(Type snapshotStoreType)
+        {
+            return ConfigurationFactory.ParseString(string.Format(_specConfigTemplate, snapshotStoreType.FullName));
+        }
 
         protected IEnumerable<SnapshotMetadata> WriteSnapshots()
         {

--- a/src/core/Akka.Persistence.Tests/GuaranteedDeliveryCrashSpec.cs
+++ b/src/core/Akka.Persistence.Tests/GuaranteedDeliveryCrashSpec.cs
@@ -13,12 +13,10 @@ namespace Akka.Persistence.Tests
 
         internal class StoppingStrategySupervisor : ActorBase
         {
-            private readonly ActorRef _testProbe;
             private readonly ActorRef _crashingActor;
 
             public StoppingStrategySupervisor(ActorRef testProbe)
             {
-                _testProbe = testProbe;
                 _crashingActor = Context.ActorOf(Props.Create(() => new CrashingActor(testProbe)), "CrashingActor");
             }
 
@@ -116,7 +114,7 @@ namespace Akka.Persistence.Tests
         {
         }
 
-        [Fact(Skip = "FIXME: random failures")]
+        [Fact(Skip = "FIXME")]
         public void GuaranteedDelivery_should_not_send_when_actor_crashes()
         {
             var testProbe = CreateTestProbe();

--- a/src/core/Akka.Persistence.Tests/GuaranteedDeliverySpec.cs
+++ b/src/core/Akka.Persistence.Tests/GuaranteedDeliverySpec.cs
@@ -17,22 +17,31 @@ namespace Akka.Persistence.Tests
         {
             private readonly ActorRef _testActor;
             private readonly string _name;
+            private readonly TimeSpan _redeliverInterval;
+            private readonly int _warn;
+            private readonly int _redeliveryBurstLimit;
             private readonly bool _isAsync;
-            private readonly IDictionary<string, string> _destinations;
+            private readonly IDictionary<string, ActorPath> _destinations;
             private readonly LoggingAdapter _log;
             private ActorRef _lastSnapshotAskedForBy;
 
-            public Sender(ActorRef testActor, string name, TimeSpan redeliverInterval, int warn, bool isAsync, IDictionary<string, string> destinations)
+            public Sender(ActorRef testActor, string name, TimeSpan redeliverInterval, int warn, int redeliveryBurstLimit, bool isAsync, IDictionary<string, ActorPath> destinations)
                 : base()
             {
                 _testActor = testActor;
                 _name = name;
+                _redeliverInterval = redeliverInterval;
+                _warn = warn;
+                _redeliveryBurstLimit = redeliveryBurstLimit;
                 _isAsync = isAsync;
                 _destinations = destinations;
                 _log = Context.GetLogger();
             }
 
             public override string PersistenceId { get { return _name; } }
+            public override TimeSpan RedeliverInterval { get { return _redeliverInterval; } }
+            public override int UnconfirmedDeliveryAttemptsToWarn { get { return _warn; } }
+            public override int RedeliveryBurstLimit { get { return _redeliveryBurstLimit; } }
 
             protected override bool ReceiveRecover(object message)
             {
@@ -294,8 +303,8 @@ namespace Akka.Persistence.Tests
         public void GuaranteedDelivery_must_deliver_messages_in_order_when_nothing_is_lost()
         {
             var probe = CreateTestProbe();
-            var destinations = new Dictionary<string, string> { { "A", Sys.ActorOf(Props.Create(() => new Destination(probe.Ref))).Path.ToString() } };
-            var sender = Sys.ActorOf(Props.Create(() => new Sender(TestActor, Name, TimeSpan.FromMilliseconds(500), 5, false, destinations)), Name);
+            var destinations = new Dictionary<string, ActorPath> { { "A", Sys.ActorOf(Props.Create(() => new Destination(probe.Ref))).Path } };
+            var sender = Sys.ActorOf(Props.Create(() => new Sender(TestActor, Name, TimeSpan.FromMilliseconds(500), 5, 1000, false, destinations)), Name);
 
             sender.Tell(new Req("a"));
             ExpectMsg(ReqAck.Instance);
@@ -308,8 +317,8 @@ namespace Akka.Persistence.Tests
         {
             var probe = CreateTestProbe();
             var dest = Sys.ActorOf(Props.Create(() => new Destination(probe.Ref)));
-            var destinations = new Dictionary<string, string> { { "A", Sys.ActorOf(Props.Create(() => new Unreliable(3, dest))).Path.ToString() } };
-            var sender = Sys.ActorOf(Props.Create(() => new Sender(TestActor, Name, TimeSpan.FromMilliseconds(500), 5, false, destinations)), Name);
+            var destinations = new Dictionary<string, ActorPath> { { "A", Sys.ActorOf(Props.Create(() => new Unreliable(3, dest))).Path } };
+            var sender = Sys.ActorOf(Props.Create(() => new Sender(TestActor, Name, TimeSpan.FromMilliseconds(500), 5, 1000, false, destinations)), Name);
 
             sender.Tell(new Req("a-1"));
             ExpectMsg(ReqAck.Instance);
@@ -335,8 +344,8 @@ namespace Akka.Persistence.Tests
         {
             var probe = CreateTestProbe();
             var dest = Sys.ActorOf(Props.Create(() => new Destination(probe.Ref)));
-            var destinations = new Dictionary<string, string> { { "A", Sys.ActorOf(Props.Create(() => new Unreliable(3, dest))).Path.ToString() } };
-            var sender = Sys.ActorOf(Props.Create(() => new Sender(TestActor, Name, TimeSpan.FromMilliseconds(500), 5, false, destinations)), Name);
+            var destinations = new Dictionary<string, ActorPath> { { "A", Sys.ActorOf(Props.Create(() => new Unreliable(3, dest))).Path } };
+            var sender = Sys.ActorOf(Props.Create(() => new Sender(TestActor, Name, TimeSpan.FromMilliseconds(500), 5, 1000, false, destinations)), Name);
 
             sender.Tell(new Req("a-1"));
             ExpectMsg(ReqAck.Instance);
@@ -369,8 +378,8 @@ namespace Akka.Persistence.Tests
         {
             var probe = CreateTestProbe();
             var dest = Sys.ActorOf(Props.Create(() => new Destination(probe.Ref)));
-            var destinations = new Dictionary<string, string> { { "A", Sys.ActorOf(Props.Create(() => new Unreliable(2, dest))).Path.ToString() } };
-            var sender = Sys.ActorOf(Props.Create(() => new Sender(TestActor, Name, TimeSpan.FromMilliseconds(500), 5, false, destinations)), Name);
+            var destinations = new Dictionary<string, ActorPath> { { "A", Sys.ActorOf(Props.Create(() => new Unreliable(2, dest))).Path } };
+            var sender = Sys.ActorOf(Props.Create(() => new Sender(TestActor, Name, TimeSpan.FromMilliseconds(500), 5, 1000, false, destinations)), Name);
 
             sender.Tell(new Req("a-1"));
             ExpectMsg(ReqAck.Instance);
@@ -403,13 +412,13 @@ namespace Akka.Persistence.Tests
             probe.ExpectNoMsg(TimeSpan.FromSeconds(1));
         }
 
-        [Fact(Skip = "FIXME")]
+        [Fact]
         public void GuaranteedDelivery_must_restore_state_from_snapshot()
         {
             var probe = CreateTestProbe();
             var dest = Sys.ActorOf(Props.Create(() => new Destination(probe.Ref)));
-            var destinations = new Dictionary<string, string> { { "A", Sys.ActorOf(Props.Create(() => new Unreliable(3, dest))).Path.ToString() } };
-            var sender = Sys.ActorOf(Props.Create(() => new Sender(TestActor, Name, TimeSpan.FromMilliseconds(500), 5, false, destinations)), Name);
+            var destinations = new Dictionary<string, ActorPath> { { "A", Sys.ActorOf(Props.Create(() => new Unreliable(3, dest))).Path } };
+            var sender = Sys.ActorOf(Props.Create(() => new Sender(TestActor, Name, TimeSpan.FromMilliseconds(500), 5, 1000, false, destinations)), Name);
 
             sender.Tell(new Req("a-1"));
             ExpectMsg(ReqAck.Instance);
@@ -428,7 +437,6 @@ namespace Akka.Persistence.Tests
 
             probe.ExpectMsg<Action>(a => a.Id == 4 && a.Payload == "a-4");
 
-            //FIXME: must have serializable ActorPath to work (github issue: #553)
             // after snapshot succeed
             ExpectMsg<SaveSnapshotSuccess>();
             // trigger restart
@@ -443,14 +451,14 @@ namespace Akka.Persistence.Tests
             probe.ExpectNoMsg(TimeSpan.FromSeconds(1));
         }
 
-        [Fact(Skip = "FIXME")]
+        [Fact]
         public void GuaranteedDelivery_must_warn_about_unconfirmed_messages()
         {
             var probeA = CreateTestProbe();
             var probeB = CreateTestProbe();
 
-            var destinations = new Dictionary<string, string> { { "A", probeA.Ref.Path.ToString() }, { "B", probeB.Ref.Path.ToString() } };
-            var sender = Sys.ActorOf(Props.Create(() => new Sender(TestActor, Name, TimeSpan.FromMilliseconds(500), 3, false, destinations)), Name);
+            var destinations = new Dictionary<string, ActorPath> { { "A", probeA.Ref.Path }, { "B", probeB.Ref.Path } };
+            var sender = Sys.ActorOf(Props.Create(() => new Sender(TestActor, Name, TimeSpan.FromMilliseconds(500), 3, 1000, false, destinations)), Name);
 
             sender.Tell(new Req("a-1"));
             sender.Tell(new Req("b-1"));
@@ -463,8 +471,8 @@ namespace Akka.Persistence.Tests
                 x is UnconfirmedWarning ? ((UnconfirmedWarning)x).UnconfirmedDeliveries : Enumerable.Empty<UnconfirmedDelivery>())
                 .SelectMany(e => e).ToArray();
 
-            var resultDestinations = unconfirmed.Select(x => x.Destination.ToString()).Distinct().ToArray();
-            resultDestinations.ShouldOnlyContainInOrder(probeA.Ref.Path.ToString(), probeB.Ref.Path.ToString());
+            var resultDestinations = unconfirmed.Select(x => x.Destination).Distinct().ToArray();
+            resultDestinations.ShouldOnlyContainInOrder(probeA.Ref.Path, probeB.Ref.Path);
             var resultMessages = unconfirmed.Select(x => x.Message).Distinct().ToArray();
             resultMessages.ShouldOnlyContainInOrder(new Action(1, "a-1"), new Action(2, "b-1"), new Action(3, "b-2"));
 
@@ -480,13 +488,13 @@ namespace Akka.Persistence.Tests
             var destA = Sys.ActorOf(Props.Create(() => new Destination(probeA.Ref)), "destination-a");
             var destB = Sys.ActorOf(Props.Create(() => new Destination(probeB.Ref)), "destination-b");
             var destC = Sys.ActorOf(Props.Create(() => new Destination(probeC.Ref)), "destination-c");
-            var destinations = new Dictionary<string, string>
+            var destinations = new Dictionary<string, ActorPath>
             {
-                { "A", Sys.ActorOf(Props.Create(() => new Unreliable(2, destA)), "unreliable-a").Path.ToString() },
-                { "B", Sys.ActorOf(Props.Create(() => new Unreliable(5, destB)), "unreliable-b").Path.ToString() },
-                { "C", Sys.ActorOf(Props.Create(() => new Unreliable(3, destC)), "unreliable-c").Path.ToString() }
+                { "A", Sys.ActorOf(Props.Create(() => new Unreliable(2, destA)), "unreliable-a").Path },
+                { "B", Sys.ActorOf(Props.Create(() => new Unreliable(5, destB)), "unreliable-b").Path },
+                { "C", Sys.ActorOf(Props.Create(() => new Unreliable(3, destC)), "unreliable-c").Path }
             };
-            var sender = Sys.ActorOf(Props.Create(() => new Sender(TestActor, Name, TimeSpan.FromMilliseconds(500), 3, false, destinations)), Name);
+            var sender = Sys.ActorOf(Props.Create(() => new Sender(TestActor, Name, TimeSpan.FromMilliseconds(1000), 5, 1000, true, destinations)), Name);
 
             const int n = 100;
             var a = new string[n];
@@ -500,20 +508,20 @@ namespace Akka.Persistence.Tests
             }
             for (int i = 0; i < n; i++)
             {
-                var x = "a-" + i;
+                var x = "b-" + i;
                 b[i] = x;
-                sender.Tell(new Req("b-" + i));
+                sender.Tell(new Req(x));
             }
             for (int i = 0; i < n; i++)
             {
-                var x = "a-" + i;
+                var x = "c-" + i;
                 c[i] = x;
-                sender.Tell(new Req("c-" + i));
+                sender.Tell(new Req(x));
             }
-            var deliverWithin = TimeSpan.FromSeconds(30);
-            var resA = probeA.ReceiveN(n, deliverWithin).Cast<Action>().Select(x => x.Payload).Distinct().ToArray();
-            var resB = probeB.ReceiveN(n, deliverWithin).Cast<Action>().Select(x => x.Payload).Distinct().ToArray();
-            var resC = probeC.ReceiveN(n, deliverWithin).Cast<Action>().Select(x => x.Payload).Distinct().ToArray();
+            var deliverWithin = TimeSpan.FromSeconds(20);
+            var resA = new SortedSet<string>(probeA.ReceiveN(n, deliverWithin).Cast<Action>().Select(x => x.Payload));
+            var resB = new SortedSet<string>(probeB.ReceiveN(n, deliverWithin).Cast<Action>().Select(x => x.Payload));
+            var resC = new SortedSet<string>(probeC.ReceiveN(n, deliverWithin).Cast<Action>().Select(x => x.Payload));
 
             resA.ShouldOnlyContainInOrder(a);
             resB.ShouldOnlyContainInOrder(b);

--- a/src/core/Akka.Persistence.Tests/Journal/ChaosJournal.cs
+++ b/src/core/Akka.Persistence.Tests/Journal/ChaosJournal.cs
@@ -77,7 +77,7 @@ namespace Akka.Persistence.Tests.Journal
                 return Task.FromResult(HighestSequenceNr(persistenceId));
         }
 
-        protected override void WriteMessages(IEnumerable<IPersistentRepresentation> messages)
+        public override void WriteMessages(IEnumerable<IPersistentRepresentation> messages)
         {
             if (ChaosSupportExtensions.ShouldFail(_writeFailureRate))
                 throw new WriteFailedException(messages);
@@ -90,7 +90,7 @@ namespace Akka.Persistence.Tests.Journal
             }
         }
 
-        protected override void DeleteMessagesTo(string persistenceId, long toSequenceNr, bool isPermanent)
+        public override void DeleteMessagesTo(string persistenceId, long toSequenceNr, bool isPermanent)
         {
             foreach (var sequenceNr in Enumerable.Range(1, (int)toSequenceNr))
             {

--- a/src/core/Akka.Persistence.Tests/PersistenceSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistenceSpec.cs
@@ -24,7 +24,7 @@ namespace Akka.Persistence.Tests
                 akka.persistence.snapshot-store.local.dir = ""target/snapshots-{2}/""
                 akka.test.single-expect-default = 10s", serialization ?? "on", plugin, test);
 
-            return c.WithFallback(ConfigurationFactory.ParseString(configString)).WithFallback(Persistence.DefaultConfig());
+            return c.WithFallback(ConfigurationFactory.ParseString(configString));
         }
 
         internal readonly Cleanup Clean;
@@ -59,11 +59,20 @@ namespace Akka.Persistence.Tests
             base.AfterAll();
             Clean.Dispose();
         }
+
+        protected void ExpectMsgInOrder(params object[] ordered)
+        {
+            var msg = ExpectMsg<object[]>();
+            msg
+                //.Select(x => x.ToString())
+                .ShouldOnlyContainInOrder(ordered);
+        }
     }
 
     internal class Cleanup : IDisposable
     {
         internal List<DirectoryInfo> StorageLocations;
+        private static readonly object _syncRoot = new object();
 
         public Cleanup(AkkaSpec spec)
         {
@@ -75,15 +84,27 @@ namespace Akka.Persistence.Tests
 
         public void Initialize()
         {
+            DeleteStorageLocations();
+        }
+
+        private void DeleteStorageLocations()
+        {
             StorageLocations.ForEach(fi =>
             {
-                if (fi.Exists) fi.Delete(true);
+                lock (_syncRoot)
+                {
+                    try
+                    {
+                        if (fi.Exists) fi.Delete(true);    
+                    }
+                    catch (IOException) { }
+                }
             });
         }
 
         public void Dispose()
         {
-            StorageLocations.ForEach(fi => fi.Delete(true));
+            DeleteStorageLocations();
         }
     }
 

--- a/src/core/Akka.Persistence.Tests/PersistentActorSpec.Actors.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorSpec.Actors.cs
@@ -60,9 +60,9 @@ namespace Akka.Persistence.Tests
 
     public partial class PersistentActorSpec
     {
-        
 
-        internal class LatchCmd
+
+        internal class LatchCmd : NoSerializationVerificationNeeded
         {
             public LatchCmd(TestLatch latch, object data)
             {
@@ -427,7 +427,8 @@ namespace Akka.Persistence.Tests
                     var cmd = message as Cmd;
                     if (cmd != null)
                     {
-                        if (cmd.Data == "a")
+                        var data = cmd.Data.ToString();
+                        if (data == "a")
                         {
                             Persist(new Evt("a"), evt =>
                             {
@@ -435,7 +436,7 @@ namespace Akka.Persistence.Tests
                                 Context.Become(ProcessC);
                             });
                         }
-                        else if (cmd.Data == "b-1" || cmd.Data == "b-2")
+                        else if (data == "b-1" || data == "b-2")
                         {
                             Persist(new Evt(cmd.Data.ToString()), UpdateStateHandler);
                         }
@@ -450,14 +451,14 @@ namespace Akka.Persistence.Tests
             protected bool ProcessC(object message)
             {
                 var cmd = message as Cmd;
-                if (cmd != null && cmd.Data == "c")
+                if (cmd != null && cmd.Data.ToString() == "c")
                 {
                     Persist(new Evt("c"), evt =>
                     {
                         UpdateState(evt);
                         Context.Unbecome();
                     });
-                    Stash.UnstashAll();
+                    UnstashAll();
                 }
                 else Stash.Stash();
                 return true;
@@ -509,7 +510,7 @@ namespace Akka.Persistence.Tests
                     if (cmd != null)
                     {
                         Sender.Tell(cmd.Data);
-                        for (int i = 0; i < 3; i++)
+                        for (int i = 1; i <= 3; i++)
                         {
                             PersistAsync(new Evt(cmd.Data.ToString() + "-" + (++_counter)), evt =>
                             {
@@ -591,6 +592,7 @@ namespace Akka.Persistence.Tests
         internal class AsyncPersistAndPersistMixedSyncAsyncActor : ExamplePersistentActor
         {
             private int _counter = 0;
+            
             public AsyncPersistAndPersistMixedSyncAsyncActor(string name)
                 : base(name)
             {
@@ -686,7 +688,7 @@ namespace Akka.Persistence.Tests
                         UpdateState(evt);
                         Context.Unbecome();
                     });
-                    Stash.UnstashAll();
+                    UnstashAll();
                 }
                 else Stash.Stash();
                 return true;

--- a/src/core/Akka.Persistence.Tests/PersistentViewSpec.Actors.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentViewSpec.Actors.cs
@@ -130,7 +130,7 @@ namespace Akka.Persistence.Tests
 
             private bool ShouldFail(object msg)
             {
-                return _failAt == msg.ToString();
+                return _failAt != null && _failAt.Equals(msg.ToString());
             }
         }
 

--- a/src/core/Akka.Persistence.Tests/PersistentViewSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentViewSpec.cs
@@ -113,7 +113,7 @@ namespace Akka.Persistence.Tests
             _viewProbe.ExpectMsg("replicated-c-3");
         }
 
-        [Fact(Skip = "FIXME")]
+        [Fact(Skip = "FIXME: working, but random timeouts can occur when running all tests at once")]
         public void PersistentView_should_run_size_limited_updates_on_user_request()
         {
             _pref.Tell("c");
@@ -125,6 +125,7 @@ namespace Akka.Persistence.Tests
             _prefProbe.ExpectMsg("e-5");
             _prefProbe.ExpectMsg("f-6");
 
+            //TODO: performance optimization 
             _view = ActorOf(() => new PassiveTestPersistentView(Name, _viewProbe.Ref, null));
             _view.Tell(new Update(isAwait: true, replayMax: 2));
             _view.Tell("get");
@@ -156,7 +157,7 @@ namespace Akka.Persistence.Tests
             _viewProbe.ExpectMsg("replicated-b-2");
             _viewProbe.ExpectMsg("replicated-c-3");
             _viewProbe.ExpectMsg("replicated-d-4");
-            
+
             replayProbe.ExpectMsg<ReplayMessages>(m => m.FromSequenceNr == 1L && m.Max == 2L);
             replayProbe.ExpectMsg<ReplayMessages>(m => m.FromSequenceNr == 3L && m.Max == 2L);
             replayProbe.ExpectMsg<ReplayMessages>(m => m.FromSequenceNr == 5L && m.Max == 2L);

--- a/src/core/Akka.Persistence/Akka.Persistence.csproj
+++ b/src/core/Akka.Persistence/Akka.Persistence.csproj
@@ -84,18 +84,17 @@
     <Compile Include="PersistentView.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Akka\Akka.csproj">
-      <Project>{5deddf90-37f0-48d3-a0b0-a5cbd8a7e377}</Project>
-      <Name>Akka</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <None Include="Akka.Persistence.nuspec" />
     <None Include="packages.config" />
     <EmbeddedResource Include="persistence.conf" />
     <None Include="README.md" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="..\Akka\Akka.csproj">
+      <Project>{5deddf90-37f0-48d3-a0b0-a5cbd8a7e377}</Project>
+      <Name>Akka</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/core/Akka.Persistence/Eventsourced.cs
+++ b/src/core/Akka.Persistence/Eventsourced.cs
@@ -44,7 +44,7 @@ namespace Akka.Persistence
         public Action<object> Handler { get; private set; }
     }
 
-    public abstract partial class Eventsourced : ActorBase, IWithPersistenceId, WithUnboundedStash
+    public abstract partial class Eventsourced : ActorBase, IPersistentIdentity, WithUnboundedStash
     {
         private static readonly AtomicCounter InstanceCounter = new AtomicCounter(1);
 
@@ -85,14 +85,18 @@ namespace Akka.Persistence
 
         public IStash Stash { get; set; }
 
+        public string JournalPluginId { get; protected set; }
+
+        public string SnapshotPluginId { get; protected set; }
+
         public ActorRef Journal
         {
-            get { return _journal ?? (_journal = Extension.JournalFor(SnapshotterId)); }
+            get { return _journal ?? (_journal = Extension.JournalFor(JournalPluginId)); }
         }
 
         public ActorRef SnapshotStore
         {
-            get { return _snapshotStore ?? (_snapshotStore = Extension.SnapshotStoreFor(SnapshotterId)); }
+            get { return _snapshotStore ?? (_snapshotStore = Extension.SnapshotStoreFor(SnapshotPluginId)); }
         }
 
         /// <summary>

--- a/src/core/Akka.Persistence/GuaranteedDelivery.cs
+++ b/src/core/Akka.Persistence/GuaranteedDelivery.cs
@@ -254,17 +254,18 @@ namespace Akka.Persistence
             _unconfirmed = new ConcurrentDictionary<long, Delivery>(unconfirmedDeliveries);
         }
 
-        protected override void PreRestart(Exception reason, object message)
+        public override void AroundPostRestart(Exception cause, object message)
         {
             _redeliverScheduleCancelable.Cancel();
-            base.PreRestart(reason, message);
+            base.AroundPostRestart(cause, message);
         }
 
-        protected override void PostStop()
+        public override void AroundPostStop()
         {
             _redeliverScheduleCancelable.Cancel();
-            base.PostStop();
+            base.AroundPostStop();
         }
+
 
         protected override void OnReplaySuccess()
         {

--- a/src/core/Akka.Persistence/Journal/SyncWriteJournal.cs
+++ b/src/core/Akka.Persistence/Journal/SyncWriteJournal.cs
@@ -29,14 +29,14 @@ namespace Akka.Persistence.Journal
         /// Synchronously writes a batch of a persistent messages to the journal. The batch must be atomic,
         /// i.e. all persistent messages in batch are written at once or none of them.
         /// </summary>
-        protected abstract void WriteMessages(IEnumerable<IPersistentRepresentation> messages);
+        public abstract void WriteMessages(IEnumerable<IPersistentRepresentation> messages);
 
         /// <summary>
         /// Synchronously deletes all persistent messages up to inclusive <paramref name="toSequenceNr"/>
         /// bound. If <paramref name="isPermanent"/> flag is clear, the persistent messages are marked as
         /// deleted, otherwise they're permanently deleted.
         /// </summary>
-        protected abstract void DeleteMessagesTo(string persistenceId, long toSequenceNr, bool isPermanent);
+        public abstract void DeleteMessagesTo(string persistenceId, long toSequenceNr, bool isPermanent);
 
         protected override bool Receive(object message)
         {

--- a/src/core/Akka.Persistence/Persistent.cs
+++ b/src/core/Akka.Persistence/Persistent.cs
@@ -7,7 +7,27 @@ namespace Akka.Persistence
 {
     public interface IWithPersistenceId
     {
+        /// <summary>
+        /// Identifier of the persistent identity for which messages should be replayed.
+        /// </summary>
         string PersistenceId { get; }
+    }
+
+    public interface IPersistentIdentity : IWithPersistenceId
+    {
+        /// <summary>
+        /// Configuration identifier of the journal plugin servicing current persistent actor or view.
+        /// When empty, looks in [akka.persistence.journal.plugin] to find configuration entry path.
+        /// Otherwise uses string value as an absolute path to the journal configuration entry.
+        /// </summary>
+        string JournalPluginId { get; }
+
+        /// <summary>
+        /// Configuration identifier of the snapshot store plugin servicing current persistent actor or view.
+        /// When empty, looks in [akka.persistence.snapshot-store.plugin] to find configuration entry path.
+        /// Otherwise uses string value as an absolute path to the snapshot store configuration entry.
+        /// </summary>
+        string SnapshotPluginId { get; }
     }
 
     /// <summary>

--- a/src/core/Akka.Persistence/PersistentActor.cs
+++ b/src/core/Akka.Persistence/PersistentActor.cs
@@ -46,9 +46,19 @@ namespace Akka.Persistence
         public RecoveryFailure(Exception cause)
         {
             Cause = cause;
+            SequenceNr = -1;
+        }
+
+        public RecoveryFailure(Exception cause, long sequenceNr, object payload)
+        {
+            Cause = cause;
+            SequenceNr = sequenceNr;
+            Payload = payload;
         }
 
         public Exception Cause { get; private set; }
+        public long SequenceNr { get; set; }
+        public object Payload { get; set; }
     }
 
     [Serializable]

--- a/src/core/Akka.Persistence/PersistentView.Recovery.cs
+++ b/src/core/Akka.Persistence/PersistentView.Recovery.cs
@@ -140,10 +140,7 @@ namespace Akka.Persistence
         private void OnReplayComplete(bool shouldAwait)
         {
             ChangeState(Idle());
-            if (IsAutoUpdate)
-            {
-                _scheduleCancellation = Context.System.Scheduler.ScheduleTellOnceCancelable(AutoUpdateInterval, Self, new Update(false, AutoUpdateReplayMax), Self);
-            }
+
             if (shouldAwait)
             {
                 _internalStash.UnstashAll();
@@ -160,35 +157,26 @@ namespace Akka.Persistence
             {
                 if (message is ReplayMessagesFailure)
                 {
-                    ReplayFailureCompleted(cause);
+                    OnReplayFailureCompleted(receive, cause, failedMessage as IPersistentRepresentation);
                     // journal couldn't tell the maximum stored sequence number, hence the next
                     // replay must be a full replay (up to the highest stored sequence number)
                     // Recover(lastSequenceNr) is sent by preRestart
                     LastSequenceNr = long.MaxValue;
                 }
-                else if (message is ReplayMessagesSuccess) ReplayFailureCompleted(cause);
+                else if (message is ReplayMessagesSuccess) OnReplayFailureCompleted(receive, cause, failedMessage as IPersistentRepresentation);
                 else if (message is ReplayedMessage) UpdateLastSequenceNr(((ReplayedMessage)message).Persistent);
                 else if (message is Recover) ; // ignore
                 else _internalStash.Stash();
             });
         }
 
-        private void ReplayFailureCompleted(Exception cause)
+        private void OnReplayFailureCompleted(Receive receive, Exception cause, IPersistentRepresentation failed)
         {
-            ChangeState(PrepareRestart(cause));
-            Context.EnqueueMessageFirst(cause);
+            ChangeState(Idle());
+            var recoveryFailure = failed != null ? new RecoveryFailure(cause, failed.SequenceNr, failed.Payload) : new RecoveryFailure(cause);
+            base.AroundReceive(receive, recoveryFailure);
         }
 
-        /// <summary>
-        /// Re-receives the replayed message that caused an exception and re-throws that exception.
-        /// </summary>
-        private ViewState PrepareRestart(Exception cause)
-        {
-            return new ViewState("prepare restart", true, (receive, message) =>
-            {
-                if (message is ReplayedMessage) throw cause;
-            });
-        }
 
         /// <summary>
         /// When receiving an <see cref="Update"/> event, switches to <see cref="ReplayStarted"/> state
@@ -202,12 +190,22 @@ namespace Akka.Persistence
                 if (message is Update)
                 {
                     var update = (Update)message;
-                    ChangeState(ReplayStarted(update.IsAwait));
-                    Journal.Tell(new ReplayMessages(LastSequenceNr + 1, long.MaxValue, update.ReplayMax, PersistenceId, Self));
+                    ChangeStateToReplayStarted(update.IsAwait, update.ReplayMax);
+                }
+                else if (message is ScheduledUpdate)
+                {
+                    var scheduled = (ScheduledUpdate) message;
+                    ChangeStateToReplayStarted(false, scheduled.ReplayMax);
                 }
                 else if (message is Recover) ; // ignore
                 else base.AroundReceive(receive, message);
             });
+        }
+
+        private void ChangeStateToReplayStarted(bool isAwait, long replayMax)
+        {
+            ChangeState(ReplayStarted(isAwait));
+            Journal.Tell(new ReplayMessages(LastSequenceNr + 1, long.MaxValue, replayMax, PersistenceId, Self));
         }
     }
 }

--- a/src/core/Akka.Persistence/PersistentView.cs
+++ b/src/core/Akka.Persistence/PersistentView.cs
@@ -45,6 +45,17 @@ namespace Akka.Persistence
         public long ReplayMax { get; private set; }
     }
 
+    [Serializable]
+    public sealed class ScheduledUpdate
+    {
+        public ScheduledUpdate(long replayMax)
+        {
+            ReplayMax = replayMax;
+        }
+
+        public long ReplayMax { get; private set; }
+    }
+
     /// <summary>
     /// A view replicates the persistent message stream of a <see cref="PersistentActor"/>. Implementation classes receive
     /// the message stream directly from the Journal. These messages can be processed to update internal state
@@ -65,7 +76,7 @@ namespace Akka.Persistence
     /// `akka.persistence.view.auto-update-interval` configuration key. Applications may trigger additional
     /// view updates by sending the view <see cref="Update"/> requests. See also methods
     /// </summary>
-    public abstract partial class PersistentView : ActorBase, ISnapshotter, IWithPersistenceId, WithUnboundedStash
+    public abstract partial class PersistentView : ActorBase, ISnapshotter, IPersistentIdentity, WithUnboundedStash
     {
         protected readonly PersistenceExtension Extension;
 
@@ -87,9 +98,18 @@ namespace Akka.Persistence
             _currentState = RecoveryPending();
         }
 
+        public string JournalPluginId { get; protected set; }
+
+        public string SnapshotPluginId { get; protected set; }
+
+        public ActorRef Journal
+        {
+            get { return _journal ?? (_journal = Extension.JournalFor(JournalPluginId)); }
+        }
+
         public ActorRef SnapshotStore
         {
-            get { return _snapshotStore ?? (_snapshotStore = Extension.SnapshotStoreFor(SnapshotterId)); }
+            get { return _snapshotStore ?? (_snapshotStore = Extension.SnapshotStoreFor(SnapshotPluginId)); }
         }
 
         /// <summary>
@@ -143,11 +163,6 @@ namespace Akka.Persistence
         /// Gets last sequence number.
         /// </summary>
         public long SnapshotSequenceNr { get { return LastSequenceNr; } }
-
-        public ActorRef Journal
-        {
-            get { return _journal ?? (_journal = Extension.JournalFor(PersistenceId)); }
-        }
 
         private void ChangeState(ViewState state)
         {

--- a/src/core/Akka.Persistence/Snapshot/LocalSnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/LocalSnapshotStore.cs
@@ -12,6 +12,35 @@ namespace Akka.Persistence.Snapshot
 {
     public class LocalSnapshotStore : SnapshotStore
     {
+        #region settings class
+
+        public class StoreSettings
+        {
+            /// <summary>
+            /// Storage location of snapshot files;
+            /// </summary>
+            public readonly string Dir;
+
+            /// <summary>
+            /// Dispatcher for streaming snapshot IO.
+            /// </summary>
+            public readonly string StreamDispatcher;
+
+            /// <summary>
+            /// Number of attempts made to load a subsequent snapshots in case they were corrupted.
+            /// </summary>
+            public readonly int LoadAttempts;
+
+            public StoreSettings(Config config)
+            {
+                Dir = config.GetString("dir");
+                StreamDispatcher = config.GetString("stream-dispatcher");
+                LoadAttempts = config.GetInt("load-attempts");
+            }
+        }
+
+        #endregion
+
         private static readonly Regex FilenameRegex = new Regex(@"^snapshot-(.+)-(\d+)-(\d+)", RegexOptions.Compiled);
 
         private readonly DirectoryInfo _snapshotDirectory;
@@ -23,18 +52,15 @@ namespace Akka.Persistence.Snapshot
         public LocalSnapshotStore()
         {
             var config = Context.System.Settings.Config.GetConfig("akka.persistence.snapshot-store.local");
-            _snapshotDirectory = new DirectoryInfo(config.GetString("dir"));
-            ResolveDispatcher(config);
+            _settings = new StoreSettings(config);
+            _snapshotDirectory = new DirectoryInfo(_settings.Dir);
+            _streamDispatcher = Context.System.Dispatchers.Lookup(_settings.StreamDispatcher);
             _saving = new SortedSet<SnapshotMetadata>(SnapshotMetadata.TimestampComparer);
             _serialization = Context.System.Serialization;
-            _streamDispatcher = ResolveDispatcher(config);
         }
 
-        private MessageDispatcher ResolveDispatcher(Config config)
-        {
-            var dispatcherConfigPath = config.GetString("stream-dispatcher");
-            return Context.System.Dispatchers.Lookup(dispatcherConfigPath);
-        }
+        private readonly StoreSettings _settings;
+        public StoreSettings Settings { get { return _settings; } }
 
         private LoggingAdapter _log;
         public LoggingAdapter Log { get { return _log ?? (_log = Context.GetLogger()); } }
@@ -51,17 +77,18 @@ namespace Akka.Persistence.Snapshot
 
         protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
         {
-            // Heurisitics: take 3 latest snapshots
-            //TODO: convert 3 to configurable value
             var metas = GetSnapshotMetadata(persistenceId, criteria);
-            return Task.FromResult(Load(metas, 3));
+            return RunWithStreamDispatcher(() => Load(metas.Reverse().GetEnumerator(), Settings.LoadAttempts));
         }
 
         protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot)
         {
             _saving.Add(metadata);
-            Save(metadata, snapshot);
-            return Task.FromResult(new object());
+            return RunWithStreamDispatcher(() =>
+            {
+                Save(metadata, snapshot);
+                return new object();
+            });
         }
 
         protected override void Saved(SnapshotMetadata metadata)
@@ -83,13 +110,13 @@ namespace Akka.Persistence.Snapshot
             }
         }
 
-        private SelectedSnapshot Load(IEnumerable<SnapshotMetadata> metas, int dec)
+        private SelectedSnapshot Load(IEnumerator<SnapshotMetadata> metas, int dec)
         {
             if (dec > 0)
             {
-                var metadata = metas.LastOrDefault();
-                if (metadata != null)
+                if (metas.MoveNext())
                 {
+                    var metadata = metas.Current;
                     using (var stream = ReadableStream(metadata))
                     {
                         try
@@ -101,8 +128,9 @@ namespace Akka.Persistence.Snapshot
                         catch (Exception exc)
                         {
                             Log.Error(exc, "Error loading a snapshot [{0}]", exc.Message);
-                            return Load(metas.Skip(1), dec - 1);
+                            return Load(metas, dec - 1);
                         }
+
                     }
                 }
             }
@@ -181,6 +209,26 @@ namespace Akka.Persistence.Snapshot
             var filename = string.Format("snapshot-{0}-{1}-{2}{3}", metadata.PersistenceId, metadata.SequenceNr, metadata.Timestamp.Ticks, extension);
             var file = _snapshotDirectory.GetFiles(filename, SearchOption.TopDirectoryOnly).FirstOrDefault();
             return file ?? new FileInfo(Path.Combine(_snapshotDirectory.FullName, filename));
+        }
+
+        private Task<T> RunWithStreamDispatcher<T>(Func<T> fn)
+        {
+            var promise = new TaskCompletionSource<T>();
+
+            _streamDispatcher.Schedule(() =>
+            {
+                try
+                {
+                    var result = fn();
+                    promise.SetResult(result);
+                }
+                catch (Exception e)
+                {
+                    promise.SetException(e);
+                }
+            });
+
+            return promise.Task;
         }
     }
 }

--- a/src/core/Akka.Persistence/persistence.conf
+++ b/src/core/Akka.Persistence/persistence.conf
@@ -67,6 +67,9 @@ akka {
 
         # Storage location of snapshot files.
         dir = "snapshots"
+
+		# Number of attempts made to load subsequent snapshots in case they're corrupted
+		load-attempts = 3
       }
     }
 

--- a/src/core/Akka.TestKit/TestKitBase_Expect.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Expect.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using Akka.Actor;
 using Akka.TestKit.Internal;
+using Akka.Util;
 
 namespace Akka.TestKit
 {
@@ -251,6 +252,28 @@ namespace Akka.TestKit
                 ConditionalLog(failMessage, duration,t, elapsed);
                 _assertions.Fail(failMessage,duration, t, elapsed);
             }
+        }
+
+        /// <summary>
+        /// Receive a message from the test actor and assert that it equals 
+        /// one of the given <paramref name="messages"/>. Wait time is bounded by 
+        /// <see cref="RemainingOrDefault"/> as duration, with an assertion exception being thrown in case of timeout.
+        /// </summary>
+        /// <typeparam name="T">The type of the messages</typeparam>
+        /// <param name="messages">The messages.</param>
+        /// <returns>The received messages in received order</returns>
+        public T ExpectMsgAnyOf<T>(params T[] messages)
+        {
+            return InternalExpectMsgAnyOf<T>(RemainingOrDefault, messages);
+        }
+
+        private T InternalExpectMsgAnyOf<T>(TimeSpan max, T[] messages)
+        {
+            var o = ReceiveOne(max);
+            _assertions.AssertTrue(o != null, string.Format("Timeout {0} during waiting for ExpectMsgAnyOf waiting for ({1})", max, StringFormat.SafeJoin(",", messages)));
+            _assertions.AssertTrue(messages.Contains((T)o), "ExpectMsgAnyOf found unexpected {0}", o);
+
+            return (T)o;
         }
 
         /// <summary>

--- a/src/examples/PersistenceExample.FsApi/Program.fs
+++ b/src/examples/PersistenceExample.FsApi/Program.fs
@@ -19,7 +19,7 @@ module Scenario0 =
     let exec (mailbox: Eventsourced<_,_,_>) state cmd = 
         match cmd with
         | "print" -> printf "State is: %A\n" state          // print current actor state
-        | s       -> mailbox.Persist (update state) [s]     // persist event and call update state on complete
+        | s       -> mailbox.PersistEvent (update state) [s]     // persist event and call update state on complete
 
     let run() =
         printfn "--- SCENARIO 0 ---\n"
@@ -58,7 +58,7 @@ module Scenario1 =
 
     let exec (mailbox: Eventsourced<Command,obj,string list>) state cmd =
         match cmd with
-        | Update s -> mailbox.Persist (update state) [s]
+        | Update s -> mailbox.PersistEvent (update state) [s]
         | TakeSnapshot -> mailbox.SaveSnapshot state
         | Print -> printf "State is: %A\n" state
         | Crash -> failwith "planned crash"


### PR DESCRIPTION
Change log:

1. Minor changes in F# Persistence API:
    - Added `Defer` method from core F# actors API
    - Renamed `Persist`, `AsyncPersist` and `Defer` to `PersistEvent`, `AsyncPersistEvent` and `DeferEvent` due to `Defer` method naming conflict with core F# API for `Defer` method.
2. Altered state machine for `PersistentView` - these changes mirror latest updates of canonical akka-persistence API: 
    - Removed *PrepareRestart* state (it's logic has been moved to *ReplayFailed* state). 
    - Moved update scheduler initialization from *ReplayStarted* state to `PreStart` method. Also it now uses new `ScheduledUpdate` message instead of `Update`. This message has a dedicated behavior in *Idle* state.
3. Better support for `LocalSnapshotStore`:
    - Asynchronous tasks are now activated using Akka dispatchers.
    - Local snapshot store has now custom settings class defined and configurable number (it was fixed before) of subsequent load attempts of the file-based snapshots - it's used in case of i.e. corrupted snapshots. 
4. Additional Journal/SnapshotStore specs constructors (see #745)
5. Local snapshot store folder for persistence spec is now generated for each test case separately.
6. Introduced new test kit method - `ExpectMsgAnyOf` (from canonical akka-testkit).
7. Fixed all failing tests in `PersistentActorSpec`.
8. Changed all actor path strings in `GuaranteedDeliverySpec` back to `ActorPath`, since they are correctly serialized/deserialized now.
