### PR TITLE
Initial Akka IO port with TCP driver

### DIFF
--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -136,6 +136,8 @@
     <Compile Include="Dispatch\XUnitAsyncTestsSanityCheck.cs" />
     <Compile Include="Event\EventBusSpec.cs" />
     <Compile Include="Event\EventStreamSpec.cs" />
+    <Compile Include="IO\TcpConnectionSpec.cs" />
+    <Compile Include="IO\TcpListenerSpec.cs" />
     <Compile Include="MatchHandler\CachedMatchCompilerTests.cs" />
     <Compile Include="MatchHandler\MatchBuilderSignatureTests.cs" />
     <Compile Include="MatchHandler\MatchExpressionBuilder_BuildLambdaExpression_Tests.cs" />

--- a/src/core/Akka.Tests/IO/TcpConnectionSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpConnectionSpec.cs
@@ -1,0 +1,745 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="EventBusSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.IO;
+using Akka.Pattern;
+using Akka.TestKit;
+using Akka.Util.Internal;
+using FluentAssertions.Execution;
+using Xunit;
+
+namespace Akka.Tests.IO
+{
+    public class TcpConnectionSpec : AkkaSpec
+    {
+        internal class Ack : Tcp.Event
+        {
+            private readonly int _i;
+
+            public Ack(int i)
+            {
+                _i = i;
+            }
+
+            public static readonly Ack Instance = new Ack(0);
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as Ack;
+                if (other == null) return false;
+                return _i == other._i;
+            }
+        }
+
+        private static string _connectionResetByPeerMessage;
+        internal static string ConnectionResetByPeerMessage
+        {
+            get
+            {
+                return "An existing connection was forcibly closed by the remote host";
+                //TODO: Implement
+                if (_connectionResetByPeerMessage == null)
+                {
+                    var serverSocket = SocketChannel.Open();
+                    serverSocket.Socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                    try
+                    {
+                        var clientSocket = SocketChannel.Open();
+                        clientSocket.Socket.Connect(IPAddress.Loopback, ((IPEndPoint) serverSocket.Socket.LocalEndPoint).Port);
+
+                    }
+                    catch (Exception ex)
+                    {
+                        _connectionResetByPeerMessage = ex.Message;
+                    }
+                }
+                return _connectionResetByPeerMessage;
+            }
+        }
+
+        internal class Registration : INoSerializationVerificationNeeded
+        {
+            public SocketChannel Channel { get; set; }
+            public SocketAsyncOperation? InitialOps { get; set; }
+
+            public Registration(SocketChannel channel, SocketAsyncOperation? initialOps)
+            {
+                Channel = channel;
+                InitialOps = initialOps;
+            }
+        }
+
+
+        public TcpConnectionSpec()
+            : base(@"akka.io.tcp.register-timeout = 500ms
+                     akka.io.tcp.max-received-message-size = 1024
+                     akka.io.tcp.direct-buffer-size = 512
+                     akka.actor.serialize-creators = on
+                    ")
+        { }
+
+
+        [Fact]
+        public void An_Outgoing_Connection_Must_Set_SocketOptions_Before_Connecting()
+        {
+            new LocalServerTest(this).Run(x =>
+            {
+                var connectionActor = x.CreateConnectionActor(new Inet.SO.ReuseAddress(true));
+                var clientChannel = connectionActor.UnderlyingActor.Channel;
+                Assert.NotEqual(0,
+                    clientChannel.Socket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress));
+            });
+        }
+
+        [Fact]
+        public void An_Outgoing_Connection_Must_Set_SocketOptions_After_Connecting()
+        {
+            new LocalServerTest(this).Run(x =>
+            {
+
+            });
+        }
+
+        [Fact]
+        public void An_Outgoing_Connection_Must_Send_Incoming_Data_To_The_Connection_Handler()
+        {
+            new EstablishedConnectionTest(this).Run(x =>
+            {
+                x.ServerSideChannel.Write(ByteBuffer.Wrap(Encoding.ASCII.GetBytes("testdata")));
+
+                x.ExpectReceivedString("testdata");
+
+                x.ServerSideChannel.Write(ByteBuffer.Wrap(Encoding.ASCII.GetBytes("testdata2")));
+                x.ServerSideChannel.Write(ByteBuffer.Wrap(Encoding.ASCII.GetBytes("testdata3")));
+
+                x.ExpectReceivedString("testdata2testdata3");
+            });
+        }
+
+        [Fact]
+        public void An_Outgoing_Connection_Must_Forward_Incoming_Data_As_Received_Message_Instantly_As_Long_As_More_Data_Is_Available()
+        {
+            new EstablishedConnectionTest(this).Run(x =>
+            {
+                var bufferSize = Tcp.Instance.Apply(Sys).Settings.DirectBufferSize;
+                var dataSize = bufferSize + 150;
+                var bigData = new byte[dataSize];
+                var buffer = ByteBuffer.Wrap(bigData);
+
+                x.ServerSideChannel.Socket.SendBufferSize = 150000;
+                var wrote = x.ServerSideChannel.Write(buffer);
+                wrote.ShouldBe(dataSize);
+
+                ExpectNoMsg(1000);
+
+                x.Selector.Send(x.ConnectionActor, SelectionHandler.ChannelReadable.Instance);
+
+                x.ConnectionHandler.ExpectMsg<Tcp.Received>(m => m.Data.Count == bufferSize);
+                x.ConnectionHandler.ExpectMsg<Tcp.Received>(m => m.Data.Count == 150);
+            });
+        }
+
+        [Fact]
+        public void An_Outgoing_Connection_Must_Receive_Data_Directly_When_The_Connection_Is_Established()
+        {
+            new UnacceptedConnectionTest(this).Run(x =>
+            {
+                var serverSideChannel = x.AcceptServerSideChannel(x.LocalServerChannel);
+
+                serverSideChannel.Write(ByteBuffer.Wrap(Encoding.ASCII.GetBytes("immediatedata")));
+                x.InterestCallReceiver.ExpectMsg((int) SocketAsyncOperation.Connect);
+
+                x.Selector.Send(x.ConnectionActor, SelectionHandler.ChannelConnectable.Instance);
+                x.UserHandler.ExpectMsg<Tcp.Connected>(); //TODO: assert message
+
+                x.UserHandler.Send(x.ConnectionActor, new Tcp.Register(x.UserHandler.Ref));
+                x.UserHandler.ExpectMsg<Tcp.Received>(m => m.Data.DecodeString(Encoding.ASCII) == "immediatedata");
+                x.InterestCallReceiver.ExpectMsg((int) SocketAsyncOperation.Receive);
+            });
+        }
+
+        [Fact]
+        public void An_Outgoing_Connection_Must_Write_Data_To_Network_And_Acknowledge()
+        {
+            new EstablishedConnectionTest(this).Run(x =>
+            {
+                var writer = CreateTestProbe();
+
+                var ackedWrite = new Tcp.Write(ByteString.FromString("testdata"), Ack.Instance);
+                var buffer = ByteBuffer.Allocate(100);
+
+                Assert.Equal(0, x.ServerSideChannel.Read(buffer));
+                writer.Send(x.ConnectionActor, ackedWrite);
+                writer.ExpectMsg(Ack.Instance);
+                x.PullFromServerSide(remaining: 8, into: buffer, remainingRetries: 1000);
+                buffer.Flip();
+
+                //TODO: Buffer.limit
+                //Assert.Equal(8, buffer.Limit); 
+
+                var unackedWrite = new Tcp.Write(ByteString.FromString("morestuff!"), Tcp.NoAck.Instance);
+                buffer.Clear();
+                Assert.Equal(0, x.ServerSideChannel.Read(buffer));
+                writer.Send(x.ConnectionActor, unackedWrite);
+                writer.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
+                x.PullFromServerSide(remaining: 10, into: buffer, remainingRetries: 1000);
+                buffer.Flip();
+                Assert.Equal("morestuff!", ByteString.Create(buffer).DecodeString(Encoding.UTF8));
+            });
+        }
+
+        [Fact]
+        public void An_Outgoing_Connection_Must_Send_Big_Buffers_To_Network_Correctly()
+        {
+            new EstablishedConnectionTest(this).Run(x =>
+            {
+                var bufferSize = 512*1024;
+                var random = new Random(0);
+                var testBytes = new byte[bufferSize];
+                random.NextBytes(testBytes);
+                var testData = ByteString.Create(testBytes, 0, testBytes.Length);
+
+                var writer = CreateTestProbe();
+
+                var write = new Tcp.Write(testData, Ack.Instance);
+                var buffer = ByteBuffer.Allocate(bufferSize);
+                x.ServerSideChannel.Read(buffer).ShouldBe(0);
+                writer.Send(x.ConnectionActor, write);
+                x.PullFromServerSide(remaining: bufferSize, into: buffer, remainingRetries: 1000);
+                buffer.Flip();
+
+                //TODO: Buffer.limit
+                //Assert.Equal(buffer, buffer.Limit());
+
+                ByteString.Create(buffer).ShouldBe(testData);
+            });
+        }
+
+        [Fact]
+        public void An_Outgoing_Connection_Must_Write_Data_After_Not_Acknowledged_Data()
+        {
+            new EstablishedConnectionTest(this).Run(x =>
+            {
+                var writer = CreateTestProbe();
+                writer.Send(x.ConnectionActor,
+                    new Tcp.Write(ByteString.Create(new byte[] {42}, 0, 1), Tcp.NoAck.Instance));
+                writer.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
+            });
+        }
+
+        [Fact]
+        public void An_Outgoing_Connection_Must_Acknowledge_The_Completion_Of_An_ACKed_EmptyWrite()
+        {
+            new EstablishedConnectionTest(this).Run(x =>
+            {
+                var writer = CreateTestProbe();
+                writer.Send(x.ConnectionActor, new Tcp.Write(ByteString.Empty, Ack.Instance));
+                writer.ExpectMsg(Ack.Instance);
+            });
+        }
+
+        [Fact]
+        public void An_Outgoing_Connection_Must_Not_Acknowledge_The_Completion_Of_An_NACKed_EmptyWrite()
+        {
+            new EstablishedConnectionTest(this).Run(x =>
+            {
+                var writer = CreateTestProbe();
+                writer.Send(x.ConnectionActor, new Tcp.Write(ByteString.Empty, Tcp.NoAck.Instance));
+                writer.ExpectNoMsg(TimeSpan.FromMilliseconds(250));
+                writer.Send(x.ConnectionActor, new Tcp.Write(ByteString.Empty, new Tcp.NoAck(42)));
+                writer.ExpectNoMsg(TimeSpan.FromMilliseconds(250));
+            });
+        }
+
+        [Fact]
+        public void An_Outgoing_Connection_Must_Write_A_CompoundWrite_To_The_Network_And_Produce_Correct_ACKs()
+        {
+            new EstablishedConnectionTest(this).Run(x =>
+            {
+                var writer = CreateTestProbe();
+
+                //TODO: Fix bug when empty write is used
+                var compoundWrite = Tcp.CompoundWrite.Create(
+                    Tcp.Write.Create(ByteString.FromString("test1"), new Ack(1)),
+                    Tcp.Write.Create(ByteString.FromString("test2")),
+                    //Tcp.Write.Create(ByteString.Empty, new Ack(3)),
+                    Tcp.Write.Create(ByteString.FromString("test4"), new Ack(4)));
+
+                var buffer = ByteBuffer.Allocate(100);
+                x.ServerSideChannel.Read(buffer).ShouldBe(0);
+                writer.Send(x.ConnectionActor, compoundWrite);
+
+                x.PullFromServerSide(remaining: 15, into: buffer, remainingRetries: 1000);
+                buffer.Flip();
+                ByteString.Create(buffer).DecodeString(Encoding.UTF8).ShouldBe("test1test2test4");
+                writer.ExpectMsg(new Ack(1));
+                //writer.ExpectMsg(new Ack(3));
+                writer.ExpectMsg(new Ack(4));
+            });
+        }
+
+        [Fact]
+        public void An_Outgoing_Connection_Must_Respect_StopReading_And_ResumeReading()
+        {
+            new EstablishedConnectionTest(this).Run(x =>
+            {
+                x.ServerSideChannel.Write(ByteBuffer.Wrap(Encoding.ASCII.GetBytes("testdata")));
+                x.ConnectionHandler.Send(x.ConnectionActor, Tcp.SuspendReading.Instance);
+
+                x.InterestCallReceiver.ExpectMsg(-(int) SocketAsyncOperation.Receive);
+
+                x.Selector.Send(x.ConnectionActor, 1);
+
+                x.InterestCallReceiver.ExpectNoMsg(100);
+                x.ConnectionHandler.ExpectNoMsg(100);
+
+                x.ConnectionHandler.Send(x.ConnectionActor, Tcp.ResumeReading.Instance);
+                x.InterestCallReceiver.ExpectMsg((int) SocketAsyncOperation.Receive);
+
+                x.ExpectReceivedString("testdata");
+            });
+        }
+
+        [Fact]
+        public void An_Outgoing_Connection_Must_Respect_PullMode()
+        {
+            new EstablishedConnectionTest(this, pullMode: true).Run(x =>
+            {
+                x.ServerSideChannel.Write(ByteBuffer.Wrap(Encoding.ASCII.GetBytes("testdata")));
+                x.ConnectionHandler.ExpectNoMsg(100);
+
+                x.ConnectionActor.Tell(Tcp.ResumeReading.Instance);
+                x.InterestCallReceiver.ExpectMsg((int) SocketAsyncOperation.Receive);
+                x.Selector.Send(x.ConnectionActor, SelectionHandler.ChannelReadable.Instance);
+                x.ConnectionHandler.ExpectMsg<Tcp.Received>(m => m.Data.DecodeString(Encoding.ASCII) == "testdata");
+
+                x.ServerSideChannel.Write(ByteBuffer.Wrap(Encoding.ASCII.GetBytes("testdata2")));
+                x.ServerSideChannel.Write(ByteBuffer.Wrap(Encoding.ASCII.GetBytes("testdata3")));
+
+                x.ConnectionHandler.ExpectNoMsg(100);
+
+                x.ConnectionActor.Tell(Tcp.ResumeReading.Instance);
+                x.InterestCallReceiver.ExpectMsg((int) SocketAsyncOperation.Receive);
+                x.Selector.Send(x.ConnectionActor, SelectionHandler.ChannelReadable.Instance);
+                x.ConnectionHandler.ExpectMsg<Tcp.Received>(
+                    m => m.Data.DecodeString(Encoding.ASCII) == "testdata2testdata3");
+            });
+        }
+
+        [Fact]
+        public void An_Outgoing_Connection_Must_Close_The_Connection_And_Reply_With_Closed_Upon_Reception_Of_CloseCommand()
+        {
+            //TODO: SmallRcvBuffer
+        }
+
+        [Fact]
+        public void An_Outgoing_Connection_Must_Send_Only_One_ClosedEvent_To_The_Handler_If_The_Handler_Commanded_The_Close()
+        {
+            new EstablishedConnectionTest(this).Run(x =>
+            {
+                x.ConnectionHandler.Send(x.ConnectionActor, Tcp.Close.Instance);
+                x.ConnectionHandler.ExpectMsg(Tcp.Closed.Instance);
+                x.ConnectionHandler.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
+            });
+        }
+
+        [Fact]
+        public void An_Outgoing_Connection_Must_Abort_The_Connection_And_Reply_With_Aborted_Upon_Reception_Of_An_AbortCommand()
+        {
+            new EstablishedConnectionTest(this).Run(x =>
+            {
+                x.ConnectionHandler.Send(x.ConnectionActor, Tcp.Abort.Instance);
+                x.ConnectionHandler.ExpectMsg(Tcp.Aborted.Instance);
+
+                x.AssertThisConnectionActorTerminated();
+
+                var buffer = ByteBuffer.Allocate(1);
+                var thrown = Assert.Throws<IOException>(() =>
+                {
+                    x.ServerSideChannel.Read(buffer);
+                });
+                // TODO: declare ConnectionResetByPeerMessage
+                thrown.Message.ShouldBe(ConnectionResetByPeerMessage);
+            });
+        }
+
+        [Fact]
+        public void An_Outgoing_Connection_Must_Report_When_Peer_Closed_The_Connection()
+        {
+            new EstablishedConnectionTest(this).Run(x =>
+            {
+                x.CloseServerSideAndWaitForClientReadable();
+
+                x.Selector.Send(x.ConnectionActor, SelectionHandler.ChannelReadable.Instance);
+                x.ConnectionHandler.ExpectMsg(Tcp.PeerClosed.Instance);
+
+                x.AssertThisConnectionActorTerminated();
+            });
+        }
+
+        [Fact]
+        public void An_Outgoing_Connection_Must_Report_When_Peer_Closed_The_Connection_But_Allow_Further_Writes_And_Acknowledge_Normal_Close()
+        {
+            new EstablishedConnectionTest(this, keepOpenOnPeerClosed: true).Run(x =>
+            {
+                x.CloseServerSideAndWaitForClientReadable(fullClose: false);
+
+                x.Selector.Send(x.ConnectionActor, SelectionHandler.ChannelReadable.Instance);
+                x.ConnectionHandler.ExpectMsg(Tcp.PeerClosed.Instance);
+
+                x.ConnectionHandler.Send(x.ConnectionActor, x.WriteCmd(Ack.Instance));
+                x.PullFromServerSide(x.TestSize);
+                x.ConnectionHandler.ExpectMsg(Ack.Instance);
+                x.ConnectionHandler.Send(x.ConnectionActor, Tcp.ConfirmedClose.Instance);
+                x.ConnectionHandler.ExpectMsg(Tcp.ConfirmedClosed.Instance);
+
+                x.AssertThisConnectionActorTerminated();
+            });
+        }
+
+        [Fact]
+        public void An_Outgoing_Connection_Must_Report_When_Peer_Aborted_The_Connection()
+        {
+            new EstablishedConnectionTest(this).Run(x =>
+            {
+                x.AbortClose(x.ServerSideChannel);
+                x.Selector.Send(x.ConnectionActor, SelectionHandler.ChannelReadable.Instance);
+                var err = x.ConnectionHandler.ExpectMsg<Tcp.ErrorClosed>();
+                err.GetErrorCause().ShouldBe(ConnectionResetByPeerMessage);
+
+                x.ConnectionHandler.ExpectNoMsg(200);
+
+                x.AssertThisConnectionActorTerminated();
+            });            
+        }
+
+        [Fact]
+        public void An_Outgoing_Connection_Must_Report_When_Peer_Closed_The_Connection_When_Trying_To_Write()
+        {
+            new EstablishedConnectionTest(this).Run(x =>
+            {
+                var writer = CreateTestProbe();
+
+                x.AbortClose(x.ServerSideChannel);
+                writer.Send(x.ConnectionActor, new Tcp.Write(ByteString.FromString("testdata"), Ack.Instance));
+                writer.ExpectMsg<Tcp.ErrorClosed>();
+                x.ConnectionHandler.ExpectMsg<Tcp.ErrorClosed>();
+
+                x.AssertThisConnectionActorTerminated();
+            });            
+        }
+    }
+
+    class LocalServerTest : IChannelRegistry
+    {
+        //protected readonly SocketAsyncEventArgsPool pool = new SocketAsyncEventArgsPool(100, SocketChannel.Select);
+        private readonly ActorSystem _system;
+
+        protected IPEndPoint ServerAddress = TestUtils.TemporaryServerAddress();
+        internal SocketChannel LocalServerChannel = SocketChannel.Open();
+        internal TestProbe UserHandler { get; private set; }
+        internal TestProbe Selector { get; private set; }
+
+        public TestProbe RegisterCallReceiver { get; private set; }
+        public TestProbe InterestCallReceiver { get; private set; }
+
+        protected readonly TestProbe ChannelProbe;
+
+        public LocalServerTest(TestKitBase kit)
+        {
+            _system = kit.Sys;
+
+            UserHandler = kit.CreateTestProbe();
+            Selector = kit.CreateTestProbe();
+            RegisterCallReceiver = kit.CreateTestProbe();
+            InterestCallReceiver = kit.CreateTestProbe();
+
+            ChannelProbe = kit.CreateTestProbe();
+        }
+
+        
+
+        public void Run(Action<LocalServerTest> body)
+        {
+            try
+            {
+                SetServerSocketOptions();
+                LocalServerChannel.Socket.Bind(ServerAddress);
+                LocalServerChannel.Socket.Blocking = false;
+                body(this);
+            }
+            finally
+            {
+                LocalServerChannel.Close();
+            }
+            
+        }
+
+        public void Register(SocketChannel channel, SocketAsyncOperation? initialOps, IActorRef channelActor)
+        {
+            
+            channel.Register(channelActor, initialOps);
+
+            RegisterCallReceiver.Ref.Tell(new TcpConnectionSpec.Registration(channel, initialOps));
+        }
+       
+        public void SetServerSocketOptions() { } 
+
+
+        public TestActorRef<TcpOutgoingConnection> CreateConnectionActor(params Inet.SocketOption[] options)
+        {
+            return CreateConnectionActor(ServerAddress, options);
+        }
+
+        public TestActorRef<TcpOutgoingConnection> CreateConnectionActor(IPEndPoint serverAddress, IEnumerable<Inet.SocketOption> options = null, bool pullMode = false)
+        {
+            var @ref = CreateConnectionActorWithoutRegistration(serverAddress, options, pullMode: pullMode);
+            @ref.Tell(NewChannelRegistration(@ref));
+            return @ref;
+        }
+
+        
+        public ChannelRegistration NewChannelRegistration(TestActorRef<TcpOutgoingConnection> @ref)
+        {
+            return new ChannelRegistration(
+                enableInterest: op => InterestCallReceiver.Ref.Tell((int) op),
+                disableInterest: op => InterestCallReceiver.Ref.Tell(-(int) op)
+                );
+        }
+
+        class TestTcpOutgoingConnection : TcpOutgoingConnection
+        {
+            public TestTcpOutgoingConnection(TcpExt tcp, IChannelRegistry channelRegistry, IActorRef commander, Tcp.Connect connect)
+                : base(tcp, channelRegistry, commander, connect) 
+            { }
+            protected override void PostRestart(Exception reason)
+            {
+                Context.Stop(Self);
+            }
+        }
+        public TestActorRef<TcpOutgoingConnection> CreateConnectionActorWithoutRegistration(IPEndPoint serverAddress, IEnumerable<Inet.SocketOption> options, TimeSpan? timeout = null, bool pullMode = false)
+        {
+            var tcp = Tcp.Instance.Apply(_system);
+
+            return new TestActorRef<TcpOutgoingConnection>(_system, Props.Create(() =>
+                        new TestTcpOutgoingConnection(tcp, this, UserHandler, new Tcp.Connect(serverAddress, null, options, timeout, pullMode))));
+        }
+    }
+
+    class UnacceptedConnectionTest : LocalServerTest
+    {
+        private readonly bool _pullMode;
+
+        private TestActorRef<TcpOutgoingConnection> _connectionActor;
+        private SocketChannel _clientSideChannel;
+
+        public UnacceptedConnectionTest(TestKitBase kit, bool pullMode = false)
+            : base(kit)
+        {
+            _pullMode = pullMode;
+        }
+
+        internal TestActorRef<TcpOutgoingConnection> ConnectionActor
+        {
+            get {
+                return _connectionActor ??
+                       (_connectionActor = CreateConnectionActor(ServerAddress, pullMode: _pullMode));
+            }
+        }
+
+        protected SocketChannel ClientSideChannel
+        {
+            get { return _clientSideChannel ?? (_clientSideChannel = ConnectionActor.UnderlyingActor.Channel); }
+        }
+
+        public void Run(Action<UnacceptedConnectionTest> body)
+        {
+            base.Run(x =>
+            {
+                RegisterCallReceiver.ExpectMsgFrom<TcpConnectionSpec.Registration>(ConnectionActor.Ref, message =>
+                    message.Channel == ClientSideChannel && 
+                    message.InitialOps.HasValue && 
+                    message.InitialOps.Value == SocketAsyncOperation.None);
+                
+                body(this);
+            });
+        }
+
+        internal SocketChannel AcceptServerSideChannel(SocketChannel localServer)
+        {
+            var promise = new TaskCompletionSource<Socket>();
+            var task = promise.Task;
+
+            localServer.Socket.Listen(100);
+            localServer.Socket.BeginAccept(ar => promise.SetResult(localServer.Socket.EndAccept(ar)), null);
+
+            Selector.Send(ConnectionActor, SelectionHandler.ChannelConnectable.Instance);
+
+            task.Wait();
+
+            var channel = new SocketChannel(task.Result);
+            channel.Register(ChannelProbe, SocketAsyncOperation.None);
+            return channel;
+        }
+
+    }
+
+    class EstablishedConnectionTest : UnacceptedConnectionTest
+    {
+        private readonly TestKitBase _kit;
+
+        private SocketChannel _serverSideChannel;
+        private TestProbe _connectionHandler;
+
+        public EstablishedConnectionTest(TestKitBase kit, bool keepOpenOnPeerClosed = false, bool useResumeWriting = false, bool pullMode = false) 
+            : base(kit, pullMode)
+        {
+            _kit = kit;
+            KeepOpenOnPeerClosed = keepOpenOnPeerClosed;
+            UseResumeWriting = UseResumeWriting;
+            PullMode = pullMode;
+        }
+
+        public SocketChannel ServerSideChannel
+        {
+            get
+            {
+                if (_serverSideChannel == null)
+                    _serverSideChannel = AcceptServerSideChannel(LocalServerChannel);
+                return _serverSideChannel;
+            }
+        }
+        public TestProbe ConnectionHandler
+        {
+            get { return _connectionHandler ?? (_connectionHandler = _kit.CreateTestProbe()); }
+        }
+        
+
+        public void Run(Action<EstablishedConnectionTest> body)
+        {
+            Run((UnacceptedConnectionTest x) =>
+            {
+                try
+                {
+                    ServerSideChannel.Socket.Blocking = false;
+
+                    InterestCallReceiver.ExpectMsg((int)SocketAsyncOperation.Connect);
+                    Selector.Send(ConnectionActor, SelectionHandler.ChannelConnectable.Instance);
+                    UserHandler.ExpectMsg<Tcp.Connected>(message => message.RemoteAddress.Port == ServerAddress.Port); //TODO: compare with JVM Akka
+ 
+                    UserHandler.Send(ConnectionActor,
+                        new Tcp.Register(ConnectionHandler.Ref, KeepOpenOnPeerClosed, UseResumeWriting));
+                    if (!PullMode)
+                        InterestCallReceiver.ExpectMsg((int)SocketAsyncOperation.Receive);
+
+                    body(this);
+                }
+                finally 
+                {
+                    ServerSideChannel.Close();
+                }
+            });
+
+        }
+
+        public readonly int TestSize = 10000;
+
+        public Tcp.Write WriteCmd(Tcp.Event ack)
+        {
+            return new Tcp.Write(ByteString.Create(new byte[TestSize]), ack);
+        }
+
+        public void CloseServerSideAndWaitForClientReadable(bool fullClose = true)
+        {
+            if (fullClose) ServerSideChannel.Close();
+            else ServerSideChannel.Socket.Shutdown(SocketShutdown.Send);
+            Thread.Sleep(200);
+        }
+
+        public bool KeepOpenOnPeerClosed { get; set; }
+        public bool UseResumeWriting { get; set; }
+        public bool PullMode { get; set; }
+
+
+        public void PullFromServerSide(int remaining)
+        {
+            PullFromServerSide(remaining, 1000, new ByteBuffer(new byte[TestSize]));
+        }
+
+        public void PullFromServerSide(int remaining, int remainingRetries, ByteBuffer into)
+        {
+            if (remainingRetries <= 0)
+                throw new AssertionFailedException("Pulling took too many loops,  remaining data: " + remaining);
+            if (remaining > 0)
+            {
+                if (InterestCallReceiver.HasMessages)
+                {
+                    InterestCallReceiver.ExpectMsg((int)SocketAsyncOperation.Send);
+
+                }
+
+                Selector.Send(ConnectionActor, SelectionHandler.ChannelWritable.Instance);
+
+                var read = ServerSideChannel.Read(into);
+                if (read == -1) throw new IllegalStateException("Connection was closed unexpectedly with remaining bytes " + remaining);
+                if (read == 0) throw new IllegalStateException("Made no progress");
+
+                PullFromServerSide(remaining - read, remainingRetries - 1, into);
+            }
+        }
+
+        public void ExpectReceivedString(string data)
+        {
+            Selector.Send(ConnectionActor, SelectionHandler.ChannelReadable.Instance);
+
+            var gotReceived = ConnectionHandler.ExpectMsg<Tcp.Received>();
+            var receivedString = gotReceived.Data.DecodeString(Encoding.ASCII);
+            data.ShouldStartWith(receivedString);
+            if (receivedString.Length < data.Length)
+                ExpectReceivedString(new string(data.Drop(receivedString.Length).ToArray()));
+        }
+
+        public void AssertThisConnectionActorTerminated()
+        {
+            //TODO: Impliment
+        }
+
+        public void AbortClose(SocketChannel channel)
+        {
+            // TODO: Do we need to handle expection like JVM?
+
+            channel.Socket.LingerState = new LingerOption(true, 0);
+            channel.Close();
+        }
+    }
+
+
+    public static class TestUtils
+    {
+        public static IPEndPoint TemporaryServerAddress()
+        {
+            var host = new IPEndPoint(IPAddress.Loopback, 0);
+            using (var socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
+            {
+                socket.Bind(host);
+                return new IPEndPoint(IPAddress.Loopback, ((IPEndPoint) socket.LocalEndPoint).Port);
+            }
+        }
+    }
+
+    
+}

