### PR TITLE
async/await support via custom awaiter

### DIFF
--- a/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
+++ b/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
@@ -98,6 +98,7 @@ namespace Akka.Actor
             else if (m is PoisonPill) HandlePoisonPill();
             else if (m is ActorSelectionMessage) ReceiveSelection(m as ActorSelectionMessage);
             else if (m is Identify) HandleIdentity(m as Identify);
+            else if (m is CompleteReentrantAwaitedTask) HandleCompleteReentrantAwaitedTask(m as CompleteReentrantAwaitedTask);
         }
 
         /// <summary>
@@ -209,6 +210,14 @@ namespace Akka.Actor
             Sender = task.State.Sender;
             task.SetResult();
         }
+
+        private void HandleCompleteReentrantAwaitedTask(CompleteReentrantAwaitedTask task)
+        {
+            CurrentMessage = task.State.Message;
+            Sender = task.State.Sender;
+            task.SetResult();
+        }
+
         public void SwapMailbox(DeadLetterMailbox mailbox)
         {
             Mailbox.DebugPrint("{0} Swapping mailbox to DeadLetterMailbox", Self);

--- a/src/core/Akka/Actor/Await/ActorAwareTaskAwaitable.cs
+++ b/src/core/Akka/Actor/Await/ActorAwareTaskAwaitable.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Dispatch;
+
+namespace Akka.Actor.Await
+{
+    public struct ActorAwareTaskAwaitable
+    {
+        private readonly Task _task;
+        private readonly AsyncBehavior _behavior;
+
+        public ActorAwareTaskAwaitable(Task task, AsyncBehavior behavior)
+        {
+            _task = task;
+            _behavior = behavior;
+        }
+
+        public ActorAwareTaskAwaiter GetAwaiter()
+        {
+            return new ActorAwareTaskAwaiter(_task, _behavior);
+        }
+    }
+
+    public struct ActorAwareTaskAwaitable<TResult>
+    {
+        private readonly Task<TResult> _task;
+        private readonly AsyncBehavior _behavior;
+
+        public ActorAwareTaskAwaitable(Task<TResult> task, AsyncBehavior behavior)
+        {
+            _task = task;
+            _behavior = behavior;
+        }
+
+        public ActorAwareTaskAwaiter<TResult> GetAwaiter()
+        {
+            return new ActorAwareTaskAwaiter<TResult>(_task, _behavior);
+        }
+    }
+}

--- a/src/core/Akka/Actor/Await/ActorAwareTaskAwaitableExtensions.cs
+++ b/src/core/Akka/Actor/Await/ActorAwareTaskAwaitableExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Dispatch;
+
+namespace Akka.Actor.Await
+{
+    public static class ActorAwareTaskAwaitableExtensions
+    {
+        public static ActorAwareTaskAwaitable ActorAwait(this Task task, AsyncBehavior behavior = AsyncBehavior.Suspend)
+        {
+            return new ActorAwareTaskAwaitable(task, behavior);
+        }
+
+        public static ActorAwareTaskAwaitable<TResult> ActorAwait<TResult>(this Task<TResult> task, AsyncBehavior behavior = AsyncBehavior.Suspend)
+        {
+            return new ActorAwareTaskAwaitable<TResult>(task, behavior);
+        }
+    }
+}

--- a/src/core/Akka/Actor/Await/ActorAwareTaskAwaiter.cs
+++ b/src/core/Akka/Actor/Await/ActorAwareTaskAwaiter.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.Remoting.Messaging;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor.Internal;
+using Akka.Dispatch;
+using Akka.Dispatch.SysMsg;
+
+namespace Akka.Actor.Await
+{
+    public class ActorAwareTaskAwaiterBase : ICriticalNotifyCompletion, INotifyCompletion
+    {
+        private readonly Task _task;
+        private readonly AsyncBehavior _behavior;
+        private readonly AmbientState _state;
+        private readonly ActorCell _context;
+
+        public ActorAwareTaskAwaiterBase(Task task, AsyncBehavior behavior)
+        {
+            _task = task;
+            _behavior = behavior;
+            _context = ActorCell.Current;
+            _state = new AmbientState
+            {
+                Sender = _context.Sender,
+                Self = _context.Self
+            };
+        }
+
+        public bool IsCompleted
+        {
+            get { return _task.IsCompleted; }
+        }
+
+        class SuspendState
+        {
+            public int ReentrancySuspensionDepth;
+        }
+
+        [ThreadStatic]
+        private static SuspendState _tlsSuspendState;
+
+        public void OnCompleted(Action continuation)
+        {
+            var state = _tlsSuspendState ?? new SuspendState();
+            if (_behavior == AsyncBehavior.Suspend)
+            {
+                state.ReentrancySuspensionDepth++;
+                if (state.ReentrancySuspensionDepth == 1)
+                    _context.SuspendReentrancy();
+            }
+            _task.ContinueWith(t =>
+            {
+                _state.Self.Tell(new CompleteTask(_state, () =>
+                {
+                    _tlsSuspendState = state;
+                    try
+                    {
+                        continuation();
+                    }
+                    finally
+                    {
+                        _tlsSuspendState = null;
+                        if (_behavior == AsyncBehavior.Suspend)
+                        {
+                            state.ReentrancySuspensionDepth--;
+                            if (state.ReentrancySuspensionDepth == 0)
+                                _context.ResumeReentrancy();
+                        }
+                    }
+                }), _state.Sender);
+            }, TaskContinuationOptions.ExecuteSynchronously);
+        }
+
+        public void UnsafeOnCompleted(Action continuation)
+        {
+            OnCompleted(continuation);
+        }
+    }
+
+    public class ActorAwareTaskAwaiter : ActorAwareTaskAwaiterBase
+    {
+        private readonly Task _task;
+
+        public void GetResult()
+        {
+            _task.GetAwaiter().GetResult();
+        }
+
+        public ActorAwareTaskAwaiter(Task task, AsyncBehavior behavior) : base(task, behavior)
+        {
+            _task = task;
+        }
+    }
+
+    public class ActorAwareTaskAwaiter<TResult> : ActorAwareTaskAwaiterBase
+    {
+        private readonly Task<TResult> _task;
+
+        public ActorAwareTaskAwaiter(Task<TResult> task, AsyncBehavior behavior) : base(task, behavior)
+        {
+            _task = task;
+        }
+
+        public TResult GetResult()
+        {
+            return _task.GetAwaiter().GetResult();
+        }
+    }
+}

--- a/src/core/Akka/Actor/IAutoReceivedMessage.cs
+++ b/src/core/Akka/Actor/IAutoReceivedMessage.cs
@@ -5,6 +5,9 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
+using Akka.Dispatch;
+using Akka.Dispatch.SysMsg;
 using Akka.Event;
 
 namespace Akka.Actor
@@ -96,6 +99,32 @@ namespace Akka.Actor
         }
     }
 
