### PR TITLE
BecomeStacked instead of Become?

### DIFF
--- a/src/core/Akka.Persistence.Tests/PersistentActorSpec.Actors.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorSpec.Actors.cs
@@ -186,7 +186,7 @@ namespace Akka.Persistence.Tests
                     Persist(new Evt(cmd.Data + "-22"), evt =>
                     {
                         UpdateState(evt);
-                        Context.Unbecome();
+                        Context.UnbecomeStacked();
                     });
                     return true;
                 }
@@ -224,7 +224,7 @@ namespace Akka.Persistence.Tests
                     Persist(new Evt(cmd.Data + "-21"), evt =>
                     {
                         UpdateState(evt);
-                        Context.Unbecome();
+                        Context.UnbecomeStacked();
                     });
                     Persist(new Evt(cmd.Data + "-22"), UpdateStateHandler);
                     return true;
@@ -255,7 +255,7 @@ namespace Akka.Persistence.Tests
                 if (message is Cmd)
                 {
                     var cmd = message as Cmd;
-                    Context.Unbecome();
+                    Context.UnbecomeStacked();
                     Persist(new[] { new Evt(cmd.Data + "-31"), new Evt(cmd.Data + "-32") }, UpdateStateHandler);
                     UpdateState(new Evt(cmd.Data + "-30"));
                     return true;
@@ -289,7 +289,7 @@ namespace Akka.Persistence.Tests
                     var cmd = message as Cmd;
                     Persist(new[] { new Evt(cmd.Data + "-31"), new Evt(cmd.Data + "-32") }, UpdateStateHandler);
                     UpdateState(new Evt(cmd.Data + "-30"));
-                    Context.Unbecome();
+                    Context.UnbecomeStacked();
                     return true;
                 }
                 return false;
@@ -456,7 +456,7 @@ namespace Akka.Persistence.Tests
                     Persist(new Evt("c"), evt =>
                     {
                         UpdateState(evt);
-                        Context.Unbecome();
+                        Context.UnbecomeStacked();
                     });
                     UnstashAll();
                 }
@@ -686,7 +686,7 @@ namespace Akka.Persistence.Tests
                     Persist(new Evt("c"), evt =>
                     {
                         UpdateState(evt);
-                        Context.Unbecome();
+                        Context.UnbecomeStacked();
                     });
                     UnstashAll();
                 }

--- a/src/core/Akka.Persistence/PersistentActor.cs
+++ b/src/core/Akka.Persistence/PersistentActor.cs
@@ -143,10 +143,38 @@ namespace Akka.Persistence
 
         protected abstract void OnCommand(object message);
         protected abstract void OnRecover(object message);
+
+        [Obsolete("Use Become or BecomeStacked instead. This method will be removed in future versions")]
         protected void Become(UntypedReceive receive, bool discardOld = true)
         {
-            Context.Become(receive, discardOld);
+            if (discardOld)
+                Context.Become(receive);
+            else
+                Context.BecomeStacked(receive);
         }
+
+
+        /// <summary>
+        /// Changes the actor's behavior and replaces the current receive handler with the specified handler.
+        /// </summary>
+        /// <param name="receive">The new message handler.</param>
+        protected void Become(UntypedReceive receive)
+        {
+            Context.Become(receive);
+        }
+
+        /// <summary>
+        /// Changes the actor's behavior and replaces the current receive handler with the specified handler.
+        /// The current handler is stored on a stack, and you can revert to it by calling <see cref="IUntypedActorContext.UnbecomeStacked"/>
+        /// <remarks>Please note, that in order to not leak memory, make sure every call to <see cref="BecomeStacked"/>
+        /// is matched with a call to <see cref="IUntypedActorContext.UnbecomeStacked"/>.</remarks>
+        /// </summary>
+        /// <param name="receive">The new message handler.</param>
+        protected void BecomeStacked(UntypedReceive receive)
+        {
+            Context.BecomeStacked(receive);
+        }
+
 
         protected static new IUntypedActorContext Context { get { return (IUntypedActorContext)ActorBase.Context; } }
     }

--- a/src/core/Akka.Tests/Actor/ActorBecomeTests.cs
+++ b/src/core/Akka.Tests/Actor/ActorBecomeTests.cs
@@ -86,7 +86,7 @@ namespace Akka.Tests.Actor
                         Become(OnReceive2);
                         break;
                     case "BECOMESTACKED":
-                        Become(OnReceive2,discardOld: false);
+                        BecomeStacked(OnReceive2);
                         break;
                     default:
                         Sender.Tell("1:" + s, Self);
