### PR TITLE
serialization fixes #1275 

### DIFF
--- a/src/contrib/testkits/Akka.TestKit.NUnit.Tests/Akka.TestKit.NUnit.Tests.csproj
+++ b/src/contrib/testkits/Akka.TestKit.NUnit.Tests/Akka.TestKit.NUnit.Tests.csproj
@@ -66,6 +66,9 @@
       <Name>Akka.TestKit.NUnit</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/core/Akka.Persistence.Tests/AtLeastOnceDeliveryCrashSpec.cs
+++ b/src/core/Akka.Persistence.Tests/AtLeastOnceDeliveryCrashSpec.cs
@@ -38,7 +38,7 @@ namespace Akka.Persistence.Tests
                 return new OneForOneStrategy(10, TimeSpan.FromSeconds(10), reason =>
                 {
                     if (reason is IllegalActorStateException) return Directive.Stop;
-                    return Actor.SupervisorStrategy.DefaultDecider(reason);
+                    return Actor.SupervisorStrategy.DefaultDecider.Decide(reason);
                 });
             }
         }

--- a/src/core/Akka.Remote.Tests/Serialization/DaemonMsgCreateSerializerSpec.cs
+++ b/src/core/Akka.Remote.Tests/Serialization/DaemonMsgCreateSerializerSpec.cs
@@ -64,7 +64,10 @@ namespace Akka.Remote.Tests.Serialization
         [Fact]
         public void Serialization_must_serialize_and_deserialize_DaemonMsgCreate_with_Deploy_and_RouterConfig()
         {
-            var supervisorStrategy = new OneForOneStrategy(3, TimeSpan.FromSeconds(10), exception => Directive.Escalate);
+            var decider = Decider.From(
+              Directive.Escalate);
+
+            var supervisorStrategy = new OneForOneStrategy(3, TimeSpan.FromSeconds(10), decider);
             var deploy1 = new Deploy("path1",
                 ConfigurationFactory.ParseString("a=1"),
                 new RoundRobinPool(5, null, supervisorStrategy, null),

--- a/src/core/Akka.Tests/Serialization/SerializationSpec.cs
+++ b/src/core/Akka.Tests/Serialization/SerializationSpec.cs
@@ -283,7 +283,14 @@ namespace Akka.Tests.Serialization
         [Fact]
         public void CanSerializeRoundRobinPool()
         {
-            var message = new RoundRobinPool(10, new DefaultResizer(0,1));
+            var decider = Decider.From(
+             Directive.Restart,
+             Directive.Stop.When<ArgumentException>(),
+             Directive.Stop.When<NullReferenceException>());
+
+            var supervisor = new OneForOneStrategy(decider);
+
+            var message = new RoundRobinPool(10, new DefaultResizer(0,1),supervisor,"abc");
             AssertEqual(message);
         }
 
@@ -297,7 +304,14 @@ namespace Akka.Tests.Serialization
         [Fact]
         public void CanSerializeRandomPool()
         {
-            var message = new RandomPool(10, new DefaultResizer(0, 1));
+            var decider = Decider.From(
+             Directive.Restart,
+             Directive.Stop.When<ArgumentException>(),
+             Directive.Stop.When<NullReferenceException>());
+
+            var supervisor = new OneForOneStrategy(decider);
+
+            var message = new RandomPool(10, new DefaultResizer(0, 1),supervisor,"abc");
             AssertEqual(message);
         }
 
@@ -311,29 +325,57 @@ namespace Akka.Tests.Serialization
         [Fact]
         public void CanSerializeConsistentHashPool()
         {
-            var message = new ConsistentHashingPool(10);
+            var decider = Decider.From(
+               Directive.Restart,
+               Directive.Stop.When<ArgumentException>(),
+               Directive.Stop.When<NullReferenceException>());
+
+            var supervisor = new OneForOneStrategy(decider);
+
+            var message = new ConsistentHashingPool(10,null,supervisor,"abc");
             AssertEqual(message);
         }
 
 
         [Fact]
         public void CanSerializeTailChoppingPool()
-        {            
-            var message = new TailChoppingPool(10,TimeSpan.FromSeconds(10),TimeSpan.FromSeconds(2));
+        {
+            var decider = Decider.From(
+             Directive.Restart,
+             Directive.Stop.When<ArgumentException>(),
+             Directive.Stop.When<NullReferenceException>());
+
+            var supervisor = new OneForOneStrategy(decider);
+
+            var message = new TailChoppingPool(10,null,supervisor,"abc",TimeSpan.FromSeconds(10),TimeSpan.FromSeconds(2));
             AssertEqual(message);
         }
 
         [Fact]
         public void CanSerializeScatterGatherFirstCompletedPool()
         {
-            var message = new ScatterGatherFirstCompletedPool(10);
+            var decider = Decider.From(
+             Directive.Restart,
+             Directive.Stop.When<ArgumentException>(),
+             Directive.Stop.When<NullReferenceException>());
+
+            var supervisor = new OneForOneStrategy(decider);
+
+            var message = new ScatterGatherFirstCompletedPool(10,null,supervisor,"abc",TimeSpan.MaxValue);
             AssertEqual(message);
         }
 
         [Fact]
         public void CanSerializeSmallestMailboxPool()
         {
-            var message = new SmallestMailboxPool(10);
+            var decider = Decider.From(
+             Directive.Restart,
+             Directive.Stop.When<ArgumentException>(),
+             Directive.Stop.When<NullReferenceException>());
+
+            var supervisor = new OneForOneStrategy(decider);
+
+            var message = new SmallestMailboxPool(10,null,supervisor,"abc");
             AssertEqual(message);
         }
 
@@ -348,7 +390,8 @@ namespace Akka.Tests.Serialization
         {
             var serializer = Sys.Serialization.FindSerializerFor(message);
             var serialized = serializer.ToBinary(message);
-            var deserialized = (T)serializer.FromBinary(serialized, typeof(T));
+            var result = serializer.FromBinary(serialized, typeof(T));
+            var deserialized = (T) result;
 
        //     Assert.True(message.Equals(deserialized));
             Assert.Equal(message, deserialized);

--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -86,8 +86,8 @@ namespace Akka.Actor
                 if (ReferenceEquals(null, obj)) return false;
                 if (ReferenceEquals(this, obj)) return true;
                 var actorPath = obj as ActorPath;
-                if (actorPath != null) return Equals(actorPath);
-                return Equals((Surrogate) obj);
+
+                return Equals(actorPath);
             }
 
             public override int GetHashCode()

--- a/src/core/Akka/Actor/SupervisorStrategy.cs
+++ b/src/core/Akka/Actor/SupervisorStrategy.cs
@@ -80,17 +80,10 @@ namespace Akka.Actor
         /// </summary>
         /// <param name="exception">The exception.</param>
         /// <returns>Directive.</returns>
-        public static Directive DefaultDecider(Exception exception)
-        {
-            if (exception is ActorInitializationException)
-                return Directive.Stop;
-            if (exception is ActorKilledException)
-                return Directive.Stop;
-            if (exception is DeathPactException)
-                return Directive.Stop;
-
-            return Directive.Restart;
-        }
+        public static IDecider DefaultDecider = Decider.From(Directive.Restart,
+            Directive.Stop.When<ActorInitializationException>(),
+            Directive.Stop.When<ActorKilledException>(),
+            Directive.Stop.When<DeathPactException>());
 
         /// <summary>
         ///     Restarts the child.
@@ -364,6 +357,8 @@ namespace Akka.Actor
 
         public override ISurrogate ToSurrogate(ActorSystem system)
         {
+            if (Decider is LocalOnlyDecider)
+                throw new NotSupportedException("Can not serialize LocalOnlyDecider");
             return new OneForOneStrategySurrogate
             {
                 Decider = Decider,

--- a/src/core/Akka/Routing/RouterConfig.cs
+++ b/src/core/Akka/Routing/RouterConfig.cs
@@ -412,7 +412,7 @@ namespace Akka.Routing
         /// </summary>
         public static SupervisorStrategy DefaultStrategy
         {
-            get { return new OneForOneStrategy(10, TimeSpan.FromSeconds(10), ex => Directive.Escalate); }
+            get { return new OneForOneStrategy(10, TimeSpan.FromSeconds(10), Decider.From(Directive.Escalate)); }
         }
 
         #endregion

--- a/src/core/Akka/packages.config
+++ b/src/core/Akka/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="Wire" version="0.0.1" targetFramework="net45" />
 </packages>

--- a/src/examples/FSharp.Api/Supervisioning.fs
+++ b/src/examples/FSharp.Api/Supervisioning.fs
@@ -59,7 +59,7 @@ let main() =
                     Strategy.OneForOne(fun e ->
                     match e with
                     | :? CustomException -> Directive.Restart 
-                    | _ -> SupervisorStrategy.DefaultDecider(e)))  ]
+                    | _ -> SupervisorStrategy.DefaultDecider.Decide(e)))  ]
 
     async {
         let! response = parent <? Echo "hello world"


### PR DESCRIPTION
Fixes #1275 

This PR replaces the default deciders in SupervisorStrategy and Pool with deployable deciders with the same semantics.
There is also a fix that prevents supervisorstrategies with local only deciders to be serialized, current code just ignores the local decider and sends an incomplete message

This could have some impact on user code, that is, if the user have used local only deciders in a remote deploy scenario, there will now be an exception thrown.
One could argue that this is a breaking change, but it is really a bug in user code if a local only decider is used in remote cases.