### PR TITLE
1088 - Skip attribute on MultiNodeFact does not work

### DIFF
--- a/src/core/Akka.MultiNodeTestRunner/Akka.MultiNodeTestRunner.csproj
+++ b/src/core/Akka.MultiNodeTestRunner/Akka.MultiNodeTestRunner.csproj
@@ -36,13 +36,14 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="xunit.abstractions">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.runner.utility.desktop, Version=2.1.0.2981, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="xunit.runner.utility.desktop">
       <HintPath>..\..\packages\xunit.runner.utility.2.1.0-beta2-build2981\lib\net35\xunit.runner.utility.desktop.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.core">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -67,7 +68,7 @@
       <Name>Akka.MultiNodeTestRunner.Shared</Name>
     </ProjectReference>
     <ProjectReference Include="..\Akka.MultiNodeTests\Akka.MultiNodeTests.csproj">
-      <Project>{f0781bea-5ba0-4af0-bb15-e3f209b681f5}</Project>
+      <Project>{F0781BEA-5BA0-4AF0-BB15-E3F209B681F5}</Project>
       <Name>Akka.MultiNodeTests</Name>
     </ProjectReference>
     <ProjectReference Include="..\Akka.NodeTestRunner\Akka.NodeTestRunner.csproj">
@@ -86,6 +87,7 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Import Project="..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>

--- a/src/core/Akka.MultiNodeTestRunner/packages.config
+++ b/src/core/Akka.MultiNodeTestRunner/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
   <package id="xunit.runner.utility" version="2.1.0-beta2-build2981" targetFramework="net45" />
 </packages>

--- a/src/core/Akka.MultiNodeTests/MultiNodeFact.cs
+++ b/src/core/Akka.MultiNodeTests/MultiNodeFact.cs
@@ -27,7 +27,7 @@ namespace Akka.MultiNodeTests
             get
             {
                 return ExecutedByMultiNodeRunner.Value
-                    ? null
+                    ? base.Skip
                     : "Must be executed by multi-node test runner";
             }
             set { base.Skip = value; }

--- a/src/core/Akka.MultiNodeTests/Routing/ClusterConsistentHashingGroupSpec.cs
+++ b/src/core/Akka.MultiNodeTests/Routing/ClusterConsistentHashingGroupSpec.cs
@@ -107,7 +107,7 @@ namespace Akka.MultiNodeTests.Routing
             return actorRef.Path.Address;
         }
 
-        //[MultiNodeFact(Skip = "Race conditions - needs debugging")]
+        [MultiNodeFact(Skip = "Race conditions - needs debugging")]
         public void AClusterRouterWithConsistentHashingGroupMustSendToSameDestinationsFromDifferentNodes()
         {
             Sys.ActorOf(Props.Create<ClusterConsistentHashingGroupSpecConfig.Destination>(), "dest");

--- a/src/core/Akka.MultiNodeTests/Routing/ClusterConsistentHashingRouterSpec.cs
+++ b/src/core/Akka.MultiNodeTests/Routing/ClusterConsistentHashingRouterSpec.cs
@@ -127,7 +127,7 @@ namespace Akka.MultiNodeTests.Routing
             ExpectMsg(destinationA);
         }
 
-        //[MultiNodeFact(Skip = "Race conditions - needs debugging")]
+        [MultiNodeFact(Skip = "Race conditions - needs debugging")]
         public void ClusterConsistentHashingRouterSpecs()
         {
             AClusterRouterWithConsistentHashingPoolMustStartClusterWith2Nodes();


### PR DESCRIPTION
It seems that the discovery process was ignoring the presence of the Skip in the MultiNodeFact attribute.
I added a filter that checks if it is null or not and prevents the skipped facts from being added to the tests to run.