### PR TITLE
Support of "await" continuation

### DIFF
--- a/src/core/Akka.Tests/Actor/AkkaSyncContextSpec.cs
+++ b/src/core/Akka.Tests/Actor/AkkaSyncContextSpec.cs
@@ -43,13 +43,12 @@ namespace Akka.Tests.Actor
                 switch(message as string)
                 {
                     case "start":
-                        var sender = Sender;
                         System.Diagnostics.Debug.WriteLine("{0:O} Before async thread: {1}", DateTime.Now, Thread.CurrentThread.ManagedThreadId);
                         await Task.Delay(100);
                         System.Diagnostics.Debug.WriteLine("{0:O} After async thread: {1}", DateTime.Now, Thread.CurrentThread.ManagedThreadId);
                         Thread.Sleep(300);
                         System.Diagnostics.Debug.WriteLine("{0:O} After sleep thread: {1}", DateTime.Now, Thread.CurrentThread.ManagedThreadId);
-                        sender.Tell("finish");
+                        Sender.Tell("finish");
                         break;
                     case "start2":
                         System.Diagnostics.Debug.WriteLine("{0:O} Got start2 in thread {1}", DateTime.Now, Thread.CurrentThread.ManagedThreadId);

--- a/src/core/Akka.Tests/Actor/AkkaSyncContextSpec.cs
+++ b/src/core/Akka.Tests/Actor/AkkaSyncContextSpec.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Event;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Tests.Actor
+{
+    public class AkkaSyncContextSpec : AkkaSpec
+    {
+        private readonly IActorRef _actor;
+
+        [Fact]
+        public void Continuation_is_in_the_same_thread_as_initiation()
+        {
+            var sys = ActorSystem.Create("sys");
+            var actor = sys.ActorOf(Props.Create<MyActor>());
+
+            actor.Tell("start");
+            Thread.Sleep(200);
+            actor.Tell("start2");
+
+            ExpectMsg("finish");
+            ExpectMsg("finish2");
+        }
+
+        public class MyActor : UntypedActor
+        {
+            ILoggingAdapter Log;
+
+            public MyActor()
+            {
+                Log = Logging.GetLogger(Context.System, GetType());
+            }
+
+            async protected override void OnReceive(object message)
+            {
+                switch(message as string)
+                {
+                    case "start":
+                        var sender = Sender;
+                        System.Diagnostics.Debug.WriteLine("{0:O} Before async thread: {1}", DateTime.Now, Thread.CurrentThread.ManagedThreadId);
+                        await Task.Delay(100);
+                        System.Diagnostics.Debug.WriteLine("{0:O} After async thread: {1}", DateTime.Now, Thread.CurrentThread.ManagedThreadId);
+                        Thread.Sleep(300);
+                        System.Diagnostics.Debug.WriteLine("{0:O} After sleep thread: {1}", DateTime.Now, Thread.CurrentThread.ManagedThreadId);
+                        sender.Tell("finish");
+                        break;
+                    case "start2":
+                        System.Diagnostics.Debug.WriteLine("{0:O} Got start2 in thread {1}", DateTime.Now, Thread.CurrentThread.ManagedThreadId);
+                        Sender.Tell("finish2");
+                        break;
+                    default:
+                        Unhandled(message);
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Actor\ActorProducerPipelineTests.cs" />
     <Compile Include="Actor\ActorRefSpec.cs" />
     <Compile Include="Actor\AddressSpec.cs" />
+    <Compile Include="Actor\AkkaSyncContextSpec.cs" />
     <Compile Include="Actor\AskTimeoutSpec.cs" />
     <Compile Include="Actor\Cancellation\AlreadyCancelledCancelableTests.cs" />
     <Compile Include="Actor\Cancellation\CancelableTests.cs" />

--- a/src/core/Akka/Actor/ActorSynchronizationContext.cs
+++ b/src/core/Akka/Actor/ActorSynchronizationContext.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Threading;
+
+
+namespace Akka.Actor
+{
+    /// <summary>
+    /// Schedule execution of "await" continuation into the mailbox
+    /// </summary>
+    class ActorSynchronizationContext : SynchronizationContext
+    {
+        private readonly ActorCell _cell;
+        private readonly IActorRef _sender;
+
+        public ActorSynchronizationContext(ActorCell cell)
+        {
+            _cell = cell;
+            _sender = cell.Sender;
+        }
+
+        public override void Post(SendOrPostCallback d, object state)
+        {
+            if(_cell.IsTerminated)
+                return;
+
+            var envelope = new Envelope 
+            { 
+                Message = new AsyncContinuation(d, state), 
+                Sender = _sender
+            };
+            
+            _cell.Mailbox.Post(_cell.Self, envelope);
+        }
+    }
+
+    public class AsyncContinuation : IAutoReceivedMessage
+    {
+        public readonly SendOrPostCallback Continuation;
+        public readonly object State;
+
+        public AsyncContinuation(SendOrPostCallback continuation, object state)
+        {
+            Continuation = continuation;
+            State = state;
+        }
+    }
+}

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -71,6 +71,7 @@
     <Compile Include="ActorState.cs" />
     <Compile Include="Actor\ActorCell.DeathWatch.cs" />
     <Compile Include="Actor\ActorProducerPipeline.cs" />
+    <Compile Include="Actor\ActorSynchronizationContext.cs" />
     <Compile Include="Actor\ChildrenContainer\Internal\ChildrenContainer.cs" />
     <Compile Include="Actor\ChildrenContainer\Internal\ChildrenContainerBase.cs" />
     <Compile Include="Actor\ChildrenContainer\Internal\ChildStats.cs" />


### PR DESCRIPTION
I know, I know, there were several (heated) discussions about async support for actor model (#946), also there were some blogs and documentation, encouraging usage of PipeTo.

Why am I trying to do it again than? The answer is, because PipeTo, UntypedActor.RunTask, etc are not support of async, but a synchronous invocation of asynchronous operation. 

I do understand the reasoning behind it. State of the actor can change after "await" and it might introduce subtle bugs and make code less reliable.

But let's think about some use cases one more time. Lets say I have a dynamic configuration module, which does long http polls. (https://www.consul.io/) When change in config happen, the module will receive a response from http, update its internal configuration structures, and issue another poll. 
  At the same time this module is responsible for handling "get me config X" requests. Obviously, if long poll was issued with PipeTo, all requests to get configuration property will be queued and not handled. So this is not the way to go.

In general, c# programmers are well trained by now, that Task.Run means no lock, so the behavior of PipeTo comes as a surprise.

Once I learn limitations of PipeTo, I started thinking, how to work around it. At first, I thought about having another child actor, which would do only polls, thus freeing configuration component to respond to configuration property requests. But it would complicate otherwise simple code. And I thought about all other cases, when I need to perform async action in actor. 

Next iteration was to execute polling in a dedicated thread, separate from actor, and send messages to "self" with updates. This would solve async problem, but what about supervision? The main point of akka is to supervise the code which is prone to failures. And http request is exactly the code, I would like to keep an eye on. But now it is executed in a separate thread, and I have to resort to old school try-catch. Still not the experience I want from akka.

So I started to think that what "await" does is so similar to akka's mailbox. In fact, Await split the function into "before await" and "after await" functions. When 1st function is complete, the second one is invoked with result from the previous one. What if I could intercept this moment and instead of invoking the invisible function after "await", send it to the actor's mailbox? This way, every span of code which is split by "await" becomes a message and is routed through actor's mailbox.

Luckily I do have experience with doing exactly this. The fundamental fifference between "await" and Task.ContinueWith is that await will check for presence of SynchronizationContext, and if present, will delegate invocation of continuation to the context. With custom context set, we can schedule execution of continuation as a message to ourselves. And this is exactly what this patch does. I introduce new type of message, AsyncContinuation, set async context before handling the message to capture asyncs, and when task is done, it delegates continuation to my sync context, which delegates it to the actor's mailbox. I even manage to preserve Sender, so it is set correctly even after "await" (which solves #1292). Pay attention to the way I do async. Instead of spawning a task, I mark OnReceive as async. This means that the code before 1st await has System Self and Sender set up properly. After await is scheduled to be executed through mailbox, so context is set up properly again. It seems to me, my solution solves context problem completely.

But I can see a problem. For example, I have no idea how FSM would work.
Another problem is that actor state can change between awaits. If you have someting like

    if(_myList.Length == 0) {
        await _myList.Add(LoadList());
bad things may happen, because by the time load is complete, list might be not empty anymore. This problem cant be solved with akka, and developer must be aware of await side effects.

I am not too confident in unit test at the moment, not sure how to test it properly. Because Dispatch can schedule different runs onto different threads, I can't validate that multiple messages are not executed simultenously. So test needs improvement. But debugging indicates that code does right things.

Let me know what do you think.