### PR TITLE
RemoteDaemonMsgSerializer bug fix

### DIFF
--- a/src/core/Akka.Remote/Serialization/DaemonMsgCreateSerializer.cs
+++ b/src/core/Akka.Remote/Serialization/DaemonMsgCreateSerializer.cs
@@ -133,7 +133,7 @@ namespace Akka.Remote.Serialization
 
             RouterConfig routerConfig;
             if (protoDeploy.HasRouterConfig)
-                routerConfig = (RouterConfig) Deserialize(protoDeploy.RouterConfig, protoDeploy.RouterConfig.GetType());
+                routerConfig = (RouterConfig)Deserialize(protoDeploy.RouterConfig, typeof(RouterConfig));
             else
                 routerConfig = RouterConfig.NoRouter;
 


### PR DESCRIPTION
This fixes a bug in the remotedaemonmsgserializer that incorrectly passes ByteString as the type to the Deserialize method instead of RouterConfig

This bug **is not observable using our json.net serializer as it ignores the Type argument** and relies on Type manifest embedded in the json itself.
But if we replace the json serializer, the bug presents itself. (as in my bson PoC)