@@ -100,7 +100,7 @@ namespace Akka.Tests.Actor
                 switch(s)
                 {
                     case "UNBECOME":
-                        Unbecome();
+                        UnbecomeStacked();
                         break;
                     default:
                         Sender.Tell("2:" + s, Self);
@@ -120,7 +120,7 @@ namespace Akka.Tests.Actor
                         Become(OnReceive2);
                         break;
                     case "BECOMESTACKED":
-                        Become(OnReceive2, discardOld: false);
+                        BecomeStacked(OnReceive2);
                         break;
                     default:
                         Sender.Tell("1:" + s, Self);
@@ -137,10 +137,10 @@ namespace Akka.Tests.Actor
                         Become(OnReceive3);
                         break;
                     case "BECOMESTACKED":
-                        Become(OnReceive3, discardOld: false);
+                        BecomeStacked(OnReceive3);
                         break;
                     case "UNBECOME":
-                        Unbecome();
+                        UnbecomeStacked();
                         break;
                     default:
                         Sender.Tell("2:" + s, Self);
@@ -154,7 +154,7 @@ namespace Akka.Tests.Actor
                 switch(s)
                 {
                     case "UNBECOME":
-                        Unbecome();
+                        UnbecomeStacked();
                         break;
                     default:
                         Sender.Tell("3:" + s, Self);

--- a/src/core/Akka.Tests/Actor/DeathWatchSpec.cs
+++ b/src/core/Akka.Tests/Actor/DeathWatchSpec.cs
@@ -312,7 +312,7 @@ namespace Akka.Tests.Actor
                                 if (y.ActorRef == kid)
                                 {
                                     _testActor.Tell(Bonk);
-                                    Context.Unbecome();
+                                    Context.UnbecomeStacked();
                                 }
                             });
                             return true;

--- a/src/core/Akka.Tests/Actor/ReceiveActorTests_Become.cs
+++ b/src/core/Akka.Tests/Actor/ReceiveActorTests_Become.cs
@@ -83,22 +83,22 @@ namespace Akka.Tests.Actor
         {
             public BecomeActor()
             {
-                Receive<string>(s => s == "UNBECOME", __ => Unbecome());
-                Receive<string>(s => s == "BECOME", _ => Become(State2, discardOld: false));
+                Receive<string>(s => s == "UNBECOME", __ => UnbecomeStacked());
+                Receive<string>(s => s == "BECOME", _ => BecomeStacked(State2));
                 Receive<string>(s => Sender.Tell("string1:" + s, Self));
                 Receive<int>(i => Sender.Tell("int1:" + i, Self));
             }
 
             private void State2()
             {
-                Receive<string>(s => s == "UNBECOME", __ => Unbecome());
-                Receive<string>(s => s == "BECOME", _ => Become(State3, discardOld: false));
+                Receive<string>(s => s == "UNBECOME", __ => UnbecomeStacked());
+                Receive<string>(s => s == "BECOME", _ => BecomeStacked(State3));
                 Receive<string>(s => Sender.Tell("string2:" + s, Self));
             }
 
             private void State3()
             {
-                Receive<string>(s => s == "UNBECOME", __ => Unbecome());
+                Receive<string>(s => s == "UNBECOME", __ => UnbecomeStacked());
                 Receive<string>(s => Sender.Tell("string3:" + s, Self));
             }
         }
@@ -107,24 +107,24 @@ namespace Akka.Tests.Actor
         {
             public BecomeDirectlyInConstructorActor()
             {
-                Receive<string>(s => s == "UNBECOME", __ => Unbecome());
-                Receive<string>(s => s == "BECOME", _ => Become(State2, discardOld: false));
+                Receive<string>(s => s == "UNBECOME", __ => UnbecomeStacked());
+                Receive<string>(s => s == "BECOME", _ => BecomeStacked(State2));
                 Receive<string>(s => Sender.Tell("string1:" + s, Self));
                 Receive<int>(i => Sender.Tell("int1:" + i, Self));
-                Become(State2, discardOld: false);
-                Become(State3, discardOld: false);
+                BecomeStacked(State2);
+                BecomeStacked(State3);
             }
 
             private void State2()
             {
-                Receive<string>(s => s == "UNBECOME", __ => Unbecome());
-                Receive<string>(s => s == "BECOME", _ => Become(State3, discardOld: false));
+                Receive<string>(s => s == "UNBECOME", __ => UnbecomeStacked());
+                Receive<string>(s => s == "BECOME", _ => BecomeStacked(State3));
                 Receive<string>(s => Sender.Tell("string2:" + s, Self));
             }
 
             private void State3()
             {
-                Receive<string>(s => s == "UNBECOME", __ => Unbecome());
+                Receive<string>(s => s == "UNBECOME", __ => UnbecomeStacked());
                 Receive<string>(s => Sender.Tell("string3:" + s, Self));
             }
         }

