### PR TITLE
Better exception message when a remote actor deploy fails because of missing reference #1279

### DIFF
--- a/src/contrib/testkits/Akka.TestKit.Xunit2/Akka.TestKit.Xunit2.csproj
+++ b/src/contrib/testkits/Akka.TestKit.Xunit2/Akka.TestKit.Xunit2.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Internals\AkkaAssertEqualityComparer.cs" />
     <Compile Include="Internals\AkkaAssertEqualityComparerAdapter.cs" />
     <Compile Include="Internals\AkkaEqualException.cs" />
+    <Compile Include="Internals\Loggers.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestKit.cs" />
     <Compile Include="XunitAssertions.cs" />

--- a/src/contrib/testkits/Akka.TestKit.Xunit2/Internals/Loggers.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit2/Internals/Loggers.cs
@@ -1,0 +1,21 @@
+﻿using Akka.Actor;
+using Akka.Event;
+using Xunit.Abstractions;
+
+namespace Akka.TestKit.Xunit2.Internals
+{
+    public class TestOutputLogger : ReceiveActor
+    {
+        public TestOutputLogger(ITestOutputHelper output)
+        {
+            Receive<Debug>(e => output.WriteLine(e.ToString()));
+            Receive<Info>(e => output.WriteLine(e.ToString()));
+            Receive<Warning>(e => output.WriteLine(e.ToString()));
+            Receive<Error>(e => output.WriteLine(e.ToString()));
+            Receive<InitializeLogger>(e =>
+            {
+                e.LoggingBus.Subscribe(Self, typeof (LogEvent));
+            });
+        }
+    }
+}

--- a/src/core/Akka.Persistence.Tests/PersistenceSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistenceSpec.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using Akka.Configuration;
 using Akka.TestKit;
 using Akka.Util.Internal;
