### PR TITLE
added version number for next release of Akka.NET to RELEASE_NOTES for nightly build support

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+#### 1.0.3 July 1 2015
+
 #### 1.0.2 June 2 2015
 **Bugfix release for Akka.NET v1.0.1.**
 


### PR DESCRIPTION
This ensures that the nightly builds produced by the build server have a higher version number than the current stable release.