### PR TITLE
Do not send if payload size > max allowed. Fixes #879

### DIFF
--- a/src/core/Akka.MultiNodeTestRunner/Akka.MultiNodeTestRunner.csproj
+++ b/src/core/Akka.MultiNodeTestRunner/Akka.MultiNodeTestRunner.csproj
@@ -94,28 +94,6 @@
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
     <Error Condition="!Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
   </Target>
-  <PropertyGroup>
-    <PreBuildEvent>echo PREBUILDSTEP for $(ProjectName)
-
-echo Copying files from $(SolutionDir)core\Akka.Remote.Tests.MultiNode\$(OutDir) to $(ProjectDir)bin\$(Configuration)\Akka.Remote
-
-if not exist "$(ProjectDir)bin\$(Configuration)\Akka.Remote" mkdir "$(ProjectDir)bin\$(Configuration)\Akka.Remote"
- 
-xcopy "$(SolutionDir)core\Akka.Remote.Tests.MultiNode\$(OutDir)*.dll" "$(ProjectDir)bin\$(Configuration)\Akka.Remote" /i /d /y
-if errorlevel 1 goto BuildEventFailed
-
-if errorlevel 1 goto BuildEventFailed 
-
-REM Exit properly because the build will not fail 
-REM unless the final step exits with an error code
-
-goto BuildEventOK
-:BuildEventFailed
-echo PREBUILDSTEP for $(ProjectName) FAILED
-exit 1
-:BuildEventOK
-echo PREBUILDSTEP for $(ProjectName) COMPLETED OK</PreBuildEvent>
-  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -1234,17 +1234,28 @@ namespace Akka.Remote
 
                 //todo: RemoteMetrics https://github.com/akka/akka/blob/dc0547dd73b54b5de9c3e0b45a21aa865c5db8e2/akka-remote/src/main/scala/akka/remote/Endpoint.scala#L742
 
-                //todo: max payload size validation
-
-                var ok = _handle.Write(pdu);
-
-                if (ok)
+                if (pdu.Length > Transport.MaximumPayloadBytes)
                 {
-                    _ackDeadline = NewAckDeadline();
-                    _lastAck = null;
+                    var reason = new OversizedPayloadException(
+                        string.Format("Discarding oversized payload sent to {0}: max allowed size {1} bytes, actual size of encoded {2} was {3} bytes.",
+                            send.Recipient,
+                            Transport.MaximumPayloadBytes,
+                            send.Message.GetType(),
+                            pdu.Length));
+                    _log.Error(reason, "Transient association error (association remains live)");
                     return true;
                 }
+                else
+                {
+                    var ok = _handle.Write(pdu);
 
+                    if (ok)
+                    {
+                        _ackDeadline = NewAckDeadline();
+                        _lastAck = null;
+                        return true;
+                    }
+                }
                 return false;
             }
             catch (SerializationException ex)
@@ -1519,6 +1530,7 @@ namespace Akka.Remote
             _provider = RARP.For(Context.System).Provider;
         }
 
+        private readonly ILoggingAdapter _log = Context.GetLogger();
         private readonly AkkaPduCodec _codec;
         private readonly IActorRef _reliableDeliverySupervisor;
         private readonly ConcurrentDictionary<EndpointManager.Link, EndpointManager.ResendState> _receiveBuffers;
@@ -1553,23 +1565,34 @@ namespace Akka.Remote
             }
             else if (message is InboundPayload)
             {
-                var payload = message as InboundPayload;
-                var ackAndMessage = TryDecodeMessageAndAck(payload.Payload);
-                if (ackAndMessage.AckOption != null && _reliableDeliverySupervisor != null)
-                    _reliableDeliverySupervisor.Tell(ackAndMessage.AckOption);
-                if (ackAndMessage.MessageOption != null)
+                var payload = ((InboundPayload)message).Payload;
+                if (payload.Length > Transport.MaximumPayloadBytes)
                 {
-                    if (ackAndMessage.MessageOption.ReliableDeliveryEnabled)
+                    var reason = new OversizedPayloadException(
+                        string.Format("Discarding oversized payload received: max allowed size {0} bytes, actual size {1} bytes.",
+                            Transport.MaximumPayloadBytes,
+                            payload.Length));
+                    _log.Error(reason, "Transient error while reading from association (association remains live)");
+                }
+                else
+                {
+                    var ackAndMessage = TryDecodeMessageAndAck(payload);
+                    if (ackAndMessage.AckOption != null && _reliableDeliverySupervisor != null)
+                        _reliableDeliverySupervisor.Tell(ackAndMessage.AckOption);
+                    if (ackAndMessage.MessageOption != null)
                     {
-                        _ackedReceiveBuffer = _ackedReceiveBuffer.Receive(ackAndMessage.MessageOption);
-                        DeliverAndAck();
-                    }
-                    else
-                    {
-                        _msgDispatch.Dispatch(ackAndMessage.MessageOption.Recipient,
-                            ackAndMessage.MessageOption.RecipientAddress,
-                            ackAndMessage.MessageOption.SerializedMessage,
-                            ackAndMessage.MessageOption.SenderOptional);
+                        if (ackAndMessage.MessageOption.ReliableDeliveryEnabled)
+                        {
+                            _ackedReceiveBuffer = _ackedReceiveBuffer.Receive(ackAndMessage.MessageOption);
+                            DeliverAndAck();
+                        }
+                        else
+                        {
+                            _msgDispatch.Dispatch(ackAndMessage.MessageOption.Recipient,
+                                ackAndMessage.MessageOption.RecipientAddress,
+                                ackAndMessage.MessageOption.SerializedMessage,
+                                ackAndMessage.MessageOption.SenderOptional);
+                        }
                     }
                 }
             }