--- a/src/core/Akka.Tests/IO/TcpListenerSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpListenerSpec.cs
@@ -1,0 +1,289 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="EventBusSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Text.RegularExpressions;
+using Akka.Actor;
+using Akka.IO;
+using Akka.TestKit;
+using Xunit;
+using TcpListener = Akka.IO.TcpListener;
+
+namespace Akka.Tests.IO
+{
+    public class TcpListenerSpec : AkkaSpec
+    {
+        public TcpListenerSpec()
+            : base(@"akka.io.tcp.register-timeout = 500ms
+                     akka.io.tcp.max-received-message-size = 1024
+                     akka.io.tcp.direct-buffer-size = 512
+                     akka.actor.serialize-creators = on
+                     akka.io.tcp.batch-accept-limit = 2
+                    ")
+        { }
+
+        [Fact]
+        public void A_TCP_Listner_must_register_its_server_socket_channel_with_its_selector()
+        {
+            new TestSetup(this, pullMode: false).Run(x => { });
+        }
+
+        [Fact]
+        public void A_TCP_Listner_must_let_the_bind_commander_know_when_binding_is_complete()
+        {
+            new TestSetup(this, pullMode: false).Run(x =>
+            {
+                x.Listner.Tell(new ChannelRegistration(
+                    o => { }, 
+                    o => { }));
+
+                x.BindCommander.ExpectMsg<Tcp.Bound>();
+            });           
+        }
+
+        [Fact]
+        public void A_TCP_Listner_must_accept_acceptable_connection_and_register_them_with_its_parent()
+        {
+            new TestSetup(this, pullMode: false).Run(x =>
+            {
+                x.BindListener();
+   
+                x.AttemptConnectionToEndpoint();
+                x.AttemptConnectionToEndpoint();
+                x.AttemptConnectionToEndpoint();
+
+                // since the batch-accept-limit is 2 we must only receive 2 accepted connections
+                x.Listner.Tell(SelectionHandler.ChannelAcceptable.Instance);
+
+                x.ExpectWorkerForCommand();
+                x.ExpectWorkerForCommand();
+                x.SelectorRouter.ExpectNoMsg(100);
+                x.InterestCallReceiver.ExpectMsg((int) SocketAsyncOperation.Accept);
+
+                // and pick up the last remaining connection on the next ChannelAcceptable
+                x.Listner.Tell(SelectionHandler.ChannelAcceptable.Instance);
+                x.ExpectWorkerForCommand();
+            });
+        }
+
+        [Fact]
+        public void A_TCP_Listner_must_continue_to_accept_connections_after_a_previous_accept()
+        {
+            new TestSetup(this, pullMode: false).Run(x =>
+            {
+                x.BindListener();
+
+                x.AttemptConnectionToEndpoint();
+                x.Listner.Tell(SelectionHandler.ChannelAcceptable.Instance);
+                x.ExpectWorkerForCommand();
+                x.SelectorRouter.ExpectNoMsg(100);
+                x.InterestCallReceiver.ExpectMsg((int) SocketAsyncOperation.Accept);
+
+                x.AttemptConnectionToEndpoint();
+                x.Listner.Tell(SelectionHandler.ChannelAcceptable.Instance);
+                x.ExpectWorkerForCommand();
+                x.SelectorRouter.ExpectNoMsg(100);
+                x.InterestCallReceiver.ExpectMsg((int) SocketAsyncOperation.Accept);
+            });
+        }
+
+        [Fact]
+        public void A_TCP_Listner_must_not_accept_connections_after_a_previous_accept_unit_read_is_reenabled()
+        {
+            new TestSetup(this, pullMode: true).Run(x =>
+            {
+                x.BindListener();
+
+                x.AttemptConnectionToEndpoint();
+                ExpectNoMsg(100);
+
+                x.Listner.Tell(new Tcp.ResumeAccepting(batchSize: 1));
+                x.Listner.Tell(SelectionHandler.ChannelAcceptable.Instance);
+                x.ExpectWorkerForCommand();
+                x.SelectorRouter.ExpectNoMsg(100);
+                x.InterestCallReceiver.ExpectMsg((int) SocketAsyncOperation.Accept);
+
+                // No more accepts are allowed now
+                x.InterestCallReceiver.ExpectNoMsg(100);
+
+                x.Listner.Tell(new Tcp.ResumeAccepting(batchSize: 2));
+                x.InterestCallReceiver.ExpectMsg((int) SocketAsyncOperation.Accept);
+
+                x.AttemptConnectionToEndpoint();
+                x.Listner.Tell(SelectionHandler.ChannelAcceptable.Instance);
+                x.ExpectWorkerForCommand();
+                x.SelectorRouter.ExpectNoMsg(100);
+                // There is still one token remaining, accepting
+                x.InterestCallReceiver.ExpectMsg((int)SocketAsyncOperation.Accept);
+
+                x.AttemptConnectionToEndpoint();
+                x.Listner.Tell(SelectionHandler.ChannelAcceptable.Instance);
+                x.ExpectWorkerForCommand();
+                x.SelectorRouter.ExpectNoMsg(100);
+
+                // Tokens are depleted now
+                x.InterestCallReceiver.ExpectNoMsg(100);
+            });
+        }
+
+        [Fact]
+        public void A_TCP_Listner_must_react_to_unbind_commands_by_replying_with_unbound_and_stopping_itself()
+        {
+            new TestSetup(this, pullMode:false).Run(x =>
+            {
+                x.BindListener();
+
+                var unbindCommander = CreateTestProbe();
+                unbindCommander.Send(x.Listner, Tcp.Unbind.Instance);
+
+                unbindCommander.ExpectMsg(Tcp.Unbound.Instance);
+                x.Parent.ExpectTerminated(x.Listner);
+            });    
+        }
+
+        [Fact]
+        public void A_TCP_Listner_must_drop_an_incoming_connection_if_it_cannot_be_registered_with_a_selector()
+        {
+            new TestSetup(this, pullMode: false).Run(x =>
+            {
+                x.BindListener();
+
+                x.AttemptConnectionToEndpoint();
+
+                x.Listner.Tell(SelectionHandler.ChannelAcceptable.Instance);
+                var channel = x.ExpectWorkerForCommand();
+
+                EventFilter.Warning(pattern: new Regex("selector capacity limit")).Expect(1, () =>
+                {
+                    x.Listner.Tell(new TcpListener.FailedRegisterIncoming(channel));
+                    AwaitCondition(() => !channel.IsOpen());
+                });
+            });
+        }
+
+        class TestSetup
+        {
+            private readonly TestKitBase _kit;
+            private readonly bool _pullMode;
+
+            private readonly TestProbe _handler;
+            private readonly IActorRef _handlerRef;
+            private readonly TestProbe _bindCommander;
+            private readonly TestProbe _parent;
+            private readonly TestProbe _selectorRouter;
+            private readonly IPEndPoint _endpoint;
+            
+            private TestProbe _registerCallReceiver;
+            private TestProbe _interestCallReceiver;
+            
+            private readonly TestActorRef<ListenerParent> _parentRef;
+
+            public TestSetup(TestKitBase kit, bool pullMode)
+            {
+                _kit = kit;
+                _pullMode = pullMode;
+
+                _handler = kit.CreateTestProbe();
+                _handlerRef = _handler.Ref;
+                _bindCommander = kit.CreateTestProbe();
+                _parent = kit.CreateTestProbe();
+                _selectorRouter = kit.CreateTestProbe();
+                _endpoint = TestUtils.TemporaryServerAddress();
+
+                _registerCallReceiver = kit.CreateTestProbe();
+                _interestCallReceiver = kit.CreateTestProbe();
+
+                _parentRef = new TestActorRef<ListenerParent>(kit.Sys, Props.Create(() => new ListenerParent(this, pullMode)));
+            }
+
+            public void Run(Action<TestSetup> test)
+            {
+                _registerCallReceiver.ExpectMsg<SocketAsyncOperation>(x => (_pullMode && x == 0) || x == SocketAsyncOperation.Accept);
+                test(this);
+            }
+
+            public void BindListener()
+            {
+                Listner.Tell(new ChannelRegistration(
+                    x => _interestCallReceiver.Ref.Tell((int) x),
+                    x => _interestCallReceiver.Ref.Tell(-(int) x)));
+                _bindCommander.ExpectMsg<Tcp.Bound>();
+            }
+
+            public void AttemptConnectionToEndpoint()
+            {
+                new Socket(_endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp).Connect(_endpoint);
+            }
+
+            public IActorRef Listner { get { return _parentRef.UnderlyingActor.Listner; } }
+
+            public TestProbe SelectorRouter
+            {
+                get { return _selectorRouter; }
+            }
+
+            public TestProbe InterestCallReceiver
+            {
+                get { return _interestCallReceiver; }
+            }
+            public TestProbe BindCommander { get { return _bindCommander; } }
+            public TestProbe Parent { get { return _parent; } }
+
+            public SocketChannel ExpectWorkerForCommand()
+            {
+                var message = _selectorRouter.ExpectMsg<SelectionHandler.WorkerForCommand>(TimeSpan.FromSeconds(10));
+                var command = (TcpListener.RegisterIncoming) message.ApiCommand;
+                command.Channel.IsOpen().ShouldBeTrue();
+                message.Commander.ShouldBe(Listner);
+                return command.Channel;
+            }
+
+            class ListenerParent : ActorBase, IChannelRegistry
+            {
+                private readonly TestSetup _test;
+                private readonly bool _pullMode;
+                private readonly IActorRef _listner;
+
+                public ListenerParent(TestSetup test, bool pullMode)
+                {
+                    _test = test;
+                    _pullMode = pullMode;
+
+                    _listner = Context.ActorOf(Props.Create(() =>
+                        new TcpListener(test._selectorRouter.Ref,
+                            Tcp.Instance.Apply(Context.System),
+                            this,
+                            test._bindCommander.Ref,
+                            new Tcp.Bind(_test._handler.Ref, test._endpoint, 100, new Inet.SocketOption[]{}, pullMode)))
+                                                              .WithDeploy(Deploy.Local));
+
+                    _test._parent.Watch(_listner);
+                }
+
+                internal IActorRef Listner { get { return _listner; } }
+
+                protected override bool Receive(object message)
+                {
+                    _test._parent.Forward(message);
+                    return true;
+                }
+
+                protected override SupervisorStrategy SupervisorStrategy()
+                {
+                    return Akka.Actor.SupervisorStrategy.StoppingStrategy;
+                }
+
+                public void Register(SocketChannel channel, SocketAsyncOperation? initialOps, IActorRef channelActor)
+                {
+                    _test._registerCallReceiver.Ref.Tell(initialOps, channelActor);
+                }
+            }
+        }
+    }
+}

--- a/src/core/Akka/Actor/SupervisorStrategy.cs
+++ b/src/core/Akka/Actor/SupervisorStrategy.cs
@@ -185,6 +185,12 @@ namespace Akka.Actor
         public static readonly SupervisorStrategy DefaultStrategy = new OneForOneStrategy(DefaultDecider);    
 
         /// <summary>
+        ///     This strategy resembles Erlang in that failing children are always
+        ///     terminated (one-for-one).
+        /// </summary>
+        public static readonly OneForOneStrategy StoppingStrategy = new OneForOneStrategy(ex => Directive.Stop);
+
+        /// <summary>
         /// This method is called after the child has been removed from the set of children.
         /// It does not need to do anything special. Exceptions thrown from this method
         /// do NOT make the actor fail if this happens during termination.

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -233,6 +233,21 @@
     <Compile Include="Helios.Concurrency.DedicatedThreadPool.cs" />
     <Compile Include="Routing\ConsistentHashRouter.cs" />
     <Compile Include="Serialization\JavaSerializer.cs" />
+    <Compile Include="IO\ByteBuffer.cs" />
+    <Compile Include="IO\DirectByteBufferPool.cs" />
+    <Compile Include="IO\Inet.cs" />
+    <Compile Include="IO\IO.cs" />
+    <Compile Include="IO\SelectionHandler.cs" />
+    <Compile Include="IO\SocketAsyncEventArgsPool.cs" />
+    <Compile Include="IO\SocketChannel.cs" />
+    <Compile Include="IO\Tcp.cs" />
+    <Compile Include="IO\TcpConnection.cs" />
+    <Compile Include="IO\TcpIncomingConnection.cs" />
+    <Compile Include="IO\TcpListener.cs" />
+    <Compile Include="IO\TcpManager.cs" />
+    <Compile Include="IO\TcpOutgoingConnection.cs" />
+    <Compile Include="Util\ByteIterator.cs" />
+    <Compile Include="Util\ByteString.cs" />
     <Compile Include="Util\ContinuousEnumerator.cs" />
     <Compile Include="Util\Internal\Collections\EnumeratorExtensions.cs" />
     <Compile Include="Util\Internal\Collections\Iterator.cs" />
@@ -343,6 +358,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/core/Akka/IO/ByteBuffer.cs
+++ b/src/core/Akka/IO/ByteBuffer.cs
@@ -1,0 +1,115 @@
+//-----------------------------------------------------------------------
+// <copyright file="ActorBase.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+
+namespace Akka.IO
+{
+    public class ByteBuffer
+    {
+        private byte[] _array;
+        private int _limit;
+        private int _position;
+        private ByteOrder _order;
+
+        public ByteBuffer(byte[] array)
+            : this(array, 0, array.Length)
+        {
+        }
+
+        public ByteBuffer(byte[] array, int offset, int length)
+        {
+            _array = array;
+            _position = offset;
+            _limit = offset + length;
+        }
+
+        public void Clear()
+        {
+            _position = 0;
+            _limit = _array.Length;
+        }
+
+        public void Limit(int maxBufferSize)
+        {
+            _array = new byte[maxBufferSize];
+            _limit = maxBufferSize;
+        }
+
+        public void Flip()
+        {
+            _limit = _position;
+            _position = 0;
+        }
+
+        public bool HasRemaining
+        {
+            get { return _position < _limit; }
+        }
+
+        public int Remaining
+        {
+            get { return _limit - _position; }
+        }
+
+        public byte[] Array()
+        {
+            return _array;
+        }
+
+        public void Put(byte[] src)
+        {
+            var len = Math.Min(src.Length, Remaining);
+            System.Array.Copy(src, 0, _array, _position, len);
+            _position += len;
+        }
+
+        public static ByteBuffer Wrap(byte[] array, int start, int len)
+        {
+            return new ByteBuffer(array, start, len);
+        }
+        public static ByteBuffer Wrap(byte[] array)
+        {
+            return new ByteBuffer(array, 0, array.Length);
+        }
+
+        public static ByteBuffer Allocate(int capacity)
+        {
+            return new ByteBuffer(new byte[capacity]);
+        }
+
+        public void Order(ByteOrder byteOrder)
+        {
+            _order = byteOrder;
+        }
+
+        public void Put(byte[] array, int @from, int copyLength)
+        {
+            System.Array.Copy(array, @from, _array, _position, copyLength);
+            _position += copyLength;
+        }
+
+        public void Get(byte[] ar, int offset, int length)
+        {
+            if (length > Remaining)
+                throw new Exception(); //TODO: throw proper exception
+            System.Array.Copy(_array, _position, ar, offset, length);
+            _position += length;
+        }
+
+        public void Get(byte[] ar)
+        {
+            Get(ar, 0, ar.Length);
+        }
+
+        public void Put(ByteBuffer src, int length)
+        {
+            Put(src._array, src._position, length);
+            src._position += length;
+        }
+    }
+}

--- a/src/core/Akka/IO/DirectByteBufferPool.cs
+++ b/src/core/Akka/IO/DirectByteBufferPool.cs
@@ -1,0 +1,57 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="DirectByteBufferPool.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+
+namespace Akka.IO
+{
+    public interface IBufferPool
+    {
+        ByteBuffer Acquire();
+        void Release(ByteBuffer buf);
+    }
+
+    internal class DirectByteBufferPool : IBufferPool
+    {
+        private readonly ConcurrentStack<ByteBuffer> _pool;
+
+        public DirectByteBufferPool()
+        {
+            var items = Enumerable.Range(0, PoolSize)
+                                  .Select(x => new ByteBuffer(new byte[BufferSize]));
+            _pool = new ConcurrentStack<ByteBuffer>(items);
+        }
+
+        public int BufferSize
+        {
+            get { return 128; }
+        }
+
+        public int PoolSize
+        {
+            get { return 128; }
+        }
+
+        public ByteBuffer Acquire()
+        {
+            ByteBuffer buffer;
+            if (_pool.TryPop(out buffer))
+            {
+                buffer.Clear();
+                return buffer;
+            }
+            throw new Exception(); // TODO: What do we do? throw proper exception?
+        }
+
+        public void Release(ByteBuffer buf)
+        {
+            _pool.Push(buf);
+        }
+    }
+}

--- a/src/core/Akka/IO/IO.cs
+++ b/src/core/Akka/IO/IO.cs
@@ -1,0 +1,16 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="IO.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Actor;
+
+namespace Akka.IO
+{
+    public abstract class Extension : IExtension
+    {
+        public abstract IActorRef Manager { get; }
+    }
+}

--- a/src/core/Akka/IO/Inet.cs
+++ b/src/core/Akka/IO/Inet.cs
@@ -1,0 +1,112 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Inet.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Net.Sockets;
+
+namespace Akka.IO
+{
+    public class Inet
+    {
+        public class SocketOption
+        {
+            public virtual void BeforeDatagramBind(Socket ds) 
+            { }
+
+            public virtual void BeforeServerSocketBind(Socket ss)
+            { }
+
+            public virtual void BeforeConnect(Socket s)
+            { }
+            public virtual void AfterConnect(Socket s)
+            { }
+        }
+
+        public static class SO
+        {
+            public class ReceiveBufferSize : SocketOption
+            {
+                private readonly int _size;
+
+                public ReceiveBufferSize(int size)
+                {
+                    _size = size;
+                }
+
+                public override void BeforeServerSocketBind(Socket ss)
+                {
+                    ss.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveBuffer, _size);
+                }
+                public override void BeforeDatagramBind(Socket ds)
+                {
+                    ds.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveBuffer, _size);
+                }
+                public override void BeforeConnect(Socket s)
+                {
+                    s.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveBuffer, _size);
+                }
+            }
+
+            public class ReuseAddress : SocketOption
+            {
+                private readonly bool _on;
+
+                public ReuseAddress(bool on)
+                {
+                    _on = @on;
+                }
+
+                public override void BeforeServerSocketBind(Socket ss)
+                {
+                    ss.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, _on);
+                }
+                public override void BeforeDatagramBind(Socket ds)
+                {
+                    ds.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, _on);
+                }
+                public override void BeforeConnect(Socket s)
+                {
+                    s.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, _on);
+                }
+            }
+
+            public class SendBufferSize : SocketOption
+            {
+                private readonly int _size;
+
+                public SendBufferSize(int size)
+                {
+                    _size = size;
+                }
+
+                public override void AfterConnect(Socket s)
+                {
+                    s.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.SendBuffer, _size);
+                }
+            }
+
+            public class TrafficClass : SocketOption
+            {
+                private readonly int _tc;
+
+                public TrafficClass(int tc)
+                {
+                    _tc = tc;
+                }
+
+                public override void AfterConnect(Socket s)
+                {
+                    //TODO: What is the .NET equivalent
+                }
+            }
+        }
+
+        public abstract class SoForwarders
+        {
+            
+        }
+    }
+}

