### PR TITLE
Added generic interface method for Props

### DIFF
--- a/src/contrib/dependencyInjection/Akka.DI.Core/DIExt.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.Core/DIExt.cs
@@ -31,6 +31,9 @@ namespace Akka.DI.Core
             return new Props(typeof(DIActorProducer), new object[] { dependencyResolver, actorType });
         }
 
+        public Props Props<TActor>() {
+            return Props(typeof(TActor));
+        }
     }
 }
 


### PR DESCRIPTION
Since the latest DI api changes, we can now resolve dependencies based
on type. However a generic convenience method is missing.
Since generics are used throughout Akka already. I see no reason not to
add this method.