### PR TITLE
Removed redundant copyright notices

### DIFF
--- a/src/core/Akka.Tests/Dispatch/DispatchersSpec.cs
+++ b/src/core/Akka.Tests/Dispatch/DispatchersSpec.cs
@@ -5,11 +5,6 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-/**
- * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
- * Original C# code written by Akka.NET project <http://getakka.net/>
- */
-
 using System;
 using System.Threading;
 using Akka.Actor;

--- a/src/core/Akka/Dispatch/CachingConfig.cs
+++ b/src/core/Akka/Dispatch/CachingConfig.cs
@@ -5,11 +5,6 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-/**
- * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
- * Original C# code written by Akka.NET project <http://getakka.net/>
- */
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/core/Akka/Dispatch/DispatcherConfigurator.cs
+++ b/src/core/Akka/Dispatch/DispatcherConfigurator.cs
@@ -5,11 +5,6 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-/**
- * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
- * Original C# code written by Akka.NET project <http://getakka.net/>
- */
-
 namespace Akka.Dispatch
 {
    

--- a/src/core/Akka/Dispatch/Dispatchers.cs
+++ b/src/core/Akka/Dispatch/Dispatchers.cs
@@ -5,10 +5,6 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-/**
- * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
- * Original C# code written by Akka.NET project <http://getakka.net/>
- */
 using System;
 using System.Collections.Concurrent;
 using System.Threading;

--- a/src/core/Akka/Helios.Concurrency.DedicatedThreadPool.cs
+++ b/src/core/Akka/Helios.Concurrency.DedicatedThreadPool.cs
@@ -1,12 +1,7 @@
-﻿//-----------------------------------------------------------------------
-// <copyright file="Helios.Concurrency.DedicatedThreadPool.cs" company="Akka.NET Project">
-//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
-//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
-//
-//     Copyright 2015 Roger Alsing, Aaron Stannard
-//     Helios.DedicatedThreadPool - https://github.com/helios-io/DedicatedThreadPool
-// </copyright>
-//-----------------------------------------------------------------------
+﻿/*
+ * Copyright 2015 Roger Alsing, Aaron Stannard
+ * Helios.DedicatedThreadPool - https://github.com/helios-io/DedicatedThreadPool
+ */
 
 using System;
 using System.Collections.Concurrent;

--- a/src/core/Akka/Helios.Concurrency.DedicatedThreadPool.cs
+++ b/src/core/Akka/Helios.Concurrency.DedicatedThreadPool.cs
@@ -2,13 +2,12 @@
 // <copyright file="Helios.Concurrency.DedicatedThreadPool.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+//
+//     Copyright 2015 Roger Alsing, Aaron Stannard
+//     Helios.DedicatedThreadPool - https://github.com/helios-io/DedicatedThreadPool
 // </copyright>
 //-----------------------------------------------------------------------
 
-/*
- * Copyright 2015 Roger Alsing, Aaron Stannard
- * Helios.DedicatedThreadPool - https://github.com/helios-io/DedicatedThreadPool
- */
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;


### PR DESCRIPTION
Some files had redundant copyright notices in them. I removed the ones
that didn't follow the <copyright> convention.

I'm not sure about Helios.Concurrency.DedicatedThreadPool.cs though. So
I concat'ed the two notices together. If I could get a second opinion on that.