### PR TITLE
Replaced string concatenation with format templates in log statements

### DIFF
--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -985,8 +985,7 @@ namespace Akka.Cluster
             }
             else if (address.System != _cluster.SelfAddress.System)
             {
-                _log.Warning(
-                    "Trying to join member with wrong ActorSystem name, but was ignored, expected [{0}] but was [{1}]",
+                _log.Warning("Trying to join member with wrong ActorSystem name, but was ignored, expected [{0}] but was [{1}]",
                     _cluster.SelfAddress.System, address.System);
             }
             else
@@ -1036,8 +1035,7 @@ namespace Akka.Cluster
             }
             else if (node.Address.System != _cluster.SelfAddress.System)
             {
-                _log.Warning(
-                    "Member with wrong ActorSystem name tried to join, but was ignored, expected [{0}] but was [{1}]",
+                _log.Warning("Member with wrong ActorSystem name tried to join, but was ignored, expected [{0}] but was [{1}]",
                     _cluster.SelfAddress.System, node.Address.System);
             }
             else

--- a/src/core/Akka.Persistence.Tests/AtLeastOnceDeliveryCrashSpec.cs
+++ b/src/core/Akka.Persistence.Tests/AtLeastOnceDeliveryCrashSpec.cs
@@ -94,7 +94,7 @@ namespace Akka.Persistence.Tests
                 }
                 else
                 {
-                    Log.Debug("Recover message: " + message);
+                    Log.Debug("Recover message: {0}", message);
                 }
 
                 return true;
@@ -142,4 +142,3 @@ namespace Akka.Persistence.Tests
         }
     }
 }
-

--- a/src/core/Akka.Persistence.Tests/AtLeastOnceDeliveryFailureSpec.cs
+++ b/src/core/Akka.Persistence.Tests/AtLeastOnceDeliveryFailureSpec.cs
@@ -185,7 +185,7 @@ namespace Akka.Persistence.Tests
                                 if (ChaosSupportExtensions.ShouldFail(failureRate))
                                     throw new TestException(DebugMessage("failed at payload " + sent.I));
                                 else
-                                    Log.Debug(DebugMessage("processed payload " + sent.I));
+                                    Log.Debug(DebugMessage(String.Format("processed payload {0}", sent.I)));
                             });
                     })
                     .With<Confirm>(confirm =>
@@ -351,4 +351,3 @@ namespace Akka.Persistence.Tests
     }
 
 }
-

--- a/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
+++ b/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
@@ -603,7 +603,7 @@ namespace Akka.Remote.TestKit
                         // controller node is finished/exited before r.addr is run
                         // on the other nodes
                         var unresolved = "akka://unresolved-replacement-" + r.Role.Name;
-                        Log.Warning(unresolved + " due to: " + e.ToString());
+		         Log.Warning(unresolved + " due to: {0}", e.ToString());
                         replaceWith = unresolved;
                     }
                     return @base.Replace(r.Tag, replaceWith);

--- a/src/core/Akka.Remote.TestKit/Player.cs
+++ b/src/core/Akka.Remote.TestKit/Player.cs
@@ -117,7 +117,7 @@ namespace Akka.Remote.TestKit
         /// </summary>
         public void Enter(TimeSpan timeout, ImmutableList<string> names)
         {
-            _system.Log.Debug("entering barriers " + names.Aggregate((a,b) => a = ", " + b));
+            _system.Log.Debug("entering barriers {0}", names.Aggregate((a,b) => a = ", " + b));
             var stop = Deadline.Now + timeout;
 
             foreach (var name in names)

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -1357,8 +1357,7 @@ namespace Akka.Remote
                     var now = MonotonicClock.GetNanos();
                     if (now - _largeBufferLogTimestamp >= LogBufferSizeInterval)
                     {
-                        _log.Warning("[{0}] buffered messages in EndpointWriter for [{1}]. " +
-                                     "You should probably implement flow control to avoid flooding the remote connection.", size, RemoteAddress);
+                        _log.Warning("[{0}] buffered messages in EndpointWriter for [{1}]. You should probably implement flow control to avoid flooding the remote connection.", size, RemoteAddress);
                         _largeBufferLogTimestamp = now;
                     }
                 }

