### PR TITLE
Replaced DateTime.Now with DateTime.UtcNow/MonotonicClock

### DIFF
--- a/src/core/Akka.Cluster/ClusterMetricsCollector.cs
+++ b/src/core/Akka.Cluster/ClusterMetricsCollector.cs
@@ -623,7 +623,7 @@ namespace Akka.Cluster
 
         public static long NewTimestamp()
         {
-            return DateTime.Now.Ticks;
+            return DateTime.UtcNow.Ticks;
         }
 
         public sealed class SystemMemory

--- a/src/core/Akka.Persistence/AtLeastOnceDelivery.cs
+++ b/src/core/Akka.Persistence/AtLeastOnceDelivery.cs
@@ -209,7 +209,7 @@ namespace Akka.Persistence
             }
 
             var deliveryId = NextDeliverySequenceNr();
-            var now = IsRecovering ? DateTime.Now - RedeliverInterval : DateTime.Now;
+            var now = IsRecovering ? DateTime.UtcNow - RedeliverInterval : DateTime.UtcNow;
             var delivery = new Delivery(destination, deliveryMessageMapper(deliveryId), now, attempt: 0);
 
             if (IsRecovering)
@@ -254,7 +254,7 @@ namespace Akka.Persistence
         public void SetDeliverySnapshot(AtLeastOnceDeliverySnapshot snapshot)
         {
             _deliverySequenceNr = snapshot.DeliveryId;
-            var now = DateTime.Now;
+            var now = DateTime.UtcNow;
             var unconfirmedDeliveries = snapshot.UnconfirmedDeliveries
                 .Select(u => new KeyValuePair<long, Delivery>(u.DeliveryId, new Delivery(u.Destination, u.Message, now, 0)));
 
@@ -302,7 +302,7 @@ namespace Akka.Persistence
 
         private void RedeliverOverdue()
         {
-            var now = DateTime.Now;
+            var now = DateTime.UtcNow;
             var deadline = now - RedeliverInterval;
             var warnings = new List<UnconfirmedDelivery>();
 

--- a/src/core/Akka.Persistence/Snapshot/SnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/SnapshotStore.cs
@@ -42,7 +42,7 @@ namespace Akka.Persistence.Snapshot
             else if (message is SaveSnapshot)
             {
                 var msg = (SaveSnapshot)message;
-                var metadata = new SnapshotMetadata(msg.Metadata.PersistenceId, msg.Metadata.SequenceNr, DateTime.Now);
+                var metadata = new SnapshotMetadata(msg.Metadata.PersistenceId, msg.Metadata.SequenceNr, DateTime.UtcNow);
 
                 SaveAsync(metadata, msg.Snapshot).ContinueWith(t => !t.IsFaulted
                         ? (object)new SaveSnapshotSuccess(metadata)

--- a/src/core/Akka.Remote/Deadline.cs
+++ b/src/core/Akka.Remote/Deadline.cs
@@ -21,12 +21,12 @@ namespace Akka.Remote
 
         public bool IsOverdue
         {
-            get { return DateTime.Now > When; }
+            get { return DateTime.UtcNow > When; }
         }
 
         public bool HasTimeLeft
         {
-            get { return DateTime.Now < When; }
+            get { return DateTime.UtcNow < When; }
         }
 
         public DateTime When { get; private set; }
@@ -34,7 +34,7 @@ namespace Akka.Remote
         /// <summary>
         /// Warning: creates a new <see cref="TimeSpan"/> instance each time it's used
         /// </summary>
-        public TimeSpan TimeLeft { get { return When - DateTime.Now; } }
+        public TimeSpan TimeLeft { get { return When - DateTime.UtcNow; } }
 
         #region Overrides
 
@@ -60,13 +60,13 @@ namespace Akka.Remote
         #region Static members
 
         /// <summary>
-        /// Returns a deadline that is due <see cref="DateTime.Now"/>
+        /// Returns a deadline that is due <see cref="DateTime.UtcNow"/>
         /// </summary>
         public static Deadline Now
         {
             get
             {
-                return new Deadline(DateTime.Now);
+                return new Deadline(DateTime.UtcNow);
             }
         }
 

--- a/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
@@ -11,6 +11,7 @@ using Akka.TestKit;
 using Xunit;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Akka.Tests.Actor
 {
@@ -54,11 +55,10 @@ namespace Akka.Tests.Actor
         {
             var actorSystem = ActorSystem
                 .Create(Guid.NewGuid().ToString());
-            var startTime = DateTime.UtcNow;
+            var st = Stopwatch.StartNew();
             var asyncShutdownTask = Task.Delay(TimeSpan.FromSeconds(1)).ContinueWith(_ => actorSystem.Shutdown());
             actorSystem.AwaitTermination(TimeSpan.FromSeconds(2)).ShouldBeTrue();
-            var endTime = DateTime.UtcNow;
-            Assert.True((endTime - startTime).TotalSeconds >= .9);
+            Assert.True(st.Elapsed.TotalSeconds >= .9);
         }
 
         [Fact]

--- a/src/core/Akka.Tests/Actor/InboxSpec.cs
+++ b/src/core/Akka.Tests/Actor/InboxSpec.cs
@@ -138,7 +138,7 @@ namespace Akka.Tests.Actor
         [Fact]
         public void Select_WithClient_should_update_Client_and_copy_the_rest_of_the_properties_BUG_427()
         {
-            var deadline = new DateTime(1919, 5, 24);
+            var deadline = new TimeSpan(Sys.Scheduler.MonotonicClock.Ticks/2); //Some point in the past
             Predicate<object> predicate = o => true;
             var actorRef = new EmptyLocalActorRef(((ActorSystemImpl)Sys).Provider, new RootActorPath(new Address("akka", "test")), Sys.EventStream);
             var select = new Select(deadline, predicate, actorRef);

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/ChildStats.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/ChildStats.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using Akka.Util;
 
 namespace Akka.Actor.Internal
 {
@@ -79,7 +80,7 @@ namespace Akka.Actor.Internal
             // after a restart and if enough restarts happen during this time, it
             // denies. Otherwise window closes and the scheme starts over.
             var retriesDone = _maxNrOfRetriesCount + 1;
-            var now = DateTime.Now.Ticks;
+            var now = MonotonicClock.Elapsed.Ticks;
             long windowStart;
             if (_restartTimeWindowStartTicks == 0)
             {

--- a/src/core/Akka/Actor/Inbox.Actor.cs
+++ b/src/core/Akka/Actor/Inbox.Actor.cs
@@ -22,7 +22,7 @@ namespace Akka.Actor
 
         private object _currentMessage;
         private Select? _currentSelect;
-        private Tuple<DateTime, ICancelable> _currentDeadline;
+        private Tuple<TimeSpan, ICancelable> _currentDeadline;
 
         private int _size;
         private ILoggingAdapter _log = Context.GetLogger();
@@ -120,7 +120,7 @@ namespace Akka.Actor
                 .With<StopWatch>(sw => Context.Unwatch(sw.Target))
                 .With<Kick>(() =>
                 {
-                    var now = DateTime.Now;
+                    var now = Context.System.Scheduler.MonotonicClock;
                     var overdue = _clientsByTimeout.TakeWhile(q => q.Deadline < now);
                     foreach (var query in overdue)
                     {
@@ -169,7 +169,7 @@ namespace Akka.Actor
                     {
                         _currentDeadline.Item2.Cancel();
                     }
-                    var cancelable = Context.System.Scheduler.ScheduleTellOnceCancelable(next.Deadline - DateTime.Now, Self, new Kick(), Self);
+                    var cancelable = Context.System.Scheduler.ScheduleTellOnceCancelable(next.Deadline - Context.System.Scheduler.MonotonicClock, Self, new Kick(), Self);
 
                     _currentDeadline = Tuple.Create(next.Deadline, cancelable);
                 }

--- a/src/core/Akka/Actor/Inbox.cs
+++ b/src/core/Akka/Actor/Inbox.cs
@@ -16,21 +16,21 @@ namespace Akka.Actor
 {
     internal interface IQuery
     {
-        DateTime Deadline { get; }
+        TimeSpan Deadline { get; }
         IActorRef Client { get; }
         IQuery WithClient(IActorRef client);
     }
 
     internal struct Get : IQuery
     {
-        public Get(DateTime deadline, IActorRef client = null)
+        public Get(TimeSpan deadline, IActorRef client = null)
             : this()
         {
             Deadline = deadline;
             Client = client;
         }
 
-        public DateTime Deadline { get; private set; }
+        public TimeSpan Deadline { get; private set; }
         public IActorRef Client { get; private set; }
         public IQuery WithClient(IActorRef client)
         {
@@ -40,7 +40,7 @@ namespace Akka.Actor
 
     internal struct Select : IQuery
     {
-        public Select(DateTime deadline, Predicate<object> predicate, IActorRef client = null)
+        public Select(TimeSpan deadline, Predicate<object> predicate, IActorRef client = null)
             : this()
         {
             Deadline = deadline;
@@ -48,7 +48,7 @@ namespace Akka.Actor
             Client = client;
         }
 
-        public DateTime Deadline { get; private set; }
+        public TimeSpan Deadline { get; private set; }
         public Predicate<object> Predicate { get; set; }
         public IActorRef Client { get; private set; }
         public IQuery WithClient(IActorRef client)
@@ -319,7 +319,7 @@ namespace Akka.Actor
 
         public object ReceiveWhere(Predicate<object> predicate, TimeSpan timeout)
         {
-            var task = Receiver.Ask(new Select(DateTime.Now + timeout, predicate), Timeout.InfiniteTimeSpan);
+            var task = Receiver.Ask(new Select(_system.Scheduler.MonotonicClock + timeout, predicate), Timeout.InfiniteTimeSpan);
             return AwaitResult(task, timeout);
         }
 
@@ -330,7 +330,7 @@ namespace Akka.Actor
 
         public Task<object> ReceiveAsync(TimeSpan timeout)
         {
-            return Receiver.Ask(new Get(DateTime.Now + timeout), Timeout.InfiniteTimeSpan);
+            return Receiver.Ask(new Get(_system.Scheduler.MonotonicClock + timeout), Timeout.InfiniteTimeSpan);
         }
 
         public void Dispose()

--- a/src/core/Akka/Event/LogEvent.cs
+++ b/src/core/Akka/Event/LogEvent.cs
@@ -21,7 +21,7 @@ namespace Akka.Event
         /// </summary>
         protected LogEvent()
         {
-            Timestamp = DateTime.Now;
+            Timestamp = DateTime.UtcNow;
             Thread = Thread.CurrentThread;
         }
 

--- a/src/examples/TimeServer/TimeServer/Program.cs
+++ b/src/examples/TimeServer/TimeServer/Program.cs
@@ -33,7 +33,7 @@ namespace TimeServer
             {
                 if (message.ToLowerInvariant() == "gettime")
                 {
-                    var time =DateTime.Now.ToLongTimeString();
+                    var time =DateTime.UtcNow.ToLongTimeString();
                     Sender.Tell(time, Self);
                 }
                 else


### PR DESCRIPTION
#846

In some cases (like Akka.Persistence) it seems that some long-term timestamp is needed, not ephemeral one (which monotonic clock is), so there I've replaced  `DateTime.Now` with `DateTime.UtcNow`, which should be safe but still improve things regarding daylight saving transitions.

I think that current time offset is irrelevant even for logging purposes, so I've replaced it there too.