### PR TITLE
 #853 fixed race condition in RoutingSpec

### DIFF
--- a/src/core/Akka.Tests/Routing/RoutingSpec.cs
+++ b/src/core/Akka.Tests/Routing/RoutingSpec.cs
@@ -65,24 +65,28 @@ namespace Akka.Tests.Routing
         public void Router_in_general_must_evict_terminated_routees()
         {
             var router = Sys.ActorOf(new RoundRobinPool(2).Props(Props.Create<Echo>()), "router");
-            router.Tell("",TestActor);
-            router.Tell("",TestActor);
+            router.Tell("", TestActor);
+            router.Tell("", TestActor);
+
             var c1 = ExpectMsg<IActorRef>();
             var c2 = ExpectMsg<IActorRef>();
+
             Watch(router);
             Watch(c2);
             Sys.Stop(c2);
+
+            AwaitCondition(() => ((RoutedActorRef) router).Children.Count() == 1);
+
             ExpectTerminated(c2).ExistenceConfirmed.ShouldBe(true);
-            // it might take a while until the Router has actually processed the Terminated message
-            Task.Delay(100).Wait();
-            AwaitCondition(() =>
-            {
-                router.Tell("", TestActor);
-                router.Tell("", TestActor);
-                var res = ReceiveWhile(TimeSpan.FromMilliseconds(100), o => o is IActorRef ? (IActorRef) o : ActorRefs.NoSender, 2);
-                return res.SequenceEqual(new[] {c1, c1});
-            });
-            
+
+            router.Tell("", TestActor);
+            var msg1 = ExpectMsg<IActorRef>();
+            msg1.ShouldBe(c1);
+
+            router.Tell("", TestActor);
+            var msg2 = ExpectMsg<IActorRef>();
+            msg2.ShouldBe(c1);
+
             Sys.Stop(c1);
             ExpectTerminated(router).ExistenceConfirmed.ShouldBe(true);
         }


### PR DESCRIPTION
test Router_in_general_must_evict_terminated_routees 
