### PR TITLE
All Pool routers from configuration now use DefaultSupervisorStrategy

### DIFF
--- a/src/core/Akka/Routing/RouterConfig.cs
+++ b/src/core/Akka/Routing/RouterConfig.cs
@@ -267,6 +267,7 @@ namespace Akka.Routing
             _nrOfInstances = config.GetInt("nr-of-instances");
             _resizer = DefaultResizer.FromConfig(config);
             _usePoolDispatcher = config.HasPath("pool-dispatcher");
+            _supervisorStrategy = DefaultStrategy;
             // ReSharper restore DoNotCallOverridableMethodsInConstructor
         }
 


### PR DESCRIPTION
Fixed a bug that caused clustered pool routers to have a null `SupervisoryStrategy` by default when loaded from configuration. Big problem if one of your routees under a clustered router dies :p 