### PR TITLE
Added tests for F# null bug

### DIFF
--- a/src/core/Akka.FSharp.Tests/ApiTests.fs
+++ b/src/core/Akka.FSharp.Tests/ApiTests.fs
@@ -72,3 +72,71 @@ let ``can serialize and deserialize discriminated unions over remote nodes`` () 
     response
     |> equals msg
 
+//[<Fact>]
+// FAILS
+let ``actor that accepts _ will receive unit message`` () =    
+    let timeoutConfig =
+        """
+        akka { 
+            actor {
+                ask-timeout = 5s
+            }
+        }
+        """
+        |> Configuration.parse 
+
+    let getWhateverHandler (mailbox : Actor<_>) _ = 
+        mailbox.Sender() <! "SomethingToReturn"
+
+    let system = System.create "my-system" timeoutConfig
+    let aref = spawn system "UnitActor" (actorOf2 getWhateverHandler)
+
+    let response = aref <? () |> Async.RunSynchronously
+    response
+    |> equals "SomethingToReturn"
+
+[<Fact>]
+// SUCCEEDS
+let ``actor that accepts _ will receive string message`` () =    
+    let timeoutConfig =
+        """
+        akka { 
+            actor {
+                ask-timeout = 5s
+            }
+        }
+        """
+        |> Configuration.parse 
+
+    let getWhateverHandler (mailbox : Actor<_>) _ = 
+        mailbox.Sender() <! "SomethingToReturn"
+
+    let system = System.create "my-system" timeoutConfig
+    let aref = spawn system "UnitActor" (actorOf2 getWhateverHandler)
+
+    let response = aref <? "SomeRandomInput" |> Async.RunSynchronously
+    response
+    |> equals "SomethingToReturn"
+
+[<Fact>]
+// SUCCEEDS
+let ``actor that accepts unit will receive unit message`` () =    
+    let timeoutConfig =
+        """
+        akka { 
+            actor {
+                ask-timeout = 5s
+            }
+        }
+        """
+        |> Configuration.parse 
+
+    let getWhateverHandler (mailbox : Actor<unit>) () = 
+        mailbox.Sender() <! "SomethingToReturn"
+
+    let system = System.create "my-system" timeoutConfig
+    let aref = spawn system "UnitActor" (actorOf2 getWhateverHandler)
+
+    let response = aref <? () |> Async.RunSynchronously
+    response
+    |> equals "SomethingToReturn"


### PR DESCRIPTION
This PR contains the F# tests that @raymens created in #1285

The failing test is commented out for now.
@Horusiath the actual problem is in here:

```fsharp
   let private tryCast (t:Task<obj>) : 'Message =
        match t.Result with
        | :? 'Message as m -> m
        | o ->                         //<------------- here, if the user Tells () to an actorref, the () will not be matched by the above line as it is not of that type. 
                                         //instead the unit will be processed here, as a JObject, which it is not..
                                         //my F#-fu is not strong enough to know how to deal with the F# type system :-/

            let context = Akka.Actor.Internal.InternalCurrentActorCellKeeper.Current
            if context = null 
            then failwith "Cannot cast JObject outside the actor system context "
            else
                let serializer = context.System.Serialization.FindSerializerForType typeof<'Message> :?> Akka.Serialization.NewtonSoftJsonSerializer
                match Serialization.tryDeserializeJObject serializer.Serializer o with
                | Some m -> m
                | None -> raise (InvalidCastException("Tried to cast JObject to " + typeof<'Message>.ToString()))
```

So we either need to fix this, or just decide that we should not be able to pass () to F# actors
