### PR TITLE
For review only: Async/await fixes and optimizations

### DIFF
--- a/src/benchmark/PingPong/ClientActorBase.cs
+++ b/src/benchmark/PingPong/ClientActorBase.cs
@@ -11,7 +11,7 @@ using Akka.Actor;
 
 namespace PingPong
 {
-    public class ClientActorBase : ActorBase
+    public class ClientActorBase : ActorBase, ISyncActor
     {
         private readonly IActorRef _actor;
         private readonly TaskCompletionSource<bool> _latch;

--- a/src/benchmark/PingPong/ClientReceiveActor.cs
+++ b/src/benchmark/PingPong/ClientReceiveActor.cs
@@ -11,7 +11,7 @@ using Akka.Actor;
 
 namespace PingPong
 {
-    public class ClientReceiveActor : ReceiveActor
+    public class ClientReceiveActor : ReceiveActor, ISyncActor
     {
         public ClientReceiveActor(IActorRef actor, long repeat, TaskCompletionSource<bool> latch)
         {

--- a/src/benchmark/PingPong/Program.cs
+++ b/src/benchmark/PingPong/Program.cs
@@ -199,7 +199,7 @@ namespace PingPong
             return numberOfRepeats * 2;
         }
 
-        public class Destination : UntypedActor
+        public class Destination : UntypedActor, ISyncActor
         {
             protected override void OnReceive(object message)
             {
@@ -210,7 +210,7 @@ namespace PingPong
             }
         }
 
-        public class WaitForStarts : UntypedActor
+        public class WaitForStarts : UntypedActor, ISyncActor
         {
             private readonly CountdownEvent _countdown;
 

--- a/src/core/Akka.TestKit/TestKitBase.cs
+++ b/src/core/Akka.TestKit/TestKitBase.cs
@@ -106,10 +106,16 @@ namespace Akka.TestKit
                 return repRef == null || repRef.IsStarted;
             }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(10));
 
+            // use threadlocal to store the current actor cell during tests, this
+            // requires a custom SyncCtx to pass the context in xunit, but prevents
+            // it from crashing due to serialization issues with CallContext crossing AppDomains
+            InternalCurrentActorCellKeeper.UseThreadStatic = true;
+
             if(!(this is INoImplicitSender))
             {
                 InternalCurrentActorCellKeeper.Current = (ActorCell)((ActorRefWithCell)testActor).Underlying;
             }
+
             SynchronizationContext.SetSynchronizationContext(
                 new ActorCellKeepingSynchronizationContext(InternalCurrentActorCellKeeper.Current));
             _testActor = testActor;

--- a/src/core/Akka.Tests/Dispatch/AsyncAwaitSpec.cs
+++ b/src/core/Akka.Tests/Dispatch/AsyncAwaitSpec.cs
@@ -210,10 +210,10 @@ namespace Akka.Tests.Dispatch
             _callback = callback;
             Receive<string>(m =>
             {
-                RunTask(() =>
+                RunTask(async () =>
                 {
-                    Task.Delay(TimeSpan.FromSeconds(1))
-                   .ContinueWith(t => { throw new Exception("foo"); });
+                    await Task.Delay(TimeSpan.FromSeconds(1))
+                        .ContinueWith(t => { throw new Exception("foo"); });
                 });               
             });
         }

--- a/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
+++ b/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
@@ -153,7 +153,7 @@ namespace Akka.Actor
             {
                 var m = envelope.Message;
 
-                if (m is CompleteTask) HandleCompleteTask(m as CompleteTask);
+                if (m is FailedTask) HandleFailedTask(m as FailedTask);
                 else if (m is Failed) HandleFailed(m as Failed);
                 else if (m is DeathWatchNotification)
                 {
@@ -191,12 +191,11 @@ namespace Akka.Actor
             }
         }
 
-        private void HandleCompleteTask(CompleteTask task)
+        private void HandleFailedTask(FailedTask failedTask)
         {
-            CurrentMessage = task.State.Message;
-            Sender = task.State.Sender;
-            task.SetResult();
+            failedTask.ExceptionInfo.Throw();
         }
+
         public void SwapMailbox(DeadLetterMailbox mailbox)
         {
             Mailbox.DebugPrint("{0} Swapping mailbox to DeadLetterMailbox", Self);

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -65,6 +65,7 @@ namespace Akka.Actor
         public int NumberOfMessages { get { return Mailbox.NumberOfMessages; } }
         internal bool ActorHasBeenCleared { get { return _actorHasBeenCleared; } }
         internal static Props TerminatedProps { get { return terminatedProps; } }
+        internal bool IsSyncOnly { get { return _actor == null || _actor is ISyncActor; } }
 
         public void Init(bool sendSupervise, Func<Mailbox> createMailbox /*, MailboxType mailboxType*/) //TODO: switch from  Func<Mailbox> createMailbox to MailboxType mailboxType
         {

--- a/src/core/Akka/Actor/BuiltInActors.cs
+++ b/src/core/Akka/Actor/BuiltInActors.cs
@@ -15,7 +15,7 @@ namespace Akka.Actor
     /// <summary>
     ///     Class EventStreamActor.
     /// </summary>
-    public class EventStreamActor : ActorBase
+    public class EventStreamActor : ActorBase, ISyncActor
     {
         /// <summary>
         ///     Processor for user defined messages.
@@ -30,7 +30,7 @@ namespace Akka.Actor
     /// <summary>
     ///     Class GuardianActor.
     /// </summary>
-    public class GuardianActor : ActorBase
+    public class GuardianActor : ActorBase, ISyncActor
     {
         protected override bool Receive(object message)
         {
@@ -44,7 +44,7 @@ namespace Akka.Actor
         }
     }
 
-    public class SystemGuardianActor : ActorBase
+    public class SystemGuardianActor : ActorBase, ISyncActor
     {
         private readonly IActorRef _userGuardian;
         private readonly HashSet<IActorRef> _terminationHooks;
@@ -151,7 +151,7 @@ namespace Akka.Actor
     /// <summary>
     ///     Class DeadLetterActorRef.
     /// </summary>
-    public class DeadLetterActorRef : EmptyLocalActorRef
+    public class DeadLetterActorRef : EmptyLocalActorRef, ISyncActor
     {
         private readonly EventStream _eventStream;
 

--- a/src/core/Akka/Actor/ISyncActor.cs
+++ b/src/core/Akka/Actor/ISyncActor.cs
@@ -1,0 +1,8 @@
+﻿namespace Akka.Actor
+{
+    /// <summary>
+    /// Marker interface - used to indicate that optimizations not available when using async/await can be applied.
+    /// </summary>
+    public interface ISyncActor
+    { }
+}

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Actor\Internals\InternalCurrentActorCellKeeper.cs" />
     <Compile Include="Actor\Internals\InternalSupportsTestFSMRef.cs" />
     <Compile Include="Actor\Internals\InitializableActor.cs" />
+    <Compile Include="Actor\ISyncActor.cs" />
     <Compile Include="Actor\Scheduler\DateTimeNowTimeProvider.cs" />
     <Compile Include="Actor\Scheduler\IDateTimeNowTimeProvider.cs" />
     <Compile Include="Actor\Scheduler\ITimeProvider.cs" />

--- a/src/core/Akka/Dispatch/ActorTaskScheduler.cs
+++ b/src/core/Akka/Dispatch/ActorTaskScheduler.cs
@@ -5,40 +5,23 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using Akka.Actor;
+using Akka.Actor.Internal;
+using Akka.Dispatch.SysMsg;
 using System;
 using System.Collections.Generic;
-using System.Runtime.Remoting.Messaging;
+using System.Diagnostics.Contracts;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Akka.Actor;
-using Akka.Dispatch.SysMsg;
 
 namespace Akka.Dispatch
 {
-    public class AmbientState
-    {
-        public IActorRef Self { get; set; }
-        public IActorRef Sender { get; set; }
-        public object Message { get; set; }
-    }
-
     public class ActorTaskScheduler : TaskScheduler
     {
         public static readonly TaskScheduler Instance = new ActorTaskScheduler();
         public static readonly TaskFactory TaskFactory = new TaskFactory(Instance);
-        public static readonly string StateKey = "akka.state";
         private const string Faulted = "faulted";
-        private static readonly object Outer = new object();
-
-        public static void SetCurrentState(IActorRef self, IActorRef sender, object message)
-        {
-            CallContext.LogicalSetData(StateKey, new AmbientState
-            {
-                Sender = sender,
-                Self = self,
-                Message = message
-            });
-        }
 
         protected override IEnumerable<Task> GetScheduledTasks()
         {
@@ -47,25 +30,7 @@ namespace Akka.Dispatch
 
         protected override void QueueTask(Task task)
         {
-            var s = CallContext.LogicalGetData(StateKey) as AmbientState;
-            if (task.AsyncState == Outer || s == null)
-            {
-                TryExecuteTask(task);
-                return;
-            }
-
-            //we get here if the task needs to be marshalled back to the mailbox
-            //e.g. if previous task was an IO completion
-            s = CallContext.LogicalGetData(StateKey) as AmbientState;
-
-            s.Self.Tell(new CompleteTask(s, () =>
-            {
-                SetCurrentState(s.Self,s.Sender,s.Message);
-                TryExecuteTask(task);
-                if (task.IsFaulted)
-                    Rethrow(task, null);
-
-            }), ActorRefs.NoSender);
+            TryExecuteTask(task);
         }
 
         protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
@@ -73,21 +38,7 @@ namespace Akka.Dispatch
             if (taskWasPreviouslyQueued)
                 return false;
 
-            var s = CallContext.LogicalGetData(StateKey) as AmbientState;
-            var cell = ActorCell.Current;
-
-            //Is the current cell and the current state the same?
-            if (cell != null &&
-                s != null &&
-                Equals(cell.Self, s.Self) &&
-                Equals(cell.Sender, s.Sender) &&
-                cell.CurrentMessage == s.Message)
-            {
-                var res = TryExecuteTask(task);
-                return res;
-            }
-
-            return false;
+            return TryExecuteTask(task);
         }
 
         public static void RunTask(Action action)
@@ -101,44 +52,48 @@ namespace Akka.Dispatch
 
         public static void RunTask(Func<Task> action)
         {
-            var context = ActorCell.Current;
-            var mailbox = context.Mailbox;
+            // try to execute the task inline
+            var task = action();
 
-            //suspend the mailbox
+            if (task == null)
+                return;
+
+            if (task.Status == TaskStatus.Faulted)
+                ExceptionDispatchInfo.Capture(task.Exception.InnerException).Throw();
+
+            if (task.IsCompleted)
+                return;
+
+            // at this point, the task is running asyncrhnously, so
+            // we capture the context, suspend the mailbox and resume
+            // only when the task is finished
+
+            var current = InternalCurrentActorCellKeeper.Current;
+            var mailbox = current.Mailbox;
+
             mailbox.Suspend(MailboxSuspendStatus.AwaitingTask);
 
-            SetCurrentState(context.Self, context.Sender, null);
-
-            //wrap our action inside a task, so that everything executing 
-            //directly or indirectly from the action is executed on our task scheduler
-
-            Task.Factory.StartNew(async _ =>
+            Task.Factory.StartNew(async () =>
             {
+                InternalCurrentActorCellKeeper.Current = current;
 
-                //start executing our action and potential promise style
-                //tasks
-                await action()
-                    //we need to use ContinueWith so that any exception is
-                    //thrown inside the actor context.
-                    //this is needed for IO completion tasks that execute out of context                    
-                    .ContinueWith(
-                        Rethrow,
-                        Faulted,
-                        TaskContinuationOptions.None);
-
-                //if mailbox was suspended, make sure we re-enable message processing again
-                mailbox.Resume(MailboxSuspendStatus.AwaitingTask);
+                try
+                {
+                    await task.ContinueWith(t =>
+                    {
+                        var exceptionInfo = ExceptionDispatchInfo.Capture(t.Exception.InnerException);
+                        current.Self.Tell(new FailedTask(exceptionInfo));
+                    },
+                    TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+                }
+                finally
+                {
+                    mailbox.Resume(MailboxSuspendStatus.AwaitingTask);
+                }
             },
-                Outer,
                 CancellationToken.None,
                 TaskCreationOptions.None,
                 Instance);
-        }
-
-        private static void Rethrow(Task x, object s)
-        {
-            //this just rethrows the exception the task contains
-            x.Wait();
         }
     }
 }

--- a/src/core/Akka/Dispatch/ConcurrentQueueMailbox.cs
+++ b/src/core/Akka/Dispatch/ConcurrentQueueMailbox.cs
@@ -14,6 +14,7 @@ using Akka.Dispatch.SysMsg;
 using TQueue = Akka.Util.MonoConcurrentQueue<Akka.Actor.Envelope>;
 #else
 using TQueue = System.Collections.Concurrent.ConcurrentQueue<Akka.Actor.Envelope>;
+using Akka.Actor.Internal;
 //using TQueue = Akka.Util.MonoConcurrentQueue<Akka.Actor.Envelope>;
 #endif
 
@@ -37,7 +38,11 @@ namespace Akka.Dispatch
                 return;
             }
 
+            // uses thread locals for ActorCell.Current for actors that don't require async/await behavior
+            InternalCurrentActorCellKeeper.UseThreadStatic = ActorCell.IsSyncOnly;
+
             var throughputDeadlineTime = dispatcher.ThroughputDeadlineTime;
+
             ActorCell.UseThreadContext(() =>
             {
                 //if ThroughputDeadlineTime is enabled, start a stopwatch

--- a/src/core/Akka/Dispatch/GenericMailbox.cs
+++ b/src/core/Akka/Dispatch/GenericMailbox.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using Akka.Actor;
 using Akka.Dispatch.MessageQueues;
 using Akka.Dispatch.SysMsg;
+using Akka.Actor.Internal;
 
 namespace Akka.Dispatch
 {
@@ -57,6 +58,9 @@ namespace Akka.Dispatch
             {
                 return;
             }
+
+            // uses thread locals for ActorCell.Current for actors that don't require async/await behavior
+            InternalCurrentActorCellKeeper.UseThreadStatic = ActorCell.IsSyncOnly;
 
             var throughputDeadlineTime = dispatcher.ThroughputDeadlineTime;
             ActorCell.UseThreadContext(() =>

--- a/src/core/Akka/Dispatch/SysMsg/ISystemMessage.cs
+++ b/src/core/Akka/Dispatch/SysMsg/ISystemMessage.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Threading.Tasks;
 using Akka.Actor;
+using System.Runtime.ExceptionServices;
 
 namespace Akka.Dispatch.SysMsg
 {
@@ -244,32 +245,38 @@ namespace Akka.Dispatch.SysMsg
         public Task Task { get; private set; }
     }
 
-    public sealed class CompleteTask : ISystemMessage
+    public sealed class FailedTask : ISystemMessage
     {
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="CompleteTask" /> class.
-        /// </summary>
-        /// <param name="state"></param>
-        /// <param name="action">The action.</param>
-        public CompleteTask(AmbientState state, Action action)
+        public FailedTask(ExceptionDispatchInfo exceptionInfo)
         {
-            State = state;
-            SetResult = action;
+            this.ExceptionInfo = exceptionInfo;
         }
 
-        public AmbientState State { get; private set; }
-
-        /// <summary>
-        ///     Gets the set result.
-        /// </summary>
-        /// <value>The set result.</value>
-        public Action SetResult { get; private set; }
-
-        public override string ToString()
-        {
-            return "CompleteTask - AmbientState: " + State;
-        }
+        public ExceptionDispatchInfo ExceptionInfo { get; private set; }
     }
+
+    //public sealed class CompleteTask : ISystemMessage
+    //{
+    //    /// <summary>
+    //    ///     Initializes a new instance of the <see cref="CompleteTask" /> class.
+    //    /// </summary>
+    //    /// <param name="action">The action.</param>
+    //    public CompleteTask(Action action)
+    //    {
+    //        SetResult = action;
+    //    }
+
+    //    /// <summary>
+    //    ///     Gets the set result.
+    //    /// </summary>
+    //    /// <value>The set result.</value>
+    //    public Action SetResult { get; private set; }
+
+    //    public override string ToString()
+    //    {
+    //        return "CompleteTask";
+    //    }
+    //}
 
     /// <summary>
     ///     Class Restart.

--- a/src/core/Akka/Event/DeadLetterListener.cs
+++ b/src/core/Akka/Event/DeadLetterListener.cs
@@ -13,7 +13,7 @@ namespace Akka.Event
     /// <summary>
     ///     Class DeadLetterListener.
     /// </summary>
-    public class DeadLetterListener : ActorBase
+    public class DeadLetterListener : ActorBase, ISyncActor
     {
         /// <summary>
         ///     The event stream

--- a/src/core/Akka/Event/DefaultLogger.cs
+++ b/src/core/Akka/Event/DefaultLogger.cs
@@ -12,7 +12,7 @@ namespace Akka.Event
     /// <summary>
     ///     Class DefaultLogger.
     /// </summary>
-    public class DefaultLogger : ActorBase
+    public class DefaultLogger : ActorBase, ISyncActor
     {
         /// <summary>
         ///     Processor for user defined messages.


### PR DESCRIPTION
This is a proposal **for review and discussion only** to fix the remaining async/await issues (as seen in #907 and others). I only ran the tests and they pass, didn't do any extensive testing.

The idea of this implementation is:

* Fix possible context flow issues during async/await by using CallContext for everything - the fix for xunit works, but other environments are still susceptible
* Pay the price of CallContext overhead only when needed
* Simplify the ActorTaskScheduler logic and prepare for future enhancements

This is working is by storing the entire `InternalCurrentActorCellKeeper` in the CallContext by default, unless the actor implements the `ISyncActor` marker interface. In that case, it uses only the old ThreadStatic field. The check happens only when the mailbox is about to run, so the price decreases when the throughput increases.

The reason I'm doing `ISyncOnly` instead of some form of `IEnableAsyncAwait` is because I believe most users will expect a language feature working by default. All system actors have the marker, so we avoid overhead there.

Even though there is a real drop in performance without the marker in the benchmark, most user code shouldn't notice. From my tests, the benchmark app performance should be similar to what it was with the interface.

Some notes:

* Since the ActorCell.Current is kept in CallContext, there is no logic required in the TaskScheduler to keep the state anymore
* Without async reentrancy, there is no need to pass messages to complete the task in the actor - it only receives messages when the task failed so it can throw the exception correctly
* XUnit still requires a custom SynchronizationContext because it runs in a different AppDomain - TestKitBase forces ThreadStatic so the SyncCtx can use that correctly

Let me know what you guys think and if this is a viable option.