### PR TITLE
147 circuit breaker

### DIFF
--- a/src/Akka.sln
+++ b/src/Akka.sln
@@ -2,6 +2,8 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.22823.1
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{69279534-1DBA-4115-BF8B-03F77FC8125E}"
 EndProject
@@ -211,6 +213,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.MultiNodeTests", "core\Akka.MultiNodeTests\Akka.MultiNodeTests.csproj", "{F0781BEA-5BA0-4AF0-BB15-E3F209B681F5}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PersistenceBenchmark", "benchmark\PersistenceBenchmark\PersistenceBenchmark.csproj", "{39E6F51F-FA1E-4C62-B8F8-19065DE6D55D}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A59BAE84-70E2-46A0-9E26-7413C103E2D7}"
+	ProjectSection(SolutionItems) = preProject
+		WebEssentials-Settings.json = WebEssentials-Settings.json
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/core/Akka.TestKit/Akka.TestKit.csproj
+++ b/src/core/Akka.TestKit/Akka.TestKit.csproj
@@ -111,6 +111,7 @@
     <Compile Include="TestActors\BlackHoleActor.cs" />
     <Compile Include="TestActors\EchoActor.cs" />
     <Compile Include="TestBarrier.cs" />
+    <Compile Include="TestBreaker.cs" />
     <Compile Include="TestFSMRef.cs" />
     <Compile Include="ITestKitAssertions.cs" />
     <Compile Include="MessageEnvelope.cs" />

--- a/src/core/Akka.TestKit/TestBreaker.cs
+++ b/src/core/Akka.TestKit/TestBreaker.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Pattern;
+
+namespace Akka.TestKit
+{
+    public class TestBreaker
+    {
+        public CountdownEvent HalfOpenLatch { get; private set; }
+        public CountdownEvent OpenLatch { get; private set; }
+        public CountdownEvent ClosedLatch { get; private set; }
+        public CircuitBreaker Instance { get; private set; }
+
+        public TestBreaker( CircuitBreaker instance )
+        {
+            HalfOpenLatch = new CountdownEvent( 1 );
+            OpenLatch = new CountdownEvent( 1 );
+            ClosedLatch = new CountdownEvent( 1 );
+            Instance = instance;
+            Instance.OnClose( ( ) => { if ( !ClosedLatch.IsSet ) ClosedLatch.Signal( ); } )
+                    .OnHalfOpen( ( ) => { if ( !HalfOpenLatch.IsSet ) HalfOpenLatch.Signal( ); } )
+                    .OnOpen( ( ) => { if ( !OpenLatch.IsSet ) OpenLatch.Signal( ); } );
+        }
+
+
+    }
+}

--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -150,6 +150,7 @@
     <Compile Include="MatchHandler\MatchHandlerBuilderTests.cs" />
     <Compile Include="MatchHandler\PartialActionBuilderTests.cs" />
     <Compile Include="Pattern\BackoffSupervisorSpec.cs" />
+    <Compile Include="Pattern\CircuitBreakerSpec.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Routing\BroadcastSpec.cs" />
     <Compile Include="Routing\ConsistentHashingRouterSpec.cs" />

