### PR TITLE
Added ability to filter multinode test assemblies

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -248,8 +248,12 @@ Target "RunTestsMono" <| fun _ ->
         xunitTestAssemblies
 
 Target "MultiNodeTests" <| fun _ ->
+    let testSearchPath =
+        let assemblyFilter = getBuildParamOrDefault "spec-assembly" String.Empty
+        sprintf "src/**/bin/Release/*%s*.Tests.MultiNode.dll" assemblyFilter
+
     let multiNodeTestPath = findToolInSubPath "Akka.MultiNodeTestRunner.exe" "bin/core/Akka.MultiNodeTestRunner*"
-    let multiNodeTestAssemblies = !! "src/**/bin/Release/*.Tests.MultiNode.dll"
+    let multiNodeTestAssemblies = !! testSearchPath
     printfn "Using MultiNodeTestRunner: %s" multiNodeTestPath
 
     let runMultiNodeSpec assembly =


### PR DESCRIPTION
By specifying 'spec-assembly' as part of the build it'll filter
out multinode tests assemblies that don't have the supplied word
in their name.

eg: build multinodetests spec-assembly=remote
Will run all multinode tests from all assemblies with 'remote' in
their name.