### PR TITLE
[api-doc] Documentation of namespaces

### DIFF
--- a/documentation/akkadoc.shfbproj
+++ b/documentation/akkadoc.shfbproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <!-- The configuration and platform will be used to determine which assemblies to include from solution and
-				 project documentation sources -->
+                 project documentation sources -->
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
@@ -88,9 +88,190 @@
       <DocumentationSource sourceFile="..\src\contrib\testkits\Akka.TestKit.Xunit\bin\Release\Akka.TestKit.Xunit.xml" />
       <DocumentationSource sourceFile="..\src\core\Akka\bin\Release\Akka.xml" />
     </DocumentationSources>
+    <NamespaceSummaries>
+      <NamespaceSummaryItem name="(global)" isDocumented="False">
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka" isDocumented="True">
+        Akka.NET is an open-source library for building concurrent, fault-tolerant and scalable systems using the actor model.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Actor" isDocumented="True">
+        The Akka.Actor namespace contains classes used to create and manage actors.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Actor.Dsl" isDocumented="True">
+	    The Akka.Actor.Dsl namespace contains classes used to manage an actor including lifecycle, message receiving and handling.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Actor.Internal" isDocumented="True">
+        The Akka.Actor.Internal namespace contains classes used to create and manage actors within the system. These classes are part
+        of an internal API. As such, these classes may break without warning. Use at your own risk.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Actor.Internals" isDocumented="True">
+        The Akka.Actor.Internals namespace contains classes used to create and manage actors within the system. These classes are part
+        of an internal API. As such, these classes may break without warning. Use at your own risk.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Cluster" isDocumented="True">
+        The Akka.Cluster namespace contains classes that provide cluster services including membership, gossip protocols and fault-tolerance.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Cluster.Proto.Msg" isDocumented="True">
+        The Akka.Cluster.Proto.Msg namespace contains classes that provide for internal cluster messaging. These messages include items
+		like node member and reachability statuses.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Cluster.Routing" isDocumented="True">
+        The Akka.Cluster.Routing namespace contains classes that provide for routing messages within the cluster.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Configuration" isDocumented="True">
+        The Akka.Configuration namespace contains classes used to configure the system via a variety of means including configuration
+        files, embedded resources and bare HOCON (Human-Optimized Config Object Notation) strings.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Configuration.Hocon" isDocumented="True">
+        The Akka.Configuration.Hocon namespace contains classes used to interact with configuration values via their internal
+        HOCON (Human-Optimized Config Object Notation) representation.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.DI.AutoFac" isDocumented="True">
+        The Akka.DI.AutoFac namespace contains classes used to perform dependency injection using the AutoFac library.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.DI.CastleWindsor" isDocumented="True">
+        The Akka.DI.CastleWindsor namespace contains classes used to perform dependency injection using the CastleWindsor library.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.DI.Core" isDocumented="True">
+        The Akka.DI.Core namespace contains classes used to provide extension points for dependency injection (DI).
+        These classes rely on the different DI libraries to do the heavy lifting.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.DI.Ninject" isDocumented="True">
+        The Akka.DI.Ninject namespace contains classes used to perform dependency injection using the Ninject library.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Dispatch" isDocumented="True">
+        The Akka.Dispatch namespace contains classes used to dispatch messages to the actors.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Dispatch.MessageQueues" isDocumented="True">
+        The Akka.Dispatch.MessageQueues namespace contains classes used to queue messages for an actor.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Dispatch.SysMsg" isDocumented="True">
+        The Akka.Dispatch.SysMsg namespace contains classes used to dispatch system messages to the actors.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Event" isDocumented="True">
+        The Akka.Event namespace contains classes used to publish/subscribe to events in the Event Stream.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.FSharp" isDocumented="True">
+        The Akka.FSharp namespace contains an API used to interact and control the system via F#.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Logger.NLog" isDocumented="True">
+        The Akka.Logger.NLog namespace contains classes used to log messages using the NLog library.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Logger.Serilog" isDocumented="True">
+        The Akka.Logger.Serilog namespace contains classes used to log messages using the Serilog library.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Logger.slf4net" isDocumented="True">
+        The Akka.Logger.slf4net namespace contains classes used to log messages using the slf4net library.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Pattern" isDocumented="True">
+        TBD
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Persistence" isDocumented="True">
+        The Akka.Persistence namespace contains classes used to save/restore an actor's state into a persistence store.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Persistence.Journal" isDocumented="True">
+        The Akka.Persistence.Journal namespace contains classes used to journal sequences of events the actor state.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Persistence.Serialization" isDocumented="True">
+        The Akka.Persistence.Serialization namespace contains classes used to (de-)serialize messages and snapshots.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Persistence.Snapshot" isDocumented="True">
+        The Akka.Persistence.Snapshot namespace contains classes used to snapshot an actor's internal state.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Persistence.TestKit" isDocumented="True">
+        The Akka.Persistence.TestKit namespace contains classes that provide base testing functionality used to test
+        new persistence extensions.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Persistence.TestKit.Journal" isDocumented="True">
+        The Akka.Persistence.TestKit.Journal namespace contains classes that provide base testing functionality used to test
+        journalling in new persistence extensions.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Persistence.TestKit.Snapshot" isDocumented="True">
+        The Akka.Persistence.TestKit.Snapshot namespace contains classes that provide base testing functionality used to test
+        snapshotting in new persistence extensions.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Remote" isDocumented="True">
+        The Akka.Remote namespace contains classes that provide for interacting to remote actors.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Remote.Routing" isDocumented="True">
+        The Akka.Remote.Routing namespace contains classes that provide for routing messages to remote actors.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Remote.Serialization" isDocumented="True">
+        The Akka.Remote.Serialization namespace contains classes that provide for serializing messages to and deserializing
+        messages from remote actors.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Remote.TestKit" isDocumented="True">
+        The Akka.Remote.TestKit namespace contains classes that provide base testing functionality used to test remote actors.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Remote.TestKit.Proto" isDocumented="True">
+        The Akka.Remote.TestKit.Proto namespace contains classes that provide base testing functionality used to test message encoding.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Remote.Transport" isDocumented="True">
+        The Akka.Remote.Transport namespace contains classes that provide for transporting messages over the network via TCP or UDP.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Routing" isDocumented="True">
+        The Akka.Routing namespace contains classes that provide for routing messages within the system.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Serialization" isDocumented="True">
+        The Akka.Serialization namespace contains classes used to (de-)serialize messages.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Serilog.Event.Serilog" isDocumented="False">
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.TestKit" isDocumented="True">
+        The Akka.TestKit namespace contains classes that provide base testing functionality used by the different testkit extensions.
+        This functionality allows for writing tests in the extension's framework.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.TestKit.Internal" isDocumented="True">
+        The Akka.TestKit.Internal namespace contains classes that provide base testing functionality used by the different testkit extensions.
+        This functionality allows for writing tests in the extension's framework. These classes are part of an internal API.
+        As such, these classes may break without warning. Use at your own risk.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.TestKit.Internal.StringMatcher" isDocumented="True">
+        The Akka.TestKit.Internal.StringMatcher namespace contains classes that provide basic string matching functionality used for testing
+        purposes. This functionality allows for writing tests in the extension's framework. These classes are part of an internal API.
+        As such, these classes may break without warning. Use at your own risk.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.TestKit.TestActors" isDocumented="True">
+        The Akka.TestKit.TestActors namespace contains classes that provide basic actors used for testing purposes.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.TestKit.TestEvent" isDocumented="True">
+        The Akka.TestKit.TestEvent namespace contains classes that provide basic events used for event-filtering testing purposes.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.TestKit.VsTest" isDocumented="True">
+        The Akka.TestKit.VsTest namespace contains classes that provide for writing tests in MSTest.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.TestKit.Xunit" isDocumented="True">
+        The Akka.TestKit.Xunit namespace contains classes that provide for writing tests in Xunit.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.TestKit.Xunit.Internals" isDocumented="True">
+        The Akka.TestKit.Xunit.Internals namespace contains classes that provide for writing tests in Xunit.
+        These classes are part of an internal API. As such, these classes may break without warning. Use at
+        your own risk.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Tools.MatchHandler" isDocumented="True">
+        The Akka.Tools.MatchHandler namespace contains classes that provide for matching messages with their correct actor.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Util" isDocumented="True">
+        The Akka.Util namespace contains classes that provide utilitarian functionality.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Util.Internal" isDocumented="True">
+        The Akka.Util.Internal namespace contains classes that provide utilitarian functionality. These classes are part of an internal API.
+        As such, these classes may break without warning. Use at your own risk.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Util.Internal.Collections" isDocumented="True">
+        The Akka.Util.Internal.Collections namespace contains classes that provide collection-based utilitarian functionality.
+        These classes are part of an internal API. As such, these classes may break without warning. Use at your own risk.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Util.Reflection" isDocumented="True">
+        The Akka.Util.Reflection namespace contains classes that provide reflection-based utilitarian functionality.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="TCP" isDocumented="True">
+        The TCP namespace contains classes used to interact with Google ProtocolBuffers.
+      </NamespaceSummaryItem>
+    </NamespaceSummaries>   
   </PropertyGroup>
   <!-- There are no properties for these groups.  AnyCPU needs to appear in order for Visual Studio to perform
-			 the build.  The others are optional common platform types that may appear. -->
+             the build.  The others are optional common platform types that may appear. -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">


### PR DESCRIPTION
Documented namespaces.

Note: I put a TBD on Akka.Pattern since it looks like the only class in
that namespace could be put into another.

Note2: As mentioned in gitter chat, it looks like Akka.Actor.Internal
and Akka.Actor.Internals is an oversight and should be merged.