### PR TITLE
RemoteDaemon bug, not removing children

### DIFF
--- a/src/core/Akka.Remote/Akka.Remote.csproj
+++ b/src/core/Akka.Remote/Akka.Remote.csproj
@@ -86,7 +86,7 @@
     <Compile Include="Proto\Containerformats.cs" />
     <Compile Include="Proto\Wireformats.cs" />
     <Compile Include="RemoteActorRef.cs" />
-    <Compile Include="RemoteDaemon.cs" />
+    <Compile Include="RemoteSystemDaemon.cs" />
     <Compile Include="RemoteDeployer.cs" />
     <Compile Include="RemoteSettings.cs" />
     <Compile Include="RemoteTransport.cs" />

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -50,7 +50,7 @@ namespace Akka.Remote
                 return _internals ??
                        (_internals =
                            new Internals(new Remoting(_system, this), _system.Serialization,
-                               new RemoteSystemDaemon(_system, RootPath / "remote", SystemGuardian, _log)));
+                               new RemoteSystemDaemon(_system, RootPath / "remote", SystemGuardian,this.DeadLetters /* TODO: should be RemoteTerminator*/, _log)));
             }
         }
 

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -50,7 +50,7 @@ namespace Akka.Remote
                 return _internals ??
                        (_internals =
                            new Internals(new Remoting(_system, this), _system.Serialization,
-                               new RemoteDaemon(_system, RootPath / "remote", SystemGuardian, _log)));
+                               new RemoteSystemDaemon(_system, RootPath / "remote", SystemGuardian, _log)));
             }
         }
 

--- a/src/core/Akka.Remote/RemoteDaemon.cs
+++ b/src/core/Akka.Remote/RemoteDaemon.cs
@@ -115,6 +115,30 @@ namespace Akka.Remote
                     if(@ref.Parent.Path.Address == addressTerminated.Address) _system.Stop(@ref);
                 });
             }
+            else if (message is DeathWatchNotification)
+            {
+                var deathWatchNotification = message as DeathWatchNotification;
+
+    //case DeathWatchNotification(child: ActorRefWithCell with ActorRefScope, _, _) if child.isLocal ⇒
+    //  terminating.locked {
+    //    removeChild(child.path.elements.drop(1).mkString("/"), child)
+    //    val parent = child.getParent
+    //    if (removeChildParentNeedsUnwatch(parent, child)) parent.sendSystemMessage(Unwatch(parent, this))
+    //    terminationHookDoneWhenNoChildren()
+    //  }
+    //case DeathWatchNotification(parent: ActorRef with ActorRefScope, _, _) if !parent.isLocal ⇒
+    //  terminating.locked {
+    //    parent2children.remove(parent) match {
+    //      case null ⇒
+    //      case children ⇒
+    //        for (c ← children) {
+    //          system.stop(c)
+    //          removeChild(c.path.elements.drop(1).mkString("/"), c)
+    //        }
+    //        terminationHookDoneWhenNoChildren()
+    //    }
+    //  }
+            }
         }
 
         /// <summary>

--- a/src/core/Akka.Remote/RemoteSystemDaemon.cs
+++ b/src/core/Akka.Remote/RemoteSystemDaemon.cs
@@ -286,17 +286,17 @@ namespace Akka.Remote
             }
         }
 
-        private void RemoveChildParentNeedsUnwatch(IActorRef parent, IActorRef child)
+        private bool RemoveChildParentNeedsUnwatch(IActorRef parent, IActorRef child)
         {
             const bool weDontHaveTailRecursion = true;
             while (weDontHaveTailRecursion)
             {
                 IImmutableSet<IActorRef> children;
                 if (!_parent2Children.TryGetValue(parent, out children)) 
-                    return; //parent is missing, so child does not need to be removed
+                    return false; //parent is missing, so child does not need to be removed
 
                 if (_parent2Children.TryUpdate(parent, children.Remove(child), children))
-                    return; //child was removed
+                    return true; //child was removed
             }
         }
     }

--- a/src/core/Akka.Remote/RemoteSystemDaemon.cs
+++ b/src/core/Akka.Remote/RemoteSystemDaemon.cs
@@ -11,6 +11,7 @@ using Akka.Actor;
 using Akka.Actor.Internals;
 using Akka.Dispatch.SysMsg;
 using Akka.Event;
+using Akka.Util;
 using Akka.Util.Internal;
 
 namespace Akka.Remote
@@ -72,18 +73,19 @@ namespace Akka.Remote
     /// 
     /// It acts as the brain of the remote that response to system remote messages and executes actions accordingly.
     /// </summary>
-    internal class RemoteDaemon : VirtualPathContainer
+    internal class RemoteSystemDaemon : VirtualPathContainer
     {
         private readonly ActorSystemImpl _system;
+        private Switch _terminating = new Switch(false);
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="RemoteDaemon" /> class.
+        ///     Initializes a new instance of the <see cref="RemoteSystemDaemon" /> class.
         /// </summary>
         /// <param name="system">The system.</param>
         /// <param name="path">The path.</param>
         /// <param name="parent">The parent.</param>
         /// <param name="log"></param>
-        public RemoteDaemon(ActorSystemImpl system, ActorPath path, IInternalActorRef parent, ILoggingAdapter log)
+        public RemoteSystemDaemon(ActorSystemImpl system, ActorPath path, IInternalActorRef parent, ILoggingAdapter log)
             : base(system.Provider, path, parent, log)
         {
             _system = system;

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -402,7 +402,7 @@ namespace Akka.Actor
         {
             _children.AddOrUpdate(name, actor, (k, v) =>
             {
-                //TODO:  log.debug("{} replacing child {} ({} -> {})", path, name, old, ref)
+                Log.Warning("{0} replacing child {1} ({2} -> {3})", name, actor, v, actor);
                 return v;
             });
         }
@@ -412,7 +412,16 @@ namespace Akka.Actor
             IInternalActorRef tmp;
             if (!_children.TryRemove(name, out tmp))
             {
-                //TODO: log.warning("{} trying to remove non-child {}", path, name)
+                Log.Warning("{0} trying to remove non-child {1}", Path, name);
+            }
+        }
+
+        public void RemoveChild(string name,IActorRef child)
+        {
+            IInternalActorRef tmp;
+            if (!_children.TryRemove(name, out tmp))
+            {
+                Log.Warning("{0} trying to remove non-child {1}",Path,name);
             }
         }
 

--- a/src/core/Akka/Util/Switch.cs
+++ b/src/core/Akka/Util/Switch.cs
@@ -177,6 +177,14 @@ namespace Akka.Util
         {
             get { return !_switch.Value; }
         }
+
+        public void Locked(Action action)
+        {
+            lock (_lock)
+            {
+                action();
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Pinpoints the bug found in this conversation:

```
 @AndrewEgorov if the Context.Stop isn't working, you can try sending a PoisonPill.Instance to that remote actor and see if that removes it
but this sounds like a bug
I'll log it and see if we can fix it
Horusiath 21:02
@Aaronontheweb I tried @AndrewEgorov example with PoisonPill - same result. Looks like bug
rogeralsing 21:38
I found the problem
we dont have any code for handling deathwatchnotification in RemoteDaemon..
```

cc @AndrewEgorov

I will port the missing code. opening this PR so everyone knows we are working on it