### PR TITLE
More interface prefixing

### DIFF
--- a/src/contrib/loggers/Akka.Logger.NLog/NLogLogger.cs
+++ b/src/contrib/loggers/Akka.Logger.NLog/NLogLogger.cs
@@ -8,7 +8,7 @@ namespace Akka.Logger.NLog
 {
     public class NLogLogger : ReceiveActor
     {
-        private readonly LoggingAdapter _log = Context.GetLogger();
+        private readonly ILoggingAdapter _log = Context.GetLogger();
 
         private static void Log(LogEvent logEvent, Action<NLogger> logStatement)
         {

--- a/src/contrib/loggers/Akka.Logger.Serilog/SerilogLogger.cs
+++ b/src/contrib/loggers/Akka.Logger.Serilog/SerilogLogger.cs
@@ -7,7 +7,7 @@ namespace Akka.Logger.Serilog
 {
     public class SerilogLogger : ReceiveActor
     {
-        private readonly LoggingAdapter _log = Context.GetLogger();
+        private readonly ILoggingAdapter _log = Context.GetLogger();
 
         private void WithSerilog(Action<ILogger> logStatement)
         {

--- a/src/contrib/loggers/Akka.Logger.slf4net/Slf4jLogger.cs
+++ b/src/contrib/loggers/Akka.Logger.slf4net/Slf4jLogger.cs
@@ -11,7 +11,7 @@ namespace Akka.Logger.slf4net
         //private string mdcAkkaSourceAttributeName = "akkaSource";
         //private string mdcAkkaTimestamp = "akkaTimestamp";
 
-        private readonly LoggingAdapter _log = Context.GetLogger();
+        private readonly ILoggingAdapter _log = Context.GetLogger();
 
         private void WithMDC(Action<ILogger> logStatement)
         {

--- a/src/core/Akka.Cluster/AutoDown.cs
+++ b/src/core/Akka.Cluster/AutoDown.cs
@@ -196,6 +196,6 @@ namespace Akka.Cluster
             _pendingUnreachable = _pendingUnreachable.Remove(node);
         }
 
-        public LoggingAdapter Log { get; private set; }
+        public ILoggingAdapter Log { get; private set; }
     }
 }

--- a/src/core/Akka.Cluster/Cluster.cs
+++ b/src/core/Akka.Cluster/Cluster.cs
@@ -245,7 +245,7 @@ namespace Akka.Cluster
 
         internal ActorSystemImpl System { get; private set; }
 
-        readonly LoggingAdapter _log;
+        readonly ILoggingAdapter _log;
         readonly ClusterReadView _readView;
         public ClusterReadView ReadView {get { return _readView; }}
 

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -582,7 +582,7 @@ namespace Akka.Cluster
                     });
         }
 
-        private readonly LoggingAdapter _log = Context.GetLogger();
+        private readonly ILoggingAdapter _log = Context.GetLogger();
     }
 
     /// <summary>
@@ -594,7 +594,7 @@ namespace Akka.Cluster
         readonly IActorRef _publisher;
         readonly IActorRef _coreDaemon;
 
-        private readonly LoggingAdapter _log = Context.GetLogger();
+        private readonly ILoggingAdapter _log = Context.GetLogger();
 
         public ClusterCoreSupervisor()
         {
@@ -1708,7 +1708,7 @@ namespace Akka.Cluster
             _publisher.Tell(new ClusterEvent.CurrentInternalStats(_gossipStats, vclockStats));
         }
 
-        readonly LoggingAdapter _log = Context.GetLogger();
+        readonly ILoggingAdapter _log = Context.GetLogger();
     }
 
     /// <summary>
