### PR TITLE
Fixed a number of compiler warnings

### DIFF
--- a/src/contrib/dependencyInjection/Akka.DI.AutoFac/AutoFacDependencyResolver.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.AutoFac/AutoFacDependencyResolver.cs
@@ -13,8 +13,6 @@ using System.Text;
 using Akka.DI.Core;
 using System.Runtime.CompilerServices;
 using Autofac;
-using System.Text;
-using System.Runtime.CompilerServices;
 
 namespace Akka.DI.AutoFac
 {

--- a/src/contrib/testkits/Akka.TestKit.Xunit/TestKit.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit/TestKit.cs
@@ -97,7 +97,7 @@ namespace Akka.TestKit.Xunit
         /// user's code. Managed and unmanaged resources will be disposed.<br />
         /// if set to <c>false</c> the method has been called by the runtime from inside the finalizer and only 
         /// unmanaged resources can be disposed.</param>
-        private void Dispose(bool disposing)
+        protected virtual void Dispose(bool disposing)
         {
             // If disposing equals false, the method has been called by the
             // runtime from inside the finalizer and you should not reference

--- a/src/core/Akka.Cluster.Tests/ClusterHeartBeatSenderStateSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterHeartBeatSenderStateSpec.cs
@@ -266,7 +266,7 @@ namespace Akka.Cluster.Tests
                             break;
                     }
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     Debug.WriteLine("Failure context: i = {0}, node = {1}, op={2}, unreachable={3}, ringReceivers={4}, ringNodes={5}", i, node, operation, 
                         string.Join(",",state.Unreachable), 

--- a/src/core/Akka.Cluster.Tests/EWMASpec.cs
+++ b/src/core/Akka.Cluster.Tests/EWMASpec.cs
@@ -126,13 +126,7 @@ namespace Akka.Cluster.Tests
 
         #region IDisposable members
 
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing)
+        protected override void Dispose(bool disposing)
         {
             if (disposing)
             {

--- a/src/core/Akka.Cluster.Tests/MetricsCollectorSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MetricsCollectorSpec.cs
@@ -119,13 +119,7 @@ namespace Akka.Cluster.Tests
 
         #region IDisposable members
 
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing)
+        protected override void Dispose(bool disposing)
         {
             if (disposing)
             {

--- a/src/core/Akka.Cluster.Tests/MultiNode/ClusterDeathWatchSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MultiNode/ClusterDeathWatchSpec.cs
@@ -291,7 +291,7 @@ namespace Akka.Cluster.Tests.MultiNode
                     {
                         Sys.AwaitTermination(timeout);
                     }
-                    catch (TimeoutException ex)
+                    catch (TimeoutException)
                     {
                         Assert.True(false, String.Format("Failed to stop [{0}] within [{1}]", Sys.Name, timeout));
                     }

--- a/src/core/Akka.Persistence.Tests/PersistentActorSpec.Actors.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorSpec.Actors.cs
@@ -328,8 +328,8 @@ namespace Akka.Persistence.Tests
 
             protected override bool ReceiveCommand(object message)
             {
-                if (CommonBehavior(message)) ;
-                else if (message is Cmd) HandleCmd(message as Cmd);
+                if (CommonBehavior(message)) return true;
+                if (message is Cmd) HandleCmd(message as Cmd);
                 else if (message is SaveSnapshotSuccess) Probe.Tell("saved");
                 else if (message.ToString() == "snap") SaveSnapshot(Events);
                 else return false;
@@ -368,8 +368,8 @@ namespace Akka.Persistence.Tests
 
             private bool BecomingCommand(object message)
             {
-                if (ReceiveCommand(message)) ;
-                else if (message.ToString() == Message) Probe.Tell(Response);
+                if (ReceiveCommand(message)) return true;
+                if (message.ToString() == Message) Probe.Tell(Response);
                 else return false;
                 return true;
             }

--- a/src/core/Akka.Persistence/Eventsourced.Lifecycle.cs
+++ b/src/core/Akka.Persistence/Eventsourced.Lifecycle.cs
@@ -70,22 +70,22 @@ namespace Akka.Persistence
 
         protected override void Unhandled(object message)
         {
-            if (message is RecoveryCompleted) ; // ignore
-            else if (message is RecoveryFailure)
+            if (message is RecoveryCompleted) return; // ignore
+            if (message is RecoveryFailure)
             {
                 var msg = string.Format("{0} was killed after recovery failure (persistence id = {1}). To avoid killing persistent actors on recovery failure, a PersistentActor must handle RecoveryFailure messages. Recovery failure was caused by: {2}", 
                     GetType().Name, PersistenceId, (message as RecoveryFailure).Cause.Message);
 
                 throw new ActorKilledException(msg);
             }
-            else if (message is PersistenceFailure)
+            if (message is PersistenceFailure)
             {
                 var fail = message as PersistenceFailure;
                 var msg = string.Format("{0} was killed after persistence failure (persistence id = {1}, sequence nr: {2}, payload type: {3}). To avoid killing persistent actors on recovery failure, a PersistentActor must handle RecoveryFailure messages. Persistence failure was caused by: {4}",
                     GetType().Name, PersistenceId, fail.SequenceNr, fail.Payload.GetType().Name, fail.Cause.Message);
                 throw new ActorKilledException(msg);
             }
-            else base.Unhandled(message);
+            base.Unhandled(message);
         }
     }
 }

--- a/src/core/Akka.Persistence/Eventsourced.Recovery.cs
+++ b/src/core/Akka.Persistence/Eventsourced.Recovery.cs
@@ -165,7 +165,7 @@ namespace Akka.Persistence
                 }
                 else if (message is ReplayMessagesSuccess) ReplayCompleted(cause, failureMessage);
                 else if (message is ReplayedMessage) UpdateLastSequenceNr(((ReplayedMessage)message).Persistent);
-                else if (message is Recover) ;  // ignore
+                else if (message is Recover) return;  // ignore
                 else _internalStash.Stash();
             });
         }