--- a/src/core/Akka.Remote/Transport/Helios/HeliosTransport.cs
+++ b/src/core/Akka.Remote/Transport/Helios/HeliosTransport.cs
@@ -172,6 +172,14 @@ namespace Akka.Remote.Transport.Helios
             }
         }
 
+        public override long MaximumPayloadBytes
+        {
+            get
+            {
+                return Settings.MaxFrameSize;
+            }
+        }
+
         protected ILoggingAdapter Log;
 
         /// <summary>

--- a/src/core/Akka.Remote/Transport/TestTransport.cs
+++ b/src/core/Akka.Remote/Transport/TestTransport.cs
@@ -41,8 +41,11 @@ namespace Akka.Remote.Transport
 
         public TestTransport(ActorSystem system, Config conf)
             : this(
-                Address.Parse(GetConfigString(conf, "local-address")), AssociationRegistry.Get(GetConfigString(conf,"registry-key")),
-                GetConfigString(conf,"scheme-identifier")) { }
+                Address.Parse(GetConfigString(conf, "local-address")), 
+                AssociationRegistry.Get(GetConfigString(conf,"registry-key")),
+                conf.GetByteSize("maximum-payload-bytes") ?? 32000,
+                GetConfigString(conf,"scheme-identifier")
+            ) { }
 
         private static string GetConfigString(Config conf, string name)
         {
@@ -51,10 +54,11 @@ namespace Akka.Remote.Transport
             return value;
         }
 
-        public TestTransport(Address localAddress, AssociationRegistry registry, string schemeIdentifier = "test")
+        public TestTransport(Address localAddress, AssociationRegistry registry, long maximumPayloadBytes = 32000, string schemeIdentifier = "test")
         {
             LocalAddress = localAddress;
             _registry = registry;
+            MaximumPayloadBytes = maximumPayloadBytes;
             SchemeIdentifier = schemeIdentifier;
             ListenBehavior =
                 new SwitchableLoggedBehavior<bool, Tuple<Address, TaskCompletionSource<IAssociationEventListener>>>(

--- a/src/core/Akka.Remote/Transport/Transport.cs
+++ b/src/core/Akka.Remote/Transport/Transport.cs
@@ -21,6 +21,7 @@ namespace Akka.Remote.Transport
         public ActorSystem System { get; protected set; }
 
         public virtual string SchemeIdentifier { get; protected set; }
+        public virtual long MaximumPayloadBytes { get; protected set; }
         public abstract Task<Tuple<Address, TaskCompletionSource<IAssociationEventListener>>> Listen();
 
         public abstract bool IsResponsibleFor(Address remote);

--- a/src/core/Akka.Remote/Transport/TransportAdapters.cs
+++ b/src/core/Akka.Remote/Transport/TransportAdapters.cs
@@ -147,6 +147,14 @@ namespace Akka.Remote.Transport
             }
         }
 
+        public override long MaximumPayloadBytes
+        {
+            get
+            {
+                return WrappedTransport.MaximumPayloadBytes;
+            }
+        }
+
         protected abstract Task<IAssociationEventListener> InterceptListen(Address listenAddress,
             Task<IAssociationEventListener> listenerTask);
 


### PR DESCRIPTION
- Added property MaximumPayloadBytes to Transport. For HeliosTransport
  this is the same as MaxFrameSize.
- If payload size > MaximumPayloadBytes, log OversizedPayloadException
  and do not send message.

Corresponding Akka Scala code:
https://github.com/akka/akka/blob/master/akka-remote/src/main/scala/akka/remote/Endpoint.scala#L745
https://github.com/akka/akka/blob/master/akka-remote/src/test/scala/akka/remote/RemotingSpec.scala#L527
https://github.com/akka/akka/search?utf8=%E2%9C%93&q=maximumpayloadbytes