### PR TITLE
Akka.Persistence - SqlServer and TestKit fixes

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.SqlServer/Snapshot/QueryBuilder.cs
+++ b/src/contrib/persistence/Akka.Persistence.SqlServer/Snapshot/QueryBuilder.cs
@@ -97,7 +97,7 @@ namespace Akka.Persistence.SqlServer.Snapshot
 
             if (maxTimestamp > DateTime.MinValue && maxTimestamp < DateTime.MaxValue)
             {
-                sb.Append(" AND SequenceNr <= @SequenceNr ");
+                sb.Append(" AND Timestamp <= @Timestamp ");
                 sqlCommand.Parameters.Add(new SqlParameter("@Timestamp", SqlDbType.DateTime2) { Value = maxTimestamp });
             }
 

--- a/src/core/Akka.Persistence.TestKit/PluginSpec.cs
+++ b/src/core/Akka.Persistence.TestKit/PluginSpec.cs
@@ -16,7 +16,7 @@ namespace Akka.Persistence.TestKit
 {
     public abstract class PluginSpec : TestKitBase, IDisposable
     {
-        private readonly AtomicCounter _counter = new AtomicCounter(0);
+        private static readonly AtomicCounter Counter = new AtomicCounter(0);
         private readonly PersistenceExtension _extension;
         private string _pid;
 
@@ -26,7 +26,7 @@ namespace Akka.Persistence.TestKit
             : base(new XunitAssertions(), FromConfig(config), actorSystemName, testActorName)
         {
             _extension = Persistence.Instance.Apply(Sys as ExtendedActorSystem);
-            _pid = "p-" + _counter.IncrementAndGet();
+            _pid = "p-" + Counter.IncrementAndGet();
         }
 
         protected static Config FromConfig(Config config = null)


### PR DESCRIPTION
1. Fix on Akka.Persistence.SqlServer snapshot store query builder (thx to @Silv3rcircl3 for pointing that out).
2. Fix for Akka.Peristence.TestKit plugin counter - it has been made static. This way it should handle parallel test runs.