### PR TITLE
akka-io: fixed #1225 - High CPU load using the Akka.IO TCP server

### DIFF
--- a/src/core/Akka/IO/SelectionHandler.cs
+++ b/src/core/Akka/IO/SelectionHandler.cs
@@ -212,7 +212,7 @@ namespace Akka.IO
                     var writeable = _write.Keys.ToList();
                     try
                     {
-                        Socket.Select(readable, writeable, null, 0);
+                        Socket.Select(readable, writeable, null, 1);
                         foreach (var socket in readable)
                         {
                             var channel = _read[socket];


### PR DESCRIPTION
TL;DR; This PR resolve issue #1225. 

The JVM socket selector will block until one socket is selected, or when wakeup is called. The behavior in JVM Akka is to block indefinitely until a socket is selected, or whenever a socket interest is added/removed  to wake-up the selector and then select again.

In .NET sockets there is unfortunately no way I'm aware of to wake-up the Socket.Select method. The high CPU usage here was caused because we never blocked on Select. 

I've changed the Select to block for 1 millisecond (the lowest timespan), which (in my testing at least) changed the idle CPU usage from 15% to 0%. The compromise is of course that some socket operation might wait a average of 0.5 ms, before they complete. I still have to do detailed measurement on the performance impact, but from my initial testing is seems reasonable.

The longer term solution is to switch to completely asynchronous sockets. I have a working version of this, but it breaks most TcpConnectionSpec tests - which are white box tests.
