### PR TITLE
Fix for issue #1065 NUnit to destroy ActorSystem after each test run inline with XUnit

### DIFF
--- a/src/contrib/testkits/Akka.TestKit.NUnit.Tests/Akka.TestKit.NUnit.Tests.csproj
+++ b/src/contrib/testkits/Akka.TestKit.NUnit.Tests/Akka.TestKit.NUnit.Tests.csproj
@@ -46,6 +46,7 @@
   <ItemGroup>
     <Compile Include="AssertionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestKitTestFixtureTest.cs" />
     <Compile Include="TestKitTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/contrib/testkits/Akka.TestKit.NUnit.Tests/TestKitTestFixtureTest.cs
+++ b/src/contrib/testkits/Akka.TestKit.NUnit.Tests/TestKitTestFixtureTest.cs
@@ -1,0 +1,30 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TestKitTests.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.TestKit.TestActors;
+using NUnit.Framework;
+
+namespace Akka.TestKit.NUnit.Tests
+{
+    [TestFixture]
+    public class TestKitTestFixtureTest : TestKit
+    {
+        [Test]
+        public void Can_create_more_than_one_test_in_a_fixture_with_the_same_actor_name_test1()
+        {
+            Sys.ActorOf<BlackHoleActor>("actor-name");
+        }
+
+        [Test]
+        public void Can_create_more_than_one_test_in_a_fixture_with_the_same_actor_name_test2()
+        {
+            Sys.ActorOf<BlackHoleActor>("actor-name");
+        }
+    }
+}

