### PR TITLE
#853 Fixed some racy tests

### DIFF
--- a/src/core/Akka.Tests/Actor/SupervisorHierarchySpec.cs
+++ b/src/core/Akka.Tests/Actor/SupervisorHierarchySpec.cs
@@ -263,7 +263,7 @@ namespace Akka.Tests.Actor
                         {
                             var ca = createAttempt.IncrementAndGet();
                             if (ca <= 6 && ca % 3 == 0)
-                                childContext.ActorOf(BlackHoleActor.Props, "workingChild");
+                                childContext.ActorOf(BlackHoleActor.Props, "workingChild" + ca);
                             if (ca < 6)
                                 throw new InvalidOperationException("OH NO!");
                             childDsl.OnPreStart = _ => preStartCalled.IncrementAndGet();

--- a/src/core/Akka.Tests/Routing/ConsistentHashingRouterSpec.cs
+++ b/src/core/Akka.Tests/Routing/ConsistentHashingRouterSpec.cs
@@ -224,16 +224,14 @@ namespace Akka.Tests.Routing
             ExpectMsg(destinationC);
         }
 
-        [Fact(Skip = "Broken")] //TODO: fix this
-        public async Task ConsistentHashingRouterMustAdjustNodeRingWhenRouteeDies()
+        [Fact]
+        public void ConsistentHashingRouterMustAdjustNodeRingWhenRouteeDies()
         {
             //create pool router with two routees
             var router5 =
                 Sys.ActorOf(Props.Create<Echo>().WithRouter(new ConsistentHashingPool(2, null, null, null)), "router5");
 
-            //verify that we have at least 2 routees
-            var currentRoutees = await router5.Ask<Routees>(new GetRoutees(), GetTimeoutOrDefault(null));
-            currentRoutees.Members.Count().ShouldBe(2);
+            ((RoutedActorRef)router5).Children.Count().ShouldBe(2);
 
             router5.Tell(new Msg("a", "A"), TestActor);
             var actorWhoDies = ExpectMsg<IActorRef>();
@@ -249,8 +247,6 @@ namespace Akka.Tests.Routing
                 var actorWhoDidntDie = ExpectMsg<IActorRef>(TimeSpan.FromMilliseconds(50));
                 actorWhoDidntDie.ShouldNotBe(actorWhoDies);
             }, TimeSpan.FromSeconds(5));
-
-            
         }
     }
 }

--- a/src/core/Akka/Routing/TailChoppingRoutingLogic.cs
+++ b/src/core/Akka/Routing/TailChoppingRoutingLogic.cs
@@ -119,27 +119,36 @@ namespace Akka.Routing
             var completion = new TaskCompletionSource<object>();
             var cancelable = new Cancelable(_scheduler);
 
-            _scheduler.Advanced.ScheduleRepeatedly(TimeSpan.Zero, _interval, async () => 
+            completion.Task
+                .ContinueWith(task => cancelable.Cancel(false));
+
+            if (_routees.Length == 0)
             {
-                var currentIndex = routeeIndex.GetAndIncrement();
-                if(currentIndex < _routees.Length)
+                completion.TrySetResult(NoRoutee);
+            }
+            else
+            {
+                _scheduler.Advanced.ScheduleRepeatedly(TimeSpan.Zero, _interval, async () =>
                 {
-                    completion.TrySetResult(await ((Task<object>)_routees[currentIndex].Ask(message, null)));
-                }
-            }, cancelable);
+                    var currentIndex = routeeIndex.GetAndIncrement();
+                    if (currentIndex >= _routees.Length) 
+                        return;
 
-            _scheduler.Advanced.ScheduleOnce(_within, () => 
-            {
-                completion.TrySetException(new TimeoutException(String.Format("Ask timed out on {0} after {1}", sender, _within)));
-            }, cancelable);
+                    try
+                    {
 
-            var request = completion.Task;
-            completion.Task.ContinueWith(task => 
-            {
-                cancelable.Cancel(false);
-            });
+                        completion.TrySetResult(await ((Task<object>)_routees[currentIndex].Ask(message, _within)));
+                    }
+                    catch (TaskCanceledException)
+                    {
+                        completion.TrySetResult(
+                            new Status.Failure(
+                                new TimeoutException(String.Format("Ask timed out on {0} after {1}", sender, _within))));
+                    }
+                }, cancelable);
+            }
 
-            request.PipeTo(sender);
+            completion.Task.PipeTo(sender);
         }
     }
 


### PR DESCRIPTION
* fixed the race condition in ConsistentHashingRouterSpec.ConsistentHashingRouterMustAdjustNodeRingWhenRouteeDies
* fixed some timeout logic in the TailChoppingSpec
* fixed the TailChoppingRouterLogic use timeouts on the asks to cancel the overall request instead of scheduling another task
* made the child name unique for SupervisorHierarchySpec.A_supervisor_hierarchy_must_handle_failure_in_creation_when_supervision_strategy_returns_Resume_and_Restart to fix test