### PR TITLE
Logging message/template fixes

### DIFF
--- a/src/core/Akka.Cluster/Cluster.cs
+++ b/src/core/Akka.Cluster/Cluster.cs
@@ -295,12 +295,12 @@ namespace Akka.Cluster
 
         public void LogInfo(string template, object arg1)
         {
-            _log.Info(String.Format("Cluster Node [{0}] - " + template, SelfAddress, arg1));
+            _log.Info("Cluster Node [{0}] - " + template, SelfAddress, arg1);
         }
 
         public void LogInfo(string template, object arg1, object arg2)
         {
-            _log.Info(String.Format("Cluster Node [{0}] - " + template, SelfAddress, arg1, arg2));
+            _log.Info("Cluster Node [{0}] - " + template, SelfAddress, arg1, arg2);
         }
     }
 }

--- a/src/core/Akka.Persistence.Tests/AtLeastOnceDeliveryFailureSpec.cs
+++ b/src/core/Akka.Persistence.Tests/AtLeastOnceDeliveryFailureSpec.cs
@@ -259,18 +259,18 @@ namespace Akka.Persistence.Tests
                 {
                     if (ChaosSupportExtensions.ShouldFail(_confirmFailureRate))
                     {
-                        Log.Error(string.Format("[destination] confirm message failed (message = {0}, {1})", m.DeliveryId, m.I));
+                        Log.Error("[destination] confirm message failed (message = {0}, {1})", m.DeliveryId, m.I);
                     }
                     else if (State.Contains(m.I))
                     {
-                        Log.Debug(string.Format("[destination] ignored duplicate (message = {0}, {1})", m.DeliveryId, m.I));
+                        Log.Debug("[destination] ignored duplicate (message = {0}, {1})", m.DeliveryId, m.I);
                         Sender.Tell(new Confirm(m.DeliveryId, m.I));
                     }
                     else
                     {
                         this.Add(m.I);
                         Sender.Tell(new Confirm(m.DeliveryId, m.I));
-                        Log.Debug(string.Format("[destination] received and confirmed (message = {0}, {1})", m.DeliveryId, m.I));
+                        Log.Debug("[destination] received and confirmed (message = {0}, {1})", m.DeliveryId, m.I);
                     }
                 });
             }

--- a/src/core/Akka.Remote.TestKit/Conductor.cs
+++ b/src/core/Akka.Remote.TestKit/Conductor.cs
@@ -281,21 +281,21 @@ namespace Akka.Remote.TestKit
 
         public void OnMessage(object message, IConnection responseChannel)
         {
-            _log.Debug(string.Format("message from {0}: {1}", responseChannel.RemoteHost, message));
+            _log.Debug("message from {0}: {1}", responseChannel.RemoteHost, message);
             if (message is INetworkOp)
             {
                 _clients[responseChannel].Tell(message);
             }
             else
             {
-                _log.Debug(string.Format("client {0} sent garbage `{1}`, disconnecting", responseChannel.RemoteHost, message));
+                _log.Debug("client {0} sent garbage `{1}`, disconnecting", responseChannel.RemoteHost, message);
                 responseChannel.Close();
             }
         }
 
         public void OnException(Exception ex, IConnection erroredChannel)
         {
-            _log.Warning(string.Format("handled network error from {0}: {1}", erroredChannel.RemoteHost, ex.Message));
+            _log.Warning("handled network error from {0}: {1}", erroredChannel.RemoteHost, ex.Message);
         }
     }
 

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -1225,9 +1225,8 @@ namespace Akka.Remote
                         "Internal error: Endpoint is in state Writing, but no association handle is present.");
                 if (_provider.RemoteSettings.LogSend)
                 {
-                    var msgLog = string.Format("RemoteMessage: {0} to [{1}]<+[{2}] from [{3}]", send.Message,
+                    _log.Debug("RemoteMessage: {0} to [{1}]<+[{2}] from [{3}]", send.Message,
                         send.Recipient, send.Recipient.Path, send.SenderOption ?? _system.DeadLetters);
-                    _log.Debug(msgLog);
                 }
 
                 var pdu = _codec.ConstructMessage(send.Recipient.LocalAddressToUse, send.Recipient,

--- a/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
+++ b/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
@@ -609,7 +609,7 @@ namespace Akka.Remote.Transport
                                     })
                                     .Default(d =>
                                     {
-                                        _log.Debug(string.Format("Expected message of type Associate; instead received {0}", d));
+                                        _log.Debug("Expected message of type Associate; instead received {0}", d);
                                         //Expect handshake to be finished, dropping connection
                                         SendDisassociate(wrappedHandle, DisassociateInfo.Unknown);
                                         nextState = Stop();

--- a/src/core/Akka.Remote/Transport/FailureInjectorTransportAdapter.cs
+++ b/src/core/Akka.Remote/Transport/FailureInjectorTransportAdapter.cs
@@ -228,9 +228,8 @@ namespace Akka.Remote.Transport
                 var drop = mode as Drop;
                 if (Rng.NextDouble() <= drop.InboundDropP)
                 {
-                    var logString = string.Format("Dropping inbound [{0}] for [{1}] {2}", instance.GetType(),
-                        remoteAddress, debugMessage);
-                    if(_shouldDebugLog) _log.Debug(logString);
+                    if (_shouldDebugLog) _log.Debug("Dropping inbound [{0}] for [{1}] {2}", instance.GetType(),
+                         remoteAddress, debugMessage);
                     return true;
                 }
             }
@@ -247,8 +246,8 @@ namespace Akka.Remote.Transport
                 var drop = mode as Drop;
                 if (Rng.NextDouble() <= drop.OutboundDropP)
                 {
-                    var logString = string.Format("Dropping outbound [{0}] for [{1}] {2}", instance.GetType(), remoteAddress, debugMessage);
-                    if (_shouldDebugLog) _log.Debug(logString);
+                    if (_shouldDebugLog) 
+                        _log.Debug("Dropping outbound [{0}] for [{1}] {2}", instance.GetType(), remoteAddress, debugMessage);
                     return true;
                 }
             }

