### PR TITLE
Update FsPickler version used by Akka.FSharp

### DIFF
--- a/src/core/Akka.FSharp/Akka.FSharp.fsproj
+++ b/src/core/Akka.FSharp/Akka.FSharp.fsproj
@@ -82,6 +82,7 @@
     <None Include="packages.config" />
     <None Include="Akka.FSharp.nuspec" />
     <None Include="README.md" />
+    <Content Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FSharp.PowerPack">
@@ -91,7 +92,8 @@
       <HintPath>..\..\packages\FSPowerPack.Linq.Community.3.0.0.0\Lib\Net40\FSharp.PowerPack.Linq.dll</HintPath>
     </Reference>
     <Reference Include="FsPickler">
-      <HintPath>..\..\packages\FsPickler.0.9.11\lib\net45\FsPickler.dll</HintPath>
+      <HintPath>..\..\packages\FsPickler.1.2.21\lib\net45\FsPickler.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
@@ -104,6 +106,8 @@
     <Reference Include="FSharp.Core, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/core/Akka.FSharp/packages.config
+++ b/src/core/Akka.FSharp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FsPickler" version="0.9.11" targetFramework="net45" />
+  <package id="FsPickler" version="1.2.21" targetFramework="net45" />
   <package id="FSPowerPack.Core.Community" version="3.0.0.0" targetFramework="net45" />
   <package id="FSPowerPack.Linq.Community" version="3.0.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Ref #1206

I am new to both Akka and F#, so please go easy on me!

Per the referenced issue, Akka.FSharp is using an old version of FsPickler, which I have updated in this PR. The key change in the FsPickler API was the removal of overloads for `Serialize`/`Deserialize` taking a type as a method parameter; instead it is a generic parameter on the method. I made the few minor changes to account for this, hopefully they are idiomatic/appropriate.

I ran the F# tests by hand and they passed. I was also able to use the updated Akka.FSharp.dll in conjunction with Vagabond in an FSI session, which I was unable to do with the existing FsPickler.0.9.11-based version.