### PR TITLE
Akka IO: Fixes #1113 - ByteString1C indexer always returns first element

### DIFF
--- a/src/core/Akka/Util/ByteString.cs
+++ b/src/core/Akka/Util/ByteString.cs
@@ -99,7 +99,7 @@ namespace Akka.IO
 
             public override byte this[int idx]
             {
-                get { return _bytes[0]; }
+                get { return _bytes[idx]; }
             }
 
             public override int Count


### PR DESCRIPTION
Fix for issue #1113.