--- a/src/core/Akka/IO/SelectionHandler.cs
+++ b/src/core/Akka/IO/SelectionHandler.cs
@@ -1,0 +1,377 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="IO.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Dispatch;
+using Akka.Event;
+using Akka.Routing;
+
+namespace Akka.IO
+{
+    public abstract class SelectionHandlerSettings
+    {
+        protected SelectionHandlerSettings(Config config)
+        {
+            //TODO: requiring
+
+            MaxChannels = config.GetString("max-channels") == "unlimited" 
+                ? -1 
+                : config.GetInt("max-channels");
+            
+            SelectorAssociationRetries = config.GetInt("selector-association-retries");
+
+            SelectorDispatcher = config.GetString("selector-dispatcher");
+            WorkerDispatcher = config.GetString("worker-dispatcher");
+            TraceLogging = config.GetBoolean("trace-logging");
+        }
+
+        public int MaxChannels { get; private set; }
+        public int SelectorAssociationRetries { get; private set; }
+        public string SelectorDispatcher { get; private set; }
+        public string WorkerDispatcher { get; private set; }
+        public bool TraceLogging { get; private set; }
+        
+        public int MaxChannelsPerSelector { get; protected set; }
+    }
+
+    internal interface IChannelRegistry
+    {
+        void Register(SocketChannel channel, SocketAsyncOperation? initialOps, IActorRef channelActor);
+    }
+
+    internal class ChannelRegistration
+    {
+        public ChannelRegistration(Action<SocketAsyncOperation> enableInterest, Action<SocketAsyncOperation> disableInterest)
+        {
+            EnableInterest = enableInterest;
+            DisableInterest = disableInterest;
+        }
+
+        public Action<SocketAsyncOperation> EnableInterest { get; private set; }
+        public Action<SocketAsyncOperation> DisableInterest { get; private set; }
+    }
+
+    internal class SelectionHandler : ActorBase, IRequiresMessageQueue<IUnboundedMessageQueueSemantics>
+    {
+        // OBJECT 
+
+        public interface IHasFailureMessage
+        {
+            object FailureMessage { get; }
+        }
+
+        public class WorkerForCommand : INoSerializationVerificationNeeded
+        {
+            public WorkerForCommand(IHasFailureMessage apiCommand, IActorRef commander, Func<IChannelRegistry, Props> childProps)
+            {
+                ApiCommand = apiCommand;
+                Commander = commander;
+                ChildProps = childProps;
+            }
+
+            public IHasFailureMessage ApiCommand { get; private set; }
+            public IActorRef Commander { get; private set; }
+            public Func<IChannelRegistry, Props> ChildProps { get; private set; }
+        }
+
+        public class Retry : INoSerializationVerificationNeeded
+        {
+            public Retry(WorkerForCommand command, int retriesLeft)
+            {
+                Command = command;
+                RetriesLeft = retriesLeft;
+            }
+
+            public WorkerForCommand Command { get; private set; }
+            public int RetriesLeft { get; private set; }
+        }
+
+        public class ChannelConnectable
+        {
+            public static readonly ChannelConnectable Instance = new ChannelConnectable();
+
+            private ChannelConnectable()
+            { }
+        }
+        public class ChannelAcceptable
+        {
+            public static readonly ChannelAcceptable Instance = new ChannelAcceptable();
+
+            private ChannelAcceptable()
+            { }
+        }
+        public class ChannelReadable
+        {
+            public static readonly ChannelReadable Instance = new ChannelReadable();
+
+            private ChannelReadable()
+            { }
+        }
+        public class ChannelWritable
+        {
+            public static readonly ChannelWritable Instance = new ChannelWritable();
+
+            private ChannelWritable()
+            { }
+        }
+
+        public abstract class SelectorBasedManager : ActorBase
+        {
+            protected readonly IActorRef SelectorPool;
+
+            protected SelectorBasedManager(SelectionHandlerSettings selectorSettings, int nrOfSelectors)
+            {
+                SelectorPool = Context.ActorOf(
+                    props: new RandomPool(nrOfSelectors).Props(Props.Create(() => new SelectionHandler(selectorSettings)).WithDeploy(Deploy.Local)),
+                    name: "selectors");
+            }
+
+            protected override SupervisorStrategy SupervisorStrategy()
+            {
+                return ConnectionSupervisorStrategy;
+            }
+
+            protected Receive WorkerForCommandHandler(Func<IHasFailureMessage, Func<IChannelRegistry, Props>> pf)
+            {
+                return message =>
+                {
+                    var cmd = message as IHasFailureMessage;
+                    if (cmd != null)
+                    {
+                        SelectorPool.Tell(new WorkerForCommand(cmd, Sender, pf(cmd)));
+                        return true;
+                    }
+                    return false;
+                };
+            }
+        }
+
+        /* 
+         * Special supervisor strategy for parents of TCP connection and listener actors.
+         * Stops the child on all errors and logs DeathPactExceptions only at debug level.
+         */
+        private class ConnectionSupervisorStrategyImp : OneForOneStrategy
+        {
+            public ConnectionSupervisorStrategyImp()
+                : base(StoppingStrategy.Decider)
+            { }
+
+            protected override void LogFailure(IActorContext context, IActorRef child, Exception cause, Directive directive)
+            {
+                if (cause is DeathPactException)
+                {
+                    try
+                    {
+                        Context.System.EventStream.Publish(new Debug(child.Path.ToString(), GetType(), "Closed after handler termination"));
+                    }
+                    catch (Exception _) { }
+                }
+                else base.LogFailure(context, child, cause, directive);
+            }
+        }
+        public static readonly SupervisorStrategy ConnectionSupervisorStrategy = new ConnectionSupervisorStrategyImp();
+
+        private class ChannelRegistryImpl : IChannelRegistry
+        {
+            private readonly ILoggingAdapter _log;
+            private readonly SocketAsyncEventArgsPool _pool;
+
+            public ChannelRegistryImpl(ILoggingAdapter log)
+            {
+                _log = log;
+                //_pool = new SocketAsyncEventArgsPool(1000, SocketChannel.Select);
+
+                Task.Run(() => Select());
+            }
+
+            private readonly IDictionary<Socket, SocketChannel> read = new Dictionary<Socket, SocketChannel>();
+            private readonly IDictionary<Socket, SocketChannel> write = new Dictionary<Socket, SocketChannel>();
+            private readonly IList error = new List<Socket>();
+
+            private void Select()
+            {
+                if (read.Count > 0 || write.Count > 0)
+                {
+                    var readable = read.Keys.ToList();
+                    var writeable = write.Keys.ToList();
+                    Socket.Select(readable, writeable, error, 100);
+                    foreach (var socket in readable)
+                    {
+                        var channel = read[socket];
+                        if (channel.IsOpen())
+                            channel.Connection.Tell(ChannelReadable.Instance);
+                        else
+                            channel.Connection.Tell(ChannelAcceptable.Instance);
+                        read.Remove(socket);
+                    }
+                    foreach (var socket in writeable)
+                    {
+                        var channel = write[socket];
+                        if (channel.IsOpen())
+                            channel.Connection.Tell(ChannelWritable.Instance);
+                        else
+                            channel.Connection.Tell(ChannelConnectable.Instance);
+                        write.Remove(socket);
+                    }
+                }
+                Task.Run(() => Select());
+            }
+
+            public void Register(SocketChannel channel, SocketAsyncOperation? initialOps, IActorRef channelActor)
+            {
+                channel.Register(channelActor, initialOps);
+
+                if (initialOps.HasValue)
+                    EnableInterest(channel, initialOps.Value);
+
+                channelActor.Tell(new ChannelRegistration(
+                    enableInterest: op => EnableInterest(channel, op), 
+                    disableInterest: op => DisableInterest(channel, op) 
+                    ));
+            }
+
+            private void EnableInterest(SocketChannel channel, SocketAsyncOperation op)
+            {
+                switch (op)
+                {
+                        case SocketAsyncOperation.Accept:
+                        case SocketAsyncOperation.Receive:
+                            read.Add(channel.Socket, channel);
+                            break;
+                        case SocketAsyncOperation.Connect:
+                        case SocketAsyncOperation.Send:
+                            write.Add(channel.Socket, channel);
+                            break;
+                }
+            }
+            private void DisableInterest(SocketChannel channel, SocketAsyncOperation op)
+            {
+                switch (op)
+                {
+                    case SocketAsyncOperation.Accept:
+                    case SocketAsyncOperation.Receive:
+                        read.Remove(channel.Socket);
+                        break;
+                    case SocketAsyncOperation.Connect:
+                    case SocketAsyncOperation.Send:
+                        write.Remove(channel.Socket);
+                        break;
+                }
+            }
+
+            public void Shutdown()
+            {
+                //TODO: ??
+            }
+        }
+
+        // CLASS
+        private readonly SelectionHandlerSettings _settings;
+        private readonly ChannelRegistryImpl _registry;
+        private int _sequenceNumber;
+        private int _childCount;
+
+        public SelectionHandler(SelectionHandlerSettings settings)
+        {
+            _settings = settings;
+            _registry = new ChannelRegistryImpl(Context.GetLogger());
+        }
+
+        protected override bool Receive(object message)
+        {
+            var cmd = message as WorkerForCommand;
+            if (cmd != null)
+            {
+                SpawnChildWithCapacityProtection(cmd, _settings.SelectorAssociationRetries);
+                return true;
+            }
+            var retry = message as Retry;
+            if (retry != null)
+            {
+                SpawnChildWithCapacityProtection(retry.Command, retry.RetriesLeft);
+                return true;
+            }
+            var _ = message as Terminated;
+            if (_ != null)
+            {
+                _childCount -= 1;
+                return true;
+            }
+            return false;
+        }
+
+        protected override void PostStop()
+        {
+            _registry.Shutdown();
+        }
+
+        // we can never recover from failures of a connection or listener child
+        // and log the failure at debug level
+        private class SelectionHandlerSupervisorStrategy : OneForOneStrategy
+        {
+            public SelectionHandlerSupervisorStrategy()
+                : base(StoppingStrategy.Decider)
+            { }
+
+            protected override void LogFailure(IActorContext context, IActorRef child, Exception cause, Directive directive)
+            {
+                try
+                {
+                    var e = (ActorInitializationException) cause;
+                    var logMessage = e != null
+                        ? e.GetBaseException() .Message
+                        : cause.Message;
+                    Context.System.EventStream.Publish(
+                        new Debug(child.Path.ToString(), typeof (SelectionHandler), logMessage));
+                }
+                catch(Exception _) { }
+            }
+        }
+        protected override SupervisorStrategy SupervisorStrategy()
+        {
+            return new SelectionHandlerSupervisorStrategy();
+        }
+
+        private void SpawnChildWithCapacityProtection(WorkerForCommand cmd, int retriesLeft)
+        {
+            var log = Context.GetLogger();
+            if (_settings.TraceLogging) log.Debug("Executing [{0}]", cmd);
+            if (_settings.MaxChannelsPerSelector == -1 || _childCount < _settings.MaxChannelsPerSelector)
+            {
+                var newName = _sequenceNumber.ToString(CultureInfo.InvariantCulture);
+                _sequenceNumber += 1;
+                var child = Context.ActorOf(props: cmd.ChildProps(_registry) 
+                                                      .WithDispatcher(_settings.WorkerDispatcher)
+                                                      .WithDeploy(Deploy.Local), 
+                                            name: newName);
+                _childCount += 1;
+                if (_settings.MaxChannelsPerSelector > 0) Context.Watch(child);
+            }
+            else
+            {
+                if (retriesLeft >= 1)
+                {
+                    log.Debug("Rejecting [{0}] with [{1}] retries left, retrying...", cmd, retriesLeft);
+                    Context.Parent.Forward(new Retry(cmd, retriesLeft - 1));
+                }
+                else
+                {
+                    log.Warning("Rejecting [{0}] with no retries left, aborting...", cmd);
+                    cmd.Commander.Tell(cmd.ApiCommand.FailureMessage);
+                }
+            }
+        }
+    }
+}

