### PR TITLE
Upgrade FAKE to version 4.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,3 +214,6 @@ FakesAssemblies/
 /src/.Akka.boltdata/TestResults.json
 resetdev.bat
 /src/packages/repositories.config
+
+# FAKE build folder
+.fake/

--- a/build.cmd
+++ b/build.cmd
@@ -4,12 +4,12 @@ pushd %~dp0
 
 src\.nuget\NuGet.exe update -self
 
-src\.nuget\NuGet.exe install FAKE -ConfigFile src\.nuget\Nuget.Config -OutputDirectory src\packages -ExcludeVersion -Version 3.28.8
+src\.nuget\NuGet.exe install FAKE -ConfigFile src\.nuget\Nuget.Config -OutputDirectory src\packages -ExcludeVersion -Version 4.1.0
 
 src\.nuget\NuGet.exe install xunit.runner.console -ConfigFile src\.nuget\Nuget.Config -OutputDirectory src\packages\FAKE -ExcludeVersion -Version 2.0.0
 src\.nuget\NuGet.exe install nunit.runners -ConfigFile src\.nuget\Nuget.Config -OutputDirectory src\packages\FAKE -ExcludeVersion -Version 2.6.4
 
-if not exist src\packages\SourceLink.Fake\tools\SourceLink.fsx ( 
+if not exist src\packages\SourceLink.Fake\tools\SourceLink.fsx (
   src\.nuget\nuget.exe install SourceLink.Fake -ConfigFile src\.nuget\Nuget.Config -OutputDirectory src\packages -ExcludeVersion
 )
 rem cls

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,4 +1,3 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FAKE" version="3.17.0" />
 </packages>


### PR DESCRIPTION
Altered build command to install 4.1.0
Added .fake/ directory to .gitignore. Directory contains build artifacts.
Removed Fake 3.17.0 from packages.config as build.cmd dicates version.

Fixes #1241