### PR TITLE
Hocon include support

### DIFF
--- a/src/core/Akka.Persistence.TestKit.Tests/Akka.Persistence.TestKit.Tests.csproj
+++ b/src/core/Akka.Persistence.TestKit.Tests/Akka.Persistence.TestKit.Tests.csproj
@@ -77,6 +77,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/core/Akka.Tests/Configuration/HoconTests.cs
+++ b/src/core/Akka.Tests/Configuration/HoconTests.cs
@@ -5,8 +5,10 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Linq;
 using Akka.Configuration;
+using Akka.Configuration.Hocon;
 using Akka.TestKit;
 using Xunit;
 
@@ -554,7 +556,7 @@ a {
             var config2 = config.GetConfig("a");
             var enumerable = config2.AsEnumerable();
 
-            enumerable.Select(kvp => kvp.Key).First().ShouldBe("some quoted, key");            
+            enumerable.Select(kvp => kvp.Key).First().ShouldBe("some quoted, key");
         }
 
         [Fact]
@@ -583,7 +585,10 @@ akka.actor {
             var serializersConfig = config.GetConfig("akka.actor.serializers").AsEnumerable().ToList();
             var serializerBindingConfig = config.GetConfig("akka.actor.serialization-bindings").AsEnumerable().ToList();
 
-            serializersConfig.Select(kvp => kvp.Value).First().GetString().ShouldBe("Akka.Remote.Serialization.MessageContainerSerializer, Akka.Remote");
+            serializersConfig.Select(kvp => kvp.Value)
+                .First()
+                .GetString()
+                .ShouldBe("Akka.Remote.Serialization.MessageContainerSerializer, Akka.Remote");
             serializerBindingConfig.Select(kvp => kvp.Key).Last().ShouldBe("Akka.Remote.DaemonMsgCreate, Akka.Remote");
         }
 
@@ -598,6 +603,101 @@ test.value = 456
 ";
             var config = ConfigurationFactory.ParseString(hocon);
             config.GetInt("test.value").ShouldBe(456);
+        }
+
+        [Fact]
+        public void CanCSubstituteObject()
+        {
+            var hocon = @"a {
+  b {
+      foo = hello
+      bar = 123
+  }
+  c {
+     d = xyz
+     e = ${a.b}
+  }  
+}";
+            var ace = ConfigurationFactory.ParseString(hocon).GetConfig("a.c.e");
+            Assert.Equal("hello", ace.GetString("foo"));
+            Assert.Equal(123, ace.GetInt("bar"));
+        }
+
+        [Fact]
+        public void CanAssignNullStringToField()
+        {
+            var hocon = @"a=null";
+            Assert.Equal(null, ConfigurationFactory.ParseString(hocon).GetString("a"));
+        }
+
+        [Fact(Skip = "we currently do not make any destinction between quoted and unquoted strings once parsed")]
+        public void CanAssignQuotedNullStringToField()
+        {
+            var hocon = @"a=""null""";
+            Assert.Equal("null", ConfigurationFactory.ParseString(hocon).GetString("a"));
+        }
+
+        [Fact]
+        public void CanParseInclude()
+        {
+            var hocon = @"a {
+  b { 
+       include ""foo""
+  }";
+            var includeHocon = @"
+x = 123
+y = hello
+";
+            Func<string, HoconRoot> include = s => Parser.Parse(includeHocon, null);
+            var config = ConfigurationFactory.ParseString(hocon,include);
+
+            Assert.Equal(123,config.GetInt("a.b.x"));
+            Assert.Equal("hello", config.GetString("a.b.y"));
+        }
+
+        [Fact]
+        public void CanResolveSubstitutesInInclude()
+        {
+            var hocon = @"a {
+  b { 
+       include ""foo""
+  }";
+            var includeHocon = @"
+x = 123
+y = ${x}
+";
+            Func<string, HoconRoot> include = s => Parser.Parse(includeHocon, null);
+            var config = ConfigurationFactory.ParseString(hocon, include);
+
+            Assert.Equal(123, config.GetInt("a.b.x"));
+            Assert.Equal(123, config.GetInt("a.b.y"));
+        }
+
+        [Fact]
+        public void CanResolveSubstitutesInNestedIncludes()
+        {
+            var hocon = @"a.b.c {
+  d { 
+       include ""foo""
+  }";
+            var includeHocon = @"
+f = 123
+e {
+      include ""foo""
+}
+";
+
+            var includeHocon2 = @"
+x = 123
+y = ${x}
+";
+
+            Func<string, HoconRoot> include2 = s => Parser.Parse(includeHocon2, null);
+            Func<string, HoconRoot> include = s => Parser.Parse(includeHocon, include2);
+            var config = ConfigurationFactory.ParseString(hocon, include);
+
+            Assert.Equal(123, config.GetInt("a.b.c.d.e.x"));
+            Assert.Equal(123, config.GetInt("a.b.c.d.e.y"));
         }
     }
 }