--- a/src/contrib/testkits/Akka.TestKit.NUnit/TestKit.cs
+++ b/src/contrib/testkits/Akka.TestKit.NUnit/TestKit.cs
@@ -18,7 +18,6 @@ namespace Akka.TestKit.NUnit
     public class TestKit : TestKitBase, IDisposable
     {
         private static readonly NUnitAssertions _assertions = new NUnitAssertions();
-        private readonly ActorSystem _actorSystem;
         private readonly Config _config;
         private readonly string _actorSystemName;
         private bool _isFirstRun = true;
@@ -33,7 +32,8 @@ namespace Akka.TestKit.NUnit
         public TestKit(ActorSystem system = null)
             : base(_assertions, system)
         {
-            _actorSystem = system;
+            if(system != null)
+                throw new NotSupportedException("Due to the way NUnit works, providing an ActorSystem is not supported.  For further details please see https://github.com/akkadotnet/akka.net/pull/1092");
         }
 
         /// <summary>
@@ -66,18 +66,26 @@ namespace Akka.TestKit.NUnit
 
         protected static NUnitAssertions Assertions { get { return _assertions; } }
 
+        /// <summary>
+        /// This method is called before each test run, it initializes the test including
+        /// creating and setting up the ActorSystem.
+        /// </summary>
         [SetUp]
         public void InitializeActorSystemOnSetUp()
         {
             if (!_isFirstRun)
-                InitializeTest(_actorSystem, _config, _actorSystemName, null);
+                InitializeTest(null, _config, _actorSystemName, null);
         }
 
+        /// <summary>
+        /// This method is called after each test finishes, which calls
+        /// into the AfterAll method.
+        /// </summary>
         [TearDown]
         public void ShutDownActorSystemOnTearDown()
         {
             _isFirstRun = false;
-            Shutdown();
+            AfterAll();
         }
 
         /// <summary>

--- a/src/core/Akka.TestKit/TestKitBase.cs
+++ b/src/core/Akka.TestKit/TestKitBase.cs
@@ -21,6 +21,24 @@ namespace Akka.TestKit
     /// </summary>
     public abstract partial class TestKitBase : IActorRefFactory
     {
+        private class TestState
+        {
+            public TestState()
+            {
+                LastMessage = NullMessageEnvelope.Instance;
+            }
+
+            public ActorSystem System { get; set; }
+            public TestKitSettings TestKitSettings { get; set; }
+            public BlockingQueue<MessageEnvelope> Queue { get; set; }
+            public MessageEnvelope LastMessage  { get; set; }
+            public IActorRef TestActor { get; set; }
+            public TimeSpan? End { get; set; }
+            public bool LastWasNoMsg { get; set; } //if last assertion was expectNoMsg, disable timing failure upon within() block end.
+            public ILoggingAdapter Log { get; set; }
+            public EventFilterFactory EventFilterFactory { get; set; }
+        }
+
         private static readonly Config _defaultConfig = ConfigurationFactory.FromResource<TestKitBase>("Akka.TestKit.Internal.Reference.conf");
         private static readonly Config _fullDebugConfig = ConfigurationFactory.ParseString(@"
                 akka.log-dead-letters-during-shutdown = true
@@ -34,18 +52,10 @@ namespace Akka.TestKit
                 akka.log-dead-letters = true
                 akka.loglevel = DEBUG
                 akka.stdout-loglevel = DEBUG");
+        private static readonly AtomicCounter _testActorId = new AtomicCounter(0);
 
         private readonly ITestKitAssertions _assertions;
-        private readonly ActorSystem _system;
-        private readonly TestKitSettings _testKitSettings;
-        private readonly BlockingQueue<MessageEnvelope> _queue;
-        private MessageEnvelope _lastMessage = NullMessageEnvelope.Instance;
-        private static readonly AtomicCounter _testActorId = new AtomicCounter(0);
-        private readonly IActorRef _testActor;
-        private TimeSpan? _end;
-        private bool _lastWasNoMsg; //if last assertion was expectNoMsg, disable timing failure upon within() block end.
-        private readonly ILoggingAdapter _log;
-        private readonly EventFilterFactory _eventFilterFactory;
+        private TestState _testState;
 
         /// <summary>
         /// Create a new instance of the <see cref="TestKitBase"/> class.
@@ -76,24 +86,35 @@ namespace Akka.TestKit
         private TestKitBase(ITestKitAssertions assertions, ActorSystem system, Config config, string actorSystemName, string testActorName)
         {
             if(assertions == null) throw new ArgumentNullException("assertions");
-            if(system == null)
+
+            _assertions = assertions;
+            
+            InitializeTest(system, config, actorSystemName, testActorName);
+        }
+
+        protected void InitializeTest(ActorSystem system, Config config, string actorSystemName, string testActorName)
+        {
+            _testState = new TestState();
+
+            if (system == null)
             {
                 var configWithDefaultFallback = config.SafeWithFallback(_defaultConfig);
                 system = ActorSystem.Create(actorSystemName ?? "test", configWithDefaultFallback);
             }
 
-            _assertions = assertions;
-            _system = system;
+            _testState.System = system;
+
             system.RegisterExtension(new TestKitExtension());
-            system.RegisterExtension(new TestKitAssertionsExtension(assertions));
-            _testKitSettings = TestKitExtension.For(_system);
-            _queue = new BlockingQueue<MessageEnvelope>();
-            _log = Logging.GetLogger(system, GetType());
-            _eventFilterFactory = new EventFilterFactory(this);
-            
+            system.RegisterExtension(new TestKitAssertionsExtension(_assertions));
+
+            _testState.TestKitSettings = TestKitExtension.For(_testState.System);
+            _testState.Queue = new BlockingQueue<MessageEnvelope>();
+            _testState.Log = Logging.GetLogger(system, GetType());
+            _testState.EventFilterFactory = new EventFilterFactory(this);
+
             //register the CallingThreadDispatcherConfigurator
-            _system.Dispatchers.RegisterConfigurator(CallingThreadDispatcher.Id,
-                new CallingThreadDispatcherConfigurator(_system.Settings.Config, _system.Dispatchers.Prerequisites));
+            _testState.System.Dispatchers.RegisterConfigurator(CallingThreadDispatcher.Id,
+                new CallingThreadDispatcherConfigurator(_testState.System.Settings.Config, _testState.System.Dispatchers.Prerequisites));
 
             if (string.IsNullOrEmpty(testActorName))
                 testActorName = "testActor" + _testActorId.IncrementAndGet();
@@ -106,32 +127,32 @@ namespace Akka.TestKit
                 return repRef == null || repRef.IsStarted;
             }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(10));
 
-            if(!(this is INoImplicitSender))
+            if (!(this is INoImplicitSender))
             {
                 InternalCurrentActorCellKeeper.Current = (ActorCell)((ActorRefWithCell)testActor).Underlying;
             }
-            else if(!(this is TestProbe)) 
-                //HACK: we need to clear the current context when running a No Implicit Sender test as sender from an async test may leak
-                //but we should not clear the current context when creating a testprobe from a test
+            else if (!(this is TestProbe))
+            //HACK: we need to clear the current context when running a No Implicit Sender test as sender from an async test may leak
+            //but we should not clear the current context when creating a testprobe from a test
             {
                 InternalCurrentActorCellKeeper.Current = null;
             }
             SynchronizationContext.SetSynchronizationContext(
                 new ActorCellKeepingSynchronizationContext(InternalCurrentActorCellKeeper.Current));
-            _testActor = testActor;
 
+            _testState.TestActor = testActor;
         }
 
-        private TimeSpan SingleExpectDefaultTimeout { get { return _testKitSettings.SingleExpectDefault; } }
+        private TimeSpan SingleExpectDefaultTimeout { get { return _testState.TestKitSettings.SingleExpectDefault; } }
 
-        public ActorSystem Sys { get { return _system; } }
-        public TestKitSettings TestKitSettings { get { return _testKitSettings; } }
-        public IActorRef LastSender { get { return _lastMessage.Sender; } }
+        public ActorSystem Sys { get { return _testState.System; } }
+        public TestKitSettings TestKitSettings { get { return _testState.TestKitSettings; } }
+        public IActorRef LastSender { get { return _testState.LastMessage.Sender; } }
         public static Config DefaultConfig { get { return _defaultConfig; } }
         public static Config FullDebugConfig { get { return _fullDebugConfig; } }
         public static TimeSpan Now { get { return TimeSpan.FromTicks(DateTime.UtcNow.Ticks); } }
-        public ILoggingAdapter Log { get { return _log; } }
-        public object LastMessage { get { return _lastMessage.Message; } }
+        public ILoggingAdapter Log { get { return _testState.Log; } }
+        public object LastMessage { get { return _testState.LastMessage.Message; } }
 
         /// <summary>
         /// The default TestActor. The actor can be controlled by sending it 
@@ -141,7 +162,7 @@ namespace Akka.TestKit
         /// <see cref="SetAutoPilot"/>. All other messages are forwarded to the queue
         /// and can be retrieved with Receive and the ExpectMsg overloads.
         /// </summary>
-        public IActorRef TestActor { get { return _testActor; } }
+        public IActorRef TestActor { get { return _testState.TestActor; } }
 
         /// <summary>
         /// Filter <see cref="LogEvent"/> sent to the system's <see cref="EventStream"/>.
@@ -150,7 +171,7 @@ namespace Akka.TestKit
         /// <code>akka.loggers = ["Akka.TestKit.TestEventListener, Akka.TestKit"]</code>
         /// It is installed by default in testkit.
         /// </summary>
-        public EventFilterFactory EventFilter { get { return _eventFilterFactory; } }
+        public EventFilterFactory EventFilter { get { return _testState.EventFilterFactory; } }
 
 
         /// <summary>
@@ -161,7 +182,7 @@ namespace Akka.TestKit
         /// </value>
         public bool HasMessages
         {
-            get { return _queue.Count > 0; }
+            get { return _testState.Queue.Count > 0; }
         }
 
         /// <summary>
@@ -172,13 +193,13 @@ namespace Akka.TestKit
         /// <c>true</c> the message will be ignored by <see cref="TestActor"/>.</param>
         public void IgnoreMessages(Func<object, bool> shouldIgnoreMessage)
         {
-            _testActor.Tell(new TestActor.SetIgnore(m => shouldIgnoreMessage(m)));
+            _testState.TestActor.Tell(new TestActor.SetIgnore(m => shouldIgnoreMessage(m)));
         }
 
         /// <summary>Stop ignoring messages in the test actor.</summary>
         public void IgnoreNoMessages()
         {
-            _testActor.Tell(new TestActor.SetIgnore(null));
+            _testState.TestActor.Tell(new TestActor.SetIgnore(null));
         }
 
         /// <summary>
@@ -189,7 +210,7 @@ namespace Akka.TestKit
         /// <returns>The actor to watch, i.e. the parameter <paramref name="actorToWatch"/></returns>
         public IActorRef Watch(IActorRef actorToWatch)
         {
-            _testActor.Tell(new TestActor.Watch(actorToWatch));
+            _testState.TestActor.Tell(new TestActor.Watch(actorToWatch));
             return actorToWatch;
         }
 
@@ -200,7 +221,7 @@ namespace Akka.TestKit
         /// <returns>The actor to unwatch, i.e. the parameter <paramref name="actorToUnwatch"/></returns>
         public IActorRef Unwatch(IActorRef actorToUnwatch)
         {
-            _testActor.Tell(new TestActor.Unwatch(actorToUnwatch));
+            _testState.TestActor.Tell(new TestActor.Unwatch(actorToUnwatch));
             return actorToUnwatch;
         }
 
@@ -214,7 +235,7 @@ namespace Akka.TestKit
         /// <param name="pilot">The pilot to install.</param>
         public void SetAutoPilot(AutoPilot pilot)
         {
-            _testActor.Tell(new TestActor.SetAutoPilot(pilot));
+            _testState.TestActor.Tell(new TestActor.SetAutoPilot(pilot));
         }
 
 
@@ -239,7 +260,7 @@ namespace Akka.TestKit
             get
             {
                 // ReSharper disable once PossibleInvalidOperationException
-                if(_end.IsPositiveFinite()) return _end.Value - Now;
+                if (_testState.End.IsPositiveFinite()) return _testState.End.Value - Now;
                 throw new InvalidOperationException(@"Remaining may not be called outside of ""within""");
             }
         }
