### PR TITLE
akka-io: Ported a few tests in ByteStringSpec with bug fixes

### DIFF
--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -61,6 +61,14 @@
     <Reference Include="FluentAssertions.Core">
       <HintPath>..\..\packages\FluentAssertions.3.3.0\lib\net45\FluentAssertions.Core.dll</HintPath>
     </Reference>
+    <Reference Include="FsCheck, Version=2.0.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FsCheck.2.0.5\lib\net45\FsCheck.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FSharp.Core, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FSharp.Core.3.1.2.5\lib\net40\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web" />
@@ -166,6 +174,7 @@
     <Compile Include="TestUtils\Comparable.cs" />
     <Compile Include="TestUtils\PropsWithName.cs" />
     <Compile Include="TestUtils\Supervisor.cs" />
+    <Compile Include="Util\ByteStringSpec.cs" />
     <Compile Include="Util\CollectionExtensionsSpec.cs" />
     <Compile Include="Util\ContinuousEnumeratorSpec.cs" />
     <Compile Include="Util\Internal\Collections\IteratorTests.cs" />

--- a/src/core/Akka.Tests/Util/ByteStringSpec.cs
+++ b/src/core/Akka.Tests/Util/ByteStringSpec.cs
@@ -1,0 +1,97 @@
+﻿using System.Linq;
+using System.Text;
+using Akka.IO;
+using FsCheck;
+using Xunit;
+
+namespace Akka.Tests.Util
+{
+
+    /// <summary>
+    /// TODO: Should we use the FsCheck.XUnit integration when they upgrade to xUnit 2
+    /// </summary>
+    public class ByteStringSpec
+    {
+        class Generators
+        {
+
+            // TODO: Align with JVM Akka Generator
+            public static Arbitrary<ByteString> ByteStrings()
+            {
+                return Arb.From(Arb.Generate<byte[]>().Select(ByteString.Create));
+            }
+        }
+
+        public ByteStringSpec()
+        {
+            Arb.Register<Generators>();
+        }
+
+        [Fact]
+        public void A_ByteString_must_have_correct_size_when_concatenating()
+        {
+            Prop.ForAll((ByteString a, ByteString b) => (a + b).Count == a.Count + b.Count)
+                .QuickCheckThrowOnFailure();
+        }
+
+        [Fact]
+        public void A_ByteString_must_have_correct_size_when_dropping()
+        {
+            Prop.ForAll((ByteString a, ByteString b) => (a + b).Drop(b.Count).Count == a.Count)
+                .QuickCheckThrowOnFailure();
+        }
+
+        [Fact]
+        public void A_ByteString_must_be_sequential_when_taking()
+        {
+            Prop.ForAll((ByteString a, ByteString b) => (a + b).Take(a.Count).SequenceEqual(a))
+                .QuickCheckThrowOnFailure();
+        }
+        [Fact]
+        public void A_ByteString_must_be_sequential_when_dropping()
+        {
+            Prop.ForAll((ByteString a, ByteString b) => (a + b).Drop(a.Count).SequenceEqual(b))
+                .QuickCheckThrowOnFailure();
+        }
+
+        [Fact]
+        public void A_ByteString_must_be_equal_to_the_original_when_compacting()
+        {
+            Prop.ForAll((ByteString xs) =>
+            {
+                var ys = xs.Compact();
+                return xs.SequenceEqual(ys) && ys.IsCompact();
+            }).QuickCheckThrowOnFailure();
+        }
+        [Fact]
+        public void A_ByteString_must_be_equal_to_the_original_when_recombining()
+        {
+            Prop.ForAll((ByteString xs, int from, int until) =>
+            {
+                var tmp1 = xs.SplitAt(until);
+                var tmp2 = tmp1.Item1.SplitAt(until);
+                return (tmp2.Item1 + tmp2.Item2 + tmp1.Item2).SequenceEqual(xs);
+            }).QuickCheckThrowOnFailure();
+        }
+
+        [Fact]
+        public void A_ByteString_must_behave_as_expected_when_created_from_and_decoding_to_String()
+        {
+            Prop.ForAll((string s) => ByteString.FromString(s, Encoding.UTF8).DecodeString(Encoding.UTF8) == (s ?? "")) // TODO: What should we do with null string?
+                .QuickCheckThrowOnFailure();
+        }
+        [Fact]
+        public void A_ByteString_must_behave_as_expected_when_compacting()
+        {
+            Prop.ForAll((ByteString a) =>
+            {
+                var wasCompact = a.IsCompact();
+                var b = a.Compact();
+                return ((!wasCompact) || (b == a)) && 
+                       b.SequenceEqual(a) && 
+                       b.IsCompact() && 
+                       b.Compact() == b;
+            }).QuickCheckThrowOnFailure();
+        }
+    }
+}

--- a/src/core/Akka.Tests/packages.config
+++ b/src/core/Akka.Tests/packages.config
@@ -2,6 +2,8 @@
 <packages>
   <package id="fastJSON" version="2.0.27.1" targetFramework="net45" />
   <package id="FluentAssertions" version="3.3.0" targetFramework="net45" />
+  <package id="FsCheck" version="2.0.5" targetFramework="net45" />
+  <package id="FSharp.Core" version="3.1.2.5" targetFramework="net45" />
   <package id="xunit" version="2.0.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.0.0" targetFramework="net45" />

--- a/src/core/Akka/Util/ByteString.cs
+++ b/src/core/Akka/Util/ByteString.cs
@@ -81,7 +81,7 @@ namespace Akka.IO
             return Create(buffer);
         }
 
-        public static readonly ByteString Empty = new ByteString1C(new byte[0]);
+        public static readonly ByteString Empty = CompactByteString.EmptyCompactByteString;
 
         public static ByteStringBuilder NewBuilder()
         {
@@ -224,6 +224,11 @@ namespace Akka.IO
             public override string DecodeString(Encoding charset)
             {
                 return charset.GetString(_length == _bytes.Length ? _bytes : ToArray());
+            }
+
+            public override IEnumerator<byte> GetEnumerator()
+            {
+                return _bytes.Skip(_startIndex).Take(_length).GetEnumerator();
             }
         }
 
@@ -499,9 +504,13 @@ namespace Akka.IO
 
     partial /*object*/ class CompactByteString
     {
+        internal static readonly CompactByteString EmptyCompactByteString = new ByteString1C(new byte[0]);
+
         public static CompactByteString FromString(string str, Encoding encoding)
         {
-            return new ByteString1C(encoding.GetBytes(str));
+            return string.IsNullOrEmpty(str)
+                ? EmptyCompactByteString
+                : new ByteString1C(encoding.GetBytes(str));
         }
 
         public static ByteString FromArray(byte[] array, int offset, int length)


### PR DESCRIPTION
I found a few issues with ByteString while using akka-io. This PR contains a few tests from the ByteStringSpec, as well as fixes to bugs identified with these tests.

ByteStringSpec uses FsCheck, a port of ScalaCheck. 