### PR TITLE
Removed debug code from earlier F# DU serialization fix

### DIFF
--- a/src/core/Akka/Serialization/NewtonSoftJsonSerializer.cs
+++ b/src/core/Akka/Serialization/NewtonSoftJsonSerializer.cs
@@ -110,7 +110,6 @@ namespace Akka.Serialization
         public override object FromBinary(byte[] bytes, Type type)
         {
             string data = Encoding.Default.GetString(bytes);
-            JsonConvert.DefaultSettings =  () => _settings;
             object res = JsonConvert.DeserializeObject(data, _settings);
             return TranslateSurrogate(res, this, type);
         }


### PR DESCRIPTION
This removes a line of code used for debugging when we fixed the F# DU serialization problems earlier.
It sets the Json default settings, thus mutating shared state, resulting in racy code if anything else uses JsonConvert in our code, in our tests or **in external code**.
