### PR TITLE
Implement RemotingTerminator and add RemoteNodeShutdownAndComeBackSpec

### DIFF
--- a/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
+++ b/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
@@ -77,7 +77,6 @@
     <Compile Include="MultiNode\JoinSeedNodeSpec.cs" />
     <Compile Include="MultiNode\LeaderLeavingSpec.cs" />
     <Compile Include="MultiNode\MultiNodeClusterSpec.cs" />
-    <Compile Include="MultiNode\MultiNodeFact.cs" />
     <Compile Include="MultiNode\MultiNodeLoggingConfig.cs" />
     <Compile Include="MultiNode\Routing\ClusterConsistentHashingGroupSpec.cs" />
     <Compile Include="MultiNode\Routing\ClusterConsistentHashingRouterSpec.cs" />

--- a/src/core/Akka.Remote.TestKit/Akka.Remote.TestKit.csproj
+++ b/src/core/Akka.Remote.TestKit/Akka.Remote.TestKit.csproj
@@ -44,6 +44,10 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BarrierCoordinator.cs" />
@@ -55,6 +59,7 @@
     <Compile Include="Internals\TestConductorConfigFactory.cs" />
     <Compile Include="MsgDecoder.cs" />
     <Compile Include="MsgEncoder.cs" />
+    <Compile Include="MultiNodeFact.cs" />
     <Compile Include="Player.cs" />
     <Compile Include="Proto\ProtobufDecoder.cs" />
     <Compile Include="Proto\ProtobufEncoder.cs" />

