### PR TITLE
TaskContinuationOptions bitwise fix

### DIFF
--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/MessageSink.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/MessageSink.cs
@@ -64,7 +64,7 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
             //Signal that the test run has ended
             return await MessageSinkActorRef.Ask<MessageSinkActor.SinkCanBeTerminated>(new EndTestRun())
                 .ContinueWith(tr => MessageSinkActorRef.GracefulStop(TimeSpan.FromSeconds(2)), 
-                TaskContinuationOptions.AttachedToParent & TaskContinuationOptions.ExecuteSynchronously).Unwrap();
+                TaskContinuationOptions.ExecuteSynchronously).Unwrap();
         }
 
         #endregion

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/SinkCoordinator.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/SinkCoordinator.cs
@@ -147,7 +147,7 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
                     sink.RequestExitCode(Self);
                     sink.Close(Context.System)
                         .ContinueWith(r => new SinkClosed(),
-                        TaskContinuationOptions.ExecuteSynchronously & TaskContinuationOptions.AttachedToParent)
+                        TaskContinuationOptions.ExecuteSynchronously)
                         .PipeTo(Self);
                 }
             });

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/TestCoordinatorEnabledMessageSink.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/TestCoordinatorEnabledMessageSink.cs
@@ -34,7 +34,7 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
                             return new SinkCoordinator.RecommendedExitCode(task.Result.Passed.GetValueOrDefault(false)
                                 ? 0
                                 : 1);
-                        }, TaskContinuationOptions.ExecuteSynchronously & TaskContinuationOptions.AttachedToParent)
+                        }, TaskContinuationOptions.ExecuteSynchronously)
                             .PipeTo(Sender, Self);
                 }
             });
@@ -133,7 +133,7 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
                     {
                         var testRunTree = tr.Result;
                         return new BeginSinkTerminate(testRunTree, sender);
-                    }, TaskContinuationOptions.AttachedToParent & TaskContinuationOptions.ExecuteSynchronously)
+                    }, TaskContinuationOptions.ExecuteSynchronously)
                     .PipeTo(Self);
             }
         }

--- a/src/core/Akka.Remote/Transport/FailureInjectorTransportAdapter.cs
+++ b/src/core/Akka.Remote/Transport/FailureInjectorTransportAdapter.cs
@@ -170,9 +170,7 @@ namespace Akka.Remote.Transport
                 // Listen is called only during the initialization of the stack, and upstreamListener is not read before this
                 // finishes.
                 _upstreamListener = tr.Result;
-            }, TaskContinuationOptions.AttachedToParent & 
-            TaskContinuationOptions.ExecuteSynchronously & 
-            TaskContinuationOptions.OnlyOnRanToCompletion);
+            }, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnRanToCompletion);
             return Task.FromResult((IAssociationEventListener)this);
         }
 
@@ -193,7 +191,7 @@ namespace Akka.Remote.Transport
                    addressChaosTable.AddOrUpdate(NakedAddress(handle.RemoteAddress), address => PassThru.Instance,
                        (address, mode) => PassThru.Instance);
                    statusPromise.SetResult(new FailureInjectorHandle(handle, this));
-               }, TaskContinuationOptions.AttachedToParent & TaskContinuationOptions.ExecuteSynchronously);
+               }, TaskContinuationOptions.ExecuteSynchronously);
             }
         }
 
@@ -297,9 +295,7 @@ namespace Akka.Remote.Transport
             {
                 _upstreamListener = tr.Result;
                 WrappedHandle.ReadHandlerSource.SetResult(this);
-            }, TaskContinuationOptions.AttachedToParent 
-            & TaskContinuationOptions.ExecuteSynchronously 
-            & TaskContinuationOptions.OnlyOnRanToCompletion);
+            }, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnRanToCompletion);
         }
 
         public override bool Write(ByteString payload)

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -206,7 +206,7 @@ namespace Akka.Actor
                 {
                     c.Cancel(false);
                 }
-            }, TaskContinuationOptions.AttachedToParent & TaskContinuationOptions.ExecuteSynchronously);
+            }, TaskContinuationOptions.ExecuteSynchronously);
 
             return a;
         }


### PR DESCRIPTION
This PR cleans up some of the broken bitwise operations used in the `ContinueWith`.
The cases that have been fixed is ones that use  `&` instead of `|` to combine `TaskContinuationOptions`, which always result in `TaskContinuationOptions.None`

