### PR TITLE
Added Extensions methods to ActorSystem and ActorContext to make DI more accessible

### DIFF
--- a/src/contrib/dependencyInjection/Akka.DI.Core/Akka.DI.Core.csproj
+++ b/src/contrib/dependencyInjection/Akka.DI.Core/Akka.DI.Core.csproj
@@ -44,6 +44,7 @@
     </Compile>
     <Compile Include="DIActorContextAdapter.cs" />
     <Compile Include="DIActorProducer.cs" />
+    <Compile Include="DIActorSystemAdapter.cs" />
     <Compile Include="DIExt.cs" />
     <Compile Include="DIExtension.cs" />
     <Compile Include="Extensions.cs" />

--- a/src/contrib/dependencyInjection/Akka.DI.Core/DIActorContextAdapter.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.Core/DIActorContextAdapter.cs
@@ -20,16 +20,22 @@ namespace Akka.DI.Core
             this.context = context;
             this.producer = context.System.GetExtension<DIExt>();
         }
+
+        [Obsolete("Use Props methods for actor creation. This method will be removed in future versions")]
         public IActorRef ActorOf<TActor>(string name = null) where TActor : ActorBase
         {
             return context.ActorOf(producer.Props(typeof(TActor)), name);
         }
 
-        public Props Props<TActor>() where TActor : ActorBase
+        public Props Props(Type actorType) 
         {
-            return producer.Props(typeof(TActor));
+            return producer.Props(actorType);
         }
 
-    }
+        public Props Props<TActor>() where TActor : ActorBase
+        {
+            return Props(typeof(TActor));
+        }
+     }
 }
 

--- a/src/contrib/dependencyInjection/Akka.DI.Core/DIActorSystemAdapter.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.Core/DIActorSystemAdapter.cs
@@ -20,14 +20,15 @@ namespace Akka.DI.Core
             this.system = system;
             this.producer = system.GetExtension<DIExt>();
         }
-        public IActorRef ActorOf<TActor>(string name = null) where TActor : ActorBase
+
+        public Props Props(Type actorType) 
         {
-            return system.ActorOf(producer.Props(typeof(TActor)), name);
+            return producer.Props(actorType);
         }
 
         public Props Props<TActor>() where TActor : ActorBase
         {
-            return producer.Props(typeof(TActor));
+            return Props(typeof(TActor));
         }
     }
 }

--- a/src/contrib/dependencyInjection/Akka.DI.Core/DIActorSystemAdapter.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.Core/DIActorSystemAdapter.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="DIActorContextAdapter.cs" company="Akka.NET Project">
+// <copyright file="DIActorSystemAdapter.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>
@@ -10,26 +10,25 @@ using Akka.Actor;
 
 namespace Akka.DI.Core
 {
-    public class DIActorContextAdapter
+    public class DIActorSystemAdapter
     {
         readonly DIExt producer;
-        readonly IActorContext context;
-        public DIActorContextAdapter(IActorContext context)
+        readonly ActorSystem system;
+        public DIActorSystemAdapter(ActorSystem system)
         {
-            if (context == null) throw new ArgumentNullException("context");
-            this.context = context;
-            this.producer = context.System.GetExtension<DIExt>();
+            if (system == null) throw new ArgumentNullException("system");
+            this.system = system;
+            this.producer = system.GetExtension<DIExt>();
         }
         public IActorRef ActorOf<TActor>(string name = null) where TActor : ActorBase
         {
-            return context.ActorOf(producer.Props(typeof(TActor)), name);
+            return system.ActorOf(producer.Props(typeof(TActor)), name);
         }
 
         public Props Props<TActor>() where TActor : ActorBase
         {
             return producer.Props(typeof(TActor));
         }
-
     }
 }
 

--- a/src/contrib/dependencyInjection/Akka.DI.Core/Extensions.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.Core/Extensions.cs
@@ -28,7 +28,11 @@ namespace Akka.DI.Core
             system.RegisterExtension(DIExtension.DIExtensionProvider);
             DIExtension.DIExtensionProvider.Get(system).Initialize(dependencyResolver);
         }