@@ -250,10 +271,10 @@ namespace Akka.TestKit
         /// </summary>
         protected TimeSpan RemainingOr(TimeSpan duration)
         {
-            if(!_end.HasValue) return duration;
-            if(_end.IsInfinite())
+            if (!_testState.End.HasValue) return duration;
+            if (_testState.End.IsInfinite())
                 throw new ArgumentException("end cannot be infinite");
-            return _end.Value - Now;
+            return _testState.End.Value - Now;
 
         }
 
@@ -282,7 +303,7 @@ namespace Akka.TestKit
         public TimeSpan Dilated(TimeSpan duration)
         {
             if(duration.IsPositiveFinite())
-                return new TimeSpan((long)(duration.Ticks * _testKitSettings.TestTimeFactor));
+                return new TimeSpan((long)(duration.Ticks * _testState.TestKitSettings.TestTimeFactor));
             //Else: 0 or infinite (negative)
             return duration;
         }
@@ -306,7 +327,7 @@ namespace Akka.TestKit
         /// <param name="verifySystemShutdown">if set to <c>true</c> an exception will be thrown on failure.</param>
         public virtual void Shutdown(TimeSpan? duration = null, bool verifySystemShutdown = false)
         {
-            Shutdown(_system, duration, verifySystemShutdown);
+            Shutdown(_testState.System, duration, verifySystemShutdown);
         }
 
         /// <summary>
