### PR TITLE
Either usability improvements

### DIFF
--- a/src/core/Akka/Util/Either.cs
+++ b/src/core/Akka/Util/Either.cs
@@ -5,6 +5,8 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
+
 namespace Akka.Util
 {
     public abstract class Either<TA,TB>
@@ -39,7 +41,53 @@ namespace Akka.Util
         {
             return new Left<TA, TB>(Left);
         }
+
+        public static implicit operator Either<TA, TB>(Left<TA> left)
+        {
+            return new Left<TA, TB>(left.Value);
+        }
+
+        public static implicit operator Either<TA, TB>(Right<TB> right)
+        {
+            return new Right<TA, TB>(right.Value);
+        }
+
+        public Either<TRes1, TRes2> Map<TRes1, TRes2>(Func<TA, TRes1> map1, Func<TB, TRes2> map2)
+        {
+            if (IsLeft)
+                return new Left<TRes1, TRes2>(map1(ToLeft().Value));
+            return new Right<TRes1, TRes2>(map2(ToRight().Value));
+        }
+
+        public Either<TRes, TB> MapLeft<TRes>(Func<TA, TRes> map)
+        {
+            return Map(map, x => x);
+        }
+
+        public Either<TA, TRes> MapRight<TRes>(Func<TB, TRes> map)
+        {
+            return Map(x => x, map);
+        }
+
+        public TRes Fold<TRes>(Func<TA, TRes> left, Func<TB, TRes> right)
+        {
+            return IsLeft ? left(ToLeft().Value) : right(ToRight().Value);
+        }
     }
+
+    public static class Either
+    {
+        public static Left<T> Left<T>(T value)
+        {
+            return new Left<T>(value);
+        }
+
+        public static Right<T> Right<T>(T value)
+        {
+            return new Right<T>(value);
+        }
+    }
+
 
     public class Right<TA, TB> : Either<TA, TB>
     {
@@ -63,6 +111,26 @@ namespace Akka.Util
         }
     }
 
+    public class Right<T>
+    {
+        public Right(T value)
+        {
+            Value = value;
+        }
+
+        public T Value { get; private set; }
+
+        public bool IsLeft
+        {
+            get { return false; }
+        }
+
+        public bool IsRight
+        {
+            get { return true; }
+        }
+    }
+
     public class Left<TA, TB> : Either<TA, TB>
     {
         public Left(TA a) : base(a, default(TB))
@@ -82,6 +150,26 @@ namespace Akka.Util
         public new TA Value
         {
             get { return Left; }
+        }
+    }
+
+    public class Left<T>
+    {
+        public Left(T value)
+        {
+            Value = value;
+        }
+
+        public T Value { get; private set; }
+
+        public bool IsLeft
+        {
+            get { return true; }
+        }
+
+        public bool IsRight
+        {
+            get { return false; }
         }
     }
 }


### PR DESCRIPTION
**Construction**
Before:
```csharp
static Either<int, string> Foo(bool left)
{
    if (left)
        return new Left<int, string>(123);
    else
        return new Right<int, string>("321");
}
```
After (first variant is still supported):
```csharp
static Either<int, string> Bar(bool left)
{
    if (left)
        return Either.Left(123);
    else
        return Either.Right("123");
}
```

**Transformations**
```csharp
var either = new Left<int, string>(123);
return either.
    .MapLeft(x => x + 1)
    .MapRight(s => s.Substring(1))
    .Map(x => x + 2, s => s + "123")
    .Fold(x => x/2, s => s.Length);
```