### PR TITLE
pass exception to NLogLogger exception logging

### DIFF
--- a/src/contrib/loggers/Akka.Logger.NLog/NLogLogger.cs
+++ b/src/contrib/loggers/Akka.Logger.NLog/NLogLogger.cs
@@ -34,7 +34,7 @@ namespace Akka.Logger.NLog
         /// </summary>
         public NLogLogger()
         {
-            Receive<Error>(m => Log(m, logger => logger.Error("{0}", m.Message)));
+            Receive<Error>(m => Log(m, logger => logger.Error(string.Format("{0}", m.Message), m.Cause)));
             Receive<Warning>(m => Log(m, logger => logger.Warn("{0}", m.Message)));
             Receive<Info>(m => Log(m, logger => logger.Info("{0}", m.Message)));
             Receive<Debug>(m => Log(m, logger => logger.Debug("{0}", m.Message)));


### PR DESCRIPTION
Currently, NLogLogger simply logs exception messages as strings. This commit passes the exception to NLog as well. This allows clients to use ${exception:...} layout renderers to choose if they want to log exception details (including stack traces) or not.