### PR TITLE
Added missing validate call

### DIFF
--- a/src/core/Akka/Routing/Resizer.cs
+++ b/src/core/Akka/Routing/Resizer.cs
@@ -93,6 +93,8 @@ namespace Akka.Routing
             BackoffThreshold = backoffThreshold;
             BackoffRate = backoffRate;
             MessagesPerResize = messagesPerResize;
+
+            Validate();
         }
 
         /// <summary>


### PR DESCRIPTION
The `DefaultResizer` does not currently validate constructor arguments, it only validates values read from configuration.
Added missing Validate(); call in argument ctor.