@@ -319,7 +340,7 @@ namespace Akka.TestKit
         /// <param name="verifySystemShutdown">if set to <c>true</c> an exception will be thrown on failure.</param>
         protected virtual void Shutdown(ActorSystem system, TimeSpan? duration = null, bool verifySystemShutdown = false)
         {
-            if(system == null) system = _system;
+            if (system == null) system = _testState.System;
 
             var durationValue = duration.GetValueOrDefault(Dilated(TimeSpan.FromSeconds(5)).Min(TimeSpan.FromSeconds(10)));
             system.Shutdown();
@@ -346,12 +367,12 @@ namespace Akka.TestKit
         /// <returns></returns>
         public IActorRef CreateTestActor(string name)
         {
-            return CreateTestActor(_system, name);
+            return CreateTestActor(_testState.System, name);
         }
 
         private IActorRef CreateTestActor(ActorSystem system, string name)
         {
-            var testActorProps = Props.Create(() => new InternalTestActor(new BlockingCollectionTestActorQueue<MessageEnvelope>(_queue)))
+            var testActorProps = Props.Create(() => new InternalTestActor(new BlockingCollectionTestActorQueue<MessageEnvelope>(_testState.Queue)))
                 .WithDispatcher("akka.test.test-actor.dispatcher");
             var testActor = system.ActorOf(testActorProps, name);
             return testActor;
@@ -390,7 +411,7 @@ namespace Akka.TestKit
         /// <returns>A new <see cref="TestLatch"/></returns>
         public virtual TestLatch CreateTestLatch(int count=1)
         {
-            return new TestLatch(Dilated,count,_testKitSettings.DefaultTimeout);
+            return new TestLatch(Dilated, count, _testState.TestKitSettings.DefaultTimeout);
         }
 
         /// <summary>
@@ -400,7 +421,7 @@ namespace Akka.TestKit
         /// </summary>
         public TestBarrier CreateTestBarrier(int count)
         {
-            return new TestBarrier(this, count, _testKitSettings.DefaultTimeout);
+            return new TestBarrier(this, count, _testState.TestKitSettings.DefaultTimeout);
         }
 
     }

--- a/src/core/Akka.TestKit/TestKitBase_AwaitConditions.cs
+++ b/src/core/Akka.TestKit/TestKitBase_AwaitConditions.cs
@@ -31,7 +31,7 @@ namespace Akka.TestKit
         {
             var maxDur = RemainingOrDefault;
             var interval = new TimeSpan(maxDur.Ticks / 10);
-            var logger = _testKitSettings.LogTestKitCalls ? _log : null;
+            var logger = _testState.TestKitSettings.LogTestKitCalls ? _testState.Log : null;
             InternalAwaitCondition(conditionIsFulfilled, maxDur, interval, (format, args) => _assertions.Fail(format, args), logger);
         }
 
@@ -57,7 +57,7 @@ namespace Akka.TestKit
         {
             var maxDur = RemainingOrDilated(max);
             var interval = new TimeSpan(maxDur.Ticks / 10);
-            var logger = _testKitSettings.LogTestKitCalls ? _log : null;
+            var logger = _testState.TestKitSettings.LogTestKitCalls ? _testState.Log : null;
             InternalAwaitCondition(conditionIsFulfilled, maxDur, interval, (format, args) => _assertions.Fail(format, args), logger);
         }
 
@@ -84,7 +84,7 @@ namespace Akka.TestKit
         {
             var maxDur = RemainingOrDilated(max);
             var interval = new TimeSpan(maxDur.Ticks / 10);
-            var logger = _testKitSettings.LogTestKitCalls ? _log : null;
+            var logger = _testState.TestKitSettings.LogTestKitCalls ? _testState.Log : null;
             InternalAwaitCondition(conditionIsFulfilled, maxDur, interval, (format, args) => AssertionsFail(format, args, message), logger);
         }
 
@@ -118,7 +118,7 @@ namespace Akka.TestKit
         public void AwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan? max, TimeSpan? interval, string message = null)
         {
             var maxDur = RemainingOrDilated(max);
-            var logger = _testKitSettings.LogTestKitCalls ? _log : null;
+            var logger = _testState.TestKitSettings.LogTestKitCalls ? _testState.Log : null;
             InternalAwaitCondition(conditionIsFulfilled, maxDur, interval, (format, args) => AssertionsFail(format, args, message), logger);
         }
 

