### PR TITLE
Extension method for dispatcher returning task

### DIFF
--- a/src/core/Akka/Dispatch/Dispatchers.cs
+++ b/src/core/Akka/Dispatch/Dispatchers.cs
@@ -14,6 +14,7 @@ namespace Akka.Dispatch
         PinnedDispatcher,
         SynchronizedDispatcher,
     }
+
     public static class DispatcherTypeMembers
     {
         public static string GetName(this DispatcherType self)
@@ -22,6 +23,32 @@ namespace Akka.Dispatch
             return self.ToString();
         }
     }
+
+    public static class DispatcherExtensions
+    {
+        /// <summary>
+        /// Schedules the specified run and returns a continuation task.
+        /// </summary>
+        public static Task<T> ScheduleAsync<T>(this MessageDispatcher dispatcher, Func<T> fn)
+        {
+            var promise = new TaskCompletionSource<T>();
+            dispatcher.Schedule(() =>
+            {
+                try
+                {
+                    var result = fn();
+                    promise.SetResult(result);
+                }
+                catch (Exception e)
+                {
+                    promise.SetException(e);
+                }
+            });
+
+            return promise.Task;
+        }
+    }
+
     /// <summary>
     ///     Class MessageDispatcher.
     /// </summary>


### PR DESCRIPTION
This is proposition of generic dispatcher `Schedule` variation returning TPL task used for tracking completion status. I've found it a pretty useful, because sometimes I want to delegate action through Akka dispatcher but still be able to wait/continue/pipe work from it. 

It works with any type of dispatcher, also one not using TPL internally. 

@akkadotnet/developers What do you think about this?