### PR TITLE
fixed AzCopy MIME type encoding

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -125,7 +125,7 @@ Target "AzureDocsDeploy" (fun _ ->
     let rec pushToAzure docDir azureUrl container azureKey trialsLeft =
         let tracing = enableProcessTracing
         enableProcessTracing <- false
-        let arguments = sprintf "/Source:%s /Dest:%s /DestKey:%s /S /Y" (Path.GetFullPath docDir) (azureUrl @@ container) azureKey
+        let arguments = sprintf "/Source:%s /Dest:%s /DestKey:%s /S /Y /SetContentType" (Path.GetFullPath docDir) (azureUrl @@ container) azureKey
         tracefn "Pushing docs to %s. Attempts left: %d" (azureUrl) trialsLeft
         try 
             


### PR DESCRIPTION
Needed to a set a flag to enable the correct MIME types to be set based on file extension with AzCopy for API docs.