### PR TITLE
implemented event adapters

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryMapper.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryMapper.cs
@@ -41,14 +41,14 @@ namespace Akka.Persistence.Sql.Common.Journal
             var persistenceId = reader.GetString(0);
             var sequenceNr = reader.GetInt64(1);
             var isDeleted = reader.GetBoolean(2);
-            var payload = GetPayload(reader);
+            var payloadType = reader.GetString(3);
+            var payload = GetPayload(reader, payloadType);
 
-            return new Persistent(payload, sequenceNr, persistenceId, isDeleted, sender);
+            return new Persistent(payload, sequenceNr, payloadType, persistenceId, isDeleted, sender);
         }
 
-        private object GetPayload(DbDataReader reader)
+        private object GetPayload(DbDataReader reader, string payloadType)
         {
-            var payloadType = reader.GetString(3);
             var type = Type.GetType(payloadType, true);
             var binary = (byte[]) reader[4];
 

--- a/src/core/Akka.Persistence.TestKit/Journal/JournalSpec.cs
+++ b/src/core/Akka.Persistence.TestKit/Journal/JournalSpec.cs
@@ -75,7 +75,7 @@ namespace Akka.Persistence.TestKit.Journal
 
         private Persistent[] WriteMessages(int from, int to, string pid, IActorRef sender)
         {
-            var messages = Enumerable.Range(from, to).Select(i => new Persistent("a-" + i, i, pid, false, sender)).ToArray();
+            var messages = Enumerable.Range(from, to).Select(i => new Persistent("a-" + i, i, string.Empty, pid, false, sender)).ToArray();
             var probe = CreateTestProbe();
 
             Journal.Tell(new WriteMessages(messages, probe.Ref, ActorInstanceId));

--- a/src/core/Akka.Persistence.Tests/Akka.Persistence.Tests.csproj
+++ b/src/core/Akka.Persistence.Tests/Akka.Persistence.Tests.csproj
@@ -62,7 +62,9 @@
     <Compile Include="AtLeastOnceDeliveryCrashSpec.cs" />
     <Compile Include="AtLeastOnceDeliveryFailureSpec.cs" />
     <Compile Include="AtLeastOnceDeliverySpec.cs" />
+    <Compile Include="EndToEndEventAdapterSpec.cs" />
     <Compile Include="Journal\ChaosJournal.cs" />
+    <Compile Include="MemoryEventAdapterSpec.cs" />
     <Compile Include="PersistenceSpec.cs" />
     <Compile Include="PersistentActorFailureSpec.cs" />
     <Compile Include="PersistentActorSpec.cs" />

--- a/src/core/Akka.Persistence.Tests/EndToEndEventAdapterSpec.cs
+++ b/src/core/Akka.Persistence.Tests/EndToEndEventAdapterSpec.cs
@@ -1,0 +1,392 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="EndToEndEventAdapterSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Persistence.Journal;
+using Akka.TestKit;
+using Akka.TestKit.Xunit2;
+using Xunit;
+
+namespace Akka.Persistence.Tests
+{
+    public class MemoryEndToEndAdapterSpec : EndToEndEventAdapterSpec
+    {
+        private static readonly Config Config = ConfigurationFactory.ParseString(@"akka.persistence.journal.inmem.shared = true");
+        public MemoryEndToEndAdapterSpec() : base("inmem", PersistenceSpec.Configuration("inmem", "MemoryEndToEndAdapterSpec").WithFallback(Config))
+        {
+        }
+    }
+
+    internal class InternalTestKit : TestKitBase
+    {
+        public InternalTestKit(string actorSystemName, Config config) : base(new XunitAssertions(), config, actorSystemName)
+        {
+        }
+    }
+
+    public abstract class EndToEndEventAdapterSpec : PersistenceSpec
+    {
+        private readonly string _journalName;
+        private readonly Config _journalConfig;
+
+        #region Internal test classes
+
+        internal interface IAppModel
+        {
+            object Payload { get; }
+        }
+
+        [Serializable]
+        public sealed class A : IAppModel
+        {
+            public A(object payload)
+            {
+                Payload = payload;
+            }
+
+            public object Payload { get; private set; }
+        }
+
+        [Serializable]
+        public sealed class B : IAppModel
+        {
+            public B(object payload)
+            {
+                Payload = payload;
+            }
+
+            public object Payload { get; private set; }
+        }
+
+        [Serializable]
+        public sealed class NewA : IAppModel
+        {
+            public NewA(object payload)
+            {
+                Payload = payload;
+            }
+
+            public object Payload { get; private set; }
+        }
+
+        [Serializable]
+        public sealed class NewB : IAppModel
+        {
+            public NewB(object payload)
+            {
+                Payload = payload;
+            }
+
+            public object Payload { get; private set; }
+        }
+
+        [Serializable]
+        public sealed class Json
+        {
+            public readonly object Payload;
+
+            public Json(object payload)
+            {
+                Payload = payload;
+            }
+        }
+
+        public class AEndToEndAdapter : IEventAdapter
+        {
+            public AEndToEndAdapter(ExtendedActorSystem system)
+            {
+            }
+
+            public string Manifest(object evt)
+            {
+                return evt.GetType().Name;
+            }
+
+            public object ToJournal(object evt)
+            {
+                if (evt is IAppModel) return new Json((evt as IAppModel).Payload);
+                return null;
+            }
+
+            public IEventSequence FromJournal(object evt, string manifest)
+            {
+                Json m;
+                if ((m = evt as Json) != null && m.Payload.ToString().StartsWith("a"))
+                    return EventSequence.Single(new A(m.Payload));
+                else
+                    return EventSequence.Empty;
+            }
+        }
+
+        public class NewAEndToEndAdapter : IEventAdapter
+        {
+            public NewAEndToEndAdapter(ExtendedActorSystem system)
+            {
+            }
+
+            public string Manifest(object evt)
+            {
+                return evt.GetType().Name;
+            }
+
+            public object ToJournal(object evt)
+            {
+                if (evt is IAppModel) return new Json((evt as IAppModel).Payload);
+                return null;
+            }
+
+            public IEventSequence FromJournal(object evt, string manifest)
+            {
+                Json m;
+                if ((m = evt as Json) != null && m.Payload.ToString().StartsWith("a"))
+                    return EventSequence.Single(new NewA(m.Payload));
+                else
+                    return EventSequence.Empty;
+            }
+        }
+
+        public class BEndToEndAdapter : IEventAdapter
+        {
+            public BEndToEndAdapter(ExtendedActorSystem system)
+            {
+            }
+
+            public string Manifest(object evt)
+            {
+                return evt.GetType().Name;
+            }
+
+            public object ToJournal(object evt)
+            {
+                if (evt is IAppModel) return new Json((evt as IAppModel).Payload);
+                return null;
+            }
+
+            public IEventSequence FromJournal(object evt, string manifest)
+            {
+                Json m;
+                if ((m = evt as Json) != null && m.Payload.ToString().StartsWith("b"))
+                    return EventSequence.Single(new B(m.Payload));
+                else
+                    return EventSequence.Empty;
+            }
+        }
+
+        public class NewBEndToEndAdapter : IEventAdapter
+        {
+            public NewBEndToEndAdapter(ExtendedActorSystem system)
+            {
+            }
+
+            public string Manifest(object evt)
+            {
+                return evt.GetType().Name;
+            }
+
+            public object ToJournal(object evt)
+            {
+                if (evt is IAppModel) return new Json((evt as IAppModel).Payload);
+                return null;
+            }
+
+            public IEventSequence FromJournal(object evt, string manifest)
+            {
+                Json m;
+                if ((m = evt as Json) != null && m.Payload.ToString().StartsWith("b"))
+                    return EventSequence.Single(new NewB(m.Payload));
+                else
+                    return EventSequence.Empty;
+            }
+        }
+
+        public class EndToEndAdapterActor : NamedPersistentActor
+        {
+            private readonly LinkedList<object> _state = new LinkedList<object>();
+
+            private readonly IActorRef _probe;
+            public EndToEndAdapterActor(string name, string journalPluginId, IActorRef probe) : base(name)
+            {
+                _probe = probe;
+                JournalPluginId = journalPluginId;
+            }
+
+            protected bool PersistIncomming(object message)
+            {
+                if (message is GetState)
+                {
+                    foreach (var e in _state)
+                    {
+                        Sender.Tell(e);
+                    }
+                }
+                else
+                {
+                    var sender = Sender;
+                    Persist(message, e =>
+                    {
+                        _state.AddLast(e);
+                        sender.Tell(e);
+                    });
+                }
+                return true;
+            }
+
+            protected override bool ReceiveRecover(object message)
+            {
+                if (message is RecoveryCompleted) ;
+                else _state.AddLast(message);
+                return true;
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                return PersistIncomming(message);
+            }
+        }
+
+        #endregion
+
+        protected readonly Config NoAdaptersConfig = ConfigurationFactory.Empty;
+        protected readonly Config AdaptersConfig;
+        private static readonly string AdaptersConfigFormat = @"
+            akka.persistence.journal {{
+                {0} {{
+                    event-adapters {{
+                        a = ""{1}+AEndToEndAdapter, Akka.Persistence.Tests""
+                        b = ""{1}+BEndToEndAdapter, Akka.Persistence.Tests""
+                    }}
+                    event-adapter-bindings {{
+                        # to journal
+                        ""{1}+A, Akka.Persistence.Tests"" = a
+                        ""{1}+B, Akka.Persistence.Tests"" = b
+
+                        # from journal
+                        ""{1}+Json, Akka.Persistence.Tests"" = [a,b]
+                    }}
+                }}
+            }}";
+        protected readonly Config NewAdaptersConfig;
+        private static readonly string NewAdaptersConfigFormat = @"
+            akka.persistence.journal {{
+                {0} {{
+                    event-adapters {{
+                        a = ""{1}+NewAEndToEndAdapter, Akka.Persistence.Tests""
+                        b = ""{1}+NewBEndToEndAdapter, Akka.Persistence.Tests""
+                    }}
+                    event-adapter-bindings {{
+                        # to journal
+                        ""{1}+A, Akka.Persistence.Tests"" = a
+                        ""{1}+B, Akka.Persistence.Tests"" = b
+
+                        # from journal
+                        ""{1}+Json, Akka.Persistence.Tests"" = [a,b]
+                    }}
+                }}
+            }}";
+
+        protected EndToEndEventAdapterSpec(string journalName, Config journalConfig)
+            : base(PersistenceSpec.Configuration("inmem", "EndToEndEventAdapterSpec"))
+        {
+            _journalName = journalName;
+            _journalConfig = journalConfig;
+
+            AdaptersConfig = string.Format(AdaptersConfigFormat, journalName, typeof(EndToEndEventAdapterSpec).FullName);
+            NewAdaptersConfig = string.Format(NewAdaptersConfigFormat, journalName, typeof(EndToEndEventAdapterSpec).FullName);
+        }
+
+        private IActorRef Persister(string name, IActorRef probe, ActorSystem system)
+        {
+            return (system ?? Sys).ActorOf(Props.Create(() => new EndToEndAdapterActor(name, "akka.persistence.journal." + _journalName, probe)), name);
+        }
+
+        private T WithActorSystem<T>(string name, Config config, Func<ActorSystem, T> block)
+        {
+            var testKit = new InternalTestKit(name, _journalConfig.WithFallback(config));
+            using (var system = testKit.Sys)
+            {
+                return block(system);
+            }
+        }
+
+        [Fact]
+        public void EventAdapters_in_end_to_end_scenarios_should_use_the_same_adapter_when_reading_as_was_used_when_writing_to_journal()
+        {
+            WithActorSystem("SimpleSystem", AdaptersConfig, system =>
+            {
+                var probe = new TestProbe(system, Assertions);
+
+                var p1 = Persister("p1", probe, system);
+                var a = new A("a1");
+                var b = new B("b1");
+                p1.Tell(a, probe.Ref);
+                p1.Tell(b, probe.Ref);
+
+                probe.ExpectMsg<A>(x => x.Payload.Equals("a1"));
+                probe.ExpectMsg<B>(x => x.Payload.Equals("b1"));
+
+                probe.Watch(p1);
+                p1.Tell(PoisonPill.Instance);
+                probe.ExpectTerminated(p1);
+
+                var p11 = Persister("p1", probe, system);
+                p11.Tell(GetState.Instance, probe.Ref);
+
+                probe.ExpectMsg<A>(x => x.Payload.Equals("a1"));
+                probe.ExpectMsg<B>(x => x.Payload.Equals("b1"));
+
+                return true;
+            });
+        }
+
+        [Fact]
+        public void EventAdapters_in_end_to_end_scenarios_should_allow_using_an_adapter_when_write_was_performed_without_an_adapter()
+        {
+            var pid = "p2";
+            WithActorSystem("NoAdapterSystem", AdaptersConfig, system =>
+            {
+                var probe = new TestProbe(system, Assertions);
+
+                var p2 = Persister(pid, probe, system);
+                var a = new A("a1");
+                var b = new B("b1");
+                p2.Tell(a, probe.Ref);
+                p2.Tell(b, probe.Ref);
+
+                probe.ExpectMsg<A>(x => x.Payload.Equals("a1"));
+                probe.ExpectMsg<B>(x => x.Payload.Equals("b1"));
+
+                probe.Watch(p2);
+                p2.Tell(PoisonPill.Instance);
+                probe.ExpectTerminated(p2);
+
+                var p21 = Persister(pid, probe, system);
+                p21.Tell(GetState.Instance, probe.Ref);
+
+                probe.ExpectMsg<A>(x => x.Payload.Equals("a1"));
+                probe.ExpectMsg<B>(x => x.Payload.Equals("b1"));
+
+                return true;
+            });
+
+            WithActorSystem("NoAdaptersAdded", NewAdaptersConfig, system =>
+            {
+                var probe = new TestProbe(system, Assertions);
+                var p22 = Persister(pid, probe, system);
+                p22.Tell(GetState.Instance, probe.Ref);
+
+                probe.ExpectMsg<NewA>(x => x.Payload.Equals("a1"));
+                probe.ExpectMsg<NewB>(x => x.Payload.Equals("b1"));
+
+                return true;
+            });
+        }
+    }
+}

--- a/src/core/Akka.Persistence.Tests/MemoryEventAdapterSpec.cs
+++ b/src/core/Akka.Persistence.Tests/MemoryEventAdapterSpec.cs
@@ -1,0 +1,386 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.Persistence.Journal;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Persistence.Tests
+{
+    public class MemoryEventAdapterSpec : PersistenceSpec
+    {
+        #region Internal test classes
+
+        public interface IJournalModel
+        {
+            object Payload { get; }
+            ISet<string> Tags { get; }
+        }
+
+        [Serializable]
+        public sealed class Tagged : IJournalModel, IEquatable<IJournalModel>
+        {
+            public object Payload { get; private set; }
+            public ISet<string> Tags { get; private set; }
+
+            public Tagged(object payload, ISet<string> tags)
+            {
+                Payload = payload;
+                Tags = tags;
+            }
+
+            public bool Equals(IJournalModel other)
+            {
+                return other != null && Payload.Equals(other.Payload) && Tags.SetEquals(other.Tags);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return Equals(obj as IJournalModel);
+            }
+        }
+
+        [Serializable]
+        public sealed class NotTagged : IJournalModel, IEquatable<IJournalModel>
+        {
+            public object Payload { get; private set; }
+            public ISet<string> Tags { get { return new HashSet<string>(); } }
+
+            public NotTagged(object payload)
+            {
+                Payload = payload;
+            }
+
+            public bool Equals(IJournalModel other)
+            {
+                return other != null && Payload.Equals(other.Payload) && Tags.SetEquals(other.Tags);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return Equals(obj as IJournalModel);
+            }
+        }
+
+        public interface IDomainEvent { }
+
+        [Serializable]
+        public sealed class TaggedDataChanged : IDomainEvent, IEquatable<TaggedDataChanged>
+        {
+            public readonly ISet<string> Tags;
+            public readonly int Value;
+
+            public TaggedDataChanged(ISet<string> tags, int value)
+            {
+                Tags = tags;
+                Value = value;
+            }
+
+            public bool Equals(TaggedDataChanged other)
+            {
+                return other != null && Tags.SetEquals(other.Tags) && Value == other.Value;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return Equals(obj as TaggedDataChanged);
+            }
+        }
+
+        [Serializable]
+        public sealed class UserDataChanged : IDomainEvent, IEquatable<UserDataChanged>
+        {
+            public readonly string CountryCode;
+            public readonly int Age;
+
+            public UserDataChanged(string countryCode, int age)
+            {
+                CountryCode = countryCode;
+                Age = age;
+            }
+
+            public bool Equals(UserDataChanged other)
+            {
+                return other != null && Age == other.Age && CountryCode.Equals(other.CountryCode);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return Equals(obj as UserDataChanged);
+            }
+        }
+
+        public class UserAgeTaggingAdapter : IEventAdapter
+        {
+            public readonly ISet<string> Adult = new HashSet<string> { "adult" };
+            public readonly ISet<string> Minor = new HashSet<string> { "minor" };
+
+            public string Manifest(object evt)
+            {
+                return string.Empty;
+            }
+
+            public object ToJournal(object evt)
+            {
+                var e = evt as UserDataChanged;
+                if (e == null) return new NotTagged(evt);
+                return new Tagged(e, e.Age > 18 ? Adult : Minor);
+            }
+
+            public virtual IEventSequence FromJournal(object evt, string manifest)
+            {
+                IJournalModel m;
+                return EventSequence.Single((m = evt as IJournalModel) != null ? m.Payload : null);
+            }
+        }
+
+        public class ReplayPassThroughAdapter : UserAgeTaggingAdapter
+        {
+            public override IEventSequence FromJournal(object evt, string manifest)
+            {
+                // don't unpack, just pass through the JournalModel
+                return EventSequence.Single(evt);
+            }
+        }
+
+        public class LoggingAdapter : IEventAdapter
+        {
+            public readonly ILoggingAdapter Log;
+            public LoggingAdapter(ExtendedActorSystem system)
+            {
+                Log = system.Log;
+            }
+
+            public string Manifest(object evt)
+            {
+                return string.Empty;
+            }
+
+            public object ToJournal(object evt)
+            {
+                Log.Info("On it's way to the journal: {0}", evt);
+                return evt;
+            }
+
+            public IEventSequence FromJournal(object evt, string manifest)
+            {
+                Log.Info("On it's way from the journal: {0}", evt);
+                return EventSequence.Single(evt);
+            }
+        }
+
+        public class PersistAllIncommingActor : NamedPersistentActor
+        {
+            public readonly LinkedList<object> State = new LinkedList<object>();
+
+            public PersistAllIncommingActor(string name, string journalPluginId) : base(name)
+            {
+                JournalPluginId = journalPluginId;
+            }
+
+            private bool PersistIncoming(object message)
+            {
+                if (message is GetState)
+                    foreach (var e in State)
+                    {
+                        Sender.Tell(e);
+                    }
+                else
+                {
+                    var sender = Sender;
+                    Persist(message, e =>
+                    {
+                        State.AddLast(e);
+                        sender.Tell(e);
+                    });
+                }
+                return true;
+            }
+
+            protected override bool ReceiveRecover(object message)
+            {
+                if (message is RecoveryCompleted) ;
+                else
+                {
+                    State.AddLast(message);
+                }
+                return true;
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                return PersistIncoming(message);
+            }
+        }
+
+        #endregion
+
+        private readonly string _journalName;
+        private static readonly string JournalModelTypeName = typeof(IJournalModel).FullName + ", Akka.Persistence.Tests";
+        private static readonly string DomainEventTypeName = typeof(IDomainEvent).FullName + ", Akka.Persistence.Tests";
+
+        private static readonly string _configFormat = @"
+            akka.persistence.journal {{
+                common-event-adapters {{
+                    age = ""{0}""
+                    replay-pass-through = ""{1}""
+                }}
+                inmem {{
+                    # change to path reference $akka.persistence.journal.common-event-adapters
+                    event-adapters {{
+                        age = ""{0}""
+                        replay-pass-through = ""{1}""
+                    }}
+                    event-adapter-bindings {{
+                        ""{2}"" = age
+                        ""{3}"" = age
+                    }}
+                }}
+                with-actor-system {{
+                    class = ""Akka.Persistence.Journal.MemoryJournal, Akka.Persistence""
+                    dispatcher = default-dispatcher
+                    dir = ""journal-1""
+
+                    event-adapters {{
+                        logging = ""{4}""
+                    }}
+                    event-adapters-bindings {{
+                        ""System.Object"" = logging
+                    }}
+                }}
+                replay-pass-through-adapter-journal {{
+                    class = ""Akka.Persistence.Journal.MemoryJournal, Akka.Persistence""
+                    dispatcher = default-dispatcher
+                    dir = ""journal-2""
+
+                    # change to path reference $akka.persistence.journal.common-event-adapters
+                    event-adapters {{
+                        age = ""{0}""
+                        replay-pass-through = ""{1}""
+                    }}
+                    event-adapter-bindings {{
+                        ""{2}"" = replay-pass-through
+                        ""{3}"" = replay-pass-through
+                    }}
+                }}
+                no-adapter {{
+                    class = ""Akka.Persistence.Journal.MemoryJournal, Akka.Persistence""
+                    dispatcher = default-dispatcher
+                    dir = ""journal-3""                    
+                }}
+            }}";
+
+        public static readonly string AdapterSpecConfig = string.Format(_configFormat,
+            typeof(UserAgeTaggingAdapter).FullName + ", Akka.Persistence.Tests",
+            typeof(ReplayPassThroughAdapter).FullName + ", Akka.Persistence.Tests",
+            DomainEventTypeName,
+            JournalModelTypeName,
+            typeof(LoggingAdapter).FullName + ", Akka.Persistence.Tests");
+
+        public MemoryEventAdapterSpec()
+            : this("inmem", PersistenceSpec.Configuration("inmem", "MemoryEventAdapterSpec"), ConfigurationFactory.ParseString(AdapterSpecConfig))
+        {
+
+        }
+
+        protected MemoryEventAdapterSpec(string journalName, Config journalConfig, Config adapterConfig)
+            : base(journalConfig.WithFallback(adapterConfig))
+        {
+            _journalName = journalName;
+        }
+
+        private IActorRef Persister(string name, string journalName = null)
+        {
+            return Sys.ActorOf(Props.Create(() => new PersistAllIncommingActor(name, "akka.persistence.journal." + (journalName ?? _journalName))), name);
+        }
+
+        private object ToJournal(object message, string journalName = null)
+        {
+            journalName = string.IsNullOrEmpty(journalName) ? _journalName : journalName;
+            return Persistence.Instance.Apply(Sys).AdaptersFor("akka.persistence.journal." + journalName).Get(message.GetType()).ToJournal(message);
+        }
+
+        private object FromJournal(object message, string journalName = null)
+        {
+            journalName = string.IsNullOrEmpty(journalName) ? _journalName : journalName;
+            return Persistence.Instance.Apply(Sys).AdaptersFor("akka.persistence.journal." + journalName).Get(message.GetType()).FromJournal(message, string.Empty);
+        }
+
+        [Fact]
+        public void EventAdapter_should_wrap_with_tags()
+        {
+            var e = new UserDataChanged("name", 42);
+            ToJournal(e).ShouldBe(new Tagged(e, new HashSet<string> { "adult" }));
+        }
+
+        [Fact]
+        public void EventAdapter_should_unwrap_when_reading()
+        {
+            var e = new UserDataChanged("name", 42);
+            var tagged = new Tagged(e, new HashSet<string> { "adult" });
+
+            ToJournal(e).ShouldBe(tagged);
+            FromJournal(tagged, string.Empty).ShouldBe(new SingleEventSequence(e));
+        }
+
+        [Fact]
+        public void EventAdapter_should_create_adapter_requiring_actor_system()
+        {
+            var e = new UserDataChanged("name", 42);
+
+            ToJournal(e, "with-actor-system").ShouldBe(e);
+            FromJournal(e, "with-actor-system").ShouldBe(new SingleEventSequence(e));
+        }
+
+        [Fact]
+        public void EventAdapter_should_store_events_after_applying_adapter()
+        {
+            var replayPassThroughJournalId = "replay-pass-through-adapter-journal";
+
+            var p1 = Persister("p1", replayPassThroughJournalId);
+            var m1 = new UserDataChanged("name", 64);
+            var m2 = "hello";
+
+            p1.Tell(m1);
+            p1.Tell(m2);
+            ExpectMsg(m1);
+            ExpectMsg(m2);
+
+            Watch(p1);
+            p1.Tell(PoisonPill.Instance);
+            ExpectTerminated(p1);
+
+            var p11 = Persister("p1", replayPassThroughJournalId);
+            p11.Tell(GetState.Instance);
+            ExpectMsg(new Tagged(m1, new HashSet<string> { "adult" }));
+            ExpectMsg(m2);
+        }
+
+        [Fact]
+        public void EventAdapter_should_work_when_plugin_defines_no_adapter()
+        {
+            var noAdapter = "no-adapter";
+
+            var p1 = Persister("p1", noAdapter);
+            var m1 = new UserDataChanged("name", 64);
+            var m2 = "hello";
+
+            p1.Tell(m1);
+            p1.Tell(m2);
+            ExpectMsg(m1);
+            ExpectMsg(m2);
+
+            Watch(p1);
+            p1.Tell(PoisonPill.Instance);
+            ExpectTerminated(p1);
+
+            var p11 = Persister("p1", noAdapter);
+            p11.Tell(GetState.Instance);
+            ExpectMsg(m1);
+            ExpectMsg(m2);
+        }
+    }
+}

--- a/src/core/Akka.Persistence/Akka.Persistence.csproj
+++ b/src/core/Akka.Persistence/Akka.Persistence.csproj
@@ -59,6 +59,8 @@
     <Compile Include="Eventsourced.cs" />
     <Compile Include="Eventsourced.Recovery.cs" />
     <Compile Include="InternalExtensions.cs" />
+    <Compile Include="Journal\EventAdapters.cs" />
+    <Compile Include="Journal\EventSequences.cs" />
     <Compile Include="PersistentActor.cs" />
     <Compile Include="PersistentView.Recovery.cs" />
     <Compile Include="PersistentView.Lifecycle.cs" />

--- a/src/core/Akka.Persistence/InternalExtensions.cs
+++ b/src/core/Akka.Persistence/InternalExtensions.cs
@@ -5,8 +5,10 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Configuration.Hocon;
 using Akka.Dispatch;
 using Akka.Dispatch.MessageQueues;
 

--- a/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
@@ -89,7 +89,13 @@ namespace Akka.Persistence.Journal
             // to resequence replayed messages relative to written and looped messages.
             ReplayMessagesAsync(message.PersistenceId, message.FromSequenceNr, message.ToSequenceNr, message.Max, p =>
             {
-                if (!p.IsDeleted || message.ReplayDeleted) message.PersistentActor.Tell(new ReplayedMessage(p), p.Sender);
+                if (!p.IsDeleted || message.ReplayDeleted)
+                {
+                    foreach (var adaptedRepresentation in AdaptFromJournal(p))
+                    {
+                        message.PersistentActor.Tell(new ReplayedMessage(adaptedRepresentation), p.Sender);
+                    }
+                }
             })
             .NotifyAboutReplayCompletion(message.PersistentActor)
             .ContinueWith(t =>
@@ -127,21 +133,22 @@ namespace Akka.Persistence.Journal
              * execution context.
              */
             var self = Self;
-            WriteMessagesAsync(CreatePersistentBatch(message.Messages)).ContinueWith(t =>
-            {
-                if (!t.IsFaulted)
-                {
-                    _resequencer.Tell(new Desequenced(WriteMessagesSuccessful.Instance, counter, message.PersistentActor, self));
-                    resequence(x => new WriteMessageSuccess(x, message.ActorInstanceId));
-                }
-                else
-                {
-                    _resequencer.Tell(new Desequenced(new WriteMessagesFailed(t.Exception), counter, message.PersistentActor, self));
-                    resequence(x => new WriteMessageFailure(x, t.Exception, message.ActorInstanceId));
-                }
-            }, _continuationOptions);
             var resequencablesLength = message.Messages.Count();
             _resequencerCounter += resequencablesLength + 1;
+            WriteMessagesAsync(CreatePersistentBatch(message.Messages).ToArray())
+                .ContinueWith(t =>
+                {
+                    if (!t.IsFaulted)
+                    {
+                        _resequencer.Tell(new Desequenced(WriteMessagesSuccessful.Instance, counter, message.PersistentActor, self));
+                        resequence(x => new WriteMessageSuccess(x, message.ActorInstanceId));
+                    }
+                    else
+                    {
+                        _resequencer.Tell(new Desequenced(new WriteMessagesFailed(t.Exception), counter, message.PersistentActor, self));
+                        resequence(x => new WriteMessageFailure(x, t.Exception, message.ActorInstanceId));
+                    }
+                }, _continuationOptions);
         }
 
         internal sealed class Desequenced

--- a/src/core/Akka.Persistence/Journal/EventAdapters.cs
+++ b/src/core/Akka.Persistence/Journal/EventAdapters.cs
@@ -1,0 +1,282 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="EventAdapters.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Configuration.Hocon;
+using Akka.Event;
+using Akka.Pattern;
+
+namespace Akka.Persistence.Journal
+{
+    /// <summary>
+    /// <para>Facility to convert from and to specialised data models, as may be required by specialized persistence Journals.</para>
+    ///
+    /// <para>Typical use cases include(but are not limited to):</para>
+    /// <para>- adding metadata, a.k.a. "tagging" - by wrapping objects into tagged counterparts</para>
+    /// <para>- manually converting to the Journals storage format, such as JSON, BSON or any specialised binary format</para>
+    /// <para>- adapting incoming events in any way before persisting them by the journal</para>
+    /// </summary>
+    public interface IEventAdapter
+    {
+        /// <summary>
+        /// Return the manifest (type hint) that will be provided in the <see cref="FromJournal"/> method. Use empty string if not needed.
+        /// </summary>
+        /// <param name="evt"></param>
+        /// <returns></returns>
+        string Manifest(object evt);
+
+        /// <summary>
+        /// <para>Convert domain event to journal event type.</para>
+        ///
+        /// <para>Some journal may require a specific type to be returned to them,
+        /// for example if a primary key has to be associated with each event then a journal
+        /// may require adapters to return "EventWithPrimaryKey(event, key)".</para>
+        ///
+        /// <para>The <see cref="ToJournal"/> adaptation must be an 1-to-1 transformation.
+        /// It is not allowed to drop incoming events during the `toJournal` adaptation.</para>
+        /// </summary>
+        /// <param name="evt">the application-side domain event to be adapted to the journal model</param>
+        /// <returns>the adapted event object, possibly the same object if no adaptation was performed</returns>
+        object ToJournal(object evt);
+
+        /// <summary>
+        /// <para>Convert a event from its journal model to the applications domain model.</para>
+        ///
+        /// <para>One event may be adapter into multiple(or none) events which should be delivered to the <see cref="PersistentActor"/>.
+        /// Use the specialised <see cref="EventSequence.Single"/> method to emit exactly one event,
+        /// or <see cref="EventSequence.Empty"/> in case the adapter is not handling this event. Multiple <see cref="IEventAdapter"/> instances are
+        /// applied in order as defined in configuration and their emitted event seqs are concatenated and delivered in order
+        /// to the PersistentActor.</para>
+        /// </summary>
+        /// <param name="evt">event to be adapted before delivering to the PersistentActor</param>
+        /// <param name="manifest">optionally provided manifest(type hint) in case the Adapter has stored one for this event. Use empty string if none.</param>
+        /// <returns>sequence containing the adapted events (possibly zero) which will be delivered to the PersistentActor</returns>
+        IEventSequence FromJournal(object evt, string manifest);
+    }
+
+    [Serializable]
+    public class IdentityEventAdapter : IEventAdapter
+    {
+        public static readonly IdentityEventAdapter Instance = new IdentityEventAdapter();
+
+        private IdentityEventAdapter() { }
+
+        public string Manifest(object evt)
+        {
+            return string.Empty;
+        }
+
+        public object ToJournal(object evt)
+        {
+            return evt;
+        }
+
+        public IEventSequence FromJournal(object evt, string manifest)
+        {
+            return EventSequence.Single(evt);
+        }
+    }
+
+    [Serializable]
+    public sealed class CombinedReadEventAdapter : IEventAdapter
+    {
+        private static readonly Exception OnlyReadSideException = new IllegalStateException(
+                "CombinedReadEventAdapter must not be used when writing (creating manifests) events!");
+
+        private readonly IEventAdapter[] _adapters;
+
+        public IEnumerable<IEventAdapter> Adapters { get { return _adapters; } }
+
+        public CombinedReadEventAdapter(IEnumerable<IEventAdapter> adapters)
+        {
+            _adapters = adapters.ToArray();
+        }
+
+        public string Manifest(object evt)
+        {
+            throw OnlyReadSideException;
+        }
+
+        public object ToJournal(object evt)
+        {
+            throw OnlyReadSideException;
+        }
+
+        public IEventSequence FromJournal(object evt, string manifest)
+        {
+            return EventSequence.Create(_adapters.SelectMany(adapter => adapter.FromJournal(evt, manifest).Events));
+        }
+    }
+
+    internal class IdentityEventAdapters : EventAdapters
+    {
+        public static readonly EventAdapters Instance = new IdentityEventAdapters();
+
+        private IdentityEventAdapters() : base(null, null, null)
+        {
+        }
+
+        public override IEventAdapter Get(Type type)
+        {
+            return IdentityEventAdapter.Instance;
+        }
+    }
+
+    public class EventAdapters
+    {
+        private readonly ConcurrentDictionary<Type, IEventAdapter> _map;
+        private readonly IEnumerable<KeyValuePair<Type, IEventAdapter>> _bindings;
+        private readonly ILoggingAdapter _log;
+
+        public static EventAdapters Create(ExtendedActorSystem system, Config config)
+        {
+            var adapters = ConfigToMap(config, "event-adapters");
+            var adapterBindings = ConfigToListMap(config, "event-adapter-bindings");
+
+            return Create(system, adapters, adapterBindings);
+        }
+
+        private static EventAdapters Create(ExtendedActorSystem system, IDictionary<string, string> adapters, IDictionary<string, string[]> adapterBindings)
+        {
+            var adapterNames = new HashSet<string>(adapters.Keys);
+            foreach (var kv in adapterBindings)
+            {
+                foreach (var boundAdapter in kv.Value)
+                {
+                    if (!adapterNames.Contains(boundAdapter))
+                        throw new ArgumentException(string.Format("{0} was bound to undefined event-adapter: {1} (bindings: [{2}], known adapters: [{3}])",
+                            kv.Key, boundAdapter, string.Join(", ", kv.Value), string.Join(", ", adapters.Keys)));
+                }
+            }
+
+            // A Map of handler from alias to implementation (i.e. class implementing Akka.Serialization.ISerializer)
+            // For example this defines a handler named 'country': `"country" -> com.example.comain.CountryTagsAdapter`
+            var handlers = adapters.ToDictionary(kv => kv.Key, kv => Instantiate<IEventAdapter>(kv.Value, system));
+
+            // bindings is a enumerable of key-val representing the mapping from Type to handler.
+            // It is primarily ordered by the most specific classes first, and secondly in the configured order.
+            var bindings = Sort(adapterBindings.Select(kv =>
+            {
+                var type = Type.GetType(kv.Key);
+                var adapter = kv.Value.Length == 1
+                    ? handlers[kv.Value[0]]
+                    : new CombinedReadEventAdapter(kv.Value.Select(h => handlers[h]));
+                return new KeyValuePair<Type, IEventAdapter>(type, adapter);
+            }).ToList());
+
+            var backing = new ConcurrentDictionary<Type, IEventAdapter>();
+
+            foreach (var pair in bindings)
+            {
+                backing.AddOrUpdate(pair.Key, pair.Value, (type, adapter) => pair.Value);
+            }
+
+            return new EventAdapters(backing, bindings, system.Log);
+        }
+
+        private static List<KeyValuePair<Type, IEventAdapter>> Sort(List<KeyValuePair<Type, IEventAdapter>> bindings)
+        {
+            return bindings.Aggregate(new List<KeyValuePair<Type, IEventAdapter>>(bindings.Count), (buf, ca) =>
+            {
+
+                var idx = IndexWhere(buf, x => x.Key.IsAssignableFrom(ca.Key));
+
+                if (idx == -1)
+                    buf.Add(ca);
+                else
+                    buf.Insert(idx, ca);
+
+                return buf;
+            });
+        }
+
+        private static int IndexWhere<T>(IList<T> list, Predicate<T> predicate)
+        {
+            for (int i = 0; i < list.Count; i++)
+                if (predicate(list[i])) return i;
+
+            return -1;
+        }
+
+        protected EventAdapters(ConcurrentDictionary<Type, IEventAdapter> map, IEnumerable<KeyValuePair<Type, IEventAdapter>> bindings, ILoggingAdapter log)
+        {
+            _map = map;
+            _bindings = bindings;
+            _log = log;
+        }
+
+        public IEventAdapter Get<T>()
+        {
+            return Get(typeof(T));
+        }
+
+        public virtual IEventAdapter Get(Type type)
+        {
+            IEventAdapter adapter;
+            if (_map.TryGetValue(type, out adapter))
+                return adapter;
+
+            // bindings are ordered from most specific to least specific
+            var pair = _bindings.FirstOrDefault(kv => kv.Key.IsAssignableFrom(type));
+            var value = !pair.Equals(default(KeyValuePair<Type, IEventAdapter>)) ? pair.Value : IdentityEventAdapter.Instance;
+
+            adapter = _map.GetOrAdd(type, value);
+            return adapter;
+        }
+
+        private static T Instantiate<T>(string qualifiedName, ExtendedActorSystem system)
+        {
+            var instanceType = Type.GetType(qualifiedName);
+            if (!typeof(T).IsAssignableFrom(instanceType))
+                throw new ArgumentException(string.Format("Couldn't create instance of [{0}] from provided qualified type name [{1}], because it's not assignable from it",
+                    typeof(T), qualifiedName));
+
+            try
+            {
+                return (T)Activator.CreateInstance(instanceType, system);
+            }
+            catch (MissingMethodException)
+            {
+                return (T)Activator.CreateInstance(instanceType);
+            }
+        }
+
+        private static IDictionary<string, string> ConfigToMap(Config config, string path)
+        {
+            if (config.HasPath(path))
+            {
+                var hoconObject = config.GetConfig(path).Root.GetObject();
+                return hoconObject.Unwrapped.ToDictionary(kv => kv.Key, kv => kv.Value.ToString().Trim('"'));
+            }
+            else return new Dictionary<string, string> { };
+        }
+
+        private static IDictionary<string, string[]> ConfigToListMap(Config config, string path)
+        {
+            if (config.HasPath(path))
+            {
+                var hoconObject = config.GetConfig(path).Root.GetObject();
+                return hoconObject.Unwrapped.ToDictionary(kv => kv.Key, kv =>
+                {
+                    var hoconValue = kv.Value as HoconValue;
+                    if (hoconValue != null)
+                    {
+                        var str = hoconValue.GetString();
+                        return str != null ? new[] { str } : hoconValue.GetStringList().ToArray();
+                    }
+                    else return new[] { kv.Value.ToString().Trim('"') };
+                });
+            }
+            else return new Dictionary<string, string[]> { };
+        }
+    }
+}

--- a/src/core/Akka.Persistence/Journal/EventSequences.cs
+++ b/src/core/Akka.Persistence/Journal/EventSequences.cs
@@ -1,0 +1,106 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="EventSequences.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Akka.Persistence.Journal
+{
+    public interface IEventSequence
+    {
+        IEnumerable<object> Events { get; }
+    }
+
+    public interface IEmptyEventSequence : IEventSequence { }
+
+    [Serializable]
+    public sealed class EmptyEventSequence : IEmptyEventSequence, IEquatable<IEventSequence>
+    {
+        public static readonly EmptyEventSequence Instance = new EmptyEventSequence();
+
+        private EmptyEventSequence() { }
+
+        public IEnumerable<object> Events { get { return Enumerable.Empty<object>(); } }
+
+        public bool Equals(IEventSequence other)
+        {
+            return other is EmptyEventSequence;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as IEventSequence);
+        }
+    }
+
+    [Serializable]
+    public class EventSequence<T> : IEventSequence, IEquatable<IEventSequence>
+    {
+        private readonly ISet<object> _events;
+        public EventSequence(IEnumerable<object> events)
+        {
+            _events = new HashSet<object>(events);
+        }
+
+        public IEnumerable<object> Events { get { return _events; } }
+
+        public bool Equals(IEventSequence other)
+        {
+            return other != null && _events.SetEquals(other.Events);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as IEventSequence);
+        }
+    }
+
+    [Serializable]
+    public struct SingleEventSequence : IEventSequence, IEquatable<IEventSequence>
+    {
+        private readonly object[] _events;
+        public SingleEventSequence(object e) : this()
+        {
+            _events = new[] { e };
+        }
+
+        public IEnumerable<object> Events { get { return _events; } }
+
+        public bool Equals(IEventSequence other)
+        {
+            if (other == null) return false;
+            var e = other.Events.FirstOrDefault();
+            return e != null && e.Equals(_events[0]) && other.Events.Count() == 1;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as IEventSequence);
+        }
+    }
+
+    public static class EventSequence
+    {
+        public static IEventSequence Empty = EmptyEventSequence.Instance;
+
+        public static IEventSequence Single(object e)
+        {
+            return new SingleEventSequence(e);
+        }
+
+        public static IEventSequence Create(params object[] events)
+        {
+            return new EventSequence<object>(events);
+        }
+
+        public static IEventSequence Create(IEnumerable<object> events)
+        {
+            return new EventSequence<object>(events);
+        }
+    }
+}

