### PR TITLE
Implemented BackoffSupervisor

### DIFF
--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -142,6 +142,7 @@
     <Compile Include="MatchHandler\MatchExpressionBuilder_CreateArgumentValuesArray_Tests.cs" />
     <Compile Include="MatchHandler\MatchHandlerBuilderTests.cs" />
     <Compile Include="MatchHandler\PartialActionBuilderTests.cs" />
+    <Compile Include="Pattern\BackoffSupervisorSpec.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Routing\BroadcastSpec.cs" />
     <Compile Include="Routing\ConsistentHashingRouterSpec.cs" />

--- a/src/core/Akka.Tests/Pattern/BackoffSupervisorSpec.cs
+++ b/src/core/Akka.Tests/Pattern/BackoffSupervisorSpec.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Akka.Actor;
+using Akka.Pattern;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Tests.Pattern
+{
+    public class BackoffSupervisorSpec : AkkaSpec
+    {
+        internal class Child : ReceiveActor
+        {
+            public Child(IActorRef probe)
+            {
+                ReceiveAny(msg => probe.Tell(msg));
+            }
+        }
+
+        [Fact]
+        public void BackoffSupervisor_should_start_child_again_when_it_stops()
+        {
+            var childProps = Props.Create(() => new Child(TestActor));
+            var supervisor = Sys.ActorOf(Props.Create(() =>
+                new BackoffSupervisor(childProps, "c1", TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(3), 0.2)));
+
+            supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
+            var c1 = ExpectMsg<BackoffSupervisor.CurrentChild>().Ref;
+
+            Watch(c1);
+            c1.Tell(PoisonPill.Instance);
+            ExpectTerminated(c1);
+
+            AwaitAssert(() =>
+            {
+                supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
+                // new instance
+                Assert.NotEqual(c1, ExpectMsg<BackoffSupervisor.CurrentChild>().Ref);
+            });
+        }
+
+        [Fact]
+        public void BackoffSupervisor_should_forward_messages_to_the_child()
+        {
+            var childProps = Props.Create(() => new Child(TestActor));
+            var supervisor = Sys.ActorOf(Props.Create(() => 
+                new BackoffSupervisor(childProps, "c2", TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(3), 0.2)));
+
+            supervisor.Tell("hello");
+            ExpectMsg("hello");
+        }
+    }
+}

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -231,6 +231,7 @@
     <Compile Include="Event\LogMessage.cs" />
     <Compile Include="Event\StandardOutLogger.cs" />
     <Compile Include="Helios.Concurrency.DedicatedThreadPool.cs" />
+    <Compile Include="Pattern\BackoffSupervisor.cs" />
     <Compile Include="Routing\ConsistentHashRouter.cs" />
     <Compile Include="Serialization\JavaSerializer.cs" />
     <Compile Include="Util\ContinuousEnumerator.cs" />

