### PR TITLE
Attempts to resolve issue #908

### DIFF
--- a/src/core/Akka/Routing/RoundRobin.cs
+++ b/src/core/Akka/Routing/RoundRobin.cs
@@ -35,7 +35,7 @@ namespace Akka.Routing
             {
                 return Routee.NoRoutee;
             }
-            return routees[Interlocked.Increment(ref _next)%routees.Length];
+            return routees[(Interlocked.Increment(ref _next) % routees.Length + routees.Length) % routees.Length];
         }
     }
 


### PR DESCRIPTION
When `_next` rolls over to a negative value, this will ensure that the
negative value is corrected to be positive.

Reference: http://stackoverflow.com/questions/4412179/best-way-to-make-javas-modulus-behave-like-it-should-with-negative-numbers/4412200#4412200