### PR TITLE
added release notes for v1.0.2 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -41,12 +41,12 @@ PM> Install-Package Akka.TestKit.XUnit2
 **Akka.Persistence.PostgreSql** and **Akka.Persistence.Cassandra**
 Akka.Persistence now has two additional concrete implementations for PostgreSQL and Cassandra! You can install either of the packages using the following commandline:
 
-PostgreSQL
+[Akka.Persistence.PostgreSql Configuration Docs](https://github.com/akkadotnet/akka.net/tree/dev/src/contrib/persistence/Akka.Persistence.PostgreSql)
 ```
 PM> Install-Package Akka.Persistence.PostgreSql
 ```
 
-Cassandra
+[Akka.Persistence.Cassandra Configuration Docs](https://github.com/akkadotnet/akka.net/tree/dev/src/contrib/persistence/Akka.Persistence.Cassandra)
 ```
 PM> Install-Package Akka.Persistence.Cassandra
 ```

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,62 @@
-#### 1.0.2 May 1 2015
+#### 1.0.2 June 2 2015
+**Bugfix release for Akka.NET v1.0.1.**
+
+Fixes & Changes - Akka.NET Core
+* [Routers seem ignore supervision strategy](https://github.com/akkadotnet/akka.net/issues/996)
+* [Replaced DateTime.Now with DateTime.UtcNow/MonotonicClock](https://github.com/akkadotnet/akka.net/pull/1009)
+* [DedicatedThreadScheduler](https://github.com/akkadotnet/akka.net/pull/1002)
+* [Add ability to specify scheduler implementation in configuration](https://github.com/akkadotnet/akka.net/pull/994)
+* [Added generic extensions to EventStream subscribe/unsubscribe.](https://github.com/akkadotnet/akka.net/pull/990)
+* [Convert null to NoSender.](https://github.com/akkadotnet/akka.net/pull/993)
+* [Supervisor strategy bad timeouts](https://github.com/akkadotnet/akka.net/pull/986)
+* [Updated Pigeon.conf throughput values](https://github.com/akkadotnet/akka.net/pull/980)
+* [Add PipeTo for non-generic Tasks for exception handling](https://github.com/akkadotnet/akka.net/pull/978)
+
+Fixes & Changes - Akka.NET Dependency Injection
+* [Added Extensions methods to ActorSystem and ActorContext to make DI more accessible](https://github.com/akkadotnet/akka.net/pull/966)
+* [DIActorProducer fixes](https://github.com/akkadotnet/akka.net/pull/961)
+* [closes akkadotnet/akka.net#1020 structuremap dependency injection](https://github.com/akkadotnet/akka.net/pull/1021)
+
+Fixes & Changes - Akka.Remote and Akka.Cluster
+* [Fixing up cluster rejoin behavior](https://github.com/akkadotnet/akka.net/pull/962)
+* [Added dispatcher fixes for remote and cluster ](https://github.com/akkadotnet/akka.net/pull/983)
+* [Fixes to ClusterRouterGroup](https://github.com/akkadotnet/akka.net/pull/953)
+* [Two actors are created by remote deploy using Props.WithDeploy](https://github.com/akkadotnet/akka.net/issues/1025)
+
+Fixes & Changes - Akka.Persistence
+* [Renamed GuaranteedDelivery classes to AtLeastOnceDelivery](https://github.com/akkadotnet/akka.net/pull/984)
+* [Changes in Akka.Persistence SQL backend](https://github.com/akkadotnet/akka.net/pull/963)
+* [PostgreSQL persistence plugin for both event journal and snapshot store](https://github.com/akkadotnet/akka.net/pull/971)
+* [Cassandra persistence plugin](https://github.com/akkadotnet/akka.net/pull/995)
+
+**New Features:**
+
+**Akka.TestKit.XUnit2**
+Akka.NET now has support for [XUnit 2.0](http://xunit.github.io/)! You can install Akka.TestKit.XUnit2 via the NuGet commandline:
+
+```
+PM> Install-Package Akka.TestKit.XUnit2
+```
+
+**Akka.Persistence.PostgreSql** and **Akka.Persistence.Cassandra**
+Akka.Persistence now has two additional concrete implementations for PostgreSQL and Cassandra! You can install either of the packages using the following commandline:
+
+PostgreSQL
+```
+PM> Install-Package Akka.Persistence.PostgreSql
+```
+
+Cassandra
+```
+PM> Install-Package Akka.Persistence.Cassandra
+```
+
+**Akka.DI.StructureMap**
+Akka.NET's dependency injection system now supports [StructureMap](http://structuremap.github.io/)! You can install Akka.DI.StructureMap via the NuGet commandline:
+
+```
+PM> Install-Package Akka.DI.StructureMap
+```
 
 #### 1.0.1 Apr 28 2015
 


### PR DESCRIPTION
**Bugfix release for Akka.NET v1.0.1.**

Fixes & Changes - Akka.NET Core
* [Routers seem ignore supervision strategy](https://github.com/akkadotnet/akka.net/issues/996)
* [Replaced DateTime.Now with DateTime.UtcNow/MonotonicClock](https://github.com/akkadotnet/akka.net/pull/1009)
* [DedicatedThreadScheduler](https://github.com/akkadotnet/akka.net/pull/1002)
* [Add ability to specify scheduler implementation in configuration](https://github.com/akkadotnet/akka.net/pull/994)
* [Added generic extensions to EventStream subscribe/unsubscribe.](https://github.com/akkadotnet/akka.net/pull/990)
* [Convert null to NoSender.](https://github.com/akkadotnet/akka.net/pull/993)
* [Supervisor strategy bad timeouts](https://github.com/akkadotnet/akka.net/pull/986)
* [Updated Pigeon.conf throughput values](https://github.com/akkadotnet/akka.net/pull/980)
* [Add PipeTo for non-generic Tasks for exception handling](https://github.com/akkadotnet/akka.net/pull/978)

Fixes & Changes - Akka.NET Dependency Injection
* [Added Extensions methods to ActorSystem and ActorContext to make DI more accessible](https://github.com/akkadotnet/akka.net/pull/966)
* [DIActorProducer fixes](https://github.com/akkadotnet/akka.net/pull/961)
* [closes akkadotnet/akka.net#1020 structuremap dependency injection](https://github.com/akkadotnet/akka.net/pull/1021)

Fixes & Changes - Akka.Remote and Akka.Cluster
* [Fixing up cluster rejoin behavior](https://github.com/akkadotnet/akka.net/pull/962)
* [Added dispatcher fixes for remote and cluster ](https://github.com/akkadotnet/akka.net/pull/983)
* [Fixes to ClusterRouterGroup](https://github.com/akkadotnet/akka.net/pull/953)
* [Two actors are created by remote deploy using Props.WithDeploy](https://github.com/akkadotnet/akka.net/issues/1025)

Fixes & Changes - Akka.Persistence
* [Renamed GuaranteedDelivery classes to AtLeastOnceDelivery](https://github.com/akkadotnet/akka.net/pull/984)
* [Changes in Akka.Persistence SQL backend](https://github.com/akkadotnet/akka.net/pull/963)
* [PostgreSQL persistence plugin for both event journal and snapshot store](https://github.com/akkadotnet/akka.net/pull/971)
* [Cassandra persistence plugin](https://github.com/akkadotnet/akka.net/pull/995)

**New Features:**

**Akka.TestKit.XUnit2**
Akka.NET now has support for [XUnit 2.0](http://xunit.github.io/)! You can install Akka.TestKit.XUnit2 via the NuGet commandline:

```
PM> Install-Package Akka.TestKit.XUnit2
```

**Akka.Persistence.PostgreSql** and **Akka.Persistence.Cassandra**
Akka.Persistence now has two additional concrete implementations for PostgreSQL and Cassandra! You can install either of the packages using the following commandline:

PostgreSQL
```
PM> Install-Package Akka.Persistence.PostgreSql
```

Cassandra
```
PM> Install-Package Akka.Persistence.Cassandra
```

**Akka.DI.StructureMap**
Akka.NET's dependency injection system now supports [StructureMap](http://structuremap.github.io/)! You can install Akka.DI.StructureMap via the NuGet commandline:

```
PM> Install-Package Akka.DI.StructureMap
```