### PR TITLE
New config setting akka.persistence.xyz.connection-string-name

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Settings.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Settings.cs
@@ -21,6 +21,11 @@ namespace Akka.Persistence.Sql.Common
         public string ConnectionString { get; private set; }
 
         /// <summary>
+        /// Name of the connection string stored in &lt;connectionStrings&gt; section of *.config file.
+        /// </summary>
+        public string ConnectionStringName { get; private set; }
+
+        /// <summary>
         /// Connection timeout for SQL Server related operations.
         /// </summary>
         public TimeSpan ConnectionTimeout { get; private set; }
@@ -40,6 +45,7 @@ namespace Akka.Persistence.Sql.Common
             if (config == null) throw new ArgumentNullException("config", "SqlServer journal settings cannot be initialized, because required HOCON section couldn't been found");
 
             ConnectionString = config.GetString("connection-string");
+            ConnectionStringName = config.GetString("connection-string-name");
             ConnectionTimeout = config.GetTimeSpan("connection-timeout");
             SchemaName = config.GetString("schema-name");
             TableName = config.GetString("table-name");
@@ -55,6 +61,11 @@ namespace Akka.Persistence.Sql.Common
         /// Connection string used to access a persistent SQL Server instance.
         /// </summary>
         public string ConnectionString { get; private set; }
+
+        /// <summary>
+        /// Name of the connection string stored in &lt;connectionStrings&gt; section of *.config file.
+        /// </summary>
+        public string ConnectionStringName { get; private set; }
 
         /// <summary>
         /// Connection timeout for SQL Server related operations.
@@ -76,6 +87,7 @@ namespace Akka.Persistence.Sql.Common
             if (config == null) throw new ArgumentNullException("config", "SqlServer snapshot store settings cannot be initialized, because required HOCON section couldn't been found");
 
             ConnectionString = config.GetString("connection-string");
+            ConnectionStringName = config.GetString("connection-string-name");
             ConnectionTimeout = config.GetTimeSpan("connection-timeout");
             SchemaName = config.GetString("schema-name");
             TableName = config.GetString("table-name");


### PR DESCRIPTION
This is a new key for `JournalSettings` and `SnapshotStoreSettings` for persistence plugin based on SQL-backends to give users ability to specify their connection strings not only inside HOCON configs, but as references to <connectionStrings> sections of Web.config/App.config files as well. 

This will also need a corresponding update in Akka.Persistence.SqlServer and Akka.Persistence.PostgreSql in order to work - this PR only adds new common key for settings classes.

/cc #1107