### PR TITLE
[misc] fixed copyright headers for Akka.IO

### DIFF
--- a/src/contrib/transports/Akka.Remote.AkkaIOTransport/AddressConverters.cs
+++ b/src/contrib/transports/Akka.Remote.AkkaIOTransport/AddressConverters.cs
@@ -1,9 +1,10 @@
 //-----------------------------------------------------------------------
-// <copyright file="ActorBase.cs" company="Akka.NET Project">
+// <copyright file="AddressConverters.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>
 //-----------------------------------------------------------------------
+
 using System;
 using System.Net;
 using System.Net.Sockets;

--- a/src/contrib/transports/Akka.Remote.AkkaIOTransport/AkkaIOTransport.cs
+++ b/src/contrib/transports/Akka.Remote.AkkaIOTransport/AkkaIOTransport.cs
@@ -1,9 +1,10 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="ActorBase.cs" company="Akka.NET Project">
+// <copyright file="AkkaIOTransport.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>
 //-----------------------------------------------------------------------
+
 using System;
 using System.Threading.Tasks;
 using Akka.Actor;

--- a/src/contrib/transports/Akka.Remote.AkkaIOTransport/ConnectionAssociation.cs
+++ b/src/contrib/transports/Akka.Remote.AkkaIOTransport/ConnectionAssociation.cs
@@ -1,9 +1,10 @@
 //-----------------------------------------------------------------------
-// <copyright file="ActorBase.cs" company="Akka.NET Project">
+// <copyright file="ConnectionAssociation.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>
 //-----------------------------------------------------------------------
+
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.IO;

--- a/src/contrib/transports/Akka.Remote.AkkaIOTransport/Properties/AssemblyInfo.cs
+++ b/src/contrib/transports/Akka.Remote.AkkaIOTransport/Properties/AssemblyInfo.cs
@@ -1,4 +1,11 @@
-﻿using System.Reflection;
+﻿//-----------------------------------------------------------------------
+// <copyright file="AssemblyInfo.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/contrib/transports/Akka.Remote.AkkaIOTransport/TransportListener.cs
+++ b/src/contrib/transports/Akka.Remote.AkkaIOTransport/TransportListener.cs
@@ -1,9 +1,10 @@
 //-----------------------------------------------------------------------
-// <copyright file="ActorBase.cs" company="Akka.NET Project">
+// <copyright file="TransportListener.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>
 //-----------------------------------------------------------------------
+
 using Akka.Actor;
 using Akka.IO;
 using Akka.Remote.Transport;

--- a/src/contrib/transports/Akka.Remote.AkkaIOTransport/TransportManager.cs
+++ b/src/contrib/transports/Akka.Remote.AkkaIOTransport/TransportManager.cs
@@ -1,9 +1,10 @@
 //-----------------------------------------------------------------------
-// <copyright file="ActorBase.cs" company="Akka.NET Project">
+// <copyright file="TransportManager.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>
 //-----------------------------------------------------------------------
+
 using System;
 using System.Net;
 using System.Threading.Tasks;

--- a/src/core/Akka.Tests/IO/SimpleDnsCacheSpec.cs
+++ b/src/core/Akka.Tests/IO/SimpleDnsCacheSpec.cs
@@ -1,4 +1,11 @@
-﻿using Akka.IO;
+﻿//-----------------------------------------------------------------------
+// <copyright file="SimpleDnsCacheSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.IO;
 using Akka.TestKit;
 using Akka.Util;
 using Xunit;

--- a/src/core/Akka.Tests/IO/TcpConnectionSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpConnectionSpec.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="EventBusSpec.cs" company="Akka.NET Project">
+// <copyright file="TcpConnectionSpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka.Tests/IO/TcpIntegrationSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpIntegrationSpec.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿//-----------------------------------------------------------------------
+// <copyright file="TcpIntegrationSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;

--- a/src/core/Akka.Tests/IO/TcpListenerSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpListenerSpec.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="EventBusSpec.cs" company="Akka.NET Project">
+// <copyright file="TcpListenerSpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka.Tests/IO/UdpConnectedIntegrationSpec.cs
+++ b/src/core/Akka.Tests/IO/UdpConnectedIntegrationSpec.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿//-----------------------------------------------------------------------
+// <copyright file="UdpConnectedIntegrationSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
 using System.Linq;
 using System.Net;
 using Akka.Actor;

--- a/src/core/Akka.Tests/IO/UdpIntegrationSpec.cs
+++ b/src/core/Akka.Tests/IO/UdpIntegrationSpec.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿//-----------------------------------------------------------------------
+// <copyright file="UdpIntegrationSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;

--- a/src/core/Akka/IO/ByteBuffer.cs
+++ b/src/core/Akka/IO/ByteBuffer.cs
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------
-// <copyright file="ActorBase.cs" company="Akka.NET Project">
+// <copyright file="ByteBuffer.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/IO/DatagramChannel.cs
+++ b/src/core/Akka/IO/DatagramChannel.cs
@@ -1,9 +1,10 @@
 //-----------------------------------------------------------------------
-// <copyright file="IO.cs" company="Akka.NET Project">
+// <copyright file="DatagramChannel.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>
 //-----------------------------------------------------------------------
+
 using System.Net;
 using System.Net.Sockets;
 

