### PR TITLE
fixed `IDisposable` calls on EMWASpec and MetricsCollectorSpec

### DIFF
--- a/src/core/Akka.Cluster.Tests/EWMASpec.cs
+++ b/src/core/Akka.Cluster.Tests/EWMASpec.cs
@@ -126,13 +126,13 @@ namespace Akka.Cluster.Tests
 
         #region IDisposable members
 
-        protected override void Dispose(bool disposing)
+        /// <summary>
+        /// Needs to hide previous Dispose implementation in order to avoid recursive disposal.
+        /// </summary>
+        public new void Dispose()
         {
-            if (disposing)
-            {
-                _collector.Dispose();
-                base.Dispose();
-            }
+            _collector.Dispose();
+            base.Dispose();
         }
 
         #endregion

--- a/src/core/Akka.Cluster.Tests/MetricsCollectorSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MetricsCollectorSpec.cs
@@ -119,13 +119,13 @@ namespace Akka.Cluster.Tests
 
         #region IDisposable members
 
-        protected override void Dispose(bool disposing)
+        /// <summary>
+        /// Needs to hide previous Dispose implementation in order to avoid recursive disposal.
+        /// </summary>
+        public new void Dispose()
         {
-            if (disposing)
-            {
-                _collector.Dispose();
-                base.Dispose();
-            }
+            _collector.Dispose();
+            base.Dispose();
         }
 
         #endregion


### PR DESCRIPTION
#867 inadvertently included a commit that introduced some recursive disposal calls in these two specs.

This undoes those changes and leaves a comment explaining why they're there.