### PR TITLE
HOCON config key for replay receive timeout for AsyncWriteProxy

### DIFF
--- a/src/core/Akka.Persistence/persistence.conf
+++ b/src/core/Akka.Persistence/persistence.conf
@@ -24,6 +24,9 @@ akka {
 
     journal {
 
+      # replay receive timeout for async proxy mediators
+	  async-proxy-replay-timeout = 5s
+
       # Maximum size of a persistent message batch written to the journal.
       max-message-batch-size = 200
 


### PR DESCRIPTION
New config value **akka.persistence.journal.async-proxy-replay-timeout** that can be used to set receive timeout (it was fixed 5sec before) on `ReplayMediator` actor used by `AsyncWriteProxy` journals.