--- a/src/core/Akka.TestKit/TestKitBase_Expect.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Expect.cs
@@ -357,9 +357,9 @@ namespace Akka.TestKit
 
         private void ConditionalLog(string format, params object[] args)
         {
-            if (_testKitSettings.LogTestKitCalls)
+            if (_testState.TestKitSettings.LogTestKitCalls)
             {
-                _log.Debug(format, args);
+                _testState.Log.Debug(format, args);
             }
         }
     }

--- a/src/core/Akka.TestKit/TestKitBase_Receive.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Receive.cs
@@ -137,17 +137,17 @@ namespace Akka.TestKit
             if (maxDuration.IsZero())
             {
                 ConditionalLog(shouldLog, "Trying to receive message from TestActor queue. Will not wait.");
-                didTake = _queue.TryTake(out envelope);
+                didTake = _testState.Queue.TryTake(out envelope);
             }
             else if (maxDuration.IsPositiveFinite())
             {
                 ConditionalLog(shouldLog, "Trying to receive message from TestActor queue within {0}", maxDuration);
-                didTake = _queue.TryTake(out envelope, (int) maxDuration.TotalMilliseconds, cancellationToken);
+                didTake = _testState.Queue.TryTake(out envelope, (int)maxDuration.TotalMilliseconds, cancellationToken);
             }
             else if (maxDuration == Timeout.InfiniteTimeSpan)
             {
                 ConditionalLog(shouldLog, "Trying to receive message from TestActor queue. Will wait indefinitely.");
-                didTake = _queue.TryTake(out envelope, -1, cancellationToken);
+                didTake = _testState.Queue.TryTake(out envelope, -1, cancellationToken);
             }
             else
             {
@@ -157,16 +157,16 @@ namespace Akka.TestKit
                 didTake = false;
             }
 
-            _lastWasNoMsg = false;
+            _testState.LastWasNoMsg = false;
             if (didTake)
             {
                 ConditionalLog(shouldLog, "Received message after {0}.", Now - start);
-                _lastMessage = envelope;
+                _testState.LastMessage = envelope;
                 return true;
             }
             ConditionalLog(shouldLog, "Received no message after {0}.{1}", Now - start, cancellationToken.IsCancellationRequested ? " Was canceled" : "");
             envelope = NullMessageEnvelope.Instance;
-            _lastMessage = envelope;
+            _testState.LastMessage = envelope;
             return false;
         }
 
