### PR TITLE
stashing reference equality

### DIFF
--- a/src/core/Akka.TestKit/Internal/BlockingQueue.cs
+++ b/src/core/Akka.TestKit/Internal/BlockingQueue.cs
@@ -193,9 +193,6 @@ namespace Akka.TestKit.Internal
             public object SyncRoot { get { throw new NotImplementedException(); } }
 
             public bool IsSynchronized { get { return false; } }
-
-
-
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/Stash/ActorWithStashSpec.cs
+++ b/src/core/Akka.Tests/Actor/Stash/ActorWithStashSpec.cs
@@ -302,8 +302,85 @@ namespace Akka.Tests.Actor.Stash
             public TestBarrier Finished;
             public TestLatch ExpectedException;
         }
+
+        [Fact]
+        public void An_actor_should_not_throw_an_exception_if_sent_two_messages_with_same_value_different_reference()
+        {
+            _state.ExpectedException = new TestLatch();
+            var stasher = ActorOf<StashEverythingActor>("stashing-actor");
+            stasher.Tell(new CustomMessageOverrideEquals("A"));
+            stasher.Tell(new CustomMessageOverrideEquals("A"));
+
+            // NOTE:
+            // here we should test for no exception thrown..
+            // but I don't know how....
+        }
+
+        public class CustomMessageOverrideEquals
+        {
+
+            public CustomMessageOverrideEquals(string cargo)
+            {
+                Cargo = cargo;
+            }
+            public override int GetHashCode()
+            {
+                return base.GetHashCode() ^ 314;
+            }
+            public override bool Equals(System.Object obj)
+            {
+                // If parameter is null return false.
+                if (obj == null)
+                {
+                    return false;
+                }
+
+                // If parameter cannot be cast to Point return false.
+                CustomMessageOverrideEquals p = obj as CustomMessageOverrideEquals;
+                if ((System.Object)p == null)
+                {
+                    return false;
+                }
+
+                // Return true if the fields match:
+                return (Cargo == p.Cargo);
+            }
+
+            public bool Equals(CustomMessageOverrideEquals p)
+            {
+                // If parameter is null return false:
+                if ((object)p == null)
+                {
+                    return false;
+                }
+
+                // Return true if the fields match:
+                return (Cargo == p.Cargo);
+            }
+            public static bool operator ==(CustomMessageOverrideEquals a, CustomMessageOverrideEquals b)
+            {
+                // If both are null, or both are same instance, return true.
+                if (System.Object.ReferenceEquals(a, b))
+                {
+                    return true;
+                }
+
+                // If one is null, but not both, return false.
+                if (((object)a == null) || ((object)b == null))
+                {
+                    return false;
+                }
+
+                // Return true if the fields match:
+                return (a.Cargo == b.Cargo);
+            }
+
+            public static bool operator !=(CustomMessageOverrideEquals a, CustomMessageOverrideEquals b)
+            {
+                return !(a == b);
+            }
+            public string Cargo { get; private set; }
+        }
     }
-
-
 }
 

--- a/src/core/Akka/Actor/Stash/Internal/AbstractStash.cs
+++ b/src/core/Akka/Actor/Stash/Internal/AbstractStash.cs
@@ -64,7 +64,7 @@ An (unbounded) deque-based mailbox can be configured as follows:
             if(_theStash.Count > 0)
             {
                 var lastEnvelope = _theStash.Last.Value;
-                if(lastEnvelope.Message.Equals(currMsg) && lastEnvelope.Sender == sender)
+                if(ReferenceEquals(lastEnvelope.Message,currMsg) && lastEnvelope.Sender == sender)
                     throw new IllegalActorStateException(string.Format("Can't stash the same message {0} more than once", currMsg));
             }
             if(_capacity <= 0 || _theStash.Count < _capacity)


### PR DESCRIPTION
Fix for #1312

Our stashing support currently uses structural equality, which makes it impossible to stash two different objects with the same structural equality comparison.
e.g. this affects pretty much every F# type as they do structural comparisons.

In scala the comparison is done using `eq` which is the scala version of `ReferenceEquals`
I've updated our code to work the same way.