--- a/src/core/Akka.Persistence/Journal/SyncWriteJournal.cs
+++ b/src/core/Akka.Persistence/Journal/SyncWriteJournal.cs
@@ -63,7 +63,7 @@ namespace Akka.Persistence.Journal
 
                 if (CanPublish) Context.System.EventStream.Publish(msg);
             }
-            catch (Exception e) { /* do nothing */ }
+            catch (Exception) { /* do nothing */ }
         }
 
         private void HandleReadHighestSequenceNr(ReadHighestSequenceNr msg)

--- a/src/core/Akka.Persistence/PersistentView.Lifecycle.cs
+++ b/src/core/Akka.Persistence/PersistentView.Lifecycle.cs
@@ -54,15 +54,15 @@ namespace Akka.Persistence
 
         protected override void Unhandled(object message)
         {
-            if (message is RecoveryCompleted) ; // ignore
-            else if (message is RecoveryFailure)
+            if (message is RecoveryCompleted) return; // ignore
+            if (message is RecoveryFailure)
             {
                 var fail = (RecoveryFailure)message;
                 var errorMessage = string.Format("Persistent view killed after the recovery failure (Persistence id: {0}). To avoid killing persistent actors on recovery failures, PersistentView must handle RecoveryFailure messages. Failure was caused by: {1}", PersistenceId, fail.Cause.Message);
 
                 throw new ActorKilledException(errorMessage);
             }
-            else base.Unhandled(message);
+            base.Unhandled(message);
         }
     }
 }

