### PR TITLE
Updated Pigeon.conf throughput values

### DIFF
--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -246,12 +246,12 @@ akka {
 
 	task-dispatcher {
 		type = "Akka.Dispatch.TaskDispatcherConfigurator"
-		throughput = 100
+		throughput = 30
 	}
 
 	default-fork-join-dispatcher{
 		type = ForkJoinDispatcher
-		throughput = 100
+		throughput = 30
 		dedicated-thread-pool{ #settings for Helios.DedicatedThreadPool
 			thread-count = 3 #number of threads
 			#deadlock-timeout = 3s #optional timeout for deadlock detection
@@ -273,7 +273,7 @@ akka {
  
       # Throughput defines the number of messages that are processed in a batch
       # before the thread is returned to the pool. Set to 1 for as fair as possible.
-      throughput = 100
+      throughput = 30
  
       # Throughput deadline for Dispatcher, set to 0 or negative for no deadline
       throughput-deadline-time = 0ms


### PR DESCRIPTION
Updated default throughput values to conform with JVM and promote fairness amongst actors and tasks.

This means that 3 times more events will get through between mailbox runs. instead of mailbox hogging threads for long periods of time