### PR TITLE
added some more descriptive comments to the remoting components

### DIFF
--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -1023,8 +1023,8 @@ namespace Akka.Cluster
             }
         }
 
-        //State transition to JOINING - new node joining.
-        //Received `Join` message and replies with `Welcome` message, containing
+        // State transition to JOINING - new node joining.
+        // Received `Join` message and replies with `Welcome` message, containing
         // current gossip state, including the new joining member.
         public void Joining(UniqueAddress node, ImmutableHashSet<string> roles)
         {

--- a/src/core/Akka.Remote/EndpointManager.cs
+++ b/src/core/Akka.Remote/EndpointManager.cs
@@ -711,8 +711,8 @@ namespace Akka.Remote
 
                     // Collect all transports, listen addresses, and listener promises in one Task
                     var tasks = transports.Select(x => x.Listen().ContinueWith(
-                        result => Tuple.Create(new ProtocolTransportAddressPair(x, result.Result.Item1), result.Result.Item2), TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.AttachedToParent));
-                    _listens = Task.WhenAll(tasks).ContinueWith(transportResults => transportResults.Result.ToList(), TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.AttachedToParent);
+                        result => Tuple.Create(new ProtocolTransportAddressPair(x, result.Result.Item1), result.Result.Item2), TaskContinuationOptions.ExecuteSynchronously & TaskContinuationOptions.AttachedToParent));
+                    _listens = Task.WhenAll(tasks).ContinueWith(transportResults => transportResults.Result.ToList(), TaskContinuationOptions.ExecuteSynchronously & TaskContinuationOptions.AttachedToParent);
                 }
                 return _listens;
             }

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -406,6 +406,10 @@ namespace Akka.Remote
 
         #region Internals
 
+        /// <summary>
+        /// All of the private internals used by <see cref="RemoteActorRefProvider"/>, namely its transport
+        /// registry, remote serializers, and the <see cref="RemoteDaemon"/> instance.
+        /// </summary>
         class Internals : INoSerializationVerificationNeeded
         {
             public Internals(RemoteTransport transport, Akka.Serialization.Serialization serialization, IInternalActorRef remoteDaemon)

--- a/src/core/Akka.Remote/Transport/Helios/HeliosTcpTransport.cs
+++ b/src/core/Akka.Remote/Transport/Helios/HeliosTcpTransport.cs
@@ -200,6 +200,14 @@ namespace Akka.Remote.Transport.Helios
         }
     }
 
+    /// <summary>
+    /// TCP implementation of a <see cref="HeliosTransport"/>.
+    /// 
+    /// <remarks>
+    /// Due to the connection-oriented nature of TCP connections, this transport doesn't have to do any
+    /// additional bookkeeping when transports are disposed or opened.
+    /// </remarks>
+    /// </summary>
     class HeliosTcpTransport : HeliosTransport
     {
         public HeliosTcpTransport(ActorSystem system, Config config)


### PR DESCRIPTION
I'm in the process of documenting how all of the Akka.Remote internals work in an effort to make it easier for multiple contributors to get involved in Akka.NET v1.1 and Akka.Cluster.

This is my first pass at adding some additional XML-DOC comments. I also cleaned up a couple of small to-dos here and there.