### PR TITLE
Attempts to resolve issue #908

### DIFF
--- a/src/core/Akka/Routing/RoundRobin.cs
+++ b/src/core/Akka/Routing/RoundRobin.cs
@@ -35,7 +35,7 @@ namespace Akka.Routing
             {
                 return Routee.NoRoutee;
             }
-            return routees[Interlocked.Increment(ref _next)%routees.Length];
+            return routees[(Interlocked.Increment(ref _next) & int.MaxValue) % routees.Length];
         }
     }
 

--- a/src/core/Akka/Routing/SmallestMailbox.cs
+++ b/src/core/Akka/Routing/SmallestMailbox.cs
@@ -35,7 +35,7 @@ namespace Akka.Routing
             var winningScore = long.MaxValue;
 
             // round robin fallback
-            var winner = routees[Interlocked.Increment(ref next) % routees.Length];
+            var winner = routees[(Interlocked.Increment(ref next) & int.MaxValue) % routees.Length];
 
             for (int i = 0; i < routees.Length; i++)
             {


### PR DESCRIPTION
Per the suggestion from @Aaronontheweb (#909), bitmask Interlocked.Increment(ref _next)
to ensure that it will always be a positive number.