### PR TITLE
Fix the url for Building Akka docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ PM> Install-Package Akka.FSharp
 ### Contribute
 If you are interested in helping porting Akka to .NET please take a look at [Contributing to Akka.NET](http://akkadotnet.github.io/wiki/Contributing to Akka.NET).
 
-Also, please see [Building Akka.NET](https://github.com/akkadotnet/akka.net/wiki/Building-and-Distributing-Pigeon).
+Also, please see [Building Akka.NET](http://getakka.net/docs/Building%20and%20Distributing%20Akka).
 
 <a href="http://www.jetbrains.com/resharper"><img src="http://i61.tinypic.com/15qvwj7.jpg" alt="ReSharper" title="ReSharper"></a>


### PR DESCRIPTION
The old url seems not exists anymore.