--- a/src/core/Akka/IO/Dns.cs
+++ b/src/core/Akka/IO/Dns.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="IO.cs" company="Akka.NET Project">
+// <copyright file="Dns.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/IO/DnsProvider.cs
+++ b/src/core/Akka/IO/DnsProvider.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="IO.cs" company="Akka.NET Project">
+// <copyright file="DnsProvider.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/IO/InetAddressDnsProvider.cs
+++ b/src/core/Akka/IO/InetAddressDnsProvider.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="IO.cs" company="Akka.NET Project">
+// <copyright file="InetAddressDnsProvider.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/IO/InetAddressDnsResolver.cs
+++ b/src/core/Akka/IO/InetAddressDnsResolver.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="IO.cs" company="Akka.NET Project">
+// <copyright file="InetAddressDnsResolver.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/IO/SelectionHandler.cs
+++ b/src/core/Akka/IO/SelectionHandler.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="IO.cs" company="Akka.NET Project">
+// <copyright file="SelectionHandler.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/IO/SimpleDnsCache.cs
+++ b/src/core/Akka/IO/SimpleDnsCache.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="IO.cs" company="Akka.NET Project">
+// <copyright file="SimpleDnsCache.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/IO/SimpleDnsManager.cs
+++ b/src/core/Akka/IO/SimpleDnsManager.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="IO.cs" company="Akka.NET Project">
+// <copyright file="SimpleDnsManager.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/IO/SocketAsyncEventArgsPool.cs
+++ b/src/core/Akka/IO/SocketAsyncEventArgsPool.cs
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------
-// <copyright file="ActorBase.cs" company="Akka.NET Project">
+// <copyright file="SocketAsyncEventArgsPool.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/IO/SocketChannel.cs
+++ b/src/core/Akka/IO/SocketChannel.cs
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------
-// <copyright file="ActorBase.cs" company="Akka.NET Project">
+// <copyright file="SocketChannel.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/IO/TcpConnection.cs
+++ b/src/core/Akka/IO/TcpConnection.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="ActorBase.cs" company="Akka.NET Project">
+// <copyright file="TcpConnection.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/IO/TcpIncomingConnection.cs
+++ b/src/core/Akka/IO/TcpIncomingConnection.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="ActorBase.cs" company="Akka.NET Project">
+// <copyright file="TcpIncomingConnection.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/IO/TcpListener.cs
+++ b/src/core/Akka/IO/TcpListener.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="ActorBase.cs" company="Akka.NET Project">
+// <copyright file="TcpListener.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/IO/TcpManager.cs
+++ b/src/core/Akka/IO/TcpManager.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="ActorBase.cs" company="Akka.NET Project">
+// <copyright file="TcpManager.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/IO/TcpOutgoingConnection.cs
+++ b/src/core/Akka/IO/TcpOutgoingConnection.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="ActorBase.cs" company="Akka.NET Project">
+// <copyright file="TcpOutgoingConnection.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/IO/Udp.cs
+++ b/src/core/Akka/IO/Udp.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="IO.cs" company="Akka.NET Project">
+// <copyright file="Udp.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/IO/UdpConnected.cs
+++ b/src/core/Akka/IO/UdpConnected.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="IO.cs" company="Akka.NET Project">
+// <copyright file="UdpConnected.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/IO/UdpConnectedManager.cs
+++ b/src/core/Akka/IO/UdpConnectedManager.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="IO.cs" company="Akka.NET Project">
+// <copyright file="UdpConnectedManager.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/IO/UdpConnection.cs
+++ b/src/core/Akka/IO/UdpConnection.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="IO.cs" company="Akka.NET Project">
+// <copyright file="UdpConnection.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/IO/UdpListener.cs
+++ b/src/core/Akka/IO/UdpListener.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="IO.cs" company="Akka.NET Project">
+// <copyright file="UdpListener.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/IO/UdpManager.cs
+++ b/src/core/Akka/IO/UdpManager.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="IO.cs" company="Akka.NET Project">
+// <copyright file="UdpManager.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/IO/UdpSender.cs
+++ b/src/core/Akka/IO/UdpSender.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="IO.cs" company="Akka.NET Project">
+// <copyright file="UdpSender.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/IO/WithUdpSend.cs
+++ b/src/core/Akka/IO/WithUdpSend.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="IO.cs" company="Akka.NET Project">
+// <copyright file="WithUdpSend.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/Util/ByteIterator.cs
+++ b/src/core/Akka/Util/ByteIterator.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="ActorBase.cs" company="Akka.NET Project">
+// <copyright file="ByteIterator.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/Util/ByteString.cs
+++ b/src/core/Akka/Util/ByteString.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="ActorBase.cs" company="Akka.NET Project">
+// <copyright file="ByteString.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/examples/TcpEchoService.Server/Actors.cs
+++ b/src/examples/TcpEchoService.Server/Actors.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿//-----------------------------------------------------------------------
+// <copyright file="Actors.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
 using System.Net;
 using System.Text;
 using Akka.Actor;

--- a/src/examples/TcpEchoService.Server/Program.cs
+++ b/src/examples/TcpEchoService.Server/Program.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿//-----------------------------------------------------------------------
+// <copyright file="Program.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
 using System.Net;
 using Akka.Actor;
 

--- a/src/examples/TcpEchoService.Server/Properties/AssemblyInfo.cs
+++ b/src/examples/TcpEchoService.Server/Properties/AssemblyInfo.cs
@@ -1,4 +1,11 @@
-﻿using System.Reflection;
+﻿//-----------------------------------------------------------------------
+// <copyright file="AssemblyInfo.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 


### PR DESCRIPTION
The recently merged Akka.IO had incorrect or missing copyright headers.
This PR fixes that.