### PR TITLE
Cassandra persistence plugin (issue #987)

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -218,7 +218,8 @@ Target "RunTests" <| fun _ ->
                                     "src/**/bin/Release/Akka.TestKit.VsTest.Tests.dll" -- 
                                     "src/**/bin/Release/Akka.TestKit.NUnit.Tests.dll" --
                                     "src/**/bin/Release/Akka.Persistence.SqlServer.Tests.dll" --
-                                    "src/**/bin/Release/Akka.Persistence.PostgreSql.Tests.dll"
+                                    "src/**/bin/Release/Akka.Persistence.PostgreSql.Tests.dll" --
+                                    "src/**/bin/Release/Akka.Persistence.Cassandra.Tests.dll"
 
     mkdir testOutput
 
@@ -279,6 +280,14 @@ Target "RunPostgreSqlTests" <| fun _ ->
     xUnit2
         (fun p -> { p with OutputDir = testOutput; ToolPath = xunitToolPath })
         postgreSqlTests
+
+Target "RunCassandraTests" <| fun _ ->
+    let cassandraTests = !! "src/**/bin/Release/Akka.Persistence.Cassandra.Tests.dll"
+    let xunitToolPath = findToolInSubPath "xunit.console.exe" "src/packages/xunit.runner.console*/tools"
+    printfn "Using XUnit runner: %s" xunitToolPath
+    xUnit2
+        (fun p -> { p with OutputDir = testOutput; ToolPath = xunitToolPath })
+        cassandraTests
 
 //--------------------------------------------------------------------------------
 // Nuget targets 

--- a/src/Akka.sln
+++ b/src/Akka.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+VisualStudioVersion = 12.0.30723.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{69279534-1DBA-4115-BF8B-03F77FC8125E}"
 EndProject
@@ -199,6 +199,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.MultiNodeTests", "core\Akka.MultiNodeTests\Akka.MultiNodeTests.csproj", "{F0781BEA-5BA0-4AF0-BB15-E3F209B681F5}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Persistence.Sql.Common", "contrib\persistence\Akka.Persistence.Sql.Common\Akka.Persistence.Sql.Common.csproj", "{3B9E6211-9488-4DB5-B714-24248693B38F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Persistence.Cassandra", "contrib\persistence\Akka.Persistence.Cassandra\Akka.Persistence.Cassandra.csproj", "{54BD0B45-8A46-4194-8C33-AD287CAC8FA4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Persistence.Cassandra.Tests", "contrib\persistence\Akka.Persistence.Cassandra.Tests\Akka.Persistence.Cassandra.Tests.csproj", "{1FE6CA3D-4996-4A2A-AC0F-76F3BD66B4C4}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Persistence.PostgreSql", "contrib\persistence\Akka.Persistence.PostgreSql\Akka.Persistence.PostgreSql.csproj", "{4B89227B-5AD1-4061-816F-570067C3727F}"
 EndProject
@@ -753,6 +757,22 @@ Global
 		{2D1812FD-70C0-43EE-9C25-3980E41F30E1}.Release Mono|Any CPU.Build.0 = Release|Any CPU
 		{2D1812FD-70C0-43EE-9C25-3980E41F30E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2D1812FD-70C0-43EE-9C25-3980E41F30E1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{54BD0B45-8A46-4194-8C33-AD287CAC8FA4}.Debug Mono|Any CPU.ActiveCfg = Debug|Any CPU
+		{54BD0B45-8A46-4194-8C33-AD287CAC8FA4}.Debug Mono|Any CPU.Build.0 = Debug|Any CPU
+		{54BD0B45-8A46-4194-8C33-AD287CAC8FA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{54BD0B45-8A46-4194-8C33-AD287CAC8FA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{54BD0B45-8A46-4194-8C33-AD287CAC8FA4}.Release Mono|Any CPU.ActiveCfg = Release|Any CPU
+		{54BD0B45-8A46-4194-8C33-AD287CAC8FA4}.Release Mono|Any CPU.Build.0 = Release|Any CPU
+		{54BD0B45-8A46-4194-8C33-AD287CAC8FA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{54BD0B45-8A46-4194-8C33-AD287CAC8FA4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1FE6CA3D-4996-4A2A-AC0F-76F3BD66B4C4}.Debug Mono|Any CPU.ActiveCfg = Debug|Any CPU
+		{1FE6CA3D-4996-4A2A-AC0F-76F3BD66B4C4}.Debug Mono|Any CPU.Build.0 = Debug|Any CPU
+		{1FE6CA3D-4996-4A2A-AC0F-76F3BD66B4C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1FE6CA3D-4996-4A2A-AC0F-76F3BD66B4C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1FE6CA3D-4996-4A2A-AC0F-76F3BD66B4C4}.Release Mono|Any CPU.ActiveCfg = Release|Any CPU
+		{1FE6CA3D-4996-4A2A-AC0F-76F3BD66B4C4}.Release Mono|Any CPU.Build.0 = Release|Any CPU
+		{1FE6CA3D-4996-4A2A-AC0F-76F3BD66B4C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1FE6CA3D-4996-4A2A-AC0F-76F3BD66B4C4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -844,5 +864,7 @@ Global
 		{3B9E6211-9488-4DB5-B714-24248693B38F} = {264C22A4-CAFC-41F6-B82C-4DDC5C196767}
 		{4B89227B-5AD1-4061-816F-570067C3727F} = {264C22A4-CAFC-41F6-B82C-4DDC5C196767}
 		{2D1812FD-70C0-43EE-9C25-3980E41F30E1} = {264C22A4-CAFC-41F6-B82C-4DDC5C196767}
+		{54BD0B45-8A46-4194-8C33-AD287CAC8FA4} = {264C22A4-CAFC-41F6-B82C-4DDC5C196767}
+		{1FE6CA3D-4996-4A2A-AC0F-76F3BD66B4C4} = {264C22A4-CAFC-41F6-B82C-4DDC5C196767}
 	EndGlobalSection
 EndGlobal

--- a/src/contrib/persistence/Akka.Persistence.Cassandra.Tests/Akka.Persistence.Cassandra.Tests.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra.Tests/Akka.Persistence.Cassandra.Tests.csproj
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{1FE6CA3D-4996-4A2A-AC0F-76F3BD66B4C4}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Akka.Persistence.Cassandra.Tests</RootNamespace>
+    <AssemblyName>Akka.Persistence.Cassandra.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>176cb39d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Cassandra, Version=2.5.0.0, Culture=neutral, PublicKeyToken=10b231fbfc8c4b4d, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\CassandraCSharpDriver.2.5.2\lib\net40\Cassandra.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="LZ4, Version=1.0.5.93, Culture=neutral, PublicKeyToken=fd2bda0a70c5a705, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\lz4net.1.0.5.93\lib\net40-client\LZ4.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="CassandraIntegrationSpec.cs" />
+    <Compile Include="CassandraJournalSpec.cs" />
+    <Compile Include="CassandraSnapshotStoreSpec.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestSetupHelpers.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\core\Akka.Persistence.TestKit\Akka.Persistence.TestKit.csproj">
+      <Project>{ad9418b6-c452-4169-94fb-d43de0bfa966}</Project>
+      <Name>Akka.Persistence.TestKit</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\core\Akka.Persistence\Akka.Persistence.csproj">
+      <Project>{fca84dea-c118-424b-9eb8-34375dfef18a}</Project>
+      <Name>Akka.Persistence</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\core\Akka.TestKit\Akka.TestKit.csproj">
+      <Project>{0d3cbad0-bbdb-43e5-afc4-ed1d3ecdc224}</Project>
+      <Name>Akka.TestKit</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\core\Akka\Akka.csproj">
+      <Project>{5deddf90-37f0-48d3-a0b0-a5cbd8a7e377}</Project>
+      <Name>Akka</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\testkits\Akka.TestKit.Xunit2\Akka.TestKit.Xunit2.csproj">
+      <Project>{7dbd5c17-5e9d-40c4-9201-d092751532a7}</Project>
+      <Name>Akka.TestKit.Xunit2</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Akka.Persistence.Cassandra\Akka.Persistence.Cassandra.csproj">
+      <Project>{54bd0b45-8a46-4194-8c33-ad287cac8fa4}</Project>
+      <Name>Akka.Persistence.Cassandra</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/contrib/persistence/Akka.Persistence.Cassandra.Tests/CassandraIntegrationSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra.Tests/CassandraIntegrationSpec.cs
@@ -1,0 +1,455 @@
+﻿using System;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.TestKit;
+using Akka.Util.Internal;
+using Xunit;
+
+namespace Akka.Persistence.Cassandra.Tests
+{
+    /// <summary>
+    /// Some integration tests for Cassandra Journal and Snapshot plugins.
+    /// </summary>
+    public class CassandraIntegrationSpec : Akka.TestKit.Xunit2.TestKit
+    {
+        private static readonly Config IntegrationConfig = ConfigurationFactory.ParseString(@"
+            akka.persistence.journal.plugin = ""cassandra-journal""
+            akka.persistence.snapshot-store.plugin = ""cassandra-snapshot-store""
+            akka.persistence.publish-plugin-commands = on
+            akka.test.single-expect-default = 10s
+            cassandra-journal.partition-size = 5
+            cassandra-journal.max-result-size = 3
+        ");
+
+        // Static so that each test run gets a different Id number
+        private static readonly AtomicCounter ActorIdCounter = new AtomicCounter();
+
+        private readonly string _actorId;
+
+        public CassandraIntegrationSpec()
+            : base(IntegrationConfig, "CassandraIntegration")
+        {
+            TestSetupHelpers.ResetJournalData(Sys);
+            TestSetupHelpers.ResetSnapshotStoreData(Sys);
+
+            // Increment actor Id with each test that's run
+            int id = ActorIdCounter.IncrementAndGet();
+            _actorId = string.Format("p{0}", id);
+        }
+
+        [Fact]
+        public void Cassandra_journal_should_write_and_replay_messages()
+        {
+            // Start a persistence actor and write some messages to it
+            var actor1 = Sys.ActorOf(Props.Create<PersistentActorA>(_actorId));
+            WriteAndVerifyMessages(actor1, 1L, 16L);
+
+            // Now start a new instance (same persistence Id) and it should recover with those same messages
+            var actor2 = Sys.ActorOf(Props.Create<PersistentActorA>(_actorId));
+            for (long i = 1L; i <= 16L; i++)
+            {
+                string msg = string.Format("a-{0}", i);
+                ExpectHandled(msg, i, true);
+            }
+
+            // We should then be able to send that actor another message and have it be persisted
+            actor2.Tell("b");
+            ExpectHandled("b", 17L, false);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Cassandra_journal_should_not_replay_deleted_messages(bool permanentDelete)
+        {
+            // Listen for delete messages on the event stream
+            TestProbe deleteProbe = CreateTestProbe();
+            Sys.EventStream.Subscribe(deleteProbe.Ref, typeof (DeleteMessagesTo));
+
+            var actor1 = Sys.ActorOf(Props.Create<PersistentActorA>(_actorId));
+            WriteAndVerifyMessages(actor1, 1L, 16L);
+
+            // Tell the actor to delete some messages and make sure it's finished
+            actor1.Tell(new DeleteToCommand(3L, permanentDelete));
+            deleteProbe.ExpectMsg<DeleteMessagesTo>();
+
+            // Start a second copy of the actor and verify it starts replaying from the correct spot
+            Sys.ActorOf(Props.Create<PersistentActorA>(_actorId));
+            for (long i = 4L; i <= 16L; i++)
+            {
+                string msg = string.Format("a-{0}", i);
+                ExpectHandled(msg, i, true);
+            }
+
+            // Delete some more messages and wait for confirmation
+            actor1.Tell(new DeleteToCommand(7L, permanentDelete));
+            deleteProbe.ExpectMsg<DeleteMessagesTo>();
+
+            // Start another copy and verify playback again
+            Sys.ActorOf(Props.Create<PersistentActorA>(_actorId));
+            for (long i = 8L; i <= 16L; i++)
+            {
+                string msg = string.Format("a-{0}", i);
+                ExpectHandled(msg, i, true);
+            }
+        }
+
+        [Fact]
+        public void Cassandra_journal_should_replay_message_incrementally()
+        {
+            // Write some messages to a Persistent Actor
+            var actor = Sys.ActorOf(Props.Create<PersistentActorA>(_actorId));
+            WriteAndVerifyMessages(actor, 1L, 6L);
+
+            TestProbe probe = CreateTestProbe();
+            
+            // Create a persistent view from the actor that does not do auto-updating
+            var view = Sys.ActorOf(Props.Create<ViewA>(_actorId + "-view", _actorId, probe.Ref));
+            probe.ExpectNoMsg(200);
+
+            // Tell the view to update and verify we get the messages we wrote earlier replayed
+            view.Tell(new Update(true, 3L));
+            probe.ExpectMsg("a-1");
+            probe.ExpectMsg("a-2");
+            probe.ExpectMsg("a-3");
+            probe.ExpectNoMsg(200);
+
+            // Update the view again and verify we get the rest of the messages
+            view.Tell(new Update(true, 3L));
+            probe.ExpectMsg("a-4");
+            probe.ExpectMsg("a-5");
+            probe.ExpectMsg("a-6");
+            probe.ExpectNoMsg(200);
+        }
+
+        [Fact]
+        public void Persistent_actor_should_recover_from_a_snapshot_with_follow_up_messages()
+        {
+            // Write a message, snapshot, then another follow-up message
+            var actor1 = Sys.ActorOf(Props.Create<PersistentActorC>(_actorId, TestActor));
+            actor1.Tell("a");
+            ExpectHandled("a", 1, false);
+            actor1.Tell("snap");
+            ExpectMsg("snapped-a-1");
+            actor1.Tell("b");
+            ExpectHandled("b", 2, false);
+
+            // Start the actor again and verify we get a snapshot, followed by the message that wasn't in the snapshot
+            var actor2 = Sys.ActorOf(Props.Create<PersistentActorC>(_actorId, TestActor));
+            ExpectMsg("offered-a-1");
+            ExpectHandled("b", 2, true);
+        }
+
+        [Fact]
+        public void Persistent_actor_should_recover_from_a_snapshot_with_follow_up_messages_and_an_upper_bound()
+        {
+            // Create an actor and trigger manual recovery so it will accept new messages
+            var actor1 = Sys.ActorOf(Props.Create<PersistentActorCWithManualRecovery>(_actorId, TestActor));
+            actor1.Tell(new Recover(SnapshotSelectionCriteria.None));
+
+            // Write a message, snapshot, then write some follow-up messages
+            actor1.Tell("a");
+            ExpectHandled("a", 1, false);
+            actor1.Tell("snap");
+            ExpectMsg("snapped-a-1");
+            WriteSameMessageAndVerify(actor1, "a", 2L, 7L);
+
+            // Create another copy of that actor and manually recover to an upper bound (i.e. past state) and verify
+            // we get the expected messages after the snapshot
+            var actor2 = Sys.ActorOf(Props.Create<PersistentActorCWithManualRecovery>(_actorId, TestActor));
+            actor2.Tell(new Recover(SnapshotSelectionCriteria.Latest, toSequenceNr: 3L));
+            ExpectMsg("offered-a-1");
+            ExpectHandled("a", 2, true);
+            ExpectHandled("a", 3, true);
+
+            // Should continue working after recovery to previous state, but highest sequence number should take into 
+            // account other messages that were written but not replayed
+            actor2.Tell("d");
+            ExpectHandled("d", 8L, false);
+        }
+
+        [Fact]
+        public void Persistent_actor_should_recover_from_a_snapshot_without_follow_up_messages_inside_a_partition()
+        {
+            // Write a message, then snapshot, no follow-up messages after snapshot
+            var actor1 = Sys.ActorOf(Props.Create<PersistentActorC>(_actorId, TestActor));
+            actor1.Tell("a");
+            ExpectHandled("a", 1L, false);
+            actor1.Tell("snap");
+            ExpectMsg("snapped-a-1");
+
+            // Start another copy and verify we recover with the snapshot
+            var actor2 = Sys.ActorOf(Props.Create<PersistentActorC>(_actorId, TestActor));
+            ExpectMsg("offered-a-1");
+
+            // Write another message to verify
+            actor2.Tell("b");
+            ExpectHandled("b", 2L, false);
+        }
+
+        [Fact]
+        public void Persistent_actor_should_recover_from_a_snapshot_without_follow_up_messages_at_a_partition_boundary_where_next_partition_is_invalid()
+        {
+            // Partition size for tests is 5 (see Config above), so write messages up to partition boundary (but don't write any
+            // messages to the next partition)
+            var actor1 = Sys.ActorOf(Props.Create<PersistentActorC>(_actorId, TestActor));
+            WriteSameMessageAndVerify(actor1, "a", 1L, 5L);
+
+            // Snapshot and verify without any follow-up messages
+            actor1.Tell("snap");
+            ExpectMsg("snapped-a-5");
+
+            // Create a second copy of that actor and verify it recovers from the snapshot and continues working
+            var actor2 = Sys.ActorOf(Props.Create<PersistentActorC>(_actorId, TestActor));
+            ExpectMsg("offered-a-5");
+            actor2.Tell("b");
+            ExpectHandled("b", 6L, false);
+        }
+        
+        /// <summary>
+        /// Write messages "a-xxx" where xxx is an index number from start to end and verify that each message returns
+        /// a Handled response.
+        /// </summary>
+        private void WriteAndVerifyMessages(IActorRef persistentActor, long start, long end)
+        {
+            for (long i = start; i <= end; i++)
+            {
+                string msg = string.Format("a-{0}", i);
+                persistentActor.Tell(msg, TestActor);
+                ExpectHandled(msg, i, false);
+            }
+        }
+
+        /// <summary>
+        /// Writes the same message multiple times and verify that we get a Handled response.
+        /// </summary>
+        private void WriteSameMessageAndVerify(IActorRef persistentActor, string message, long start, long end)
+        {
+            for (long i = start; i <= end; i++)
+            {
+                persistentActor.Tell(message, TestActor);
+                ExpectHandled(message, i, false);
+            }
+        }
+
+        private void ExpectHandled(string message, long sequenceNumber, bool isRecovering)
+        {
+            object msg = ReceiveOne();
+            var handledMsg = Assert.IsType<HandledMessage>(msg);
+            Assert.Equal(message, handledMsg.Message);
+            Assert.Equal(sequenceNumber, handledMsg.SequenceNumber);
+            Assert.Equal(isRecovering, handledMsg.IsRecovering);
+        }
+
+        #region Test Messages and Actors
+
+        [Serializable]
+        public class DeleteToCommand
+        {
+            public long SequenceNumber { get; private set; }
+            public bool Permanent { get; private set; }
+
+            public DeleteToCommand(long sequenceNumber, bool permanent)
+            {
+                SequenceNumber = sequenceNumber;
+                Permanent = permanent;
+            }
+        }
+
+        [Serializable]
+        public class HandledMessage
+        {
+            public string Message { get; private set; }
+            public long SequenceNumber { get; private set; }
+            public bool IsRecovering { get; private set; }
+
+            public HandledMessage(string message, long sequenceNumber, bool isRecovering)
+            {
+                Message = message;
+                SequenceNumber = sequenceNumber;
+                IsRecovering = isRecovering;
+            }
+        }
+
+        public class PersistentActorA : PersistentActor
+        {
+            private readonly string _persistenceId;
+
+            public PersistentActorA(string persistenceId)
+            {
+                _persistenceId = persistenceId;
+            }
+
+            public override string PersistenceId
+            {
+                get { return _persistenceId; }
+            }
+
+            protected override bool ReceiveRecover(object message)
+            {
+                if (message is string)
+                {
+                    var payload = (string) message;
+                    Handle(payload);
+                    return true;
+                }
+
+                return false;
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (message is DeleteToCommand)
+                {
+                    var delete = (DeleteToCommand) message;
+                    DeleteMessages(delete.SequenceNumber, delete.Permanent);
+                    return true;
+                }
+
+                if (message is string)
+                {
+                    var payload = (string) message;
+                    Persist(payload, Handle);
+                    return true;
+                }
+
+                return false;
+            }
+
+            private void Handle(string payload)
+            {
+                Context.Sender.Tell(new HandledMessage(payload, LastSequenceNr, IsRecovering), Self);
+            }
+        }
+
+        public class PersistentActorC : PersistentActor
+        {
+            private readonly string _persistenceId;
+            private readonly IActorRef _probe;
+
+            private string _last;
+
+            public override string PersistenceId
+            {
+                get { return _persistenceId; }
+            }
+
+            public PersistentActorC(string persistenceId, IActorRef probe)
+            {
+                _persistenceId = persistenceId;
+                _probe = probe;
+            }
+
+            protected override bool ReceiveRecover(object message)
+            {
+                if (message is SnapshotOffer)
+                {
+                    var offer = (SnapshotOffer) message;
+                    _last = (string) offer.Snapshot;
+                    _probe.Tell(string.Format("offered-{0}", _last));
+                    return true;
+                }
+
+                if (message is string)
+                {
+                    var payload = (string) message;
+                    Handle(payload);
+                    return true;
+                }
+
+                return false;
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (message is string)
+                {
+                    var msg = (string) message;
+                    if (msg == "snap")
+                        SaveSnapshot(_last);
+                    else
+                        Persist(msg, Handle);
+
+                    return true;
+                }
+
+                if (message is SaveSnapshotSuccess)
+                {
+                    _probe.Tell(string.Format("snapped-{0}", _last), Context.Sender);
+                    return true;
+                }
+
+                if (message is DeleteToCommand)
+                {
+                    var delete = (DeleteToCommand) message;
+                    DeleteMessages(delete.SequenceNumber, delete.Permanent);
+                    return true;
+                }
+                
+                return false;
+            }
+
+            private void Handle(string payload)
+            {
+                _last = string.Format("{0}-{1}", payload, LastSequenceNr);
+                _probe.Tell(new HandledMessage(payload, LastSequenceNr, IsRecovering));
+            }
+        }
+
+        public class PersistentActorCWithManualRecovery : PersistentActorC
+        {
+            public PersistentActorCWithManualRecovery(string persistenceId, IActorRef probe)
+                : base(persistenceId, probe)
+            {
+            }
+
+            protected override void PreRestart(Exception reason, object message)
+            {
+                // Don't do automatic recovery
+            }
+        }
+
+        public class ViewA : PersistentView
+        {
+            private readonly string _viewId;
+            private readonly string _persistenceId;
+            private readonly IActorRef _probe;
+
+            public override string ViewId
+            {
+                get { return _viewId; }
+            }
+
+            public override string PersistenceId
+            {
+                get { return _persistenceId; }
+            }
+
+            public override bool IsAutoUpdate
+            {
+                get { return false; }
+            }
+
+            public override long AutoUpdateReplayMax
+            {
+                get { return 0L; }
+            }
+            
+            public ViewA(string viewId, string persistenceId, IActorRef probe)
+            {
+                _viewId = viewId;
+                _persistenceId = persistenceId;
+                _probe = probe;
+            }
+
+            protected override bool Receive(object message)
+            {
+                // Just forward messages to the test probe
+                _probe.Tell(message, Context.Sender);
+                return true;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Cassandra.Tests/CassandraJournalSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra.Tests/CassandraJournalSpec.cs
@@ -1,0 +1,26 @@
+﻿using Akka.Configuration;
+using Akka.Persistence.TestKit.Journal;
+
+namespace Akka.Persistence.Cassandra.Tests
+{
+    public class CassandraJournalSpec : JournalSpec
+    {
+        private static readonly Config JournalConfig = ConfigurationFactory.ParseString(@"
+            akka.persistence.journal.plugin = ""cassandra-journal""
+            akka.test.single-expect-default = 10s
+        ");
+
+        public CassandraJournalSpec()
+            : base(JournalConfig, "CassandraJournalSystem")
+        {
+            TestSetupHelpers.ResetJournalData(Sys);
+            Initialize();
+        }
+        
+        protected override void Dispose(bool disposing)
+        {
+            TestSetupHelpers.ResetJournalData(Sys);
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Cassandra.Tests/CassandraSnapshotStoreSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra.Tests/CassandraSnapshotStoreSpec.cs
@@ -1,0 +1,26 @@
+﻿using Akka.Configuration;
+using Akka.Persistence.TestKit.Snapshot;
+
+namespace Akka.Persistence.Cassandra.Tests
+{
+    public class CassandraSnapshotStoreSpec : SnapshotStoreSpec
+    {
+        private static readonly Config SnapshotConfig = ConfigurationFactory.ParseString(@"
+            akka.persistence.snapshot-store.plugin = ""cassandra-snapshot-store""
+            akka.test.single-expect-default = 10s
+        ");
+
+        public CassandraSnapshotStoreSpec()
+            : base(SnapshotConfig, "CassandraSnapshotSystem")
+        {
+            TestSetupHelpers.ResetSnapshotStoreData(Sys);
+            Initialize();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            TestSetupHelpers.ResetSnapshotStoreData(Sys);
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Cassandra.Tests/Properties/AssemblyInfo.cs
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,18 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Akka.Persistence.Cassandra.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyProduct("Akka.Persistence.Cassandra.Tests")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("64d0cc80-1160-4ae7-89fe-304252260860")]

--- a/src/contrib/persistence/Akka.Persistence.Cassandra.Tests/TestSetupHelpers.cs
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra.Tests/TestSetupHelpers.cs
@@ -1,0 +1,33 @@
+﻿using Akka.Actor;
+using Cassandra;
+
+namespace Akka.Persistence.Cassandra.Tests
+{
+    /// <summary>
+    /// Some static helper methods for resetting Cassandra between tests or test contexts.
+    /// </summary>
+    public static class TestSetupHelpers
+    {
+        public static void ResetJournalData(ActorSystem sys)
+        {
+            // Get or add the extension
+            var ext = CassandraPersistence.Instance.Apply(sys);
+
+            // Use session to remove keyspace
+            ISession session = ext.SessionManager.ResolveSession(ext.JournalSettings.SessionKey);
+            session.DeleteKeyspaceIfExists(ext.JournalSettings.Keyspace);
+            ext.SessionManager.ReleaseSession(session);
+        }
+
+        public static void ResetSnapshotStoreData(ActorSystem sys)
+        {
+            // Get or add the extension
+            var ext = CassandraPersistence.Instance.Apply(sys);
+
+            // Use session to remove the keyspace
+            ISession session = ext.SessionManager.ResolveSession(ext.SnapshotStoreSettings.SessionKey);
+            session.DeleteKeyspaceIfExists(ext.SnapshotStoreSettings.Keyspace);
+            ext.SessionManager.ReleaseSession(session);
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Cassandra.Tests/packages.config
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra.Tests/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="CassandraCSharpDriver" version="2.5.2" targetFramework="net45" />
+  <package id="lz4net" version="1.0.5.93" targetFramework="net45" />
+  <package id="xunit" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
+</packages>

--- a/src/contrib/persistence/Akka.Persistence.Cassandra/Akka.Persistence.Cassandra.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra/Akka.Persistence.Cassandra.csproj
@@ -1,0 +1,116 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{54BD0B45-8A46-4194-8C33-AD287CAC8FA4}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Akka.Persistence.Cassandra</RootNamespace>
+    <AssemblyName>Akka.Persistence.Cassandra</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Cassandra">
+      <HintPath>..\..\..\packages\CassandraCSharpDriver.2.5.2\lib\net40\Cassandra.dll</HintPath>
+    </Reference>
+    <Reference Include="LZ4">
+      <HintPath>..\..\..\packages\lz4net.1.0.5.93\lib\net40-client\LZ4.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="CassandraExtension.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="CassandraPersistence.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SessionManagement\CassandraSession.cs" />
+    <Compile Include="CassandraSettings.cs" />
+    <Compile Include="SessionManagement\SessionSettings.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SessionManagement\DefaultSessionManager.cs" />
+    <Compile Include="ExtensionMethods.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SessionManagement\IManageSessions.cs" />
+    <Compile Include="Journal\CassandraJournal.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Journal\CassandraJournalSettings.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Journal\JournalStatements.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Snapshot\CassandraSnapshotStore.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Snapshot\CassandraSnapshotStoreSettings.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Snapshot\SnapshotStoreStatements.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Akka.Persistence.Cassandra.nuspec" />
+    <None Include="packages.config" />
+    <EmbeddedResource Include="reference.conf" />
+  </ItemGroup>
+  <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\core\Akka.Persistence\Akka.Persistence.csproj">
+      <Project>{fca84dea-c118-424b-9eb8-34375dfef18a}</Project>
+      <Name>Akka.Persistence</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\core\Akka\Akka.csproj">
+      <Project>{5deddf90-37f0-48d3-a0b0-a5cbd8a7e377}</Project>
+      <Name>Akka</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/contrib/persistence/Akka.Persistence.Cassandra/Akka.Persistence.Cassandra.nuspec
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra/Akka.Persistence.Cassandra.nuspec
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <id>@project@</id>
+    <title>@project@@title@</title>
+    <version>@build.number@</version>
+    <authors>@authors@</authors>
+    <owners>@authors@</owners>
+    <description>Cassandra Persistence support for Akka.NET</description>
+    <licenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/akkadotnet/akka.net</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/akkadotnet/akka.net/gh-pages/images/icon-32x32.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes>@releaseNotes@</releaseNotes>
+    <copyright>@copyright@</copyright>
+    <tags>@tags@ Persistence Cassandra</tags>
+    @dependencies@
+    @references@
+  </metadata>
+</package>

--- a/src/contrib/persistence/Akka.Persistence.Cassandra/CassandraExtension.cs
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra/CassandraExtension.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Akka.Actor;
+using Akka.Persistence.Cassandra.Journal;
+using Akka.Persistence.Cassandra.SessionManagement;
+using Akka.Persistence.Cassandra.Snapshot;
+
+namespace Akka.Persistence.Cassandra
+{
+    /// <summary>
+    /// An Akka.NET extension for Cassandra persistence.
+    /// </summary>
+    public class CassandraExtension : IExtension
+    {
+        /// <summary>
+        /// The settings for the Cassandra journal.
+        /// </summary>
+        public CassandraJournalSettings JournalSettings { get; private set; }
+
+        /// <summary>
+        /// The settings for the Cassandra snapshot store.
+        /// </summary>
+        public CassandraSnapshotStoreSettings SnapshotStoreSettings { get; private set; }
+
+        /// <summary>
+        /// The session manager for resolving session instances.
+        /// </summary>
+        public IManageSessions SessionManager { get; private set; }
+        
+        public CassandraExtension(ExtendedActorSystem system)
+        {
+            if (system == null) throw new ArgumentNullException("system");
+            
+            // Initialize fallback configuration defaults
+            system.Settings.InjectTopLevelFallback(CassandraPersistence.DefaultConfig());
+
+            // Get or add the session manager
+            SessionManager = CassandraSession.Instance.Apply(system);
+            
+            // Read config
+            var journalConfig = system.Settings.Config.GetConfig("cassandra-journal");
+            JournalSettings = new CassandraJournalSettings(journalConfig);
+
+            var snapshotConfig = system.Settings.Config.GetConfig("cassandra-snapshot-store");
+            SnapshotStoreSettings = new CassandraSnapshotStoreSettings(snapshotConfig);
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Cassandra/CassandraPersistence.cs
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra/CassandraPersistence.cs
@@ -1,0 +1,23 @@
+﻿using Akka.Actor;
+using Akka.Configuration;
+
+namespace Akka.Persistence.Cassandra
+{
+    /// <summary>
+    /// Extension Id provider for the Cassandra Persistence extension.
+    /// </summary>
+    public class CassandraPersistence : ExtensionIdProvider<CassandraExtension>
+    {
+        public static readonly CassandraPersistence Instance = new CassandraPersistence();
+        
+        public override CassandraExtension CreateExtension(ExtendedActorSystem system)
+        {
+            return new CassandraExtension(system);
+        }
+
+        public static Config DefaultConfig()
+        {
+            return ConfigurationFactory.FromResource<CassandraPersistence>("Akka.Persistence.Cassandra.reference.conf");
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Cassandra/CassandraSettings.cs
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra/CassandraSettings.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using Akka.Configuration;
+using Cassandra;
+
+namespace Akka.Persistence.Cassandra
+{
+    /// <summary>
+    /// Abstract class for parsing common settings used by both the Journal and Snapshot store from HOCON configuration.
+    /// </summary>
+    public abstract class CassandraSettings
+    {
+        /// <summary>
+        /// The name (key) of the session to use when resolving an ISession instance. When using default session management,
+        /// this points at configuration under the "cassandra-sessions" section where the session's configuration is found.
+        /// </summary>
+        public string SessionKey { get; private set; }
+
+        /// <summary>
+        /// The keyspace to be created/used.
+        /// </summary>
+        public string Keyspace { get; private set; }
+
+        /// <summary>
+        /// A string to be appended to the CREATE KEYSPACE statement after the WITH clause when the keyspace is 
+        /// automatically created. Use this to define options like replication strategy.
+        /// </summary>
+        public string KeyspaceCreationOptions { get; private set; }
+
+        /// <summary>
+        /// When true the plugin will automatically try to create the keyspace if it doesn't already exist on start.
+        /// </summary>
+        public bool KeyspaceAutocreate { get; private set; }
+
+        /// <summary>
+        /// Name of the table to be created/used.
+        /// </summary>
+        public string Table { get; private set; }
+
+        /// <summary>
+        /// A string to be appended to the CREATE TABLE statement after the WITH clause. Use this to define things
+        /// like gc_grace_seconds or one of the many other table options.
+        /// </summary>
+        public string TableCreationProperties { get; private set; }
+
+        /// <summary>
+        /// Consistency level for reads.
+        /// </summary>
+        public ConsistencyLevel ReadConsistency { get; private set; }
+
+        /// <summary>
+        /// Consistency level for writes.
+        /// </summary>
+        public ConsistencyLevel WriteConsistency { get; private set; }
+
+        protected CassandraSettings(Config config)
+        {
+            SessionKey = config.GetString("session-key");
+
+            Keyspace = config.GetString("keyspace");
+            KeyspaceCreationOptions = config.GetString("keyspace-creation-options");
+            KeyspaceAutocreate = config.GetBoolean("keyspace-autocreate");
+
+            Table = config.GetString("table");
+            TableCreationProperties = config.GetString("table-creation-properties");
+
+            // Quote keyspace and table if necessary
+            if (config.GetBoolean("use-quoted-identifiers"))
+            {
+                Keyspace = string.Format("\"{0}\"", Keyspace);
+                Table = string.Format("\"{0}\"", Keyspace);
+            }
+
+            ReadConsistency = (ConsistencyLevel) Enum.Parse(typeof(ConsistencyLevel), config.GetString("read-consistency"), true);
+            WriteConsistency = (ConsistencyLevel) Enum.Parse(typeof(ConsistencyLevel), config.GetString("write-consistency"), true);
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Cassandra/ExtensionMethods.cs
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra/ExtensionMethods.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Akka.Actor;
+using Cassandra;
+
+namespace Akka.Persistence.Cassandra
+{
+    /// <summary>
+    /// Extension methods used by the Cassandra persistence plugin.
+    /// </summary>
+    internal static class ExtensionMethods
+    {
+       /// <summary>
+        /// Gets the PersistenceExtension instance registered with the ActorSystem. Throws an InvalidOperationException if not found.
+        /// </summary>
+        internal static PersistenceExtension PersistenceExtension(this ActorSystem system)
+        {
+            var ext = system.GetExtension<PersistenceExtension>();
+            if (ext == null)
+                throw new InvalidOperationException("Persistence extension not found.");
+
+            return ext;
+        }
+
+        /// <summary>
+        /// Converts a Type to a string representation that can be stored in Cassandra.
+        /// </summary>
+        internal static string ToQualifiedString(this Type t)
+        {
+            return string.Format("{0}, {1}", t.FullName, t.Assembly.GetName().Name);
+        }
+
+        /// <summary>
+        /// Prepares a CQL string with format arguments using the session.
+        /// </summary>
+        internal static PreparedStatement PrepareFormat(this ISession session, string cqlFormatString, params object[] args)
+        {
+            return session.Prepare(string.Format(cqlFormatString, args));
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Cassandra/Journal/CassandraJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra/Journal/CassandraJournal.cs
@@ -1,0 +1,375 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Akka.Configuration;
+using Akka.Persistence.Journal;
+using Akka.Serialization;
+using Cassandra;
+
+namespace Akka.Persistence.Cassandra.Journal
+{
+    /// <summary>
+    /// An Akka.NET journal implementation that writes events asynchronously to Cassandra.
+    /// </summary>
+    public class CassandraJournal : AsyncWriteJournal
+    {
+        private const string InvalidPartitionSizeException =
+            "Partition size cannot change after initial table creation. (Value at creation: {0}, Currently configured value in Akka configuration: {1})";
+
+        private static readonly Type PersistentRepresentationType = typeof (IPersistentRepresentation);
+
+        private readonly CassandraExtension _cassandraExtension;
+        private readonly Serializer _serializer;
+        private readonly int _maxDeletionBatchSize;
+
+        private ISession _session;
+        private PreparedStatement _writeMessage;
+        private PreparedStatement _writeHeader;
+        private PreparedStatement _selectHeaderSequence;
+        private PreparedStatement _selectLastMessageSequence;
+        private PreparedStatement _selectMessages;
+        private PreparedStatement _writeDeleteMarker;
+        private PreparedStatement _deleteMessagePermanent;
+        private PreparedStatement _selectDeletedToSequence;
+        private PreparedStatement _selectConfigurationValue;
+        private PreparedStatement _writeConfigurationValue;
+        
+        public CassandraJournal()
+        {
+            _cassandraExtension = CassandraPersistence.Instance.Apply(Context.System);
+            _serializer = Context.System.Serialization.FindSerializerForType(PersistentRepresentationType);
+
+            // Use setting from the persistence extension when batch deleting
+            PersistenceExtension persistence = Context.System.PersistenceExtension();
+            _maxDeletionBatchSize = persistence.Settings.Journal.MaxDeletionBatchSize;
+        }
+        
+        protected override void PreStart()
+        {
+            base.PreStart();
+
+            // Create session
+            CassandraJournalSettings settings = _cassandraExtension.JournalSettings;
+            _session = _cassandraExtension.SessionManager.ResolveSession(settings.SessionKey);
+            
+            // Create keyspace if necessary and always try to create table
+            if (settings.KeyspaceAutocreate)
+                _session.Execute(string.Format(JournalStatements.CreateKeyspace, settings.Keyspace, settings.KeyspaceCreationOptions));
+
+            var fullyQualifiedTableName = string.Format("{0}.{1}", settings.Keyspace, settings.Table);
+
+            string createTable = string.IsNullOrWhiteSpace(settings.TableCreationProperties)
+                                     ? string.Format(JournalStatements.CreateTable, fullyQualifiedTableName, string.Empty, string.Empty)
+                                     : string.Format(JournalStatements.CreateTable, fullyQualifiedTableName, " WITH ",
+                                                     settings.TableCreationProperties);
+            _session.Execute(createTable);
+
+            // Prepare some statements against C*
+            _writeMessage = _session.PrepareFormat(JournalStatements.WriteMessage, fullyQualifiedTableName);
+            _writeHeader = _session.PrepareFormat(JournalStatements.WriteHeader, fullyQualifiedTableName);
+            _selectHeaderSequence = _session.PrepareFormat(JournalStatements.SelectHeaderSequence, fullyQualifiedTableName);
+            _selectLastMessageSequence = _session.PrepareFormat(JournalStatements.SelectLastMessageSequence, fullyQualifiedTableName);
+            _selectMessages = _session.PrepareFormat(JournalStatements.SelectMessages, fullyQualifiedTableName);
+            _writeDeleteMarker = _session.PrepareFormat(JournalStatements.WriteDeleteMarker, fullyQualifiedTableName);
+            _deleteMessagePermanent = _session.PrepareFormat(JournalStatements.DeleteMessagePermanent, fullyQualifiedTableName);
+            _selectDeletedToSequence = _session.PrepareFormat(JournalStatements.SelectDeletedToSequence, fullyQualifiedTableName);
+            _selectConfigurationValue = _session.PrepareFormat(JournalStatements.SelectConfigurationValue, fullyQualifiedTableName);
+            _writeConfigurationValue = _session.PrepareFormat(JournalStatements.WriteConfigurationValue, fullyQualifiedTableName);
+
+            // The partition size can only be set once (the first time the table is created) so see if it's already been set
+            long partitionSize = GetConfigurationValueOrDefault("partition-size", -1L);
+            if (partitionSize == -1L)
+            {
+                // Persist the partition size specified in the cluster settings
+                WriteConfigurationValue("partition-size", settings.PartitionSize);
+            }
+            else if (partitionSize != settings.PartitionSize)
+            {
+                throw new ConfigurationException(string.Format(InvalidPartitionSizeException, partitionSize, settings.PartitionSize));
+            }
+        }
+
+        public override async Task ReplayMessagesAsync(string persistenceId, long fromSequenceNr, long toSequenceNr, long max,
+                                                       Action<IPersistentRepresentation> replayCallback)
+        {
+            long partitionNumber = GetPartitionNumber(fromSequenceNr);
+
+            // A sequence number may have been moved to the next partition if it was part of a batch that was too large
+            // to write to a single partition
+            long maxPartitionNumber = GetPartitionNumber(toSequenceNr) + 1L;
+            long count = 0L;
+
+            while (partitionNumber <= maxPartitionNumber && count < max)
+            {
+                // Check for header and deleted to sequence number in parallel
+                RowSet[] rowSets = await GetHeaderAndDeletedTo(persistenceId, partitionNumber).ConfigureAwait(false);
+
+                // If header doesn't exist, just bail on the non-existent partition
+                if (rowSets[0].SingleOrDefault() == null)
+                    return;
+
+                // See what's been deleted in the partition and if no record found, just use long's min value
+                Row deletedToRow = rowSets[1].SingleOrDefault();
+                long deletedTo = deletedToRow == null ? long.MinValue : deletedToRow.GetValue<long>("sequence_number");
+
+                // Page through messages in the partition
+                bool hasNextPage = true;
+                byte[] pageState = null;
+                while (count < max && hasNextPage)
+                {
+                    // Get next page from current partition
+                    IStatement getRows = _selectMessages.Bind(persistenceId, partitionNumber, fromSequenceNr, toSequenceNr)
+                                                        .SetConsistencyLevel(_cassandraExtension.JournalSettings.ReadConsistency)
+                                                        .SetPageSize(_cassandraExtension.JournalSettings.MaxResultSize)
+                                                        .SetPagingState(pageState)
+                                                        .SetAutoPage(false);
+
+                    RowSet messageRows = await _session.ExecuteAsync(getRows).ConfigureAwait(false);
+                    pageState = messageRows.PagingState;
+                    hasNextPage = pageState != null;
+                    IEnumerator<IPersistentRepresentation> messagesEnumerator =
+                        messageRows.Select(row => MapRowToPersistentRepresentation(row, deletedTo))
+                                   .GetEnumerator();
+
+                    // Process page
+                    while (count < max && messagesEnumerator.MoveNext())
+                    {
+                        replayCallback(messagesEnumerator.Current);
+                        count++;
+                    }
+                }
+                
+                // Go to next partition
+                partitionNumber++;
+            }
+        }
+
+        public override async Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
+        {
+            fromSequenceNr = Math.Max(1L, fromSequenceNr);
+            long partitionNumber = GetPartitionNumber(fromSequenceNr);
+            long maxSequenceNumber = 0L;
+            while (true)
+            {
+                // Check for header and deleted to sequence number in parallel
+                RowSet[] rowSets = await GetHeaderAndDeletedTo(persistenceId, partitionNumber).ConfigureAwait(false);
+
+                // If header doesn't exist, just bail on the non-existent partition
+                if (rowSets[0].SingleOrDefault() == null)
+                    break;
+
+                // See what's been deleted in the partition and if no record found, just use long's min value
+                Row deletedToRow = rowSets[1].SingleOrDefault();
+                long deletedTo = deletedToRow == null ? long.MinValue : deletedToRow.GetValue<long>("sequence_number");
+
+                // Try to avoid reading possible tombstones by skipping deleted records if higher than the fromSequenceNr provided
+                long from = Math.Max(fromSequenceNr, deletedTo);
+
+                // Get the last sequence number in the partition, skipping deleted messages
+                IStatement getLastMessageSequence = _selectLastMessageSequence.Bind(persistenceId, partitionNumber, from)
+                                                                              .SetConsistencyLevel(_cassandraExtension.JournalSettings.ReadConsistency);
+                RowSet sequenceRows = await _session.ExecuteAsync(getLastMessageSequence).ConfigureAwait(false);
+
+                // If there aren't any non-deleted messages, use the delete marker's value as the max, otherwise, use whatever value was returned
+                Row sequenceRow = sequenceRows.SingleOrDefault();
+                maxSequenceNumber = sequenceRow == null ? Math.Max(maxSequenceNumber, deletedTo) : sequenceRow.GetValue<long>("sequence_number");
+
+                // Go to next partition
+                partitionNumber++;
+            }
+
+            return maxSequenceNumber;
+        }
+
+        protected override Task WriteMessagesAsync(IEnumerable<IPersistentRepresentation> messages)
+        {
+            // It's implied by the API/docs that a batch of messages will be for a single persistence id
+            List<IPersistentRepresentation> messageList = messages.ToList();
+            string persistenceId = messageList[0].PersistenceId;
+
+            long seqNr = messageList[0].SequenceNr;
+            bool writeHeader = IsNewPartition(seqNr);
+            long partitionNumber = GetPartitionNumber(seqNr);
+
+            if (messageList.Count > 1)
+            {
+                // See if this collection of writes would span multiple partitions and if so, move all the writes to the next partition
+                long lastMessagePartition = GetPartitionNumber(messageList[messageList.Count - 1].SequenceNr);
+                if (lastMessagePartition != partitionNumber)
+                {
+                    partitionNumber = lastMessagePartition;
+                    writeHeader = true;
+                }
+            }
+
+            // No need for a batch if writing a single message
+            if (messageList.Count == 1 && writeHeader == false)
+            {
+                IPersistentRepresentation message = messageList[0];
+                IStatement statement = _writeMessage.Bind(persistenceId, partitionNumber, message.SequenceNr, Serialize(message))
+                                                    .SetConsistencyLevel(_cassandraExtension.JournalSettings.WriteConsistency);
+                return _session.ExecuteAsync(statement);
+            }
+
+            // Use a batch and add statements for each message
+            var batch = new BatchStatement();
+            foreach (IPersistentRepresentation message in messageList)
+            {
+                batch.Add(_writeMessage.Bind(message.PersistenceId, partitionNumber, message.SequenceNr, Serialize(message)));
+            }
+
+            // Add header if necessary
+            if (writeHeader)
+                batch.Add(_writeHeader.Bind(persistenceId, partitionNumber, seqNr));
+
+            batch.SetConsistencyLevel(_cassandraExtension.JournalSettings.WriteConsistency);
+            return _session.ExecuteAsync(batch);
+        }
+
+        protected override async Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, bool isPermanent)
+        {
+            long maxPartitionNumber = GetPartitionNumber(toSequenceNr) + 1L;
+            long partitionNumber = 0L;
+
+            while (partitionNumber <= maxPartitionNumber)
+            {
+                // Check for header and deleted to sequence number in parallel
+                RowSet[] rowSets = await GetHeaderAndDeletedTo(persistenceId, partitionNumber).ConfigureAwait(false);
+
+                // If header doesn't exist, just bail on the non-existent partition
+                Row headerRow = rowSets[0].SingleOrDefault();
+                if (headerRow == null)
+                    return;
+
+                // Start deleting either from the first sequence number after the last deletion, or the beginning of the partition
+                Row deletedToRow = rowSets[1].SingleOrDefault();
+                long deleteFrom = deletedToRow == null
+                                      ? headerRow.GetValue<long>("sequence_number")
+                                      : deletedToRow.GetValue<long>("sequence_number") + 1L;
+                
+                // Nothing to delete if we're going to start higher than the specified sequence number
+                if (deleteFrom > toSequenceNr)
+                    return;
+
+                // Get the last sequence number in the partition and try to avoid tombstones by skipping deletes
+                IStatement getLastMessageSequence = _selectLastMessageSequence.Bind(persistenceId, partitionNumber, deleteFrom)
+                                                                              .SetConsistencyLevel(_cassandraExtension.JournalSettings.ReadConsistency);
+                RowSet lastSequenceRows = await _session.ExecuteAsync(getLastMessageSequence).ConfigureAwait(false);
+                
+                // If we have a sequence number, we've got messages to delete still in the partition
+                Row lastSequenceRow = lastSequenceRows.SingleOrDefault();
+                if (lastSequenceRow != null)
+                {
+                    // Delete either to the end of the partition or to the number specified, whichever comes first
+                    long deleteTo = Math.Min(lastSequenceRow.GetValue<long>("sequence_number"), toSequenceNr);
+                    if (isPermanent == false)
+                    {
+                        IStatement writeMarker = _writeDeleteMarker.Bind(persistenceId, partitionNumber, deleteTo)
+                                                                   .SetConsistencyLevel(_cassandraExtension.JournalSettings.WriteConsistency);
+                        await _session.ExecuteAsync(writeMarker).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        // Permanently delete using batches in parallel
+                        long batchFrom = deleteFrom;
+                        long batchTo;
+                        var batches = new List<Task>();
+                        do
+                        {
+                            batchTo = Math.Min(batchFrom + _maxDeletionBatchSize - 1L, deleteTo);
+
+                            var batch = new BatchStatement();
+                            for (long seq = batchFrom; seq <= batchTo; seq++)
+                                batch.Add(_deleteMessagePermanent.Bind(persistenceId, partitionNumber, seq));
+
+                            batch.Add(_writeDeleteMarker.Bind(persistenceId, partitionNumber, batchTo));
+                            batch.SetConsistencyLevel(_cassandraExtension.JournalSettings.WriteConsistency);
+
+                            batches.Add(_session.ExecuteAsync(batch));
+                            batchFrom = batchTo + 1L;
+                        } while (batchTo < deleteTo);
+
+                        await Task.WhenAll(batches).ConfigureAwait(false);
+                    }
+                    
+                    // If we've deleted everything we're supposed to, no need to continue
+                    if (deleteTo == toSequenceNr)
+                        return;
+                }
+                
+                // Go to next partition
+                partitionNumber++;
+            }
+        }
+
+        private Task<RowSet[]> GetHeaderAndDeletedTo(string persistenceId, long partitionNumber)
+        {
+            return Task.WhenAll(new[]
+            {
+                _selectHeaderSequence.Bind(persistenceId, partitionNumber).SetConsistencyLevel(_cassandraExtension.JournalSettings.ReadConsistency),
+                _selectDeletedToSequence.Bind(persistenceId, partitionNumber).SetConsistencyLevel(_cassandraExtension.JournalSettings.ReadConsistency)
+            }.Select(_session.ExecuteAsync));
+        }
+
+        private IPersistentRepresentation MapRowToPersistentRepresentation(Row row, long deletedTo)
+        {
+            IPersistentRepresentation pr = Deserialize(row.GetValue<byte[]>("message"));
+            if (pr.SequenceNr <= deletedTo)
+                pr = pr.Update(pr.SequenceNr, pr.PersistenceId, true, pr.Sender);
+
+            return pr;
+        }
+
+        private long GetPartitionNumber(long sequenceNumber)
+        {
+            return (sequenceNumber - 1L)/_cassandraExtension.JournalSettings.PartitionSize;
+        }
+
+        private bool IsNewPartition(long sequenceNumber)
+        {
+            return (sequenceNumber - 1L)%_cassandraExtension.JournalSettings.PartitionSize == 0L;
+        }
+
+        private T GetConfigurationValueOrDefault<T>(string key, T defaultValue)
+        {
+            IStatement bound = _selectConfigurationValue.Bind(key).SetConsistencyLevel(_cassandraExtension.JournalSettings.ReadConsistency);
+            RowSet rows = _session.Execute(bound);
+            Row row = rows.SingleOrDefault();
+            if (row == null)
+                return defaultValue;
+
+            IPersistentRepresentation persistent = Deserialize(row.GetValue<byte[]>("message"));
+            return (T) persistent.Payload;
+        }
+
+        private void WriteConfigurationValue<T>(string key, T value)
+        {
+            var persistent = new Persistent(value);
+            IStatement bound = _writeConfigurationValue.Bind(key, Serialize(persistent))
+                                                       .SetConsistencyLevel(_cassandraExtension.JournalSettings.WriteConsistency);
+            _session.Execute(bound);
+        }
+
+        private IPersistentRepresentation Deserialize(byte[] bytes)
+        {
+            return (IPersistentRepresentation) _serializer.FromBinary(bytes, PersistentRepresentationType);
+        }
+
+        private byte[] Serialize(IPersistentRepresentation message)
+        {
+            return _serializer.ToBinary(message);
+        }
+        
+        protected override void PostStop()
+        {
+            base.PostStop();
+
+            if (_cassandraExtension != null && _session != null)
+            {
+                _cassandraExtension.SessionManager.ReleaseSession(_session);
+                _session = null;
+            }
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Cassandra/Journal/CassandraJournalSettings.cs
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra/Journal/CassandraJournalSettings.cs
@@ -1,0 +1,27 @@
+using Akka.Configuration;
+
+namespace Akka.Persistence.Cassandra.Journal
+{
+    /// <summary>
+    /// Settings for the Cassandra journal implementation, parsed from HOCON configuration.
+    /// </summary>
+    public class CassandraJournalSettings : CassandraSettings
+    {
+        /// <summary>
+        /// The approximate number of rows per partition to use. Cannot be changed after table creation.
+        /// </summary>
+        public long PartitionSize { get; private set; }
+
+        /// <summary>
+        /// The maximum number of messages to retrieve in one request when replaying messages.
+        /// </summary>
+        public int MaxResultSize { get; private set; }
+
+        public CassandraJournalSettings(Config config)
+            : base(config)
+        {
+            PartitionSize = config.GetLong("partition-size");
+            MaxResultSize = config.GetInt("max-result-size");
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Cassandra/Journal/JournalStatements.cs
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra/Journal/JournalStatements.cs
@@ -1,0 +1,63 @@
+﻿namespace Akka.Persistence.Cassandra.Journal
+{
+    /// <summary>
+    /// CQL strings for use with the CassandraJournal.
+    /// </summary>
+    internal static class JournalStatements
+    {
+        public const string CreateKeyspace = @"
+            CREATE KEYSPACE IF NOT EXISTS {0}
+            WITH {1}";
+
+        public const string CreateTable = @"
+            CREATE TABLE IF NOT EXISTS {0} (
+                persistence_id text,
+                partition_number bigint,
+                marker text,
+                sequence_number bigint,
+                message blob,
+                PRIMARY KEY ((persistence_id, partition_number), marker, sequence_number)
+            ){1}{2}";
+
+        public const string WriteMessage = @"
+            INSERT INTO {0} (persistence_id, partition_number, marker, sequence_number, message)
+            VALUES (?, ?, 'A', ?, ?)";
+
+        public const string WriteHeader = @"
+            INSERT INTO {0} (persistence_id, partition_number, marker, sequence_number)
+            VALUES (?, ?, 'H', ?)";
+
+        public const string SelectMessages = @"
+            SELECT message FROM {0} WHERE persistence_id = ? AND partition_number = ?
+            AND marker = 'A' AND sequence_number >= ? AND sequence_number <= ?";
+
+        public const string WriteDeleteMarker = @"
+            INSERT INTO {0} (persistence_id, partition_number, marker, sequence_number)
+            VALUES (?, ?, 'D', ?)";
+
+        public const string DeleteMessagePermanent = @"
+            DELETE FROM {0} WHERE persistence_id = ? AND partition_number = ? 
+            AND marker = 'A' AND sequence_number = ?";
+
+        public const string SelectDeletedToSequence = @"
+            SELECT sequence_number FROM {0} WHERE persistence_id = ? AND partition_number = ? 
+            AND marker = 'D' ORDER BY marker DESC, sequence_number DESC LIMIT 1";
+
+        public const string SelectLastMessageSequence = @"
+            SELECT sequence_number FROM {0} WHERE persistence_id = ? AND partition_number = ? 
+            AND marker = 'A' AND sequence_number >= ? 
+            ORDER BY marker DESC, sequence_number DESC LIMIT 1";
+
+        public const string SelectHeaderSequence = @"
+            SELECT sequence_number FROM {0} WHERE persistence_id = ? AND partition_number = ? 
+            AND marker = 'H'";
+
+        public const string SelectConfigurationValue = @"
+            SELECT message FROM {0}
+            WHERE persistence_id = 'akkanet-configuration-values' AND partition_number = 0 AND marker = ?";
+
+        public const string WriteConfigurationValue = @"
+            INSERT INTO {0} (persistence_id, partition_number, marker, sequence_number, message) 
+            VALUES ('akkanet-configuration-values', 0, ?, 0, ?)";
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Cassandra/Properties/AssemblyInfo.cs
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra/Properties/AssemblyInfo.cs
@@ -1,0 +1,18 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Akka.Persistence.Cassandra")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyProduct("Akka.Persistence.Cassandra")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("3c96b6f4-572a-4559-9487-bb91db490506")]

--- a/src/contrib/persistence/Akka.Persistence.Cassandra/README.md
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra/README.md
@@ -1,0 +1,224 @@
+Akka.Persistence.Cassandra
+==========================
+A replicated journal and snapshot store implementation for Akka.Persistence backed by 
+[Apache Cassandra](http://planetcassandra.org/).
+
+**WARNING: The Akka.Persistence.Cassandra plugin is still in beta and the mechanics described below are subject to
+change.**
+
+Quick Start
+-----------
+To activate the journal plugin, add the following line to the actor system configuration file:
+```
+akka.persistence.journal.plugin = "cassandra-journal"
+```
+To activate the snapshot store plugin, add the following line to the actor system configuration file:
+```
+akka.persistence.snasphot-store.plugin = "cassandra-snapshot-store"
+```
+The default configuration will try to connect to a Cassandra cluster running on `127.0.0.1` for persisting messages
+and snapshots. More information on the available configuration options is in the sections below.
+
+Connecting to the Cluster
+-------------------------
+Both the journal and the snapshot store plugins use the [DataStax .NET Driver](https://github.com/datastax/csharp-driver)
+for Cassandra to communicate with the cluster. The driver has an `ISession` object which is used to execute statements
+against the cluster (very similar to a `DbConnection` object in ADO.NET). You can control the creation and
+configuration of these session instance(s) by modifying the configuration under `cassandra-sessions`. Out of the
+box, both the journal and the snapshot store plugin will try to use a session called `default`. You can override 
+the settings for that session with the following configuration keys:
+
+- `cassandra-sessions.default.contact-points`: A comma-seperated list of contact points in the cluster in the format 
+of either `host` or `host:port`. Default value is *`[ "127.0.0.1" ]`*.
+- `cassandra-sessions.default.port`: Default port for contact points in the cluster, used if a contact point is not 
+in [host:port] format. Default value is *`9042`*.
+- `cassandra-sessions.default.credentials.username`: The username to login to Cassandra hosts. No authentication is
+used by default.
+- `cassandra-sessions.default.credentials.password`: The password corresponding to the username. No authentication
+is used by default.
+- `cassandra-sessions.default.ssl`: Boolean value indicating whether to use SSL when connecting to the cluster. No
+default value is set and so SSL is not used by default.
+- `cassandra-sessions.default.compression`: The [type of compression](https://github.com/datastax/csharp-driver/blob/master/src/Cassandra/CompressionType.cs) 
+to use when communicating with the cluster. No default value is set and so compression is not used by default. 
+
+If you require more advanced configuration of the `ISession` object than the options provided here (for example, to
+use a different session for the journal and snapshot store plugins or to configure the session via code or manage
+it with an IoC container), see the [Advanced Session Management](#advanced-session-management) section below.
+
+Journal
+-------
+### Features
+- All operations of the journal plugin API are fully supported
+- Uses Cassandra in a log-oriented way (i.e. data is only ever inserted but never updated)
+- Uses marker records for permanent deletes to try and avoid the problem of [reading many tombstones](http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
+  when replaying messages.
+- Messages for a single persistence Id are partitioned across the cluster to avoid unbounded partition
+  growth and support scalability by adding more nodes to the cluster.
+
+### Configuration
+As mentioned in the Quick Start section, you can activate the journal plugin by adding the following line to your
+actor system configuration file:
+```
+akka.persistence.journal.plugin = "cassandra-journal"
+```
+You can also override the journal's default settings with the following configuration keys:
+- `cassandra-journal.class`: The Type name of the Cassandra journal plugin. Default value is *`Akka.Persistence.Cassandra.Journal.CassandraJournal, Akka.Persistence.Cassandra`*.
+- `cassandra-journal.session-key`: The name (key) of the session to use when resolving an `ISession` instance. When
+using default session management, this points at a configuration section under `cassandra-sessions` where the
+session's configuration is found. Default value is *`default`*.
+- `cassandra-journal.use-quoted-identifiers`: Whether or not to quote the table and keyspace names when executing
+statements against Cassandra. Default value is *`false`*.
+- `cassandra-journal.keyspace`: The keyspace to be created/used by the journal. Default value is *`akkanet`*.
+- `cassandra-journal.keyspace-creation-options`: A string to be appended to the `CREATE KEYSPACE` statement after
+the `WITH` clause when the keyspace is automatically created. Use this to define options like the replication
+strategy. Default value is *`REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }`*.
+- `cassandra-journal.keyspace-autocreate`: When true, the journal will automatically try to create the keyspace if
+it doesn't already exist on startup. Default value is *`true`*.
+- `cassandra-journal.table`: The name of the table to be created/used by the journal. Default value is *`messages`*.
+- `cassandra-journal.table-creation-properties`: A string to be appended to the `CREATE TABLE` statement after the 
+`WITH` clause. Use this to define advanced table options like `gc_grace_seconds` or one of the other many table 
+options. Default value is *an empty string*.
+- `cassandra-journal.partition-size`: The approximate number of message rows to store in a single partition. Cannot 
+be changed after table creation. Default value is *`5000000`*.
+- `cassandra-journal.max-result-size`: The maximum number of messages to retrieve in a single request to Cassandra 
+when replaying messages. Default value is *`50001`*.
+- `cassandra-journal.read-consistency`: The consistency level to use for read operations. Default value is *`Quorum`*.
+- `cassandra-journal.write-consistency`: The consistency level to use for write operations. Default value is 
+*`Quorum`*.
+
+The default value for read and write consistency levels ensure that persistent actors can read their own writes.
+Consider using `LocalQuorum` for both reads and writes if using a Cassandra cluster with multiple datacenters.
+
+Snapshot Store
+--------------
+### Features
+- Snapshot IO is done in a fully asynchronous fashion, including deletes (the snapshot store plugin API only
+directly specifies synchronous methods for doing deletes)
+
+### Configuration
+As mentioned in the Quick Start section, you can activate the snapshot store plugin by adding the following line 
+to your actor system configuration file:
+```
+akka.persistence.snapshot-store.plugin = "cassandra-snapshot-store"
+```
+You can also override the snapshot store's default settings with the following configuration keys:
+- `cassandra-snapshot-store.class`: The Type name of the Cassandra snapshot store plugin. Default value is 
+*`Akka.Persistence.Cassandra.Snapshot.CassandraSnapshotStore, Akka.Persistence.Cassandra`*.
+- `cassandra-snapshot-store.session-key`: The name (key) of the session to use when resolving an `ISession` 
+instance. When using default session management, this points at a configuration section under `cassandra-sessions` 
+where the session's configuration is found. Default value is *`default`*.
+- `cassandra-snapshot-store.use-quoted-identifiers`: Whether or not to quote the table and keyspace names when
+executing statements against Cassandra. Default value is *`false`*.
+- `cassandra-snapshot-store.keyspace`: The keyspace to be created/used by the snapshot store. Default value is 
+*`akkanet`*.
+- `cassandra-snapshot-store.keyspace-creation-options`: A string to be appended to the `CREATE KEYSPACE` statement 
+after the `WITH` clause when the keyspace is automatically created. Use this to define options like the replication 
+strategy. Default value is *`REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }`*.
+- `cassandra-snapshot-store.keyspace-autocreate`: When true, the snapshot store will automatically try to create
+the keyspace if it doesn't already exist on startup. Default value is *`true`*.
+- `cassandra-snapshot-store.table`: The name of the table to be created/used by the snapshot store. Default value 
+is *`snapshots`*.
+- `cassandra-snapshot-store.table-creation-properties`: A string to be appended to the `CREATE TABLE` statement 
+after the `WITH` clause. Use this to define advanced table options like `gc_grace_seconds` or one of the other 
+many table options. Default value is *an empty string*.
+- `cassandra-snapshot-store.max-metadata-result-size`: The maximum number of snapshot metadata instances to 
+retrieve in a single request when trying to find a snapshot that matches criteria. Default value is *`10`*.
+- `cassandra-snapshot-store.read-consistency`: The consistency level to use for read operations. Default value 
+is *`One`*.
+- `cassandra-snapshot-store.write-consistency`: The consistency level to use for write operations. Default value 
+is *`One`*.
+
+Consider using `LocalOne` consistency level for both reads and writes if using a Cassandra cluster with multiple
+datacenters.
+
+Advanced Session Management
+---------------------------
+In some advanced scenarios, you may want to have more control over how `ISession` instances are created. Some
+example scenarios might include:
+- to use a different session instance for the journal and snapshot store plugins (i.e. maybe you have more than one
+Cassandra cluster and are storing journal messages and snapshots in different clusters)
+- to access more advanced configuration options for building the session instance in code using the DataStax 
+driver's cluster builder API directly
+- to use session instances that have already been registered with an IoC container and are being managed there
+
+If you want more control over how session instances are created or managed, you have two options depending on how
+much control you need.
+
+### Defining multiple session instances in the `cassandra-sessions` section
+It is possible to define configuration for more than one session instance under the `cassandra-sessions` section of
+your actor system's configuration file. To do this, just create your own section with a unique name/key for the
+sub-section. All of the same options listed above in the [Connecting to the Cluster](#connecting-to-the-cluster)
+can then be used to configure that session.  For example, I might define seperate configurations for my journal and
+snapshot store plugins like this:
+```
+cassandra-sessions {
+  my-journal-session {
+    contact-points = [ "10.1.1.1", "10.1.1.2" ]
+    port = 9042
+    credentials { 
+      username = "myusername"
+      password = "mypassword"
+    }
+  }
+  
+  my-snapshot-session {
+    contact-points = [ "10.2.1.1:9142", "10.2.1.2:9142" ]
+  }
+}
+```
+I can then tell the journal and snapshot store plugins to use those sessions by overriding each plugin's `session-key`
+configuration like this:
+```
+cassandra-journal.session-key = "my-journal-session"
+cassandra-snapshot-store.session-key = "my-snapshot-session"
+```
+
+### Controlling session configuration and management with code
+You can also override how sessions are created, managed and resolved with your own code. Session management is
+done as its own plugin for Akka.NET and a default implementation that uses the `cassandra-sessions` section is
+provided out of the box. If you want to provide your own implementation for doing this (for example, to manage
+sessions with an IoC container or use the DataStax driver's cluster builder API to do more advanced configuration),
+here are the steps you'll need to follow:
+
+1. Create a class that implements the `IManageSessions` interface from `Akka.Persistence.Cassandra.SessionManagement`.
+  This interface is simple and just requires that you provide a way for resolving and releasing session instances. For
+  example:
+
+  ```cs
+  public class MySessionManager : IManageSessions
+  {
+      public override ISession ResolveSession(string key)
+      {
+          // Do something here to get the ISession instance (pull from IoC container, etc)
+      }
+    
+      public override ISession ReleaseSession(ISession session)
+      {
+          // Do something here to release the session instance if necessary
+      }
+  }
+  ```
+1. Next, you'll need to create an extension id provider class by inheriting from
+  `ExtensionIdProvider<IManageSessions>`.  This class is responsible for actually providing a copy of your
+  `IManageSessions` implementation. For example:
+
+  ```cs
+  public class MySessionExtension : ExtensionIdProvider<IManageSessions>
+  {
+      public override IManageSessions CreateExtension(ExtendedActorSystem system)
+      {
+          // Return a copy of your implementation of IManageSessions
+          return new MySessionManager();
+      }
+  }
+  ```
+1. Lastly, you'll need to register your extension with the actor system when creating it in your application. For
+  example:
+
+  ```cs
+  var actorSystem = ActorSystem.Create("MyApplicationActorSystem");
+  var extensionId = new MySessionExtension();
+  actorSystem.RegisterExtension(extensionId);
+  ```
+
+The journal and snapshot store plugins will now call your code when resolving or releasing sessions.

--- a/src/contrib/persistence/Akka.Persistence.Cassandra/SessionManagement/CassandraSession.cs
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra/SessionManagement/CassandraSession.cs
@@ -1,0 +1,17 @@
+﻿using Akka.Actor;
+
+namespace Akka.Persistence.Cassandra.SessionManagement
+{
+    /// <summary>
+    /// Extension Id provider for Cassandra Session management extension.
+    /// </summary>
+    public class CassandraSession : ExtensionIdProvider<IManageSessions>
+    {
+        public static CassandraSession Instance = new CassandraSession();
+
+        public override IManageSessions CreateExtension(ExtendedActorSystem system)
+        {
+            return new DefaultSessionManager(system);
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Cassandra/SessionManagement/DefaultSessionManager.cs
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra/SessionManagement/DefaultSessionManager.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Concurrent;
+using Akka.Actor;
+using Akka.Configuration;
+using Cassandra;
+
+namespace Akka.Persistence.Cassandra.SessionManagement
+{
+    /// <summary>
+    /// A default session manager implementation that reads configuration from the system's "cassandra-cluster"
+    /// section and builds ISession instances from that configuration. Caches session instances for reuse.
+    /// </summary>
+    public class DefaultSessionManager : IManageSessions
+    {
+        private readonly Config _sessionConfigs;
+        private readonly ConcurrentDictionary<string, Lazy<ISession>> _sessionCache;
+        
+        public DefaultSessionManager(ExtendedActorSystem system)
+        {
+            if (system == null) throw new ArgumentNullException("system");
+
+            // Read configuration sections
+            _sessionConfigs = system.Settings.Config.GetConfig("cassandra-sessions");
+
+            _sessionCache = new ConcurrentDictionary<string, Lazy<ISession>>();
+        }
+
+        /// <summary>
+        /// Resolves the session with the key specified.
+        /// </summary>
+        public ISession ResolveSession(string key)
+        {
+            return _sessionCache.GetOrAdd(key, k => new Lazy<ISession>(() => CreateSession(k))).Value;
+        }
+
+        /// <summary>
+        /// Releases the session instance.
+        /// </summary>
+        public void ReleaseSession(ISession session)
+        {
+            // No-op since we want session instance to live for actor system's duration 
+            // (TODO: Dispose of session instance if hooks are added to listen for Actor system shutdown?)
+        }
+        
+        private ISession CreateSession(string clusterName)
+        {
+            if (_sessionConfigs.HasPath(clusterName) == false)
+                throw new ConfigurationException(string.Format("Cannot find cluster configuration named '{0}'", clusterName));
+
+            // Get a cluster builder from the settings, build the cluster, and connect for a session
+            var clusterSettings = new SessionSettings(_sessionConfigs.GetConfig(clusterName));
+            return clusterSettings.Builder.Build().Connect();
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Cassandra/SessionManagement/IManageSessions.cs
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra/SessionManagement/IManageSessions.cs
@@ -1,0 +1,22 @@
+﻿using Akka.Actor;
+using Cassandra;
+
+namespace Akka.Persistence.Cassandra.SessionManagement
+{
+    /// <summary>
+    /// Contract for extension responsible for resolving/releasing Cassandra ISession instances used by the
+    /// Cassandra Persistence plugin.
+    /// </summary>
+    public interface IManageSessions : IExtension
+    {
+        /// <summary>
+        /// Resolves the session with the key specified.
+        /// </summary>
+        ISession ResolveSession(string key);
+
+        /// <summary>
+        /// Releases the session instance.
+        /// </summary>
+        void ReleaseSession(ISession session);
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Cassandra/SessionManagement/SessionSettings.cs
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra/SessionManagement/SessionSettings.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using Akka.Configuration;
+using Cassandra;
+
+namespace Akka.Persistence.Cassandra.SessionManagement
+{
+    /// <summary>
+    /// Internal class for converting basic session settings in HOCON configuration to a Builder instance from the
+    /// DataStax driver for Cassandra.
+    /// </summary>
+    internal class SessionSettings
+    {
+        /// <summary>
+        /// A Builder instance with the appropriate configuration settings applied to it.
+        /// </summary>
+        public Builder Builder { get; private set; }
+
+        public SessionSettings(Config config)
+        {
+            if (config == null) throw new ArgumentNullException("config");
+
+            Builder = Cluster.Builder();
+            
+            // Get IP and port configuration
+            int port = config.GetInt("port", 9042);
+            IPEndPoint[] contactPoints = ParseContactPoints(config.GetStringList("contact-points"), port);
+            Builder.AddContactPoints(contactPoints);
+
+            // Support user/pass authentication
+            if (config.HasPath("credentials"))
+                Builder.WithCredentials(config.GetString("credentials.username"), config.GetString("credentials.password"));
+
+            // Support SSL
+            if (config.GetBoolean("ssl"))
+                Builder.WithSSL();
+
+            // Support compression
+            string compressionTypeConfig = config.GetString("compression");
+            if (compressionTypeConfig != null)
+            {
+                var compressionType = (CompressionType) Enum.Parse(typeof (CompressionType), compressionTypeConfig, true);
+                Builder.WithCompression(compressionType);
+            }
+        }
+        
+        private static IPEndPoint[] ParseContactPoints(IList<string> contactPoints, int port)
+        {
+            if (contactPoints == null || contactPoints.Count == 0)
+                throw new ConfigurationException("List of contact points cannot be empty.");
+
+            return contactPoints.Select(cp =>
+            {
+                string[] ipAndPort = cp.Split(':');
+                if (ipAndPort.Length == 1)
+                    return new IPEndPoint(IPAddress.Parse(ipAndPort[0]), port);
+
+                if (ipAndPort.Length == 2)
+                    return new IPEndPoint(IPAddress.Parse(ipAndPort[0]), int.Parse(ipAndPort[1]));
+
+                throw new ConfigurationException(string.Format("Contact points should have format [host:post] or [host] but found: {0}", cp));
+            }).ToArray();
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Cassandra/Snapshot/CassandraSnapshotStore.cs
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra/Snapshot/CassandraSnapshotStore.cs
@@ -1,0 +1,251 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Akka.Event;
+using Akka.Persistence.Snapshot;
+using Akka.Serialization;
+using Cassandra;
+
+namespace Akka.Persistence.Cassandra.Snapshot
+{
+    /// <summary>
+    /// A SnapshotStore implementation for writing snapshots to Cassandra.
+    /// </summary>
+    public class CassandraSnapshotStore : SnapshotStore
+    {
+        private static readonly Type SnapshotType = typeof (Serialization.Snapshot);
+
+        private readonly CassandraExtension _cassandraExtension;
+        private readonly Serializer _serializer;
+        private readonly ILoggingAdapter _log;
+        private readonly bool _publish;
+
+        private ISession _session;
+        private PreparedStatement _writeSnapshot;
+        private PreparedStatement _deleteSnapshot;
+        private PreparedStatement _selectSnapshot;
+        private PreparedStatement _selectSnapshotMetadata;
+        
+        public CassandraSnapshotStore()
+        {
+            _cassandraExtension = CassandraPersistence.Instance.Apply(Context.System);
+            _serializer = Context.System.Serialization.FindSerializerForType(SnapshotType);
+            _log = Context.System.Log;
+
+            // Here so we can emulate the base class behavior but do deletes async
+            PersistenceExtension persistence = Context.System.PersistenceExtension();
+            _publish = persistence.Settings.Internal.PublishPluginCommands;
+        }
+
+        protected override void PreStart()
+        {
+            base.PreStart();
+            
+            // Get a session to talk to Cassandra with
+            CassandraSnapshotStoreSettings settings = _cassandraExtension.SnapshotStoreSettings;
+            _session = _cassandraExtension.SessionManager.ResolveSession(settings.SessionKey);
+
+            // Create the keyspace if necessary and always attempt to create the table
+            if (settings.KeyspaceAutocreate)
+                _session.Execute(string.Format(SnapshotStoreStatements.CreateKeyspace, settings.Keyspace, settings.KeyspaceCreationOptions));
+
+            var fullyQualifiedTableName = string.Format("{0}.{1}", settings.Keyspace, settings.Table);
+            var createTable = string.IsNullOrWhiteSpace(settings.TableCreationProperties)
+                                  ? string.Format(SnapshotStoreStatements.CreateTable, fullyQualifiedTableName, string.Empty, string.Empty)
+                                  : string.Format(SnapshotStoreStatements.CreateTable, fullyQualifiedTableName, " AND ",
+                                                  settings.TableCreationProperties);
+
+            _session.Execute(createTable);
+
+            // Prepare some statements
+            _writeSnapshot = _session.PrepareFormat(SnapshotStoreStatements.WriteSnapshot, fullyQualifiedTableName);
+            _deleteSnapshot = _session.PrepareFormat(SnapshotStoreStatements.DeleteSnapshot, fullyQualifiedTableName);
+            _selectSnapshot = _session.PrepareFormat(SnapshotStoreStatements.SelectSnapshot, fullyQualifiedTableName);
+            _selectSnapshotMetadata = _session.PrepareFormat(SnapshotStoreStatements.SelectSnapshotMetadata, fullyQualifiedTableName);
+        }
+
+        protected override bool Receive(object message)
+        {
+            // Make deletes async as well, but make sure we still publish like the base class does
+            if (message is DeleteSnapshot)
+            {
+                HandleDeleteAsync((DeleteSnapshot) message, msg => DeleteAsync(msg.Metadata));
+            }
+            else if (message is DeleteSnapshots)
+            {
+                HandleDeleteAsync((DeleteSnapshots) message, msg => DeleteAsync(msg.PersistenceId, msg.Criteria));
+            }
+            else
+            {
+                return base.Receive(message);
+            }
+
+            return true;
+        }
+
+        protected override async Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        {
+            bool hasNextPage = true;
+            byte[] nextPageState = null;
+
+            while (hasNextPage)
+            {
+                // Get a page of metadata that match the criteria
+                IStatement getMetadata = _selectSnapshotMetadata.Bind(persistenceId, criteria.MaxSequenceNr)
+                                                                .SetConsistencyLevel(_cassandraExtension.SnapshotStoreSettings.ReadConsistency)
+                                                                .SetPageSize(_cassandraExtension.SnapshotStoreSettings.MaxMetadataResultSize)
+                                                                .SetPagingState(nextPageState)
+                                                                .SetAutoPage(false);
+                RowSet metadataRows = await _session.ExecuteAsync(getMetadata).ConfigureAwait(false);
+
+                nextPageState = metadataRows.PagingState;
+                hasNextPage = nextPageState != null;
+                IEnumerable<SnapshotMetadata> page = metadataRows.Select(MapRowToSnapshotMetadata)
+                                                                 .Where(md => md.Timestamp <= criteria.MaxTimeStamp);
+
+                // Try to get the first available snapshot from the page
+                foreach (SnapshotMetadata md in page)
+                {
+                    try
+                    {
+                        IStatement getSnapshot = _selectSnapshot.Bind(md.PersistenceId, md.SequenceNr)
+                                                                .SetConsistencyLevel(_cassandraExtension.SnapshotStoreSettings.ReadConsistency);
+                        RowSet snapshotRows = await _session.ExecuteAsync(getSnapshot).ConfigureAwait(false);
+
+                        // If we didn't get a snapshot for some reason, just try the next one
+                        Row snapshotRow = snapshotRows.SingleOrDefault();
+                        if (snapshotRow == null)
+                            continue;
+
+                        // We found a snapshot so create the necessary class and return the result
+                        return new SelectedSnapshot(md, Deserialize(snapshotRow.GetValue<byte[]>("snapshot")));
+                    }
+                    catch (Exception e)
+                    {
+                        // If there is a problem, just try the next snapshot
+                        _log.Warning("Unexpected exception while retrieveing snapshot {0} for id {1}: {2}", md.SequenceNr, md.PersistenceId, e);
+                    }
+                }
+
+                // Just try the next page if available
+            }
+
+            // Out of snapshots that match or none found
+            return null;
+        }
+        
+        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot)
+        {
+            IStatement bound = _writeSnapshot.Bind(metadata.PersistenceId, metadata.SequenceNr, metadata.Timestamp.Ticks, Serialize(snapshot))
+                                             .SetConsistencyLevel(_cassandraExtension.SnapshotStoreSettings.WriteConsistency);
+            return _session.ExecuteAsync(bound);
+        }
+
+        protected Task DeleteAsync(SnapshotMetadata metadata)
+        {
+            IStatement bound = _deleteSnapshot.Bind(metadata.PersistenceId, metadata.SequenceNr)
+                                              .SetConsistencyLevel(_cassandraExtension.SnapshotStoreSettings.WriteConsistency);
+            return _session.ExecuteAsync(bound);
+        }
+
+        protected async Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        {
+            // Use a batch to delete all matching snapshots
+            var batch = new BatchStatement();
+
+            bool hasNextPage = true;
+            byte[] nextPageState = null;
+
+            while (hasNextPage)
+            {
+                // Get a page of metadata that match the criteria
+                IStatement getMetadata = _selectSnapshotMetadata.Bind(persistenceId, criteria.MaxSequenceNr)
+                                                                .SetConsistencyLevel(_cassandraExtension.SnapshotStoreSettings.ReadConsistency)
+                                                                .SetPageSize(_cassandraExtension.SnapshotStoreSettings.MaxMetadataResultSize)
+                                                                .SetPagingState(nextPageState)
+                                                                .SetAutoPage(false);
+                RowSet metadataRows = await _session.ExecuteAsync(getMetadata).ConfigureAwait(false);
+
+                nextPageState = metadataRows.PagingState;
+                hasNextPage = nextPageState != null;
+                IEnumerable<SnapshotMetadata> page = metadataRows.Select(MapRowToSnapshotMetadata)
+                                                                 .Where(md => md.Timestamp <= criteria.MaxTimeStamp);
+                // Add any matching snapshots from the page to the batch
+                foreach (SnapshotMetadata md in page)
+                    batch.Add(_deleteSnapshot.Bind(md.PersistenceId, md.SequenceNr));
+
+                // Go to next page if available
+            }
+            
+            if (batch.IsEmpty)
+                return;
+
+            // Send the batch of deletes
+            batch.SetConsistencyLevel(_cassandraExtension.SnapshotStoreSettings.WriteConsistency);
+            await _session.ExecuteAsync(batch).ConfigureAwait(false);
+        }
+
+        protected override void Saved(SnapshotMetadata metadata)
+        {
+            // No op
+        }
+
+        protected override void Delete(SnapshotMetadata metadata)
+        {
+            // Should never get called
+            throw new NotSupportedException("Deletes are handled async by this snapshot store.");
+        }
+
+        protected override void Delete(string persistenceId, SnapshotSelectionCriteria criteria)
+        {
+            // Should never get called
+            throw new NotSupportedException("Deletes are handled async by this snapshot store.");
+        }
+
+        protected override void PostStop()
+        {
+            base.PostStop();
+
+            if (_cassandraExtension != null && _session != null)
+            {
+                _cassandraExtension.SessionManager.ReleaseSession(_session);
+                _session = null;
+            }
+        }
+
+        private async Task HandleDeleteAsync<T>(T message, Func<T, Task> handler)
+        {
+            try
+            {
+                // Capture event stream so we can use it after await
+                EventStream es = Context.System.EventStream;
+
+                // Delete async, then publish if necessary
+                await handler(message).ConfigureAwait(false);
+                if (_publish)
+                    es.Publish(message);
+            }
+            catch (Exception e)
+            {
+                _log.Error(e, "Unexpected error while deleting snapshot(s).");
+            }
+        }
+
+        private object Deserialize(byte[] bytes)
+        {
+            return ((Serialization.Snapshot) _serializer.FromBinary(bytes, SnapshotType)).Data;
+        }
+
+        private byte[] Serialize(object snapshotData)
+        {
+            return _serializer.ToBinary(new Serialization.Snapshot(snapshotData));
+        }
+
+        private static SnapshotMetadata MapRowToSnapshotMetadata(Row row)
+        {
+            return new SnapshotMetadata(row.GetValue<string>("persistence_id"), row.GetValue<long>("sequence_number"),
+                                        new DateTime(row.GetValue<long>("timestamp_ticks")));
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Cassandra/Snapshot/CassandraSnapshotStoreSettings.cs
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra/Snapshot/CassandraSnapshotStoreSettings.cs
@@ -1,0 +1,22 @@
+﻿using Akka.Configuration;
+
+namespace Akka.Persistence.Cassandra.Snapshot
+{
+    /// <summary>
+    /// Settings for the Cassandra snapshot store implementation, parsed from HOCON configuration.
+    /// </summary>
+    public class CassandraSnapshotStoreSettings : CassandraSettings
+    {
+        /// <summary>
+        /// The maximum number of snapshot metadata records to retrieve in a single request when trying to find
+        /// snapshots that meet criteria.
+        /// </summary>
+        public int MaxMetadataResultSize { get; private set; }
+
+        public CassandraSnapshotStoreSettings(Config config) 
+            : base(config)
+        {
+            MaxMetadataResultSize = config.GetInt("max-metadata-result-size");
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Cassandra/Snapshot/SnapshotStoreStatements.cs
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra/Snapshot/SnapshotStoreStatements.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Cassandra;
+
+namespace Akka.Persistence.Cassandra.Snapshot
+{
+    /// <summary>
+    /// CQL strings used by the CassandraSnapshotStore.
+    /// </summary>
+    internal static class SnapshotStoreStatements
+    {
+        public const string CreateKeyspace = @"
+            CREATE KEYSPACE IF NOT EXISTS {0}
+            WITH {1}";
+
+        public const string CreateTable = @"
+            CREATE TABLE IF NOT EXISTS {0} (
+                persistence_id text,
+                sequence_number bigint,
+                timestamp_ticks bigint,
+                snapshot blob,
+                PRIMARY KEY (persistence_id, sequence_number)
+            ) WITH CLUSTERING ORDER BY (sequence_number DESC){1}{2}";
+
+        public const string WriteSnapshot = @"
+            INSERT INTO {0} (persistence_id, sequence_number, timestamp_ticks, snapshot)
+            VALUES (?, ?, ?, ?)";
+
+        public const string DeleteSnapshot = @"
+            DELETE FROM {0} WHERE persistence_id = ? AND sequence_number = ?";
+
+        public const string SelectSnapshot = @"
+            SELECT snapshot FROM {0} WHERE persistence_id = ? AND sequence_number = ?";
+
+        public const string SelectSnapshotMetadata = @"
+            SELECT persistence_id, sequence_number, timestamp_ticks FROM {0}
+            WHERE persistence_id = ? AND sequence_number <= ?";
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Cassandra/packages.config
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="CassandraCSharpDriver" version="2.5.2" targetFramework="net45" />
+  <package id="lz4net" version="1.0.5.93" targetFramework="net45" />
+</packages>

--- a/src/contrib/persistence/Akka.Persistence.Cassandra/reference.conf
+++ b/src/contrib/persistence/Akka.Persistence.Cassandra/reference.conf
@@ -1,0 +1,95 @@
+﻿cassandra-sessions {
+
+  # The "default" Cassandra session, used by both the journal and snapshot store if not changed in 
+  # the cassandra-journal and cassandra-snapshot-store configuration sections below
+  default {
+
+    # Comma-seperated list of contact points in the cluster in the format of either [host] or [host:port]
+    contact-points = [ "127.0.0.1" ]
+
+    # Default port for contact points in the cluster, used if a contact point is not in [host:port] format
+    port = 9042
+  }
+}
+
+cassandra-journal {
+
+  # Type name of the cassandra journal plugin
+  class = "Akka.Persistence.Cassandra.Journal.CassandraJournal, Akka.Persistence.Cassandra"
+
+  # The name (key) of the session to use when resolving an ISession instance. When using default session management,
+  # this points at configuration under the "cassandra-sessions" section where the session's configuration is found.
+  session-key = "default"
+
+  # Whether or not to quote table and keyspace names when executing statements against Cassandra
+  use-quoted-identifiers = false
+
+  # The keyspace to be created/used by the journal
+  keyspace = "akkanet"
+
+  # A string to be appended to the CREATE KEYSPACE statement after the WITH clause when the keyspace is 
+  # automatically created. Use this to define options like replication strategy.
+  keyspace-creation-options = "REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }"
+
+  # When true the journal will automatically try to create the keyspace if it doesn't already exist on start
+  keyspace-autocreate = true
+
+  # Name of the table to be created/used by the journal
+  table = "messages"
+
+  # A string to be appended to the CREATE TABLE statement after the WITH clause. Use this to define things
+  # like gc_grace_seconds or one of the many other table options.
+  table-creation-properties = ""
+
+  # The approximate number of rows per partition to use. Cannot be changed after table creation.
+  partition-size = 5000000
+
+  # The maximum number of messages to retrieve in one request when replaying messages
+  max-result-size = 50001
+  
+  # Consistency level for reads
+  read-consistency = "Quorum"
+
+  # Consistency level for writes
+  write-consistency = "Quorum"
+}
+
+cassandra-snapshot-store {
+
+  # Type name of the cassandra snapshot store plugin
+  class = "Akka.Persistence.Cassandra.Snapshot.CassandraSnapshotStore, Akka.Persistence.Cassandra"
+
+  # The name (key) of the session to use when resolving an ISession instance. When using default session management,
+  # this points at configuration under the "cassandra-sessions" section where the session's configuration is found.
+  session-key = "default"
+
+  # Whether or not to quote table and keyspace names when executing statements against Cassandra
+  use-quoted-identifiers = false
+
+  # The keyspace to be created/used by the snapshot store
+  keyspace = "akkanet"
+
+  # A string to be appended to the CREATE KEYSPACE statement after the WITH clause when the keyspace is 
+  # automatically created. Use this to define options like replication strategy.
+  keyspace-creation-options = "REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }"
+
+  # When true the journal will automatically try to create the keyspace if it doesn't already exist on start
+  keyspace-autocreate = true
+
+  # Name of the table to be created/used by the snapshot store
+  table = "snapshots"
+
+  # A string to be appended to the CREATE TABLE statement after the WITH clause. Use this to define things
+  # like gc_grace_seconds or one of the many other table options.
+  table-creation-properties = ""
+
+  # The maximum number of snapshot metadata instances to retrieve in a single request when trying to find a
+  # snapshot that matches the criteria
+  max-metadata-result-size = 10
+  
+  # Consistency level for reads
+  read-consistency = "One"
+
+  # Consistency level for writes
+  write-consistency = "One"
+}


### PR DESCRIPTION
- Based partially on the great Scala version by Martin Krasser (https://github.com/krasserm/akka-persistence-cassandra)

- Modified from Scala version:
    * Different schema for the Journal to try and avoid reading tombstones if using permanent deletions
    * Ensures batches of writes in the Journal will only go to one partition to ensure atomicity and isolation
    * Share ISession instance from DataStax driver across journal and session by default
    * Make ISession resolution pluggable (allows for more advanced creation options and possible DI integration)

- Implementations for both Journal and Snapshot Store passing specs

- Readme with instructions for setup

- Separate task in build script for running tests