+using Xunit.Abstractions;
 
 namespace Akka.Persistence.Tests
 {
@@ -40,16 +41,16 @@ namespace Akka.Persistence.Tests
 
         private readonly string _name;
 
-        protected PersistenceSpec(string config)
-            : base(config)
+        protected PersistenceSpec(string config, ITestOutputHelper output = null)
+            : base(config, output)
         {
             _name = NamePrefix + "-" + _counter.GetAndIncrement();
             Clean = new Cleanup(this);
             Clean.Initialize();
         }
 
-        protected PersistenceSpec(Config config = null)
-            : base(config)
+        protected PersistenceSpec(Config config = null, ITestOutputHelper output = null)
+            : base(config, output)
         {
             _name = NamePrefix + "-" + _counter.GetAndIncrement();
             Clean = new Cleanup(this);

--- a/src/core/Akka.Persistence.Tests/PersistentActorSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorSpec.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using Akka.Actor;
 using Akka.TestKit;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Akka.Persistence.Tests
 {

--- a/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
@@ -12,6 +12,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using Akka.Configuration;
 using Xunit;
+using Xunit.Abstractions;
 using Xunit.Sdk;
 
 // ReSharper disable once CheckNamespace
@@ -39,13 +40,13 @@ namespace Akka.TestKit
 
         private static int _systemNumber = 0;
 
-        public AkkaSpec(string config)
-            : this(ConfigurationFactory.ParseString(config).WithFallback(_akkaSpecConfig))
+        public AkkaSpec(string config, ITestOutputHelper output = null)
+            : this(ConfigurationFactory.ParseString(config).WithFallback(_akkaSpecConfig), output)
         {
         }
 
-        public AkkaSpec(Config config = null)
-            : base(config.SafeWithFallback(_akkaSpecConfig), GetCallerName())
+        public AkkaSpec(Config config = null, ITestOutputHelper output = null)
+            : base(config.SafeWithFallback(_akkaSpecConfig), GetCallerName(), output)
         {
             BeforeAll();
         }

--- a/src/core/Akka.Tests/Actor/PropsSpec.cs
+++ b/src/core/Akka.Tests/Actor/PropsSpec.cs
@@ -8,6 +8,7 @@
 using Akka.Actor;
 using Akka.TestKit;
 using System;
+using System.Linq;
 using Xunit;
 
 namespace Akka.Tests.Actor
@@ -56,6 +57,25 @@ namespace Akka.Tests.Actor
             Assert.Equal(strategy, props.SupervisorStrategy);
         }
 
+        [Fact]
+        public void Props_created_with_null_type_must_throw()
+        {
+            Type missingType = null;
+            object[] args = new object[0];
+            var argsEnumerable = Enumerable.Empty<object>();
+            var defaultStrategy = SupervisorStrategy.DefaultStrategy;
+            var defaultDeploy = Deploy.Local;
+
+            Props p = null;
+
+            Assert.Throws<ArgumentNullException>("type", () => p = new Props(missingType, args));
+            Assert.Throws<ArgumentNullException>("type", () => p = new Props(missingType));
+            Assert.Throws<ArgumentNullException>("type", () => p = new Props(missingType, defaultStrategy, argsEnumerable));
+            Assert.Throws<ArgumentNullException>("type", () => p = new Props(missingType, defaultStrategy, args));
+            Assert.Throws<ArgumentNullException>("type", () => p = new Props(defaultDeploy, missingType, argsEnumerable));
+            Assert.Throws<ArgumentNullException>("type", () => p = Props.Create(missingType, args));
+        }
+        
         private class TestProducer : IIndirectActorProducer
         {
             TestLatch latchActor;

--- a/src/core/Akka.Tests/Routing/BroadcastSpec.cs
+++ b/src/core/Akka.Tests/Routing/BroadcastSpec.cs
@@ -11,12 +11,12 @@ using Akka.Routing;
 using Akka.TestKit;
 using Akka.Util.Internal;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Akka.Tests.Routing
 {
     public class BroadcastSpec : AkkaSpec
     {
-
         public new class TestActor : UntypedActor
         {
             protected override void OnReceive(object message)
@@ -51,8 +51,7 @@ namespace Akka.Tests.Routing
                 }
             }
         }
-
-
+        
         [Fact]
         public void BroadcastGroup_router_must_broadcast_message_using_Tell()
         {

--- a/src/core/Akka/Actor/Props.cs
+++ b/src/core/Akka/Actor/Props.cs
@@ -32,6 +32,8 @@ namespace Akka.Actor
     /// </summary>
     public class Props : IEquatable<Props> , ISurrogated
     {
+        private const string NullActorTypeExceptionText = "Props must be instantiated with an actor type.";
+
         public class PropsSurrogate : ISurrogate
         {
             public Type Type { get; set; }
@@ -183,6 +185,8 @@ namespace Akka.Actor
         public Props(Type type, object[] args)
             : this(defaultDeploy, type, args)
         {
+            if (type == null)
+                throw new ArgumentNullException("type", NullActorTypeExceptionText);
         }
 
         /// <summary>
@@ -192,6 +196,8 @@ namespace Akka.Actor
         public Props(Type type)
             : this(defaultDeploy, type, noArgs)
         {
+            if (type == null)
+                throw new ArgumentNullException("type", NullActorTypeExceptionText);
         }
 
         /// <summary>
@@ -203,6 +209,9 @@ namespace Akka.Actor
         public Props(Type type, SupervisorStrategy supervisorStrategy, IEnumerable<object> args)
             : this(defaultDeploy, type, args.ToArray())
         {
+            if (type == null)
+                throw new ArgumentNullException("type", NullActorTypeExceptionText);
+
             SupervisorStrategy = supervisorStrategy;
         }
 
@@ -215,6 +224,9 @@ namespace Akka.Actor
         public Props(Type type, SupervisorStrategy supervisorStrategy, params object[] args)
             : this(defaultDeploy, type, args)
         {
+            if (type == null)
+                throw new ArgumentNullException("type", NullActorTypeExceptionText);
+
             SupervisorStrategy = supervisorStrategy;
         }
 
@@ -227,6 +239,8 @@ namespace Akka.Actor
         public Props(Deploy deploy, Type type, IEnumerable<object> args)
             : this(deploy, type, args.ToArray())
         {
+            if (type == null)
+                throw new ArgumentNullException("type", NullActorTypeExceptionText);
         }
 
         /// <summary>
@@ -394,6 +408,9 @@ namespace Akka.Actor
         /// <returns>Props.</returns>
         public static Props Create(Type type, params object[] args)
         {
+            if (type == null)
+                throw new ArgumentNullException("type", NullActorTypeExceptionText);
+
             return new Props(type, args);
         }
 


### PR DESCRIPTION
This addresses #1279. 

As suggested, I added checks to the `Props` constructors to handle cases where the `type` constructor parameter was `null`. I added a single test for the six methods changed (if preferred, I can split them out). Finally, I added the check to `DaemonMsgCreateSerializer` - when `GetType` returns `null` for the actor type name, an exception is thrown informing the user that the type should be referenced.