### PR TITLE
Missing xmldoc comments and typo fix

### DIFF
--- a/src/contrib/loggers/Akka.Logger.NLog/NLogLogger.cs
+++ b/src/contrib/loggers/Akka.Logger.NLog/NLogLogger.cs
@@ -5,14 +5,20 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using Akka.Actor;
 using Akka.Event;
 using NLog;
-using System;
 using NLogger = global::NLog.Logger;
 
 namespace Akka.Logger.NLog
 {
+    /// <summary>
+    /// This class is used to receive log events and sends them to
+    /// the configured NLog logger. The following log events are
+    /// recognized: <see cref="Debug"/>, <see cref="Info"/>,
+    /// <see cref="Warning"/> and <see cref="Error"/>.
+    /// </summary>
     public class NLogLogger : ReceiveActor
     {
         private readonly ILoggingAdapter _log = Context.GetLogger();
@@ -23,6 +29,9 @@ namespace Akka.Logger.NLog
             logStatement(logger);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NLogLogger"/> class.
+        /// </summary>
         public NLogLogger()
         {
             Receive<Error>(m => Log(m, logger => logger.Error("{0}", m.Message)));

--- a/src/contrib/loggers/Akka.Logger.Serilog/SerilogLogMessageFormatter.cs
+++ b/src/contrib/loggers/Akka.Logger.Serilog/SerilogLogMessageFormatter.cs
@@ -13,15 +13,32 @@ using Serilog.Parsing;
 
 namespace Akka.Logger.Serilog
 {
+    /// <summary>
+    /// This class contains methods used to convert Serilog templated messages
+    /// into normal text messages.
+    /// </summary>
     public class SerilogLogMessageFormatter : ILogMessageFormatter
     {
         private readonly MessageTemplateCache _templateCache;
-            
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SerilogLogMessageFormatter"/> class.
+        /// </summary>
         public SerilogLogMessageFormatter()
         {
             _templateCache = new MessageTemplateCache(new MessageTemplateParser());
         }
 
+        /// <summary>
+        /// Converts the specified template string to a text string using the specified
+        /// token array to match replacements.
+        /// </summary>
+        /// <param name="format">The template string used in the conversion.</param>
+        /// <param name="args">The array that contains values to replace in the template.</param>
+        /// <returns>
+        /// A text string where the template placeholders have been replaced with
+        /// their corresponding values.
+        /// </returns>
         public string Format(string format, params object[] args)
         {
             var template = _templateCache.Parse(format);

--- a/src/contrib/loggers/Akka.Logger.Serilog/SerilogLogger.cs
+++ b/src/contrib/loggers/Akka.Logger.Serilog/SerilogLogger.cs
@@ -5,13 +5,19 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using Akka.Actor;
 using Akka.Event;
 using Serilog;
-using System;
 
 namespace Akka.Logger.Serilog
 {
+    /// <summary>
+    /// This class is used to receive log events and sends them to
+    /// the configured Serilog logger. The following log events are
+    /// recognized: <see cref="Debug"/>, <see cref="Info"/>,
+    /// <see cref="Warning"/> and <see cref="Error"/>.
+    /// </summary>
     public class SerilogLogger : ReceiveActor
     {
         private readonly ILoggingAdapter _log = Context.GetLogger();
@@ -30,19 +36,6 @@ namespace Akka.Logger.Serilog
             return logger;
         }
 
-        public SerilogLogger()
-        {
-            Receive<Error>(m => WithSerilog(logger => SetContextFromLogEvent(logger, m).Error(m.Cause, GetFormat(m.Message), GetArgs(m.Message))));
-            Receive<Warning>(m => WithSerilog(logger => SetContextFromLogEvent(logger, m).Warning(GetFormat(m.Message), GetArgs(m.Message))));
-            Receive<Info>(m => WithSerilog(logger => SetContextFromLogEvent(logger, m).Information(GetFormat(m.Message), GetArgs(m.Message))));
-            Receive<Debug>(m => WithSerilog(logger => SetContextFromLogEvent(logger, m).Debug(GetFormat(m.Message), GetArgs(m.Message))));
-            Receive<InitializeLogger>(m =>
-            {
-                _log.Info("SerilogLogger started");
-                Sender.Tell(new LoggerInitialized());
-            });
-        }
-
         private static string GetFormat(object message)
         {
             var logMessage = message as LogMessage;
@@ -59,6 +52,22 @@ namespace Akka.Logger.Serilog
             return logMessage != null
                 ? logMessage.Args
                 : new[] { message };
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SerilogLogger"/> class.
+        /// </summary>
+        public SerilogLogger()
+        {
+            Receive<Error>(m => WithSerilog(logger => SetContextFromLogEvent(logger, m).Error(m.Cause, GetFormat(m.Message), GetArgs(m.Message))));
+            Receive<Warning>(m => WithSerilog(logger => SetContextFromLogEvent(logger, m).Warning(GetFormat(m.Message), GetArgs(m.Message))));
+            Receive<Info>(m => WithSerilog(logger => SetContextFromLogEvent(logger, m).Information(GetFormat(m.Message), GetArgs(m.Message))));
+            Receive<Debug>(m => WithSerilog(logger => SetContextFromLogEvent(logger, m).Debug(GetFormat(m.Message), GetArgs(m.Message))));
+            Receive<InitializeLogger>(m =>
+            {
+                _log.Info("SerilogLogger started");
+                Sender.Tell(new LoggerInitialized());
+            });
         }
     }
 }

--- a/src/contrib/loggers/Akka.Logger.slf4net/Akka.Logger.slf4net.csproj
+++ b/src/contrib/loggers/Akka.Logger.slf4net/Akka.Logger.slf4net.csproj
@@ -65,7 +65,7 @@
     <Compile Include="..\..\..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="Slf4jLogger.cs" />
+    <Compile Include="Slf4NetLogger.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/contrib/loggers/Akka.Logger.slf4net/Slf4NetLogger.cs
+++ b/src/contrib/loggers/Akka.Logger.slf4net/Slf4NetLogger.cs
@@ -5,19 +5,21 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using Akka.Actor;
 using Akka.Event;
 using slf4net;
-using System;
 
 namespace Akka.Logger.slf4net
 {
+    /// <summary>
+    /// This class is used to receive log events and sends them to
+    /// the configured slf4net logger. The following log events are
+    /// recognized: <see cref="Debug"/>, <see cref="Info"/>,
+    /// <see cref="Warning"/> and <see cref="Error"/>.
+    /// </summary>
     public class Slf4NetLogger : UntypedActor
     {
-        //private string mdcThreadAttributeName = "sourceThread";
-        //private string mdcAkkaSourceAttributeName = "akkaSource";
-        //private string mdcAkkaTimestamp = "akkaTimestamp";
-
         private readonly ILoggingAdapter _log = Context.GetLogger();
 
         private void WithMDC(Action<ILogger> logStatement)
@@ -26,6 +28,10 @@ namespace Akka.Logger.slf4net
             logStatement(logger);
         }
 
+        /// <summary>
+        /// Receives an event and logs it to the slf4net logger.
+        /// </summary>
+        /// <param name="message">The event sent to the logger.</param>
         protected override void OnReceive(object message)
         {
             message


### PR DESCRIPTION
- added missing xmldoc comments to the contrib loggers
- file rename Slf4jLogger => Slf4NetLogger to match the class name