### PR TITLE
Convert null to NoSender.

### DIFF
--- a/src/core/Akka.TestKit.Tests/NoImplicitSenderSpec.cs
+++ b/src/core/Akka.TestKit.Tests/NoImplicitSenderSpec.cs
@@ -19,7 +19,7 @@ namespace Akka.Testkit.Tests
         {
             var echoActor = Sys.ActorOf(c => c.ReceiveAny((m, ctx) => TestActor.Tell(ctx.Sender)));
             echoActor.Tell("message");
-            ExpectMsg<IActorRef>(actorRef => actorRef == ActorRefs.NoSender);
+            ExpectMsg<IActorRef>(actorRef => Equals(actorRef, ActorRefs.NoSender));
         }
 
     }
@@ -31,11 +31,11 @@ namespace Akka.Testkit.Tests
         {
             var echoActor = Sys.ActorOf(c => c.ReceiveAny((m, ctx) => TestActor.Tell(ctx.Sender)));
             echoActor.Tell("message");
-            ExpectMsg<IActorRef>(actorRef => actorRef == TestActor);
+            ExpectMsg<IActorRef>(actorRef => Equals(actorRef, TestActor));
 
             //Test that it works after we know that context has been changed
             echoActor.Tell("message");
-            ExpectMsg<IActorRef>(actorRef => actorRef == TestActor);
+            ExpectMsg<IActorRef>(actorRef => Equals(actorRef, TestActor));
 
         }
 
@@ -59,6 +59,5 @@ namespace Akka.Testkit.Tests
             LastSender.ShouldBe(TestActor);
         }
     }
-
 }
 

--- a/src/core/Akka.TestKit/TestKitBase.cs
+++ b/src/core/Akka.TestKit/TestKitBase.cs
@@ -110,6 +110,12 @@ namespace Akka.TestKit
             {
                 InternalCurrentActorCellKeeper.Current = (ActorCell)((ActorRefWithCell)testActor).Underlying;
             }
+            else if(!(this is TestProbe)) 
+                //HACK: we need to clear the current context when running a No Implicit Sender test as sender from an async test may leak
+                //but we should not clear the current context when creating a testprobe from a test
+            {
+                InternalCurrentActorCellKeeper.Current = null;
+            }
             SynchronizationContext.SetSynchronizationContext(
                 new ActorCellKeepingSynchronizationContext(InternalCurrentActorCellKeeper.Current));
             _testActor = testActor;

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -178,7 +178,10 @@ namespace Akka.Actor
 
         public void Tell(object message, IActorRef sender)
         {
-            if (sender == null) throw new ArgumentNullException("sender", "A sender must be specified");
+            if (sender == null)
+            {
+                sender = ActorRefs.NoSender;
+            }
 
             TellInternal(message, sender);
         }


### PR DESCRIPTION
This PR makes it possible to explicitly pass null as `sender` to `Tell` as it is a fairly common mistake and we have no real reason to throw on it.

This PR also fixes some context leakage in the testkit