### PR TITLE
NinjectDependencyResolver should use GetOrAdd not TryAdd

### DIFF
--- a/src/contrib/dependencyInjection/Akka.DI.Ninject/NinjectDependencyResolver.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.Ninject/NinjectDependencyResolver.cs
@@ -49,9 +49,7 @@ namespace Akka.DI.Ninject
         /// <returns>The type with the specified actor name</returns>
         public Type GetType(string actorName)
         {
-            typeCache.TryAdd(actorName, actorName.GetTypeValue());
-
-            return typeCache[actorName];
+            return typeCache.GetOrAdd(actorName, key => key.GetTypeValue());
         }
 
         /// <summary>


### PR DESCRIPTION
From reading the original code, it seems the intention was to use the cache in the case that `GetTypeValue()` assembly scanned. Unfortunately, this was always being evaluated which made the use of the cache pretty pointless.   This PR changes the implementation to `GetOrAdd`.