### PR TITLE
[xml-doc] replaced scala x-references with c# x-references

### DIFF
--- a/src/core/Akka.Cluster/Cluster.cs
+++ b/src/core/Akka.Cluster/Cluster.cs
@@ -27,13 +27,13 @@ namespace Akka.Cluster
 
     //TODO: xmldoc
     /// <summary>
-    /// This module is responsible cluster membership information. Changes to the cluster
-    /// information is retrieved through [[#subscribe]]. Commands to operate the cluster is
-    /// available through methods in this class, such as [[#join]], [[#down]] and [[#leave]].
+    /// This module is responsible for cluster membership information. Changes to the cluster
+    /// information is retrieved through <see cref="Akka.Cluster.Cluster.Subscribe"/>. Commands to operate the cluster is
+    /// available through methods in this class, such as <see cref="Akka.Cluster.Cluster.Join"/>, <see cref="Akka.Cluster.Cluster.Down"/> and <see cref="Akka.Cluster.Cluster.Leave"/>.
     /// 
-    /// Each cluster [[Member]] is identified by its [[akka.actor.Address]], and
+    /// Each cluster <see cref="Akka.Cluster.Member"/> is identified by its <see cref="Akka.Actor.Address"/>, and
     /// the cluster address of this actor system is [[#selfAddress]]. A member also has a status;
-    /// initially [[MemberStatus.Joining]] followed by [[MemberStatus.Up]].
+    /// initially <see cref="Akka.Cluster.MemberStatus.Joining"/> followed by <see cref="Akka.Cluster.MemberStatus.Up"/>.
     /// </summary>
     public class Cluster :IExtension
     {

--- a/src/core/Akka.Cluster/ClusterEvent.cs
+++ b/src/core/Akka.Cluster/ClusterEvent.cs
@@ -29,7 +29,7 @@ namespace Akka.Cluster
             //TODO: Sort out xml doc references
             /// <summary>
             /// When using this subscription mode a snapshot of
-            /// [[akka.cluster.ClusterEvent.CurrentClusterState]] will be sent to the
+            /// <see cref="CurrentClusterState"/> will be sent to the
             /// subscriber as the first message.
             /// </summary>
             InitialStateAsSnapshot,
@@ -215,7 +215,7 @@ namespace Akka.Cluster
 
         //TODO: Sort out xml doc references
         /// <summary>
-        /// Member status changed to [[MemberStatus.Exiting]] and will be removed
+        /// Member status changed to <see cref="Akka.Cluster.MemberStatus.Exiting"/> and will be removed
         /// when all members have seen the `Exiting` status.
         /// </summary>
         public sealed class MemberExited : MemberStatusChange
@@ -363,10 +363,9 @@ namespace Akka.Cluster
             public static readonly IClusterDomainEvent Instance = new ClusterShuttingDown();
         }
 
-        //TODO: xml doc
         /// <summary>