--- a/src/core/Akka.Remote.TestKit/MsgEncoder.cs
+++ b/src/core/Akka.Remote.TestKit/MsgEncoder.cs
@@ -77,6 +77,7 @@ namespace Akka.Remote.TestKit
                             w.SetFailure(
                                 InjectFailure.CreateBuilder()
                                     .SetAddress(Address2Proto(throttle.Target))
+                                    .SetFailure(FailType.Throttle)
                                     .SetDirection(Direction2Proto(throttle.Direction))
                                     .SetRateMBit(throttle.RateMBit)))
                     .With<DisconnectMsg>(

--- a/src/core/Akka.Remote.TestKit/MultiNodeFact.cs
+++ b/src/core/Akka.Remote.TestKit/MultiNodeFact.cs
@@ -8,7 +8,7 @@
 using System;
 using Xunit;
 
-namespace Akka.Cluster.Tests.MultiNode
+namespace Akka.Remote.TestKit
 {
     public class MultiNodeFactAttribute : FactAttribute
     {

--- a/src/core/Akka.Remote.TestKit/packages.config
+++ b/src/core/Akka.Remote.TestKit/packages.config
@@ -4,4 +4,5 @@
   <package id="Helios" version="1.4.0" targetFramework="net45" />
   <package id="Microsoft.Bcl.Immutable" version="1.0.34" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
+++ b/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
@@ -53,6 +53,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>..\..\packages\Microsoft.Bcl.Immutable.1.0.34\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>
@@ -77,6 +80,7 @@
     <Compile Include="DeadlineFailureDetectorSpec.cs" />
     <Compile Include="EndpointRegistrySpec.cs" />
     <Compile Include="FailureDetectorRegistrySpec.cs" />
+    <Compile Include="MultiNode\RemoteNodeShutdownAndComeBackSpec.cs" />
     <Compile Include="RemoteConfigSpec.cs" />
     <Compile Include="RemoteDaemonSpec.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -97,6 +101,10 @@
     <ProjectReference Include="..\..\contrib\testkits\Akka.TestKit.Xunit\Akka.TestKit.Xunit.csproj">
       <Project>{11F4D4B8-7E07-4457-ABF2-609B3E7B2649}</Project>
       <Name>Akka.TestKit.Xunit</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Akka.Remote.TestKit\Akka.Remote.TestKit.csproj">
+      <Project>{e5957c3e-2b1e-469f-a680-7953b4dea31b}</Project>
+      <Name>Akka.Remote.TestKit</Name>
     </ProjectReference>
     <ProjectReference Include="..\Akka.Remote\Akka.Remote.csproj">
       <Project>{EA4FF8FD-7C53-49C8-B9AA-02E458B3E6A7}</Project>

--- a/src/core/Akka.Remote.Tests/MultiNode/RemoteNodeShutdownAndComeBackSpec.cs
+++ b/src/core/Akka.Remote.Tests/MultiNode/RemoteNodeShutdownAndComeBackSpec.cs
@@ -1,0 +1,221 @@
+﻿using System;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.Remote.TestKit;
+using Akka.Remote.Transport;
+using Akka.Util.Internal;
+
+namespace Akka.Remote.Tests.MultiNode
+{
+    public class RemoteNodeShutdownAndComeBackSpecConfig : MultiNodeConfig
+    {
+        readonly RoleName _first;
+        public RoleName First { get { return _first; } }
+        readonly RoleName _second;
+        public RoleName Second { get { return _second; } }
+
+        public RemoteNodeShutdownAndComeBackSpecConfig(int port = 0)
+        {
+            _first = Role("first");
+            _second = Role("second");
+          
+            CommonConfig =
+                ConfigurationFactory.ParseString(String.Format(@"akka.remote.helios.tcp.port = {0}", port)).WithFallback(
+                DebugConfig(true).WithFallback(
+                ConfigurationFactory.ParseString(@"
+                  akka.loglevel = DEBUG
+                  akka.remote.log-remote-lifecycle-events = Debug
+                  ## Keep it tight, otherwise reestablishing a connection takes too much time
+                  akka.remote.transport-failure-detector.heartbeat-interval = 1 s
+                  akka.remote.transport-failure-detector.acceptable-heartbeat-pause = 3 s
+                  akka.remote.watch-failure-detector.acceptable-heartbeat-pause = 60 s
+                  akka.remote.gate-invalid-addresses-for = 0.5 s
+                   akka.loglevel = DEBUG
+                    akka.remote {
+                        log-received-messages = on
+                        log-sent-messages = on
+                    }
+                    akka.actor.debug {
+                        receive = on
+                        fsm = on
+                    }
+                    akka.remote.log-remote-lifecycle-events = on
+                    akka.log-dead-letters = on
+                  akka.loggers = [""Akka.Logger.NLog.NLogLogger, Akka.Logger.NLog""]
+            )")));
+
+            TestTransport = true;
+        }
+
+        public class RemoteNodeShutdownAndComesBackMultiNode1 : RemoteNodeShutdownAndComeBackSpec
+        {
+            public RemoteNodeShutdownAndComesBackMultiNode1() : base(10000)
+            { 
+            }
+        }
+
+        public class RemoteNodeShutdownAndComesBackMultiNode2 : RemoteNodeShutdownAndComeBackSpec
+        {
+            public RemoteNodeShutdownAndComesBackMultiNode2() : base(10001)
+            { 
+            }
+        }
+
+        public class RemoteNodeShutdownAndComeBackSpec : MultiNodeSpec
+        {
+            readonly RemoteNodeShutdownAndComeBackSpecConfig _config;
+
+            protected RemoteNodeShutdownAndComeBackSpec()
+                : this(new RemoteNodeShutdownAndComeBackSpecConfig())
+            {
+            }
+
+            protected RemoteNodeShutdownAndComeBackSpec(int port)
+                : this(new RemoteNodeShutdownAndComeBackSpecConfig(port))
+            {
+            }
+
+            protected override int InitialParticipantsValueFactory
+            {
+                get { return Roles.Count; }
+            }
+
+            private RemoteNodeShutdownAndComeBackSpec(RemoteNodeShutdownAndComeBackSpecConfig config)
+                : base(config)
+            {
+                _config = config;
+            }
+
+            public IActorRef Identify(RoleName role, string actorName)
+            {
+                Sys.ActorSelection(Node(role) / "user" / actorName).Tell(new Identify(actorName));
+                return ExpectMsg<ActorIdentity>().Subject;
+            }
+
+            [MultiNodeFact]
+            public void
+                RemoteNodeShutDownAndComesBackMustProperlyResetSystemMessageBufferStateWhenNewSystemWithSameAddressComesUp()
+            {
+                RunOn(() =>
+                {
+                    var secondAddress = Node(_config.Second).Address;
+                    Sys.ActorOf(Props.Create(() => new Subject()), "subject1");
+                    EnterBarrier("actors-started");
+
+                    var subject = Identify(_config.Second, "subject");
+                    var sysMsgBarrier = Identify(_config.Second, "sysmsgBarrier");
+
+                    //Prime up the system message buffer
+                    Watch(subject);
+                    EnterBarrier("watch-established");
+
+                    // Wait for proper system message propagation
+                    // (Using a helper actor to ensure that all previous system messages arrived)
+                    Watch(sysMsgBarrier);
+                    Sys.Stop(sysMsgBarrier);
+                    ExpectTerminated(sysMsgBarrier);
+
+                    // Drop all messages from this point so no SHUTDOWN is ever received
+                    TestConductor.Blackhole(_config.Second, _config.First, ThrottleTransportAdapter.Direction.Send)
+                        .Wait();
+                    // Shut down all existing connections so that the system can enter recovery mode (association attempts)
+                    RARP.For(Sys)
+                        .Provider.Transport.ManagementCommand(new ForceDisassociate(Node(_config.Second).Address))
+                        .Wait(TimeSpan.FromSeconds(3));
+                            
+                    // Trigger reconnect attempt and also queue up a system message to be in limbo state (UID of remote system
+                    // is unknown, and system message is pending)
+                    Sys.Stop(subject);
+
+                    Log.Info("Shutting down second");
+                    // Get rid of old system -- now SHUTDOWN is lost
+                    TestConductor.Shutdown(_config.Second).Wait();
+
+                    // At this point the second node is restarting, while the first node is trying to reconnect without resetting
+                    // the system message send state
+
+                    // Now wait until second system becomes alive again
+                    AwaitAssert(() =>
+                    {
+                        var p = CreateTestProbe();
+                        Sys.ActorSelection(new RootActorPath(secondAddress) / "user" / "subject").Tell(new Identify("subject"), p.Ref);
+                        p.ExpectMsg<ActorIdentity>(m => (string)m.MessageId == "subject" && m.Subject != null,
+                            TimeSpan.FromSeconds(1));
+                    }, TimeSpan.FromSeconds(30));
+
+                    ExpectTerminated(subject);
+
+                    // Establish watch with the new system. This triggers additional system message traffic. If buffers are out
+                    // of synch the remote system will be quarantined and the rest of the test will fail (or even in earlier
+                    // stages depending on circumstances).
+                    Sys.ActorSelection(new RootActorPath(secondAddress)/"user"/"subject").Tell(new Identify("subject"));
+                    var subjectNew = ExpectMsg<ActorIdentity>().Subject;
+                    Watch(subjectNew);
+
+                    subjectNew.Tell("shutdown");
+                    FishForMessage(m =>
+                    {
+                        var terminated = m as Terminated;
+                        if (terminated != null && terminated.ActorRef.Equals(subjectNew)) return true;
+                        return false;
+                    });
+                }, _config.First);
+
+                RunOn(() =>
+                {
+                    var addr = Sys.AsInstanceOf<ExtendedActorSystem>().Provider.DefaultAddress;
+                    Sys.ActorOf(Props.Create(() => new Subject()), "subject");
+                    Sys.ActorOf(Props.Create(() => new Subject()), "sysmsgBarrier");
+                    var path = Node(_config.First);
+                    EnterBarrier("actors-started");
+
+                    EnterBarrier("watch-established");
+
+                    Sys.AwaitTermination(TimeSpan.FromSeconds(30));
+
+                    var config = String.Format(@"
+                        akka.remote.helios.tcp {{
+                          hostname = {0}
+                          port = {1}
+                        }}
+                    ", addr.Host, addr.Port);
+
+                    var freshSystem = ActorSystem.Create(Sys.Name, ConfigurationFactory.ParseString(config)
+                        .WithFallback(Sys.Settings.Config));
+
+                    var b = freshSystem.ActorOf(Props.Create(() => new Blah()));
+
+                    freshSystem.EventStream.Subscribe(b, typeof (DeadLetter));
+
+                    freshSystem.AwaitTermination(TimeSpan.FromSeconds(30));
+                }, _config.Second);
+            }
+
+            class Blah : ReceiveActor
+            {
+                private ILoggingAdapter _log = Context.GetLogger();
+
+                public Blah()
+                {
+                    Receive<DeadLetter>(l => _log.Warning("DeadLetter of {0}", l.Message.GetType()));
+                }
+            }
+
+            class Subject : UntypedActor
+            {
+                protected override void OnReceive(object message)
+                {
+                    var @string = message as string;
+                    if (@string == "shutdown")
+                    {
+                        Context.System.Shutdown();
+                        return;
+                    }
+
+                    Sender.Tell(message);
+                }
+            }
+        }
+    }
+}

--- a/src/core/Akka.Remote.Tests/packages.config
+++ b/src/core/Akka.Remote.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Google.ProtocolBuffers" version="2.4.1.521" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Immutable" version="1.0.34" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/core/Akka.Remote/EndpointManager.cs
+++ b/src/core/Akka.Remote/EndpointManager.cs
@@ -680,7 +680,7 @@ namespace Akka.Remote
                 if (_listens == null)
                 {
                     /*
-                 * Constructs chains of adapters on top of each driven given in configuration. The result structure looks like the following:
+                 * Constructs chains of adapters on top of each driver given in configuration. The resulting structure looks like the following:
                  * 
                  *      AkkaProtocolTransport <-- Adapter <-- ... <-- Adapter <-- Driver
                  * 

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -50,7 +50,7 @@ namespace Akka.Remote
                 return _internals ??
                        (_internals =
                            new Internals(new Remoting(_system, this), _system.Serialization,
-                               new RemoteDaemon(_system, RootPath / "remote", SystemGuardian, _log)));
+                               new RemoteDaemon(_system, RootPath / "remote", SystemGuardian, _remotingTerminator, _log)));
             }
         }
 
@@ -93,8 +93,8 @@ namespace Akka.Remote
             _local.UnregisterTempActor(path);
         }
 
-        //TODO: Why volatile?
-        private IActorRef _remoteWatcher;
+        private volatile IActorRef _remoteWatcher;
+        private volatile IActorRef _remotingTerminator;
 
         public virtual void Init(ActorSystemImpl system)
         {
@@ -102,7 +102,12 @@ namespace Akka.Remote
 
             _local.Init(system);
 
-            //TODO: RemotingTerminator
+            _remotingTerminator =
+                system.SystemActorOf(
+                    RemoteSettings.ConfigureDispatcher(Props.Create(() => new RemotingTerminator(_local.SystemGuardian))),
+                    "remoting-terminator");
+
+            _remotingTerminator.Tell(RemoteInternals);
 
             Transport.Start();
             _remoteWatcher = CreateRemoteWatcher(system);
@@ -442,28 +447,85 @@ namespace Akka.Remote
         private class RemotingTerminator : FSM<TerminatorState, Internals>
         {
             private readonly IActorRef _systemGuardian;
+            private readonly ILoggingAdapter _log;
 
             public RemotingTerminator(IActorRef systemGuardian)
             {
                 _systemGuardian = systemGuardian;
+                _log = Context.GetLogger();
                 InitFSM();
             }
 
             private void InitFSM()
             {
-
                 When(TerminatorState.Uninitialized, @event =>
                 {
-                    var internals = @event.StateData;
+                    var internals = @event.FsmEvent as Internals;
                     if (internals != null)
                     {
-                        //TODO: add a termination hook to the system guardian
+                        _systemGuardian.Tell(RegisterTerminationHook.Instance);
                         return GoTo(TerminatorState.Idle).Using(internals);
                     }
                     return null;
                 });
 
+                When(TerminatorState.Idle, @event =>
+                {
+                    if (@event.StateData != null && @event.FsmEvent is TerminationHook)
+                    {
+                        _log.Info("Shutting down remote daemon.");
+                        @event.StateData.RemoteDaemon.Tell(TerminationHook.Instance);
+                        return GoTo(TerminatorState.WaitDaemonShutdown);
+                    }
+                    return null;
+                });
+
+                When(TerminatorState.WaitDaemonShutdown, @event =>
+                {
+                    if (@event.StateData != null && @event.FsmEvent is TerminationHookDone)
+                    {
+                        _log.Info("Remote daemon shut down; proceeding with flushing remote transports.");
+                        @event.StateData.Transport.Shutdown()
+                            .ContinueWith(t => TransportShutdown.Instance,
+                                TaskContinuationOptions.ExecuteSynchronously & TaskContinuationOptions.AttachedToParent)
+                            .PipeTo(Self);
+                        return GoTo(TerminatorState.WaitTransportShutdown);
+                    }
+
+                    return null;
+                });
+
+                When(TerminatorState.WaitTransportShutdown, @event =>
+                {
+                    if (@event.FsmEvent is TransportShutdown)
+                    {
+                        _log.Info("Remoting shut down.");
+                        _systemGuardian.Tell(TerminationHookDone.Instance);
+                        Stop();
+                        return GoTo(TerminatorState.Finished);
+                    }
+                    return null;
+                });
+
                 StartWith(TerminatorState.Uninitialized, null);
+            }
+
+            public sealed class TransportShutdown
+            {
+                private TransportShutdown() { }
+                private static readonly TransportShutdown _instance = new TransportShutdown();
+                public static TransportShutdown Instance
+                {
+                    get
+                    {
+                        return _instance;
+                    }
+                }
+
+                public override string ToString()
+                {
+                    return "<TransportShutdown>";
+                }
             }
         }
 

--- a/src/core/Akka.Remote/RemoteDaemon.cs
+++ b/src/core/Akka.Remote/RemoteDaemon.cs
@@ -5,12 +5,14 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Akka.Actor;
 using Akka.Actor.Internals;
 using Akka.Dispatch.SysMsg;
 using Akka.Event;
+using Akka.Util;
 using Akka.Util.Internal;
 
 namespace Akka.Remote
@@ -75,6 +77,8 @@ namespace Akka.Remote
     internal class RemoteDaemon : VirtualPathContainer
     {
         private readonly ActorSystemImpl _system;
+        private readonly Switch _terminating;
+        private readonly IActorRef _terminator;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="RemoteDaemon" /> class.
@@ -82,11 +86,14 @@ namespace Akka.Remote
         /// <param name="system">The system.</param>
         /// <param name="path">The path.</param>
         /// <param name="parent">The parent.</param>
+	    /// <param name="terminator">The remoting terminator.</param>
         /// <param name="log"></param>
-        public RemoteDaemon(ActorSystemImpl system, ActorPath path, IInternalActorRef parent, ILoggingAdapter log)
+        public RemoteDaemon(ActorSystemImpl system, ActorPath path, IInternalActorRef parent, IActorRef terminator, ILoggingAdapter log)
             : base(system.Provider, path, parent, log)
         {
             _system = system;
+            _terminating = new Switch(false);
+            _terminator = terminator;
             AddressTerminatedTopic.Get(system).Subscribe(this);
         }
 
@@ -102,11 +109,25 @@ namespace Akka.Remote
             {
                 Log.Debug("Received command [{0}] to RemoteSystemDaemon on [{1}]", message, Path.Address);
                 if (message is DaemonMsgCreate) HandleDaemonMsgCreate((DaemonMsgCreate)message);
+                return;
+            }
+
+            if (message is TerminationHook)
+            {
+                _terminating.SwitchOn(() =>
+                {
+                    TerminationHookDoneWhenNoChildren();
+                    ForEachChild(c =>
+                    {
+                        _system.Stop(c);
+                    });                    
+                });
+                return;
             }
 
             //Remote ActorSystem on another process / machine has died. 
             //Need to clean up any references to remote deployments here.
-            else if (message is AddressTerminated)
+            if (message is AddressTerminated)
             {
                 var addressTerminated = (AddressTerminated) message;
                 //stop any remote actors that belong to this address
@@ -114,6 +135,7 @@ namespace Akka.Remote
                 {
                     if(@ref.Parent.Path.Address == addressTerminated.Address) _system.Stop(@ref);
                 });
+                return;
             }
         }
 
@@ -183,6 +205,13 @@ namespace Akka.Remote
             }
             return ActorRefs.Nobody;
         }
+
+        public void TerminationHookDoneWhenNoChildren()
+        {
+            _terminating.WhileOn(() =>
+            {
+                if (!HasChildren) _terminator.Tell(TerminationHookDone.Instance, this);
+            });
+        }
     }
 }
-


### PR DESCRIPTION
PR from @smalldave's branch - adds some new multinode tests for Akka.Remote specifically and implements the `RemotingTerminator` (#774)

I'd like to pull this in and start work on implementing the Akka.Remote MultiNodeTests to better help identify some of the connect / disconnect issues in Akka.Cluster.