### PR TITLE
[docs] Fixed documentation links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Submit only relevant commits. We don't mind many commits in a pull request, but 
 
 - __Use a feature branch__ The pull request should be created from a feature branch, and not from _dev_. See below for why.
 - __No merge-commits__
-If you have commits that looks like this _"Merge branch 'my-branch' into dev"_ or _"Merge branch 'dev' of github .com/akkadotnet/akka.net into dev"_ you're probaly using merge instead of [rebase](https://help.github.com/articles/about-git-rebase) locally. See below on _Handling updates from upstream_. 
+If you have commits that looks like this _"Merge branch 'my-branch' into dev"_ or _"Merge branch 'dev' of github .com/akkadotnet/akka.net into dev"_ you're probaly using merge instead of [rebase](https://help.github.com/articles/about-git-rebase) locally. See below on _Handling updates from upstream_.
 - __Squash commits__ Often we create temporary commits like _"Started implementing feature x"_ and then _"Did a bit more on feature x"_. Squash these commits together using [interactive rebase](https://help.github.com/articles/about-git-rebase). Also see [Squashing commits with rebase](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html).
 - __Descriptive commit messages__ If a commit's message isn't descriptive, change it using [interactive rebase](https://help.github.com/articles/about-git-rebase). Refer to issues using `#issue`. Example of a bad message ~~"Small cleanup"~~. Example of good message: _"Removed Security.Claims header from FSM, which broke Mono build per #62"_. Don't be afraid to write long messages, if needed. Try to explain _why_ you've done the changes. The Erlang repo has some info on [writing good commit messages](https://github.com/erlang/otp/wiki/Writing-good-commit-messages).
 - __No one-commit-to-rule-them-all__ Large commits that changes too many things at the same time are very hard to review. Split large commits into smaller. See this [StackOverflow question](http://stackoverflow.com/questions/6217156/break-a-previous-commit-into-multiple-commits) for information on how to do this.
@@ -31,17 +31,17 @@ Make sure you have a [GitHub](https://github.com/) account.
 - Fork, clone, add upstream to the Akka.NET repository. See [Fork a repo](https://help.github.com/articles/fork-a-repo) for more detailed instructions or follow the instructions below.
 
 - Fork by clicking _Fork_ on https://github.com/akkadotnet/akka.net
-- Clone your fork locally. 
+- Clone your fork locally.
 ```
 git clone https://github.com/YOUR-USERNAME/akka.net
 ```
-- Add an upstream remote. 
+- Add an upstream remote.
 ```
 git remote add upstream https://github.com/akkadotnet/akka.net
 ```
 You now have two remotes: _upstream_ points to https://github.com/akkadotnet/akka.net, and _origin_ points to your fork on GitHub.
 
-- Make changes. See below. 
+- Make changes. See below.
 
 Unsure where to start? Issues marked with [_up for grabs_](https://github.com/akkadotnet/akka.net/labels/up%20for%20grabs) are things we want help with.
 
@@ -52,8 +52,8 @@ New to Git? See https://help.github.com/articles/what-are-other-good-resources-f
 ### Making changes
 __Never__ work directly on _dev_ or _master_ and you should never send a pull request from master - always from a feature branch created by you.
 
-- Pick an [issue](https://github.com/akkadotnet/akka.net/issues). If no issue exists (search first) create one. 
--  Get any changes from _upstream_. 
+- Pick an [issue](https://github.com/akkadotnet/akka.net/issues). If no issue exists (search first) create one.
+-  Get any changes from _upstream_.
 ```
 git checkout dev
 git fetch upstream
@@ -68,7 +68,7 @@ See https://help.github.com/articles/fetching-a-remote for more info
 git checkout -b my-new-branch-123
 ```
 - Work on your feature. Commit.
-- Rebase often, see below. 
+- Rebase often, see below.
 - Make sure you adhere to _Checklist before creating a Pull Request_ described above.
 - Push the branch to your fork on GitHub
 ```
@@ -91,7 +91,7 @@ git stash
 git checkout dev
 git fetch upstream
 git merge --ff-only upstream/dev
-``` 
+```
 - Rebase your feature branch on _dev_. See [Git Branching - Rebasing](http://git-scm.com/book/en/Git-Branching-Rebasing) for more info on rebasing
 ```
 git checkout my-new-branch-123
@@ -110,7 +110,7 @@ git push -f origin my-new-branch-123
 ```
 
 ### All my commits are on dev. How do I get them to a new branch? ###
-If all commits are on _dev_ you need to move them to a new feature branch. 
+If all commits are on _dev_ you need to move them to a new feature branch.
 
 You can rebase your local _dev_ on _upstream/dev_ (to remove any merge commits), rename it, and recreate _dev_
 ```
@@ -130,7 +130,7 @@ git branch dev upstream/dev   #create a new dev
 
 ## Code guidelines
 
-See [Contributor Guidelines](http://akkadotnet.github.io/wiki/Contributor%20guidelines) on the wiki.
+See our [Contributor Guidelines](http://getakka.net/docs/Contributor%20guidelines) for more information on following the project's conventions.
 
 ---
 Props to [NancyFX](https://github.com/NancyFx/Nancy) from which we've "borrowed" some of this text.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ PM> Install-Package Akka.FSharp
 ```
 
 ### Contribute
-If you are interested in helping porting Akka to .NET please take a look at [Contributing to Akka.NET](http://akkadotnet.github.io/wiki/Contributing to Akka.NET).
+If you are interested in helping porting Akka to .NET please take a look at [Contributing to Akka.NET](http://getakka.net/docs/Contributing%20to%20Akka).
 
 Also, please see [Building Akka.NET](http://getakka.net/docs/Building%20and%20Distributing%20Akka).
 

--- a/src/contrib/dependencyInjection/Akka.DI.AutoFac/Readme.md
+++ b/src/contrib/dependencyInjection/Akka.DI.AutoFac/Readme.md
@@ -4,7 +4,7 @@
 
 #What is it?
 
-**Akka.DI.Autofac** is an **ActorSystem extension** for the Akka.NET framework that provides an alternative to the basic capabilities of [Props](http://akkadotnet.github.io/wiki/Props) when you have Actors with multiple dependencies.  
+**Akka.DI.Autofac** is an **ActorSystem extension** for the Akka.NET framework that provides an alternative to the basic capabilities of [Props](http://getakka.net/docs/Props) when you have Actors with multiple dependencies.  
 
 If Autofac is your IoC container of choice and your actors have dependencies that make using the factory method provided by Props prohibitive  and code maintenance is an important concern then this is the extension for you.
 

--- a/src/contrib/dependencyInjection/Akka.DI.CastleWindsor/Readme.md
+++ b/src/contrib/dependencyInjection/Akka.DI.CastleWindsor/Readme.md
@@ -4,7 +4,7 @@
 
 #What is it?
 
-**Akka.DI.CastleWindsor** is an **ActorSystem extension** for the Akka.NET framework that provides an alternative to the basic capabilities of [Props](http://akkadotnet.github.io/wiki/Props) when you have Actors with multiple dependencies.  
+**Akka.DI.CastleWindsor** is an **ActorSystem extension** for the Akka.NET framework that provides an alternative to the basic capabilities of [Props](http://getakka.net/docs/Props) when you have Actors with multiple dependencies.  
 
 If CastleWindsor is your IoC container of choice and your actors have dependencies that make using the factory method provided by Props prohibitive  and code maintenance is an important concern then this is the extension for you.
 

--- a/src/contrib/dependencyInjection/Akka.DI.Core/Readme.md
+++ b/src/contrib/dependencyInjection/Akka.DI.Core/Readme.md
@@ -4,7 +4,7 @@
 
 #What is it?
 
-**Akka.DI.Core** is an **ActorSystem extension** library for the Akka.NET framework that provides a simple way to create an Actor Dependency Resolver that can be used as an alternative to the basic capabilities of [Props](http://akkadotnet.github.io/wiki/Props) when you have actors with multiple dependencies.  
+**Akka.DI.Core** is an **ActorSystem extension** library for the Akka.NET framework that provides a simple way to create an Actor Dependency Resolver that can be used as an alternative to the basic capabilities of [Props](http://getakka.net/docs/Props) when you have actors with multiple dependencies.  
 
 #How do you create an Extension?
 

--- a/src/contrib/dependencyInjection/Akka.DI.Ninject/Readme.md
+++ b/src/contrib/dependencyInjection/Akka.DI.Ninject/Readme.md
@@ -4,7 +4,7 @@
 
 #What is it?
 
-**Akka.DI.Ninject** is an **ActorSystem extension** for the Akka.NET framework that provides an alternative to the basic capabilities of [Props](http://akkadotnet.github.io/wiki/Props) when you have Actors with multiple dependencies.  
+**Akka.DI.Ninject** is an **ActorSystem extension** for the Akka.NET framework that provides an alternative to the basic capabilities of [Props](http://getakka.net/docs/Props) when you have Actors with multiple dependencies.  
 
 If Ninject is your IoC container of choice and your actors have dependencies that make using the factory method provided by Props prohibitive  and code maintenance is an important concern then this is the extension for you.
 

--- a/src/contrib/dependencyInjection/Akka.DI.StructureMap/Readme.md
+++ b/src/contrib/dependencyInjection/Akka.DI.StructureMap/Readme.md
@@ -4,7 +4,7 @@
 
 #What is it?
 
-**Akka.DI.StructureMap** is an **ActorSystem extension** for the Akka.NET framework that provides an alternative to the basic capabilities of [Props](http://akkadotnet.github.io/wiki/Props) when you have Actors with multiple dependencies.  
+**Akka.DI.StructureMap** is an **ActorSystem extension** for the Akka.NET framework that provides an alternative to the basic capabilities of [Props](http://getakka.net/docs/Props) when you have Actors with multiple dependencies.  
 
 If StructureMap is your IoC container of choice and your actors have dependencies that make using the factory method provided by Props prohibitive and code maintenance is an important concern then this is the extension for you.
 
@@ -16,7 +16,7 @@ Start by creating your StructureMap ```Container```, registering your actors and
 
 ```csharp
 // Setup StructureMap
-IContainer container = new Container(cfg => 
+IContainer container = new Container(cfg =>
     {
         cfg.For<IWorkerService>().Use<WorkerService>();
         cfg.For<TypedWorker>().Use<TypedWorker>();
@@ -65,7 +65,7 @@ The resulting code should look similar to the the following:
 
 ```csharp
 // Setup StructureMap
-IContainer container = new Container(cfg => 
+IContainer container = new Container(cfg =>
     {
         cfg.For<IWorkerService>().Use<WorkerService>();
         cfg.For<TypedWorker>().Use<TypedWorker>();

--- a/src/contrib/dependencyInjection/Akka.DI.Unity/Readme.md
+++ b/src/contrib/dependencyInjection/Akka.DI.Unity/Readme.md
@@ -4,7 +4,7 @@
 
 #What is it?
 
-**Akka.DI.Unity** is an **ActorSystem extension** for the Akka.NET framework that provides an alternative to the basic capabilities of [Props](http://akkadotnet.github.io/wiki/Props) when you have Actors with multiple dependencies.  
+**Akka.DI.Unity** is an **ActorSystem extension** for the Akka.NET framework that provides an alternative to the basic capabilities of [Props](http://getakka.net/docs/Props) when you have Actors with multiple dependencies.  
 
 If Unity is your IoC container of choice and your actors have dependencies that make using the factory method provided by Props prohibitive  and code maintenance is an important concern then this is the extension for you.
 

--- a/src/core/Akka.FSharp/README.md
+++ b/src/core/Akka.FSharp/README.md
@@ -17,15 +17,15 @@ F# also gives you it's own actor system Configuration module with support of fol
 
 ### Creating actors with `actor` computation expression
 
-Unlike C# actors, which represent object oriented nature of the language, F# is able to define an actor's logic in more functional way. It is done by using `actor` computation expression. In most of the cases, an expression inside `actor` is expected to be represented as self-invoking recursive function - also invoking an other functions while maintaining recursive cycle is allowed, i.e. to change actor's behavior or even to create more advanced constructs like Finite State Machines. 
+Unlike C# actors, which represent object oriented nature of the language, F# is able to define an actor's logic in more functional way. It is done by using `actor` computation expression. In most of the cases, an expression inside `actor` is expected to be represented as self-invoking recursive function - also invoking an other functions while maintaining recursive cycle is allowed, i.e. to change actor's behavior or even to create more advanced constructs like Finite State Machines.
 
-It's important to remember, that each actor returning point should point to the next recursive function call - any other value returned will result in stopping current actor (see: [Actor Lifecycle](http://akkadotnet.github.io/wiki/Actor%20lifecycle)).
+It's important to remember, that each actor returning point should point to the next recursive function call - any other value returned will result in stopping current actor (see: [Actor Lifecycle](http://getakka.net/docs/Actor%20lifecycle)).
 
 Example:
 
-    let aref = 
-        spawn system "my-actor" 
-            (fun mailbox -> 
+    let aref =
+        spawn system "my-actor"
+            (fun mailbox ->
                 let rec loop() = actor {
                     let! message = mailbox.Receive()
                     // handle an incoming message
@@ -52,8 +52,8 @@ Example:
 
 Paragraph above already has shown, how actors may be created with help of the spawning function. There are several spawning function, which may be used to instantiate actors:
 
--   `spawn (actorFactory : ActorRefFactory) (name : string) (f : Actor<'Message> -> Cont<'Message, 'Returned>) : ActorRef` - spawns an actor using specified actor computation expression. The actor can only be used locally. 
--   `spawnOpt (actorFactory : ActorRefFactory) (name : string) (f : Actor<'Message> -> Cont<'Message, 'Returned>) (options : SpawnOption list) : ActorRef` - spawns an actor using specified actor computation expression, with custom spawn option settings. The actor can only be used locally. 
+-   `spawn (actorFactory : ActorRefFactory) (name : string) (f : Actor<'Message> -> Cont<'Message, 'Returned>) : ActorRef` - spawns an actor using specified actor computation expression. The actor can only be used locally.
+-   `spawnOpt (actorFactory : ActorRefFactory) (name : string) (f : Actor<'Message> -> Cont<'Message, 'Returned>) (options : SpawnOption list) : ActorRef` - spawns an actor using specified actor computation expression, with custom spawn option settings. The actor can only be used locally.
 -   `spawne (actorFactory : ActorRefFactory) (name : string) (expr : Expr<Actor<'Message> -> Cont<'Message, 'Returned>>) (options : SpawnOption list) : ActorRef` - spawns an actor using specified actor computation expression, using an Expression AST. The actor code can be deployed remotely.
 -   `spawnObj (actorFactory : ActorRefFactory) (name : string) (f : Quotations.Expr<(unit -> #ActorBase)>) : ActorRef` - spawns an actor using specified actor quotation. The actor can only be used locally.
 -   `spawnObjOpt (actorFactory : ActorRefFactory) (name : string) (f : Quotations.Expr<(unit -> #ActorBase)>) (options : SpawnOption list) : ActorRef` - spawns an actor using specified actor quotation, with custom spawn option settings. The actor can only be used locally.
@@ -71,28 +71,28 @@ Example:
     let disposableActor (mailbox:Actor<_>) =
         let resource = new DisposableResource()
         mailbox.Defer ((resource :> IDisposable).Dispose)
-        let rec loop () = 
+        let rec loop () =
             actor {
                 let! msg = mailbox.Receive()
-                return! loop ()   
+                return! loop ()
             }
         loop()
 
 ### Actor spawning options
 
-To be able to specifiy more precise actor creation behavior, you may use `spawnOpt` and `spawne` methods, both taking a list of `SpawnOption` values. Each specific option should be present only once in the collection. When a conflict occurs (more than one option of specified type has been found), the latest value found inside the list will be chosen.
+To be able to specify more precise actor creation behavior, you may use `spawnOpt` and `spawne` methods, both taking a list of `SpawnOption` values. Each specific option should be present only once in the collection. When a conflict occurs (more than one option of specified type has been found), the latest value found inside the list will be chosen.
 
 -   `SpawnOption.Deploy(Akka.Actor.Deploy)` - defines deployment strategy for created actors (see: Deploy). This option may be used along with `spawne` function to enable remote actors deployment.
--   `SpawnOption.Router(Akka.Routing.RouterConfig)` - defines an actor to be a router as well as it's routing specifics (see: [Routing](http://akkadotnet.github.io/wiki/Routing)).
--   `SpawnOption.SupervisiorStrategy(Akka.Actor.SupervisiorStrategy)` - defines a supervisor strategy of the current actor. It will affect it's children (see: [Supervision](http://akkadotnet.github.io/wiki/Supervision)).
--   `SpawnOption.Dispatcher(string)` - defines a type of the dispatcher used for resources management for the created actors. (See: [Dispatchers](http://akkadotnet.github.io/wiki/Dispatchers))
--   `SpawnOption.Mailbox(string)` - defines a type of the mailbox used for the created actors. (See: [Mailboxes](http://akkadotnet.github.io/wiki/Mailbox))
+-   `SpawnOption.Router(Akka.Routing.RouterConfig)` - defines an actor to be a router as well as it's routing specifics (see: [Routing](http://getakka.net/docs/working-with-actors/Routers)).
+-   `SpawnOption.SupervisiorStrategy(Akka.Actor.SupervisiorStrategy)` - defines a supervisor strategy of the current actor. It will affect it's children (see: [Supervision](http://getakka.net/docs/concepts/supervision)).
+-   `SpawnOption.Dispatcher(string)` - defines a type of the dispatcher used for resources management for the created actors. (See: [Dispatchers](http://getakka.net/docs/working-with-actors/Dispatchers))
+-   `SpawnOption.Mailbox(string)` - defines a type of the mailbox used for the created actors. (See: [Mailboxes](http://getakka.net/docs/working-with-actors/Mailbox))
 
 Example (deploy actor remotely):
 
     open Akka.Actor
-    let remoteRef = 
-        spawne system "my-actor" <@ actorOf myFunc @> 
+    let remoteRef =
+        spawne system "my-actor" <@ actorOf myFunc @>
             [SpawnOption.Deploy (Deploy(RemoteScope(Address.Parse "akka.tcp://remote-system@127.0.0.1:9000/")))]
 
 ### Ask and tell operators
@@ -106,7 +106,7 @@ Example:
 
 ### Actor selection
 
-Actors may be referenced not only by `ActorRef`s, but also through actor path selection (see: [Addressing](http://akkadotnet.github.io/wiki/Addressing)). With F# API you may select an actor with known path using `select` function:
+Actors may be referenced not only by `ActorRef`s, but also through actor path selection (see: [Addressing](http://getakka.net/docs/concepts/addressing)). With F# API you may select an actor with known path using `select` function:
 
 -   `select (path : string) (selector : ActorRefFactory) : ActorSelection` - where path is a valid URI string used to recognize actor path, and the selector is either actor system or actor itself.
 
@@ -147,7 +147,7 @@ Monitored actors will automatically send a `Terminated` message to their watcher
 
 ### Actor supervisor strategies
 
-Actors have a place in their system's hierarchy trees. To manage failures done by the child actors, their parents/supervisors may decide to use specific supervisor strategies (see: [Supervision](http://akkadotnet.github.io/wiki/Supervision)) in order to react to the specific types of errors. In F# this may be configured using functions of the `Strategy` module:
+Actors have a place in their system's hierarchy trees. To manage failures done by the child actors, their parents/supervisors may decide to use specific supervisor strategies (see: [Supervision](http://getakka.net/docs/concepts/supervision)) in order to react to the specific types of errors. In F# this may be configured using functions of the `Strategy` module:
 
 -   `Strategy.OneForOne (decider : exn -> Directive) : SupervisorStrategy` - returns a supervisor strategy applicable only to child actor which faulted during execution.
 -   `Strategy.OneForOne (decider : exn -> Directive, ?retries : int, ?timeout : TimeSpan) : SupervisorStrategy` - returns a supervisor strategy applicable only to child actor which faulted during execution. [retries] param defines a number of times, an actor could be restarted. If it's a negative value, there is not limit. [timeout] param defines a time window for number of retries to occur.
@@ -158,16 +158,16 @@ Actors have a place in their system's hierarchy trees. To manage failures done b
 
 Example:
 
-    let aref = 
-        spawnOpt system "my-actor" (actorOf myFunc) 
-            [ SpawnOption.SupervisorStrategy (Strategy.OneForOne (fun error -> 
+    let aref =
+        spawnOpt system "my-actor" (actorOf myFunc)
+            [ SpawnOption.SupervisorStrategy (Strategy.OneForOne (fun error ->
                 match error with
                 | :? ArithmeticException -> Directive.Escalate
                 | _ -> SupervisorStrategy.DefaultDecider error )) ]
-    
-    let remoteRef = 
+
+    let remoteRef =
         spawne system "remote-actor" <@ actorOf myFunc @>
-            [ SpawnOption.SupervisorStrategy (Strategy.OneForOne <@ fun error -> 
+            [ SpawnOption.SupervisorStrategy (Strategy.OneForOne <@ fun error ->
                 match error with
                 | :? ArithmeticException -> Directive.Escalate
                 | _ -> SupervisorStrategy.DefaultDecider error ) @>
@@ -181,25 +181,25 @@ While you may use built-in set of the event stream methods (see: Event Streams),
 -   `unsubscribe (channel: System.Type) (ref: ActorRef) (eventStream: Akka.Event.EventStream) : bool` - unsubscribes an actor reference from target channel of the provided event stream.
 -   `publish (event: 'Event) (eventStream: Akka.Event.EventStream) : unit` - publishes an event on the provided event stream. Event channel is resolved from event's type.
 
-Example: 
+Example:
 
-    type Message = 
-        | Subscribe 
+    type Message =
+        | Subscribe
         | Unsubscribe
         | Msg of ActorRef * string
 
-    let subscriber = 
-        spawn system "subscriber" 
-            (actorOf2 (fun mailbox msg -> 
+    let subscriber =
+        spawn system "subscriber"
+            (actorOf2 (fun mailbox msg ->
                 let eventStream = mailbox.Context.System.EventStream
                 match msg with
                 | Msg (sender, content) -> printfn "%A says %s" (sender.Path) content
                 | Subscribe -> subscribe typeof<Message> mailbox.Self eventStream |> ignore
                 | Unsubscribe -> unsubscribe typeof<Message> mailbox.Self eventStream |> ignore ))
-            
-    let publisher = 
-        spawn system "publisher" 
-            (actorOf2 (fun mailbox msg -> 
+
+    let publisher =
+        spawn system "publisher"
+            (actorOf2 (fun mailbox msg ->
                 publish msg mailbox.Context.System.EventStream))
 
     subscriber <! Subscribe
@@ -241,11 +241,11 @@ To operate directly between `Async` results and actors, use `pipeTo` function (a
 Example:
 
     open System.IO
-    let handler (mailbox: Actor<obj>) msg = 
+    let handler (mailbox: Actor<obj>) msg =
         match box msg with
-        | :? FileInfo as fi -> 
+        | :? FileInfo as fi ->
             let reader = new StreamReader(fi.OpenRead())
-            reader.AsyncReadToEnd() |!> mailbox.Self 
+            reader.AsyncReadToEnd() |!> mailbox.Self
         | :? string as content ->
             printfn "File content: %s" content
         | _ -> mailbox.Unhandled()


### PR DESCRIPTION
There were some old links to the getakka wiki which doesn't exist
anymore. This PR fixed those links.

Also fixed a typo (specifiy -> specify).

Note: It looks like Atom.io got a little carried away with some of the
EOL formatting. :(

Note2: I didn't change the links in older entries of
RELEASE_NOTES.md since that's basically a historical record
of the software.