### PR TITLE
Supervisor strategy bad timeouts

### DIFF
--- a/src/core/Akka.Tests/Actor/SupervisorStrategySpecs.cs
+++ b/src/core/Akka.Tests/Actor/SupervisorStrategySpecs.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using Akka.Actor;
+using Xunit;
+
+namespace Akka.Tests.Actor
+{
+    public class SupervisorStrategySpecs
+    {
+        public static readonly object[][] RetriesTestData = new[]
+        {
+            new object[] { new int?(), -1 },
+            new object[] { new int?(-1), -1 },
+            new object[] { new int?(0), 0 },
+            new object[] { new int?(5), 5 },
+        };
+
+        public static readonly object[][] TimeoutTestData = new[]
+        {
+            new object[] { new TimeSpan?(), -1 },
+            new object[] { new TimeSpan?(System.Threading.Timeout.InfiniteTimeSpan), -1 },
+            new object[] { new TimeSpan?(TimeSpan.FromMilliseconds(0)), 0 },
+            new object[] { new TimeSpan?(TimeSpan.FromMilliseconds(100)), 100 },
+            new object[] { new TimeSpan?(TimeSpan.FromMilliseconds(100).Add(TimeSpan.FromTicks(75))), 100 },
+            new object[] { new TimeSpan?(TimeSpan.FromMilliseconds(10000)), 10000 },
+        };
+
+        [Theory]
+        [MemberData("RetriesTestData")]
+        public void A_constructed_OneForOne_supervisor_strategy_with_nullable_retries_has_the_expected_properties(int? retries, int expectedRetries)
+        {
+            var uut = new OneForOneStrategy(retries, null, exn => Directive.Restart);
+
+            Assert.Equal(uut.MaxNumberOfRetries, expectedRetries);
+        }
+
+        [Theory]
+        [MemberData("TimeoutTestData")]
+        public void A_constructed_OneForOne_supervisor_strategy_with_nullable_timeouts_has_the_expected_properties(TimeSpan? timeout, int expectedTimeoutMilliseconds)
+        {
+            var uut = new OneForOneStrategy(-1, timeout, exn => Directive.Restart);
+
+            Assert.Equal(uut.WithinTimeRangeMilliseconds, expectedTimeoutMilliseconds);
+        }
+
+        [Theory]
+        [MemberData("RetriesTestData")]
+        public void A_constructed_OneForOne_supervisor_strategy_with_nullable_retries_and_a_decider_has_the_expected_properties(int? retries, int expectedRetries)
+        {
+            var uut = new OneForOneStrategy(retries, null, Decider.From(Directive.Restart));
+
+            Assert.Equal(uut.MaxNumberOfRetries, expectedRetries);
+        }
+
+        [Theory]
+        [MemberData("TimeoutTestData")]
+        public void A_constructed_OneForOne_supervisor_strategy_with_nullable_timeouts_and_a_decider_has_the_expected_properties(TimeSpan? timeout, int expectedTimeoutMilliseconds)
+        {
+            var uut = new OneForOneStrategy(-1, timeout, Decider.From(Directive.Restart));
+
+            Assert.Equal(uut.WithinTimeRangeMilliseconds, expectedTimeoutMilliseconds);
+        }
+
+        [Theory]
+        [MemberData("RetriesTestData")]
+        public void A_constructed_AllForOne_supervisor_strategy_with_nullable_retries_has_the_expected_properties(int? retries, int expectedRetries)
+        {
+            var uut = new AllForOneStrategy(retries, null, exn => Directive.Restart);
+
+            Assert.Equal(uut.MaxNumberOfRetries, expectedRetries);
+        }
+
+        [Theory]
+        [MemberData("TimeoutTestData")]
+        public void A_constructed_AllForOne_supervisor_strategy_with_nullable_timeouts_has_the_expected_properties(TimeSpan? timeout, int expectedTimeoutMilliseconds)
+        {
+            var uut = new AllForOneStrategy(-1, timeout, exn => Directive.Restart);
+
+            Assert.Equal(uut.WithinTimeRangeMilliseconds, expectedTimeoutMilliseconds);
+        }
+
+        [Theory]
+        [MemberData("RetriesTestData")]
+        public void A_constructed_AllForOne_supervisor_strategy_with_nullable_retries_and_a_decider_has_the_expected_properties(int? retries, int expectedRetries)
+        {
+            var uut = new OneForOneStrategy(retries, null, Decider.From(Directive.Restart));
+
+            Assert.Equal(uut.MaxNumberOfRetries, expectedRetries);
+        }
+
+        [Theory]
+        [MemberData("TimeoutTestData")]
+        public void A_constructed_AllForOne_supervisor_strategy_with_nullable_timeouts_and_a_decider_has_the_expected_properties(TimeSpan? timeout, int expectedTimeoutMilliseconds)
+        {
+            var uut = new OneForOneStrategy(-1, timeout, Decider.From(Directive.Restart));
+
+            Assert.Equal(uut.WithinTimeRangeMilliseconds, expectedTimeoutMilliseconds);
+        }
+    }
+}