--- a/src/core/Akka/Actor/FSM.cs
+++ b/src/core/Akka/Actor/FSM.cs
@@ -184,8 +184,7 @@ namespace Akka.Actor
                 if(_debugLog != null)
                     send = () =>
                     {
-                        _debugLog.Debug("{3}Timer '{0}' went off. Sending {1} -> {2}", name, message, actor,
-                            _ref.IsCancellationRequested ? "Cancelled " : "");
+                        _debugLog.Debug("{0}Timer '{1}' went off. Sending {2} -> {3}",_ref.IsCancellationRequested ? "Cancelled " : "", name, message, actor);
                         actor.Tell(this, Context.Self);
                     };
                 else
@@ -691,7 +690,7 @@ namespace Akka.Actor
             {
                 return delegate(Event<TData> @event)
                 {
-                    _log.Warning(String.Format("unhandled event {0} in state {1}", @event.FsmEvent, StateName));
+                    _log.Warning("unhandled event {0} in state {1}", @event.FsmEvent, StateName);
                     return Stay();
                 };
             }

--- a/src/core/Akka/Serialization/Serialization.cs
+++ b/src/core/Akka/Serialization/Serialization.cs
@@ -45,8 +45,7 @@ namespace Akka.Serialization
                 var serializerType = Type.GetType(serializerTypeName);
                 if (serializerType == null)
                 {
-                    system.Log.Warning(string.Format("The type name for serializer '{0}' did not resolve to an actual Type: '{1}'",
-                            kvp.Key, serializerTypeName));
+                    system.Log.Warning("The type name for serializer '{0}' did not resolve to an actual Type: '{1}'",kvp.Key, serializerTypeName);
                     continue;
                 }
 
@@ -64,17 +63,14 @@ namespace Akka.Serialization
                 if (messageType == null)
                 {
 
-                    system.Log.Warning(string.Format(
-                            "The type name for message/serializer binding '{0}' did not resolve to an actual Type: '{1}'",
-                            serializerName, typename));
+                    system.Log.Warning("The type name for message/serializer binding '{0}' did not resolve to an actual Type: '{1}'",serializerName, typename);
                     continue;
                 }
 
                 var serializer = namedSerializers[serializerName];
                 if (serializer == null)
                 {
-                    system.Log.Warning(string.Format(
-                            "Serialization binding to non existing serializer: '{0}'", serializerName));
+                    system.Log.Warning("Serialization binding to non existing serializer: '{0}'", serializerName);
                     continue;
                 }
                 _serializerMap.Add(messageType,serializer);


### PR DESCRIPTION
There are a few places where the log message is pre-formatted using string.Format and some random  place where the order of the format arguments are non-ordered.
This PR cleans that up.