### PR TITLE
Akka IO UDP driver port

### DIFF
--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -138,6 +138,8 @@
     <Compile Include="Event\EventStreamSpec.cs" />
     <Compile Include="IO\TcpConnectionSpec.cs" />
     <Compile Include="IO\TcpListenerSpec.cs" />
+    <Compile Include="IO\UdpConnectedIntegrationSpec.cs" />
+    <Compile Include="IO\UdpIntegrationSpec.cs" />
     <Compile Include="MatchHandler\CachedMatchCompilerTests.cs" />
     <Compile Include="MatchHandler\MatchBuilderSignatureTests.cs" />
     <Compile Include="MatchHandler\MatchExpressionBuilder_BuildLambdaExpression_Tests.cs" />

--- a/src/core/Akka.Tests/IO/TcpConnectionSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpConnectionSpec.cs
@@ -730,15 +730,22 @@ namespace Akka.Tests.IO
 
     public static class TestUtils
     {
-        public static IPEndPoint TemporaryServerAddress()
+        public static IPEndPoint TemporaryServerAddress(string hostName = "127.0.0.1", bool udp = false)
         {
-            var host = new IPEndPoint(IPAddress.Loopback, 0);
-            using (var socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
+            var host = new IPEndPoint(IPAddress.Parse(hostName), 0);
+            using (var socket = new Socket(
+                udp ? SocketType.Dgram : SocketType.Stream,
+                udp ? ProtocolType.Udp : ProtocolType.Tcp))
             {
                 socket.Bind(host);
                 return new IPEndPoint(IPAddress.Loopback, ((IPEndPoint) socket.LocalEndPoint).Port);
             }
         }
+        public static IEnumerable<IPEndPoint> TemporaryServerAddresses(int numberOfAddresses, string hostName = "127.0.0.1", bool udp = false)
+        {
+            return Enumerable.Range(0, numberOfAddresses).Select(i => TemporaryServerAddress(hostName, udp));
+        }
+
     }
 
     

--- a/src/core/Akka.Tests/IO/UdpConnectedIntegrationSpec.cs
+++ b/src/core/Akka.Tests/IO/UdpConnectedIntegrationSpec.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using Akka.Actor;
+using Akka.IO;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Tests.IO
+{
+    public class UdpConnectedIntegrationSpec : AkkaSpec
+    {
+        private readonly IPEndPoint[] _addresses;
+
+        public UdpConnectedIntegrationSpec()
+            : base(@"
+                    akka.io.udp-connected.nr-of-selectors = 1
+                    akka.io.udp-connected.direct-buffer-pool-limit = 100
+                    akka.io.udp-connected.direct-buffer-size = 1024
+                    akka.io.udp.nr-of-selectors = 1
+                    akka.io.udp.direct-buffer-pool-limit = 100
+                    akka.io.udp.direct-buffer-size = 1024
+                    akka.loglevel = INFO
+                    akka.actor.serialize-creators = on")
+        {
+            _addresses = TestUtils.TemporaryServerAddresses(3, udp: true).ToArray();
+        }
+
+        private IActorRef BindUdp(IPEndPoint address, IActorRef handler)
+        {
+            var commander = CreateTestProbe();
+            commander.Send(Udp.Instance.Apply(Sys).Manager, new Udp.Bind(handler, address));
+            commander.ExpectMsg<Udp.Bound>(x => x.LocalAddress.Equals(address)); 
+            return commander.Sender;
+        }
+
+        private IActorRef ConnectUdp(IPEndPoint localAddress, IPEndPoint remoteAddress, IActorRef handler)
+        {
+            var commander = CreateTestProbe();
+            commander.Send(UdpConnected.Instance.Apply(Sys).Manager, new UdpConnected.Connect(handler, remoteAddress, localAddress));
+            commander.ExpectMsg<UdpConnected.Connected>();
+            return commander.Sender;
+        }
+
+        [Fact]
+        public void The_UDP_connection_oriented_implementation_must_be_able_to_send_and_receive_without_binding()
+        {
+            var serverAddress = _addresses[0];
+            var server = BindUdp(serverAddress, TestActor);
+            var data1 = ByteString.FromString("To infinity and beyond!");
+            var data2 = ByteString.FromString("All your datagram belong to us");
+
+            ConnectUdp(null, serverAddress, TestActor).Tell(UdpConnected.Send.Create(data1));
+
+            var clientAddress = ExpectMsgPf(TimeSpan.FromSeconds(3), "", msg =>
+            {
+                var received = msg as Udp.Received;
+                if (received != null)
+                {
+                    received.Data.ShouldBe(data1);
+                    return received.Sender;
+                }
+                throw new Exception();
+            });
+
+            server.Tell(Udp.Send.Create(data2, clientAddress));
+
+            ExpectMsg<UdpConnected.Received>(x => x.Data.ShouldBe(data2));
+        }
+
+        [Fact]
+        public void The_UDP_connection_oriented_implementation_must_be_able_to_send_and_receive_with_binding()
+        {
+            var serverAddress = _addresses[0];
+            var clientAddress = _addresses[1];
+            var server = BindUdp(serverAddress, TestActor);
+            var data1 = ByteString.FromString("To infinity and beyond!");
+            var data2 = ByteString.FromString("All your datagram belong to us");
+            ConnectUdp(clientAddress, serverAddress, TestActor).Tell(UdpConnected.Send.Create(data1));
+
+            ExpectMsgPf(TimeSpan.FromSeconds(3), "", msg =>
+            {
+                var received = msg as Udp.Received;
+                if (received != null)
+                {
+                    received.Data.ShouldBe(data1);
+                    received.Sender.Address.ShouldBe(clientAddress.Address);
+                    return received.Sender;
+                }
+                throw new Exception();
+            });
+
+            server.Tell(Udp.Send.Create(data2, clientAddress));
+
+            ExpectMsg<UdpConnected.Received>(x => x.Data.ShouldBe(data2));
+        }
+    }
+}

--- a/src/core/Akka.Tests/IO/UdpIntegrationSpec.cs
+++ b/src/core/Akka.Tests/IO/UdpIntegrationSpec.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using Akka.Actor;
+using Akka.IO;
+using Akka.TestKit;
+using Akka.Util.Internal;
+using Xunit;
+
+namespace Akka.Tests.IO
+{
+    public class UdpIntegrationSpec : AkkaSpec
+    {
+        private readonly IPEndPoint[] _addresses;
+
+        public UdpIntegrationSpec()
+            : base(@"
+                    akka.io.udp.max-channels = unlimited
+                    akka.io.udp.nr-of-selectors = 1
+                    akka.io.udp.direct-buffer-pool-limit = 100
+                    akka.io.udp.direct-buffer-size = 1024
+                    akka.loglevel = INFO
+                    akka.actor.serialize-creators = on")
+        {
+            _addresses = TestUtils.TemporaryServerAddresses(6, udp: true).ToArray();
+        }
+
+        private IActorRef BindUdp(IPEndPoint address, IActorRef handler)
+        {
+            var commander = CreateTestProbe();
+            commander.Send(Udp.Instance.Apply(Sys).Manager, new Udp.Bind(handler, address));
+            commander.ExpectMsg<Udp.Bound>(x => x.LocalAddress.Equals(address));
+            return commander.Sender;
+        }
+
+        private IActorRef SimpleSender()
+        {
+            var commander = CreateTestProbe();
+            commander.Send(Udp.Instance.Apply(Sys).Manager, Udp.SimpleSender.Instance);
+            commander.ExpectMsg<Udp.SimpleSenderReady>(TimeSpan.FromSeconds(10));
+            return commander.Sender;
+        }
+
+        [Fact]
+        public void The_UDP_Fire_and_Forget_implementation_must_be_able_to_send_without_binding()
+        {
+            var serverAddress = _addresses[0];
+            var server = BindUdp(serverAddress, TestActor);
+            var data = ByteString.FromString("To infinity and beyond!");
+            SimpleSender().Tell(Udp.Send.Create(data, serverAddress));
+
+            ExpectMsg<Udp.Received>(x => x.Data.ShouldBe(data));
+        }
+
+        [Fact]
+        public void The_UDP_Fire_and_Forget_implementation_must_be_able_to_send_several_packet_back_and_forth_with_binding()
+        {
+            var serverAddress = _addresses[0];
+            var clientAddress = _addresses[1];
+            var server = BindUdp(serverAddress, TestActor);
+            var client = BindUdp(clientAddress, TestActor);
+            var data = ByteString.FromString("Fly little packet!");
+
+            Action checkSendingToClient = () =>
+            {
+                server.Tell(Udp.Send.Create(data, clientAddress));
+                ExpectMsg<Udp.Received>(x =>
+                {
+                    x.Data.ShouldBe(data);
+                    x.Sender.ShouldBe(serverAddress);
+                });
+            };
+            Action checkSendingToServer = () =>
+            {
+                client.Tell(Udp.Send.Create(data, serverAddress));
+                ExpectMsg<Udp.Received>(x =>
+                {
+                    x.Data.ShouldBe(data);
+                    x.Sender.ShouldBe(clientAddress);
+                });
+            };
+
+            Enumerable.Range(0, 20).ForEach(_ => checkSendingToServer());
+            Enumerable.Range(0, 20).ForEach(_ => checkSendingToClient());
+            Enumerable.Range(0, 20).ForEach(i =>
+            {
+                if (i%2 == 0) checkSendingToServer();
+                else checkSendingToClient();
+            });
+        }
+
+        [Fact]
+        public void The_UDP_Fire_and_Forget_implementation_must_call_SocketOption_beforeBind_method_before_bind()
+        {
+            var commander = CreateTestProbe();
+            var assertOption = new AssertBeforeBind();
+            commander.Send(Udp.Instance.Apply(Sys).Manager, new Udp.Bind(TestActor, _addresses[2], options: new[] {assertOption}));
+            commander.ExpectMsg<Udp.Bound>(x => x.LocalAddress.ShouldBe(_addresses[2]));
+            Assert.Equal(1, assertOption.BeforeCalled);
+        }
+
+        [Fact]
+        public void The_UDP_Fire_and_Forget_implementation_must_call_SocketOption_afterConnect_method_after_binding()
+        {
+            var commander = CreateTestProbe();
+            var assertOption = new AssertAfterChannelBind();
+            commander.Send(Udp.Instance.Apply(Sys).Manager, new Udp.Bind(TestActor, _addresses[3], options: new[] { assertOption }));
+            commander.ExpectMsg<Udp.Bound>(x => x.LocalAddress.ShouldBe(_addresses[3]));
+            Assert.Equal(1, assertOption.AfterCalled);
+        }
+
+        [Fact]
+        public void The_UDP_Fire_and_Forget_implementation_must_call_DatagramChannelCreator_create_method_when_opening_channel()
+        {
+            var commander = CreateTestProbe();
+            var assertOption = new AssertOpenDatagramChannel();
+            commander.Send(Udp.Instance.Apply(Sys).Manager, new Udp.Bind(TestActor, _addresses[4], options: new[] { assertOption }));
+            commander.ExpectMsg<Udp.Bound>(x => x.LocalAddress.ShouldBe(_addresses[4]));
+            Assert.Equal(1, assertOption.OpenCalled);
+        }
+
+
+        class AssertBeforeBind : Inet.SocketOption
+        {
+            public int BeforeCalled { get; private set; }
+
+            public override void BeforeDatagramBind(Socket ds)
+            {
+                Assert.True(!ds.IsBound);
+                BeforeCalled += 1;
+            }
+        }
+
+        class AssertAfterChannelBind : Inet.SocketOptionV2
+        {
+            public int AfterCalled { get; set; }
+            public override void AfterBind(Socket s)
+            {
+                Assert.True(s.IsBound);
+                AfterCalled += 1;
+            }
+        }
+
+        class AssertOpenDatagramChannel : Inet.DatagramChannelCreator
+        {
+            public int OpenCalled { get; set; }
+
+            public override DatagramChannel Create()
+            {
+                OpenCalled += 1;
+                return base.Create();
+            }
+        }
+    }
+}

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -231,6 +231,15 @@
     <Compile Include="Event\LogMessage.cs" />
     <Compile Include="Event\StandardOutLogger.cs" />
     <Compile Include="Helios.Concurrency.DedicatedThreadPool.cs" />
+    <Compile Include="IO\DatagramChannel.cs" />
+    <Compile Include="IO\Udp.cs" />
+    <Compile Include="IO\UdpConnected.cs" />
+    <Compile Include="IO\UdpConnectedManager.cs" />
+    <Compile Include="IO\UdpConnection.cs" />
+    <Compile Include="IO\UdpListener.cs" />
+    <Compile Include="IO\UdpManager.cs" />
+    <Compile Include="IO\UdpSender.cs" />
+    <Compile Include="IO\WithUdpSend.cs" />
     <Compile Include="Routing\ConsistentHashRouter.cs" />
     <Compile Include="Serialization\JavaSerializer.cs" />
     <Compile Include="IO\ByteBuffer.cs" />

--- a/src/core/Akka/IO/DatagramChannel.cs
+++ b/src/core/Akka/IO/DatagramChannel.cs
@@ -1,0 +1,62 @@
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Akka.IO
+{
+    public class DatagramChannel : SocketChannel
+    {
+        private DatagramChannel(Socket socket) : base(socket)
+        {
+            
+        }
+
+        public static DatagramChannel Open()
+        {
+            return new DatagramChannel(new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp));
+        }
+
+        public override bool IsOpen()
+        {
+            return true;
+        }
+
+        public int Send(ByteBuffer buffer, IPEndPoint target)
+        {
+            try
+            {
+                var data = new byte[buffer.Remaining];
+                buffer.Get(data);
+                return Socket.SendTo(data, target);
+            }
+            catch (SocketException ex)
+            {
+                if (ex.SocketErrorCode == SocketError.WouldBlock)
+                {
+                    buffer.Flip();
+                    return 0;
+                }
+                throw new IOException(ex.Message, ex);
+            }
+        }
+
+        public EndPoint Receive(ByteBuffer buffer)
+        {
+            try
+            {
+                var ep = Socket.LocalEndPoint;
+                var data = new byte[buffer.Remaining];
+                var length = Socket.ReceiveFrom(data, ref ep);
+                buffer.Put(data, 0, length);
+                return ep;
+            }
+            catch (SocketException ex)
+            {
+                if (ex.SocketErrorCode == SocketError.WouldBlock)
+                    return null;
+                throw new IOException(ex.Message, ex);
+            }
+            
+        }
+    }
+}

--- a/src/core/Akka/IO/DirectByteBufferPool.cs
+++ b/src/core/Akka/IO/DirectByteBufferPool.cs
@@ -21,6 +21,13 @@ namespace Akka.IO
     {
         private readonly ConcurrentStack<ByteBuffer> _pool;
 
+        public DirectByteBufferPool(int bufferSize, int poolSize)
+        {
+            var items = Enumerable.Range(0, poolSize)
+                                  .Select(x => new ByteBuffer(new byte[bufferSize]));
+            _pool = new ConcurrentStack<ByteBuffer>(items);
+        }
+
         public DirectByteBufferPool()
         {
             var items = Enumerable.Range(0, PoolSize)

--- a/src/core/Akka/IO/Inet.cs
+++ b/src/core/Akka/IO/Inet.cs
@@ -11,7 +11,7 @@ namespace Akka.IO
 {
     public class Inet
     {
-        public class SocketOption
+        public abstract class SocketOption
         {
             public virtual void BeforeDatagramBind(Socket ds) 
             { }
@@ -23,6 +23,24 @@ namespace Akka.IO
             { }
             public virtual void AfterConnect(Socket s)
             { }
+        }
+
+        public abstract class AbstractSocketOption : SocketOption { }
+
+        public abstract class SocketOptionV2 : SocketOption
+        {
+            public virtual void AfterBind(Socket s)
+            { }
+        }
+
+        public abstract class AbstractSocketOptionV2 : SocketOptionV2 { }
+
+        public class DatagramChannelCreator : SocketOption
+        {
+            public virtual DatagramChannel Create()
+            {
+                return DatagramChannel.Open();
+            }
         }
 
         public static class SO

--- a/src/core/Akka/IO/SocketChannel.cs
+++ b/src/core/Akka/IO/SocketChannel.cs
@@ -52,7 +52,7 @@ namespace Akka.IO
         }
 
 
-        public bool IsOpen()
+        public virtual bool IsOpen()
         {
             return _connected;
         }

--- a/src/core/Akka/IO/Udp.cs
+++ b/src/core/Akka/IO/Udp.cs
@@ -1,0 +1,322 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using Akka.Actor;
+using Akka.Configuration;
+
+namespace Akka.IO
+{
+    /// <summary>
+    /// UDP Extension for Akka’s IO layer.
+    ///
+    /// This extension implements the connectionless UDP protocol without
+    /// calling `connect` on the underlying sockets, i.e. without restricting
+    /// from whom data can be received. For “connected” UDP mode see <see cref="UdpConnected"/>.
+    ///
+    /// For a full description of the design and philosophy behind this IO
+    /// implementation please refer to <see href="http://doc.akka.io/">the Akka online documentation</see>.
+    /// </summary>
+    public class Udp : ExtensionIdProvider<UdpExt>
+    {
+        public static readonly Udp Instance = new Udp();
+
+        public override UdpExt CreateExtension(ExtendedActorSystem system)
+        {
+            return new UdpExt(system);
+        }
+
+        /// <summary>The common interface for <see cref="Command"/> and <see cref="Event"/>.</summary>
+        public abstract class Message { }
+
+        /// <summary>The common type of all commands supported by the UDP implementation.</summary>
+        public abstract class Command : Message, SelectionHandler.IHasFailureMessage
+        {
+            private object _failureMessage;
+
+            public object FailureMessage {
+                get { return _failureMessage = _failureMessage ?? new CommandFailed(this); }
+            }
+        }
+
+        /// <summary>
+        /// Each <see cref="Send"/> can optionally request a positive acknowledgment to be sent
+        /// to the commanding actor. If such notification is not desired the <see cref="Send.Ack"/>
+        /// must be set to an instance of this class. The token contained within can be used
+        /// to recognize which write failed when receiving a <see cref="CommandFailed"/> message.
+        /// </summary>
+        public class NoAck : Event
+        {
+            /// <summary>
+            /// Default <see cref="NoAck"/> instance which is used when no acknowledgment information is
+            /// explicitly provided. Its “token” is `null`.
+            /// </summary>
+            public static readonly NoAck Instance = new NoAck(null);
+
+            public NoAck(object token)
+            {
+                Token = token;
+            }
+
+            public object Token { get; private set; }
+        }
+
+        /// <summary>
+        /// This message is understood by the “simple sender” which can be obtained by
+        /// sending the <see cref="SimpleSender"/> query to the <see cref="UdpExt.Manager"/> as well as by
+        /// the listener actors which are created in response to <see cref="Bind"/>. It will send
+        /// the given payload data as one UDP datagram to the given target address. The
+        /// UDP actor will respond with <see cref="CommandFailed"/> if the send could not be
+        /// enqueued to the O/S kernel because the send buffer was full. If the given
+        /// `ack` is not of type <see cref="NoAck"/> the UDP actor will reply with the given
+        /// object as soon as the datagram has been successfully enqueued to the O/S
+        /// kernel.
+        ///
+        /// The sending UDP socket’s address belongs to the “simple sender” which does
+        /// not handle inbound datagrams and sends from an ephemeral port; therefore
+        /// sending using this mechanism is not suitable if replies are expected, use
+        /// <see cref="Bind"/> in that case.
+        /// </summary>
+        public sealed class Send : Command
+        {
+            public Send(ByteString payload, IPEndPoint target, Event ack)
+            {
+                if (ack == null)
+                    throw new ArgumentNullException("ack", "ack must be non-null. Use NoAck if you don't want acks.");
+                Payload = payload;
+                Target = target;
+                Ack = ack;
+            }
+
+            public ByteString Payload { get; private set; }
+            public IPEndPoint Target { get; private set; }
+            public Event Ack { get; private set; }
+
+            public bool WantsAck
+            {
+                get { return !(Ack is NoAck); }
+            }
+
+            public static Send Create(ByteString data, IPEndPoint target)
+            {
+                return new Send(data, target, NoAck.Instance);
+            }
+        }
+
+        /// <summary>
+        ///  Send this message to the <see cref="UdpExt.Manager"/> in order to bind to the given
+        ///  local port (or an automatically assigned one if the port number is zero).
+        ///  The listener actor for the newly bound port will reply with a <see cref="Bound"/>
+        ///  message, or the manager will reply with a <see cref="CommandFailed"/> message.
+        /// </summary>
+        public sealed class Bind : Command
+        {
+            public Bind(IActorRef handler, IPEndPoint localAddress, IEnumerable<Inet.SocketOption> options = null)
+            {
+                Handler = handler;
+                LocalAddress = localAddress;
+                Options = options ?? Enumerable.Empty<Inet.SocketOption>();
+            }
+
+            public IActorRef Handler { get; private set; }
+            public IPEndPoint LocalAddress { get; private set; }
+            public IEnumerable<Inet.SocketOption> Options { get; private set; }
+        }
+
+        /// <summary>
+        /// Send this message to the listener actor that previously sent a <see cref="Bound"/>
+        /// message in order to close the listening socket. The recipient will reply
+        /// with an <see cref="Unbound"/> message.
+        /// </summary>
+        public class Unbind : Command
+        {
+            public static readonly Unbind Instance = new Unbind();
+
+            private Unbind() { }
+        }
+
+        /// <summary>
+        /// Retrieve a reference to a “simple sender” actor of the UDP extension.
+        /// The newly created “simple sender” will reply with the <see cref="SimpleSenderReady" /> notification.
+        ///
+        /// The “simple sender” is a convenient service for being able to send datagrams
+        /// when the originating address is meaningless, i.e. when no reply is expected.
+        ///
+        /// The “simple sender” will not stop itself, you will have to send it a <see cref="Akka.Actor.PoisonPill"/>
+        /// when you want to close the socket.
+        /// </summary>
+        public class SimpleSender : Command
+        {
+            public static readonly SimpleSender Instance = new SimpleSender();
+
+            public SimpleSender(IEnumerable<Inet.SocketOption> options = null)
+            {
+                Options = options ?? Enumerable.Empty<Inet.SocketOption>();
+            }
+
+            public IEnumerable<Inet.SocketOption> Options { get; private set; }
+        }
+
+        /// <summary>
+        /// Send this message to a listener actor (which sent a <see cref="Bound"/> message) to
+        /// have it stop reading datagrams from the network. If the O/S kernel’s receive
+        /// buffer runs full then subsequent datagrams will be silently discarded.
+        /// Re-enable reading from the socket using the `ResumeReading` command.
+        /// </summary>
+        public class SuspendReading : Command
+        {
+            public static readonly SuspendReading Instance = new SuspendReading();
+
+            private SuspendReading()
+            { }
+        }
+
+        /// <summary>
+        ///  This message must be sent to the listener actor to re-enable reading from
+        ///  the socket after a `SuspendReading` command.
+        /// </summary>
+        public class ResumeReading : Command
+        {
+            public static readonly ResumeReading Instance = new ResumeReading();
+
+            private ResumeReading()
+            { }
+        }
+
+        /// <summary>The common type of all events emitted by the UDP implementation.</summary>
+        public abstract class Event : Message { }
+
+        /// <summary>
+        ///  When a listener actor receives a datagram from its socket it will send
+        ///  it to the handler designated in the <see cref="Bind"/> message using this message type.
+        /// </summary>
+        public sealed class Received : Event
+        {
+            public Received(ByteString data, IPEndPoint sender)
+            {
+                Data = data;
+                Sender = sender;
+            }
+
+            public ByteString Data { get; private set; }
+            public IPEndPoint Sender { get; private set; }
+        }
+
+        /// <summary>
+        /// When a command fails it will be replied to with this message type,
+        /// wrapping the failing command object.
+        /// </summary>
+        public sealed class CommandFailed : Event
+        {
+            public CommandFailed(Command cmd)
+            {
+                Cmd = cmd;
+            }
+            public Command Cmd { get; private set; }
+        }
+
+        /// <summary>
+        /// This message is sent by the listener actor in response to a <see cref="Bind"/> command.
+        /// If the address to bind to specified a port number of zero, then this message
+        /// can be inspected to find out which port was automatically assigned.
+        /// </summary>
+        public sealed class Bound : Event
+        {
+            public Bound(IPEndPoint localAddress)
+            {
+                LocalAddress = localAddress;
+            }
+
+            public IPEndPoint LocalAddress { get; private set; }
+        }
+
+        /// <summary> The “simple sender” sends this message type in response to a <see cref="SimpleSender"/> query. </summary>
+        public sealed class SimpleSenderReady : Event
+        {
+            public static readonly SimpleSenderReady Instance = new SimpleSenderReady();
+
+            private  SimpleSenderReady() { }
+        }
+
+        /// <summary>
+        /// This message is sent by the listener actor in response to an `Unbind` command
+        /// after the socket has been closed.
+        /// </summary>
+        public class Unbound
+        {
+            public static readonly Unbound Instance = new Unbound();
+            private Unbound() { }
+        }
+
+        public class SO : Inet.SoForwarders
+        {
+            /// <summary>
+            /// <see cref="Akka.IO.Inet.SocketOption"/> to set the SO_BROADCAST option
+            ///
+            /// For more information see cref="System.Net.Sockets.Socket.EnableBroadcast"/>
+            /// </summary>
+            public sealed class Broadcast : Inet.SocketOption
+            {
+                public Broadcast(bool on)
+                {
+                    On = on;
+                }
+
+                public bool On { get; private set; }
+
+                public override void BeforeDatagramBind(Socket s)
+                {
+                    s.EnableBroadcast = On;
+                }
+            }
+        }
+
+        internal class UdpSettings : SelectionHandlerSettings
+        {
+            public UdpSettings(Config config) 
+                : base(config)
+            {
+                NrOfSelectors = config.GetInt("nr-of-selectors");
+                DirectBufferSize = config.GetInt("direct-buffer-size");
+                MaxDirectBufferPoolSize = config.GetInt("direct-buffer-pool-limit");
+                BatchReceiveLimit = config.GetInt("receive-throughput");
+
+                ManagementDispatcher = config.GetString("management-dispatcher");
+
+                MaxChannelsPerSelector = MaxChannels == -1 ? -1 : Math.Max(MaxChannels/NrOfSelectors, 1);
+            }
+
+            public int NrOfSelectors { get; private set; }
+            public int DirectBufferSize { get; private set; }
+            public int MaxDirectBufferPoolSize { get; private set; }
+            public int BatchReceiveLimit { get; private set; }
+            public string ManagementDispatcher { get; private set; }
+        }
+    }
+
+    public class UdpExt : Extension
+    {
+        private readonly Udp.UdpSettings _settings;
+        private readonly IActorRef _manager;
+
+        public UdpExt(ExtendedActorSystem system)
+        {
+            _settings = new Udp.UdpSettings(system.Settings.Config.GetConfig("akka.io.udp"));
+            _manager = system.SystemActorOf(
+                props: Props.Create(() => new UdpManager(this)).WithDeploy(Deploy.Local), 
+                name: "IO-UDP-FF");
+
+            BufferPool = new DirectByteBufferPool();
+        }
+
+        public override IActorRef Manager
+        {
+            get { return _manager; }
+        }
+
+        internal Udp.UdpSettings Setting { get { return _settings; } }
+
+        internal DirectByteBufferPool BufferPool { get; private set; }
+    }
+}

--- a/src/core/Akka/IO/UdpConnected.cs
+++ b/src/core/Akka/IO/UdpConnected.cs
@@ -1,0 +1,248 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using Akka.Actor;
+
+namespace Akka.IO
+{
+    /// <summary>
+    /// UDP Extension for Akka’s IO layer.
+    ///
+    /// This extension implements the connectionless UDP protocol with
+    /// calling `connect` on the underlying sockets, i.e. with restricting
+    /// from whom data can be received. For “unconnected” UDP mode see <see cref="Udp"/>.
+    ///
+    /// For a full description of the design and philosophy behind this IO
+    /// implementation please refer to <see href="http://doc.akka.io/">the Akka online documentation</see>.
+    /// </summary>
+    public class UdpConnected : ExtensionIdProvider<UdpConnectedExt>
+    {
+        public static readonly UdpConnected Instance = new UdpConnected();
+
+        public override UdpConnectedExt CreateExtension(ExtendedActorSystem system)
+        {
+            return new UdpConnectedExt(system);
+        }
+
+        /// <summary>
+        /// The common interface for <see cref="Command"/> and <see cref="Event"/>.
+        /// </summary>
+        public abstract class Message { }
+
+        /// <summary>
+        /// The common type of all commands supported by the UDP implementation.
+        /// </summary>
+        public abstract class Command : Message, SelectionHandler.IHasFailureMessage
+        {
+            protected Command()
+            {
+                FailureMessage = new CommandFailed(this);
+            }
+
+            public object FailureMessage { get; private set; }
+        }
+
+        /// <summary>
+        /// Each <see cref="Send"/> can optionally request a positive acknowledgment to be sent
+        /// to the commanding actor. If such notification is not desired the <see cref="Send.Ack"/>
+        /// must be set to an instance of this class. The token contained within can be used
+        /// to recognize which write failed when receiving a <see cref="CommandFailed"/> message.
+        /// </summary>
+        public class NoAck : Event
+        {
+            /// <summary>
+            /// Default <see cref="NoAck"/> instance which is used when no acknowledgment information is
+            /// explicitly provided. Its “token” is `null`.
+            /// </summary>
+            public static readonly NoAck Instance = new NoAck(null);
+
+            public NoAck(object token)
+            {
+                Token = token;
+            }
+
+            public object Token { get; private set; }
+        }
+
+        /// <summary>
+        /// This message is understood by the connection actors to send data to their
+        /// designated destination. The connection actor will respond with
+        /// <see cref="CommandFailed"/> if the send could not be enqueued to the O/S kernel
+        /// because the send buffer was full. If the given `ack` is not of type <see cref="NoAck"/>
+        /// the connection actor will reply with the given object as soon as the datagram
+        /// has been successfully enqueued to the O/S kernel.
+        /// </summary>
+        public sealed class Send : Command
+        {
+            public Send(ByteString payload, object ack)
+            {
+                if(ack == null)
+                    throw new ArgumentNullException("ack", "ack must be non-null. Use NoAck if you don't want acks.");
+
+                Payload = payload;
+                Ack = ack;
+            }
+
+            public ByteString Payload { get; private set; }
+            public object Ack { get; private set; }
+
+            public bool WantsAck
+            {
+                get { return !(Ack is NoAck); }
+            }
+
+            public static Send Create(ByteString data)
+            {
+                return new Send(data, NoAck.Instance);
+            }
+        }
+
+        /// <summary>
+        /// Send this message to the <see cref="UdpExt.Manager"/> in order to bind to a local
+        /// port (optionally with the chosen `localAddress`) and create a UDP socket
+        /// which is restricted to sending to and receiving from the given `remoteAddress`.
+        /// All received datagrams will be sent to the designated `handler` actor.
+        /// </summary>
+        public sealed class Connect : Command
+        {
+            public Connect(IActorRef handler, 
+                           IPEndPoint remoteAddress,
+                           IPEndPoint localAddress = null, 
+                           IEnumerable<Inet.SocketOption> options = null)
+            {
+                Handler = handler;
+                RemoteAddress = remoteAddress;
+                LocalAddress = localAddress;
+                Options = options ?? Enumerable.Empty<Inet.SocketOption>();
+            }
+
+            public IActorRef Handler { get; private set; }
+            public IPEndPoint RemoteAddress { get; private set; }
+            public IPEndPoint LocalAddress { get; private set; }
+            public IEnumerable<Inet.SocketOption> Options { get; private set; }
+        }
+
+        /// <summary>
+        /// Send this message to a connection actor (which had previously sent the
+        /// <see cref="Connected"/> message) in order to close the socket. The connection actor
+        /// will reply with a <see cref="Disconnected"/> message.
+        /// </summary>
+        public class Disconnect : Command
+        {
+            public static readonly Disconnect Instance = new Disconnect();
+
+            private Disconnect()
+            {
+                
+            }
+        }
+
+        /// <summary>
+        /// Send this message to a listener actor (which sent a <see cref="Udp.Bound"/> message) to
+        /// have it stop reading datagrams from the network. If the O/S kernel’s receive
+        /// buffer runs full then subsequent datagrams will be silently discarded.
+        /// Re-enable reading from the socket using the `ResumeReading` command.
+        /// </summary>
+        public class SuspendReading : Command
+        {
+            public static readonly SuspendReading Instance = new SuspendReading();
+
+            private SuspendReading()
+            { }
+        }
+
+        /// <summary>
+        /// This message must be sent to the listener actor to re-enable reading from
+        /// the socket after a `SuspendReading` command.
+        /// </summary>
+        public class ResumeReading : Command
+        {
+            public static readonly ResumeReading Instance = new ResumeReading();
+
+            private ResumeReading()
+            { }
+        }
+
+        /// <summary>
+        /// The common type of all events emitted by the UDP implementation.
+        /// </summary>
+        public abstract class Event : Message { }
+
+        /// <summary>
+        /// When a connection actor receives a datagram from its socket it will send
+        /// it to the handler designated in the <see cref="Udp.Bind"/> message using this message type.
+        /// </summary>
+        public sealed class Received : Event
+        {
+            public Received(ByteString data)
+            {
+                Data = data;
+            }
+
+            public ByteString Data { get; private set; }
+        }
+
+        /// <summary>
+        /// When a command fails it will be replied to with this message type,
+        /// wrapping the failing command object.
+        /// </summary>
+        public sealed class CommandFailed : Event
+        {
+            public CommandFailed(Command cmd)
+            {
+                Cmd = cmd;
+            }
+
+            public Command Cmd { get; private set; }
+        }
+
+        /// <summary>
+        /// This message is sent by the connection actor to the actor which sent the
+        /// <see cref="Connect"/> message when the UDP socket has been bound to the local and
+        /// remote addresses given.
+        /// </summary>
+        public class Connected : Event
+        {
+            public static readonly Connected Instance = new Connected();
+
+            private Connected()
+            { }
+        }
+
+        /// <summary>
+        /// This message is sent by the connection actor to the actor which sent the
+        /// `Disconnect` message when the UDP socket has been closed.
+        /// </summary>
+        public class Disconnected : Event
+        {
+            public static readonly Disconnected Instance = new Disconnected();
+
+            private Disconnected()
+            { }
+        }
+
+    }
+
+    public class UdpConnectedExt : Extension
+    {
+        private readonly IActorRef _manager;
+
+        public UdpConnectedExt(ExtendedActorSystem system)
+        {
+            Settings = new Udp.UdpSettings(system.Settings.Config.GetConfig("akka.io.udp-connected"));
+            BufferPool = new DirectByteBufferPool(Settings.DirectBufferSize, Settings.MaxDirectBufferPoolSize);
+            _manager = system.SystemActorOf(
+                props: Props.Create(() => new UdpConnectedManager(this)).WithDeploy(Deploy.Local),
+                name: "IO-UDP-CONN");
+        }
+
+        public override IActorRef Manager
+        {
+            get { return _manager; }
+        }
+
+        internal IBufferPool BufferPool { get; private set; }
+        internal Udp.UdpSettings Settings { get; private set; }
+    }
+}

--- a/src/core/Akka/IO/UdpConnectedManager.cs
+++ b/src/core/Akka/IO/UdpConnectedManager.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Akka.Actor;
+
+namespace Akka.IO
+{
+    // INTERNAL API
+    class UdpConnectedManager : SelectionHandler.SelectorBasedManager
+    {
+        private readonly UdpConnectedExt _udpConn;
+
+        public UdpConnectedManager(UdpConnectedExt udpConn)
+            : base(udpConn.Settings, udpConn.Settings.NrOfSelectors)
+        {
+            _udpConn = udpConn;
+        }
+
+        protected override bool Receive(object m)
+        {
+            return WorkerForCommandHandler(message =>
+            {
+                var c = message as UdpConnected.Connect;
+                if (c != null)
+                {
+                    var commander = Sender;
+                    return registry => Props.Create(() => new UdpConnection(_udpConn, registry, commander, c));
+                }
+                throw new Exception();
+            })(m);
+        }
+
+    }
+}

--- a/src/core/Akka/IO/UdpConnection.cs
+++ b/src/core/Akka/IO/UdpConnection.cs
@@ -1,0 +1,216 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using Akka.Actor;
+using Akka.Dispatch;
+using Akka.Event;
+using Akka.Util.Internal;
+
+namespace Akka.IO
+{
+    internal class UdpConnection : ActorBase, IRequiresMessageQueue<IUnboundedMessageQueueSemantics>
+    {
+        private readonly UdpConnectedExt _udpConn;
+        private readonly IChannelRegistry _channelRegistry;
+        private readonly IActorRef _commander;
+        private readonly UdpConnected.Connect _connect;
+
+        private readonly ILoggingAdapter _log = Context.GetLogger();
+
+        private DatagramChannel _channel;
+
+        public UdpConnection(UdpConnectedExt udpConn, 
+                             IChannelRegistry channelRegistry, 
+                             IActorRef commander, 
+                             UdpConnected.Connect connect)
+        {
+            _udpConn = udpConn;
+            _channelRegistry = channelRegistry;
+            _commander = commander;
+            _connect = connect;
+
+            Context.Watch(connect.Handler);
+
+            //TODO: DNS lookup
+
+            DoConnect(_connect.RemoteAddress);
+        }
+
+        private Tuple<UdpConnected.Send, IActorRef> _pendingSend;
+        private bool WritePending
+        {
+            get { return _pendingSend != null; }
+        }
+
+        private void DoConnect(IPEndPoint address)
+        {
+            ReportConnectFailure(() =>
+            {
+                _channel = DatagramChannel.Open();
+                _channel.ConfigureBlocking(false);
+                var socket = _channel.Socket;
+                _connect.Options.ForEach(x => x.BeforeDatagramBind(socket));
+                if (_connect.LocalAddress != null)
+                    socket.Bind(_connect.LocalAddress);
+                _channel.Connect(_connect.RemoteAddress);
+                _channelRegistry.Register(_channel, SocketAsyncOperation.Receive, Self);
+            });
+            _log.Debug("Successfully connected to [{0}]", _connect.RemoteAddress);
+        }
+
+        protected override bool Receive(object message)
+        {
+            var registration = message as ChannelRegistration;
+            if (registration != null)
+            {
+                _connect.Options
+                        .OfType<Inet.SocketOptionV2>().ForEach(v2 => v2.AfterConnect(_channel.Socket));
+                _commander.Tell(UdpConnected.Connected.Instance);
+                Context.Become(Connected(registration));
+                return true;
+            }
+            return false;
+        }
+
+        private Receive Connected(ChannelRegistration registration)
+        {
+            return message =>
+            {
+                if (message is UdpConnected.SuspendReading)
+                {
+                    registration.DisableInterest(SocketAsyncOperation.Receive);
+                    return true;
+                }
+                if (message is UdpConnected.ResumeReading)
+                {
+                    registration.EnableInterest(SocketAsyncOperation.Receive);
+                    return true;
+                }
+                if (message is SelectionHandler.ChannelReadable)
+                {
+                    DoRead(registration, _connect.Handler);   
+                    return true;
+                }
+
+                if (message is UdpConnected.Disconnect)
+                {
+                    _log.Debug("Closing UDP connection to [{0}]", _connect.RemoteAddress);
+                    _channel.Close();
+                    Sender.Tell(UdpConnected.Disconnected.Instance);
+                    _log.Debug("Connection closed to [{0}], stopping listener", _connect.RemoteAddress);
+                    Context.Stop(Self);
+                    return true;
+                }
+
+                var send = message as UdpConnected.Send;
+                if (send != null && WritePending)
+                {
+                    if (_udpConn.Settings.TraceLogging) _log.Debug("Dropping write because queue is full");
+                    Sender.Tell(new UdpConnected.CommandFailed(send));
+                    return true;
+                }
+                if (send != null && send.Payload.IsEmpty)
+                {
+                    if (send.WantsAck)
+                        Sender.Tell(send.Ack);
+                    return true;
+                }
+                if (send != null)
+                {
+                    _pendingSend = Tuple.Create(send, Sender);
+                    registration.EnableInterest(SocketAsyncOperation.Send);
+                    return true;
+                }
+                if (message is SelectionHandler.ChannelWritable)
+                {
+                    DoWrite();
+                    return true;
+                }
+                return false;
+            };
+        }
+
+        private void DoRead(ChannelRegistration registration, IActorRef handler)
+        {
+            Action<int, ByteBuffer> innerRead = null;
+            innerRead = (readsLeft, buffer) =>
+            {
+                buffer.Clear();
+                buffer.Limit(_udpConn.Settings.DirectBufferSize);
+                if (_channel.Read(buffer) > 0)
+                {
+                    buffer.Flip();
+                    handler.Tell(new UdpConnected.Received(ByteString.Create(buffer)));
+                    innerRead(readsLeft - 1, buffer);
+                }
+
+            };
+            var buffr = _udpConn.BufferPool.Acquire();
+            try
+            {
+                innerRead(_udpConn.Settings.BatchReceiveLimit, buffr);
+            }
+            finally
+            {
+                registration.EnableInterest(SocketAsyncOperation.Receive);
+                _udpConn.BufferPool.Release(buffr);
+            }
+
+        }
+
+        private void DoWrite()
+        {
+            var buffer = _udpConn.BufferPool.Acquire();
+            try
+            {
+                var send = _pendingSend.Item1;
+                var commander = _pendingSend.Item2;
+                buffer.Clear();
+                send.Payload.CopyToBuffer(buffer);
+                buffer.Flip();
+                var writtenBytes = _channel.Write(buffer);
+                if (_udpConn.Settings.TraceLogging) _log.Debug("Wrote [{0}] bytes to channel", writtenBytes);
+
+                // Datagram channel either sends the whole message, or nothing
+                if (writtenBytes == 0) commander.Tell(new UdpConnected.CommandFailed(send));
+                else if (send.WantsAck) commander.Tell(send.Ack);
+            }
+            finally
+            {
+                _udpConn.BufferPool.Release(buffer);
+                _pendingSend = null;
+            }
+        }
+
+        protected override void PostStop()
+        {
+            if (_channel.IsOpen())
+            {
+                _log.Debug("Closing DatagramChannel after being stopped");
+                try
+                {
+                    _channel.Close();
+                }
+                catch (Exception ex)
+                {
+                    _log.Debug("Error closing DatagramChannel: {0}", ex);
+                }
+            }
+        }
+
+        private void ReportConnectFailure(Action thunk)
+        {
+            try
+            {
+                thunk();
+            }
+            catch (Exception e)
+            {
+                _log.Debug("Failure while connecting UDP channel to remote address [{0}] local address [{1}]: {2}", _connect.RemoteAddress, _connect.LocalAddress, e);
+                _commander.Tell(new UdpConnected.CommandFailed(_connect));
+                Context.Stop(Self);
+            }
+        }
+    }
+}

--- a/src/core/Akka/IO/UdpListener.cs
+++ b/src/core/Akka/IO/UdpListener.cs
@@ -1,0 +1,173 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using Akka.Actor;
+using Akka.Dispatch;
+using Akka.Event;
+using Akka.Util.Internal;
+
+namespace Akka.IO
+{
+    // INTERNAL API
+    class UdpListener : WithUdpSend, IRequiresMessageQueue<IUnboundedMessageQueueSemantics>
+    {
+        private readonly UdpExt _udp;
+        private readonly IChannelRegistry _channelRegistry;
+        private readonly IActorRef _bindCommander;
+        private readonly Udp.Bind _bind;
+
+        private readonly ILoggingAdapter _log = Context.GetLogger();
+        private readonly DatagramChannel _channel;
+        
+        private IActorRef _selector;
+
+        public UdpListener(UdpExt udp, IChannelRegistry channelRegistry, IActorRef bindCommander, Udp.Bind bind)
+        {
+            _udp = udp;
+            _channelRegistry = channelRegistry;
+            _bindCommander = bindCommander;
+            _bind = bind;
+
+            _selector = Context.Parent;
+
+            Context.Watch(bind.Handler);        // sign death pact
+
+            _channel = (bind.Options.OfType<Inet.DatagramChannelCreator>()
+                            .FirstOrDefault() ?? new Inet.DatagramChannelCreator()).Create();
+            _channel.ConfigureBlocking(false);
+
+            var localAddress = new Func<object>(() =>
+            {
+                try
+                {
+                    var socket = Channel.Socket;
+                    bind.Options.ForEach(x => x.BeforeDatagramBind(socket));
+                    socket.Bind(bind.LocalAddress);
+                    var ret = socket.LocalEndPoint as IPEndPoint;
+                    if (ret == null)
+                        throw new ArgumentException(string.Format("bound to unknown SocketAddress [{0}]", socket.LocalEndPoint));
+                    channelRegistry.Register(Channel, SocketAsyncOperation.Receive, Self);
+                    _log.Debug("Successfully bound to [{0}]", ret);
+                    bind.Options.OfType<Inet.SocketOptionV2>().ForEach(x => x.AfterBind(socket));
+                    return ret;
+                }
+                catch (Exception e)
+                {
+                    bindCommander.Tell(new Udp.CommandFailed(bind));
+                    _log.Error(e, "Failed to bind UDP channel to endpoint [{0}]", bind.LocalAddress);
+                    Context.Stop(Self);
+                    return null;
+                }
+            })();
+        }
+
+        protected override DatagramChannel Channel
+        {
+            get { return _channel; }
+        }
+        protected override UdpExt Udp
+        {
+            get { return _udp; }
+        }
+
+      
+
+
+        protected override bool Receive(object message)
+        {
+            var registration = message as ChannelRegistration;
+            if (registration != null)
+            {
+                _bindCommander.Tell(new Udp.Bound(Channel.Socket.LocalEndPoint as IPEndPoint));
+                Context.Become(m => ReadHandlers(registration)(m) || SendHandlers(registration)(m));
+                return true;
+            }
+            return false;
+        }
+
+        private Receive ReadHandlers(ChannelRegistration registration)
+        {
+            return message =>
+            {
+                if (message is Udp.SuspendReading)
+                {
+                    registration.DisableInterest(SocketAsyncOperation.Receive);
+                    return true;
+                }
+                if (message is Udp.ResumeReading)
+                {
+                    registration.EnableInterest(SocketAsyncOperation.Receive);
+                    return true;
+                }
+                if (message is SelectionHandler.ChannelReadable)
+                {
+                    DoReceive(registration, _bind.Handler);
+                    return true;
+                }
+
+                if (message is Udp.Unbind)
+                {
+                    _log.Debug("Unbinding endpoint [{0}]", _bind.LocalAddress);
+                    try
+                    {
+                        Channel.Close();
+                        Sender.Tell(IO.Udp.Unbound.Instance);
+                        _log.Debug("Unbound endpoint [{0}], stopping listener", _bind.LocalAddress);
+                    }
+                    finally
+                    {
+                        Context.Stop(Self);
+                    }
+                    return true;
+                }
+                return false;
+            };
+        }
+
+        private void DoReceive(ChannelRegistration registration, IActorRef handler)
+        {
+            Action<int, ByteBuffer> innerReceive = null;
+            innerReceive = (readsLeft, buffer) =>
+            {
+                buffer.Clear();
+                buffer.Limit(_udp.Setting.DirectBufferSize);
+
+                var sender = Channel.Receive(buffer) as IPEndPoint;
+                if (sender != null)
+                {
+                    buffer.Flip();
+                    handler.Tell(new Udp.Received(ByteString.Create(buffer), sender));
+                    if (readsLeft > 0) innerReceive(readsLeft - 1, buffer);
+                }
+            };
+
+            var buffr = _udp.BufferPool.Acquire();
+            try
+            {
+                innerReceive(_udp.Setting.BatchReceiveLimit, buffr);
+            }
+            finally
+            {
+                _udp.BufferPool.Release(buffr);
+                registration.EnableInterest(SocketAsyncOperation.Receive);
+            }
+        }
+
+        protected override void PostStop()
+        {
+            if (Channel.IsOpen())
+            {
+                _log.Debug("Closing DatagramChannel after being stopped");
+                try
+                {
+                    Channel.Close();
+                }
+                catch (Exception e)
+                {
+                    _log.Debug("Error closing DatagramChannel: {0}", e);
+                }
+            }
+        }
+    }
+}

--- a/src/core/Akka/IO/UdpManager.cs
+++ b/src/core/Akka/IO/UdpManager.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using Akka.Actor;
+
+namespace Akka.IO
+{
+    /**
+     * TODO: CLRify comment
+     * 
+     * INTERNAL API
+     *
+     * UdpManager is a facade for simple fire-and-forget style UDP operations
+     *
+     * UdpManager is obtainable by calling {{{ IO(Udp) }}} (see [[akka.io.IO]] and [[akka.io.Udp]])
+     *
+     * *Warning!* Udp uses [[java.nio.channels.DatagramChannel#send]] to deliver datagrams, and as a consequence if a
+     * security manager  has been installed then for each datagram it will verify if the target address and port number are
+     * permitted. If this performance overhead is undesirable use the connection style Udp extension.
+     *
+     * == Bind and send ==
+     *
+     * To bind and listen to a local address, a [[akka.io.Udp..Bind]] command must be sent to this actor. If the binding
+     * was successful, the sender of the [[akka.io.Udp.Bind]] will be notified with a [[akka.io.Udp.Bound]]
+     * message. The sender of the [[akka.io.Udp.Bound]] message is the Listener actor (an internal actor responsible for
+     * listening to server events). To unbind the port an [[akka.io.Tcp.Unbind]] message must be sent to the Listener actor.
+     *
+     * If the bind request is rejected because the Udp system is not able to register more channels (see the nr-of-selectors
+     * and max-channels configuration options in the akka.io.udp section of the configuration) the sender will be notified
+     * with a [[akka.io.Udp.CommandFailed]] message. This message contains the original command for reference.
+     *
+     * The handler provided in the [[akka.io.Udp.Bind]] message will receive inbound datagrams to the bound port
+     * wrapped in [[akka.io.Udp.Received]] messages which contain the payload of the datagram and the sender address.
+     *
+     * UDP datagrams can be sent by sending [[akka.io.Udp.Send]] messages to the Listener actor. The sender port of the
+     * outbound datagram will be the port to which the Listener is bound.
+     *
+     * == Simple send ==
+     *
+     * Udp provides a simple method of sending UDP datagrams if no reply is expected. To acquire the Sender actor
+     * a SimpleSend message has to be sent to the manager. The sender of the command will be notified by a SimpleSenderReady
+     * message that the service is available. UDP datagrams can be sent by sending [[akka.io.Udp.Send]] messages to the
+     * sender of SimpleSenderReady. All the datagrams will contain an ephemeral local port as sender and answers will be
+     * discarded.
+     *
+     */
+
+    internal class UdpManager : SelectionHandler.SelectorBasedManager
+    {
+        private readonly UdpExt _udp;
+
+        public UdpManager(UdpExt udp) 
+            : base(udp.Setting, udp.Setting.NrOfSelectors)
+        {
+            _udp = udp;
+        }
+
+        protected override bool Receive(object m)
+        {
+            return WorkerForCommandHandler(message =>
+            {
+                var b = message as Udp.Bind;
+                if (b != null)
+                {
+                    var commander = Sender;
+                    return registry => Props.Create(() => new UdpListener(_udp, registry, commander, b));
+                }
+                var s = message as Udp.SimpleSender;
+                if (s != null)
+                {
+                    var commander = Sender;
+                    return registry => Props.Create(() => new UdpSender(_udp, registry, commander, s.Options));
+                }
+                throw new Exception();
+            })(m);
+        }
+    }
+}

--- a/src/core/Akka/IO/UdpSender.cs
+++ b/src/core/Akka/IO/UdpSender.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Sockets;
+using Akka.Actor;
+using Akka.Dispatch;
+using Akka.Event;
+using Akka.Util.Internal;
+
+namespace Akka.IO
+{
+    class UdpSender : WithUdpSend, IRequiresMessageQueue<IUnboundedMessageQueueSemantics>
+    {
+        private readonly UdpExt _udp;
+        private readonly IActorRef _commander;
+        private readonly IEnumerable<Inet.SocketOption> _options;
+
+        private readonly DatagramChannel _channel;
+
+        private readonly ILoggingAdapter _log = Context.GetLogger();
+
+        public UdpSender(UdpExt udp, IChannelRegistry channelRegistry, IActorRef commander, IEnumerable<Inet.SocketOption> options)
+        {
+            _udp = udp;
+            _commander = commander;
+            _options = options;
+
+            _channel = new Func<DatagramChannel>(() =>
+            {
+                var datagramChannel = DatagramChannel.Open();
+                datagramChannel.ConfigureBlocking(false);
+                var socket = datagramChannel.Socket;
+                _options.ForEach(x => x.BeforeDatagramBind(socket));
+
+                return datagramChannel;
+            })();
+
+            channelRegistry.Register(_channel, SocketAsyncOperation.None, Self);
+        }
+
+        protected override UdpExt Udp
+        {
+            get { return _udp; }
+        }
+        protected override DatagramChannel Channel
+        {
+            get { return _channel; }
+        }
+
+        protected override bool Receive(object message)
+        {
+            var registration = message as ChannelRegistration;
+            if (registration != null)
+            {
+                _options
+                    .OfType<Inet.SocketOptionV2>()
+                    .ForEach(x => x.AfterConnect(Channel.Socket));
+                _commander.Tell(IO.Udp.SimpleSenderReady.Instance);
+                Context.Become(SendHandlers(registration));
+                return true;
+            }
+            return false;
+        }
+
+        protected override void PostStop()
+        {
+            if (Channel.IsOpen())
+            {
+                _log.Debug("Closing DatagramChannel after being stopped");
+                try
+                {
+                    Channel.Close();
+                }
+                catch (Exception e)
+                {
+                    _log.Debug("Error closing DatagramChannel: {0}", e);
+                }
+            }
+        }
+    }
+}

--- a/src/core/Akka/IO/WithUdpSend.cs
+++ b/src/core/Akka/IO/WithUdpSend.cs
@@ -1,0 +1,101 @@
+﻿using System.Net.Sockets;
+using Akka.Actor;
+using Akka.Event;
+
+namespace Akka.IO
+{
+    abstract class WithUdpSend : ActorBase
+    {
+        private readonly ILoggingAdapter _log = Context.GetLogger();
+
+        private Udp.Send _pendingSend;
+        private IActorRef _pendingCommander;
+        private bool _retriedSend;
+
+        private bool HasWritePending
+        {
+            get { return _pendingSend != null; }
+        }
+
+        protected abstract DatagramChannel Channel { get; }
+        protected abstract UdpExt Udp { get; }
+
+        public Receive SendHandlers(ChannelRegistration registration)
+        {
+            return message =>
+            {
+                var send = message as Udp.Send;
+                if (send != null && HasWritePending)
+                {
+                    if (Udp.Setting.TraceLogging) _log.Debug("Dropping write because queue is full");
+                    Sender.Tell(new Udp.CommandFailed(send));
+                    return true;
+                }
+                if (send != null && send.Payload.IsEmpty)
+                {
+                    if (send.WantsAck)
+                        Sender.Tell(send.Ack);
+                    return true;
+                }
+                if (send != null)
+                {
+                    _pendingSend = send;
+                    _pendingCommander = Sender;
+
+                    //TODO: DNS resolve
+
+                    DoSend(registration);
+
+                    return true;
+                }
+                if (message is SelectionHandler.ChannelWritable && HasWritePending)
+                {
+                    DoSend(registration);
+                    return true;
+                }
+                return false;
+            };
+        }
+
+        private void DoSend(ChannelRegistration registration)
+        {
+            var buffer = Udp.BufferPool.Acquire();
+            try
+            {
+                buffer.Clear();
+                _pendingSend.Payload.CopyToBuffer(buffer);
+                buffer.Flip();
+                var writtenBytes = Channel.Send(buffer, _pendingSend.Target);
+                if (Udp.Setting.TraceLogging) _log.Debug("Wrote [{0}] bytes to channel", writtenBytes);
+
+                // Datagram channel either sends the whole message, or nothing
+                if (writtenBytes == 0)
+                {
+                    if (_retriedSend)
+                    {
+                        _pendingCommander.Tell(new Udp.CommandFailed(_pendingSend));
+                        _retriedSend = false;
+                        _pendingSend = null;
+                        _pendingCommander = null;
+                    }
+                    else
+                    {
+                        registration.EnableInterest(SocketAsyncOperation.Send);
+                        _retriedSend = true;
+                    }
+                }
+                else
+                {
+                    if (_pendingSend.WantsAck) _pendingCommander.Tell(_pendingSend.Ack);
+                    _retriedSend = false;
+                    _pendingSend = null;
+                    _pendingCommander = null;
+                }
+            }
+            finally
+            {
+                Udp.BufferPool.Release(buffer);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added the Akka IO UDP driver, including all tests.  

The UDP driver also uses Socket.Select and therefore has the same allocation issue as described in #1023. 