+    public sealed class CompleteReentrantAwaitedTask : IAutoReceivedMessage
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="CompleteTask" /> class.
+        /// </summary>
+        /// <param name="state"></param>
+        /// <param name="action">The action.</param>
+        public CompleteReentrantAwaitedTask(AmbientState state, Action action)
+        {
+            State = state;
+            SetResult = action;
+        }
+
+        public AmbientState State { get; private set; }
+
+        /// <summary>
+        ///     Gets the set result.
+        /// </summary>
+        /// <value>The set result.</value>
+        public Action SetResult { get; private set; }
+
+        public override string ToString()
+        {
+            return "CompleteReentrantAwaitedTask - AmbientState: " + State;
+        }
+    }
 
     /// <summary>
     /// Sending an <see cref="Kill"/> message to an actor causes the actor to throw an 

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -70,6 +70,9 @@
     <Compile Include="ActorState.cs" />
     <Compile Include="Actor\ActorCell.DeathWatch.cs" />
     <Compile Include="Actor\ActorProducerPipeline.cs" />
+    <Compile Include="Actor\Await\ActorAwareTaskAwaitable.cs" />
+    <Compile Include="Actor\Await\ActorAwareTaskAwaitableExtensions.cs" />
+    <Compile Include="Actor\Await\ActorAwareTaskAwaiter.cs" />
     <Compile Include="Actor\ChildrenContainer\Internal\ChildrenContainer.cs" />
     <Compile Include="Actor\ChildrenContainer\Internal\ChildrenContainerBase.cs" />
     <Compile Include="Actor\ChildrenContainer\Internal\ChildStats.cs" />


### PR DESCRIPTION
Usage
```csharp
protected override async void OnReceive(object message)
{
    await Task.Delay(1000).ActorAwait(AsyncBehavior.Suspend);
}
```

Advantages:
- no overhead of using `Task.Factory.StartNew`
- no any additional threads
- one can await from UI thread
- one can mix `AsyncBehavior.Reentrant` and `AsyncBehaviour.Suspended` inside one handler

Disadvantages:
- People might forget to call ActorAwait

Example usage:

```csharp
private class AsyncActor : UntypedActor
{
    protected override async void OnReceive(object message)
    {
        if (message.Equals("crash"))
        {
            try
            {
                await ThrowExceptionAsync().ActorAwait();
            }
            catch (Exception e)
            {
                Console.WriteLine("Catched: "+ e);
            }
        }
        else if (message is string)
        {
            Console.WriteLine("Before first delay, message: " + message);
            await Task.Delay(1000).ActorAwait(AsyncBehavior.Suspend);
            Console.WriteLine("After suspended delay, message: " + message);
            await Task.Delay(1000).ActorAwait(AsyncBehavior.Reentrant);
            Console.WriteLine("After reentrant delay, message: " + message);
        }
    }

    private async Task ThrowExceptionAsync()
    {
        await Task.Delay(100);
        throw new Exception("crash");
    }
}

public static void Main()
{
    var system = ActorSystem.Create("test");
    var actor = system.ActorOf(Props.Create<AsyncActor>());
    actor.Tell("1");
    actor.Tell("2");
    actor.Tell("crash");
    system.AwaitTermination();
}
```