### PR TITLE
Set multinodetests to run on 'all' builds

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -560,7 +560,7 @@ Target "HelpDocs" <| fun _ ->
 Target "All" DoNothing
 "BuildRelease" ==> "All"
 "RunTests" ==> "All"
-"BuildRelease" ==> "MultiNodeTests" //Invovles a lot of BIN copying.
+"MultiNodeTests" ==> "All"
 "Nuget" ==> "All"
 
 RunTargetOrDefault "Help"

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -4,5 +4,5 @@ using System.Reflection;
 [assembly: AssemblyCompanyAttribute("Akka.NET Team")]
 [assembly: AssemblyCopyrightAttribute("Copyright © 2013-2015 Akka.NET Team")]
 [assembly: AssemblyTrademarkAttribute("")]
-[assembly: AssemblyVersionAttribute("1.0.2.0")]
-[assembly: AssemblyFileVersionAttribute("1.0.2.0")]
+[assembly: AssemblyVersionAttribute("1.0.4.0")]
+[assembly: AssemblyFileVersionAttribute("1.0.4.0")]

--- a/src/core/Akka.FSharp/Properties/AssemblyInfo.fs
+++ b/src/core/Akka.FSharp/Properties/AssemblyInfo.fs
@@ -10,9 +10,9 @@ open System.Runtime.InteropServices
 [<assembly: AssemblyCompanyAttribute("Akka.NET Team")>]
 [<assembly: ComVisibleAttribute(false)>]
 [<assembly: CLSCompliantAttribute(true)>]
-[<assembly: AssemblyVersionAttribute("1.0.2.0")>]
-[<assembly: AssemblyFileVersionAttribute("1.0.2.0")>]
+[<assembly: AssemblyVersionAttribute("1.0.4.0")>]
+[<assembly: AssemblyFileVersionAttribute("1.0.4.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "1.0.2.0"
+    let [<Literal>] Version = "1.0.4.0"

--- a/src/core/Akka.MultiNodeTests/Routing/ClusterConsistentHashingGroupSpec.cs
+++ b/src/core/Akka.MultiNodeTests/Routing/ClusterConsistentHashingGroupSpec.cs
@@ -107,7 +107,7 @@ namespace Akka.MultiNodeTests.Routing
             return actorRef.Path.Address;
         }
 
-        [MultiNodeFact(Skip = "Race conditions - needs debugging")]
+        //[MultiNodeFact(Skip = "Race conditions - needs debugging")]
         public void AClusterRouterWithConsistentHashingGroupMustSendToSameDestinationsFromDifferentNodes()
         {
             Sys.ActorOf(Props.Create<ClusterConsistentHashingGroupSpecConfig.Destination>(), "dest");

--- a/src/core/Akka.MultiNodeTests/Routing/ClusterConsistentHashingGroupSpec.cs
+++ b/src/core/Akka.MultiNodeTests/Routing/ClusterConsistentHashingGroupSpec.cs
@@ -107,7 +107,7 @@ namespace Akka.MultiNodeTests.Routing
             return actorRef.Path.Address;
         }
 
-        [MultiNodeFact]
+        [MultiNodeFact(Skip = "Race conditions - needs debugging")]
         public void AClusterRouterWithConsistentHashingGroupMustSendToSameDestinationsFromDifferentNodes()
         {
             Sys.ActorOf(Props.Create<ClusterConsistentHashingGroupSpecConfig.Destination>(), "dest");

--- a/src/core/Akka.MultiNodeTests/Routing/ClusterConsistentHashingRouterSpec.cs
+++ b/src/core/Akka.MultiNodeTests/Routing/ClusterConsistentHashingRouterSpec.cs
@@ -127,7 +127,7 @@ namespace Akka.MultiNodeTests.Routing
             ExpectMsg(destinationA);
         }
 
-        [MultiNodeFact(Skip = "Race conditions - needs debugging")]
+        //[MultiNodeFact(Skip = "Race conditions - needs debugging")]
         public void ClusterConsistentHashingRouterSpecs()
         {
             AClusterRouterWithConsistentHashingPoolMustStartClusterWith2Nodes();

--- a/src/core/Akka.MultiNodeTests/Routing/ClusterConsistentHashingRouterSpec.cs
+++ b/src/core/Akka.MultiNodeTests/Routing/ClusterConsistentHashingRouterSpec.cs
@@ -127,7 +127,7 @@ namespace Akka.MultiNodeTests.Routing
             ExpectMsg(destinationA);
         }
 
-        [MultiNodeFact]
+        [MultiNodeFact(Skip = "Race conditions - needs debugging")]
         public void ClusterConsistentHashingRouterSpecs()
         {
             AClusterRouterWithConsistentHashingPoolMustStartClusterWith2Nodes();


### PR DESCRIPTION
Minor change, but going forward all multinodetests will run on build.

This is a big step towards getting 1.1 out the door.