### PR TITLE
Adds support for a default Ask timeout in HOCON conf.

### DIFF
--- a/src/core/Akka.Tests/Actor/AskTimeoutSpec.cs
+++ b/src/core/Akka.Tests/Actor/AskTimeoutSpec.cs
@@ -1,0 +1,54 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AskSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Akka.Actor;
+using Akka.TestKit;
+
+using Xunit;
+
+namespace Akka.Tests.Actor
+{
+    public class AskTimeoutSpec : AkkaSpec
+    {
+
+        public class SleepyActor : UntypedActor
+        {
+
+            protected override void OnReceive(object message)
+            {
+                Thread.Sleep(5000);
+                Sender.Tell(message);
+            }
+
+        }
+
+        public AskTimeoutSpec()
+            : base(@"akka.actor.ask-timeout = 100ms")
+        {}
+
+        [Fact]
+        public async Task Ask_should_honor_config_specified_timeout()
+        {
+            var actor = Sys.ActorOf<SleepyActor>();
+            try
+            {
+                await actor.Ask<string>("should time out");
+                Assert.True(false, "the ask should have timed out");
+            }
+            catch (Exception e)
+            {
+                Assert.True(e is TaskCanceledException);
+            }
+        }
+
+    }
+}

--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Actor\ActorProducerPipelineTests.cs" />
     <Compile Include="Actor\ActorRefSpec.cs" />
     <Compile Include="Actor\AddressSpec.cs" />
+    <Compile Include="Actor\AskTimeoutSpec.cs" />
     <Compile Include="Actor\Cancellation\AlreadyCancelledCancelableTests.cs" />
     <Compile Include="Actor\Cancellation\CancelableTests.cs" />
     <Compile Include="Actor\InboxSpec.cs" />

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -65,7 +65,10 @@ namespace Akka.Actor
             TimeSpan? timeout)
         {
             var result = new TaskCompletionSource<object>(TaskContinuationOptions.AttachedToParent);
-            if (timeout.HasValue)
+
+            timeout = timeout ?? provider.Settings.AskTimeout;
+
+            if (timeout != Timeout.InfiniteTimeSpan && timeout.Value > default(TimeSpan))
             {
                 var cancellationSource = new CancellationTokenSource();
                 cancellationSource.Token.Register(() => result.TrySetCanceled());

--- a/src/core/Akka/Actor/Settings.cs
+++ b/src/core/Akka/Actor/Settings.cs
@@ -68,6 +68,7 @@ namespace Akka.Actor
             
             SupervisorStrategyClass = Config.GetString("akka.actor.guardian-supervisor-strategy");
 
+            AskTimeout = Config.GetTimeSpan("akka.actor.ask-timeout", allowInfinite: true);
             CreationTimeout = Config.GetTimeSpan("akka.actor.creation-timeout");
             UnstartedPushTimeout = Config.GetTimeSpan("akka.actor.unstarted-push-timeout");
 
@@ -158,6 +159,12 @@ namespace Akka.Actor
         /// </summary>
         /// <value><c>true</c> if [serialize all creators]; otherwise, <c>false</c>.</value>
         public bool SerializeAllCreators { get; private set; }
+
+        /// <summary>
+        ///     Gets the default timeout for <see cref="Futures.Ask" /> calls.
+        /// </summary>
+        /// <value>The ask timeout.</value>
+        public TimeSpan AskTimeout { get; private set; }
 
         /// <summary>
         ///     Gets the creation timeout.

--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -92,6 +92,9 @@ akka {
     # of being started. This is only relevant if using a bounded mailbox or the
     # CallingThreadDispatcher for a top-level actor.
     unstarted-push-timeout = 10
+
+    # Default timeout for IActorRef.Ask.
+    ask-timeout = infinite
  
 
     # THIS DOES NOT APPLY TO .NET


### PR DESCRIPTION
This is an attempt to resolve #1163. Instead of defaulting to `null`, I wasn't sure on how that should be represented, it defaults to `infinite`. This should provided the same effective result.