### PR TITLE
Bugfix - unused supervisorStrategy in props create is fixed

### DIFF
--- a/src/core/Akka.Tests/Actor/PropsSpec.cs
+++ b/src/core/Akka.Tests/Actor/PropsSpec.cs
@@ -33,6 +33,22 @@ namespace Akka.Tests.Actor
             latchActor.Ready(TimeSpan.FromSeconds(1));
         }
 
+        [Fact]
+        public void Props_created_without_strategy_must_have_it_null()
+        {
+            var props = Props.Create(() => new PropsTestActor());
+            Assert.Null(props.SupervisorStrategy);
+        }
+
+        [Fact]
+        public void Props_created_with_strategy_must_have_it_set()
+        {
+            var strategy = new OneForOneStrategy(_ => Directive.Stop);
+            var props = Props.Create(() => new PropsTestActor(), strategy);
+
+            Assert.Equal(strategy, props.SupervisorStrategy);
+        }
+
         private class TestProducer : IIndirectActorProducer
         {
             TestLatch latchActor;

--- a/src/core/Akka/Actor/Props.cs
+++ b/src/core/Akka/Actor/Props.cs
@@ -342,7 +342,7 @@ namespace Akka.Actor
 
             object[] args = newExpression.GetArguments().ToArray();
 
-            return new Props(typeof (TActor), args);
+            return new Props(typeof (TActor), supervisorStrategy, args);
         }
 
         /// <summary>


### PR DESCRIPTION
I believe I found a tiny bug with unused strategy argument passed to Props.Create in Props.cs.

Tests demonstrate expected (at least by me) functionality - on upstream `Props_created_with_strategy_must_have_it_set` would not pass.

After merge both tests should pass.