### PR TITLE
changed the HeliosTcpHandle to report disassociations for "unknown" reasons

### DIFF
--- a/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
+++ b/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
@@ -762,12 +762,12 @@ namespace Akka.Remote.Transport
                                     associationFailure =
                                         new AkkaProtocolException(
                                             "The remote system has a UID that has been quarantined. Association aborted."))
-                            .With<DisassociateInfo>(info => associationFailure = DisassociateException(info))
-                            .Default(
+                            .With<DisassociateInfo>(info => associationFailure = DisassociateException(info)))
+                        .Default(
                                 msg =>
                                     associationFailure =
                                         new AkkaProtocolException(
-                                            "Transport disassociated before handshake finished")));
+                                            "Transport disassociated before handshake finished"));
 
                     oua.StatusCompletionSource.TrySetException(associationFailure);
                     oua.WrappedHandle.Disassociate();

--- a/src/core/Akka.Remote/Transport/Helios/HeliosTcpTransport.cs
+++ b/src/core/Akka.Remote/Transport/Helios/HeliosTcpTransport.cs
@@ -78,15 +78,10 @@ namespace Akka.Remote.Transport.Helios
         /// <param name="closedChannel">The handle to the socket channel that closed.</param>
         protected override void OnDisconnect(HeliosConnectionException cause, IConnection closedChannel)
         {
-            if(cause != null)
+            if (cause != null)
                 ChannelLocalActor.Notify(closedChannel, new UnderlyingTransportError(cause, "Underlying transport closed."));
-            if (cause != null && cause.Type == ExceptionType.Closed)
-                ChannelLocalActor.Notify(closedChannel, new Disassociated(DisassociateInfo.Shutdown));
-            else
-            {
-                ChannelLocalActor.Notify(closedChannel, new Disassociated(DisassociateInfo.Unknown));
-            }
-                
+
+            ChannelLocalActor.Notify(closedChannel, new Disassociated(DisassociateInfo.Unknown));
             ChannelLocalActor.Remove(closedChannel);
         }
 
@@ -120,7 +115,7 @@ namespace Akka.Remote.Transport.Helios
 
         public override void Dispose()
         {
-           
+
             ChannelLocalActor.Remove(UnderlyingConnection);
             base.Dispose();
         }
@@ -220,7 +215,7 @@ namespace Akka.Remote.Transport.Helios
 
         public override void Disassociate()
         {
-            if(!_channel.WasDisposed)
+            if (!_channel.WasDisposed)
                 _channel.Close();
         }
     }
@@ -247,7 +242,7 @@ namespace Akka.Remote.Transport.Helios
             var socketAddress = client.RemoteHost;
             client.Open();
 
-            return ((TcpClientHandler) client).StatusFuture;
+            return ((TcpClientHandler)client).StatusFuture;
         }
     }
 }


### PR DESCRIPTION
changed the HeliosTcpHandler so it reports disassociations for reasons unknown, which causes the EndpointManager to apply a less severe policy to the failed node and should allow for reconnects. This is equivalent to what the NettyTcpHandler does in JVM Akka.

fixed termination issue inside AkkaProtocolTransport - had improperly nested `PatternMatch` was responsible for throwing a null exception when trying to set an exception.

Related to #918 