### PR TITLE
Adds test to the MailboxesSpec to catch the issue fixed in #882

### DIFF
--- a/src/core/Akka.Tests/Dispatch/MailboxesSpec.cs
+++ b/src/core/Akka.Tests/Dispatch/MailboxesSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Linq;
 using Akka.Actor;
 using Akka.Dispatch;
 using Akka.Dispatch.SysMsg;
@@ -32,6 +33,14 @@ namespace Akka.Tests.Dispatch
         }
     }
 
+    public class IntPriorityMailbox : UnboundedPriorityMailbox
+    {
+        protected override int PriorityGenerator(object message)
+        {
+            return message as int? ?? Int32.MaxValue;
+        }
+    }
+
     public class MailboxesSpec : AkkaSpec
     {
         public MailboxesSpec() : base(GetConfig())
@@ -44,6 +53,10 @@ namespace Akka.Tests.Dispatch
 akka.actor.default-dispatcher.throughput = 100  #ensure we process 100 messages per mailbox run
 string-prio-mailbox {
     mailbox-type : """ + typeof(TestPriorityMailbox).AssemblyQualifiedName  + @"""
+}
+
+int-prio-mailbox {
+    mailbox-type : """ + typeof(IntPriorityMailbox).AssemblyQualifiedName + @"""
 }
 ";
         }
@@ -82,6 +95,43 @@ string-prio-mailbox {
 
             ExpectNoMsg(TimeSpan.FromSeconds(0.3));
         }       
+
+        [Fact]
+        public void PriorityMailboxKeepsOrderingWithManyPriorityValues()
+        {
+            var actor = Sys.ActorOf(EchoActor.Props(this).WithMailbox("int-prio-mailbox"), "echo");
+
+            //pause mailbox until all messages have been told
+            actor.Tell(Suspend.Instance);
+
+            // creates 50 messages with values spanning from Int32.MinValue to Int32.MaxValue
+            var values = new int[50];
+            var increment = (int)(UInt32.MaxValue / values.Length);
+
+            for (var i = 0; i < values.Length; i++)
+                values[i] = Int32.MinValue + increment * i;
+
+            // tell the actor in reverse order
+            foreach (var value in values.Reverse())
+            {
+                actor.Tell(value);
+                actor.Tell(value);
+                actor.Tell(value);
+            }
+
+            //resume mailbox, this prevents the mailbox from running to early
+            actor.Tell(new Resume(null));
+
+            // expect the messages in the correct order
+            foreach (var value in values)
+            {
+                ExpectMsg(value);
+                ExpectMsg(value);
+                ExpectMsg(value);
+            }
+
+            ExpectNoMsg(TimeSpan.FromSeconds(0.3));
+        }
     }
 }
 


### PR DESCRIPTION
The existing tests don't catch the ordering issue reported on #881, fixed on #882.

This adds a test with ordering values spanning through the Int32 range in order to ensure ordering is maintained with many ordering values.