--- a/src/core/Akka.Tests/Actor/ReceiveActorTests_LifeCycle.cs
+++ b/src/core/Akka.Tests/Actor/ReceiveActorTests_LifeCycle.cs
@@ -59,8 +59,8 @@ namespace Akka.Tests.Actor
             public CrashActor()
             {
                 Receive<string>(s => s == "CRASH", s => { throw new Exception("Crash!"); });
-                Receive<string>(s => s == "BECOME", _ => Become(State2, discardOld: false));
-                Receive<string>(s => s == "BECOME-DISCARD", _ => Become(State2, discardOld: true));
+                Receive<string>(s => s == "BECOME", _ => BecomeStacked(State2));
+                Receive<string>(s => s == "BECOME-DISCARD", _ => BecomeStacked(State2));
                 Receive<string>(s => Sender.Tell("1:"+s));
             }
 

--- a/src/core/Akka/Actor/ActorBase.cs
+++ b/src/core/Akka/Actor/ActorBase.cs
@@ -181,29 +181,49 @@ namespace Akka.Actor
             Context.System.EventStream.Publish(new UnhandledMessage(message, Sender, Self));
         }
 
-        /// <summary>
-        /// Changes the Actor's behavior to become the new <see cref="Actor.Receive"/> handler.
-        /// This method acts upon the behavior stack as follows:
-        /// <para>if <paramref name="discardOld"/>==<c>true</c> it will replace the current behavior (i.e. the top element)</para>
-        /// <para>if <paramref name="discardOld"/>==<c>false</c> it will keep the current behavior and push the given one atop</para>
-        /// The default of replacing the current behavior on the stack has been chosen to avoid memory
-        /// leaks in case client code is written without consulting this documentation first (i.e.
-        /// always pushing new behaviors and never issuing an <see cref="Unbecome"/>)
-        /// </summary>
-        /// <param name="receive">The receive delegate.</param>
-        /// <param name="discardOld">If <c>true</c> it will replace the current behavior; 
-        /// otherwise it will keep the current behavior and it can be reverted using <see cref="Unbecome"/></param>
+
+        [Obsolete("Use Become or BecomeStacked instead. This method will be removed in future versions")]
         protected void Become(Receive receive, bool discardOld = true)
         {
-            Context.Become(receive, discardOld);
+            if(discardOld)
+                Context.Become(receive);
+            else
+                Context.BecomeStacked(receive);
+        }
+
+        /// <summary>
+        /// Changes the actor's behavior and replaces the current receive handler with the specified handler.
+        /// </summary>
+        /// <param name="receive">The new message handler.</param>
+        protected void Become(Receive receive)
+        {
+            Context.Become(receive);
+        }
+
+        /// <summary>
+        /// Changes the actor's behavior and replaces the current receive handler with the specified handler.
+        /// The current handler is stored on a stack, and you can revert to it by calling <see cref="IActorContext.UnbecomeStacked"/>
+        /// <remarks>Please note, that in order to not leak memory, make sure every call to <see cref="BecomeStacked"/>
+        /// is matched with a call to <see cref="IActorContext.UnbecomeStacked"/>.</remarks>
+        /// </summary>
+        /// <param name="receive">The new message handler.</param>
+        protected void BecomeStacked(Receive receive)
+        {
+            Context.BecomeStacked(receive);
         }
 
         /// <summary>
         /// Reverts the Actor behavior to the previous one on the behavior stack.
         /// </summary>
+        protected void UnbecomeStacked()
+        {
+            Context.UnbecomeStacked();
+        }
+
+        [Obsolete("Use UnbecomeStacked instead. This method will be removed in future versions")]
         protected void Unbecome()
         {
-            Context.Unbecome();
+            UnbecomeStacked();
         }
 
         internal void Clear(ActorRef self)

--- a/src/core/Akka/Actor/Dsl/Act.cs
+++ b/src/core/Akka/Actor/Dsl/Act.cs
@@ -21,17 +21,22 @@ namespace Akka.Actor.Dsl
         void DefaultPostStop();
 
         /// <summary>
-        /// Become new behavior with discard of the old one. Equivalent of: Context.Become(_, discardOld: true).
+        /// Changes the actor's behavior and replaces the current handler with the specified handler.
         /// </summary>
         void Become(Action<object, IActorContext> handler);
 
         /// <summary>