--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Actor\StashMailboxSpec.cs" />
     <Compile Include="Actor\Stash\ActorWithStashSpec.cs" />
     <Compile Include="Actor\SupervisorHierarchySpec.cs" />
+    <Compile Include="Actor\SupervisorStrategySpecs.cs" />
     <Compile Include="Actor\SystemGuardianTests.cs" />
     <Compile Include="Configuration\ConfigurationSpec.cs" />
     <Compile Include="Actor\ReceiveActorTests_Become.cs" />

--- a/src/core/Akka/Actor/SupervisorStrategy.cs
+++ b/src/core/Akka/Actor/SupervisorStrategy.cs
@@ -231,7 +231,7 @@ namespace Akka.Actor
         /// <param name="withinTimeRange">duration of the time window for maxNrOfRetries, Duration.Inf means no window.</param>
         /// <param name="localOnlyDecider">mapping from Exception to <see cref="Directive" /></param>
         public OneForOneStrategy(int? maxNrOfRetries, TimeSpan? withinTimeRange, Func<Exception, Directive> localOnlyDecider)
-            : this(maxNrOfRetries.GetValueOrDefault(-1), withinTimeRange.GetValueOrDefault(Timeout.InfiniteTimeSpan).Milliseconds, localOnlyDecider)
+            : this(maxNrOfRetries.GetValueOrDefault(-1), (int) withinTimeRange.GetValueOrDefault(Timeout.InfiniteTimeSpan).TotalMilliseconds, localOnlyDecider)
         {
             //Intentionally left blank
         }
@@ -248,7 +248,7 @@ namespace Akka.Actor
         /// <param name="withinTimeRange">duration of the time window for maxNrOfRetries, Duration.Inf means no window.</param>
         /// <param name="decider">mapping from Exception to <see cref="Directive" /></param>
         public OneForOneStrategy(int? maxNrOfRetries, TimeSpan? withinTimeRange, IDecider decider)
-            : this(maxNrOfRetries.GetValueOrDefault(-1), withinTimeRange.GetValueOrDefault(Timeout.InfiniteTimeSpan).Milliseconds, decider)
+            : this(maxNrOfRetries.GetValueOrDefault(-1), (int) withinTimeRange.GetValueOrDefault(Timeout.InfiniteTimeSpan).TotalMilliseconds, decider)
         {
             //Intentionally left blank
         }
@@ -265,7 +265,8 @@ namespace Akka.Actor
         /// <param name="withinTimeMilliseconds">duration in milliseconds of the time window for <paramref name="maxNrOfRetries"/>, negative values means no window.</param>
         /// <param name="localOnlyDecider">Mapping from an <see cref="Exception"/> to <see cref="Directive"/></param>
         /// <param name="loggingEnabled">If <c>true</c> failures will be logged</param>
