### PR TITLE
added clearer logging and validation to Remote / Cluster

### DIFF
--- a/src/core/Akka.Cluster/Routing/ClusterRoutingConfig.cs
+++ b/src/core/Akka.Cluster/Routing/ClusterRoutingConfig.cs
@@ -553,6 +553,7 @@ namespace Akka.Cluster.Routing
         {
             Settings = settings;
             _supervisorStrategy = supervisorStrategy;
+            if (_supervisorStrategy == null) throw new ArgumentNullException("supervisorStrategy");
             _pool = (Pool)Cell.RouterConfig;
         }
 

--- a/src/core/Akka.Remote/EndpointManager.cs
+++ b/src/core/Akka.Remote/EndpointManager.cs
@@ -347,7 +347,7 @@ namespace Akka.Remote
                     .With<ShutDownAssociation>(shutdown =>
                     {
                         log.Debug("Remote system with address [{0}] has shut down. " +
-                                  "Address is not gated for {1}ms, all messages to this address will be delivered to dead letters.",
+                                  "Address is now gated for {1}ms, all messages to this address will be delivered to dead letters.",
                                   shutdown.RemoteAddress, settings.RetryGateClosedFor.TotalMilliseconds);
                         endpoints.MarkAsFailed(Sender, Deadline.Now + settings.RetryGateClosedFor);
                         AddressTerminatedTopic.Get(Context.System).Publish(new AddressTerminated(shutdown.RemoteAddress));

--- a/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
+++ b/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
@@ -836,7 +836,7 @@ namespace Akka.Remote.Transport
                 failure.Cause.Match()
                     .With<DisassociateInfo>(() => { }) //no logging
                     .With<ForbiddenUidReason>(() => { }) //no logging
-                    .With<TimeoutReason>(timeoutReason => _log.Info(timeoutReason.ErrorMessage));
+                    .With<TimeoutReason>(timeoutReason => _log.Error(timeoutReason.ErrorMessage));
             }
             else
                 base.LogTermination(reason);


### PR DESCRIPTION
Added a null argument check for supervisor strategy inside ClusterPoolRouters - saw this come up inside the WebCrawler demo.
Made it so heartbeat timeouts get logged to the error log.