### PR TITLE
Changes in Akka.Persistence SQL backend

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -58,7 +58,7 @@ let libDir = workingDir @@ @"lib\net45\"
 let nugetExe = FullName @"src\.nuget\NuGet.exe"
 let docDir = "bin" @@ "doc"
 
-
+open Fake.RestorePackageHelper
 Target "RestorePackages" (fun _ -> 
      "./src/Akka.sln"
      |> RestoreMSSolutionPackages (fun p ->

--- a/src/Akka.sln
+++ b/src/Akka.sln
@@ -198,6 +198,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.TestKit.Xunit2", "cont
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.MultiNodeTests", "core\Akka.MultiNodeTests\Akka.MultiNodeTests.csproj", "{F0781BEA-5BA0-4AF0-BB15-E3F209B681F5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Persistence.Sql.Common", "contrib\persistence\Akka.Persistence.Sql.Common\Akka.Persistence.Sql.Common.csproj", "{3B9E6211-9488-4DB5-B714-24248693B38F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug Mono|Any CPU = Debug Mono|Any CPU
@@ -723,6 +725,14 @@ Global
 		{F0781BEA-5BA0-4AF0-BB15-E3F209B681F5}.Release Mono|Any CPU.Build.0 = Release|Any CPU
 		{F0781BEA-5BA0-4AF0-BB15-E3F209B681F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F0781BEA-5BA0-4AF0-BB15-E3F209B681F5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B9E6211-9488-4DB5-B714-24248693B38F}.Debug Mono|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B9E6211-9488-4DB5-B714-24248693B38F}.Debug Mono|Any CPU.Build.0 = Debug|Any CPU
+		{3B9E6211-9488-4DB5-B714-24248693B38F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B9E6211-9488-4DB5-B714-24248693B38F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B9E6211-9488-4DB5-B714-24248693B38F}.Release Mono|Any CPU.ActiveCfg = Release|Any CPU
+		{3B9E6211-9488-4DB5-B714-24248693B38F}.Release Mono|Any CPU.Build.0 = Release|Any CPU
+		{3B9E6211-9488-4DB5-B714-24248693B38F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B9E6211-9488-4DB5-B714-24248693B38F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -811,5 +821,6 @@ Global
 		{5A3C24D7-0D1C-4974-BBB4-22AC792666DE} = {264C22A4-CAFC-41F6-B82C-4DDC5C196767}
 		{7DBD5C17-5E9D-40C4-9201-D092751532A7} = {7625FD95-4B2C-4A5B-BDD5-94B1493FAC8E}
 		{F0781BEA-5BA0-4AF0-BB15-E3F209B681F5} = {01167D3C-49C4-4CDE-9787-C176D139ACDD}
+		{3B9E6211-9488-4DB5-B714-24248693B38F} = {264C22A4-CAFC-41F6-B82C-4DDC5C196767}
 	EndGlobalSection
 EndGlobal

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj
@@ -4,11 +4,11 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{BAC85686-AFC4-413E-98DC-5ED8F468BC63}</ProjectGuid>
+    <ProjectGuid>{3B9E6211-9488-4DB5-B714-24248693B38F}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Akka.Persistence.SqlServer</RootNamespace>
-    <AssemblyName>Akka.Persistence.SqlServer</AssemblyName>
+    <RootNamespace>Akka.Persistence.Sql.Common</RootNamespace>
+    <AssemblyName>Akka.Persistence.Sql.Common</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -39,14 +39,15 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Extension.cs" />
     <Compile Include="InternalExtensions.cs" />
-    <Compile Include="Snapshot\QueryBuilder.cs" />
-    <Compile Include="SqlServerInitializer.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Journal\JournalDbEngine.cs" />
     <Compile Include="Journal\QueryBuilder.cs" />
-    <Compile Include="Journal\SqlServerJournal.cs" />
-    <Compile Include="Snapshot\SqlServerSnapshotStore.cs" />
+    <Compile Include="Journal\QueryMapper.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Settings.cs" />
+    <Compile Include="Snapshot\DbSnapshotStore.cs" />
+    <Compile Include="Snapshot\QueryBuilder.cs" />
+    <Compile Include="Snapshot\QueryMapper.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Akka.Persistence\Akka.Persistence.csproj">
@@ -57,22 +58,7 @@
       <Project>{5deddf90-37f0-48d3-a0b0-a5cbd8a7e377}</Project>
       <Name>Akka</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Akka.Persistence.Sql.Common\Akka.Persistence.Sql.Common.csproj">
-      <Project>{3b9e6211-9488-4db5-b714-24248693b38f}</Project>
-      <Name>Akka.Persistence.Sql.Common</Name>
-    </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="sql-server.conf">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Akka.Persistence.SqlServer.nuspec" />
-    <None Include="app.config" />
-    <None Include="README.md" />
-  </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/InternalExtensions.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/InternalExtensions.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Akka.Persistence.Sql.Common
+{
+    internal static class InternalExtensions
+    {
+        public static string QualifiedTypeName(this Type type)
+        {
+            return type.FullName + ", " + type.Assembly.GetName().Name;
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/JournalDbEngine.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/JournalDbEngine.cs
@@ -1,0 +1,335 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+
+namespace Akka.Persistence.Sql.Common.Journal
+{
+    /// <summary>
+    /// Class used for storing intermediate result of the <see cref="IPersistentRepresentation"/>
+    /// in form which is ready to be stored directly in the SQL table.
+    /// </summary>
+    public class JournalEntry
+    {
+        public readonly string PersistenceId;
+        public readonly long SequenceNr;
+        public readonly bool IsDeleted;
+        public readonly string PayloadType;
+        public readonly byte[] Payload;
+
+        public JournalEntry(string persistenceId, long sequenceNr, bool isDeleted, string payloadType, byte[] payload)
+        {
+            PersistenceId = persistenceId;
+            SequenceNr = sequenceNr;
+            IsDeleted = isDeleted;
+            PayloadType = payloadType;
+            Payload = payload;
+        }
+    }
+
+    /// <summary>
+    /// Class used to abstract SQL persistence capabilities for concrete implementation of actor journal.
+    /// </summary>
+    public abstract class JournalDbEngine : IDisposable
+    {
+        /// <summary>
+        /// Settings applied to journal mapped from HOCON config file.
+        /// </summary>
+        public readonly JournalSettings Settings;
+
+        /// <summary>
+        /// List of cancellation tokens for each of the currently pending database operations.
+        /// </summary>
+        protected readonly LinkedList<CancellationTokenSource> PendingOperations;
+
+        private readonly Akka.Serialization.Serialization _serialization;
+        private DbConnection _dbConnection;
+
+        protected JournalDbEngine(JournalSettings settings, Akka.Serialization.Serialization serialization)
+        {
+            Settings = settings;
+            _serialization = serialization;
+
+            QueryMapper = new DefaultJournalQueryMapper(serialization);
+
+            PendingOperations = new LinkedList<CancellationTokenSource>();
+        }
+
+        /// <summary>
+        /// Initializes a database connection.
+        /// </summary>
+        protected abstract DbConnection CreateDbConnection();
+
+        /// <summary>
+        /// Copies values from entities to database command.
+        /// </summary>
+        /// <param name="sqlCommand"></param>
+        /// <param name="entry"></param>
+        protected abstract void CopyParamsToCommand(DbCommand sqlCommand, JournalEntry entry);
+
+        /// <summary>
+        /// Gets database connection.
+        /// </summary>
+        public IDbConnection DbConnection { get { return _dbConnection; } }
+
+        /// <summary>
+        /// Used for generating SQL commands for journal-related database operations.
+        /// </summary>
+        public IJournalQueryBuilder QueryBuilder { get; protected set; }
+
+        /// <summary>
+        /// Used for mapping results returned from database into <see cref="IPersistentRepresentation"/> objects.
+        /// </summary>
+        public IJournalQueryMapper QueryMapper { get; protected set; }
+
+        /// <summary>
+        /// Initializes and opens a database connection.
+        /// </summary>
+        public void Open()
+        {
+            // close connection if it was open
+            Close();
+
+            _dbConnection = CreateDbConnection();
+            _dbConnection.Open();
+        }
+
+        /// <summary>
+        /// Closes database connection if exists.
+        /// </summary>
+        public void Close()
+        {
+            if (_dbConnection != null)
+            {
+                StopPendingOperations();
+
+                _dbConnection.Dispose();
+                _dbConnection = null;
+            }
+        }
+
+        /// <summary>
+        /// Stops all currently executing database operations.
+        /// </summary>
+        protected void StopPendingOperations()
+        {
+            // stop all operations executed in the background
+            var node = PendingOperations.First;
+            while (node != null)
+            {
+                var curr = node;
+                node = node.Next;
+
+                curr.Value.Cancel();
+                PendingOperations.Remove(curr);
+            }
+        }
+
+        void IDisposable.Dispose()
+        {
+            Close();
+        }
+
+        /// <summary>
+        /// Asynchronously replays all requested messages related to provided <paramref name="persistenceId"/>,
+        /// using provided sequence ranges (inclusive) with <paramref name="max"/> number of messages replayed
+        /// (counting from the beginning). Replay callback is invoked for each replayed message.
+        /// </summary>
+        /// <param name="persistenceId">Identifier of persistent messages stream to be replayed.</param>
+        /// <param name="fromSequenceNr">Lower inclusive sequence number bound. Unbound by default.</param>
+        /// <param name="toSequenceNr">Upper inclusive sequence number bound. Unbound by default.</param>
+        /// <param name="max">Maximum number of messages to be replayed. Unbound by default.</param>
+        /// <param name="replayCallback">Action invoked for each replayed message.</param>
+        public Task ReplayMessagesAsync(string persistenceId, long fromSequenceNr, long toSequenceNr, long max, IActorRef sender, Action<IPersistentRepresentation> replayCallback)
+        {
+            var sqlCommand = QueryBuilder.SelectMessages(persistenceId, fromSequenceNr, toSequenceNr, max);
+            CompleteCommand(sqlCommand);
+
+            var tokenSource = GetCancellationTokenSource();
+
+            return sqlCommand
+                .ExecuteReaderAsync(tokenSource.Token)
+                .ContinueWith(task =>
+                {
+                    var reader = task.Result;
+                    try
+                    {
+                        while (reader.Read())
+                        {
+                            var persistent = QueryMapper.Map(reader, sender);
+                            if (persistent != null)
+                            {
+                                replayCallback(persistent);
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        PendingOperations.Remove(tokenSource);
+                        reader.Close();
+                    }
+                }, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.AttachedToParent);
+        }
+
+        /// <summary>
+        /// Asynchronously reads a highest sequence number of the event stream related with provided <paramref name="persistenceId"/>.
+        /// </summary>
+        public Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
+        {
+            var sqlCommand = QueryBuilder.SelectHighestSequenceNr(persistenceId);
+            CompleteCommand(sqlCommand);
+
+            var tokenSource = GetCancellationTokenSource();
+
+            return sqlCommand
+                .ExecuteScalarAsync(tokenSource.Token)
+                .ContinueWith(task =>
+                {
+                    PendingOperations.Remove(tokenSource);
+                    var result = task.Result;
+                    return result is long ? Convert.ToInt64(task.Result) : 0L;
+                }, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.AttachedToParent);
+        }
+
+        /// <summary>
+        /// Synchronously writes all persistent <paramref name="messages"/> inside SQL Server database.
+        /// 
+        /// Specific table used for message persistence may be defined through configuration within 
+        /// 'akka.persistence.journal.sql-server' scope with 'schema-name' and 'table-name' keys.
+        /// </summary>
+        public void WriteMessages(IEnumerable<IPersistentRepresentation> messages)
+        {
+            var persistentMessages = messages.ToArray();
+            var sqlCommand = QueryBuilder.InsertBatchMessages(persistentMessages);
+            CompleteCommand(sqlCommand);
+
+            var journalEntires = persistentMessages.Select(ToJournalEntry).ToList();
+
+            InsertInTransaction(sqlCommand, journalEntires);
+        }
+
+        /// <summary>
+        /// Synchronously deletes all persisted messages identified by provided <paramref name="persistenceId"/>
+        /// up to provided message sequence number (inclusive). If <paramref name="isPermanent"/> flag is cleared,
+        /// messages will still reside inside database, but will be logically counted as deleted.
+        /// </summary>
+        public void DeleteMessagesTo(string persistenceId, long toSequenceNr, bool isPermanent)
+        {
+            var sqlCommand = QueryBuilder.DeleteBatchMessages(persistenceId, toSequenceNr, isPermanent);
+            CompleteCommand(sqlCommand);
+
+            sqlCommand.ExecuteNonQuery();
+        }
+
+        /// <summary>
+        /// Asynchronously writes all persistent <paramref name="messages"/> inside SQL Server database.
+        /// 
+        /// Specific table used for message persistence may be defined through configuration within 
+        /// 'akka.persistence.journal.sql-server' scope with 'schema-name' and 'table-name' keys.
+        /// </summary>
+        public async Task WriteMessagesAsync(IEnumerable<IPersistentRepresentation> messages)
+        {
+            var persistentMessages = messages.ToArray();
+            var sqlCommand = QueryBuilder.InsertBatchMessages(persistentMessages);
+            CompleteCommand(sqlCommand);
+
+            var journalEntires = persistentMessages.Select(ToJournalEntry).ToList();
+
+            await InsertInTransactionAsync(sqlCommand, journalEntires);
+        }
+
+        /// <summary>
+        /// Asynchronously deletes all persisted messages identified by provided <paramref name="persistenceId"/>
+        /// up to provided message sequence number (inclusive). If <paramref name="isPermanent"/> flag is cleared,
+        /// messages will still reside inside database, but will be logically counted as deleted.
+        /// </summary>
+        public async Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, bool isPermanent)
+        {
+            var sqlCommand = QueryBuilder.DeleteBatchMessages(persistenceId, toSequenceNr, isPermanent);
+            CompleteCommand(sqlCommand);
+
+            await sqlCommand.ExecuteNonQueryAsync();
+        }
+
+        private void CompleteCommand(DbCommand sqlCommand)
+        {
+            sqlCommand.Connection = _dbConnection;
+            sqlCommand.CommandTimeout = (int)Settings.ConnectionTimeout.TotalMilliseconds;
+        }
+
+        private CancellationTokenSource GetCancellationTokenSource()
+        {
+            var source = new CancellationTokenSource();
+            PendingOperations.AddLast(source);
+            return source;
+        }
+
+        private JournalEntry ToJournalEntry(IPersistentRepresentation message)
+        {
+            var payloadType = message.Payload.GetType();
+            var serializer = _serialization.FindSerializerForType(payloadType);
+
+            return new JournalEntry(message.PersistenceId, message.SequenceNr, message.IsDeleted,
+                payloadType.QualifiedTypeName(), serializer.ToBinary(message.Payload));
+        }
+
+        private void InsertInTransaction(DbCommand sqlCommand, IEnumerable<JournalEntry> journalEntires)
+        {
+            using (var tx = _dbConnection.BeginTransaction())
+            {
+                sqlCommand.Transaction = tx;
+                try
+                {
+                    foreach (var entry in journalEntires)
+                    {
+                        CopyParamsToCommand(sqlCommand, entry);
+
+                        if (sqlCommand.ExecuteNonQuery() != 1)
+                        {
+                            //TODO: something went wrong, ExecuteNonQuery() should return 1 (number of rows added)
+                        }
+                    }
+
+                    tx.Commit();
+                }
+                catch (Exception)
+                {
+                    tx.Rollback();
+                    throw;
+                }
+            }
+        }
+
+        private async Task InsertInTransactionAsync(DbCommand sqlCommand, IEnumerable<JournalEntry> journalEntires)
+        {
+            using (var tx = _dbConnection.BeginTransaction())
+            {
+                sqlCommand.Transaction = tx;
+                try
+                {
+                    foreach (var entry in journalEntires)
+                    {
+                        CopyParamsToCommand(sqlCommand, entry);
+
+                        var commandResult = await sqlCommand.ExecuteNonQueryAsync();
+                        if (commandResult != 1)
+                        {
+                            //TODO: something went wrong, ExecuteNonQuery() should return 1 (number of rows added)
+                        }
+                    }
+
+                    tx.Commit();
+                }
+                catch (Exception)
+                {
+                    tx.Rollback();
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryBuilder.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryBuilder.cs
@@ -1,0 +1,31 @@
+﻿using System.Data.Common;
+
+namespace Akka.Persistence.Sql.Common.Journal
+{
+    /// <summary>
+    /// SQL query builder used for generating queries required to perform journal's tasks.
+    /// </summary>
+    public interface IJournalQueryBuilder
+    {
+        /// <summary>
+        /// Returns query which should return a frame of messages filtered accordingly to provided parameters.
+        /// </summary>
+        DbCommand SelectMessages(string persistenceId, long fromSequenceNr, long toSequenceNr, long max);
+
+        /// <summary>
+        /// Returns query returning single number considered as the highest sequence number in current journal.
+        /// </summary>
+        DbCommand SelectHighestSequenceNr(string persistenceId);
+
+        /// <summary>
+        /// Returns a non-query command used to insert collection of <paramref name="messages"/> in journal table.
+        /// </summary>
+        DbCommand InsertBatchMessages(IPersistentRepresentation[] messages);
+
+        /// <summary>
+        /// Depending on <paramref name="permanent"/> flag this method may return either UPDATE or DELETE statement
+        /// used to alter IsDeleted field or delete rows permanently.
+        /// </summary>
+        DbCommand DeleteBatchMessages(string persistenceId, long toSequenceNr, bool permanent);
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryMapper.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryMapper.cs
@@ -1,7 +1,8 @@
 ﻿using System;
-using System.Data.SqlClient;
+using System.Data.Common;
+using Akka.Actor;
 
-namespace Akka.Persistence.SqlServer.Journal
+namespace Akka.Persistence.Sql.Common.Journal
 {
     /// <summary>
     /// Mapper used for generating persistent representations based on SQL query results.
@@ -12,9 +13,13 @@ namespace Akka.Persistence.SqlServer.Journal
         /// Takes a current row from the SQL data reader and produces a persistent representation object in result.
         /// It's not supposed to move reader's cursor in any way.
         /// </summary>
-        IPersistentRepresentation Map(SqlDataReader reader);
+        IPersistentRepresentation Map(DbDataReader reader, IActorRef sender = null);
     }
 
+    /// <summary>
+    /// Default implementation of <see cref="IJournalQueryMapper"/> used for mapping data 
+    /// returned from ADO.NET data readers back to <see cref="IPersistentRepresentation"/> messages.
+    /// </summary>
     internal class DefaultJournalQueryMapper : IJournalQueryMapper
     {
         private readonly Akka.Serialization.Serialization _serialization;
@@ -24,17 +29,17 @@ namespace Akka.Persistence.SqlServer.Journal
             _serialization = serialization;
         }
 
-        public IPersistentRepresentation Map(SqlDataReader reader)
+        public IPersistentRepresentation Map(DbDataReader reader, IActorRef sender = null)
         {
             var persistenceId = reader.GetString(0);
             var sequenceNr = reader.GetInt64(1);
             var isDeleted = reader.GetBoolean(2);
             var payload = GetPayload(reader);
 
-            return new Persistent(payload, sequenceNr, persistenceId, isDeleted);
+            return new Persistent(payload, sequenceNr, persistenceId, isDeleted, sender);
         }
 
-        private object GetPayload(SqlDataReader reader)
+        private object GetPayload(DbDataReader reader)
         {
             var payloadType = reader.GetString(3);
             var type = Type.GetType(payloadType, true);

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Properties/AssemblyInfo.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Akka.Persistence.Sql.Common")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Akka.Persistence.Sql.Common")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e438d2c3-1075-4b01-bb84-e9efd3a36691")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Settings.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Settings.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using Akka.Configuration;
+
+namespace Akka.Persistence.Sql.Common
+{
+    /// <summary>
+    /// Configuration settings representation targeting Sql Server journal actor.
+    /// </summary>
+    public class JournalSettings
+    {
+        /// <summary>
+        /// Connection string used to access a persistent SQL Server instance.
+        /// </summary>
+        public string ConnectionString { get; private set; }
+
+        /// <summary>
+        /// Connection timeout for SQL Server related operations.
+        /// </summary>
+        public TimeSpan ConnectionTimeout { get; private set; }
+
+        /// <summary>
+        /// Schema name, where table corresponding to event journal is placed.
+        /// </summary>
+        public string SchemaName { get; private set; }
+
+        /// <summary>
+        /// Name of the table corresponding to event journal.
+        /// </summary>
+        public string TableName { get; private set; }
+
+        public JournalSettings(Config config)
+        {
+            if (config == null) throw new ArgumentNullException("config", "SqlServer journal settings cannot be initialized, because required HOCON section couldn't been found");
+
+            ConnectionString = config.GetString("connection-string");
+            ConnectionTimeout = config.GetTimeSpan("connection-timeout");
+            SchemaName = config.GetString("schema-name");
+            TableName = config.GetString("table-name");
+        }
+    }
+
+    /// <summary>
+    /// Configuration settings representation targeting Sql Server snapshot store actor.
+    /// </summary>
+    public class SnapshotStoreSettings
+    {
+        /// <summary>
+        /// Connection string used to access a persistent SQL Server instance.
+        /// </summary>
+        public string ConnectionString { get; private set; }
+
+        /// <summary>
+        /// Connection timeout for SQL Server related operations.
+        /// </summary>
+        public TimeSpan ConnectionTimeout { get; private set; }
+
+        /// <summary>
+        /// Schema name, where table corresponding to snapshot store is placed.
+        /// </summary>
+        public string SchemaName { get; private set; }
+
+        /// <summary>
+        /// Name of the table corresponding to snapshot store.
+        /// </summary>
+        public string TableName { get; private set; }
+
+        public SnapshotStoreSettings(Config config)
+        {
+            if (config == null) throw new ArgumentNullException("config", "SqlServer snapshot store settings cannot be initialized, because required HOCON section couldn't been found");
+
+            ConnectionString = config.GetString("connection-string");
+            ConnectionTimeout = config.GetTimeSpan("connection-timeout");
+            SchemaName = config.GetString("schema-name");
+            TableName = config.GetString("table-name");
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Snapshot/DbSnapshotStore.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Snapshot/DbSnapshotStore.cs
@@ -1,0 +1,168 @@
+﻿using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Persistence.Snapshot;
+
+namespace Akka.Persistence.Sql.Common.Snapshot
+{
+    /// <summary>
+    /// Abstract snapshot store implementation, customized to work with SQL-based persistence providers.
+    /// </summary>
+    public abstract class DbSnapshotStore : SnapshotStore
+    {
+        /// <summary>
+        /// List of cancellation tokens for all pending asynchronous database operations.
+        /// </summary>
+        protected readonly LinkedList<CancellationTokenSource> PendingOperations;
+
+        private DbConnection _connection;
+
+        protected DbSnapshotStore()
+        {
+            QueryMapper = new DefaultSnapshotQueryMapper(Context.System.Serialization);
+            PendingOperations = new LinkedList<CancellationTokenSource>();
+        }
+
+        /// <summary>
+        /// Returns a new instance of database connection.
+        /// </summary>
+        protected abstract DbConnection CreateDbConnection();
+
+        /// <summary>
+        /// Gets settings for the current snapshot store.
+        /// </summary>
+        protected abstract SnapshotStoreSettings Settings { get; }
+
+        /// <summary>
+        /// Gets current database connection.
+        /// </summary>
+        public DbConnection DbConnection { get { return _connection; } }
+
+        /// <summary>
+        /// Query builder used to convert snapshot store related operations into corresponding SQL queries.
+        /// </summary>
+        public ISnapshotQueryBuilder QueryBuilder { get; set; }
+
+        /// <summary>
+        /// Query mapper used to map SQL query results into snapshots.
+        /// </summary>
+        public ISnapshotQueryMapper QueryMapper { get; set; }
+
+        protected override void PreStart()
+        {
+            base.PreStart();
+
+            _connection = CreateDbConnection();
+            _connection.Open();
+        }
+
+        protected override void PostStop()
+        {
+            base.PostStop();
+
+            // stop all operations executed in the background
+            var node = PendingOperations.First;
+            while (node != null)
+            {
+                var curr = node;
+                node = node.Next;
+
+                curr.Value.Cancel();
+                PendingOperations.Remove(curr);
+            }
+
+            _connection.Close();
+        }
+
+        /// <summary>
+        /// Asynchronously loads snapshot with the highest sequence number for a persistent actor/view matching specified criteria.
+        /// </summary>
+        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        {
+            var sqlCommand = QueryBuilder.SelectSnapshot(persistenceId, criteria.MaxSequenceNr, criteria.MaxTimeStamp);
+            CompleteCommand(sqlCommand);
+
+            var tokenSource = GetCancellationTokenSource();
+            return sqlCommand
+                .ExecuteReaderAsync(tokenSource.Token)
+                .ContinueWith(task =>
+                {
+                    var reader = task.Result;
+                    try
+                    {
+                        return reader.Read() ? QueryMapper.Map(reader) : null;
+                    }
+                    finally
+                    {
+                        PendingOperations.Remove(tokenSource);
+                        reader.Close();
+                    }
+                }, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.AttachedToParent);
+        }
+
+        /// <summary>
+        /// Asynchronously stores a snapshot with metadata as record in SQL table.
+        /// </summary>
+        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot)
+        {
+            var entry = ToSnapshotEntry(metadata, snapshot);
+            var sqlCommand = QueryBuilder.InsertSnapshot(entry);
+            CompleteCommand(sqlCommand);
+
+            var tokenSource = GetCancellationTokenSource();
+
+            return sqlCommand.ExecuteNonQueryAsync(tokenSource.Token)
+                .ContinueWith(task =>
+                {
+                    PendingOperations.Remove(tokenSource);
+                }, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.AttachedToParent);
+        }
+
+        protected override void Saved(SnapshotMetadata metadata) { }
+
+        protected override void Delete(SnapshotMetadata metadata)
+        {
+            var sqlCommand = QueryBuilder.DeleteOne(metadata.PersistenceId, metadata.SequenceNr, metadata.Timestamp);
+            CompleteCommand(sqlCommand);
+
+            sqlCommand.ExecuteNonQuery();
+        }
+
+        protected override void Delete(string persistenceId, SnapshotSelectionCriteria criteria)
+        {
+            var sqlCommand = QueryBuilder.DeleteMany(persistenceId, criteria.MaxSequenceNr, criteria.MaxTimeStamp);
+            CompleteCommand(sqlCommand);
+
+            sqlCommand.ExecuteNonQuery();
+        }
+
+        private void CompleteCommand(DbCommand command)
+        {
+            command.Connection = _connection;
+            command.CommandTimeout = (int)Settings.ConnectionTimeout.TotalMilliseconds;
+        }
+
+        private CancellationTokenSource GetCancellationTokenSource()
+        {
+            var source = new CancellationTokenSource();
+            PendingOperations.AddLast(source);
+            return source;
+        }
+
+        private SnapshotEntry ToSnapshotEntry(SnapshotMetadata metadata, object snapshot)
+        {
+            var snapshotType = snapshot.GetType();
+            var serializer = Context.System.Serialization.FindSerializerForType(snapshotType);
+
+            var binary = serializer.ToBinary(snapshot);
+
+            return new SnapshotEntry(
+                persistenceId: metadata.PersistenceId, 
+                sequenceNr: metadata.SequenceNr,
+                timestamp: metadata.Timestamp,
+                snapshotType: snapshotType.QualifiedTypeName(),
+                snapshot: binary);
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Snapshot/QueryBuilder.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Snapshot/QueryBuilder.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Data.Common;
+
+namespace Akka.Persistence.Sql.Common.Snapshot
+{
+    /// <summary>
+    /// Flattened and serialized snapshot object used as intermediate representation 
+    /// before saving snapshot with metadata inside SQL Server database.
+    /// </summary>
+    public class SnapshotEntry
+    {
+        /// <summary>
+        /// Persistence identifier of persistent actor, current snapshot relates to.
+        /// </summary>
+        public readonly string PersistenceId;
+
+        /// <summary>
+        /// Sequence number used to identify snapshot in it's persistent actor scope.
+        /// </summary>
+        public readonly long SequenceNr;
+
+        /// <summary>
+        /// Timestamp used to specify date, when the snapshot has been made.
+        /// </summary>
+        public readonly DateTime Timestamp;
+
+        /// <summary>
+        /// Stringified fully qualified CLR type name of the serialized object.
+        /// </summary>
+        public readonly string SnapshotType;
+
+        /// <summary>
+        /// Serialized object data.
+        /// </summary>
+        public readonly byte[] Snapshot;
+
+        public SnapshotEntry(string persistenceId, long sequenceNr, DateTime timestamp, string snapshotType, byte[] snapshot)
+        {
+            PersistenceId = persistenceId;
+            SequenceNr = sequenceNr;
+            Timestamp = timestamp;
+            SnapshotType = snapshotType;
+            Snapshot = snapshot;
+        }
+    }
+
+    /// <summary>
+    /// Query builder used for prepare SQL commands used for snapshot store persistence operations.
+    /// </summary>
+    public interface ISnapshotQueryBuilder
+    {
+        /// <summary>
+        /// Deletes a single snapshot identified by it's persistent actor's <paramref name="persistenceId"/>, 
+        /// <paramref name="sequenceNr"/> and <paramref name="timestamp"/>.
+        /// </summary>
+        DbCommand DeleteOne(string persistenceId, long sequenceNr, DateTime timestamp);
+
+        /// <summary>
+        /// Deletes all snapshot matching persistent actor's <paramref name="persistenceId"/> as well as 
+        /// upper (inclusive) bounds of the both <paramref name="maxSequenceNr"/> and <paramref name="maxTimestamp"/>.
+        /// </summary>
+        DbCommand DeleteMany(string persistenceId, long maxSequenceNr, DateTime maxTimestamp);
+
+        /// <summary>
+        /// Inserts a single snapshot represented by provided <see cref="SnapshotEntry"/> instance.
+        /// </summary>
+        DbCommand InsertSnapshot(SnapshotEntry entry);
+
+        /// <summary>
+        /// Selects a single snapshot identified by persistent actor's <paramref name="persistenceId"/>,
+        /// matching upper (inclusive) bounds of both <paramref name="maxSequenceNr"/> and <paramref name="maxTimestamp"/>.
+        /// In case, when more than one snapshot matches specified criteria, one with the highest sequence number will be selected.
+        /// </summary>
+        DbCommand SelectSnapshot(string persistenceId, long maxSequenceNr, DateTime maxTimestamp);
+    }
+
+}

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Snapshot/QueryMapper.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Snapshot/QueryMapper.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using System.Data.SqlClient;
+using System.Data.Common;
 
-namespace Akka.Persistence.SqlServer.Snapshot
+namespace Akka.Persistence.Sql.Common.Snapshot
 {
     /// <summary>
     /// Mapper used to map results of snapshot SELECT queries into valid snapshot objects.
@@ -11,7 +11,7 @@ namespace Akka.Persistence.SqlServer.Snapshot
         /// <summary>
         /// Map data found under current cursor pointed by SQL data reader into <see cref="SelectedSnapshot"/> instance.
         /// </summary>
-        SelectedSnapshot Map(SqlDataReader reader);
+        SelectedSnapshot Map(DbDataReader reader);
     }
 
     internal class DefaultSnapshotQueryMapper : ISnapshotQueryMapper
@@ -23,7 +23,7 @@ namespace Akka.Persistence.SqlServer.Snapshot
             _serialization = serialization;
         }
 
-        public SelectedSnapshot Map(SqlDataReader reader)
+        public SelectedSnapshot Map(DbDataReader reader)
         {
             var persistenceId = reader.GetString(0);
             var sequenceNr = reader.GetInt64(1);
@@ -35,7 +35,7 @@ namespace Akka.Persistence.SqlServer.Snapshot
             return new SelectedSnapshot(metadata, snapshot);
         }
 
-        private object GetSnapshot(SqlDataReader reader)
+        private object GetSnapshot(DbDataReader reader)
         {
             var type = Type.GetType(reader.GetString(3), true);
             var serializer = _serialization.FindSerializerForType(type);

--- a/src/contrib/persistence/Akka.Persistence.SqlServer.Tests/Akka.Persistence.SqlServer.Tests.csproj
+++ b/src/contrib/persistence/Akka.Persistence.SqlServer.Tests/Akka.Persistence.SqlServer.Tests.csproj
@@ -85,6 +85,10 @@
       <Project>{11f4d4b8-7e07-4457-abf2-609b3e7b2649}</Project>
       <Name>Akka.TestKit.Xunit</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Akka.Persistence.Sql.Common\Akka.Persistence.Sql.Common.csproj">
+      <Project>{3b9e6211-9488-4db5-b714-24248693b38f}</Project>
+      <Name>Akka.Persistence.Sql.Common</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Akka.Persistence.SqlServer\Akka.Persistence.SqlServer.csproj">
       <Project>{bac85686-afc4-413e-98dc-5ed8f468bc63}</Project>
       <Name>Akka.Persistence.SqlServer</Name>

--- a/src/contrib/persistence/Akka.Persistence.SqlServer/Extension.cs
+++ b/src/contrib/persistence/Akka.Persistence.SqlServer/Extension.cs
@@ -1,93 +1,37 @@
 ﻿using System;
 using Akka.Actor;
 using Akka.Configuration;
+using Akka.Persistence.Sql.Common;
 
 namespace Akka.Persistence.SqlServer
 {
-    /// <summary>
-    /// Configuration settings representation targeting Sql Server journal actor.
-    /// </summary>
-    public class JournalSettings
+
+    public class SqlServerJournalSettings : JournalSettings
     {
         public const string ConfigPath = "akka.persistence.journal.sql-server";
-
-        /// <summary>
-        /// Connection string used to access a persistent SQL Server instance.
-        /// </summary>
-        public string ConnectionString { get; private set; }
-
-        /// <summary>
-        /// Connection timeout for SQL Server related operations.
-        /// </summary>
-        public TimeSpan ConnectionTimeout { get; private set; }
-
-        /// <summary>
-        /// Schema name, where table corresponding to event journal is placed.
-        /// </summary>
-        public string SchemaName { get; private set; }
-
-        /// <summary>
-        /// Name of the table corresponding to event journal.
-        /// </summary>
-        public string TableName { get; private set; }
 
         /// <summary>
         /// Flag determining in in case of event journal table missing, it should be automatically initialized.
         /// </summary>
         public bool AutoInitialize { get; private set; }
 
-        public JournalSettings(Config config)
+        public SqlServerJournalSettings(Config config) : base(config)
         {
-            if (config == null) throw new ArgumentNullException("config", "SqlServer journal settings cannot be initialized, because required HOCON section couldn't been found");
-
-            ConnectionString = config.GetString("connection-string");
-            ConnectionTimeout = config.GetTimeSpan("connection-timeout");
-            SchemaName = config.GetString("schema-name");
-            TableName = config.GetString("table-name");
             AutoInitialize = config.GetBoolean("auto-initialize");
         }
     }
 
-    /// <summary>
-    /// Configuration settings representation targeting Sql Server snapshot store actor.
-    /// </summary>
-    public class SnapshotStoreSettings
+    public class SqlServerSnapshotSettings : SnapshotStoreSettings
     {
         public const string ConfigPath = "akka.persistence.snapshot-store.sql-server";
-
-        /// <summary>
-        /// Connection string used to access a persistent SQL Server instance.
-        /// </summary>
-        public string ConnectionString { get; private set; }
-
-        /// <summary>
-        /// Connection timeout for SQL Server related operations.
-        /// </summary>
-        public TimeSpan ConnectionTimeout { get; private set; }
-
-        /// <summary>
-        /// Schema name, where table corresponding to snapshot store is placed.
-        /// </summary>
-        public string SchemaName { get; private set; }
-
-        /// <summary>
-        /// Name of the table corresponding to snapshot store.
-        /// </summary>
-        public string TableName { get; private set; }
 
         /// <summary>
         /// Flag determining in in case of snapshot store table missing, it should be automatically initialized.
         /// </summary>
         public bool AutoInitialize { get; private set; }
 
-        public SnapshotStoreSettings(Config config)
+        public SqlServerSnapshotSettings(Config config) : base(config)
         {
-            if (config == null) throw new ArgumentNullException("config", "SqlServer snapshot store settings cannot be initialized, because required HOCON section couldn't been found");
-
-            ConnectionString = config.GetString("connection-string");
-            ConnectionTimeout = config.GetTimeSpan("connection-timeout");
-            SchemaName = config.GetString("schema-name");
-            TableName = config.GetString("table-name");
             AutoInitialize = config.GetBoolean("auto-initialize");
         }
     }
@@ -100,19 +44,19 @@ namespace Akka.Persistence.SqlServer
         /// <summary>
         /// Journal-related settings loaded from HOCON configuration.
         /// </summary>
-        public readonly JournalSettings JournalSettings;
+        public readonly SqlServerJournalSettings JournalSettings;
 
         /// <summary>
         /// Snapshot store related settings loaded from HOCON configuration.
         /// </summary>
-        public readonly SnapshotStoreSettings SnapshotStoreSettings;
+        public readonly SqlServerSnapshotSettings SnapshotStoreSettings;
 
         public SqlServerPersistenceExtension(ExtendedActorSystem system)
         {
             system.Settings.InjectTopLevelFallback(SqlServerPersistence.DefaultConfiguration());
 
-            JournalSettings = new JournalSettings(system.Settings.Config.GetConfig(JournalSettings.ConfigPath));
-            SnapshotStoreSettings = new SnapshotStoreSettings(system.Settings.Config.GetConfig(SnapshotStoreSettings.ConfigPath));
+            JournalSettings = new SqlServerJournalSettings(system.Settings.Config.GetConfig(SqlServerJournalSettings.ConfigPath));
+            SnapshotStoreSettings = new SqlServerSnapshotSettings(system.Settings.Config.GetConfig(SqlServerSnapshotSettings.ConfigPath));
 
             if (JournalSettings.AutoInitialize)
             {

--- a/src/contrib/persistence/Akka.Persistence.SqlServer/InternalExtensions.cs
+++ b/src/contrib/persistence/Akka.Persistence.SqlServer/InternalExtensions.cs
@@ -5,11 +5,6 @@ namespace Akka.Persistence.SqlServer
 {
     internal static class InternalExtensions
     {
-        public static string QualifiedTypeName(this Type type)
-        {
-            return type.FullName + ", " + type.Assembly.GetName().Name;
-        }
-
         public static string QuoteSchemaAndTable(this string sqlQuery, string schemaName, string tableName)
         {
             var cb = new SqlCommandBuilder();

--- a/src/contrib/persistence/Akka.Persistence.SqlServer/Journal/SqlServerJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.SqlServer/Journal/SqlServerJournal.cs
@@ -1,232 +1,154 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Data.SqlClient;
-using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Akka.Persistence.Journal;
+using Akka.Persistence.Sql.Common;
+using Akka.Persistence.Sql.Common.Journal;
 
 namespace Akka.Persistence.SqlServer.Journal
 {
     /// <summary>
-    /// Persistent journal actor using SQL Server as persistence layer. It processes write requests
-    /// one by one in synchronous manner, while reading results asynchronously.
+    /// Specialization of the <see cref="JournalDbEngine"/> which uses SQL Server as it's sql backend database.
     /// </summary>
-    public class SqlServerJournal : SyncWriteJournal
+    public class SqlJournalEngine : JournalDbEngine
     {
-        #region journal internal types definitions
-
-        internal class JournalEntry
+        public SqlJournalEngine(JournalSettings journalSettings, Akka.Serialization.Serialization serialization)
+            : base(journalSettings, serialization)
         {
-            public readonly string PersistenceId;
-            public readonly long SequenceNr;
-            public readonly bool IsDeleted;
-            public readonly string PayloadType;
-            public readonly byte[] Payload;
-
-            public JournalEntry(string persistenceId, long sequenceNr, bool isDeleted, string payloadType, byte[] payload)
-            {
-                PersistenceId = persistenceId;
-                SequenceNr = sequenceNr;
-                IsDeleted = isDeleted;
-                PayloadType = payloadType;
-                Payload = payload;
-            }
+            QueryBuilder = new DefaultJournalQueryBuilder(journalSettings.TableName, journalSettings.SchemaName);
         }
 
-        #endregion
+        protected override DbConnection CreateDbConnection()
+        {
+            return new SqlConnection(Settings.ConnectionString);
+        }
 
+        protected override void CopyParamsToCommand(DbCommand sqlCommand, JournalEntry entry)
+        {
+            sqlCommand.Parameters["@PersistenceId"].Value = entry.PersistenceId;
+            sqlCommand.Parameters["@SequenceNr"].Value = entry.SequenceNr;
+            sqlCommand.Parameters["@IsDeleted"].Value = entry.IsDeleted;
+            sqlCommand.Parameters["@PayloadType"].Value = entry.PayloadType;
+            sqlCommand.Parameters["@Payload"].Value = entry.Payload;
+        }
+    }
+
+    /// <summary>
+    /// Persistent journal actor using SQL Server as persistence layer. It processes write requests
+    /// one by one in asynchronous manner, while reading results asynchronously.
+    /// </summary>
+    public class SqlServerJournal : AsyncWriteJournal
+    {
         private readonly SqlServerPersistenceExtension _extension;
-        private SqlConnection _connection;
 
-        protected readonly LinkedList<CancellationTokenSource> PendingOperations;
-
-        /// <summary>
-        /// Used for generating SQL commands for journal-related database operations.
-        /// </summary>
-        public IJournalQueryBuilder QueryBuilder { get; protected set; }
-
-        /// <summary>
-        /// Used for mapping results returned from database into <see cref="IPersistentRepresentation"/> objects.
-        /// </summary>
-        public IJournalQueryMapper QueryMapper { get; protected set; }
+        private JournalDbEngine _engine;
 
         public SqlServerJournal()
         {
             _extension = SqlServerPersistence.Instance.Apply(Context.System);
+        }
 
-            var settings = _extension.JournalSettings;
-            QueryBuilder = new DefaultJournalQueryBuilder(settings.TableName, settings.SchemaName);
-            QueryMapper = new DefaultJournalQueryMapper(Context.System.Serialization);
-            PendingOperations = new LinkedList<CancellationTokenSource>();
+        /// <summary>
+        /// Gets an engine instance responsible for handling all database-related journal requests.
+        /// </summary>
+        protected virtual JournalDbEngine Engine
+        {
+            get
+            {
+                return _engine ?? (_engine = new SqlJournalEngine(_extension.JournalSettings, Context.System.Serialization));
+            }
         }
 
         protected override void PreStart()
         {
             base.PreStart();
-
-            _connection = new SqlConnection(_extension.JournalSettings.ConnectionString);
-            _connection.Open();
+            Engine.Open();
         }
 
         protected override void PostStop()
         {
             base.PostStop();
-
-            // stop all operations executed in the background
-            var node = PendingOperations.First;
-            while (node != null)
-            {
-                var curr = node;
-                node = node.Next;
-
-                curr.Value.Cancel();
-                PendingOperations.Remove(curr);
-            }
-
-            _connection.Close();
+            Engine.Close();
         }
 
-        /// <summary>
-        /// Asynchronously replays all requested messages related to provided <paramref name="persistenceId"/>,
-        /// using provided sequence ranges (inclusive) with <paramref name="max"/> number of messages replayed
-        /// (counting from the beginning). Replay callback is invoked for each replayed message.
-        /// </summary>
-        /// <param name="persistenceId">Identifier of persistent messages stream to be replayed.</param>
-        /// <param name="fromSequenceNr">Lower inclusive sequence number bound. Unbound by default.</param>
-        /// <param name="toSequenceNr">Upper inclusive sequence number bound. Unbound by default.</param>
-        /// <param name="max">Maximum number of messages to be replayed. Unbound by default.</param>
-        /// <param name="replayCallback">Action invoked for each replayed message.</param>
         public override Task ReplayMessagesAsync(string persistenceId, long fromSequenceNr, long toSequenceNr, long max, Action<IPersistentRepresentation> replayCallback)
         {
-            var sqlCommand = QueryBuilder.SelectMessages(persistenceId, fromSequenceNr, toSequenceNr, max);
-            CompleteCommand(sqlCommand);
-
-            var tokenSource = GetCancellationTokenSource();
-
-            return sqlCommand
-                .ExecuteReaderAsync(tokenSource.Token)
-                .ContinueWith(task =>
-                {
-                    var reader = task.Result;
-                    try
-                    {
-                        while (reader.Read())
-                        {
-                            var persistent = QueryMapper.Map(reader);
-                            if (persistent != null)
-                                replayCallback(persistent);
-                        }
-                    }
-                    finally
-                    {
-                        PendingOperations.Remove(tokenSource);
-                        reader.Close();
-                    }
-                }, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.AttachedToParent);
+            return Engine.ReplayMessagesAsync(persistenceId, fromSequenceNr, toSequenceNr, max, Context.Sender, replayCallback);
         }
 
-        /// <summary>
-        /// Asynchronously reads a highest sequence number of the event stream related with provided <paramref name="persistenceId"/>.
-        /// </summary>
         public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
         {
-            var sqlCommand = QueryBuilder.SelectHighestSequenceNr(persistenceId);
-            CompleteCommand(sqlCommand);
+            return Engine.ReadHighestSequenceNrAsync(persistenceId, fromSequenceNr);
+        }
 
-            var tokenSource = GetCancellationTokenSource();
+        protected override Task WriteMessagesAsync(IEnumerable<IPersistentRepresentation> messages)
+        {
+            return Engine.WriteMessagesAsync(messages);
+        }
 
-            return sqlCommand
-                .ExecuteScalarAsync(tokenSource.Token)
-                .ContinueWith(task =>
-                {
-                    PendingOperations.Remove(tokenSource);
-                    var result = task.Result;
-                    return result is long ? Convert.ToInt64(task.Result) : 0L;
-                }, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.AttachedToParent);
+        protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, bool isPermanent)
+        {
+            return Engine.DeleteMessagesToAsync(persistenceId, toSequenceNr, isPermanent);
+        }
+    }
+
+    /// <summary>
+    /// Persistent journal actor using SQL Server as persistence layer. It processes write requests
+    /// one by one in synchronous manner, while reading results asynchronously. Use for tests only.
+    /// </summary>
+    public class SyncSqlServerJournal : SyncWriteJournal
+    {
+        private readonly SqlServerPersistenceExtension _extension;
+        private JournalDbEngine _engine;
+
+        public SyncSqlServerJournal()
+        {
+            _extension = SqlServerPersistence.Instance.Apply(Context.System);
         }
 
         /// <summary>
-        /// Synchronously writes all persistent <paramref name="messages"/> inside SQL Server database.
-        /// 
-        /// Specific table used for message persistence may be defined through configuration within 
-        /// 'akka.persistence.journal.sql-server' scope with 'schema-name' and 'table-name' keys.
+        /// Gets an engine instance responsible for handling all database-related journal requests.
         /// </summary>
+        protected virtual JournalDbEngine Engine
+        {
+            get
+            {
+                return _engine ?? (_engine = new SqlJournalEngine(_extension.JournalSettings, Context.System.Serialization));
+            }
+        }
+
+        protected override void PreStart()
+        {
+            base.PreStart();
+            Engine.Open();
+        }
+
+        protected override void PostStop()
+        {
+            base.PostStop();
+            Engine.Close();
+        }
+
+        public override Task ReplayMessagesAsync(string persistenceId, long fromSequenceNr, long toSequenceNr, long max, Action<IPersistentRepresentation> replayCallback)
+        {
+            return Engine.ReplayMessagesAsync(persistenceId, fromSequenceNr, toSequenceNr, max, Context.Sender, replayCallback);
+        }
+
+        public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
+        {
+            return Engine.ReadHighestSequenceNrAsync(persistenceId, fromSequenceNr);
+        }
+
         public override void WriteMessages(IEnumerable<IPersistentRepresentation> messages)
         {
-            var persistentMessages = messages.ToArray();
-            var sqlCommand = QueryBuilder.InsertBatchMessages(persistentMessages);
-            CompleteCommand(sqlCommand);
-
-            var journalEntires = persistentMessages.Select(ToJournalEntry).ToList();
-
-            InsertInTransaction(sqlCommand, journalEntires);
+            Engine.WriteMessages(messages);
         }
 
-        /// <summary>
-        /// Synchronously deletes all persisted messages identified by provided <paramref name="persistenceId"/>
-        /// up to provided message sequence number (inclusive). If <paramref name="isPermanent"/> flag is cleared,
-        /// messages will still reside inside database, but will be logically counted as deleted.
-        /// </summary>
         public override void DeleteMessagesTo(string persistenceId, long toSequenceNr, bool isPermanent)
         {
-            var sqlCommand = QueryBuilder.DeleteBatchMessages(persistenceId, toSequenceNr, isPermanent);
-            CompleteCommand(sqlCommand);
-
-            sqlCommand.ExecuteNonQuery();
-        }
-
-        private void CompleteCommand(SqlCommand sqlCommand)
-        {
-            sqlCommand.Connection = _connection;
-            sqlCommand.CommandTimeout = (int)_extension.JournalSettings.ConnectionTimeout.TotalMilliseconds;
-        }
-
-        private CancellationTokenSource GetCancellationTokenSource()
-        {
-            var source = new CancellationTokenSource();
-            PendingOperations.AddLast(source);
-            return source;
-        }
-
-        private static JournalEntry ToJournalEntry(IPersistentRepresentation message)
-        {
-            var payloadType = message.Payload.GetType();
-            var serializer = Context.System.Serialization.FindSerializerForType(payloadType);
-
-            return new JournalEntry(message.PersistenceId, message.SequenceNr, message.IsDeleted,
-                payloadType.QualifiedTypeName(), serializer.ToBinary(message.Payload));
-        }
-
-        private void InsertInTransaction(SqlCommand sqlCommand, IEnumerable<JournalEntry> journalEntires)
-        {
-            using (var tx = _connection.BeginTransaction())
-            {
-                sqlCommand.Transaction = tx;
-                try
-                {
-                    foreach (var entry in journalEntires)
-                    {
-                        sqlCommand.Parameters["@PersistenceId"].Value = entry.PersistenceId;
-                        sqlCommand.Parameters["@SequenceNr"].Value = entry.SequenceNr;
-                        sqlCommand.Parameters["@IsDeleted"].Value = entry.IsDeleted;
-                        sqlCommand.Parameters["@PayloadType"].Value = entry.PayloadType;
-                        sqlCommand.Parameters["@Payload"].Value = entry.Payload;
-
-                        if (sqlCommand.ExecuteNonQuery() != 1)
-                        {
-                            //TODO: something went wrong, ExecuteNonQuery() should return 1 (number of rows added)
-                        }
-                    }
-
-                    tx.Commit();
-                }
-                catch (Exception)
-                {
-                    tx.Rollback();
-                    throw;
-                }
-            }
+            Engine.DeleteMessagesTo(persistenceId, toSequenceNr, isPermanent);
         }
     }
 }

--- a/src/contrib/persistence/Akka.Persistence.SqlServer/Snapshot/QueryBuilder.cs
+++ b/src/contrib/persistence/Akka.Persistence.SqlServer/Snapshot/QueryBuilder.cs
@@ -1,81 +1,12 @@
 ﻿using System;
 using System.Data;
+using System.Data.Common;
 using System.Data.SqlClient;
 using System.Text;
+using Akka.Persistence.Sql.Common.Snapshot;
 
 namespace Akka.Persistence.SqlServer.Snapshot
 {
-    /// <summary>
-    /// Flattened and serialized snapshot object used as intermediate representation 
-    /// before saving snapshot with metadata inside SQL Server database.
-    /// </summary>
-    public class SnapshotEntry
-    {
-        /// <summary>
-        /// Persistence identifier of persistent actor, current snapshot relates to.
-        /// </summary>
-        public readonly string PersistenceId;
-
-        /// <summary>
-        /// Sequence number used to identify snapshot in it's persistent actor scope.
-        /// </summary>
-        public readonly long SequenceNr;
-
-        /// <summary>
-        /// Timestamp used to specify date, when the snapshot has been made.
-        /// </summary>
-        public readonly DateTime Timestamp;
-
-        /// <summary>
-        /// Stringified fully qualified CLR type name of the serialized object.
-        /// </summary>
-        public readonly string SnapshotType;
-
-        /// <summary>
-        /// Serialized object data.
-        /// </summary>
-        public readonly byte[] Snapshot;
-
-        public SnapshotEntry(string persistenceId, long sequenceNr, DateTime timestamp, string snapshotType, byte[] snapshot)
-        {
-            PersistenceId = persistenceId;
-            SequenceNr = sequenceNr;
-            Timestamp = timestamp;
-            SnapshotType = snapshotType;
-            Snapshot = snapshot;
-        }
-    }
-
-    /// <summary>
-    /// Query builder used for prepare SQL commands used for snapshot store persistence operations.
-    /// </summary>
-    public interface ISnapshotQueryBuilder
-    {
-        /// <summary>
-        /// Deletes a single snapshot identified by it's persistent actor's <paramref name="persistenceId"/>, 
-        /// <paramref name="sequenceNr"/> and <paramref name="timestamp"/>.
-        /// </summary>
-        SqlCommand DeleteOne(string persistenceId, long sequenceNr, DateTime timestamp);
-
-        /// <summary>
-        /// Deletes all snapshot matching persistent actor's <paramref name="persistenceId"/> as well as 
-        /// upper (inclusive) bounds of the both <paramref name="maxSequenceNr"/> and <paramref name="maxTimestamp"/>.
-        /// </summary>
-        SqlCommand DeleteMany(string persistenceId, long maxSequenceNr, DateTime maxTimestamp);
-
-        /// <summary>
-        /// Inserts a single snapshot represented by provided <see cref="SnapshotEntry"/> instance.
-        /// </summary>
-        SqlCommand InsertSnapshot(SnapshotEntry entry);
-
-        /// <summary>
-        /// Selects a single snapshot identified by persistent actor's <paramref name="persistenceId"/>,
-        /// matching upper (inclusive) bounds of both <paramref name="maxSequenceNr"/> and <paramref name="maxTimestamp"/>.
-        /// In case, when more than one snapshot matches specified criteria, one with the highest sequence number will be selected.
-        /// </summary>
-        SqlCommand SelectSnapshot(string persistenceId, long maxSequenceNr, DateTime maxTimestamp);
-    }
-
     internal class DefaultSnapshotQueryBuilder : ISnapshotQueryBuilder
     {
         private readonly string _deleteSql;
@@ -89,7 +20,7 @@ namespace Akka.Persistence.SqlServer.Snapshot
             _selectSql = @"SELECT PersistenceId, SequenceNr, Timestamp, SnapshotType, Snapshot FROM {0}.{1} WHERE CS_PID = CHECKSUM(@PersistenceId)".QuoteSchemaAndTable(schemaName, tableName);
         }
 
-        public SqlCommand DeleteOne(string persistenceId, long sequenceNr, DateTime timestamp)
+        public DbCommand DeleteOne(string persistenceId, long sequenceNr, DateTime timestamp)
         {
             var sqlCommand = new SqlCommand();
             sqlCommand.Parameters.Add(new SqlParameter("@PersistenceId", SqlDbType.NVarChar, persistenceId.Length) { Value = persistenceId });
@@ -112,7 +43,7 @@ namespace Akka.Persistence.SqlServer.Snapshot
             return sqlCommand;
         }
 
-        public SqlCommand DeleteMany(string persistenceId, long maxSequenceNr, DateTime maxTimestamp)
+        public DbCommand DeleteMany(string persistenceId, long maxSequenceNr, DateTime maxTimestamp)
         {
             var sqlCommand = new SqlCommand();
             sqlCommand.Parameters.Add(new SqlParameter("@PersistenceId", SqlDbType.NVarChar, persistenceId.Length) { Value = persistenceId });
@@ -135,7 +66,7 @@ namespace Akka.Persistence.SqlServer.Snapshot
             return sqlCommand;
         }
 
-        public SqlCommand InsertSnapshot(SnapshotEntry entry)
+        public DbCommand InsertSnapshot(SnapshotEntry entry)
         {
             var sqlCommand = new SqlCommand(_insertSql)
             {
@@ -152,7 +83,7 @@ namespace Akka.Persistence.SqlServer.Snapshot
             return sqlCommand;
         }
 
-        public SqlCommand SelectSnapshot(string persistenceId, long maxSequenceNr, DateTime maxTimestamp)
+        public DbCommand SelectSnapshot(string persistenceId, long maxSequenceNr, DateTime maxTimestamp)
         {
             var sqlCommand = new SqlCommand();
             sqlCommand.Parameters.Add(new SqlParameter("@PersistenceId", SqlDbType.NVarChar, persistenceId.Length) { Value = persistenceId });

--- a/src/contrib/persistence/Akka.Persistence.SqlServer/Snapshot/SqlServerSnapshotStore.cs
+++ b/src/contrib/persistence/Akka.Persistence.SqlServer/Snapshot/SqlServerSnapshotStore.cs
@@ -1,149 +1,28 @@
-﻿using System.Collections.Generic;
+﻿using System.Data.Common;
 using System.Data.SqlClient;
-using System.Threading;
-using System.Threading.Tasks;
-using Akka.Persistence.Snapshot;
+using Akka.Persistence.Sql.Common;
+using Akka.Persistence.Sql.Common.Snapshot;
 
 namespace Akka.Persistence.SqlServer.Snapshot
 {
     /// <summary>
     /// Actor used for storing incoming snapshots into persistent snapshot store backed by SQL Server database.
     /// </summary>
-    public class SqlServerSnapshotStore : SnapshotStore
+    public class SqlServerSnapshotStore : DbSnapshotStore
     {
-        private readonly SqlServerPersistenceExtension _extension;
-        private SqlConnection _connection;
+        private readonly SqlServerSnapshotSettings _settings;
 
-        protected readonly LinkedList<CancellationTokenSource> PendingOperations;
-
-        public SqlServerSnapshotStore()
+        public SqlServerSnapshotStore() : base()
         {
-            _extension = SqlServerPersistence.Instance.Apply(Context.System);
-
-            var settings = _extension.SnapshotStoreSettings;
-            QueryBuilder = new DefaultSnapshotQueryBuilder(settings.SchemaName, settings.TableName);
-            QueryMapper = new DefaultSnapshotQueryMapper(Context.System.Serialization);
-            PendingOperations = new LinkedList<CancellationTokenSource>();
+            _settings = SqlServerPersistence.Instance.Apply(Context.System).SnapshotStoreSettings;
+            QueryBuilder = new DefaultSnapshotQueryBuilder(_settings.SchemaName, _settings.TableName);
         }
 
-        /// <summary>
-        /// Query builder used to convert snapshot store related operations into corresponding SQL queries.
-        /// </summary>
-        public ISnapshotQueryBuilder QueryBuilder { get; set; }
+        protected override SnapshotStoreSettings Settings { get { return _settings; } }
 
-        /// <summary>
-        /// Query mapper used to map SQL query results into snapshots.
-        /// </summary>
-        public ISnapshotQueryMapper QueryMapper { get; set; }
-
-        protected override void PreStart()
+        protected override DbConnection CreateDbConnection()
         {
-            base.PreStart();
-
-            _connection = new SqlConnection(_extension.SnapshotStoreSettings.ConnectionString);
-            _connection.Open();
-        }
-
-        protected override void PostStop()
-        {
-            base.PostStop();
-
-            // stop all operations executed in the background
-            var node = PendingOperations.First;
-            while (node != null)
-            {
-                var curr = node;
-                node = node.Next;
-
-                curr.Value.Cancel();
-                PendingOperations.Remove(curr);
-            }
-
-            _connection.Close();
-        }
-
-        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
-        {
-            var sqlCommand = QueryBuilder.SelectSnapshot(persistenceId, criteria.MaxSequenceNr, criteria.MaxTimeStamp);
-            CompleteCommand(sqlCommand);
-
-            var tokenSource = GetCancellationTokenSource();
-            return sqlCommand
-                .ExecuteReaderAsync(tokenSource.Token)
-                .ContinueWith(task =>
-                {
-                    var reader = task.Result;
-                    try
-                    {
-                        return reader.Read() ? QueryMapper.Map(reader) : null;
-                    }
-                    finally
-                    {
-                        PendingOperations.Remove(tokenSource);
-                        reader.Close();
-                    }
-                }, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.AttachedToParent);
-        }
-
-        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot)
-        {
-            var entry = ToSnapshotEntry(metadata, snapshot);
-            var sqlCommand = QueryBuilder.InsertSnapshot(entry);
-            CompleteCommand(sqlCommand);
-
-            var tokenSource = GetCancellationTokenSource();
-
-            return sqlCommand.ExecuteNonQueryAsync(tokenSource.Token)
-                .ContinueWith(task =>
-                {
-                    PendingOperations.Remove(tokenSource);
-                }, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.AttachedToParent);
-        }
-
-        protected override void Saved(SnapshotMetadata metadata) { }
-
-        protected override void Delete(SnapshotMetadata metadata)
-        {
-            var sqlCommand = QueryBuilder.DeleteOne(metadata.PersistenceId, metadata.SequenceNr, metadata.Timestamp);
-            CompleteCommand(sqlCommand);
-
-            sqlCommand.ExecuteNonQuery();
-        }
-
-        protected override void Delete(string persistenceId, SnapshotSelectionCriteria criteria)
-        {
-            var sqlCommand = QueryBuilder.DeleteMany(persistenceId, criteria.MaxSequenceNr, criteria.MaxTimeStamp);
-            CompleteCommand(sqlCommand);
-
-            sqlCommand.ExecuteNonQuery();
-        }
-
-        private void CompleteCommand(SqlCommand command)
-        {
-            command.Connection = _connection;
-            command.CommandTimeout = (int)_extension.SnapshotStoreSettings.ConnectionTimeout.TotalMilliseconds;
-        }
-
-        private CancellationTokenSource GetCancellationTokenSource()
-        {
-            var source = new CancellationTokenSource();
-            PendingOperations.AddLast(source);
-            return source;
-        }
-
-        private SnapshotEntry ToSnapshotEntry(SnapshotMetadata metadata, object snapshot)
-        {
-            var snapshotType = snapshot.GetType();
-            var serializer = Context.System.Serialization.FindSerializerForType(snapshotType);
-
-            var binary = serializer.ToBinary(snapshot);
-
-            return new SnapshotEntry(
-                persistenceId: metadata.PersistenceId, 
-                sequenceNr: metadata.SequenceNr,
-                timestamp: metadata.Timestamp,
-                snapshotType: snapshotType.QualifiedTypeName(),
-                snapshot: binary);
+            return new SqlConnection(Settings.ConnectionString);
         }
     }
 }

--- a/src/core/Akka.MultiNodeTests/Akka.MultiNodeTests.csproj
+++ b/src/core/Akka.MultiNodeTests/Akka.MultiNodeTests.csproj
@@ -102,6 +102,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
@@ -63,10 +63,11 @@ namespace Akka.Persistence.Journal
 
         private void HandleDeleteMessagesTo(DeleteMessagesTo message)
         {
+            var eventStream = Context.System.EventStream;
             DeleteMessagesToAsync(message.PersistenceId, message.ToSequenceNr, message.IsPermanent)
                 .ContinueWith(t =>
                 {
-                    if (!t.IsFaulted && CanPublish) Context.System.EventStream.Publish(message);
+                    if (!t.IsFaulted && CanPublish) eventStream.Publish(message);
                 }, _continuationOptions);
         }
 


### PR DESCRIPTION
- I've changed Akka.Persistence.SqlServer to use asynchronous/non-blocking version of the ADO.NET where it's possible. 
- This PR also introduces `Akka.Persistence.Sql.Common` - project which may be used for faster development of SQL-based persistence plugins.
- Minor bugfix for `AsyncWriteJournal` - issuse with null EventStream reference in task continuation on delete messages.

These changes should not break existing API.