### PR TITLE
F# API - added support to override actor lifetime

### DIFF
--- a/src/core/Akka.FSharp.Tests/ApiTests.fs
+++ b/src/core/Akka.FSharp.Tests/ApiTests.fs
@@ -72,3 +72,81 @@ let ``can serialize and deserialize discriminated unions over remote nodes`` () 
     response
     |> equals msg
 
+[<Fact>]
+let ``can override PreStart method when starting actor with computation expression`` () =
+    
+    let preStartCalled = ref false
+    let preStart = Some(fun (baseFn : unit -> unit) -> preStartCalled := true)
+    
+    use system = System.create "testSystem" (Configuration.load())
+    let actor = 
+        spawnOvrd system "actor" 
+        <| actorOf2 (fun mailbox msg ->
+                mailbox.Sender() <! msg)
+        <| {defOvrd with PreStart = preStart}
+    let response = actor <? "msg" |> Async.RunSynchronously
+    (!preStartCalled, response) |> equals (true, "msg")
+
+[<Fact>]
+let ``can override PostStop methods when starting actor with computation expression`` () =
+    
+    let postStopCalled = ref false
+    let postStop = Some(fun (baseFn : unit -> unit) -> postStopCalled := true)
+    
+    use system = System.create "testSystem" (Configuration.load())
+    let actor = 
+        spawnOvrd system "actor" 
+        <| actorOf2 (fun mailbox msg ->
+                mailbox.Sender() <! msg)
+        <| {defOvrd with PostStop = postStop}
+    actor <! PoisonPill.Instance
+    system.Stop(actor)
+    system.Shutdown()
+    system.AwaitTermination()
+    (!postStopCalled) |> equals (true)
+
+[<Fact>]
+let ``can override PreRestart methods when starting actor with computation expression`` () =
+    
+    let preRestartCalled = ref false
+    let preRestart = Some(fun (baseFn : exn * obj -> unit) -> preRestartCalled := true)
+    
+    use system = System.create "testSystem" (Configuration.load())
+    let actor = 
+        spawnOptOvrd system "actor3" 
+        <| actorOf2 (fun mailbox (msg : string) ->
+                if msg = "restart" then
+                    failwith "System must be restarted"
+                else
+                    mailbox.Sender() <! msg)
+        <| [ SpawnOption.SupervisorStrategy (Strategy.OneForOne (fun error ->
+                Directive.Restart)) ]
+        <| {defOvrd with PreRestart = preRestart}
+    actor <! "restart"
+    let response = actor <? "msg" |> Async.RunSynchronously
+    system.Shutdown()
+    system.AwaitTermination()
+    (!preRestartCalled, response) |> equals (true, "msg")
+
+[<Fact>]
+let ``can override PostRestart methods when starting actor with computation expression`` () =
+    
+    let postRestartCalled = ref false
+    let postRestart = Some(fun (baseFn : exn -> unit) -> postRestartCalled := true)
+    
+    use system = System.create "testSystem" (Configuration.load())
+    let actor = 
+        spawnOptOvrd system "actor4" 
+        <| actorOf2 (fun mailbox (msg : string) ->
+                if msg = "restart" then
+                    failwith "System must be restarted"
+                else
+                    mailbox.Sender() <! msg)
+        <| [ SpawnOption.SupervisorStrategy (Strategy.OneForOne (fun error ->
+                Directive.Restart)) ]
+        <| {defOvrd with PostRestart = postRestart}
+    actor <! "restart"
+    let response = actor <? "msg" |> Async.RunSynchronously
+    system.Shutdown()
+    system.AwaitTermination()
+    (!postRestartCalled, response) |> equals (true, "msg")

--- a/src/core/Akka.FSharp/FsApi.fs
+++ b/src/core/Akka.FSharp/FsApi.fs
@@ -565,11 +565,23 @@ module Spawn =
     /// <param name="name">Name of spawned child actor</param>
     /// <param name="f">Used by actor for handling response for incoming request</param>
     /// <param name="options">List of options used to configure actor creation</param>
-    let spawnOpt (actorFactory : IActorRefFactory) (name : string) (f : Actor<'Message> -> Cont<'Message, 'Returned>) 
+    let spawnOptOvrd (actorFactory : IActorRefFactory) (name : string) (f : Actor<'Message> -> Cont<'Message, 'Returned>) 
         (options : SpawnOption list) (overrides : Overrides option) : IActorRef = 
         let e = Linq.Expression.ToExpression(fun () -> new FunActor<'Message, 'Returned>(f, overrides))
         let props = applySpawnOptions (Props.Create e) options
         actorFactory.ActorOf(props, name)
+
+    /// <summary>
+    /// Spawns an actor using specified actor computation expression, with custom spawn option settings.
+    /// The actor can only be used locally. 
+    /// </summary>
+    /// <param name="actorFactory">Either actor system or parent actor</param>
+    /// <param name="name">Name of spawned child actor</param>
+    /// <param name="f">Used by actor for handling response for incoming request</param>
+    /// <param name="options">List of options used to configure actor creation</param>
+    let spawnOpt (actorFactory : IActorRefFactory) (name : string) (f : Actor<'Message> -> Cont<'Message, 'Returned>) 
+        (options : SpawnOption list) : IActorRef = 
+        spawnOptOvrd actorFactory name f options None
 
     /// <summary>
     /// Spawns an actor using specified actor computation expression.
@@ -579,7 +591,7 @@ module Spawn =
     /// <param name="name">Name of spawned child actor</param>
     /// <param name="f">Used by actor for handling response for incoming request</param>
     let spawn (actorFactory : IActorRefFactory) (name : string) (f : Actor<'Message> -> Cont<'Message, 'Returned>) : IActorRef = 
-        spawnOpt actorFactory name f [] None
+        spawnOpt actorFactory name f []
 
     /// <summary>
     /// Spawns an actor using specified actor quotation, with custom spawn option settings.


### PR DESCRIPTION
Hi,

I thought it would be useful to have a possibility to override PreStart, PostStop, PreRestart, PostRestart lifetime methods when using F# API and actor computation expression.
I didn't change any existing api call.