### PR TITLE
Use ActorTaskScheduler.AwaitTask instead of RunTask for ReceiveActor

### DIFF
--- a/src/core/Akka/Actor/ReceiveActor.cs
+++ b/src/core/Akka/Actor/ReceiveActor.cs
@@ -116,7 +116,7 @@ namespace Akka.Actor
             _matchHandlerBuilders.Peek().Match<T>( m =>
             {
                 Func<Task> wrap = () => handler(m);
-                ActorTaskScheduler.RunTask(wrap);
+                ActorTaskScheduler.AwaitTask(wrap);
             });
         }
 


### PR DESCRIPTION
This is a proposal to make `ActorTaskScheduler.AwaitTask` the standard API for async message handlers. 

It's a simple optimization to avoid calling RunTask and pausing and resuming when the task is synchronous. This is more inline with how "await" is implemented.

The main benefit is to make code that return completed tasks perform exactly the same as if an action was used, and there is no change to the API.

@rogeralsing, this should be straightforward. See if that works for you.