-        public OneForOneStrategy(int maxNrOfRetries, int withinTimeMilliseconds, Func<Exception, Directive> localOnlyDecider, bool loggingEnabled = true) : this(maxNrOfRetries,withinTimeMilliseconds,new LocalOnlyDecider(localOnlyDecider),loggingEnabled)
+        public OneForOneStrategy(int maxNrOfRetries, int withinTimeMilliseconds, Func<Exception, Directive> localOnlyDecider, bool loggingEnabled = true)
+            : this(maxNrOfRetries, withinTimeMilliseconds, new LocalOnlyDecider(localOnlyDecider), loggingEnabled)
         {
             //Intentionally left blank
         }
@@ -403,7 +404,7 @@ namespace Akka.Actor
         /// <param name="withinTimeRange">duration of the time window for maxNrOfRetries, <see cref="Timeout.InfiniteTimeSpan"/> means no window.</param>
         /// <param name="localOnlyDecider">mapping from Exception to <see cref="Directive"/></param>
         public AllForOneStrategy(int? maxNrOfRetries, TimeSpan? withinTimeRange, Func<Exception, Directive> localOnlyDecider)
-            : this(maxNrOfRetries.GetValueOrDefault(-1), withinTimeRange.GetValueOrDefault(Timeout.InfiniteTimeSpan).Milliseconds, localOnlyDecider)
+            : this(maxNrOfRetries.GetValueOrDefault(-1), (int) withinTimeRange.GetValueOrDefault(Timeout.InfiniteTimeSpan).TotalMilliseconds, localOnlyDecider)
         {
             //Intentionally left blank
         }
@@ -420,7 +421,7 @@ namespace Akka.Actor
         /// <param name="withinTimeRange">duration of the time window for maxNrOfRetries, <see cref="Timeout.InfiniteTimeSpan"/> means no window.</param>
         /// <param name="decider">mapping from Exception to <see cref="Directive"/></param>
         public AllForOneStrategy(int? maxNrOfRetries, TimeSpan? withinTimeRange, IDecider decider)
-            : this(maxNrOfRetries.GetValueOrDefault(-1), withinTimeRange.GetValueOrDefault(Timeout.InfiniteTimeSpan).Milliseconds, decider)
+            : this(maxNrOfRetries.GetValueOrDefault(-1), (int) withinTimeRange.GetValueOrDefault(Timeout.InfiniteTimeSpan).TotalMilliseconds, decider)
         {
             //Intentionally left blank
         }
@@ -437,7 +438,8 @@ namespace Akka.Actor
         /// <param name="withinTimeMilliseconds">duration in milliseconds of the time window for <paramref name="maxNrOfRetries"/>, negative values means no window.</param>
         /// <param name="localOnlyDecider">Mapping from an <see cref="Exception"/> to <see cref="Directive"/></param>
         /// <param name="loggingEnabled">If <c>true</c> failures will be logged</param>
-        public AllForOneStrategy(int maxNrOfRetries, int withinTimeMilliseconds, Func<Exception, Directive> localOnlyDecider, bool loggingEnabled=true) : this(maxNrOfRetries,withinTimeMilliseconds,new LocalOnlyDecider(localOnlyDecider),loggingEnabled)
+        public AllForOneStrategy(int maxNrOfRetries, int withinTimeMilliseconds, Func<Exception, Directive> localOnlyDecider, bool loggingEnabled=true)
+            : this(maxNrOfRetries, withinTimeMilliseconds, new LocalOnlyDecider(localOnlyDecider), loggingEnabled)
         {
             //Intentionally left blank
         }


### PR DESCRIPTION
In chaining to other constructors, the constructors for the `AllForOne` and `OneForOne` strategies pull timeouts from `TimeSpan`s using the `Milliseconds` property. This is not the correct behavior for `TimeSpan` values greater than or equal to 1 second as it provides only the milliseconds portion of the timespan. Instead, use the `TotalMilliseconds` property and cast it to an `int`.