--- a/src/core/Akka.Persistence/Journal/MemoryJournal.cs
+++ b/src/core/Akka.Persistence/Journal/MemoryJournal.cs
@@ -34,13 +34,27 @@ namespace Akka.Persistence.Journal
         protected override void PreStart()
         {
             base.PreStart();
-            Self.Tell(new SetStore(Context.ActorOf(Props.Create<MemoryStore>())));
+            var config = Context.System.Settings.Config;
+            var storeProps = config.HasPath("akka.persistence.journal.inmem.shared") &&
+                             config.GetBoolean("akka.persistence.journal.inmem.shared")
+                ? Props.Create<SharedMemoryStore>()
+                : Props.Create<MemoryStore>();
+            Self.Tell(new SetStore(Context.ActorOf(storeProps)));
         }
     }
 
-    public class MemoryStore : ActorBase, IMemoryMessages
+    public class SharedMemoryStore : MemoryStore
+    {
+        private static readonly ConcurrentDictionary<string, LinkedList<IPersistentRepresentation>> SharedMessages = new ConcurrentDictionary<string, LinkedList<IPersistentRepresentation>>();
+
+        protected override ConcurrentDictionary<string, LinkedList<IPersistentRepresentation>> Messages { get { return SharedMessages; } }
+    }
+
+    public class MemoryStore : WriteJournalBase, IMemoryMessages
     {
         private readonly ConcurrentDictionary<string, LinkedList<IPersistentRepresentation>> _messages = new ConcurrentDictionary<string, LinkedList<IPersistentRepresentation>>();
+
+        protected virtual ConcurrentDictionary<string, LinkedList<IPersistentRepresentation>> Messages { get { return _messages; } }
 
         protected override bool Receive(object message)
         {
@@ -55,7 +69,7 @@ namespace Akka.Persistence.Journal
         private void GetHighestSequenceNumber(AsyncWriteTarget.ReadHighestSequenceNr rhsn)
         {
             LinkedList<IPersistentRepresentation> list;
-            Sender.Tell(_messages.TryGetValue(rhsn.PersistenceId, out list)
+            Sender.Tell(Messages.TryGetValue(rhsn.PersistenceId, out list)
                 ? list.Last.Value.SequenceNr
                 : 0L);
         }
@@ -63,7 +77,7 @@ namespace Akka.Persistence.Journal
         private void Read(AsyncWriteTarget.ReplayMessages replay)
         {
             LinkedList<IPersistentRepresentation> list;
-            if (_messages.TryGetValue(replay.PersistenceId, out list))
+            if (Messages.TryGetValue(replay.PersistenceId, out list))
             {
                 var filtered = list
                     .Where(x => x.SequenceNr >= replay.FromSequenceNr && x.SequenceNr <= replay.ToSequenceNr)
@@ -81,7 +95,7 @@ namespace Akka.Persistence.Journal
         private void Delete(AsyncWriteTarget.DeleteMessagesTo deleteCommand)
         {
             LinkedList<IPersistentRepresentation> list;
-            if (_messages.TryGetValue(deleteCommand.PersistenceId, out list))
+            if (Messages.TryGetValue(deleteCommand.PersistenceId, out list))
             {
                 var node = list.First;
                 if (deleteCommand.IsPermanent)
@@ -134,7 +148,7 @@ namespace Akka.Persistence.Journal
         {
             foreach (var persistent in writeMessages.Messages)
             {
-                var list = _messages.GetOrAdd(persistent.PersistenceId, new LinkedList<IPersistentRepresentation>());
+                var list = Messages.GetOrAdd(persistent.PersistenceId, new LinkedList<IPersistentRepresentation>());
                 list.AddLast(persistent);
             }
 
@@ -145,15 +159,15 @@ namespace Akka.Persistence.Journal
 
         public Messages Add(IPersistentRepresentation persistent)
         {
-            var list = _messages.GetOrAdd(persistent.PersistenceId, new LinkedList<IPersistentRepresentation>());
+            var list = Messages.GetOrAdd(persistent.PersistenceId, new LinkedList<IPersistentRepresentation>());
             list.AddLast(persistent);
-            return _messages;
+            return Messages;
         }
 
         public Messages Update(string pid, long seqNr, Func<IPersistentRepresentation, IPersistentRepresentation> updater)
         {
             LinkedList<IPersistentRepresentation> persistents;
-            if (_messages.TryGetValue(pid, out persistents))
+            if (Messages.TryGetValue(pid, out persistents))
             {
                 var node = persistents.First;
                 while (node != null)
@@ -171,7 +185,7 @@ namespace Akka.Persistence.Journal
         public Messages Delete(string pid, long seqNr)
         {
             LinkedList<IPersistentRepresentation> persistents;
-            if (_messages.TryGetValue(pid, out persistents))
+            if (Messages.TryGetValue(pid, out persistents))
             {
                 var node = persistents.First;
                 while (node != null)
@@ -183,17 +197,17 @@ namespace Akka.Persistence.Journal
                 }
             }
 
-            return _messages;
+            return Messages;
         }
 
         public IEnumerable<IPersistentRepresentation> Read(string pid, long fromSeqNr, long toSeqNr, long max)
         {
             LinkedList<IPersistentRepresentation> persistents;
-            if (_messages.TryGetValue(pid, out persistents))
+            if (Messages.TryGetValue(pid, out persistents))
             {
                 return persistents
                     .Where(x => x.SequenceNr >= fromSeqNr && x.SequenceNr <= toSeqNr)
-                    .Take(max > int.MaxValue ? int.MaxValue : (int) max);
+                    .Take(max > int.MaxValue ? int.MaxValue : (int)max);
             }
 
             return Enumerable.Empty<IPersistentRepresentation>();
@@ -202,7 +216,7 @@ namespace Akka.Persistence.Journal
         public long HighestSequenceNr(string pid)
         {
             LinkedList<IPersistentRepresentation> persistents;
-            if (_messages.TryGetValue(pid, out persistents))
+            if (Messages.TryGetValue(pid, out persistents))
             {
                 var last = persistents.LastOrDefault();
                 return last != null ? last.SequenceNr : 0L;

--- a/src/core/Akka.Persistence/Journal/SyncWriteJournal.cs
+++ b/src/core/Akka.Persistence/Journal/SyncWriteJournal.cs
@@ -81,7 +81,13 @@ namespace Akka.Persistence.Journal
             var sender = Sender;
             ReplayMessagesAsync(msg.PersistenceId, msg.FromSequenceNr, msg.ToSequenceNr, msg.Max, persistent =>
             {
-                if (!persistent.IsDeleted || msg.ReplayDeleted) msg.PersistentActor.Tell(new ReplayedMessage(persistent), sender);
+                if (!persistent.IsDeleted || msg.ReplayDeleted)
+                {
+                    foreach (var adapterRepresentation in AdaptFromJournal(persistent))
+                    {
+                        msg.PersistentActor.Tell(new ReplayedMessage(adapterRepresentation), sender);
+                    }
+                }
             })
             .NotifyAboutReplayCompletion(msg.PersistentActor)
             .ContinueWith(t =>

--- a/src/core/Akka.Persistence/persistence.conf
+++ b/src/core/Akka.Persistence/persistence.conf
@@ -47,6 +47,9 @@ akka {
 
         # Dispatcher for the plugin actor.
         plugin-dispatcher = "akka.actor.default-dispatcher"
+
+		# Determines if journal state should be globaly shared between different actor instances
+		# shared = false
       }
 
     }

--- a/src/examples/TcpEchoService.Server/Actors.cs
+++ b/src/examples/TcpEchoService.Server/Actors.cs
@@ -15,11 +15,11 @@ namespace TcpEchoService.Server
 {
     public class EchoService : ReceiveActor
     {
-        private readonly TcpExt _extension = Tcp.Instance.Apply(Context.System);
+        private readonly IActorRef _manager = Context.System.Tcp();
 
         public EchoService(EndPoint endpoint)
         {
-            _extension.Manager.Tell(new Tcp.Bind(Self, endpoint));
+            _manager.Tell(new Tcp.Bind(Self, endpoint));
 
             // To behave as TCP listener, actor should be able to handle Tcp.Connected messages
             Receive<Tcp.Connected>(connected =>


### PR DESCRIPTION
This is implementation of [Event Adapters](http://doc.akka.io/docs/akka/snapshot/scala/persistence.html#Event_Adapters) feature from canonical akka. They major role is ability to separate model stored by journal from domain model send by persistent actors through configurable mappers implementing `IEventAdapter` interface. Examples of use cases may be journal event versioning or addjusing domain model to specific schema expected by persistent backend.

Test suite is attached.
This feature should be documented.

cc #1223