-        /// Become new behavior without discarding the old one. Equivalent of: Context.Become(_, discardOld: false).
+        /// Changes the actor's behavior and replaces the current handler with the specified handler without discarding the current.
+        /// The current handler is stored on a stack, and you can revert to it by calling <see cref="UnbecomeStacked"/>
+        /// <remarks>Please note, that in order to not leak memory, make sure every call to <see cref="BecomeStacked"/>
+        /// is matched with a call to <see cref="UnbecomeStacked"/>.</remarks>
         /// </summary>
         void BecomeStacked(Action<object, IActorContext> handler);
 
         /// <summary>
-        /// Reverts <see cref="BecomeStacked"/> behavior.
+        /// Changes the actor's behavior and replaces the current handler with the previous one on the behavior stack.
+        /// <remarks>In order to store an actor on the behavior stack, a call to <see cref="BecomeStacked"/> must have been made
+        /// prior to this call</remarks>
         /// </summary>
         void UnbecomeStacked();
 
@@ -104,9 +109,10 @@ namespace Akka.Actor.Dsl
         {
             Become(msg => handler(msg, Context), false);
         }
+
         public void UnbecomeStacked()
         {
-            base.Unbecome();
+            Unbecome();
         }
 
         public ActorRef ActorOf(Action<IActorDsl> config, string name = null)

--- a/src/core/Akka/Actor/Dsl/Act.cs
+++ b/src/core/Akka/Actor/Dsl/Act.cs
@@ -102,17 +102,17 @@ namespace Akka.Actor.Dsl
 
         public void Become(Action<object, IActorContext> handler)
         {
-            Become(msg => handler(msg, Context), true);
+            Become(msg => handler(msg, Context));
         }
 
         public void BecomeStacked(Action<object, IActorContext> handler)
         {
-            Become(msg => handler(msg, Context), false);
+            BecomeStacked(msg => handler(msg, Context));
         }
 
-        public void UnbecomeStacked()
+        void IActorDsl.UnbecomeStacked()
         {
-            Unbecome();
+            base.UnbecomeStacked();
         }
 
         public ActorRef ActorOf(Action<IActorDsl> config, string name = null)

--- a/src/core/Akka/Actor/IActorContext.cs
+++ b/src/core/Akka/Actor/IActorContext.cs
@@ -55,7 +55,33 @@ namespace Akka.Actor
         /// Gets the <see cref="ActorRef"/> of the parent of the current actor.
         /// </summary>
         ActorRef Parent { get; }
+
+        /// <summary>
+        /// Changes the actor's behavior and replaces the current receive handler with the specified handler.
+        /// </summary>
+        /// <param name="receive">The new message handler.</param>
+        void Become(Receive receive);
+
+        /// <summary>
+        /// Changes the actor's behavior and replaces the current receive handler with the specified handler.
+        /// The current handler is stored on a stack, and you can revert to it by calling <see cref="UnbecomeStacked"/>
+        /// <remarks>Please note, that in order to not leak memory, make sure every call to <see cref="BecomeStacked"/>
+        /// is matched with a call to <see cref="UnbecomeStacked"/>.</remarks>
+        /// </summary>
+        /// <param name="receive">The new message handler.</param>
+        void BecomeStacked(Receive receive);
+
+        [Obsolete("Use Become or BecomeStacked instead. This method will be removed in future versions")]
         void Become(Receive receive, bool discardOld = true);
+
+        /// <summary>
+        /// Changes the actor's behavior and replaces the current receive handler with the previous one on the behavior stack.
+        /// <remarks>In order to store an actor on the behavior stack, a call to <see cref="BecomeStacked"/> must have been made
+        /// prior to this call</remarks>
+        /// </summary>
+        void UnbecomeStacked();
+
+        [Obsolete("Use UnbecomeStacked instead. This method will be removed in future versions")]
         void Unbecome();
 
         /// <summary>