--- a/src/core/Akka.Tests/Pattern/CircuitBreakerSpec.cs
+++ b/src/core/Akka.Tests/Pattern/CircuitBreakerSpec.cs
@@ -1,0 +1,351 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="CircuitBreakerSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Pattern;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Tests.Pattern
+{
+    public class ASynchronousCircuitBreakerThatIsClosed : CircuitBreakerSpecBase
+    {
+        [Fact(DisplayName = "A synchronous circuit breaker that is closed should allow call through")]
+        public void Should_Allow_Call_Through( )
+        {
+            var breaker = LongCallTimeoutCb( );
+            var result = breaker.Instance.WithSyncCircuitBreaker( ( ) => "Test" );
+
+            Assert.Equal( "Test", result );
+        }
+
+        [Fact( DisplayName = "A synchronous circuit breaker that is closed should increment failure count when call fails" )]
+        public void Should_Increment_FailureCount_When_Call_Fails( )
+        {
+            var breaker = LongCallTimeoutCb( );
+
+            Assert.Equal( breaker.Instance.CurrentFailureCount, 0 );
+            Assert.True( InterceptExceptionType<TestException>( ( ) => breaker.Instance.WithSyncCircuitBreaker( ThrowException ) ) );
+            Assert.True( CheckLatch( breaker.OpenLatch ) );
+            Assert.Equal( 1, breaker.Instance.CurrentFailureCount );
+        }
+
+        [Fact( DisplayName = "A synchronous circuit breaker that is closed should reset failure count when call succeeds" )]
+        public void Should_Reset_FailureCount_When_Call_Succeeds( )
+        {
+            var breaker = MultiFailureCb( );
+
+            Assert.Equal( breaker.Instance.CurrentFailureCount, 0 );
+            Assert.True( InterceptExceptionType<TestException>( ( ) => breaker.Instance.WithSyncCircuitBreaker( ThrowException ) ) );
+            Assert.Equal( breaker.Instance.CurrentFailureCount, 1 );
+
+            breaker.Instance.WithSyncCircuitBreaker( ( ) => "Test" );
+
+            Assert.Equal( 0, breaker.Instance.CurrentFailureCount );
+        }
+
+        [Fact(DisplayName = "A synchronous circuit breaker that is closed should increment failure count when call times out")]
+        public void Should_Increment_FailureCount_When_Call_Times_Out( )
+        {
+            var breaker = ShortCallTimeoutCb( );
+
+            breaker.Instance.WithSyncCircuitBreaker( ( ) => Thread.Sleep( 500 ) );
+
+            Assert.True( CheckLatch( breaker.OpenLatch ) );
+            Assert.Equal( 1, breaker.Instance.CurrentFailureCount );
+        }
+    }
+
+    public class ASynchronousCircuitBreakerThatIsHalfOpen : CircuitBreakerSpecBase
+    {
+        [Fact(DisplayName = "A synchronous circuit breaker that is half open should pass call and transition to close on success")]
+        public void Should_Pass_Call_And_Transition_To_Close_On_Success( )
+        {
+            var breaker = ShortResetTimeoutCb( );
+            InterceptExceptionType<TestException>( ( ) => breaker.Instance.WithSyncCircuitBreaker( ThrowException ) );
+            Assert.True( CheckLatch( breaker.HalfOpenLatch ) );
+
+            var result = breaker.Instance.WithSyncCircuitBreaker( ( ) => SayTest( ) );
+
+            Assert.True( CheckLatch( breaker.ClosedLatch ) );
+            Assert.Equal( SayTest( ), result );
+        }
+
+        [Fact(DisplayName = "A synchronous circuit breaker that is half open should pass call and transition to open on exception")]
+        public void Should_Pass_Call_And_Transition_To_Open_On_Exception( )
+        {
+            var breaker = ShortResetTimeoutCb( );
+
+
+            Assert.True( InterceptExceptionType<TestException>( ( ) => breaker.Instance.WithSyncCircuitBreaker( ThrowException ) ) );
+            Assert.True( CheckLatch( breaker.HalfOpenLatch ) );
+
+            Assert.True( InterceptExceptionType<TestException>( ( ) => breaker.Instance.WithSyncCircuitBreaker( ThrowException ) ) );
+            Assert.True( CheckLatch( breaker.OpenLatch ) );
+        }
+    }
+
+    public class ASynchronousCircuitBreakerThatIsOpen : CircuitBreakerSpecBase
+    {
+        [Fact(DisplayName = "A synchronous circuit breaker that is open should throw exceptions before reset timeout")]
+        public void Should_Throw_Exceptions_Before_Reset_Timeout( )
+        {
+            var breaker = LongResetTimeoutCb( );
+
+            Assert.True( InterceptExceptionType<TestException>( ( ) => breaker.Instance.WithSyncCircuitBreaker( ThrowException ) ) );
+            Assert.True( CheckLatch( breaker.OpenLatch ) );
+            Assert.True( InterceptExceptionType<OpenCircuitException>( ( ) => breaker.Instance.WithSyncCircuitBreaker( ThrowException ) ) );
+        }
+
+        [Fact(DisplayName = "A synchronous circuit breaker that is open should transition to half open when reset times out")]
+        public void Should_Transition_To_Half_Open_When_Reset_Times_Out( )
+        {
+            var breaker = ShortResetTimeoutCb( );
+
+            Assert.True( InterceptExceptionType<TestException>( ( ) => breaker.Instance.WithSyncCircuitBreaker( ThrowException ) ) );
+            Assert.True( CheckLatch( breaker.HalfOpenLatch ) );
+        }
+    }
+
+    public class AnAsynchronousCircuitBreakerThatIsClosed : CircuitBreakerSpecBase
+    {
+        [Fact(DisplayName = "An asynchronous circuit breaker that is closed should allow call through")]
+        public void Should_Allow_Call_Through( )
+        {
+            var breaker = LongCallTimeoutCb( );
+            var result = breaker.Instance.WithCircuitBreaker( Task.Run( ( ) => SayTest( ) ) );
+
+            Assert.Equal( SayTest( ), result.Result );
+        }
+
+        [Fact(DisplayName = "An asynchronous circuit breaker that is closed should increment failure count when call fails")]
+        public void Should_Increment_Failure_Count_When_Call_Fails( )
+        {
+            var breaker = LongCallTimeoutCb( );
+
+            Assert.Equal( breaker.Instance.CurrentFailureCount, 0 );
+            Assert.True( InterceptExceptionType<TestException>( ( ) => breaker.Instance.WithCircuitBreaker( Task.Run( ( ) => ThrowException( ) ) ).Wait( AwaitTimeout ) ) );
+            Assert.True( CheckLatch( breaker.OpenLatch ) );
+            Assert.Equal( 1, breaker.Instance.CurrentFailureCount );
+        }
+
+        [Fact(DisplayName = "An asynchronous circuit breaker that is closed should reset failure count when call succeeds after failure")]
+        public void Should_Reset_Failure_Count_When_Call_Succeeds_After_Failure( )
+        {
+            var breaker = MultiFailureCb( );
+
+            Assert.Equal( breaker.Instance.CurrentFailureCount, 0 );
+
+            var whenall = Task.WhenAll(
+                breaker.Instance.WithCircuitBreaker(Task.Factory.StartNew(ThrowException))
+                , breaker.Instance.WithCircuitBreaker(Task.Factory.StartNew(ThrowException))
+                , breaker.Instance.WithCircuitBreaker(Task.Factory.StartNew(ThrowException))
+                , breaker.Instance.WithCircuitBreaker(Task.Factory.StartNew(ThrowException)));
+
+            Assert.True( InterceptExceptionType<TestException>( ( ) => whenall.Wait( AwaitTimeout ) ) );
+
+            Assert.Equal( breaker.Instance.CurrentFailureCount, 4 );
+
+            var result = breaker.Instance.WithCircuitBreaker( Task.Run( ( ) => SayTest( ) ) ).Result;
+
+            Assert.Equal( SayTest( ), result );
+            Assert.Equal( 0, breaker.Instance.CurrentFailureCount );
+        }
+
+        [Fact(DisplayName = "An asynchronous circuit breaker that is closed should increment failure count when call times out")]
+        public void Should_Increment_Failure_Count_When_Call_Times_Out( )
+        {
+            var breaker = ShortCallTimeoutCb( );
+
+            breaker.Instance.WithCircuitBreaker( Task.Factory.StartNew( ( ) =>
+            {
+                Thread.Sleep( 500 );
+                return SayTest( );
+            } ) );
+
+            Assert.True( CheckLatch( breaker.OpenLatch ) );
+            Assert.Equal( 1, breaker.Instance.CurrentFailureCount );
+        }
+    }
+
+    public class AnAsynchronousCircuitBreakerThatIsHalfOpen : CircuitBreakerSpecBase
+    {
+        [Fact(DisplayName = "An asynchronous circuit breaker that is half open should pass call and transition to close on success")]
+        public void Should_Pass_Call_And_Transition_To_Close_On_Success( )
+        {
+            var breaker = ShortResetTimeoutCb( );
+            InterceptExceptionType<TestException>( ( ) => breaker.Instance.WithCircuitBreaker( Task.Factory.StartNew( ThrowException ) ) );
+            Assert.True( CheckLatch( breaker.HalfOpenLatch ) );
+
+            var result = breaker.Instance.WithCircuitBreaker( Task.Factory.StartNew( ( ) => SayTest( ) ) );
+
+            Assert.True( CheckLatch( breaker.ClosedLatch ) );
+            Assert.Equal( SayTest( ), result.Result );
+        }
+
+        [Fact(DisplayName = "An asynchronous circuit breaker that is half open should pass call and transition to open on exception")]
+        public void Should_Pass_Call_And_Transition_To_Open_On_Exception( )
+        {
+            var breaker = ShortResetTimeoutCb( );
+
+
+            Assert.True( InterceptExceptionType<TestException>( ( ) => breaker.Instance.WithCircuitBreaker( Task.Factory.StartNew( ThrowException ) ).Wait( ) ) );
+            Assert.True( CheckLatch( breaker.HalfOpenLatch ) );
+
+            Assert.True( InterceptExceptionType<TestException>( ( ) => breaker.Instance.WithCircuitBreaker( Task.Factory.StartNew( ThrowException ) ).Wait( ) ) );
+            Assert.True( CheckLatch( breaker.OpenLatch ) );
+        }
+
+        [Fact(DisplayName = "An asynchronous circuit breaker that is half open should pass call and transition to open on async failure")]
+        public void Should_Pass_Call_And_Transition_To_Open_On_Async_Failure( )
+        {
+            var breaker = ShortResetTimeoutCb( );
+
+            breaker.Instance.WithCircuitBreaker( Task.Factory.StartNew( ThrowException ) );
+            Assert.True( CheckLatch( breaker.HalfOpenLatch ) );
+
+            breaker.Instance.WithCircuitBreaker( Task.Factory.StartNew( ThrowException ) );
+            Assert.True( CheckLatch( breaker.OpenLatch ) );
+        }
+    }
+
+    public class AnAsynchronousCircuitBreakerThatIsOpen : CircuitBreakerSpecBase
+    {
+        [Fact(DisplayName = "An asynchronous circuit breaker that is open should throw exceptions when called before reset timeout")]
+        public void Should_Throw_Exceptions_When_Called_Before_Reset_Timeout( )
+        {
+            var breaker = LongResetTimeoutCb( );
+
+            Assert.True( InterceptExceptionType<TestException>( ( ) => breaker.Instance.WithCircuitBreaker( Task.Factory.StartNew( ThrowException ) ).Wait( ) ) );
+            Assert.True( CheckLatch( breaker.OpenLatch ) );
+            Assert.True( InterceptExceptionType<OpenCircuitException>( ( ) => breaker.Instance.WithCircuitBreaker( Task.Factory.StartNew( ThrowException ) ).Wait( ) ) );
+        }
+
+        [Fact(DisplayName = "An asynchronous circuit breaker that is open should transition to half open when reset timeout")]
+        public void Should_Transition_To_Half_Open_When_Reset_Timeout( )
+        {
+            var breaker = ShortResetTimeoutCb( );
+
+            Assert.True( InterceptExceptionType<TestException>( ( ) => breaker.Instance.WithCircuitBreaker( Task.Factory.StartNew( ThrowException ) ).Wait( ) ) );
+            Assert.True( CheckLatch( breaker.HalfOpenLatch ) );
+        }
+    }
+
+    public class CircuitBreakerSpecBase : AkkaSpec
+    {
+        private readonly TimeSpan _awaitTimeout = TimeSpan.FromSeconds(2);
+        public TimeSpan AwaitTimeout { get { return _awaitTimeout; } }
+
+        public bool CheckLatch( CountdownEvent latch )
+        {
+            return latch.Wait( AwaitTimeout );
+        }
+
+        public Task Delay( TimeSpan toDelay, CancellationToken? token )
+        {
+            return token.HasValue ? Task.Delay( toDelay, token.Value ) : Task.Delay( toDelay );
+        }
+
+        public void ThrowException( )
+        {
+            throw new TestException( "Test Exception" );
+        }
+
+        public string SayTest( )
+        {
+            return "Test";
+        }
+
+        [SuppressMessage( "Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter" )]
+        public bool InterceptExceptionType<T>( Action action ) where T : Exception
+        {
+            try
+            {
+                action.Invoke( );
+                return false;
+            }
+            catch ( Exception ex )
+            {
+                var aggregate = ex as AggregateException;
+                if ( aggregate != null )
+                {
+
+                    // ReSharper disable once UnusedVariable
+                    foreach ( var temp in aggregate.InnerExceptions.Select( innerException => innerException as T ).Where( temp => temp == null ) )
+                    {
+                        throw;
+                    }
+                }
+                else
+                {
+                    var temp = ex as T;
+
+                    if ( temp == null )
+                    {
+                        throw;
+                    }
+                }
+
+            }
+            return true;
+        }
+
+        public TestBreaker ShortCallTimeoutCb( )
+        {
+            return new TestBreaker( new CircuitBreaker( 1, TimeSpan.FromMilliseconds( 50 ), TimeSpan.FromMilliseconds( 500 ) ) );
+        }
+
+        public TestBreaker ShortResetTimeoutCb( )
+        {
+            return new TestBreaker( new CircuitBreaker( 1, TimeSpan.FromMilliseconds( 1000 ), TimeSpan.FromMilliseconds( 50 ) ) );
+        }
+
+        public TestBreaker LongCallTimeoutCb( )
+        {
+            return new TestBreaker( new CircuitBreaker( 1, TimeSpan.FromMilliseconds( 5000 ), TimeSpan.FromMilliseconds( 500 ) ) );
+        }
+
+        public TestBreaker LongResetTimeoutCb( )
+        {
+            return new TestBreaker( new CircuitBreaker( 1, TimeSpan.FromMilliseconds( 100 ), TimeSpan.FromMilliseconds( 5000 ) ) );
+        }
+
+        public TestBreaker MultiFailureCb( )
+        {
+            return new TestBreaker( new CircuitBreaker( 5, TimeSpan.FromMilliseconds( 200 ), TimeSpan.FromMilliseconds( 500 ) ) );
+        }
+    }
+
+
+    internal class TestException : ApplicationException
+    {
+        public TestException( )
+        {
+        }
+
+        public TestException( string message )
+            : base( message )
+        {
+        }
+
+        public TestException( string message, Exception innerException )
+            : base( message, innerException )
+        {
+        }
+
+        protected TestException( SerializationInfo info, StreamingContext context )
+            : base( info, context )
+        {
+        }
+    }
+
+}

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -248,6 +248,9 @@
     <Compile Include="IO\UdpManager.cs" />
     <Compile Include="IO\UdpSender.cs" />
     <Compile Include="IO\WithUdpSend.cs" />
