### PR TITLE
Fix for #1126

### DIFF
--- a/src/core/Akka.FSharp.Tests/ApiTests.fs
+++ b/src/core/Akka.FSharp.Tests/ApiTests.fs
@@ -59,3 +59,19 @@ let ``can serialize nested discriminated unions`` () =
     let des = serializer.FromBinary (bytes, typeof<TestUnion2>) :?> TestUnion2
     des
     |> equals x
+
+type testType1 = 
+    string * string
+
+type testType2 = 
+    | V2 of testType1
+
+[<Fact>]
+let MyTest () =
+    let x = V2("hello!","world")
+    use sys = System.create "system" (Configuration.defaultConfig())
+    let serializer = sys.Serialization.FindSerializerFor x
+    let bytes = serializer.ToBinary x
+    let des = serializer.FromBinary (bytes, typeof<testType2>) :?> testType2
+    des
+    |> equals x


### PR DESCRIPTION
This fixes #1126 
* When a F# DU only has one entry, it doesnt generate the same structure as other DU's, which use nested types, instead, the DU and the DU entry is the same type.
* Tuples, tuples does not serialize well in Json.NET, we have a fix for this too here. 

This does in no way fix all the problems with DU's and serialization, we still can not serialze DU's contained in object array.

cc @Horusiath 