--- a/src/core/Akka/Pattern/BackoffSupervisor.cs
+++ b/src/core/Akka/Pattern/BackoffSupervisor.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using Akka.Actor;
+using Akka.Util;
+
+namespace Akka.Pattern
+{
+    /// <summary>
+    /// Actor used to supervise actors with ability to restart them after back-off timeout occurred. 
+    /// It's designed for cases when i.e. persistent actor stops due to journal unavailability or failure. 
+    /// In this case it better to wait before restart.
+    /// </summary>
+    public class BackoffSupervisor : UntypedActor
+    {
+        #region Messages
+
+        /// <summary>
+        /// Request <see cref="BackoffSupervisor"/> with this message to receive <see cref="CurrentChild"/> response with current child.
+        /// </summary>
+        [Serializable]
+        public sealed class GetCurrentChild
+        {
+            public static readonly GetCurrentChild Instance = new GetCurrentChild();
+            private GetCurrentChild() { }
+        }
+
+        [Serializable]
+        public sealed class CurrentChild
+        {
+            public readonly IActorRef Ref;
+
+            public CurrentChild(IActorRef @ref)
+            {
+                Ref = @ref;
+            }
+        }
+
+        [Serializable]
+        public sealed class StartChild
+        {
+            public static readonly StartChild Instance = new StartChild();
+            private StartChild() { }
+        }
+
+        [Serializable]
+        public sealed class ResetRestartCount
+        {
+            public readonly int Current;
+
+            public ResetRestartCount(int current)
+            {
+                Current = current;
+            }
+        }
+
+        #endregion
+
+        private readonly Props _childProps;
+        private readonly string _childName;
+        private readonly TimeSpan _minBackoff;
+        private readonly TimeSpan _maxBackoff;
+        private readonly double _randomFactor;
+
+        private int _restartCount = 0;
+        private IActorRef _child = null;
+
+        public BackoffSupervisor(Props childProps, string childName, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor)
+        {
+            if (minBackoff <= TimeSpan.Zero) throw new ArgumentException("MinBackoff must be greater than 0");
+            if (maxBackoff < minBackoff) throw new ArgumentException("MaxBackoff must be greater than MinBackoff");
+            if (randomFactor < 0.0 || randomFactor > 1.0) throw new ArgumentException("RandomFactor must be between 0.0 and 1.0");
+
+            _childProps = childProps;
+            _childName = childName;
+            _minBackoff = minBackoff;
+            _maxBackoff = maxBackoff;
+            _randomFactor = randomFactor;
+        }
+
+        protected override void PreStart()
+        {
+            StartChildActor();
+            base.PreStart();
+        }
+
+        protected override void OnReceive(object message)
+        {
+            if (message is Terminated)
+            {
+                var terminated = (Terminated)message;
+                if (_child != null && _child.Equals(terminated.ActorRef))
+                {
+                    _child = null;
+                    var rand = 1.0 + ThreadLocalRandom.Current.NextDouble() * _randomFactor;
+                    TimeSpan restartDelay;
+                    if (_restartCount >= 30)
+                        restartDelay = _maxBackoff; // duration overflow protection (> 100 years)
+                    else
+                    {
+                        var max = Math.Min(_maxBackoff.Ticks, _minBackoff.Ticks * Math.Pow(2, _restartCount)) * rand;
+                        if (max >= Double.MaxValue) restartDelay = _maxBackoff;
+                        else restartDelay = new TimeSpan((long)max);
+                    }
+
+                    Context.System.Scheduler.ScheduleTellOnce(restartDelay, Self, StartChild.Instance, Self);
+                    _restartCount++;
+                }
+                else Unhandled(message);
+            }
+            else if (message is StartChild)
+            {
+                StartChildActor();
+                Context.System.Scheduler.ScheduleTellOnce(_minBackoff, Self, new ResetRestartCount(_restartCount), Self);
+            }
+            else if (message is ResetRestartCount)
+            {
+                var restartCount = (ResetRestartCount)message;
+                if (restartCount.Current == _restartCount) _restartCount = 0;
+            }
+            else if (message is GetCurrentChild)
+            {
+                Sender.Tell(new CurrentChild(_child));
+            }
+            else
+            {
+                if (_child != null) _child.Forward(message);
+                else Context.System.DeadLetters.Forward(message);
+            }
+        }
+
+        private void StartChildActor()
+        {
+            if (_child == null) _child = Context.Watch(Context.ActorOf(_childProps, _childName));
+        }
+    }
+}


### PR DESCRIPTION
**Ported from Akka JVM**: This is implementation of the exponential backoff algorithm for actor supervisors. It's useful in cases, when for example persistent actor fails due to underlying persistence mechanism failures or unavailability. In that case it's quite probable that in this case immediate restart of an actor will fail again. Solution is to apply some delay before restart.

This implementation uses exponential back-off i.e. given minimal back-off 3 sec. and maximal back-off 30 sec. the following start attempts will be delayed with 3, 6, 12, 24, 30 seconds. In addition back-off uses random delay multiplier configured by `randomFactor` variable (example 0.2 &rArr; 20%). Reason for that is to avoid hitting the persistence backend by all restarting actors at the same time.

**Don't merge yet!**