### PR TITLE
Added BuildRelease and CleanTests targets as dependency for MultiNodeTests target

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -531,6 +531,7 @@ Target "HelpDocs" <| fun _ ->
 
 // tests dependencies
 "CleanTests" ==> "RunTests"
+"BuildRelease" ==> "CleanTests" ==> "MultiNodeTests"
 
 // nuget dependencies
 "CleanNuget" ==> "CreateNuget"


### PR DESCRIPTION
`MultiNodeTests` target should have dependency on the following two targets in order to build the solution before running the tests

- BuildRelease
- CleanTests 