### PR TITLE
Rename interfaces

### DIFF
--- a/src/contrib/dependencyInjection/Akka.DI.Core/DIActorProducer.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.Core/DIActorProducer.cs
@@ -6,7 +6,7 @@ namespace Akka.DI.Core
     /// <summary>
     /// Dependency Injection Backed IndirectActorProducer
     /// </summary>
-    public class DIActorProducer : IndirectActorProducer
+    public class DIActorProducer : IIndirectActorProducer
     {
         private IDependencyResolver dependencyResolver;
         private string actorName;

--- a/src/core/Akka.Persistence/GuaranteedDelivery.cs
+++ b/src/core/Akka.Persistence/GuaranteedDelivery.cs
@@ -134,7 +134,7 @@ namespace Akka.Persistence
     /// Support for snapshot is provided by get and set delivery snapshot methods. These snapshots contains full
     /// delivery state including unconfirmed messages. For custom snapshots remember to include those delivery ones.
     /// </summary>
-    public abstract class GuaranteedDeliveryActor : PersistentActor, InitializableActor
+    public abstract class GuaranteedDeliveryActor : PersistentActor, IInitializableActor
     {
         private ICancelable _redeliverScheduleCancelable;
         private long _deliverySequenceNr = 0L;

--- a/src/core/Akka.Persistence/PersistentActor.cs
+++ b/src/core/Akka.Persistence/PersistentActor.cs
@@ -179,7 +179,7 @@ namespace Akka.Persistence
         protected static new IUntypedActorContext Context { get { return (IUntypedActorContext)ActorBase.Context; } }
     }
 
-    public abstract class ReceivePersistentActor : UntypedPersistentActor, InitializableActor
+    public abstract class ReceivePersistentActor : UntypedPersistentActor, IInitializableActor
     {
         
         private bool _shouldUnhandle = true;
@@ -194,7 +194,7 @@ namespace Akka.Persistence
             PrepareConfigureMessageHandlers();
         }
 
-        void InitializableActor.Init()
+        void IInitializableActor.Init()
         {
             //This might be called directly after the constructor, or when the same actor instance has been returned
             //during recreate. Make sure what happens here is idempotent

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -67,7 +67,7 @@ namespace Akka.Remote
             }
 
             //message is intended for a local recipient
-            else if ((recipient is LocalRef || recipient is RepointableActorRef) && recipient.IsLocal)
+            else if ((recipient is ILocalRef || recipient is RepointableActorRef) && recipient.IsLocal)
             {
                 if (settings.LogReceive) log.Debug("received local message [{0}]", msgLog);
                 payload.Match()

--- a/src/core/Akka.Remote/RemoteActorRef.cs
+++ b/src/core/Akka.Remote/RemoteActorRef.cs
@@ -9,7 +9,7 @@ namespace Akka.Remote
     /// Marker interface for Actors that are deployed in a remote scope
     /// </summary>
 // ReSharper disable once InconsistentNaming
-    internal interface RemoteRef : ActorRefScope { }
+    internal interface RemoteRef : IActorRefScope { }
 
     /// <summary>
     /// Class RemoteActorRef.

--- a/src/core/Akka.Remote/RemoteActorRef.cs
+++ b/src/core/Akka.Remote/RemoteActorRef.cs
@@ -77,7 +77,7 @@ namespace Akka.Remote
         /// Gets the provider.
         /// </summary>
         /// <value>The provider.</value>
-        public override ActorRefProvider Provider
+        public override IActorRefProvider Provider
         {
             get { return Remote.Provider; }
         }

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -16,7 +16,7 @@ namespace Akka.Remote
     /// <summary>
     /// INTERNAL API
     /// </summary>
-    public class RemoteActorRefProvider : ActorRefProvider
+    public class RemoteActorRefProvider : IActorRefProvider
     {
         private readonly LoggingAdapter _log;
 
@@ -460,7 +460,7 @@ namespace Akka.Remote
 
         private class RemoteDeadLetterActorRef : DeadLetterActorRef
         {
-            public RemoteDeadLetterActorRef(ActorRefProvider provider, ActorPath actorPath, EventStream eventStream)
+            public RemoteDeadLetterActorRef(IActorRefProvider provider, ActorPath actorPath, EventStream eventStream)
                 : base(provider, actorPath, eventStream)
             {
             }

--- a/src/core/Akka.TestKit/Internal/InternalTestActorRef.cs
+++ b/src/core/Akka.TestKit/Internal/InternalTestActorRef.cs
@@ -190,7 +190,7 @@ namespace Akka.TestKit.Internal
         }
 
 
-        public class InternalGetActor : AutoReceivedMessage, PossiblyHarmful
+        public class InternalGetActor : IAutoReceivedMessage, PossiblyHarmful
         {
             public static readonly InternalGetActor Instance = new InternalGetActor();
             private InternalGetActor() { }

--- a/src/core/Akka.TestKit/TestActorRefBase.cs
+++ b/src/core/Akka.TestKit/TestActorRefBase.cs
@@ -193,7 +193,7 @@ namespace Akka.TestKit
 
         IInternalActorRef IInternalActorRef.Parent { get { return _internalRef.Parent; } }
 
-        ActorRefProvider IInternalActorRef.Provider { get { return _internalRef.Provider; } }
+        IActorRefProvider IInternalActorRef.Provider { get { return _internalRef.Provider; } }
 
         bool IInternalActorRef.IsTerminated { get { return _internalRef.IsTerminated; } }
 

--- a/src/core/Akka.TestKit/TestActorRefBase.cs
+++ b/src/core/Akka.TestKit/TestActorRefBase.cs
@@ -189,7 +189,7 @@ namespace Akka.TestKit
             return _internalRef.ToSurrogate(system);
         }
 
-        bool ActorRefScope.IsLocal { get { return _internalRef.IsLocal; } }
+        bool IActorRefScope.IsLocal { get { return _internalRef.IsLocal; } }
 
         IInternalActorRef IInternalActorRef.Parent { get { return _internalRef.Parent; } }
 

--- a/src/core/Akka.TestKit/TestFSMRef.cs
+++ b/src/core/Akka.TestKit/TestFSMRef.cs
@@ -63,7 +63,7 @@ namespace Akka.TestKit
         /// </summary>
         public void SetState(TState stateName, TData stateData, TimeSpan? timeout = null, FSMBase.Reason stopReason = null)
         {
-            var fsm = ((InternalSupportsTestFSMRef<TState, TData>)UnderlyingActor);
+            var fsm = ((IInternalSupportsTestFSMRef<TState, TData>)UnderlyingActor);
             InternalRef.Cell.UseThreadContext(() => fsm.ApplyState(new FSMBase.State<TState, TData>(stateName, stateData, timeout, stopReason)));
         }
 
@@ -98,7 +98,7 @@ namespace Akka.TestKit
         /// <returns><c>true</c> if the FSM has a active state timer active; <c>false</c> otherwise</returns>
         public bool IsStateTimerActive()
         {
-            var fsm = ((InternalSupportsTestFSMRef<TState, TData>)UnderlyingActor);
+            var fsm = ((IInternalSupportsTestFSMRef<TState, TData>)UnderlyingActor);
             return fsm.IsStateTimerActive;
         }
     }

--- a/src/core/Akka.TestKit/TestKitBase.cs
+++ b/src/core/Akka.TestKit/TestKitBase.cs
@@ -95,7 +95,7 @@ namespace Akka.TestKit
             //Wait for the testactor to start
             AwaitCondition(() =>
             {
-                var repRef = testActor as RepointableRef;
+                var repRef = testActor as IRepointableRef;
                 return repRef == null || repRef.IsStarted;
             }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(10));
 

--- a/src/core/Akka.TestKit/TestProbe.cs
+++ b/src/core/Akka.TestKit/TestProbe.cs
@@ -98,7 +98,7 @@ namespace Akka.TestKit
 
         IInternalActorRef IInternalActorRef.Parent { get { return ((IInternalActorRef)TestActor).Parent; } }
 
-        ActorRefProvider IInternalActorRef.Provider { get { return ((IInternalActorRef)TestActor).Provider; } }
+        IActorRefProvider IInternalActorRef.Provider { get { return ((IInternalActorRef)TestActor).Provider; } }
 
         bool IInternalActorRef.IsTerminated { get { return ((IInternalActorRef)TestActor).IsTerminated; } }
 

--- a/src/core/Akka.TestKit/TestProbe.cs
+++ b/src/core/Akka.TestKit/TestProbe.cs
@@ -94,7 +94,7 @@ namespace Akka.TestKit
             return TestActor.ToSurrogate(system);
         }
 
-        bool ActorRefScope.IsLocal { get { return ((IInternalActorRef) TestActor).IsLocal; } }
+        bool IActorRefScope.IsLocal { get { return ((IInternalActorRef) TestActor).IsLocal; } }
 
         IInternalActorRef IInternalActorRef.Parent { get { return ((IInternalActorRef)TestActor).Parent; } }
 

--- a/src/core/Akka.Tests/Actor/PropsSpec.cs
+++ b/src/core/Akka.Tests/Actor/PropsSpec.cs
@@ -33,7 +33,7 @@ namespace Akka.Tests.Actor
             latchActor.Ready(TimeSpan.FromSeconds(1));
         }
 
