### PR TITLE
fixed bug where new ActorSystem UID was generated on every call

### DIFF
--- a/src/core/Akka.Remote.Tests/RemoteWatcherSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteWatcherSpec.cs
@@ -99,22 +99,35 @@ namespace Akka.Remote.Tests
                     get { return _uid; }
                 }
 
+                protected bool Equals(Quarantined other)
+                {
+                    return Equals(_address, other._address) && _uid == other._uid;
+                }
+
                 public override bool Equals(object obj)
                 {
-                    var other = obj as Quarantined;
-                    if (other == null) return false;
-                    return _address.Equals(other._address); //TODO: Ignoring uid? /&& _uid == other._uid;
+                    if (ReferenceEquals(null, obj)) return false;
+                    if (ReferenceEquals(this, obj)) return true;
+                    if (obj.GetType() != this.GetType()) return false;
+                    return Equals((Quarantined) obj);
                 }
 
                 public override int GetHashCode()
                 {
                     unchecked
                     {
-                        var hash = 17;
-                        hash = hash*23 + _address.GetHashCode();
-                        //TODO: Ignoring uid hash = hash*23 + _uid.GetHashCode();
-                        return hash;
+                        return ((_address != null ? _address.GetHashCode() : 0)*397) ^ _uid.GetHashCode();
                     }
+                }
+
+                public static bool operator ==(Quarantined left, Quarantined right)
+                {
+                    return Equals(left, right);
+                }
+
+                public static bool operator !=(Quarantined left, Quarantined right)
+                {
+                    return !Equals(left, right);
                 }
             }
 

--- a/src/core/Akka.Remote/AddressUidExtension.cs
+++ b/src/core/Akka.Remote/AddressUidExtension.cs
@@ -38,10 +38,7 @@ namespace Akka.Remote
     /// </summary>
     public class AddressUid : IExtension
     {
-        public int Uid
-        {
-            get { return ThreadLocalRandom.Current.Next(); }
-        }
+        public readonly int Uid = ThreadLocalRandom.Current.Next();
     }
 }
 


### PR DESCRIPTION
This fixes a major bug in Akka.Remote where the `AddressUIDExtension` was generating a brand new UID for the calling `ActorSystem` each time it was invoked, which means that invalid handshake information could be sent under otherwise normal circumstances. I'm not sure what the real-world impact of this error is, but it's resolved now.