### PR TITLE
Migrant serializer

### DIFF
--- a/src/core/Akka.Tests/Serialization/SerializationSpec.cs
+++ b/src/core/Akka.Tests/Serialization/SerializationSpec.cs
@@ -495,7 +495,7 @@ namespace Akka.Tests.Serialization
             Sys.Serialization.FindSerializerFor(null).GetType().ShouldBe(typeof(NullSerializer));
             Sys.Serialization.FindSerializerFor(new byte[]{1,2,3}).GetType().ShouldBe(typeof(ByteArraySerializer));
             Sys.Serialization.FindSerializerFor("dummy").GetType().ShouldBe(typeof(DummySerializer));
-            Sys.Serialization.FindSerializerFor(123).GetType().ShouldBe(typeof(NewtonSoftJsonSerializer));
+            Sys.Serialization.FindSerializerFor(123).GetType().ShouldBe(typeof(MigrantSerializer));
         }
 
 

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -54,6 +54,10 @@
     <Optimize>false</Optimize>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Migrant, Version=0.10.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Migrant.0.10.3\lib\net40\Migrant.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -266,6 +270,7 @@
     <Compile Include="IO\TcpListener.cs" />
     <Compile Include="IO\TcpManager.cs" />
     <Compile Include="IO\TcpOutgoingConnection.cs" />
+    <Compile Include="Serialization\MigrantSerializer.cs" />
     <Compile Include="Util\ByteIterator.cs" />
     <Compile Include="Util\ByteString.cs" />
     <Compile Include="Util\ContinuousEnumerator.cs" />
@@ -379,7 +384,6 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -391,7 +391,7 @@ akka {
 
     serializers {
         json = "Akka.Serialization.NewtonSoftJsonSerializer"
-		migrant = "Akka.Serialization.MigrantSerializer"
+        migrant = "Akka.Serialization.MigrantSerializer"
         java = "Akka.Serialization.JavaSerializer"				# not used, reserves java serializer identifier
         bytes = "Akka.Serialization.ByteArraySerializer"
     }

--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -391,6 +391,7 @@ akka {
 
     serializers {
         json = "Akka.Serialization.NewtonSoftJsonSerializer"
+		migrant = "Akka.Serialization.MigrantSerializer"
         java = "Akka.Serialization.JavaSerializer"				# not used, reserves java serializer identifier
         bytes = "Akka.Serialization.ByteArraySerializer"
     }
@@ -404,7 +405,7 @@ akka {
     # "java.io.Serializable" = none
     serialization-bindings {
       "System.Byte[]" = bytes
-      "System.Object" = json
+      "System.Object" = migrant
     }
   }
  

--- a/src/core/Akka/Serialization/MigrantSerializer.cs
+++ b/src/core/Akka/Serialization/MigrantSerializer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Security.Policy;
 using Akka.Actor;
 using Akka.Util;
 
@@ -25,17 +24,10 @@ namespace Akka.Serialization
               public MigrantSerializer(ExtendedActorSystem system) : base(system)
         {
             _serializer = new Antmicro.Migrant.Serializer();
-
-            _serializer.ForObject<ISurrogated>().SetSurrogate(x => 
-                x.ToSurrogate(system));
-
-            _serializer.ForSurrogate<ISurrogate>().SetObject(x => 
-                x.FromSurrogate(system));
-
-            _serializer.ForObject<Type>().SetSurrogate(t => 
-                new TypeSurrogate(t.AssemblyQualifiedName));
-            _serializer.ForSurrogate<TypeSurrogate>().SetObject(t => 
-                t.Restore());
+            _serializer.ForObject<ISurrogated>().SetSurrogate(x => x.ToSurrogate(system));
+            _serializer.ForSurrogate<ISurrogate>().SetObject(x => x.FromSurrogate(system));
+            _serializer.ForObject<Type>().SetSurrogate(t => new TypeSurrogate(t.AssemblyQualifiedName));
+            _serializer.ForSurrogate<TypeSurrogate>().SetObject(t => t.Restore());
         }
         
 

--- a/src/core/Akka/Serialization/MigrantSerializer.cs
+++ b/src/core/Akka/Serialization/MigrantSerializer.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.IO;
+using System.Security.Policy;
+using Akka.Actor;
+using Akka.Util;
+
+namespace Akka.Serialization
+{
+    public class TypeSurrogate
+    {
+        public TypeSurrogate(string typeName)
+        {
+            TypeName = typeName;
+        }
+        public string TypeName { get;private set; }
+
+        public Type Restore()
+        {
+            return Type.GetType(TypeName);
+        }
+    }
+    public class MigrantSerializer : Serializer
+    {
+        private readonly Antmicro.Migrant.Serializer _serializer;
+              public MigrantSerializer(ExtendedActorSystem system) : base(system)
+        {
+            _serializer = new Antmicro.Migrant.Serializer();
+
+            _serializer.ForObject<ISurrogated>().SetSurrogate(x => 
+                x.ToSurrogate(system));
+
+            _serializer.ForSurrogate<ISurrogate>().SetObject(x => 
+                x.FromSurrogate(system));
+
+            _serializer.ForObject<Type>().SetSurrogate(t => 
+                new TypeSurrogate(t.AssemblyQualifiedName));
+            _serializer.ForSurrogate<TypeSurrogate>().SetObject(t => 
+                t.Restore());
+        }
+        
+
+        public override int Identifier
+        {
+            get { return -4; }
+        }
+
+        public override bool IncludeManifest
+        {
+            get { return false; }
+        }
+
+        public override byte[] ToBinary(object obj)
+        {
+            using (var stream = new MemoryStream())
+            {
+                _serializer.Serialize(obj,stream);
+                stream.Position = 0;
+                return stream.ToArray();
+            }
+        }
+
+        public override object FromBinary(byte[] bytes, Type type)
+        {
+            using (var stream = new MemoryStream())
+            {
+                stream.Write(bytes,0,bytes.Length);
+                stream.Position = 0;
+                return _serializer.Deserialize<object>(stream);
+            }
+        }
+    }
+}

--- a/src/core/Akka/packages.config
+++ b/src/core/Akka/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Migrant" version="0.10.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
# Do not merge

This is a first PoC using the Migrant serializer instead of Json.NET

Migrant handles all of the problems that we have had with Json.NET, primitives are deserialized with their correct type, int will be int, long will be long etc. F# Discriminated Unions works fine, even when stored in an object property.

There are a lot more to investigate here, e.g. is migrant threadsafe ? does it alter its own state when serializing/deserializing? (e.g. caching)
But from my early tests, this is exactly what we have been looking for.

@Horusiath can you pull this one and experiment with F# and persistence modules to see if there are anything funky that I have missed so far?