### PR TITLE
QueueUserWorkItem vs UnsafeQueueUserWorkItem issue in .NetFiddle

### DIFF
--- a/src/core/Akka/Dispatch/Dispatchers.cs
+++ b/src/core/Akka/Dispatch/Dispatchers.cs
@@ -50,7 +50,8 @@ namespace Akka.Dispatch
     /// </summary>
     public class ThreadPoolDispatcher : MessageDispatcher
     {
-	    private static readonly bool _isFullTrusted = AppDomain.CurrentDomain.IsFullyTrusted;
+
+        private static readonly bool _isFullTrusted = AppDomain.CurrentDomain.IsFullyTrusted;
 
         /// <summary>
         /// Takes a <see cref="MessageDispatcherConfigurator"/>
@@ -66,11 +67,12 @@ namespace Akka.Dispatch
         public override void Schedule(Action run)
         {
             var wc = new WaitCallback(_ => run());
-			if (_isFullTrusted)
-				ThreadPool.UnsafeQueueUserWorkItem(wc, null);
-			else
-				ThreadPool.QueueUserWorkItem(wc, null);
-		}
+            // we use unsafe version if current application domain is FullTrusted
+            if (_isFullTrusted)
+                ThreadPool.UnsafeQueueUserWorkItem(wc, null);
+            else
+                ThreadPool.QueueUserWorkItem(wc, null);
+        }
     }
 
     /// <summary>

--- a/src/core/Akka/Dispatch/Dispatchers.cs
+++ b/src/core/Akka/Dispatch/Dispatchers.cs
@@ -50,6 +50,8 @@ namespace Akka.Dispatch
     /// </summary>
     public class ThreadPoolDispatcher : MessageDispatcher
     {
+	    private static readonly bool _isFullTrusted = AppDomain.CurrentDomain.IsFullyTrusted;
+
         /// <summary>
         /// Takes a <see cref="MessageDispatcherConfigurator"/>
         /// </summary>
@@ -64,9 +66,11 @@ namespace Akka.Dispatch
         public override void Schedule(Action run)
         {
             var wc = new WaitCallback(_ => run());
-            ThreadPool.UnsafeQueueUserWorkItem(wc, null);
-            //ThreadPool.QueueUserWorkItem(wc, null);
-        }
+			if (_isFullTrusted)
+				ThreadPool.UnsafeQueueUserWorkItem(wc, null);
+			else
+				ThreadPool.QueueUserWorkItem(wc, null);
+		}
     }
 
     /// <summary>


### PR DESCRIPTION
Hey guys,

As you asked i've made a pull request for the issue. The reason why default thread-pool dispatcher doesn't work in .NetFiddle is that you are using `ThreadPool.UnsafeQueueUserWorkItem(wc, null);` in `ThreadPoolDispatcher` instead of `ThreadPool.QueueUserWorkItem(wc, null);` 

The main difference between these two calls is that `UnsafeQueueUserWorkItem` call doesn't check for Code Access Security(CAS), so it works a bit faster without these checks, but it requires FullTrust permissions. In .NetFiddle we can't allow to use FullTrust permissions as code executes on server, so logic that requires FullTrust doesn't work here.

In this pull request i've added check that is based on `AppDomain.CurrentDomain.IsFullyTrusted`, so if current AppDomain is FullTrusted, then the code will use `UnsafeQueueUserWorkItem`, otherwise it will use safe version `QueueUserWorkItem`. I've tested it with local .NetFiddle and it works fine on original code sample