### PR TITLE
#1088 MultiNode tests can now be skipped by specifying a SkipReason

### DIFF
--- a/src/core/Akka.MultiNodeTestRunner.Shared/NodeTest.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/NodeTest.cs
@@ -13,6 +13,7 @@ namespace Akka.MultiNodeTestRunner.Shared
         public string TestName { get; set; }
         public string TypeName { get; set; }
         public string MethodName { get; set; }
+        public string SkipReason { get; set; }
     }
 }
 

--- a/src/core/Akka.MultiNodeTestRunner/Discovery.cs
+++ b/src/core/Akka.MultiNodeTestRunner/Discovery.cs
@@ -65,7 +65,8 @@ namespace Akka.MultiNodeTestRunner
                 Node = Convert.ToInt32(matches.Groups[2].Value),
                 TestName = matches.Groups[1].Value,
                 TypeName = nodeTest.TestClass.Class.Name,
-                MethodName = nodeTest.TestCase.TestMethod.Method.Name
+                MethodName = nodeTest.TestCase.TestMethod.Method.Name,
+                SkipReason = nodeTest.TestCase.SkipReason
             };
         }
 

--- a/src/core/Akka.MultiNodeTestRunner/Program.cs
+++ b/src/core/Akka.MultiNodeTestRunner/Program.cs
@@ -75,6 +75,12 @@ namespace Akka.MultiNodeTestRunner
 
                     foreach (var test in discovery.Tests.Reverse())
                     {
+                        if (!string.IsNullOrEmpty(test.Value.First().SkipReason))
+                        {
+                            PublishRunnerMessage(string.Format("Skipping test {0}. Reason - {1}", test.Value.First().MethodName, test.Value.First().SkipReason));
+                            continue;
+                        }
+
                         PublishRunnerMessage(string.Format("Starting test {0}", test.Value.First().MethodName));
 
                         var processes = new List<Process>();

--- a/src/core/Akka.MultiNodeTests/MultiNodeFact.cs
+++ b/src/core/Akka.MultiNodeTests/MultiNodeFact.cs
@@ -27,7 +27,7 @@ namespace Akka.MultiNodeTests
             get
             {
                 return ExecutedByMultiNodeRunner.Value
-                    ? null
+                    ? base.Skip
                     : "Must be executed by multi-node test runner";
             }
             set { base.Skip = value; }


### PR DESCRIPTION
#1088 MultiNode tests can now be skipped by specifying a SkipReason

I have learned that XUnit works in two phases - discovery of tests and execution of tests. 

The tests that are to be skipped are skipped during execution and not discovery. I believe this is because you would want to show a message that a test was not executed but skipped for a particular reason. Since MultiNodeTestRunner has its own test execution logic, a change was needed in that logic to skip the tests.