### PR TITLE
Revert ILoggingAdapter Warn method removal

### DIFF
--- a/src/core/Akka/Event/ILoggingAdapter.cs
+++ b/src/core/Akka/Event/ILoggingAdapter.cs
@@ -42,6 +42,12 @@ namespace Akka.Event
         /// <summary>Logs a message with the Warning level.</summary>
         /// <param name="format">The format.</param>
         /// <param name="args">The arguments.</param>
+        [Obsolete("Use Warning instead!")]
+        void Warn(string format, params object[] args);
+
+        /// <summary>Logs a message with the Warning level.</summary>
+        /// <param name="format">The format.</param>
+        /// <param name="args">The arguments.</param>
         void Warning(string format, params object[] args);
 
         /// <summary>Logs a message with the Error level.</summary>

--- a/src/core/Akka/Event/LoggingAdapterBase.cs
+++ b/src/core/Akka/Event/LoggingAdapterBase.cs
@@ -99,6 +99,11 @@ namespace Akka.Event
             }
         }
 
+        public void Warn(string format, params object[] args)
+        {
+            Warning(format, args);
+        }
+
         public void Warning(string format, params object[] args)
         {
             if (!IsWarningEnabled) 


### PR DESCRIPTION
I made a mistake on #947 - should not have approved the removal of the `ILoggingAdapter.Warn` method. Needs to stay in there until next major version upgrade per our change management rules around breaking changes.