@@ -222,15 +222,15 @@ namespace Akka.TestKit
                 MessageEnvelope envelope;
                 if (!TryReceiveOne(out envelope, (stop - Now).Min(idleValue)))
                 {
-                    _lastMessage = msg;
+                    _testState.LastMessage = msg;
                     break;
                 }
                 var message = envelope.Message;
                 var result = filter(message);
                 if (result == null)
                 {
-                    _queue.AddFirst(envelope);  //Put the message back in the queue
-                    _lastMessage = msg;
+                    _testState.Queue.AddFirst(envelope);  //Put the message back in the queue
+                    _testState.LastMessage = msg;
                     break;
                 }
                 msg = envelope;
@@ -239,7 +239,7 @@ namespace Akka.TestKit
             }
             ConditionalLog("Received {0} messages with filter during {1}", count, Now - start);
 
-            _lastWasNoMsg = true;
+            _testState.LastWasNoMsg = true;
             return acc;
         }
 
@@ -272,7 +272,7 @@ namespace Akka.TestKit
                 MessageEnvelope envelope;
                 if (!TryReceiveOne(out envelope, (stop - Now).Min(idleValue)))
                 {
-                    _lastMessage = msg;
+                    _testState.LastMessage = msg;
                     break;
                 }
                 var message = envelope.Message;
@@ -296,15 +296,15 @@ namespace Akka.TestKit
                 }
                 if (shouldStop)
                 {
-                    _queue.AddFirst(envelope);  //Put the message back in the queue
-                    _lastMessage = msg;
+                    _testState.Queue.AddFirst(envelope);  //Put the message back in the queue
+                    _testState.LastMessage = msg;
                     break;
                 }
                 msg = envelope;
             }
             ConditionalLog("Received {0} messages with filter during {1}", count, Now - start);
 
-            _lastWasNoMsg = true;
+            _testState.LastWasNoMsg = true;
             return acc;
         }
 

--- a/src/core/Akka.TestKit/TestKitBase_Within.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Within.cs
@@ -64,14 +64,14 @@ namespace Akka.TestKit
             min.EnsureIsPositiveFinite("max");
             max = Dilated(max);
             var start = Now;
-            var rem = _end.HasValue ? _end.Value - start : Timeout.InfiniteTimeSpan;
+            var rem = _testState.End.HasValue ? _testState.End.Value - start : Timeout.InfiniteTimeSpan;
             _assertions.AssertTrue(rem.IsInfiniteTimeout() || rem >= min, "Required min time {0} not possible, only {1} left. {2}", min, rem, hint ?? "");
 
-            _lastWasNoMsg = false;
+            _testState.LastWasNoMsg = false;
 
             var maxDiff = max.Min(rem);
-            var prevEnd = _end;
-            _end = start + maxDiff;
+            var prevEnd = _testState.End;
+            _testState.End = start + maxDiff;
 
             T ret;
             try
@@ -80,7 +80,7 @@ namespace Akka.TestKit
             }
             finally
             {
-                _end = prevEnd;
+                _testState.End = prevEnd;
             }
 
             var elapsed = Now - start;
@@ -91,7 +91,7 @@ namespace Akka.TestKit
                 ConditionalLog(failMessage, elapsed, min, hint ?? "");
                 _assertions.Fail(failMessage, elapsed, min, hint ?? "");
             }
-            if(!_lastWasNoMsg)
+            if (!_testState.LastWasNoMsg)
             {
                 var tookTooLong = elapsed > maxDiff;
                 if(tookTooLong)


### PR DESCRIPTION
I've made changes as outlined in #1065 to allow NUnit's TestKit to work in the same way as xunit.

#### Problems
##### Providing an ActorSystem in the constructor will fail
Unlike xunit (and I think mstest), NUnit does not create a new instance of the test class for each test run.  If the user provides an ```ActorSystem``` in the constructor, all tests will attempt to use the same system, however after each test the system is destroyed.  One possible fix would be to take a ```Func<ActorSystem>``` instead, however that would introduce a breaking change to the API for all TestKit implementations and I wasn't sure how you'd feel about that.  Another option is simply to throw a ```NotSupportedException``` in the NUnit TestKit if the user provides an instance of ```ActorSystem```.

##### Redundant methods
The NUnit TestKit has ```AfterAll(), Dispose(), and Dispose(bool disposing)``` methods, however these are redundant as the class now uses a TearDown attribute to clean up.  Removing these methods makes sense but again introduces a breaking change.  Would this be a problem?


