### PR TITLE
Make ActorRef an interface or The breaking-just-about-everything PR

### DIFF
--- a/src/benchmark/PingPong/ClientActorBase.cs
+++ b/src/benchmark/PingPong/ClientActorBase.cs
@@ -6,13 +6,13 @@ namespace PingPong
 {
     public class ClientActorBase : ActorBase
     {
-        private readonly ActorRef _actor;
+        private readonly IActorRef _actor;
         private readonly TaskCompletionSource<bool> _latch;
         private long _received;
         private readonly long _repeat;
         private long _sent;
 
-        public ClientActorBase(ActorRef actor, long repeat, TaskCompletionSource<bool> latch)
+        public ClientActorBase(IActorRef actor, long repeat, TaskCompletionSource<bool> latch)
         {
             _actor = actor;
             _repeat = repeat;

--- a/src/benchmark/PingPong/ClientReceiveActor.cs
+++ b/src/benchmark/PingPong/ClientReceiveActor.cs
@@ -6,7 +6,7 @@ namespace PingPong
 {
     public class ClientReceiveActor : ReceiveActor
     {
-        public ClientReceiveActor(ActorRef actor, long repeat, TaskCompletionSource<bool> latch)
+        public ClientReceiveActor(IActorRef actor, long repeat, TaskCompletionSource<bool> latch)
         {
             var received=0L;
             var sent=0L;

--- a/src/benchmark/PingPong/Program.cs
+++ b/src/benchmark/PingPong/Program.cs
@@ -124,7 +124,7 @@ namespace PingPong
 
             var countdown = new CountdownEvent(numberOfClients * 2);
             var waitForStartsActor = system.ActorOf(Props.Create(() => new WaitForStarts(countdown)), "wait-for-starts");
-            var clients = new List<ActorRef>();
+            var clients = new List<IActorRef>();
             var tasks = new List<Task>();
             var started = new Messages.Started();
             for(int i = 0; i < numberOfClients; i++)

--- a/src/contrib/testkits/Akka.TestKit.VsTest.Tests/TestKitTests.cs
+++ b/src/contrib/testkits/Akka.TestKit.VsTest.Tests/TestKitTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Akka.Actor;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Akka.TestKit.VsTest.Tests
 {

--- a/src/core/Akka.Cluster.Tests/AutoDownSpec.cs
+++ b/src/core/Akka.Cluster.Tests/AutoDownSpec.cs
@@ -35,9 +35,9 @@ namespace Akka.Cluster.Tests
 
         class AutoDownTestActor : AutoDownBase
         {
-            readonly ActorRef _probe;
+            readonly IActorRef _probe;
 
-            public AutoDownTestActor(TimeSpan autoDownUnreachableAfter, ActorRef probe): base(autoDownUnreachableAfter)
+            public AutoDownTestActor(TimeSpan autoDownUnreachableAfter, IActorRef probe): base(autoDownUnreachableAfter)
             {
                 _probe = probe;
             }
@@ -65,7 +65,7 @@ namespace Akka.Cluster.Tests
             }
         }
 
-        private ActorRef AutoDownActor(TimeSpan autoDownUnreachableAfter)
+        private IActorRef AutoDownActor(TimeSpan autoDownUnreachableAfter)
         {
             return
                 Sys.ActorOf(new Props(typeof(AutoDownTestActor),

--- a/src/core/Akka.Cluster.Tests/ClusterDomainEventPublisherSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterDomainEventPublisherSpec.cs
@@ -8,7 +8,7 @@ namespace Akka.Cluster.Tests
 {
     public class ClusterDomainEventPublisherSpec : AkkaSpec
     {
-        ActorRef _publisher;
+        IActorRef _publisher;
         static readonly Member aUp = TestMember.Create(new Address("akka.tcp", "sys", "a", 2552), MemberStatus.Up);
         static readonly Member aLeaving = aUp.Copy(status: MemberStatus.Leaving);
         static readonly Member aExiting = aLeaving.Copy(status: MemberStatus.Exiting);

--- a/src/core/Akka.Cluster.Tests/ClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterSpec.cs
@@ -19,7 +19,7 @@ namespace Akka.Cluster.Tests
         akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""
         akka.remote.helios.tcp.port = 0";
 
-        public ActorRef Self { get { return TestActor; } }
+        public IActorRef Self { get { return TestActor; } }
 
         readonly Address _selfAddress;
         readonly Cluster _cluster;

--- a/src/core/Akka.Cluster.Tests/MetricsCollectorSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MetricsCollectorSpec.cs
@@ -19,7 +19,7 @@ namespace Akka.Cluster.Tests
 
     public class MetricsCollectorSpec : MetricsCollectorFactory, IDisposable
     {
-        public ActorRef Self { get { return TestActor; } }
+        public IActorRef Self { get { return TestActor; } }
 
         private readonly IMetricsCollector _collector;
 

--- a/src/core/Akka.Cluster.Tests/MetricsGossipSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MetricsGossipSpec.cs
@@ -8,7 +8,7 @@ namespace Akka.Cluster.Tests
 {
     public class MetricsGossipSpec : MetricsCollectorFactory
     {
-        public ActorRef Self { get { return TestActor; } }
+        public IActorRef Self { get { return TestActor; } }
 
         private IMetricsCollector _collector;
 

--- a/src/core/Akka.Cluster.Tests/MultiNode/ClusterDeathWatchSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MultiNode/ClusterDeathWatchSpec.cs
@@ -73,9 +73,9 @@ namespace Akka.Cluster.Tests.MultiNode
             _config = config;
         }
 
-        private ActorRef _remoteWatcher;
+        private IActorRef _remoteWatcher;
 
-        protected ActorRef RemoteWatcher
+        protected IActorRef RemoteWatcher
         {
             get
             {
@@ -207,7 +207,7 @@ namespace Akka.Cluster.Tests.MultiNode
                     AwaitAssert(() =>
                     {
                         RemoteWatcher.Tell(Remote.RemoteWatcher.Stats.Empty);
-                        ExpectMsg<Remote.RemoteWatcher.Stats>().WatchingRefs.Contains(new Tuple<ActorRef, ActorRef>(subject5, TestActor)).ShouldBeTrue();
+                        ExpectMsg<Remote.RemoteWatcher.Stats>().WatchingRefs.Contains(new Tuple<IActorRef, IActorRef>(subject5, TestActor)).ShouldBeTrue();
                     });
                 }, _config.First);
                 EnterBarrier("remote-watch");
@@ -331,10 +331,10 @@ namespace Akka.Cluster.Tests.MultiNode
         /// </summary>
         class Observer : ReceiveActor
         {
-            private readonly ActorRef _testActorRef;
+            private readonly IActorRef _testActorRef;
             readonly TestLatch _watchEstablished;
 
-            public Observer(ActorPath path2, ActorPath path3, TestLatch watchEstablished, ActorRef testActorRef)
+            public Observer(ActorPath path2, ActorPath path3, TestLatch watchEstablished, IActorRef testActorRef)
             {
                 _watchEstablished = watchEstablished;
                 _testActorRef = testActorRef;
@@ -364,9 +364,9 @@ namespace Akka.Cluster.Tests.MultiNode
 
         class DumbObserver : ReceiveActor
         {
-            private readonly ActorRef _testActorRef;
+            private readonly IActorRef _testActorRef;
 
-            public DumbObserver(ActorPath path2, ActorRef testActorRef)
+            public DumbObserver(ActorPath path2, IActorRef testActorRef)
             {
                 _testActorRef = testActorRef;
 

--- a/src/core/Akka.Cluster.Tests/MultiNode/MultiNodeClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MultiNode/MultiNodeClusterSpec.cs
@@ -99,10 +99,10 @@ namespace Akka.Cluster.Tests.MultiNode
                 }
             }
 
-            readonly ActorRef _testActor;
+            readonly IActorRef _testActor;
             readonly Address _target;
 
-            public EndActor(ActorRef testActor, Address target)
+            public EndActor(IActorRef testActor, Address target)
             {
                 _testActor = testActor;
                 _target = target;

--- a/src/core/Akka.Cluster.Tests/MultiNode/Routing/ClusterConsistentHashingGroupSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MultiNode/Routing/ClusterConsistentHashingGroupSpec.cs
@@ -84,7 +84,7 @@ namespace Akka.Cluster.Tests.MultiNode.Routing
             _config = config;
         }
 
-        protected Routees CurrentRoutees(ActorRef router)
+        protected Routees CurrentRoutees(IActorRef router)
         {
             var routerAsk = router.Ask<Routees>(new GetRoutees(), GetTimeoutOrDefault(null));
             return routerAsk.Result;
@@ -93,7 +93,7 @@ namespace Akka.Cluster.Tests.MultiNode.Routing
         /// <summary>
         /// Fills in the self address for local ActorRef
         /// </summary>
-        protected Address FullAddress(ActorRef actorRef)
+        protected Address FullAddress(IActorRef actorRef)
         {
             if (string.IsNullOrEmpty(actorRef.Path.Address.Host) || !actorRef.Path.Address.Port.HasValue)
                 return Cluster.SelfAddress;

--- a/src/core/Akka.Cluster.Tests/MultiNode/Routing/ClusterConsistentHashingRouterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MultiNode/Routing/ClusterConsistentHashingRouterSpec.cs
@@ -72,14 +72,14 @@ namespace Akka.Cluster.Tests.MultiNode.Routing
             _config = config;
         }
 
-        private ActorRef _router1 = null;
+        private IActorRef _router1 = null;
 
-        protected ActorRef Router1
+        protected IActorRef Router1
         {
             get { return _router1 ?? (_router1 = CreateRouter1()); }
         }
 
-        private ActorRef CreateRouter1()
+        private IActorRef CreateRouter1()
         {
             return
                 Sys.ActorOf(
@@ -87,7 +87,7 @@ namespace Akka.Cluster.Tests.MultiNode.Routing
                     "router1");
         }
 
-        protected Routees CurrentRoutees(ActorRef router)
+        protected Routees CurrentRoutees(IActorRef router)
         {
             var routerAsk = router.Ask<Routees>(new GetRoutees(), GetTimeoutOrDefault(null));
             return routerAsk.Result;
@@ -96,14 +96,14 @@ namespace Akka.Cluster.Tests.MultiNode.Routing
         /// <summary>
         /// Fills in the self address for local ActorRef
         /// </summary>
-        protected Address FullAddress(ActorRef actorRef)
+        protected Address FullAddress(IActorRef actorRef)
         {
             if (string.IsNullOrEmpty(actorRef.Path.Address.Host) || !actorRef.Path.Address.Port.HasValue)
                 return Cluster.SelfAddress;
             return actorRef.Path.Address;
         }
 
-        protected void AssertHashMapping(ActorRef router)
+        protected void AssertHashMapping(IActorRef router)
         {
             // it may take some time until router receives cluster member events
             AwaitAssert(() =>
@@ -115,7 +115,7 @@ namespace Akka.Cluster.Tests.MultiNode.Routing
             routerMembers.ShouldBe(Roles.Select(GetAddress).ToList());
 
             router.Tell("a", TestActor);
-            var destinationA = ExpectMsg<ActorRef>();
+            var destinationA = ExpectMsg<IActorRef>();
             router.Tell("a", TestActor);
             ExpectMsg(destinationA);
         }
@@ -162,7 +162,7 @@ namespace Akka.Cluster.Tests.MultiNode.Routing
             RunOn(() =>
             {
                 Router1.Tell(new ConsistentHashableEnvelope("A", "a"));
-                var destinationA = ExpectMsg<ActorRef>();
+                var destinationA = ExpectMsg<IActorRef>();
                 Router1.Tell(new ConsistentHashableEnvelope("AA", "a"));
                 ExpectMsg(destinationA);
             }, _config.First);

--- a/src/core/Akka.Cluster.Tests/Routing/ClusterRouterSupervisorSpec.cs
+++ b/src/core/Akka.Cluster.Tests/Routing/ClusterRouterSupervisorSpec.cs
@@ -22,9 +22,9 @@ namespace Akka.Cluster.Tests.Routing
 
         class KillableActor : ReceiveActor
         {
-            private readonly ActorRef TestActor;
+            private readonly IActorRef TestActor;
 
-            public KillableActor(ActorRef testActor)
+            public KillableActor(IActorRef testActor)
             {
                 TestActor = testActor;
                 Receive<string>(s => s == "go away", s =>

--- a/src/core/Akka.Cluster/Cluster.cs
+++ b/src/core/Akka.Cluster/Cluster.cs
@@ -82,12 +82,12 @@ namespace Akka.Cluster
         /// <summary>
         /// Handles initialization logic for the <see cref="Cluster"/>
         /// </summary>
-        private async Task<ActorRef> GetClusterCoreRef()
+        private async Task<IActorRef> GetClusterCoreRef()
         {
             var timeout = System.Settings.CreationTimeout;
             try
             {
-                return await _clusterDaemons.Ask<ActorRef>(InternalClusterAction.GetClusterCoreRef.Instance, timeout).ConfigureAwait(false);
+                return await _clusterDaemons.Ask<IActorRef>(InternalClusterAction.GetClusterCoreRef.Instance, timeout).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -105,7 +105,7 @@ namespace Akka.Cluster
         /// <param name="subscriber">The actor who'll receive the cluster domain events</param>
         /// <param name="to"><see cref="ClusterEvent.IClusterDomainEvent"/> subclasses</param>
         /// <remarks>A snapshot of <see cref="ClusterEvent.CurrentClusterState"/> will be sent to <see cref="subscriber"/> as the first message</remarks>
-        public void Subscribe(ActorRef subscriber, Type[] to)
+        public void Subscribe(IActorRef subscriber, Type[] to)
         {
             Subscribe(subscriber, ClusterEvent.SubscriptionInitialStateMode.InitialStateAsSnapshot, to);
         }
@@ -121,7 +121,7 @@ namespace Akka.Cluster
         /// If set to <see cref="ClusterEvent.SubscriptionInitialStateMode.InitialStateAsSnapshot"/> 
         /// a snapshot of <see cref="ClusterEvent.CurrentClusterState"/> will be sent to <see cref="subscriber"/> as the first message. </param>
         /// <param name="to"><see cref="ClusterEvent.IClusterDomainEvent"/> subclasses</param>
-        public void Subscribe(ActorRef subscriber, ClusterEvent.SubscriptionInitialStateMode initialStateMode, Type[] to)
+        public void Subscribe(IActorRef subscriber, ClusterEvent.SubscriptionInitialStateMode initialStateMode, Type[] to)
         {
             var val = _clusterCore;
             _clusterCore.Tell(new InternalClusterAction.Subscribe(subscriber, initialStateMode, ImmutableHashSet.Create<Type>(to)));
@@ -130,7 +130,7 @@ namespace Akka.Cluster
         /// <summary>
         /// Unsubscribe to all cluster domain events.
         /// </summary>
-        public void Unsubscribe(ActorRef subscriber)
+        public void Unsubscribe(IActorRef subscriber)
         {
             Unsubscribe(subscriber,null);
         }
@@ -138,7 +138,7 @@ namespace Akka.Cluster
         /// <summary>
         /// Unsubscribe to a specific type of cluster domain event
         /// </summary>
-        public void Unsubscribe(ActorRef subscriber, Type to)
+        public void Unsubscribe(IActorRef subscriber, Type to)
         {
             _clusterCore.Tell(new InternalClusterAction.Unsubscribe(subscriber, to));
         }
@@ -148,7 +148,7 @@ namespace Akka.Cluster
         /// If you want this to happen periodically, you can use the <see cref="Scheduler"/> to schedule
         /// a call to this method. You can also call <see cref="State"/> directly for this information.
         /// </summary>
-        public void SendCurrentClusterState(ActorRef receiver)
+        public void SendCurrentClusterState(IActorRef receiver)
         {
             _clusterCore.Tell(new InternalClusterAction.SendCurrentClusterState(receiver));
         }
@@ -277,9 +277,9 @@ namespace Akka.Cluster
             }
         }
 
-        readonly ActorRef _clusterDaemons;
-        ActorRef _clusterCore;
-        public ActorRef ClusterCore { get { return _clusterCore; } }
+        readonly IActorRef _clusterDaemons;
+        IActorRef _clusterCore;
+        public IActorRef ClusterCore { get { return _clusterCore; } }
 
         public void LogInfo(string message)
         {

--- a/src/core/Akka.Cluster/ClusterActorRefProvider.cs
+++ b/src/core/Akka.Cluster/ClusterActorRefProvider.cs
@@ -37,7 +37,7 @@ namespace Akka.Cluster
             Cluster.Get(system);
         }
 
-        protected override ActorRef CreateRemoteWatcher(ActorSystemImpl system)
+        protected override IActorRef CreateRemoteWatcher(ActorSystemImpl system)
         {
             // make sure Cluster extension is initialized/loaded from init thread
             Cluster.Get(system);

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -408,14 +408,14 @@ namespace Akka.Cluster
 
         internal sealed class PublisherCreated
         {
-            readonly ActorRef _publisher;
+            readonly IActorRef _publisher;
 
-            public PublisherCreated(ActorRef publisher)
+            public PublisherCreated(IActorRef publisher)
             {
                 _publisher = publisher;
             }
 
-            public ActorRef Publisher
+            public IActorRef Publisher
             {
                 get { return _publisher; }
             }
@@ -444,11 +444,11 @@ namespace Akka.Cluster
 
         public sealed class Subscribe : ISubscriptionMessage
         {
-            readonly ActorRef _subscriber;
+            readonly IActorRef _subscriber;
             readonly ClusterEvent.SubscriptionInitialStateMode _initialStateMode;
             readonly ImmutableHashSet<Type> _to;
 
-            public Subscribe(ActorRef subscriber, ClusterEvent.SubscriptionInitialStateMode initialStateMode,
+            public Subscribe(IActorRef subscriber, ClusterEvent.SubscriptionInitialStateMode initialStateMode,
                 ImmutableHashSet<Type> to)
             {
                 _subscriber = subscriber;
@@ -456,7 +456,7 @@ namespace Akka.Cluster
                 _to = to;
             }
 
-            public ActorRef Subscriber
+            public IActorRef Subscriber
             {
                 get { return _subscriber; }
             }
@@ -474,16 +474,16 @@ namespace Akka.Cluster
 
         public sealed class Unsubscribe : ISubscriptionMessage
         {
-            readonly ActorRef _subscriber;
+            readonly IActorRef _subscriber;
             readonly Type _to;
 
-            public Unsubscribe(ActorRef subscriber, Type to)
+            public Unsubscribe(IActorRef subscriber, Type to)
             {
                 _to = to;
                 _subscriber = subscriber;
             }
 
-            public ActorRef Subscriber
+            public IActorRef Subscriber
             {
                 get { return _subscriber; }
             }
@@ -496,15 +496,15 @@ namespace Akka.Cluster
 
         public sealed class SendCurrentClusterState : ISubscriptionMessage
         {
-            readonly ActorRef _receiver;
+            readonly IActorRef _receiver;
 
-            public ActorRef Receiver
+            public IActorRef Receiver
             {
                 get { return _receiver; }
             }
 
             /// <param name="receiver"><see cref="Akka.Cluster.ClusterEvent.CurrentClusterState"/> will be sent to the `receiver`</param>
-            public SendCurrentClusterState(ActorRef receiver)
+            public SendCurrentClusterState(IActorRef receiver)
             {
                 _receiver = receiver;
             }
@@ -549,7 +549,7 @@ namespace Akka.Cluster
     /// </summary>
     internal sealed class ClusterDaemon : UntypedActor
     {
-        readonly ActorRef _coreSupervisor;
+        readonly IActorRef _coreSupervisor;
         readonly ClusterSettings _settings;
 
         public ClusterDaemon(ClusterSettings settings)
@@ -591,8 +591,8 @@ namespace Akka.Cluster
     /// </summary>
     class ClusterCoreSupervisor : ReceiveActor
     {
-        readonly ActorRef _publisher;
-        readonly ActorRef _coreDaemon;
+        readonly IActorRef _publisher;
+        readonly IActorRef _coreDaemon;
 
         private readonly LoggingAdapter _log = Context.GetLogger();
 
@@ -643,13 +643,13 @@ namespace Akka.Cluster
 
         readonly bool _statsEnabled;
         GossipStats _gossipStats = new GossipStats();
-        ActorRef _seedNodeProcess;
+        IActorRef _seedNodeProcess;
         int _seedNodeProcessCounter = 0; //for unique names
         private bool _logInfo;
 
-        readonly ActorRef _publisher;
+        readonly IActorRef _publisher;
 
-        public ClusterCoreDaemon(ActorRef publisher)
+        public ClusterCoreDaemon(IActorRef publisher)
         {
             _publisher = publisher;
             SelfUniqueAddress = _cluster.SelfUniqueAddress;
@@ -1660,7 +1660,7 @@ namespace Akka.Cluster
                 ClusterCore(node.Address).Tell(new GossipEnvelope(SelfUniqueAddress, node, _latestGossip));
         }
 
-        public void GossipTo(UniqueAddress node, ActorRef destination)
+        public void GossipTo(UniqueAddress node, IActorRef destination)
         {
             if (ValidNodeForGossip(node))
                 destination.Tell(new GossipEnvelope(SelfUniqueAddress, node, _latestGossip));
@@ -1672,7 +1672,7 @@ namespace Akka.Cluster
                 ClusterCore(node.Address).Tell(new GossipStatus(SelfUniqueAddress, _latestGossip.Version));
         }
 
-        public void GossipStatusTo(UniqueAddress node, ActorRef destination)
+        public void GossipStatusTo(UniqueAddress node, IActorRef destination)
         {
             if (ValidNodeForGossip(node))
                 destination.Tell(new GossipStatus(SelfUniqueAddress, _latestGossip.Version));

--- a/src/core/Akka.Cluster/ClusterEvent.cs
+++ b/src/core/Akka.Cluster/ClusterEvent.cs
@@ -703,7 +703,7 @@ namespace Akka.Cluster
         /// The current snapshot state corresponding to latest gossip 
         /// to mimic what you would have seen if you were listening to the events.
         /// </summary>
-        private void SendCurrentClusterState(ActorRef receiver)
+        private void SendCurrentClusterState(IActorRef receiver)
         {
             var state = new ClusterEvent.CurrentClusterState(
                 _latestGossip.Members,
@@ -716,7 +716,7 @@ namespace Akka.Cluster
             receiver.Tell(state);
         }
 
-        private void Subscribe(ActorRef subscriber, ClusterEvent.SubscriptionInitialStateMode initMode,
+        private void Subscribe(IActorRef subscriber, ClusterEvent.SubscriptionInitialStateMode initMode,
             IEnumerable<Type> to)
         {
             if (initMode == ClusterEvent.SubscriptionInitialStateMode.InitialStateAsEvents)
@@ -738,7 +738,7 @@ namespace Akka.Cluster
             foreach (var t in to) _eventStream.Subscribe(subscriber, t);
         }
 
-        private void Unsubscribe(ActorRef subscriber, Type to)
+        private void Unsubscribe(IActorRef subscriber, Type to)
         {
             if (to == null) _eventStream.Unsubscribe(subscriber);
             else _eventStream.Unsubscribe(subscriber, to);

--- a/src/core/Akka.Cluster/ClusterMetricsCollector.cs
+++ b/src/core/Akka.Cluster/ClusterMetricsCollector.cs
@@ -54,9 +54,9 @@ namespace Akka.Cluster
 
         private Cluster _cluster;
 
-        private readonly ActorRef _publisher;
+        private readonly IActorRef _publisher;
 
-        public ClusterMetricsCollector(ActorRef publisher)
+        public ClusterMetricsCollector(IActorRef publisher)
         {
             _publisher = publisher;
             _cluster = Cluster.Get(Context.System);

--- a/src/core/Akka.Cluster/ClusterReadView.cs
+++ b/src/core/Akka.Cluster/ClusterReadView.cs
@@ -51,7 +51,7 @@ namespace Akka.Cluster
             get { return _selfAddress; }
         }
 
-        readonly ActorRef _eventBusListener;
+        readonly IActorRef _eventBusListener;
 
         private readonly Cluster _cluster;
 

--- a/src/core/Akka.Cluster/Routing/ClusterRoutingConfig.cs
+++ b/src/core/Akka.Cluster/Routing/ClusterRoutingConfig.cs
@@ -352,7 +352,7 @@ namespace Akka.Cluster.Routing
         }
 
         /// <summary>
-        /// Fills in self address for local <see cref="ActorRef"/>
+        /// Fills in self address for local <see cref="IActorRef"/>
         /// </summary>
         public Address FullAddress(Routee routee)
         {

--- a/src/core/Akka.FSharp/FsApi.fs
+++ b/src/core/Akka.FSharp/FsApi.fs
@@ -28,10 +28,10 @@ module Actors =
         Async.StartWithContinuations(computation, success, failure, failure)
 
     /// Pipe operator which sends an output of asynchronous expression directly to the recipients mailbox.
-    let inline (|!>) (computation : Async<'T>) (recipient : ICanTell) = pipeTo computation recipient ActorRef.NoSender
+    let inline (|!>) (computation : Async<'T>) (recipient : ICanTell) = pipeTo computation recipient ActorRefs.NoSender
 
     /// Pipe operator which sends an output of asynchronous expression directly to the recipients mailbox
-    let inline (<!|) (recipient : ICanTell) (computation : Async<'T>) = pipeTo computation recipient ActorRef.NoSender
+    let inline (<!|) (recipient : ICanTell) (computation : Async<'T>) = pipeTo computation recipient ActorRefs.NoSender
 
     type IO<'T> =
         | Input
@@ -60,7 +60,7 @@ module Actors =
         abstract Context : IActorContext
     
         /// <summary>
-        /// Returns a sender of current message or <see cref="ActorRef.NoSender" />, if none could be determined.
+        /// Returns a sender of current message or <see cref="ActorRefs.NoSender" />, if none could be determined.
         /// </summary>
         abstract Sender : unit -> ActorRef
     
@@ -104,7 +104,7 @@ module Actors =
 
     /// <summary>
     /// Returns an instance of <see cref="ActorSelection" /> for specified path. 
-    /// If no matching receiver will be found, a <see cref="ActorRef.NoSender" /> instance will be returned. 
+    /// If no matching receiver will be found, a <see cref="ActorRefs.NoSender" /> instance will be returned. 
     /// </summary>
     let inline select (path : string) (selector : ActorRefFactory) : ActorSelection = selector.ActorSelection path
         

--- a/src/core/Akka.FSharp/Schedulers.fs
+++ b/src/core/Akka.FSharp/Schedulers.fs
@@ -42,7 +42,7 @@ type Akka.Actor.ITellScheduler with
     /// <param name="receiver">Message receiver.</param>
     /// <param name="sender">Optional actor reference set up as message sender</param>
     /// <param name="cancelable">Optional cancelation token</param>
-    member this.ScheduleTellRepeatedly(after: TimeSpan, every: TimeSpan, receiver: ActorRef, message: 'Message, ?sender: ActorRef, ?cancelable: ICancelable) : unit =
+    member this.ScheduleTellRepeatedly(after: TimeSpan, every: TimeSpan, receiver: IActorRef, message: 'Message, ?sender: IActorRef, ?cancelable: ICancelable) : unit =
         let s = match sender with
                 | Some aref -> aref
                 | None -> ActorCell.GetCurrentSelfOrNoSender()
@@ -58,7 +58,7 @@ type Akka.Actor.ITellScheduler with
     /// <param name="receiver">Message receiver.</param>
     /// <param name="sender">Optional actor reference set up as message sender</param>
     /// <param name="cancelable">Optional cancelation token</param>
-    member this.ScheduleTellOnce(after: TimeSpan, receiver: ActorRef, message: 'Message, ?sender: ActorRef, ?cancelable: ICancelable) : unit =
+    member this.ScheduleTellOnce(after: TimeSpan, receiver: IActorRef, message: 'Message, ?sender: IActorRef, ?cancelable: ICancelable) : unit =
         let s = match sender with
                 | Some aref -> aref
                 | None -> ActorCell.GetCurrentSelfOrNoSender()

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Reporting/SpecRunCoordinator.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Reporting/SpecRunCoordinator.cs
@@ -17,7 +17,7 @@ namespace Akka.MultiNodeTestRunner.Shared.Reporting
             MethodName = methodName;
             ClassName = className;
             FactData = new FactData(string.Format("{0}.{1}", className, methodName));
-            _nodeActors = new Dictionary<int, ActorRef>();
+            _nodeActors = new Dictionary<int, IActorRef>();
             SetReceive();
         }
 
@@ -35,7 +35,7 @@ namespace Akka.MultiNodeTestRunner.Shared.Reporting
         /// <summary>
         /// Internal dictionary used to route messages to their discrete nodes
         /// </summary>
-        private readonly Dictionary<int, ActorRef> _nodeActors;
+        private readonly Dictionary<int, IActorRef> _nodeActors;
 
         #region Actor Lifecycle
 

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Reporting/TestRunCoordinator.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Reporting/TestRunCoordinator.cs
@@ -24,12 +24,12 @@ namespace Akka.MultiNodeTestRunner.Shared.Reporting
         /// </summary>
         public class SubscribeFactCompletionMessages
         {
-            public SubscribeFactCompletionMessages(ActorRef subscriber)
+            public SubscribeFactCompletionMessages(IActorRef subscriber)
             {
                 Subscriber = subscriber;
             }
 
-            public ActorRef Subscriber { get; private set; }
+            public IActorRef Subscriber { get; private set; }
         }
 
         /// <summary>
@@ -37,13 +37,13 @@ namespace Akka.MultiNodeTestRunner.Shared.Reporting
         /// </summary>
         public class UnsubscribeFactCompletionMessages
         {
-            public UnsubscribeFactCompletionMessages(ActorRef subscriber)
+            public UnsubscribeFactCompletionMessages(IActorRef subscriber)
             {
                 Subscriber = subscriber;
             }
 
 
-            public ActorRef Subscriber { get; private set; }
+            public IActorRef Subscriber { get; private set; }
         }
 
         #endregion
@@ -57,7 +57,7 @@ namespace Akka.MultiNodeTestRunner.Shared.Reporting
         {
             TestRunStarted = testRunStarted;
             TestRunData = new TestRunTree(testRunStarted.Ticks);
-            Subscribers = new List<ActorRef>();
+            Subscribers = new List<IActorRef>();
             SetReceive();
         }
 
@@ -65,7 +65,7 @@ namespace Akka.MultiNodeTestRunner.Shared.Reporting
 
         protected readonly DateTime TestRunStarted;
 
-        protected ActorRef _currentSpecRunActor;
+        protected IActorRef _currentSpecRunActor;
 
         /// <summary>
         /// Automatically set when <see cref="EndTestRun"/> is sent to this actor.
@@ -91,7 +91,7 @@ namespace Akka.MultiNodeTestRunner.Shared.Reporting
         /// <summary>
         /// All of the subscribers who wish to receive <see cref="FactData"/> notifications
         /// </summary>
-        protected List<ActorRef> Subscribers;
+        protected List<IActorRef> Subscribers;
 
         #endregion
 

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/IMessageSink.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/IMessageSink.cs
@@ -38,7 +38,7 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
         /// 
         /// During instances of when a test run has been successfully started, this method
         /// will wait up to 10 seconds for any <see cref="Actor"/> instances included as part of this
-        /// <see cref="IMessageSink"/> to shutdown, via the <see cref="GracefulStopSupport.GracefulStop(ActorRef, TimeSpan)"/> method.
+        /// <see cref="IMessageSink"/> to shutdown, via the <see cref="GracefulStopSupport.GracefulStop(IActorRef, TimeSpan)"/> method.
         /// </summary>
         Task<bool> Close(ActorSystem context);
 

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/MessageSink.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/MessageSink.cs
@@ -17,7 +17,7 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
         /// <summary>
         /// ActorRef for the actor who coordinates all of reporting for each test run
         /// </summary>
-        protected ActorRef MessageSinkActorRef;
+        protected IActorRef MessageSinkActorRef;
 
         protected readonly Props MessageSinkActorProps;
 
@@ -42,7 +42,7 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
         public bool IsOpen { get; private set; }
         public bool IsClosed { get; private set; }
 
-        internal void RequestExitCode(ActorRef sender)
+        internal void RequestExitCode(IActorRef sender)
         {
             MessageSinkActorRef.Tell(new SinkCoordinator.RequestExitCode(), sender);
         }

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/MessageSinkActor.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/MessageSinkActor.cs
@@ -18,14 +18,14 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
         /// </summary>
         public class BeginSinkTerminate
         {
-            public BeginSinkTerminate(TestRunTree testRun, ActorRef subscriber)
+            public BeginSinkTerminate(TestRunTree testRun, IActorRef subscriber)
             {
                 Subscriber = subscriber;
                 TestRun = testRun;
             }
 
             public TestRunTree TestRun { get; private set; }
-            public ActorRef Subscriber { get; private set; }
+            public IActorRef Subscriber { get; private set; }
         }
 
         /// <summary>

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/TestCoordinatorEnabledMessageSink.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/TestCoordinatorEnabledMessageSink.cs
@@ -11,7 +11,7 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
     /// </summary>
     public abstract class TestCoordinatorEnabledMessageSink : MessageSinkActor
     {
-        protected ActorRef TestCoordinatorActorRef;
+        protected IActorRef TestCoordinatorActorRef;
         protected bool UseTestCoordinator;
 
         protected TestCoordinatorEnabledMessageSink(bool useTestCoordinator)

--- a/src/core/Akka.MultiNodeTestRunner/Program.cs
+++ b/src/core/Akka.MultiNodeTestRunner/Program.cs
@@ -171,7 +171,7 @@ namespace Akka.MultiNodeTestRunner
 
         static void PublishToAllSinks(string message)
         {
-            SinkCoordinator.Tell(message, ActorRef.NoSender);
+            SinkCoordinator.Tell(message, ActorRefs.NoSender);
         }
     }
 }

--- a/src/core/Akka.MultiNodeTestRunner/Program.cs
+++ b/src/core/Akka.MultiNodeTestRunner/Program.cs
@@ -19,7 +19,7 @@ namespace Akka.MultiNodeTestRunner
     {
         protected static ActorSystem TestRunSystem;
 
-        protected static ActorRef SinkCoordinator;
+        protected static IActorRef SinkCoordinator;
 
         
 

--- a/src/core/Akka.Persistence.FSharp/FsApi.fs
+++ b/src/core/Akka.Persistence.FSharp/FsApi.fs
@@ -31,7 +31,7 @@ type Eventsourced<'Command, 'Event, 'State> =
     abstract Context : IActorContext
     
     /// <summary>
-    /// Returns a sender of current message or <see cref="ActorRef.NoSender" />, if none could be determined.
+    /// Returns a sender of current message or <see cref="ActorRefs.NoSender" />, if none could be determined.
     /// </summary>
     abstract Sender : unit -> ActorRef
     
@@ -169,7 +169,7 @@ type View<'Event, 'State> =
     abstract Context : IActorContext
     
     /// <summary>
-    /// Returns a sender of current message or <see cref="ActorRef.NoSender" />, if none could be determined.
+    /// Returns a sender of current message or <see cref="ActorRefs.NoSender" />, if none could be determined.
     /// </summary>
     abstract Sender : unit -> ActorRef
     

--- a/src/core/Akka.Persistence.FSharp/FsApi.fs
+++ b/src/core/Akka.Persistence.FSharp/FsApi.fs
@@ -21,9 +21,9 @@ type Eventsourced<'Command, 'Event, 'State> =
     inherit Snapshotter<'State>
         
     /// <summary>
-    /// Gets <see cref="ActorRef" /> for the current actor.
+    /// Gets <see cref="IActorRef" /> for the current actor.
     /// </summary>
-    abstract Self : ActorRef
+    abstract Self : IActorRef
     
     /// <summary>
     /// Gets the current actor context.
@@ -33,7 +33,7 @@ type Eventsourced<'Command, 'Event, 'State> =
     /// <summary>
     /// Returns a sender of current message or <see cref="ActorRefs.NoSender" />, if none could be determined.
     /// </summary>
-    abstract Sender : unit -> ActorRef
+    abstract Sender : unit -> IActorRef
     
     /// <summary>
     /// Explicit signalization of unhandled message.
@@ -72,12 +72,12 @@ type Eventsourced<'Command, 'Event, 'State> =
     /// <summary>
     /// Returns currently attached journal actor reference.
     /// </summary>
-    abstract Journal: unit -> ActorRef
+    abstract Journal: unit -> IActorRef
     
     /// <summary>
     /// Returns currently attached snapshot store actor reference.
     /// </summary>
-    abstract SnapshotStore: unit -> ActorRef
+    abstract SnapshotStore: unit -> IActorRef
     
     /// <summary>
     /// Returns value determining if current persistent actor is actually recovering.
@@ -119,8 +119,8 @@ type FunPersistentActor<'Command, 'Event, 'State>(aggregate: Aggregate<'Command,
             member __.ActorOf(props, name) = context.ActorOf(props, name)
             member __.ActorSelection(path : string) = context.ActorSelection(path)
             member __.ActorSelection(path : ActorPath) = context.ActorSelection(path)
-            member __.Watch(aref:ActorRef) = context.Watch aref
-            member __.Unwatch(aref:ActorRef) = context.Unwatch aref
+            member __.Watch(aref:IActorRef) = context.Watch aref
+            member __.Unwatch(aref:IActorRef) = context.Unwatch aref
             member __.Log = lazy (Akka.Event.Logging.GetLogger(context)) 
             member __.Defer fn = deferables <- fn::deferables
             member __.DeferEvent callback events = this.Defer(events, Action<_>(updateState callback))
@@ -136,7 +136,7 @@ type FunPersistentActor<'Command, 'Event, 'State>(aggregate: Aggregate<'Command,
             member __.DeleteSnapshot seqNr timestamp = this.DeleteSnapshot(seqNr, timestamp)
             member __.DeleteSnapshots criteria = this.DeleteSnapshots(criteria) }
       
-    member __.Sender() : ActorRef = base.Sender
+    member __.Sender() : IActorRef = base.Sender
     member __.Unhandled msg = base.Unhandled msg
     override x.OnCommand (msg: obj) = 
         match msg with
@@ -159,9 +159,9 @@ type View<'Event, 'State> =
     inherit Snapshotter<'State>
 
     /// <summary>
-    /// Gets <see cref="ActorRef" /> for the current actor.
+    /// Gets <see cref="IActorRef" /> for the current actor.
     /// </summary>
-    abstract Self : ActorRef
+    abstract Self : IActorRef
     
     /// <summary>
     /// Gets the current actor context.
@@ -171,7 +171,7 @@ type View<'Event, 'State> =
     /// <summary>
     /// Returns a sender of current message or <see cref="ActorRefs.NoSender" />, if none could be determined.
     /// </summary>
-    abstract Sender : unit -> ActorRef
+    abstract Sender : unit -> IActorRef
     
     /// <summary>
     /// Explicit signalization of unhandled message.
@@ -192,12 +192,12 @@ type View<'Event, 'State> =
     /// <summary>
     /// Returns currently attached journal actor reference.
     /// </summary>
-    abstract Journal: unit -> ActorRef
+    abstract Journal: unit -> IActorRef
     
     /// <summary>
     /// Returns currently attached snapshot store actor reference.
     /// </summary>
-    abstract SnapshotStore: unit -> ActorRef
+    abstract SnapshotStore: unit -> IActorRef
         
     /// <summary>
     /// Returns last sequence number attached to latest persisted event.
@@ -238,8 +238,8 @@ type FunPersistentView<'Event, 'State>(perspective: Perspective<'Event, 'State>,
             member __.ActorOf(props, name) = context.ActorOf(props, name)
             member __.ActorSelection(path : string) = context.ActorSelection(path)
             member __.ActorSelection(path : ActorPath) = context.ActorSelection(path)
-            member __.Watch(aref:ActorRef) = context.Watch aref
-            member __.Unwatch(aref:ActorRef) = context.Unwatch aref
+            member __.Watch(aref:IActorRef) = context.Watch aref
+            member __.Unwatch(aref:IActorRef) = context.Unwatch aref
             member __.Log = lazy (Akka.Event.Logging.GetLogger(context)) 
             member __.Defer fn = deferables <- fn::deferables
             member __.Journal() = this.Journal
@@ -252,7 +252,7 @@ type FunPersistentView<'Event, 'State>(perspective: Perspective<'Event, 'State>,
             member __.DeleteSnapshot seqNr timestamp = this.DeleteSnapshot(seqNr, timestamp)
             member __.DeleteSnapshots criteria = this.DeleteSnapshots(criteria) }
       
-    member __.Sender() : ActorRef = base.Sender
+    member __.Sender() : IActorRef = base.Sender
     member __.Unhandled msg = base.Unhandled msg
     override x.Receive (msg: obj): bool = 
         match msg with
@@ -301,8 +301,8 @@ type Deliverer<'Command, 'Event, 'State>(aggregate: DeliveryAggregate<'Command, 
             member __.ActorOf(props, name) = context.ActorOf(props, name)
             member __.ActorSelection(path : string) = context.ActorSelection(path)
             member __.ActorSelection(path : ActorPath) = context.ActorSelection(path)
-            member __.Watch(aref:ActorRef) = context.Watch aref
-            member __.Unwatch(aref:ActorRef) = context.Unwatch aref
+            member __.Watch(aref:IActorRef) = context.Watch aref
+            member __.Unwatch(aref:IActorRef) = context.Unwatch aref
             member __.Log = lazy (Akka.Event.Logging.GetLogger(context)) 
             member __.Defer fn = deferables <- fn::deferables
             member __.DeferEvent callback events = this.Defer(events, Action<_>(updateState callback))
@@ -323,7 +323,7 @@ type Deliverer<'Command, 'Event, 'State>(aggregate: DeliveryAggregate<'Command, 
             member __.SetDeliverySnapshot snap = this.SetDeliverySnapshot snap
             member __.UnconfirmedCount() = this.UnconfirmedCount }
       
-    member __.Sender() : ActorRef = base.Sender
+    member __.Sender() : IActorRef = base.Sender
     member __.Unhandled msg = base.Unhandled msg
     override x.ReceiveCommand (msg: obj) = 
         match msg with
@@ -372,7 +372,7 @@ module Linq =
 /// <param name="name">Identifies uniquely current actor across different incarnations. It's necessary to identify it's event source.</param>
 /// <param name="aggregate">Aggregate containing state of the actor, but also an event- and command-handling behavior.</param>
 /// <param name="options">Additional spawning options.</param>
-let spawnPersist (actorFactory : ActorRefFactory) (name : PersistenceId) (aggregate: Aggregate<'Command, 'Event, 'State>) (options : SpawnOption list) : ActorRef =
+let spawnPersist (actorFactory : ActorRefFactory) (name : PersistenceId) (aggregate: Aggregate<'Command, 'Event, 'State>) (options : SpawnOption list) : IActorRef =
     let e = Linq.PersistentExpression.ToExpression(fun () -> new FunPersistentActor<'Command, 'Event, 'State>(aggregate, name))
     let props = applySpawnOptions (Props.Create e) options
     actorFactory.ActorOf(props, name)
@@ -385,7 +385,7 @@ let spawnPersist (actorFactory : ActorRefFactory) (name : PersistenceId) (aggreg
 /// <param name="viewName">Identifies uniquely current view's state. It's different that event source, since many views with different internal states can relate to single event source.</param>
 /// <param name="aggregate">Aggregate containing state of the actor, but also an command-handling behavior.</param>
 /// <param name="options">Additional spawning options.</param>
-let spawnView (actorFactory : ActorRefFactory) (viewName: PersistenceId) (name : PersistenceId)  (perspective: Perspective<'Event, 'State>) (options : SpawnOption list) : ActorRef =
+let spawnView (actorFactory : ActorRefFactory) (viewName: PersistenceId) (name : PersistenceId)  (perspective: Perspective<'Event, 'State>) (options : SpawnOption list) : IActorRef =
     let e = Linq.PersistentExpression.ToExpression(fun () -> new FunPersistentView<'Event, 'State>(perspective, name, viewName))
     let props = applySpawnOptions (Props.Create e) options
     actorFactory.ActorOf(props, viewName)
@@ -397,7 +397,7 @@ let spawnView (actorFactory : ActorRefFactory) (viewName: PersistenceId) (name :
 /// <param name="name">Identifies uniquely current actor across different incarnations. It's necessary to identify it's event source.</param>
 /// <param name="aggregate">Aggregate containing state of the actor, but also an event- and command-handling behavior.</param>
 /// <param name="options">Additional spawning options.</param>
-let spawnDeliverer (actorFactory : ActorRefFactory) (name : PersistenceId) (aggregate: DeliveryAggregate<'Command, 'Event, 'State>) (options : SpawnOption list) : ActorRef =
+let spawnDeliverer (actorFactory : ActorRefFactory) (name : PersistenceId) (aggregate: DeliveryAggregate<'Command, 'Event, 'State>) (options : SpawnOption list) : IActorRef =
     let e = Linq.PersistentExpression.ToExpression(fun () -> new Deliverer<'Command, 'Event, 'State>(aggregate, name))
     let props = applySpawnOptions (Props.Create e) options
     actorFactory.ActorOf(props, name)

--- a/src/core/Akka.Persistence.TestKit/Journal/JournalSpec.cs
+++ b/src/core/Akka.Persistence.TestKit/Journal/JournalSpec.cs
@@ -42,7 +42,7 @@ namespace Akka.Persistence.TestKit.Journal
         {
         }
 
-        protected ActorRef Journal { get { return Extension.JournalFor(null); } }
+        protected IActorRef Journal { get { return Extension.JournalFor(null); } }
 
         private static Config ConfigFromTemplate(Type journalType)
         {
@@ -59,7 +59,7 @@ namespace Akka.Persistence.TestKit.Journal
                    && p.SequenceNr == seqNr;
         }
 
-        protected void WriteMessages(int from, int to, string pid, ActorRef sender)
+        protected void WriteMessages(int from, int to, string pid, IActorRef sender)
         {
             var messages = Enumerable.Range(from, to).Select(i => new Persistent("a-" + i, i, pid, false, sender)).ToArray();
             var probe = CreateTestProbe();

--- a/src/core/Akka.Persistence.TestKit/PluginSpec.cs
+++ b/src/core/Akka.Persistence.TestKit/PluginSpec.cs
@@ -32,7 +32,7 @@ namespace Akka.Persistence.TestKit
         public string Pid { get { return _pid; } }
         public PersistenceExtension Extension { get { return _extension; } }
 
-        public void Subscribe<T>(ActorRef subscriber)
+        public void Subscribe<T>(IActorRef subscriber)
         {
             Sys.EventStream.Subscribe(subscriber, typeof (T));
         }

--- a/src/core/Akka.Persistence.TestKit/Snapshot/SnapshotStoreSpec.cs
+++ b/src/core/Akka.Persistence.TestKit/Snapshot/SnapshotStoreSpec.cs
@@ -39,7 +39,7 @@ namespace Akka.Persistence.TestKit.Snapshot
         {
         }
 
-        protected ActorRef SnapshotStore { get { return Extension.SnapshotStoreFor(null); } }
+        protected IActorRef SnapshotStore { get { return Extension.SnapshotStoreFor(null); } }
 
         private static Config ConfigFromTemplate(Type snapshotStoreType)
         {

--- a/src/core/Akka.Persistence.Tests/GuaranteedDeliveryCrashSpec.cs
+++ b/src/core/Akka.Persistence.Tests/GuaranteedDeliveryCrashSpec.cs
@@ -13,9 +13,9 @@ namespace Akka.Persistence.Tests
 
         internal class StoppingStrategySupervisor : ActorBase
         {
-            private readonly ActorRef _crashingActor;
+            private readonly IActorRef _crashingActor;
 
-            public StoppingStrategySupervisor(ActorRef testProbe)
+            public StoppingStrategySupervisor(IActorRef testProbe)
             {
                 _crashingActor = Context.ActorOf(Props.Create(() => new CrashingActor(testProbe)), "CrashingActor");
             }
@@ -62,12 +62,12 @@ namespace Akka.Persistence.Tests
 
         internal class CrashingActor : GuaranteedDeliveryActor
         {
-            private readonly ActorRef _testProbe;
+            private readonly IActorRef _testProbe;
             private LoggingAdapter _adapter;
 
             LoggingAdapter Log { get { return _adapter ?? (_adapter = Context.GetLogger()); } }
 
-            public CrashingActor(ActorRef testProbe)
+            public CrashingActor(IActorRef testProbe)
             {
                 _testProbe = testProbe;
             }

--- a/src/core/Akka.Persistence.Tests/GuaranteedDeliveryFailureSpec.cs
+++ b/src/core/Akka.Persistence.Tests/GuaranteedDeliveryFailureSpec.cs
@@ -124,14 +124,14 @@ namespace Akka.Persistence.Tests
 
         internal interface IChaosSupport
         {
-            ActorRef Probe { get; }
+            IActorRef Probe { get; }
             List<int> State { get; set; }
         }
 
         internal class ChaosSender : GuaranteedDeliveryActor
         {
             private readonly string _persistenceId;
-            private readonly ActorRef _destination;
+            private readonly IActorRef _destination;
             private readonly Config _config;
             private readonly double _liveProcessingFailureRate;
             private readonly double _replayProcessingFailureRate;
@@ -139,7 +139,7 @@ namespace Akka.Persistence.Tests
 
             public LoggingAdapter Log { get { return _log ?? (_log = Context.GetLogger()); }}
 
-            public ChaosSender(ActorRef destination, ActorRef probe)
+            public ChaosSender(IActorRef destination, IActorRef probe)
             {
                 _destination = destination;
                 Probe = probe;
@@ -229,7 +229,7 @@ namespace Akka.Persistence.Tests
             }
 
 
-            public ActorRef Probe { get; private set; }
+            public IActorRef Probe { get; private set; }
             public List<int> State { get; set; }
         }
 
@@ -241,7 +241,7 @@ namespace Akka.Persistence.Tests
 
             public LoggingAdapter Log { get { return _log ?? (_log = Context.GetLogger()); } }
 
-            public ChaosDestination(ActorRef probe)
+            public ChaosDestination(IActorRef probe)
             {
                 Probe = probe;
                 State = new List<int>();
@@ -268,17 +268,17 @@ namespace Akka.Persistence.Tests
                 });
             }
 
-            public ActorRef Probe { get; private set; }
+            public IActorRef Probe { get; private set; }
             public List<int> State { get; set; }
         }
 
         internal class ChaosApp : ReceiveActor
         {
-            private readonly ActorRef _probe;
-            private readonly ActorRef _destination;
-            private readonly ActorRef _sender;
+            private readonly IActorRef _probe;
+            private readonly IActorRef _destination;
+            private readonly IActorRef _sender;
 
-            public ChaosApp(ActorRef probe)
+            public ChaosApp(IActorRef probe)
             {
                 _probe = probe;
                 _destination = Context.ActorOf(Props.Create(() => new ChaosDestination(_probe)), "destination");

--- a/src/core/Akka.Persistence.Tests/GuaranteedDeliverySpec.cs
+++ b/src/core/Akka.Persistence.Tests/GuaranteedDeliverySpec.cs
@@ -15,7 +15,7 @@ namespace Akka.Persistence.Tests
 
         class Sender : GuaranteedDeliveryActor
         {
-            private readonly ActorRef _testActor;
+            private readonly IActorRef _testActor;
             private readonly string _name;
             private readonly TimeSpan _redeliverInterval;
             private readonly int _warn;
@@ -23,9 +23,9 @@ namespace Akka.Persistence.Tests
             private readonly bool _isAsync;
             private readonly IDictionary<string, ActorPath> _destinations;
             private readonly LoggingAdapter _log;
-            private ActorRef _lastSnapshotAskedForBy;
+            private IActorRef _lastSnapshotAskedForBy;
 
-            public Sender(ActorRef testActor, string name, TimeSpan redeliverInterval, int warn, int redeliveryBurstLimit, bool isAsync, IDictionary<string, ActorPath> destinations)
+            public Sender(IActorRef testActor, string name, TimeSpan redeliverInterval, int warn, int redeliveryBurstLimit, bool isAsync, IDictionary<string, ActorPath> destinations)
                 : base()
             {
                 _testActor = testActor;
@@ -131,7 +131,7 @@ namespace Akka.Persistence.Tests
         {
             private readonly ISet<long> _allReceived;
 
-            public Destination(ActorRef testActor)
+            public Destination(IActorRef testActor)
             {
                 _allReceived = new HashSet<long>();
                 Receive<Action>(a =>
@@ -149,7 +149,7 @@ namespace Akka.Persistence.Tests
         class Unreliable : ReceiveActor
         {
             private int _count = 0;
-            public Unreliable(int dropMod, ActorRef target)
+            public Unreliable(int dropMod, IActorRef target)
             {
                 Receive<object>((message) =>
                 {

--- a/src/core/Akka.Persistence.Tests/PersistentActorFailureSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorFailureSpec.cs
@@ -48,9 +48,9 @@ namespace Akka.Persistence.Tests
 
         internal class Supervisor : ActorBase
         {
-            private readonly ActorRef _testActor;
+            private readonly IActorRef _testActor;
 
-            public Supervisor(ActorRef testActor)
+            public Supervisor(IActorRef testActor)
             {
                 _testActor = testActor;
             }
@@ -93,7 +93,7 @@ namespace Akka.Persistence.Tests
             var supervisor = ActorOf(() => new Supervisor(TestActor));
             supervisor.Tell(Props.Create(() => new BehaviorOneActor(Name)));
 
-            ExpectMsg<ActorRef>();
+            ExpectMsg<IActorRef>();
             ExpectMsg<ActorKilledException>();
         }
     }

--- a/src/core/Akka.Persistence.Tests/PersistentActorSpec.Actors.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorSpec.Actors.cs
@@ -298,8 +298,8 @@ namespace Akka.Persistence.Tests
 
         internal class SnapshottingPersistentActor : ExamplePersistentActor
         {
-            protected readonly ActorRef Probe;
-            public SnapshottingPersistentActor(string name, ActorRef probe)
+            protected readonly IActorRef Probe;
+            public SnapshottingPersistentActor(string name, IActorRef probe)
                 : base(name)
             {
                 Probe = probe;
@@ -339,7 +339,7 @@ namespace Akka.Persistence.Tests
         {
             public const string Message = "It's changing me";
             public const string Response = "I'm becoming";
-            public SnapshottingBecomingPersistentActor(string name, ActorRef probe) : base(name, probe) { }
+            public SnapshottingBecomingPersistentActor(string name, IActorRef probe) : base(name, probe) { }
 
             private bool BecomingRecover(object message)
             {
@@ -719,7 +719,7 @@ namespace Akka.Persistence.Tests
 
         internal class HandleRecoveryFinishedEventPersistentActor : SnapshottingPersistentActor
         {
-            public HandleRecoveryFinishedEventPersistentActor(string name, ActorRef probe)
+            public HandleRecoveryFinishedEventPersistentActor(string name, IActorRef probe)
                 : base(name, probe)
             {
             }

--- a/src/core/Akka.Persistence.Tests/PersistentViewSpec.Actors.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentViewSpec.Actors.cs
@@ -9,9 +9,9 @@ namespace Akka.Persistence.Tests
 
         internal class TestPersistentActor : NamedPersistentActor
         {
-            private readonly ActorRef _probe;
+            private readonly IActorRef _probe;
 
-            public TestPersistentActor(string name, ActorRef probe)
+            public TestPersistentActor(string name, IActorRef probe)
                 : base(name)
             {
                 _probe = probe;
@@ -33,13 +33,13 @@ namespace Akka.Persistence.Tests
         internal class TestPersistentView : PersistentView
         {
             private readonly string _name;
-            private readonly ActorRef _probe;
+            private readonly IActorRef _probe;
             private readonly TimeSpan _interval;
 
             private string _failAt;
             private string _last;
 
-            public TestPersistentView(string name, ActorRef probe, TimeSpan interval, string failAt = null)
+            public TestPersistentView(string name, IActorRef probe, TimeSpan interval, string failAt = null)
             {
                 _name = name;
                 _probe = probe;
@@ -47,7 +47,7 @@ namespace Akka.Persistence.Tests
                 _failAt = failAt;
             }
 
-            public TestPersistentView(string name, ActorRef probe)
+            public TestPersistentView(string name, IActorRef probe)
                 : this(name, probe, TimeSpan.FromMilliseconds(100))
             {
             }
@@ -85,12 +85,12 @@ namespace Akka.Persistence.Tests
         internal class PassiveTestPersistentView : PersistentView
         {
             private readonly string _name;
-            private readonly ActorRef _probe;
+            private readonly IActorRef _probe;
 
             private string _failAt;
             private string _last;
 
-            public PassiveTestPersistentView(string name, ActorRef probe, string failAt = null)
+            public PassiveTestPersistentView(string name, IActorRef probe, string failAt = null)
             {
                 _name = name;
                 _probe = probe;
@@ -137,9 +137,9 @@ namespace Akka.Persistence.Tests
         internal class ActiveTestPersistentView : PersistentView
         {
             private readonly string _name;
-            private readonly ActorRef _probe;
+            private readonly IActorRef _probe;
 
-            public ActiveTestPersistentView(string name, ActorRef probe)
+            public ActiveTestPersistentView(string name, IActorRef probe)
             {
                 _name = name;
                 _probe = probe;
@@ -161,9 +161,9 @@ namespace Akka.Persistence.Tests
         internal class BecomingPersistentView : PersistentView
         {
             private readonly string _name;
-            private readonly ActorRef _probe;
+            private readonly IActorRef _probe;
 
-            public BecomingPersistentView(string name, ActorRef probe)
+            public BecomingPersistentView(string name, IActorRef probe)
             {
                 _name = name;
                 _probe = probe;
@@ -186,12 +186,12 @@ namespace Akka.Persistence.Tests
         internal class PersistentOrNotTestPersistentView : PersistentView
         {
             private readonly string _name;
-            private readonly ActorRef _probe;
+            private readonly IActorRef _probe;
 
             public override string ViewId { get { return _name + "-view"; } }
             public override string PersistenceId { get { return _name; } }
 
-            public PersistentOrNotTestPersistentView(string name, ActorRef probe)
+            public PersistentOrNotTestPersistentView(string name, IActorRef probe)
             {
                 _name = name;
                 _probe = probe;
@@ -209,7 +209,7 @@ namespace Akka.Persistence.Tests
         internal class SnapshottingPersistentView : PersistentView
         {
             private readonly string _name;
-            private readonly ActorRef _probe;
+            private readonly IActorRef _probe;
 
             private string _last;
 
@@ -218,7 +218,7 @@ namespace Akka.Persistence.Tests
 
             public override TimeSpan AutoUpdateInterval { get { return TimeSpan.FromMilliseconds(100); } }
 
-            public SnapshottingPersistentView(string name, ActorRef probe)
+            public SnapshottingPersistentView(string name, IActorRef probe)
             {
                 _name = name;
                 _probe = probe;

--- a/src/core/Akka.Persistence.Tests/PersistentViewSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentViewSpec.cs
@@ -7,8 +7,8 @@ namespace Akka.Persistence.Tests
 {
     public partial class PersistentViewSpec : PersistenceSpec
     {
-        protected ActorRef _pref;
-        protected ActorRef _view;
+        protected IActorRef _pref;
+        protected IActorRef _view;
         protected TestProbe _prefProbe;
         protected TestProbe _viewProbe;
 

--- a/src/core/Akka.Persistence.Tests/SnapshotSpec.cs
+++ b/src/core/Akka.Persistence.Tests/SnapshotSpec.cs
@@ -21,10 +21,10 @@ namespace Akka.Persistence.Tests
 
         internal class SaveSnapshotTestActor : NamedPersistentActor
         {
-            private readonly ActorRef _probe;
+            private readonly IActorRef _probe;
             protected LinkedList<string> _state = new LinkedList<string>();
 
-            public SaveSnapshotTestActor(string name, ActorRef probe)
+            public SaveSnapshotTestActor(string name, IActorRef probe)
                 : base(name)
             {
                 _probe = probe;
@@ -51,9 +51,9 @@ namespace Akka.Persistence.Tests
 
         internal class LoadSnapshotTestActor : NamedPersistentActor
         {
-            private readonly ActorRef _probe;
+            private readonly IActorRef _probe;
 
-            public LoadSnapshotTestActor(string name, ActorRef probe)
+            public LoadSnapshotTestActor(string name, IActorRef probe)
                 : base(name)
             {
                 _probe = probe;
@@ -108,7 +108,7 @@ namespace Akka.Persistence.Tests
 
         internal class DeleteSnapshotTestActor : LoadSnapshotTestActor
         {
-            public DeleteSnapshotTestActor(string name, ActorRef probe)
+            public DeleteSnapshotTestActor(string name, IActorRef probe)
                 : base(name, probe)
             {
             }

--- a/src/core/Akka.Persistence/Eventsourced.cs
+++ b/src/core/Akka.Persistence/Eventsourced.cs
@@ -50,8 +50,8 @@ namespace Akka.Persistence
 
         private readonly int _instanceId;
         private readonly IStash _internalStash;
-        private ActorRef _snapshotStore;
-        private ActorRef _journal;
+        private IActorRef _snapshotStore;
+        private IActorRef _journal;
         private ICollection<IPersistentEnvelope> _journalBatch = new List<IPersistentEnvelope>();
         private readonly int _maxMessageBatchSize;
         private bool _isWriteInProgress = false;
@@ -89,12 +89,12 @@ namespace Akka.Persistence
 
         public string SnapshotPluginId { get; protected set; }
 
-        public ActorRef Journal
+        public IActorRef Journal
         {
             get { return _journal ?? (_journal = Extension.JournalFor(JournalPluginId)); }
         }
 
-        public ActorRef SnapshotStore
+        public IActorRef SnapshotStore
         {
             get { return _snapshotStore ?? (_snapshotStore = Extension.SnapshotStoreFor(SnapshotPluginId)); }
         }

--- a/src/core/Akka.Persistence/InternalExtensions.cs
+++ b/src/core/Akka.Persistence/InternalExtensions.cs
@@ -11,7 +11,7 @@ namespace Akka.Persistence
         /// Sends <paramref name="task"/> result to the <paramref name="receiver"/> in form of <see cref="ReplayMessagesSuccess"/> 
         /// or <see cref="ReplayMessagesFailure"/> depending on the success or failure of the task.
         /// </summary>
-        public static Task NotifyAboutReplayCompletion(this Task task, ActorRef receiver)
+        public static Task NotifyAboutReplayCompletion(this Task task, IActorRef receiver)
         {
             return task
                 .ContinueWith(t => !t.IsFaulted ? (object) ReplayMessagesSuccess.Instance : new ReplayMessagesFailure(t.Exception))

--- a/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
@@ -11,7 +11,7 @@ namespace Akka.Persistence.Journal
         private static readonly TaskContinuationOptions _continuationOptions = TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.AttachedToParent;
         protected readonly bool CanPublish;
         private readonly PersistenceExtension _extension;
-        private readonly ActorRef _resequencer;
+        private readonly IActorRef _resequencer;
 
         private long _resequencerCounter = 1L;
 
@@ -132,7 +132,7 @@ namespace Akka.Persistence.Journal
 
         internal sealed class Desequenced
         {
-            public Desequenced(object message, long sequenceNr, ActorRef target, ActorRef sender)
+            public Desequenced(object message, long sequenceNr, IActorRef target, IActorRef sender)
             {
                 Message = message;
                 SequenceNr = sequenceNr;
@@ -142,8 +142,8 @@ namespace Akka.Persistence.Journal
 
             public object Message { get; private set; }
             public long SequenceNr { get; private set; }
-            public ActorRef Target { get; private set; }
-            public ActorRef Sender { get; private set; }
+            public IActorRef Target { get; private set; }
+            public IActorRef Sender { get; private set; }
         }
 
         internal class Resequencer : ActorBase

--- a/src/core/Akka.Persistence/Journal/AsyncWriteProxy.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteProxy.cs
@@ -28,7 +28,7 @@ namespace Akka.Persistence.Journal
     [Serializable]
     public sealed class SetStore
     {
-        public SetStore(ActorRef store)
+        public SetStore(IActorRef store)
         {
             if (store == null)
                 throw new ArgumentNullException("store", "SetStore requires non-null reference to store actor");
@@ -36,7 +36,7 @@ namespace Akka.Persistence.Journal
             Store = store;
         }
 
-        public ActorRef Store { get; private set; }
+        public IActorRef Store { get; private set; }
     }
 
     public static class AsyncWriteTarget
@@ -154,7 +154,7 @@ namespace Akka.Persistence.Journal
     public abstract class AsyncWriteProxy : AsyncWriteJournal, WithUnboundedStash
     {
         private readonly Receive _initialized;
-        private ActorRef _store;
+        private IActorRef _store;
 
         public IStash Stash { get; set; }
         public TimeSpan Timeout { get; private set; }

--- a/src/core/Akka.Persistence/JournalProtocol.cs
+++ b/src/core/Akka.Persistence/JournalProtocol.cs
@@ -6,7 +6,7 @@ namespace Akka.Persistence
 {
     public sealed class DeleteMessages
     {
-        public DeleteMessages(IEnumerable<IPersistentEnvelope> messageIds, bool isPermanent, ActorRef requestor)
+        public DeleteMessages(IEnumerable<IPersistentEnvelope> messageIds, bool isPermanent, IActorRef requestor)
         {
             MessageIds = messageIds;
             IsPermanent = isPermanent;
@@ -15,7 +15,7 @@ namespace Akka.Persistence
 
         public IEnumerable<IPersistentEnvelope> MessageIds { get; private set; }
         public bool IsPermanent { get; private set; }
-        public ActorRef Requestor { get; private set; }
+        public IActorRef Requestor { get; private set; }
     }
 
     public sealed class DeleteMessagesSuccess
@@ -89,7 +89,7 @@ namespace Akka.Persistence
 
     public sealed class WriteMessages
     {
-        public WriteMessages(IEnumerable<IPersistentEnvelope> messages, ActorRef persistentActor,
+        public WriteMessages(IEnumerable<IPersistentEnvelope> messages, IActorRef persistentActor,
             int actorInstanceId)
         {
             Messages = messages;
@@ -98,7 +98,7 @@ namespace Akka.Persistence
         }
 
         public IEnumerable<IPersistentEnvelope> Messages { get; private set; }
-        public ActorRef PersistentActor { get; private set; }
+        public IActorRef PersistentActor { get; private set; }
         public int ActorInstanceId { get; private set; }
     }
 
@@ -187,7 +187,7 @@ namespace Akka.Persistence
 
     public sealed class LoopMessage
     {
-        public LoopMessage(object message, ActorRef persistentActor, int actorInstanceId)
+        public LoopMessage(object message, IActorRef persistentActor, int actorInstanceId)
         {
             Message = message;
             PersistentActor = persistentActor;
@@ -195,7 +195,7 @@ namespace Akka.Persistence
         }
 
         public object Message { get; private set; }
-        public ActorRef PersistentActor { get; private set; }
+        public IActorRef PersistentActor { get; private set; }
         public int ActorInstanceId { get; private set; }
     }
 
@@ -224,7 +224,7 @@ namespace Akka.Persistence
     public sealed class ReplayMessages : IEquatable<ReplayMessages>
     {
         public ReplayMessages(long fromSequenceNr, long toSequenceNr, long max, string persistenceId,
-            ActorRef persistentActor, bool replayDeleted = false)
+            IActorRef persistentActor, bool replayDeleted = false)
         {
             FromSequenceNr = fromSequenceNr;
             ToSequenceNr = toSequenceNr;
@@ -257,7 +257,7 @@ namespace Akka.Persistence
         /// <summary>
         /// Requesting persistent actor.
         /// </summary>
-        public ActorRef PersistentActor { get; private set; }
+        public IActorRef PersistentActor { get; private set; }
 
         /// <summary>
         /// If true, message marked as deleted shall be replayed.
@@ -320,7 +320,7 @@ namespace Akka.Persistence
 
     public sealed class ReadHighestSequenceNr : IEquatable<ReadHighestSequenceNr>
     {
-        public ReadHighestSequenceNr(long fromSequenceNr, string persistenceId, ActorRef persistentActor)
+        public ReadHighestSequenceNr(long fromSequenceNr, string persistenceId, IActorRef persistentActor)
         {
             FromSequenceNr = fromSequenceNr;
             PersistenceId = persistenceId;
@@ -331,7 +331,7 @@ namespace Akka.Persistence
 
         public string PersistenceId { get; private set; }
 
-        public ActorRef PersistentActor { get; private set; }
+        public IActorRef PersistentActor { get; private set; }
 
         public bool Equals(ReadHighestSequenceNr other)
         {

--- a/src/core/Akka.Persistence/Persistence.cs
+++ b/src/core/Akka.Persistence/Persistence.cs
@@ -12,8 +12,8 @@ namespace Akka.Persistence
 
         private readonly Config _config;
         private readonly ExtendedActorSystem _system;
-        private readonly ActorRef _journal;
-        private readonly ActorRef _snapshotStore;
+        private readonly IActorRef _journal;
+        private readonly IActorRef _snapshotStore;
 
         public PersistenceSettings Settings { get; private set; }
 
@@ -30,24 +30,24 @@ namespace Akka.Persistence
             Settings = new PersistenceSettings(_system, _config);
         }
 
-        public string PersistenceId(ActorRef actor)
+        public string PersistenceId(IActorRef actor)
         {
             return actor.Path.ToStringWithoutAddress();
         }
 
-        public ActorRef SnapshotStoreFor(string persistenceId)
+        public IActorRef SnapshotStoreFor(string persistenceId)
         {
             // currently always returns _snapshotStore, but in future it may return dedicated actor for each persistence id
             return _snapshotStore;
         }
 
-        public ActorRef JournalFor(string persistenceId)
+        public IActorRef JournalFor(string persistenceId)
         {
             // currently always returns _journal, but in future it may return dedicated actor for each persistence id
             return _journal;
         }
 
-        private ActorRef CreatePlugin(string type, Func<Type, string> dispatcherSelector)
+        private IActorRef CreatePlugin(string type, Func<Type, string> dispatcherSelector)
         {
             var pluginConfigPath = _config.GetString(type + ".plugin");
             var pluginConfig = _system.Settings.Config.GetConfig(pluginConfigPath);

--- a/src/core/Akka.Persistence/Persistent.cs
+++ b/src/core/Akka.Persistence/Persistent.cs
@@ -36,7 +36,7 @@ namespace Akka.Persistence
     public interface IPersistentEnvelope
     {
         object Payload { get; }
-        ActorRef Sender { get; }
+        IActorRef Sender { get; }
     }
 
     /// <summary>
@@ -44,7 +44,7 @@ namespace Akka.Persistence
     /// </summary>
     internal sealed class NonPersistentMessage : IPersistentEnvelope
     {
-        public NonPersistentMessage(object payload, ActorRef sender)
+        public NonPersistentMessage(object payload, IActorRef sender)
         {
             Payload = payload;
             Sender = sender;
@@ -58,7 +58,7 @@ namespace Akka.Persistence
         /// <summary>
         /// Sender of this message.
         /// </summary>
-        public ActorRef Sender { get; private set; }
+        public IActorRef Sender { get; private set; }
     }
 
     /// <summary>
@@ -84,11 +84,11 @@ namespace Akka.Persistence
         /// <summary>
         /// Creates a new deep copy of this message.
         /// </summary>
-        IPersistentRepresentation Update(long sequenceNr, string persistenceId, bool isDeleted, ActorRef sender);
+        IPersistentRepresentation Update(long sequenceNr, string persistenceId, bool isDeleted, IActorRef sender);
 
         #region Internal API
 
-        IPersistentRepresentation PrepareWrite(ActorRef sender);
+        IPersistentRepresentation PrepareWrite(IActorRef sender);
 
         IPersistentRepresentation PrepareWrite(IActorContext context);
 
@@ -98,7 +98,7 @@ namespace Akka.Persistence
     [Serializable]
     public class Persistent : IPersistentRepresentation
     {
-        public Persistent(object payload, long sequenceNr = 0L, string persistenceId = null, bool isDeleted = false, ActorRef sender = null)
+        public Persistent(object payload, long sequenceNr = 0L, string persistenceId = null, bool isDeleted = false, IActorRef sender = null)
         {
             Payload = payload;
             SequenceNr = sequenceNr;
@@ -108,7 +108,7 @@ namespace Akka.Persistence
         }
 
         public object Payload { get; private set; }
-        public ActorRef Sender { get; private set; }
+        public IActorRef Sender { get; private set; }
         public string PersistenceId { get; private set; }
         public bool IsDeleted { get; private set; }
         public long SequenceNr { get; private set; }
@@ -118,12 +118,12 @@ namespace Akka.Persistence
             return new Persistent(payload, SequenceNr, PersistenceId, IsDeleted, Sender);
         }
 
-        public IPersistentRepresentation Update(long sequenceNr, string persistenceId, bool isDeleted, ActorRef sender)
+        public IPersistentRepresentation Update(long sequenceNr, string persistenceId, bool isDeleted, IActorRef sender)
         {
             return new Persistent(Payload, sequenceNr, persistenceId, isDeleted, sender);
         }
 
-        public IPersistentRepresentation PrepareWrite(ActorRef sender)
+        public IPersistentRepresentation PrepareWrite(IActorRef sender)
         {
             return new Persistent(Payload, SequenceNr, PersistenceId, IsDeleted, sender);
         }

--- a/src/core/Akka.Persistence/PersistentView.cs
+++ b/src/core/Akka.Persistence/PersistentView.cs
@@ -81,8 +81,8 @@ namespace Akka.Persistence
         protected readonly PersistenceExtension Extension;
 
         private readonly PersistenceSettings.ViewSettings _viewSettings;
-        private ActorRef _snapshotStore;
-        private ActorRef _journal;
+        private IActorRef _snapshotStore;
+        private IActorRef _journal;
 
         private ICancelable _scheduleCancellation;
 
@@ -102,12 +102,12 @@ namespace Akka.Persistence
 
         public string SnapshotPluginId { get; protected set; }
 
-        public ActorRef Journal
+        public IActorRef Journal
         {
             get { return _journal ?? (_journal = Extension.JournalFor(JournalPluginId)); }
         }
 
-        public ActorRef SnapshotStore
+        public IActorRef SnapshotStore
         {
             get { return _snapshotStore ?? (_snapshotStore = Extension.SnapshotStoreFor(SnapshotPluginId)); }
         }

--- a/src/core/Akka.Remote.TestKit.Tests/BarrierSpec.cs
+++ b/src/core/Akka.Remote.TestKit.Tests/BarrierSpec.cs
@@ -10,16 +10,16 @@ namespace Akka.Remote.TestKit.Tests
     {
         private sealed class Failed
         {
-            private readonly ActorRef _ref;
+            private readonly IActorRef _ref;
             private readonly Exception _exception;
 
-            public Failed(ActorRef @ref, Exception exception)
+            public Failed(IActorRef @ref, Exception exception)
             {
                 _ref = @ref;
                 _exception = exception;
             }
 
-            public ActorRef Ref
+            public IActorRef Ref
             {
                 get { return _ref; }
             }
@@ -274,7 +274,7 @@ namespace Akka.Remote.TestKit.Tests
                 new BarrierCoordinator.Data(
                     ImmutableHashSet.Create<Controller.NodeInfo>(),
                     "",
-                    ImmutableHashSet.Create<ActorRef>(),
+                    ImmutableHashSet.Create<IActorRef>(),
                     ((BarrierCoordinator.BarrierEmpty)msg.Exception).BarrierData.Deadline)
                 , "cannot remove RoleName(a): no client to remove"), msg.Exception);
             barrier.Tell(new Controller.NodeInfo(A, Address.Parse("akka://sys"), a.Ref));
@@ -322,28 +322,28 @@ namespace Akka.Remote.TestKit.Tests
                 new BarrierCoordinator.Data(
                     ImmutableHashSet.Create(nodeA),
                     "",
-                    ImmutableHashSet.Create<ActorRef>(),
+                    ImmutableHashSet.Create<IActorRef>(),
                     ((BarrierCoordinator.DuplicateNode)msg.Exception).BarrierData.Deadline)
                 , nodeB), msg.Exception);
         }
 
         //TODO: Controller tests.
 
-        private ActorRef GetBarrier()
+        private IActorRef GetBarrier()
         {
             var actor =
                 Sys.ActorOf(
                     new Props(typeof (BarrierCoordinatorSupervisor), new object[] {TestActor}).WithDeploy(Deploy.Local));
             actor.Tell("", TestActor);
-            return ExpectMsg<ActorRef>();
+            return ExpectMsg<IActorRef>();
         }
 
         private class BarrierCoordinatorSupervisor : UntypedActor
         {
-            readonly ActorRef _testActor;
-            readonly ActorRef _barrier;
+            readonly IActorRef _testActor;
+            readonly IActorRef _barrier;
 
-            public BarrierCoordinatorSupervisor(ActorRef testActor)
+            public BarrierCoordinatorSupervisor(IActorRef testActor)
             {
                 _testActor = testActor;
                 _barrier = Context.ActorOf(Props.Create<BarrierCoordinator>());
@@ -370,7 +370,7 @@ namespace Akka.Remote.TestKit.Tests
             foreach (var probe in probes) Assert.False(probe.HasMessages);
         }
 
-        public ActorRef Self
+        public IActorRef Self
         {
             get { return TestActor; }
         }

--- a/src/core/Akka.Remote.TestKit/BarrierCoordinator.cs
+++ b/src/core/Akka.Remote.TestKit/BarrierCoordinator.cs
@@ -43,15 +43,15 @@ namespace Akka.Remote.TestKit
 
         public sealed class Data
         {
-            public Data(IEnumerable<Controller.NodeInfo> clients, string barrier, IEnumerable<ActorRef> arrived, Deadline deadline) : 
+            public Data(IEnumerable<Controller.NodeInfo> clients, string barrier, IEnumerable<IActorRef> arrived, Deadline deadline) : 
                 this(clients == null ? ImmutableHashSet.Create<Controller.NodeInfo>() : ImmutableHashSet.Create(clients.ToArray()), 
                 barrier, 
-                arrived == null ? ImmutableHashSet.Create<ActorRef>() : ImmutableHashSet.Create(arrived.ToArray()), 
+                arrived == null ? ImmutableHashSet.Create<IActorRef>() : ImmutableHashSet.Create(arrived.ToArray()), 
                 deadline)
             {
             }
 
-            public Data(ImmutableHashSet<Controller.NodeInfo> clients, string barrier, ImmutableHashSet<ActorRef> arrived, Deadline deadline)
+            public Data(ImmutableHashSet<Controller.NodeInfo> clients, string barrier, ImmutableHashSet<IActorRef> arrived, Deadline deadline)
             {
                 Deadline = deadline;
                 Arrived = arrived;
@@ -63,12 +63,12 @@ namespace Akka.Remote.TestKit
 
             public string Barrier { get; private set; }
 
-            public ImmutableHashSet<ActorRef> Arrived { get; private set; }
+            public ImmutableHashSet<IActorRef> Arrived { get; private set; }
 
             public Deadline Deadline { get; private set; }
 
             public Data Copy(ImmutableHashSet<Controller.NodeInfo> clients = null, string barrier = null,
-                ImmutableHashSet<ActorRef> arrived = null, Deadline deadline = null)
+                ImmutableHashSet<IActorRef> arrived = null, Deadline deadline = null)
             {
                 return new Data(clients ?? Clients, 
                     barrier ?? Barrier,
@@ -236,7 +236,7 @@ namespace Akka.Remote.TestKit
 
         public sealed class WrongBarrier : Exception
         {
-            public WrongBarrier(string barrier, ActorRef client, Data barrierData)
+            public WrongBarrier(string barrier, IActorRef client, Data barrierData)
                 : base(string.Format("tried"))
             {
                 BarrierData = barrierData;
@@ -246,7 +246,7 @@ namespace Akka.Remote.TestKit
 
             public string Barrier { get; private set; }
 
-            public ActorRef Client { get; private set; }
+            public IActorRef Client { get; private set; }
 
             public Data BarrierData { get; private set; }
 
@@ -386,7 +386,7 @@ namespace Akka.Remote.TestKit
 
         protected void InitFSM()
         {
-            StartWith(State.Idle, new Data(ImmutableHashSet.Create<Controller.NodeInfo>(), "", ImmutableHashSet.Create<ActorRef>(), null));
+            StartWith(State.Idle, new Data(ImmutableHashSet.Create<Controller.NodeInfo>(), "", ImmutableHashSet.Create<IActorRef>(), null));
 
             WhenUnhandled(@event =>
             {
@@ -430,7 +430,7 @@ namespace Akka.Remote.TestKit
                         if (_failed)
                             nextState =
                                 Stay().Replying(new ToClient<BarrierResult>(new BarrierResult(barrier.Name, false)));
-                        else if (clients.Select(x => x.FSM).SequenceEqual(new List<ActorRef>() {Sender}))
+                        else if (clients.Select(x => x.FSM).SequenceEqual(new List<IActorRef>() {Sender}))
                             nextState =
                                 Stay().Replying(new ToClient<BarrierResult>(new BarrierResult(barrier.Name, true)));
                         else if (clients.All(x => x.FSM != Sender))
@@ -531,7 +531,7 @@ namespace Akka.Remote.TestKit
                 }
                 return
                     GoTo(State.Idle)
-                        .Using(data.Copy(barrier: string.Empty, arrived: ImmutableHashSet.Create<ActorRef>()));
+                        .Using(data.Copy(barrier: string.Empty, arrived: ImmutableHashSet.Create<IActorRef>()));
             }
             else
             {

--- a/src/core/Akka.Remote.TestKit/Controller.cs
+++ b/src/core/Akka.Remote.TestKit/Controller.cs
@@ -113,9 +113,9 @@ namespace Akka.Remote.TestKit
         {
             readonly RoleName _name;
             readonly Address _addr;
-            readonly ActorRef _fsm;
+            readonly IActorRef _fsm;
 
-            public NodeInfo(RoleName name, Address addr, ActorRef fsm)
+            public NodeInfo(RoleName name, Address addr, IActorRef fsm)
             {
                 _name = name;
                 _addr = addr;
@@ -132,7 +132,7 @@ namespace Akka.Remote.TestKit
                 get { return _addr; }
             }
 
-            public ActorRef FSM
+            public IActorRef FSM
             {
                 get { return _fsm; }
             }
@@ -184,12 +184,12 @@ namespace Akka.Remote.TestKit
         int _initialParticipants;
         readonly TestConductorSettings _settings = TestConductor.Get(Context.System).Settings;
         readonly IConnection _connection;
-        readonly ActorRef _barrier;
+        readonly IActorRef _barrier;
         ImmutableDictionary<RoleName, NodeInfo> _nodes =
             ImmutableDictionary.Create<RoleName, NodeInfo>();
         // map keeping unanswered queries for node addresses (enqueued upon GetAddress, serviced upon NodeInfo)
-        ImmutableDictionary<RoleName, ImmutableHashSet<ActorRef>> _addrInterest =
-            ImmutableDictionary.Create<RoleName, ImmutableHashSet<ActorRef>>();
+        ImmutableDictionary<RoleName, ImmutableHashSet<IActorRef>> _addrInterest =
+            ImmutableDictionary.Create<RoleName, ImmutableHashSet<IActorRef>>();
         int _generation = 1;
 
         public Controller(int initialParticipants, INode controllerPort)
@@ -309,11 +309,11 @@ namespace Akka.Remote.TestKit
                         Sender.Tell(new ToClient<AddressReply>(new AddressReply(node, _nodes[node].Addr)));
                     else
                     {
-                        ImmutableHashSet<ActorRef> existing;
+                        ImmutableHashSet<IActorRef> existing;
                         _addrInterest = _addrInterest.SetItem(node,
                             (_addrInterest.TryGetValue(node, out existing)
                                 ? existing
-                                : ImmutableHashSet.Create<ActorRef>()
+                                : ImmutableHashSet.Create<IActorRef>()
                                 ).Add(Sender));
                     }
                     return;

--- a/src/core/Akka.Remote.TestKit/Player.cs
+++ b/src/core/Akka.Remote.TestKit/Player.cs
@@ -20,9 +20,9 @@ namespace Akka.Remote.TestKit
     /// </summary>
     partial class TestConductor //Player trait in JVM version
     {
-        ActorRef _client;
+        IActorRef _client;
 
-        public ActorRef Client
+        public IActorRef Client
         {
             get
             {
@@ -55,11 +55,11 @@ namespace Akka.Remote.TestKit
 
         private class WaitForClientFSMToConnect : UntypedActor
         {
-            ActorRef _waiting;
+            IActorRef _waiting;
 
             protected override void OnReceive(object message)
             {
-                var fsm = message as ActorRef;
+                var fsm = message as IActorRef;
                 if (fsm != null)
                 {
                     _waiting = Sender;
@@ -171,10 +171,10 @@ namespace Akka.Remote.TestKit
         {
             readonly RemoteConnection _channel;
             public RemoteConnection Channel { get { return _channel; } }
-            readonly Tuple<string, ActorRef> _runningOp;
-            public Tuple<string, ActorRef> RunningOp { get { return _runningOp; } }
+            readonly Tuple<string, IActorRef> _runningOp;
+            public Tuple<string, IActorRef> RunningOp { get { return _runningOp; } }
             
-            public Data(RemoteConnection channel, Tuple<string, ActorRef> runningOp)
+            public Data(RemoteConnection channel, Tuple<string, IActorRef> runningOp)
             {
                 _channel = channel;
                 _runningOp = runningOp;
@@ -212,7 +212,7 @@ namespace Akka.Remote.TestKit
                 return !Equals(left, right);
             }
 
-            public Data Copy(Tuple<string, ActorRef> runningOp)
+            public Data Copy(Tuple<string, IActorRef> runningOp)
             {
                 return new Data(Channel, runningOp);
             }
@@ -511,14 +511,14 @@ namespace Akka.Remote.TestKit
         int _reconnects;
         readonly TimeSpan _backoff;
         readonly int _poolSize;
-        readonly ActorRef _fsm;
+        readonly IActorRef _fsm;
         readonly LoggingAdapter _log;
         readonly IScheduler _scheduler;
         private bool _loggedDisconnect = false;
         
         Deadline _nextAttempt;
         
-        public PlayerHandler(INode server, int reconnects, TimeSpan backoff, int poolSize, ActorRef fsm,
+        public PlayerHandler(INode server, int reconnects, TimeSpan backoff, int poolSize, IActorRef fsm,
             LoggingAdapter log, IScheduler scheduler)
         {
             _server = server;

--- a/src/core/Akka.Remote.Tests/EndpointRegistrySpec.cs
+++ b/src/core/Akka.Remote.Tests/EndpointRegistrySpec.cs
@@ -9,8 +9,8 @@ namespace Akka.Remote.Tests
     
     public class EndpointRegistrySpec : AkkaSpec
     {
-        private ActorRef actorA;
-        private ActorRef actorB;
+        private IActorRef actorA;
+        private IActorRef actorB;
         
         Address address1 = new Address("test", "testsys1", "testhost1", 1234);
         Address address2 = new Address("test", "testsy2", "testhost2", 1234);

--- a/src/core/Akka.Remote.Tests/RemoteRouterSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteRouterSpec.cs
@@ -110,7 +110,7 @@ namespace Akka.Remote.Tests
             for (var i = 0; i < 5; i++)
             {
                 router.Tell("", probe.Ref);
-                var expected = probe.ExpectMsg<ActorRef>(GetTimeoutOrDefault(null));
+                var expected = probe.ExpectMsg<IActorRef>(GetTimeoutOrDefault(null));
                 replies.Add(expected.Path);
             }
 
@@ -130,7 +130,7 @@ namespace Akka.Remote.Tests
             for (var i = 0; i < 5; i++)
             {
                 router.Tell("", probe.Ref);
-                var expected = probe.ExpectMsg<ActorRef>(GetTimeoutOrDefault(null));
+                var expected = probe.ExpectMsg<IActorRef>(GetTimeoutOrDefault(null));
                 replies.Add(expected.Path);
             }
 
@@ -150,7 +150,7 @@ namespace Akka.Remote.Tests
             for (var i = 0; i < 5000; i++)
             {
                 router.Tell("", probe.Ref);
-                var expected = probe.ExpectMsg<ActorRef>(GetTimeoutOrDefault(null));
+                var expected = probe.ExpectMsg<IActorRef>(GetTimeoutOrDefault(null));
                 replies.Add(expected.Path);
             }
 
@@ -171,7 +171,7 @@ namespace Akka.Remote.Tests
             for (var i = 0; i < 5; i++)
             {
                 router.Tell("", probe.Ref);
-                var expected = probe.ExpectMsg<ActorRef>(GetTimeoutOrDefault(null));
+                var expected = probe.ExpectMsg<IActorRef>(GetTimeoutOrDefault(null));
                 replies.Add(expected.Path);
             }
 
@@ -197,7 +197,7 @@ namespace Akka.Remote.Tests
             for (var i = 0; i < 5; i++)
             {
                 router.Tell("", probe.Ref);
-                var expected = probe.ExpectMsg<ActorRef>(GetTimeoutOrDefault(null));
+                var expected = probe.ExpectMsg<IActorRef>(GetTimeoutOrDefault(null));
                 replies.Add(expected.Path);
             }
 
@@ -222,7 +222,7 @@ namespace Akka.Remote.Tests
             for (var i = 0; i < 5; i++)
             {
                 router.Tell("", probe.Ref);
-                var expected = probe.ExpectMsg<ActorRef>(GetTimeoutOrDefault(null));
+                var expected = probe.ExpectMsg<IActorRef>(GetTimeoutOrDefault(null));
                 replies.Add(expected.Path);
             }
 
@@ -248,7 +248,7 @@ namespace Akka.Remote.Tests
             for (var i = 0; i < 5; i++)
             {
                 router.Tell("", probe.Ref);
-                var expected = probe.ExpectMsg<ActorRef>(GetTimeoutOrDefault(null));
+                var expected = probe.ExpectMsg<IActorRef>(GetTimeoutOrDefault(null));
                 replies.Add(expected.Path);
             }
 
@@ -274,7 +274,7 @@ namespace Akka.Remote.Tests
             for (var i = 0; i < 5; i++)
             {
                 router.Tell("", probe.Ref);
-                var expected = probe.ExpectMsg<ActorRef>(GetTimeoutOrDefault(null));
+                var expected = probe.ExpectMsg<IActorRef>(GetTimeoutOrDefault(null));
                 replies.Add(expected.Path);
             }
 

--- a/src/core/Akka.Remote.Tests/RemoteWatcherSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteWatcherSpec.cs
@@ -10,9 +10,9 @@ namespace Akka.Remote.Tests
     {
         class TestActorProxy : UntypedActor
         {
-            readonly ActorRef _testActor;
+            readonly IActorRef _testActor;
 
-            public TestActorProxy(ActorRef TestActor)
+            public TestActorProxy(IActorRef TestActor)
             {
                 _testActor = TestActor;
             }
@@ -178,7 +178,7 @@ namespace Akka.Remote.Tests
             get { return AddressUidExtension.Uid(_remoteSystem); }
         }
 
-        private ActorRef CreateRemoteActor(Props props, string name)
+        private IActorRef CreateRemoteActor(Props props, string name)
         {
             _remoteSystem.ActorOf(props, name);
             Sys.ActorSelection(new RootActorPath(_remoteAddress) / "user" / name).Tell(new Identify(name), TestActor);

--- a/src/core/Akka.Remote.Tests/RemotingSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemotingSpec.cs
@@ -152,7 +152,7 @@ namespace Akka.Remote.Tests
             //TODO: using smaller numbers for the cancellation here causes a bug.
             //the remoting layer uses some "initialdelay task.delay" for 4 seconds.
             //so the token is cancelled before the delay completed.. 
-            var msg = await here.Ask<Tuple<string,ActorRef>>("ping", TimeSpan.FromSeconds(1.5));
+            var msg = await here.Ask<Tuple<string,IActorRef>>("ping", TimeSpan.FromSeconds(1.5));
             Assert.Equal("pong", msg.Item1);
             Assert.IsType<FutureActorRef>(msg.Item2);
         }
@@ -218,9 +218,9 @@ namespace Akka.Remote.Tests
 
         private class Forwarder : UntypedActor
         {
-            private readonly ActorRef _testActor;
+            private readonly IActorRef _testActor;
 
-            public Forwarder(ActorRef testActor)
+            public Forwarder(IActorRef testActor)
             {
                 _testActor = testActor;
             }
@@ -300,7 +300,7 @@ namespace Akka.Remote.Tests
 
         class Echo1 : UntypedActor
         {
-            private ActorRef target = Context.System.DeadLetters;
+            private IActorRef target = Context.System.DeadLetters;
             protected override void OnReceive(object message)
             {
                 message.Match()
@@ -337,7 +337,7 @@ namespace Akka.Remote.Tests
                     {
                         if (str.Equals("ping")) Sender.Tell(Tuple.Create("pong", Sender));
                     })
-                    .With<Tuple<string, ActorRef>>(actorTuple =>
+                    .With<Tuple<string, IActorRef>>(actorTuple =>
                     {
                         if (actorTuple.Item1.Equals("ping"))
                         {
@@ -353,10 +353,10 @@ namespace Akka.Remote.Tests
 
         class Proxy : UntypedActor
         {
-            private ActorRef _one;
-            private ActorRef _another;
+            private IActorRef _one;
+            private IActorRef _another;
 
-            public Proxy(ActorRef one, ActorRef another)
+            public Proxy(IActorRef one, IActorRef another)
             {
                 _one = one;
                 _another = another;

--- a/src/core/Akka.Remote.Tests/Serialization/DaemonMsgCreateSerializerSpec.cs
+++ b/src/core/Akka.Remote.Tests/Serialization/DaemonMsgCreateSerializerSpec.cs
@@ -22,7 +22,7 @@ namespace Akka.Remote.Tests.Serialization
         }
 
         private Akka.Serialization.Serialization ser;
-        private ActorRef supervisor;
+        private IActorRef supervisor;
 
         public DaemonMsgCreateSerializerSpec()
             : base(@"akka.actor.provider = ""Akka.Remote.RemoteActorRefProvider, Akka.Remote""")

--- a/src/core/Akka.Remote.Tests/Transport/AkkaProtocolSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaProtocolSpec.cs
@@ -456,6 +456,6 @@ namespace Akka.Remote.Tests.Transport
 
         #endregion
 
-        public ActorRef Self { get { return TestActor; } }
+        public IActorRef Self { get { return TestActor; } }
     }
 }

--- a/src/core/Akka.Remote.Tests/Transport/AkkaProtocolStressTest.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaProtocolStressTest.cs
@@ -64,10 +64,10 @@ namespace Akka.Remote.Tests.Transport
             private int MaxSeq = -1;
             private int Losses = 0;
 
-            private ActorRef _remote;
-            private ActorRef _controller;
+            private IActorRef _remote;
+            private IActorRef _controller;
 
-            public SequenceVerifier(ActorRef remote, ActorRef controller)
+            public SequenceVerifier(IActorRef remote, IActorRef controller)
             {
                 _remote = remote;
                 _controller = controller;
@@ -139,7 +139,7 @@ namespace Akka.Remote.Tests.Transport
         }
 
         private ActorSystem systemB;
-        private ActorRef remote;
+        private IActorRef remote;
 
         private Address AddressB
         {
@@ -151,7 +151,7 @@ namespace Akka.Remote.Tests.Transport
             get { return new RootActorPath(AddressB); }
         }
 
-        private ActorRef Here
+        private IActorRef Here
         {
             get
             {

--- a/src/core/Akka.Remote.Tests/Transport/TestTransportSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/TestTransportSpec.cs
@@ -18,7 +18,7 @@ namespace Akka.Remote.Tests.Transport{
         protected Address addressB = new Address("test", "testsystemB", "testhostB", 5432);
         protected Address nonExistantAddress = new Address("test", "nosystem", "nohost", 0);
 
-        public ActorRef Self { get { return TestActor; } }
+        public IActorRef Self { get { return TestActor; } }
         private TimeSpan DefaultTimeout { get { return Dilated(TestKitSettings.DefaultTimeout); } }
         #endregion
 

--- a/src/core/Akka.Remote.Tests/Transport/ThrottlerTransportAdapterSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/ThrottlerTransportAdapterSpec.cs
@@ -42,14 +42,14 @@ namespace Akka.Remote.Tests.Transport
 
         public class ThrottlingTester : ReceiveActor
         {
-            private ActorRef _remoteRef;
-            private ActorRef _controller;
+            private IActorRef _remoteRef;
+            private IActorRef _controller;
 
             private int _received = 0;
             private int _messageCount = MessageCount;
             private long _startTime = 0L;
 
-            public ThrottlingTester(ActorRef remoteRef, ActorRef controller)
+            public ThrottlingTester(IActorRef remoteRef, IActorRef controller)
             {
                 _remoteRef = remoteRef;
                 _controller = controller;
@@ -118,14 +118,14 @@ namespace Akka.Remote.Tests.Transport
         }
 
         private ActorSystem systemB;
-        private ActorRef remote;
+        private IActorRef remote;
 
         private RootActorPath RootB
         {
             get { return new RootActorPath(systemB.AsInstanceOf<ExtendedActorSystem>().Provider.DefaultAddress); }
         }
 
-        private ActorRef Here
+        private IActorRef Here
         {
             get
             {

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -1117,7 +1117,7 @@ namespace Akka.Remote
                         }
                     };
                     backoff();
-                    s.Tell(BackoffTimer.Instance, ActorRef.NoSender);
+                    s.Tell(BackoffTimer.Instance, ActorRefs.NoSender);
                 });
             }
         }

--- a/src/core/Akka.Remote/EndpointRegistry.cs
+++ b/src/core/Akka.Remote/EndpointRegistry.cs
@@ -11,14 +11,14 @@ namespace Akka.Remote
     /// </summary>
     internal class EndpointRegistry
     {
-        private readonly Dictionary<Address, ActorRef> addressToReadonly = new Dictionary<Address, ActorRef>();
+        private readonly Dictionary<Address, IActorRef> addressToReadonly = new Dictionary<Address, IActorRef>();
 
         private Dictionary<Address, EndpointManager.EndpointPolicy> addressToWritable =
             new Dictionary<Address, EndpointManager.EndpointPolicy>();
 
-        private readonly Dictionary<ActorRef, Address> readonlyToAddress = new Dictionary<ActorRef, Address>();
-        private readonly Dictionary<ActorRef, Address> writableToAddress = new Dictionary<ActorRef, Address>();
-        public ActorRef RegisterWritableEndpoint(Address address, ActorRef endpoint, int? uid = null)
+        private readonly Dictionary<IActorRef, Address> readonlyToAddress = new Dictionary<IActorRef, Address>();
+        private readonly Dictionary<IActorRef, Address> writableToAddress = new Dictionary<IActorRef, Address>();
+        public IActorRef RegisterWritableEndpoint(Address address, IActorRef endpoint, int? uid = null)
         {
             EndpointManager.EndpointPolicy existing;
             if (addressToWritable.TryGetValue(address, out existing))
@@ -32,7 +32,7 @@ namespace Akka.Remote
             return endpoint;
         }
 
-        public void RegisterWritableEndpointUid(ActorRef writer, int uid)
+        public void RegisterWritableEndpointUid(IActorRef writer, int uid)
         {
             var address = writableToAddress[writer];
             if (addressToWritable[address] is EndpointManager.Pass)
@@ -42,14 +42,14 @@ namespace Akka.Remote
             }
         }
 
-        public ActorRef RegisterReadOnlyEndpoint(Address address, ActorRef endpoint)
+        public IActorRef RegisterReadOnlyEndpoint(Address address, IActorRef endpoint)
         {
             addressToReadonly.Add(address, endpoint);
             readonlyToAddress.Add(endpoint, address);
             return endpoint;
         }
 
-        public void UnregisterEndpoint(ActorRef endpoint)
+        public void UnregisterEndpoint(IActorRef endpoint)
         {
             if (IsWritable(endpoint))
             {
@@ -73,9 +73,9 @@ namespace Akka.Remote
             }
         }
 
-        public ActorRef ReadOnlyEndpointFor(Address address)
+        public IActorRef ReadOnlyEndpointFor(Address address)
         {
-            ActorRef tmp;
+            IActorRef tmp;
             if (addressToReadonly.TryGetValue(address, out tmp))
             {
                 return tmp;
@@ -83,12 +83,12 @@ namespace Akka.Remote
             return null;
         }
 
-        public bool IsWritable(ActorRef endpoint)
+        public bool IsWritable(IActorRef endpoint)
         {
             return writableToAddress.ContainsKey(endpoint);
         }
 
-        public bool IsReadOnly(ActorRef endpoint)
+        public bool IsReadOnly(IActorRef endpoint)
         {
             return readonlyToAddress.ContainsKey(endpoint);
         }
@@ -126,7 +126,7 @@ namespace Akka.Remote
         /// Marking an endpoint as failed means that we will not try to connect to the remote system within
         /// the gated period but it is ok for the remote system to try to connect with us (inbound-only.)
         /// </summary>
-        public void MarkAsFailed(ActorRef endpoint, Deadline timeOfRelease)
+        public void MarkAsFailed(IActorRef endpoint, Deadline timeOfRelease)
         {
             if (IsWritable(endpoint))
             {
@@ -150,7 +150,7 @@ namespace Akka.Remote
             addressToWritable.Remove(address);
         }
 
-        public IList<ActorRef> AllEndpoints
+        public IList<IActorRef> AllEndpoints
         {
             get { return writableToAddress.Keys.Concat(readonlyToAddress.Keys).ToList(); }
         }

--- a/src/core/Akka.Remote/RemoteActorRef.cs
+++ b/src/core/Akka.Remote/RemoteActorRef.cs
@@ -26,7 +26,7 @@ namespace Akka.Remote
         /// <summary>
         /// The parent
         /// </summary>
-        private readonly InternalActorRef _parent;
+        private readonly IInternalActorRef _parent;
         /// <summary>
         /// The props
         /// </summary>
@@ -41,7 +41,7 @@ namespace Akka.Remote
         /// <param name="parent">The parent.</param>
         /// <param name="props">The props.</param>
         /// <param name="deploy">The deploy.</param>
-        internal RemoteActorRef(RemoteTransport remote, Address localAddressToUse, ActorPath path, InternalActorRef parent,
+        internal RemoteActorRef(RemoteTransport remote, Address localAddressToUse, ActorPath path, IInternalActorRef parent,
             Props props, Deploy deploy)
         {
             Remote = remote;
@@ -68,7 +68,7 @@ namespace Akka.Remote
         /// Gets the parent.
         /// </summary>
         /// <value>The parent.</value>
-        public override InternalActorRef Parent
+        public override IInternalActorRef Parent
         {
             get { return _parent; }
         }
@@ -90,7 +90,7 @@ namespace Akka.Remote
         /// <param name="name">The name.</param>
         /// <returns>ActorRef.</returns>
         /// <exception cref="System.NotImplementedException"></exception>
-        public override ActorRef GetChild(IEnumerable<string> name)
+        public override IActorRef GetChild(IEnumerable<string> name)
         {
             throw new NotImplementedException();
         }
@@ -154,7 +154,7 @@ namespace Akka.Remote
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="sender">The sender.</param>
-        protected override void TellInternal(object message, ActorRef sender)
+        protected override void TellInternal(object message, IActorRef sender)
         {
             Remote.Send(message, sender, this);
             var systemMessage = message as SystemMessage;

--- a/src/core/Akka.Remote/RemoteActorRef.cs
+++ b/src/core/Akka.Remote/RemoteActorRef.cs
@@ -14,7 +14,7 @@ namespace Akka.Remote
     /// <summary>
     /// Class RemoteActorRef.
     /// </summary>
-    public class RemoteActorRef : InternalActorRef, RemoteRef
+    public class RemoteActorRef : InternalActorRefBase, RemoteRef
     {
         /// <summary>
         /// The deploy

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -244,7 +244,7 @@ namespace Akka.Remote
                 Transport,
                 Transport.LocalAddressForRemote(address),
                 new RootActorPath(address),
-                ActorRef.Nobody,
+                ActorRefs.Nobody,
                 Props.None,
                 Deploy.None);
         }
@@ -286,7 +286,7 @@ namespace Akka.Remote
                 //the actor's local address was already included in the ActorPath
                 if (HasAddress(actorPath.Address))
                     return (InternalActorRef)ResolveActorRef(actorPath);
-                return new RemoteActorRef(Transport, localAddress, new RootActorPath(actorPath.Address) / actorPath.Elements, ActorRef.Nobody, Props.None, Deploy.None);
+                return new RemoteActorRef(Transport, localAddress, new RootActorPath(actorPath.Address) / actorPath.Elements, ActorRefs.Nobody, Props.None, Deploy.None);
             }
             _log.Debug("resolve of unknown path [{0}] failed", path);
             return InternalDeadLetters;
@@ -295,7 +295,7 @@ namespace Akka.Remote
         public ActorRef ResolveActorRef(string path)
         {
             if (path == "")
-                return ActorRef.NoSender;
+                return ActorRefs.NoSender;
 
             ActorPath actorPath;
             if (ActorPath.TryParse(path, out actorPath))
@@ -338,7 +338,7 @@ namespace Akka.Remote
             return new RemoteActorRef(Transport,
                 Transport.LocalAddressForRemote(actorPath.Address),
                 actorPath,
-                ActorRef.Nobody,
+                ActorRefs.Nobody,
                 Props.None,
                 Deploy.None);
         }

--- a/src/core/Akka.Remote/RemoteDaemon.cs
+++ b/src/core/Akka.Remote/RemoteDaemon.cs
@@ -174,7 +174,7 @@ namespace Akka.Remote
                     return child.GetChild(rest);
                 }
             }
-            return Nobody;
+            return ActorRefs.Nobody;
         }
     }
 }

--- a/src/core/Akka.Remote/RemoteTransport.cs
+++ b/src/core/Akka.Remote/RemoteTransport.cs
@@ -63,7 +63,7 @@ namespace Akka.Remote
         /// <summary>
         /// Sends the given message to the recipient, supplying <see cref="sender"/> if any.
         /// </summary>
-        public abstract void Send(object message, ActorRef sender, RemoteActorRef recipient);
+        public abstract void Send(object message, IActorRef sender, RemoteActorRef recipient);
 
         /// <summary>
         /// Sends a management command to the underlying transport stack. The call returns with a Task that

--- a/src/core/Akka.Remote/RemoteWatcher.cs
+++ b/src/core/Akka.Remote/RemoteWatcher.cs
@@ -42,49 +42,49 @@ namespace Akka.Remote
 
         public abstract class WatchCommand
         {
-            readonly ActorRef _watchee;
-            readonly ActorRef _watcher;
+            readonly IActorRef _watchee;
+            readonly IActorRef _watcher;
 
-            protected WatchCommand(ActorRef watchee, ActorRef watcher)
+            protected WatchCommand(IActorRef watchee, IActorRef watcher)
             {
                 _watchee = watchee;
                 _watcher = watcher;
             }
 
-            public ActorRef Watchee
+            public IActorRef Watchee
             {
                 get { return _watchee; }
             }
 
-            public ActorRef Watcher
+            public IActorRef Watcher
             {
                 get { return _watcher; }
             }
         }
         public sealed class WatchRemote : WatchCommand
         {
-            public WatchRemote(ActorRef watchee, ActorRef watcher)
+            public WatchRemote(IActorRef watchee, IActorRef watcher)
                 : base(watchee, watcher)
             {
             }
         }
         public sealed class UnwatchRemote : WatchCommand
         {
-            public UnwatchRemote(ActorRef watchee, ActorRef watcher)
+            public UnwatchRemote(IActorRef watchee, IActorRef watcher)
                 : base(watchee, watcher)
             {
             }
         }
         public sealed class RewatchRemote : WatchCommand
         {
-            public RewatchRemote(ActorRef watchee, ActorRef watcher)
+            public RewatchRemote(IActorRef watchee, IActorRef watcher)
                 : base(watchee, watcher)
             {
             }
         }
         public class Rewatch : Watch
         {
-            public Rewatch(InternalActorRef watchee, InternalActorRef watcher)
+            public Rewatch(IInternalActorRef watchee, IInternalActorRef watcher)
                 : base(watchee, watcher)
             {
             }
@@ -192,16 +192,16 @@ namespace Akka.Remote
 
             public static Stats Counts(int watching, int watchingNodes)
             {
-                return new Stats(watching, watchingNodes, new HashSet<Tuple<ActorRef, ActorRef>>());
+                return new Stats(watching, watchingNodes, new HashSet<Tuple<IActorRef, IActorRef>>());
             }
 
             readonly int _watching;
             readonly int _watchingNodes;
             //TODO: This should either be a deep copy or immutable
             //@Aaronontheweb 2/7/2015 - we now return a deep copy everytime the refs get shared, see line 334
-            readonly HashSet<Tuple<ActorRef, ActorRef>> _watchingRefs;
+            readonly HashSet<Tuple<IActorRef, IActorRef>> _watchingRefs;
 
-            public Stats(int watching, int watchingNodes, HashSet<Tuple<ActorRef, ActorRef>> watchingRefs)
+            public Stats(int watching, int watchingNodes, HashSet<Tuple<IActorRef, IActorRef>> watchingRefs)
             {
                 _watching = watching;
                 _watchingNodes = watchingNodes;
@@ -218,7 +218,7 @@ namespace Akka.Remote
                 get { return _watchingNodes; }
             }
 
-            public HashSet<Tuple<ActorRef, ActorRef>> WatchingRefs
+            public HashSet<Tuple<IActorRef, IActorRef>> WatchingRefs
             {
                 get { return _watchingRefs; }
             }
@@ -238,18 +238,18 @@ namespace Akka.Remote
                     formatWatchingRefs());
             }
 
-            public static Stats Copy(int watching, int watchingNodes, HashSet<Tuple<ActorRef, ActorRef>> watchingRefs = null)
+            public static Stats Copy(int watching, int watchingNodes, HashSet<Tuple<IActorRef, IActorRef>> watchingRefs = null)
             {
-                HashSet<Tuple<ActorRef, ActorRef>> finalRefs;
+                HashSet<Tuple<IActorRef, IActorRef>> finalRefs;
                 if (watchingRefs != null)
                 {
-                    var arr = new Tuple<ActorRef, ActorRef>[watchingRefs.Count];
+                    var arr = new Tuple<IActorRef, IActorRef>[watchingRefs.Count];
                     watchingRefs.CopyTo(arr);
-                    finalRefs = new HashSet<Tuple<ActorRef, ActorRef>>(arr);
+                    finalRefs = new HashSet<Tuple<IActorRef, IActorRef>>(arr);
                 }
                 else
                 {
-                    finalRefs = new HashSet<Tuple<ActorRef, ActorRef>>();
+                    finalRefs = new HashSet<Tuple<IActorRef, IActorRef>>();
                 }
 
                 return new Stats(watching, watchingNodes, finalRefs);
@@ -278,8 +278,8 @@ namespace Akka.Remote
         readonly IScheduler _scheduler = Context.System.Scheduler;
         readonly RemoteActorRefProvider _remoteProvider;
         readonly HeartbeatRsp _selfHeartbeatRspMsg = new HeartbeatRsp(AddressUidExtension.Uid(Context.System));
-        readonly HashSet<Tuple<ActorRef, ActorRef>> _watching = new HashSet<Tuple<ActorRef, ActorRef>>();
-        protected HashSet<Tuple<ActorRef, ActorRef>> Watching { get { return _watching; } } //TODO: this needs to be immutable
+        readonly HashSet<Tuple<IActorRef, IActorRef>> _watching = new HashSet<Tuple<IActorRef, IActorRef>>();
+        protected HashSet<Tuple<IActorRef, IActorRef>> Watching { get { return _watching; } } //TODO: this needs to be immutable
         readonly HashSet<Address> _watchingNodes = new HashSet<Address>();
         readonly HashSet<Address> _unreachable = new HashSet<Address>();
         protected HashSet<Address> Unreachable { get { return _unreachable; } }
@@ -382,7 +382,7 @@ namespace Akka.Remote
             _remoteProvider.Quarantine(address, addressUid);
         }
 
-        private void ProcessRewatchRemote(ActorRef watchee, ActorRef watcher)
+        private void ProcessRewatchRemote(IActorRef watchee, IActorRef watcher)
         {
             if (_watching.Contains(Tuple.Create(watchee, watcher)))
                 ProcessWatchRemote(watchee, watcher);
@@ -392,7 +392,7 @@ namespace Akka.Remote
                     watchee.Path);
         }
 
-        private void ProcessWatchRemote(ActorRef watchee, ActorRef watcher)
+        private void ProcessWatchRemote(IActorRef watchee, IActorRef watcher)
         {
             if (watcher != Self)
             {
@@ -405,7 +405,7 @@ namespace Akka.Remote
             }
         }
 
-        private void AddWatching(ActorRef watchee, ActorRef watcher)
+        private void AddWatching(IActorRef watchee, IActorRef watcher)
         {
             _watching.Add(Tuple.Create(watchee, watcher));
             var watcheeAddress = watchee.Path.Address;
@@ -418,7 +418,7 @@ namespace Akka.Remote
             _watchingNodes.Add(watcheeAddress);
         }
 
-        protected void ProcessUnwatchRemote(ActorRef watchee, ActorRef watcher)
+        protected void ProcessUnwatchRemote(IActorRef watchee, IActorRef watcher)
         {
             if (watcher != Self)
             {
@@ -436,7 +436,7 @@ namespace Akka.Remote
             }
         }
 
-        private void ProcessTerminated(ActorRef watchee, bool existenceConfirmed, bool addressTerminated)
+        private void ProcessTerminated(IActorRef watchee, bool existenceConfirmed, bool addressTerminated)
         {
             _log.Debug("Watchee terminated: [{0}]", watchee.Path);
 
@@ -513,8 +513,8 @@ namespace Akka.Remote
         {
             foreach (var t in _watching)
             {
-                var wee = t.Item1 as InternalActorRef;
-                var wer = t.Item2 as InternalActorRef;
+                var wee = t.Item1 as IInternalActorRef;
+                var wer = t.Item2 as IInternalActorRef;
                 if (wee != null && wer != null)
                 {
                     if (wee.Path.Address == address)

--- a/src/core/Akka.Remote/Remoting.cs
+++ b/src/core/Akka.Remote/Remoting.cs
@@ -228,7 +228,7 @@ namespace Akka.Remote
                 throw new RemoteTransportException("Attempted to send remote message but Remoting is not running.", null);
             }
             if (sender == null)
-                sender = ActorRef.NoSender;
+                sender = ActorRefs.NoSender;
 
             _endpointManager.Tell(new EndpointManager.Send(message, recipient, sender), sender);
         }

--- a/src/core/Akka.Remote/Remoting.cs
+++ b/src/core/Akka.Remote/Remoting.cs
@@ -88,7 +88,7 @@ namespace Akka.Remote
     {
         private readonly LoggingAdapter log;
         private volatile IDictionary<string, HashSet<ProtocolTransportAddressPair>> _transportMapping;
-        private volatile ActorRef _endpointManager;
+        private volatile IActorRef _endpointManager;
 
         // This is effectively a write-once variable similar to a lazy val. The reason for not using a lazy val is exception
         // handling.
@@ -98,7 +98,7 @@ namespace Akka.Remote
         // a lazy val
         private volatile Address _defaultAddress;
 
-        private ActorRef _transportSupervisor;
+        private IActorRef _transportSupervisor;
         private EventPublisher _eventPublisher;
 
         public Remoting(ExtendedActorSystem system, RemoteActorRefProvider provider)
@@ -221,7 +221,7 @@ namespace Akka.Remote
             }
         }
 
-        public override void Send(object message, ActorRef sender, RemoteActorRef recipient)
+        public override void Send(object message, IActorRef sender, RemoteActorRef recipient)
         {
             if (_endpointManager == null)
             {

--- a/src/core/Akka.Remote/Serialization/DaemonMsgCreateSerializer.cs
+++ b/src/core/Akka.Remote/Serialization/DaemonMsgCreateSerializer.cs
@@ -24,7 +24,7 @@ namespace Akka.Remote.Serialization
             get { return false; }
         }
 
-        private ActorRefData SerializeActorRef(ActorRef @ref)
+        private ActorRefData SerializeActorRef(IActorRef @ref)
         {
             return ActorRefData.CreateBuilder()
                 .SetPath(Akka.Serialization.Serialization.SerializedActorPath(@ref))
@@ -168,7 +168,7 @@ namespace Akka.Remote.Serialization
             return args;
         }
 
-        private ActorRef DeserializeActorRef(ActorRefData actorRefData)
+        private IActorRef DeserializeActorRef(ActorRefData actorRefData)
         {
             var path = actorRefData.Path;
             var @ref = system.Provider.ResolveActorRef(path);

--- a/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
+++ b/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
@@ -57,7 +57,7 @@ namespace Akka.Remote.Transport
 
     internal sealed class Message : IAkkaPdu, IHasSequenceNumber
     {
-        public Message(InternalActorRef recipient, Address recipientAddress, SerializedMessage serializedMessage, ActorRef senderOptional = null, SeqNo seq = null)
+        public Message(IInternalActorRef recipient, Address recipientAddress, SerializedMessage serializedMessage, IActorRef senderOptional = null, SeqNo seq = null)
         {
             Seq = seq;
             SenderOptional = senderOptional;
@@ -66,13 +66,13 @@ namespace Akka.Remote.Transport
             Recipient = recipient;
         }
 
-        public InternalActorRef Recipient { get; private set; }
+        public IInternalActorRef Recipient { get; private set; }
 
         public Address RecipientAddress { get; private set; }
 
         public SerializedMessage SerializedMessage { get; private set; }
 
-        public ActorRef SenderOptional { get; private set; }
+        public IActorRef SenderOptional { get; private set; }
 
         public bool ReliableDeliveryEnabled { get { return Seq != null; } }
 
@@ -138,8 +138,8 @@ namespace Akka.Remote.Transport
 
         public abstract AckAndMessage DecodeMessage(ByteString raw, RemoteActorRefProvider provider, Address localAddress);
 
-        public abstract ByteString ConstructMessage(Address localAddress, ActorRef recipient,
-            SerializedMessage serializedMessage, ActorRef senderOption = null, SeqNo seqOption = null, Ack ackOption = null);
+        public abstract ByteString ConstructMessage(Address localAddress, IActorRef recipient,
+            SerializedMessage serializedMessage, IActorRef senderOption = null, SeqNo seqOption = null, Ack ackOption = null);
 
         public abstract ByteString ConstructPureAck(Ack ack);
     }
@@ -216,7 +216,7 @@ namespace Akka.Remote.Transport
                     Address recipientAddress;
                     ActorPath.TryParseAddress(envelopeContainer.Recipient.Path, out recipientAddress);
                     var serializedMessage = envelopeContainer.Message;
-                    ActorRef senderOption = null;
+                    IActorRef senderOption = null;
                     if (envelopeContainer.HasSender)
                     {
                         senderOption = provider.ResolveActorRefWithLocalAddress(envelopeContainer.Sender.Path, localAddress);
@@ -245,8 +245,8 @@ namespace Akka.Remote.Transport
             return ack.Nacks.Aggregate(ackBuilder, (current, nack) => current.AddNacks((ulong) nack.RawValue));
         }
 
-        public override ByteString ConstructMessage(Address localAddress, ActorRef recipient, SerializedMessage serializedMessage,
-            ActorRef senderOption = null, SeqNo seqOption = null, Ack ackOption = null)
+        public override ByteString ConstructMessage(Address localAddress, IActorRef recipient, SerializedMessage serializedMessage,
+            IActorRef senderOption = null, SeqNo seqOption = null, Ack ackOption = null)
         {
             var ackAndEnvelopeBuilder = AckAndEnvelopeContainer.CreateBuilder();
             var envelopeBuilder = RemoteEnvelope.CreateBuilder().SetRecipient(SerializeActorRef(recipient.Path.Address, recipient));
@@ -324,7 +324,7 @@ namespace Akka.Remote.Transport
             return new Address(origin.Protocol, origin.System, origin.Hostname, (int)origin.Port);
         }
 
-        private ActorRefData SerializeActorRef(Address defaultAddress, ActorRef actorRef)
+        private ActorRefData SerializeActorRef(Address defaultAddress, IActorRef actorRef)
         {
             return ActorRefData.CreateBuilder()
                 .SetPath((!string.IsNullOrEmpty(actorRef.Path.Address.Host))

--- a/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
+++ b/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
@@ -245,7 +245,7 @@ namespace Akka.Remote.Transport
     {
         public AkkaProtocolHandle(Address originalLocalAddress, Address originalRemoteAddress,
             TaskCompletionSource<IHandleEventListener> readHandlerCompletionSource, AssociationHandle wrappedHandle,
-            HandshakeInfo handshakeInfo, ActorRef stateActor, AkkaPduCodec codec)
+            HandshakeInfo handshakeInfo, IActorRef stateActor, AkkaPduCodec codec)
             : base(originalLocalAddress, originalRemoteAddress, wrappedHandle, RemoteSettings.AkkaScheme)
         {
             HandshakeInfo = handshakeInfo;
@@ -256,7 +256,7 @@ namespace Akka.Remote.Transport
 
         public readonly HandshakeInfo HandshakeInfo;
 
-        public readonly ActorRef StateActor;
+        public readonly IActorRef StateActor;
 
         public readonly AkkaPduCodec Codec;
 

--- a/src/core/Akka.Remote/Transport/ThrottleTransportAdapter.cs
+++ b/src/core/Akka.Remote/Transport/ThrottleTransportAdapter.cs
@@ -401,7 +401,7 @@ namespace Akka.Remote.Transport
                 return Task.FromResult(SetThrottleAck.Instance);
         }
 
-        private Task<SetThrottleAck> AskModeWithDeathCompletion(ActorRef target, ThrottleMode mode, TimeSpan timeout)
+        private Task<SetThrottleAck> AskModeWithDeathCompletion(IActorRef target, ThrottleMode mode, TimeSpan timeout)
         {
             if (target.IsNobody()) return Task.FromResult(SetThrottleAck.Instance);
             else
@@ -663,12 +663,12 @@ namespace Akka.Remote.Transport
     /// </summary>
     internal sealed class ThrottlerHandle : AbstractTransportAdapterHandle
     {
-        internal readonly ActorRef ThrottlerActor;
+        internal readonly IActorRef ThrottlerActor;
         internal AtomicReference<ThrottleMode> OutboundThrottleMode = new AtomicReference<ThrottleMode>(Unthrottled.Instance);
 
         
 
-        public ThrottlerHandle(AssociationHandle wrappedHandle, ActorRef throttlerActor) : base(wrappedHandle, ThrottleTransportAdapter.Scheme)
+        public ThrottlerHandle(AssociationHandle wrappedHandle, IActorRef throttlerActor) : base(wrappedHandle, ThrottleTransportAdapter.Scheme)
         {
             ThrottlerActor = throttlerActor;
         }
@@ -790,7 +790,7 @@ namespace Akka.Remote.Transport
 
         #endregion
 
-        protected ActorRef Manager;
+        protected IActorRef Manager;
         protected IAssociationEventListener AssociationHandler;
         protected AssociationHandle OriginalHandle;
         protected bool Inbound;
@@ -804,7 +804,7 @@ namespace Akka.Remote.Transport
         /// </summary>
         private static readonly AkkaPduProtobuffCodec Codec = new AkkaPduProtobuffCodec();
 
-        public ThrottledAssociation(ActorRef manager, IAssociationEventListener associationHandler, AssociationHandle originalHandle, bool inbound)
+        public ThrottledAssociation(IActorRef manager, IAssociationEventListener associationHandler, AssociationHandle originalHandle, bool inbound)
         {
             Manager = manager;
             AssociationHandler = associationHandler;

--- a/src/core/Akka.Remote/Transport/Transport.cs
+++ b/src/core/Akka.Remote/Transport/Transport.cs
@@ -135,14 +135,14 @@ namespace Akka.Remote.Transport
     }
 
     /// <summary>
-    /// Converts an <see cref="ActorRef"/> instance into an <see cref="IHandleEventListener"/>, so <see cref="IHandleEvent"/> messages
+    /// Converts an <see cref="IActorRef"/> instance into an <see cref="IHandleEventListener"/>, so <see cref="IHandleEvent"/> messages
     /// can be passed directly to the Actor.
     /// </summary>
     public sealed class ActorHandleEventListener : IHandleEventListener
     {
-        public readonly ActorRef Actor;
+        public readonly IActorRef Actor;
 
-        public ActorHandleEventListener(ActorRef actor)
+        public ActorHandleEventListener(IActorRef actor)
         {
             Actor = actor;
         }
@@ -185,17 +185,17 @@ namespace Akka.Remote.Transport
     }
 
     /// <summary>
-    /// Converts an <see cref="ActorRef"/> instance into an <see cref="IAssociationEventListener"/>, so <see cref="IAssociationEvent"/> messages
+    /// Converts an <see cref="IActorRef"/> instance into an <see cref="IAssociationEventListener"/>, so <see cref="IAssociationEvent"/> messages
     /// can be passed directly to the Actor.
     /// </summary>
     public sealed class ActorAssociationEventListener : IAssociationEventListener
     {
-        public ActorAssociationEventListener(ActorRef actor)
+        public ActorAssociationEventListener(IActorRef actor)
         {
             Actor = actor;
         }
 
-        public ActorRef Actor { get; private set; }
+        public IActorRef Actor { get; private set; }
 
         public void Notify(IAssociationEvent ev)
         {

--- a/src/core/Akka.Remote/Transport/TransportAdapters.cs
+++ b/src/core/Akka.Remote/Transport/TransportAdapters.cs
@@ -355,7 +355,7 @@ namespace Akka.Remote.Transport
                     associationListener = listener.Listener;
                     foreach (var dEvent in DelayedEvents)
                     {
-                        Self.Tell(dEvent, ActorRef.NoSender);
+                        Self.Tell(dEvent, ActorRefs.NoSender);
                     }
                     DelayedEvents = new Queue<object>();
                     Context.Become(Ready);

--- a/src/core/Akka.Remote/Transport/TransportAdapters.cs
+++ b/src/core/Akka.Remote/Transport/TransportAdapters.cs
@@ -293,11 +293,11 @@ namespace Akka.Remote.Transport
 
         public static readonly TimeSpan AskTimeout = TimeSpan.FromSeconds(5);
 
-        protected volatile ActorRef manager;
+        protected volatile IActorRef manager;
 
-        private Task<ActorRef> RegisterManager()
+        private Task<IActorRef> RegisterManager()
         {
-            return System.ActorSelection("/system/transports").Ask<ActorRef>(new RegisterTransportActor(ManagerProps, ManagerName));
+            return System.ActorSelection("/system/transports").Ask<IActorRef>(new RegisterTransportActor(ManagerProps, ManagerName));
         }
 
         protected override Task<IAssociationEventListener> InterceptListen(Address listenAddress, Task<IAssociationEventListener> listenerTask)

--- a/src/core/Akka.TestKit.Tests/NoImplicitSenderSpec.cs
+++ b/src/core/Akka.TestKit.Tests/NoImplicitSenderSpec.cs
@@ -12,7 +12,7 @@ namespace Akka.Testkit.Tests
         {
             var echoActor = Sys.ActorOf(c => c.ReceiveAny((m, ctx) => TestActor.Tell(ctx.Sender)));
             echoActor.Tell("message");
-            ExpectMsg<ActorRef>(actorRef => actorRef == ActorRefs.NoSender);
+            ExpectMsg<IActorRef>(actorRef => actorRef == ActorRefs.NoSender);
         }
 
     }
@@ -24,11 +24,11 @@ namespace Akka.Testkit.Tests
         {
             var echoActor = Sys.ActorOf(c => c.ReceiveAny((m, ctx) => TestActor.Tell(ctx.Sender)));
             echoActor.Tell("message");
-            ExpectMsg<ActorRef>(actorRef => actorRef == TestActor);
+            ExpectMsg<IActorRef>(actorRef => actorRef == TestActor);
 
             //Test that it works after we know that context has been changed
             echoActor.Tell("message");
-            ExpectMsg<ActorRef>(actorRef => actorRef == TestActor);
+            ExpectMsg<IActorRef>(actorRef => actorRef == TestActor);
 
         }
 

--- a/src/core/Akka.TestKit.Tests/NoImplicitSenderSpec.cs
+++ b/src/core/Akka.TestKit.Tests/NoImplicitSenderSpec.cs
@@ -12,7 +12,7 @@ namespace Akka.Testkit.Tests
         {
             var echoActor = Sys.ActorOf(c => c.ReceiveAny((m, ctx) => TestActor.Tell(ctx.Sender)));
             echoActor.Tell("message");
-            ExpectMsg<ActorRef>(actorRef => actorRef == DeadLetterActorRef.NoSender);
+            ExpectMsg<ActorRef>(actorRef => actorRef == ActorRefs.NoSender);
         }
 
     }

--- a/src/core/Akka.TestKit.Tests/TestActorRefTests/NestingActor.cs
+++ b/src/core/Akka.TestKit.Tests/TestActorRefTests/NestingActor.cs
@@ -4,7 +4,7 @@ namespace Akka.TestKit.Tests.TestActorRefTests
 {
     public class NestingActor : ActorBase
     {
-        private readonly ActorRef _nested;
+        private readonly IActorRef _nested;
 
         public NestingActor(bool createTestActorRef)
         {

--- a/src/core/Akka.TestKit.Tests/TestActorRefTests/ReceiveTimeoutActor.cs
+++ b/src/core/Akka.TestKit.Tests/TestActorRefTests/ReceiveTimeoutActor.cs
@@ -7,10 +7,10 @@ namespace Akka.TestKit.Tests.TestActorRefTests
 {
     public class ReceiveTimeoutActor : ActorBase
     {
-        private readonly ActorRef _target;
+        private readonly IActorRef _target;
         private CancellationTokenSource _cancellationTokenSource;
 
-        public ReceiveTimeoutActor(ActorRef target)
+        public ReceiveTimeoutActor(IActorRef target)
         {
             _target = target;
 

--- a/src/core/Akka.TestKit.Tests/TestActorRefTests/ReplyActor.cs
+++ b/src/core/Akka.TestKit.Tests/TestActorRefTests/ReplyActor.cs
@@ -4,7 +4,7 @@ namespace Akka.TestKit.Tests.TestActorRefTests
 {
     public class ReplyActor : TActorBase
     {
-        private ActorRef _replyTo;
+        private IActorRef _replyTo;
 
         protected override bool ReceiveMessage(object message)
         {

--- a/src/core/Akka.TestKit.Tests/TestActorRefTests/SenderActor.cs
+++ b/src/core/Akka.TestKit.Tests/TestActorRefTests/SenderActor.cs
@@ -4,9 +4,9 @@ namespace Akka.TestKit.Tests.TestActorRefTests
 {
     public class SenderActor : TActorBase
     {
-        private readonly ActorRef _replyActor;
+        private readonly IActorRef _replyActor;
 
-        public SenderActor(ActorRef replyActor)
+        public SenderActor(IActorRef replyActor)
         {
             _replyActor = replyActor;
         }

--- a/src/core/Akka.TestKit.Tests/TestActorRefTests/TestActorRefSpec.cs
+++ b/src/core/Akka.TestKit.Tests/TestActorRefTests/TestActorRefSpec.cs
@@ -54,7 +54,7 @@ namespace Akka.TestKit.Tests.TestActorRefTests
         {
             var a = new TestActorRef<NestingActor>(Sys, Props.Create(() => new NestingActor(true)));
             Assert.NotNull(a);
-            var nested = a.Ask<ActorRef>("any", DefaultTimeout).Result;
+            var nested = a.Ask<IActorRef>("any", DefaultTimeout).Result;
             Assert.NotNull(nested);
             Assert.NotSame(a, nested);
         }
@@ -64,7 +64,7 @@ namespace Akka.TestKit.Tests.TestActorRefTests
         {
             var a = new TestActorRef<NestingActor>(Sys, Props.Create(() => new NestingActor(false)));
             Assert.NotNull(a);
-            var nested = a.Ask<ActorRef>("any", DefaultTimeout).Result;
+            var nested = a.Ask<IActorRef>("any", DefaultTimeout).Result;
             Assert.NotNull(nested);
             Assert.NotSame(a, nested);
         }

--- a/src/core/Akka.TestKit.Tests/TestActorRefTests/WatchAndForwardActor.cs
+++ b/src/core/Akka.TestKit.Tests/TestActorRefTests/WatchAndForwardActor.cs
@@ -4,9 +4,9 @@ namespace Akka.TestKit.Tests.TestActorRefTests
 {
     public class WatchAndForwardActor : ActorBase
     {
-        private readonly ActorRef _forwardToActor;
+        private readonly IActorRef _forwardToActor;
 
-        public WatchAndForwardActor(ActorRef watchedActor, ActorRef forwardToActor)
+        public WatchAndForwardActor(IActorRef watchedActor, IActorRef forwardToActor)
         {
             _forwardToActor = forwardToActor;
             Context.Watch(watchedActor);

--- a/src/core/Akka.TestKit.Tests/TestActorRefTests/WorkerActor.cs
+++ b/src/core/Akka.TestKit.Tests/TestActorRefTests/WorkerActor.cs
@@ -14,9 +14,9 @@ namespace Akka.TestKit.Tests.TestActorRefTests
 
             }
             //TODO: case replyTo: Promise[_] ⇒ replyTo.asInstanceOf[Promise[Any]].success("complexReply")
-            if(message is ActorRef)
+            if(message is IActorRef)
             {
-                ((ActorRef)message).Tell("complexReply", Self);
+                ((IActorRef)message).Tell("complexReply", Self);
                 return true;
             }
             return false;

--- a/src/core/Akka.TestKit.Tests/TestEventListenerTests/DeadLettersEventFilterTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestEventListenerTests/DeadLettersEventFilterTests.cs
@@ -7,7 +7,7 @@ namespace Akka.Testkit.Tests.TestEventListenerTests
 {
     public class DeadLettersEventFilterTests : EventFilterTestBase
     {
-        private readonly ActorRef _deadActor;
+        private readonly IActorRef _deadActor;
         // ReSharper disable ConvertToLambdaExpression
         public DeadLettersEventFilterTests() : base("akka.loglevel=ERROR")
         {

--- a/src/core/Akka.TestKit.Tests/TestEventListenerTests/ForwardAllEventsTestEventListener.cs
+++ b/src/core/Akka.TestKit.Tests/TestEventListenerTests/ForwardAllEventsTestEventListener.cs
@@ -6,7 +6,7 @@ namespace Akka.Testkit.Tests.TestEventListenerTests
 {
     public class ForwardAllEventsTestEventListener : TestEventListener
     {
-        private ActorRef _forwarder;
+        private IActorRef _forwarder;
 
         protected override void Print(LogEvent m)
         {           
@@ -27,14 +27,14 @@ namespace Akka.Testkit.Tests.TestEventListenerTests
 
         public class ForwardAllEventsTo
         {
-            private readonly ActorRef _forwarder;
+            private readonly IActorRef _forwarder;
 
-            public ForwardAllEventsTo(ActorRef forwarder)
+            public ForwardAllEventsTo(IActorRef forwarder)
             {
                 _forwarder = forwarder;
             }
 
-            public ActorRef Forwarder { get { return _forwarder; } }
+            public IActorRef Forwarder { get { return _forwarder; } }
         }
     }
 

--- a/src/core/Akka.TestKit.Tests/TestKitBaseTests/ExpectTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestKitBaseTests/ExpectTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Akka.Actor;
 using Akka.TestKit;
 using Xunit;
 

--- a/src/core/Akka.TestKit.Tests/TestKitBaseTests/ReceiveTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestKitBaseTests/ReceiveTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Akka.Actor;
 using Akka.TestKit;
 using Xunit;
 

--- a/src/core/Akka.TestKit/AutoPilots.cs
+++ b/src/core/Akka.TestKit/AutoPilots.cs
@@ -22,7 +22,7 @@ namespace Akka.TestKit
         /// <param name="sender">The sender.</param>
         /// <param name="message">The message.</param>
         /// <returns>The <see cref="AutoPilot"/> to be used for the next round</returns>
-        abstract public AutoPilot Run(ActorRef sender, object message);
+        abstract public AutoPilot Run(IActorRef sender, object message);
 
         /// <summary>
         /// When returned by another <see cref="AutoPilot"/> then no
@@ -50,7 +50,7 @@ namespace Akka.TestKit
         public static NoAutoPilot Instance = new NoAutoPilot();
 
         private NoAutoPilot() { }
-        public override AutoPilot Run(ActorRef sender, object message)
+        public override AutoPilot Run(IActorRef sender, object message)
         {
             return this;
         }
@@ -66,13 +66,13 @@ namespace Akka.TestKit
 
         private KeepRunning(){}
 
-        public override AutoPilot Run(ActorRef sender, object message)
+        public override AutoPilot Run(IActorRef sender, object message)
         {
             throw new Exception("Must not call");
         }
     }
 
-    public delegate AutoPilot AutoPilotDelegate(ActorRef sender, object message);
+    public delegate AutoPilot AutoPilotDelegate(IActorRef sender, object message);
 
     /// <summary>
     /// Creates an <see cref="AutoPilot"/>.
@@ -93,7 +93,7 @@ namespace Akka.TestKit
             _autoPilotDelegate = autoPilotDelegate;
         }
 
-        public override AutoPilot Run(ActorRef sender, object message)
+        public override AutoPilot Run(IActorRef sender, object message)
         {
             return _autoPilotDelegate(sender,message);
         }

--- a/src/core/Akka.TestKit/EventFilter/TestEventListener.cs
+++ b/src/core/Akka.TestKit/EventFilter/TestEventListener.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Akka.Actor;
 using Akka.Dispatch.SysMsg;
 using Akka.Event;
 using Akka.TestKit.TestEvent;

--- a/src/core/Akka.TestKit/Internal/InternalTestActorRef.cs
+++ b/src/core/Akka.TestKit/Internal/InternalTestActorRef.cs
@@ -34,12 +34,12 @@ namespace Akka.TestKit.Internal
             //So it adds one $. The second is added by akka.util.Helpers.base64(l) which by default 
             //creates a StringBuilder and adds adds $. Hence, 2 $$
         }
-        private InternalTestActorRef(ActorSystem system, Props props, MessageDispatcher dispatcher, Func<Mailbox> createMailbox, InternalActorRef supervisor, ActorPath path) //TODO: switch from  Func<Mailbox> createMailbox to MailboxType mailboxType      
+        private InternalTestActorRef(ActorSystem system, Props props, MessageDispatcher dispatcher, Func<Mailbox> createMailbox, IInternalActorRef supervisor, ActorPath path) //TODO: switch from  Func<Mailbox> createMailbox to MailboxType mailboxType      
             : base(system, props, dispatcher, createMailbox, supervisor, path, actorRef => NewActorCell(system, actorRef, props, dispatcher, supervisor, createMailbox))
         {
         }
 
-        protected static ActorCell NewActorCell(ActorSystem system, LocalActorRef actorRef, Props props, MessageDispatcher dispatcher, InternalActorRef supervisor, Func<Mailbox> createMailbox)
+        protected static ActorCell NewActorCell(ActorSystem system, LocalActorRef actorRef, Props props, MessageDispatcher dispatcher, IInternalActorRef supervisor, Func<Mailbox> createMailbox)
         {
             var cell = new TestActorCell((ActorSystemImpl)system, actorRef, props, dispatcher, supervisor);
             cell.Init(sendSupervise: true, createMailbox: createMailbox);
@@ -61,7 +61,7 @@ namespace Akka.TestKit.Internal
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="sender">The sender.</param>
-        public void Receive(object message, ActorRef sender = null)
+        public void Receive(object message, IActorRef sender = null)
         {
             var cell = Cell;
             sender = sender.IsNobody() ? cell.System.DeadLetters : sender;
@@ -93,7 +93,7 @@ namespace Akka.TestKit.Internal
         /// </summary>
         /// <param name="subject">The subject to watch.</param>
         /// <returns>Returns the same ActorRef that is provided to it, to allow for cleaner invocations.</returns>
-        public void Watch(ActorRef subject)
+        public void Watch(IActorRef subject)
         {
             Cell.Watch(subject);
         }
@@ -106,7 +106,7 @@ namespace Akka.TestKit.Internal
         /// </summary>
         /// <returns>Returns the same ActorRef that is provided to it, to allow for cleaner invocations.</returns>
         /// <param name="subject">The subject to unwatch.</param>
-        public void Unwatch(ActorRef subject)
+        public void Unwatch(IActorRef subject)
         {
             Cell.Unwatch(subject);
         }
@@ -119,7 +119,7 @@ namespace Akka.TestKit.Internal
         /// INTERNAL
         /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
         /// </summary>
-        public static InternalTestActorRef Create(ActorSystem system, Props props, ActorRef supervisor = null, string name = null)
+        public static InternalTestActorRef Create(ActorSystem system, Props props, IActorRef supervisor = null, string name = null)
         {
             if(name == null)
                 name = CreateUniqueName();
@@ -166,7 +166,7 @@ namespace Akka.TestKit.Internal
             }
             //TODO: Should be: Func<Mailbox> mailbox = () => system.Mailboxes.FromConfig(dispatcher.Configurator.Config);
             Func<Mailbox> mailbox = () => system.Mailboxes.CreateMailbox(props, null);
-            var testActorRef = new InternalTestActorRef(system, props, dispatcher, mailbox, (InternalActorRef)supervisor, supervisor.Path / name);
+            var testActorRef = new InternalTestActorRef(system, props, dispatcher, mailbox, (IInternalActorRef)supervisor, supervisor.Path / name);
 
             // we need to start ourselves since the creation of an actor has been split into initialization and starting
             testActorRef.Underlying.Start();
@@ -176,7 +176,7 @@ namespace Akka.TestKit.Internal
 
         protected class TestActorCell : ActorCell
         {
-            public TestActorCell(ActorSystemImpl system, InternalActorRef self, Props props, MessageDispatcher dispatcher, InternalActorRef parent)
+            public TestActorCell(ActorSystemImpl system, IInternalActorRef self, Props props, MessageDispatcher dispatcher, IInternalActorRef parent)
                 : base(system, self, props, dispatcher, parent)
             {
             }

--- a/src/core/Akka.TestKit/MessageEnvelope.cs
+++ b/src/core/Akka.TestKit/MessageEnvelope.cs
@@ -6,6 +6,6 @@ namespace Akka.TestKit
     {
         public abstract object Message { get; }
 
-        public abstract ActorRef Sender { get; }
+        public abstract IActorRef Sender { get; }
     }
 }

--- a/src/core/Akka.TestKit/NullMessageEnvelope.cs
+++ b/src/core/Akka.TestKit/NullMessageEnvelope.cs
@@ -13,7 +13,7 @@ namespace Akka.TestKit
             get { throw new IllegalActorStateException("last receive did not dequeue a message"); }
         }
 
-        public override ActorRef Sender
+        public override IActorRef Sender
         {
             get { throw new IllegalActorStateException("last receive did not dequeue a message"); }
         }

--- a/src/core/Akka.TestKit/RealMessageEnvelope.cs
+++ b/src/core/Akka.TestKit/RealMessageEnvelope.cs
@@ -5,16 +5,16 @@ namespace Akka.TestKit
     public class RealMessageEnvelope : MessageEnvelope
     {
         private readonly object _message;
-        private readonly ActorRef _sender;
+        private readonly IActorRef _sender;
 
-        public RealMessageEnvelope(object message, ActorRef sender)
+        public RealMessageEnvelope(object message, IActorRef sender)
         {
             _message = message;
             _sender = sender;
         }
 
         public override object Message { get { return _message; } }
-        public override ActorRef Sender{get { return _sender; }}
+        public override IActorRef Sender{get { return _sender; }}
 
         public override string ToString()
         {

--- a/src/core/Akka.TestKit/TestActor.cs
+++ b/src/core/Akka.TestKit/TestActor.cs
@@ -37,11 +37,11 @@ namespace Akka.TestKit
         /// </summary>
         public class Watch : NoSerializationVerificationNeeded
         {
-            private readonly ActorRef _actorToWatch;
+            private readonly IActorRef _actorToWatch;
 
-            public Watch(ActorRef actorToWatch) { _actorToWatch = actorToWatch; }
+            public Watch(IActorRef actorToWatch) { _actorToWatch = actorToWatch; }
 
-            public ActorRef Actor { get { return _actorToWatch; } }
+            public IActorRef Actor { get { return _actorToWatch; } }
         }
 
         /// <summary>
@@ -50,11 +50,11 @@ namespace Akka.TestKit
         /// </summary>
         public class Unwatch : NoSerializationVerificationNeeded
         {
-            private readonly ActorRef _actorToUnwatch;
+            private readonly IActorRef _actorToUnwatch;
 
-            public Unwatch(ActorRef actorToUnwatch) { _actorToUnwatch = actorToUnwatch; }
+            public Unwatch(IActorRef actorToUnwatch) { _actorToUnwatch = actorToUnwatch; }
 
-            public ActorRef Actor { get { return _actorToUnwatch; } }
+            public IActorRef Actor { get { return _actorToUnwatch; } }
         }
 
         /// <summary>

--- a/src/core/Akka.TestKit/TestActorRef.cs
+++ b/src/core/Akka.TestKit/TestActorRef.cs
@@ -6,8 +6,8 @@ namespace Akka.TestKit
     /// This special ActorRef is exclusively for use during unit testing in a single-threaded environment. Therefore, it
     /// overrides the dispatcher to <see cref="CallingThreadDispatcher"/> and sets the receiveTimeout to None. Otherwise,
     /// it acts just like a normal ActorRef. You may retrieve a reference to the underlying actor to test internal logic.
-    /// A <see cref="TestActorRef{TActor}"/> can be implicitly casted to an <see cref="ActorRef"/> or you can get the actual
-    /// <see cref="ActorRef"/> from the <see cref="TestActorRefBase{TActor}.Ref">Ref</see> property.
+    /// A <see cref="TestActorRef{TActor}"/> can be implicitly casted to an <see cref="IActorRef"/> or you can get the actual
+    /// <see cref="IActorRef"/> from the <see cref="TestActorRefBase{TActor}.Ref">Ref</see> property.
     /// </summary>
     /// <typeparam name="TActor">The type of actor</typeparam>
     public class TestActorRef<TActor> : TestActorRefBase<TActor> where TActor : ActorBase
@@ -19,29 +19,29 @@ namespace Akka.TestKit
         /// <param name="actorProps">The actor props.</param>
         /// <param name="supervisor">Optional: The supervisor.</param>
         /// <param name="name">Optional: The name.</param>
-        public TestActorRef(ActorSystem system, Props actorProps, ActorRef supervisor = null, string name = null) : base(system, actorProps, supervisor, name)
+        public TestActorRef(ActorSystem system, Props actorProps, IActorRef supervisor = null, string name = null) : base(system, actorProps, supervisor, name)
         {
         }
 
-        public static bool operator ==(TestActorRef<TActor> testActorRef, ActorRef actorRef)
+        public static bool operator ==(TestActorRef<TActor> testActorRef, IActorRef actorRef)
         {
             if(ReferenceEquals(testActorRef, null)) return ReferenceEquals(actorRef, null);
             return testActorRef.Equals(actorRef);
         }
 
-        public static bool operator !=(TestActorRef<TActor> testActorRef, ActorRef actorRef)
+        public static bool operator !=(TestActorRef<TActor> testActorRef, IActorRef actorRef)
         {
             if(ReferenceEquals(testActorRef, null)) return !ReferenceEquals(actorRef, null);
             return !testActorRef.Equals(actorRef);
         }
 
-        public static bool operator ==(ActorRef actorRef, TestActorRef<TActor> testActorRef)
+        public static bool operator ==(IActorRef actorRef, TestActorRef<TActor> testActorRef)
         {
             if(ReferenceEquals(testActorRef, null)) return ReferenceEquals(actorRef, null);
             return testActorRef.Equals(actorRef);
         }
 
-        public static bool operator !=(ActorRef actorRef, TestActorRef<TActor> testActorRef)
+        public static bool operator !=(IActorRef actorRef, TestActorRef<TActor> testActorRef)
         {
             if(ReferenceEquals(testActorRef, null)) return !ReferenceEquals(actorRef, null);
             return !testActorRef.Equals(actorRef);

--- a/src/core/Akka.TestKit/TestActorRef.cs
+++ b/src/core/Akka.TestKit/TestActorRef.cs
@@ -47,11 +47,6 @@ namespace Akka.TestKit
             return !testActorRef.Equals(actorRef);
         }
 
-        public static implicit operator ActorRef(TestActorRef<TActor> actorRef)
-        {
-            return actorRef.Ref;
-        }
-
         //Here to suppress CS0660, 'class' defines operator == or operator != but does not override Object.Equals(object o)
         public override bool Equals(object obj)
         {

--- a/src/core/Akka.TestKit/TestActorRefBase.cs
+++ b/src/core/Akka.TestKit/TestActorRefBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Akka.Actor;
 using Akka.Dispatch;
 using Akka.TestKit.Internal;
@@ -10,7 +11,7 @@ namespace Akka.TestKit
     /// This is the base class for TestActorRefs
     /// </summary>
     /// <typeparam name="TActor">The type of actor</typeparam>
-    public abstract class TestActorRefBase<TActor> : ICanTell, IEquatable<ActorRef>, ActorRef where TActor : ActorBase
+    public abstract class TestActorRefBase<TActor> : ICanTell, IEquatable<ActorRef>, InternalActorRef where TActor : ActorBase
     {
         private readonly InternalTestActorRef _internalRef;
 
@@ -168,24 +169,62 @@ namespace Akka.TestKit
         //ActorRef implementations
         int IComparable<ActorRef>.CompareTo(ActorRef other)
         {
-            return Ref.CompareTo(other);
+            return _internalRef.CompareTo(other);
         }
 
         bool IEquatable<ActorRef>.Equals(ActorRef other)
         {
-            return Ref.Equals(other);
+            return _internalRef.Equals(other);
         }
 
-        ActorPath ActorRef.Path { get { return Ref.Path; } }
+        ActorPath ActorRef.Path { get { return _internalRef.Path; } }
 
         void ICanTell.Tell(object message, ActorRef sender)
         {
-            Ref.Tell(message, sender);
+            _internalRef.Tell(message, sender);
         }
 
         ISurrogate ISurrogated.ToSurrogate(ActorSystem system)
         {
-            return Ref.ToSurrogate(system);
+            return _internalRef.ToSurrogate(system);
+        }
+
+        bool ActorRefScope.IsLocal { get { return _internalRef.IsLocal; } }
+
+        InternalActorRef InternalActorRef.Parent { get { return _internalRef.Parent; } }
+
+        ActorRefProvider InternalActorRef.Provider { get { return _internalRef.Provider; } }
+
+        bool InternalActorRef.IsTerminated { get { return _internalRef.IsTerminated; } }
+
+        ActorRef InternalActorRef.GetChild(IEnumerable<string> name)
+        {
+            return _internalRef.GetChild(name);
+        }
+
+        void InternalActorRef.Resume(Exception causedByFailure)
+        {
+            _internalRef.Resume(causedByFailure);
+        }
+
+        void InternalActorRef.Start()
+        {
+            _internalRef.Start();
+        }
+
+        void InternalActorRef.Stop()
+        {
+            _internalRef.Stop();
+        }
+
+        void InternalActorRef.Restart(Exception cause)
+        {
+            _internalRef.Restart(cause);
+        }
+
+        void InternalActorRef.Suspend()
+        {
+            _internalRef.Suspend();
         }
     }
 }

--- a/src/core/Akka.TestKit/TestActorRefBase.cs
+++ b/src/core/Akka.TestKit/TestActorRefBase.cs
@@ -2,6 +2,7 @@
 using Akka.Actor;
 using Akka.Dispatch;
 using Akka.TestKit.Internal;
+using Akka.Util;
 
 namespace Akka.TestKit
 {
@@ -9,7 +10,7 @@ namespace Akka.TestKit
     /// This is the base class for TestActorRefs
     /// </summary>
     /// <typeparam name="TActor">The type of actor</typeparam>
-    public abstract class TestActorRefBase<TActor> : ICanTell, IEquatable<ActorRef> where TActor : ActorBase
+    public abstract class TestActorRefBase<TActor> : ICanTell, IEquatable<ActorRef>, ActorRef where TActor : ActorBase
     {
         private readonly InternalTestActorRef _internalRef;
 
@@ -159,9 +160,32 @@ namespace Akka.TestKit
             return !testActorRef.Equals(actorRef);
         }
 
-        public static implicit operator ActorRef(TestActorRefBase<TActor> actorRef)
+        public static ActorRef ToActorRef(TestActorRefBase<TActor> actorRef)
         {
             return actorRef._internalRef;
+        }
+
+        //ActorRef implementations
+        int IComparable<ActorRef>.CompareTo(ActorRef other)
+        {
+            return Ref.CompareTo(other);
+        }
+
+        bool IEquatable<ActorRef>.Equals(ActorRef other)
+        {
+            return Ref.Equals(other);
+        }
+
+        ActorPath ActorRef.Path { get { return Ref.Path; } }
+
+        void ICanTell.Tell(object message, ActorRef sender)
+        {
+            Ref.Tell(message, sender);
+        }
+
+        ISurrogate ISurrogated.ToSurrogate(ActorSystem system)
+        {
+            return Ref.ToSurrogate(system);
         }
     }
 }

--- a/src/core/Akka.TestKit/TestActorRefBase.cs
+++ b/src/core/Akka.TestKit/TestActorRefBase.cs
@@ -11,11 +11,11 @@ namespace Akka.TestKit
     /// This is the base class for TestActorRefs
     /// </summary>
     /// <typeparam name="TActor">The type of actor</typeparam>
-    public abstract class TestActorRefBase<TActor> : ICanTell, IEquatable<ActorRef>, InternalActorRef where TActor : ActorBase
+    public abstract class TestActorRefBase<TActor> : ICanTell, IEquatable<IActorRef>, IInternalActorRef where TActor : ActorBase
     {
         private readonly InternalTestActorRef _internalRef;
 
-        protected TestActorRefBase(ActorSystem system, Props actorProps, ActorRef supervisor=null, string name=null)
+        protected TestActorRefBase(ActorSystem system, Props actorProps, IActorRef supervisor=null, string name=null)
         {
             _internalRef = InternalTestActorRef.Create(system, actorProps, supervisor, name);
         }
@@ -27,12 +27,12 @@ namespace Akka.TestKit
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="sender">The sender.</param>
-        public void Receive(object message, ActorRef sender = null)
+        public void Receive(object message, IActorRef sender = null)
         {
             _internalRef.Receive(message, sender);
         }
 
-        public ActorRef Ref
+        public IActorRef Ref
         {
             get { return _internalRef; }
         }
@@ -83,7 +83,7 @@ namespace Akka.TestKit
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="sender">The sender</param>
-        public void Tell(object message, ActorRef sender)
+        public void Tell(object message, IActorRef sender)
         {
             _internalRef.Tell(message, sender);
 
@@ -97,7 +97,7 @@ namespace Akka.TestKit
         /// </summary>
         /// <param name="subject">The subject to watch.</param>
         /// <returns>Returns the same ActorRef that is provided to it, to allow for cleaner invocations.</returns>
-        public void Watch(ActorRef subject)
+        public void Watch(IActorRef subject)
         {
             _internalRef.Watch(subject);
         }
@@ -110,7 +110,7 @@ namespace Akka.TestKit
         /// </summary>
         /// <returns>Returns the same ActorRef that is provided to it, to allow for cleaner invocations.</returns>
         /// <param name="subject">The subject to unwatch.</param>
-        public void Unwatch(ActorRef subject)
+        public void Unwatch(IActorRef subject)
         {
             _internalRef.Unwatch(subject);
         }
@@ -120,7 +120,7 @@ namespace Akka.TestKit
             return _internalRef.ToString();
         }
 
-        protected delegate TActorRef CreateTestActorRef<out TActorRef>(ActorSystem system, Props props, MessageDispatcher dispatcher, Func<Mailbox> mailbox, InternalActorRef supervisor, ActorPath path) where TActorRef : TestActorRefBase<TActor>;
+        protected delegate TActorRef CreateTestActorRef<out TActorRef>(ActorSystem system, Props props, MessageDispatcher dispatcher, Func<Mailbox> mailbox, IInternalActorRef supervisor, ActorPath path) where TActorRef : TestActorRefBase<TActor>;
 
         public override bool Equals(object obj)
         {
@@ -132,54 +132,54 @@ namespace Akka.TestKit
             return _internalRef.GetHashCode();
         }
 
-        public bool Equals(ActorRef other)
+        public bool Equals(IActorRef other)
         {
             return _internalRef.Equals(other);
         }
 
-        public static bool operator ==(TestActorRefBase<TActor> testActorRef, ActorRef actorRef)
+        public static bool operator ==(TestActorRefBase<TActor> testActorRef, IActorRef actorRef)
         {
             if(ReferenceEquals(testActorRef, null)) return ReferenceEquals(actorRef, null);
             return testActorRef.Equals(actorRef);
         }
 
-        public static bool operator !=(TestActorRefBase<TActor> testActorRef, ActorRef actorRef)
+        public static bool operator !=(TestActorRefBase<TActor> testActorRef, IActorRef actorRef)
         {
             if(ReferenceEquals(testActorRef, null)) return !ReferenceEquals(actorRef, null);
             return !testActorRef.Equals(actorRef);
         }
 
-        public static bool operator ==(ActorRef actorRef, TestActorRefBase<TActor> testActorRef)
+        public static bool operator ==(IActorRef actorRef, TestActorRefBase<TActor> testActorRef)
         {
             if(ReferenceEquals(testActorRef, null)) return ReferenceEquals(actorRef, null);
             return testActorRef.Equals(actorRef);
         }
 
-        public static bool operator !=(ActorRef actorRef, TestActorRefBase<TActor> testActorRef)
+        public static bool operator !=(IActorRef actorRef, TestActorRefBase<TActor> testActorRef)
         {
             if(ReferenceEquals(testActorRef, null)) return !ReferenceEquals(actorRef, null);
             return !testActorRef.Equals(actorRef);
         }
 
-        public static ActorRef ToActorRef(TestActorRefBase<TActor> actorRef)
+        public static IActorRef ToActorRef(TestActorRefBase<TActor> actorRef)
         {
             return actorRef._internalRef;
         }
 
         //ActorRef implementations
-        int IComparable<ActorRef>.CompareTo(ActorRef other)
+        int IComparable<IActorRef>.CompareTo(IActorRef other)
         {
             return _internalRef.CompareTo(other);
         }
 
-        bool IEquatable<ActorRef>.Equals(ActorRef other)
+        bool IEquatable<IActorRef>.Equals(IActorRef other)
         {
             return _internalRef.Equals(other);
         }
 
-        ActorPath ActorRef.Path { get { return _internalRef.Path; } }
+        ActorPath IActorRef.Path { get { return _internalRef.Path; } }
 
-        void ICanTell.Tell(object message, ActorRef sender)
+        void ICanTell.Tell(object message, IActorRef sender)
         {
             _internalRef.Tell(message, sender);
         }
@@ -191,38 +191,38 @@ namespace Akka.TestKit
 
         bool ActorRefScope.IsLocal { get { return _internalRef.IsLocal; } }
 
-        InternalActorRef InternalActorRef.Parent { get { return _internalRef.Parent; } }
+        IInternalActorRef IInternalActorRef.Parent { get { return _internalRef.Parent; } }
 
-        ActorRefProvider InternalActorRef.Provider { get { return _internalRef.Provider; } }
+        ActorRefProvider IInternalActorRef.Provider { get { return _internalRef.Provider; } }
 
-        bool InternalActorRef.IsTerminated { get { return _internalRef.IsTerminated; } }
+        bool IInternalActorRef.IsTerminated { get { return _internalRef.IsTerminated; } }
 
-        ActorRef InternalActorRef.GetChild(IEnumerable<string> name)
+        IActorRef IInternalActorRef.GetChild(IEnumerable<string> name)
         {
             return _internalRef.GetChild(name);
         }
 
-        void InternalActorRef.Resume(Exception causedByFailure)
+        void IInternalActorRef.Resume(Exception causedByFailure)
         {
             _internalRef.Resume(causedByFailure);
         }
 
-        void InternalActorRef.Start()
+        void IInternalActorRef.Start()
         {
             _internalRef.Start();
         }
 
-        void InternalActorRef.Stop()
+        void IInternalActorRef.Stop()
         {
             _internalRef.Stop();
         }
 
-        void InternalActorRef.Restart(Exception cause)
+        void IInternalActorRef.Restart(Exception cause)
         {
             _internalRef.Restart(cause);
         }
 
-        void InternalActorRef.Suspend()
+        void IInternalActorRef.Suspend()
         {
             _internalRef.Suspend();
         }

--- a/src/core/Akka.TestKit/TestFSMRef.cs
+++ b/src/core/Akka.TestKit/TestFSMRef.cs
@@ -13,7 +13,7 @@ namespace Akka.TestKit
     /// <typeparam name="TData">The type of the data.</typeparam>
     public class TestFSMRef<TActor, TState, TData> : TestActorRefBase<TActor> where TActor : FSM<TState, TData>
     {
-        public TestFSMRef(ActorSystem system, Props props, ActorRef supervisor = null, string name = null, bool activateLogging = false)
+        public TestFSMRef(ActorSystem system, Props props, IActorRef supervisor = null, string name = null, bool activateLogging = false)
             : base(system, props, supervisor, name)
         {
             if(activateLogging)

--- a/src/core/Akka.TestKit/TestKitBase.cs
+++ b/src/core/Akka.TestKit/TestKitBase.cs
@@ -34,7 +34,7 @@ namespace Akka.TestKit
         private readonly BlockingQueue<MessageEnvelope> _queue;
         private MessageEnvelope _lastMessage = NullMessageEnvelope.Instance;
         private static readonly AtomicCounter _testActorId = new AtomicCounter(0);
-        private readonly ActorRef _testActor;
+        private readonly IActorRef _testActor;
         private TimeSpan? _end;
         private bool _lastWasNoMsg; //if last assertion was expectNoMsg, disable timing failure upon within() block end.
         private readonly LoggingAdapter _log;
@@ -106,7 +106,7 @@ namespace Akka.TestKit
 
         public ActorSystem Sys { get { return _system; } }
         public TestKitSettings TestKitSettings { get { return _testKitSettings; } }
-        public ActorRef LastSender { get { return _lastMessage.Sender; } }
+        public IActorRef LastSender { get { return _lastMessage.Sender; } }
         public static Config DefaultConfig { get { return _defaultConfig; } }
         public static Config FullDebugConfig { get { return _fullDebugConfig; } }
         public static TimeSpan Now { get { return TimeSpan.FromTicks(DateTime.UtcNow.Ticks); } }
@@ -121,7 +121,7 @@ namespace Akka.TestKit
         /// <see cref="SetAutoPilot"/>. All other messages are forwarded to the queue
         /// and can be retrieved with Receive and the ExpectMsg overloads.
         /// </summary>
-        public ActorRef TestActor { get { return _testActor; } }
+        public IActorRef TestActor { get { return _testActor; } }
 
         /// <summary>
         /// Filter <see cref="LogEvent"/> sent to the system's <see cref="EventStream"/>.
@@ -167,7 +167,7 @@ namespace Akka.TestKit
         /// </summary>
         /// <param name="actorToWatch">The actor to watch.</param>
         /// <returns>The actor to watch, i.e. the parameter <paramref name="actorToWatch"/></returns>
-        public ActorRef Watch(ActorRef actorToWatch)
+        public IActorRef Watch(IActorRef actorToWatch)
         {
             _testActor.Tell(new TestActor.Watch(actorToWatch));
             return actorToWatch;
@@ -178,7 +178,7 @@ namespace Akka.TestKit
         /// </summary>
         /// <param name="actorToUnwatch">The actor to unwatch.</param>
         /// <returns>The actor to unwatch, i.e. the parameter <paramref name="actorToUnwatch"/></returns>
-        public ActorRef Unwatch(ActorRef actorToUnwatch)
+        public IActorRef Unwatch(IActorRef actorToUnwatch)
         {
             _testActor.Tell(new TestActor.Unwatch(actorToUnwatch));
             return actorToUnwatch;
@@ -324,12 +324,12 @@ namespace Akka.TestKit
         /// </summary>
         /// <param name="name">The name of the new actor.</param>
         /// <returns></returns>
-        public ActorRef CreateTestActor(string name)
+        public IActorRef CreateTestActor(string name)
         {
             return CreateTestActor(_system, name);
         }
 
-        private ActorRef CreateTestActor(ActorSystem system, string name)
+        private IActorRef CreateTestActor(ActorSystem system, string name)
         {
             var testActorProps = Props.Create(() => new InternalTestActor(new BlockingCollectionTestActorQueue<MessageEnvelope>(_queue)))
                 .WithDispatcher("akka.test.test-actor.dispatcher");

--- a/src/core/Akka.TestKit/TestKitBase_ActorOf.cs
+++ b/src/core/Akka.TestKit/TestKitBase_ActorOf.cs
@@ -7,13 +7,13 @@ namespace Akka.TestKit
 {
     public partial class TestKitBase
     {
-        private const ActorRef NoSupervisor = null;
+        private const IActorRef NoSupervisor = null;
 
         /// <summary>
         /// Create a new actor as child of <see cref="Sys" />.
         /// </summary>
         /// <param name="props">The props configuration object</param>
-        public ActorRef ActorOf(Props props)
+        public IActorRef ActorOf(Props props)
         {
             return Sys.ActorOf(props, null);
         }
@@ -23,7 +23,7 @@ namespace Akka.TestKit
         /// </summary>
         /// <param name="props">The props configuration object</param>
         /// <param name="name">The name of the actor.</param>
-        public ActorRef ActorOf(Props props, string name)
+        public IActorRef ActorOf(Props props, string name)
         {
             return Sys.ActorOf(props, name);
         }
@@ -32,7 +32,7 @@ namespace Akka.TestKit
         /// Create a new actor as child of <see cref="Sys" />.
         /// </summary>
         /// <typeparam name="TActor">The type of the actor. It must have a parameterless public constructor</typeparam>
-        public ActorRef ActorOf<TActor>() where TActor : ActorBase, new()
+        public IActorRef ActorOf<TActor>() where TActor : ActorBase, new()
         {
             return Sys.ActorOf(Props.Create<TActor>(), null);
         }
@@ -42,7 +42,7 @@ namespace Akka.TestKit
         /// </summary>
         /// <typeparam name="TActor">The type of the actor. It must have a parameterless public constructor</typeparam>
         /// <param name="name">The name of the actor.</param>
-        public ActorRef ActorOf<TActor>(string name) where TActor : ActorBase, new()
+        public IActorRef ActorOf<TActor>(string name) where TActor : ActorBase, new()
         {
             return Sys.ActorOf(Props.Create<TActor>(), name);
         }
@@ -56,7 +56,7 @@ namespace Akka.TestKit
         /// </summary>
         /// <typeparam name="TActor">The type of the actor.</typeparam>
         /// <param name="factory">An expression that calls the constructor of <typeparamref name="TActor"/></param>
-        public ActorRef ActorOf<TActor>(Expression<Func<TActor>> factory) where TActor : ActorBase
+        public IActorRef ActorOf<TActor>(Expression<Func<TActor>> factory) where TActor : ActorBase
         {
             return Sys.ActorOf(Props.Create(factory), null);
         }
@@ -71,7 +71,7 @@ namespace Akka.TestKit
         /// <typeparam name="TActor">The type of the actor.</typeparam>
         /// <param name="factory">An expression that calls the constructor of <typeparamref name="TActor"/></param>
         /// <param name="name">The name of the actor.</param>
-        public ActorRef ActorOf<TActor>(Expression<Func<TActor>> factory, string name) where TActor : ActorBase
+        public IActorRef ActorOf<TActor>(Expression<Func<TActor>> factory, string name) where TActor : ActorBase
         {
             return Sys.ActorOf(Props.Create(factory), name);
         }
@@ -89,7 +89,7 @@ namespace Akka.TestKit
         /// </summary>
         /// <param name="configure">An action that configures the actor's behavior.</param>
         /// <param name="name">Optional: The name of the actor.</param>
-        public ActorRef ActorOf(Action<IActorDsl, IActorContext> configure, string name = null)
+        public IActorRef ActorOf(Action<IActorDsl, IActorContext> configure, string name = null)
         {
             return ActExtensions.ActorOf(this, configure, name);
         }
@@ -107,7 +107,7 @@ namespace Akka.TestKit
         /// </summary>
         /// <param name="configure">An action that configures the actor's behavior.</param>
         /// <param name="name">Optional: The name of the actor.</param>
-        public ActorRef ActorOf(Action<IActorDsl> configure, string name = null)
+        public IActorRef ActorOf(Action<IActorDsl> configure, string name = null)
         {
             return ActExtensions.ActorOf(this, configure, name);
         }
@@ -132,7 +132,7 @@ namespace Akka.TestKit
         /// <param name="props">The <see cref="Props"/> object</param>
         /// <param name="supervisor">The supervisor</param>
         /// <param name="name">Optional: The name.</param>
-        public TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(Props props, ActorRef supervisor, string name = null) where TActor : ActorBase
+        public TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(Props props, IActorRef supervisor, string name = null) where TActor : ActorBase
         {
             return new TestActorRef<TActor>(Sys, props, supervisor, name);
         }
@@ -161,7 +161,7 @@ namespace Akka.TestKit
         /// <param name="factory">An expression that calls the constructor of <typeparamref name="TActor"/></param>
         /// <param name="supervisor">The supervisor</param>
         /// <param name="name">Optional: The name.</param>
-        public TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(Expression<Func<TActor>> factory, ActorRef supervisor, string name = null) where TActor : ActorBase
+        public TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(Expression<Func<TActor>> factory, IActorRef supervisor, string name = null) where TActor : ActorBase
         {
             return new TestActorRef<TActor>(Sys, Props.Create(factory), supervisor, name);
         }
@@ -189,7 +189,7 @@ namespace Akka.TestKit
         /// <typeparam name="TActor">The type of the actor. It must have a parameterless public constructor</typeparam>
         /// <param name="supervisor">The supervisor</param>
         /// <param name="name">Optional: The name.</param>
-        public TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(ActorRef supervisor, string name = null) where TActor : ActorBase, new()
+        public TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(IActorRef supervisor, string name = null) where TActor : ActorBase, new()
         {
             return new TestActorRef<TActor>(Sys, Props.Create<TActor>(), supervisor, name);
         }
@@ -221,7 +221,7 @@ namespace Akka.TestKit
         /// <param name="supervisor">The supervisor</param>
         /// <param name="name">Optional: The name.</param>
         /// <param name="withLogging">Optional: If set to <c>true</c> logs state changes of the FSM as Debug messages. Default is <c>false</c>.</param>
-        public TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(Props props, ActorRef supervisor, string name = null, bool withLogging = false)
+        public TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(Props props, IActorRef supervisor, string name = null, bool withLogging = false)
             where TFsmActor : FSM<TState, TData>
         {
             return new TestFSMRef<TFsmActor, TState, TData>(Sys, props, supervisor, name, withLogging);
@@ -255,7 +255,7 @@ namespace Akka.TestKit
         /// <param name="supervisor">The supervisor</param>
         /// <param name="name">Optional: The name.</param>
         /// <param name="withLogging">Optional: If set to <c>true</c> logs state changes of the FSM as Debug messages. Default is <c>false</c>.</param>
-        public TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(ActorRef supervisor, string name = null, bool withLogging = false)
+        public TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(IActorRef supervisor, string name = null, bool withLogging = false)
             where TFsmActor : FSM<TState, TData>, new()
         {
             return new TestFSMRef<TFsmActor, TState, TData>(Sys,Props.Create<TFsmActor>(), supervisor, name, withLogging);
@@ -289,7 +289,7 @@ namespace Akka.TestKit
         /// <param name="supervisor">The supervisor</param>
         /// <param name="name">Optional: The name.</param>
         /// <param name="withLogging">Optional: If set to <c>true</c> logs state changes of the FSM as Debug messages. Default is <c>false</c>.</param>
-        public TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(Expression<Func<TFsmActor>> factory, ActorRef supervisor, string name = null, bool withLogging = false)
+        public TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(Expression<Func<TFsmActor>> factory, IActorRef supervisor, string name = null, bool withLogging = false)
             where TFsmActor : FSM<TState, TData>
         {
             return new TestFSMRef<TFsmActor, TState, TData>(Sys, Props.Create(factory), supervisor, name, withLogging);

--- a/src/core/Akka.TestKit/TestKitBase_Expect.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Expect.cs
@@ -80,7 +80,7 @@ namespace Akka.TestKit
         /// block, if inside a 'within' block; otherwise by the config value 
         /// "akka.test.single-expect-default".
         /// </summary>
-        public T ExpectMsg<T>(Func<T, ActorRef, bool> isMessageAndSender, TimeSpan? timeout = null, string hint = null)
+        public T ExpectMsg<T>(Func<T, IActorRef, bool> isMessageAndSender, TimeSpan? timeout = null, string hint = null)
         {
             return InternalExpectMsg<T>(RemainingOrDilated(RemainingOrDilated(timeout)), (m, sender) =>
             {
@@ -98,7 +98,7 @@ namespace Akka.TestKit
         /// block, if inside a 'within' block; otherwise by the config value 
         /// "akka.test.single-expect-default".
         /// </summary>
-        public T ExpectMsg<T>(Action<T, ActorRef> assertMessageAndSender, TimeSpan? timeout = null, string hint = null)
+        public T ExpectMsg<T>(Action<T, IActorRef> assertMessageAndSender, TimeSpan? timeout = null, string hint = null)
         {
             return InternalExpectMsg<T>(RemainingOrDilated(RemainingOrDilated(timeout)), assertMessageAndSender, hint);
         }
@@ -133,7 +133,7 @@ namespace Akka.TestKit
         /// block, if inside a 'within' block; otherwise by the config value 
         /// "akka.test.single-expect-default".
         /// </summary>       
-        public Terminated ExpectTerminated(ActorRef target, TimeSpan? timeout = null, string hint = null)
+        public Terminated ExpectTerminated(IActorRef target, TimeSpan? timeout = null, string hint = null)
         {
             var msg = string.Format("Terminated {0}. {1}", target.Path, hint ?? "");
             return InternalExpectMsg<Terminated>(RemainingOrDilated(timeout), terminated => _assertions.AssertEqual(target, terminated.ActorRef, msg), msg);
@@ -156,23 +156,23 @@ namespace Akka.TestKit
             return (T)envelope.Message;
         }
 
-        private T InternalExpectMsg<T>(TimeSpan? timeout, Action<T> msgAssert, Action<ActorRef> senderAssert, string hint)
+        private T InternalExpectMsg<T>(TimeSpan? timeout, Action<T> msgAssert, Action<IActorRef> senderAssert, string hint)
         {
             var envelope = InternalExpectMsgEnvelope<T>(timeout, msgAssert, senderAssert, hint);
             return (T)envelope.Message;
         }
 
-        private T InternalExpectMsg<T>(TimeSpan? timeout, Action<T, ActorRef> assert, string hint)
+        private T InternalExpectMsg<T>(TimeSpan? timeout, Action<T, IActorRef> assert, string hint)
         {
             var envelope = InternalExpectMsgEnvelope<T>(timeout, assert, hint);
             return (T)envelope.Message;
         }
 
-        private MessageEnvelope InternalExpectMsgEnvelope<T>(TimeSpan? timeout, Action<T> msgAssert, Action<ActorRef> senderAssert, string hint)
+        private MessageEnvelope InternalExpectMsgEnvelope<T>(TimeSpan? timeout, Action<T> msgAssert, Action<IActorRef> senderAssert, string hint)
         {
             msgAssert = msgAssert ?? (m => { });
             senderAssert = senderAssert ?? (sender => { });
-            Action<T, ActorRef> combinedAssert = (m, sender) =>
+            Action<T, IActorRef> combinedAssert = (m, sender) =>
             {
                 senderAssert(sender);
                 msgAssert(m);
@@ -181,7 +181,7 @@ namespace Akka.TestKit
             return envelope;
         }
 
-        private MessageEnvelope InternalExpectMsgEnvelope<T>(TimeSpan? timeout, Action<T, ActorRef> assert, string hint, bool shouldLog=false)
+        private MessageEnvelope InternalExpectMsgEnvelope<T>(TimeSpan? timeout, Action<T, IActorRef> assert, string hint, bool shouldLog=false)
         {
             MessageEnvelope envelope;
             ConditionalLog(shouldLog, "Expecting message of type {0}. {1}", typeof(T), hint);

--- a/src/core/Akka.TestKit/TestKitBase_ExpectMsgFrom.cs
+++ b/src/core/Akka.TestKit/TestKitBase_ExpectMsgFrom.cs
@@ -15,7 +15,7 @@ namespace Akka.TestKit
         /// block, if inside a 'within' block; otherwise by the config value 
         /// "akka.test.single-expect-default".
         /// </summary>
-        public T ExpectMsgFrom<T>(ActorRef sender, TimeSpan? duration = null, string hint = null)
+        public T ExpectMsgFrom<T>(IActorRef sender, TimeSpan? duration = null, string hint = null)
         {
             return InternalExpectMsg<T>(RemainingOrDilated(duration), null, s => _assertions.AssertEqual(sender, s, FormatWrongSenderMessage(s,sender.ToString(),hint)), null);
         }
@@ -29,7 +29,7 @@ namespace Akka.TestKit
         /// block, if inside a 'within' block; otherwise by the config value 
         /// "akka.test.single-expect-default".
         /// </summary>
-        public T ExpectMsgFrom<T>(ActorRef sender, T message, TimeSpan? timeout = null, string hint = null)
+        public T ExpectMsgFrom<T>(IActorRef sender, T message, TimeSpan? timeout = null, string hint = null)
         {
             return InternalExpectMsg<T>(RemainingOrDilated(timeout), m => _assertions.AssertEqual(message, m), s => _assertions.AssertEqual(sender, s, FormatWrongSenderMessage(s, sender.ToString(), hint)), hint);
         }
@@ -43,7 +43,7 @@ namespace Akka.TestKit
         /// "akka.test.single-expect-default".
         /// Use this variant to implement more complicated or conditional processing.
         /// </summary>
-        public T ExpectMsgFrom<T>(ActorRef sender, Predicate<T> isMessage, TimeSpan? timeout = null, string hint = null)
+        public T ExpectMsgFrom<T>(IActorRef sender, Predicate<T> isMessage, TimeSpan? timeout = null, string hint = null)
         {
             return InternalExpectMsg<T>(RemainingOrDilated(timeout), (m, s) =>
             {
@@ -63,7 +63,7 @@ namespace Akka.TestKit
         /// "akka.test.single-expect-default".
         /// Use this variant to implement more complicated or conditional processing.
         /// </summary>
-        public T ExpectMsgFrom<T>(Predicate<ActorRef> isSender, Predicate<T> isMessage, TimeSpan? timeout = null, string hint = null)
+        public T ExpectMsgFrom<T>(Predicate<IActorRef> isSender, Predicate<T> isMessage, TimeSpan? timeout = null, string hint = null)
         {
             return InternalExpectMsg<T>(RemainingOrDilated(timeout), (m, sender) =>
             {
@@ -74,12 +74,12 @@ namespace Akka.TestKit
             }, hint);
         }
 
-        private string FormatWrongSenderMessage(ActorRef actualSender, string expectedSender, string hint)
+        private string FormatWrongSenderMessage(IActorRef actualSender, string expectedSender, string hint)
         {
             return "Sender does not match. Got a message from sender " + actualSender + ". But expected " + expectedSender + (hint ?? "");
         }
 
-        private void AssertPredicateIsTrueForSender(Predicate<ActorRef> isSender, ActorRef sender, string hint, object message)
+        private void AssertPredicateIsTrueForSender(Predicate<IActorRef> isSender, IActorRef sender, string hint, object message)
         {
             _assertions.AssertTrue(isSender(sender), FormatWrongSenderMessage(sender, hint ?? "the predicate to return true", null) + " The message was {{" + message + "}}");
         }
@@ -93,7 +93,7 @@ namespace Akka.TestKit
         /// "akka.test.single-expect-default".
         /// Use this variant to implement more complicated or conditional processing.
         /// </summary>
-        public T ExpectMsgFrom<T>(ActorRef sender, Action<T> assertMessage, TimeSpan? timeout = null, string hint = null)
+        public T ExpectMsgFrom<T>(IActorRef sender, Action<T> assertMessage, TimeSpan? timeout = null, string hint = null)
         {
             return InternalExpectMsg(RemainingOrDilated(timeout), assertMessage, s => _assertions.AssertEqual(sender, s, hint), hint);
         }
@@ -108,7 +108,7 @@ namespace Akka.TestKit
         /// "akka.test.single-expect-default".
         /// Use this variant to implement more complicated or conditional processing.
         /// </summary>
-        public T ExpectMsgFrom<T>(Action<ActorRef> assertSender, Action<T> assertMessage, TimeSpan? timeout = null, string hint = null)
+        public T ExpectMsgFrom<T>(Action<IActorRef> assertSender, Action<T> assertMessage, TimeSpan? timeout = null, string hint = null)
         {
             return InternalExpectMsg(RemainingOrDilated(timeout), assertMessage, assertSender, hint);
         }

--- a/src/core/Akka.TestKit/TestProbe.cs
+++ b/src/core/Akka.TestKit/TestProbe.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Akka.Actor;
 using Akka.Util;
 
@@ -9,7 +10,7 @@ namespace Akka.TestKit
     /// Use <see cref="TestKitBase.CreateTestProbe(string)" /> inside your test 
     /// to create new instances.
     /// </summary>
-    public class TestProbe : TestKitBase, NoImplicitSender, ActorRef
+    public class TestProbe : TestKitBase, NoImplicitSender, InternalActorRef
     {      
         public TestProbe(ActorSystem system, TestKitAssertions assertions, string testProbeName=null)
             : base(assertions, system, testProbeName)
@@ -73,24 +74,62 @@ namespace Akka.TestKit
 
         int IComparable<ActorRef>.CompareTo(ActorRef other)
         {
-            return Ref.CompareTo(other);
+            return TestActor.CompareTo(other);
         }
 
         bool IEquatable<ActorRef>.Equals(ActorRef other)
         {
-            return Ref.Equals(other);
+            return TestActor.Equals(other);
         }
 
-        ActorPath ActorRef.Path { get { return Ref.Path; } }
+        ActorPath ActorRef.Path { get { return TestActor.Path; } }
 
         void ICanTell.Tell(object message, ActorRef sender)
         {
-            Ref.Tell(message,sender);
+            TestActor.Tell(message, sender);
         }
 
         ISurrogate ISurrogated.ToSurrogate(ActorSystem system)
         {
-            return Ref.ToSurrogate(system);
+            return TestActor.ToSurrogate(system);
+        }
+
+        bool ActorRefScope.IsLocal { get { return ((InternalActorRef) TestActor).IsLocal; } }
+
+        InternalActorRef InternalActorRef.Parent { get { return ((InternalActorRef)TestActor).Parent; } }
+
+        ActorRefProvider InternalActorRef.Provider { get { return ((InternalActorRef)TestActor).Provider; } }
+
+        bool InternalActorRef.IsTerminated { get { return ((InternalActorRef)TestActor).IsTerminated; } }
+
+        ActorRef InternalActorRef.GetChild(IEnumerable<string> name)
+        {
+            return ((InternalActorRef)TestActor).GetChild(name);
+        }
+
+        void InternalActorRef.Resume(Exception causedByFailure)
+        {
+            ((InternalActorRef)TestActor).Resume(causedByFailure);
+        }
+
+        void InternalActorRef.Start()
+        {
+            ((InternalActorRef)TestActor).Start();
+        }
+
+        void InternalActorRef.Stop()
+        {
+            ((InternalActorRef)TestActor).Stop();
+        }
+
+        void InternalActorRef.Restart(Exception cause)
+        {
+            ((InternalActorRef)TestActor).Restart(cause);
+        }
+
+        void InternalActorRef.Suspend()
+        {
+            ((InternalActorRef)TestActor).Suspend();
         }
     }
 }

--- a/src/core/Akka.TestKit/TestProbe.cs
+++ b/src/core/Akka.TestKit/TestProbe.cs
@@ -10,7 +10,7 @@ namespace Akka.TestKit
     /// Use <see cref="TestKitBase.CreateTestProbe(string)" /> inside your test 
     /// to create new instances.
     /// </summary>
-    public class TestProbe : TestKitBase, NoImplicitSender, InternalActorRef
+    public class TestProbe : TestKitBase, NoImplicitSender, IInternalActorRef
     {      
         public TestProbe(ActorSystem system, TestKitAssertions assertions, string testProbeName=null)
             : base(assertions, system, testProbeName)
@@ -18,10 +18,10 @@ namespace Akka.TestKit
         }
 
         /// <summary>Gets the reference of this probe.</summary>
-        public ActorRef Ref { get { return TestActor; } }
+        public IActorRef Ref { get { return TestActor; } }
 
         /// <summary>Gets the sender of the last message</summary>
-        public ActorRef Sender { get { return LastSender; } }
+        public IActorRef Sender { get { return LastSender; } }
 
         /// <summary>
         /// Send message to an actor while using the probe as the sender.
@@ -30,7 +30,7 @@ namespace Akka.TestKit
         /// </summary>
         /// <param name="actor">The actor.</param>
         /// <param name="message">The message.</param>
-        public void Send(ActorRef actor, object message)
+        public void Send(IActorRef actor, object message)
         {
             actor.Tell(message, TestActor);
         }
@@ -41,7 +41,7 @@ namespace Akka.TestKit
         /// </summary>
         /// <param name="actor">The actor to forward to.</param>
         /// <param name="message">The message.</param>
-        public void Forward(ActorRef actor, object message)
+        public void Forward(IActorRef actor, object message)
         {
             actor.Tell(message, Sender);
         }
@@ -51,7 +51,7 @@ namespace Akka.TestKit
         /// <see cref="TestKitBase.LastMessage"/> was sent directly to the actor in the first place.
         /// </summary>
         /// <param name="actor">The actor to forward to.</param>
-        public void Forward(ActorRef actor)
+        public void Forward(IActorRef actor)
         {
             actor.Tell(LastMessage, Sender);
         }
@@ -72,19 +72,19 @@ namespace Akka.TestKit
             throw new NotSupportedException("Cannot create a TestProbe from a TestProbe");
         }
 
-        int IComparable<ActorRef>.CompareTo(ActorRef other)
+        int IComparable<IActorRef>.CompareTo(IActorRef other)
         {
             return TestActor.CompareTo(other);
         }
 
-        bool IEquatable<ActorRef>.Equals(ActorRef other)
+        bool IEquatable<IActorRef>.Equals(IActorRef other)
         {
             return TestActor.Equals(other);
         }
 
-        ActorPath ActorRef.Path { get { return TestActor.Path; } }
+        ActorPath IActorRef.Path { get { return TestActor.Path; } }
 
-        void ICanTell.Tell(object message, ActorRef sender)
+        void ICanTell.Tell(object message, IActorRef sender)
         {
             TestActor.Tell(message, sender);
         }
@@ -94,42 +94,42 @@ namespace Akka.TestKit
             return TestActor.ToSurrogate(system);
         }
 
-        bool ActorRefScope.IsLocal { get { return ((InternalActorRef) TestActor).IsLocal; } }
+        bool ActorRefScope.IsLocal { get { return ((IInternalActorRef) TestActor).IsLocal; } }
 
-        InternalActorRef InternalActorRef.Parent { get { return ((InternalActorRef)TestActor).Parent; } }
+        IInternalActorRef IInternalActorRef.Parent { get { return ((IInternalActorRef)TestActor).Parent; } }
 
-        ActorRefProvider InternalActorRef.Provider { get { return ((InternalActorRef)TestActor).Provider; } }
+        ActorRefProvider IInternalActorRef.Provider { get { return ((IInternalActorRef)TestActor).Provider; } }
 
-        bool InternalActorRef.IsTerminated { get { return ((InternalActorRef)TestActor).IsTerminated; } }
+        bool IInternalActorRef.IsTerminated { get { return ((IInternalActorRef)TestActor).IsTerminated; } }
 
-        ActorRef InternalActorRef.GetChild(IEnumerable<string> name)
+        IActorRef IInternalActorRef.GetChild(IEnumerable<string> name)
         {
-            return ((InternalActorRef)TestActor).GetChild(name);
+            return ((IInternalActorRef)TestActor).GetChild(name);
         }
 
-        void InternalActorRef.Resume(Exception causedByFailure)
+        void IInternalActorRef.Resume(Exception causedByFailure)
         {
-            ((InternalActorRef)TestActor).Resume(causedByFailure);
+            ((IInternalActorRef)TestActor).Resume(causedByFailure);
         }
 
-        void InternalActorRef.Start()
+        void IInternalActorRef.Start()
         {
-            ((InternalActorRef)TestActor).Start();
+            ((IInternalActorRef)TestActor).Start();
         }
 
-        void InternalActorRef.Stop()
+        void IInternalActorRef.Stop()
         {
-            ((InternalActorRef)TestActor).Stop();
+            ((IInternalActorRef)TestActor).Stop();
         }
 
-        void InternalActorRef.Restart(Exception cause)
+        void IInternalActorRef.Restart(Exception cause)
         {
-            ((InternalActorRef)TestActor).Restart(cause);
+            ((IInternalActorRef)TestActor).Restart(cause);
         }
 
-        void InternalActorRef.Suspend()
+        void IInternalActorRef.Suspend()
         {
-            ((InternalActorRef)TestActor).Suspend();
+            ((IInternalActorRef)TestActor).Suspend();
         }
     }
 }

--- a/src/core/Akka.TestKit/TestProbe.cs
+++ b/src/core/Akka.TestKit/TestProbe.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Akka.Actor;
+using Akka.Util;
 
 namespace Akka.TestKit
 {
@@ -8,7 +9,7 @@ namespace Akka.TestKit
     /// Use <see cref="TestKitBase.CreateTestProbe(string)" /> inside your test 
     /// to create new instances.
     /// </summary>
-    public class TestProbe : TestKitBase, NoImplicitSender
+    public class TestProbe : TestKitBase, NoImplicitSender, ActorRef
     {      
         public TestProbe(ActorSystem system, TestKitAssertions assertions, string testProbeName=null)
             : base(assertions, system, testProbeName)
@@ -70,9 +71,26 @@ namespace Akka.TestKit
             throw new NotSupportedException("Cannot create a TestProbe from a TestProbe");
         }
 
-        public static implicit operator ActorRef(TestProbe probe)
+        int IComparable<ActorRef>.CompareTo(ActorRef other)
         {
-            return probe.Ref;
+            return Ref.CompareTo(other);
+        }
+
+        bool IEquatable<ActorRef>.Equals(ActorRef other)
+        {
+            return Ref.Equals(other);
+        }
+
+        ActorPath ActorRef.Path { get { return Ref.Path; } }
+
+        void ICanTell.Tell(object message, ActorRef sender)
+        {
+            Ref.Tell(message,sender);
+        }
+
+        ISurrogate ISurrogated.ToSurrogate(ActorSystem system)
+        {
+            return Ref.ToSurrogate(system);
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/ActorCellTests_SerializationOfUserMessages.cs
+++ b/src/core/Akka.Tests/Actor/ActorCellTests_SerializationOfUserMessages.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Akka.Actor;
 using Akka.TestKit;
 using Akka.Tests.TestUtils;
 using Xunit;

--- a/src/core/Akka.Tests/Actor/ActorLifeCycleSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorLifeCycleSpec.cs
@@ -17,9 +17,9 @@ namespace Akka.Tests
         {
             private AtomicCounter generationProvider;
             private string id;
-            private ActorRef testActor;
+            private IActorRef testActor;
             private int CurrentGeneration;
-            public LifeCycleTestActor(ActorRef testActor,string id,AtomicCounter generationProvider)
+            public LifeCycleTestActor(IActorRef testActor,string id,AtomicCounter generationProvider)
             {
                 this.testActor = testActor;
                 this.id = id;
@@ -65,9 +65,9 @@ namespace Akka.Tests
         {
             private AtomicCounter generationProvider;
             private string id;
-            private ActorRef testActor;
+            private IActorRef testActor;
             private int CurrentGeneration;
-            public LifeCycleTest2Actor(ActorRef testActor, string id, AtomicCounter generationProvider)
+            public LifeCycleTest2Actor(IActorRef testActor, string id, AtomicCounter generationProvider)
             {
                 this.testActor = testActor;
                 this.id = id;
@@ -106,7 +106,7 @@ namespace Akka.Tests
             string id = Guid.NewGuid().ToString();
             var supervisor = Sys.ActorOf(Props.Create(() => new Supervisor(new OneForOneStrategy(3, TimeSpan.FromSeconds(1000), x => Directive.Restart))));
             var restarterProps = Props.Create(() => new LifeCycleTestActor(TestActor, id, generationProvider));
-            var restarter = supervisor.Ask<ActorRef>(restarterProps).Result;
+            var restarter = supervisor.Ask<IActorRef>(restarterProps).Result;
 
             ExpectMsg(Tuple.Create( "preStart", id, 0));
             restarter.Tell(Kill.Instance);
@@ -137,7 +137,7 @@ namespace Akka.Tests
             string id = Guid.NewGuid().ToString();            
             var supervisor = Sys.ActorOf(Props.Create(() => new Supervisor(new OneForOneStrategy(3, TimeSpan.FromSeconds(1000), x => Directive.Restart))));
             var restarterProps = Props.Create(() => new LifeCycleTest2Actor(TestActor, id, generationProvider));
-            var restarter = supervisor.Ask<ActorRef>(restarterProps).Result;
+            var restarter = supervisor.Ask<IActorRef>(restarterProps).Result;
 
             ExpectMsg(Tuple.Create("preStart", id, 0));
             restarter.Tell(Kill.Instance);
@@ -168,7 +168,7 @@ namespace Akka.Tests
             string id = Guid.NewGuid().ToString();            
             var supervisor = Sys.ActorOf(Props.Create(() => new Supervisor(new OneForOneStrategy(3, TimeSpan.FromSeconds(1000), x => Directive.Restart))));
             var restarterProps = Props.Create(() => new LifeCycleTest2Actor(TestActor, id, generationProvider));
-            var restarter = supervisor.Ask<InternalActorRef>(restarterProps).Result;
+            var restarter = supervisor.Ask<IInternalActorRef>(restarterProps).Result;
 
             ExpectMsg(Tuple.Create("preStart", id, 0));
             restarter.Tell("status");
@@ -206,8 +206,8 @@ namespace Akka.Tests
         }
         public class BecomeActor : UntypedActor
         {
-            private ActorRef testActor;
-            public BecomeActor(ActorRef testActor)
+            private IActorRef testActor;
+            public BecomeActor(IActorRef testActor)
             {
                 this.testActor = testActor;
             }
@@ -266,8 +266,8 @@ namespace Akka.Tests
 
         public class SupervisorTestActor : UntypedActor
         {
-            private ActorRef testActor;
-            public SupervisorTestActor(ActorRef testActor)
+            private IActorRef testActor;
+            public SupervisorTestActor(IActorRef testActor)
             {
                 this.testActor = testActor;
             }
@@ -288,7 +288,7 @@ namespace Akka.Tests
                     .With<Stop>(m =>
                     {
                         var child = Context.Child(m.Name);
-                        ((InternalActorRef)child).Stop();
+                        ((IInternalActorRef)child).Stop();
                     })
                     .With<Count>(m => 
                         testActor.Tell(Context.GetChildren().Count()));
@@ -314,8 +314,8 @@ namespace Akka.Tests
 
         public class KillableActor : UntypedActor
         {
-            private ActorRef testActor;
-            public KillableActor(ActorRef testActor)
+            private IActorRef testActor;
+            public KillableActor(IActorRef testActor)
             {
                 this.testActor = testActor;
             }

--- a/src/core/Akka.Tests/Actor/ActorRefSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorRefSpec.cs
@@ -32,8 +32,8 @@ namespace Akka.Tests.Actor
 
             equalTestActorRef1.Equals(equalTestActorRef2).ShouldBeTrue();
             // ReSharper disable EqualExpressionComparison
-            (equalTestActorRef1 == equalTestActorRef2).ShouldBeTrue();
-            (equalTestActorRef1 != equalTestActorRef2).ShouldBeFalse();
+            (Equals(equalTestActorRef1, equalTestActorRef2)).ShouldBeTrue();
+            (!Equals(equalTestActorRef1, equalTestActorRef2)).ShouldBeFalse();
             // ReSharper restore EqualExpressionComparison
         }
 
@@ -532,7 +532,7 @@ namespace Akka.Tests.Actor
             }
         }
 
-        private class EqualTestActorRef : ActorRef
+        private class EqualTestActorRef : ActorRefBase
         {
             private ActorPath _path;
 

--- a/src/core/Akka.Tests/Actor/ActorRefSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorRefSpec.cs
@@ -79,7 +79,7 @@ namespace Akka.Tests.Actor
             var aref = ActorOf<BlackHoleActor>();
             var serializer = Sys.Serialization.FindSerializerFor(aref);
             var binary = serializer.ToBinary(aref);
-            var bref = serializer.FromBinary(binary, typeof(ActorRef));
+            var bref = serializer.FromBinary(binary, typeof(IActorRef));
 
             bref.ShouldBe(aref);
         }
@@ -93,7 +93,7 @@ namespace Akka.Tests.Actor
             Intercept(() =>
             {
                 var binary = serializer.ToBinary(aref);
-                var bref = serializer.FromBinary(binary, typeof(ActorRef));
+                var bref = serializer.FromBinary(binary, typeof(IActorRef));
             });
         }
 
@@ -101,14 +101,14 @@ namespace Akka.Tests.Actor
         public void An_ActoRef_should_return_EmptyLocalActorRef_on_deserialize_if_not_present_in_actor_hierarchy_and_remoting_is_not_enabled()
         {
             var aref = ActorOf<BlackHoleActor>("non-existing");
-            var aserializer = Sys.Serialization.FindSerializerForType(typeof(ActorRef));
+            var aserializer = Sys.Serialization.FindSerializerForType(typeof(IActorRef));
             var binary = aserializer.ToBinary(aref);
 
             aref.Tell(PoisonPill.Instance);
             VerifyActorTermination(aref);
 
-            var bserializer = Sys.Serialization.FindSerializerForType(typeof (ActorRef));
-            var bref = (ActorRef)bserializer.FromBinary(binary, typeof(ActorRef));
+            var bserializer = Sys.Serialization.FindSerializerForType(typeof (IActorRef));
+            var bref = (IActorRef)bserializer.FromBinary(binary, typeof(IActorRef));
 
             bref.GetType().ShouldBe(typeof(EmptyLocalActorRef));
             bref.Path.ShouldBe(aref.Path);
@@ -151,7 +151,7 @@ namespace Akka.Tests.Actor
             var a = Sys.ActorOf(Props.Create(() => new NestingActor(Sys)));
             var t1 = a.Ask("any");
             t1.Wait(TimeSpan.FromSeconds(3));
-            var nested = t1.Result as ActorRef;
+            var nested = t1.Result as IActorRef;
 
             Assert.NotNull(a);
             Assert.NotNull(nested);
@@ -166,17 +166,17 @@ namespace Akka.Tests.Actor
 
             var t1 = a.Ask("innerself");
             t1.Wait(TimeSpan.FromSeconds(3));
-            var inner = t1.Result as ActorRef;
+            var inner = t1.Result as IActorRef;
             Assert.True(inner != a);
 
             var t2 = a.Ask(a);
             t2.Wait(TimeSpan.FromSeconds(3));
-            var self = t2.Result as ActorRef;
+            var self = t2.Result as IActorRef;
             self.ShouldBe(a);
 
             var t3 = a.Ask("self");
             t3.Wait(TimeSpan.FromSeconds(3));
-            var self2 = t3.Result as ActorRef;
+            var self2 = t3.Result as IActorRef;
             self2.ShouldBe(a);
 
             var t4 = a.Ask("msg");
@@ -253,7 +253,7 @@ namespace Akka.Tests.Actor
             Assert.True(!(bool)t2.Result);
         }
 
-        private void VerifyActorTermination(ActorRef actorRef)
+        private void VerifyActorTermination(IActorRef actorRef)
         {
             var watcher = CreateTestProbe();
             watcher.Watch(actorRef);
@@ -262,7 +262,7 @@ namespace Akka.Tests.Actor
 
         private class NestingActor : ActorBase
         {
-            internal readonly ActorRef Nested;
+            internal readonly IActorRef Nested;
 
             public NestingActor(ActorSystem system)
             {
@@ -278,18 +278,18 @@ namespace Akka.Tests.Actor
 
         private struct ReplyTo
         {
-            public ReplyTo(ActorRef sender)
+            public ReplyTo(IActorRef sender)
                 : this()
             {
                 Sender = sender;
             }
 
-            public ActorRef Sender { get; set; }
+            public IActorRef Sender { get; set; }
         }
 
         private class ReplyActor : ActorBase
         {
-            private ActorRef _replyTo;
+            private IActorRef _replyTo;
 
             protected override bool Receive(object message)
             {
@@ -362,10 +362,10 @@ namespace Akka.Tests.Actor
 
         private class SenderActor : ActorBase
         {
-            private ActorRef _replyTo;
+            private IActorRef _replyTo;
             private TestLatch _latch;
 
-            public SenderActor(ActorRef replyTo, TestLatch latch)
+            public SenderActor(IActorRef replyTo, TestLatch latch)
             {
                 _latch = latch;
                 _replyTo = replyTo;
@@ -436,9 +436,9 @@ namespace Akka.Tests.Actor
 
         private class OuterActor : ActorBase
         {
-            private readonly ActorRef _inner;
+            private readonly IActorRef _inner;
 
-            public OuterActor(ActorRef inner)
+            public OuterActor(IActorRef inner)
             {
                 _inner = inner;
             }
@@ -459,10 +459,10 @@ namespace Akka.Tests.Actor
 
         private class FailingOuterActor : ActorBase
         {
-            private readonly ActorRef _inner;
+            private readonly IActorRef _inner;
             protected ActorBase Fail;
 
-            public FailingOuterActor(ActorRef inner)
+            public FailingOuterActor(IActorRef inner)
             {
                 _inner = inner;
                 Fail = new InnerActor();
@@ -483,7 +483,7 @@ namespace Akka.Tests.Actor
 
         private class FailingChildOuterActor : FailingOuterActor
         {
-            public FailingChildOuterActor(ActorRef inner)
+            public FailingChildOuterActor(IActorRef inner)
                 : base(inner)
             {
                 Fail = new InnerActor();
@@ -511,7 +511,7 @@ namespace Akka.Tests.Actor
 
         private class ChildAwareActor : ActorBase
         {
-            private readonly ActorRef _child;
+            private readonly IActorRef _child;
 
             public ChildAwareActor(string name)
             {
@@ -543,7 +543,7 @@ namespace Akka.Tests.Actor
 
             public override ActorPath Path { get { return _path; } }
 
-            protected override void TellInternal(object message, ActorRef sender)
+            protected override void TellInternal(object message, IActorRef sender)
             {
                 throw new NotImplementedException();
             }

--- a/src/core/Akka.Tests/Actor/ActorSelectionSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorSelectionSpec.cs
@@ -11,8 +11,8 @@ namespace Akka.Tests.Actor
     public class ActorSelectionSpec : AkkaSpec
     {
         // ReSharper disable NotAccessedField.Local
-        private ActorRef _echoActor;
-        private ActorRef _selectionTestActor;
+        private IActorRef _echoActor;
+        private IActorRef _selectionTestActor;
         // ReSharper restore NotAccessedField.Local
 
         public ActorSelectionSpec()

--- a/src/core/Akka.Tests/Actor/AskSpec.cs
+++ b/src/core/Akka.Tests/Actor/AskSpec.cs
@@ -26,15 +26,15 @@ namespace Akka.Tests.Actor
 
         public class WaitActor : UntypedActor
         {
-            public WaitActor(ActorRef replyActor, ActorRef testActor)
+            public WaitActor(IActorRef replyActor, IActorRef testActor)
             {
                 _replyActor = replyActor;
                 _testActor = testActor;
             }
 
-            private ActorRef _replyActor;
+            private IActorRef _replyActor;
 
-            private ActorRef _testActor;
+            private IActorRef _testActor;
 
             protected override void OnReceive(object message)
             {

--- a/src/core/Akka.Tests/Actor/DeadLettersSpec.cs
+++ b/src/core/Akka.Tests/Actor/DeadLettersSpec.cs
@@ -1,4 +1,5 @@
-﻿using Akka.Event;
+﻿using Akka.Actor;
+using Akka.Event;
 using Akka.TestKit;
 using Xunit;
 

--- a/src/core/Akka.Tests/Actor/FSMTimingSpec.cs
+++ b/src/core/Akka.Tests/Actor/FSMTimingSpec.cs
@@ -10,11 +10,11 @@ namespace Akka.Tests.Actor
 
     public class FSMTimingSpec : AkkaSpec
     {
-        public ActorRef Self { get { return TestActor; } }
+        public IActorRef Self { get { return TestActor; } }
 
-        public ActorRef _fsm;
+        public IActorRef _fsm;
 
-        public ActorRef fsm
+        public IActorRef fsm
         {
             get { return _fsm ?? (_fsm = Sys.ActorOf(Props.Create(() => new StateMachine(Self)), "fsm")); }
         }
@@ -208,13 +208,13 @@ namespace Akka.Tests.Actor
 
         #region Actors
 
-        static void Suspend(ActorRef actorRef)
+        static void Suspend(IActorRef actorRef)
         {
             actorRef.Match()
                 .With<ActorRefWithCell>(l => l.Suspend());
         }
 
-        static void Resume(ActorRef actorRef)
+        static void Resume(IActorRef actorRef)
         {
             actorRef.Match()
                 .With<ActorRefWithCell>(l => l.Resume());
@@ -265,7 +265,7 @@ namespace Akka.Tests.Actor
 
         public class StateMachine : FSM<State, int>, LoggingFSM
         {
-            public StateMachine(ActorRef tester)
+            public StateMachine(IActorRef tester)
             {
                 Tester = tester;
                 StartWith(State.Initial, 0);
@@ -466,7 +466,7 @@ namespace Akka.Tests.Actor
 
 
 
-            public ActorRef Tester { get; private set; }
+            public IActorRef Tester { get; private set; }
         }
 
         #endregion

--- a/src/core/Akka.Tests/Actor/FSMTransitionSpec.cs
+++ b/src/core/Akka.Tests/Actor/FSMTransitionSpec.cs
@@ -8,7 +8,7 @@ namespace Akka.Tests.Actor
     
     public class FSMTransitionSpec : AkkaSpec
     {
-        public ActorRef Self { get { return TestActor; } }
+        public IActorRef Self { get { return TestActor; } }
 
         
             
@@ -90,7 +90,7 @@ namespace Akka.Tests.Actor
 
         public class MyFSM : FSM<int, object>
         {
-            public MyFSM(ActorRef target)
+            public MyFSM(IActorRef target)
             {
                 Target = target;
                 StartWith(0, new object());
@@ -115,7 +115,7 @@ namespace Akka.Tests.Actor
                 Initialize();
             }
 
-            public ActorRef Target { get; private set; }
+            public IActorRef Target { get; private set; }
 
             protected override void PreRestart(Exception reason, object message)
             {
@@ -125,7 +125,7 @@ namespace Akka.Tests.Actor
 
         public class OtherFSM : FSM<int, int>
         {
-            public OtherFSM(ActorRef target)
+            public OtherFSM(IActorRef target)
             {
                 Target = target;
                 StartWith(0, 0);
@@ -146,10 +146,10 @@ namespace Akka.Tests.Actor
                 });
             }
 
-            public ActorRef Target { get; private set; }
+            public IActorRef Target { get; private set; }
         }
 
-        public class LeakyFSM : FSM<int, ActorRef>
+        public class LeakyFSM : FSM<int, IActorRef>
         {
             public LeakyFSM()
             {
@@ -191,12 +191,12 @@ namespace Akka.Tests.Actor
 
         public class Forwarder : UntypedActor
         {
-            public Forwarder(ActorRef target)
+            public Forwarder(IActorRef target)
             {
                 Target = target;
             }
 
-            public ActorRef Target { get; private set; }
+            public IActorRef Target { get; private set; }
 
             protected override void OnReceive(object message)
             {

--- a/src/core/Akka.Tests/Actor/LocalActorRefProviderSpec.cs
+++ b/src/core/Akka.Tests/Actor/LocalActorRefProviderSpec.cs
@@ -18,7 +18,7 @@ namespace Akka.Tests.Actor
         {
             var parent = Sys.ActorOf(Props.Create(() => new ParentActor()));
             parent.Tell("GetChild", TestActor);
-            var child = ExpectMsg<ActorRef>();
+            var child = ExpectMsg<IActorRef>();
             var childPropsBeforeTermination = ((LocalActorRef)child).Underlying.Props;
             Assert.Equal(Props.Empty, childPropsBeforeTermination);
             Watch(parent);
@@ -101,7 +101,7 @@ namespace Akka.Tests.Actor
 
         private class ParentActor : ActorBase
         {
-            private readonly ActorRef childActorRef;
+            private readonly IActorRef childActorRef;
 
             public ParentActor()
             {

--- a/src/core/Akka.Tests/Actor/PropsSpec.cs
+++ b/src/core/Akka.Tests/Actor/PropsSpec.cs
@@ -19,7 +19,7 @@ namespace Akka.Tests.Actor
         public void Props_must_create_actor_by_expression()
         {
             var props = Props.Create(() => new PropsTestActor());
-            ActorRef actor = Sys.ActorOf(props);
+            IActorRef actor = Sys.ActorOf(props);
             Assert.NotNull(actor);
         }
 
@@ -29,7 +29,7 @@ namespace Akka.Tests.Actor
             TestLatch latchProducer = new TestLatch(Sys);
             TestLatch latchActor = new TestLatch(Sys);
             var props = Props.CreateBy<TestProducer>(latchProducer, latchActor);
-            ActorRef actor = Sys.ActorOf(props);
+            IActorRef actor = Sys.ActorOf(props);
             latchActor.Ready(TimeSpan.FromSeconds(1));
         }
 

--- a/src/core/Akka.Tests/Actor/RootGuardianActorRef_Tests.cs
+++ b/src/core/Akka.Tests/Actor/RootGuardianActorRef_Tests.cs
@@ -21,7 +21,7 @@ namespace Akka.Tests.Actor
         public void Path_Should_be_the_same_path_as_specified()
         {
             var props = Props.Create<GuardianActor>(new OneForOneStrategy(e => Directive.Stop));
-            var rootGuardianActorRef = new RootGuardianActorRef((ActorSystemImpl) Sys, props, _dispatcher, () => Sys.Mailboxes.CreateMailbox(props,null), ActorRef.Nobody, _rootActorPath, _deadLetters, _emptyExtraNames);
+            var rootGuardianActorRef = new RootGuardianActorRef((ActorSystemImpl) Sys, props, _dispatcher, () => Sys.Mailboxes.CreateMailbox(props,null), ActorRefs.Nobody, _rootActorPath, _deadLetters, _emptyExtraNames);
             Assert.Equal(_rootActorPath, rootGuardianActorRef.Path);
         }
 
@@ -29,7 +29,7 @@ namespace Akka.Tests.Actor
         public void Parent_Should_be_itself()
         {
             var props = Props.Create<GuardianActor>(new OneForOneStrategy(e => Directive.Stop));
-            var rootGuardianActorRef = new RootGuardianActorRef((ActorSystemImpl) Sys, props, _dispatcher, () => Sys.Mailboxes.CreateMailbox(props,null), ActorRef.Nobody, _rootActorPath, _deadLetters, _emptyExtraNames);
+            var rootGuardianActorRef = new RootGuardianActorRef((ActorSystemImpl) Sys, props, _dispatcher, () => Sys.Mailboxes.CreateMailbox(props,null), ActorRefs.Nobody, _rootActorPath, _deadLetters, _emptyExtraNames);
             var parent = rootGuardianActorRef.Parent;
             Assert.Same(rootGuardianActorRef, parent);
         }
@@ -39,7 +39,7 @@ namespace Akka.Tests.Actor
         public void Getting_temp_child_Should_return_tempContainer()
         {
             var props = Props.Create<GuardianActor>(new OneForOneStrategy(e => Directive.Stop));
-            var rootGuardianActorRef = new RootGuardianActorRef((ActorSystemImpl)Sys, props, _dispatcher, () => Sys.Mailboxes.CreateMailbox(props, null), ActorRef.Nobody, _rootActorPath, _deadLetters, _emptyExtraNames);
+            var rootGuardianActorRef = new RootGuardianActorRef((ActorSystemImpl)Sys, props, _dispatcher, () => Sys.Mailboxes.CreateMailbox(props, null), ActorRefs.Nobody, _rootActorPath, _deadLetters, _emptyExtraNames);
             var tempContainer = new DummyActorRef(_rootActorPath / "temp");
             rootGuardianActorRef.SetTempContainer(tempContainer);
             var actorRef = rootGuardianActorRef.GetSingleChild("temp");
@@ -50,7 +50,7 @@ namespace Akka.Tests.Actor
         public void Getting_deadLetters_child_Should_return_tempContainer()
         {
             var props = Props.Create<GuardianActor>(new OneForOneStrategy(e => Directive.Stop));
-            var rootGuardianActorRef = new RootGuardianActorRef((ActorSystemImpl)Sys, props, _dispatcher, () => Sys.Mailboxes.CreateMailbox(props, null), ActorRef.Nobody, _rootActorPath, _deadLetters, _emptyExtraNames);
+            var rootGuardianActorRef = new RootGuardianActorRef((ActorSystemImpl)Sys, props, _dispatcher, () => Sys.Mailboxes.CreateMailbox(props, null), ActorRefs.Nobody, _rootActorPath, _deadLetters, _emptyExtraNames);
             var actorRef = rootGuardianActorRef.GetSingleChild("deadLetters");
             Assert.Same(_deadLetters, actorRef);
         }
@@ -62,7 +62,7 @@ namespace Akka.Tests.Actor
             var extraNameChild = new DummyActorRef(_rootActorPath / "extra");
             var extraNames = new Dictionary<string, InternalActorRef> { { "extra", extraNameChild } };
             var props = Props.Create<GuardianActor>(new OneForOneStrategy(e => Directive.Stop));
-            var rootGuardianActorRef = new RootGuardianActorRef((ActorSystemImpl)Sys, props, _dispatcher, () => Sys.Mailboxes.CreateMailbox(props, null), ActorRef.Nobody, _rootActorPath, _deadLetters, extraNames);
+            var rootGuardianActorRef = new RootGuardianActorRef((ActorSystemImpl)Sys, props, _dispatcher, () => Sys.Mailboxes.CreateMailbox(props, null), ActorRefs.Nobody, _rootActorPath, _deadLetters, extraNames);
             var actorRef = rootGuardianActorRef.GetSingleChild("extra");
             Assert.Same(extraNameChild, actorRef);
         }
@@ -71,9 +71,9 @@ namespace Akka.Tests.Actor
         public void Getting_an_unknown_child_that_exists_in_extraNames_Should_return_nobody()
         {
             var props = Props.Create<GuardianActor>(new OneForOneStrategy(e => Directive.Stop));
-            var rootGuardianActorRef = new RootGuardianActorRef((ActorSystemImpl)Sys, props, _dispatcher, () => Sys.Mailboxes.CreateMailbox(props, null), ActorRef.Nobody, _rootActorPath, _deadLetters, _emptyExtraNames);
+            var rootGuardianActorRef = new RootGuardianActorRef((ActorSystemImpl)Sys, props, _dispatcher, () => Sys.Mailboxes.CreateMailbox(props, null), ActorRefs.Nobody, _rootActorPath, _deadLetters, _emptyExtraNames);
             var actorRef = rootGuardianActorRef.GetSingleChild("unknown-child");
-            Assert.Same(ActorRef.Nobody, actorRef);
+            Assert.Same(ActorRefs.Nobody, actorRef);
         }
 
 

--- a/src/core/Akka.Tests/Actor/RootGuardianActorRef_Tests.cs
+++ b/src/core/Akka.Tests/Actor/RootGuardianActorRef_Tests.cs
@@ -14,7 +14,7 @@ namespace Akka.Tests.Actor
     {
         static RootActorPath _rootActorPath = new RootActorPath(new Address("akka", "test"));
         DummyActorRef _deadLetters = new DummyActorRef(_rootActorPath / "deadLetters");
-        ReadOnlyDictionary<string, InternalActorRef> _emptyExtraNames = new ReadOnlyDictionary<string, InternalActorRef>(new Dictionary<string, InternalActorRef>());
+        ReadOnlyDictionary<string, IInternalActorRef> _emptyExtraNames = new ReadOnlyDictionary<string, IInternalActorRef>(new Dictionary<string, IInternalActorRef>());
         SameThreadMessageDispatcher _dispatcher = new SameThreadMessageDispatcher();
 
         [Fact]
@@ -60,7 +60,7 @@ namespace Akka.Tests.Actor
         public void Getting_a_child_that_exists_in_extraNames_Should_return_the_child()
         {
             var extraNameChild = new DummyActorRef(_rootActorPath / "extra");
-            var extraNames = new Dictionary<string, InternalActorRef> { { "extra", extraNameChild } };
+            var extraNames = new Dictionary<string, IInternalActorRef> { { "extra", extraNameChild } };
             var props = Props.Create<GuardianActor>(new OneForOneStrategy(e => Directive.Stop));
             var rootGuardianActorRef = new RootGuardianActorRef((ActorSystemImpl)Sys, props, _dispatcher, () => Sys.Mailboxes.CreateMailbox(props, null), ActorRefs.Nobody, _rootActorPath, _deadLetters, extraNames);
             var actorRef = rootGuardianActorRef.GetSingleChild("extra");

--- a/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_TellScheduler_Cancellation_Tests.cs
+++ b/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_TellScheduler_Cancellation_Tests.cs
@@ -14,8 +14,8 @@ namespace Akka.Tests.Actor.Scheduler
             ITellScheduler scheduler = new TaskBasedScheduler();
 
             var canceled = Cancelable.CreateCanceled();
-            scheduler.ScheduleTellOnce(0, TestActor, "Test", ActorRef.NoSender, canceled);
-            scheduler.ScheduleTellOnce(1, TestActor, "Test", ActorRef.NoSender, canceled);
+            scheduler.ScheduleTellOnce(0, TestActor, "Test", ActorRefs.NoSender, canceled);
+            scheduler.ScheduleTellOnce(1, TestActor, "Test", ActorRefs.NoSender, canceled);
 
             //Validate that no messages were sent
             ExpectNoMsg(100);
@@ -28,8 +28,8 @@ namespace Akka.Tests.Actor.Scheduler
             ITellScheduler scheduler = new TaskBasedScheduler();
 
             var canceled = Cancelable.CreateCanceled();
-            scheduler.ScheduleTellRepeatedly(0, 2, TestActor, "Test", ActorRef.NoSender, canceled);
-            scheduler.ScheduleTellRepeatedly(1, 2, TestActor, "Test", ActorRef.NoSender, canceled);
+            scheduler.ScheduleTellRepeatedly(0, 2, TestActor, "Test", ActorRefs.NoSender, canceled);
+            scheduler.ScheduleTellRepeatedly(1, 2, TestActor, "Test", ActorRefs.NoSender, canceled);
 
             //Validate that no messages were sent
             ExpectNoMsg(100);
@@ -42,7 +42,7 @@ namespace Akka.Tests.Actor.Scheduler
             IScheduler scheduler = new TaskBasedScheduler();
 
             var cancelable = new Cancelable(scheduler);
-            scheduler.ScheduleTellOnce(100, TestActor, "Test", ActorRef.NoSender, cancelable);
+            scheduler.ScheduleTellOnce(100, TestActor, "Test", ActorRefs.NoSender, cancelable);
             cancelable.Cancel();
 
             //Validate that no messages were sent
@@ -57,7 +57,7 @@ namespace Akka.Tests.Actor.Scheduler
             IScheduler scheduler = new TaskBasedScheduler();
 
             var cancelable = new Cancelable(scheduler);
-            scheduler.ScheduleTellRepeatedly(100, 2, TestActor, "Test", ActorRef.NoSender, cancelable);
+            scheduler.ScheduleTellRepeatedly(100, 2, TestActor, "Test", ActorRefs.NoSender, cancelable);
             cancelable.Cancel();
 
             //Validate that no messages were sent
@@ -72,7 +72,7 @@ namespace Akka.Tests.Actor.Scheduler
             IScheduler scheduler = new TaskBasedScheduler();
 
             var cancelable = new Cancelable(scheduler);
-            scheduler.ScheduleTellRepeatedly(0, 150, TestActor, "Test", ActorRef.NoSender, cancelable);
+            scheduler.ScheduleTellRepeatedly(0, 150, TestActor, "Test", ActorRefs.NoSender, cancelable);
             ExpectMsg("Test");
             cancelable.Cancel();
 
@@ -87,7 +87,7 @@ namespace Akka.Tests.Actor.Scheduler
             IScheduler scheduler = new TaskBasedScheduler();
 
             var cancelableOdd = new Cancelable(scheduler);
-            scheduler.ScheduleTellRepeatedly(1, 150, TestActor, "Test", ActorRef.NoSender, cancelableOdd);
+            scheduler.ScheduleTellRepeatedly(1, 150, TestActor, "Test", ActorRefs.NoSender, cancelableOdd);
             cancelableOdd.CancelAfter(50);
 
             //Expect one message

--- a/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_TellScheduler_Schedule_Tests.cs
+++ b/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_TellScheduler_Schedule_Tests.cs
@@ -34,7 +34,7 @@ namespace Akka.Tests.Actor.Scheduler
                     }
                 });
             });
-            scheduler.ScheduleTellRepeatedly(initialDelay, interval, receiver, "Test", ActorRef.NoSender, cancelable);
+            scheduler.ScheduleTellRepeatedly(initialDelay, interval, receiver, "Test", ActorRefs.NoSender, cancelable);
 
             //Expect to get a list from receiver after it has received three messages
             var dateTimeOffsets = ExpectMsg<List<DateTimeOffset>>();
@@ -62,7 +62,7 @@ namespace Akka.Tests.Actor.Scheduler
             //Prepare, set up actions to be fired
             IScheduler scheduler = new TaskBasedScheduler();
 
-            scheduler.ScheduleTellRepeatedly(TimeSpan.FromMilliseconds(initialDelay), TimeSpan.FromMilliseconds(interval), TestActor, "Test", ActorRef.NoSender);
+            scheduler.ScheduleTellRepeatedly(TimeSpan.FromMilliseconds(initialDelay), TimeSpan.FromMilliseconds(interval), TestActor, "Test", ActorRefs.NoSender);
 
             //Just check that we receives more than one message
             ExpectMsg("Test");
@@ -80,7 +80,7 @@ namespace Akka.Tests.Actor.Scheduler
 
             foreach(var time in times)
             {
-                scheduler.ScheduleTellOnce(time, TestActor, "Test" + time, ActorRef.NoSender);
+                scheduler.ScheduleTellOnce(time, TestActor, "Test" + time, ActorRefs.NoSender);
             }
 
             ExpectMsg("Test1");
@@ -100,7 +100,7 @@ namespace Akka.Tests.Actor.Scheduler
 
             foreach(var time in times)
             {
-                scheduler.ScheduleTellOnce(time, TestActor, "Test" + time, ActorRef.NoSender);
+                scheduler.ScheduleTellOnce(time, TestActor, "Test" + time, ActorRefs.NoSender);
             }
 
             //Perform the test
@@ -122,7 +122,7 @@ namespace Akka.Tests.Actor.Scheduler
             IScheduler scheduler = new TaskBasedScheduler();
 
             XAssert.Throws<ArgumentOutOfRangeException>(() =>
-                scheduler.ScheduleTellOnce(invalidTime, TestActor, "Test", ActorRef.NoSender)
+                scheduler.ScheduleTellOnce(invalidTime, TestActor, "Test", ActorRefs.NoSender)
                 );
             ExpectNoMsg(50);
         }
@@ -135,7 +135,7 @@ namespace Akka.Tests.Actor.Scheduler
             IScheduler scheduler = new TaskBasedScheduler();
 
             XAssert.Throws<ArgumentOutOfRangeException>(() =>
-                scheduler.ScheduleTellRepeatedly(invalidTime, 100, TestActor, "Test", ActorRef.NoSender)
+                scheduler.ScheduleTellRepeatedly(invalidTime, 100, TestActor, "Test", ActorRefs.NoSender)
                 );
             ExpectNoMsg(50);
         }
@@ -149,7 +149,7 @@ namespace Akka.Tests.Actor.Scheduler
             IScheduler scheduler = new TaskBasedScheduler();
 
             XAssert.Throws<ArgumentOutOfRangeException>(() =>
-                scheduler.ScheduleTellRepeatedly(42, invalidInterval, TestActor, "Test", ActorRef.NoSender)
+                scheduler.ScheduleTellRepeatedly(42, invalidInterval, TestActor, "Test", ActorRefs.NoSender)
                 );
             ExpectNoMsg(50);
         }
@@ -158,7 +158,7 @@ namespace Akka.Tests.Actor.Scheduler
         public void When_ScheduleTellOnce_with_0_delay_Then_action_is_executed_immediately()
         {
             IScheduler scheduler = new TaskBasedScheduler();
-            scheduler.ScheduleTellOnce(0, TestActor, "Test", ActorRef.NoSender);
+            scheduler.ScheduleTellOnce(0, TestActor, "Test", ActorRefs.NoSender);
             ExpectMsg("Test");
         }
 
@@ -166,7 +166,7 @@ namespace Akka.Tests.Actor.Scheduler
         public void When_ScheduleTellRepeatedly_with_0_delay_Then_action_is_executed_immediately()
         {
             IScheduler scheduler = new TaskBasedScheduler();
-            scheduler.ScheduleTellRepeatedly(0, 60 * 1000, TestActor, "Test", ActorRef.NoSender);
+            scheduler.ScheduleTellRepeatedly(0, 60 * 1000, TestActor, "Test", ActorRefs.NoSender);
             ExpectMsg("Test");
         }
     }

--- a/src/core/Akka.Tests/Actor/Stash/ActorWithStashSpec.cs
+++ b/src/core/Akka.Tests/Actor/Stash/ActorWithStashSpec.cs
@@ -78,7 +78,7 @@ namespace Akka.Tests.Actor.Stash
             var slaveProps = Props.Create(() => new SlaveActor(restartLatch, hasMsgLatch, "stashme"));
 
             //Send the props to supervisor, which will create an actor and return the ActorRef
-            var slave = boss.AskAndWait<ActorRef>(slaveProps, TestKitSettings.DefaultTimeout);
+            var slave = boss.AskAndWait<IActorRef>(slaveProps, TestKitSettings.DefaultTimeout);
 
             //send a message that will be stashed
             slave.Tell("stashme");
@@ -101,7 +101,7 @@ namespace Akka.Tests.Actor.Stash
             var slaveProps = Props.Create(() => new ActorsThatClearsStashOnPreRestart(restartLatch));
 
             //Send the props to supervisor, which will create an actor and return the ActorRef
-            var slave = boss.AskAndWait<ActorRef>(slaveProps, TestKitSettings.DefaultTimeout);
+            var slave = boss.AskAndWait<IActorRef>(slaveProps, TestKitSettings.DefaultTimeout);
 
             //send messages that will be stashed
             slave.Tell("stashme 1");
@@ -259,7 +259,7 @@ namespace Akka.Tests.Actor.Stash
 
         private class TerminatedMessageStashingActor : TestReceiveActor, WithUnboundedStash
         {
-            public TerminatedMessageStashingActor(ActorRef probe)
+            public TerminatedMessageStashingActor(IActorRef probe)
             {
                 var watchedActor=Context.Watch(Context.ActorOf<BlackHoleActor>("watched-actor"));
                 var stashed = false;

--- a/src/core/Akka.Tests/Actor/SupervisorHierarchySpec.cs
+++ b/src/core/Akka.Tests/Actor/SupervisorHierarchySpec.cs
@@ -97,12 +97,12 @@ namespace Akka.Tests.Actor
 
             Func<Exception, Directive> decider = _ => { return Directive.Escalate; };
             var managerProps = new PropsWithName(Props.Create(() => new CountDownActor(countDown, new AllForOneStrategy(decider))), "manager");
-            var manager = boss.Ask<ActorRef>(managerProps, TestKitSettings.DefaultTimeout).Result;
+            var manager = boss.Ask<IActorRef>(managerProps, TestKitSettings.DefaultTimeout).Result;
 
             var workerProps = Props.Create(() => new CountDownActor(countDown, SupervisorStrategy.DefaultStrategy));
-            var worker1 = manager.Ask<ActorRef>(new PropsWithName(workerProps, "worker1"), TestKitSettings.DefaultTimeout).Result;
-            var worker2 = manager.Ask<ActorRef>(new PropsWithName(workerProps, "worker2"), TestKitSettings.DefaultTimeout).Result;
-            var worker3 = manager.Ask<ActorRef>(new PropsWithName(workerProps, "worker3"), TestKitSettings.DefaultTimeout).Result;
+            var worker1 = manager.Ask<IActorRef>(new PropsWithName(workerProps, "worker1"), TestKitSettings.DefaultTimeout).Result;
+            var worker2 = manager.Ask<IActorRef>(new PropsWithName(workerProps, "worker2"), TestKitSettings.DefaultTimeout).Result;
+            var worker3 = manager.Ask<IActorRef>(new PropsWithName(workerProps, "worker3"), TestKitSettings.DefaultTimeout).Result;
 
             EventFilter.Exception<ActorKilledException>().ExpectOne(() =>
             {
@@ -160,9 +160,9 @@ namespace Akka.Tests.Actor
             //    worker
             var boss = ActorOf<Resumer>("resumer");
             boss.Tell("spawn:middle");
-            var middle = ExpectMsg<ActorRef>();
+            var middle = ExpectMsg<IActorRef>();
             middle.Tell("spawn:worker");
-            var worker = ExpectMsg<ActorRef>();
+            var worker = ExpectMsg<IActorRef>();
 
             //Check everything is in place by sending ping to worker and expect it to respond with pong
             worker.Tell("ping");
@@ -201,11 +201,11 @@ namespace Akka.Tests.Actor
             //      |
             //    worker
             slowResumer.Tell("spawn:boss");
-            var boss = ExpectMsg<ActorRef>();
+            var boss = ExpectMsg<IActorRef>();
             boss.Tell("spawn:middle");
-            var middle = ExpectMsg<ActorRef>();
+            var middle = ExpectMsg<IActorRef>();
             middle.Tell("spawn:worker");
-            var worker = ExpectMsg<ActorRef>();
+            var worker = ExpectMsg<IActorRef>();
 
             //Check everything is in place by sending ping to worker and expect it to respond with pong
             worker.Tell("ping");

--- a/src/core/Akka.Tests/Dispatch/AsyncAwaitSpec.cs
+++ b/src/core/Akka.Tests/Dispatch/AsyncAwaitSpec.cs
@@ -79,7 +79,7 @@ namespace Akka.Tests.Dispatch
 
     public class Asker : ReceiveActor
     {
-        public Asker(ActorRef other)
+        public Asker(IActorRef other)
         {
             Receive<string>(async _ =>
             {
@@ -95,9 +95,9 @@ namespace Akka.Tests.Dispatch
 
     public class UntypedAsker : UntypedActor
     {
-        private readonly ActorRef _other;
+        private readonly IActorRef _other;
 
-        public UntypedAsker(ActorRef other)
+        public UntypedAsker(IActorRef other)
         {
             _other = other;
         }
@@ -121,7 +121,7 @@ namespace Akka.Tests.Dispatch
 
     public class BlockingAsker : ReceiveActor
     {
-        public BlockingAsker(ActorRef other)
+        public BlockingAsker(IActorRef other)
         {
             Receive<string>(_ =>
             {
@@ -153,9 +153,9 @@ namespace Akka.Tests.Dispatch
 
     public class AsyncExceptionActor : ReceiveActor
     {
-        private readonly ActorRef _callback;
+        private readonly IActorRef _callback;
 
-        public AsyncExceptionActor(ActorRef callback)
+        public AsyncExceptionActor(IActorRef callback)
         {
             _callback = callback;
             Receive<string>(async _ =>
@@ -195,9 +195,9 @@ namespace Akka.Tests.Dispatch
 
     public class AsyncTplExceptionActor : ReceiveActor
     {
-        private readonly ActorRef _callback;
+        private readonly IActorRef _callback;
 
-        public AsyncTplExceptionActor(ActorRef callback)
+        public AsyncTplExceptionActor(IActorRef callback)
         {
             _callback = callback;
             Receive<string>(m =>

--- a/src/core/Akka.Tests/Dispatch/AsyncAwaitSpec.cs
+++ b/src/core/Akka.Tests/Dispatch/AsyncAwaitSpec.cs
@@ -225,7 +225,7 @@ namespace Akka.Tests.Dispatch
             var actor = Sys.ActorOf(Props.Create<UntypedAsyncAwaitActor>(), "Worker");
             var asker = Sys.ActorOf(Props.Create(() => new UntypedAsker(actor)), "Asker");
             var task = asker.Ask("start", TimeSpan.FromSeconds(5));
-            actor.Tell(123, ActorRef.NoSender);
+            actor.Tell(123, ActorRefs.NoSender);
             var res = await task;
             Assert.Equal("done", res);
         }
@@ -235,7 +235,7 @@ namespace Akka.Tests.Dispatch
         {
             var actor = Sys.ActorOf(Props.Create<AsyncAwaitActor>());
             var task = actor.Ask<string>("start", TimeSpan.FromSeconds(5));
-            actor.Tell(123, ActorRef.NoSender);
+            actor.Tell(123, ActorRefs.NoSender);
             var res = await task;
             Assert.Equal("done", res);
         }
@@ -246,7 +246,7 @@ namespace Akka.Tests.Dispatch
             var actor = Sys.ActorOf(Props.Create<AsyncAwaitActor>(), "Worker");
             var asker = Sys.ActorOf(Props.Create(() => new Asker(actor)), "Asker");
             var task = asker.Ask("start", TimeSpan.FromSeconds(5));
-            actor.Tell(123, ActorRef.NoSender);
+            actor.Tell(123, ActorRefs.NoSender);
             var res = await task;
             Assert.Equal("done", res);
         }
@@ -257,7 +257,7 @@ namespace Akka.Tests.Dispatch
             var actor = Sys.ActorOf(Props.Create<AsyncAwaitActor>().WithDispatcher("akka.actor.task-dispatcher"),"Worker");
             var asker =Sys.ActorOf(Props.Create(() => new BlockingAsker(actor)).WithDispatcher("akka.actor.task-dispatcher"),"Asker");
             var task = asker.Ask("start", TimeSpan.FromSeconds(5));
-            actor.Tell(123, ActorRef.NoSender);
+            actor.Tell(123, ActorRefs.NoSender);
             var res = await task;
             Assert.Equal("done", res);
         }

--- a/src/core/Akka.Tests/Dispatch/MailboxesSpec.cs
+++ b/src/core/Akka.Tests/Dispatch/MailboxesSpec.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Akka.Actor;
 using Akka.Dispatch;
 using Akka.Dispatch.SysMsg;
 using Akka.TestKit;

--- a/src/core/Akka.Tests/Event/EventBusSpec.cs
+++ b/src/core/Akka.Tests/Event/EventBusSpec.cs
@@ -19,7 +19,7 @@ namespace Akka.Tests.Event
             return child.IsAssignableFrom(parent);
         }
 
-        protected override void Publish(object evt, ActorRef subscriber)
+        protected override void Publish(object evt, IActorRef subscriber)
         {
             subscriber.Tell(evt);
         }
@@ -37,9 +37,9 @@ namespace Akka.Tests.Event
 
     internal class TestActorWrapperActor : ActorBase
     {
-        private readonly ActorRef _ref;
+        private readonly IActorRef _ref;
 
-        public TestActorWrapperActor(ActorRef actorRef)
+        public TestActorWrapperActor(IActorRef actorRef)
         {
             _ref = actorRef;
         }
@@ -53,13 +53,13 @@ namespace Akka.Tests.Event
 
     internal struct Notification
     {
-        public Notification(ActorRef @ref, int payload) : this()
+        public Notification(IActorRef @ref, int payload) : this()
         {
             Ref = @ref;
             Payload = payload;
         }
 
-        public ActorRef Ref { get; set; }
+        public IActorRef Ref { get; set; }
         public int Payload { get; set; }
     }
 
@@ -69,7 +69,7 @@ namespace Akka.Tests.Event
 
         protected object _evt;
         protected Type _classifier;
-        protected ActorRef _subscriber;
+        protected IActorRef _subscriber;
 
         public EventBusSpec()
         {
@@ -118,7 +118,7 @@ namespace Akka.Tests.Event
         public void EventBus_allow_to_add_multiple_subscribers()
         {
             const int max = 10;
-            IEnumerable<ActorRef> subscribers = Enumerable.Range(0, max).Select(_ => CreateSubscriber(TestActor)).ToList();
+            IEnumerable<IActorRef> subscribers = Enumerable.Range(0, max).Select(_ => CreateSubscriber(TestActor)).ToList();
             foreach (var subscriber in subscribers)
             {
                 _bus.Subscribe(subscriber, _classifier).ShouldBe(true);
@@ -195,12 +195,12 @@ namespace Akka.Tests.Event
             DisposeSubscriber(_subscriber);
         }
 
-        protected ActorRef CreateSubscriber(ActorRef actor)
+        protected IActorRef CreateSubscriber(IActorRef actor)
         {
             return Sys.ActorOf(Props.Create(() => new TestActorWrapperActor(actor)));
         }
 
-        protected void DisposeSubscriber(ActorRef subscriber)
+        protected void DisposeSubscriber(IActorRef subscriber)
         {
             Sys.Stop(subscriber);
         }

--- a/src/core/Akka.Tests/Event/EventStreamSpec.cs
+++ b/src/core/Akka.Tests/Event/EventStreamSpec.cs
@@ -221,9 +221,9 @@ namespace Akka.Tests.Event
 
         public class SetTarget
         {
-            public ActorRef Ref { get; private set; }
+            public IActorRef Ref { get; private set; }
 
-            public SetTarget(ActorRef @ref)
+            public SetTarget(IActorRef @ref)
             {
                 this.Ref = @ref;
             }
@@ -273,7 +273,7 @@ namespace Akka.Tests.Event
 
         public class MyLog : UntypedActor
         {
-            private ActorRef dst = Context.System.DeadLetters;
+            private IActorRef dst = Context.System.DeadLetters;
 
             protected override void OnReceive(object message)
             {

--- a/src/core/Akka.Tests/Routing/ConsistentHashingRouterSpec.cs
+++ b/src/core/Akka.Tests/Routing/ConsistentHashingRouterSpec.cs
@@ -67,9 +67,9 @@ namespace Akka.Tests.Routing
 
         #endregion
 
-        private ActorRef router1;
-        private ActorRef router3;
-        private ActorRef a, b, c;
+        private IActorRef router1;
+        private IActorRef router3;
+        private IActorRef a, b, c;
 
         public ConsistentHashingRouterSpec()
             : base(@"
@@ -112,17 +112,17 @@ namespace Akka.Tests.Routing
         public void ConsistentHashingRouterMustSelectDestinationBasedOnConsistentHashKeyOfMessage()
         {
             router1.Tell(new Msg("a", "A"));
-            var destinationA = ExpectMsg<ActorRef>();
+            var destinationA = ExpectMsg<IActorRef>();
             router1.Tell(new ConsistentHashableEnvelope("AA", "a"));
             ExpectMsg(destinationA);
 
             router1.Tell(new Msg(17, "A"));
-            var destinationB = ExpectMsg<ActorRef>();
+            var destinationB = ExpectMsg<IActorRef>();
             router1.Tell(new ConsistentHashableEnvelope("BB", 17));
             ExpectMsg(destinationB);
 
             router1.Tell(new Msg(new MsgKey("c"), "C"));
-            var destinationC = ExpectMsg<ActorRef>();
+            var destinationC = ExpectMsg<IActorRef>();
             router1.Tell(new ConsistentHashableEnvelope("CC", new MsgKey("c")));
             ExpectMsg(destinationC);
         }
@@ -144,17 +144,17 @@ namespace Akka.Tests.Routing
                 Sys.ActorOf(new ConsistentHashingPool(1, null, null, null, hashMapping: hashMapping).Props(Props.Create<Echo>()), "router2");
 
             router2.Tell(new Msg2("a", "A"));
-            var destinationA = ExpectMsg<ActorRef>();
+            var destinationA = ExpectMsg<IActorRef>();
             router2.Tell(new ConsistentHashableEnvelope("AA", "a"));
             ExpectMsg(destinationA);
 
             router2.Tell(new Msg2(17, "A"));
-            var destinationB = ExpectMsg<ActorRef>();
+            var destinationB = ExpectMsg<IActorRef>();
             router2.Tell(new ConsistentHashableEnvelope("BB", 17));
             ExpectMsg(destinationB);
 
             router2.Tell(new Msg2(new MsgKey("c"), "C"));
-            var destinationC = ExpectMsg<ActorRef>();
+            var destinationC = ExpectMsg<IActorRef>();
             router2.Tell(new ConsistentHashableEnvelope("CC", new MsgKey("c")));
             ExpectMsg(destinationC);
         }
@@ -170,17 +170,17 @@ namespace Akka.Tests.Routing
         public void ConsistentHashingGroupRouterMustSelectDestinationBasedOnConsistentHashKeyOfMessage()
         {
             router3.Tell(new Msg("a", "A"));
-            var destinationA = ExpectMsg<ActorRef>();
+            var destinationA = ExpectMsg<IActorRef>();
             router3.Tell(new ConsistentHashableEnvelope("AA", "a"));
             ExpectMsg(destinationA);
 
             router3.Tell(new Msg(17, "A"));
-            var destinationB = ExpectMsg<ActorRef>();
+            var destinationB = ExpectMsg<IActorRef>();
             router3.Tell(new ConsistentHashableEnvelope("BB", 17));
             ExpectMsg(destinationB);
 
             router3.Tell(new Msg(new MsgKey("c"), "C"));
-            var destinationC = ExpectMsg<ActorRef>();
+            var destinationC = ExpectMsg<IActorRef>();
             router3.Tell(new ConsistentHashableEnvelope("CC", new MsgKey("c")));
             ExpectMsg(destinationC);
         }
@@ -202,17 +202,17 @@ namespace Akka.Tests.Routing
                 Sys.ActorOf(Props.Empty.WithRouter(new ConsistentHashingGroup(new[]{c},hashMapping: hashMapping)), "router4");
 
             router4.Tell(new Msg2("a", "A"));
-            var destinationA = ExpectMsg<ActorRef>();
+            var destinationA = ExpectMsg<IActorRef>();
             router4.Tell(new ConsistentHashableEnvelope("AA", "a"));
             ExpectMsg(destinationA);
 
             router4.Tell(new Msg2(17, "A"));
-            var destinationB = ExpectMsg<ActorRef>();
+            var destinationB = ExpectMsg<IActorRef>();
             router4.Tell(new ConsistentHashableEnvelope("BB", 17));
             ExpectMsg(destinationB);
 
             router4.Tell(new Msg2(new MsgKey("c"), "C"));
-            var destinationC = ExpectMsg<ActorRef>();
+            var destinationC = ExpectMsg<IActorRef>();
             router4.Tell(new ConsistentHashableEnvelope("CC", new MsgKey("c")));
             ExpectMsg(destinationC);
         }
@@ -229,7 +229,7 @@ namespace Akka.Tests.Routing
             currentRoutees.Members.Count().ShouldBe(2);
 
             router5.Tell(new Msg("a", "A"), TestActor);
-            var actorWhoDies = ExpectMsg<ActorRef>();
+            var actorWhoDies = ExpectMsg<IActorRef>();
 
             //kill off the actor
             actorWhoDies.Tell(PoisonPill.Instance);
@@ -239,7 +239,7 @@ namespace Akka.Tests.Routing
             {
                 router5.Tell(new Msg("a", "A"), TestActor);
                 //verify that a different actor now owns this hash range
-                var actorWhoDidntDie = ExpectMsg<ActorRef>(TimeSpan.FromMilliseconds(50));
+                var actorWhoDidntDie = ExpectMsg<IActorRef>(TimeSpan.FromMilliseconds(50));
                 actorWhoDidntDie.ShouldNotBe(actorWhoDies);
             }, TimeSpan.FromSeconds(5));
 

--- a/src/core/Akka.Tests/Routing/ResizerSpec.cs
+++ b/src/core/Akka.Tests/Routing/ResizerSpec.cs
@@ -228,7 +228,7 @@ namespace Akka.Tests.Routing
 
         #region Internal methods
 
-        private int RouteeSize(ActorRef router)
+        private int RouteeSize(IActorRef router)
         {
             var routeesTask = router.Ask<Routees>(new GetRoutees(), TestKitSettings.DefaultTimeout);
             routeesTask.Wait(TestKitSettings.DefaultTimeout);

--- a/src/core/Akka.Tests/Routing/RoutingSpec.cs
+++ b/src/core/Akka.Tests/Routing/RoutingSpec.cs
@@ -60,8 +60,8 @@ namespace Akka.Tests.Routing
             var router = Sys.ActorOf(new RoundRobinPool(2).Props(Props.Create<Echo>()), "router");
             router.Tell("",TestActor);
             router.Tell("",TestActor);
-            var c1 = ExpectMsg<ActorRef>();
-            var c2 = ExpectMsg<ActorRef>();
+            var c1 = ExpectMsg<IActorRef>();
+            var c2 = ExpectMsg<IActorRef>();
             Watch(router);
             Watch(c2);
             Sys.Stop(c2);
@@ -72,7 +72,7 @@ namespace Akka.Tests.Routing
             {
                 router.Tell("", TestActor);
                 router.Tell("", TestActor);
-                var res = ReceiveWhile(TimeSpan.FromMilliseconds(100), o => o is ActorRef ? (ActorRef) o : ActorRefs.NoSender, 2);
+                var res = ReceiveWhile(TimeSpan.FromMilliseconds(100), o => o is IActorRef ? (IActorRef) o : ActorRefs.NoSender, 2);
                 return res.SequenceEqual(new[] {c1, c1});
             });
             
@@ -162,11 +162,11 @@ namespace Akka.Tests.Routing
         {
             var router = Sys.ActorOf(new BroadcastPool(5).Props(Props.Create<Echo>()));
             router.Tell("hello",TestActor);
-            ExpectMsg<ActorRef>();
-            ExpectMsg<ActorRef>();
-            ExpectMsg<ActorRef>();
-            ExpectMsg<ActorRef>();
-            ExpectMsg<ActorRef>();
+            ExpectMsg<IActorRef>();
+            ExpectMsg<IActorRef>();
+            ExpectMsg<IActorRef>();
+            ExpectMsg<IActorRef>();
+            ExpectMsg<IActorRef>();
             ExpectNoMsg(TimeSpan.FromSeconds(1));
         }
 

--- a/src/core/Akka.Tests/Routing/RoutingSpec.cs
+++ b/src/core/Akka.Tests/Routing/RoutingSpec.cs
@@ -72,7 +72,7 @@ namespace Akka.Tests.Routing
             {
                 router.Tell("", TestActor);
                 router.Tell("", TestActor);
-                var res = ReceiveWhile(TimeSpan.FromMilliseconds(100), o => o is ActorRef ? (ActorRef) o : ActorRef.NoSender, 2);
+                var res = ReceiveWhile(TimeSpan.FromMilliseconds(100), o => o is ActorRef ? (ActorRef) o : ActorRefs.NoSender, 2);
                 return res.SequenceEqual(new[] {c1, c1});
             });
             

--- a/src/core/Akka.Tests/Routing/ScatterGatherFirstCompletedSpec.cs
+++ b/src/core/Akka.Tests/Routing/ScatterGatherFirstCompletedSpec.cs
@@ -53,7 +53,7 @@ namespace Akka.Tests.Routing
      routedActor.isTerminated should be(false)*/
 
             var routedActor = Sys.ActorOf(Props.Create<TestActor>().WithRouter(new ScatterGatherFirstCompletedPool(1)));
-            ((InternalActorRef)routedActor).IsTerminated.ShouldBe(false);
+            ((IInternalActorRef)routedActor).IsTerminated.ShouldBe(false);
         }
 
         [Fact]

--- a/src/core/Akka.Tests/Routing/TailChoppingSpec.cs
+++ b/src/core/Akka.Tests/Routing/TailChoppingSpec.cs
@@ -82,7 +82,7 @@ namespace Akka.Tests.Routing
             }
         }
 
-        public Func<Func<ActorRef, int>, bool> OneOfShouldEqual(int what, IEnumerable<ActorRef> actors)
+        public Func<Func<IActorRef, int>, bool> OneOfShouldEqual(int what, IEnumerable<IActorRef> actors)
         {
             return func =>
             {
@@ -91,7 +91,7 @@ namespace Akka.Tests.Routing
             };
         }
 
-        public Func<Func<ActorRef, int>, bool> AllShouldEqual(int what, IEnumerable<ActorRef> actors)
+        public Func<Func<IActorRef, int>, bool> AllShouldEqual(int what, IEnumerable<IActorRef> actors)
         {
             return func =>
             {
@@ -137,7 +137,7 @@ namespace Akka.Tests.Routing
             probe.Send(routedActor, "");
             probe.ExpectMsg("ack");
 
-            var actorList = new List<ActorRef> { actor1, actor2 };
+            var actorList = new List<IActorRef> { actor1, actor2 };
             Assert.True(OneOfShouldEqual(1, actorList)((x => (int)x.Ask("times").Result)));
 
             routedActor.Tell(new Broadcast("stop"));
@@ -157,7 +157,7 @@ namespace Akka.Tests.Routing
             probe.Send(routedActor, "");
             probe.ExpectMsg<Status.Failure>();
 
-            var actorList = new List<ActorRef> { actor1, actor2 };
+            var actorList = new List<IActorRef> { actor1, actor2 };
             Assert.True(AllShouldEqual(1, actorList)((x => (int)x.Ask("times").Result)));
 
             routedActor.Tell(new Broadcast("stop"));

--- a/src/core/Akka.Tests/Serialization/SerializationSpec.cs
+++ b/src/core/Akka.Tests/Serialization/SerializationSpec.cs
@@ -144,7 +144,7 @@ namespace Akka.Tests.Serialization
         }
         public class SomeMessage
         {
-            public ActorRef ActorRef { get; set; }
+            public IActorRef ActorRef { get; set; }
         }
 
         [Fact]

--- a/src/core/Akka/Actor/ActorBase.cs
+++ b/src/core/Akka/Actor/ActorBase.cs
@@ -78,7 +78,7 @@ namespace Akka.Actor
     /// </summary>
     public abstract partial class ActorBase : IInternalActor
     {
-        private ActorRef _clearedSelf;
+        private IActorRef _clearedSelf;
         private bool HasBeenCleared { get { return _clearedSelf != null; } }
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace Akka.Actor
         ///     Gets the sending ActorRef of the current message
         /// </summary>
         /// <value>The sender ActorRef</value>
-        protected ActorRef Sender
+        protected IActorRef Sender
         {
             get { return Context.Sender; }
         }
@@ -105,7 +105,7 @@ namespace Akka.Actor
         ///     Gets the self ActorRef
         /// </summary>
         /// <value>Self ActorRef</value>
-        protected ActorRef Self { get { return HasBeenCleared ? _clearedSelf : Context.Self; } }
+        protected IActorRef Self { get { return HasBeenCleared ? _clearedSelf : Context.Self; } }
 
         /// <summary>
         ///     Gets the context.
@@ -206,7 +206,7 @@ namespace Akka.Actor
             Context.Unbecome();
         }
 
-        internal void Clear(ActorRef self)
+        internal void Clear(IActorRef self)
         {
             _clearedSelf = self;
         }

--- a/src/core/Akka/Actor/ActorCell.Children.cs
+++ b/src/core/Akka/Actor/ActorCell.Children.cs
@@ -23,12 +23,12 @@ namespace Akka.Actor
             get { return _childrenContainerDoNotCallMeDirectly; }   //TODO: Hmm do we need memory barriers here???
         }
 
-        private IReadOnlyCollection<ActorRef> Children
+        private IReadOnlyCollection<IActorRef> Children
         {
             get { return ChildrenContainer.Children; }
         }
 
-        private bool TryGetChild(string name, out ActorRef child)
+        private bool TryGetChild(string name, out IActorRef child)
         {
             ChildStats stats;
             if (ChildrenContainer.TryGetByName(name, out stats))
@@ -44,17 +44,17 @@ namespace Akka.Actor
             return false;
         }
 
-        public virtual ActorRef AttachChild(Props props, bool isSystemService, string name = null)
+        public virtual IActorRef AttachChild(Props props, bool isSystemService, string name = null)
         {
             return ActorOf(props, name, true, isSystemService);
         }
         
-        public virtual ActorRef ActorOf(Props props, string name = null)
+        public virtual IActorRef ActorOf(Props props, string name = null)
         {
             return ActorOf(props, name, false, false);
         }
 
-        private ActorRef ActorOf(Props props, string name, bool isAsync, bool isSystemService)
+        private IActorRef ActorOf(Props props, string name, bool isAsync, bool isSystemService)
         {
             if (name == null)
                 name = GetRandomActorName();
@@ -74,7 +74,7 @@ namespace Akka.Actor
         ///     Stops the specified child.
         /// </summary>
         /// <param name="child">The child.</param>
-        public void Stop(ActorRef child)
+        public void Stop(IActorRef child)
         {
             ChildRestartStats stats;
             if (ChildrenContainer.TryGetByRef(child, out stats))
@@ -85,7 +85,7 @@ namespace Akka.Actor
                     UpdateChildrenRefs(c => c.ShallDie(child));
                 }
             }
-            ((InternalActorRef)child).Stop();
+            ((IInternalActorRef)child).Stop();
         }
 
         [Obsolete("Use UpdateChildrenRefs instead", true)]
@@ -134,7 +134,7 @@ namespace Akka.Actor
         }
 
         /// <summary>This should only be used privately or when creating the root actor. </summary>
-        public ChildRestartStats InitChild(InternalActorRef actor)
+        public ChildRestartStats InitChild(IInternalActorRef actor)
         {
             return UpdateChildrenRefs(cc =>
             {
@@ -195,7 +195,7 @@ namespace Akka.Actor
         /// <summary>
         ///     Suspends the children.
         /// </summary>
-        private void SuspendChildren(List<ActorRef> exceptFor = null)
+        private void SuspendChildren(List<IActorRef> exceptFor = null)
         {
             if (exceptFor == null)
             {
@@ -219,7 +219,7 @@ namespace Akka.Actor
         /// <summary>
         ///     Resumes the children.
         /// </summary>
-        private void ResumeChildren(Exception causedByFailure, ActorRef perpetrator)
+        private void ResumeChildren(Exception causedByFailure, IActorRef perpetrator)
         {
             foreach (var stats in ChildrenContainer.Stats)
             {
@@ -259,7 +259,7 @@ namespace Akka.Actor
         /// Tries to get the stats for the specified child.
         /// <remarks>Since the child exists <see cref="ChildRestartStats"/> is the only valid <see cref="ChildStats"/>.</remarks>
         /// </summary>
-        protected bool TryGetChildStatsByRef(ActorRef actor, out ChildRestartStats child)   //This is called getChildByRef in Akka JVM
+        protected bool TryGetChildStatsByRef(IActorRef actor, out ChildRestartStats child)   //This is called getChildByRef in Akka JVM
         {
             return ChildrenContainer.TryGetByRef(actor, out child);
         }
@@ -267,13 +267,13 @@ namespace Akka.Actor
         // In Akka JVM there is a getAllChildStats here. Use ChildrenRefs.Stats instead
 
         [Obsolete("Use TryGetSingleChild")]
-        public InternalActorRef GetSingleChild(string name)
+        public IInternalActorRef GetSingleChild(string name)
         {
-            InternalActorRef child;
+            IInternalActorRef child;
             return TryGetSingleChild(name, out child) ? child : ActorRefs.Nobody;
         }
 
-        public bool TryGetSingleChild(string name, out InternalActorRef child)
+        public bool TryGetSingleChild(string name, out IInternalActorRef child)
         {
             if (name.IndexOf('#') < 0)
             {
@@ -303,7 +303,7 @@ namespace Akka.Actor
             return false;
         }
 
-        protected SuspendReason RemoveChildAndGetStateChange(ActorRef child)
+        protected SuspendReason RemoveChildAndGetStateChange(IActorRef child)
         {
             var terminating = ChildrenContainer as TerminatingChildrenContainer;
             if (terminating != null)
@@ -326,7 +326,7 @@ namespace Akka.Actor
             }
         }
 
-        private InternalActorRef MakeChild(Props props, string name, bool async, bool systemService)
+        private IInternalActorRef MakeChild(Props props, string name, bool async, bool systemService)
         {
             //TODO: Implement SerializeAllCreators
             //   if (cell.system.settings.SerializeAllCreators && !systemService && props.deploy.scope != LocalScope)
@@ -346,7 +346,7 @@ namespace Akka.Actor
                 throw new InvalidOperationException("Cannot create child while terminating or terminated");
             //reserve the name before we create the actor
             ReserveChild(name);
-            InternalActorRef actor;
+            IInternalActorRef actor;
             try
             {
                 var childPath = new ChildActorPath(Self.Path, name, NewUid());

--- a/src/core/Akka/Actor/ActorCell.Children.cs
+++ b/src/core/Akka/Actor/ActorCell.Children.cs
@@ -270,7 +270,7 @@ namespace Akka.Actor
         public InternalActorRef GetSingleChild(string name)
         {
             InternalActorRef child;
-            return TryGetSingleChild(name, out child) ? child : ActorRef.Nobody;
+            return TryGetSingleChild(name, out child) ? child : ActorRefs.Nobody;
         }
 
         public bool TryGetSingleChild(string name, out InternalActorRef child)
@@ -299,7 +299,7 @@ namespace Akka.Actor
                     }
                 }
             }
-            child = ActorRef.Nobody;
+            child = ActorRefs.Nobody;
             return false;
         }
 

--- a/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
+++ b/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
@@ -224,12 +224,12 @@ namespace Akka.Actor
             }
         }
 
-        private void Supervise(ActorRef child, bool async)
+        private void Supervise(IActorRef child, bool async)
         {
             //TODO: complete this
             if (!IsTerminating)
             {
-                var childRestartStats = InitChild((InternalActorRef)child);
+                var childRestartStats = InitChild((IInternalActorRef)child);
                 if (childRestartStats != null)
                 {
                     HandleSupervise(child, async);
@@ -245,7 +245,7 @@ namespace Akka.Actor
             }
         }
 
-        private void HandleSupervise(ActorRef child, bool async)
+        private void HandleSupervise(IActorRef child, bool async)
         {
             if (async && child is RepointableActorRef)
             {

--- a/src/core/Akka/Actor/ActorCell.FaultHandling.cs
+++ b/src/core/Akka/Actor/ActorCell.FaultHandling.cs
@@ -21,9 +21,9 @@ namespace Akka.Actor
         }
 
         // ReSharper disable once InconsistentNaming
-        private ActorRef _failed_DoNotUseMeDirectly;
+        private IActorRef _failed_DoNotUseMeDirectly;
         private bool IsFailed { get { return _failed_DoNotUseMeDirectly != null; } }
-        private void SetFailed(ActorRef perpetrator)
+        private void SetFailed(IActorRef perpetrator)
         {
             _failed_DoNotUseMeDirectly = perpetrator;
         }
@@ -31,7 +31,7 @@ namespace Akka.Actor
         {
             _failed_DoNotUseMeDirectly = null;
         }
-        private ActorRef Perpetrator { get { return _failed_DoNotUseMeDirectly; } }
+        private IActorRef Perpetrator { get { return _failed_DoNotUseMeDirectly; } }
 
         /// <summary>Re-create the actor in response to a failure.</summary>
         private void FaultRecreate(Exception cause)
@@ -210,7 +210,7 @@ namespace Akka.Actor
             }
         }
 
-        private void HandleInvokeFailure(Exception cause, IEnumerable<ActorRef> childrenNotToSuspend = null)
+        private void HandleInvokeFailure(Exception cause, IEnumerable<IActorRef> childrenNotToSuspend = null)
         {
             // prevent any further messages to be processed until the actor has been restarted
             if (!IsFailed)
@@ -397,7 +397,7 @@ namespace Akka.Actor
             }
         }
 
-        private void HandleChildTerminated(ActorRef child)
+        private void HandleChildTerminated(IActorRef child)
         {
             var status = RemoveChildAndGetStateChange(child);
 

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -12,7 +12,7 @@ namespace Akka.Actor
     public partial class ActorCell : IUntypedActorContext, Cell 
     {
         /// <summary>NOTE! Only constructor and ClearActorFields is allowed to update this</summary>
-        private InternalActorRef _self;
+        private IInternalActorRef _self;
         public const int UndefinedUid = 0;
         private Props _props;
         private static readonly Props terminatedProps=new TerminatedProps();
@@ -25,7 +25,7 @@ namespace Akka.Actor
         private readonly ActorSystemImpl _systemImpl;
 
 
-        public ActorCell(ActorSystemImpl system, InternalActorRef self, Props props, MessageDispatcher dispatcher, InternalActorRef parent)
+        public ActorCell(ActorSystemImpl system, IInternalActorRef self, Props props, MessageDispatcher dispatcher, IInternalActorRef parent)
         {
             _self = self;
             _props = props;
@@ -49,10 +49,10 @@ namespace Akka.Actor
         public ActorSystem System { get { return _systemImpl; } }
         public ActorSystemImpl SystemImpl { get { return _systemImpl; } }
         public Props Props { get { return _props; } }
-        public ActorRef Self { get { return _self; } }
-        ActorRef IActorContext.Parent { get { return Parent; } }
-        public InternalActorRef Parent { get; private set; }
-        public ActorRef Sender { get; private set; }
+        public IActorRef Self { get { return _self; } }
+        IActorRef IActorContext.Parent { get { return Parent; } }
+        public IInternalActorRef Parent { get; private set; }
+        public IActorRef Sender { get; private set; }
         public bool HasMessages { get { return Mailbox.HasUnscheduledMessages; } }
         public int NumberOfMessages { get { return Mailbox.NumberOfMessages; } }
         internal bool ActorHasBeenCleared { get { return _actorHasBeenCleared; } }
@@ -102,15 +102,15 @@ namespace Akka.Actor
         }
 
         [Obsolete("Use TryGetChildStatsByName", true)]
-        public InternalActorRef GetChildByName(string name)   //TODO: Should return  Option[ChildStats]
+        public IInternalActorRef GetChildByName(string name)   //TODO: Should return  Option[ChildStats]
         {
-            InternalActorRef child;
+            IInternalActorRef child;
             return TryGetSingleChild(name, out child) ? child : ActorRefs.Nobody;
         }
 
-        ActorRef IActorContext.Child(string name)
+        IActorRef IActorContext.Child(string name)
         {
-            InternalActorRef child;
+            IInternalActorRef child;
             return TryGetSingleChild(name, out child) ? child : ActorRefs.Nobody;
         }
 
@@ -125,12 +125,12 @@ namespace Akka.Actor
         }
 
 
-        IEnumerable<ActorRef> IActorContext.GetChildren()
+        IEnumerable<IActorRef> IActorContext.GetChildren()
         {
             return GetChildren();
         }
 
-        public IEnumerable<InternalActorRef> GetChildren()
+        public IEnumerable<IInternalActorRef> GetChildren()
         {
             return ChildrenContainer.Children;
         }
@@ -207,7 +207,7 @@ namespace Akka.Actor
         }
 
 
-        public virtual void Post(ActorRef sender, object message)
+        public virtual void Post(IActorRef sender, object message)
         {
             if (Mailbox == null)
             {
@@ -288,13 +288,13 @@ namespace Akka.Actor
                 : new NameAndUid(name.Substring(0, i), Int32.Parse(name.Substring(i + 1)));
         }
 
-        public static ActorRef GetCurrentSelfOrNoSender()
+        public static IActorRef GetCurrentSelfOrNoSender()
         {
             var current = Current;
             return current != null ? current.Self : NoSender.Instance;
         }
 
-        public static ActorRef GetCurrentSenderOrNoSender()
+        public static IActorRef GetCurrentSenderOrNoSender()
         {
             var current = Current;
             return current != null ? current.Sender : NoSender.Instance;

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -105,13 +105,13 @@ namespace Akka.Actor
         public InternalActorRef GetChildByName(string name)   //TODO: Should return  Option[ChildStats]
         {
             InternalActorRef child;
-            return TryGetSingleChild(name, out child) ? child : ActorRef.Nobody;
+            return TryGetSingleChild(name, out child) ? child : ActorRefs.Nobody;
         }
 
         ActorRef IActorContext.Child(string name)
         {
             InternalActorRef child;
-            return TryGetSingleChild(name, out child) ? child : ActorRef.Nobody;
+            return TryGetSingleChild(name, out child) ? child : ActorRefs.Nobody;
         }
 
         public ActorSelection ActorSelection(string path)

--- a/src/core/Akka/Actor/ActorRef.Extensions.cs
+++ b/src/core/Akka/Actor/ActorRef.Extensions.cs
@@ -10,7 +10,7 @@
         ///     and don't receive a valid result in return, this method will indicate
         ///     whether or not the actor we received is valid.
         /// </summary>
-        public static bool IsNobody(this ActorRef actorRef)
+        public static bool IsNobody(this IActorRef actorRef)
         {
             return actorRef == null || actorRef is Nobody || actorRef is NoSender || actorRef is DeadLetterActorRef;
         }

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -77,9 +77,9 @@ namespace Akka.Actor
         private const int INITIATED = 0;
         private const int COMPLETED = 1;
         private int status = INITIATED;
-        private readonly ActorRef _actorAwaitingResultSender;
+        private readonly IActorRef _actorAwaitingResultSender;
 
-        protected override void TellInternal(object message, ActorRef sender)
+        protected override void TellInternal(object message, IActorRef sender)
         {
 
             if (message is SystemMessage) //we have special handling for system messages
@@ -96,7 +96,7 @@ namespace Akka.Actor
             }
         }
 
-        protected void SendSystemMessage(SystemMessage message, ActorRef sender)
+        protected void SendSystemMessage(SystemMessage message, IActorRef sender)
         {
             var d = message as DeathWatchNotification;
             if (message is Terminate)
@@ -114,20 +114,20 @@ namespace Akka.Actor
 
     internal static class ActorRefSender
     {
-        public static ActorRef GetSelfOrNoSender()
+        public static IActorRef GetSelfOrNoSender()
         {
             var actorCell = ActorCell.Current;
             return actorCell != null ? actorCell.Self : ActorRefs.NoSender;
         }
     }
-    public interface ActorRef : ICanTell, IEquatable<ActorRef>, IComparable<ActorRef>, ISurrogated
+    public interface IActorRef : ICanTell, IEquatable<IActorRef>, IComparable<IActorRef>, ISurrogated
     {
         ActorPath Path { get; }
     }
 
     public static class ActorRefImplicitSenderExtensions
     {
-        public static void Tell(this ActorRef receiver, object message)
+        public static void Tell(this IActorRef receiver, object message)
         {
             var sender = ActorCell.GetCurrentSelfOrNoSender();
             receiver.Tell(message, sender);
@@ -138,7 +138,7 @@ namespace Akka.Actor
         /// Forwards the message using the current Sender
         /// </summary>
         /// <param name="message"></param>
-        public static void Forward(this ActorRef receiver, object message)
+        public static void Forward(this IActorRef receiver, object message)
         {
             var sender = ActorCell.GetCurrentSenderOrNoSender();
             receiver.Tell(message, sender);
@@ -148,10 +148,10 @@ namespace Akka.Actor
     public static class ActorRefs
     {
         public static readonly Nobody Nobody = Nobody.Instance;
-        public static readonly ActorRef NoSender = Actor.NoSender.Instance; //In Akka this is just null
+        public static readonly IActorRef NoSender = Actor.NoSender.Instance; //In Akka this is just null
     }
 
-    public abstract class ActorRefBase : ActorRef
+    public abstract class ActorRefBase : IActorRef
     {
         public class Surrogate : ISurrogate
         {
@@ -170,14 +170,14 @@ namespace Akka.Actor
 
         public abstract ActorPath Path { get; }
 
-        public void Tell(object message, ActorRef sender)
+        public void Tell(object message, IActorRef sender)
         {
             if (sender == null) throw new ArgumentNullException("sender", "A sender must be specified");
 
             TellInternal(message, sender);
         }
 
-        protected abstract void TellInternal(object message, ActorRef sender);
+        protected abstract void TellInternal(object message, IActorRef sender);
 
         public override string ToString()
         {
@@ -186,7 +186,7 @@ namespace Akka.Actor
 
         public override bool Equals(object obj)
         {
-            var other = obj as ActorRef;
+            var other = obj as IActorRef;
             if (other == null) return false;
             return Equals(other);
         }
@@ -202,12 +202,12 @@ namespace Akka.Actor
             }
         }
 
-        public bool Equals(ActorRef other)
+        public bool Equals(IActorRef other)
         {
             return Path.Uid == other.Path.Uid && Path.Equals(other.Path);
         }
 
-        public int CompareTo(ActorRef other)
+        public int CompareTo(IActorRef other)
         {
             var pathComparisonResult = Path.CompareTo(other.Path);
             if (pathComparisonResult != 0) return pathComparisonResult;
@@ -222,9 +222,9 @@ namespace Akka.Actor
     }
 
 
-    public interface InternalActorRef : ActorRef, ActorRefScope
+    public interface IInternalActorRef : IActorRef, ActorRefScope
     {
-        InternalActorRef Parent { get; }
+        IInternalActorRef Parent { get; }
         ActorRefProvider Provider { get; }
         bool IsTerminated { get; }
 
@@ -235,8 +235,8 @@ namespace Akka.Actor
         /// If the requested path does not exist, returns <see cref="Nobody"/>.
         /// </summary>
         /// <param name="name">The path elements.</param>
-        /// <returns>The <see cref="ActorRef"/>, or if the requested path does not exist, returns <see cref="Nobody"/>.</returns>
-        ActorRef GetChild(IEnumerable<string> name);
+        /// <returns>The <see cref="IActorRef"/>, or if the requested path does not exist, returns <see cref="Nobody"/>.</returns>
+        IActorRef GetChild(IEnumerable<string> name);
 
         void Resume(Exception causedByFailure = null);
         void Start();
@@ -245,9 +245,9 @@ namespace Akka.Actor
         void Suspend();
     }
 
-    public abstract class InternalActorRefBase : ActorRefBase, InternalActorRef
+    public abstract class InternalActorRefBase : ActorRefBase, IInternalActorRef
     {
-        public abstract InternalActorRef Parent { get; }
+        public abstract IInternalActorRef Parent { get; }
         public abstract ActorRefProvider Provider { get; }
 
         /// <summary>
@@ -257,8 +257,8 @@ namespace Akka.Actor
         /// If the requested path does not exist, returns <see cref="Nobody"/>.
         /// </summary>
         /// <param name="name">The path elements.</param>
-        /// <returns>The <see cref="ActorRef"/>, or if the requested path does not exist, returns <see cref="Nobody"/>.</returns>
-        public abstract ActorRef GetChild(IEnumerable<string> name);    //TODO: Refactor this to use an IEnumerator instead as this will be faster instead of enumerating multiple times over name, as the implementations currently do.
+        /// <returns>The <see cref="IActorRef"/>, or if the requested path does not exist, returns <see cref="Nobody"/>.</returns>
+        public abstract IActorRef GetChild(IEnumerable<string> name);    //TODO: Refactor this to use an IEnumerator instead as this will be faster instead of enumerating multiple times over name, as the implementations currently do.
         public abstract void Resume(Exception causedByFailure = null);
         public abstract void Start();
         public abstract void Stop();
@@ -271,12 +271,12 @@ namespace Akka.Actor
 
     public abstract class MinimalActorRef : InternalActorRefBase, LocalRef
     {
-        public override InternalActorRef Parent
+        public override IInternalActorRef Parent
         {
             get { return ActorRefs.Nobody; }
         }
 
-        public override ActorRef GetChild(IEnumerable<string> name)
+        public override IActorRef GetChild(IEnumerable<string> name)
         {
             if (name.All(string.IsNullOrEmpty))
                 return this;
@@ -303,7 +303,7 @@ namespace Akka.Actor
         {
         }
 
-        protected override void TellInternal(object message, ActorRef sender)
+        protected override void TellInternal(object message, IActorRef sender)
         {
         }
 
@@ -336,9 +336,9 @@ namespace Akka.Actor
     {
         public abstract Cell Underlying { get; }
 
-        public abstract IEnumerable<ActorRef> Children { get; }
+        public abstract IEnumerable<IActorRef> Children { get; }
 
-        public abstract InternalActorRef GetSingleChild(string name);
+        public abstract IInternalActorRef GetSingleChild(string name);
 
     }
 
@@ -351,21 +351,21 @@ namespace Akka.Actor
 
         public override ActorPath Path { get { return _path; } }
 
-        protected override void TellInternal(object message, ActorRef sender)
+        protected override void TellInternal(object message, IActorRef sender)
         {
         }
     }
 
     internal class VirtualPathContainer : MinimalActorRef
     {
-        private readonly InternalActorRef _parent;
+        private readonly IInternalActorRef _parent;
         private readonly LoggingAdapter _log;
         private readonly ActorRefProvider _provider;
         private readonly ActorPath _path;
 
-        private readonly ConcurrentDictionary<string, InternalActorRef> _children = new ConcurrentDictionary<string, InternalActorRef>();
+        private readonly ConcurrentDictionary<string, IInternalActorRef> _children = new ConcurrentDictionary<string, IInternalActorRef>();
 
-        public VirtualPathContainer(ActorRefProvider provider, ActorPath path, InternalActorRef parent, LoggingAdapter log)
+        public VirtualPathContainer(ActorRefProvider provider, ActorPath path, IInternalActorRef parent, LoggingAdapter log)
         {
             _parent = parent;
             _log = log;
@@ -378,7 +378,7 @@ namespace Akka.Actor
             get { return _provider; }
         }
 
-        public override InternalActorRef Parent
+        public override IInternalActorRef Parent
         {
             get { return _parent; }
         }
@@ -394,12 +394,12 @@ namespace Akka.Actor
         }
 
 
-        protected bool TryGetChild(string name, out InternalActorRef child)
+        protected bool TryGetChild(string name, out IInternalActorRef child)
         {
             return _children.TryGetValue(name, out child);
         }
 
-        public void AddChild(string name, InternalActorRef actor)
+        public void AddChild(string name, IInternalActorRef actor)
         {
             _children.AddOrUpdate(name, actor, (k, v) =>
             {
@@ -410,7 +410,7 @@ namespace Akka.Actor
 
         public void RemoveChild(string name)
         {
-            InternalActorRef tmp;
+            IInternalActorRef tmp;
             if (!_children.TryRemove(name, out tmp))
             {
                 //TODO: log.warning("{} trying to remove non-child {}", path, name)
@@ -433,7 +433,7 @@ override def getChild(name: Iterator[String]): InternalActorRef = {
   }
 */
 
-        public override ActorRef GetChild(IEnumerable<string> name)
+        public override IActorRef GetChild(IEnumerable<string> name)
         {
             //Using enumerator to avoid multiple enumerations of name.
             var enumerator = name.GetEnumerator();
@@ -445,15 +445,15 @@ override def getChild(name: Iterator[String]): InternalActorRef = {
             var firstName = enumerator.Current;
             if (string.IsNullOrEmpty(firstName))
                 return this;
-            InternalActorRef child;
+            IInternalActorRef child;
             if (_children.TryGetValue(firstName, out child))
                 return child.GetChild(new Enumerable<string>(enumerator));
             return ActorRefs.Nobody;
         }
 
-        public void ForeachActorRef(Action<InternalActorRef> action)
+        public void ForeachActorRef(Action<IInternalActorRef> action)
         {
-            foreach (InternalActorRef child in _children.Values)
+            foreach (IInternalActorRef child in _children.Values)
             {
                 action(child);
             }

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -222,7 +222,30 @@ namespace Akka.Actor
     }
 
 
-    public abstract class InternalActorRef : ActorRefBase, ActorRefScope
+    public interface InternalActorRef : ActorRef, ActorRefScope
+    {
+        InternalActorRef Parent { get; }
+        ActorRefProvider Provider { get; }
+        bool IsTerminated { get; }
+
+        /// <summary>
+        /// Obtain a child given the paths element to that actor, by possibly traversing the actor tree or 
+        /// looking it up at some provider-specific location. 
+        /// A path element of ".." signifies the parent, a trailing "" element must be disregarded. 
+        /// If the requested path does not exist, returns <see cref="Nobody"/>.
+        /// </summary>
+        /// <param name="name">The path elements.</param>
+        /// <returns>The <see cref="ActorRef"/>, or if the requested path does not exist, returns <see cref="Nobody"/>.</returns>
+        ActorRef GetChild(IEnumerable<string> name);
+
+        void Resume(Exception causedByFailure = null);
+        void Start();
+        void Stop();
+        void Restart(Exception cause);
+        void Suspend();
+    }
+
+    public abstract class InternalActorRefBase : ActorRefBase, InternalActorRef
     {
         public abstract InternalActorRef Parent { get; }
         public abstract ActorRefProvider Provider { get; }
@@ -246,7 +269,7 @@ namespace Akka.Actor
         public abstract bool IsLocal { get; }
     }
 
-    public abstract class MinimalActorRef : InternalActorRef, LocalRef
+    public abstract class MinimalActorRef : InternalActorRefBase, LocalRef
     {
         public override InternalActorRef Parent
         {
@@ -309,7 +332,7 @@ namespace Akka.Actor
 
     }
 
-    public abstract class ActorRefWithCell : InternalActorRef
+    public abstract class ActorRefWithCell : InternalActorRefBase
     {
         public abstract Cell Underlying { get; }
 

--- a/src/core/Akka/Actor/ActorRefFactory.cs
+++ b/src/core/Akka/Actor/ActorRefFactory.cs
@@ -20,7 +20,7 @@
         /// <param name="props">The props.</param>
         /// <param name="name">The name.</param>
         /// <returns>InternalActorRef.</returns>
-        ActorRef ActorOf(Props props, string name = null);
+        IActorRef ActorOf(Props props, string name = null);
 
        
         /// <summary>

--- a/src/core/Akka/Actor/ActorRefFactoryExtensions.cs
+++ b/src/core/Akka/Actor/ActorRefFactoryExtensions.cs
@@ -2,7 +2,7 @@
 {
     public static class ActorRefFactoryExtensions
     {
-        public static ActorRef ActorOf<TActor>(this ActorRefFactory factory, string name = null) where TActor : ActorBase, new()
+        public static IActorRef ActorOf<TActor>(this ActorRefFactory factory, string name = null) where TActor : ActorBase, new()
         {
             return factory.ActorOf(Props.Create<TActor>(), name: name);
         }

--- a/src/core/Akka/Actor/ActorRefFactoryShared.cs
+++ b/src/core/Akka/Actor/ActorRefFactoryShared.cs
@@ -31,7 +31,7 @@ namespace Akka.Actor
         ///     the supplied path, it is recommended to send a message and gather the
         ///     replies in order to resolve the matching set of actors.
         /// </summary>
-        public static ActorSelection ActorSelection(string path, ActorSystem system, ActorRef lookupRoot)
+        public static ActorSelection ActorSelection(string path, ActorSystem system, IActorRef lookupRoot)
         {
             var provider = ((ActorSystemImpl)system).Provider;
 

--- a/src/core/Akka/Actor/ActorSelection.cs
+++ b/src/core/Akka/Actor/ActorSelection.cs
@@ -92,7 +92,7 @@ namespace Akka.Actor
         /// <param name="message">The message.</param>
         public void Tell(object message)
         {
-            var sender = ActorRef.NoSender;
+            var sender = ActorRefs.NoSender;
             if (ActorCell.Current != null && ActorCell.Current.Self != null)
                 sender = ActorCell.Current.Self;
 

--- a/src/core/Akka/Actor/ActorSelection.cs
+++ b/src/core/Akka/Actor/ActorSelection.cs
@@ -25,7 +25,7 @@ namespace Akka.Actor
         /// </summary>
         /// <param name="anchor">The anchor.</param>
         /// <param name="path">The path.</param>
-        public ActorSelection(ActorRef anchor, SelectionPathElement[] path)
+        public ActorSelection(IActorRef anchor, SelectionPathElement[] path)
         {
             Anchor = anchor;
             Elements = path;
@@ -36,7 +36,7 @@ namespace Akka.Actor
         /// </summary>
         /// <param name="anchor">The anchor.</param>
         /// <param name="path">The path.</param>
-        public ActorSelection(ActorRef anchor, string path)
+        public ActorSelection(IActorRef anchor, string path)
             : this(anchor, path == "" ? new string[] {} : path.Split('/'))
         {
         }
@@ -46,7 +46,7 @@ namespace Akka.Actor
         /// </summary>
         /// <param name="anchor">The anchor.</param>
         /// <param name="elements">The elements.</param>
-        public ActorSelection(ActorRef anchor, IEnumerable<string> elements)
+        public ActorSelection(IActorRef anchor, IEnumerable<string> elements)
         {
             Anchor = anchor;
             Elements = elements.Select<string, SelectionPathElement>(e =>
@@ -63,7 +63,7 @@ namespace Akka.Actor
         ///     Gets the anchor.
         /// </summary>
         /// <value>The anchor.</value>
-        public ActorRef Anchor { get; private set; }
+        public IActorRef Anchor { get; private set; }
 
         /// <summary>
         ///     Gets or sets the elements.
@@ -81,7 +81,7 @@ namespace Akka.Actor
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="sender">The sender.</param>
-        public void Tell(object message, ActorRef sender)
+        public void Tell(object message, IActorRef sender)
         {
             Deliver(message, sender, 0, Anchor);
         }
@@ -99,12 +99,12 @@ namespace Akka.Actor
             Deliver(message, sender, 0, Anchor);
         }
 
-        public Task<ActorRef> ResolveOne(TimeSpan timeout)
+        public Task<IActorRef> ResolveOne(TimeSpan timeout)
         {
             return InnerResolveOne(timeout);
         }
 
-        private async Task<ActorRef> InnerResolveOne(TimeSpan timeout)
+        private async Task<IActorRef> InnerResolveOne(TimeSpan timeout)
         {
             try
             {
@@ -124,7 +124,7 @@ namespace Akka.Actor
         /// <param name="sender">The sender.</param>
         /// <param name="pathIndex">Index of the path.</param>
         /// <param name="current">The current.</param>
-        private void Deliver(object message, ActorRef sender, int pathIndex, ActorRef current)
+        private void Deliver(object message, IActorRef sender, int pathIndex, IActorRef current)
         {
             if (pathIndex == Elements.Length)
             {
@@ -146,7 +146,7 @@ namespace Akka.Actor
                         var pattern = element as SelectChildPattern;
                         var children =
                             withCell.Children.Where(c => c.Path.Name.Like(pattern.PatternStr));
-                        foreach (ActorRef matchingChild in children)
+                        foreach (IActorRef matchingChild in children)
                         {
                             Deliver(message, sender, pathIndex + 1, matchingChild);
                         }
@@ -165,7 +165,7 @@ namespace Akka.Actor
         ///     Convenience method used by remoting when receiving <see cref="ActorSelectionMessage" /> from a remote
         ///     actor.
         /// </summary>
-        internal static void DeliverSelection(InternalActorRef anchor, ActorRef sender, ActorSelectionMessage sel)
+        internal static void DeliverSelection(IInternalActorRef anchor, IActorRef sender, ActorSelectionMessage sel)
         {
             var actorSelection = new ActorSelection(anchor, sel.Elements);
             actorSelection.Tell(sel.Message, sender);

--- a/src/core/Akka/Actor/ActorSystem.cs
+++ b/src/core/Akka/Actor/ActorSystem.cs
@@ -48,7 +48,7 @@ namespace Akka.Actor
         ///     Gets the dead letters.
         /// </summary>
         /// <value>The dead letters.</value>
-        public abstract ActorRef DeadLetters { get; }
+        public abstract IActorRef DeadLetters { get; }
 
         /// <summary>Gets the dispatchers.</summary>
         /// <value>The dispatchers.</value>
@@ -175,7 +175,7 @@ namespace Akka.Actor
         public abstract bool AwaitTermination(TimeSpan timeout, CancellationToken cancellationToken);
 
 
-        public abstract void Stop(ActorRef actor);
+        public abstract void Stop(IActorRef actor);
         private bool _isDisposed; //Automatically initialized to false;
 
         //Destructor:
@@ -229,7 +229,7 @@ namespace Akka.Actor
 
         public abstract object RegisterExtension(IExtensionId extension);
 
-        public abstract ActorRef ActorOf(Props props, string name = null);
+        public abstract IActorRef ActorOf(Props props, string name = null);
         
         public abstract ActorSelection ActorSelection(ActorPath actorPath);
         public abstract ActorSelection ActorSelection(string actorPath);

--- a/src/core/Akka/Actor/AutoReceivedMessage.cs
+++ b/src/core/Akka/Actor/AutoReceivedMessage.cs
@@ -9,14 +9,14 @@ namespace Akka.Actor
     public sealed class
         Terminated : AutoReceivedMessage, PossiblyHarmful
     {
-        public Terminated(ActorRef actorRef, bool existenceConfirmed, bool addressTerminated)
+        public Terminated(IActorRef actorRef, bool existenceConfirmed, bool addressTerminated)
         {
             ActorRef = actorRef;
             ExistenceConfirmed = existenceConfirmed;
             AddressTerminated = addressTerminated;
         }
 
-        public ActorRef ActorRef { get; private set; }
+        public IActorRef ActorRef { get; private set; }
 
 
         public bool AddressTerminated { get; private set; }
@@ -48,14 +48,14 @@ namespace Akka.Actor
     //response to the Identity message, get identity by Sender
     public sealed class ActorIdentity
     {
-        public ActorIdentity(object messageId, ActorRef subject)
+        public ActorIdentity(object messageId, IActorRef subject)
         {
             MessageId = messageId;
             Subject = subject;
         }
 
         public object MessageId { get; private set; }
-        public ActorRef Subject { get; private set; }
+        public IActorRef Subject { get; private set; }
 
         public override string ToString()
         {

--- a/src/core/Akka/Actor/BuiltInActors.cs
+++ b/src/core/Akka/Actor/BuiltInActors.cs
@@ -38,9 +38,9 @@ namespace Akka.Actor
 
     public class SystemGuardianActor : ActorBase
     {
-        private readonly ActorRef _userGuardian;
+        private readonly IActorRef _userGuardian;
 
-        public SystemGuardianActor(ActorRef userGuardian)
+        public SystemGuardianActor(IActorRef userGuardian)
         {
             _userGuardian = userGuardian;
         }
@@ -119,7 +119,7 @@ namespace Akka.Actor
             return true;
         }
 
-        private void StopWhenAllTerminationHooksDone(ActorRef remove)
+        private void StopWhenAllTerminationHooksDone(IActorRef remove)
         {
             //TODO: Implement termination hook support
             //_terminationHooks.Remove(terminatedActor)
@@ -165,7 +165,7 @@ namespace Akka.Actor
                 _eventStream.Publish(deadLetter);
         }
 
-        protected override bool SpecialHandle(object message, ActorRef sender)
+        protected override bool SpecialHandle(object message, IActorRef sender)
         {
             var w = message as Watch;
             if(w != null)

--- a/src/core/Akka/Actor/Cell.cs
+++ b/src/core/Akka/Actor/Cell.cs
@@ -12,7 +12,7 @@ namespace Akka.Actor
     public interface Cell
     {
         /// <summary>Gets the “self” reference which this Cell is attached to.</summary>
-        ActorRef Self { get; }
+        IActorRef Self { get; }
 
         /// <summary>The system within which this Cell lives.</summary>
         ActorSystem System { get; }        
@@ -41,7 +41,7 @@ namespace Akka.Actor
 
 
         /// <summary>The supervisor of this actor.</summary>
-        InternalActorRef Parent { get; }
+        IInternalActorRef Parent { get; }
 
         /// <summary>Returns true if the actor is local.</summary>
         bool IsLocal { get; }
@@ -64,18 +64,18 @@ namespace Akka.Actor
 
         bool IsTerminated { get; }
 
-        void Post(ActorRef sender, object message);
+        void Post(IActorRef sender, object message);
 
 
 
-        IEnumerable<InternalActorRef> GetChildren();    //TODO: Should be replaced by childrenRefs: ChildrenContainer
+        IEnumerable<IInternalActorRef> GetChildren();    //TODO: Should be replaced by childrenRefs: ChildrenContainer
 
         /// <summary>
         /// Method for looking up a single child beneath this actor.
         /// It is racy if called from the outside.</summary>
-        InternalActorRef GetSingleChild(string name);
+        IInternalActorRef GetSingleChild(string name);
 
-        InternalActorRef GetChildByName(string name);
+        IInternalActorRef GetChildByName(string name);
 
         /// <summary>
         /// Tries to get the stats for the child with the specified name. The stats can be either <see cref="ChildNameReserved"/> 

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/ChildStats.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/ChildStats.cs
@@ -25,11 +25,11 @@ namespace Akka.Actor.Internal
     /// </summary>
     public class ChildRestartStats : ChildStats
     {
-        private readonly InternalActorRef _child;
+        private readonly IInternalActorRef _child;
         private uint _maxNrOfRetriesCount;
         private long _restartTimeWindowStartTicks;
 
-        public ChildRestartStats(InternalActorRef child, uint maxNrOfRetriesCount = 0, long restartTimeWindowStartTicks = 0)
+        public ChildRestartStats(IInternalActorRef child, uint maxNrOfRetriesCount = 0, long restartTimeWindowStartTicks = 0)
         {
             _child = child;
             _maxNrOfRetriesCount = maxNrOfRetriesCount;
@@ -38,7 +38,7 @@ namespace Akka.Actor.Internal
 
         public long Uid { get { return Child.Path.Uid; } }
 
-        public InternalActorRef Child { get { return _child; } }
+        public IInternalActorRef Child { get { return _child; } }
 
         public uint MaxNrOfRetriesCount { get { return _maxNrOfRetriesCount; } }
 

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainer.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainer.cs
@@ -6,16 +6,16 @@ namespace Akka.Actor.Internal
     public interface ChildrenContainer
     {
         ChildrenContainer Add(string name, ChildRestartStats stats);
-        ChildrenContainer Remove(ActorRef child);
+        ChildrenContainer Remove(IActorRef child);
         bool TryGetByName(string name, out ChildStats stats);
-        bool TryGetByRef(ActorRef actor, out ChildRestartStats stats);
-        IReadOnlyList<InternalActorRef> Children { get; }
+        bool TryGetByRef(IActorRef actor, out ChildRestartStats stats);
+        IReadOnlyList<IInternalActorRef> Children { get; }
         IReadOnlyList<ChildRestartStats> Stats { get; }
-        ChildrenContainer ShallDie(ActorRef actor);
+        ChildrenContainer ShallDie(IActorRef actor);
         ChildrenContainer Reserve(string name);
         ChildrenContainer Unreserve(string name);
         bool IsTerminating { get; }
         bool IsNormal { get; }
-        bool Contains(ActorRef actor);
+        bool Contains(IActorRef actor);
     }
 }

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainerBase.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainerBase.cs
@@ -17,12 +17,12 @@ namespace Akka.Actor.Internal
         public virtual bool IsTerminating { get { return false; } }
         public virtual bool IsNormal { get { return true; } }
         public abstract ChildrenContainer Add(string name, ChildRestartStats stats);
-        public abstract ChildrenContainer Remove(ActorRef child);
+        public abstract ChildrenContainer Remove(IActorRef child);
         public abstract ChildrenContainer Reserve(string name);
-        public abstract ChildrenContainer ShallDie(ActorRef actor);
+        public abstract ChildrenContainer ShallDie(IActorRef actor);
         public abstract ChildrenContainer Unreserve(string name);
 
-        public IReadOnlyList<InternalActorRef> Children
+        public IReadOnlyList<IInternalActorRef> Children
         {
             get
             {
@@ -53,7 +53,7 @@ namespace Akka.Actor.Internal
             return false;
         }
 
-        public bool TryGetByRef(ActorRef actor, out ChildRestartStats childRestartStats)
+        public bool TryGetByRef(IActorRef actor, out ChildRestartStats childRestartStats)
         {
             ChildStats stats;
             if (InternalChildren.TryGet(actor.Path.Name, out stats))
@@ -70,7 +70,7 @@ namespace Akka.Actor.Internal
             return false;
         }
 
-        public bool Contains(ActorRef actor)
+        public bool Contains(IActorRef actor)
         {
             ChildRestartStats stats;
             return TryGetByRef(actor, out stats);

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/EmptyChildrenContainer.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/EmptyChildrenContainer.cs
@@ -24,7 +24,7 @@ namespace Akka.Actor.Internal
             return NormalChildrenContainer.Create(newMap);
         }
 
-        public ChildrenContainer Remove(ActorRef child)
+        public ChildrenContainer Remove(IActorRef child)
         {
             return this;
         }
@@ -35,22 +35,22 @@ namespace Akka.Actor.Internal
             return false;
         }
 
-        public bool TryGetByRef(ActorRef actor, out ChildRestartStats childRestartStats)
+        public bool TryGetByRef(IActorRef actor, out ChildRestartStats childRestartStats)
         {
             childRestartStats = null;
             return false;
         }
 
-        public bool Contains(ActorRef actor)
+        public bool Contains(IActorRef actor)
         {
             return false;
         }
 
-        public IReadOnlyList<InternalActorRef> Children { get { return EmptyReadOnlyCollections<InternalActorRef>.List; } }
+        public IReadOnlyList<IInternalActorRef> Children { get { return EmptyReadOnlyCollections<IInternalActorRef>.List; } }
 
         public IReadOnlyList<ChildRestartStats> Stats { get { return EmptyReadOnlyCollections<ChildRestartStats>.List; } }
 
-        public ChildrenContainer ShallDie(ActorRef actor)
+        public ChildrenContainer ShallDie(IActorRef actor)
         {
             return this;
         }

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/NormalChildrenContainer.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/NormalChildrenContainer.cs
@@ -27,12 +27,12 @@ namespace Akka.Actor.Internal
             return Create(InternalChildren.AddOrUpdate(name, stats));
         }
 
-        public override ChildrenContainer Remove(ActorRef child)
+        public override ChildrenContainer Remove(IActorRef child)
         {
             return Create(InternalChildren.Remove(child.Path.Name));
         }
 
-        public override ChildrenContainer ShallDie(ActorRef actor)
+        public override ChildrenContainer ShallDie(IActorRef actor)
         {
             return new TerminatingChildrenContainer(InternalChildren, actor, SuspendReason.UserRequest.Instance);
         }

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/TerminatingChildrenContainer.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/TerminatingChildrenContainer.cs
@@ -16,15 +16,15 @@ namespace Akka.Actor.Internal
     /// </summary>
     public class TerminatingChildrenContainer : ChildrenContainerBase
     {
-        private readonly IImmutableSet<ActorRef> _toDie;
+        private readonly IImmutableSet<IActorRef> _toDie;
         private readonly SuspendReason _reason;
 
-        public TerminatingChildrenContainer(IImmutableMap<string, ChildStats> children, ActorRef toDie, SuspendReason reason)
-            : this(children, ImmutableTreeSet<ActorRef>.Create(toDie), reason)
+        public TerminatingChildrenContainer(IImmutableMap<string, ChildStats> children, IActorRef toDie, SuspendReason reason)
+            : this(children, ImmutableTreeSet<IActorRef>.Create(toDie), reason)
         {
             //Intentionally left blank
         }
-        public TerminatingChildrenContainer(IImmutableMap<string, ChildStats> children, IImmutableSet<ActorRef> toDie, SuspendReason reason)
+        public TerminatingChildrenContainer(IImmutableMap<string, ChildStats> children, IImmutableSet<IActorRef> toDie, SuspendReason reason)
             : base(children)
         {
             _toDie = toDie;
@@ -39,7 +39,7 @@ namespace Akka.Actor.Internal
             return new TerminatingChildrenContainer(newMap, _toDie, _reason);
         }
 
-        public override ChildrenContainer Remove(ActorRef child)
+        public override ChildrenContainer Remove(IActorRef child)
         {
             var set = _toDie.Remove(child);
             if (set.IsEmpty)
@@ -50,7 +50,7 @@ namespace Akka.Actor.Internal
             return new TerminatingChildrenContainer(InternalChildren.Remove(child.Path.Name), set, _reason);
         }
 
-        public override ChildrenContainer ShallDie(ActorRef actor)
+        public override ChildrenContainer ShallDie(IActorRef actor)
         {
             return new TerminatingChildrenContainer(InternalChildren, _toDie.Add(actor), _reason);
         }

--- a/src/core/Akka/Actor/DeadLetterMailbox.cs
+++ b/src/core/Akka/Actor/DeadLetterMailbox.cs
@@ -6,14 +6,14 @@ namespace Akka.Actor
 {
     public class DeadLetterMailbox : Mailbox
     {
-        private readonly ActorRef _deadLetters;
+        private readonly IActorRef _deadLetters;
 
-        public DeadLetterMailbox(ActorRef deadLetters)
+        public DeadLetterMailbox(IActorRef deadLetters)
         {
             _deadLetters = deadLetters;
         }
 
-        public override void Post(ActorRef receiver, Envelope envelope)
+        public override void Post(IActorRef receiver, Envelope envelope)
         {
             var message = envelope.Message;
             if(message is SystemMessage)

--- a/src/core/Akka/Actor/Dsl/Act.cs
+++ b/src/core/Akka/Actor/Dsl/Act.cs
@@ -35,7 +35,7 @@ namespace Akka.Actor.Dsl
         /// </summary>
         void UnbecomeStacked();
 
-        ActorRef ActorOf(Action<IActorDsl> config, string name = null);
+        IActorRef ActorOf(Action<IActorDsl> config, string name = null);
     }
 
     public sealed class Act : ReceiveActor, IActorDsl
@@ -109,7 +109,7 @@ namespace Akka.Actor.Dsl
             base.Unbecome();
         }
 
-        public ActorRef ActorOf(Action<IActorDsl> config, string name = null)
+        public IActorRef ActorOf(Action<IActorDsl> config, string name = null)
         {
             var props = Props.Create(() => new Act(config));
             return Context.ActorOf(props, name);
@@ -171,12 +171,12 @@ namespace Akka.Actor.Dsl
 
     public static class ActExtensions
     {
-        public static ActorRef ActorOf(this ActorRefFactory factory, Action<IActorDsl> config, string name = null)
+        public static IActorRef ActorOf(this ActorRefFactory factory, Action<IActorDsl> config, string name = null)
         {
             return factory.ActorOf(Props.Create(() => new Act(config)), name);
         }
 
-        public static ActorRef ActorOf(this ActorRefFactory factory, Action<IActorDsl, IActorContext> config, string name = null)
+        public static IActorRef ActorOf(this ActorRefFactory factory, Action<IActorDsl, IActorContext> config, string name = null)
         {
             return factory.ActorOf(Props.Create(() => new Act(config)), name);
         }

--- a/src/core/Akka/Actor/EmptyLocalActorRef.cs
+++ b/src/core/Akka/Actor/EmptyLocalActorRef.cs
@@ -22,7 +22,7 @@ namespace Akka.Actor
         public override ActorRefProvider Provider { get { return _provider; } }
         public override bool IsTerminated { get { return true; } }
 
-        protected override void TellInternal(object message, ActorRef sender)
+        protected override void TellInternal(object message, IActorRef sender)
         {
             var systemMessage = message as SystemMessage;
             if(systemMessage != null)
@@ -33,7 +33,7 @@ namespace Akka.Actor
             SendUserMessage(message, sender);
         }
 
-        protected virtual void SendUserMessage(object message, ActorRef sender)
+        protected virtual void SendUserMessage(object message, IActorRef sender)
         {
             if(message == null) throw new InvalidMessageException();
             var deadLetter = message as DeadLetter;
@@ -60,7 +60,7 @@ namespace Akka.Actor
             SpecialHandle(message, _provider.DeadLetters);
         }
 
-        protected virtual bool SpecialHandle(object message, ActorRef sender)
+        protected virtual bool SpecialHandle(object message, IActorRef sender)
         {
             var w = message as Watch;
             if(w != null)

--- a/src/core/Akka/Actor/Exceptions.cs
+++ b/src/core/Akka/Actor/Exceptions.cs
@@ -77,13 +77,13 @@ namespace Akka.Actor
     /// </summary>
     public class ActorInitializationException : AkkaException
     {
-        private readonly ActorRef _actor;
+        private readonly IActorRef _actor;
         protected ActorInitializationException() : base(){}
 
         public ActorInitializationException(string message) : base(message) { }
 
         public ActorInitializationException(string message, Exception cause) : base(message, cause) { }
-        public ActorInitializationException(ActorRef actor, string message, Exception cause = null) : base(message, cause)
+        public ActorInitializationException(IActorRef actor, string message, Exception cause = null) : base(message, cause)
         {
             _actor = actor;
         }
@@ -93,7 +93,7 @@ namespace Akka.Actor
         {
         }
 
-        public ActorRef Actor { get { return _actor; } }
+        public IActorRef Actor { get { return _actor; } }
 
         public override string ToString()
         {
@@ -173,9 +173,9 @@ namespace Akka.Actor
     /// </summary>
     public class DeathPactException : AkkaException
     {
-        private readonly ActorRef _deadActor;
+        private readonly IActorRef _deadActor;
 
-        public DeathPactException(ActorRef deadActor)
+        public DeathPactException(IActorRef deadActor)
             : base("Monitored actor [" + deadActor + "] terminated")
         {
             _deadActor = deadActor;
@@ -186,7 +186,7 @@ namespace Akka.Actor
         {
         }
 
-        public ActorRef DeadActor
+        public IActorRef DeadActor
         {
             get { return _deadActor; }
         }
@@ -197,12 +197,12 @@ namespace Akka.Actor
     /// </summary>
     public class PreRestartException : AkkaException
     {
-        private ActorRef Actor;
+        private IActorRef Actor;
         private Exception e; //TODO: what is this?
         private Exception exception;
         private object optionalMessage;
 
-        public PreRestartException(ActorRef actor, Exception restartException, Exception cause,
+        public PreRestartException(IActorRef actor, Exception restartException, Exception cause,
             object optionalMessage)
         {
             Actor = actor;
@@ -234,7 +234,7 @@ namespace Akka.Actor
         /// <param name="actor">The actor whose constructor or postRestart() hook failed.</param>
         /// <param name="cause">Cause is the exception thrown by that actor within preRestart().</param>
         /// <param name="originalCause">The original causeis the exception which caused the restart in the first place.</param>
-        public PostRestartException(ActorRef actor, Exception cause, Exception originalCause)
+        public PostRestartException(IActorRef actor, Exception cause, Exception originalCause)
             :base(actor,"Exception post restart (" + (originalCause == null ?"null" : originalCause.GetType().ToString()) + ")", cause)
         {
             _originalCause = originalCause;

--- a/src/core/Akka/Actor/ExtendedActorSystem.cs
+++ b/src/core/Akka/Actor/ExtendedActorSystem.cs
@@ -18,13 +18,13 @@
         /// Gets the top-level supervisor of all user actors created using 
         /// <see cref="ActorSystem.ActorOf">system.ActorOf(...)</see>
         /// </summary>
-        public abstract InternalActorRef Guardian { get; }
+        public abstract IInternalActorRef Guardian { get; }
 
 
         /// <summary>
         /// Gets the top-level supervisor of all system-internal services like logging.
         /// </summary>
-        public abstract InternalActorRef SystemGuardian { get; }
+        public abstract IInternalActorRef SystemGuardian { get; }
 
         /// <summary>
         /// Gets the actor producer pipeline resolver for current actor system. It may be used by
@@ -35,12 +35,12 @@
         /// <summary>Creates a new system actor in the "/system" namespace. This actor 
         /// will be shut down during system shutdown only after all user actors have
         /// terminated.</summary>
-        public abstract ActorRef SystemActorOf(Props props, string name = null);
+        public abstract IActorRef SystemActorOf(Props props, string name = null);
 
         /// <summary>Creates a new system actor in the "/system" namespace. This actor 
         /// will be shut down during system shutdown only after all user actors have
         /// terminated.</summary>
-        public abstract ActorRef SystemActorOf<TActor>(string name = null) where TActor : ActorBase, new();
+        public abstract IActorRef SystemActorOf<TActor>(string name = null) where TActor : ActorBase, new();
 
         //TODO: Missing threadFactory, dynamicAccess, printTree
         //  /**

--- a/src/core/Akka/Actor/FSM.cs
+++ b/src/core/Akka/Actor/FSM.cs
@@ -22,13 +22,13 @@ namespace Akka.Actor
         /// <typeparam name="TS">The type of the state being used in this finite state machine.</typeparam>
         public class CurrentState<TS>
         {
-            public CurrentState(ActorRef fsmRef, TS state)
+            public CurrentState(IActorRef fsmRef, TS state)
             {
                 State = state;
                 FsmRef = fsmRef;
             }
 
-            public ActorRef FsmRef { get; private set; }
+            public IActorRef FsmRef { get; private set; }
 
             public TS State { get; private set; }
         }
@@ -40,14 +40,14 @@ namespace Akka.Actor
         /// <typeparam name="TS">The type of state used</typeparam>
         public class Transition<TS>
         {
-            public Transition(ActorRef fsmRef, TS @from, TS to)
+            public Transition(IActorRef fsmRef, TS @from, TS to)
             {
                 To = to;
                 From = @from;
                 FsmRef = fsmRef;
             }
 
-            public ActorRef FsmRef { get; private set; }
+            public IActorRef FsmRef { get; private set; }
 
             public TS From { get; private set; }
 
@@ -66,12 +66,12 @@ namespace Akka.Actor
         /// </summary>
         public class SubscribeTransitionCallBack
         {
-            public SubscribeTransitionCallBack(ActorRef actorRef)
+            public SubscribeTransitionCallBack(IActorRef actorRef)
             {
                 ActorRef = actorRef;
             }
 
-            public ActorRef ActorRef { get; private set; }
+            public IActorRef ActorRef { get; private set; }
         }
 
         /// <summary>
@@ -80,12 +80,12 @@ namespace Akka.Actor
         /// </summary>
         public class UnsubscribeTransitionCallBack
         {
-            public UnsubscribeTransitionCallBack(ActorRef actorRef)
+            public UnsubscribeTransitionCallBack(IActorRef actorRef)
             {
                 ActorRef = actorRef;
             }
 
-            public ActorRef ActorRef { get; private set; }
+            public IActorRef ActorRef { get; private set; }
         }
 
         /// <summary>
@@ -168,7 +168,7 @@ namespace Akka.Actor
 
             public IActorContext Context { get; private set; }
 
-            public void Schedule(ActorRef actor, TimeSpan timeout)
+            public void Schedule(IActorRef actor, TimeSpan timeout)
             {
                 var name = Name;
                 var message = Message;
@@ -849,7 +849,7 @@ namespace Akka.Actor
             if(s != null) return s;
             var timer = source as Timer;
             if(timer != null) return "timer '" + timer.Name + "'";
-            var actorRef = source as ActorRef;
+            var actorRef = source as IActorRef;
             if(actorRef != null) return actorRef.ToString();
             return "unknown";
         }

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -33,7 +33,7 @@ namespace Akka.Actor
             return result;
         }
 
-        internal static ActorRef ResolveReplyTo()
+        internal static IActorRef ResolveReplyTo()
         {
             if (ActorCell.Current != null)
                 return ActorCell.Current.Self;
@@ -46,8 +46,8 @@ namespace Akka.Actor
             if (ActorCell.Current != null)
                 return InternalCurrentActorCellKeeper.Current.SystemImpl.Provider;
 
-            if (self is InternalActorRef)
-                return self.AsInstanceOf<InternalActorRef>().Provider;
+            if (self is IInternalActorRef)
+                return self.AsInstanceOf<IInternalActorRef>().Provider;
 
             if (self is ActorSelection)
                 return ResolveProvider(self.AsInstanceOf<ActorSelection>().Anchor);
@@ -176,7 +176,7 @@ namespace Akka.Actor
         private static readonly Status.Failure ActorStopResult = new Status.Failure(new ActorKilledException("Stopped"));
 
         public static PromiseActorRef Apply(ActorRefProvider provider, TimeSpan timeout, object targetName,
-            string messageClassName, ActorRef sender = null)
+            string messageClassName, IActorRef sender = null)
         {
             sender = sender ?? ActorRefs.NoSender;
             var result = new TaskCompletionSource<object>();
@@ -205,14 +205,14 @@ namespace Akka.Actor
         #endregion
 
         //TODO: ActorCell.emptyActorRefSet ?
-        private readonly AtomicReference<HashSet<ActorRef>> _watchedByDoNotCallMeDirectly = new AtomicReference<HashSet<ActorRef>>();
+        private readonly AtomicReference<HashSet<IActorRef>> _watchedByDoNotCallMeDirectly = new AtomicReference<HashSet<IActorRef>>();
 
-        private HashSet<ActorRef> WatchedBy
+        private HashSet<IActorRef> WatchedBy
         {
             get { return _watchedByDoNotCallMeDirectly; }
         }
 
-        private bool UpdateWatchedBy(HashSet<ActorRef> oldWatchedBy, HashSet<ActorRef> newWatchedBy)
+        private bool UpdateWatchedBy(HashSet<IActorRef> oldWatchedBy, HashSet<IActorRef> newWatchedBy)
         {
             return _watchedByDoNotCallMeDirectly.CompareAndSet(oldWatchedBy, newWatchedBy);
         }
@@ -225,7 +225,7 @@ namespace Akka.Actor
         /// <summary>
         /// Returns false if the <see cref="Result"/> is already completed.
         /// </summary>
-        private bool AddWatcher(ActorRef watcher)
+        private bool AddWatcher(IActorRef watcher)
         {
             if (WatchedBy.Contains(watcher))
             {
@@ -234,7 +234,7 @@ namespace Akka.Actor
             return UpdateWatchedBy(WatchedBy, WatchedBy.CopyAndAdd(watcher)) || AddWatcher(watcher);
         }
 
-        private void RemoveWatcher(ActorRef watcher)
+        private void RemoveWatcher(IActorRef watcher)
         {
             if (!WatchedBy.Contains(watcher))
             {
@@ -243,10 +243,10 @@ namespace Akka.Actor
             if (!UpdateWatchedBy(WatchedBy, WatchedBy.CopyAndRemove(watcher))) RemoveWatcher(watcher);
         }
 
-        private HashSet<ActorRef> ClearWatchers()
+        private HashSet<IActorRef> ClearWatchers()
         {
             //TODO: ActorCell.emptyActorRefSet ?
-            if (WatchedBy == null) return new HashSet<ActorRef>();
+            if (WatchedBy == null) return new HashSet<IActorRef>();
             if (!UpdateWatchedBy(WatchedBy, null)) return ClearWatchers();
             else return WatchedBy;
         }
@@ -262,7 +262,7 @@ namespace Akka.Actor
             return _stateDoNotCallMeDirectly.CompareAndSet(oldState, newState);
         }
 
-        public override InternalActorRef Parent
+        public override IInternalActorRef Parent
         {
             get { return Provider.TempContainer; }
         }
@@ -316,7 +316,7 @@ namespace Akka.Actor
             }
         }
 
-        protected override void TellInternal(object message, ActorRef sender)
+        protected override void TellInternal(object message, IActorRef sender)
         {
             if (message is SystemMessage)
             {

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -178,7 +178,7 @@ namespace Akka.Actor
         public static PromiseActorRef Apply(ActorRefProvider provider, TimeSpan timeout, object targetName,
             string messageClassName, ActorRef sender = null)
         {
-            sender = sender ?? NoSender;
+            sender = sender ?? ActorRefs.NoSender;
             var result = new TaskCompletionSource<object>();
             var a = new PromiseActorRef(provider, result, messageClassName);
             var scheduler = provider.Guardian.Underlying.System.Scheduler.Advanced;
@@ -345,7 +345,7 @@ namespace Akka.Actor
             else if (message is DeathWatchNotification)
             {
                 var dw = message as DeathWatchNotification;
-                Tell(new Terminated(dw.Actor, dw.ExistenceConfirmed, dw.AddressTerminated));
+                Tell(new Terminated(dw.Actor, dw.ExistenceConfirmed, dw.AddressTerminated), this);
             }
             else if (message is Watch)
             {

--- a/src/core/Akka/Actor/GracefulStopSupport.cs
+++ b/src/core/Akka/Actor/GracefulStopSupport.cs
@@ -52,7 +52,7 @@ namespace Akka.Actor
 
             var fref = new FutureActorRef(promise, unregister, path);
             internalTarget.Tell(new Watch(internalTarget, fref));
-            target.Tell(stopMessage, ActorRef.NoSender);
+            target.Tell(stopMessage, ActorRefs.NoSender);
             return promise.Task.ContinueWith(t =>
             {
                 var returnResult = false;

--- a/src/core/Akka/Actor/GracefulStopSupport.cs
+++ b/src/core/Akka/Actor/GracefulStopSupport.cs
@@ -27,14 +27,14 @@ namespace Akka.Actor
     /// </summary>
     public static class GracefulStopSupport
     {
-        public static Task<bool> GracefulStop(this ActorRef target, TimeSpan timeout)
+        public static Task<bool> GracefulStop(this IActorRef target, TimeSpan timeout)
         {
             return GracefulStop(target, timeout, PoisonPill.Instance);
         }
 
-        public static Task<bool> GracefulStop(this ActorRef target, TimeSpan timeout, object stopMessage)
+        public static Task<bool> GracefulStop(this IActorRef target, TimeSpan timeout, object stopMessage)
         {
-            var internalTarget = target.AsInstanceOf<InternalActorRef>();
+            var internalTarget = target.AsInstanceOf<IInternalActorRef>();
             if (internalTarget.IsTerminated) return Task.Run(() => true);
 
             var provider = Futures.ResolveProvider(target);

--- a/src/core/Akka/Actor/IActorContext.cs
+++ b/src/core/Akka/Actor/IActorContext.cs
@@ -37,7 +37,7 @@ namespace Akka.Actor
         /// Gets the <see cref="ActorRef"/> of the actor who sent the current message.
         /// 
         /// If the message was not sent by an actor (i.e. some external non-actor code
-        /// sent this actor a message) then this value will default to <see cref="ActorRef.NoSender"/>.
+        /// sent this actor a message) then this value will default to <see cref="ActorRefs.NoSender"/>.
         /// </summary>
         ActorRef Sender { get; }
 
@@ -62,7 +62,7 @@ namespace Akka.Actor
         /// Retrieves a child actor with the specified name, if it exists.
         /// 
         /// If the child with the given name cannot be found, 
-        /// then <see cref="ActorRef.Nobody"/> will be returned instead.
+        /// then <see cref="ActorRefs.Nobody"/> will be returned instead.
         /// </summary>
         /// <param name="name">
         /// The name of the child actor.
@@ -71,7 +71,7 @@ namespace Akka.Actor
         /// 
         /// Not the path, just the name of the child at the time it was created by this parent.
         /// </param>
-        /// <returns>The <see cref="ActorRef"/> belonging to the child if found, <see cref="ActorRef.Nobody"/> otherwise.</returns>
+        /// <returns>The <see cref="ActorRef"/> belonging to the child if found, <see cref="ActorRefs.Nobody"/> otherwise.</returns>
         ActorRef Child(string name);
 
         /// <summary>

--- a/src/core/Akka/Actor/IActorContext.cs
+++ b/src/core/Akka/Actor/IActorContext.cs
@@ -15,31 +15,31 @@ namespace Akka.Actor
 		/// </summary>
 		/// <param name="subject">The actor to monitor for termination.</param>
 		/// <returns>Returns the provided subject</returns>
-        ActorRef Watch(ActorRef subject);
+        IActorRef Watch(IActorRef subject);
 
 		/// <summary>
 		/// Stops monitoring the <paramref name="subject"/> for termination.
 		/// </summary>
 		/// <param name="subject">The actor to stop monitor for termination.</param>
 		/// <returns>Returns the provided subject</returns>
-        ActorRef Unwatch(ActorRef subject);
+        IActorRef Unwatch(IActorRef subject);
     }
 
     public interface IActorContext : ActorRefFactory, ICanWatch
     {
         /// <summary>
-        /// Gets the <see cref="ActorRef"/> belonging to the current actor.
+        /// Gets the <see cref="IActorRef"/> belonging to the current actor.
         /// </summary>
-        ActorRef Self { get; }
+        IActorRef Self { get; }
         Props Props { get; }
 
         /// <summary>
-        /// Gets the <see cref="ActorRef"/> of the actor who sent the current message.
+        /// Gets the <see cref="IActorRef"/> of the actor who sent the current message.
         /// 
         /// If the message was not sent by an actor (i.e. some external non-actor code
         /// sent this actor a message) then this value will default to <see cref="ActorRefs.NoSender"/>.
         /// </summary>
-        ActorRef Sender { get; }
+        IActorRef Sender { get; }
 
         /// <summary>
         /// Gets a reference to the <see cref="ActorSystem"/> to which this actor belongs.
@@ -52,9 +52,9 @@ namespace Akka.Actor
         ActorSystem System { get; }
 
         /// <summary>
-        /// Gets the <see cref="ActorRef"/> of the parent of the current actor.
+        /// Gets the <see cref="IActorRef"/> of the parent of the current actor.
         /// </summary>
-        ActorRef Parent { get; }
+        IActorRef Parent { get; }
         void Become(Receive receive, bool discardOld = true);
         void Unbecome();
 
@@ -71,16 +71,16 @@ namespace Akka.Actor
         /// 
         /// Not the path, just the name of the child at the time it was created by this parent.
         /// </param>
-        /// <returns>The <see cref="ActorRef"/> belonging to the child if found, <see cref="ActorRefs.Nobody"/> otherwise.</returns>
-        ActorRef Child(string name);
+        /// <returns>The <see cref="IActorRef"/> belonging to the child if found, <see cref="ActorRefs.Nobody"/> otherwise.</returns>
+        IActorRef Child(string name);
 
         /// <summary>
         /// Gets all of the children that belong to this actor.
         /// 
         /// If this actor has no children, 
-        /// an empty collection of <see cref="ActorRef"/> is returned instead.
+        /// an empty collection of <see cref="IActorRef"/> is returned instead.
         /// </summary>
-        IEnumerable<ActorRef> GetChildren();
+        IEnumerable<IActorRef> GetChildren();
 
         /// <summary>
         /// <para>
@@ -119,9 +119,9 @@ namespace Akka.Actor
          */
 
         /// <summary>
-        /// Issues a stop command to the provided <see cref="ActorRef"/>, which will cause that actor
+        /// Issues a stop command to the provided <see cref="IActorRef"/>, which will cause that actor
         /// to terminate.
         /// </summary>
-        void Stop(ActorRef child);
+        void Stop(IActorRef child);
     }
 }

--- a/src/core/Akka/Actor/ICanTell.cs
+++ b/src/core/Akka/Actor/ICanTell.cs
@@ -2,6 +2,6 @@
 {
     public interface ICanTell
     {
-        void Tell(object message, ActorRef sender);
+        void Tell(object message, IActorRef sender);
     }
 }

--- a/src/core/Akka/Actor/Internals/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internals/ActorSystemImpl.cs
@@ -17,7 +17,7 @@ namespace Akka.Actor.Internals
     /// </summary>
     public class ActorSystemImpl : ExtendedActorSystem
     {
-        private ActorRef _logDeadLetterListener;
+        private IActorRef _logDeadLetterListener;
         private readonly ConcurrentDictionary<Type, Lazy<object>> _extensions = new ConcurrentDictionary<Type, Lazy<object>>();
 
         private LoggingAdapter _log;
@@ -60,7 +60,7 @@ namespace Akka.Actor.Internals
         public override string Name { get { return _name; } }
         public override Serialization.Serialization Serialization { get { return _serialization; } }
         public override EventStream EventStream { get { return _eventStream; } }
-        public override ActorRef DeadLetters { get { return Provider.DeadLetters; } }
+        public override IActorRef DeadLetters { get { return Provider.DeadLetters; } }
         public override Dispatchers Dispatchers { get { return _dispatchers; } }
         public override Mailboxes Mailboxes { get { return _mailboxes; } }
         public override IScheduler Scheduler { get { return _scheduler; } }
@@ -69,18 +69,18 @@ namespace Akka.Actor.Internals
         public override ActorProducerPipelineResolver ActorPipelineResolver { get { return _actorProducerPipelineResolver; } }
 
 
-        public override InternalActorRef Guardian { get { return _provider.Guardian; } }
-        public override InternalActorRef SystemGuardian { get { return _provider.SystemGuardian; } }
+        public override IInternalActorRef Guardian { get { return _provider.Guardian; } }
+        public override IInternalActorRef SystemGuardian { get { return _provider.SystemGuardian; } }
 
 
         /// <summary>Creates a new system actor.</summary>
-        public override ActorRef SystemActorOf(Props props, string name = null)
+        public override IActorRef SystemActorOf(Props props, string name = null)
         {
             return _provider.SystemGuardian.Cell.ActorOf(props, name: name);
         }
 
         /// <summary>Creates a new system actor.</summary>
-        public override ActorRef SystemActorOf<TActor>(string name = null)
+        public override IActorRef SystemActorOf<TActor>(string name = null)
         {
             return _provider.SystemGuardian.Cell.ActorOf<TActor>(name);
         }
@@ -102,7 +102,7 @@ namespace Akka.Actor.Internals
             }
         }
 
-        public override ActorRef ActorOf(Props props, string name = null)
+        public override IActorRef ActorOf(Props props, string name = null)
         {
             return _provider.Guardian.Cell.ActorOf(props, name: name);
         }
@@ -323,7 +323,7 @@ namespace Akka.Actor.Internals
             }
         }
 
-        public override void Stop(ActorRef actor)
+        public override void Stop(IActorRef actor)
         {
             var path = actor.Path;
             var parentPath = path.Parent;
@@ -332,7 +332,7 @@ namespace Akka.Actor.Internals
             else if(parentPath == _provider.SystemGuardian.Path)
                 _provider.SystemGuardian.Tell(new StopChild(actor));
             else
-                ((InternalActorRef)actor).Stop();
+                ((IInternalActorRef)actor).Stop();
         }
 
 

--- a/src/core/Akka/Actor/LocalActorRef.cs
+++ b/src/core/Akka/Actor/LocalActorRef.cs
@@ -143,7 +143,7 @@ namespace Akka.Actor
         public override InternalActorRef GetSingleChild(string name)
         {
             InternalActorRef child;
-            return _cell.TryGetSingleChild(name, out child) ? child : Nobody;
+            return _cell.TryGetSingleChild(name, out child) ? child : ActorRefs.Nobody;
         }
 
         public override ActorRef GetChild(IEnumerable<string> name)

--- a/src/core/Akka/Actor/LocalActorRef.cs
+++ b/src/core/Akka/Actor/LocalActorRef.cs
@@ -13,7 +13,7 @@ namespace Akka.Actor
         private readonly Props _props;
         private readonly MessageDispatcher _dispatcher;
         private readonly Func<Mailbox> _createMailbox;
-        private readonly InternalActorRef _supervisor;
+        private readonly IInternalActorRef _supervisor;
         private readonly ActorPath _path;
         private ActorCell _cell;
 
@@ -33,7 +33,7 @@ namespace Akka.Actor
         //      actorCell.init(sendSupervise = true, _mailboxType)
         //      ...
         //    }
-        public LocalActorRef(ActorSystemImpl system, Props props, MessageDispatcher dispatcher, Func<Mailbox> createMailbox, InternalActorRef supervisor, ActorPath path) //TODO: switch from  Func<Mailbox> createMailbox to MailboxType mailboxType      
+        public LocalActorRef(ActorSystemImpl system, Props props, MessageDispatcher dispatcher, Func<Mailbox> createMailbox, IInternalActorRef supervisor, ActorPath path) //TODO: switch from  Func<Mailbox> createMailbox to MailboxType mailboxType      
             : this(system, props, dispatcher, createMailbox, supervisor, path, self =>
             {
                 var cell= new ActorCell(system, self, props, dispatcher, supervisor);
@@ -48,7 +48,7 @@ namespace Akka.Actor
         /// <summary>
         /// Inheritors should only call this constructor
         /// </summary>
-        internal protected  LocalActorRef(ActorSystem system, Props props, MessageDispatcher dispatcher, Func<Mailbox> createMailbox, InternalActorRef supervisor, ActorPath path, Func<LocalActorRef, ActorCell> createActorCell) //TODO: switch from  Func<Mailbox> createMailbox to MailboxType mailboxType      
+        internal protected  LocalActorRef(ActorSystem system, Props props, MessageDispatcher dispatcher, Func<Mailbox> createMailbox, IInternalActorRef supervisor, ActorPath path, Func<LocalActorRef, ActorCell> createActorCell) //TODO: switch from  Func<Mailbox> createMailbox to MailboxType mailboxType      
         {
             _system = system;
             _props = props;
@@ -75,12 +75,12 @@ namespace Akka.Actor
             get { return _cell.SystemImpl.Provider; }
         }
 
-        public override InternalActorRef Parent
+        public override IInternalActorRef Parent
         {
             get { return _cell.Parent; }
         }
 
-        public override IEnumerable<ActorRef> Children
+        public override IEnumerable<IActorRef> Children
         {
             get { return _cell.GetChildren(); }
         }
@@ -116,7 +116,7 @@ namespace Akka.Actor
 
         protected MessageDispatcher Dispatcher{get { return _dispatcher; }}
 
-        protected InternalActorRef Supervisor{get { return _supervisor; }}
+        protected IInternalActorRef Supervisor{get { return _supervisor; }}
 
         public override bool IsTerminated { get { return _cell.IsTerminated; } }
 
@@ -135,20 +135,20 @@ namespace Akka.Actor
             _cell.Restart(cause);
         }
 
-        protected override void TellInternal(object message, ActorRef sender)
+        protected override void TellInternal(object message, IActorRef sender)
         {
             _cell.Post(sender, message);
         }
 
-        public override InternalActorRef GetSingleChild(string name)
+        public override IInternalActorRef GetSingleChild(string name)
         {
-            InternalActorRef child;
+            IInternalActorRef child;
             return _cell.TryGetSingleChild(name, out child) ? child : ActorRefs.Nobody;
         }
 
-        public override ActorRef GetChild(IEnumerable<string> name)
+        public override IActorRef GetChild(IEnumerable<string> name)
         {
-            var current = (ActorRef) this;
+            var current = (IActorRef) this;
             int index = 0;
             foreach (string element in name)
             {
@@ -173,7 +173,7 @@ namespace Akka.Actor
                     if (current != null)
                     {
                         var rest = name.Skip(index).ToList();
-                        return current.AsInstanceOf<InternalActorRef>().GetChild(rest);
+                        return current.AsInstanceOf<IInternalActorRef>().GetChild(rest);
                     }
                     throw new NotSupportedException("Bug, we should not get here");
                 }

--- a/src/core/Akka/Actor/Message.cs
+++ b/src/core/Akka/Actor/Message.cs
@@ -11,7 +11,7 @@
         ///     Gets or sets the sender.
         /// </summary>
         /// <value>The sender.</value>
-        public ActorRef Sender { get; set; }
+        public IActorRef Sender { get; set; }
 
         /// <summary>
         ///     Gets or sets the message.

--- a/src/core/Akka/Actor/PipeToSupport.cs
+++ b/src/core/Akka/Actor/PipeToSupport.cs
@@ -12,7 +12,7 @@ namespace Akka.Actor
         /// Pipes the output of a Task directly to the <see cref="recipient"/>'s mailbox once
         /// the task completes
         /// </summary>
-        public static Task PipeTo<T>(this Task<T> taskToPipe, ICanTell recipient, ActorRef sender = null)
+        public static Task PipeTo<T>(this Task<T> taskToPipe, ICanTell recipient, IActorRef sender = null)
         {
             sender = sender ?? ActorRefs.NoSender;
             return taskToPipe.ContinueWith(tresult =>

--- a/src/core/Akka/Actor/PipeToSupport.cs
+++ b/src/core/Akka/Actor/PipeToSupport.cs
@@ -14,7 +14,7 @@ namespace Akka.Actor
         /// </summary>
         public static Task PipeTo<T>(this Task<T> taskToPipe, ICanTell recipient, ActorRef sender = null)
         {
-            sender = sender ?? ActorRef.NoSender;
+            sender = sender ?? ActorRefs.NoSender;
             return taskToPipe.ContinueWith(tresult =>
             {
                 if(tresult.IsCanceled  || tresult.IsFaulted)

--- a/src/core/Akka/Actor/RepointableActorRef.cs
+++ b/src/core/Akka/Actor/RepointableActorRef.cs
@@ -19,10 +19,10 @@ namespace Akka.Actor
         private readonly Props _props;
         private readonly MessageDispatcher _dispatcher;
         private readonly Func<Mailbox> _createMailbox;
-        private readonly InternalActorRef _supervisor;
+        private readonly IInternalActorRef _supervisor;
         private readonly ActorPath _path;
 
-        public RepointableActorRef(ActorSystemImpl system, Props props, MessageDispatcher dispatcher, Func<Mailbox> createMailbox, InternalActorRef supervisor, ActorPath path)
+        public RepointableActorRef(ActorSystemImpl system, Props props, MessageDispatcher dispatcher, Func<Mailbox> createMailbox, IInternalActorRef supervisor, ActorPath path)
         {
             _system = system;
             _props = props;
@@ -122,7 +122,7 @@ namespace Akka.Actor
 
         public override ActorPath Path { get { return _path; } }
 
-        public override InternalActorRef Parent { get { return Underlying.Parent; } }
+        public override IInternalActorRef Parent { get { return Underlying.Parent; } }
 
         public override ActorRefProvider Provider { get { return _system.Provider; } }
 
@@ -166,14 +166,14 @@ namespace Akka.Actor
             }
         }
 
-        protected override void TellInternal(object message, ActorRef sender)
+        protected override void TellInternal(object message, IActorRef sender)
         {
             Underlying.Post(sender, message);
         }
 
-        public override ActorRef GetChild(IEnumerable<string> name)
+        public override IActorRef GetChild(IEnumerable<string> name)
         {
-            var current = (ActorRef)this;
+            var current = (IActorRef)this;
             var index = 0;
             foreach(var element in name)
             {
@@ -202,12 +202,12 @@ namespace Akka.Actor
             return current;
         }
 
-        public override InternalActorRef GetSingleChild(string name)
+        public override IInternalActorRef GetSingleChild(string name)
         {
             return Lookup.GetSingleChild(name);
         }
 
-        public override IEnumerable<ActorRef> Children
+        public override IEnumerable<IActorRef> Children
         {
             get { return Lookup.GetChildren(); }
         }
@@ -219,12 +219,12 @@ namespace Akka.Actor
         private readonly ActorSystemImpl _system;
         private readonly RepointableActorRef _self;
         private readonly Props _props;
-        private readonly InternalActorRef _supervisor;
+        private readonly IInternalActorRef _supervisor;
         private readonly object _lock = new object();
         private readonly List<Envelope> _messageQueue = new List<Envelope>();
         private readonly TimeSpan _timeout;
 
-        public UnstartedCell(ActorSystemImpl system, RepointableActorRef self, Props props, InternalActorRef supervisor)
+        public UnstartedCell(ActorSystemImpl system, RepointableActorRef self, Props props, IInternalActorRef supervisor)
         {
             _system = system;
             _self = self;
@@ -279,19 +279,19 @@ namespace Akka.Actor
             SendSystemMessage(Terminate.Instance, ActorCell.GetCurrentSelfOrNoSender());
         }
 
-        public InternalActorRef Parent { get { return _supervisor; } }
+        public IInternalActorRef Parent { get { return _supervisor; } }
 
-        public IEnumerable<InternalActorRef> GetChildren()
+        public IEnumerable<IInternalActorRef> GetChildren()
         {
-            return Enumerable.Empty<InternalActorRef>();
+            return Enumerable.Empty<IInternalActorRef>();
         }
 
-        public InternalActorRef GetSingleChild(string name)
+        public IInternalActorRef GetSingleChild(string name)
         {
             return Nobody.Instance;
         }
 
-        public InternalActorRef GetChildByName(string name)
+        public IInternalActorRef GetChildByName(string name)
         {
             return Nobody.Instance;
         }
@@ -302,7 +302,7 @@ namespace Akka.Actor
             return false;
         }
 
-        public void Post(ActorRef sender, object message)
+        public void Post(IActorRef sender, object message)
         {
             if(message is SystemMessage)
                 SendSystemMessage(message, sender);
@@ -310,7 +310,7 @@ namespace Akka.Actor
                 SendMessage(message, sender);
         }
 
-        private void SendMessage(object message, ActorRef sender)
+        private void SendMessage(object message, IActorRef sender)
         {
             if(Monitor.TryEnter(_lock, _timeout))
             {
@@ -339,7 +339,7 @@ namespace Akka.Actor
             }
         }
 
-        private void SendSystemMessage(object message, ActorRef sender)
+        private void SendSystemMessage(object message, IActorRef sender)
         {
             lock(_lock)
             {
@@ -442,7 +442,7 @@ namespace Akka.Actor
             }
         }
 
-        public ActorRef Self { get { return _self; } }
+        public IActorRef Self { get { return _self; } }
         public Props Props { get { return _props; } }
     }
 }

--- a/src/core/Akka/Actor/RepointableActorRef.cs
+++ b/src/core/Akka/Actor/RepointableActorRef.cs
@@ -195,7 +195,7 @@ namespace Akka.Actor
                                 crs.Child.GetChild(name.Skip(index));
                             }
                         }
-                        return Nobody;
+                        return ActorRefs.Nobody;
                 }
                 index++;
             }

--- a/src/core/Akka/Actor/RootGuardianActorRef.cs
+++ b/src/core/Akka/Actor/RootGuardianActorRef.cs
@@ -7,26 +7,26 @@ namespace Akka.Actor
 {
     public class RootGuardianActorRef : LocalActorRef
     {
-        private InternalActorRef _tempContainer;
-        private readonly InternalActorRef _deadLetters;
-        private readonly IReadOnlyDictionary<string, InternalActorRef> _extraNames;
+        private IInternalActorRef _tempContainer;
+        private readonly IInternalActorRef _deadLetters;
+        private readonly IReadOnlyDictionary<string, IInternalActorRef> _extraNames;
 
         public RootGuardianActorRef(ActorSystemImpl system, Props props, MessageDispatcher dispatcher, Func<Mailbox> createMailbox, //TODO: switch from  Func<Mailbox> createMailbox to MailboxType mailboxType
-            InternalActorRef supervisor, ActorPath path, InternalActorRef deadLetters, IReadOnlyDictionary<string, InternalActorRef> extraNames)
+            IInternalActorRef supervisor, ActorPath path, IInternalActorRef deadLetters, IReadOnlyDictionary<string, IInternalActorRef> extraNames)
             : base(system,props,dispatcher,createMailbox,supervisor,path)
         {
             _deadLetters = deadLetters;
             _extraNames = extraNames;
         }
 
-        public override InternalActorRef Parent { get { return this; } }
+        public override IInternalActorRef Parent { get { return this; } }
 
-        public void SetTempContainer(InternalActorRef tempContainer)
+        public void SetTempContainer(IInternalActorRef tempContainer)
         {
             _tempContainer = tempContainer;
         }
 
-        public override InternalActorRef GetSingleChild(string name)
+        public override IInternalActorRef GetSingleChild(string name)
         {
             switch(name)
             {
@@ -35,7 +35,7 @@ namespace Akka.Actor
                 case "deadLetters":
                     return _deadLetters;
                 default:
-                    InternalActorRef extraActorRef;
+                    IInternalActorRef extraActorRef;
                     if(_extraNames.TryGetValue(name, out extraActorRef))
                         return extraActorRef;
                     return base.GetSingleChild(name);

--- a/src/core/Akka/Actor/RootGuardianSupervisor.cs
+++ b/src/core/Akka/Actor/RootGuardianSupervisor.cs
@@ -26,7 +26,7 @@ namespace Akka.Actor
             _path = root / "_Root-guardian-supervisor";   //In akka this is root / "bubble-walker" 
         }
 
-        protected override void TellInternal(object message, ActorRef sender)
+        protected override void TellInternal(object message, IActorRef sender)
         {
             var systemMessage = message as SystemMessage;
             if(systemMessage!=null)
@@ -54,7 +54,7 @@ namespace Akka.Actor
                     var child = failed.Child;
                     _log.Error(cause, "guardian {0} failed, shutting down!", child);
                     CauseOfTermination = cause;
-                    ((InternalActorRef) child).Stop();
+                    ((IInternalActorRef) child).Stop();
                     return;
                 }
                 var supervise = systemMessage as Supervise;

--- a/src/core/Akka/Actor/Scheduler/DeprecatedSchedulerExtensions.cs
+++ b/src/core/Akka/Actor/Scheduler/DeprecatedSchedulerExtensions.cs
@@ -7,21 +7,21 @@ namespace Akka.Actor
     public static class DeprecatedSchedulerExtensions
     {
         [Obsolete("Use ScheduleTellOnce() or Context.SelfTellOnce() which will return an ICancelable. This method will be removed in future versions.")]
-        public static void ScheduleOnce(this IScheduler scheduler, TimeSpan initialDelay, ActorRef receiver, object message)
+        public static void ScheduleOnce(this IScheduler scheduler, TimeSpan initialDelay, IActorRef receiver, object message)
         {
             var sender = ActorCell.GetCurrentSelfOrNoSender();
             scheduler.Advanced.ScheduleOnce(initialDelay, () => receiver.Tell(message, sender), null);
         }
 
         [Obsolete("Use ScheduleTellOnce() or Context.SelfTellOnce() which will return an ICancelable. This method will be removed in future versions.")]
-        public static void ScheduleOnce(this IScheduler scheduler, TimeSpan initialDelay, ActorRef receiver, object message, CancellationToken cancellationToken)
+        public static void ScheduleOnce(this IScheduler scheduler, TimeSpan initialDelay, IActorRef receiver, object message, CancellationToken cancellationToken)
         {
             var sender = ActorCell.GetCurrentSelfOrNoSender();
             scheduler.Advanced.ScheduleOnce(initialDelay, () => receiver.Tell(message, sender), null);
         }
 
         [Obsolete("Use ScheduleTellRepeatedly() or Context.SelfTellRepeatedely() which will return an ICancelable. This method will be removed in future versions.")]
-        public static void Schedule(this IScheduler scheduler, TimeSpan initialDelay, TimeSpan interval, ActorRef receiver, object message)
+        public static void Schedule(this IScheduler scheduler, TimeSpan initialDelay, TimeSpan interval, IActorRef receiver, object message)
         {
             var sender = ActorCell.GetCurrentSelfOrNoSender();
             scheduler.Advanced.ScheduleRepeatedly(initialDelay, interval, () => receiver.Tell(message, sender), null);
@@ -29,7 +29,7 @@ namespace Akka.Actor
 
 
         [Obsolete("Use ScheduleTellRepeatedly() or Context.SelfTellRepeatedely() instead. This method will be removed in future versions.")]
-        public static void Schedule(this IScheduler scheduler, TimeSpan initialDelay, TimeSpan interval, ActorRef receiver, object message, CancellationToken cancellationToken)
+        public static void Schedule(this IScheduler scheduler, TimeSpan initialDelay, TimeSpan interval, IActorRef receiver, object message, CancellationToken cancellationToken)
         {
             var sender = ActorCell.GetCurrentSelfOrNoSender();
             scheduler.Advanced.ScheduleRepeatedly(initialDelay, interval, () => receiver.Tell(message, sender), null);

--- a/src/core/Akka/Actor/Scheduler/ITellScheduler.cs
+++ b/src/core/Akka/Actor/Scheduler/ITellScheduler.cs
@@ -12,7 +12,7 @@ namespace Akka.Actor
         /// <param name="receiver">The receiver.</param>
         /// <param name="message">The message.</param>
         /// <param name="sender">The sender.</param>
-        void ScheduleTellOnce(TimeSpan delay, ICanTell receiver, object message, ActorRef sender);
+        void ScheduleTellOnce(TimeSpan delay, ICanTell receiver, object message, IActorRef sender);
 
         /// <summary>Schedules to send a message once after a specified period of time.</summary>
         /// <param name="delay">The time period that has to pass before the message is sent.</param>
@@ -20,7 +20,7 @@ namespace Akka.Actor
         /// <param name="message">The message.</param>
         /// <param name="sender">The sender.</param>
         /// <param name="cancelable">An <see cref="ICancelable"/> that can be used to cancel sending of the message. Once the message has been sent, it cannot be canceled.</param>
-        void ScheduleTellOnce(TimeSpan delay, ICanTell receiver, object message, ActorRef sender, ICancelable cancelable);
+        void ScheduleTellOnce(TimeSpan delay, ICanTell receiver, object message, IActorRef sender, ICancelable cancelable);
 
         /// <summary>Schedules to send a message repeatedly. The first message will be sent after the specified initial delay and there after at the rate specified.</summary>
         /// <param name="initialDelay">The time period that has to pass before the first message is sent.</param>
@@ -28,7 +28,7 @@ namespace Akka.Actor
         /// <param name="receiver">The receiver.</param>
         /// <param name="message">The message.</param>
         /// <param name="sender">The sender.</param>
-        void ScheduleTellRepeatedly(TimeSpan initialDelay, TimeSpan interval, ICanTell receiver, object message, ActorRef sender);
+        void ScheduleTellRepeatedly(TimeSpan initialDelay, TimeSpan interval, ICanTell receiver, object message, IActorRef sender);
 
         /// <summary>Schedules to send a message repeatedly. The first message will be sent after the specified initial delay and there after at the rate specified.</summary>
         /// <param name="initialDelay">The time period that has to pass before the first message is sent.</param>
@@ -37,6 +37,6 @@ namespace Akka.Actor
         /// <param name="message">The message.</param>
         /// <param name="sender">The sender.</param>
         /// <param name="cancelable">An <see cref="ICancelable"/> that can be used to cancel sending of the message. Once the message has been sent, it cannot be canceled.</param>
-        void ScheduleTellRepeatedly(TimeSpan initialDelay, TimeSpan interval, ICanTell receiver, object message, ActorRef sender, ICancelable cancelable);
+        void ScheduleTellRepeatedly(TimeSpan initialDelay, TimeSpan interval, ICanTell receiver, object message, IActorRef sender, ICancelable cancelable);
     }
 }

--- a/src/core/Akka/Actor/Scheduler/SchedulerBase.cs
+++ b/src/core/Akka/Actor/Scheduler/SchedulerBase.cs
@@ -4,27 +4,27 @@ namespace Akka.Actor
 {
     public abstract class SchedulerBase : IScheduler, IAdvancedScheduler
     {
-        void ITellScheduler.ScheduleTellOnce(TimeSpan delay, ICanTell receiver, object message, ActorRef sender)
+        void ITellScheduler.ScheduleTellOnce(TimeSpan delay, ICanTell receiver, object message, IActorRef sender)
         {
             ValidateDelay(delay, "delay");
             InternalScheduleTellOnce(delay, receiver, message, sender, null);
         }
 
-        void ITellScheduler.ScheduleTellOnce(TimeSpan delay, ICanTell receiver, object message, ActorRef sender, ICancelable cancelable)
+        void ITellScheduler.ScheduleTellOnce(TimeSpan delay, ICanTell receiver, object message, IActorRef sender, ICancelable cancelable)
         {
             ValidateDelay(delay, "delay");
             InternalScheduleTellOnce(delay, receiver, message, sender, cancelable);
 
         }
 
-        void ITellScheduler.ScheduleTellRepeatedly(TimeSpan initialDelay, TimeSpan interval, ICanTell receiver, object message, ActorRef sender)
+        void ITellScheduler.ScheduleTellRepeatedly(TimeSpan initialDelay, TimeSpan interval, ICanTell receiver, object message, IActorRef sender)
         {
             ValidateDelay(initialDelay, "initialDelay");
             ValidateInterval(interval, "interval");
             InternalScheduleTellRepeatedly(initialDelay, interval, receiver, message, sender, null);
         }
 
-        void ITellScheduler.ScheduleTellRepeatedly(TimeSpan initialDelay, TimeSpan interval, ICanTell receiver, object message, ActorRef sender, ICancelable cancelable)
+        void ITellScheduler.ScheduleTellRepeatedly(TimeSpan initialDelay, TimeSpan interval, ICanTell receiver, object message, IActorRef sender, ICancelable cancelable)
         {
             ValidateDelay(initialDelay, "initialDelay");
             ValidateInterval(interval, "interval");
@@ -64,9 +64,9 @@ namespace Akka.Actor
 
         protected abstract DateTimeOffset TimeNow { get; }
 
-        protected abstract void InternalScheduleTellOnce(TimeSpan delay, ICanTell receiver, object message, ActorRef sender, ICancelable cancelable);
+        protected abstract void InternalScheduleTellOnce(TimeSpan delay, ICanTell receiver, object message, IActorRef sender, ICancelable cancelable);
 
-        protected abstract void InternalScheduleTellRepeatedly(TimeSpan initialDelay, TimeSpan interval, ICanTell receiver, object message, ActorRef sender, ICancelable cancelable);
+        protected abstract void InternalScheduleTellRepeatedly(TimeSpan initialDelay, TimeSpan interval, ICanTell receiver, object message, IActorRef sender, ICancelable cancelable);
 
         protected abstract void InternalScheduleOnce(TimeSpan delay, Action action, ICancelable cancelable);
         protected abstract void InternalScheduleRepeatedly(TimeSpan initialDelay, TimeSpan interval, Action action, ICancelable cancelable);

--- a/src/core/Akka/Actor/Scheduler/SchedulerExtensions.cs
+++ b/src/core/Akka/Actor/Scheduler/SchedulerExtensions.cs
@@ -11,7 +11,7 @@ namespace Akka.Actor
         /// <param name="message">The message.</param>
         /// <param name="sender">The sender.</param>
         /// <param name="cancelable">OPTIONAL. An <see cref="ICancelable"/> that can be used to cancel sending of the message. Notye that once the message has been sent, it cannot be canceled.</param>
-        public static void ScheduleTellOnce(this ITellScheduler scheduler, int millisecondsDelay, ICanTell receiver, object message, ActorRef sender, ICancelable cancelable = null)
+        public static void ScheduleTellOnce(this ITellScheduler scheduler, int millisecondsDelay, ICanTell receiver, object message, IActorRef sender, ICancelable cancelable = null)
         {
             scheduler.ScheduleTellOnce(TimeSpan.FromMilliseconds(millisecondsDelay), receiver, message, sender, cancelable);
         }
@@ -25,7 +25,7 @@ namespace Akka.Actor
         /// <param name="message">The message.</param>
         /// <param name="sender">The sender.</param>
         /// <param name="cancelable">OPTIONAL. An <see cref="ICancelable"/> that can be used to cancel sending of the message. Notye that once the message has been sent, it cannot be canceled.</param>
-        public static void ScheduleTellRepeatedly(this ITellScheduler scheduler, int initialMillisecondsDelay, int millisecondsInterval, ICanTell receiver, object message, ActorRef sender, ICancelable cancelable = null)
+        public static void ScheduleTellRepeatedly(this ITellScheduler scheduler, int initialMillisecondsDelay, int millisecondsInterval, ICanTell receiver, object message, IActorRef sender, ICancelable cancelable = null)
         {
             scheduler.ScheduleTellRepeatedly(TimeSpan.FromMilliseconds(initialMillisecondsDelay), TimeSpan.FromMilliseconds(millisecondsInterval), receiver, message, sender, cancelable);
         }
@@ -68,7 +68,7 @@ namespace Akka.Actor
         /// <param name="message">The message.</param>
         /// <param name="sender">The sender.</param>
         /// <returns>An <see cref="ICancelable"/> that can be used to cancel sending of the message. Once the message already has been sent, it cannot be cancelled.</returns>
-        public static ICancelable ScheduleTellOnceCancelable(this IScheduler scheduler, TimeSpan delay, ICanTell receiver, object message, ActorRef sender)
+        public static ICancelable ScheduleTellOnceCancelable(this IScheduler scheduler, TimeSpan delay, ICanTell receiver, object message, IActorRef sender)
         {
             var cancelable = new Cancelable(scheduler);
             scheduler.ScheduleTellOnce(delay, receiver, message, sender, cancelable);
@@ -82,7 +82,7 @@ namespace Akka.Actor
         /// <param name="message">The message.</param>
         /// <param name="sender">The sender.</param>
         /// <returns>An <see cref="ICancelable"/> that can be used to cancel sending of the message. Once the message already has been sent, it cannot be cancelled.</returns>
-        public static ICancelable ScheduleTellOnceCancelable(this IScheduler scheduler, int millisecondsDelay, ICanTell receiver, object message, ActorRef sender)
+        public static ICancelable ScheduleTellOnceCancelable(this IScheduler scheduler, int millisecondsDelay, ICanTell receiver, object message, IActorRef sender)
         {
             var cancelable = new Cancelable(scheduler);
             scheduler.ScheduleTellOnce(millisecondsDelay, receiver, message, sender, cancelable);
@@ -97,7 +97,7 @@ namespace Akka.Actor
         /// <param name="message">The message.</param>
         /// <param name="sender">The sender.</param>
         /// <returns>An <see cref="ICancelable"/> that can be used to cancel sending of the message. Once the message already has been sent, it cannot be cancelled.</returns>
-        public static ICancelable ScheduleTellRepeatedlyCancelable(this IScheduler scheduler, TimeSpan initialDelay, TimeSpan interval, ICanTell receiver, object message, ActorRef sender)
+        public static ICancelable ScheduleTellRepeatedlyCancelable(this IScheduler scheduler, TimeSpan initialDelay, TimeSpan interval, ICanTell receiver, object message, IActorRef sender)
         {
             var cancelable = new Cancelable(scheduler);
             scheduler.ScheduleTellRepeatedly(initialDelay, interval, receiver, message, sender, cancelable);
@@ -112,7 +112,7 @@ namespace Akka.Actor
         /// <param name="message">The message.</param>
         /// <param name="sender">The sender.</param>
         /// <returns>An <see cref="ICancelable"/> that can be used to cancel sending of the message. Once the message already has been sent, it cannot be cancelled.</returns>
-        public static ICancelable ScheduleTellRepeatedlyCancelable(this IScheduler scheduler, int initialMillisecondsDelay, int millisecondsInterval, ICanTell receiver, object message, ActorRef sender)
+        public static ICancelable ScheduleTellRepeatedlyCancelable(this IScheduler scheduler, int initialMillisecondsDelay, int millisecondsInterval, ICanTell receiver, object message, IActorRef sender)
         {
             var cancelable = new Cancelable(scheduler);
             scheduler.ScheduleTellRepeatedly(initialMillisecondsDelay, millisecondsInterval, receiver, message, sender, cancelable);

--- a/src/core/Akka/Actor/Scheduler/TaskBasedScheduler.cs
+++ b/src/core/Akka/Actor/Scheduler/TaskBasedScheduler.cs
@@ -12,13 +12,13 @@ namespace Akka.Actor
 
         protected override DateTimeOffset TimeNow { get { return DateTimeOffset.Now; } }
 
-        protected override void InternalScheduleTellOnce(TimeSpan delay, ICanTell receiver, object message, ActorRef sender, ICancelable cancelable)
+        protected override void InternalScheduleTellOnce(TimeSpan delay, ICanTell receiver, object message, IActorRef sender, ICancelable cancelable)
         {
             var cancellationToken = cancelable == null ? CancellationToken.None : cancelable.Token;
             InternalScheduleOnce(delay, () => receiver.Tell(message, sender), cancellationToken);
         }
 
-        protected override void InternalScheduleTellRepeatedly(TimeSpan initialDelay, TimeSpan interval, ICanTell receiver, object message, ActorRef sender, ICancelable cancelable)
+        protected override void InternalScheduleTellRepeatedly(TimeSpan initialDelay, TimeSpan interval, ICanTell receiver, object message, IActorRef sender, ICancelable cancelable)
         {
             var cancellationToken = cancelable == null ? CancellationToken.None : cancelable.Token;
             InternalScheduleRepeatedly(initialDelay, interval, () => receiver.Tell(message, sender), cancellationToken);

--- a/src/core/Akka/Actor/SupervisorStrategy.cs
+++ b/src/core/Akka/Actor/SupervisorStrategy.cs
@@ -19,7 +19,7 @@ namespace Akka.Actor
         /// <param name="child">The actor that caused the evaluation to occur</param>
         /// <param name="x">The exception that caused the evaluation to occur.</param>
         /// <returns>Directive.</returns>
-        protected abstract Directive Handle(ActorRef child, Exception x);
+        protected abstract Directive Handle(IActorRef child, Exception x);
 
         /// <summary>
         ///     This is the main entry point: in case of a child’s failure, this method
@@ -90,12 +90,12 @@ namespace Akka.Actor
         /// <param name="child">The child.</param>
         /// <param name="cause">The cause.</param>
         /// <param name="suspendFirst">if set to <c>true</c> [suspend first].</param>
-        protected void RestartChild(ActorRef child, Exception cause, bool suspendFirst)
+        protected void RestartChild(IActorRef child, Exception cause, bool suspendFirst)
         {
-            var c = child.AsInstanceOf<InternalActorRef>();
+            var c = child.AsInstanceOf<IInternalActorRef>();
             if (suspendFirst)
                 c.Suspend();
-            c.AsInstanceOf<InternalActorRef>().Restart(cause);
+            c.AsInstanceOf<IInternalActorRef>().Restart(cause);
         }
 
         /// <summary>
@@ -115,9 +115,9 @@ namespace Akka.Actor
         /// </summary>
         /// <param name="child">The child.</param>
         /// <param name="exception">The exception.</param>
-        protected void ResumeChild(ActorRef child, Exception exception)
+        protected void ResumeChild(IActorRef child, Exception exception)
         {
-            child.AsInstanceOf<InternalActorRef>().Resume(exception);
+            child.AsInstanceOf<IInternalActorRef>().Resume(exception);
         }
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace Akka.Actor
         /// <param name="child">The child.</param>
         /// <param name="cause">The cause.</param>
         /// <param name="directive">The directive.</param>
-        protected virtual void LogFailure(IActorContext context, ActorRef child, Exception cause, Directive directive)
+        protected virtual void LogFailure(IActorContext context, IActorRef child, Exception cause, Directive directive)
         {
             if(LoggingEnabled)
             {
@@ -181,7 +181,7 @@ namespace Akka.Actor
         /// It does not need to do anything special. Exceptions thrown from this method
         /// do NOT make the actor fail if this happens during termination.
         /// </summary>
-        public abstract void HandleChildTerminated(IActorContext actorContext, ActorRef child, IEnumerable<InternalActorRef> children);
+        public abstract void HandleChildTerminated(IActorContext actorContext, IActorRef child, IEnumerable<IInternalActorRef> children);
 
     }
 
@@ -296,7 +296,7 @@ namespace Akka.Actor
         /// <param name="child">The child.</param>
         /// <param name="x">The x.</param>
         /// <returns>Directive.</returns>
-        protected override Directive Handle(ActorRef child, Exception x)
+        protected override Directive Handle(IActorRef child, Exception x)
         {
             return Decider.Decide(x);
         }
@@ -312,7 +312,7 @@ namespace Akka.Actor
         }
 
 
-        public override void HandleChildTerminated(IActorContext actorContext, ActorRef child, IEnumerable<InternalActorRef> children)
+        public override void HandleChildTerminated(IActorContext actorContext, IActorRef child, IEnumerable<IInternalActorRef> children)
         {
             //Intentionally left blank
         }
@@ -431,7 +431,7 @@ namespace Akka.Actor
         /// <param name="child">The child.</param>
         /// <param name="x">The x.</param>
         /// <returns>Directive.</returns>
-        protected override Directive Handle(ActorRef child, Exception x)
+        protected override Directive Handle(IActorRef child, Exception x)
         {
             return Decider.Decide(x);
         }
@@ -459,7 +459,7 @@ namespace Akka.Actor
             }
         }
 
-        public override void HandleChildTerminated(IActorContext actorContext, ActorRef child, IEnumerable<InternalActorRef> children)
+        public override void HandleChildTerminated(IActorContext actorContext, IActorRef child, IEnumerable<IInternalActorRef> children)
         {
             //Intentionally left blank
         }

--- a/src/core/Akka/Dispatch/ActorTaskScheduler.cs
+++ b/src/core/Akka/Dispatch/ActorTaskScheduler.cs
@@ -62,7 +62,7 @@ namespace Akka.Dispatch
                 if (task.IsFaulted)
                     Rethrow(task, null);
 
-            }), ActorRef.NoSender);
+            }), ActorRefs.NoSender);
         }
 
         protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)

--- a/src/core/Akka/Dispatch/ActorTaskScheduler.cs
+++ b/src/core/Akka/Dispatch/ActorTaskScheduler.cs
@@ -16,8 +16,8 @@ namespace Akka.Dispatch
 
     public class AmbientState
     {
-        public ActorRef Self { get; set; }
-        public ActorRef Sender { get; set; }
+        public IActorRef Self { get; set; }
+        public IActorRef Sender { get; set; }
         public object Message { get; set; }
     }
 
@@ -29,7 +29,7 @@ namespace Akka.Dispatch
         private const string Faulted = "faulted";
         private static readonly object Outer = new object();
 
-        public static void SetCurrentState(ActorRef self, ActorRef sender, object message)
+        public static void SetCurrentState(IActorRef self, IActorRef sender, object message)
         {
             CallContext.LogicalSetData(StateKey, new AmbientState
             {

--- a/src/core/Akka/Dispatch/ConcurrentQueueMailbox.cs
+++ b/src/core/Akka/Dispatch/ConcurrentQueueMailbox.cs
@@ -136,7 +136,7 @@ namespace Akka.Dispatch
         /// </summary>
         /// <param name="receiver"></param>
         /// <param name="envelope"> The envelope. </param>
-        public override void Post(ActorRef receiver, Envelope envelope)
+        public override void Post(IActorRef receiver, Envelope envelope)
         {
             if (_isClosed)
                 return;

--- a/src/core/Akka/Dispatch/DequeBasedMailbox.cs
+++ b/src/core/Akka/Dispatch/DequeBasedMailbox.cs
@@ -21,6 +21,6 @@ namespace Akka.Dispatch
         /// </summary>
         /// <param name="receiver">The intended recipient of the message.</param>
         /// <param name="envelope">The message that will be appended to the queue.</param>
-        void Post(ActorRef receiver, Envelope envelope);
+        void Post(IActorRef receiver, Envelope envelope);
     }
 }

--- a/src/core/Akka/Dispatch/FutureActor.cs
+++ b/src/core/Akka/Dispatch/FutureActor.cs
@@ -8,7 +8,7 @@ namespace Akka.Dispatch
     /// </summary>
     public class FutureActor : ActorBase
     {
-        private ActorRef respondTo;
+        private IActorRef respondTo;
         private TaskCompletionSource<object> result;
 
         /// <summary>
@@ -23,7 +23,7 @@ namespace Akka.Dispatch
         /// </summary>
         /// <param name="completionSource">The completion source.</param>
         /// <param name="respondTo">The respond to.</param>
-        public FutureActor(TaskCompletionSource<object> completionSource, ActorRef respondTo)
+        public FutureActor(TaskCompletionSource<object> completionSource, IActorRef respondTo)
         {
             result = completionSource;
             this.respondTo = respondTo ?? ActorRefs.NoSender;
@@ -37,7 +37,7 @@ namespace Akka.Dispatch
         {
             //if there is no listening actor asking,
             //just eval the result directly
-            ((InternalActorRef)Self).Stop();
+            ((IInternalActorRef)Self).Stop();
             Become(EmptyReceive);
 
             result.SetResult(message);

--- a/src/core/Akka/Dispatch/FutureActor.cs
+++ b/src/core/Akka/Dispatch/FutureActor.cs
@@ -26,7 +26,7 @@ namespace Akka.Dispatch
         public FutureActor(TaskCompletionSource<object> completionSource, ActorRef respondTo)
         {
             result = completionSource;
-            this.respondTo = respondTo ?? ActorRef.NoSender;
+            this.respondTo = respondTo ?? ActorRefs.NoSender;
         }
 
         /// <summary>

--- a/src/core/Akka/Dispatch/GenericMailbox.cs
+++ b/src/core/Akka/Dispatch/GenericMailbox.cs
@@ -157,7 +157,7 @@ namespace Akka.Dispatch
         /// </summary>
         /// <param name="receiver"></param>
         /// <param name="envelope"> The envelope. </param>
-        public override void Post(ActorRef receiver, Envelope envelope)
+        public override void Post(IActorRef receiver, Envelope envelope)
         {
             if (_isClosed)
                 return;

--- a/src/core/Akka/Dispatch/Mailbox.cs
+++ b/src/core/Akka/Dispatch/Mailbox.cs
@@ -56,7 +56,7 @@ namespace Akka.Dispatch
         /// </summary>
         /// <param name="receiver"></param>
         /// <param name="envelope">The envelope.</param>
-        public abstract void Post(ActorRef receiver, Envelope envelope);
+        public abstract void Post(IActorRef receiver, Envelope envelope);
 
         /// <summary>
         ///     Stops this instance.

--- a/src/core/Akka/Dispatch/SysMsg/SystemMessage.cs
+++ b/src/core/Akka/Dispatch/SysMsg/SystemMessage.cs
@@ -39,7 +39,7 @@ namespace Akka.Dispatch.SysMsg
         /// <param name="actor">The actor.</param>
         /// <param name="existenceConfirmed">if set to <c>true</c> [existence confirmed].</param>
         /// <param name="addressTerminated">if set to <c>true</c> [address terminated].</param>
-        public DeathWatchNotification(ActorRef actor, bool existenceConfirmed, bool addressTerminated)
+        public DeathWatchNotification(IActorRef actor, bool existenceConfirmed, bool addressTerminated)
         {
             Actor = actor;
             ExistenceConfirmed = existenceConfirmed;
@@ -50,7 +50,7 @@ namespace Akka.Dispatch.SysMsg
         ///     Gets the actor.
         /// </summary>
         /// <value>The actor.</value>
-        public ActorRef Actor { get; private set; }
+        public IActorRef Actor { get; private set; }
 
         /// <summary>
         ///     Gets a value indicating whether [existence confirmed].
@@ -77,7 +77,7 @@ namespace Akka.Dispatch.SysMsg
     {
         private readonly long _uid;
         private readonly Exception _cause;
-        private readonly ActorRef _child;
+        private readonly IActorRef _child;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="Failed" /> class.
@@ -85,7 +85,7 @@ namespace Akka.Dispatch.SysMsg
         /// <param name="child">The child.</param>
         /// <param name="cause">The cause.</param>
         /// <param name="uid">The uid</param>
-        public Failed(ActorRef child, Exception cause, long uid)
+        public Failed(IActorRef child, Exception cause, long uid)
         {
             _uid = uid;
             _child = child;
@@ -96,7 +96,7 @@ namespace Akka.Dispatch.SysMsg
         ///     Gets the child.
         /// </summary>
         /// <value>The child.</value>
-        public ActorRef Child { get { return _child; } }
+        public IActorRef Child { get { return _child; } }
 
         /// <summary>
         ///     Gets the cause.
@@ -122,7 +122,7 @@ namespace Akka.Dispatch.SysMsg
         /// </summary>
         /// <param name="child">The child.</param>
         /// <param name="async">if set to <c>true</c> [asynchronous].</param>
-        public Supervise(ActorRef child, bool async)
+        public Supervise(IActorRef child, bool async)
         {
             Child = child;
             Async = async;
@@ -138,7 +138,7 @@ namespace Akka.Dispatch.SysMsg
         ///     Gets the child.
         /// </summary>
         /// <value>The child.</value>
-        public ActorRef Child { get; private set; }
+        public IActorRef Child { get; private set; }
 
         public override string ToString()
         {
@@ -157,7 +157,7 @@ namespace Akka.Dispatch.SysMsg
         /// </summary>
         /// <param name="watchee">The watchee.</param>
         /// <param name="watcher">The watcher.</param>
-        public Watch(ActorRef watchee, ActorRef watcher)
+        public Watch(IActorRef watchee, IActorRef watcher)
         {
             Watchee = watchee;
             Watcher = watcher;
@@ -167,13 +167,13 @@ namespace Akka.Dispatch.SysMsg
         ///     Gets the watchee.
         /// </summary>
         /// <value>The watchee.</value>
-        public ActorRef Watchee { get; private set; }
+        public IActorRef Watchee { get; private set; }
 
         /// <summary>
         ///     Gets the watcher.
         /// </summary>
         /// <value>The watcher.</value>
-        public ActorRef Watcher { get; private set; }
+        public IActorRef Watcher { get; private set; }
 
         public override string ToString()
         {
@@ -192,7 +192,7 @@ namespace Akka.Dispatch.SysMsg
         /// </summary>
         /// <param name="watchee">The watchee.</param>
         /// <param name="watcher">The watcher.</param>
-        public Unwatch(ActorRef watchee, ActorRef watcher)
+        public Unwatch(IActorRef watchee, IActorRef watcher)
         {
             Watchee = watchee;
             Watcher = watcher;
@@ -202,13 +202,13 @@ namespace Akka.Dispatch.SysMsg
         ///     Gets the watchee.
         /// </summary>
         /// <value>The watchee.</value>
-        public ActorRef Watchee { get; private set; }
+        public IActorRef Watchee { get; private set; }
 
         /// <summary>
         ///     Gets the watcher.
         /// </summary>
         /// <value>The watcher.</value>
-        public ActorRef Watcher { get; private set; }
+        public IActorRef Watcher { get; private set; }
 
         public override string ToString()
         {
@@ -415,7 +415,7 @@ namespace Akka.Dispatch.SysMsg
         ///     Initializes a new instance of the <see cref="StopChild" /> class.
         /// </summary>
         /// <param name="child">The child.</param>
-        public StopChild(ActorRef child)
+        public StopChild(IActorRef child)
         {
             Child = child;
         }
@@ -424,7 +424,7 @@ namespace Akka.Dispatch.SysMsg
         ///     Gets the child.
         /// </summary>
         /// <value>The child.</value>
-        public ActorRef Child { get; private set; }
+        public IActorRef Child { get; private set; }
 
 
         public override string ToString()

--- a/src/core/Akka/Event/ActorEventBus.cs
+++ b/src/core/Akka/Event/ActorEventBus.cs
@@ -7,7 +7,7 @@ namespace Akka.Event
     /// </summary>
     /// <typeparam name="TEvent">The type of the t event.</typeparam>
     /// <typeparam name="TClassifier">The type of the t classifier.</typeparam>
-    public abstract class ActorEventBus<TEvent, TClassifier> : EventBus<TEvent, TClassifier, ActorRef>
+    public abstract class ActorEventBus<TEvent, TClassifier> : EventBus<TEvent, TClassifier, IActorRef>
     {
     }
 }

--- a/src/core/Akka/Event/AddressTerminatedTopic.cs
+++ b/src/core/Akka/Event/AddressTerminatedTopic.cs
@@ -21,30 +21,30 @@ namespace Akka.Event
     /// </summary>
     internal sealed class AddressTerminatedTopic : IExtension
     {
-        private readonly AtomicReference<HashSet<ActorRef>> _subscribers = new AtomicReference<HashSet<ActorRef>>(new HashSet<ActorRef>());
+        private readonly AtomicReference<HashSet<IActorRef>> _subscribers = new AtomicReference<HashSet<IActorRef>>(new HashSet<IActorRef>());
 
         public static AddressTerminatedTopic Get(ActorSystem system)
         {
             return system.WithExtension<AddressTerminatedTopic>(typeof(AddressTerminatedTopicProvider));
         }
 
-        public void Subscribe(ActorRef subscriber)
+        public void Subscribe(IActorRef subscriber)
         {
             while (true)
             {
                 var current = _subscribers;
-                if (!_subscribers.CompareAndSet(current, new HashSet<ActorRef>(current.Value) {subscriber}))
+                if (!_subscribers.CompareAndSet(current, new HashSet<IActorRef>(current.Value) {subscriber}))
                     continue;
                 break;
             }
         }
 
-        public void Unsubscribe(ActorRef subscriber)
+        public void Unsubscribe(IActorRef subscriber)
         {
             while (true)
             {
                 var current = _subscribers;
-                var newSet = new HashSet<ActorRef>(_subscribers.Value);
+                var newSet = new HashSet<IActorRef>(_subscribers.Value);
                 newSet.Remove(subscriber);
                 if (!_subscribers.CompareAndSet(current, newSet))
                     continue;

--- a/src/core/Akka/Event/AddressTerminatedTopic.cs
+++ b/src/core/Akka/Event/AddressTerminatedTopic.cs
@@ -56,7 +56,7 @@ namespace Akka.Event
         {
             foreach (var subscriber in _subscribers.Value)
             {
-                subscriber.Tell(msg, ActorRef.NoSender);
+                subscriber.Tell(msg, ActorRefs.NoSender);
             }
         }
     }

--- a/src/core/Akka/Event/DeadLetter.cs
+++ b/src/core/Akka/Event/DeadLetter.cs
@@ -13,7 +13,7 @@ namespace Akka.Event
         /// <param name="message">The message.</param>
         /// <param name="sender">The sender.</param>
         /// <param name="recipient">The recipient.</param>
-        public DeadLetter(object message, ActorRef sender, ActorRef recipient)
+        public DeadLetter(object message, IActorRef sender, IActorRef recipient)
         {
             Message = message;
             Sender = sender;
@@ -30,13 +30,13 @@ namespace Akka.Event
         /// Gets the recipient.
         /// </summary>
         /// <value>The recipient.</value>
-        public ActorRef Recipient { get; private set; }
+        public IActorRef Recipient { get; private set; }
 
         /// <summary>
         /// Gets the sender.
         /// </summary>
         /// <value>The sender.</value>
-        public ActorRef Sender { get; private set; }
+        public IActorRef Sender { get; private set; }
 
         public override string ToString()
         {

--- a/src/core/Akka/Event/DeadLetterListener.cs
+++ b/src/core/Akka/Event/DeadLetterListener.cs
@@ -44,8 +44,8 @@ namespace Akka.Event
         protected override bool Receive(object message)
         {
             var deadLetter = (DeadLetter)message;
-            ActorRef snd = deadLetter.Sender;
-            ActorRef rcp = deadLetter.Recipient;
+            IActorRef snd = deadLetter.Sender;
+            IActorRef rcp = deadLetter.Recipient;
             _count++;
             bool done = _maxCount != int.MaxValue && _count >= _maxCount;
             string doneMsg = done ? ", no more dead letters will be logged" : "";
@@ -60,7 +60,7 @@ namespace Akka.Event
             }
             if (done)
             {
-                ((InternalActorRef)Self).Stop();
+                ((IInternalActorRef)Self).Stop();
             }
             return true;
         }

--- a/src/core/Akka/Event/DeadLetterListener.cs
+++ b/src/core/Akka/Event/DeadLetterListener.cs
@@ -51,8 +51,8 @@ namespace Akka.Event
             string doneMsg = done ? ", no more dead letters will be logged" : "";
             if (!done)
             {
-                var rcpPath = rcp == ActorRef.NoSender ? "NoSender" : rcp.Path.ToString();
-                var sndPath = snd == ActorRef.NoSender ? "NoSender" : snd.Path.ToString();
+                var rcpPath = rcp == ActorRefs.NoSender ? "NoSender" : rcp.Path.ToString();
+                var sndPath = snd == ActorRefs.NoSender ? "NoSender" : snd.Path.ToString();
 
                 _eventStream.Publish(new Info(rcpPath, rcp.GetType(),
                     string.Format("Message {0} from {1} to {2} was not delivered. {3} dead letters encountered.{4}",

--- a/src/core/Akka/Event/EventStream.cs
+++ b/src/core/Akka/Event/EventStream.cs
@@ -29,7 +29,7 @@ namespace Akka.Event
         /// <param name="channel">The channel.</param>
         /// <returns><c>true</c> if XXXX, <c>false</c> otherwise.</returns>
         /// <exception cref="System.ArgumentNullException">subscriber</exception>
-        public override bool Subscribe(ActorRef subscriber, Type channel)
+        public override bool Subscribe(IActorRef subscriber, Type channel)
         {
             if (subscriber == null)
                 throw new ArgumentNullException("subscriber");
@@ -46,7 +46,7 @@ namespace Akka.Event
         /// <param name="channel">The channel.</param>
         /// <returns><c>true</c> if XXXX, <c>false</c> otherwise.</returns>
         /// <exception cref="System.ArgumentNullException">subscriber</exception>
-        public override bool Unsubscribe(ActorRef subscriber, Type channel)
+        public override bool Unsubscribe(IActorRef subscriber, Type channel)
         {
             if (subscriber == null)
                 throw new ArgumentNullException("subscriber");
@@ -64,7 +64,7 @@ namespace Akka.Event
         /// <param name="subscriber">The subscriber.</param>
         /// <returns><c>true</c> if XXXX, <c>false</c> otherwise.</returns>
         /// <exception cref="System.ArgumentNullException">subscriber</exception>
-        public override bool Unsubscribe(ActorRef subscriber)
+        public override bool Unsubscribe(IActorRef subscriber)
         {
             if (subscriber == null)
                 throw new ArgumentNullException("subscriber");

--- a/src/core/Akka/Event/LoggingBus.cs
+++ b/src/core/Akka/Event/LoggingBus.cs
@@ -16,7 +16,7 @@ namespace Akka.Event
     {
         private static int _loggerId = 0;
         private static readonly LogLevel[] _allLogLevels = Enum.GetValues(typeof(LogLevel)).Cast<LogLevel>().ToArray();
-        private readonly List<ActorRef> _loggers = new List<ActorRef>();
+        private readonly List<IActorRef> _loggers = new List<IActorRef>();
 
         private LogLevel _logLevel;
 
@@ -42,7 +42,7 @@ namespace Akka.Event
         /// </summary>
         /// <param name="event">The event.</param>
         /// <param name="subscriber">The subscriber.</param>
-        protected override void Publish(object @event, ActorRef subscriber)
+        protected override void Publish(object @event, IActorRef subscriber)
         {
             subscriber.Tell(@event);
         }
@@ -182,7 +182,7 @@ namespace Akka.Event
         public void SetLogLevel(LogLevel logLevel)
         {
             _logLevel = logLevel;
-            foreach (ActorRef logger in _loggers)
+            foreach (IActorRef logger in _loggers)
             {
                 //subscribe to given log level and above
                 SubscribeLogLevelAndAbove(logLevel, logger);
@@ -195,7 +195,7 @@ namespace Akka.Event
             }
         }
 
-        private void SubscribeLogLevelAndAbove(LogLevel logLevel, ActorRef logger)
+        private void SubscribeLogLevelAndAbove(LogLevel logLevel, IActorRef logger)
         {
             //subscribe to given log level and above
             foreach (LogLevel level in _allLogLevels.Where(l => l >= logLevel))

--- a/src/core/Akka/Event/StandardOutLogger.cs
+++ b/src/core/Akka/Event/StandardOutLogger.cs
@@ -43,7 +43,7 @@ namespace Akka.Event
         /// <param name="message">The message.</param>
         /// <param name="sender">The sender.</param>
         /// <exception cref="System.ArgumentNullException">message</exception>
-        protected override void TellInternal(object message, ActorRef sender)
+        protected override void TellInternal(object message, IActorRef sender)
         {
             if(message == null)
                 throw new ArgumentNullException("message");

--- a/src/core/Akka/Event/UnhandledMessage.cs
+++ b/src/core/Akka/Event/UnhandledMessage.cs
@@ -13,7 +13,7 @@ namespace Akka.Event
         /// <param name="message">The message.</param>
         /// <param name="sender">The sender.</param>
         /// <param name="recipient">The recipient.</param>
-        internal UnhandledMessage(object message, ActorRef sender, ActorRef recipient)
+        internal UnhandledMessage(object message, IActorRef sender, IActorRef recipient)
         {
             Message = message;
             Sender = sender;
@@ -30,12 +30,12 @@ namespace Akka.Event
         ///     Gets the sender.
         /// </summary>
         /// <value>The sender.</value>
-        public ActorRef Sender { get; private set; }
+        public IActorRef Sender { get; private set; }
 
         /// <summary>
         ///     Gets the recipient.
         /// </summary>
         /// <value>The recipient.</value>
-        public ActorRef Recipient { get; private set; }
+        public IActorRef Recipient { get; private set; }
     }
 }

--- a/src/core/Akka/Routing/Broadcast.cs
+++ b/src/core/Akka/Routing/Broadcast.cs
@@ -150,7 +150,7 @@ namespace Akka.Routing
         ///     Initializes a new instance of the <see cref="BroadcastGroup" /> class.
         /// </summary>
         /// <param name="routees">The routees.</param>
-        public BroadcastGroup(IEnumerable<ActorRef> routees)
+        public BroadcastGroup(IEnumerable<IActorRef> routees)
             : base(routees)
         {
         }

--- a/src/core/Akka/Routing/ConsistentHashRouter.cs
+++ b/src/core/Akka/Routing/ConsistentHashRouter.cs
@@ -280,7 +280,7 @@ namespace Akka.Routing
             HashMapping = hashMapping;
         }
 
-        public ConsistentHashingGroup(IEnumerable<ActorRef> routees, int virtualNodesFactor = 0,
+        public ConsistentHashingGroup(IEnumerable<IActorRef> routees, int virtualNodesFactor = 0,
             ConsistentHashMapping hashMapping = null)
             : base(routees)
         {

--- a/src/core/Akka/Routing/Listeners.cs
+++ b/src/core/Akka/Routing/Listeners.cs
@@ -95,7 +95,7 @@ namespace Akka.Routing
         /// </summary>
         public void Gossip(object msg)
         {
-            Gossip(msg, ActorRef.NoSender);
+            Gossip(msg, ActorRefs.NoSender);
         }
 
         /// <summary>

--- a/src/core/Akka/Routing/Listeners.cs
+++ b/src/core/Akka/Routing/Listeners.cs
@@ -21,32 +21,32 @@ namespace Akka.Routing
 
     public class Listen : ListenerMessage
     {
-        public Listen(ActorRef listener)
+        public Listen(IActorRef listener)
         {
             Listener = listener;
         }
 
-        public ActorRef Listener { get; private set; }
+        public IActorRef Listener { get; private set; }
     }
 
     public class Deafen : ListenerMessage
     {
-        public Deafen(ActorRef listener)
+        public Deafen(IActorRef listener)
         {
             Listener = listener;
         }
 
-        public ActorRef Listener { get; private set; }
+        public IActorRef Listener { get; private set; }
     }
 
     public class WithListeners : ListenerMessage
     {
-        public WithListeners(Action<ActorRef> listenerFunction)
+        public WithListeners(Action<IActorRef> listenerFunction)
         {
             ListenerFunction = listenerFunction;
         }
 
-        public Action<ActorRef> ListenerFunction { get; private set; }
+        public Action<IActorRef> ListenerFunction { get; private set; }
     }
 
     /// <summary>
@@ -55,7 +55,7 @@ namespace Akka.Routing
     /// </summary>
     public class ListenerSupport
     {
-        protected readonly HashSet<ActorRef> Listeners = new HashSet<ActorRef>();
+        protected readonly HashSet<IActorRef> Listeners = new HashSet<IActorRef>();
 
         /// <summary>
         /// Chain this into the <see cref="ActorBase.OnReceive"/> function.
@@ -78,13 +78,13 @@ namespace Akka.Routing
             };}
         }
 
-        public void Add(ActorRef actor)
+        public void Add(IActorRef actor)
         {
             if(!Listeners.Contains(actor))
                 Listeners.Add(actor);
         }
 
-        public void Remove(ActorRef actor)
+        public void Remove(IActorRef actor)
         {
             if(Listeners.Contains(actor))
                 Listeners.Remove(actor);
@@ -101,7 +101,7 @@ namespace Akka.Routing
         /// <summary>
         /// Send the supplied message to all listeners
         /// </summary>
-        public void Gossip(object msg, ActorRef sender)
+        public void Gossip(object msg, IActorRef sender)
         {
             foreach(var listener in Listeners)
                 listener.Tell(msg, sender);

--- a/src/core/Akka/Routing/ResizablePoolCell.cs
+++ b/src/core/Akka/Routing/ResizablePoolCell.cs
@@ -22,7 +22,7 @@ namespace Akka.Routing
         private readonly Props _routerProps;
         private Pool _pool;
 
-        public ResizablePoolCell(ActorSystemImpl system, InternalActorRef self, Props routerProps, MessageDispatcher dispatcher, Props routeeProps, InternalActorRef supervisor, Pool pool)
+        public ResizablePoolCell(ActorSystemImpl system, IInternalActorRef self, Props routerProps, MessageDispatcher dispatcher, Props routeeProps, IInternalActorRef supervisor, Pool pool)
             : base(system,self, routerProps,dispatcher, routeeProps, supervisor)
         {
 
@@ -45,7 +45,7 @@ namespace Akka.Routing
 
         }
 
-        public override void Post(ActorRef sender, object message)
+        public override void Post(IActorRef sender, object message)
         {
             if(!(_routerProps.RouterConfig.IsManagementMessage(message)) &&
                 resizer.IsTimeForResize(_resizeCounter.GetAndIncrement()) &&

--- a/src/core/Akka/Routing/RoundRobin.cs
+++ b/src/core/Akka/Routing/RoundRobin.cs
@@ -90,7 +90,7 @@ namespace Akka.Routing
         ///     Initializes a new instance of the <see cref="RoundRobinGroup" /> class.
         /// </summary>
         /// <param name="routees">The routees.</param>
-        public RoundRobinGroup(IEnumerable<ActorRef> routees) : base(routees)
+        public RoundRobinGroup(IEnumerable<IActorRef> routees) : base(routees)
         {
         }
 

--- a/src/core/Akka/Routing/RoutedActorCell.cs
+++ b/src/core/Akka/Routing/RoutedActorCell.cs
@@ -19,7 +19,7 @@ namespace Akka.Routing
         private readonly Props _routeeProps;
 
 
-        public RoutedActorCell(ActorSystemImpl system, InternalActorRef self, Props routerProps, MessageDispatcher dispatcher, Props routeeProps, InternalActorRef supervisor)
+        public RoutedActorCell(ActorSystemImpl system, IInternalActorRef self, Props routerProps, MessageDispatcher dispatcher, Props routeeProps, IInternalActorRef supervisor)
             : base(system, self, routerProps, dispatcher, supervisor)
         {
             _routeeProps = routeeProps;
@@ -149,13 +149,13 @@ namespace Akka.Routing
             RemoveRoutees(new List<Routee>() { routee }, stopChild);
         }
 
-        public override void Post(ActorRef sender, object message)
+        public override void Post(IActorRef sender, object message)
         {
             if (message is SystemMessage) base.Post(sender, message);
             else SendMessage(sender, message);
         }
 
-        private void SendMessage(ActorRef sender, object message)
+        private void SendMessage(IActorRef sender, object message)
         {
             //Route the message via the router to the selected destination.
             if (_routerConfig.IsManagementMessage(message))

--- a/src/core/Akka/Routing/RoutedActorRef.cs
+++ b/src/core/Akka/Routing/RoutedActorRef.cs
@@ -12,10 +12,10 @@ namespace Akka.Routing
         private readonly MessageDispatcher _routerDispatcher;
         private readonly Func<Mailbox> _createMailbox;
         private readonly Props _routeeProps;
-        private readonly InternalActorRef _supervisor;
+        private readonly IInternalActorRef _supervisor;
 
         public RoutedActorRef(ActorSystemImpl system, Props routerProps, MessageDispatcher routerDispatcher,
-            Func<Mailbox> createMailbox, Props routeeProps, InternalActorRef supervisor, ActorPath path)
+            Func<Mailbox> createMailbox, Props routeeProps, IInternalActorRef supervisor, ActorPath path)
             : base(system, routerProps, routerDispatcher, createMailbox, supervisor, path)
         {
             _system = system;

--- a/src/core/Akka/Routing/Router.cs
+++ b/src/core/Akka/Routing/Router.cs
@@ -9,7 +9,7 @@ namespace Akka.Routing
 {
     internal class NoRoutee : Routee
     {
-        public override void Send(object message, ActorRef sender)
+        public override void Send(object message, IActorRef sender)
         {
             if (sender is LocalActorRef)
             {
@@ -22,7 +22,7 @@ namespace Akka.Routing
     {
         public static readonly Routee NoRoutee = new NoRoutee();
 
-        public virtual void Send(object message, ActorRef sender)
+        public virtual void Send(object message, IActorRef sender)
         {
         }
 
@@ -32,7 +32,7 @@ namespace Akka.Routing
         }
 
 
-        public static Routee FromActorRef(ActorRef actorRef)
+        public static Routee FromActorRef(IActorRef actorRef)
         {
             return new ActorRefRoutee(actorRef);
         }
@@ -40,14 +40,14 @@ namespace Akka.Routing
 
     public class ActorRefRoutee : Routee
     {
-        public ActorRef Actor { get; private set; }
+        public IActorRef Actor { get; private set; }
 
-        public ActorRefRoutee(ActorRef actor)
+        public ActorRefRoutee(IActorRef actor)
         {
             this.Actor = actor;
         }
 
-        public override void Send(object message, ActorRef sender)
+        public override void Send(object message, IActorRef sender)
         {
             Actor.Tell(message, sender);
         }
@@ -87,7 +87,7 @@ namespace Akka.Routing
             _actor = actor;
         }
 
-        public override void Send(object message, ActorRef sender)
+        public override void Send(object message, IActorRef sender)
         {
             _actor.Tell(message, sender);
         }
@@ -143,7 +143,7 @@ namespace Akka.Routing
             this.routees = routees;
         }
 
-        public override void Send(object message, ActorRef sender)
+        public override void Send(object message, IActorRef sender)
         {
             foreach (Routee routee in  routees)
             {
@@ -165,7 +165,7 @@ namespace Akka.Routing
         //The signature might look funky. Why not just Router(RoutingLogic logic, params ActorRef[] routees) ? 
         //We need one unique constructor to handle this call: new Router(logic). The other constructor will handle that.
         //So in order to not confuse the compiler we demand at least one ActorRef. /@hcanber
-        public Router(RoutingLogic logic, ActorRef routee, params ActorRef[] routees)
+        public Router(RoutingLogic logic, IActorRef routee, params IActorRef[] routees)
         {
             var routeesLength = routees.Length;
             if (routees == null || routeesLength == 0)
@@ -221,7 +221,7 @@ namespace Akka.Routing
             return message;
         }
 
-        public void Route(object message, ActorRef sender)
+        public void Route(object message, IActorRef sender)
         {
             if (message is Broadcast)
             {
@@ -233,7 +233,7 @@ namespace Akka.Routing
             }
         }
 
-        protected virtual void Send(Routee routee, object message, ActorRef sender)
+        protected virtual void Send(Routee routee, object message, IActorRef sender)
         {
             routee.Send(UnWrap(message), sender);
         }
@@ -257,7 +257,7 @@ namespace Akka.Routing
         /// <summary>
         /// Create a new instance with one more routee and the same <see cref="RoutingLogic"/>.
         /// </summary>
-        public Router AddRoutee(ActorRef routee)
+        public Router AddRoutee(IActorRef routee)
         {
             return AddRoutee(new ActorRefRoutee(routee));
         }
@@ -282,7 +282,7 @@ namespace Akka.Routing
         /// <summary>
         /// Create a new instance without the specified routee.
         /// </summary>
-        public Router RemoveRoutee(ActorRef routee)
+        public Router RemoveRoutee(IActorRef routee)
         {
             return RemoveRoutee(new ActorRefRoutee(routee));
         }

--- a/src/core/Akka/Routing/RouterConfig.cs
+++ b/src/core/Akka/Routing/RouterConfig.cs
@@ -150,7 +150,7 @@ namespace Akka.Routing
             _paths = paths.ToArray();
         }
 
-        protected Group(IEnumerable<ActorRef> routees)
+        protected Group(IEnumerable<IActorRef> routees)
         {
             _paths = routees.Select(x => x.Path.ToStringWithAddress()).ToArray();
         }

--- a/src/core/Akka/Routing/ScatterGatherFirstCompleted.cs
+++ b/src/core/Akka/Routing/ScatterGatherFirstCompleted.cs
@@ -34,7 +34,7 @@ namespace Akka.Routing
             _within = within;
         }
 
-        public override void Send(object message, ActorRef sender)
+        public override void Send(object message, IActorRef sender)
         {
             var tasks = new List<Task>();
             foreach(var routee in _routees)
@@ -105,7 +105,7 @@ namespace Akka.Routing
         /// </summary>
         /// <param name="routees">The routees.</param>
         /// <param name="within">Expect a response within the given timespan</param>
-        public ScatterGatherFirstCompletedGroup(IEnumerable<ActorRef> routees,TimeSpan within) : base(routees)
+        public ScatterGatherFirstCompletedGroup(IEnumerable<IActorRef> routees,TimeSpan within) : base(routees)
         {
             Within = within;
         }

--- a/src/core/Akka/Routing/TailChoppingRoutingLogic.cs
+++ b/src/core/Akka/Routing/TailChoppingRoutingLogic.cs
@@ -104,7 +104,7 @@ namespace Akka.Routing
         /// </summary>
         /// <param name="message">The message to send.</param>
         /// <param name="sender">The sender of the message.</param>
-        public override void Send(object message, ActorRef sender)
+        public override void Send(object message, IActorRef sender)
         {
             _routees.Shuffle();
             var routeeIndex = new AtomicCounter(0);

--- a/src/core/Akka/Serialization/Serialization.cs
+++ b/src/core/Akka/Serialization/Serialization.cs
@@ -120,7 +120,7 @@ namespace Akka.Serialization
             throw new Exception("Serializer not found for type " + objectType.Name);
         }
 
-        public static string SerializedActorPath(ActorRef @ref)
+        public static string SerializedActorPath(IActorRef @ref)
         {
             /*
 val path = actorRef.path

--- a/src/examples/Chat/ChatClient/Program.cs
+++ b/src/examples/Chat/ChatClient/Program.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
-using Akka;
 using Akka.Actor;
+using Akka.Configuration;
 using ChatMessages;
 
 namespace ChatClient

--- a/src/examples/Chat/ChatMessages/Messages.cs
+++ b/src/examples/Chat/ChatMessages/Messages.cs
@@ -42,7 +42,7 @@ namespace ChatMessages
 
     public class ChannelsResponse 
     {
-        public ActorRef[] channels { get; set; }
+        public IActorRef[] channels { get; set; }
     }
 
     public class Disconnect 

--- a/src/examples/Chat/ChatServer/Program.cs
+++ b/src/examples/Chat/ChatServer/Program.cs
@@ -47,7 +47,7 @@ akka {
         ILogReceive
 
     {
-        private readonly HashSet<ActorRef> _clients = new HashSet<ActorRef>();
+        private readonly HashSet<IActorRef> _clients = new HashSet<IActorRef>();
 
         public void Handle(SayRequest message)
         {

--- a/src/examples/Cluster/Roles/Samples.Cluster.Transformation/TransformationFrontend.cs
+++ b/src/examples/Cluster/Roles/Samples.Cluster.Transformation/TransformationFrontend.cs
@@ -5,7 +5,7 @@ namespace Samples.Cluster.Transformation
 {
     public class TransformationFrontend : UntypedActor
     {
-        protected List<ActorRef> Backends = new List<ActorRef>();
+        protected List<IActorRef> Backends = new List<IActorRef>();
         protected int Jobs = 0;
 
         protected override void OnReceive(object message)

--- a/src/examples/Cluster/Routing/Samples.Cluster.ConsistentHashRouting/FrontendActor.cs
+++ b/src/examples/Cluster/Routing/Samples.Cluster.ConsistentHashRouting/FrontendActor.cs
@@ -6,10 +6,10 @@ namespace Samples.Cluster.ConsistentHashRouting
 {
     public class FrontendActor : UntypedActor, WithUnboundedStash
     {
-        protected readonly ActorRef BackendRouter;
+        protected readonly IActorRef BackendRouter;
         protected int jobCount = 0;
 
-        public FrontendActor(ActorRef backendRouter)
+        public FrontendActor(IActorRef backendRouter)
         {
             BackendRouter = backendRouter;
         }

--- a/src/examples/FSharp.Api/MapReduce.fs
+++ b/src/examples/FSharp.Api/MapReduce.fs
@@ -33,7 +33,7 @@ let reduce (dict:ConcurrentDictionary<string, int>) (mailbox: Actor<MRMsg>) = fu
 
 /// Master actor function, used as proxy between system user and internal Map/Reduce implementation
 /// Can either forward data chunk to mappers or forward a request of returning all reduced data
-let master mapper (reducer:ActorRef) (mailbox: Actor<MRMsg>) = function
+let master mapper (reducer:IActorRef) (mailbox: Actor<MRMsg>) = function
     | Map line  -> mapper <! Map line
     | Collect   -> reducer.Forward Collect
     | m         -> mailbox.Unhandled m

--- a/src/examples/FaultTolerance/Program.cs
+++ b/src/examples/FaultTolerance/Program.cs
@@ -100,8 +100,8 @@ namespace FaultTolerance
         LoggingAdapter log = Logging.GetLogger(Context);
 
         // The sender of the initial Start message will continuously be notified about progress
-        ActorRef progressListener;
-        ActorRef counterService = Context.ActorOf<CounterService>("counter");
+        IActorRef progressListener;
+        IActorRef counterService = Context.ActorOf<CounterService>("counter");
         int totalCount = 51;
 
         // Stop the CounterService child if it throws ServiceUnavailable
@@ -198,8 +198,8 @@ namespace FaultTolerance
         LoggingAdapter log = Logging.GetLogger(Context);
 
         string key = Context.Self.Path.Name;
-        ActorRef storage;
-        ActorRef counter;
+        IActorRef storage;
+        IActorRef counter;
         List<SenderMessagePair> backlog = new List<SenderMessagePair>();
         int MAX_BACKLOG = 10000;
 
@@ -309,13 +309,13 @@ namespace FaultTolerance
 
         private class SenderMessagePair
         {
-            public SenderMessagePair(ActorRef sender, object message)
+            public SenderMessagePair(IActorRef sender, object message)
             {
                 this.Sender = sender;
                 this.Message = message;
             }
 
-            public ActorRef Sender { get; private set; }
+            public IActorRef Sender { get; private set; }
             public object Message { get; private set; }
         }
     }
@@ -326,12 +326,12 @@ namespace FaultTolerance
 
     public class UseStorage
     {
-        public UseStorage(ActorRef storage)
+        public UseStorage(IActorRef storage)
         {
             this.Storage = storage;
         }
 
-        public ActorRef Storage { get; private set; }
+        public IActorRef Storage { get; private set; }
 
         public override string ToString()
         {
@@ -350,7 +350,7 @@ namespace FaultTolerance
         LoggingAdapter log = Logging.GetLogger(Context);
         string key;
         long count;
-        ActorRef storage;
+        IActorRef storage;
 
         public Counter(string key, long initialValue)
         {

--- a/src/examples/PersistenceExample/Program.cs
+++ b/src/examples/PersistenceExample/Program.cs
@@ -32,8 +32,8 @@ namespace PersistenceExample
             var pref = system.ActorOf(Props.Create<ViewExampleActor>());
             var view = system.ActorOf(Props.Create<ExampleView>());
 
-            system.Scheduler.ScheduleTellRepeatedly(TimeSpan.Zero, TimeSpan.FromSeconds(2), pref, "scheduled", ActorRef.NoSender);
-            system.Scheduler.ScheduleTellRepeatedly(TimeSpan.Zero, TimeSpan.FromSeconds(5), view, "snap", ActorRef.NoSender);
+            system.Scheduler.ScheduleTellRepeatedly(TimeSpan.Zero, TimeSpan.FromSeconds(2), pref, "scheduled", ActorRefs.NoSender);
+            system.Scheduler.ScheduleTellRepeatedly(TimeSpan.Zero, TimeSpan.FromSeconds(5), view, "snap", ActorRefs.NoSender);
         }
 
         private static void SnapshotedActor(ActorSystem system)

--- a/src/examples/Stocks/SymbolLookup/Actors/DispatcherActor.cs
+++ b/src/examples/Stocks/SymbolLookup/Actors/DispatcherActor.cs
@@ -14,8 +14,8 @@ namespace SymbolLookup.Actors
     {
         private readonly EventHandler<FullStockData> _dataHandler;
         private readonly EventHandler<string> _statusHandler;
-        private ActorRef rss = Context.ActorOf(Props.Create(() => new SymbolRssActor(new HttpFeedFactory())), "symbolrss");
-        private ActorRef stock = Context.ActorOf(Props.Create(() => new StockQuoteActor(new HttpClient())), "symbolquotes");
+        private IActorRef rss = Context.ActorOf(Props.Create(() => new SymbolRssActor(new HttpFeedFactory())), "symbolrss");
+        private IActorRef stock = Context.ActorOf(Props.Create(() => new StockQuoteActor(new HttpClient())), "symbolquotes");
         private int _stockActorNumber = 1;
         public DispatcherActor(EventHandler<FullStockData> dataHandler, EventHandler<string> statusHandler)
         {
@@ -39,7 +39,7 @@ namespace SymbolLookup.Actors
         {
             _statusHandler(this, string.Format("Received data for {0}", sd.Symbol));
             _dataHandler(this, sd);
-            ((InternalActorRef)Sender).Stop(); //tell the sender to shut down
+            ((IInternalActorRef)Sender).Stop(); //tell the sender to shut down
         }
 
         public void Handle(Failure fail)

--- a/src/examples/Stocks/SymbolLookup/Actors/Messages/Failure.cs
+++ b/src/examples/Stocks/SymbolLookup/Actors/Messages/Failure.cs
@@ -5,7 +5,7 @@ namespace SymbolLookup.Actors.Messages
 {
     public class Failure
     {
-        public Failure(Exception ex, ActorRef actor)
+        public Failure(Exception ex, IActorRef actor)
         {
             Cause = ex;
             Child = actor;
@@ -13,6 +13,6 @@ namespace SymbolLookup.Actors.Messages
 
         public Exception Cause { get; private set; }
 
-        public ActorRef Child { get; private set; }
+        public IActorRef Child { get; private set; }
     }
 }

--- a/src/examples/Stocks/SymbolLookup/MainForm.cs
+++ b/src/examples/Stocks/SymbolLookup/MainForm.cs
@@ -15,7 +15,7 @@ namespace SymbolLookup
         private readonly object m_lock = new object();
         public ImmutableDictionary<string, Tuple<Quote, IFeed>> StockData { get; set; }
         public ActorSystem ActorSystem;
-        public ActorRef StockActor;
+        public IActorRef StockActor;
 
         public event EventHandler<FullStockData> DataAvailable;
         public event EventHandler<string> StatusChange;

--- a/src/examples/Stocks/SymbolLookup/MainForm.cs
+++ b/src/examples/Stocks/SymbolLookup/MainForm.cs
@@ -80,7 +80,7 @@ namespace SymbolLookup
             //Do nothing
             if (string.IsNullOrEmpty(txtSymbols.Text))
                 return;
-            StockActor.Tell(txtSymbols.Text, ActorRef.NoSender);
+            StockActor.Tell(txtSymbols.Text, ActorRefs.NoSender);
         }
     }
 }


### PR DESCRIPTION
Fixes #480 __Make ActorRef an interface__
Related to #633 __Fix interface naming conventions__ 
and #652 __Prefix user-facing interfaces with "I" to match .NET Convention__

### The current implementation
The hierarchy for an actor ref looks like this:
```
Akka.Actor.ActorRef                (abstract class)
+ Akka.Actor.InternalActorRef      (abstract class)
|  + Akka.Actor.ActorRefWithCell
|  |  + Akka.Actor.LocalActorRef
|  |  |  + Akka.Actor.RootGuardianActorRef
... and so on
```

Every actor ref, except `Akka.Actor.NoSender`, has to inherit from `InternalActorRef` as the core framework casts actor refs to `InternalActorRef` to get access to internal members.

### The new implementation
This PR introduces two new interfaces: `IActorRef` and `IInternalActorRef`. Every concrete class has to implement these two interfaces, but does not otherwise have to inherit from any base classes.

### What's been done
The existing abstract class `ActorRef` has been renamed to `ActorRefBase` and the new interface `IActorRef` is used everywhere instead of `ActorRef`.
The same thing has been done to `InternalActorRef`: It has been renamed to `InternalActorRefBase` and the new interface `IInternalActorRef` is used.

Since `IActorRef` is an interface the operators `==` `!=` has been removed. 
`ActorRef.Nobody` and `ActorRef.NoSender` has been moved to `ActorRefs`.
`Tell(object message)` is now an extension method.

### The commits and reviewing
This PR consists of three commits (oldest to newest):
- The first renames `ActorRef` to `ActorRefBase` and introduces an interface `ActorRef` and other things that had to change due to  `ActorRef` being an interface.
- The second renames `InternalActorRef` to `InternalActorRefBase` and introduces a interface `InternalActorRef`
- The third only renames the interface `ActorRef` to `IActorRef` and `InternalActorRef` to `IInternalActorRef`

This should make it a bit easier to review as renaming from ActorRef to IActorRef modifies 206 files and has been lifted out to its own commit. 
The first two commits contains the real code changes and needs reviewing.


# Breaking changes to the public API
- Renamed:
  - `ActorRef`          --> `IActorRef`
  - `ActorRef.Nobody`   --> `ActorRefs.Nobody`
  - `ActorRef.NoSender` --> `ActorRefs.NoSender`
- `ActorRef`'s  operators `==` and `!=` has been removed. This means all expressions like `actorRef1 == actorRef2` must be replaced with `Equals(actorRef1, actorRef2)`
- `Tell(object message)`, i.e. the implicit sender overload, has been moved
to an extension method, and requires `using Akka.Actor;` to be accessible.
- Implicit cast from `ActorRef` to `Routee` has been replaced with `Routee.FromActorRef(actorRef)`
