### PR TITLE
Completed rewriting Akka.Cluster.Sharding.Tests

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Akka.Cluster.Sharding.Tests.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Akka.Cluster.Sharding.Tests.csproj
@@ -59,6 +59,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ClusterShardingFailureSpec.cs" />
+    <Compile Include="ClusterShardingGracefulShutdownSpec.cs" />
+    <Compile Include="ClusterShardingLeavingSpec.cs" />
     <Compile Include="ClusterShardingSpec.cs" />
     <Compile Include="CustomShardAllocationSpec.cs" />
     <Compile Include="LeastShardAllocationStrategySpec.cs" />

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingFailureSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingFailureSpec.cs
@@ -1,0 +1,305 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.MultiNodeTests;
+using Akka.Persistence.Journal;
+using Akka.Remote.TestKit;
+using Akka.Remote.Transport;
+using Xunit;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    public class ClusterShardingFailureSpecConfig : MultiNodeConfig
+    {
+        public ClusterShardingFailureSpecConfig()
+        {
+            var controller = Role("controller");
+            var first = Role("first");
+            var second = Role("second");
+
+            CommonConfig = ConfigurationFactory.ParseString(@"
+                akka.loglevel = INFO
+                akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider""
+                akka.remote.log-remote-lifecycle-events = off
+                akka.cluster.auto-down-unreachable-after = 0s
+                akka.cluster.down-removal-margin = 5s
+                akka.cluster.roles = [""backend""]
+                akka.persistence.journal.plugin = ""akka.persistence.journal.in-mem""
+                akka.persistence.journal.in-mem {
+                  timeout = 5s
+                  store {
+                    native = off
+                    dir = ""target/journal-ClusterShardingFailureSpec""
+                  }
+                }
+                akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.local""
+                akka.persistence.snapshot-store.local.dir = ""target/snapshots-ClusterShardingFailureSpec""
+                akka.cluster.sharding.coordinator-failure-backoff = 3s
+                akka.cluster.sharding.shard-failure-backoff = 3s
+            ");
+
+            TestTransport = true;
+        }
+    }
+
+    public class ClusterShardingFailureNode1 : ClusterShardingFailureSpec { }
+    public class ClusterShardingFailureNode2 : ClusterShardingFailureSpec { }
+    public class ClusterShardingFailureNode3 : ClusterShardingFailureSpec { }
+
+    public class ClusterShardingFailureSpec : MultiNodeClusterSpec
+    {
+        #region setup
+
+        [Serializable]
+        internal sealed class Get
+        {
+            public readonly string Id;
+            public Get(string id)
+            {
+                Id = id;
+            }
+        }
+
+        [Serializable]
+        internal sealed class Add
+        {
+            public readonly string Id;
+            public readonly int I;
+            public Add(string id, int i)
+            {
+                Id = id;
+                I = i;
+            }
+        }
+
+        [Serializable]
+        internal sealed class Value
+        {
+            public readonly string Id;
+            public readonly int N;
+            public Value(string id, int n)
+            {
+                Id = id;
+                N = n;
+            }
+        }
+
+        internal class Entity : ReceiveActor
+        {
+            private int _n = 0;
+
+            public Entity()
+            {
+                Receive<Get>(get => Sender.Tell(new Value(get.Id, _n)));
+                Receive<Add>(add => _n += add.I);
+            }
+        }
+
+        internal IdExtractor extractEntityId = message =>
+        {
+            if (message is Get) return Tuple.Create((message as Get).Id, message);
+            if (message is Add) return Tuple.Create((message as Add).Id, message);
+            return null;
+        };
+
+        internal ShardResolver extractShardId = message =>
+        {
+            if (message is Get) return (message as Get).Id[0].ToString();
+            if (message is Add) return (message as Add).Id[0].ToString();
+            return null;
+        };
+
+        private DirectoryInfo[] _storageLocations;
+        private Lazy<IActorRef> _region;
+        private RoleName _first;
+        private RoleName _second;
+        private RoleName _controller;
+
+        public ClusterShardingFailureSpec() : base(new ClusterShardingFailureSpecConfig())
+        {
+            _storageLocations = new[]
+            {
+                "akka.persistence.journal.leveldb.dir",
+                "akka.persistence.journal.leveldb-shared.store.dir",
+                "akka.persistence.snapshot-store.local.dir"
+            }.Select(s => new DirectoryInfo(Sys.Settings.Config.GetString(s))).ToArray();
+
+            _region = new Lazy<IActorRef>(() => ClusterSharding.Get(Sys).ShardRegion("Entity"));
+
+            _controller = new RoleName("controller");
+            _first = new RoleName("first");
+            _second = new RoleName("second");
+        }
+
+
+        protected override void AtStartup()
+        {
+            base.AtStartup();
+            RunOn(() =>
+            {
+                foreach (var location in _storageLocations) if (location.Exists) location.Delete();
+            }, _first);
+        }
+
+        protected override void AfterTermination()
+        {
+            base.AfterTermination();
+            RunOn(() =>
+            {
+                foreach (var location in _storageLocations) if (location.Exists) location.Delete();
+            }, _first);
+        }
+
+        #endregion
+
+        private void Join(RoleName from, RoleName to)
+        {
+            RunOn(() =>
+            {
+                Cluster.Join(Node(to).Address);
+                StartSharding();
+            }, from);
+            EnterBarrier(from.Name + "-joined");
+        }
+
+        private void StartSharding()
+        {
+            ClusterSharding.Get(Sys).Start(
+                typeName: "Entity",
+                entryProps: Props.Create<Entity>(),
+                settings: ClusterShardingSettings.Create(Sys),
+                idExtractor: extractEntityId,
+                shardResolver: extractShardId);
+        }
+
+        [MultiNodeFact(Skip = "TODO")]
+        public void ClusterSharding_with_flaky_journal_should_setup_shared_journal()
+        {
+            // start the Persistence extension
+            Persistence.Persistence.Instance.Apply(Sys);
+            RunOn(() =>
+            {
+                Sys.ActorOf(Props.Create<MemoryJournal>(), "store");
+            }, _controller);
+            EnterBarrier("persistence-started");
+
+            RunOn(() =>
+            {
+                Sys.ActorSelection(Node(_first) / "user" / "store").Tell(new Identify(null));
+                var sharedStore = ExpectMsg<ActorIdentity>().Subject;
+                //TODO: SharedLeveldbJournal.setStore(sharedStore, system)
+            }, _first, _second);
+            EnterBarrier("after-1");
+        }
+
+        [MultiNodeFact(Skip = "TODO")]
+        public void ClusterSharding_with_flaky_journal_should_join_cluster()
+        {
+            Within(TimeSpan.FromSeconds(20), () =>
+            {
+                Join(_first, _first);
+                Join(_second, _first);
+
+                RunOn(() =>
+                {
+                    var region = _region.Value;
+                    region.Tell(new Add("10", 1));
+                    region.Tell(new Add("20", 2));
+                    region.Tell(new Add("21", 3));
+                    region.Tell(new Get("10"));
+                    ExpectMsg<Value>(v => v.Id == "10" && v.N == 1);
+                    region.Tell(new Get("20"));
+                    ExpectMsg<Value>(v => v.Id == "20" && v.N == 2);
+                    region.Tell(new Get("21"));
+                    ExpectMsg<Value>(v => v.Id == "21" && v.N == 3);
+                }, _first);
+                EnterBarrier("after-2");
+            });
+        }
+
+        [MultiNodeFact(Skip = "TODO")]
+        public void ClusterSharding_with_flaky_journal_should_recover_after_journal_failure()
+        {
+            Within(TimeSpan.FromSeconds(20), () =>
+            {
+                RunOn(() =>
+                {
+                    TestConductor.Blackhole(_controller, _first, ThrottleTransportAdapter.Direction.Both).Wait();
+                    TestConductor.Blackhole(_controller, _second, ThrottleTransportAdapter.Direction.Both).Wait();
+                }, _controller);
+                EnterBarrier("journal-backholded");
+
+                RunOn(() =>
+                {
+                // try with a new shard, will not reply until journal is available again
+                var region = _region.Value;
+                    region.Tell(new Add("40", 4));
+                    var probe = CreateTestProbe();
+                    region.Tell(new Get("40"), probe.Ref);
+                    probe.ExpectNoMsg(TimeSpan.FromSeconds(1));
+                }, _first);
+                EnterBarrier("first-delayed");
+
+                RunOn(() =>
+                {
+                    TestConductor.PassThrough(_controller, _first, ThrottleTransportAdapter.Direction.Both).Wait();
+                    TestConductor.PassThrough(_controller, _second, ThrottleTransportAdapter.Direction.Both).Wait();
+                }, _controller);
+                EnterBarrier("journal-ok");
+
+                RunOn(() =>
+                {
+                    var region = _region.Value;
+                    region.Tell(new Get("21"));
+                    ExpectMsg<Value>(v => v.Id == "21" && v.N == 3);
+                    var entity21 = LastSender;
+                    var shard2 = Sys.ActorSelection(entity21.Path.Parent);
+
+
+                //Test the ShardCoordinator allocating shards during a journal failure
+                region.Tell(new Add("30", 3));
+
+                //Test the Shard starting entities and persisting during a journal failure
+                region.Tell(new Add("11", 1));
+
+                //Test the Shard passivate works during a journal failure
+                shard2.Tell(new Passivate(PoisonPill.Instance), entity21);
+                    region.Tell(new Add("21", 1));
+
+                    region.Tell(new Get("21"));
+                    ExpectMsg<Value>(v => v.Id == "21" && v.N == 1);
+
+                    region.Tell(new Get("30"));
+                    ExpectMsg<Value>(v => v.Id == "30" && v.N == 3);
+
+                    region.Tell(new Get("11"));
+                    ExpectMsg<Value>(v => v.Id == "11" && v.N == 1);
+
+                    region.Tell(new Get("40"));
+                    ExpectMsg<Value>(v => v.Id == "40" && v.N == 4);
+                }, _first);
+                EnterBarrier("verified-first");
+
+                RunOn(() =>
+                {
+                    var region = _region.Value;
+                    region.Tell(new Add("10", 1));
+                    region.Tell(new Add("20", 2));
+                    region.Tell(new Add("30", 3));
+                    region.Tell(new Add("11", 4));
+                    region.Tell(new Get("10"));
+                    ExpectMsg<Value>(v => v.Id == "10" && v.N == 2);
+                    region.Tell(new Get("11"));
+                    ExpectMsg<Value>(v => v.Id == "11" && v.N == 5);
+                    region.Tell(new Get("20"));
+                    ExpectMsg<Value>(v => v.Id == "20" && v.N == 4);
+                    region.Tell(new Get("30"));
+                    ExpectMsg<Value>(v => v.Id == "30" && v.N == 6);
+                }, _second);
+                EnterBarrier("after-3");
+            });
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingGracefulShutdownSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingGracefulShutdownSpec.cs
@@ -1,0 +1,230 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.MultiNodeTests;
+using Akka.Persistence.Journal;
+using Akka.Remote.TestKit;
+using Xunit;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    public class ClusterShardingGracefulShutdownSpecConfig : MultiNodeConfig
+    {
+        public ClusterShardingGracefulShutdownSpecConfig()
+        {
+            var first = Role("first");
+            var second = Role("second");
+
+            CommonConfig = ConfigurationFactory.ParseString(@"
+                akka.loglevel = INFO
+                akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider""
+                akka.remote.log-remote-lifecycle-events = off
+                akka.persistence.journal.plugin = ""Akka.Persistence.Journal.in-mem""
+                akka.persistence.journal.in-mem {
+                  timeout = 5s
+                  store {
+                    native = off
+                    dir = ""target/journal-ClusterShardingGracefulShutdownSpec""
+                  }
+                }
+                akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.local""
+                akka.persistence.snapshot-store.local.dir = ""target/snapshots-ClusterShardingGracefulShutdownSpec""
+            ");
+        }
+    }
+
+    public class ClusterShardingGracefulShutdownNode1 : ClusterShardingGracefulShutdownSpec { }
+    public class ClusterShardingGracefulShutdownNode2 : ClusterShardingGracefulShutdownSpec { }
+
+    public class ClusterShardingGracefulShutdownSpec : MultiNodeClusterSpec
+    {
+        #region setup
+
+        [Serializable]
+        internal sealed class StopEntity
+        {
+            public static readonly StopEntity Instance = new StopEntity();
+
+            private StopEntity()
+            {
+            }
+        }
+
+        internal class Entity : ReceiveActor
+        {
+            public Entity()
+            {
+                Receive<int>(id => Sender.Tell(id));
+                Receive<StopEntity>(_ => Context.Stop(Self));
+            }
+        }
+
+        internal class IllustrateGracefulShutdown : UntypedActor
+        {
+            private readonly Cluster _cluster;
+            private readonly IActorRef _region;
+            public IllustrateGracefulShutdown()
+            {
+                _cluster = Cluster.Get(Context.System);
+                _region = ClusterSharding.Get(Context.System).ShardRegion("Entity");
+            }
+
+            protected override void OnReceive(object message)
+            {
+                Terminated terminated;
+                if (message.Equals("leave"))
+                {
+                    Context.Watch(_region);
+                    _region.Tell(GracefulShutdown.Instance);
+                }
+                else if ((terminated = message as Terminated) != null && terminated.ActorRef.Equals(_region))
+                {
+                    _cluster.RegisterOnMemberRemoved(() => Context.System.Shutdown());
+                    _cluster.Leave(_cluster.SelfAddress);
+                }
+            }
+        }
+
+        internal IdExtractor extractEntityId = message => message is int ? Tuple.Create(message.ToString(), message) : null;
+
+        internal ShardResolver extractShardId = message => message is int ? message.ToString() : null;
+
+        private readonly Lazy<IActorRef> _region;
+
+        private DirectoryInfo[] _storageLocations;
+        private RoleName _first;
+        private RoleName _second;
+
+        public ClusterShardingGracefulShutdownSpec() : base(new ClusterShardingGracefulShutdownSpecConfig())
+        {
+            _storageLocations = new[]
+            {
+                "akka.persistence.journal.leveldb.dir",
+                "akka.persistence.journal.leveldb-shared.store.dir",
+                "akka.persistence.snapshot-store.local.dir"
+            }.Select(s => new DirectoryInfo(Sys.Settings.Config.GetString(s))).ToArray();
+
+            _region = new Lazy<IActorRef>(() => ClusterSharding.Get(Sys).ShardRegion("Entity"));
+
+            _first = new RoleName("first");
+            _second = new RoleName("second");
+        }
+
+        protected override void AtStartup()
+        {
+            base.AtStartup();
+            RunOn(() =>
+            {
+                foreach (var location in _storageLocations) if (location.Exists) location.Delete();
+            }, _first);
+        }
+
+        protected override void AfterTermination()
+        {
+            base.AfterTermination();
+            RunOn(() =>
+            {
+                foreach (var location in _storageLocations) if (location.Exists) location.Delete();
+            }, _first);
+        }
+
+        #endregion
+
+        private void Join(RoleName from, RoleName to)
+        {
+            RunOn(() =>
+            {
+                Cluster.Join(Node(to).Address);
+                StartSharding();
+            }, from);
+            EnterBarrier(from.Name + "-joined");
+        }
+
+        private void StartSharding()
+        {
+            var allocationStrategy = new LeastShardAllocationStrategy(2, 1);
+            ClusterSharding.Get(Sys).Start(
+                typeName: "Entity",
+                entryProps: Props.Create<Entity>(),
+                settings: ClusterShardingSettings.Create(Sys),
+                idExtractor: extractEntityId,
+                shardResolver: extractShardId,
+                allocationStrategy: allocationStrategy,
+                handOffStopMessage: StopEntity.Instance);
+        }
+
+        [MultiNodeFact(Skip = "TODO")]
+        public void ClusterSharding_should_setup_shared_journal()
+        {
+            // start the Persistence extension
+            Persistence.Persistence.Instance.Apply(Sys);
+            RunOn(() =>
+            {
+                Sys.ActorOf(Props.Create<MemoryJournal>(), "store");
+            }, _first);
+            EnterBarrier("persistence-started");
+
+            RunOn(() =>
+            {
+                Sys.ActorSelection(Node(_first) / "user" / "store").Tell(new Identify(null));
+                var sharedStore = ExpectMsg<ActorIdentity>().Subject;
+                //TODO: SharedLeveldbJournal.setStore(sharedStore, system)
+            }, _first, _second);
+            EnterBarrier("after-1");
+        }
+
+        [MultiNodeFact(Skip = "TODO")]
+        public void ClusterSharding_should_start_some_shards_in_both_regions()
+        {
+            Join(_first, _first);
+            Join(_second, _first);
+
+            AwaitAssert(() =>
+            {
+                var probe = CreateTestProbe();
+                var regionAddresses = Enumerable.Range(1, 100)
+                    .Select(n =>
+                    {
+                        _region.Value.Tell(n, probe.Ref);
+                        probe.ExpectMsg(n, TimeSpan.FromSeconds(1));
+                        return probe.LastSender.Path.Address;
+                    })
+                    .ToArray();
+
+                Assert.Equal(2, regionAddresses.Length);
+            });
+            EnterBarrier("after-2");
+        }
+
+        [MultiNodeFact(Skip = "TODO")]
+        public void ClusterSharding_should_gracefully_shutdown_a_region()
+        {
+            RunOn(() =>
+            {
+                _region.Value.Tell(GracefulShutdown.Instance);
+            }, _second);
+
+            RunOn(() =>
+            {
+                var probe = CreateTestProbe();
+                for (int i = 1; i <= 200; i++)
+                {
+                    _region.Value.Tell(i, probe.Ref);
+                    probe.ExpectMsg(i, TimeSpan.FromSeconds(1));
+                    Assert.Equal(_region.Value.Path / i.ToString() / i.ToString(), probe.LastSender.Path);
+                }
+            }, _first);
+            EnterBarrier("handoff-completed");
+
+            RunOn(() =>
+            {
+                var region = _region.Value;
+                Watch(region);
+                ExpectTerminated(region);
+            }, _second);
+            EnterBarrier("after-3");
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingLeavingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingLeavingSpec.cs
@@ -1,0 +1,275 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.MultiNodeTests;
+using Akka.Persistence.Journal;
+using Akka.Remote.TestKit;
+using Xunit;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    public class ClusterShardingLeavingSpecConfig : MultiNodeConfig
+    {
+        public ClusterShardingLeavingSpecConfig()
+        {
+            var first = Role("first");
+            var second = Role("second");
+            var third = Role("third");
+            var fourth = Role("fourth");
+
+            CommonConfig = ConfigurationFactory.ParseString(@"
+                akka.loglevel = INFO
+                akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider""
+                akka.remote.log-remote-lifecycle-events = off
+                akka.cluster.auto-down-unreachable-after = 0s
+                akka.cluster.down-removal-margin = 5s
+                akka.persistence.journal.plugin = ""Akka.Persistence.Journal.in-mem""
+                akka.persistence.journal.in-mem {
+                  timeout = 5s
+                  store {
+                    native = off
+                    dir = ""target/journal-ClusterShardingLeavingSpec""
+                  }
+                }
+                akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.local""
+                akka.persistence.snapshot-store.local.dir = ""target/snapshots-ClusterShardingLeavingSpec""
+            ");
+        }
+    }
+
+    public class ClusterShardingLeavingNode1 : ClusterShardinLeavingSpec { }
+    public class ClusterShardingLeavingNode2 : ClusterShardinLeavingSpec { }
+    public class ClusterShardingLeavingNode3 : ClusterShardinLeavingSpec { }
+    public class ClusterShardingLeavingNode4 : ClusterShardinLeavingSpec { }
+
+    public class ClusterShardinLeavingSpec : MultiNodeClusterSpec
+    {
+        #region setup
+
+        [Serializable]
+        internal sealed class Ping
+        {
+            public readonly string Id;
+
+            public Ping(string id)
+            {
+                Id = id;
+            }
+        }
+
+        [Serializable]
+        internal sealed class GetLocations
+        {
+            public static readonly GetLocations Instance = new GetLocations();
+
+            private GetLocations()
+            {
+            }
+        }
+
+        [Serializable]
+        internal sealed class Locations
+        {
+            public readonly IDictionary<string, IActorRef> LocationMap;
+            public Locations(IDictionary<string, IActorRef> locationMap)
+            {
+                LocationMap = locationMap;
+            }
+        }
+
+        internal class Entity : ReceiveActor
+        {
+            public Entity()
+            {
+                Receive<Ping>(_ => Sender.Tell(Self));
+            }
+        }
+
+        internal class ShardLocations : ReceiveActor
+        {
+            private Locations _locations = null;
+
+            public ShardLocations()
+            {
+                Receive<GetLocations>(_ => Sender.Tell(_locations));
+                Receive<Locations>(l => _locations = l);
+            }
+        }
+
+        internal IdExtractor extractEntityId = message => message is Ping ? Tuple.Create((message as Ping).Id, message) : null;
+        internal ShardResolver extractShardId = message => message is Ping ? (message as Ping).Id[0].ToString() : null;
+
+        private readonly DirectoryInfo[] _storageLocations;
+        private readonly Lazy<IActorRef> _region;
+
+        private RoleName _first;
+        private RoleName _second;
+        private RoleName _third;
+        private RoleName _fourth;
+
+        public ClusterShardinLeavingSpec() : base(new ClusterShardingLeavingSpecConfig())
+        {
+            _storageLocations = new[]
+            {
+                "akka.persistence.journal.leveldb.dir",
+                "akka.persistence.journal.leveldb-shared.store.dir",
+                "akka.persistence.snapshot-store.local.dir"
+            }.Select(s => new DirectoryInfo(Sys.Settings.Config.GetString(s))).ToArray();
+
+            _first = new RoleName("first");
+            _second = new RoleName("second");
+            _third = new RoleName("third");
+            _fourth = new RoleName("fourth");
+
+            _region = new Lazy<IActorRef>(() => ClusterSharding.Get(Sys).ShardRegion("Entity"));
+        }
+
+        protected override int InitialParticipantsValueFactory { get { return Roles.Count; } }
+
+        protected override void AtStartup()
+        {
+            base.AtStartup();
+            RunOn(() =>
+            {
+                foreach (var location in _storageLocations) if (location.Exists) location.Delete();
+            }, _first);
+        }
+
+        protected override void AfterTermination()
+        {
+            base.AfterTermination();
+            RunOn(() =>
+            {
+                foreach (var location in _storageLocations) if (location.Exists) location.Delete();
+            }, _first);
+        }
+
+        #endregion
+
+        private void Join(RoleName from, RoleName to)
+        {
+            RunOn(() =>
+            {
+                Cluster.Join(Node(to).Address);
+                StartSharding();
+                Within(TimeSpan.FromSeconds(5), () =>
+                {
+                    AwaitAssert(() => Assert.True(Cluster.ReadView.State.Members.Any(m => m.UniqueAddress == Cluster.SelfUniqueAddress && m.Status == MemberStatus.Up)));
+                });
+            }, from);
+            EnterBarrier(from.Name + "-joined");
+        }
+
+        private void StartSharding()
+        {
+            ClusterSharding.Get(Sys).Start(
+                typeName: "Entity",
+                entryProps: Props.Create<Entity>(),
+                settings: ClusterShardingSettings.Create(Sys),
+                idExtractor: extractEntityId,
+                shardResolver: extractShardId);
+        }
+
+        [MultiNodeFact(Skip = "TODO")]
+        public void ClusterSharding_with_leaving_member_should_setup_shared_journal()
+        {
+            // start the Persistence extension
+            Persistence.Persistence.Instance.Apply(Sys);
+            RunOn(() =>
+            {
+                Sys.ActorOf(Props.Create<MemoryJournal>(), "store");
+            }, _first);
+            EnterBarrier("persistence-started");
+
+            Sys.ActorSelection(Node(_first) / "user" / "store").Tell(new Identify(null));
+            var sharedStore = ExpectMsg<ActorIdentity>().Subject;
+
+            //SharedLeveldbJournal.setStore(sharedStore, system)
+            EnterBarrier("after-1");
+        }
+
+        [MultiNodeFact(Skip = "TODO")]
+        public void ClusterSharding_with_leaving_member_should_join_cluster()
+        {
+            Within(TimeSpan.FromSeconds(20), () =>
+            {
+                Join(_first, _first);
+                Join(_second, _first);
+                Join(_third, _first);
+                Join(_fourth, _first);
+
+                EnterBarrier("after-2");
+            });
+        }
+
+        [MultiNodeFact(Skip = "TODO")]
+        public void ClusterSharding_with_leaving_member_should_initialize_shards()
+        {
+            RunOn(() =>
+            {
+                var shardLocations = Sys.ActorOf(Props.Create<ShardLocations>(), "shardLocations");
+                var locations = Enumerable.Range(1, 10)
+                    .Select(n =>
+                    {
+                        var id = n.ToString();
+                        _region.Value.Tell(new Ping(id));
+                        return new KeyValuePair<string, IActorRef>(id, ExpectMsg<IActorRef>());
+                    })
+                    .ToDictionary(kv => kv.Key, kv => kv.Value);
+
+                shardLocations.Tell(new Locations(locations));
+            }, _first);
+            EnterBarrier("after-3");
+        }
+
+        [MultiNodeFact(Skip="TODO")]
+        public void ClusterSharding_with_leaving_member_should_recover_after_leaving_coordinator_node()
+        {
+            Within(TimeSpan.FromSeconds(30), () =>
+            {
+                RunOn(() =>
+                {
+                    Cluster.Leave(Node(_first).Address);
+                }, _third);
+
+                RunOn(() =>
+                {
+                    var region = _region.Value;
+                    Watch(region);
+                    ExpectTerminated(region, TimeSpan.FromSeconds(15));
+                }, _first);
+                EnterBarrier("stopped");
+
+                RunOn(() =>
+                {
+                    Sys.ActorSelection(Node(_first) / "user" / "sharedLocations").Tell(GetLocations.Instance);
+                    var locations = ExpectMsg<Locations>();
+                    var firstAddress = Node(_first).Address;
+                    AwaitAssert(() =>
+                    {
+                        var region = _region.Value;
+                        var probe = CreateTestProbe();
+                        foreach (var kv in locations.LocationMap)
+                        {
+                            var id = kv.Key;
+                            var r = kv.Value;
+                            region.Tell(new Ping(id), probe.Ref);
+                            if (r.Path.Address.Equals(firstAddress))
+                            {
+                                Assert.NotEqual(r, probe.ExpectMsg<IActorRef>(TimeSpan.FromSeconds(1)));
+                            }
+                            else
+                            {
+                                probe.ExpectMsg(r, TimeSpan.FromSeconds(1)); // should not move
+                            }
+                        }
+                    });
+                }, _second, _third, _fourth);
+                EnterBarrier("after-4");
+            });
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingSpec.cs
@@ -725,7 +725,7 @@ namespace Akka.Cluster.Sharding.Tests
                 RunOn(() =>
                 {
                     //#counter-usage
-                    var counterRegion = ClusterSharding.Get(Sys).ShardingRegion("Counter");
+                    var counterRegion = ClusterSharding.Get(Sys).ShardRegion("Counter");
                     counterRegion.Tell(new Counter.Get(123));
                     ExpectMsg(0);
 
@@ -734,7 +734,7 @@ namespace Akka.Cluster.Sharding.Tests
                     ExpectMsg(1);
 
                     //#counter-usage
-                    var anotherCounterRegion = ClusterSharding.Get(Sys).ShardingRegion("AnotherCounter");
+                    var anotherCounterRegion = ClusterSharding.Get(Sys).ShardRegion("AnotherCounter");
                     anotherCounterRegion.Tell(new Counter.EntityEnvelope(123, Counter.Decrement.Instance));
                     anotherCounterRegion.Tell(new Counter.Get(123));
                     ExpectMsg(-1);
@@ -746,8 +746,8 @@ namespace Akka.Cluster.Sharding.Tests
                 {
                     for (int i = 1000; i <= 1010; i++)
                     {
-                        ClusterSharding.Get(Sys).ShardingRegion("Counter").Tell(new Counter.EntityEnvelope(i, Counter.Increment.Instance));
-                        ClusterSharding.Get(Sys).ShardingRegion("Counter").Tell(new Counter.Get(i));
+                        ClusterSharding.Get(Sys).ShardRegion("Counter").Tell(new Counter.EntityEnvelope(i, Counter.Increment.Instance));
+                        ClusterSharding.Get(Sys).ShardRegion("Counter").Tell(new Counter.Get(i));
                         ExpectMsg(1);
                         Assert.NotEqual(Cluster.SelfAddress, LastSender.Path.Address);
                     }
@@ -770,7 +770,7 @@ namespace Akka.Cluster.Sharding.Tests
                         idExtractor: Counter.ExtractEntityId,
                         shardResolver: Counter.ExtractShardId);
 
-                    var counterRegionViaGet = ClusterSharding.Get(Sys).ShardingRegion("ApiTest");
+                    var counterRegionViaGet = ClusterSharding.Get(Sys).ShardRegion("ApiTest");
 
                     Assert.Equal(counterRegionViaGet, counterRegionViaStart);
                 }, _first);

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CustomShardAllocationSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CustomShardAllocationSpec.cs
@@ -7,14 +7,44 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
+using Akka.MultiNodeTests;
+using Akka.Persistence.Journal;
 using Akka.Remote.TestKit;
+using Xunit;
 
 namespace Akka.Cluster.Sharding.Tests
 {
-    public class CustomShardAllocationSpec : MultiNodeConfig
+    public class CustomShardAllocationSpecConfig : MultiNodeConfig
+    {
+
+        public CustomShardAllocationSpecConfig()
+        {
+            var first = Role("first");
+            var second = Role("second");
+
+            CommonConfig = ConfigurationFactory.ParseString(@"
+                akka.loglevel = INFO
+                akka.actor.provider = ""akka.cluster.ClusterActorRefProvider""
+                akka.remote.log-remote-lifecycle-events = off
+                akka.persistence.journal.plugin = ""akka.persistence.journal.in-mem""
+                akka.persistence.journal.in-mem {
+                  timeout = 5s
+                  store {
+                    native = off
+                    dir = ""target/journal-ClusterShardingCustomShardAllocationSpec""
+                  }
+                }
+                akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.local""
+                akka.persistence.snapshot-store.local.dir = ""target/snapshots-ClusterShardingCustomShardAllocationSpec""");
+        }
+    }
+
+    public class CustomShardAllocationSpec : MultiNodeClusterSpec
     {
         #region messages
 
@@ -63,6 +93,8 @@ namespace Akka.Cluster.Sharding.Tests
         }
 
         #endregion
+
+        #region actors
 
         class Entity : ReceiveActor
         {
@@ -125,31 +157,174 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        private readonly IdExtractor _idExtractor = id => Tuple.Create(id.ToString(), id);
-        private readonly ShardResolver _shardResolver = msg => msg.ToString();
-        
+        #endregion
+
+        private readonly IdExtractor extractEntityId = id => Tuple.Create(id.ToString(), id);
+        private readonly ShardResolver extractShardId = msg => msg.ToString();
+
         private readonly RoleName _first;
         private readonly RoleName _second;
+        private DirectoryInfo[] _storageLocations;
+        private Lazy<IActorRef> _region;
+        private Lazy<IActorRef> _allocator;
 
-        public CustomShardAllocationSpec()
+        public CustomShardAllocationSpec() : base(new CustomShardAllocationSpecConfig())
         {
-            _first = Role("first");
-            _second = Role("second");
+            _storageLocations = new[]
+            {
+                "akka.persistence.journal.leveldb.dir",
+                "akka.persistence.journal.leveldb-shared.store.dir",
+                "akka.persistence.snapshot-store.local.dir"
+            }.Select(s => new DirectoryInfo(Sys.Settings.Config.GetString(s))).ToArray();
 
-            CommonConfig = ConfigurationFactory.ParseString(@"
-                akka.loglevel = INFO
-                akka.actor.provider = ""akka.cluster.ClusterActorRefProvider""
-                akka.remote.log-remote-lifecycle-events = off
-                akka.persistence.journal.plugin = ""akka.persistence.journal.leveldb-shared""
-                akka.persistence.journal.leveldb-shared {
-                  timeout = 5s
-                  store {
-                    native = off
-                    dir = ""target/journal-ClusterShardingCustomShardAllocationSpec""
-                  }
-                }
-                akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.local""
-                akka.persistence.snapshot-store.local.dir = ""target/snapshots-ClusterShardingCustomShardAllocationSpec""");
+            _region = new Lazy<IActorRef>(() => ClusterSharding.Get(Sys).ShardRegion("Entity"));
+            _allocator = new Lazy<IActorRef>(() => Sys.ActorOf(Props.Create<Allocator>(), "allocator"));
+
+            _first = new RoleName("first");
+            _second = new RoleName("second");
+        }
+
+        protected override void AtStartup()
+        {
+            base.AtStartup();
+            RunOn(() =>
+            {
+                foreach (var location in _storageLocations) if (location.Exists) location.Delete();
+            }, _first);
+        }
+
+        protected override void AfterTermination()
+        {
+            base.AfterTermination();
+            RunOn(() =>
+            {
+                foreach (var location in _storageLocations) if (location.Exists) location.Delete();
+            }, _first);
+        }
+
+        private void Join(RoleName from, RoleName to)
+        {
+            RunOn(() =>
+            {
+                Cluster.Join(Node(to).Address);
+                StartSharding();
+            }, from);
+            EnterBarrier(from.Name + "-joined");
+        }
+
+        private void StartSharding()
+        {
+            var allocationStrategy = new LeastShardAllocationStrategy(2, 1);
+            ClusterSharding.Get(Sys).Start(
+                typeName: "Entity",
+                entryProps: Props.Create<ClusterShardingGracefulShutdownSpec.Entity>(),
+                settings: ClusterShardingSettings.Create(Sys),
+                idExtractor: extractEntityId,
+                shardResolver: extractShardId,
+                allocationStrategy: new TestAllocationStrategy(_allocator.Value),
+                handOffStopMessage: PoisonPill.Instance);
+        }
+
+        [MultiNodeFact(Skip = "TODO")]
+        public void ClusterSharding_with_custom_allocation_strategy_should_setup_shared_journal()
+        {
+            // start the Persistence extension
+            Persistence.Persistence.Instance.Apply(Sys);
+            RunOn(() =>
+            {
+                Sys.ActorOf(Props.Create<MemoryJournal>(), "store");
+            }, _first);
+            EnterBarrier("persistence-started");
+
+            RunOn(() =>
+            {
+                Sys.ActorSelection(Node(_first) / "user" / "store").Tell(new Identify(null));
+                var sharedStore = ExpectMsg<ActorIdentity>().Subject;
+                //TODO: SharedLeveldbJournal.setStore(sharedStore, system)
+            }, _first, _second);
+            EnterBarrier("after-1");
+        }
+
+        [MultiNodeFact(Skip = "TODO")]
+        public void ClusterSharding_with_custom_allocation_strategy_should_use_specified_region()
+        {
+            Within(TimeSpan.FromSeconds(20), () =>
+            {
+                Join(_first, _first);
+
+                RunOn(() =>
+                {
+                    _allocator.Value.Tell(new UseRegion(_region.Value));
+                    ExpectMsg<UseRegionAck>();
+                    _region.Value.Tell(1);
+                    ExpectMsg(1);
+                    Assert.Equal(_region.Value.Path / "1" / "1", LastSender.Path);
+                }, _first);
+                EnterBarrier("first-started");
+
+                Join(_second, _first);
+
+                _region.Value.Tell(2);
+                ExpectMsg(2);
+
+                RunOn(() =>
+                {
+                    Assert.Equal(_region.Value.Path / "2" / "2", LastSender.Path);
+                }, _first);
+                RunOn(() =>
+                {
+                    Assert.Equal(Node(_first) / "user" / "sharding" / "Entity" / "2" / "2", LastSender.Path);
+                }, _second);
+                EnterBarrier("second-started");
+
+                RunOn(() =>
+                {
+                    Sys.ActorSelection(Node(_second) / "user" / "sharding" / "Entity").Tell(new Identify(null));
+                    var secondRegion = ExpectMsg<ActorIdentity>().Subject;
+                    _allocator.Value.Tell(new UseRegion(secondRegion));
+                    ExpectMsg<UseRegionAck>();
+                }, _first);
+                EnterBarrier("second-active");
+
+                _region.Value.Tell(3);
+                ExpectMsg(3);
+
+                RunOn(() =>
+                {
+                    Assert.Equal(_region.Value.Path / "3" / "3", LastSender.Path);
+                }, _second);
+
+                RunOn(() =>
+                {
+                    Assert.Equal(Node(_second) / "user" / "sharding" / "Entity" / "3" / "3", LastSender.Path);
+                }, _first);
+                EnterBarrier("after-2");
+            });
+        }
+
+        [MultiNodeFact(Skip = "TODO")]
+        public void ClusterSharding_with_custom_allocation_strategy_should_rebalance_specified_shards()
+        {
+            Within(TimeSpan.FromSeconds(15), () =>
+            {
+                RunOn(() =>
+                {
+                    _allocator.Value.Tell(new RebalanceShards(new[] { "2" }));
+                    ExpectMsg<RebalanceShardsAck>();
+
+                    AwaitAssert(() =>
+                    {
+                        var probe = CreateTestProbe();
+                        _region.Value.Tell(2, probe.Ref);
+                        probe.ExpectMsg(2, TimeSpan.FromSeconds(2));
+                        Assert.Equal(Node(_second) / "user" / "sharding" / "Entity" / "2" / "2", LastSender.Path);
+                    });
+
+                    _region.Value.Tell(1);
+                    ExpectMsg(1);
+                    Assert.Equal(_region.Value.Path / "1" / "1", LastSender.Path);
+                }, _first);
+            });
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
@@ -343,7 +343,7 @@ namespace Akka.Cluster.Sharding
         * Messages to the entry is always sent via the `ShardRegion`.
         */
 
-        public IActorRef ShardingRegion(string typeName)
+        public IActorRef ShardRegion(string typeName)
         {
             IActorRef region;
             if (_regions.TryGetValue(typeName, out region))

--- a/src/core/Akka.Cluster/Cluster.cs
+++ b/src/core/Akka.Cluster/Cluster.cs
@@ -229,6 +229,20 @@ namespace Akka.Cluster
         }
 
         /// <summary>
+        /// The supplied thunk will be run, once, when current cluster member is removed 
+        /// and if the cluster have been shutdown, that thunk will run on the caller thread immediately.  
+        /// Typically used together <see cref="Cluster.Leave"/> and then <see cref="System.Shutdown"/>.
+        /// </summary>
+        /// <param name="callback"></param>
+        public void RegisterOnMemberRemoved(Action callback)
+        {
+            if (_isTerminated.Value)
+                callback();
+            else
+                _clusterDaemons.Tell(new InternalClusterAction.AddOnMemberRemovedListener(callback));
+        }
+
+        /// <summary>
         /// The address of this cluster member.
         /// </summary>
         public Address SelfAddress

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -447,6 +447,21 @@ namespace Akka.Cluster
             }
         }
 
+        public sealed class AddOnMemberRemovedListener : INoSerializationVerificationNeeded
+        {
+            readonly Action _callback;
+
+            public AddOnMemberRemovedListener(Action callback)
+            {
+                _callback = callback;
+            }
+
+            public Action Callback
+            {
+                get { return _callback; }
+            }
+        }
+
         public interface ISubscriptionMessage { }
 
         public sealed class Subscribe : ISubscriptionMessage
@@ -578,7 +593,10 @@ namespace Akka.Cluster
                 .With<InternalClusterAction.GetClusterCoreRef>(msg => _coreSupervisor.Forward(msg))
                 .With<InternalClusterAction.AddOnMemberUpListener>(
                     msg =>
-                        Context.ActorOf(Props.Create(() => new OnMemberUpListener(msg.Callback)).WithDispatcher(_settings.UseDispatcher).WithDeploy(Deploy.Local)))
+                        Context.ActorOf(Props.Create(() => new OnMemberStatusChangedListener(msg.Callback, MemberStatus.Up)).WithDispatcher(_settings.UseDispatcher).WithDeploy(Deploy.Local)))
+                .With<InternalClusterAction.AddOnMemberRemovedListener>(
+                    msg =>
+                        Context.ActorOf(Props.Create(() => new OnMemberStatusChangedListener(msg.Callback, MemberStatus.Removed)).WithDispatcher(_settings.UseDispatcher).WithDeploy(Deploy.Local)))
                 .With<InternalClusterAction.PublisherCreated>(
                     msg =>
                     {
@@ -662,7 +680,7 @@ namespace Akka.Cluster
             _publisher = publisher;
             SelfUniqueAddress = _cluster.SelfUniqueAddress;
             _vclockNode = new VectorClock.Node(VclockName(SelfUniqueAddress));
-            
+
             var settings = _cluster.Settings;
             var scheduler = _cluster.Scheduler;
 
@@ -672,36 +690,36 @@ namespace Akka.Cluster
 
             _gossipTaskCancellable =
                 scheduler.ScheduleTellRepeatedlyCancelable(
-                    settings.PeriodicTasksInitialDelay.Max(settings.GossipInterval), 
-                    settings.GossipInterval, 
-                    Self, 
-                    InternalClusterAction.GossipTick.Instance, 
+                    settings.PeriodicTasksInitialDelay.Max(settings.GossipInterval),
+                    settings.GossipInterval,
+                    Self,
+                    InternalClusterAction.GossipTick.Instance,
                     Self);
 
             _failureDetectorReaperTaskCancellable =
                 scheduler.ScheduleTellRepeatedlyCancelable(
-                    settings.PeriodicTasksInitialDelay.Max(settings.UnreachableNodesReaperInterval), 
-                    settings.UnreachableNodesReaperInterval, 
-                    Self, 
-                    InternalClusterAction.ReapUnreachableTick.Instance, 
+                    settings.PeriodicTasksInitialDelay.Max(settings.UnreachableNodesReaperInterval),
+                    settings.UnreachableNodesReaperInterval,
+                    Self,
+                    InternalClusterAction.ReapUnreachableTick.Instance,
                     Self);
 
             _leaderActionsTaskCancellable =
                 scheduler.ScheduleTellRepeatedlyCancelable(
-                    settings.PeriodicTasksInitialDelay.Max(settings.LeaderActionsInterval), 
-                    settings.LeaderActionsInterval, 
-                    Self, 
-                    InternalClusterAction.LeaderActionsTick.Instance, 
+                    settings.PeriodicTasksInitialDelay.Max(settings.LeaderActionsInterval),
+                    settings.LeaderActionsInterval,
+                    Self,
+                    InternalClusterAction.LeaderActionsTick.Instance,
                     Self);
 
             if (settings.PublishStatsInterval != null && settings.PublishStatsInterval > TimeSpan.Zero && settings.PublishStatsInterval != TimeSpan.MaxValue)
             {
                 _publishStatsTaskTaskCancellable =
                     scheduler.ScheduleTellRepeatedlyCancelable(
-                        settings.PeriodicTasksInitialDelay.Max(settings.PublishStatsInterval.Value), 
-                        settings.PublishStatsInterval.Value, 
-                        Self, 
-                        InternalClusterAction.PublishStatsTick.Instance, 
+                        settings.PeriodicTasksInitialDelay.Max(settings.PublishStatsInterval.Value),
+                        settings.PublishStatsInterval.Value,
+                        Self,
+                        InternalClusterAction.PublishStatsTick.Instance,
                         Self);
             }
 
@@ -1469,7 +1487,7 @@ namespace Akka.Cluster
                 else
                 {
                     _leaderActionCounter += 1;
-                    if (_leaderActionCounter == firstNotice || _leaderActionCounter%periodicNotice == 0)
+                    if (_leaderActionCounter == firstNotice || _leaderActionCounter % periodicNotice == 0)
                     {
                         _log.Info(
                             "Leader can currently not perform its duties, reachability status: [{0}], member status: [{1}]",
@@ -1998,38 +2016,52 @@ namespace Akka.Cluster
     /// <summary>
     /// INTERNAL API
     /// 
-    /// The supplied callback will be run once when the current cluster member is <see cref="MemberStatus.Up"/>
+    /// The supplied callback will be run once when the current cluster member comes up with the same status.
     /// </summary>
-    class OnMemberUpListener : ReceiveActor
+    class OnMemberStatusChangedListener : ReceiveActor
     {
         readonly Action _callback;
+        private readonly MemberStatus _status;
         readonly ILoggingAdapter _log = Context.GetLogger();
         readonly Cluster _cluster;
+        private readonly Type _to;
 
-        public OnMemberUpListener(Action callback)
+        public OnMemberStatusChangedListener(Action callback, MemberStatus status)
         {
             _callback = callback;
+            _status = status;
             _cluster = Cluster.Get(Context.System);
+
+            switch (status)
+            {
+                case MemberStatus.Up: _to = typeof(ClusterEvent.MemberUp); break;
+                case MemberStatus.Removed: _to = typeof(ClusterEvent.MemberRemoved); break;
+            }
+
             Receive<ClusterEvent.CurrentClusterState>(state =>
             {
-                if (state.Members.Any(IsSelfUp))
-                    Done();
+                if (state.Members.Any(IsTriggered)) Done();
             });
 
             Receive<ClusterEvent.MemberUp>(up =>
             {
-                if (IsSelfUp(up.Member))
-                    Done();
+                if (IsTriggered(up.Member)) Done();
+            });
+
+            Receive<ClusterEvent.MemberRemoved>(up =>
+            {
+                if (IsTriggered(up.Member)) Done();
             });
         }
 
         protected override void PreStart()
         {
-            _cluster.Subscribe(Self, new[] { typeof(ClusterEvent.MemberUp) });
+            _cluster.Subscribe(Self, new[] { _to });
         }
 
         protected override void PostStop()
         {
+            if (_status == MemberStatus.Removed) Done();
             _cluster.Unsubscribe(Self);
         }
 
@@ -2037,7 +2069,7 @@ namespace Akka.Cluster
         {
             try
             {
-                _callback.Invoke();
+                _callback();
             }
             catch (Exception ex)
             {
@@ -2049,9 +2081,9 @@ namespace Akka.Cluster
             }
         }
 
-        private bool IsSelfUp(Member m)
+        private bool IsTriggered(Member m)
         {
-            return m.UniqueAddress == _cluster.SelfUniqueAddress && m.Status == MemberStatus.Up;
+            return m.UniqueAddress == _cluster.SelfUniqueAddress && m.Status == _status;
         }
     }
 


### PR DESCRIPTION
These are complete specs for Akka.Cluster.Sharding, including:

- ClusterShardingCustomAllocationSpec
- ClusterShardingFailureSpec
- ClusterShardingGracefulShutdownSpec
- ClusterShardingLeavingSpec

These are not yet passing tests. 

Also some changes in pub/sub for cluster messages (included listeners on MemberRemoved).