### PR TITLE
Added an overload using non-generic System.Type

### DIFF
--- a/src/contrib/dependencyInjection/Akka.DI.AutoFac/AutoFacDependencyResolver.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.AutoFac/AutoFacDependencyResolver.cs
@@ -89,7 +89,17 @@ namespace Akka.DI.AutoFac
         /// <returns>The configuration object for the given actor type</returns>
         public Props Create<TActor>() where TActor : ActorBase
         {
-            return system.GetExtension<DIExt>().Props(typeof(TActor));
+            return Create(typeof(TActor));
+        }
+
+        /// <summary>
+        /// Used to register the configuration for an actor of the specified type <paramref name="actorType"/> 
+        /// </summary>
+        /// <param name="actorType">The <see cref="Type"/> of actor the configuration is based</param>
+        /// <returns>The configuration object for the given actor type</returns>
+        public virtual Props Create(Type actorType)
+        {
+            return system.GetExtension<DIExt>().Props(actorType);
         }
 
         /// <summary>

--- a/src/contrib/dependencyInjection/Akka.DI.CastleWindsor/WindsorDependencyResolver.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.CastleWindsor/WindsorDependencyResolver.cs
@@ -79,7 +79,17 @@ namespace Akka.DI.CastleWindsor
         /// <returns>The configuration object for the given actor type</returns>
         public Props Create<TActor>() where TActor : ActorBase
         {
-            return system.GetExtension<DIExt>().Props(typeof(TActor));
+            return Create(typeof(TActor));
+        }
+
+        /// <summary>
+        /// Used to register the configuration for an actor of the specified type <paramref name="actorType"/> 
+        /// </summary>
+        /// <param name="actorType">The <see cref="Type"/> of actor the configuration is based</param>
+        /// <returns>The configuration object for the given actor type</returns>
+        public virtual Props Create(Type actorType)
+        {
+            return system.GetExtension<DIExt>().Props(actorType);
         }
 
         /// <summary>

--- a/src/contrib/dependencyInjection/Akka.DI.Core/IDependencyResolver.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.Core/IDependencyResolver.cs
@@ -34,6 +34,12 @@ namespace Akka.DI.Core
         /// <returns>The configuration object for the given actor type</returns>
         Props Create<TActor>() where TActor : ActorBase;
         /// <summary>
+        /// Used to register the configuration for an actor of the specified type <paramref name="actorType"/> 
+        /// </summary>
+        /// <param name="actorType">The <see cref="Type"/> of actor the configuration is based</param>
+        /// <returns>The configuration object for the given actor type</returns>
+        Props Create(Type actorType);
+        /// <summary>
         /// Signals the DI container to release it's reference to the actor.
         /// <see href="http://www.amazon.com/Dependency-Injection-NET-Mark-Seemann/dp/1935182501/ref=sr_1_1?ie=UTF8&qid=1425861096&sr=8-1&keywords=mark+seemann">HERE</see> 
         /// </summary>

--- a/src/contrib/dependencyInjection/Akka.DI.Ninject/NinjectDependencyResolver.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.Ninject/NinjectDependencyResolver.cs
@@ -79,7 +79,17 @@ namespace Akka.DI.Ninject
         /// <returns>The configuration object for the given actor type</returns>
         public Props Create<TActor>() where TActor : ActorBase
         {
-            return system.GetExtension<DIExt>().Props(typeof(TActor));
+            return Create(typeof(TActor));
+        }
+
+        /// <summary>
+        /// Used to register the configuration for an actor of the specified type <paramref name="actorType"/> 
+        /// </summary>
+        /// <param name="actorType">The <see cref="Type"/> of actor the configuration is based</param>
+        /// <returns>The configuration object for the given actor type</returns>
+        public virtual Props Create(Type actorType)
+        {
+            return system.GetExtension<DIExt>().Props(actorType);
         }
 
         /// <summary>

--- a/src/contrib/dependencyInjection/Akka.DI.StructureMap/StructureMapDependencyResolver.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.StructureMap/StructureMapDependencyResolver.cs
@@ -81,7 +81,17 @@ namespace Akka.DI.StructureMap
         /// <returns>The configuration object for the given actor type</returns>
         public Props Create<TActor>() where TActor : ActorBase
         {
-            return system.GetExtension<DIExt>().Props(typeof(TActor));
+            return Create(typeof(TActor));
+        }
+
+        /// <summary>
+        /// Used to register the configuration for an actor of the specified type <paramref name="actorType"/> 
+        /// </summary>
+        /// <param name="actorType">The <see cref="Type"/> of actor the configuration is based</param>
+        /// <returns>The configuration object for the given actor type</returns>
+        public virtual Props Create(Type actorType)
+        {
+            return system.GetExtension<DIExt>().Props(actorType);
         }
 
         /// <summary>

--- a/src/contrib/dependencyInjection/Akka.DI.Unity/UnityDependencyResolver.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.Unity/UnityDependencyResolver.cs
@@ -79,7 +79,17 @@ namespace Akka.DI.Unity
         /// <returns>The configuration object for the given actor type</returns>
         public Props Create<TActor>() where TActor : ActorBase
         {
-            return system.GetExtension<DIExt>().Props(typeof(TActor));
+            return Create(typeof(TActor));
+        }
+
+        /// <summary>
+        /// Used to register the configuration for an actor of the specified type <paramref name="actorType"/> 
+        /// </summary>
+        /// <param name="actorType">The <see cref="Type"/> of actor the configuration is based</param>
+        /// <returns>The configuration object for the given actor type</returns>
+        public virtual Props Create(Type actorType)
+        {
+            return system.GetExtension<DIExt>().Props(actorType);
         }
 
         /// <summary>


### PR DESCRIPTION
As discussed with Andrew Skotzko, when you dynamically want to resolve an actor, without an overload using System.Type, and only having generic types, you are forced to hard code large switch statements and also have the class know the entire universe.

This doesn't change the implementation, it just adds an overload.