### PR TITLE
Semantc Serilog

### DIFF
--- a/src/Akka.sln
+++ b/src/Akka.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+VisualStudioVersion = 12.0.40629.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{69279534-1DBA-4115-BF8B-03F77FC8125E}"
 EndProject

--- a/src/contrib/loggers/Akka.Logger.Serilog/Akka.Logger.Serilog.csproj
+++ b/src/contrib/loggers/Akka.Logger.Serilog/Akka.Logger.Serilog.csproj
@@ -49,6 +49,8 @@
     </Compile>
     <Compile Include="Event\Serilog\SerilogLogMessageFormatter.cs" />
     <Compile Include="MessageTemplateCache.cs" />
+    <Compile Include="SemanticAdapter\FormatPart.cs" />
+    <Compile Include="SemanticAdapter\TemplateTransform.cs" />
     <Compile Include="SerilogLogMessageFormatter.cs" />
     <Compile Include="SerilogLogger.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/contrib/loggers/Akka.Logger.Serilog/SemanticAdapter/FormatPart.cs
+++ b/src/contrib/loggers/Akka.Logger.Serilog/SemanticAdapter/FormatPart.cs
@@ -1,0 +1,16 @@
+﻿
+namespace Akka.Logger.Serilog.SemanticAdapter
+{
+    internal class FormatPart
+    {
+        public FormatPart(string text, int index)
+        {
+            Text = text;
+            Index = index;
+        }
+
+        public string Text { get;private set; }
+
+        public int Index { get;private set; }
+    }
+}

--- a/src/contrib/loggers/Akka.Logger.Serilog/SemanticAdapter/TemplateTransform.cs
+++ b/src/contrib/loggers/Akka.Logger.Serilog/SemanticAdapter/TemplateTransform.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace Akka.Logger.Serilog.SemanticAdapter
+{
+    internal class TemplateTransform
+    {
+        private static readonly TextInfo TextInfo = new CultureInfo("en-US", false).TextInfo;
+
+        private static readonly ConcurrentDictionary<string, string> Templates =
+            new ConcurrentDictionary<string, string>();
+
+        public static string Transform(string template)
+        {
+            //template is not of old format
+            if (!template.Contains("{0"))
+                return template;
+
+            string transformed;
+
+            if (!Templates.TryGetValue(template, out transformed))
+            {
+                try
+                {
+                    var unknownIndex = 0;
+
+                    var parts = Parse(template);
+                    var sb = new StringBuilder();
+                    foreach (var part in parts)
+                    {
+                        sb.Append(part.Text);
+                        if (part.Index >= 0)
+                        {
+                            sb.Append("{");
+                            var cleaned = TextInfo.ToTitleCase(part.Text);
+                            var x = (from c in cleaned
+                                where char.IsLetterOrDigit(c)
+                                select c).ToArray();
+                            var formatName = new string(x);
+                            if (string.IsNullOrEmpty(formatName))
+                            {
+                                formatName = "Obj" + unknownIndex++;
+                            }
+                            sb.Append(formatName);
+                            sb.Append("}");
+                        }
+                    }
+                    transformed = sb.ToString();
+                    Templates.TryAdd(template, transformed);
+                }
+                catch
+                {
+                    //transform broke, fall back to original
+                    transformed = template;
+                    Templates.TryAdd(template, transformed);
+                }
+            }
+
+            return transformed;
+        }
+
+        private static List<FormatPart> Parse(string template)
+        {
+            var sb = new StringBuilder();
+            var parts = new List<FormatPart>();
+
+
+            int lastGoodIndex = 0;
+            Func<List<FormatPart>> appendEnd = () =>
+            {
+                parts.Add(new FormatPart(template.Substring(lastGoodIndex, template.Length - lastGoodIndex), -1));
+                return parts;
+            };
+            for (var i = 0; i < template.Length; i++)
+            {
+                var c = template[i];
+                if (c == '{')
+                {
+                    var prefix = template.Substring(lastGoodIndex, i - lastGoodIndex);
+                    i++;
+                    if (i >= template.Length)
+                        return appendEnd();
+
+                    int index = 0;
+                    while (char.IsDigit(template[i]))
+                    {
+                        index = index * 10 + template[i] - '0';
+                        i++;
+                        //walk past index
+                        if (i >= template.Length)
+                            return appendEnd();
+                    }
+
+                    if (template[i] == ':')
+                    {
+                        //skip format
+                        i++;
+                        if (i >= template.Length)
+                            return appendEnd();
+
+                    }
+                    while (template[i] != '}')
+                    {
+                        sb.Append(template[i]);
+                        //walk to closing }
+                        i++;
+                        if (i >= template.Length)
+                            return appendEnd();
+
+                    }
+                    parts.Add(new FormatPart(prefix, index));
+                    sb.Clear();
+                    lastGoodIndex = i + 1;
+                }
+            }
+            //append any text present after the last placeholder
+            return appendEnd();
+        }
+    }
+}


### PR DESCRIPTION
This PR contains an alternative Serilog implementation.

The standard serilog implementation does not deal well with log templates of the `string.Format` kind.
That is. if there is a logging statement like so: `log.Debug("Bar {0}, Foo {1}",bar, foo)` , this will be logged as property `0` and property `1`.
Which gives very little value for log analyzers.

The logger in this PR, deals with both the specialized Serilog format, _and_ the old `string.Format` style log statements.
This is extremely useful since Akka.NET internally uses the `string.Format` approach, so if you want to analyze what is going on inside Akka.NET itself, this logger lets you do that.

The SemanticSerilogger here solves this by checking if a log statement use the `string.Format` style template, if so, it will extract any textual prefix before any property placeholder, like so:
`"Connecting to {0} using protocol {1}"` -> `"Connecting to {ConnectingTo} using protocol {UsingProtocol}"`

This is of-course a compromise, using semantic logging internally in Akka.NET would have been a better way to solve this.
But as a non-intrusive addition to the contrib packages, this works surprisingly well.

For example, the dashboard below is generated only from the built in logging statements inside Akka.NET(Remote+Cluster) using this logger
![akkadashboard](https://cloud.githubusercontent.com/assets/647031/9704195/8f9f2870-549d-11e5-863f-649ea61e8901.png)

The reason why I did not make this an addition to the default Serilogger package is that this also takes dependency on Sprache parsing library.
There are also some behaviors in the other Serilog package that I don't want to touch due to backwards compat issues.

