### PR TITLE
adding the latest ncrunch files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,9 @@ _TeamCity*
 # NCrunch
 _NCrunch_*
 .*crunch*.local.xml
+*.ncrunchsolution
+*.v2.ncrunchproject
+
 
 # MightyMoose
 *.mm.*


### PR DESCRIPTION
New version of NCrunch gives new guidance files.
As the old ones are in the gitignore I included .ncrunchsolution and .ncrunchproject.

