### PR TITLE
SnapshotStoreSpec not implementing default snapshot store by default

### DIFF
--- a/src/core/Akka.Persistence.TestKit/Snapshot/SnapshotStoreSpec.cs
+++ b/src/core/Akka.Persistence.TestKit/Snapshot/SnapshotStoreSpec.cs
@@ -21,10 +21,8 @@ namespace Akka.Persistence.TestKit.Snapshot
     /// </summary>
     public abstract class SnapshotStoreSpec : PluginSpec
     {
-        protected static readonly Config Config =
-            ConfigurationFactory.ParseString("akka.persistence.publish-plugin-commands = on");
-
         private static readonly string _specConfigTemplate = @"
+            akka.persistence.publish-plugin-commands = on
             akka.persistence.snapshot-store {
                 plugin = ""akka.persistence.snapshot-store.my""
                 my {
@@ -32,6 +30,9 @@ namespace Akka.Persistence.TestKit.Snapshot
                     plugin-dispatcher = ""akka.persistence.dispatchers.default-plugin-dispatcher""
                 }
             }";
+
+        protected static readonly Config Config =
+            ConfigurationFactory.ParseString(_specConfigTemplate);
 
         private readonly TestProbe _senderProbe;
         protected List<SnapshotMetadata> Metadata;


### PR DESCRIPTION
Related issue: #1067 . Until this PR, if none snapshot store was attached to the `SnapshotStoreSpec`, tests were run against default snapshot store (using local file system). Now this won't be a case - spec by default loads non-existing snapshot store, allowing all tests to fails if no implementation was provided.