### PR TITLE
FSharp API: fixed problem with JObject deserialization

### DIFF
--- a/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
+++ b/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
@@ -93,6 +93,11 @@
       <Name>Akka.FSharp</Name>
       <Project>{81574240-BC31-4BE4-B447-ADF0D32F4246}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\Akka.Remote\Akka.Remote.csproj">
+      <Name>Akka.Remote</Name>
+      <Project>{ea4ff8fd-7c53-49c8-b9aa-02e458b3e6a7}</Project>
+      <Private>True</Private>
+    </ProjectReference>
     <ProjectReference Include="..\Akka.TestKit\Akka.TestKit.csproj">
       <Name>Akka.TestKit</Name>
       <Project>{0D3CBAD0-BBDB-43E5-AFC4-ED1D3ECDC224}</Project>

--- a/src/core/Akka.FSharp.Tests/ApiTests.fs
+++ b/src/core/Akka.FSharp.Tests/ApiTests.fs
@@ -39,39 +39,36 @@ type TestUnion2 =
     | C of string * TestUnion
     | D of int
 
-
 [<Fact>]
-let ``can serialize discriminated unions`` () =
-    let x = B (23,"hello")
-    use sys = System.create "system" (Configuration.defaultConfig())
-    let serializer = sys.Serialization.FindSerializerFor x
-    let bytes = serializer.ToBinary x
-    let des = serializer.FromBinary (bytes, typeof<TestUnion>) :?> TestUnion
-    des
-    |> equals x
+let ``can serialize and deserialize discriminated unions over remote nodes`` () =     
+    let remoteConfig port = 
+        sprintf """
+        akka { 
+            actor {
+                ask-timeout = 5s
+                provider = "Akka.Remote.RemoteActorRefProvider, Akka.Remote"
+            }
+            remote {
+                helios.tcp {
+                    port = %i
+                    hostname = localhost
+                }
+            }
+        }
+        """ port
+        |> Configuration.parse
 
-[<Fact>]
-let ``can serialize nested discriminated unions`` () =
-    let x = C("bar",B (23,"hello"))
-    use sys = System.create "system" (Configuration.defaultConfig())
-    let serializer = sys.Serialization.FindSerializerFor x
-    let bytes = serializer.ToBinary x
-    let des = serializer.FromBinary (bytes, typeof<TestUnion2>) :?> TestUnion2
-    des
-    |> equals x
+    use server = System.create "server-system" (remoteConfig 9911)
+    use client = System.create "client-system" (remoteConfig 0)
 
-type testType1 = 
-    string * int
+    let aref = 
+        spawne client "a-1" <@ actorOf2 (fun mailbox msg -> 
+               match msg with
+               | C("a-11", B(11, "a-12")) -> mailbox.Sender() <! msg
+               | _ -> mailbox.Unhandled msg) @>
+            [SpawnOption.Deploy (Deploy(RemoteScope (Address.Parse "akka.tcp://server-system@localhost:9911")))]
+    let msg = C("a-11", B(11, "a-12"))
+    let response = aref <? msg |> Async.RunSynchronously
+    response
+    |> equals msg
 
-type testType2 = 
-    | V2 of testType1
-
-[<Fact>]
-let MyTest () =
-    let x = V2("hello!",123)
-    use sys = System.create "system" (Configuration.defaultConfig())
-    let serializer = sys.Serialization.FindSerializerFor x
-    let bytes = serializer.ToBinary x
-    let des = serializer.FromBinary (bytes, typeof<testType2>) :?> testType2
-    des
-    |> equals x

--- a/src/core/Akka/Serialization/NewtonSoftJsonSerializer.cs
+++ b/src/core/Akka/Serialization/NewtonSoftJsonSerializer.cs
@@ -29,6 +29,7 @@ namespace Akka.Serialization
         private readonly JsonSerializer _serializer;
 
         public JsonSerializerSettings Settings { get { return _settings; } }
+        public object Serializer { get { return _serializer; } }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NewtonSoftJsonSerializer" /> class.


### PR DESCRIPTION
This should fix #999 . The issue was that F# actor applied pattern matching on the generic type in case when message was not fully deserialized (it was an intermediate representation in form of json.net `JObject`). In result any try of pattern matching was failing. 

This PR solves that problem by adding additional step - in case when we have a `JObject` instance passed it tries a build in `ToObject(type)` conversion and if it succeeds, pass the result to the actor's receive function.