### PR TITLE
Dynamic resolution of snapshot stores and journals

### DIFF
--- a/src/core/Akka.Persistence/Persistence.cs
+++ b/src/core/Akka.Persistence/Persistence.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Concurrent;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Dispatch;
@@ -19,51 +20,97 @@ namespace Akka.Persistence
 
         private readonly Config _config;
         private readonly ExtendedActorSystem _system;
-        private readonly IActorRef _journal;
-        private readonly IActorRef _snapshotStore;
 
-        public PersistenceSettings Settings { get; private set; }
+        // both defaults are lazy, so that they don't need to be configured if they're not used
+        private readonly Lazy<string> _defaultJournalPluginId;
+        private readonly Lazy<string> _defaultSnapshotPluginId;
+
+        private readonly ConcurrentDictionary<string, Lazy<IActorRef>> _journalPluginExtensionIds = new ConcurrentDictionary<string, Lazy<IActorRef>>();
+        private readonly ConcurrentDictionary<string, Lazy<IActorRef>> _snapshotPluginExtensionIds = new ConcurrentDictionary<string, Lazy<IActorRef>>();
 
         public PersistenceExtension(ExtendedActorSystem system)
         {
             _system = system;
             _system.Settings.InjectTopLevelFallback(Persistence.DefaultConfig());
             _config = system.Settings.Config.GetConfig("akka.persistence");
-            _journal = CreatePlugin("journal", type => typeof (AsyncWriteJournal).IsAssignableFrom(type)
-                ? Dispatchers.DefaultDispatcherId
-                : DefaultPluginDispatcherId);
-            _snapshotStore = CreatePlugin("snapshot-store", _ => DefaultPluginDispatcherId);
+
+            _defaultJournalPluginId = new Lazy<string>(() =>
+            {
+                var configPath = _config.GetString("journal.plugin");
+                if (string.IsNullOrEmpty(configPath)) throw new NullReferenceException("Default journal plugin is not configured");
+                return configPath;
+            });
+
+            _defaultSnapshotPluginId = new Lazy<string>(() =>
+            {
+                var configPath = _config.GetString("snapshot-store.plugin");
+                if (string.IsNullOrEmpty(configPath)) throw new NullReferenceException("Default snapshot-store plugin is not configured");
+                return configPath;
+            });
 
             Settings = new PersistenceSettings(_system, _config);
         }
+
+        public PersistenceSettings Settings { get; private set; }
 
         public string PersistenceId(IActorRef actor)
         {
             return actor.Path.ToStringWithoutAddress();
         }
 
-        public IActorRef SnapshotStoreFor(string persistenceId)
+        /// <summary>
+        /// Returns a snapshot store plugin actor identified by <paramref name="snapshotPluginId"/>. 
+        /// When empty looks for default path under "akka.persistence.snapshot-store.plugin".
+        /// </summary>
+        public IActorRef SnapshotStoreFor(string snapshotPluginId)
         {
-            // currently always returns _snapshotStore, but in future it may return dedicated actor for each persistence id
-            return _snapshotStore;
+            var configPath = string.IsNullOrEmpty(snapshotPluginId) ? _defaultSnapshotPluginId.Value : snapshotPluginId;
+            Lazy<IActorRef> pluginContainer;
+            if (!_snapshotPluginExtensionIds.TryGetValue(configPath, out pluginContainer))
+            {
+                pluginContainer = _snapshotPluginExtensionIds.AddOrUpdate(configPath, new Lazy<IActorRef>(() => CreatePlugin(configPath, _ => DefaultPluginDispatcherId)), (key, old) => old);
+            }
+
+            return pluginContainer.Value;
         }
 
-        public IActorRef JournalFor(string persistenceId)
+        /// <summary>
+        /// Returns a journal plugin actor identified by <paramref name="journalPluginId"/>. 
+        /// When empty looks for default path under "akka.persistence.journal.plugin".
+        /// </summary>
+        public IActorRef JournalFor(string journalPluginId)
         {
-            // currently always returns _journal, but in future it may return dedicated actor for each persistence id
-            return _journal;
+            var configPath = string.IsNullOrEmpty(journalPluginId) ? _defaultJournalPluginId.Value : journalPluginId;
+            Lazy<IActorRef> pluginContainer;
+            if (!_journalPluginExtensionIds.TryGetValue(configPath, out pluginContainer))
+            {
+                pluginContainer = _journalPluginExtensionIds.AddOrUpdate(configPath, new Lazy<IActorRef>(() => CreatePlugin(configPath, type =>
+                    typeof(AsyncWriteJournal).IsAssignableFrom(type) ? Dispatchers.DefaultDispatcherId : DefaultPluginDispatcherId)), (key, old) => old);
+            }
+
+            return pluginContainer.Value;
         }
 
-        private IActorRef CreatePlugin(string type, Func<Type, string> dispatcherSelector)
+        private IActorRef CreatePlugin(string configPath, Func<Type, string> dispatcherSelector)
         {
-            var pluginConfigPath = _config.GetString(type + ".plugin");
-            var pluginConfig = _system.Settings.Config.GetConfig(pluginConfigPath);
+            if (string.IsNullOrEmpty(configPath) || !_system.Settings.Config.HasPath(configPath))
+            {
+                throw new ArgumentException("Persistence config is missing plugin config path for: " + configPath, "configPath");
+            }
+
+            var pluginConfig = _system.Settings.Config.GetConfig(configPath);
             var pluginTypeName = pluginConfig.GetString("class");
             var pluginType = Type.GetType(pluginTypeName);
+
+            var shouldInjectConfig = pluginConfig.HasPath("inject-config") && pluginConfig.GetBoolean("inject-config");
             var pluginDispatcherId = pluginConfig.HasPath("plugin-dispatcher")
                 ? pluginConfig.GetString("plugin-dispatcher")
                 : dispatcherSelector(pluginType);
-            return _system.SystemActorOf(Props.Create(pluginType).WithDispatcher(pluginDispatcherId), type);
+            var pluginActorArgs = shouldInjectConfig ? new object[] { pluginConfig } : null;
+            var pluginActorProps = new Props(pluginType, pluginActorArgs).WithDispatcher(pluginDispatcherId);
+
+            var pluginRef = _system.SystemActorOf(pluginActorProps, configPath);
+            return pluginRef;
         }
     }
 


### PR DESCRIPTION
cc #926

This PR for Akka.Persistence will allow to resolve different snapshot stores and journals depending on `SnapshotPluginId` and `JournalPluginId` values provided by persistent actors or views. This way we could handle multiple peristence providers inside single actor system.

This change is backward compatible.