--- a/src/core/Akka.Persistence/PersistentView.Recovery.cs
+++ b/src/core/Akka.Persistence/PersistentView.Recovery.cs
@@ -65,8 +65,8 @@ namespace Akka.Persistence
         {
             return new ViewState("recovery started - replayMax: " + replayMax, true, (receive, message) =>
             {
-                if (message is Recover) ; // ignore
-                else if (message is LoadSnapshotResult)
+                if (message is Recover) return; // ignore
+                if (message is LoadSnapshotResult)
                 {
                     var loadResult = (LoadSnapshotResult)message;
                     if (loadResult.Snapshot != null)
@@ -110,7 +110,7 @@ namespace Akka.Persistence
                         _internalStash.Stash();
                     }
                 }
-                else if (message is Recover) ; // ignore
+                else if (message is Recover) return; // ignore
                 else if (message is ReplayedMessage)
                 {
                     var replayedMessage = (ReplayedMessage)message;
@@ -172,7 +172,7 @@ namespace Akka.Persistence
                 }
                 else if (message is ReplayMessagesSuccess) OnReplayFailureCompleted(receive, cause, failedMessage as IPersistentRepresentation);
                 else if (message is ReplayedMessage) UpdateLastSequenceNr(((ReplayedMessage)message).Persistent);
-                else if (message is Recover) ; // ignore
+                else if (message is Recover) return; // ignore
                 else _internalStash.Stash();
             });
         }
@@ -204,7 +204,7 @@ namespace Akka.Persistence
                     var scheduled = (ScheduledUpdate) message;
                     ChangeStateToReplayStarted(false, scheduled.ReplayMax);
                 }
-                else if (message is Recover) ; // ignore
+                else if (message is Recover) return; // ignore
                 else base.AroundReceive(receive, message);
             });
         }

--- a/src/core/Akka.Remote/Transport/FailureInjectorTransportAdapter.cs
+++ b/src/core/Akka.Remote/Transport/FailureInjectorTransportAdapter.cs
@@ -38,7 +38,7 @@ namespace Akka.Remote.Transport
             Msg = msg;
         }
 
-        protected FailureInjectorException(SerializationInfo info, StreamingContext context)
+        private FailureInjectorException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }

--- a/src/core/Akka.Tests/Actor/ActorDslSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorDslSpec.cs
@@ -38,7 +38,7 @@ namespace Akka.Tests.Actor
                 else if (message == "switch")
                     c.BecomeStacked((msg2, ctx2) =>
                     {
-                        var message2 = msg as string;
+                        var message2 = msg2 as string;
                         if (message2 == null) return;
                         
                         if (message2 == "info")

--- a/src/core/Akka.Tests/Actor/ActorDslSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorDslSpec.cs
@@ -30,17 +30,23 @@ namespace Akka.Tests.Actor
         {
             var a = Sys.ActorOf(c => c.Become((msg, ctx) =>
             {
-                if (msg == "info")
+                var message = msg as string;
+                if (message == null) return;
+
+                if (message == "info")
                     TestActor.Tell("A");
-                else if (msg == "switch")
+                else if (message == "switch")
                     c.BecomeStacked((msg2, ctx2) =>
                     {
-                        if (msg2 == "info")
+                        var message2 = msg as string;
+                        if (message2 == null) return;
+                        
+                        if (message2 == "info")
                             TestActor.Tell("B");
-                        else if (msg2 == "switch")
+                        else if (message2 == "switch")
                             c.UnbecomeStacked();
                     });
-                else if (msg == "lobotomize")
+                else if (message == "lobotomize")
                     c.UnbecomeStacked();
             }));
 

--- a/src/core/Akka.Tests/Actor/LocalActorRefProviderSpec.cs
+++ b/src/core/Akka.Tests/Actor/LocalActorRefProviderSpec.cs
@@ -96,7 +96,7 @@ namespace Akka.Tests.Actor
         {
             protected override bool Receive(object message)
             {
-                if (message == "")
+                if (message as string == "")
                 {
                     var a = Context.ActorOf(Props.Empty, "duplicate");
                     var b = Context.ActorOf(Props.Empty, "duplicate");
@@ -117,7 +117,7 @@ namespace Akka.Tests.Actor
 
             protected override bool Receive(object message)
             {
-                if (message == "GetChild")
+                if (message as string == "GetChild")
                 {
                     Sender.Tell(this.childActorRef);
                     return true;

--- a/src/core/Akka.Tests/Actor/Stash/ActorWithStashSpec.cs
+++ b/src/core/Akka.Tests/Actor/Stash/ActorWithStashSpec.cs
@@ -193,7 +193,7 @@ namespace Akka.Tests.Actor.Stash
                     {
                         Stash.Stash();
                     }
-                    catch(IllegalActorStateException e)
+                    catch(IllegalActorStateException)
                     {
                         _state.ExpectedException.Open();
                     }

--- a/src/core/Akka.Tests/Serialization/SerializationSpec.cs
+++ b/src/core/Akka.Tests/Serialization/SerializationSpec.cs
@@ -206,7 +206,7 @@ namespace Akka.Tests.Serialization
         [Fact]
         public void CanSerializeLong()
         {
-            var message = 123l;
+            var message = 123L;
             AssertEqual(message);
         }
 
@@ -510,7 +510,7 @@ namespace Akka.Tests.Serialization
 akka.actor {
     serializers {
         dummy = """ + typeof(DummySerializer).AssemblyQualifiedName + @"""
-	}
+    }
 
     serialization-bindings {
       ""System.String"" = dummy

--- a/src/core/Akka/Actor/ActorRefProvider.cs
+++ b/src/core/Akka/Actor/ActorRefProvider.cs
@@ -429,7 +429,7 @@ namespace Akka.Actor
                     routedActorRef.Initialize(async);
                     return routedActorRef;
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     throw new ConfigurationException(string.Format("Configuration problem while creating [{0}] with router dispatcher [{1}] and mailbox {2}" +
                                                                    " and routee dispatcher [{3}] and mailbox [{4}].", path, routerProps.Dispatcher, routerProps.Mailbox,

--- a/src/core/Akka/Actor/Address.cs
+++ b/src/core/Akka/Actor/Address.cs
@@ -220,9 +220,9 @@ namespace Akka.Actor
                 var finalAddr = addr;
                 // need to add a special case for URI fragments containing #, since those don't get counted
                 // as relative URIs by C#
-				if(Uri.IsWellFormedUriString(addr, UriKind.Absolute) || (!Uri.IsWellFormedUriString(addr, UriKind.Relative) 
+                if(Uri.IsWellFormedUriString(addr, UriKind.Absolute) || (!Uri.IsWellFormedUriString(addr, UriKind.Relative) 
                     && !addr.Contains("#"))) return null;
-				if(!addr.StartsWith("/"))
+                if(!addr.StartsWith("/"))
                 {
                     //hack to cause the URI not to explode when we're only given an actor name
                     finalAddr = "/" + addr;
@@ -230,7 +230,7 @@ namespace Akka.Actor
 
                 return finalAddr.Split('/').SkipWhile(string.IsNullOrEmpty);
             }
-            catch (UriFormatException ex)
+            catch (UriFormatException)
             {
                 return null;
             }

--- a/src/core/Akka/Actor/Scheduler/TaskBasedScheduler.cs
+++ b/src/core/Akka/Actor/Scheduler/TaskBasedScheduler.cs
@@ -55,7 +55,7 @@ namespace Akka.Actor
                 {
                     action();
                 }
-                catch(OperationCanceledException e) { }
+                catch(OperationCanceledException) { }
                 //TODO: Should we log other exceptions? /@hcanber
 
             }, token, TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Current);

--- a/src/core/Akka/Dispatch/CachingConfig.cs
+++ b/src/core/Akka/Dispatch/CachingConfig.cs
@@ -125,7 +125,7 @@ namespace Akka.Dispatch
                                 pathEntry = new ValuePathEntry(true, true, configValue.AtKey("cached"));
                             }
                         }
-                        catch (Exception ex)
+                        catch (Exception)
                         {
                             pathEntry = EmptyPathEntry;
                         }
@@ -135,7 +135,7 @@ namespace Akka.Dispatch
                         pathEntry = NonExistingPathEntry;
                     }
                 }
-                catch (Exception ex) //configuration threw some sort of error
+                catch (Exception) //configuration threw some sort of error
                 {
                     pathEntry = InvalidPathEntry;
                 }

--- a/src/core/Akka/Helios.Concurrency.DedicatedThreadPool.cs
+++ b/src/core/Akka/Helios.Concurrency.DedicatedThreadPool.cs
@@ -419,7 +419,7 @@ namespace Helios.Concurrency
                             if (_pool.ShutdownRequested) return;
                             action();
                         }
-                        catch (Exception ex)
+                        catch (Exception)
                         {
                             Failover(true);
                             return;

--- a/src/examples/PersistenceExample/ExamplePersistentActor.cs
+++ b/src/examples/PersistenceExample/ExamplePersistentActor.cs
@@ -99,9 +99,9 @@ namespace PersistenceExample
                 var cmd = message as Command;
                 Persist(new Event(cmd.Data + "-" + EventsCount), UpdateState);
             }
-            else if (message == "snap")
+            else if (message as string == "snap")
                 SaveSnapshot(State);
-            else if (message == "print")
+            else if (message as string == "print")
                 Console.WriteLine(State);
             else return false;
             return true;

--- a/src/examples/PersistenceExample/ExamplePersistentFailingActor.cs
+++ b/src/examples/PersistenceExample/ExamplePersistentFailingActor.cs
@@ -32,9 +32,9 @@ namespace PersistenceExample
 
         protected override bool ReceiveCommand(object message)
         {
-            if (message == "print")
+            if (message as string == "print")
                 Console.WriteLine("Received: " + string.Join(";, ", Enumerable.Reverse(Received)));
-            else if (message == "boom")
+            else if (message as string == "boom")
                 throw new Exception("controlled demolition");
             else if (message is string)
                 Persist(message.ToString(), s => Received.AddFirst(s));

--- a/src/examples/PersistenceExample/ExampleView.cs
+++ b/src/examples/PersistenceExample/ExampleView.cs
@@ -19,7 +19,7 @@ namespace PersistenceExample
         
         protected override bool Receive(object message)
         {
-            if (message == "snap")
+            if (message as string == "snap")
             {
                 Console.WriteLine("View saving snapshot");
                 SaveSnapshot(_numReplicated);

--- a/src/examples/PersistenceExample/GuaranteedDeliveryExampleActor.cs
+++ b/src/examples/PersistenceExample/GuaranteedDeliveryExampleActor.cs
@@ -57,11 +57,11 @@ namespace PersistenceExample
 
         protected override void OnReceive(object message)
         {
-            if (message == "start")
+            if (message as string == "start")
             {
                 Confirming = true;
             }
-            if (message == "stop")
+            if (message as string == "stop")
             {
                 Confirming = false;
             }
@@ -126,7 +126,7 @@ namespace PersistenceExample
 
         protected override bool ReceiveCommand(object message)
         {
-            if (message == "boom")
+            if (message as string == "boom")
                 throw new Exception("Controlled devastation");
             else if (message is Message)
             {

--- a/src/examples/PersistenceExample/SnapshotedExampleActor.cs
+++ b/src/examples/PersistenceExample/SnapshotedExampleActor.cs
@@ -37,9 +37,9 @@ namespace PersistenceExample
 
         protected override bool ReceiveCommand(object message)
         {
-            if (message == "print")
+            if (message as string == "print")
                 Console.WriteLine("Current actor's state: " + State);
-            else if (message == "snap")
+            else if (message as string == "snap")
                 SaveSnapshot(State);
             else if (message is SaveSnapshotFailure || message is SaveSnapshotSuccess) { }
             else if (message is string)


### PR DESCRIPTION
The compiler warnings are getting out of control with at least 102 in
HEAD. Most of these can be ignored since they look to be Obsolete tags
throwing the warnings. This PR reduces the number of warnings to 60.
