### PR TITLE
Resolves #1314. Add unit test output as TeamCity artifacts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,6 @@ resetdev.bat
 
 # FAKE build folder
 .fake/
+
+# Akka.Persistence Test Output
+target/

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Persistence/FileNameGenerator.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Persistence/FileNameGenerator.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.IO;
 
 namespace Akka.MultiNodeTestRunner.Shared.Persistence
 {
@@ -18,6 +19,14 @@ namespace Akka.MultiNodeTestRunner.Shared.Persistence
         public static string GenerateFileName(string assemblyName, string fileExtension, DateTime utcNow)
         {
             return string.Format("{0}-{1}{2}", assemblyName.Replace(".dll", ""), utcNow.Ticks, fileExtension);
+        }
+
+        public static string GenerateFileName(string folderPath, string assemblyName, string fileExtension, DateTime utcNow)
+        {
+            if(string.IsNullOrEmpty(folderPath))
+                return GenerateFileName(assemblyName, fileExtension, utcNow);
+            var assemblyNameOnly = Path.GetFileName(assemblyName);
+            return Path.Combine(folderPath, GenerateFileName(assemblyNameOnly, fileExtension, utcNow));
         }
     }
 }


### PR DESCRIPTION
Made minor changes to FAKE file and added a new flag to the multi-node test runner that will copy output to a new directory if specified.

```xml
<summary>
/// MultiNodeTestRunner takes the following <see cref="args"/>:
/// 
/// C:\> Akka.MultiNodeTestRunner.exe [assembly name] [-Dmultinode.enable-filesink=on] [-Dmultinode.output-directory={dir path}]
/// 
/// <list type="number">
/// <listheader>
///     <term>Argument</term>
///     <description>The name and possible value of a given Akka.MultiNodeTestRunner.exe argument.</description>
/// </listheader>
/// <item>
///     <term>AssemblyName</term>
///     <description>
///         The full path or name of an assembly containing as least one MultiNodeSpec in the current working directory.
/// 
///         i.e. "Akka.Cluster.Tests.MultiNode.dll"
///              "C:\akka.net\src\Akka.Cluster.Tests\bin\Debug\Akka.Cluster.Tests.MultiNode.dll"
///     </description>
/// </item>
/// <item>
///     <term>-Dmultinode.enable-filesink</term>
///     <description>Having this flag set means that the contents of this test run will be saved in the
///                 current working directory as a .JSON file.
///     </description>
/// </item>
/// <item>
///     <term>-Dmultinode.multinode.output-directory</term>
///     <description>Setting this flag means that any persistent multi-node test runner output files
///                  will be written to this directory instead of the default, which is the same folder
///                  as the test binary.
///     </description>
/// </item>
/// </list>
/// </summary>
```