--- a/src/core/Akka.Remote/EndpointManager.cs
+++ b/src/core/Akka.Remote/EndpointManager.cs
@@ -342,8 +342,7 @@ namespace Akka.Remote
                 ex.Match()
                     .With<InvalidAssociation>(ia =>
                     {
-                        log.Warning("Tried to associate with unreachable remote address [{0}]. " +
-                                 "Address is now gated for {1} ms, all messages to this address will be delivered to dead letters. Reason: [{2}]",
+                        log.Warning("Tried to associate with unreachable remote address [{0}]. Address is now gated for {1} ms, all messages to this address will be delivered to dead letters. Reason: [{2}]",
                                  ia.RemoteAddress, settings.RetryGateClosedFor.TotalMilliseconds, ia.Message);
                         endpoints.MarkAsFailed(Sender, Deadline.Now + settings.RetryGateClosedFor);
                         AddressTerminatedTopic.Get(Context.System).Publish(new AddressTerminated(ia.RemoteAddress));
@@ -351,8 +350,7 @@ namespace Akka.Remote
                     })
                     .With<ShutDownAssociation>(shutdown =>
                     {
-                        log.Debug("Remote system with address [{0}] has shut down. " +
-                                  "Address is now gated for {1}ms, all messages to this address will be delivered to dead letters.",
+                        log.Debug("Remote system with address [{0}] has shut down. Address is now gated for {1}ms, all messages to this address will be delivered to dead letters.",
                                   shutdown.RemoteAddress, settings.RetryGateClosedFor.TotalMilliseconds);
                         endpoints.MarkAsFailed(Sender, Deadline.Now + settings.RetryGateClosedFor);
                         AddressTerminatedTopic.Get(Context.System).Publish(new AddressTerminated(shutdown.RemoteAddress));
@@ -369,8 +367,7 @@ namespace Akka.Remote
                         }
                         else
                         {
-                            log.Warning("Association to [{0}] with unknown UID is irrecoverably failed. " +
-                                     "Address cannot be quarantined without knowing the UID, gating instead for {1} ms.",
+                            log.Warning("Association to [{0}] with unknown UID is irrecoverably failed. Address cannot be quarantined without knowing the UID, gating instead for {1} ms.",
                                 hopeless.RemoteAddress, settings.RetryGateClosedFor.TotalMilliseconds);
                             endpoints.MarkAsFailed(Sender, Deadline.Now + settings.RetryGateClosedFor);
                         }
@@ -508,8 +505,7 @@ namespace Akka.Remote
                         Context.Stop(pass.Endpoint);
                         if (!pass.Uid.HasValue)
                         {
-                            log.Warning("Association to [{0}] with unknown UID is reported as quarantined, but " +
-                                     "address cannot be quarantined without knowing the UID, gated instead for {0} ms",
+                            log.Warning("Association to [{0}] with unknown UID is reported as quarantined, but address cannot be quarantined without knowing the UID, gated instead for {0} ms",
                                 quarantine.RemoteAddress, settings.RetryGateClosedFor.TotalMilliseconds);
                             endpoints.MarkAsFailed(pass.Endpoint, Deadline.Now + settings.RetryGateClosedFor);
                         }

--- a/src/core/Akka.Remote/Remoting.cs
+++ b/src/core/Akka.Remote/Remoting.cs
@@ -222,8 +222,7 @@ namespace Akka.Remote
                     {
                         if (!result.Result)
                         {
-                            log.Warning(
-                                "Shutdown finished, but flushing might not have been successful and some messages might have been dropped. " +
+                            log.Warning("Shutdown finished, but flushing might not have been successful and some messages might have been dropped. " +
                                 "Increase akka.remote.flush-wait-on-shutdown to a larger value to avoid this.");
                         }
                         finalize();

--- a/src/core/Akka/Actor/ActorRefProvider.cs
+++ b/src/core/Akka/Actor/ActorRefProvider.cs
@@ -356,10 +356,8 @@ namespace Akka.Actor
                 {
                     var d = Deployer.Lookup(path);
                     if (d != null && d.RouterConfig != RouterConfig.NoRouter)
-                        Log.Warning(
-                            string.Format(
-                                "Configuration says that [{0}] should be a router, but code disagrees. Remove the config or add a RouterConfig to its Props.",
-                                path));
+                        Log.Warning("Configuration says that [{0}] should be a router, but code disagrees. Remove the config or add a RouterConfig to its Props.",
+                                	path);
                 }
 
                 var props2 = props;

--- a/src/core/Akka/Actor/Inbox.Actor.cs
+++ b/src/core/Akka/Actor/Inbox.Actor.cs
@@ -49,7 +49,7 @@ namespace Akka.Actor
             {
                 if (!_printedWarning)
                 {
-                    _log.Warning("Dropping message: Inbox size has been exceeded, use akka.actor.inbox.inbox-size to increase maximum allowed inbox size. Current is " + _size);
+                    _log.Warning("Dropping message: Inbox size has been exceeded, use akka.actor.inbox.inbox-size to increase maximum allowed inbox size. Current is {0}", _size);
                     _printedWarning = true;
                 }
             }
@@ -180,4 +180,3 @@ namespace Akka.Actor
     }
 
 }
-

--- a/src/core/Akka/IO/SimpleDnsManager.cs
+++ b/src/core/Akka/IO/SimpleDnsManager.cs
@@ -40,7 +40,7 @@ namespace Akka.IO
             var r = message as Dns.Resolve;
             if (r != null)
             {
-                _log.Debug("Resolution request for {} from {}", r.Name, Sender);
+                _log.Debug("Resolution request for {0} from {1}", r.Name, Sender);
                 _resolver.Forward(r);
             }
             if (message is CacheCleanup)

--- a/src/core/Akka/IO/TcpOutgoingConnection.cs
+++ b/src/core/Akka/IO/TcpOutgoingConnection.cs
@@ -138,8 +138,7 @@ namespace Akka.IO
                             }
                             else
                             {
-                                Log.Debug("Could not establish connection because finishConnect " +
-                                          "never returned true (consider increasing akka.io.tcp.finish-connect-retries)");
+                                Log.Debug("Could not establish connection because finishConnect never returned true (consider increasing akka.io.tcp.finish-connect-retries)");
                                 Stop();
                             }
                         }

--- a/src/core/Akka/Routing/ConsistentHashRouter.cs
+++ b/src/core/Akka/Routing/ConsistentHashRouter.cs
@@ -182,8 +182,7 @@ namespace Akka.Routing
             }
             else
             {
-                _log.Value.Warning(
-                    "Message [{0}] must be handled by hashMapping, or implement [{1}] or be wrapped in [{2}]",
+                _log.Value.Warning("Message [{0}] must be handled by hashMapping, or implement [{1}] or be wrapped in [{2}]",
                     message.GetType().Name, typeof (IConsistentHashable).Name, typeof (ConsistentHashableEnvelope).Name);
                 return Routee.NoRoutee;
             }


### PR DESCRIPTION
These fixes relate to [this issue #1283](https://github.com/akkadotnet/akka.net/issues/1283).

Basically I corrected all the places that I've found. The main idea behind fixes is
to change log statements from this 
```c#
_log.Debug("Foo" + bar + "Baz" + yo)
```
to this
```c#
_log.Debug("Foo {0} Baz {1}",bar,yo);
```
I squashed all the commits into one.