### PR TITLE
Bugfix: Make the Put on the SimpleDnsCache idempotent

### DIFF
--- a/src/core/Akka.Tests/IO/SimpleDnsCacheSpec.cs
+++ b/src/core/Akka.Tests/IO/SimpleDnsCacheSpec.cs
@@ -65,5 +65,19 @@ namespace Akka.Tests.IO
             cache.Cached("test.local").ShouldBe(null);
            
         }
+
+        [Fact]
+        public void Cache_should_be_updated_with_the_latest_resolved()
+        {
+            var localClock = new AtomicReference<long>(0);
+            var cache = new SimpleDnsCacheTestDouble(localClock);
+            var cacheEntryOne = Dns.Resolved.Create("test.local", System.Net.Dns.GetHostEntry("127.0.0.1").AddressList);
+            var cacheEntryTwo = Dns.Resolved.Create("test.local", System.Net.Dns.GetHostEntry("127.0.0.1").AddressList);
+            long ttl = 500;
+            cache.Put(cacheEntryOne, ttl);
+            cache.Cached("test.local").ShouldBe(cacheEntryOne);
+            cache.Put(cacheEntryTwo, ttl);
+            cache.Cached("test.local").ShouldBe(cacheEntryTwo);
+        }
     }
 }

--- a/src/core/Akka/IO/SimpleDnsCache.cs
+++ b/src/core/Akka/IO/SimpleDnsCache.cs
@@ -80,7 +80,10 @@ namespace Akka.IO
             {
                 var until = _clock() + ttl;
                 _queue.Add(new ExpiryEntry(answer.Name, until));
-                _cache.Add(answer.Name, new CacheEntry(answer, until));
+                if (_cache.ContainsKey(answer.Name))
+                    _cache[answer.Name] = new CacheEntry(answer, until);
+                else
+                    _cache.Add(answer.Name, new CacheEntry(answer, until));
                 return this;
             }
 


### PR DESCRIPTION
Bugfix for the exception: itemwith the same key has already been added.
Make the Put on the SimpleDnsCache idempotent when a same host is
resolved.