### PR TITLE
Xunit2 output logger for parallel TestKit runs

### DIFF
--- a/src/contrib/testkits/Akka.TestKit.Xunit2/Akka.TestKit.Xunit2.csproj
+++ b/src/contrib/testkits/Akka.TestKit.Xunit2/Akka.TestKit.Xunit2.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Internals\AkkaAssertEqualityComparer.cs" />
     <Compile Include="Internals\AkkaAssertEqualityComparerAdapter.cs" />
     <Compile Include="Internals\AkkaEqualException.cs" />
+    <Compile Include="Internals\Loggers.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestKit.cs" />
     <Compile Include="XunitAssertions.cs" />

--- a/src/contrib/testkits/Akka.TestKit.Xunit2/Internals/Loggers.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit2/Internals/Loggers.cs
@@ -1,0 +1,21 @@
+﻿using Akka.Actor;
+using Akka.Event;
+using Xunit.Abstractions;
+
+namespace Akka.TestKit.Xunit2.Internals
+{
+    public class TestOutputLogger : ReceiveActor
+    {
+        public TestOutputLogger(ITestOutputHelper output)
+        {
+            Receive<Debug>(e => output.WriteLine(e.ToString()));
+            Receive<Info>(e => output.WriteLine(e.ToString()));
+            Receive<Warning>(e => output.WriteLine(e.ToString()));
+            Receive<Error>(e => output.WriteLine(e.ToString()));
+            Receive<InitializeLogger>(e =>
+            {
+                e.LoggingBus.Subscribe(Self, typeof (LogEvent));
+            });
+        }
+    }
+}

--- a/src/core/Akka.Persistence.Tests/PersistenceSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistenceSpec.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using Akka.Configuration;
 using Akka.TestKit;
 using Akka.Util.Internal;
+using Xunit.Abstractions;
 
 namespace Akka.Persistence.Tests
 {
@@ -40,16 +41,16 @@ namespace Akka.Persistence.Tests
 
         private readonly string _name;
 
-        protected PersistenceSpec(string config)
-            : base(config)
+        protected PersistenceSpec(string config, ITestOutputHelper output = null)
+            : base(config, output)
         {
             _name = NamePrefix + "-" + _counter.GetAndIncrement();
             Clean = new Cleanup(this);
             Clean.Initialize();
         }
 
-        protected PersistenceSpec(Config config = null)
-            : base(config)
+        protected PersistenceSpec(Config config = null, ITestOutputHelper output = null)
+            : base(config, output)
         {
             _name = NamePrefix + "-" + _counter.GetAndIncrement();
             Clean = new Cleanup(this);

--- a/src/core/Akka.Persistence.Tests/PersistentActorSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorSpec.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using Akka.Actor;
 using Akka.TestKit;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Akka.Persistence.Tests
 {

--- a/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
@@ -12,6 +12,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using Akka.Configuration;
 using Xunit;
+using Xunit.Abstractions;
 using Xunit.Sdk;
 
 // ReSharper disable once CheckNamespace
@@ -39,13 +40,13 @@ namespace Akka.TestKit
 
         private static int _systemNumber = 0;
 
-        public AkkaSpec(string config)
-            : this(ConfigurationFactory.ParseString(config).WithFallback(_akkaSpecConfig))
+        public AkkaSpec(string config, ITestOutputHelper output = null)
+            : this(ConfigurationFactory.ParseString(config).WithFallback(_akkaSpecConfig), output)
         {
         }
 
-        public AkkaSpec(Config config = null)
-            : base(config.SafeWithFallback(_akkaSpecConfig), GetCallerName())
+        public AkkaSpec(Config config = null, ITestOutputHelper output = null)
+            : base(config.SafeWithFallback(_akkaSpecConfig), GetCallerName(), output)
         {
             BeforeAll();
         }

--- a/src/core/Akka.Tests/Routing/BroadcastSpec.cs
+++ b/src/core/Akka.Tests/Routing/BroadcastSpec.cs
@@ -11,12 +11,12 @@ using Akka.Routing;
 using Akka.TestKit;
 using Akka.Util.Internal;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Akka.Tests.Routing
 {
     public class BroadcastSpec : AkkaSpec
     {
-
         public new class TestActor : UntypedActor
         {
             protected override void OnReceive(object message)
@@ -51,8 +51,7 @@ namespace Akka.Tests.Routing
                 }
             }
         }
-
-
+        
         [Fact]
         public void BroadcastGroup_router_must_broadcast_message_using_Tell()
         {


### PR DESCRIPTION
This is an enhancement for TestKit using Xunit2, that allows you to see your logging data in output of xunit test runner. Even when you're running tests in parallel.

Xunit2 defines a dedicated interface `ITestOutputHelper`, that will be automatically injected to each test class constructor by the test runner itself. To allow this you must only expose it:

```csharp
class MyActorSpec : Akka.TestKit.Xunit2.TestKit 
{
    public MyActorSpec(ITestOutputHelper output) : base(output: output) { }
}
```

`AkkaSpec` used for internal testing also has this *output* param exposed in it's constructor. I think we could expose it in all of internal test projects, but this should be done in separate PR. This will help with getting log info while executing specs.