### PR TITLE
Added generic extensions to EventStream subscribe/unsubscribe.

### DIFF
--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -217,6 +217,7 @@
     <Compile Include="Event\Error.cs" />
     <Compile Include="Event\EventBus.cs" />
     <Compile Include="Event\EventStream.cs" />
+    <Compile Include="Event\EventStreamExtensions.cs" />
     <Compile Include="Event\ILogMessageFormatter.cs" />
     <Compile Include="Event\Info.cs" />
     <Compile Include="Event\InitializeLogger.cs" />

--- a/src/core/Akka/Event/EventStreamExtensions.cs
+++ b/src/core/Akka/Event/EventStreamExtensions.cs
@@ -1,0 +1,42 @@
+﻿using Akka.Actor;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Akka.Event
+{
+
+    /// <summary>
+    /// Extension methods for the EventStream class.
+    /// </summary>
+    public static class EventStreamExtensions
+    {
+        /// <summary>
+        /// Subscribes the specified subscriber.
+        /// </summary>
+        /// <typeparam name="TChannel">The channel.</typeparam>
+        /// <param name="eventStream">The event stream.</param>
+        /// <param name="subscriber">The subscriber.</param>
+        /// <returns><c>true</c> if subscription was successful, <c>false</c> otherwise.</returns>
+        /// <exception cref="System.ArgumentNullException">subscriber</exception>
+        public static bool Subscribe<TChannel>(this EventStream eventStream, IActorRef subscriber)
+        {
+            return eventStream.Subscribe(subscriber, typeof(TChannel));
+        }
+
+        /// <summary>
+        /// Unsubscribes the specified subscriber.
+        /// </summary>
+        /// <typeparam name="TChannel">The channel.</typeparam>
+        /// <param name="eventStream">The event stream.</param>
+        /// <param name="subscriber">The subscriber.</param>
+        /// <returns><c>true</c> if unsubscription was successful, <c>false</c> otherwise.</returns>
+        /// <exception cref="System.ArgumentNullException">subscriber</exception>
+        public static bool Unsubscribe<TChannel>(this EventStream eventStream, IActorRef subscriber)
+        {
+            return eventStream.Unsubscribe(subscriber, typeof(TChannel));
+        }
+    }
+}


### PR DESCRIPTION
EventStream is one of the few pieces that don't have generic counterparts.

This patch allows for:
```cs
EventStream.Subscribe<SomeMessage>(Self);
EventStream.Unsubscribe<SomeMessage>(Self);
```
instead of
```cs
EventStream.Subscribe(Self, typeof(SomeMessage));
EventStream.Unsubscribe(Self, typeof(SomeMessage));
```

I was going to add these methods directly to EventStream, but it seems these generic versions are usually extensions methods. One caveat with the extension method is that most code don't require an `using Akka.Event`, so people may miss it entirely.

Please let me know if they should be moved. 