### PR TITLE
Attempts to resolve issue #908

### DIFF
--- a/src/core/Akka.Tests/Routing/RoundRobinSpec.cs
+++ b/src/core/Akka.Tests/Routing/RoundRobinSpec.cs
@@ -62,6 +62,21 @@ namespace Akka.Tests.Routing
             Sys.Stop(router);
             testLatch.Ready(TimeSpan.FromSeconds(5));
         }
+
+        [Fact]
+        public void RoundRobin_should_not_throw_IndexOutOfRangeException_when_counter_wraps_to_be_negative()
+        {
+            Assert.DoesNotThrow(
+                () =>
+                {
+                    var routees = new[] {Routee.NoRoutee, Routee.NoRoutee, Routee.NoRoutee};
+                    var routingLogic = new RoundRobinRoutingLogic(int.MaxValue - 5);
+                    for (var i = 0; i < 10; i++)
+                    {
+                        routingLogic.Select(i, routees);
+                    }
+                });
+        }
     }
 }
 

--- a/src/core/Akka.Tests/Routing/SmallestMailboxSpec.cs
+++ b/src/core/Akka.Tests/Routing/SmallestMailboxSpec.cs
@@ -83,6 +83,21 @@ namespace Akka.Tests.Routing
             Assert.NotEqual(path2, busyPath);
             Assert.NotEqual(path3, busyPath);
         }
+
+        [Fact]
+        public void SmallestMail_should_not_throw_IndexOutOfRangeException_when_counter_wraps_to_be_negative()
+        {
+            Assert.DoesNotThrow(
+                () =>
+                {
+                    var routees = new[] {Routee.NoRoutee, Routee.NoRoutee, Routee.NoRoutee};
+                    var routingLogic = new SmallestMailboxRoutingLogic(int.MaxValue - 5);
+                    for (var i = 0; i < 10; i++)
+                    {
+                        routingLogic.Select(i, routees);
+                    }
+                });
+        }
     }
 }
 

--- a/src/core/Akka/Routing/RoundRobin.cs
+++ b/src/core/Akka/Routing/RoundRobin.cs
@@ -18,10 +18,18 @@ namespace Akka.Routing
     /// </summary>
     public class RoundRobinRoutingLogic : RoutingLogic
     {
+
+        public RoundRobinRoutingLogic() : this(-1) {}
+
+        public RoundRobinRoutingLogic(int next)
+        {
+            _next = next;
+        }
+
         /// <summary>
         ///     The next
         /// </summary>
-        private int _next = -1;
+        private int _next;
 
         /// <summary>
         ///     Selects the specified message.
@@ -35,7 +43,7 @@ namespace Akka.Routing
             {
                 return Routee.NoRoutee;
             }
-            return routees[Interlocked.Increment(ref _next)%routees.Length];
+            return routees[(Interlocked.Increment(ref _next) & int.MaxValue) % routees.Length];
         }
     }
 

--- a/src/core/Akka/Routing/SmallestMailbox.cs
+++ b/src/core/Akka/Routing/SmallestMailbox.cs
@@ -14,7 +14,15 @@ namespace Akka.Routing
 {
     public class SmallestMailboxRoutingLogic : RoutingLogic
     {
-        private int next = -1;
+
+        public SmallestMailboxRoutingLogic() {}
+
+        public SmallestMailboxRoutingLogic(int next)
+        {
+            _next = next;
+        }
+
+        private int _next;
 
         public override Routee Select(object message, Routee[] routees)
         {
@@ -35,7 +43,7 @@ namespace Akka.Routing
             var winningScore = long.MaxValue;
 
             // round robin fallback
-            var winner = routees[Interlocked.Increment(ref next) % routees.Length];
+            var winner = routees[(Interlocked.Increment(ref _next) & int.MaxValue) %  routees.Length];
 
             for (int i = 0; i < routees.Length; i++)
             {


### PR DESCRIPTION
Per the suggestion from @Aaronontheweb (#909) bitmask Interlocked.Increment(ref _next)
to ensure that it will always be a positive number.
Also, added unit tests that verify this behavior (#910).