-        private class TestProducer : IndirectActorProducer
+        private class TestProducer : IIndirectActorProducer
         {
             TestLatch latchActor;
 

--- a/src/core/Akka.Tests/Actor/RootGuardianActorRef_Tests.cs
+++ b/src/core/Akka.Tests/Actor/RootGuardianActorRef_Tests.cs
@@ -96,7 +96,7 @@ namespace Akka.Tests.Actor
                 get { return _path; }
             }
 
-            public override ActorRefProvider Provider
+            public override IActorRefProvider Provider
             {
                 get { throw new System.NotImplementedException(); }
             }

--- a/src/core/Akka/Actor/ActorCell.Children.cs
+++ b/src/core/Akka/Actor/ActorCell.Children.cs
@@ -30,7 +30,7 @@ namespace Akka.Actor
 
         private bool TryGetChild(string name, out IActorRef child)
         {
-            ChildStats stats;
+            IChildStats stats;
             if (ChildrenContainer.TryGetByName(name, out stats))
             {
                 var restartStats = stats as ChildRestartStats;
@@ -138,7 +138,7 @@ namespace Akka.Actor
         {
             return UpdateChildrenRefs(cc =>
             {
-                ChildStats stats;
+                IChildStats stats;
                 var name = actor.Path.Name;
                 if (cc.TryGetByName(name, out stats))
                 {
@@ -234,7 +234,7 @@ namespace Akka.Actor
         /// indicating that only a name has been reserved for the child, or a <see cref="ChildRestartStats"/> for a child that 
         /// has been initialized/created.
         /// </summary>
-        public bool TryGetChildStatsByName(string name, out ChildStats child)   //This is called getChildByName in Akka JVM
+        public bool TryGetChildStatsByName(string name, out IChildStats child)   //This is called getChildByName in Akka JVM
         {
             return ChildrenContainer.TryGetByName(name, out child);
         }
@@ -244,7 +244,7 @@ namespace Akka.Actor
         /// </summary>
         private bool TryGetChildRestartStatsByName(string name, out ChildRestartStats child)
         {
-            ChildStats stats;
+            IChildStats stats;
             if (ChildrenContainer.TryGetByName(name, out stats))
             {
                 child = stats as ChildRestartStats;
@@ -257,7 +257,7 @@ namespace Akka.Actor
 
         /// <summary>
         /// Tries to get the stats for the specified child.
-        /// <remarks>Since the child exists <see cref="ChildRestartStats"/> is the only valid <see cref="ChildStats"/>.</remarks>
+        /// <remarks>Since the child exists <see cref="ChildRestartStats"/> is the only valid <see cref="IChildStats"/>.</remarks>
         /// </summary>
         protected bool TryGetChildStatsByRef(IActorRef actor, out ChildRestartStats child)   //This is called getChildByRef in Akka JVM
         {

--- a/src/core/Akka/Actor/ActorCell.Children.cs
+++ b/src/core/Akka/Actor/ActorCell.Children.cs
@@ -188,7 +188,7 @@ namespace Akka.Actor
             get
             {
                 var terminating = ChildrenContainer as TerminatingChildrenContainer;
-                return terminating != null && terminating.Reason is SuspendReason.WaitingForChildren;
+                return terminating != null && terminating.Reason is SuspendReason.IWaitingForChildren;
             }
         }
 

--- a/src/core/Akka/Actor/ActorCell.DeathWatch.cs
+++ b/src/core/Akka/Actor/ActorCell.DeathWatch.cs
@@ -129,7 +129,7 @@ namespace Akka.Actor
 
         private void SendTerminated(bool ifLocal, IActorRef watcher)
         {
-            if (((ActorRefScope)watcher).IsLocal == ifLocal && !watcher.Equals(Parent))
+            if (((IActorRefScope)watcher).IsLocal == ifLocal && !watcher.Equals(Parent))
             {
                 ((IInternalActorRef)watcher).Tell(new DeathWatchNotification(Self, true, false));
             }

--- a/src/core/Akka/Actor/ActorCell.DeathWatch.cs
+++ b/src/core/Akka/Actor/ActorCell.DeathWatch.cs
@@ -280,7 +280,7 @@ namespace Akka.Actor
             get { return _ref.Path.WithUid(ActorCell.UndefinedUid); }
         }
 
-        public override ActorRefProvider Provider
+        public override IActorRefProvider Provider
         {
             get
             {

--- a/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
+++ b/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
@@ -41,7 +41,7 @@ namespace Akka.Actor
 
             try
             {
-                var autoReceivedMessage = message as AutoReceivedMessage;
+                var autoReceivedMessage = message as IAutoReceivedMessage;
                 if (autoReceivedMessage != null)
                     AutoReceiveMessage(envelope);
                 else

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -217,7 +217,7 @@ namespace Akka.Actor
             var pipeline = _systemImpl.ActorPipelineResolver.ResolvePipeline(actor.GetType());
             pipeline.AfterActorIncarnated(actor, this);
             
-            var initializableActor = actor as InitializableActor;
+            var initializableActor = actor as IInitializableActor;
             if(initializableActor != null)
             {
                 initializableActor.Init();

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -9,7 +9,7 @@ using Akka.Serialization;
 
 namespace Akka.Actor
 {
-    public partial class ActorCell : IUntypedActorContext, Cell 
+    public partial class ActorCell : IUntypedActorContext, ICell 
     {
         /// <summary>NOTE! Only constructor and ClearActorFields is allowed to update this</summary>
         private IInternalActorRef _self;

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -68,7 +68,7 @@ namespace Akka.Actor
             get { return _path; }
         }
 
-        public override ActorRefProvider Provider
+        public override IActorRefProvider Provider
         {
             get { throw new NotImplementedException(); }
         }
@@ -225,7 +225,7 @@ namespace Akka.Actor
     public interface IInternalActorRef : IActorRef, ActorRefScope
     {
         IInternalActorRef Parent { get; }
-        ActorRefProvider Provider { get; }
+        IActorRefProvider Provider { get; }
         bool IsTerminated { get; }
 
         /// <summary>
@@ -248,7 +248,7 @@ namespace Akka.Actor
     public abstract class InternalActorRefBase : ActorRefBase, IInternalActorRef
     {
         public abstract IInternalActorRef Parent { get; }
-        public abstract ActorRefProvider Provider { get; }
+        public abstract IActorRefProvider Provider { get; }
 
         /// <summary>
         /// Obtain a child given the paths element to that actor, by possibly traversing the actor tree or 
@@ -325,7 +325,7 @@ namespace Akka.Actor
 
         public override ActorPath Path { get { return _path; } }
 
-        public override ActorRefProvider Provider
+        public override IActorRefProvider Provider
         {
             get { throw new NotSupportedException("Nobody does not provide"); }
         }
@@ -360,12 +360,12 @@ namespace Akka.Actor
     {
         private readonly IInternalActorRef _parent;
         private readonly LoggingAdapter _log;
-        private readonly ActorRefProvider _provider;
+        private readonly IActorRefProvider _provider;
         private readonly ActorPath _path;
 
         private readonly ConcurrentDictionary<string, IInternalActorRef> _children = new ConcurrentDictionary<string, IInternalActorRef>();
 
-        public VirtualPathContainer(ActorRefProvider provider, ActorPath path, IInternalActorRef parent, LoggingAdapter log)
+        public VirtualPathContainer(IActorRefProvider provider, ActorPath path, IInternalActorRef parent, LoggingAdapter log)
         {
             _parent = parent;
             _log = log;
@@ -373,7 +373,7 @@ namespace Akka.Actor
             _path = path;
         }
 
-        public override ActorRefProvider Provider
+        public override IActorRefProvider Provider
         {
             get { return _provider; }
         }

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -39,7 +39,7 @@ namespace Akka.Actor
     /// actor refs will have the same behavior.
     /// INTERNAL
     /// </summary>
-    public interface RepointableRef : IActorRefScope
+    public interface IRepointableRef : IActorRefScope
     {
         bool IsStarted { get; }
     }

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -332,7 +332,7 @@ namespace Akka.Actor
 
     public abstract class ActorRefWithCell : InternalActorRefBase
     {
-        public abstract Cell Underlying { get; }
+        public abstract ICell Underlying { get; }
 
         public abstract IEnumerable<IActorRef> Children { get; }
 

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -20,18 +20,16 @@ namespace Akka.Actor
     /// method provided on the scope.
     /// INTERNAL
     /// </summary>
-    // ReSharper disable once InconsistentNaming
-    public interface ActorRefScope
+    public interface IActorRefScope
     {
         bool IsLocal { get; }
     }
 
     /// <summary>
     /// Marker interface for Actors that are deployed within local scope, 
-    /// i.e. <see cref="ActorRefScope.IsLocal"/> always returns <c>true</c>.
+    /// i.e. <see cref="IActorRefScope.IsLocal"/> always returns <c>true</c>.
     /// </summary>
-    // ReSharper disable once InconsistentNaming
-    internal interface LocalRef : ActorRefScope { }
+    internal interface LocalRef : IActorRefScope { }
 
     /// <summary>
     /// RepointableActorRef (and potentially others) may change their locality at
@@ -41,7 +39,7 @@ namespace Akka.Actor
     /// actor refs will have the same behavior.
     /// INTERNAL
     /// </summary>
-    public interface RepointableRef : ActorRefScope
+    public interface RepointableRef : IActorRefScope
     {
         bool IsStarted { get; }
     }
@@ -222,7 +220,7 @@ namespace Akka.Actor
     }
 
 
-    public interface IInternalActorRef : IActorRef, ActorRefScope
+    public interface IInternalActorRef : IActorRef, IActorRefScope
     {
         IInternalActorRef Parent { get; }
         IActorRefProvider Provider { get; }

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -29,7 +29,7 @@ namespace Akka.Actor
     /// Marker interface for Actors that are deployed within local scope, 
     /// i.e. <see cref="IActorRefScope.IsLocal"/> always returns <c>true</c>.
     /// </summary>
-    internal interface LocalRef : IActorRefScope { }
+    internal interface ILocalRef : IActorRefScope { }
 
     /// <summary>
     /// RepointableActorRef (and potentially others) may change their locality at
@@ -267,7 +267,7 @@ namespace Akka.Actor
         public abstract bool IsLocal { get; }
     }
 
-    public abstract class MinimalActorRef : InternalActorRefBase, LocalRef
+    public abstract class MinimalActorRef : InternalActorRefBase, ILocalRef
     {
         public override IInternalActorRef Parent
         {

--- a/src/core/Akka/Actor/ActorRefProvider.cs
+++ b/src/core/Akka/Actor/ActorRefProvider.cs
@@ -13,7 +13,7 @@ using Akka.Util.Internal;
 
 namespace Akka.Actor
 {
-    public interface ActorRefProvider
+    public interface IActorRefProvider
     {
         /// <summary>
         /// Reference to the supervisor of guardian and systemGuardian; this is
@@ -89,7 +89,7 @@ namespace Akka.Actor
         IActorRef ResolveActorRef(ActorPath actorPath);
 
         /// <summary>
-        /// This Future is completed upon termination of this <see cref="ActorRefProvider"/>, which
+        /// This Future is completed upon termination of this <see cref="IActorRefProvider"/>, which
         /// is usually initiated by stopping the guardian via <see cref="ActorSystem.Stop"/>.
         /// </summary>
         Task TerminationTask { get; }
@@ -109,7 +109,7 @@ namespace Akka.Actor
     /// <summary>
     ///     Class LocalActorRefProvider. This class cannot be inherited.
     /// </summary>
-    public sealed class LocalActorRefProvider : ActorRefProvider
+    public sealed class LocalActorRefProvider : IActorRefProvider
     {
         private readonly Settings _settings;
         private readonly EventStream _eventStream;

--- a/src/core/Akka/Actor/ActorSelection.cs
+++ b/src/core/Akka/Actor/ActorSelection.cs
@@ -197,7 +197,7 @@ namespace Akka.Actor
     /// <summary>
     ///     Class ActorSelectionMessage.
     /// </summary>
-    public class ActorSelectionMessage : AutoReceivedMessage, PossiblyHarmful
+    public class ActorSelectionMessage : IAutoReceivedMessage, PossiblyHarmful
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="ActorSelectionMessage" /> class.

--- a/src/core/Akka/Actor/AutoReceivedMessage.cs
+++ b/src/core/Akka/Actor/AutoReceivedMessage.cs
@@ -2,12 +2,12 @@
 
 namespace Akka.Actor
 {
-    public interface AutoReceivedMessage : NoSerializationVerificationNeeded
+    public interface IAutoReceivedMessage : NoSerializationVerificationNeeded
     {
     }
 
     public sealed class
-        Terminated : AutoReceivedMessage, PossiblyHarmful
+        Terminated : IAutoReceivedMessage, PossiblyHarmful
     {
         public Terminated(IActorRef actorRef, bool existenceConfirmed, bool addressTerminated)
         {
@@ -30,7 +30,7 @@ namespace Akka.Actor
     }
 
     //request to an actor ref, to get back the identity of the underlying actors
-    public sealed class Identify : AutoReceivedMessage
+    public sealed class Identify : IAutoReceivedMessage
     {
         public Identify(object messageId)
         {
@@ -71,7 +71,7 @@ namespace Akka.Actor
     /// it processes the message, which gets handled using the normal supervisor mechanism, and
     /// <see cref="IActorContext.Stop"/> which causes the actor to stop without processing any more messages. </para>
     /// </summary>
-    public sealed class PoisonPill : AutoReceivedMessage
+    public sealed class PoisonPill : IAutoReceivedMessage
     {
         private PoisonPill() { }
         private static readonly PoisonPill _instance = new PoisonPill();
@@ -97,7 +97,7 @@ namespace Akka.Actor
     /// is processed, without throwing an exception, and 
     /// <see cref="IActorContext.Stop"/> which causes the actor to stop without processing any more messages. </para>
     /// </summary>
-    public sealed class Kill : AutoReceivedMessage
+    public sealed class Kill : IAutoReceivedMessage
     {
         private Kill() { }
 
@@ -128,7 +128,7 @@ namespace Akka.Actor
     /// The watcher <see cref="DeathWatch"/> subscribes to the <see cref="AddressTerminatedTopic"/> and translates this
     /// event to <see cref="Terminated"/>, which is sent to itself.
     /// </summary>
-    internal class AddressTerminated : AutoReceivedMessage, PossiblyHarmful
+    internal class AddressTerminated : IAutoReceivedMessage, PossiblyHarmful
     {
         public AddressTerminated(Address address)
         {

--- a/src/core/Akka/Actor/BuiltInActors.cs
+++ b/src/core/Akka/Actor/BuiltInActors.cs
@@ -151,7 +151,7 @@ namespace Akka.Actor
     {
         private readonly EventStream _eventStream;
 
-        public DeadLetterActorRef(ActorRefProvider provider, ActorPath path, EventStream eventStream)
+        public DeadLetterActorRef(IActorRefProvider provider, ActorPath path, EventStream eventStream)
             : base(provider, path, eventStream)
         {
             _eventStream = eventStream;

--- a/src/core/Akka/Actor/Cell.cs
+++ b/src/core/Akka/Actor/Cell.cs
@@ -81,7 +81,7 @@ namespace Akka.Actor
         /// indicating that only a name has been reserved for the child, or a <see cref="ChildRestartStats"/> for a child that 
         /// has been initialized/created.
         /// </summary>
-        bool TryGetChildStatsByName(string name, out ChildStats child); //This is called getChildByName in Akka JVM
+        bool TryGetChildStatsByName(string name, out IChildStats child); //This is called getChildByName in Akka JVM
 
 
 

--- a/src/core/Akka/Actor/Cell.cs
+++ b/src/core/Akka/Actor/Cell.cs
@@ -5,11 +5,10 @@ using Akka.Actor.Internals;
 
 namespace Akka.Actor
 {
-    // ReSharper disable once InconsistentNaming
     /// <summary>
     /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
     /// </summary>
-    public interface Cell
+    public interface ICell
     {
         /// <summary>Gets the “self” reference which this Cell is attached to.</summary>
         IActorRef Self { get; }

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/ChildStats.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/ChildStats.cs
@@ -2,12 +2,11 @@
 
 namespace Akka.Actor.Internal
 {
-    // ReSharper disable once InconsistentNaming
-    public interface ChildStats
+    public interface IChildStats
     {
     }
 
-    public class ChildNameReserved : ChildStats
+    public class ChildNameReserved : IChildStats
     {
         private static readonly ChildNameReserved _instance = new ChildNameReserved();
         private ChildNameReserved() {/* Intentionally left blank */}
@@ -23,7 +22,7 @@ namespace Akka.Actor.Internal
     /// ChildRestartStats is the statistics kept by every parent Actor for every child Actor
     /// and is used for SupervisorStrategies to know how to deal with problems that occur for the children.
     /// </summary>
-    public class ChildRestartStats : ChildStats
+    public class ChildRestartStats : IChildStats
     {
         private readonly IInternalActorRef _child;
         private uint _maxNrOfRetriesCount;

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainer.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainer.cs
@@ -6,7 +6,7 @@ namespace Akka.Actor.Internal
     {
         IChildrenContainer Add(string name, ChildRestartStats stats);
         IChildrenContainer Remove(IActorRef child);
-        bool TryGetByName(string name, out ChildStats stats);
+        bool TryGetByName(string name, out IChildStats stats);
         bool TryGetByRef(IActorRef actor, out ChildRestartStats stats);
         IReadOnlyList<IInternalActorRef> Children { get; }
         IReadOnlyList<ChildRestartStats> Stats { get; }

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainer.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainer.cs
@@ -2,18 +2,17 @@
 
 namespace Akka.Actor.Internal
 {
-    // ReSharper disable once InconsistentNaming
-    public interface ChildrenContainer
+    public interface IChildrenContainer
     {
-        ChildrenContainer Add(string name, ChildRestartStats stats);
-        ChildrenContainer Remove(IActorRef child);
+        IChildrenContainer Add(string name, ChildRestartStats stats);
+        IChildrenContainer Remove(IActorRef child);
         bool TryGetByName(string name, out ChildStats stats);
         bool TryGetByRef(IActorRef actor, out ChildRestartStats stats);
         IReadOnlyList<IInternalActorRef> Children { get; }
         IReadOnlyList<ChildRestartStats> Stats { get; }
-        ChildrenContainer ShallDie(IActorRef actor);
-        ChildrenContainer Reserve(string name);
-        ChildrenContainer Unreserve(string name);
+        IChildrenContainer ShallDie(IActorRef actor);
+        IChildrenContainer Reserve(string name);
+        IChildrenContainer Unreserve(string name);
         bool IsTerminating { get; }
         bool IsNormal { get; }
         bool Contains(IActorRef actor);

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainerBase.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainerBase.cs
@@ -7,9 +7,9 @@ namespace Akka.Actor.Internal
 {
     public abstract class ChildrenContainerBase : IChildrenContainer
     {
-        private readonly IImmutableMap<string, ChildStats> _children;
+        private readonly IImmutableMap<string, IChildStats> _children;
 
-        protected ChildrenContainerBase(IImmutableMap<string, ChildStats> children)
+        protected ChildrenContainerBase(IImmutableMap<string, IChildStats> children)
         {
             _children = children;
         }
@@ -44,9 +44,9 @@ namespace Akka.Actor.Internal
             }
         }
 
-        protected IImmutableMap<string, ChildStats> InternalChildren { get { return _children; } }
+        protected IImmutableMap<string, IChildStats> InternalChildren { get { return _children; } }
 
-        public bool TryGetByName(string name, out ChildStats stats)
+        public bool TryGetByName(string name, out IChildStats stats)
         {
             if (InternalChildren.TryGet(name, out stats)) return true;
             stats = null;
@@ -55,7 +55,7 @@ namespace Akka.Actor.Internal
 
         public bool TryGetByRef(IActorRef actor, out ChildRestartStats childRestartStats)
         {
-            ChildStats stats;
+            IChildStats stats;
             if (InternalChildren.TryGet(actor.Path.Name, out stats))
             {
                 //Since the actor exists, ChildRestartStats is the only valid ChildStats.
@@ -76,7 +76,7 @@ namespace Akka.Actor.Internal
             return TryGetByRef(actor, out stats);
         }
 
-        protected void ChildStatsAppender(StringBuilder sb, IKeyValuePair<string, ChildStats> kvp, int index)
+        protected void ChildStatsAppender(StringBuilder sb, IKeyValuePair<string, IChildStats> kvp, int index)
         {
             sb.Append('<');
             var childStats = kvp.Value;

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainerBase.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainerBase.cs
@@ -5,7 +5,7 @@ using Akka.Util.Internal.Collections;
 
 namespace Akka.Actor.Internal
 {
-    public abstract class ChildrenContainerBase : ChildrenContainer
+    public abstract class ChildrenContainerBase : IChildrenContainer
     {
         private readonly IImmutableMap<string, ChildStats> _children;
 
@@ -16,11 +16,11 @@ namespace Akka.Actor.Internal
 
         public virtual bool IsTerminating { get { return false; } }
         public virtual bool IsNormal { get { return true; } }
-        public abstract ChildrenContainer Add(string name, ChildRestartStats stats);
-        public abstract ChildrenContainer Remove(IActorRef child);
-        public abstract ChildrenContainer Reserve(string name);
-        public abstract ChildrenContainer ShallDie(IActorRef actor);
-        public abstract ChildrenContainer Unreserve(string name);
+        public abstract IChildrenContainer Add(string name, ChildRestartStats stats);
+        public abstract IChildrenContainer Remove(IActorRef child);
+        public abstract IChildrenContainer Reserve(string name);
+        public abstract IChildrenContainer ShallDie(IActorRef actor);
+        public abstract IChildrenContainer Unreserve(string name);
 
         public IReadOnlyList<IInternalActorRef> Children
         {

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/EmptyChildrenContainer.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/EmptyChildrenContainer.cs
@@ -8,7 +8,7 @@ namespace Akka.Actor.Internal
     /// </summary>
     public class EmptyChildrenContainer : IChildrenContainer
     {
-        private static readonly ImmutableTreeMap<string, ChildStats> _emptyStats = ImmutableTreeMap<string, ChildStats>.Empty;
+        private static readonly ImmutableTreeMap<string, IChildStats> _emptyStats = ImmutableTreeMap<string, IChildStats>.Empty;
         private static readonly IChildrenContainer _instance = new EmptyChildrenContainer();
 
         protected EmptyChildrenContainer()
@@ -29,7 +29,7 @@ namespace Akka.Actor.Internal
             return this;
         }
 
-        public bool TryGetByName(string name, out ChildStats stats)
+        public bool TryGetByName(string name, out IChildStats stats)
         {
             stats = null;
             return false;

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/EmptyChildrenContainer.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/EmptyChildrenContainer.cs
@@ -6,25 +6,25 @@ namespace Akka.Actor.Internal
     /// <summary>
     /// This is the empty container, shared among all leaf actors.
     /// </summary>
-    public class EmptyChildrenContainer : ChildrenContainer
+    public class EmptyChildrenContainer : IChildrenContainer
     {
         private static readonly ImmutableTreeMap<string, ChildStats> _emptyStats = ImmutableTreeMap<string, ChildStats>.Empty;
-        private static readonly ChildrenContainer _instance = new EmptyChildrenContainer();
+        private static readonly IChildrenContainer _instance = new EmptyChildrenContainer();
 
         protected EmptyChildrenContainer()
         {
             //Intentionally left blank
         }
 
-        public static ChildrenContainer Instance { get { return _instance; } }
+        public static IChildrenContainer Instance { get { return _instance; } }
 
-        public virtual ChildrenContainer Add(string name, ChildRestartStats stats)
+        public virtual IChildrenContainer Add(string name, ChildRestartStats stats)
         {
             var newMap = _emptyStats.Add(name, stats);
             return NormalChildrenContainer.Create(newMap);
         }
 
-        public ChildrenContainer Remove(IActorRef child)
+        public IChildrenContainer Remove(IActorRef child)
         {
             return this;
         }
@@ -50,17 +50,17 @@ namespace Akka.Actor.Internal
 
         public IReadOnlyList<ChildRestartStats> Stats { get { return EmptyReadOnlyCollections<ChildRestartStats>.List; } }
 
-        public ChildrenContainer ShallDie(IActorRef actor)
+        public IChildrenContainer ShallDie(IActorRef actor)
         {
             return this;
         }
 
-        public virtual ChildrenContainer Reserve(string name)
+        public virtual IChildrenContainer Reserve(string name)
         {
             return NormalChildrenContainer.Create(_emptyStats.Add(name, ChildNameReserved.Instance));
         }
 
-        public ChildrenContainer Unreserve(string name)
+        public IChildrenContainer Unreserve(string name)
         {
             return this;
         }

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/NormalChildrenContainer.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/NormalChildrenContainer.cs
@@ -11,12 +11,12 @@ namespace Akka.Actor.Internal
     /// </summary>
     public class NormalChildrenContainer : ChildrenContainerBase
     {
-        private NormalChildrenContainer(IImmutableMap<string, ChildStats> children)
+        private NormalChildrenContainer(IImmutableMap<string, IChildStats> children)
             : base(children)
         {
         }
 
-        public static IChildrenContainer Create(IImmutableMap<string, ChildStats> children)
+        public static IChildrenContainer Create(IImmutableMap<string, IChildStats> children)
         {
             if (children.IsEmpty) return EmptyChildrenContainer.Instance;
             return new NormalChildrenContainer(children);
@@ -46,7 +46,7 @@ namespace Akka.Actor.Internal
 
         public override IChildrenContainer Unreserve(string name)
         {
-            ChildStats stats;
+            IChildStats stats;
             if (InternalChildren.TryGet(name, out stats) && (stats is ChildNameReserved))
             {
                 return Create(InternalChildren.Remove(name));

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/NormalChildrenContainer.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/NormalChildrenContainer.cs
@@ -16,35 +16,35 @@ namespace Akka.Actor.Internal
         {
         }
 
-        public static ChildrenContainer Create(IImmutableMap<string, ChildStats> children)
+        public static IChildrenContainer Create(IImmutableMap<string, ChildStats> children)
         {
             if (children.IsEmpty) return EmptyChildrenContainer.Instance;
             return new NormalChildrenContainer(children);
         }
 
-        public override ChildrenContainer Add(string name, ChildRestartStats stats)
+        public override IChildrenContainer Add(string name, ChildRestartStats stats)
         {
             return Create(InternalChildren.AddOrUpdate(name, stats));
         }
 
-        public override ChildrenContainer Remove(IActorRef child)
+        public override IChildrenContainer Remove(IActorRef child)
         {
             return Create(InternalChildren.Remove(child.Path.Name));
         }
 
-        public override ChildrenContainer ShallDie(IActorRef actor)
+        public override IChildrenContainer ShallDie(IActorRef actor)
         {
             return new TerminatingChildrenContainer(InternalChildren, actor, SuspendReason.UserRequest.Instance);
         }
 
-        public override ChildrenContainer Reserve(string name)
+        public override IChildrenContainer Reserve(string name)
         {
             if (InternalChildren.Contains(name))
                 throw new InvalidActorNameException(string.Format("Actor name \"{0}\" is not unique!", name));
             return new NormalChildrenContainer(InternalChildren.AddOrUpdate(name, ChildNameReserved.Instance));
         }
 
-        public override ChildrenContainer Unreserve(string name)
+        public override IChildrenContainer Unreserve(string name)
         {
             ChildStats stats;
             if (InternalChildren.TryGet(name, out stats) && (stats is ChildNameReserved))

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/SuspendReason.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/SuspendReason.cs
@@ -11,7 +11,7 @@ namespace Akka.Actor.Internal
         /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
         /// </summary>
         // ReSharper disable once InconsistentNaming
-        public interface WaitingForChildren
+        public interface IWaitingForChildren
         {
             //Intentionally left blank
         }
@@ -19,7 +19,7 @@ namespace Akka.Actor.Internal
         /// <summary>
         /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
         /// </summary>
-        public class Creation : SuspendReason, WaitingForChildren
+        public class Creation : SuspendReason, IWaitingForChildren
         {
             //Intentionally left blank
         }
@@ -27,7 +27,7 @@ namespace Akka.Actor.Internal
         /// <summary>
         /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
         /// </summary>
-        public class Recreation : SuspendReason, WaitingForChildren
+        public class Recreation : SuspendReason, IWaitingForChildren
         {
             private readonly Exception _cause;
 

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/TerminatedChildrenContainer.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/TerminatedChildrenContainer.cs
@@ -9,20 +9,20 @@ namespace Akka.Actor.Internal
     /// </summary>
     public class TerminatedChildrenContainer : EmptyChildrenContainer
     {
-        private static readonly ChildrenContainer _instance = new TerminatedChildrenContainer();
+        private static readonly IChildrenContainer _instance = new TerminatedChildrenContainer();
 
         private TerminatedChildrenContainer()
         {
             //Intentionally left blank
         }
-        public new static ChildrenContainer Instance { get { return _instance; } }
+        public new static IChildrenContainer Instance { get { return _instance; } }
 
-        public override ChildrenContainer Add(string name, ChildRestartStats stats)
+        public override IChildrenContainer Add(string name, ChildRestartStats stats)
         {
             return this;
         }
 
-        public override ChildrenContainer Reserve(string name)
+        public override IChildrenContainer Reserve(string name)
         {
             throw new InvalidOperationException("Cannot reserve actor name '" + name + "': already terminated");
         }

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/TerminatingChildrenContainer.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/TerminatingChildrenContainer.cs
@@ -33,13 +33,13 @@ namespace Akka.Actor.Internal
 
         public SuspendReason Reason { get { return _reason; } }
 
-        public override ChildrenContainer Add(string name, ChildRestartStats stats)
+        public override IChildrenContainer Add(string name, ChildRestartStats stats)
         {
             var newMap = InternalChildren.AddOrUpdate(name, stats);
             return new TerminatingChildrenContainer(newMap, _toDie, _reason);
         }
 
-        public override ChildrenContainer Remove(IActorRef child)
+        public override IChildrenContainer Remove(IActorRef child)
         {
             var set = _toDie.Remove(child);
             if (set.IsEmpty)
@@ -50,12 +50,12 @@ namespace Akka.Actor.Internal
             return new TerminatingChildrenContainer(InternalChildren.Remove(child.Path.Name), set, _reason);
         }
 
-        public override ChildrenContainer ShallDie(IActorRef actor)
+        public override IChildrenContainer ShallDie(IActorRef actor)
         {
             return new TerminatingChildrenContainer(InternalChildren, _toDie.Add(actor), _reason);
         }
 
-        public override ChildrenContainer Reserve(string name)
+        public override IChildrenContainer Reserve(string name)
         {
             if (_reason is SuspendReason.Termination) throw new InvalidOperationException(string.Format("Cannot reserve actor name\"{0}\". Is terminating.", name));
             if (InternalChildren.Contains(name))
@@ -64,7 +64,7 @@ namespace Akka.Actor.Internal
                 return new TerminatingChildrenContainer(InternalChildren.AddOrUpdate(name, ChildNameReserved.Instance), _toDie, _reason);
         }
 
-        public override ChildrenContainer Unreserve(string name)
+        public override IChildrenContainer Unreserve(string name)
         {
             ChildStats stats;
             if (!InternalChildren.TryGet(name, out stats))
@@ -99,7 +99,7 @@ namespace Akka.Actor.Internal
             return sb.ToString();
         }
 
-        public ChildrenContainer CreateCopyWithReason(SuspendReason reason)
+        public IChildrenContainer CreateCopyWithReason(SuspendReason reason)
         {
             return new TerminatingChildrenContainer(InternalChildren, _toDie, reason);
         }

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/TerminatingChildrenContainer.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/TerminatingChildrenContainer.cs
@@ -19,12 +19,12 @@ namespace Akka.Actor.Internal
         private readonly IImmutableSet<IActorRef> _toDie;
         private readonly SuspendReason _reason;
 
-        public TerminatingChildrenContainer(IImmutableMap<string, ChildStats> children, IActorRef toDie, SuspendReason reason)
+        public TerminatingChildrenContainer(IImmutableMap<string, IChildStats> children, IActorRef toDie, SuspendReason reason)
             : this(children, ImmutableTreeSet<IActorRef>.Create(toDie), reason)
         {
             //Intentionally left blank
         }
-        public TerminatingChildrenContainer(IImmutableMap<string, ChildStats> children, IImmutableSet<IActorRef> toDie, SuspendReason reason)
+        public TerminatingChildrenContainer(IImmutableMap<string, IChildStats> children, IImmutableSet<IActorRef> toDie, SuspendReason reason)
             : base(children)
         {
             _toDie = toDie;
@@ -66,7 +66,7 @@ namespace Akka.Actor.Internal
 
         public override IChildrenContainer Unreserve(string name)
         {
-            ChildStats stats;
+            IChildStats stats;
             if (!InternalChildren.TryGet(name, out stats))
                 return this;
             return new TerminatingChildrenContainer(InternalChildren.Remove(name), _toDie, _reason);

--- a/src/core/Akka/Actor/EmptyLocalActorRef.cs
+++ b/src/core/Akka/Actor/EmptyLocalActorRef.cs
@@ -6,11 +6,11 @@ namespace Akka.Actor
 {
     public class EmptyLocalActorRef : MinimalActorRef
     {
-        private readonly ActorRefProvider _provider;
+        private readonly IActorRefProvider _provider;
         private readonly ActorPath _path;
         private readonly EventStream _eventStream;
 
-        public EmptyLocalActorRef(ActorRefProvider provider, ActorPath path, EventStream eventStream)
+        public EmptyLocalActorRef(IActorRefProvider provider, ActorPath path, EventStream eventStream)
         {
             _provider = provider;
             _path = path;
@@ -19,7 +19,7 @@ namespace Akka.Actor
 
         public override ActorPath Path { get { return _path; } }
 
-        public override ActorRefProvider Provider { get { return _provider; } }
+        public override IActorRefProvider Provider { get { return _provider; } }
         public override bool IsTerminated { get { return true; } }
 
         protected override void TellInternal(object message, IActorRef sender)

--- a/src/core/Akka/Actor/ExtendedActorSystem.cs
+++ b/src/core/Akka/Actor/ExtendedActorSystem.cs
@@ -12,7 +12,7 @@
     {
         /// <summary>Gets the provider.</summary>
         /// <value>The provider.</value>
-        public abstract ActorRefProvider Provider { get; }
+        public abstract IActorRefProvider Provider { get; }
 
         /// <summary>
         /// Gets the top-level supervisor of all user actors created using 

--- a/src/core/Akka/Actor/FSM.cs
+++ b/src/core/Akka/Actor/FSM.cs
@@ -376,7 +376,7 @@ namespace Akka.Actor
     /// </summary>
     /// <typeparam name="TState">The state name type</typeparam>
     /// <typeparam name="TData">The state data type</typeparam>
-    public abstract class FSM<TState, TData> : FSMBase, IListeners, InternalSupportsTestFSMRef<TState,TData>
+    public abstract class FSM<TState, TData> : FSMBase, IListeners, IInternalSupportsTestFSMRef<TState,TData>
     {
         private readonly LoggingAdapter _log = Context.GetLogger();
         protected FSM()
@@ -552,7 +552,7 @@ namespace Akka.Actor
         }
 
         //Internal API
-        bool InternalSupportsTestFSMRef<TState, TData>.IsStateTimerActive
+        bool IInternalSupportsTestFSMRef<TState, TData>.IsStateTimerActive
         {
             get
             {
@@ -855,7 +855,7 @@ namespace Akka.Actor
         }
 
         //Internal API
-        void InternalSupportsTestFSMRef<TState, TData>.ApplyState(State<TState, TData> upcomingState)
+        void IInternalSupportsTestFSMRef<TState, TData>.ApplyState(State<TState, TData> upcomingState)
         {
             ApplyState(upcomingState);
         }

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -24,7 +24,7 @@ namespace Akka.Actor
 
         public static async Task<T> Ask<T>(this ICanTell self, object message, TimeSpan? timeout = null)
         {
-            ActorRefProvider provider = ResolveProvider(self);
+            IActorRefProvider provider = ResolveProvider(self);
             if (provider == null)
                 throw new NotSupportedException("Unable to resolve the target Provider");
 
@@ -41,7 +41,7 @@ namespace Akka.Actor
             return null;
         }
 
-        internal static ActorRefProvider ResolveProvider(ICanTell self)
+        internal static IActorRefProvider ResolveProvider(ICanTell self)
         {
             if (ActorCell.Current != null)
                 return InternalCurrentActorCellKeeper.Current.SystemImpl.Provider;
@@ -55,7 +55,7 @@ namespace Akka.Actor
             return null;
         }
 
-        private static Task<object> Ask(ICanTell self, object message, ActorRefProvider provider,
+        private static Task<object> Ask(ICanTell self, object message, IActorRefProvider provider,
             TimeSpan? timeout)
         {
             var result = new TaskCompletionSource<object>(TaskContinuationOptions.AttachedToParent);
@@ -86,14 +86,14 @@ namespace Akka.Actor
     /// </summary>
     internal sealed class PromiseActorRef : MinimalActorRef
     {
-        public PromiseActorRef(ActorRefProvider provider, TaskCompletionSource<object> result, string mcn)
+        public PromiseActorRef(IActorRefProvider provider, TaskCompletionSource<object> result, string mcn)
         {
             _provider = provider;
             Result = result;
             _mcn = mcn;
         }
 
-        private readonly ActorRefProvider _provider;
+        private readonly IActorRefProvider _provider;
         public readonly TaskCompletionSource<object> Result;
 
         /// <summary>
@@ -175,7 +175,7 @@ namespace Akka.Actor
 
         private static readonly Status.Failure ActorStopResult = new Status.Failure(new ActorKilledException("Stopped"));
 
-        public static PromiseActorRef Apply(ActorRefProvider provider, TimeSpan timeout, object targetName,
+        public static PromiseActorRef Apply(IActorRefProvider provider, TimeSpan timeout, object targetName,
             string messageClassName, IActorRef sender = null)
         {
             sender = sender ?? ActorRefs.NoSender;
@@ -217,7 +217,7 @@ namespace Akka.Actor
             return _watchedByDoNotCallMeDirectly.CompareAndSet(oldWatchedBy, newWatchedBy);
         }
 
-        public override ActorRefProvider Provider
+        public override IActorRefProvider Provider
         {
             get { return _provider; }
         }

--- a/src/core/Akka/Actor/Inbox.cs
+++ b/src/core/Akka/Actor/Inbox.cs
@@ -183,11 +183,11 @@ namespace Akka.Actor
     }
 
     /// <summary>
-    /// <see cref="Inboxable"/> is an actor-like object to be listened by external objects.
+    /// <see cref="IInboxable"/> is an actor-like object to be listened by external objects.
     /// It can watch other actors lifecycle and contains inner actor, which could be passed
     /// as reference to other actors.
     /// </summary>
-    public interface Inboxable : ICanWatch
+    public interface IInboxable : ICanWatch
     {
         /// <summary>
         /// Get a reference to internal actor. It may be for example registered in event stream.
@@ -195,13 +195,13 @@ namespace Akka.Actor
         IActorRef Receiver { get; }
 
         /// <summary>
-        /// Receive a next message from current <see cref="Inboxable"/> with default timeout. This call will return immediately,
+        /// Receive a next message from current <see cref="IInboxable"/> with default timeout. This call will return immediately,
         /// if the internal actor previously received a message, or will block until it'll receive a message.
         /// </summary>
         object Receive();
 
         /// <summary>
-        /// Receive a next message from current <see cref="Inboxable"/>. This call will return immediately,
+        /// Receive a next message from current <see cref="IInboxable"/>. This call will return immediately,
         /// if the internal actor previously received a message, or will block for time specified by 
         /// <paramref name="timeout"/> until it'll receive a message.
         /// </summary>
@@ -229,7 +229,7 @@ namespace Akka.Actor
         void Send(IActorRef target, object message);
     }
 
-    public class Inbox : Inboxable, IDisposable
+    public class Inbox : IInboxable, IDisposable
     {
         private static int inboxNr = 0;
         private readonly ISet<IObserver<object>> _subscribers;

--- a/src/core/Akka/Actor/Internals/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internals/ActorSystemImpl.cs
@@ -21,7 +21,7 @@ namespace Akka.Actor.Internals
         private readonly ConcurrentDictionary<Type, Lazy<object>> _extensions = new ConcurrentDictionary<Type, Lazy<object>>();
 
         private LoggingAdapter _log;
-        private ActorRefProvider _provider;
+        private IActorRefProvider _provider;
         private Settings _settings;
         private readonly string _name;
         private Serialization.Serialization _serialization;
@@ -55,7 +55,7 @@ namespace Akka.Actor.Internals
             ConfigureActorProducerPipeline();
         }
 
-        public override ActorRefProvider Provider { get { return _provider; } }
+        public override IActorRefProvider Provider { get { return _provider; } }
         public override Settings Settings { get { return _settings; } }
         public override string Name { get { return _name; } }
         public override Serialization.Serialization Serialization { get { return _serialization; } }
@@ -257,7 +257,7 @@ namespace Akka.Actor.Internals
         {
             Type providerType = Type.GetType(_settings.ProviderClass);
             global::System.Diagnostics.Debug.Assert(providerType != null, "providerType != null");
-            var provider = (ActorRefProvider)Activator.CreateInstance(providerType, _name, _settings, _eventStream);
+            var provider = (IActorRefProvider)Activator.CreateInstance(providerType, _name, _settings, _eventStream);
             _provider = provider;
         }
 

--- a/src/core/Akka/Actor/Internals/InitializableActor.cs
+++ b/src/core/Akka/Actor/Internals/InitializableActor.cs
@@ -4,8 +4,7 @@
     /// Marks that the actor needs to be initialized directly after it has been created.
     /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
     /// </summary>
-    // ReSharper disable once InconsistentNaming
-    public interface InitializableActor
+    public interface IInitializableActor
     {
         void Init();
     }

--- a/src/core/Akka/Actor/Internals/InternalSupportsTestFSMRef.cs
+++ b/src/core/Akka/Actor/Internals/InternalSupportsTestFSMRef.cs
@@ -5,8 +5,7 @@ namespace Akka.Actor.Internal
     /// This is used to let TestFSMRef in TestKit access to internal methods.
     /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
     /// </summary>
-    // ReSharper disable once InconsistentNaming
-    public interface InternalSupportsTestFSMRef<TState, TData>
+    public interface IInternalSupportsTestFSMRef<TState, TData>
     {
         /// <summary>
         /// INTERNAL API. Used for testing.

--- a/src/core/Akka/Actor/LocalActorRef.cs
+++ b/src/core/Akka/Actor/LocalActorRef.cs
@@ -60,7 +60,7 @@ namespace Akka.Actor
         }
 
 
-        public override Cell Underlying
+        public override ICell Underlying
         {
             get { return _cell; }
         }

--- a/src/core/Akka/Actor/LocalActorRef.cs
+++ b/src/core/Akka/Actor/LocalActorRef.cs
@@ -70,7 +70,7 @@ namespace Akka.Actor
             get { return _cell; }
         }
 
-        public override ActorRefProvider Provider
+        public override IActorRefProvider Provider
         {
             get { return _cell.SystemImpl.Provider; }
         }

--- a/src/core/Akka/Actor/LocalActorRef.cs
+++ b/src/core/Akka/Actor/LocalActorRef.cs
@@ -7,7 +7,7 @@ using Akka.Util.Internal;
 
 namespace Akka.Actor
 {
-    public class LocalActorRef : ActorRefWithCell, LocalRef
+    public class LocalActorRef : ActorRefWithCell, ILocalRef
     {
         private readonly ActorSystem _system;
         private readonly Props _props;

--- a/src/core/Akka/Actor/Props.cs
+++ b/src/core/Akka/Actor/Props.cs
@@ -135,7 +135,7 @@ namespace Akka.Actor
         /// <summary>
         ///     The default producer
         /// </summary>
-        private static readonly IndirectActorProducer defaultProducer = new DefaultProducer();
+        private static readonly IIndirectActorProducer defaultProducer = new DefaultProducer();
 
         /// <summary>
         ///     The intern type of the actor or the producer
@@ -150,7 +150,7 @@ namespace Akka.Actor
         /// <summary>
         ///     The producer of the actor
         /// </summary>
-        private IndirectActorProducer producer;
+        private IIndirectActorProducer producer;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="Props" /> class.
@@ -361,7 +361,7 @@ namespace Akka.Actor
         /// <typeparam name="TProducer">The type of the actor producer</typeparam>
         /// <param name="args">The arguments</param>
         /// <returns>Props</returns>
-        public static Props CreateBy<TProducer>(params object[] args) where TProducer : class, IndirectActorProducer
+        public static Props CreateBy<TProducer>(params object[] args) where TProducer : class, IIndirectActorProducer
         {
             return new Props(typeof(TProducer), args);
         }
@@ -512,7 +512,7 @@ namespace Akka.Actor
             }
         }
 
-        private class DefaultProducer : IndirectActorProducer
+        private class DefaultProducer : IIndirectActorProducer
         {
             public ActorBase Produce()
             {
@@ -525,7 +525,7 @@ namespace Akka.Actor
             }
         }
 
-        private class ActivatorProducer : IndirectActorProducer
+        private class ActivatorProducer : IIndirectActorProducer
         {
             private readonly Type _actorType;
             private readonly object[] _args;
@@ -547,7 +547,7 @@ namespace Akka.Actor
             }
         }
 
-        private class FactoryConsumer<TActor> : IndirectActorProducer where TActor : ActorBase
+        private class FactoryConsumer<TActor> : IIndirectActorProducer where TActor : ActorBase
         {
             private readonly Func<TActor> _factory;
 
@@ -569,13 +569,13 @@ namespace Akka.Actor
 
         #endregion
 
-        private static IndirectActorProducer CreateProducer(Type type, object[] args)
+        private static IIndirectActorProducer CreateProducer(Type type, object[] args)
         {
             if (type == null) {
                 return defaultProducer;
             }
-            if (typeof(IndirectActorProducer).IsAssignableFrom(type)) {
-                return Activator.CreateInstance(type, args).AsInstanceOf<IndirectActorProducer>();
+            if (typeof(IIndirectActorProducer).IsAssignableFrom(type)) {
+                return Activator.CreateInstance(type, args).AsInstanceOf<IIndirectActorProducer>();
             }
             if (typeof(ActorBase).IsAssignableFrom(type)) {
                 return new ActivatorProducer(type, args);
@@ -657,7 +657,7 @@ namespace Akka.Actor
     ///     subclass. It can be used to allow a dependency injection framework to
     ///     determine the actual actor class and how it shall be instantiated.
     /// </summary>
-    public interface IndirectActorProducer
+    public interface IIndirectActorProducer
     {
         /// <summary>
         ///     This factory method must produce a fresh actor instance upon each

--- a/src/core/Akka/Actor/ReceiveActor.cs
+++ b/src/core/Akka/Actor/ReceiveActor.cs
@@ -8,7 +8,7 @@ using Akka.Tools.MatchHandler;
 namespace Akka.Actor
 {
 
-    public abstract class ReceiveActor : UntypedActor, InitializableActor
+    public abstract class ReceiveActor : UntypedActor, IInitializableActor
     {
         private bool _shouldUnhandle = true;
         private readonly Stack<MatchBuilder> _matchHandlerBuilders = new Stack<MatchBuilder>();
@@ -20,7 +20,7 @@ namespace Akka.Actor
             PrepareConfigureMessageHandlers();
         }
 
-        void InitializableActor.Init()
+        void IInitializableActor.Init()
         {
             //This might be called directly after the constructor, or when the same actor instance has been returned
             //during recreate. Make sure what happens here is idempotent

--- a/src/core/Akka/Actor/RepointableActorRef.cs
+++ b/src/core/Akka/Actor/RepointableActorRef.cs
@@ -185,7 +185,7 @@ namespace Akka.Actor
                         break;
                     default:
                         var nameAndUid = ActorCell.SplitNameAndUid(element);
-                        ChildStats stats;
+                        IChildStats stats;
                         if (Lookup.TryGetChildStatsByName(nameAndUid.Name, out stats))
                         {
                             var crs = stats as ChildRestartStats;
@@ -296,7 +296,7 @@ namespace Akka.Actor
             return Nobody.Instance;
         }
 
-        public bool TryGetChildStatsByName(string name, out ChildStats child)
+        public bool TryGetChildStatsByName(string name, out IChildStats child)
         {
             child = null;
             return false;

--- a/src/core/Akka/Actor/RepointableActorRef.cs
+++ b/src/core/Akka/Actor/RepointableActorRef.cs
@@ -13,8 +13,8 @@ namespace Akka.Actor
 {
     public class RepointableActorRef : ActorRefWithCell, IRepointableRef
     {
-        private volatile Cell _underlying_DoNotCallMeDirectly;
-        private volatile Cell _lookup_DoNotCallMeDirectly;
+        private volatile ICell _underlying_DoNotCallMeDirectly;
+        private volatile ICell _lookup_DoNotCallMeDirectly;
         private readonly ActorSystemImpl _system;
         private readonly Props _props;
         private readonly MessageDispatcher _dispatcher;
@@ -33,8 +33,8 @@ namespace Akka.Actor
         }
 
 
-        public override Cell Underlying { get { return _underlying_DoNotCallMeDirectly; } }
-        public Cell Lookup { get { return _lookup_DoNotCallMeDirectly; } }
+        public override ICell Underlying { get { return _underlying_DoNotCallMeDirectly; } }
+        public ICell Lookup { get { return _lookup_DoNotCallMeDirectly; } }
 
         public override bool IsTerminated
         {
@@ -42,7 +42,7 @@ namespace Akka.Actor
         }
 
 
-        public void SwapUnderlying(Cell cell)
+        public void SwapUnderlying(ICell cell)
         {
             #pragma warning disable 0420
             //Ok to ignore CS0420 "a reference to a volatile field will not be treated as volatile" for interlocked calls http://msdn.microsoft.com/en-us/library/4bw5ewxy(VS.80).aspx
@@ -50,7 +50,7 @@ namespace Akka.Actor
             #pragma warning restore 0420
         }
 
-        private void SwapLookup(Cell cell)
+        private void SwapLookup(ICell cell)
         {
             #pragma warning disable 0420
             //Ok to ignore CS0420 "a reference to a volatile field will not be treated as volatile" for interlocked calls http://msdn.microsoft.com/en-us/library/4bw5ewxy(VS.80).aspx
@@ -214,7 +214,7 @@ namespace Akka.Actor
 
     }
 
-    public class UnstartedCell : Cell
+    public class UnstartedCell : ICell
     {
         private readonly ActorSystemImpl _system;
         private readonly RepointableActorRef _self;
@@ -233,7 +233,7 @@ namespace Akka.Actor
             _timeout = _system.Settings.UnstartedPushTimeout;
         }
 
-        public void ReplaceWith(Cell cell)
+        public void ReplaceWith(ICell cell)
         {
             lock(_lock)
             {
@@ -400,7 +400,7 @@ namespace Akka.Actor
 
         public bool IsLocal { get { return true; } }
 
-        private bool CellIsReady(Cell cell)
+        private bool CellIsReady(ICell cell)
         {
             return !ReferenceEquals(cell, this) && !ReferenceEquals(cell, null);
         }

--- a/src/core/Akka/Actor/RepointableActorRef.cs
+++ b/src/core/Akka/Actor/RepointableActorRef.cs
@@ -11,7 +11,7 @@ using Akka.Pattern;
 
 namespace Akka.Actor
 {
-    public class RepointableActorRef : ActorRefWithCell, RepointableRef
+    public class RepointableActorRef : ActorRefWithCell, IRepointableRef
     {
         private volatile Cell _underlying_DoNotCallMeDirectly;
         private volatile Cell _lookup_DoNotCallMeDirectly;

--- a/src/core/Akka/Actor/RepointableActorRef.cs
+++ b/src/core/Akka/Actor/RepointableActorRef.cs
@@ -124,7 +124,7 @@ namespace Akka.Actor
 
         public override IInternalActorRef Parent { get { return Underlying.Parent; } }
 
-        public override ActorRefProvider Provider { get { return _system.Provider; } }
+        public override IActorRefProvider Provider { get { return _system.Provider; } }
 
         public override bool IsLocal { get { return Underlying.IsLocal; } }
 

--- a/src/core/Akka/Actor/RootGuardianSupervisor.cs
+++ b/src/core/Akka/Actor/RootGuardianSupervisor.cs
@@ -16,9 +16,9 @@ namespace Akka.Actor
         private readonly TaskCompletionSource<Status> _terminationPromise;
         private readonly ActorPath _path;
         private readonly Switch _stopped=new Switch(false);
-        private readonly ActorRefProvider _provider;
+        private readonly IActorRefProvider _provider;
 
-        public RootGuardianSupervisor(RootActorPath root, ActorRefProvider provider, TaskCompletionSource<Status> terminationPromise, LoggingAdapter log)
+        public RootGuardianSupervisor(RootActorPath root, IActorRefProvider provider, TaskCompletionSource<Status> terminationPromise, LoggingAdapter log)
         {
             _log = log;
             _terminationPromise = terminationPromise;
@@ -89,7 +89,7 @@ namespace Akka.Actor
             get { return _path; }
         }
 
-        public override ActorRefProvider Provider
+        public override IActorRefProvider Provider
         {
             get { return _provider; }
         }

--- a/src/core/Akka/Actor/Settings.cs
+++ b/src/core/Akka/Actor/Settings.cs
@@ -56,7 +56,7 @@ namespace Akka.Actor
             var providerType = Type.GetType(ProviderClass);
             if (providerType == null)
                 throw new ConfigurationException(string.Format("'akka.actor.provider' is not a valid type name : '{0}'", ProviderClass));
-            if (!typeof(ActorRefProvider).IsAssignableFrom(providerType))
+            if (!typeof(IActorRefProvider).IsAssignableFrom(providerType))
                 throw new ConfigurationException(string.Format("'akka.actor.provider' is not a valid actor ref provider: '{0}'", ProviderClass));
             
             SupervisorStrategyClass = Config.GetString("akka.actor.guardian-supervisor-strategy");

--- a/src/core/Akka/Akka.csproj.DotSettings
+++ b/src/core/Akka/Akka.csproj.DotSettings
@@ -1,6 +1,7 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=actor_005Ccancellation/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=Actor_005CChildrenContainer/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=actor_005Cchildrencontainer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=actor_005Cscheduler/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=Actor_005CStash/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=Util_005CDurations/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/core/Akka/Event/StandardOutLogger.cs
+++ b/src/core/Akka/Event/StandardOutLogger.cs
@@ -27,7 +27,7 @@ namespace Akka.Event
         /// </summary>
         /// <value>The provider.</value>
         /// <exception cref="System.Exception">StandardOutLogged does not provide</exception>
-        public override ActorRefProvider Provider
+        public override IActorRefProvider Provider
         {
             get { throw new Exception("StandardOutLogger does not provide"); }
         }

--- a/src/core/Akka/Routing/RoutedActorCell.cs
+++ b/src/core/Akka/Routing/RoutedActorCell.cs
@@ -104,7 +104,7 @@ namespace Akka.Routing
         private void StopIfChild(Routee routee)
         {
             var actorRefRoutee = routee as ActorRefRoutee;
-            ChildStats childActorStats;
+            IChildStats childActorStats;
             if (actorRefRoutee != null && TryGetChildStatsByName(actorRefRoutee.Actor.Path.Name, out childActorStats))
             {
                 // The reason for the delay is to give concurrent

--- a/src/core/Akka/Routing/RouterConfig.cs
+++ b/src/core/Akka/Routing/RouterConfig.cs
@@ -34,7 +34,7 @@ namespace Akka.Routing
         public virtual bool IsManagementMessage(object message)
         {
             return
-                message is AutoReceivedMessage ||
+                message is IAutoReceivedMessage ||
                 // in akka.net this message is a subclass of AutoReceivedMessage - so removed condition that "message is Terminated ||"
                 message is RouterManagementMesssage;
         }

--- a/src/core/Akka/Routing/RouterConfig.cs
+++ b/src/core/Akka/Routing/RouterConfig.cs
@@ -419,7 +419,7 @@ namespace Akka.Routing
     }
 
     /// <summary>
-    /// Used to tell <see cref="ActorRefProvider"/> to create router based on what's stored in configuration.
+    /// Used to tell <see cref="IActorRefProvider"/> to create router based on what's stored in configuration.
     /// 
     /// For example:
     /// <code>

--- a/src/core/Akka/Routing/SmallestMailbox.cs
+++ b/src/core/Akka/Routing/SmallestMailbox.cs
@@ -55,7 +55,7 @@ namespace Akka.Routing
             return winner;
         }
 
-        private Cell TryGetActorCell(Routee routee)
+        private ICell TryGetActorCell(Routee routee)
         {
             var refRoutee = routee as ActorRefRoutee;
             if (refRoutee != null)

--- a/src/core/Akka/Util/Resolver.cs
+++ b/src/core/Akka/Util/Resolver.cs
@@ -8,7 +8,7 @@ namespace Akka.Util
         T Resolve<T>(object[] args);
     }
 
-    public abstract class Resolve : IndirectActorProducer
+    public abstract class Resolve : IIndirectActorProducer
     {
         public abstract ActorBase Produce();
         public abstract Type ActorType { get; }


### PR DESCRIPTION
Renames a few interfaces specified in #652 and prefix them with `I`.

Should we keep the commits, or should they be squashed? I'm guessing merge conflicts might be more frequent with more commits, but handling the merge conflicts are easier if the commit doesn't change too many things. Let me know. :)