@@ -1737,7 +1737,7 @@ namespace Akka.Cluster
     /// </summary>
     internal sealed class JoinSeedNodeProcess : UntypedActor
     {
-        readonly LoggingAdapter _log = Context.GetLogger();
+        readonly ILoggingAdapter _log = Context.GetLogger();
 
         readonly ImmutableList<Address> _seeds;
         readonly Address _selfAddress;
@@ -1812,7 +1812,7 @@ namespace Akka.Cluster
     /// </summary>
     internal sealed class FirstSeedNodeProcess : UntypedActor
     {
-        readonly LoggingAdapter _log = Context.GetLogger();
+        readonly ILoggingAdapter _log = Context.GetLogger();
 
         private ImmutableList<Address> _remainingSeeds;
         readonly Address _selfAddress;
@@ -1970,7 +1970,7 @@ namespace Akka.Cluster
     class OnMemberUpListener : ReceiveActor
     {
         readonly Action _callback;
-        readonly LoggingAdapter _log = Context.GetLogger();
+        readonly ILoggingAdapter _log = Context.GetLogger();
         readonly Cluster _cluster;
 
         public OnMemberUpListener(Action callback)

--- a/src/core/Akka.Cluster/ClusterHeartbeat.cs
+++ b/src/core/Akka.Cluster/ClusterHeartbeat.cs
@@ -44,7 +44,7 @@ namespace Akka.Cluster
 
         private readonly Cluster _cluster;
 
-        private readonly LoggingAdapter _log = Context.GetLogger();
+        private readonly ILoggingAdapter _log = Context.GetLogger();
 
         public ClusterHeartbeatSender()
         {

--- a/src/core/Akka.Cluster/ClusterMetricsCollector.cs
+++ b/src/core/Akka.Cluster/ClusterMetricsCollector.cs
@@ -25,7 +25,7 @@ namespace Akka.Cluster
     /// </summary>
     internal class ClusterMetricsCollector : ReceiveActor
     {
-        private readonly LoggingAdapter _log = Context.GetLogger();
+        private readonly ILoggingAdapter _log = Context.GetLogger();
 
         /// <summary>
         /// The node ring gossiped that contains only members that are <see cref="MemberStatus.Up"/>

--- a/src/core/Akka.FSharp/FsApi.fs
+++ b/src/core/Akka.FSharp/FsApi.fs
@@ -72,7 +72,7 @@ module Actors =
         /// <summary>
         /// Lazy logging adapter. It won't be initialized until logging function will be called. 
         /// </summary>
-        abstract Log : Lazy<Akka.Event.LoggingAdapter>
+        abstract Log : Lazy<Akka.Event.ILoggingAdapter>
 
         /// <summary>
         /// Defers provided function to be invoked when actor stops, regardless of reasons.

--- a/src/core/Akka.Persistence.FSharp/FsApi.fs
+++ b/src/core/Akka.Persistence.FSharp/FsApi.fs
@@ -43,7 +43,7 @@ type Eventsourced<'Command, 'Event, 'State> =
     /// <summary>
     /// Lazy logging adapter. It won't be initialized until logging function will be called. 
     /// </summary>
-    abstract Log : Lazy<Akka.Event.LoggingAdapter>
+    abstract Log : Lazy<Akka.Event.ILoggingAdapter>
 
     /// <summary>
     /// Defers a function execution to the moment, when actor is suposed to end it's lifecycle.
@@ -181,7 +181,7 @@ type View<'Event, 'State> =
     /// <summary>
     /// Lazy logging adapter. It won't be initialized until logging function will be called. 
     /// </summary>
-    abstract Log : Lazy<Akka.Event.LoggingAdapter>
+    abstract Log : Lazy<Akka.Event.ILoggingAdapter>
 
     /// <summary>
     /// Defers a function execution to the moment, when actor is suposed to end it's lifecycle.

--- a/src/core/Akka.Persistence.Tests/GuaranteedDeliveryCrashSpec.cs
+++ b/src/core/Akka.Persistence.Tests/GuaranteedDeliveryCrashSpec.cs
@@ -63,9 +63,9 @@ namespace Akka.Persistence.Tests
         internal class CrashingActor : GuaranteedDeliveryActor
         {
             private readonly IActorRef _testProbe;
-            private LoggingAdapter _adapter;
+            private ILoggingAdapter _adapter;
 
-            LoggingAdapter Log { get { return _adapter ?? (_adapter = Context.GetLogger()); } }
+            ILoggingAdapter Log { get { return _adapter ?? (_adapter = Context.GetLogger()); } }
 
             public CrashingActor(IActorRef testProbe)
             {

--- a/src/core/Akka.Persistence.Tests/GuaranteedDeliveryFailureSpec.cs
+++ b/src/core/Akka.Persistence.Tests/GuaranteedDeliveryFailureSpec.cs
@@ -135,9 +135,9 @@ namespace Akka.Persistence.Tests
             private readonly Config _config;
             private readonly double _liveProcessingFailureRate;
             private readonly double _replayProcessingFailureRate;
-            private LoggingAdapter _log;
+            private ILoggingAdapter _log;
 
-            public LoggingAdapter Log { get { return _log ?? (_log = Context.GetLogger()); }}
+            public ILoggingAdapter Log { get { return _log ?? (_log = Context.GetLogger()); }}
 
             public ChaosSender(IActorRef destination, IActorRef probe)
             {
@@ -237,9 +237,9 @@ namespace Akka.Persistence.Tests
         {
             private readonly Config _config;
             private readonly double _confirmFailureRate;
-            private LoggingAdapter _log;
+            private ILoggingAdapter _log;
 
-            public LoggingAdapter Log { get { return _log ?? (_log = Context.GetLogger()); } }
+            public ILoggingAdapter Log { get { return _log ?? (_log = Context.GetLogger()); } }
 
             public ChaosDestination(IActorRef probe)
             {

--- a/src/core/Akka.Persistence.Tests/GuaranteedDeliverySpec.cs
+++ b/src/core/Akka.Persistence.Tests/GuaranteedDeliverySpec.cs
@@ -22,7 +22,7 @@ namespace Akka.Persistence.Tests
             private readonly int _redeliveryBurstLimit;
             private readonly bool _isAsync;
             private readonly IDictionary<string, ActorPath> _destinations;
-            private readonly LoggingAdapter _log;
+            private readonly ILoggingAdapter _log;
             private IActorRef _lastSnapshotAskedForBy;
 
             public Sender(IActorRef testActor, string name, TimeSpan redeliverInterval, int warn, int redeliveryBurstLimit, bool isAsync, IDictionary<string, ActorPath> destinations)

--- a/src/core/Akka.Persistence/Snapshot/LocalSnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/LocalSnapshotStore.cs
@@ -62,8 +62,8 @@ namespace Akka.Persistence.Snapshot
         private readonly StoreSettings _settings;
         public StoreSettings Settings { get { return _settings; } }
 
-        private LoggingAdapter _log;
-        public LoggingAdapter Log { get { return _log ?? (_log = Context.GetLogger()); } }
+        private ILoggingAdapter _log;
+        public ILoggingAdapter Log { get { return _log ?? (_log = Context.GetLogger()); } }
 
         protected override void PreStart()
         {

--- a/src/core/Akka.Remote.TestKit/BarrierCoordinator.cs
+++ b/src/core/Akka.Remote.TestKit/BarrierCoordinator.cs
@@ -376,7 +376,7 @@ namespace Akka.Remote.TestKit
 
         //this shall be set to true if all subsequent barriers shall fail
         private bool _failed = false;
-        private readonly LoggingAdapter _log = Context.GetLogger();
+        private readonly ILoggingAdapter _log = Context.GetLogger();
 
         protected override void PreRestart(Exception reason, object message) { }
         protected override void PostRestart(Exception reason)

--- a/src/core/Akka.Remote.TestKit/Conductor.cs
+++ b/src/core/Akka.Remote.TestKit/Conductor.cs
@@ -242,11 +242,11 @@ namespace Akka.Remote.TestKit
     /// </summary>
     internal class ConductorHandler : IHeliosConnectionHandler
     {
-        private readonly LoggingAdapter _log;
+        private readonly ILoggingAdapter _log;
         private readonly IActorRef _controller;
         private readonly ConcurrentDictionary<IConnection, IActorRef> _clients = new ConcurrentDictionary<IConnection, IActorRef>();
 
-        public ConductorHandler(IActorRef controller, LoggingAdapter log)
+        public ConductorHandler(IActorRef controller, ILoggingAdapter log)
         {
             _controller = controller;
             _log = log;
@@ -309,7 +309,7 @@ namespace Akka.Remote.TestKit
     /// </summary>
     class ServerFSM : FSM<ServerFSM.State, IActorRef>, ILoggingFSM
     {
-        private readonly LoggingAdapter _log = Context.GetLogger();
+        private readonly ILoggingAdapter _log = Context.GetLogger();
         readonly RemoteConnection _channel;
         readonly IActorRef _controller;        
         RoleName _roleName;

--- a/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
+++ b/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
@@ -371,7 +371,7 @@ namespace Akka.Remote.TestKit
 
         readonly RoleName _myself;
         public RoleName Myself { get { return _myself; } }
-        readonly LoggingAdapter _log;
+        readonly ILoggingAdapter _log;
         readonly ImmutableList<RoleName> _roles;
         readonly Func<RoleName, ImmutableList<string>> _deployments;
         readonly ImmutableDictionary<RoleName, Replacement> _replacements;

--- a/src/core/Akka.Remote.TestKit/Player.cs
+++ b/src/core/Akka.Remote.TestKit/Player.cs
@@ -278,7 +278,7 @@ namespace Akka.Remote.TestKit
             }            
         }
 
-        private readonly LoggingAdapter _log = Context.GetLogger();
+        private readonly ILoggingAdapter _log = Context.GetLogger();
         readonly TestConductorSettings _settings;
         readonly PlayerHandler _handler;
         readonly RoleName _name;
@@ -512,14 +512,14 @@ namespace Akka.Remote.TestKit
         readonly TimeSpan _backoff;
         readonly int _poolSize;
         readonly IActorRef _fsm;
-        readonly LoggingAdapter _log;
+        readonly ILoggingAdapter _log;
         readonly IScheduler _scheduler;
         private bool _loggedDisconnect = false;
         
         Deadline _nextAttempt;
         
         public PlayerHandler(INode server, int reconnects, TimeSpan backoff, int poolSize, IActorRef fsm,
-            LoggingAdapter log, IScheduler scheduler)
+            ILoggingAdapter log, IScheduler scheduler)
         {
             _server = server;
             _reconnects = reconnects;

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -97,7 +97,7 @@ namespace Akka.Remote
                             log.Debug("operating in UntrustedMode, dropping inbound IPossiblyHarmful message of type {0}", msg.GetType());
                         }
                     })
-                    .With<SystemMessage>(msg => { recipient.Tell(msg); })
+                    .With<ISystemMessage>(msg => { recipient.Tell(msg); })
                     .Default(msg =>
                     {
                         recipient.Tell(msg, sender);
@@ -488,7 +488,7 @@ namespace Akka.Remote
                 })
                 .With<EndpointManager.Send>(send =>
                 {
-                    if (send.Message is SystemMessage)
+                    if (send.Message is ISystemMessage)
                     {
                         TryBuffer(send.Copy(NextSeq()));
                     }
@@ -570,7 +570,7 @@ namespace Akka.Remote
 
         private void HandleSend(EndpointManager.Send send)
         {
-            if (send.Message is SystemMessage)
+            if (send.Message is ISystemMessage)
             {
                 var sequencedSend = send.Copy(NextSeq());
                 TryBuffer(sequencedSend);

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -32,11 +32,11 @@ namespace Akka.Remote
     {
         private ActorSystem system;
         private RemoteActorRefProvider provider;
-        private LoggingAdapter log;
+        private ILoggingAdapter log;
         private IInternalActorRef remoteDaemon;
         private RemoteSettings settings;
 
-        public DefaultMessageDispatcher(ActorSystem system, RemoteActorRefProvider provider, LoggingAdapter log)
+        public DefaultMessageDispatcher(ActorSystem system, RemoteActorRefProvider provider, ILoggingAdapter log)
         {
             this.system = system;
             this.provider = provider;
@@ -252,7 +252,7 @@ namespace Akka.Remote
     /// </summary>
     internal class ReliableDeliverySupervisor : UntypedActor
     {
-        private readonly LoggingAdapter _log = Context.GetLogger();
+        private readonly ILoggingAdapter _log = Context.GetLogger();
 
         private AkkaProtocolHandle handleOrActive;
         private Address localAddress;
@@ -635,7 +635,7 @@ namespace Akka.Remote
         protected RemoteSettings Settings;
         protected AkkaProtocolTransport Transport;
 
-        private readonly LoggingAdapter _log = Context.GetLogger();
+        private readonly ILoggingAdapter _log = Context.GetLogger();
 
         protected readonly EventPublisher EventPublisher;
         protected bool Inbound { get; set; }
@@ -685,7 +685,7 @@ namespace Akka.Remote
     /// </summary>
     internal abstract class EndpointActor<TS, TD> : FSM<TS, TD>
     {
-        private readonly LoggingAdapter _log = Context.GetLogger();
+        private readonly ILoggingAdapter _log = Context.GetLogger();
 
         protected readonly Address LocalAddress;
         protected Address RemoteAddress;
@@ -767,7 +767,7 @@ namespace Akka.Remote
             }
         }
 
-        private readonly LoggingAdapter _log = Context.GetLogger();
+        private readonly ILoggingAdapter _log = Context.GetLogger();
         private AkkaProtocolHandle _handleOrActive;
         private readonly int? _refuseUid;
         private readonly AkkaPduCodec _codec;

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -19,7 +19,7 @@ namespace Akka.Remote
     /// INTERNAL API
     /// </summary>
     // ReSharper disable once InconsistentNaming
-    internal interface InboundMessageDispatcher
+    internal interface IInboundMessageDispatcher
     {
         void Dispatch(IInternalActorRef recipient, Address recipientAddress, SerializedMessage message,
             IActorRef senderOption = null);
@@ -28,7 +28,7 @@ namespace Akka.Remote
     /// <summary>
     /// INTERNAL API
     /// </summary>
-    internal class DefaultMessageDispatcher : InboundMessageDispatcher
+    internal class DefaultMessageDispatcher : IInboundMessageDispatcher
     {
         private ActorSystem system;
         private RemoteActorRefProvider provider;
@@ -779,7 +779,7 @@ namespace Akka.Remote
 
         private IActorRef _reader;
         private readonly AtomicCounter _readerId = new AtomicCounter(0);
-        private readonly InboundMessageDispatcher _msgDispatcher;
+        private readonly IInboundMessageDispatcher _msgDispatcher;
 
         private Ack _lastAck = null;
         private Deadline _ackDeadline;
@@ -1453,7 +1453,7 @@ namespace Akka.Remote
     internal class EndpointReader : EndpointActor
     {
         public EndpointReader(Address localAddress, Address remoteAddress, AkkaProtocolTransport transport,
-            RemoteSettings settings, AkkaPduCodec codec, InboundMessageDispatcher msgDispatch, bool inbound,
+            RemoteSettings settings, AkkaPduCodec codec, IInboundMessageDispatcher msgDispatch, bool inbound,
             int uid, ConcurrentDictionary<EndpointManager.Link, EndpointManager.ResendState> receiveBuffers,
             IActorRef reliableDeliverySupervisor = null) :
             base(localAddress, remoteAddress, transport, settings)
@@ -1471,7 +1471,7 @@ namespace Akka.Remote
         private IActorRef _reliableDeliverySupervisor;
         private ConcurrentDictionary<EndpointManager.Link, EndpointManager.ResendState> _receiveBuffers;
         private int _uid;
-        private InboundMessageDispatcher _msgDispatch;
+        private IInboundMessageDispatcher _msgDispatch;
 
         private RemoteActorRefProvider _provider;
         private AckedReceiveBuffer<Message> _ackedReceiveBuffer = new AckedReceiveBuffer<Message>();
@@ -1649,7 +1649,7 @@ namespace Akka.Remote
         #region Static members
 
         public static Props ReaderProps(Address localAddress, Address remoteAddress, AkkaProtocolTransport transport,
-            RemoteSettings settings, AkkaPduCodec codec, InboundMessageDispatcher dispatcher, bool inbound, int uid,
+            RemoteSettings settings, AkkaPduCodec codec, IInboundMessageDispatcher dispatcher, bool inbound, int uid,
             ConcurrentDictionary<EndpointManager.Link, EndpointManager.ResendState> receiveBuffers,
             IActorRef reliableDeliverySupervisor = null)
         {

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -105,7 +105,7 @@ namespace Akka.Remote
             }
 
             // message is intended for a remote-deployed recipient
-            else if ((recipient is RemoteRef || recipient is RepointableActorRef) && !recipient.IsLocal && !settings.UntrustedMode)
+            else if ((recipient is IRemoteRef || recipient is RepointableActorRef) && !recipient.IsLocal && !settings.UntrustedMode)
             {
                 if (settings.LogReceive) log.Debug("received remote-destined message {0}", msgLog);
                 if (provider.Transport.Addresses.Contains(recipientAddress))

--- a/src/core/Akka.Remote/EndpointManager.cs
+++ b/src/core/Akka.Remote/EndpointManager.cs
@@ -247,7 +247,7 @@ namespace Akka.Remote
 
         #endregion
 
-        public EndpointManager(Config config, LoggingAdapter log)
+        public EndpointManager(Config config, ILoggingAdapter log)
         {
             conf = config;
             settings = new RemoteSettings(conf);
@@ -263,7 +263,7 @@ namespace Akka.Remote
         private readonly RemoteSettings settings;
         private readonly Config conf;
         private AtomicCounterLong endpointId = new AtomicCounterLong(0L);
-        private LoggingAdapter log;
+        private ILoggingAdapter log;
         private EventPublisher eventPublisher;
 
         /// <summary>

--- a/src/core/Akka.Remote/RemoteActorRef.cs
+++ b/src/core/Akka.Remote/RemoteActorRef.cs
@@ -9,12 +9,12 @@ namespace Akka.Remote
     /// Marker interface for Actors that are deployed in a remote scope
     /// </summary>
 // ReSharper disable once InconsistentNaming
-    internal interface RemoteRef : IActorRefScope { }
+    internal interface IRemoteRef : IActorRefScope { }
 
     /// <summary>
     /// Class RemoteActorRef.
     /// </summary>
-    public class RemoteActorRef : InternalActorRefBase, RemoteRef
+    public class RemoteActorRef : InternalActorRefBase, IRemoteRef
     {
         /// <summary>
         /// The deploy

--- a/src/core/Akka.Remote/RemoteActorRef.cs
+++ b/src/core/Akka.Remote/RemoteActorRef.cs
@@ -143,7 +143,7 @@ namespace Akka.Remote
         /// Sends the system message.
         /// </summary>
         /// <param name="message">The message.</param>
-        private void SendSystemMessage(SystemMessage message)
+        private void SendSystemMessage(ISystemMessage message)
         {
             Remote.Send(message, null, this);
             Remote.Provider.AfterSendSystemMessage(message);
@@ -157,7 +157,7 @@ namespace Akka.Remote
         protected override void TellInternal(object message, IActorRef sender)
         {
             Remote.Send(message, sender, this);
-            var systemMessage = message as SystemMessage;
+            var systemMessage = message as ISystemMessage;
             if (systemMessage != null) Remote.Provider.AfterSendSystemMessage(systemMessage);
         }
 

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -387,7 +387,7 @@ namespace Akka.Remote
         ///     Afters the send system message.
         /// </summary>
         /// <param name="message">The message.</param>
-        public void AfterSendSystemMessage(SystemMessage message)
+        public void AfterSendSystemMessage(ISystemMessage message)
         {
             message.Match()
                 .With<RemoteWatcher.Rewatch>(rew => _remoteWatcher.Tell(new RemoteWatcher.RewatchRemote(rew.Watchee, rew.Watcher)))

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -18,7 +18,7 @@ namespace Akka.Remote
     /// </summary>
     public class RemoteActorRefProvider : IActorRefProvider
     {
-        private readonly LoggingAdapter _log;
+        private readonly ILoggingAdapter _log;
 
         public RemoteActorRefProvider(string systemName, Settings settings, EventStream eventStream)
         {

--- a/src/core/Akka.Remote/RemoteDaemon.cs
+++ b/src/core/Akka.Remote/RemoteDaemon.cs
@@ -76,7 +76,7 @@ namespace Akka.Remote
         /// <param name="path">The path.</param>
         /// <param name="parent">The parent.</param>
         /// <param name="log"></param>
-        public RemoteDaemon(ActorSystemImpl system, ActorPath path, IInternalActorRef parent, LoggingAdapter log)
+        public RemoteDaemon(ActorSystemImpl system, ActorPath path, IInternalActorRef parent, ILoggingAdapter log)
             : base(system.Provider, path, parent, log)
         {
             _system = system;

--- a/src/core/Akka.Remote/RemoteTransport.cs
+++ b/src/core/Akka.Remote/RemoteTransport.cs
@@ -47,7 +47,7 @@ namespace Akka.Remote
         /// <summary>
         /// A logger that can be used to log issues that may occur
         /// </summary>
-        public LoggingAdapter Log { get; protected set; }
+        public ILoggingAdapter Log { get; protected set; }
 
         /// <summary>
         /// Start up the transport, i.e. enable incoming connections

--- a/src/core/Akka.Remote/RemoteWatcher.cs
+++ b/src/core/Akka.Remote/RemoteWatcher.cs
@@ -529,6 +529,6 @@ namespace Akka.Remote
             }
         }
 
-        private readonly LoggingAdapter _log = Context.GetLogger();
+        private readonly ILoggingAdapter _log = Context.GetLogger();
     }
 }

--- a/src/core/Akka.Remote/Remoting.cs
+++ b/src/core/Akka.Remote/Remoting.cs
@@ -86,7 +86,7 @@ namespace Akka.Remote
     /// </summary>
     internal class Remoting : RemoteTransport
     {
-        private readonly LoggingAdapter log;
+        private readonly ILoggingAdapter log;
         private volatile IDictionary<string, HashSet<ProtocolTransportAddressPair>> _transportMapping;
         private volatile IActorRef _endpointManager;
 

--- a/src/core/Akka.Remote/RemotingLifecycleEvent.cs
+++ b/src/core/Akka.Remote/RemotingLifecycleEvent.cs
@@ -196,11 +196,11 @@ namespace Akka.Remote
     {
         public ActorSystem System { get; private set; }
 
-        public LoggingAdapter Log { get; private set; }
+        public ILoggingAdapter Log { get; private set; }
 
         public readonly LogLevel LogLevel;
 
-        public EventPublisher(ActorSystem system, LoggingAdapter log, LogLevel logLevel)
+        public EventPublisher(ActorSystem system, ILoggingAdapter log, LogLevel logLevel)
         {
             System = system;
             Log = log;

--- a/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
+++ b/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
@@ -437,7 +437,7 @@ namespace Akka.Remote.Transport
 
     internal class ProtocolStateActor : FSM<AssociationState, ProtocolStateData>
     {
-        private readonly LoggingAdapter _log = Context.GetLogger();
+        private readonly ILoggingAdapter _log = Context.GetLogger();
         private InitialProtocolStateData _initialData;
         private HandshakeInfo _localHandshakeInfo;
         private int? _refuseUid;

--- a/src/core/Akka.Remote/Transport/FailureInjectorTransportAdapter.cs
+++ b/src/core/Akka.Remote/Transport/FailureInjectorTransportAdapter.cs
@@ -108,7 +108,7 @@ namespace Akka.Remote.Transport
             _shouldDebugLog = ExtendedActorSystem.Settings.Config.GetBoolean("akka.remote.gremlin.debug");
         }
 
-        private LoggingAdapter _log;
+        private ILoggingAdapter _log;
         private Random Rng
         {
             get { return ThreadLocalRandom.Current; }

--- a/src/core/Akka.Remote/Transport/Helios/HeliosTransport.cs
+++ b/src/core/Akka.Remote/Transport/Helios/HeliosTransport.cs
@@ -165,7 +165,7 @@ namespace Akka.Remote.Transport.Helios
             }
         }
 
-        protected LoggingAdapter Log;
+        protected ILoggingAdapter Log;
 
         /// <summary>
         /// maintains a list of all established connections, so we can close them easily

--- a/src/core/Akka.TestKit/EventFilter/TestEventListener.cs
+++ b/src/core/Akka.TestKit/EventFilter/TestEventListener.cs
@@ -85,7 +85,7 @@ namespace Akka.TestKit
                 var warning = new Warning(recipientPath, recipientType, message);
                 if(!ShouldFilter(warning))
                 {
-                    var msgStr = (msg is SystemMessage)
+                    var msgStr = (msg is ISystemMessage)
                         ? "Received dead system message: " + msg
                         : "Received dead letter from " + snd + ": " + msg;
                     var warning2 = new Warning(recipientPath, recipientType, new DeadLetter(msgStr,snd,rcp));

--- a/src/core/Akka.TestKit/TestKitBase.cs
+++ b/src/core/Akka.TestKit/TestKitBase.cs
@@ -37,7 +37,7 @@ namespace Akka.TestKit
         private readonly IActorRef _testActor;
         private TimeSpan? _end;
         private bool _lastWasNoMsg; //if last assertion was expectNoMsg, disable timing failure upon within() block end.
-        private readonly LoggingAdapter _log;
+        private readonly ILoggingAdapter _log;
         private readonly EventFilterFactory _eventFilterFactory;
 
         /// <summary>
@@ -115,7 +115,7 @@ namespace Akka.TestKit
         public static Config DefaultConfig { get { return _defaultConfig; } }
         public static Config FullDebugConfig { get { return _fullDebugConfig; } }
         public static TimeSpan Now { get { return TimeSpan.FromTicks(DateTime.UtcNow.Ticks); } }
-        public LoggingAdapter Log { get { return _log; } }
+        public ILoggingAdapter Log { get { return _log; } }
         public object LastMessage { get { return _lastMessage.Message; } }
 
         /// <summary>

--- a/src/core/Akka.TestKit/TestKitBase_AwaitConditions.cs
+++ b/src/core/Akka.TestKit/TestKitBase_AwaitConditions.cs
@@ -197,7 +197,7 @@ namespace Akka.TestKit
         /// <param name="fail">Action that is called when the timeout expired. 
         /// The parameters conforms to <see cref="string.Format(string,object[])"/></param>
         /// <param name="logger">If a <see cref="LoggingAdapter"/> is specified, debug messages will be logged using it. If <c>null</c> nothing will be logged</param>
-        protected static bool InternalAwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan max, TimeSpan? interval, Action<string, object[]> fail, LoggingAdapter logger)
+        protected static bool InternalAwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan max, TimeSpan? interval, Action<string, object[]> fail, ILoggingAdapter logger)
         {
             max.EnsureIsPositiveFinite("max");
             var start = Now;
@@ -222,7 +222,7 @@ namespace Akka.TestKit
             return true;
         }
 
-        private static void ConditionalLog(LoggingAdapter logger, string format, params object[] args)
+        private static void ConditionalLog(ILoggingAdapter logger, string format, params object[] args)
         {
             if (logger != null)
                 logger.Debug(format, args);

--- a/src/core/Akka/Actor/ActorBase.cs
+++ b/src/core/Akka/Actor/ActorBase.cs
@@ -56,7 +56,7 @@ namespace Akka.Actor
     [Obsolete()]
     public interface IActorLogging
     {
-        LoggingAdapter Log { get; }
+        ILoggingAdapter Log { get; }
     }
 
     /// <summary>

--- a/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
+++ b/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
@@ -360,7 +360,7 @@ namespace Akka.Actor
             SendSystemMessage(Dispatch.SysMsg.ResumeReentrancy.Instance);
         }
 
-        private void SendSystemMessage(SystemMessage systemMessage)
+        private void SendSystemMessage(ISystemMessage systemMessage)
         {
             try
             {

--- a/src/core/Akka/Actor/ActorProducerPipeline.cs
+++ b/src/core/Akka/Actor/ActorProducerPipeline.cs
@@ -91,7 +91,7 @@ namespace Akka.Actor
     /// </summary>
     public class ActorProducerPipelineResolver
     {
-        private readonly Lazy<LoggingAdapter> _log;
+        private readonly Lazy<ILoggingAdapter> _log;
         private readonly List<IActorProducerPlugin> _plugins = new List<IActorProducerPlugin>
         {   
             // collection of plugins loaded by default
@@ -105,9 +105,9 @@ namespace Akka.Actor
         /// </summary>
         public int TotalPluginCount { get { return _plugins.Count; } }
 
-        public ActorProducerPipelineResolver(Func<LoggingAdapter> logBuilder)
+        public ActorProducerPipelineResolver(Func<ILoggingAdapter> logBuilder)
         {
-            _log = new Lazy<LoggingAdapter>(logBuilder);
+            _log = new Lazy<ILoggingAdapter>(logBuilder);
         }
 
         /// <summary>
@@ -187,10 +187,10 @@ namespace Akka.Actor
 
     public class ActorProducerPipeline : IEnumerable<IActorProducerPlugin>
     {
-        private Lazy<LoggingAdapter> _log;
+        private Lazy<ILoggingAdapter> _log;
         private readonly List<IActorProducerPlugin> _plugins;
 
-        public ActorProducerPipeline(Lazy<LoggingAdapter> log, IEnumerable<IActorProducerPlugin> plugins)
+        public ActorProducerPipeline(Lazy<ILoggingAdapter> log, IEnumerable<IActorProducerPlugin> plugins)
         {
             _log = log;
             _plugins = new List<IActorProducerPlugin>(plugins);

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -80,9 +80,9 @@ namespace Akka.Actor
         protected override void TellInternal(object message, IActorRef sender)
         {
 
-            if (message is SystemMessage) //we have special handling for system messages
+            if (message is ISystemMessage) //we have special handling for system messages
             {
-                SendSystemMessage(message.AsInstanceOf<SystemMessage>(), sender);
+                SendSystemMessage(message.AsInstanceOf<ISystemMessage>(), sender);
             }
             else
             {
@@ -94,7 +94,7 @@ namespace Akka.Actor
             }
         }
 
-        protected void SendSystemMessage(SystemMessage message, IActorRef sender)
+        protected void SendSystemMessage(ISystemMessage message, IActorRef sender)
         {
             var d = message as DeathWatchNotification;
             if (message is Terminate)

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -357,13 +357,13 @@ namespace Akka.Actor
     internal class VirtualPathContainer : MinimalActorRef
     {
         private readonly IInternalActorRef _parent;
-        private readonly LoggingAdapter _log;
+        private readonly ILoggingAdapter _log;
         private readonly IActorRefProvider _provider;
         private readonly ActorPath _path;
 
         private readonly ConcurrentDictionary<string, IInternalActorRef> _children = new ConcurrentDictionary<string, IInternalActorRef>();
 
-        public VirtualPathContainer(IActorRefProvider provider, ActorPath path, IInternalActorRef parent, LoggingAdapter log)
+        public VirtualPathContainer(IActorRefProvider provider, ActorPath path, IInternalActorRef parent, ILoggingAdapter log)
         {
             _parent = parent;
             _log = log;
@@ -386,7 +386,7 @@ namespace Akka.Actor
             get { return _path; }
         }
 
-        public LoggingAdapter Log
+        public ILoggingAdapter Log
         {
             get { return _log; }
         }

--- a/src/core/Akka/Actor/ActorRefProvider.cs
+++ b/src/core/Akka/Actor/ActorRefProvider.cs
@@ -116,7 +116,7 @@ namespace Akka.Actor
         private readonly Deployer _deployer;
         private readonly IInternalActorRef _deadLetters;
         private readonly RootActorPath _rootPath;
-        private readonly LoggingAdapter _log;
+        private readonly ILoggingAdapter _log;
         private readonly AtomicCounterLong _tempNumber;
         private readonly ActorPath _tempNode;
         private ActorSystemImpl _system;
@@ -439,6 +439,6 @@ namespace Akka.Actor
 
         public Address DefaultAddress { get { return _rootPath.Address; } }
 
-        public LoggingAdapter Log { get { return _log; } }
+        public ILoggingAdapter Log { get { return _log; } }
     }
 }

--- a/src/core/Akka/Actor/ActorSystem.cs
+++ b/src/core/Akka/Actor/ActorSystem.cs
@@ -64,7 +64,7 @@ namespace Akka.Actor
         public abstract IScheduler Scheduler { get; }
 
         /// <summary>Gets the log</summary>
-        public abstract LoggingAdapter Log { get; }
+        public abstract ILoggingAdapter Log { get; }
 
         /// <summary>
         ///     Creates a new ActorSystem with the specified name, and the specified Config

--- a/src/core/Akka/Actor/Cell.cs
+++ b/src/core/Akka/Actor/Cell.cs
@@ -125,6 +125,6 @@ namespace Akka.Actor
         //    * schedule the actor to run, depending on which type of cell it is.
         //    * Is only allowed to throw Fatal Throwables.
         //    */
-        //    def sendSystemMessage(msg: SystemMessage): Unit
+        //    def sendSystemMessage(msg: ISystemMessage): Unit
     }
 }

--- a/src/core/Akka/Actor/DeadLetterMailbox.cs
+++ b/src/core/Akka/Actor/DeadLetterMailbox.cs
@@ -16,7 +16,7 @@ namespace Akka.Actor
         public override void Post(IActorRef receiver, Envelope envelope)
         {
             var message = envelope.Message;
-            if(message is SystemMessage)
+            if(message is ISystemMessage)
             {
                 Mailbox.DebugPrint("DeadLetterMailbox forwarded system message " + envelope+ " as a DeadLetter");
                 _deadLetters.Tell(new DeadLetter(message, receiver, receiver), receiver);

--- a/src/core/Akka/Actor/EmptyLocalActorRef.cs
+++ b/src/core/Akka/Actor/EmptyLocalActorRef.cs
@@ -24,7 +24,7 @@ namespace Akka.Actor
 
         protected override void TellInternal(object message, IActorRef sender)
         {
-            var systemMessage = message as SystemMessage;
+            var systemMessage = message as ISystemMessage;
             if(systemMessage != null)
             {
                 SendSystemMessage(systemMessage);
@@ -54,7 +54,7 @@ namespace Akka.Actor
             SpecialHandle(deadLetter.Message, deadLetter.Sender);
         }
 
-        private void SendSystemMessage(SystemMessage message)
+        private void SendSystemMessage(ISystemMessage message)
         {
             Mailbox.DebugPrint("EmptyLocalActorRef {0} having enqueued {1}", Path, message);
             SpecialHandle(message, _provider.DeadLetters);

--- a/src/core/Akka/Actor/FSM.cs
+++ b/src/core/Akka/Actor/FSM.cs
@@ -140,9 +140,9 @@ namespace Akka.Actor
         [DebuggerDisplay("Timer {Name,nq}, message: {Message")]
         internal class Timer : INoSerializationVerificationNeeded
         {
-            private readonly LoggingAdapter _debugLog;
+            private readonly ILoggingAdapter _debugLog;
 
-            public Timer(string name, object message, bool repeat, int generation, IActorContext context, LoggingAdapter debugLog)
+            public Timer(string name, object message, bool repeat, int generation, IActorContext context, ILoggingAdapter debugLog)
             {
                 _debugLog = debugLog;
                 Context = context;
@@ -378,7 +378,7 @@ namespace Akka.Actor
     /// <typeparam name="TData">The state data type</typeparam>
     public abstract class FSM<TState, TData> : FSMBase, IListeners, IInternalSupportsTestFSMRef<TState,TData>
     {
-        private readonly LoggingAdapter _log = Context.GetLogger();
+        private readonly ILoggingAdapter _log = Context.GetLogger();
         protected FSM()
         {
             if(this is ILoggingFSM)

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -318,9 +318,9 @@ namespace Akka.Actor
 
         protected override void TellInternal(object message, IActorRef sender)
         {
-            if (message is SystemMessage)
+            if (message is ISystemMessage)
             {
-                SendSystemMessage(message as SystemMessage); 
+                SendSystemMessage(message as ISystemMessage); 
                 return;
             }
 
@@ -339,7 +339,7 @@ namespace Akka.Actor
         }
 
         //TODO: isn't SendSystemMessage supposed to be a part of ActorRef? Why isn't it overridable?
-        private void SendSystemMessage(SystemMessage message)
+        private void SendSystemMessage(ISystemMessage message)
         {
             if(message is Terminate) Stop();
             else if (message is DeathWatchNotification)

--- a/src/core/Akka/Actor/Inbox.Actor.cs
+++ b/src/core/Akka/Actor/Inbox.Actor.cs
@@ -18,7 +18,7 @@ namespace Akka.Actor
         private Tuple<DateTime, ICancelable> _currentDeadline;
 
         private int _size;
-        private LoggingAdapter _log = Context.GetLogger();
+        private ILoggingAdapter _log = Context.GetLogger();
 
         public InboxActor(int size)
         {

--- a/src/core/Akka/Actor/Internals/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internals/ActorSystemImpl.cs
@@ -20,7 +20,7 @@ namespace Akka.Actor.Internals
         private IActorRef _logDeadLetterListener;
         private readonly ConcurrentDictionary<Type, Lazy<object>> _extensions = new ConcurrentDictionary<Type, Lazy<object>>();
 
-        private LoggingAdapter _log;
+        private ILoggingAdapter _log;
         private IActorRefProvider _provider;
         private Settings _settings;
         private readonly string _name;
@@ -64,7 +64,7 @@ namespace Akka.Actor.Internals
         public override Dispatchers Dispatchers { get { return _dispatchers; } }
         public override Mailboxes Mailboxes { get { return _mailboxes; } }
         public override IScheduler Scheduler { get { return _scheduler; } }
-        public override LoggingAdapter Log { get { return _log; } }
+        public override ILoggingAdapter Log { get { return _log; } }
 
         public override ActorProducerPipelineResolver ActorPipelineResolver { get { return _actorProducerPipelineResolver; } }
 

--- a/src/core/Akka/Actor/RepointableActorRef.cs
+++ b/src/core/Akka/Actor/RepointableActorRef.cs
@@ -304,7 +304,7 @@ namespace Akka.Actor
 
         public void Post(IActorRef sender, object message)
         {
-            if(message is SystemMessage)
+            if(message is ISystemMessage)
                 SendSystemMessage(message, sender);
             else
                 SendMessage(message, sender);
@@ -382,7 +382,7 @@ namespace Akka.Actor
                 {
                     var queuedMessage = _messageQueue[queueIndex];
                     queueIndex++;
-                    if(queuedMessage.Message is SystemMessage)
+                    if(queuedMessage.Message is ISystemMessage)
                         insertIntoIndex = queueIndex;
                 }
                 else if(insertIntoIndex == -1)

--- a/src/core/Akka/Actor/RootGuardianSupervisor.cs
+++ b/src/core/Akka/Actor/RootGuardianSupervisor.cs
@@ -28,7 +28,7 @@ namespace Akka.Actor
 
         protected override void TellInternal(object message, IActorRef sender)
         {
-            var systemMessage = message as SystemMessage;
+            var systemMessage = message as ISystemMessage;
             if(systemMessage!=null)
             {
                 SendSystemMessage(systemMessage);
@@ -43,7 +43,7 @@ namespace Akka.Actor
             }
         }
 
-        private void SendSystemMessage(SystemMessage systemMessage)
+        private void SendSystemMessage(ISystemMessage systemMessage)
         {
             _stopped.IfOff(() =>
             {

--- a/src/core/Akka/Actor/RootGuardianSupervisor.cs
+++ b/src/core/Akka/Actor/RootGuardianSupervisor.cs
@@ -12,13 +12,13 @@ namespace Akka.Actor
     /// </summary>
     public class RootGuardianSupervisor : MinimalActorRef
     {
-        private readonly LoggingAdapter _log;
+        private readonly ILoggingAdapter _log;
         private readonly TaskCompletionSource<Status> _terminationPromise;
         private readonly ActorPath _path;
         private readonly Switch _stopped=new Switch(false);
         private readonly IActorRefProvider _provider;
 
-        public RootGuardianSupervisor(RootActorPath root, IActorRefProvider provider, TaskCompletionSource<Status> terminationPromise, LoggingAdapter log)
+        public RootGuardianSupervisor(RootActorPath root, IActorRefProvider provider, TaskCompletionSource<Status> terminationPromise, ILoggingAdapter log)
         {
             _log = log;
             _terminationPromise = terminationPromise;

--- a/src/core/Akka/Akka.ExternalAnnotations.xml
+++ b/src/core/Akka/Akka.ExternalAnnotations.xml
@@ -1,43 +1,43 @@
-
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿
+ <?xml version="1.0" encoding="utf-8"?>
 <assembly name="Akka">
   <!-- LoggingAdapter -->
-  <member name="M:Akka.Event.LoggingAdapter.Debug(System.String,System.Object[])">
+  <member name="M:Akka.Event.ILoggingAdapter.Debug(System.String,System.Object[])">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
   </member>
-  <member name="M:Akka.Event.LoggingAdapter.Info(System.String,System.Object[])">
+  <member name="M:Akka.Event.ILoggingAdapter.Info(System.String,System.Object[])">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
   </member>
-  <member name="M:Akka.Event.LoggingAdapter.Warning(System.String,System.Object[])">
+  <member name="M:Akka.Event.ILoggingAdapter.Warning(System.String,System.Object[])">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
   </member>
-  <member name="M:Akka.Event.LoggingAdapter.Error(System.String,System.Object[])">
+  <member name="M:Akka.Event.ILoggingAdapter.Error(System.String,System.Object[])">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
   </member>
-  <member name="M:Akka.Event.LoggingAdapter.Error(System.Exception,System.String,System.Object[])">
+  <member name="M:Akka.Event.ILoggingAdapter.Error(System.Exception,System.String,System.Object[])">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
   </member>
-  <member name="M:Akka.Event.LoggingAdapter.Log(Akka.Event.LogLevel,System.String,System.Object[])">
+  <member name="M:Akka.Event.ILoggingAdapter.Log(Akka.Event.LogLevel,System.String,System.Object[])">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
   </member>
 
   <!-- LoggingAdapterBase -->
-  <member name="M:Akka.Event.LoggingAdapterBase.Debug(System.String,System.Object[])">
+  <member name="M:Akka.Event.ILoggingAdapterBase.Debug(System.String,System.Object[])">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
   </member>
-  <member name="M:Akka.Event.LoggingAdapterBase.Info(System.String,System.Object[])">
+  <member name="M:Akka.Event.ILoggingAdapterBase.Info(System.String,System.Object[])">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
   </member>
-  <member name="M:Akka.Event.LoggingAdapterBase.Warning(System.String,System.Object[])">
+  <member name="M:Akka.Event.ILoggingAdapterBase.Warning(System.String,System.Object[])">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
   </member>
-  <member name="M:Akka.Event.LoggingAdapterBase.Error(System.String,System.Object[])">
+  <member name="M:Akka.Event.ILoggingAdapterBase.Error(System.String,System.Object[])">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
   </member>
-  <member name="M:Akka.Event.LoggingAdapterBase.Error(System.Exception,System.String,System.Object[])">
+  <member name="M:Akka.Event.ILoggingAdapterBase.Error(System.Exception,System.String,System.Object[])">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
   </member>
-  <member name="M:Akka.Event.LoggingAdapterBase.Log(Akka.Event.LogLevel,System.String,System.Object[])">
+  <member name="M:Akka.Event.ILoggingAdapterBase.Log(Akka.Event.LogLevel,System.String,System.Object[])">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
   </member>
     

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -201,7 +201,7 @@
     <Compile Include="Actor\UntypedReceive.cs" />
     <Compile Include="Dispatch\Mailboxes.cs" />
     <Compile Include="Dispatch\MessageQueues\IMessageQueue.cs" />
-    <Compile Include="Dispatch\SysMsg\SystemMessage.cs" />
+    <Compile Include="Dispatch\SysMsg\ISystemMessage.cs" />
     <Compile Include="Dispatch\TaskDispatcher.cs" />
     <Compile Include="Dispatch\ThreadPoolBuilder.cs" />
     <Compile Include="Dispatch\UnboundedDequeBasedMailbox.cs" />

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -224,7 +224,7 @@
     <Compile Include="Event\LogEvent.cs" />
     <Compile Include="Event\LoggerInitialized.cs" />
     <Compile Include="Event\Logging.cs" />
-    <Compile Include="Event\LoggingAdapter.cs" />
+    <Compile Include="Event\ILoggingAdapter.cs" />
     <Compile Include="Event\LoggingAdapterBase.cs" />
     <Compile Include="Event\LoggingBus.cs" />
     <Compile Include="Event\LogLevel.cs" />

--- a/src/core/Akka/Dispatch/AbstractDispatcher.cs
+++ b/src/core/Akka/Dispatch/AbstractDispatcher.cs
@@ -254,7 +254,7 @@ namespace Akka.Dispatch
         }
 
         /// <summary>
-        /// Dispatches a <see cref="SystemMessage"/> from a mailbox to an <see cref="ActorCell"/>        
+        /// Dispatches a <see cref="ISystemMessage"/> from a mailbox to an <see cref="ActorCell"/>        
         /// </summary>
         public virtual void SystemDispatch(ActorCell cell, Envelope envelope)
         {

--- a/src/core/Akka/Dispatch/ConcurrentQueueMailbox.cs
+++ b/src/core/Akka/Dispatch/ConcurrentQueueMailbox.cs
@@ -142,7 +142,7 @@ namespace Akka.Dispatch
                 return;
 
             hasUnscheduledMessages = true;
-            if (envelope.Message is SystemMessage)
+            if (envelope.Message is ISystemMessage)
             {
                 Mailbox.DebugPrint("{0} enqueued system message {1} to {2}", ActorCell.Self, envelope, ActorCell.Self.Equals(receiver) ? "itself" : receiver.ToString());
                 _systemMessages.Enqueue(envelope);

--- a/src/core/Akka/Dispatch/GenericMailbox.cs
+++ b/src/core/Akka/Dispatch/GenericMailbox.cs
@@ -163,7 +163,7 @@ namespace Akka.Dispatch
                 return;
 
             hasUnscheduledMessages = true;
-            if (envelope.Message is SystemMessage)
+            if (envelope.Message is ISystemMessage)
             {
                 Mailbox.DebugPrint("{0} enqueued system message {1} to {2}", ActorCell.Self, envelope, ActorCell.Self.Equals(receiver) ? "itself" : receiver.ToString());
                 _systemMessages.Enqueue(envelope);

--- a/src/core/Akka/Dispatch/SysMsg/ISystemMessage.cs
+++ b/src/core/Akka/Dispatch/SysMsg/ISystemMessage.cs
@@ -8,19 +8,19 @@ namespace Akka.Dispatch.SysMsg
  * public API
  */
     //@SerialVersionUID(1L)
-    //private[akka] case class Create(failure: Option[ActorInitializationException]) extends SystemMessage // sent to self from Dispatcher.register
+    //private[akka] case class Create(failure: Option[ActorInitializationException]) extends ISystemMessage // sent to self from Dispatcher.register
     /// <summary>
-    ///     Class SystemMessage.
+    ///     Class ISystemMessage.
     /// </summary>
     /// **
-    public interface SystemMessage : INoSerializationVerificationNeeded
+    public interface ISystemMessage : INoSerializationVerificationNeeded
     {
     }
 
     /// <summary>
     ///     Class NoMessage.
     /// </summary>
-    public sealed class NoMessage : SystemMessage
+    public sealed class NoMessage : ISystemMessage
     {
         public override string ToString()
         {
@@ -31,7 +31,7 @@ namespace Akka.Dispatch.SysMsg
     /// <summary>
     ///     Class DeathWatchNotification.
     /// </summary>
-    public sealed class DeathWatchNotification : SystemMessage
+    public sealed class DeathWatchNotification : ISystemMessage
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="DeathWatchNotification" /> class.
@@ -73,7 +73,7 @@ namespace Akka.Dispatch.SysMsg
     /// <summary>
     ///     Class Failed.
     /// </summary>
-    public sealed class Failed : SystemMessage
+    public sealed class Failed : ISystemMessage
     {
         private readonly long _uid;
         private readonly Exception _cause;
@@ -115,7 +115,7 @@ namespace Akka.Dispatch.SysMsg
     /// <summary>
     ///     Class Supervise.
     /// </summary>
-    public sealed class Supervise : SystemMessage
+    public sealed class Supervise : ISystemMessage
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="Supervise" /> class.
@@ -150,7 +150,7 @@ namespace Akka.Dispatch.SysMsg
     /// <summary>
     ///     Class Watch.
     /// </summary>
-    public class Watch : SystemMessage
+    public class Watch : ISystemMessage
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="Watch" /> class.
@@ -185,7 +185,7 @@ namespace Akka.Dispatch.SysMsg
     /// <summary>
     ///     Class Unwatch.
     /// </summary>
-    public sealed class Unwatch : SystemMessage
+    public sealed class Unwatch : ISystemMessage
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="Unwatch" /> class.
@@ -219,7 +219,7 @@ namespace Akka.Dispatch.SysMsg
     /// <summary>
     ///     Class ActorTask.
     /// </summary>
-    public sealed class ActorTask : SystemMessage
+    public sealed class ActorTask : ISystemMessage
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="ActorTask" /> class.
@@ -237,7 +237,7 @@ namespace Akka.Dispatch.SysMsg
         public Task Task { get; private set; }
     }
 
-    public sealed class CompleteTask : SystemMessage
+    public sealed class CompleteTask : ISystemMessage
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="CompleteTask" /> class.
@@ -267,7 +267,7 @@ namespace Akka.Dispatch.SysMsg
     /// <summary>
     ///     Class Restart.
     /// </summary>
-    public sealed class Restart : SystemMessage
+    public sealed class Restart : ISystemMessage
     {
         private Restart() { }
         private static readonly Restart _instance = new Restart();
@@ -283,7 +283,7 @@ namespace Akka.Dispatch.SysMsg
     /// <summary>
     ///     Class Recreate.
     /// </summary>
-    public sealed class Recreate : SystemMessage
+    public sealed class Recreate : ISystemMessage
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="Recreate" /> class.
@@ -309,7 +309,7 @@ namespace Akka.Dispatch.SysMsg
     /// <summary>
     ///     Class Resume.
     /// </summary>
-    public sealed class Resume : SystemMessage
+    public sealed class Resume : ISystemMessage
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="Resume" /> class.
@@ -335,7 +335,7 @@ namespace Akka.Dispatch.SysMsg
     /// <summary>
     ///     Class Suspend.
     /// </summary>
-    public sealed class Suspend : SystemMessage
+    public sealed class Suspend : ISystemMessage
     {
         private Suspend() { }
         private static readonly Suspend _instance = new Suspend();
@@ -356,7 +356,7 @@ namespace Akka.Dispatch.SysMsg
     /// <summary>
     ///     Class SuspendReentrancy.
     /// </summary>
-    public sealed class SuspendReentrancy : SystemMessage
+    public sealed class SuspendReentrancy : ISystemMessage
     {
         private SuspendReentrancy() { }
         private static readonly SuspendReentrancy _instance = new SuspendReentrancy();
@@ -372,7 +372,7 @@ namespace Akka.Dispatch.SysMsg
     /// <summary>
     ///     Class ResumeReentrancy.
     /// </summary>
-    public sealed class ResumeReentrancy : SystemMessage
+    public sealed class ResumeReentrancy : ISystemMessage
     {
         private ResumeReentrancy() { }
         private static readonly ResumeReentrancy _instance = new ResumeReentrancy();
@@ -388,7 +388,7 @@ namespace Akka.Dispatch.SysMsg
     /// <summary>
     ///     Class Stop.
     /// </summary>
-    public sealed class Stop : SystemMessage
+    public sealed class Stop : ISystemMessage
     {
         private Stop() { }
         private static readonly Stop _instance = new Stop();
@@ -409,7 +409,7 @@ namespace Akka.Dispatch.SysMsg
     /// <summary>
     ///     INTERNAL
     /// </summary>
-    public sealed class StopChild   //StopChild is NOT a SystemMessage
+    public sealed class StopChild   //StopChild is NOT a ISystemMessage
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="StopChild" /> class.
@@ -436,7 +436,7 @@ namespace Akka.Dispatch.SysMsg
     /// <summary>
     ///     Class Escalate.
     /// </summary>
-    public sealed class Escalate : SystemMessage
+    public sealed class Escalate : ISystemMessage
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="Escalate" /> class.
@@ -464,7 +464,7 @@ namespace Akka.Dispatch.SysMsg
     /// <summary>
     ///     Class Terminate.
     /// </summary>
-    public sealed class Terminate : SystemMessage
+    public sealed class Terminate : ISystemMessage
     {
         private Terminate() { }
         private static readonly Terminate _instance = new Terminate();
@@ -482,7 +482,7 @@ namespace Akka.Dispatch.SysMsg
         }
     }
 
-    public sealed class Create : SystemMessage
+    public sealed class Create : ISystemMessage
     {
         private readonly ActorInitializationException _failure;
 

--- a/src/core/Akka/Event/ILoggingAdapter.cs
+++ b/src/core/Akka/Event/ILoggingAdapter.cs
@@ -6,7 +6,7 @@ namespace Akka.Event
     /// Capable of logging 
     /// </summary>
     // ReSharper disable once InconsistentNaming
-    public interface LoggingAdapter
+    public interface ILoggingAdapter
     {
         /// <summary>Returns <c>true</c> if Debug level is enabled.</summary>
         bool IsDebugEnabled { get; }

--- a/src/core/Akka/Event/Logging.cs
+++ b/src/core/Akka/Event/Logging.cs
@@ -70,8 +70,8 @@ namespace Akka.Event
         /// </summary>
         /// <param name="context">The cell.</param>
         /// <param name="logMessageFormatter">The log message formatter.</param>
-        /// <returns>LoggingAdapter.</returns>
-        public static LoggingAdapter GetLogger(this IActorContext context, ILogMessageFormatter logMessageFormatter = null)
+        /// <returns>ILoggingAdapter.</returns>
+        public static ILoggingAdapter GetLogger(this IActorContext context, ILogMessageFormatter logMessageFormatter = null)
         {
             var logSource = context.Self.ToString();
             var logClass = context.Props.Type;
@@ -85,13 +85,13 @@ namespace Akka.Event
         /// <param name="system">The system.</param>
         /// <param name="logSourceObj">The log source object.</param>
         /// <param name="logMessageFormatter">The log message formatter.</param>
-        /// <returns>LoggingAdapter.</returns>
-        public static LoggingAdapter GetLogger(ActorSystem system, object logSourceObj, ILogMessageFormatter logMessageFormatter = null)
+        /// <returns>ILoggingAdapter.</returns>
+        public static ILoggingAdapter GetLogger(ActorSystem system, object logSourceObj, ILogMessageFormatter logMessageFormatter = null)
         {
             return GetLogger(system.EventStream, logSourceObj, logMessageFormatter);
         }
 
-        public static LoggingAdapter GetLogger(LoggingBus loggingBus, object logSourceObj, ILogMessageFormatter logMessageFormatter = null)
+        public static ILoggingAdapter GetLogger(LoggingBus loggingBus, object logSourceObj, ILogMessageFormatter logMessageFormatter = null)
         {
             //TODO: refine this
             string logSource;

--- a/src/core/Akka/Event/LoggingAdapterBase.cs
+++ b/src/core/Akka/Event/LoggingAdapterBase.cs
@@ -2,7 +2,7 @@
 
 namespace Akka.Event
 {
-    public abstract class LoggingAdapterBase : LoggingAdapter
+    public abstract class LoggingAdapterBase : ILoggingAdapter
     {
         private readonly ILogMessageFormatter _logMessageFormatter;
 

--- a/src/core/Akka/Routing/ConsistentHashRouter.cs
+++ b/src/core/Akka/Routing/ConsistentHashRouter.cs
@@ -85,7 +85,7 @@ namespace Akka.Routing
     /// </summary>
     public class ConsistentHashingRoutingLogic : RoutingLogic
     {
-        private readonly Lazy<LoggingAdapter> _log;
+        private readonly Lazy<ILoggingAdapter> _log;
         private ConsistentHashMapping _hashMapping;
         private readonly ActorSystem _system;
 
@@ -105,7 +105,7 @@ namespace Akka.Routing
             ConsistentHashMapping hashMapping)
         {
             _system = system;
-            _log = new Lazy<LoggingAdapter>(() => Logging.GetLogger(_system, this), true);
+            _log = new Lazy<ILoggingAdapter>(() => Logging.GetLogger(_system, this), true);
             _hashMapping = hashMapping;
             _selfAddress = system.AsInstanceOf<ExtendedActorSystem>().Provider.DefaultAddress;
             _vnodes = virtualNodesFactor == 0 ? system.Settings.DefaultVirtualNodesFactor : virtualNodesFactor;

--- a/src/core/Akka/Routing/RoutedActorCell.cs
+++ b/src/core/Akka/Routing/RoutedActorCell.cs
@@ -151,7 +151,7 @@ namespace Akka.Routing
 
         public override void Post(IActorRef sender, object message)
         {
-            if (message is SystemMessage) base.Post(sender, message);
+            if (message is ISystemMessage) base.Post(sender, message);
             else SendMessage(sender, message);
         }
 

--- a/src/examples/Cluster/Samples.Cluster.Simple/SimpleClusterListener.cs
+++ b/src/examples/Cluster/Samples.Cluster.Simple/SimpleClusterListener.cs
@@ -6,7 +6,7 @@ namespace Samples.Cluster.Simple
 {
     public class SimpleClusterListener : UntypedActor
     {
-        protected LoggingAdapter Log = Context.GetLogger();
+        protected ILoggingAdapter Log = Context.GetLogger();
         protected Akka.Cluster.Cluster Cluster = Akka.Cluster.Cluster.Get(Context.System);
 
         /// <summary>

--- a/src/examples/Cluster/Samples.Cluster.Simple/SimpleClusterListener2.cs
+++ b/src/examples/Cluster/Samples.Cluster.Simple/SimpleClusterListener2.cs
@@ -6,7 +6,7 @@ namespace Samples.Cluster.Simple
 {
     public class SimpleClusterListener2 : UntypedActor
     {
-        protected LoggingAdapter Log = Context.GetLogger();
+        protected ILoggingAdapter Log = Context.GetLogger();
         protected Akka.Cluster.Cluster Cluster = Akka.Cluster.Cluster.Get(Context.System);
 
         /// <summary>

--- a/src/examples/FaultTolerance/Program.cs
+++ b/src/examples/FaultTolerance/Program.cs
@@ -32,7 +32,7 @@ namespace FaultTolerance
     // Listens on progress from the worker and shuts down the system when enough work has been done.
     public class Listener : UntypedActor
     {
-        LoggingAdapter log = Logging.GetLogger(Context);
+        ILoggingAdapter log = Logging.GetLogger(Context);
 
         protected override void PreRestart(Exception reason, object message)
         {
@@ -97,7 +97,7 @@ namespace FaultTolerance
     // The Worker supervise the CounterService.
     public class Worker : UntypedActor
     {
-        LoggingAdapter log = Logging.GetLogger(Context);
+        ILoggingAdapter log = Logging.GetLogger(Context);
 
         // The sender of the initial Start message will continuously be notified about progress
         IActorRef progressListener;
@@ -195,7 +195,7 @@ namespace FaultTolerance
     // supervise Storage and Counter.
     public class CounterService : UntypedActor
     {
-        LoggingAdapter log = Logging.GetLogger(Context);
+        ILoggingAdapter log = Logging.GetLogger(Context);
 
         string key = Context.Self.Path.Name;
         IActorRef storage;
@@ -347,7 +347,7 @@ namespace FaultTolerance
     // if there is any storage available at the moment.
     public class Counter : UntypedActor
     {
-        LoggingAdapter log = Logging.GetLogger(Context);
+        ILoggingAdapter log = Logging.GetLogger(Context);
         string key;
         long count;
         IActorRef storage;

--- a/src/examples/TimeServer/TimeServer/Program.cs
+++ b/src/examples/TimeServer/TimeServer/Program.cs
@@ -20,7 +20,7 @@ namespace TimeServer
 
         public class TimeServerActor : TypedActor, IHandle<string>
         {
-            private readonly LoggingAdapter _log = Context.GetLogger();
+            private readonly ILoggingAdapter _log = Context.GetLogger();
 
             public void Handle(string message)
             {


### PR DESCRIPTION
Leftovers from #782.

Below is my target list of interfaces, per @HCanber's comment on #652 and what he hadn't hit yet:

- [x] Akka.Dispatch.SysMsg.SystemMessage, Akka (Public)
- [x]  Akka.Event.LoggingAdapter, Akka (Public)
- [x]  Akka.FluentConfigInternals, Akka (Public)
- [x]  Akka.Remote.InboundMessageDispatcher, Akka.Remote
- [x]  Akka.Remote.RemoteRef, Akka.Remote
- [x]  Akka.Routing.ConsistentHashable, Akka (Public)