-        /// Marker interface to facilitate subscription of
-        /// both [[UnreachableMember]] and [[ReachableMember]].
+        /// A marker interface to facilitate the subscription of
+        /// both <see cref="Akka.Cluster.ClusterEvent.UnreachableMember"/> and <see cref="Akka.Cluster.ClusterEvent.ReachableMember"/>.
         /// </summary>
         public interface IReachabilityEvent : IClusterDomainEvent
         {
@@ -419,7 +418,7 @@ namespace Akka.Cluster
         /// <summary>
         /// A member is considered as reachable by the failure detector
         /// after having been unreachable.
-        /// @see [[UnreachableMember]]
+        /// <see cref="Akka.Cluster.ClusterEvent.UnreachableMember"/>
         /// </summary>
         public sealed class ReachableMember : ReachabilityEvent
         {

--- a/src/core/Akka.Cluster/ClusterMetricsCollector.cs
+++ b/src/core/Akka.Cluster/ClusterMetricsCollector.cs
@@ -662,7 +662,7 @@ namespace Akka.Cluster
         }
 
         /**
-        * @param address [[akka.actor.Address]] of the node the metrics are gathered at
+        * @param address <see cref="Akka.Actor.Address"/> of the node the metrics are gathered at
         * @param timestamp the time of sampling, in milliseconds since midnight, January 1, 1970 UTC
         * @param systemLoadAverage OS-specific average load on the CPUs in the system, for the past 1 minute,
         *    The system is possibly nearing a bottleneck if the system load average is nearing number of cpus/cores.

--- a/src/core/Akka/Actor/ActorSystem.cs
+++ b/src/core/Akka/Actor/ActorSystem.cs
@@ -19,7 +19,7 @@ namespace Akka.Actor
     ///     An actor system is a hierarchical group of actors which share common
     ///     configuration, e.g. dispatchers, deployments, remote capabilities and
     ///     addresses. It is also the entry point for creating or looking up actors.
-    ///     There are several possibilities for creating actors (see [[Akka.Actor.Props]]
+    ///     There are several possibilities for creating actors (see <see cref="Akka.Actor.Props"/>
     ///     for details on `props`):
     ///     <code>
     /// system.ActorOf(props, "name");

--- a/src/core/Akka/Actor/Props.cs
+++ b/src/core/Akka/Actor/Props.cs
@@ -19,9 +19,9 @@ using Newtonsoft.Json;
 namespace Akka.Actor
 {
     /// <summary>
-    ///     Props is a configuration object used in creating an [[Actor]]; it is
+    ///     Props is a configuration object used in creating an <see cref="Akka.Actor.ActorBase">Actor</see>; it is
     ///     immutable, so it is thread-safe and fully shareable.
-    ///     Examples on C# API:
+    /// <example>
     /// <code>
     ///   private Props props = Props.Empty();
     ///   private Props props = Props.Create(() => new MyActor(arg1, arg2));
@@ -29,6 +29,7 @@ namespace Akka.Actor
     ///   private Props otherProps = props.WithDispatcher("dispatcher-id");
     ///   private Props otherProps = props.WithDeploy(deployment info);
     ///  </code>
+    ///  </example>
     /// </summary>
     public class Props : IEquatable<Props> , ISurrogated
     {
@@ -709,7 +710,7 @@ namespace Akka.Actor
 
     /// <summary>
     ///     This interface defines a class of actor creation strategies deviating from
-    ///     the usual default of just reflectively instantiating the [[Actor]]
+    ///     the usual default of just reflectively instantiating the <see cref="Akka.Actor.ActorBase">Actor</see>
     ///     subclass. It can be used to allow a dependency injection framework to
     ///     determine the actual actor class and how it shall be instantiated.
     /// </summary>
@@ -724,13 +725,13 @@ namespace Akka.Actor
         ActorBase Produce();
 
         /// <summary>
-        ///     This method is used by [[Props]] to determine the type of actor which will
+        ///     This method is used by <see cref="Akka.Actor.Props"/> to determine the type of actor which will
         ///     be created. The returned type is not used to produce the actor.
         /// </summary>
         Type ActorType { get; }
 
         /// <summary>
-        /// This method is used by [[Props]] to signal the Producer that it can
+        /// This method is used by <see cref="Akka.Actor.Props"/> to signal the Producer that it can
         /// release it's reference.  <see href="http://www.amazon.com/Dependency-Injection-NET-Mark-Seemann/dp/1935182501/ref=sr_1_1?ie=UTF8&qid=1425861096&sr=8-1&keywords=mark+seemann">HERE</see> 
         /// </summary>
         /// <param name="actor"></param>

--- a/src/core/Akka/IO/Tcp.cs
+++ b/src/core/Akka/IO/Tcp.cs
@@ -358,7 +358,7 @@ namespace Akka.IO
 
         /// <summary>
         /// A write command which aggregates two other write commands. Using this construct
-        /// you can chain a number of <see cref="Write" /> and/or [[WriteFile]] commands together in a way
+        /// you can chain a number of <see cref="Akka.IO.Tcp.Write" /> and/or <see cref="Akka.IO.Tcp.WriteFile" /> commands together in a way
         /// that allows them to be handled as a single write which gets written out to the
         /// network as quickly as possible.
         /// If the sub commands contain `ack` requests they will be honored as soon as the

--- a/src/core/Akka/IO/TcpManager.cs
+++ b/src/core/Akka/IO/TcpManager.cs
@@ -10,6 +10,45 @@ using Akka.Actor;
 
 namespace Akka.IO
 {
+    /**
+     * TODO: CLRify comment
+     * 
+     * INTERNAL API
+     *
+     * TcpManager is a facade for accepting commands (<see cref="Akka.IO.Tcp.Command"/>) to open client or server TCP connections.
+     *
+     * TcpManager is obtainable by calling {{{ IO(Tcp) }}} (see [[akka.io.IO]] and [[akka.io.Tcp]])
+     *
+     * == Bind ==
+     *
+     * To bind and listen to a local address, a <see cref="Akka.IO.Tcp.Bind"/> command must be sent to this actor. If the binding
+     * was successful, the sender of the <see cref="Akka.IO.Tcp.Bind"/> will be notified with a <see cref="Akka.IO.Tcp.Bound"/>
+     * message. The sender() of the <see cref="Akka.IO.Tcp.Bound"/> message is the Listener actor (an internal actor responsible for
+     * listening to server events). To unbind the port an <see cref="Akka.IO.Tcp.Unbind"/> message must be sent to the Listener actor.
+     *
+     * If the bind request is rejected because the Tcp system is not able to register more channels (see the nr-of-selectors
+     * and max-channels configuration options in the akka.io.tcp section of the configuration) the sender will be notified
+     * with a <see cref="Akka.IO.Tcp.CommandFailed"/> message. This message contains the original command for reference.
+     *
+     * When an inbound TCP connection is established, the handler will be notified by a <see cref="Akka.IO.Tcp.Connected"/> message.
+     * The sender of this message is the Connection actor (an internal actor representing the TCP connection). At this point
+     * the procedure is the same as for outbound connections (see section below).
+     *
+     * == Connect ==
+     *
+     * To initiate a connection to a remote server, a <see cref="Akka.IO.Tcp.Connect"/> message must be sent to this actor. If the
+     * connection succeeds, the sender() will be notified with a <see cref="Akka.IO.Tcp.Connected"/> message. The sender of the
+     * <see cref="Akka.IO.Tcp.Connected"/> message is the Connection actor (an internal actor representing the TCP connection). Before
+     * starting to use the connection, a handler must be registered to the Connection actor by sending a <see cref="Akka.IO.Tcp.Register"/>
+     * command message. After a handler has been registered, all incoming data will be sent to the handler in the form of
+     * <see cref="Akka.IO.Tcp.Received"/> messages. To write data to the connection, a <see cref="Akka.IO.Tcp.Write"/> message must be sent
+     * to the Connection actor.
+     *
+     * If the connect request is rejected because the Tcp system is not able to register more channels (see the nr-of-selectors
+     * and max-channels configuration options in the akka.io.tcp section of the configuration) the sender will be notified
+     * with a <see cref="Akka.IO.Tcp.CommandFailed"/> message. This message contains the original command for reference.
+     *
+     */
     internal class TcpManager : SelectionHandler.SelectorBasedManager
     {
         private readonly TcpExt _tcp;

--- a/src/core/Akka/IO/UdpManager.cs
+++ b/src/core/Akka/IO/UdpManager.cs
@@ -25,31 +25,30 @@ namespace Akka.IO
      *
      * == Bind and send ==
      *
-     * To bind and listen to a local address, a [[akka.io.Udp..Bind]] command must be sent to this actor. If the binding
-     * was successful, the sender of the [[akka.io.Udp.Bind]] will be notified with a [[akka.io.Udp.Bound]]
-     * message. The sender of the [[akka.io.Udp.Bound]] message is the Listener actor (an internal actor responsible for
-     * listening to server events). To unbind the port an [[akka.io.Tcp.Unbind]] message must be sent to the Listener actor.
+     * To bind and listen to a local address, a <see cref="Akka.IO.Udp.Bind"/> command must be sent to this actor. If the binding
+     * was successful, the sender of the <see cref="Akka.IO.Udp.Bind"/> will be notified with a <see cref="Akka.IO.Udp.Bound"/>
+     * message. The sender of the <see cref="Akka.IO.Udp.Bound"/> message is the Listener actor (an internal actor responsible for
+     * listening to server events). To unbind the port an <see cref="Akka.IO.Udp.Unbind"/> message must be sent to the Listener actor.
      *
-     * If the bind request is rejected because the Udp system is not able to register more channels (see the nr-of-selectors
-     * and max-channels configuration options in the akka.io.udp section of the configuration) the sender will be notified
-     * with a [[akka.io.Udp.CommandFailed]] message. This message contains the original command for reference.
+     * If the bind request is rejected because the Udp system is not able to register more channels (see the <c>nr-of-selectors</c>
+     * and <c>max-channels</c> configuration options in the <c>akka.io.udp</c> section of the configuration) the sender will be notified
+     * with a <see cref="Akka.IO.Udp.CommandFailed"/> message. This message contains the original command for reference.
      *
-     * The handler provided in the [[akka.io.Udp.Bind]] message will receive inbound datagrams to the bound port
-     * wrapped in [[akka.io.Udp.Received]] messages which contain the payload of the datagram and the sender address.
+     * The handler provided in the <see cref="Akka.IO.Udp.Bind"/> message will receive inbound datagrams to the bound port
+     * wrapped in <see cref="Akka.IO.Udp.Received"/> messages which contain the payload of the datagram and the sender address.
      *
-     * UDP datagrams can be sent by sending [[akka.io.Udp.Send]] messages to the Listener actor. The sender port of the
+     * UDP datagrams can be sent by sending <see cref="Akka.IO.Udp.Send"/> messages to the Listener actor. The sender port of the
      * outbound datagram will be the port to which the Listener is bound.
      *
      * == Simple send ==
      *
      * Udp provides a simple method of sending UDP datagrams if no reply is expected. To acquire the Sender actor
      * a SimpleSend message has to be sent to the manager. The sender of the command will be notified by a SimpleSenderReady
-     * message that the service is available. UDP datagrams can be sent by sending [[akka.io.Udp.Send]] messages to the
+     * message that the service is available. UDP datagrams can be sent by sending <see cref="Akka.IO.Udp.Send"/> messages to the
      * sender of SimpleSenderReady. All the datagrams will contain an ephemeral local port as sender and answers will be
      * discarded.
      *
      */
-
     internal class UdpManager : SelectionHandler.SelectorBasedManager
     {
         private readonly UdpExt _udp;

--- a/src/core/Akka/Routing/Resizer.cs
+++ b/src/core/Akka/Routing/Resizer.cs
@@ -15,8 +15,8 @@ using Akka.Dispatch;
 namespace Akka.Routing
 {
     /// <summary>
-    /// [[Pool]] routers with dynamically resizable number of routees are implemented by providing a Resizer
-    /// implementation in the [[akka.routing.Pool]] configuration
+    /// <see cref="Akka.Routing.Pool"/> routers with dynamically resizable number of routees are implemented by providing a Resizer
+    /// implementation in the <see cref="Akka.Routing.Pool"/> configuration
     /// </summary>
     public abstract class Resizer
     {
@@ -50,7 +50,7 @@ namespace Akka.Routing
     }
 
     /// <summary>
-    /// Implementation of [[Resizer]] that adjust the [[Pool]] based on specified thresholds.
+    /// Implementation of <see cref="Akka.Routing.Resizer"/> that adjust the <see cref="Akka.Routing.Pool"/> based on specified thresholds.
     /// </summary>
     public class DefaultResizer : Resizer, IEquatable<DefaultResizer>
     {


### PR DESCRIPTION
This PR replaces the scala documentation x-references with c# documentation x-references so that Sandcastle can pick these up when generating the api docs.