### PR TITLE
F# DU serialization fix

### DIFF
--- a/src/core/Akka.FSharp.Tests/ApiTests.fs
+++ b/src/core/Akka.FSharp.Tests/ApiTests.fs
@@ -28,6 +28,11 @@ type TestUnion =
     | A of string
     | B of int * string
 
+type TestUnion2 = 
+    | C of string * TestUnion
+    | D of int
+
+
 [<Fact>]
 let ``can serialize discriminated unions`` () =
     let x = B (23,"hello")
@@ -35,5 +40,15 @@ let ``can serialize discriminated unions`` () =
     let serializer = sys.Serialization.FindSerializerFor x
     let bytes = serializer.ToBinary x
     let des = serializer.FromBinary (bytes, typeof<TestUnion>) :?> TestUnion
+    des
+    |> equals x
+
+[<Fact>]
+let ``can serialize nested discriminated unions`` () =
+    let x = C("bar",B (23,"hello"))
+    use sys = System.create "system" (Configuration.defaultConfig())
+    let serializer = sys.Serialization.FindSerializerFor x
+    let bytes = serializer.ToBinary x
+    let des = serializer.FromBinary (bytes, typeof<TestUnion2>) :?> TestUnion2
     des
     |> equals x

--- a/src/core/Akka.FSharp.Tests/ApiTests.fs
+++ b/src/core/Akka.FSharp.Tests/ApiTests.fs
@@ -23,3 +23,17 @@ let ``can serialize expression decider`` () =
     let des = serializer.FromBinary (bytes, typeof<ExprDecider>) :?> IDecider
     des.Decide (Exception())
     |> equals (Directive.Resume)
+
+type TestUnion = 
+    | A of string
+    | B of int * string
+
+[<Fact>]
+let ``can serialize discriminated unions`` () =
+    let x = B (23,"hello")
+    use sys = System.create "system" (Configuration.defaultConfig())
+    let serializer = sys.Serialization.FindSerializerFor x
+    let bytes = serializer.ToBinary x
+    let des = serializer.FromBinary (bytes, typeof<TestUnion>) :?> TestUnion
+    des
+    |> equals x

--- a/src/core/Akka/Serialization/NewtonSoftJsonSerializer.cs
+++ b/src/core/Akka/Serialization/NewtonSoftJsonSerializer.cs
@@ -129,10 +129,12 @@ namespace Akka.Serialization
                     var caseTypeName = j["Case"].Value<string>();
                     var caseType = type.GetNestedType(caseTypeName);
                     var ctor = caseType.GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)[0];
-                    //var values = ????? j["Fields"]["$values"].Values<object>();
-
-                    //var res = ctor.Invoke(values.ToArray());
-                    return null;
+                    var values =
+                        j["Fields"].ToObject<object[]>()
+                            .Select(o => TranslateSurrogate(o, system, typeof (object)))
+                            .ToArray();
+                    var res = ctor.Invoke(values.ToArray());
+                    return res;
                 }
             }
             var surrogate = deserializedValue as ISurrogate;

--- a/src/core/Akka/Serialization/NewtonSoftJsonSerializer.cs
+++ b/src/core/Akka/Serialization/NewtonSoftJsonSerializer.cs
@@ -222,10 +222,6 @@ namespace Akka.Serialization
                     writer.WriteValue(GetString(value));
                     writer.WriteEndObject();
                 }
-                else if (IsDiscriminatedUnion(value))
-                {
-                    
-                }
                 else
                 {
                     var value1 = value as ISurrogated;
@@ -240,28 +236,7 @@ namespace Akka.Serialization
                         serializer.Serialize(writer, value);
                     }
                 }
-            }
-
-            private bool IsDiscriminatedUnion(object value)
-            {
-                var result = false;
-                var type = value.GetType();
-                var attributes = type.GetCustomAttributes(true);
-                foreach (object attribute in attributes)
-                {
-                    Type attributeType = attribute.GetType();
-                    if (attributeType.FullName == "Microsoft.FSharp.Core.CompilationMappingAttribute")
-                    {
-                        var fsharpReflectionAssembly = attributeType.Assembly;
-                        var fsharpType = fsharpReflectionAssembly.GetType("Microsoft.FSharp.Reflection.FSharpType");
-                        var isUnionMethodInfo = fsharpType.GetMethod("IsUnion", BindingFlags.Public | BindingFlags.Static);
-
-                        result = (bool)isUnionMethodInfo.Invoke(null, new[] { value });
-                        if (result) break;
-                    }
-                }
-                return result;
-            }
+            }           
 
             private object GetString(object value)
             {

--- a/src/core/Akka/Serialization/NewtonSoftJsonSerializer.cs
+++ b/src/core/Akka/Serialization/NewtonSoftJsonSerializer.cs
@@ -129,9 +129,10 @@ namespace Akka.Serialization
                     var caseTypeName = j["Case"].Value<string>();
                     var caseType = type.GetNestedType(caseTypeName);
                     var ctor = caseType.GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)[0];
+                    var paramTypes = ctor.GetParameters().Select(p => p.ParameterType).ToArray();
                     var values =
                         j["Fields"].ToObject<object[]>()
-                            .Select(o => TranslateSurrogate(o, system, typeof (object)))
+                            .Select((o, i) => TranslateSurrogate(o, system, paramTypes[i]))
                             .ToArray();
                     var res = ctor.Invoke(values.ToArray());
                     return res;


### PR DESCRIPTION
F# DU serialization support.

The test case @Horusiath provided now passes.
We do need more tests for this to see if there are any special cases where this does not work.
But it solves the standard case where you pass a single DU as a message.

Can we live with such solution untill Json.NET comes out with a true fix for this?