### PR TITLE
Specify NuGet.Config path in NuGet Installation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,4 +7,5 @@ root = true
 end_of_line = CRLF
 
 [*.cs]
-indent_style = tab
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
When I ran build.cmd, I encountered the shell asking for my id and password to access the corporate nuget repo. It's sensitive information and you wound't want to type in your passwords if you don't trust the script 100%. 
It happened because NuGet.exe install used the default NuGet.Config in %appdata%\Nuget. By specifying the given nuget.config in \src\.nuget, we can avoid this issue.