### PR TITLE
Small optimization in ActorCell: Create behavior stack with size 1

### DIFF
--- a/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
+++ b/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
@@ -115,7 +115,7 @@ namespace Akka.Actor
 
         internal void ReceiveMessage(object message)
         {
-            var wasHandled = _actor.AroundReceive(behaviorStack.Peek(), message);
+            var wasHandled = _actor.AroundReceive(_behaviorStack.Peek(), message);
 
             if (System.Settings.AddLoggingReceive && _actor is ILogReceive)
             {

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -17,7 +17,7 @@ namespace Akka.Actor
         private Props _props;
         private static readonly Props terminatedProps=new TerminatedProps();
 
-        protected Stack<Receive> behaviorStack = new Stack<Receive>();
+        private Stack<Receive> _behaviorStack = new Stack<Receive>(1);
         private long _uid;
         private ActorBase _actor;
         private bool _actorHasBeenCleared;
@@ -138,15 +138,15 @@ namespace Akka.Actor
 
         public void Become(Receive receive, bool discardOld = true)
         {
-            if(discardOld && behaviorStack.Count > 1) //We should never pop off the initial receiver
-                behaviorStack.Pop();
-            behaviorStack.Push(receive);
+            if(discardOld && _behaviorStack.Count > 1) //We should never pop off the initial receiver
+                _behaviorStack.Pop();
+            _behaviorStack.Push(receive);
         }
 
         public void Unbecome()
         {
-            if (behaviorStack.Count > 1) //We should never pop off the initial receiver
-                behaviorStack.Pop();                
+            if (_behaviorStack.Count > 1) //We should never pop off the initial receiver
+                _behaviorStack.Pop();                
         }
   
         void IUntypedActorContext.Become(UntypedReceive receive, bool discardOld)
@@ -167,7 +167,7 @@ namespace Akka.Actor
             //set the thread static context or things will break
             UseThreadContext(() =>
             {
-                behaviorStack = new Stack<Receive>();
+                _behaviorStack = new Stack<Receive>(1);
                 instance = CreateNewActorInstance();
                 instance.SupervisorStrategyInternal = _props.SupervisorStrategy;
                 //defaults to null - won't affect lazy instantiation unless explicitly set in props
@@ -265,12 +265,12 @@ namespace Akka.Actor
             }
             _actorHasBeenCleared = true;
             CurrentMessage = null;
-            behaviorStack = null;
+            _behaviorStack = null;
         }
 
         protected void PrepareForNewActor()
         {
-            behaviorStack = new Stack<Receive>();
+            _behaviorStack = new Stack<Receive>(1);
             _actorHasBeenCleared = false;
         }
         protected void SetActorFields(ActorBase actor)


### PR DESCRIPTION
This PR creates the behavior stack with capacity 1, i.e. `new Stack<Receive>(1)` instead of the initial size 0.
It also makes the stack private and renames it.


### Explanation
The behavior stack will _always_ contain at least 1 item, as all actors, the first thing they do, is to call Become, which pushes an item to the stack.

On first call to `Become`, as the stack has 0 capacity, a new array with size 4 is created.
As most actors do not use `Become`-stacked to push more items on the stack, this means we're wasting bytes, and allocating an empty array that's not used for long.

If we create the behavior stack with initial size 1, we avoid the creation of a new array on the first `Become`-call and for most common case the underlying array isn't larger than it has to be.

### Note
This is really a micro optimization. We might need to rethink the behavior stack and optimize for that most actors don't use it
One question for the future: As most actors don't use Become-stacked, is the behavior stack something that should exist in `ActorCell` at all? 
Or should we push the functionality down to the actor class instead?