### PR TITLE
Dedicated thread Scheduler

### DIFF
--- a/src/core/Akka/Actor/Internals/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internals/ActorSystemImpl.cs
@@ -51,11 +51,11 @@ namespace Akka.Actor.Internals
             if(config == null)
                 throw new ArgumentNullException("config");
 
-            _name = name;
-            ConfigureScheduler();
+            _name = name;            
             ConfigureSettings(config);
             ConfigureEventStream();
             ConfigureProvider();
+            ConfigureScheduler();
             ConfigureSerialization();
             ConfigureMailboxes();
             ConfigureDispatchers();
@@ -127,7 +127,7 @@ namespace Akka.Actor.Internals
 
         private void ConfigureScheduler()
         {
-            _scheduler = new TaskBasedScheduler();
+            _scheduler = new DedicatedThreadScheduler(this);;// new TaskBasedScheduler();
         }
 
         /// <summary>

--- a/src/core/Akka/Actor/Scheduler/DedicatedThreadScheduler.cs
+++ b/src/core/Akka/Actor/Scheduler/DedicatedThreadScheduler.cs
@@ -32,7 +32,7 @@ namespace Akka.Actor
                     while(_workQueue.TryDequeue(out work))
                     {
                         //has work already expired?
-                        if (work.UtcTickExpires < now)
+                        if (work.TickExpires < now)
                         {
                             work.Action();
                         }
@@ -49,7 +49,7 @@ namespace Akka.Actor
                         allWork = new List<ScheduledWork>();
                         foreach (var bufferedWork in tmp)
                         {
-                            if (bufferedWork.UtcTickExpires < now)
+                            if (bufferedWork.TickExpires < now)
                             {
                                 bufferedWork.Action();
                             }
@@ -147,15 +147,15 @@ namespace Akka.Actor
 
     public class ScheduledWork
     {
-        public ScheduledWork(long utcTickExpires, Action action,CancellationToken token)
+        public ScheduledWork(long tickExpires, Action action,CancellationToken token)
         {
-            UtcTickExpires = utcTickExpires;
+            TickExpires = tickExpires;
             Action = action;
             Token = token;
         }
 
         public CancellationToken Token { get; set; }
-        public long UtcTickExpires { get; set; }
+        public long TickExpires { get; set; }
         public Action Action { get; set; }
     }
 }

--- a/src/core/Akka/Actor/Scheduler/DedicatedThreadScheduler.cs
+++ b/src/core/Akka/Actor/Scheduler/DedicatedThreadScheduler.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Akka.Actor
+{
+    public class DedicatedThreadScheduler : SchedulerBase, IDateTimeOffsetNowTimeProvider
+    {
+        private readonly ConcurrentQueue<ScheduledWork> _workQueue = new ConcurrentQueue<ScheduledWork>();  
+        protected override DateTimeOffset TimeNow { get { return DateTimeOffset.Now; } }
+        public override TimeSpan MonotonicClock { get { return Util.MonotonicClock.Elapsed; } }
+        public override TimeSpan HighResMonotonicClock { get { return Util.MonotonicClock.ElapsedHighRes; } }
+
+        //TODO: use some more efficient approach to handle future work
+        public DedicatedThreadScheduler(ActorSystem system)
+        {
+            var precision = system.Settings.Config.GetTimeSpan("akka.scheduler.tick-duration");
+            var thread = new Thread(_ =>
+            {
+                var allWork = new List<ScheduledWork>();
+                while (true)
+                {
+                    if (system.TerminationTask.IsCompleted)
+                    {
+                        return;
+                    }
+
+                    Thread.Sleep(precision);
+                    var now = HighResMonotonicClock.Ticks;
+                    ScheduledWork work;
+                    while(_workQueue.TryDequeue(out work))
+                    {
+                        //has work already expired?
+                        if (work.UtcTickExpires < now)
+                        {
+                            work.Action();
+                        }
+                        else
+                        {
+                            //buffer it for later
+                            allWork.Add(work);
+                        }
+                    }
+                    //this is completely stupid, but does work.. 
+                    if (allWork.Count > 0)
+                    {
+                        var tmp = allWork;
+                        allWork = new List<ScheduledWork>();
+                        foreach (var bufferedWork in tmp)
+                        {
+                            if (bufferedWork.UtcTickExpires < now)
+                            {
+                                bufferedWork.Action();
+                            }
+                            else
+                            {
+                                allWork.Add(bufferedWork);
+                            }
+                        }
+                    }
+                }
+            }) {IsBackground = true};
+
+            thread.Start();
+        }
+
+        protected override void InternalScheduleTellOnce(TimeSpan delay, ICanTell receiver, object message, IActorRef sender, ICancelable cancelable)
+        {
+            var cancellationToken = cancelable == null ? CancellationToken.None : cancelable.Token;
+            InternalScheduleOnce(delay, () =>
+            {
+                receiver.Tell(message, sender);
+            }, cancellationToken);
+        }
+
+        protected override void InternalScheduleTellRepeatedly(TimeSpan initialDelay, TimeSpan interval, ICanTell receiver, object message, IActorRef sender, ICancelable cancelable)
+        {
+            var cancellationToken = cancelable == null ? CancellationToken.None : cancelable.Token;
+            InternalScheduleRepeatedly(initialDelay, interval, () => receiver.Tell(message, sender), cancellationToken);
+        }
+
+        protected override void InternalScheduleOnce(TimeSpan delay, Action action, ICancelable cancelable)
+        {
+            var cancellationToken = cancelable == null ? CancellationToken.None : cancelable.Token;
+            InternalScheduleOnce(delay, action, cancellationToken);
+        }
+
+        protected override void InternalScheduleRepeatedly(TimeSpan initialDelay, TimeSpan interval, Action action, ICancelable cancelable)
+        {
+            var cancellationToken = cancelable == null ? CancellationToken.None : cancelable.Token;
+            InternalScheduleRepeatedly(initialDelay, interval, action, cancellationToken);
+        }
+
+
+        private void InternalScheduleOnce(TimeSpan initialDelay, Action action, CancellationToken token)
+        {
+            Action executeAction = () =>
+            {
+                if (token.IsCancellationRequested)
+                    return;
+
+                try
+                {
+                    action();
+                }
+                catch (OperationCanceledException) { }
+                //TODO: Should we log other exceptions? /@hcanber
+            };
+            AddWork(initialDelay, executeAction, token);
+
+        }
+
+
+        private void InternalScheduleRepeatedly(TimeSpan initialDelay, TimeSpan interval, Action action, CancellationToken token)
+        {
+            Action executeAction = null;
+            executeAction = () =>
+            {
+                if (token.IsCancellationRequested) 
+                    return;
+
+                try
+                {
+                    action();
+                }
+                catch (OperationCanceledException) { }
+                //TODO: Should we log other exceptions? /@hcanber
+
+                if (token.IsCancellationRequested) 
+                    return;
+
+                AddWork(interval, executeAction,token);
+               
+            };
+            AddWork(initialDelay, executeAction, token);
+
+        }
+
+        private void AddWork(TimeSpan delay, Action work,CancellationToken token)
+        {
+            var expected = HighResMonotonicClock + delay;
+            var scheduledWord = new ScheduledWork(expected.Ticks, work,token);
+            _workQueue.Enqueue(scheduledWord);
+        }               
+    }
+
+    public class ScheduledWork
+    {
+        public ScheduledWork(long utcTickExpires, Action action,CancellationToken token)
+        {
+            UtcTickExpires = utcTickExpires;
+            Action = action;
+            Token = token;
+        }
+
+        public CancellationToken Token { get; set; }
+        public long UtcTickExpires { get; set; }
+        public Action Action { get; set; }
+    }
+}

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Actor\Internals\InternalSupportsTestFSMRef.cs" />
     <Compile Include="Actor\Internals\InitializableActor.cs" />
     <Compile Include="Actor\Scheduler\DateTimeNowTimeProvider.cs" />
+    <Compile Include="Actor\Scheduler\DedicatedThreadScheduler.cs" />
     <Compile Include="Actor\Scheduler\IDateTimeNowTimeProvider.cs" />
     <Compile Include="Actor\Scheduler\ITimeProvider.cs" />
     <Compile Include="Actor\Scheduler\DeprecatedSchedulerExtensions.cs" />


### PR DESCRIPTION
This is a PoC to see what happens when the scheduler runs on a dedicated thread.
When running with the TaskBasedScheduler (the default) and the thread pool gets flooded, Akka.Remote can no longer push Heartbeats through and endpoints gets disassociated.

When using this scheduler, the disassociation no longer occur.

I have tested this by letting the chat application spin up 600 blocking actors on a special command.

![scheduler](https://cloud.githubusercontent.com/assets/647031/7653688/f2d5ae30-fb17-11e4-9622-ce40f29e24af.png)

That turned out to delay Heartbeats by almost 40 seconds.

When running the new scheduler, everything works fine in my test.