--- a/src/core/Akka/IO/SocketAsyncEventArgsPool.cs
+++ b/src/core/Akka/IO/SocketAsyncEventArgsPool.cs
@@ -1,0 +1,56 @@
+//-----------------------------------------------------------------------
+// <copyright file="ActorBase.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Net.Sockets;
+
+namespace Akka.IO
+{
+    public class SocketAsyncEventArgsPool
+    {
+        private readonly ConcurrentStack<SocketAsyncEventArgs> _pool;
+        private readonly byte[] _buffer;
+
+        public SocketAsyncEventArgsPool(int capacity, Action<SocketAsyncEventArgs> select)
+        {
+            _buffer = new byte[capacity*BufferSize];
+            var items = Enumerable.Range(0, capacity).Select(i =>
+            {
+                var saea = new SocketAsyncEventArgs();
+                saea.Completed += (s, e) => select(e);
+                saea.SetBuffer(_buffer, i*BufferSize, BufferSize);
+                return saea;
+            });
+            _pool = new ConcurrentStack<SocketAsyncEventArgs>(items);
+        }
+
+        public int BufferSize
+        {
+            get { return 128; } // TODO: make configurable with good default
+        }
+
+        public SocketAsyncEventArgs Request(object token)
+        {
+            SocketAsyncEventArgs saea;
+            if (_pool.TryPop(out saea))
+            {
+                saea.UserToken = token;
+                saea.SetBuffer(saea.Offset, BufferSize);
+                return saea;
+            }
+            throw new Exception(); //TODO: What do we do when pool is empty?
+        }
+
+        public void Return(SocketAsyncEventArgs saea)
+        {
+            saea.UserToken = null;
+            _pool.Push(saea);
+        }
+    }
+}

