### PR TITLE
Fix for null sender #1212

### DIFF
--- a/src/core/Akka.Tests/Actor/ActorRefSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorRefSpec.cs
@@ -279,6 +279,17 @@ namespace Akka.Tests.Actor
             Assert.True(!(bool)t2.Result);
         }
 
+        [Fact]
+        public void An_ActorRef_should_never_have_a_null_Sender_Bug_1212()
+        {          
+            var actor = ActorOfAsTestActorRef<NonPublicActor>(Props.Create<NonPublicActor>(SupervisorStrategy.StoppingStrategy));
+            // actors with a null sender should always write to deadletters
+            EventFilter.DeadLetter<object>().ExpectOne(() => actor.Tell(new object(), null));
+
+            // will throw an exception if there's a bug
+            ExpectNoMsg();
+        }
+
         private void VerifyActorTermination(IActorRef actorRef)
         {
             var watcher = CreateTestProbe();

--- a/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
+++ b/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
@@ -44,7 +44,7 @@ namespace Akka.Actor
         {
             var message = envelope.Message;
             CurrentMessage = message;
-            Sender = envelope.Sender;
+            Sender = MatchSender(envelope);
 
             try
             {
@@ -62,6 +62,18 @@ namespace Akka.Actor
             {
                 CheckReceiveTimeout(); // Reschedule receive timeout
             }
+        }
+
+        /// <summary>
+        /// If the envelope.Sender property is null, then we'll substitute
+        /// Deadletters as the <see cref="Sender"/> of this message.
+        /// </summary>
+        /// <param name="envelope">The envelope we received</param>
+        /// <returns>An IActorRef that corresponds to a Sender</returns>
+        private IActorRef MatchSender(Envelope envelope)
+        {
+            var sender = envelope.Sender;
+            return sender ?? System.DeadLetters;
         }
 
 


### PR DESCRIPTION
Resolves #1212 - any messages for a `null` Sender now to go `Deadletters`.

Added a spec to verify.