### PR TITLE
Issue #1246 - PiercingShouldKeepQuarantineSpec

### DIFF
--- a/src/core/Akka.Remote.Tests.MultiNode/Akka.Remote.Tests.MultiNode.csproj
+++ b/src/core/Akka.Remote.Tests.MultiNode/Akka.Remote.Tests.MultiNode.csproj
@@ -59,6 +59,7 @@
   <ItemGroup>
     <Compile Include="LookupRemoteActorMultiNetSpec.cs" />
     <Compile Include="NewRemoteActorSpec.cs" />
+    <Compile Include="PiercingShouldKeepQuarantineSpec.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RemoteDeliverySpec.cs" />
     <Compile Include="RemoteRoundRobinSpec.cs" />

--- a/src/core/Akka.Remote.Tests.MultiNode/PiercingShouldKeepQuarantineSpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/PiercingShouldKeepQuarantineSpec.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Remote.TestKit;
+
+namespace Akka.Remote.Tests.MultiNode
+{
+    public class PiercingShouldKeepQuarantineMultiNodeConfig : MultiNodeConfig
+    {
+        public RoleName First { get; private set; }
+        public RoleName Second { get; private set; }
+
+        public PiercingShouldKeepQuarantineMultiNodeConfig()
+        {
+            First = Role("first");
+            Second = Role("second");
+
+            CommonConfig = DebugConfig(true)
+                .WithFallback(ConfigurationFactory.ParseString(@"
+    akka.loglevel = INFO
+    akka.remote.log-remote-lifecycle-events = INFO
+    akka.remote.retry-gate-closed-for = 10s
+                "));
+        }
+    }
+
+    public class PiercingShouldKeepQuarantineMultiNode1 : PiercingShouldKeepQuarantineSpec
+    {
+    }
+
+    public class PiercingShouldKeepQuarantineMultiNode2 : PiercingShouldKeepQuarantineSpec
+    {
+    }
+
+    public abstract class PiercingShouldKeepQuarantineSpec : MultiNodeSpec
+    {
+        private readonly PiercingShouldKeepQuarantineMultiNodeConfig _config;
+
+        protected PiercingShouldKeepQuarantineSpec() : this(new PiercingShouldKeepQuarantineMultiNodeConfig())
+        {
+        }
+
+        protected PiercingShouldKeepQuarantineSpec(PiercingShouldKeepQuarantineMultiNodeConfig config) : base(config)
+        {
+            _config = config;
+        }
+
+        protected override int InitialParticipantsValueFactory
+        {
+            get { return Roles.Count; }
+        }
+
+        public class Subject : UntypedActor
+        {
+            protected override void OnReceive(object message)
+            {
+                if (message.Equals("getuid"))
+                    Sender.Tell(AddressUidExtension.Uid(Context.System));
+            }
+        }
+
+        [MultiNodeFact]
+        public void PiercingShouldKeepQuarantineSpecs()
+        {
+            WhileProbingThroughTheQuarantineRemotingMustNotLoseExistingQuarantineMarker();
+        }
+
+        public void WhileProbingThroughTheQuarantineRemotingMustNotLoseExistingQuarantineMarker()
+        {
+            RunOn(() =>
+            {
+                EnterBarrier("actors-started");
+
+                // Communicate with second system
+                Sys.ActorSelection(Node(_config.Second) / "user" / "subject").Tell("getuid");
+                var uid = ExpectMsg<int>(TimeSpan.FromSeconds(10));
+                EnterBarrier("actor-identified");
+
+                // Manually Quarantine the other system
+                RARP.For(Sys).Provider.Transport.Quarantine(Node(_config.Second).Address, uid);
+
+                // Quarantining is not immedeiate
+                Thread.Sleep(1000);
+
+                // Quarantine is up - Should not be able to communicate with remote system any more
+                for (var i = 1; i <= 4; i++)
+                {
+                    Sys.ActorSelection(Node(_config.Second) / "user" / "subject").Tell("getuid");
+
+                    ExpectNoMsg(TimeSpan.FromSeconds(2));
+                }
+
+                EnterBarrier("quarantine-intact");
+
+            }, _config.First);
+
+            RunOn(() =>
+            {
+                Sys.ActorOf<Subject>("subject");
+                EnterBarrier("actors-started");
+                EnterBarrier("actor-identified");
+                EnterBarrier("quarantine-intact");
+            }, _config.Second);
+        }
+    }
+}

--- a/src/core/Akka.Remote/Properties/AssemblyInfo.cs
+++ b/src/core/Akka.Remote/Properties/AssemblyInfo.cs
@@ -29,6 +29,7 @@ using System.Runtime.InteropServices;
 [assembly: Guid("78986bdb-73f7-4532-8e03-1c9ccbe8148e")]
 [assembly: InternalsVisibleTo("Akka.Remote.TestKit")]
 [assembly: InternalsVisibleTo("Akka.Remote.Tests")]
+[assembly: InternalsVisibleTo("Akka.Remote.Tests.MultiNode")]
 [assembly: InternalsVisibleTo("Akka.Cluster")]
 [assembly: InternalsVisibleTo("Akka.Cluster.Tests")]
 [assembly: InternalsVisibleTo("Akka.Cluster.Tests.MultiNode")]


### PR DESCRIPTION
Ported spec from Akka, but with larger akka.remote.retry-gate-closed-for-timer.

How can akka spec actually pass ? If I set akka.remote.retry-gate-closed-for = 0.5s (as they have in their spec), then in a for part, then spec would not pass for some i > 0... as what I believe happens is, that after 0.5s quarantine is over and next assert ExpectNoMessage fails (since it waits for 2s)...

With increased retry-gate-closed-for it should pass...What am I not seeing ?