### PR TITLE
Specify Nuget config to avoid accessing private NuGet repo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,4 +7,5 @@ root = true
 end_of_line = CRLF
 
 [*.cs]
-indent_style = tab
+indent_style = space
+indent_size = 4

--- a/build.cmd
+++ b/build.cmd
@@ -4,13 +4,13 @@ pushd %~dp0
 
 src\.nuget\NuGet.exe update -self
 
-src\.nuget\NuGet.exe install FAKE -OutputDirectory src\packages -ExcludeVersion -Version 3.4.1
+src\.nuget\NuGet.exe install FAKE -ConfigFile src\.nuget\Nuget.Config -OutputDirectory src\packages -ExcludeVersion -Version 3.4.1
 
-src\.nuget\NuGet.exe install xunit.runners -OutputDirectory src\packages\FAKE -ExcludeVersion -Version 1.9.2
-src\.nuget\NuGet.exe install nunit.runners -OutputDirectory src\packages\FAKE -ExcludeVersion -Version 2.6.4
+src\.nuget\NuGet.exe install xunit.runners -ConfigFile src\.nuget\Nuget.Config -OutputDirectory src\packages\FAKE -ExcludeVersion -Version 1.9.2
+src\.nuget\NuGet.exe install nunit.runners -ConfigFile src\.nuget\Nuget.Config -OutputDirectory src\packages\FAKE -ExcludeVersion -Version 2.6.4
 
 if not exist src\packages\SourceLink.Fake\tools\SourceLink.fsx ( 
-  src\.nuget\nuget.exe install SourceLink.Fake -OutputDirectory src\packages -ExcludeVersion
+  src\.nuget\nuget.exe install SourceLink.Fake -ConfigFile src\.nuget\Nuget.Config -OutputDirectory src\packages -ExcludeVersion
 )
 rem cls
 


### PR DESCRIPTION
When I ran build.cmd, I encountered the shell asking for my id and password to access the corporate nuget repo. It's sensitive information and you wound't want to type in your passwords if you don't trust the script 100%. 
It happened because NuGet.exe install used the default NuGet.Config in %appdata%\Nuget. By specifying the given nuget.config in \src.nuget, we can avoid this issue.