--- a/src/core/Akka/IO/SocketChannel.cs
+++ b/src/core/Akka/IO/SocketChannel.cs
@@ -1,0 +1,139 @@
+//-----------------------------------------------------------------------
+// <copyright file="ActorBase.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using Akka.Actor;
+
+namespace Akka.IO
+{
+    /* 
+     * SocketChannel does not exists in the .NET BCL - This class is an adapter to hide the diffirences in CLR & JVM IO.
+     * This implimentation uses blocking IO calls, and then catch SocketExceptions if the socket is set to non bloking. 
+     * This might introduce performance issues, with lots of thrown exceptions
+     * TODO: Impliments this class with .NET Async calls
+     */
+    public class SocketChannel 
+    {
+        private readonly Socket _socket;
+        private IActorRef _connection;
+        private bool _connected;
+            
+        public SocketChannel(Socket socket) 
+        {
+            _socket = socket;
+        }
+
+        public static SocketChannel Open()
+        {
+            return new SocketChannel(new Socket(SocketType.Stream, ProtocolType.Tcp));
+        }
+
+        public SocketChannel ConfigureBlocking(bool block)
+        {
+            _socket.Blocking = block;
+            return this;
+        }
+
+        public Socket Socket
+        {
+            get { return _socket; }
+        }
+
+        public void Register(IActorRef connection, SocketAsyncOperation? initialOps)
+        {
+            _connection = connection;
+        }
+
+
+        public bool IsOpen()
+        {
+            return _connected;
+        }
+
+        public bool Connect(IPEndPoint address)
+        {
+            try
+            {
+                _socket.Connect(address);
+            }
+            catch (SocketException ex)
+            {
+                if (ex.SocketErrorCode == SocketError.WouldBlock)
+                    return false;
+                throw;
+            }
+            return _socket.Connected;
+        }
+        public bool FinishConnect()
+        {
+            _connected = _socket.Connected;
+            return _socket.Connected;
+        }
+
+        public SocketChannel Accept()
+        {
+            _socket.Blocking = false;
+            try
+            {
+                var s = _socket.Accept();
+                return new SocketChannel(s) {_connected = true};
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        public int Read(ByteBuffer buffer)
+        {
+            try
+            {
+                var data = new byte[buffer.Remaining];
+                var length = _socket.Receive(data);
+                if (length == 0)
+                    return -1;
+                buffer.Put(data, 0, length);
+                return length;
+            }
+            catch (SocketException ex)
+            {
+                if (ex.SocketErrorCode == SocketError.WouldBlock)
+                    return 0;
+                throw new IOException(ex.Message, ex);
+            }
+        }
+
+        public int Write(ByteBuffer buffer)
+        {
+            try
+            {
+                var data = new byte[buffer.Remaining];
+                buffer.Get(data);
+                return _socket.Send(data);
+            }
+            catch (SocketException ex)
+            {
+                if (ex.SocketErrorCode == SocketError.WouldBlock)
+                {
+                    buffer.Flip();
+                    return 0;
+                }
+                throw new IOException(ex.Message, ex);
+            }
+        }
+
+        public void Close()
+        {
+            _connected = false;
+            _socket.Close();
+        }
+        internal IActorRef Connection { get { return _connection; } }
+    }
+}

--- a/src/core/Akka/IO/Tcp.cs
+++ b/src/core/Akka/IO/Tcp.cs
@@ -1,0 +1,797 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Tcp.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using Akka.Actor;
+using Akka.Configuration;
+
+namespace Akka.IO
+{
+    public class Tcp : ExtensionIdProvider<TcpExt>
+    {
+        public static readonly Tcp Instance = new Tcp();
+
+        public override TcpExt CreateExtension(ExtendedActorSystem system)
+        {
+            return new TcpExt(system);
+        }
+
+        public class Message : INoSerializationVerificationNeeded
+        {
+
+        }
+
+        // COMMANDS
+        public class Command : Message, SelectionHandler.IHasFailureMessage
+        {
+            private readonly CommandFailed _failureMessage;
+
+            public Command()
+            {
+                _failureMessage = new CommandFailed(this);
+            }
+
+            public CommandFailed FailureMessage
+            {
+                get { return _failureMessage; }
+            }
+
+            object SelectionHandler.IHasFailureMessage.FailureMessage
+            {
+                get { return _failureMessage; }
+            }
+        }
+
+        /// <summary>
+        /// The Connect message is sent to the TCP manager actor, which is obtained via
+        /// <see cref="TcpExt.Manager" />. Either the manager replies with a <see cref="CommandFailed" />
+        /// or the actor handling the new connection replies with a <see cref="Connected" />
+        /// message.
+        /// </summary>
+        public class Connect : Command
+        {
+            public Connect(IPEndPoint remoteAddress,
+                IPEndPoint localAddress = null,
+                IEnumerable<Inet.SocketOption> options = null,
+                TimeSpan? timeout = null,
+                bool pullMode = false)
+            {
+                RemoteAddress = remoteAddress;
+                LocalAddress = localAddress;
+                Options = options ?? Enumerable.Empty<Inet.SocketOption>();
+                Timeout = timeout;
+                PullMode = pullMode;
+            }
+
+            public IPEndPoint RemoteAddress { get; private set; }
+            public IPEndPoint LocalAddress { get; private set; }
+            public IEnumerable<Inet.SocketOption> Options { get; private set; }
+            public TimeSpan? Timeout { get; private set; }
+            public bool PullMode { get; private set; }
+        }
+
+        /// <summary>
+        /// The Bind message is send to the TCP manager actor, which is obtained via
+        /// <see cref="TcpExt.Manager" /> in order to bind to a listening socket. The manager
+        /// replies either with a <see cref="CommandFailed" /> or the actor handling the listen
+        /// socket replies with a <see cref="Bound" /> message. If the local port is set to 0 in
+        /// the Bind message, then the <see cref="Bound" /> message should be inspected to find
+        /// the actual port which was bound to.
+        /// </summary>
+        public class Bind : Command
+        {
+            public Bind(IActorRef handler,
+                IPEndPoint localAddress,
+                int backlog = 100,
+                IEnumerable<Inet.SocketOption> options = null,
+                bool pullMode = false)
+            {
+                Handler = handler;
+                LocalAddress = localAddress;
+                Backlog = backlog;
+                Options = options;
+                PullMode = pullMode;
+            }
+
+            public IActorRef Handler { get; set; }
+            public IPEndPoint LocalAddress { get; set; }
+            public int Backlog { get; set; }
+            public IEnumerable<Inet.SocketOption> Options { get; set; }
+            public bool PullMode { get; set; }
+        }
+
+        /// <summary>
+        /// This message must be sent to a TCP connection actor after receiving the
+        /// <see cref="Connected" /> message. The connection will not read any data from the
+        /// socket until this message is received, because this message defines the
+        /// actor which will receive all inbound data.
+        /// </summary>
+        public class Register : Command
+        {
+            public Register(IActorRef handler, bool keepOpenonPeerClosed = false, bool useResumeWriting = true)
+            {
+                Handler = handler;
+                KeepOpenonPeerClosed = keepOpenonPeerClosed;
+                UseResumeWriting = useResumeWriting;
+            }
+
+            public IActorRef Handler { get; private set; }
+            public bool KeepOpenonPeerClosed { get; private set; }
+            public bool UseResumeWriting { get; private set; }
+        }
+
+        /// <summary>
+        /// In order to close down a listening socket, send this message to that socket’s
+        /// actor (that is the actor which previously had sent the <see cref="Bound" /> message). The
+        /// listener socket actor will reply with a <see cref="Unbound" /> message.
+        /// </summary>
+        public class Unbind : Command
+        {
+            public static readonly Unbind Instance = new Unbind();
+
+            private Unbind()
+            { }
+        }
+
+        /// <summary>
+        /// Common interface for all commands which aim to close down an open connection.
+        /// </summary>
+        public abstract class CloseCommand : Command
+        {
+            public abstract ConnectionClosed Event { get; }
+        }
+
+        /// <summary>
+        /// A normal close operation will first flush pending writes and then close the
+        /// socket. The sender of this command and the registered handler for incoming
+        /// data will both be notified once the socket is closed using a <see cref="Closed" />
+        /// message.
+        /// </summary>
+        public class Close : CloseCommand
+        {
+            public static readonly Close Instance = new Close();
+
+            private Close()
+            {
+            }
+
+            public override ConnectionClosed Event
+            {
+                get { return Closed.Instance; }
+            }
+        }
+
+        /// <summary>
+        /// A confirmed close operation will flush pending writes and half-close the
+        /// connection, waiting for the peer to close the other half. The sender of this
+        /// command and the registered handler for incoming data will both be notified
+        /// once the socket is closed using a <see cref="ConfirmedClosed" /> message.
+        /// </summary>
+        public class ConfirmedClose : CloseCommand
+        {
+            public static readonly ConfirmedClose Instance = new ConfirmedClose();
+
+            private ConfirmedClose()
+            {
+            }
+
+            public override ConnectionClosed Event
+            {
+                get { return ConfirmedClosed.Instance; }
+            }
+        }
+
+        /// <summary>
+        /// An abort operation will not flush pending writes and will issue a TCP ABORT
+        /// command to the O/S kernel which should result in a TCP_RST packet being sent
+        /// to the peer. The sender of this command and the registered handler for
+        /// incoming data will both be notified once the socket is closed using a
+        /// <see cref="Aborted" /> message.
+        /// </summary>
+        public class Abort : CloseCommand
+        {
+            public static readonly Abort Instance = new Abort();
+
+            private Abort()
+            {
+            }
+
+            public override ConnectionClosed Event
+            {
+                get { return Aborted.Instance; }
+            }
+        }
+
+        /// <summary>
+        /// Each <see cref="WriteCommand" /> can optionally request a positive acknowledgment to be sent
+        /// to the commanding actor. If such notification is not desired the <see cref="WriteCommand#ack" />
+        /// must be set to an instance of this class. The token contained within can be used
+        /// to recognize which write failed when receiving a <see cref="CommandFailed" /> message.
+        /// </summary>
+        public class NoAck : Event
+        {
+            public static readonly NoAck Instance = new NoAck(null);
+
+            public NoAck(object token)
+            {
+                Token = token;
+            }
+
+            public object Token { get; private set; }
+        }
+
+        public abstract class WriteCommand : Command
+        {
+            public CompoundWrite Prepend(SimpleWriteCommand other)
+            {
+                return new CompoundWrite(other, this);
+            }
+
+            public WriteCommand Prepend(IEnumerable<WriteCommand> writes)
+            {
+                return writes.Reverse().Aggregate(this, (b, a) =>
+                {
+                    var simple = a as SimpleWriteCommand;
+                    if (simple != null)
+                        return b.Prepend(simple);
+
+                    var compound = a as CompoundWrite;
+                    if (compound != null)
+                        return b.Prepend(compound);
+
+                    throw new Exception();
+                });
+            }
+
+            public static WriteCommand Create(IEnumerable<WriteCommand> writes)
+            {
+                return Write.Empty.Prepend(writes);
+            }
+
+            public static WriteCommand Create(params WriteCommand[] writes)
+            {
+                return Create((IEnumerable<WriteCommand>) writes);
+            }
+        }
+
+        public abstract class SimpleWriteCommand : WriteCommand
+        {
+            public abstract Event Ack { get; }
+
+            public bool WantsAck
+            {
+                get { return !(Ack is NoAck); }
+            }
+
+            public CompoundWrite Append(WriteCommand that)
+            {
+                return that.Prepend(this);
+            }
+        }
+
+        /// <summary>
+        /// Write data to the TCP connection. If no ack is needed use the special
+        /// `NoAck` object. The connection actor will reply with a <see cref="CommandFailed" />
+        /// message if the write could not be enqueued. If <see cref="WriteCommand#wantsAck" />
+        /// returns true, the connection actor will reply with the supplied <see cref="WriteCommand#ack" />
+        /// token once the write has been successfully enqueued to the O/S kernel.
+        /// <b>Note that this does not in any way guarantee that the data will be
+        /// or have been sent!</b> Unfortunately there is no way to determine whether
+        /// a particular write has been sent by the O/S.
+        /// </summary>
+        public class Write : SimpleWriteCommand
+        {
+            private readonly Event _ack;
+            public ByteString Data { get; private set; }
+
+            public override Event Ack
+            {
+                get { return _ack; }
+            }
+
+            public Write(ByteString data, Event ack)
+            {
+                _ack = ack;
+                Data = data;
+            }
+
+            public static Write Create(ByteString data)
+            {
+                return data.IsEmpty ? Empty : new Write(data, NoAck.Instance);
+            }
+
+            public static Write Create(ByteString data, Event ack)
+            {
+                return new Write(data, ack);
+            }
+
+            public static readonly Write Empty = new Write(ByteString.Empty, NoAck.Instance);
+        }
+
+        /// <summary>
+        /// A write command which aggregates two other write commands. Using this construct
+        /// you can chain a number of <see cref="Write" /> and/or [[WriteFile]] commands together in a way
+        /// that allows them to be handled as a single write which gets written out to the
+        /// network as quickly as possible.
+        /// If the sub commands contain `ack` requests they will be honored as soon as the
+        /// respective write has been written completely.
+        /// </summary>
+        public class CompoundWrite : WriteCommand, IEnumerable<SimpleWriteCommand>
+        {
+            private readonly SimpleWriteCommand _head;
+            private readonly WriteCommand _tailCommand;
+
+            public CompoundWrite(SimpleWriteCommand head, WriteCommand tailCommand)
+            {
+                _head = head;
+                _tailCommand = tailCommand;
+            }
+
+            public IEnumerator<SimpleWriteCommand> GetEnumerator()
+            {
+                return Enumerable().GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            private IEnumerable<SimpleWriteCommand> Enumerable()
+            {
+                WriteCommand current = this;
+                while (current != null)
+                {
+                    var compound = current as CompoundWrite;
+                    if (compound != null)
+                    {
+                        current = compound.TailCommand;
+                        yield return compound.Head;
+                    }
+
+                    var simple = current as SimpleWriteCommand;
+                    if (simple != null)
+                    {
+                        current = null;
+                        yield return simple;
+                    }
+                }
+            }
+
+            public SimpleWriteCommand Head
+            {
+                get { return _head; }
+            }
+
+            public WriteCommand TailCommand
+            {
+                get { return _tailCommand; }
+            }
+        }
+
+        /// <summary>
+        /// When `useResumeWriting` is in effect as was indicated in the <see cref="Register" /> message
+        /// then this command needs to be sent to the connection actor in order to re-enable
+        /// writing after a <see cref="CommandFailed" /> event. All <see cref="WriteCommand" /> processed by the
+        /// connection actor between the first <see cref="CommandFailed" /> and subsequent reception of
+        /// this message will also be rejected with <see cref="CommandFailed" />.
+        /// </summary>
+        public class ResumeWriting : Command
+        {
+            public static readonly ResumeWriting Instance = new ResumeWriting();
+        }
+
+        /// <summary>
+        /// Sending this command to the connection actor will disable reading from the TCP
+        /// socket. TCP flow-control will then propagate backpressure to the sender side
+        /// as buffers fill up on either end. To re-enable reading send <see cref="ResumeReading" />.
+        /// </summary>
+        public class SuspendReading : Command
+        {
+            public static SuspendReading Instance = new SuspendReading();
+
+            private SuspendReading()
+            {
+            }
+        }
+
+        /// <summary>
+        /// This command needs to be sent to the connection actor after a <see cref="SuspendReading" />
+        /// command in order to resume reading from the socket.
+        /// </summary>
+        public class ResumeReading : Command
+        {
+            public static ResumeReading Instance = new ResumeReading();
+
+            private ResumeReading()
+            {
+            }
+        }
+
+        /// <summary>
+        /// This message enables the accepting of the next connection if read throttling is enabled
+        /// for connection actors.
+        /// </summary>
+        public class ResumeAccepting : Command
+        {
+            public int BatchSize { get; private set; }
+
+            public ResumeAccepting(int batchSize)
+            {
+                BatchSize = batchSize;
+            }
+        }
+
+        // EVENTS
+
+        /// <summary>
+        /// Common interface for all events generated by the TCP layer actors.
+        /// </summary>
+        public class Event : Message
+        {
+
+        }
+
+        /// <summary>
+        /// Whenever data are read from a socket they will be transferred within this
+        /// class to the handler actor which was designated in the <see cref="Register" /> message.
+        /// </summary>
+        public sealed class Received
+        {
+            public Received(ByteString data)
+            {
+                Data = data;
+            }
+
+            public ByteString Data { get; private set; }
+        }
+
+        /// <summary>
+        /// The connection actor sends this message either to the sender of a <see cref="Connect" />
+        /// command (for outbound) or to the handler for incoming connections designated
+        /// in the <see cref="Bind" /> message. The connection is characterized by the `remoteAddress`
+        /// and `localAddress` TCP endpoints.
+        /// </summary>
+        public sealed class Connected
+        {
+            public Connected(IPEndPoint remoteAddress, IPEndPoint localAddress)
+            {
+                RemoteAddress = remoteAddress;
+                LocalAddress = localAddress;
+            }
+
+            public IPEndPoint RemoteAddress { get; private set; }
+            public IPEndPoint LocalAddress { get; private set; }
+        }
+
+        /// <summary>
+        /// Whenever a command cannot be completed, the queried actor will reply with
+        /// this message, wrapping the original command which failed.
+        /// </summary>
+        public sealed class CommandFailed : Event
+        {
+            public CommandFailed(Command cmd)
+            {
+                Cmd = cmd;
+            }
+
+            public Command Cmd { get; private set; }
+        }
+
+        /// <summary>
+        /// When `useResumeWriting` is in effect as indicated in the <see cref="Register" /> message,
+        /// the <see cref="ResumeWriting" /> command will be acknowledged by this message type, upon
+        /// which it is safe to send at least one write. This means that all writes preceding
+        /// the first <see cref="CommandFailed" /> message have been enqueued to the O/S kernel at this
+        /// point.
+        /// </summary>
+        public class WritingResumed : Event
+        {
+            public static WritingResumed Instance = new WritingResumed();
+        }
+
+        /// <summary>
+        /// The sender of a <see cref="Bind" /> command will—in case of success—receive confirmation
+        /// in this form. If the bind address indicated a 0 port number, then the contained
+        /// `localAddress` can be used to find out which port was automatically assigned.
+        /// </summary>
+        public class Bound : Event
+        {
+            public IPEndPoint LocalAddress { get; private set; }
+
+            public Bound(IPEndPoint localAddress)
+            {
+                LocalAddress = localAddress;
+            }
+        }
+
+        /// <summary>
+        /// The sender of an <see cref="Unbind" /> command will receive confirmation through this
+        /// message once the listening socket has been closed.
+        /// </summary>
+        public class Unbound : Event
+        {
+            public static Unbound Instance = new Unbound();
+        }
+
+        /// <summary>
+        /// This is the common interface for all events which indicate that a connection
+        /// has been closed or half-closed.
+        /// </summary>
+        public class ConnectionClosed : Event
+        {
+            public virtual bool IsAborted
+            {
+                get { return false; }
+            }
+
+            public virtual bool IsConfirmed
+            {
+                get { return false; }
+            }
+
+            public virtual bool IsPeerClosed
+            {
+                get { return false; }
+            }
+
+            public virtual bool IsErrorClosed
+            {
+                get { return false; }
+            }
+
+            public virtual string GetErrorCause()
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// The connection has been closed normally in response to a <see cref="Close" /> command.
+        /// </summary>
+        public class Closed : ConnectionClosed
+        {
+            public static readonly Closed Instance = new Closed();
+
+            private Closed()
+            {
+            }
+        }
+
+        /// <summary>
+        /// The connection has been aborted in response to an <see cref="Abort" /> command.
+        /// </summary>
+        public class Aborted : ConnectionClosed
+        {
+            public static Aborted Instance = new Aborted();
+
+            private Aborted()
+            {
+            }
+
+            public override bool IsAborted
+            {
+                get { return true; }
+            }
+        }
+
+        /// <summary>
+        /// The connection has been half-closed by us and then half-close by the peer
+        /// in response to a <see cref="ConfirmedClose" /> command.
+        /// </summary>
+        public class ConfirmedClosed : ConnectionClosed
+        {
+            public static ConfirmedClosed Instance = new ConfirmedClosed();
+
+            private ConfirmedClosed()
+            {
+            }
+
+            public override bool IsConfirmed
+            {
+                get { return true; }
+            }
+        }
+
+        /// <summary>
+        /// The peer has closed its writing half of the connection.
+        /// </summary>
+        public class PeerClosed : ConnectionClosed
+        {
+            public static PeerClosed Instance = new PeerClosed();
+
+            private PeerClosed()
+            {
+            }
+
+            public override bool IsPeerClosed
+            {
+                get { return true; }
+            }
+        }
+
+        /// <summary>
+        /// The connection has been closed due to an IO error.
+        /// </summary>
+        public class ErrorClosed : ConnectionClosed
+        {
+            private readonly string _cause;
+
+            public ErrorClosed(string cause)
+            {
+                _cause = cause;
+            }
+
+            public override bool IsErrorClosed
+            {
+                get { return true; }
+            }
+
+            public override string GetErrorCause()
+            {
+                return _cause;
+            }
+        }
+    }
+
+    public class TcpExt : Extension
+    {
+        private readonly TcpSettings _settings;
+        private readonly IActorRef _manager;
+        private readonly IBufferPool _bufferPool = new DirectByteBufferPool();
+
+        public class TcpSettings : SelectionHandlerSettings
+        {
+            public TcpSettings(Config config)
+                : base(config)
+            {
+                //TODO: requiring, check defaults
+                NrOfSelectors = config.GetInt("nr-of-selectors", 1);
+                BatchAcceptLimit = config.GetInt("batch-accept-limit");
+                DirectBufferSize = config.GetInt("direct-buffer-size");
+                MaxDirectBufferPoolSize = config.GetInt("direct-buffer-pool-limit");
+                RegisterTimeout = config.GetTimeSpan("register-timeout");
+                ReceivedMessageSizeLimit = config.GetString("max-received-message-size") == "unlimited"
+                    ? int.MaxValue
+                    : config.GetInt("max-received-message-size");
+                ManagementDispatcher = config.GetString("management-dispatcher");
+                MaxChannelsPerSelector = MaxChannels == -1 ? -1 : Math.Max(MaxChannels/NrOfSelectors, 1);
+                FinishConnectRetries = config.GetInt("finish-connect-retries", 3);
+            }
+
+            public int NrOfSelectors { get; private set; }
+            public int BatchAcceptLimit { get; private set; }
+            public int DirectBufferSize { get; private set; }
+            public int MaxDirectBufferPoolSize { get; private set; }
+            public TimeSpan? RegisterTimeout { get; private set; }
+            public int ReceivedMessageSizeLimit { get; private set; }
+            public string ManagementDispatcher { get; private set; }
+            public int FinishConnectRetries { get; private set; }
+        }
+
+        public TcpExt(ExtendedActorSystem system)
+        {
+            _settings = new TcpSettings(system.Settings.Config.GetConfig("akka.io.tcp"));
+            _manager = system.SystemActorOf(
+                props: Props.Create(() => new TcpManager(this))
+                                            .WithDispatcher(_settings.ManagementDispatcher)
+                                            .WithDeploy(Deploy.Local),
+                name: "IO-TCP");
+        }
+
+        public override IActorRef Manager
+        {
+            get { return _manager; }
+        }
+
+        public IActorRef GetManager()
+        {
+            return _manager;
+        }
+
+        public TcpSettings Settings
+        {
+            get { return _settings; }
+        }
+
+        internal IBufferPool BufferPool
+        {
+            get { return _bufferPool; }
+        }
+    }
+
+    public class TcpMessage
+    {
+        public static Tcp.Command Connect(IPEndPoint remoteAddress,
+            IPEndPoint localAddress,
+            IEnumerable<Inet.SocketOption> options,
+            TimeSpan? timeout,
+            bool pullMode)
+        {
+            return new Tcp.Connect(remoteAddress, localAddress, options, timeout, pullMode);
+        }
+
+        public static Tcp.Command Connect(IPEndPoint remoteAddress)
+        {
+            return Connect(remoteAddress, null, null, null, false);
+        }
+
+        public static Tcp.Command Bind(IActorRef handler,
+            IPEndPoint endpoint,
+            int backlog,
+            IEnumerable<Inet.SocketOption> options,
+            bool pullMode)
+        {
+            return new Tcp.Bind(handler, endpoint, backlog, options, pullMode);
+        }
+
+        public static Tcp.Command Bind(IActorRef handler, IPEndPoint endpoint, int backlog)
+        {
+            return new Tcp.Bind(handler, endpoint, backlog);
+        }
+
+        public static Tcp.Command Register(IActorRef handler, bool keepOpenOnPeerClosed = false,
+            bool useResumeWriting = true)
+        {
+            return new Tcp.Register(handler, keepOpenOnPeerClosed, useResumeWriting);
+        }
+
+        public static Tcp.Command Unbind()
+        {
+            return Tcp.Unbind.Instance;
+        }
+
+        public static Tcp.Command Close()
+        {
+            return Tcp.Close.Instance;
+        }
+
+        public static Tcp.Command ConfirmedClose()
+        {
+            return Tcp.ConfirmedClose.Instance;
+        }
+
+        public static Tcp.Command Abort()
+        {
+            return Tcp.Abort.Instance;
+        }
+
+        public static Tcp.NoAck NoAck(object token = null)
+        {
+            return new Tcp.NoAck(token);
+        }
+
+        public static Tcp.Command Write(ByteString data, Tcp.Event ack = null)
+        {
+            return new Tcp.Write(data, ack);
+        }
+
+        public static Tcp.Command ResumeWriting()
+        {
+            return Tcp.ResumeWriting.Instance;
+        }
+
+        public static Tcp.Command SuspendReading()
+        {
+            return Tcp.SuspendReading.Instance;
+        }
+
+        public static Tcp.Command ResumeReading()
+        {
+            return Tcp.ResumeReading.Instance;
+        }
+
+        public static Tcp.Command ResumeAccepting(int batchSize)
+        {
+            return new Tcp.ResumeAccepting(batchSize);
+        }
+    }
+}

--- a/src/core/Akka/IO/TcpConnection.cs
+++ b/src/core/Akka/IO/TcpConnection.cs
@@ -1,0 +1,810 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ActorBase.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using Akka.Actor;
+using Akka.Dispatch;
+using Akka.Event;
+using Akka.Pattern;
+using Akka.Util.Internal;
+
+namespace Akka.IO
+{
+    /**
+    *  Base class for TcpIncomingConnection and TcpOutgoingConnection.
+    *
+    *  INTERNAL API
+    */
+    internal abstract class TcpConnection : ActorBase, IRequiresMessageQueue<IUnboundedMessageQueueSemantics>
+    {
+        private readonly TcpExt _tcp;
+        private readonly SocketChannel _channel;
+        private readonly bool _pullMode;
+        private readonly ILoggingAdapter _log = Context.GetLogger();
+
+        protected TcpExt Tcp
+        {
+            get { return _tcp; }
+        }
+
+        protected ILoggingAdapter Log
+        {
+            get { return _log; }
+        }
+
+        internal SocketChannel Channel
+        {
+            get { return _channel; }
+        }
+
+        protected TcpConnection(TcpExt tcp, SocketChannel channel, bool pullMode)
+        {
+            _tcp = tcp;
+            _channel = channel;
+            _pullMode = pullMode;
+            _readingSuspended = pullMode;
+        }
+
+        private PendingWrite _pendingWrite = EmptyPendingWrite.Instance;
+        private bool _peerClosed;
+        private bool _writingSuspended;
+        private bool _readingSuspended;
+        private IActorRef _interestedInResume;
+        private CloseInformation _closedMessage;  // for ConnectionClosed message in postStop
+
+        private bool WritePending()
+        {
+            return _pendingWrite != EmptyPendingWrite.Instance;
+        }
+
+        // STATES
+
+        /** connection established, waiting for registration from user handler */
+        private Receive WaitingForRegistration(ChannelRegistration registration, IActorRef commander)
+        {
+            return message =>
+            {
+                var register = message as Tcp.Register;
+                if (register != null)
+                {
+                    // up to this point we've been watching the commander,
+                    // but since registration is now complete we only need to watch the handler from here on
+                    if (register.Handler != commander)
+                    {
+                        Context.Unwatch(commander);
+                        Context.Watch(register.Handler);
+                    }
+                    if (_tcp.Settings.TraceLogging) _log.Debug("[{0}] registered as connection handler", register.Handler);
+
+                    var info = new ConnectionInfo(registration, register.Handler, register.KeepOpenonPeerClosed, register.UseResumeWriting);
+                    
+                    // if we have resumed reading from pullMode while waiting for Register then register OP_READ interest
+                    if (_pullMode && !_readingSuspended) ResumeReading(info);
+                    DoRead(info, null); // immediately try reading, pullMode is handled by readingSuspended
+                    Context.SetReceiveTimeout(null);
+                    Context.Become(Connected(info));
+                    return true;
+                }
+                if (message is Tcp.ResumeReading)
+                {
+                    _readingSuspended = false;
+                    return true;
+                }
+                if (message is Tcp.SuspendReading)
+                {
+                    _readingSuspended = true;
+                    return false;
+                }
+                var cmd = message as Tcp.CloseCommand;
+                if (cmd != null)
+                {
+                    var info = new ConnectionInfo(registration, commander, keepOpenOnPeerClosed: false, useResumeWriting: false);
+                    HandleClose(info, Sender, cmd.Event);
+                    return true;
+                }
+                if (message is ReceiveTimeout)
+                {
+                    // after sending `Register` user should watch this actor to make sure
+                    // it didn't die because of the timeout
+                    _log.Debug("Configured registration timeout of [{0}] expired, stopping", _tcp.Settings.RegisterTimeout);
+                    Context.Stop(Self);
+                    return true;
+                }
+                return false;
+            };
+        }
+
+        /** normal connected state */
+        private Receive Connected(ConnectionInfo info)
+        {
+            return message =>
+            {
+                if (HandleWriteMessages(info)(message))
+                    return true;
+                if (message is Tcp.SuspendReading)
+                {
+                    SuspendReading(info);
+                    return true;
+                }
+                if (message is Tcp.ResumeReading)
+                {
+                    ResumeReading(info);
+                    return true;
+                }
+                if (message is SelectionHandler.ChannelReadable)
+                {
+                    DoRead(info, null);
+                    return true;
+                }
+                var cmd = message as Tcp.CloseCommand;
+                if (cmd != null)
+                {
+                    HandleClose(info, Sender, cmd.Event);
+                }
+                return false;
+            };
+        }
+
+        /** the peer sent EOF first, but we may still want to send */
+        private Receive PeerSentEOF(ConnectionInfo info)
+        {
+            return message =>
+            {
+                if (HandleWriteMessages(info)(message))
+                    return true;
+                var cmd = message as Tcp.CloseCommand;
+                if (cmd != null)
+                {
+                    HandleClose(info, Sender, cmd.Event);
+                    return true;
+                }
+                return false;
+            };
+        }
+
+        /** connection is closing but a write has to be finished first */
+        private Receive ClosingWithPendingWrite(ConnectionInfo info, IActorRef closeCommandor,
+            Tcp.ConnectionClosed closedEvent)
+        {
+            return message =>
+            {
+                if (message is Tcp.SuspendReading)
+                {
+                    SuspendReading(info);
+                    return true;
+                }
+                if (message is Tcp.ResumeReading)
+                {
+                    ResumeReading(info);
+                    return true;
+                }
+                if (message is SelectionHandler.ChannelReadable)
+                {
+                    DoRead(info, closeCommandor);
+                    return true;
+                }
+                if (message is SelectionHandler.ChannelWritable)
+                {
+                    DoWrite(info);
+                    if (!WritePending())    // writing is now finished
+                        HandleClose(info, closeCommandor, closedEvent);
+                    return true;
+                }
+                var updatePendingWrite = message as UpdatePendingWriteAndThen;
+                if (updatePendingWrite != null)
+                {
+                    _pendingWrite = updatePendingWrite.RemainingWrite;
+                    updatePendingWrite.Work();
+                    if (WritePending())
+                        info.Registration.EnableInterest(SocketAsyncOperation.Send);
+                    else
+                        HandleClose(info, closeCommandor, closedEvent);
+                    return true;
+                }
+                var writeFailed = message as WriteFileFailed;
+                if (writeFailed != null)
+                {
+                    HandleError(info.Handler, writeFailed.E);  // rethrow exception from dispatcher task
+                    return true;
+                }
+                if (message is Tcp.Abort)
+                {
+                    HandleClose(info, Sender, IO.Tcp.Aborted.Instance);
+                    return true;
+                }
+                return false;
+            };
+        }
+
+        /** connection is closed on our side and we're waiting from confirmation from the other side */
+        private Receive Closing(ConnectionInfo info, IActorRef closeCommandor)
+        {
+            return message =>
+            {
+                if (message is Tcp.SuspendReading)
+                {
+                    SuspendReading(info);
+                    return true;
+                }
+                if (message is Tcp.ResumeReading)
+                {
+                    ResumeReading(info);
+                    return true;
+                }
+                if (message is SelectionHandler.ChannelReadable)
+                {
+                    DoRead(info, closeCommandor);
+                    return true;
+                }
+                if (message is Tcp.Abort)
+                {
+                    HandleClose(info, Sender, IO.Tcp.Aborted.Instance);
+                    return true;
+                }
+                return false;
+            };
+        }
+
+        private Receive HandleWriteMessages(ConnectionInfo info)
+        {
+            return message =>
+            {
+                if (message is SelectionHandler.ChannelWritable)
+                {
+                    if (WritePending())
+                    {
+                        DoWrite(info);
+                        if (WritePending() && _interestedInResume != null)
+                        {
+                            _interestedInResume.Tell(IO.Tcp.WritingResumed.Instance);
+                            _interestedInResume = null;
+                        }
+                    }
+                    return true;
+                }
+                var write = message as Tcp.WriteCommand;
+                if (write != null)
+                {
+                    if (_writingSuspended)
+                    {
+                        if (_tcp.Settings.TraceLogging) _log.Debug("Dropping write because writing is suspended");
+                        Sender.Tell(write.FailureMessage);
+                    }
+                    else if (WritePending())
+                    {
+                        if (_tcp.Settings.TraceLogging) _log.Debug("Dropping write because queue is full");
+                        Sender.Tell(write.FailureMessage);
+                        if (info.UseResumeWriting) _writingSuspended = true;
+                    }
+                    else
+                    {
+                        _pendingWrite = CreatePendingWrite(Sender, write);
+                        if (WritePending())
+                            DoWrite(info);
+                    }
+                    return true;
+                }
+                if (message is Tcp.ResumeWriting)
+                {
+                    /*
+                     * If more than one actor sends Writes then the first to send this
+                     * message might resume too early for the second, leading to a Write of
+                     * the second to go through although it has not been resumed yet; there
+                     * is nothing we can do about this apart from all actors needing to
+                     * register themselves and us keeping track of them, which sounds bad.
+                     *
+                     * Thus it is documented that useResumeWriting is incompatible with
+                     * multiple writers. But we fail as gracefully as we can.
+                     */
+                    _writingSuspended = false;
+                    if (WritePending())
+                    {
+                        if (_interestedInResume == null) _interestedInResume = Sender;
+                        else Sender.Tell(new Tcp.CommandFailed(IO.Tcp.ResumeWriting.Instance));
+                    }
+                    else Sender.Tell(IO.Tcp.WritingResumed.Instance);
+                    return true;
+                }
+                var updatePendingWrite = message as UpdatePendingWriteAndThen;
+                if (updatePendingWrite != null)
+                {
+                    _pendingWrite = updatePendingWrite.RemainingWrite;
+                    updatePendingWrite.Work();
+                    if (WritePending())
+                        info.Registration.EnableInterest(SocketAsyncOperation.Send);
+                    return true;
+                }
+                //TODO: File IO
+                return false;
+            };
+        }
+
+        // AUXILIARIES and IMPLEMENTATION
+
+        /** used in subclasses to start the common machinery above once a channel is connected */
+        protected void CompleteConnect(ChannelRegistration registration, IActorRef commander,
+                                       IEnumerable<Inet.SocketOption> options)
+        {
+            // Turn off Nagle's algorithm by default
+            try
+            {
+                Channel.Socket.NoDelay = true;
+            }
+            catch (SocketException e)
+            {
+                _log.Debug("Could not enable TcpNoDelay: {0}", e.Message);
+            }
+            options.ForEach(x => x.AfterConnect(Channel.Socket));
+
+            commander.Tell(new Tcp.Connected(
+                (IPEndPoint) Channel.Socket.RemoteEndPoint,
+                (IPEndPoint) Channel.Socket.LocalEndPoint));
+
+            Context.SetReceiveTimeout(_tcp.Settings.RegisterTimeout);
+
+            // TODO: Not ported. The following need to be investigated before porting
+            //if (WindowsConnectionAbortWorkaroundEnabled) 
+            //    registration.EnableInterest(SocketAsyncOperation.Connect);
+
+            Context.Become(WaitingForRegistration(registration, commander));
+        }
+
+        private void SuspendReading(ConnectionInfo info)
+        {
+            _readingSuspended = true;
+            info.Registration.DisableInterest(SocketAsyncOperation.Receive);
+        }
+
+        private void ResumeReading(ConnectionInfo info)
+        {
+            _readingSuspended = false;
+            info.Registration.EnableInterest(SocketAsyncOperation.Receive);
+        }
+
+        private void DoRead(ConnectionInfo info, IActorRef closeCommander)
+        {
+            if (!_readingSuspended)
+            {
+                Func<ByteBuffer, int, ReadResult> innerRead = null;
+                innerRead = (buffer, remainingLimit) =>
+                {
+                    if (remainingLimit > 0)
+                    {
+                        buffer.Clear();
+                        var maxBufferSpace = Math.Min(_tcp.Settings.DirectBufferSize, remainingLimit);
+                        buffer.Limit(maxBufferSpace);
+                        var readBytes = Channel.Read(buffer);
+                        buffer.Flip();
+
+                        if (_tcp.Settings.TraceLogging) _log.Debug("Read [{0}] bytes.", readBytes);
+                        if (readBytes > 0)
+                            info.Handler.Tell(new Tcp.Received(ByteString.Create(buffer)));
+
+                        if (readBytes == maxBufferSpace)
+                        {
+                            return _pullMode
+                                ? MoreDataWaiting.Instance
+                                : innerRead(buffer, remainingLimit - maxBufferSpace);
+                        }
+                        if (readBytes >= 0)
+                            return AllRead.Instance;
+                        if (readBytes == -1)
+                            return EndOfStream.Instance;
+
+                        throw new IllegalStateException("Unexpected value returned from read: " + readBytes);
+                    }
+                    return MoreDataWaiting.Instance;
+                };
+                var buffr = _tcp.BufferPool.Acquire();
+                try
+                {
+                    var read = innerRead(buffr, _tcp.Settings.ReceivedMessageSizeLimit);
+                    if (read is AllRead)
+                    {
+                        if (!_pullMode)
+                            info.Registration.EnableInterest(SocketAsyncOperation.Receive);
+                    }
+                    if (read is MoreDataWaiting)
+                    {
+                        if (!_pullMode)
+                            Self.Tell(SelectionHandler.ChannelReadable.Instance);
+                    }
+
+                    // TODO: Port. Socket does not seem to expose (isOutputShutdown). It is passed as 'how' argument to Socket.Shutdown, but not exposed. 
+                    // case EndOfStream if channel.socket.isOutputShutdown ⇒
+                    //    if (TraceLogging) log.debug("Read returned end-of-stream, our side already closed")
+                    //    doCloseConnection(info.handler, closeCommander, ConfirmedClosed)
+
+                    if (read is EndOfStream)
+                    {
+                        if (_tcp.Settings.TraceLogging) _log.Debug("Read returned end-of-stream, our side not yet closed");
+                        HandleClose(info, closeCommander, IO.Tcp.PeerClosed.Instance);
+                    }
+                }
+                catch (IOException e)
+                {
+                    HandleError(info.Handler, e);
+                }
+                finally
+                {
+                    Tcp.BufferPool.Release(buffr);
+                }
+            }
+        }
+
+        private void DoWrite(ConnectionInfo info)
+        {
+            _pendingWrite = _pendingWrite.DoWrite(info);
+        }
+
+        private Tcp.ConnectionClosed CloseReason()
+        {
+            // TODO: Port. Socket does not seem to expose (isOutputShutdown). It is passed as 'how' argument to Socket.Shutdown, but not exposed. 
+            // if (channel.socket.isOutputShutdown) ConfirmedClosed
+            return IO.Tcp.PeerClosed.Instance;
+        }
+
+        private void HandleClose(ConnectionInfo info, IActorRef closeCommander, Tcp.ConnectionClosed closedEvent)
+        {
+            if (closedEvent is Tcp.Aborted)
+            {
+                if (_tcp.Settings.TraceLogging) _log.Debug("Got Abort command. RESETing connection.");
+                DoCloseConnection(info.Handler, closeCommander, closedEvent);
+                return;
+            }
+            if (closedEvent is Tcp.PeerClosed && info.KeepOpenOnPeerClosed)
+            {
+                // report that peer closed the connection
+                info.Handler.Tell(IO.Tcp.PeerClosed.Instance);
+                // used to check if peer already closed its side later
+                _peerClosed = true;
+                Context.Become(PeerSentEOF(info));
+                return;
+            }
+            if (WritePending())   // finish writing first
+            {
+                if (_tcp.Settings.TraceLogging) _log.Debug("Got Close command but write is still pending.");
+                Context.Become(ClosingWithPendingWrite(info, closeCommander, closedEvent));
+                return;
+            }
+            if (closedEvent is Tcp.ConfirmedClosed) // shutdown output and wait for confirmation
+            {
+                if (_tcp.Settings.TraceLogging) _log.Debug("Got ConfirmedClose command, sending FIN.");
+
+                // If peer closed first, the socket is now fully closed.
+                // Also, if shutdownOutput threw an exception we expect this to be an indication
+                // that the peer closed first or concurrently with this code running.
+                if (_peerClosed || !SafeShutdownOutput())
+                    DoCloseConnection(info.Handler, closeCommander, closedEvent);
+                else Context.Become(Closing(info, closeCommander));
+                return;
+            }
+            // close now
+            if (_tcp.Settings.TraceLogging) _log.Debug("Got Close command, closing connection.");
+            DoCloseConnection(info.Handler, closeCommander, closedEvent);
+        }
+
+        private void DoCloseConnection(IActorRef handler, IActorRef closeCommander, Tcp.ConnectionClosed closedEvent)
+        {
+            if (closedEvent is Tcp.Aborted) Abort();
+            else _channel.Close();
+            StopWith(new CloseInformation(new HashSet<IActorRef>(new[] { handler, closeCommander }.Where(x => x != null)), closedEvent));
+        }
+
+        private void HandleError(IActorRef handler, IOException exception)
+        {
+            _log.Debug("Closing connection due to IO error {0}", exception);
+            StopWith(new CloseInformation(new HashSet<IActorRef>(new[] {handler}), new Tcp.ErrorClosed(exception.Message)));
+        }
+
+        private bool SafeShutdownOutput()
+        {
+            try
+            {
+                Channel.Socket.Shutdown(SocketShutdown.Send);
+                return true;
+            }
+            catch (SocketException)
+            {
+                return false;
+            }
+        }
+
+        //TODO: Port. Where is this used?
+        /*
+          @tailrec private[this] def extractMsg(t: Throwable): String =
+            if (t == null) "unknown"
+            else {
+              t.getMessage match {
+                case null | "" ⇒ extractMsg(t.getCause)
+                case msg       ⇒ msg
+              }
+            }
+        */
+
+        private void Abort()
+        {
+            try
+            {
+                Channel.Socket.LingerState = new LingerOption(true, 0);  // causes the following close() to send TCP RST
+            }
+            catch (Exception e)
+            {
+                if (_tcp.Settings.TraceLogging) _log.Debug("setSoLinger(true, 0) failed with [{0}]", e);
+            }
+            Channel.Close();
+        }
+
+        protected void StopWith(CloseInformation closeInfo)
+        {
+            _closedMessage = closeInfo;
+            Context.Stop(Self);
+        }
+
+        protected override void PostStop()
+        {
+            if (Channel.IsOpen())
+                Abort();
+            if (WritePending())
+                _pendingWrite.Release();
+            if (_closedMessage != null)
+            {
+                var interestedInClose = WritePending()
+                    ? _closedMessage.NotificationsTo.Union(new[] {_pendingWrite.Commander})
+                    : _closedMessage.NotificationsTo;
+                interestedInClose.ForEach(x => x.Tell(_closedMessage.ClosedEvent));
+            }
+        }
+
+        protected override void PostRestart(Exception reason)
+        {
+            throw new IllegalStateException("Restarting not supported for connection actors.");
+        }
+
+        private PendingWrite CreatePendingWrite(IActorRef commander, Tcp.WriteCommand write)
+        {
+            Func<Tcp.WriteCommand, Tcp.WriteCommand, PendingWrite> create = null;
+            create = (head, tail) =>
+            {
+                if (head == IO.Tcp.Write.Empty)
+                    return tail == IO.Tcp.Write.Empty
+                        ? EmptyPendingWrite.Instance
+                        : create(tail, IO.Tcp.Write.Empty);
+                var w = head as Tcp.Write;
+                if (w != null && w.Data.NonEmpty)
+                {
+                    return CreatePendingBufferWrite(commander, w.Data, w.Ack, tail);
+                }
+                //TODO: Port file IO
+                var cwrite = head as Tcp.CompoundWrite;
+                if (cwrite != null)
+                {
+                    return create(cwrite.Head, cwrite.TailCommand);
+                }
+                if (w != null)  // empty write with either an ACK or a non-standard NoACK
+                {
+                    if (w.WantsAck) commander.Tell(w.Ack);
+                    create(tail, IO.Tcp.Write.Empty);
+                }
+                throw new Exception("Non reachable code");
+            };
+            return create(write, IO.Tcp.Write.Empty);
+        }
+
+        private PendingWrite CreatePendingBufferWrite(IActorRef commander, ByteString data, Tcp.Event ack, Tcp.WriteCommand tail)
+        {
+            var buffer = _tcp.BufferPool.Acquire();
+            try
+            {
+                var copied = data.CopyToBuffer(buffer);
+                buffer.Flip();
+                return new PendingBufferWrite(this, commander, data.Drop(copied), ack, buffer, tail);
+            }
+            catch (Exception)
+            {
+                _tcp.BufferPool.Release(buffer);
+                throw;
+            }
+        }
+
+        private class PendingBufferWrite : PendingWrite
+        {
+            private readonly TcpConnection _connection;
+            private readonly IActorRef _commander;
+            private readonly ByteString _remainingData;
+            private readonly object _ack;
+            private readonly ByteBuffer _buffer;
+            private readonly Tcp.WriteCommand _tail;
+
+            public PendingBufferWrite(
+                TcpConnection connection,
+                IActorRef commander,
+                ByteString remainingData,
+                object ack,
+                ByteBuffer buffer,
+                Tcp.WriteCommand tail)
+            {
+                _connection = connection;
+                _commander = commander;
+                _remainingData = remainingData;
+                _ack = ack;
+                _buffer = buffer;
+                _tail = tail;
+            }
+
+            public override IActorRef Commander
+            {
+                get { return _commander; }
+            }
+
+            public override PendingWrite DoWrite(ConnectionInfo info)
+            {
+                Func<ByteString, PendingWrite> writeToChannel = null;
+                writeToChannel = data =>
+                {
+                    var writtenBytes = _connection.Channel.Write(_buffer); // at first we try to drain the remaining bytes from the buffer
+                    if (_connection._tcp.Settings.TraceLogging) _connection._log.Debug("Wrote [{0}] bytes to channel", writtenBytes);
+                    if (_buffer.HasRemaining)
+                    {
+                        // we weren't able to write all bytes from the buffer, so we need to try again later
+                        return data == _remainingData
+                            ? this
+                            : new PendingBufferWrite(_connection, _commander, data, _ack, _buffer, _tail); // copy with updated remainingData
+                    }
+                    if (data.NonEmpty)
+                    {
+                        _buffer.Clear();
+                        var copied = data.CopyToBuffer(_buffer);
+                        _buffer.Flip();
+                        return writeToChannel(data.Drop(copied));
+                    }
+                    if (!(_ack is Tcp.NoAck)) _commander.Tell(_ack);
+                    Release();
+                    return _connection.CreatePendingWrite(_commander, _tail);
+                };
+                try
+                {
+                    var next = writeToChannel(_remainingData);
+                    if (next != EmptyPendingWrite.Instance)
+                        info.Registration.EnableInterest(SocketAsyncOperation.Send);
+                    return next;
+                }
+                catch (IOException e)
+                {
+                    _connection.HandleError(info.Handler, e);
+                    return this;
+                }
+            }
+
+            public override void Release()
+            {
+                _connection.Tcp.BufferPool.Release(_buffer);
+            }
+        }
+
+        //TODO: Port File IO
+
+        // INTERNAL API
+        private abstract class ReadResult
+        {
+        }
+        private class EndOfStream : ReadResult
+        {
+            public static readonly ReadResult Instance = new EndOfStream();
+
+            private EndOfStream()
+            { }
+        }
+        private class AllRead : ReadResult
+        {
+            public static readonly AllRead Instance = new AllRead();
+
+            private AllRead()
+            { }
+        }
+        private class MoreDataWaiting : ReadResult
+        {
+            public static readonly ReadResult Instance = new MoreDataWaiting();
+
+            private MoreDataWaiting()
+            { }
+        }
+
+        /**
+        * Used to transport information to the postStop method to notify
+        * interested party about a connection close.
+        */
+        protected class CloseInformation
+        {
+            public ISet<IActorRef> NotificationsTo { get; private set; }
+            public Tcp.Event ClosedEvent { get; private set; }
+
+            public CloseInformation(ISet<IActorRef> notificationsTo, Tcp.Event closedEvent)
+            {
+                NotificationsTo = notificationsTo;
+                ClosedEvent = closedEvent;
+            }
+        }
+
+        /**
+        * Groups required connection-related data that are only available once the connection has been fully established.
+        */
+        private class ConnectionInfo
+        {
+            public ChannelRegistration Registration { get; private set; }
+            public IActorRef Handler { get; private set; }
+            public bool KeepOpenOnPeerClosed { get; private set; }
+            public bool UseResumeWriting { get; private set; }
+
+            public ConnectionInfo(ChannelRegistration registration, IActorRef handler, bool keepOpenOnPeerClosed, bool useResumeWriting)
+            {
+                Registration = registration;
+                Handler = handler;
+                KeepOpenOnPeerClosed = keepOpenOnPeerClosed;
+                UseResumeWriting = useResumeWriting;
+            }
+        }
+
+        // INTERNAL MESSAGES
+        private class UpdatePendingWriteAndThen : INoSerializationVerificationNeeded
+        {
+            public PendingWrite RemainingWrite { get; private set; }
+            public Action Work { get; private set; }
+
+            public UpdatePendingWriteAndThen(PendingWrite remainingWrite, Action work)
+            {
+                RemainingWrite = remainingWrite;
+                Work = work;
+            }
+        }
+
+        private class WriteFileFailed
+        {
+            public IOException E { get; private set; }
+
+            public WriteFileFailed(IOException e)
+            {
+                E = e;
+            }
+        }
+
+        private abstract class PendingWrite
+        {
+            public abstract IActorRef Commander { get; }
+            public abstract PendingWrite DoWrite(ConnectionInfo info);
+            public abstract void Release();
+        }
+
+        private class EmptyPendingWrite : PendingWrite
+        {
+            public static PendingWrite Instance = new EmptyPendingWrite();
+
+            private EmptyPendingWrite()
+            { }
+
+            public override IActorRef Commander
+            {
+                get { throw new IllegalStateException(string.Empty); }
+            }
+
+            public override PendingWrite DoWrite(ConnectionInfo info)
+            {
+                throw new IllegalStateException(string.Empty);
+            }
+
+            public override void Release()
+            {
+                throw new IllegalStateException(string.Empty);
+            }
+        }
+    }
+}

--- a/src/core/Akka/IO/TcpIncomingConnection.cs
+++ b/src/core/Akka/IO/TcpIncomingConnection.cs
@@ -1,0 +1,52 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ActorBase.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Net.Sockets;
+using Akka.Actor;
+
+namespace Akka.IO
+{
+    /**
+    * An actor handling the connection state machine for an incoming, already connected
+    * SocketChannel.
+    *
+    * INTERNAL API
+    */
+    internal class TcpIncomingConnection : TcpConnection
+    {
+        private readonly IActorRef _bindHandler;
+        private readonly IEnumerable<Inet.SocketOption> _options;
+
+        public TcpIncomingConnection(TcpExt tcp, 
+                                     SocketChannel channel, 
+                                     IChannelRegistry registry, 
+                                     IActorRef bindHandler,
+                                     IEnumerable<Inet.SocketOption> options, 
+                                     bool readThrottling)
+            : base(tcp, channel, readThrottling)
+        {
+            _bindHandler = bindHandler;
+            _options = options;
+
+            Context.Watch(bindHandler); // sign death pact
+
+            registry.Register(channel, SocketAsyncOperation.None, Self);
+        }
+
+        protected override bool Receive(object message)
+        {
+            var registration = message as ChannelRegistration;
+            if (registration != null)
+            {
+                CompleteConnect(registration, _bindHandler, _options);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/core/Akka/IO/TcpListener.cs
+++ b/src/core/Akka/IO/TcpListener.cs
@@ -1,0 +1,181 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ActorBase.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using Akka.Actor;
+using Akka.Dispatch;
+using Akka.Event;
+using Akka.Util.Internal;
+
+namespace Akka.IO
+{
+    partial class TcpListener
+    {
+        public class RegisterIncoming : SelectionHandler.IHasFailureMessage, INoSerializationVerificationNeeded
+        {
+            public RegisterIncoming(SocketChannel channel)
+            {
+                Channel = channel;
+            }
+
+            public SocketChannel Channel { get; private set; }
+
+            public object FailureMessage
+            {
+                get { return new FailedRegisterIncoming(Channel); }
+            }
+        }
+
+        public class FailedRegisterIncoming
+        {
+            public FailedRegisterIncoming(SocketChannel channel)
+            {
+                Channel = channel;
+            }
+
+            public SocketChannel Channel { get; private set; }
+        }
+    }
+
+    partial class TcpListener : ActorBase, IRequiresMessageQueue<IUnboundedMessageQueueSemantics>
+    {
+        private readonly IActorRef _selectorRouter;
+        private readonly TcpExt _tcp;
+        private readonly IActorRef _bindCommander;
+        private readonly Tcp.Bind _bind;
+        private readonly SocketChannel _channel;
+        private readonly ILoggingAdapter _log = Context.GetLogger();
+
+        private int acceptLimit;
+
+        public TcpListener(IActorRef selectorRouter, TcpExt tcp, IChannelRegistry channelRegistry, IActorRef bindCommander,
+            Tcp.Bind bind)
+        {
+            _selectorRouter = selectorRouter;
+            _tcp = tcp;
+            _bindCommander = bindCommander;
+            _bind = bind;
+
+            Context.Watch(bind.Handler);
+
+            _channel = SocketChannel.Open();
+
+            acceptLimit = bind.PullMode ? 0 : _tcp.Settings.BatchAcceptLimit;
+
+            var localAddress = new Func<EndPoint>(() =>
+            {
+                var socket = _channel.Socket;
+                bind.Options.ForEach(x => x.BeforeServerSocketBind(_channel.Socket));
+
+                socket.Bind(bind.LocalAddress);
+                socket.Listen(bind.Backlog);
+
+                channelRegistry.Register(_channel,
+                    bind.PullMode ? SocketAsyncOperation.None : SocketAsyncOperation.Accept, Self);
+                return socket.LocalEndPoint;
+            })();
+        }
+
+        protected override SupervisorStrategy SupervisorStrategy()
+        {
+            return SelectionHandler.ConnectionSupervisorStrategy;
+        }
+
+        protected override bool Receive(object message)
+        {
+            var registration = message as ChannelRegistration;
+            if (registration != null)
+            {
+                _bindCommander.Tell(new Tcp.Bound((IPEndPoint) _channel.Socket.LocalEndPoint));
+                Context.Become(Bound(registration));
+            }
+
+            return false;
+        }
+
+        private Receive Bound(ChannelRegistration registration)
+        {
+            return message =>
+            {
+                if (message is SelectionHandler.ChannelAcceptable)
+                {
+                    acceptLimit = AcceptAllPending(registration, acceptLimit); 
+                    if (acceptLimit > 0)
+                        registration.EnableInterest(SocketAsyncOperation.Accept);
+                    return true;
+                }
+                var resumeAccepting = message as Tcp.ResumeAccepting;
+                if (resumeAccepting != null)
+                {
+                    acceptLimit = resumeAccepting.BatchSize;
+                    registration.EnableInterest(SocketAsyncOperation.Accept);
+                    return true;
+                }
+                var failedRegisterIncoming = message as FailedRegisterIncoming;
+                if (failedRegisterIncoming != null)
+                {
+                    _log.Warning("Could not register incoming connection since selector capacity limit is reached, closing connection");
+                    try
+                    {
+                        failedRegisterIncoming.Channel.Close();
+                    }
+                    catch (Exception ex)
+                    {
+                        //TODO: log.debug("Error closing socket channel: {}", e)
+                    }
+                    return true;
+                }
+                if (message is Tcp.Unbind)
+                {
+                    //TODO: log.debug("Unbinding endpoint {}", localAddress)
+                    _channel.Close();
+                    Sender.Tell(Tcp.Unbound.Instance);
+                    //TODO: log.debug("Unbound endpoint {}, stopping listener", localAddress)
+                    Context.Stop(Self);
+                    return true;
+                }
+                return false;
+            };
+        }
+
+        private int AcceptAllPending(ChannelRegistration registration, int limit)
+        {
+            var socketChannel = new Func<SocketChannel>(() =>
+            {
+                if (limit <= 0) return null;
+                try
+                {
+                    return _channel.Accept();
+                }
+                catch (Exception ex)
+                {
+                    // log.error(e, "Accept error: could not accept new connection")
+                    return null;
+                }
+            })();
+            if (socketChannel != null)
+            {
+                Func<IChannelRegistry, Props> props = registry => Props.Create(
+                    () => new TcpIncomingConnection(_tcp, socketChannel, registry, _bind.Handler, _bind.Options, _bind.PullMode));
+                _selectorRouter.Tell(new SelectionHandler.WorkerForCommand(new RegisterIncoming(socketChannel), Self, props));
+                return AcceptAllPending(registration, limit - 1);
+            }
+            if (_bind.PullMode) return limit;
+            return _tcp.Settings.BatchAcceptLimit; 
+        }
+
+        protected override void PostStop()
+        {
+            if (_channel.IsOpen())
+            {
+                _channel.Close();
+            }
+        }
+    }
+}

--- a/src/core/Akka/IO/TcpManager.cs
+++ b/src/core/Akka/IO/TcpManager.cs
@@ -1,0 +1,43 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ActorBase.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+
+namespace Akka.IO
+{
+    internal class TcpManager : SelectionHandler.SelectorBasedManager
+    {
+        private readonly TcpExt _tcp;
+
+        public TcpManager(TcpExt tcp)
+            : base(tcp.Settings, tcp.Settings.NrOfSelectors)
+        {
+            _tcp = tcp;
+        }
+
+        protected override bool Receive(object m)
+        {
+            return WorkerForCommandHandler(message =>
+            {
+                var c = message as Tcp.Connect;
+                if (c != null)
+                {
+                    var commander = Sender;
+                    return registry => Props.Create(() => new TcpOutgoingConnection(_tcp, registry, commander, c));
+                }
+                var b = message as Tcp.Bind;
+                if (b != null)
+                {
+                    var commander = Sender;
+                    return registry => Props.Create(() => new TcpListener(SelectorPool, _tcp, registry, commander, b));
+                }
+                throw new Exception();
+            })(m);
+        }
+    }
+}

--- a/src/core/Akka/IO/TcpOutgoingConnection.cs
+++ b/src/core/Akka/IO/TcpOutgoingConnection.cs
@@ -1,0 +1,134 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ActorBase.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using Akka.Actor;
+using Akka.Util.Internal;
+
+namespace Akka.IO
+{
+    internal class TcpOutgoingConnection : TcpConnection
+    {
+        private readonly IChannelRegistry _channelRegistry;
+        private readonly IActorRef _commander;
+        private readonly Tcp.Connect _connect;
+
+        public TcpOutgoingConnection(TcpExt tcp, IChannelRegistry channelRegistry, IActorRef commander, Tcp.Connect connect)
+            : base(tcp, SocketChannel.Open().ConfigureBlocking(false), connect.PullMode)
+        {
+            _channelRegistry = channelRegistry;
+            _commander = commander;
+            _connect = connect;
+
+            Context.Watch(commander);    // sign death pact
+
+            connect.Options.ForEach(_ => _.BeforeConnect(Channel.Socket));
+            if (connect.LocalAddress != null)
+                Channel.Socket.Bind(connect.LocalAddress);
+            channelRegistry.Register(Channel, SocketAsyncOperation.None, Self);
+            if (connect.Timeout.HasValue)
+                Context.SetReceiveTimeout(connect.Timeout.Value);  //Initiate connection timeout if supplied
+        }
+
+        private void Stop()
+        {
+            StopWith(new CloseInformation(new HashSet<IActorRef>(new[] {_commander}), _connect.FailureMessage));
+        }
+
+        private void ReportConnectFailure(Action thunk)
+        {
+            try
+            {
+                thunk();
+            }
+            catch (Exception e)
+            {
+                Log.Debug("Could not establish connection to [{0}] due to {1}", _connect.RemoteAddress, e);
+                Context.Stop(Self);
+            }
+        }
+
+        protected override bool Receive(object message)
+        {
+            var registration = message as ChannelRegistration;
+            if (registration != null)
+            {
+                ReportConnectFailure(() =>
+                {
+                    //TODO: Port DNS
+                    Register(_connect.RemoteAddress, registration);
+                });
+                return true;
+            }
+            return false;
+        }
+
+        //TODO: Port DNS
+
+        private void Register(IPEndPoint address, ChannelRegistration registration)
+        {
+            ReportConnectFailure(() =>
+            {
+                Log.Debug("Attempting connection to [{0}]", address);
+                if (Channel.Connect(address))
+                {
+                    CompleteConnect(registration, _commander, _connect.Options);
+                }
+                else
+                {
+                    registration.EnableInterest(SocketAsyncOperation.Connect);
+                    Become(Connecting(registration, Tcp.Settings.FinishConnectRetries));
+                }
+            });
+        }
+
+        private Receive Connecting(ChannelRegistration registration, int remainingFinishConnectRetries)
+        {
+            return message =>
+            {
+                if (message is SelectionHandler.ChannelConnectable)
+                {
+                    ReportConnectFailure(() =>
+                    {
+                        if (Channel.FinishConnect())
+                        {
+                            if(_connect.Timeout.HasValue) Context.SetReceiveTimeout(null);
+                            Log.Debug("Connection established to [{0}]", _connect.RemoteAddress);
+                            CompleteConnect(registration, _commander, _connect.Options);
+                        }
+                        else
+                        {
+                            if (remainingFinishConnectRetries > 0)
+                            {
+                                Context.System.Scheduler.Advanced.ScheduleOnce(1, () => _channelRegistry.Register(Channel, SocketAsyncOperation.Connect, Self));
+                                Context.Become(Connecting(registration, remainingFinishConnectRetries - 1));
+                            }
+                            else
+                            {
+                                Log.Debug("Could not establish connection because finishConnect " +
+                                          "never returned true (consider increasing akka.io.tcp.finish-connect-retries)");
+                                Stop();
+                            }
+                        }
+                    });
+                    return true;
+                }
+                if (message is ReceiveTimeout)
+                {
+                    if (_connect.Timeout.HasValue) Context.SetReceiveTimeout(null);  // Clear the timeout
+                    Log.Debug("Connect timeout expired, could not establish connection to [{0}]", _connect.RemoteAddress);
+                    Stop();
+                    return true;
+                }
+                return false;
+            };
+        }
+    }
+}

--- a/src/core/Akka/Util/ByteIterator.cs
+++ b/src/core/Akka/Util/ByteIterator.cs
@@ -1,0 +1,471 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ActorBase.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Akka.IO;
+
+namespace Akka.Util
+{
+    internal abstract class ByteIterator
+    {
+        internal class ByteArrayIterator : ByteIterator
+        {
+            private byte[] _array;
+            private int _until;
+            private int _from;
+
+            public ByteArrayIterator(byte[] array, int @from, int until)
+            {
+                _array = array;
+                _from = @from;
+                _until = until;
+            }
+
+            public override int Len
+            {
+                get { return _until - _from; }
+            }
+
+            public override bool HasNext
+            {
+                get { return _from < _until; }
+            }
+
+            public override byte Head
+            {
+                get { return _array[_from]; }
+            }
+
+            public override byte Next()
+            {
+                if (!HasNext) throw new IndexOutOfRangeException();
+                return _array[_from++];
+            }
+
+            protected override void Clear()
+            {
+                _array = new byte[0];
+                _from = _until = 0;
+            }
+
+            public int Length()
+            {
+                var l = Len;
+                Clear();
+                return l;
+            }
+
+            public new ByteArrayIterator Clone()
+            {
+                return new ByteArrayIterator(_array, _from, _until);
+            }
+
+            public override ByteIterator Take(int n)
+            {
+                if (n < Len)
+                    _until = n > 0 ? _from + n : _from;
+                return this;
+            }
+
+            public override ByteIterator Drop(int n)
+            {
+                if (n > 0)
+                    _from = n < Len ? _from + n : _until;
+                return this;
+            }
+
+            public new ByteArrayIterator TakeWhile(Func<byte, bool> p)
+            {
+                var prev = _from;
+                DropWhile(p);
+                _until = _from;
+                _from = prev;
+                return this;
+            }
+
+            public new ByteArrayIterator DropWhile(Func<byte, bool> p)
+            {
+                var stop = false;
+                while (!stop && HasNext)
+                {
+                    if (p(_array[_from]))
+                        _from++;
+                    else
+                        stop = true;
+                }
+                return this;
+            }
+
+            public void CopToArray(byte[] xs, int start, int len)
+            {
+                var n = Math.Max(0, Math.Min(Math.Min(xs.Length - start, Len), len));
+                Array.Copy(_array, _from, xs, start, n);
+                Drop(n);
+            }
+
+            public override ByteString ToByteString()
+            {
+                var result = _from == 0 && _until == _array.Length
+                    ? new ByteString.ByteString1C(_array) as ByteString
+                    : new ByteString.ByteString1(_array, _from, Len);
+                Clear();
+                return result;
+            }
+
+            public ByteArrayIterator GetBytes(byte[] xs, int offset, int n)
+            {
+                if (n > Len) throw new Exception();
+                Array.Copy(_array, _from, xs, offset, n);
+                return (ByteArrayIterator) Drop(n);
+            }
+
+            public override byte[] ToArray()
+            {
+                var array = new byte[Len];
+                CopToArray(array, 0, Len);
+                return array;
+            }
+
+            public override int CopyToBuffer(ByteBuffer buffer)
+            {
+                var copyLength = Math.Min(buffer.Remaining, Len);
+                if (copyLength > 0)
+                {
+                    buffer.Put(_array, _from, copyLength);
+                    //Drop(copyLength);
+                }
+                return copyLength;
+            }
+        }
+
+        internal class MultiByteIterator : ByteIterator
+        {
+            private ILinearSeq<ByteArrayIterator> _iterators;
+            private ByteArrayIterator _current;
+            private static readonly ByteArrayIterator[] ClearedList = new ByteArrayIterator[0];
+
+            public MultiByteIterator(params ByteArrayIterator[] iterators)
+            {
+                _iterators = new ArrayLinearSeq<ByteArrayIterator>(iterators);
+                Normalize();
+            }
+
+            public MultiByteIterator(ILinearSeq<ByteArrayIterator> iterators)
+            {
+                _iterators = iterators;
+                Normalize();
+            }
+
+            private MultiByteIterator Normalize()
+            {
+                Func<IEnumerable<ByteArrayIterator>, IEnumerable<ByteArrayIterator>> norm = null;
+                norm = xs =>
+                {
+                    if (!xs.Any()) return ClearedList;
+                    if (!xs.First().HasNext) return norm(xs.Skip(1));
+                    return xs;
+
+                };
+                _iterators = new ArrayLinearSeq<ByteArrayIterator>(norm(_iterators).ToArray());
+                return this;
+            }
+
+            private void DropCurrent()
+            {
+                _iterators = _iterators.Tail();
+            }
+
+            protected override void Clear()
+            {
+                _iterators = new ArrayLinearSeq<ByteArrayIterator>(new ByteArrayIterator[0]);
+            }
+
+            public override bool HasNext
+            {
+                get { return _current.HasNext; }
+            }
+
+            public override byte Head
+            {
+                get { return _current.Head; }
+            }
+
+            public override byte Next()
+            {
+                var result = _current.Next();
+                Normalize();
+                return result;
+            }
+
+            public override int Len
+            {
+                get { return _iterators.Aggregate(0, (a, x) => a + x.Len); }
+            }
+
+
+            public override ByteIterator Take(int n)
+            {
+                var rest = n;
+                var builder = new List<ByteArrayIterator>();
+                while (rest > 0 && !_iterators.IsEmpty)
+                {
+                    _current.Take(rest);
+                    if (_current.HasNext)
+                    {
+                        rest -= _current.Len;
+                        builder.Add(_current);
+                    }
+                    _iterators = _iterators.Tail();
+                }
+                _iterators = new ArrayLinearSeq<ByteArrayIterator>(builder.ToArray());
+                return Normalize();
+            }
+
+            public override ByteIterator Drop(int n)
+            {
+                if (n > 0 && Len > 0)
+                {
+                    var nCurrent = Math.Min(n, _current.Len);
+                    _current.Drop(n);
+                    var rest = n - nCurrent;
+                    Normalize();
+                    return Drop(rest);
+                }
+                return this;
+            }
+
+            public override ByteIterator TakeWhile(Func<byte, bool> p)
+            {
+                var stop = false;
+                var builder = new List<ByteArrayIterator>();
+                while (!stop && !_iterators.IsEmpty)
+                {
+                    var lastLen = _current.Len;
+                    _current.TakeWhile(p);
+                    if (_current.HasNext) builder.Add(_current);
+                    if (_current.Len < lastLen) stop = true;
+                    DropCurrent();
+                }
+                _iterators = new ArrayLinearSeq<ByteArrayIterator>(builder.ToArray());
+                return Normalize();
+            }
+
+            public override ByteIterator DropWhile(Func<byte, bool> p)
+            {
+                if (Len > 0)
+                {
+                    _current.DropWhile(p);
+                    var dropMore = _current.Len == 0;
+                    Normalize();
+                    if (dropMore) return DropWhile(p);
+                }
+                return this;
+            }
+
+            public override ByteString ToByteString()
+            {
+                if (_iterators.Tail().IsEmpty) return _iterators.Head.ToByteString();
+                var result = _iterators.Aggregate(ByteString.Empty, (a, x) => a + x.ToByteString());
+                Clear();
+                return result;
+            }
+
+            public override byte[] ToArray()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override int CopyToBuffer(ByteBuffer buffer)
+            {
+                var n = _iterators.Aggregate(0, (a, x) => a + x.CopyToBuffer(buffer));
+                Normalize();
+                return n;
+            }
+        }
+
+        public abstract int Len { get; }
+        public abstract bool HasNext { get; }
+        public abstract byte Head { get; }
+        public abstract byte Next();
+        protected abstract void Clear();
+
+        public virtual ByteIterator Clone()
+        {
+            throw new NotSupportedException();
+        }
+
+        public Tuple<ByteIterator, ByteIterator> Duplicate()
+        {
+            return Tuple.Create(this, Clone());
+        }
+
+        public abstract ByteIterator Take(int n);
+        public abstract ByteIterator Drop(int n);
+
+        public virtual ByteIterator Slice(int @from, int until)
+        {
+            return @from > 0
+                ? Drop(from).Take(until - @from)
+                : Take(until);
+        }
+
+        public virtual ByteIterator TakeWhile(Func<byte, bool> p)
+        {
+            throw new NotSupportedException();
+        }
+
+        public virtual ByteIterator DropWhile(Func<byte, bool> p)
+        {
+            throw new NotSupportedException();
+        }
+
+        public virtual Tuple<ByteIterator, ByteIterator> Span(Func<byte, bool> p)
+        {
+            var that = Clone();
+            TakeWhile(p);
+            that.Drop(Len);
+            return Tuple.Create(this, that);
+        }
+
+        public virtual int IndexWhere(Func<byte, bool> p)
+        {
+            var index = 0;
+            var found = false;
+            while (!found && HasNext)
+                if (p(Next())) found = true;
+                else index += 1;
+            return found ? index : -1;
+        }
+
+        public virtual int IndexOf(byte elem)
+        {
+            return IndexWhere(x => x == elem);
+        }
+
+        public abstract ByteString ToByteString();
+
+        public virtual void ForEach(Action<byte> f)
+        {
+            while (HasNext) f(Next());
+        }
+
+        public virtual T FoldLeft<T>(T z, Func<T, Byte, T> op)
+        {
+            var acc = z;
+            ForEach(x => acc = op(acc, x));
+            return acc;
+        }
+
+        public abstract byte[] ToArray();
+
+        public virtual byte GetByte()
+        {
+            return Next();
+        }
+
+        public abstract int CopyToBuffer(ByteBuffer buffer);
+    }
+
+
+
+    public interface ILinearSeq<out T> : IEnumerable<T>
+    {
+        bool IsEmpty { get; }
+        T Head { get; }
+        ILinearSeq<T> Tail();
+    }
+
+    public class ArrayLinearSeq<T> : ILinearSeq<T>
+    {
+        private readonly T[] _array;
+        private readonly int _offset;
+        private readonly int _length;
+
+        public ArrayLinearSeq(T[] array) : this(array, 0, array.Length)
+        {
+        }
+
+        private ArrayLinearSeq(T[] array, int offset, int length)
+        {
+            _array = array;
+            _offset = offset;
+            _length = length;
+        }
+
+        public bool IsEmpty
+        {
+            get { return _length > 0; }
+        }
+
+        public T Head
+        {
+            get { return _array[_offset]; }
+        }
+
+        public ILinearSeq<T> Tail()
+        {
+            return new ArrayLinearSeq<T>(_array, _offset + 1, _length - 1);
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public static implicit operator ArrayLinearSeq<T>(T[] that)
+        {
+            return new ArrayLinearSeq<T>(that);
+        }
+
+        private class Enumerator : IEnumerator<T>
+        {
+            private readonly ILinearSeq<T> _orig;
+            private ILinearSeq<T> _seq;
+
+            public Enumerator(ILinearSeq<T> seq)
+            {
+                _seq = seq;
+                _orig = _seq;
+            }
+
+            public void Dispose()
+            {
+
+            }
+
+            public bool MoveNext()
+            {
+                _seq = _seq.Tail();
+                return !_seq.IsEmpty;
+            }
+
+            public void Reset()
+            {
+                _seq = _orig;
+            }
+
+            public T Current
+            {
+                get { return _seq.Head; }
+            }
+
+            object IEnumerator.Current
+            {
+                get { return Current; }
+            }
+
+        }
+    }
+}

--- a/src/core/Akka/Util/ByteString.cs
+++ b/src/core/Akka/Util/ByteString.cs
@@ -1,0 +1,618 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ActorBase.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Akka.Util;
+using Akka.Util.Internal;
+
+namespace Akka.IO
+{
+    // TODO: Move to Akka.Util namespace - this will require changes as name clashes with PotoBuf class
+
+    partial /*object*/ class ByteString
+    {
+        private static ByteString Create(ByteString1 b, ByteStrings bs)
+        {
+            switch (Compare(b, bs))
+            {
+                case 3:
+                    return new ByteStrings(new LinkedList<ByteString1>(bs.Items).AddFirst(b).List.ToArray(),
+                        bs.Count + b.Count);
+                case 2:
+                    return bs;
+                case 1:
+                    return b;
+                case 0:
+                    return Empty;
+            }
+            throw new ArgumentOutOfRangeException();
+        }
+
+        private static int Compare(ByteString b1, ByteString b2)
+        {
+            if (b1.IsEmpty)
+                return b2.IsEmpty ? 0 : 2;
+            return b2.IsEmpty ? 1 : 3;
+        }
+
+        public ByteString FromArray(byte[] array)
+        {
+            return new ByteString1C((byte[]) array.Clone());
+        }
+
+        public ByteString FromArray(byte[] array, int offset, int length)
+        {
+            return CompactByteString.FromArray(array, offset, length);
+        }
+
+        public static ByteString FromString(string str)
+        {
+            return FromString(str, Encoding.UTF8);
+        }
+
+        public static ByteString FromString(string str, Encoding encoding)
+        {
+            return CompactByteString.FromString(str, Encoding.UTF8);
+        }
+
+        public static ByteStringBuilder NewBuilder()
+        {
+            return new ByteStringBuilder();
+        }
+
+        internal class ByteString1C : CompactByteString
+        {
+            private readonly byte[] _bytes;
+            private readonly ByteIterator.ByteArrayIterator _iterator;
+
+            public ByteString1C(byte[] bytes)
+            {
+                _bytes = bytes;
+                _iterator = new ByteIterator.ByteArrayIterator(bytes, 0, bytes.Length);
+            }
+
+            public override byte this[int idx]
+            {
+                get { return _bytes[0]; }
+            }
+
+            public override int Count
+            {
+                get { return _bytes.Length; }
+            }
+
+            internal override ByteIterator Iterator
+            {
+                get { return _iterator; }
+            }
+
+            public override IEnumerator<byte> GetEnumerator()
+            {
+                return ((IEnumerable<byte>) _bytes).GetEnumerator();
+            }
+
+            internal ByteString1 ToByteString1()
+            {
+                return new ByteString1(_bytes);
+            }
+
+            public override ByteString Concat(ByteString that)
+            {
+                if (that.IsEmpty) return this;
+                if (this.IsEmpty) return that;
+                return ToByteString1() + that;
+            }
+
+            public override ByteString Slice(int from, int until)
+            {
+                return (from != 0 || until != Count)
+                    ? ToByteString1().Slice(from, until)
+                    : this;
+            }
+
+            public override string DecodeString(Encoding charset)
+            {
+                return IsEmpty ? string.Empty : charset.GetString(_bytes);
+
+            }
+        }
+
+        internal class ByteString1 : ByteString
+        {
+            private readonly byte[] _bytes;
+            private readonly int _startIndex;
+            private readonly int _length;
+            private readonly ByteIterator.ByteArrayIterator _iterator;
+
+            public ByteString1(byte[] bytes, int startIndex, int length)
+            {
+                _bytes = bytes;
+                _startIndex = startIndex;
+                _length = length;
+                _iterator = new ByteIterator.ByteArrayIterator(bytes, startIndex, startIndex + length);
+            }
+
+            public ByteString1(byte[] bytes)
+                : this(bytes, 0, bytes.Length)
+            {
+            }
+
+            public override byte this[int idx]
+            {
+                get { return _bytes[checkRangeConvert(idx)]; }
+            }
+
+            internal override ByteIterator Iterator
+            {
+                get { return _iterator; }
+            }
+
+            private int checkRangeConvert(int index)
+            {
+                if (0 <= index && _length > index)
+                    return index + _startIndex;
+                throw new IndexOutOfRangeException(index.ToString());
+            }
+
+            public override bool IsCompact()
+            {
+                return _length == _bytes.Length;
+            }
+
+            public override CompactByteString Compact()
+            {
+                return IsCompact()
+                    ? new ByteString1C(_bytes)
+                    : new ByteString1C(ToArray());
+            }
+
+            public override int Count
+            {
+                get { return _length; }
+            }
+
+            public override ByteString Concat(ByteString that)
+            {
+                if (that.IsEmpty) return this;
+                if (this.IsEmpty) return that;
+
+                var b1C = that as ByteString1C;
+                if (b1C != null)
+                    return new ByteStrings(this, b1C.ToByteString1());
+
+                var b1 = that as ByteString1;
+                if (b1 != null)
+                {
+                    if (_bytes == b1._bytes && (_startIndex + _length == b1._startIndex))
+                        return new ByteString1(_bytes, _startIndex, _length + b1._length);
+                    return new ByteStrings(this, b1);
+                }
+
+                var bs = that as ByteStrings;
+                if (bs != null)
+                {
+                    return Create(this, bs);
+                }
+
+                throw new InvalidOperationException();
+            }
+
+            public override string DecodeString(Encoding charset)
+            {
+                return charset.GetString(_length == _bytes.Length ? _bytes : ToArray());
+            }
+        }
+
+        internal class ByteStrings : ByteString
+        {
+            private readonly ByteString1[] _byteStrings;
+            private readonly int _length;
+
+            public ByteStrings(params ByteString1[] byteStrings)
+                : this(byteStrings, byteStrings.Sum(x => x.Count))
+            {
+            }
+
+            public ByteStrings(ByteString1[] byteStrings, int length)
+            {
+                _byteStrings = byteStrings;
+                _length = length;
+            }
+
+            public override byte this[int idx]
+            {
+                get
+                {
+                    if (0 <= idx && idx < Count)
+                    {
+                        var pos = 0;
+                        var seen = 0;
+                        while (idx >= seen + _byteStrings[pos].Count)
+                        {
+                            seen += _byteStrings[pos].Count;
+                            pos += 1;
+                        }
+                        return _byteStrings[pos][idx - seen];
+                    }
+                    throw new IndexOutOfRangeException();
+                }
+            }
+
+            internal override ByteIterator Iterator
+            {
+                get
+                {
+                    return
+                        new ByteIterator.MultiByteIterator(
+                            _byteStrings.Select(x => (ByteIterator.ByteArrayIterator) x.Iterator).ToArray());
+                }
+            }
+
+            public override ByteString Concat(ByteString that)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override bool IsCompact()
+            {
+                return _byteStrings.Length == 1 && _byteStrings.Head().IsCompact();
+            }
+
+            public override CompactByteString Compact()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override int Count
+            {
+                get { return _length; }
+            }
+
+            internal ByteString1[] Items
+            {
+                get { return _byteStrings; }
+            }
+
+            public override string DecodeString(Encoding charset)
+            {
+                return Compact().DecodeString(charset);
+            }
+        }
+    }
+
+    public abstract partial class ByteString : IReadOnlyList<byte>
+    {
+        public abstract byte this[int index] { get; }
+
+        protected virtual ByteStringBuilder newBuilder()
+        {
+            return NewBuilder();
+        }
+
+        public static readonly ByteString Empty = new ByteString1C(new byte[0]);
+
+        public Byte Head
+        {
+            get { return this[0]; }
+        }
+
+        public ByteString Tail()
+        {
+            return Drop(1);
+        }
+
+        public byte Last
+        {
+            get { return this[Count - 1]; }
+        }
+
+        public ByteString Init()
+        {
+            return DropRight(1);
+        }
+
+        public virtual ByteString Slice(int @from, int until)
+        {
+            if (@from == 0 && until == Count) return this;
+            return Iterator.Slice(@from, until).ToByteString();
+        }
+
+        public ByteString Take(int n)
+        {
+            return Slice(0, n);
+        }
+
+        public ByteString TakeRight(int n)
+        {
+            return Slice(Count - n, Count);
+        }
+
+        public ByteString Drop(int n)
+        {
+            return Slice(n, Count);
+        }
+
+        public ByteString DropRight(int n)
+        {
+            return Slice(0, Count - n);
+        }
+
+        public ByteString TakeWhile(Func<byte, bool> p)
+        {
+            return Iterator.TakeWhile(p).ToByteString();
+        }
+
+        public ByteString DropWhile(Func<byte, bool> p)
+        {
+            return Iterator.DropWhile(p).ToByteString();
+        }
+
+        public Tuple<ByteString, ByteString> Span(Func<byte, bool> p)
+        {
+            var span = Iterator.Span(p);
+            return Tuple.Create(span.Item1.ToByteString(), span.Item2.ToByteString());
+        }
+
+        public Tuple<ByteString, ByteString> SplitAt(int n)
+        {
+            return Tuple.Create(Take(n), Drop(n));
+        }
+
+        public int IndexWhere(Func<byte, bool> p)
+        {
+            return Iterator.IndexWhere(p);
+        }
+
+        public int IndexOf(byte elem)
+        {
+            return Iterator.IndexOf(elem);
+        }
+
+        public byte[] ToArray()
+        {
+            return Iterator.ToArray();
+        }
+
+        public abstract CompactByteString Compact();
+        public abstract bool IsCompact();
+
+        internal abstract ByteIterator Iterator { get; }
+
+        public virtual IEnumerator<byte> GetEnumerator()
+        {
+            throw new NotSupportedException("Method iterator is not implemented in ByteString");
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public virtual bool IsEmpty
+        {
+            get { return Count == 0; }
+        }
+
+        public bool NonEmpty
+        {
+            get { return !IsEmpty; }
+        }
+
+        public abstract int Count { get; }
+        public abstract ByteString Concat(ByteString that);
+
+        public string DecodeString()
+        {
+            return DecodeString(Encoding.UTF8);
+        }
+        public abstract string DecodeString(Encoding charset);
+
+        public static ByteString operator +(ByteString lhs, ByteString rhs)
+        {
+            return lhs.Concat(rhs);
+        }
+
+        public int CopyToBuffer(ByteBuffer buffer)
+        {
+            return Iterator.CopyToBuffer(buffer);
+        }
+
+        public static ByteString Create(ByteBuffer buffer)
+        {
+            if (buffer.Remaining < 0) return Empty;
+            var ar = new byte[buffer.Remaining];
+            buffer.Get(ar);
+            return new ByteString1C(ar);
+        }
+
+        public static ByteString Create(byte[] buffer, int offset, int length)
+        {
+            if (length == 0) return Empty;
+            var ar = new byte[length];
+            Array.Copy(buffer, offset, ar, 0, length);
+            return new ByteString1C(ar);
+        }
+        public static ByteString Create(byte[] buffer)
+        {
+            return Create(buffer, 0, buffer.Length);
+        }
+    }
+
+    partial /*object*/ class CompactByteString
+    {
+        public static CompactByteString FromString(string str, Encoding encoding)
+        {
+            return new ByteString1C(encoding.GetBytes(str));
+        }
+
+        public static ByteString FromArray(byte[] array, int offset, int length)
+        {
+            var copyOffset = Math.Max(offset, 0);
+            var copyLength = Math.Max(Math.Min(array.Length - copyOffset, length), 0);
+            if (copyLength == 0) return Empty;
+            var copyArray = new byte[copyLength];
+            Array.Copy(array, copyOffset, copyArray, 0, copyLength);
+            return new ByteString1C(copyArray);
+        }
+    }
+
+    [Serializable]
+    public abstract partial class CompactByteString : ByteString
+    {
+        public override bool IsCompact()
+        {
+            return true;
+        }
+
+        public override CompactByteString Compact()
+        {
+            return this;
+        }
+    }
+
+    public class ByteStringBuilder
+    {
+        private readonly List<ByteString.ByteString1> _builder = new List<ByteString.ByteString1>();
+        private int _length;
+        private byte[] _temp;
+        private int _tempLength;
+        private int _tempCapacity;
+
+        protected Func<Action<byte[], int>, ByteStringBuilder> FillArray(int len)
+        {
+            return fill =>
+            {
+                EnsureTempSize(_tempLength + len);
+                fill(_temp, _tempLength);
+                _tempLength += len;
+                _length += len;
+                return this;
+            };
+        }
+
+        protected ByteStringBuilder FillByteBuffer(int len, ByteOrder byteOrder, Action<ByteBuffer> fill)
+        {
+            return FillArray(len)((array, start) =>
+            {
+                var buffer = ByteBuffer.Wrap(array, start, len);
+                buffer.Order(byteOrder);
+                fill(buffer);
+            });
+        }
+
+        public int Length
+        {
+            get { return _length; }
+        }
+
+        public void SizeHint(int len)
+        {
+            ResizeTemp(len - (_length - _tempLength));
+        }
+
+        private void ClearTemp()
+        {
+            if (_tempLength > 0)
+            {
+                var arr = new byte[_tempLength];
+                Array.Copy(_temp, 0, arr, 0, _tempLength);
+                _builder.Add(new ByteString.ByteString1(arr));
+                _tempLength = 0;
+            }
+        }
+
+        private void ResizeTemp(int size)
+        {
+            var newTemp = new byte[size];
+            if (_tempLength > 0) Array.Copy(_temp, 0, newTemp, 0, _tempLength);
+            _temp = newTemp;
+            _tempCapacity = _temp.Length;
+        }
+
+        private void EnsureTempSize(int size)
+        {
+            if (_tempCapacity < size || _tempCapacity == 0)
+            {
+                var newSize = _tempCapacity == 0 ? 16 : _tempCapacity*2;
+                while (newSize < size) newSize *= 2;
+                ResizeTemp(newSize);
+            }
+        }
+
+        public ByteStringBuilder Append(IEnumerable<byte> xs)
+        {
+            var bs1C = xs as ByteString.ByteString1C;
+            if (bs1C != null)
+            {
+                ClearTemp();
+                _builder.Add(bs1C.ToByteString1());
+                _length += bs1C.Count;
+                return this;
+            }
+            var bs1 = xs as ByteString.ByteString1;
+            if (bs1 != null)
+            {
+                ClearTemp();
+                _builder.Add(bs1);
+                _length += bs1.Count;
+                return this;
+            }
+            var bss = xs as ByteString.ByteStrings;
+            if (bss != null)
+            {
+                ClearTemp();
+                _builder.AddRange(bss.Items);
+                _length += bss.Count;
+                return this;
+            }
+            return xs.Aggregate(this, (a, x) => a.PutByte(x));
+        }
+
+        public ByteStringBuilder PutByte(byte x)
+        {
+            return this + x;
+        }
+
+        public ByteStringBuilder PutShort(int x, ByteOrder byteOrder)
+        {
+            if (byteOrder == ByteOrder.BigEndian)
+            {
+                PutByte(Convert.ToByte(x >> 8));
+                PutByte(Convert.ToByte(x >> 0));
+            }
+            else
+            {
+                PutByte(Convert.ToByte(x >> 0));
+                PutByte(Convert.ToByte(x >> 8));
+            }
+            return this;
+        }
+
+        public static ByteStringBuilder operator +(ByteStringBuilder lhs, byte rhs)
+        {
+            lhs.EnsureTempSize(lhs._tempLength + 1);
+            lhs._temp[lhs._tempLength] = rhs;
+            lhs._tempLength += 1;
+            lhs._length += 1;
+            return lhs;
+        }
+    }
+
+    #region JVM
+
+    public enum ByteOrder
+    {
+        BigEndian,
+        LittleEndian
+    }
+
+    #endregion
+}

--- a/src/core/Akka/Util/Internal/Extensions.cs
+++ b/src/core/Akka/Util/Internal/Extensions.cs
@@ -89,6 +89,12 @@ namespace Akka.Util.Internal
                 return itemInArray;
             return enumerable.Concat(itemInArray);
         }
+
+        public static void ForEach<T>(this IEnumerable<T> enumerable, Action<T> action)
+        {
+            foreach (var item in enumerable)
+                action(item);
+        }
     }
 }
 


### PR DESCRIPTION
This is a line-by-line port of the Akka IO TCP driver as discussed in #788.

### Known issues
This is an early alpha version with probably many issues. These are the ones I know about:
#### SocketChannel
The .NET BCL does not have a SocketChannel class. To keep the port close to JVM Akka, I've created an SocketChannel adapter. The current implementation use blocking calls, which throws an exceptions when the socket is set to non blocking. This is likely to cause some performance issues. I will create load tests and experiment with a implementation based on SocketAsyncEventArgs. 
#### SelectionHandler
Socket.Select is currently used, which requires the allocation of lists for each call, which will cause a huge amount of allocations. This is necessary for the current  SocketChannel implementation, and will likely be eliminated once SocketChannel is based on SocketAsyncEventArgs.
#### File IO
I have no requirements for File IO, but might be convinced to port it if required.
#### Unit Tests
Not all the specs have been ported yet. I plan port the remaining ones in the near future.
