### PR TITLE
Added HelpMultiNodeTests target

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -442,12 +442,14 @@ Target "Help" <| fun _ ->
       " * Build      Builds"
       " * Nuget      Create and optionally publish nugets packages"
       " * RunTests   Runs tests"
+      " * MultiNodeTests  Runs the slower multiple node specifications"
       " * All        Builds, run tests, creates and optionally publish nuget packages"
       ""
       " Other Targets"
       " * Help       Display this help" 
       " * HelpNuget  Display help about creating and pushing nuget packages" 
-      " * HelpDocs   Display help about creating and pushing API docs" 
+      " * HelpDocs   Display help about creating and pushing API docs"
+      " * HelpMultiNodeTests  Display help about running the multiple node specifications"
       ""]
 
 Target "HelpNuget" <| fun _ ->
@@ -526,6 +528,19 @@ Target "HelpDocs" <| fun _ ->
       "                                   Build and publish docs to http://fooaccount.blob.core.windows.net/docs/unstable"
       ""]
 
+Target "HelpMultiNodeTests" <| fun _ ->
+    List.iter printfn [
+      "usage: "
+      "build MultiNodeTests [spec-assembly=<filter>]"
+      "Just runs the MultiNodeTests. Does not build the projects."
+      ""
+      "Arguments for MultiNodeTests target:"
+      "   [spec-assembly=<filter>]  Restrict which spec projects are run."
+      ""
+      "       Alters the discovery filter to enable restricting which specs are run."
+      "       If not supplied the filter used is '*.Tests.Multinode.Dll'"
+      "       When supplied this is altered to '*<filter>*.Tests.Multinode.Dll'"
+      ""]
 //--------------------------------------------------------------------------------
 //  Target dependencies
 //--------------------------------------------------------------------------------


### PR DESCRIPTION
This is a documentation target for the MultiNodeTests target to explain
how to run the multiple node specs.