--- a/src/core/Akka/Actor/IUntypedActorContext.cs
+++ b/src/core/Akka/Actor/IUntypedActorContext.cs
@@ -1,15 +1,28 @@
-﻿namespace Akka.Actor
+﻿using System;
+
+namespace Akka.Actor
 {
     /// <summary>
     /// Interface IUntypedActorContext
     /// </summary>
     public interface IUntypedActorContext : IActorContext
     {
-        /// <summary>
-        /// Becomes the specified receive.
-        /// </summary>
-        /// <param name="receive">The receive.</param>
-        /// <param name="discardOld">if set to <c>true</c> [discard old].</param>
+        [Obsolete("Use Become or BecomeStacked instead. This method will be removed in future versions")]
         void Become(UntypedReceive receive, bool discardOld = true);
+
+        /// <summary>
+        /// Changes the actor's behavior and replaces the current receive handler with the specified handler.
+        /// </summary>
+        /// <param name="receive">The new message handler.</param>
+        void Become(UntypedReceive receive);
+
+        /// <summary>
+        /// Changes the actor's behavior and replaces the current receive handler with the specified handler.
+        /// The current handler is stored on a stack, and you can revert to it by calling <see cref="IUntypedActorContext.UnbecomeStacked"/>
+        /// <remarks>Please note, that in order to not leak memory, make sure every call to <see cref="BecomeStacked"/>
+        /// is matched with a call to <see cref="IUntypedActorContext.UnbecomeStacked"/>.</remarks>
+        /// </summary>
+        /// <param name="receive">The new message handler.</param>
+        void BecomeStacked(UntypedReceive receive);
     }
 }

--- a/src/core/Akka/Actor/UntypedActor.cs
+++ b/src/core/Akka/Actor/UntypedActor.cs
@@ -32,21 +32,34 @@ namespace Akka.Actor
         /// <param name="message">The message.</param>
         protected abstract void OnReceive(object message);
 
-        /// <summary>
-        /// Changes the Actor's behavior to become the new <see cref="Receive"/> handler.
-        /// This method acts upon the behavior stack as follows:
-        /// <para>if <paramref name="discardOld"/>==<c>true</c> it will replace the current behavior (i.e. the top element)</para>
-        /// <para>if <paramref name="discardOld"/>==<c>false</c> it will keep the current behavior and push the given one atop</para>
-        /// The default of replacing the current behavior on the stack has been chosen to avoid memory
-        /// leaks in case client code is written without consulting this documentation first (i.e.
-        /// always pushing new behaviors and never issuing an <see cref="ActorBase.Unbecome"/>)
-        /// </summary>
-        /// <param name="receive">The receive delegate.</param>
-        /// <param name="discardOld">If <c>true</c> it will replace the current behavior; 
-        /// otherwise it will keep the current behavior and it can be reverted using <see cref="ActorBase.Unbecome"/></param>
+        [Obsolete("Use Become or BecomeStacked instead. This method will be removed in future versions")]
         protected void Become(UntypedReceive receive, bool discardOld = true)
         {
-            Context.Become(receive, discardOld);
+            if (discardOld)
+                Context.Become(receive);
+            else
+                Context.BecomeStacked(receive);
+        }
+
+        /// <summary>
+        /// Changes the actor's behavior and replaces the current receive handler with the specified handler.
+        /// </summary>
+        /// <param name="receive">The new message handler.</param>
+        protected void Become(UntypedReceive receive)
+        {
+            Context.Become(receive);
+        }
+
+        /// <summary>
+        /// Changes the actor's behavior and replaces the current receive handler with the specified handler.
+        /// The current handler is stored on a stack, and you can revert to it by calling <see cref="IUntypedActorContext.UnbecomeStacked"/>
+        /// <remarks>Please note, that in order to not leak memory, make sure every call to <see cref="BecomeStacked"/>
+        /// is matched with a call to <see cref="IUntypedActorContext.UnbecomeStacked"/>.</remarks>
+        /// </summary>
+        /// <param name="receive">The new message handler.</param>
+        protected void BecomeStacked(UntypedReceive receive)
+        {
+            Context.BecomeStacked(receive);
         }
 
         protected static new IUntypedActorContext Context { get { return (IUntypedActorContext) ActorBase.Context; } }


### PR DESCRIPTION
This is sort of a discussion and PR at the same time. :)

The api for using `Become` and the options to store or not store the latest handler on the stack is very strange.

It's very hard to understand what differs between these calls:
``` C#
Become(newHandler);
Become(newHandler, false);
Become(newHandler, true);
```

In fact two of the calls are equivalent. Can you see which two? 
Which stores the handler on the stack so you can restore it later?

The `IActorDsl` used for inline actors has always had `Become(handler)`, `BecomeStacked(handler)` and `UnbecomeStacked()`. It's much better.

I suggest we do the same everywhere, i.e. 
- Obsolete `Become(handler,bool)` and add `Become(handler)` and `BecomeStacked(handler)`
- Obsolete `Unbecome()` and add `UnbecomeStacked()`

And incidentally, it's exactly that this PR does. ;)

So what do you think?