+    <Compile Include="Pattern\CircuitBreaker.cs" />
+    <Compile Include="Pattern\CircuitBreakerState.cs" />
+    <Compile Include="Pattern\OpenCircuitException.cs" />
     <Compile Include="Routing\ConsistentHashRouter.cs" />
     <Compile Include="Serialization\JavaSerializer.cs" />
     <Compile Include="IO\ByteBuffer.cs" />
@@ -266,6 +269,7 @@
     <Compile Include="Util\ByteIterator.cs" />
     <Compile Include="Util\ByteString.cs" />
     <Compile Include="Util\ContinuousEnumerator.cs" />
+    <Compile Include="Util\Internal\AtomicState.cs" />
     <Compile Include="Util\Internal\Collections\EnumeratorExtensions.cs" />
     <Compile Include="Util\Internal\Collections\Iterator.cs" />
     <Compile Include="Util\Internal\ImmutabilityUtils.cs" />

--- a/src/core/Akka/Pattern/CircuitBreaker.cs
+++ b/src/core/Akka/Pattern/CircuitBreaker.cs
@@ -1,0 +1,261 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="CircuitBreaker.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Util.Internal;
+
+namespace Akka.Pattern
+{
+    /// <summary>
+    /// Provides circuit breaker functionality to provide stability when working with 
+    /// "dangerous" operations, e.g. calls to remote systems
+    /// 
+    ///<list type="bullet">
+    ///<listheader>
+    ///    <description>Transitions through three states:</description>
+    ///</listheader>
+    ///<item>
+    ///    <term>In *Closed* state, </term>
+    ///    <description>calls pass through until the maxFailures count is reached. 
+    ///         This causes the circuit breaker to open. Both exceptions and calls exceeding 
+    ///         callTimeout are considered failures.</description>
+    ///</item>
+    ///<item>
+    ///    <term>In *Open* state, </term>
+    ///    <description>calls fail-fast with an exception. After resetTimeout, 
+    ///         circuit breaker transitions to half-open state.</description>
+    ///</item>
+    ///<item>
+    ///    <term>In *Half-Open* state, </term>
+    ///    <description>the first call will be allowed through, if it succeeds 
+    ///         the circuit breaker will reset to closed state. If it fails, the circuit 
+    ///         breaker will re-open to open state. All calls beyond the first that execute 
+    ///         while the first is running will fail-fast with an exception.</description>
+    ///</item>
+    ///</list>
+    /// </summary>
+    public class CircuitBreaker
+    {
+        /// <summary>
+        /// The current state of the breaker -- Closed, Half-Open, or Closed -- *access only via helper methods*
+        /// </summary>
+        private AtomicState _currentState;
+
+        /// <summary>
+        /// Helper method for access to the underlying state via Interlocked
+        /// </summary>
+        /// <param name="oldState">Previous state on transition</param>
+        /// <param name="newState">Next state on transition</param>
+        /// <returns>Whether the previous state matched correctly</returns>
+        private bool SwapState( AtomicState oldState, AtomicState newState )
+        {
+            return Interlocked.CompareExchange( ref _currentState, newState, oldState ) == oldState;
+        }
+
+        /// <summary>
+        /// Helper method for access to the underlying state via Interlocked
+        /// </summary>
+        private AtomicState CurrentState
+        {
+            get
+            {
+                Interlocked.MemoryBarrier( );
+                return _currentState;
+            }
+        }
+
+        public int MaxFailures { get; private set; }
+
+        public TimeSpan CallTimeout { get; private set; }
+        public TimeSpan ResetTimeout { get; private set; }
+        
+        //akka.io implementation is to use nested static classes and access parent member variables
+        //.Net static nested classes do not have access to parent member variables -- so we configure the states here and
+        //swap them above
+        private AtomicState Closed { get; set; } 
+        private AtomicState Open { get; set; }
+        private AtomicState HalfOpen { get; set; }
+
+        /// <summary>
+        /// Create a new CircuitBreaker
+        /// </summary>
+        /// <param name="maxFailures">Maximum number of failures before opening the circuit</param>
+        /// <param name="callTimeout"><see cref="TimeSpan"/> of time after which to consider a call a failure</param>
+        /// <param name="resetTimeout"><see cref="TimeSpan"/> of time after which to attempt to close the circuit</param>
+        /// <returns></returns>
+        public static CircuitBreaker Create( int maxFailures, TimeSpan callTimeout, TimeSpan resetTimeout )
+        {
+            return new CircuitBreaker( maxFailures, callTimeout, resetTimeout );
+        }
+
+        /// <summary>
+        /// Create a new CircuitBreaker
+        /// </summary>
+        /// <param name="maxFailures">Maximum number of failures before opening the circuit</param>
+        /// <param name="callTimeout"><see cref="TimeSpan"/> of time after which to consider a call a failure</param>
+        /// <param name="resetTimeout"><see cref="TimeSpan"/> of time after which to attempt to close the circuit</param>
+        /// <returns></returns>
+        public CircuitBreaker( int maxFailures, TimeSpan callTimeout, TimeSpan resetTimeout )
+        {
+            MaxFailures = maxFailures;
+            CallTimeout = callTimeout;
+            ResetTimeout = resetTimeout;
+            Closed = new Closed( this );
+            Open = new Open( this );
+            HalfOpen = new HalfOpen( this );
+            _currentState = Closed;
+            //_failures = new AtomicInteger();
+        }
+
+        /// <summary>
+        /// Retrieves current failure count.
+        /// </summary>
+        public long CurrentFailureCount
+        {
+            get { return Closed.Current; }
+        }
+
+        /// <summary>
+        /// Wraps invocation of asynchronous calls that need to be protected
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="body">Call needing protected</param>
+        /// <returns><see cref="Task"/> containing the call result</returns>
+        public async Task<T> WithCircuitBreaker<T>( Task<T> body )
+        {
+            return await CurrentState.Invoke( body );
+        }
+
+        /// <summary>
+        /// Wraps invocation of asynchronous calls that need to be protected
+        /// </summary>
+        /// <param name="body">Call needing protected</param>
+        /// <returns><see cref="Task"/></returns>
+        public async Task WithCircuitBreaker( Task body )
+        {
+            await CurrentState.Invoke( body );
+        }
+
+        /// <summary>
+        /// The failure will be recorded farther down.
+        /// </summary>
+        /// <param name="body"></param>
+        public void WithSyncCircuitBreaker( Action body )
+        {
+            var cbTask = WithCircuitBreaker( Task.Factory.StartNew( body ) );
+            if ( !cbTask.Wait( CallTimeout ) )
+            {
+                //throw new TimeoutException( string.Format( "Execution did not complete within the time alotted {0} ms", CallTimeout.TotalMilliseconds ) );
+            }
+            if ( cbTask.Exception != null )
+            {
+                throw cbTask.Exception;
+            }
+        }
+
+        /// <summary>
+        /// Wraps invocations of asynchronous calls that need to be protected
+        /// If this does not complete within the time allotted, it should return default(<typeparam name="T"></typeparam>)
+        /// 
+        /// <code>
+        ///  Await.result(
+        ///      withCircuitBreaker(try Future.successful(body) catch { case NonFatal(t) ⇒ Future.failed(t) }),
+        ///      callTimeout)
+        /// </code>
+        ///
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="body"></param>
+        /// <returns><typeparam name="T"></typeparam> or default(<typeparam name="T"></typeparam>)</returns>
+        public T WithSyncCircuitBreaker<T>( Func<T> body )
+        {
+            var cbTask = WithCircuitBreaker( Task.Factory.StartNew( body ) );
+            return cbTask.Wait( CallTimeout ) ? cbTask.Result : default(T);
+        }
+
+        /// <summary>
+        /// Adds a callback to execute when circuit breaker opens
+        /// </summary>
+        /// <param name="callback"><see cref="Action"/> Handler to be invoked on state change</param>
+        /// <returns>CircuitBreaker for fluent usage</returns>
+        public CircuitBreaker OnOpen( Action callback )
+        {
+            Open.AddListener( callback );
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a callback to execute when circuit breaker transitions to half-open
+        /// </summary>
+        /// <param name="callback"><see cref="Action"/> Handler to be invoked on state change</param>
+        /// <returns>CircuitBreaker for fluent usage</returns>
+        public CircuitBreaker OnHalfOpen( Action callback )
+        {
+            HalfOpen.AddListener( callback );
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a callback to execute when circuit breaker state closes
+        /// </summary>
+        /// <param name="callback"><see cref="Action"/> Handler to be invoked on state change</param>
+        /// <returns>CircuitBreaker for fluent usage</returns>
+        public CircuitBreaker OnClose( Action callback )
+        {
+            Closed.AddListener( callback );
+            return this;
+        }
+
+        /// <summary>
+        /// Implements consistent transition between states. Throws IllegalStateException if an invalid transition is attempted.
+        /// </summary>
+        /// <param name="fromState">State being transitioning from</param>
+        /// <param name="toState">State being transitioned to</param>
+        private void Transition( AtomicState fromState, AtomicState toState )
+        {
+            if ( SwapState( fromState, toState ) )
+            {
+                Debug.WriteLine( "Successful transition from {0} to {1}", fromState, toState );
+                toState.Enter( );
+            }
+            else
+            {
+                throw new IllegalStateException( string.Format( "Illegal transition attempted from {0} to {1}", fromState, toState ) );
+            }
+        }
+
+        /// <summary>
+        /// Trips breaker to an open state. This is valid from Closed or Half-Open states
+        /// </summary>
+        /// <param name="fromState">State we're coming from (Closed or Half-Open)</param>
+        internal void TripBreaker( AtomicState fromState )
+        {
+            Transition( fromState, Open );
+        }
+
+        /// <summary>
+        /// Resets breaker to a closed state.  This is valid from an Half-Open state only.
+        /// </summary>
+        internal void ResetBreaker( )
+        {
+            Transition( HalfOpen, Closed );
+        }
+
+        /// <summary>
+        /// Attempts to reset breaker by transitioning to a half-open state.  This is valid from an Open state only.
+        /// </summary>
+        internal void AttemptReset( )
+        {
+            Transition( Open, HalfOpen );
+        }
+
+        //private readonly Task timeoutTask = Task.FromResult(new TimeoutException("Circuit Breaker Timed out."));
+    }
+}

--- a/src/core/Akka/Pattern/CircuitBreakerState.cs
+++ b/src/core/Akka/Pattern/CircuitBreakerState.cs
@@ -1,0 +1,226 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="CircuitBreakerState.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Globalization;
+using System.Threading.Tasks;
+using Akka.Util;
+using Akka.Util.Internal;
+
+namespace Akka.Pattern
+{
+    /// <summary>
+    /// Concrete implementation of Open state
+    /// </summary>
+    internal class Open : AtomicState
+    {
+        private readonly CircuitBreaker _breaker;
+
+        public Open( CircuitBreaker breaker )
+            : base( breaker.CallTimeout, 0 )
+        {
+            _breaker = breaker;
+        }
+
+        /// <summary>
+        /// Fail-fast on any invocation
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="body">Implementation of the call that needs protected</param>
+        /// <returns><see cref="Task"/> containing result of protected call</returns>
+        public override Task<T> Invoke<T>( Task<T> body )
+        {
+            throw new OpenCircuitException( );
+        }
+
+        /// <summary>
+        /// Implementation of invoke, which simply attempts the call
+        /// </summary>
+        /// <param name="body">Implementation of the call that needs protected</param>
+        /// <returns><see cref="Task"/> containing result of protected call</returns>
+        public override Task Invoke( Task body )
+        {
+            throw new OpenCircuitException( );
+        }
+
+        /// <summary>
+        /// No-op for open, calls are never executed so cannot succeed or fail
+        /// </summary>
+        protected override void CallFails( )
+        {
+            //throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// No-op for open, calls are never executed so cannot succeed or fail
+        /// </summary>
+        protected override void CallSucceeds( )
+        {
+            //throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// On entering this state, schedule an attempted reset and store the entry time to
+        /// calculate remaining time before attempted reset.
+        /// </summary>
+        protected override void EnterInternal( )
+        {
+            Task.Delay( _breaker.ResetTimeout ).ContinueWith( task => _breaker.AttemptReset( ) );
+        }
+    }
+
+    /// <summary>
+    /// Concrete implementation of half-open state
+    /// </summary>
+    internal class HalfOpen : AtomicState
+    {
+        private readonly CircuitBreaker _breaker;
+        private readonly AtomicBoolean _lock;
+
+        public HalfOpen( CircuitBreaker breaker )
+            : base( breaker.CallTimeout, 0 )
+        {
+            _breaker = breaker;
+            _lock = new AtomicBoolean();
+        }
+
+        /// <summary>
+        /// Allows a single call through, during which all other callers fail-fast. If the call fails, the breaker reopens.
+        /// If the call succeeds, the breaker closes.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="body">Implementation of the call that needs protected</param>
+        /// <returns><see cref="Task"/> containing result of protected call</returns>
+        public override async Task<T> Invoke<T>( Task<T> body )
+        {
+            if ( !_lock.CompareAndSet( true, false) )
+            {
+                throw new OpenCircuitException( );
+            }
+            return await CallThrough( body );
+        }
+
+        /// <summary>
+        /// Allows a single call through, during which all other callers fail-fast. If the call fails, the breaker reopens.
+        /// If the call succeeds, the breaker closes.
+        /// </summary>
+        /// <param name="body">Implementation of the call that needs protected</param>
+        /// <returns><see cref="Task"/> containing result of protected call</returns>
+        public override async Task Invoke( Task body )
+        {
+            if ( !_lock.CompareAndSet( true, false ) )
+            {
+                throw new OpenCircuitException( );
+            }
+            await CallThrough( body );
+        }
+
+        /// <summary>
+        /// Reopen breaker on failed call.
+        /// </summary>
+        protected override void CallFails( )
+        {
+            _breaker.TripBreaker( this );
+        }
+
+        /// <summary>
+        /// Reset breaker on successful call.
+        /// </summary>
+        protected override void CallSucceeds( )
+        {
+            _breaker.ResetBreaker( );
+        }
+
+        /// <summary>
+        /// On entry, guard should be reset for that first call to get in
+        /// </summary>
+        protected override void EnterInternal( )
+        {
+            _lock.Value = true ;
+        }
+
+        /// <summary>
+        /// Override for more descriptive toString
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString( )
+        {
+            return string.Format( CultureInfo.InvariantCulture, "Half-Open currently testing call for success = {0}", ( _lock == true ) );
+        }
+    }
+
+    /// <summary>
+    /// Concrete implementation of Closed state
+    /// </summary>
+    internal class Closed : AtomicState
+    {
+        private readonly CircuitBreaker _breaker;
+
+        public Closed( CircuitBreaker breaker )
+            : base( breaker.CallTimeout, 0 )
+        {
+            _breaker = breaker;
+        }
+
+        /// <summary>
+        /// Implementation of invoke, which simply attempts the call
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="body">Implementation of the call that needs protected</param>
+        /// <returns><see cref="Task"/> containing result of protected call</returns>
+        public override async Task<T> Invoke<T>( Task<T> body )
+        {
+            return await CallThrough( body );
+        }
+
+        /// <summary>
+        /// Implementation of invoke, which simply attempts the call
+        /// </summary>
+        /// <param name="body">Implementation of the call that needs protected</param>
+        /// <returns><see cref="Task"/> containing result of protected call</returns>
+        public override async Task Invoke( Task body )
+        {
+            await CallThrough( body );
+        }
+
+        /// <summary>
+        /// On failed call, the failure count is incremented.  The count is checked against the configured maxFailures, and
+        /// the breaker is tripped if we have reached maxFailures.
+        /// </summary>
+        protected override void CallFails( )
+        {
+            if ( IncrementAndGet( ) == _breaker.MaxFailures )
+            {
+                _breaker.TripBreaker( this );
+            }
+        }
+
+        /// <summary>
+        /// On successful call, the failure count is reset to 0
+        /// </summary>
+        protected override void CallSucceeds( )
+        {
+            Reset();
+        }
+
+        /// <summary>
+        /// On entry of this state, failure count is reset.
+        /// </summary>
+        protected override void EnterInternal( )
+        {
+            Reset();
+        }
+
+        /// <summary>
+        /// Override for more descriptive toString
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString( )
+        {
+            return string.Format( "Closed with failure count = {0}", Current );
+        }
+    }
+}

--- a/src/core/Akka/Pattern/IllegalStateException.cs
+++ b/src/core/Akka/Pattern/IllegalStateException.cs
@@ -10,6 +10,10 @@ using Akka.Actor;
 
 namespace Akka.Pattern
 {
+    /// <summary>
+    /// Signals that a method has been invoked at an illegal or
+    /// inappropriate time.
+    /// </summary>
     public class IllegalStateException : AkkaException
     {
 

--- a/src/core/Akka/Pattern/OpenCircuitException.cs
+++ b/src/core/Akka/Pattern/OpenCircuitException.cs
@@ -1,0 +1,36 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="OpenCircuitException.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Runtime.Serialization;
+using Akka.Actor;
+
+namespace Akka.Pattern
+{
+    /// <summary>
+    /// Exception throws when CircuitBreaker is open
+    /// </summary>
+    public class OpenCircuitException : AkkaException
+    {
+        public OpenCircuitException( ) : base( "Circuit Breaker is open; calls are failing fast" ) { }
+
+        public OpenCircuitException( string message )
+            : base( message )
+        {
+        }
+
+        public OpenCircuitException( string message, Exception innerException )
+            : base( message, innerException )
+        {
+        }
+
+        protected OpenCircuitException( SerializationInfo info, StreamingContext context )
+            : base( info, context )
+        {
+        }
+    }
+}


### PR DESCRIPTION
#147 

- Add CircuitBreaker to codebase
- Add AtomicState, IAtomicState, OpenState, HalfOpenState, ClosedState, CircuitBreakerSpec

Ultimately I wound up ignoring the IScheduler and ExecutionContext / SynchronizationContext. I have implemented the tests from the Akka.io CircuitBreakerSpec tests and we can always come back later and add in the scheduler and execution context in a later commit and add suitable default values to a constructor.