-        
+
+        public static DIActorSystemAdapter DI(this ActorSystem system)
+        {
+            return new DIActorSystemAdapter(system);
+        }
 
         public static DIActorContextAdapter DI(this IActorContext context)
         {

--- a/src/contrib/dependencyInjection/Akka.DI.Core/Readme.md
+++ b/src/contrib/dependencyInjection/Akka.DI.Core/Readme.md
@@ -154,8 +154,8 @@ using (var system = ActorSystem.Create("MySystem"))
     IDependencyResolver resolver = new WindsorDependencyResolver(container, system);
 
     // Register the actors with the system
-    system.ActorOf(resolver.Create<TypedWorker>(), "Worker1");
-    system.ActorOf(resolver.Create<TypedWorker>(), "Worker2");
+    system.ActorOf(system.DI().Props<TypedWorker>(), "Worker1");
+    system.ActorOf(system.DI().Props<TypedWorker>(), "Worker2");
 
     // Create the router
     IActorRef router = system.ActorOf(Props.Empty.WithRouter(new ConsistentHashingGroup(config)));
@@ -176,5 +176,5 @@ using (var system = ActorSystem.Create("MySystem"))
 When you want to create child actors from within your existing actors using Dependency Injection you can use the Actor Content extension just like in the following example.
 
 ```csharp
-Context.DI().ActorOf<TypedActor>().Tell(message);
+Context.ActorOf(Context.DI().Props<TypedActor>()).Tell(message);
 ```

--- a/src/contrib/dependencyInjection/Examples/BasicAutoFacUses/Program.cs
+++ b/src/contrib/dependencyInjection/Examples/BasicAutoFacUses/Program.cs
@@ -11,6 +11,7 @@ using System;
 using System.Threading.Tasks;
 using Autofac;
 using Akka.DI.AutoFac;
+using Akka.DI.Core;
 
 namespace BasicAutoFacUses
 {
@@ -34,7 +35,7 @@ namespace BasicAutoFacUses
                 var propsResolver =
                     new AutoFacDependencyResolver(container, system);
 
-                var router = system.ActorOf(propsResolver.Create<TypedWorker>().WithRouter(FromConfig.Instance), "router1");
+                var router = system.ActorOf(system.DI().Props<TypedWorker>().WithRouter(FromConfig.Instance), "router1");
 
                 Task.Delay(500).Wait();
                 Console.WriteLine("Sending Messages");

--- a/src/contrib/dependencyInjection/Examples/BasicCastleWindsorUse/Program.cs
+++ b/src/contrib/dependencyInjection/Examples/BasicCastleWindsorUse/Program.cs
@@ -12,6 +12,7 @@ using Castle.MicroKernel.Registration;
 using Castle.Windsor;
 using System;
 using System.Threading.Tasks;
+using Akka.DI.Core;
 
 namespace BasicCastleWindsorUse
 {
@@ -33,7 +34,7 @@ namespace BasicCastleWindsorUse
                 var propsResolver =
                     new WindsorDependencyResolver(container, system);
 
-                var router = system.ActorOf(propsResolver.Create<TypedWorker>().WithRouter(FromConfig.Instance), "router1");
+                var router = system.ActorOf(system.DI().Props<TypedWorker>().WithRouter(FromConfig.Instance), "router1");
 
                 Task.Delay(500).Wait();
                 Console.WriteLine("Sending Messages");

--- a/src/contrib/dependencyInjection/Examples/BasicNinjectUses/Program.cs
+++ b/src/contrib/dependencyInjection/Examples/BasicNinjectUses/Program.cs
@@ -7,6 +7,7 @@
 
 using Akka.Actor;
 using Akka.DI.Ninject;
+using Akka.DI.Core;
 using Akka.Routing;
 using System;
 using System.Threading.Tasks;
@@ -31,7 +32,7 @@ namespace BasicNinjectUses
                 var propsResolver =
                     new NinjectDependencyResolver(container, system);
 
-                var router = system.ActorOf(propsResolver.Create<TypedWorker>().WithRouter(FromConfig.Instance), "router1");
+                var router = system.ActorOf(system.DI().Props<TypedWorker>().WithRouter(FromConfig.Instance), "router1");
 
                 Task.Delay(500).Wait();
                 Console.WriteLine("Sending Messages");

--- a/src/contrib/dependencyInjection/Examples/BasicUnityUses/Program.cs
+++ b/src/contrib/dependencyInjection/Examples/BasicUnityUses/Program.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.DI.Core;
 using Akka.DI.Unity;
 using Akka.Routing;
 using Microsoft.Practices.Unity;
@@ -32,7 +33,7 @@ namespace BasicUnityUses
                 var propsResolver =
                     new UnityDependencyResolver(container, system);
 
-                var router = system.ActorOf(propsResolver.Create<TypedWorker>().WithRouter(FromConfig.Instance), "router1");
+                var router = system.ActorOf(system.DI().Props<TypedWorker>().WithRouter(FromConfig.Instance), "router1");
 
                 Task.Delay(500).Wait();
                 Console.WriteLine("Sending Messages");


### PR DESCRIPTION
Issue #965

Added a new class `DIActorSystemAdapter.cs` containing methods to extend the `ActorSystem` with an `ActorOf` (return an `IActorRef` similar to the `DIActorContextApapter` method) and `Props` (returns a `Props` object that can be further configure) method that use DI to create the Actor dependencies. 

Added a `Props` method to `DIActorContextAdapter.cs` similar to the `DIActorSystemAdapter` class one. 

Added a `DI()` extension method for `ActorSystem` in `Extensions.cs` that uses the `DIActorSystemAdapter` class.  

With these changes it is now possible to create `Props` and `Actors` on the `ActorSystem` level without having to use a `IDependencyResolver` implementation available or through `system.GetExtensions<DIExt>().Props` call. 

    // get an Actor through DI directly from the ActorSystem
    var worker = system.DI().ActorOf<TypedWorker>("worker");
    
    // get Props through DI directly from the ActorSystem
    var router = system.ActorOf(system.DI().Props<TypedWorker>().WithRouter(FromConfig.Instance), "router");
    
It is also possible to now create `Props` from within an Actor through DI and configure it further.

    // get Props from within an Actor using the DI extension
    var router = Context.ActorOf(Context.DI().Props<TypedWorker>().WithRouter(FromConfig.Instance), "router");