### PR TITLE
Wire Serializer

### DIFF
--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -63,6 +63,10 @@
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Xml" />
+    <Reference Include="Wire, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Wire.0.0.4\lib\Wire.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\SharedAssemblyInfo.cs">
@@ -266,6 +270,7 @@
     <Compile Include="IO\TcpListener.cs" />
     <Compile Include="IO\TcpManager.cs" />
     <Compile Include="IO\TcpOutgoingConnection.cs" />
+    <Compile Include="Serialization\WireSerializer.cs" />
     <Compile Include="Util\ByteIterator.cs" />
     <Compile Include="Util\ByteString.cs" />
     <Compile Include="Util\ContinuousEnumerator.cs" />

--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -391,6 +391,7 @@ akka {
 
     serializers {
         json = "Akka.Serialization.NewtonSoftJsonSerializer"
+		wire = "Akka.Serialization.WireSerializer"
         java = "Akka.Serialization.JavaSerializer"				# not used, reserves java serializer identifier
         bytes = "Akka.Serialization.ByteArraySerializer"
     }

--- a/src/core/Akka/Serialization/WireSerializer.cs
+++ b/src/core/Akka/Serialization/WireSerializer.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Util;
+using Wire;
+
+namespace Akka.Serialization
+{
+    public class WireSerializer : Serializer
+    {
+        private readonly Wire.Serializer _seralizer;
+
+        public WireSerializer(ExtendedActorSystem system) : base(system)
+        {
+            var akkaSurrogate = Surrogate.Create<ISurrogated,ISurrogate>(from => from.ToSurrogate(system),to => to.FromSurrogate(system));
+            _seralizer = new  Wire.Serializer(new SerializerOptions(preserveObjectReferences: true, versionTolerance:true,surrogates: new Surrogate[]{ akkaSurrogate }));
+        }
+        public override int Identifier
+        {
+            get { return -4; }
+        }
+
+        public override bool IncludeManifest
+        {
+            get { return false; }
+        }
+
+        public override byte[] ToBinary(object obj)
+        {
+            using (var ms = new MemoryStream())
+            {
+                _seralizer.Serialize(obj,ms);
+                return ms.ToArray();
+            }
+        }
+
+        public override object FromBinary(byte[] bytes, Type type)
+        {
+            using (var ms = new MemoryStream())
+            {
+                ms.Write(bytes,0,bytes.Length);
+                ms.Position = 0;
+                var res = _seralizer.Deserialize<object>(ms);
+                return res;
+            }
+        }
+    }
+}

--- a/src/core/Akka/packages.config
+++ b/src/core/Akka/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-  <package id="Wire" version="0.0.1" targetFramework="net45" />
+  <package id="Wire" version="0.0.4" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This PR introduces the Wire serializer as an alternative serializer for Akka.NET.

The serializer is not set as the default serializer here, it is only included so users can activate it manually by changing what objects should use it in the config.
All tests pass when the serializer is enabled instead of the json.net serializer.

I would like users to evaluate this for some time and try it out in real world scenarios.

To enable the serializer:

```javascript
    serialization-bindings {
      "System.Byte[]" = bytes
      "System.Object" = wire //instead of json
    }
```

The main features this addresses

* Fully supports all F# types
* 27 times faster than our current Json.NET setup