--- a/src/core/Akka/Configuration/ConfigurationFactory.cs
+++ b/src/core/Akka/Configuration/ConfigurationFactory.cs
@@ -11,6 +11,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using Akka.Configuration.Hocon;
+using Newtonsoft.Json;
 
 namespace Akka.Configuration
 {
@@ -34,11 +35,24 @@ namespace Akka.Configuration
         /// HOCON (Human-Optimized Config Object Notation) string.
         /// </summary>
         /// <param name="hocon">A string that contains configuration options to use.</param>
+        /// <param name="includeCallback">callback used to resolve includes</param>
+        /// <returns>The configuration defined in the supplied HOCON string.</returns>
+        public static Config ParseString(string hocon, Func<string,HoconRoot> includeCallback)
+        {
+            HoconRoot res = Parser.Parse(hocon, includeCallback);
+            return new Config(res);
+        }
+
+        /// <summary>
+        /// Generates a configuration defined in the supplied
+        /// HOCON (Human-Optimized Config Object Notation) string.
+        /// </summary>
+        /// <param name="hocon">A string that contains configuration options to use.</param>
         /// <returns>The configuration defined in the supplied HOCON string.</returns>
         public static Config ParseString(string hocon)
         {
-            HoconRoot res = Parser.Parse(hocon);
-            return new Config(res);
+            //TODO: add default include resolver
+            return ParseString(hocon, null);
         }
 
         /// <summary>
@@ -125,6 +139,18 @@ namespace Akka.Configuration
                     return ParseString(result);
                 }
             }
+        }
+
+        /// <summary>
+        /// Creates a configuration based on the supplied source object
+        /// </summary>
+        /// <param name="source">The source object</param>
+        /// <returns>The configuration created from the source object</returns>
+        public static Config FromObject(object source)
+        {
+            var json = JsonConvert.SerializeObject(source);
+            var config = ParseString(json);
+            return config;
         }
     }
 }

--- a/src/core/Akka/Configuration/Hocon/HoconObject.cs
+++ b/src/core/Akka/Configuration/Hocon/HoconObject.cs
@@ -177,6 +177,33 @@ namespace Akka.Configuration.Hocon
             }
             return text;
         }
+
+        public void Merge(HoconObject other)
+        {
+            var thisItems = Items;
+            var otherItems = other.Items;
+
+            foreach (var otherItem in otherItems)
+            {
+                if (thisItems.ContainsKey(otherItem.Key))
+                {
+                    //other key was present in this object.
+                    //if we have a value, just ignore the other value, unless it is an object
+                    var thisItem = thisItems[otherItem.Key];
+
+                    //if both values are objects, merge them
+                    if (thisItem.IsObject() && otherItem.Value.IsObject())
+                    {
+                        thisItem.GetObject().Merge(otherItem.Value.GetObject());
+                    }
+                }
+                else
+                {
+                    //other key was not present in this object, just copy it over
+                    Items.Add(otherItem.Key,otherItem.Value);
+                }
+            }            
+        }
     }
 }
 

--- a/src/core/Akka/Configuration/Hocon/HoconSubstitution.cs
+++ b/src/core/Akka/Configuration/Hocon/HoconSubstitution.cs
@@ -44,7 +44,7 @@ namespace Akka.Configuration.Hocon
         /// <summary>
         ///     The full path to the value which should substitute this instance.
         /// </summary>
-        public string Path { get; private set; }
+        public string Path { get; set; }
 
         /// <summary>
         ///     The evaluated value from the Path property
@@ -104,20 +104,6 @@ namespace Akka.Configuration.Hocon
         {
             return ResolvedValue.GetObject();
         }
-
-        #region Implicit operators
-
-        /// <summary>
-        /// Performs an implicit conversion from <see cref="HoconSubstitution" /> to <see cref="HoconObject" />.
-        /// </summary>
-        /// <param name="substitution">The HOCON object that contains the substitution.</param>
-        /// <returns>The HOCON object contained in the substitution.</returns>
-        public static implicit operator HoconObject(HoconSubstitution substitution)
-        {
-            return substitution.GetObject();
-        }
-
-        #endregion
     }
 }
 

--- a/src/core/Akka/Configuration/Hocon/HoconToken.cs
+++ b/src/core/Akka/Configuration/Hocon/HoconToken.cs
@@ -71,7 +71,8 @@ namespace Akka.Configuration.Hocon
         /// <summary>
         /// This token type represents a replacement variable, <c>$foo</c> .
         /// </summary>
-        Substitute
+        Substitute,
+        Include
     }
 
     /// <summary>
@@ -157,6 +158,15 @@ namespace Akka.Configuration.Hocon
             {
                 Type = TokenType.LiteralValue,
                 Value = value,
+            };
+        }
+
+        internal static Token Include(string path)
+        {
+            return new Token
+            {
+                Value = path,
+                Type = TokenType.Include
             };
         }
     }


### PR DESCRIPTION
Related to #1164 

* Added Hocon Include support
* Added Hocon include resolver support
* Added Hocon Include substitution support
* Added more Hocon tests
* Added HoconObject.Merge support
* Added Config from Object support (.NET object to Hocon Config)

This allows us to use Hocon includes:

```javascript
a {
   include "some resource"
}
```

The 'some resource' can then be resolved by an optional resolver callback. so the resource could be a file on disk, an url, or whatever you want that could result in a new hocon sub config.

**see inline comments for explanations of the code to help the review**