### PR TITLE
Added specs for Ask clustered router timeout error (#1343)

### DIFF
--- a/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
+++ b/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Proto\ClusterMessageSerializerSpec.cs" />
     <Compile Include="ReachabilitySpec.cs" />
+    <Compile Include="Routing\ClusterRouterAsk1343BugFixSpec.cs" />
     <Compile Include="Routing\ClusterRouterSupervisorSpec.cs" />
     <Compile Include="SerializationChecksSpec.cs" />
     <Compile Include="TestMember.cs" />

--- a/src/core/Akka.Cluster.Tests/Routing/ClusterRouterAsk1343BugFixSpec.cs
+++ b/src/core/Akka.Cluster.Tests/Routing/ClusterRouterAsk1343BugFixSpec.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Cluster.Routing;
+using Akka.Routing;
+using Akka.TestKit;
+using Akka.TestKit.TestActors;
+using Xunit;
+
+namespace Akka.Cluster.Tests.Routing
+{
+    /// <summary>
+    /// Spec to get to the bottom of https://github.com/akkadotnet/akka.net/issues/1343
+    /// </summary>
+    public class ClusterRouterAsk1343BugFixSpec : AkkaSpec
+    {
+        public ClusterRouterAsk1343BugFixSpec()
+            : base(@"
+    akka{
+        actor{
+            ask-timeout = 0.5s # use a default ask timeout
+            provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""
+            deployment {
+                /router1 {
+                        router = round-robin-pool
+                        nr-of-instances = 1
+                        cluster {
+                            enabled = on
+                            max-nr-of-instances-per-node = 1
+                            allow-local-routees = true
+                        }
+                    } 
+                /router2 {
+                    router = round-robin-group
+                    nr-of-instances = 1
+                    routees.paths = [""/user/echo""]
+                    cluster {
+                        enabled = on
+                        max-nr-of-instances-per-node = 1
+                        allow-local-routees = true
+                    }
+                }
+                /router3 {
+                    router = round-robin-group
+                    nr-of-instances = 1
+                    routees.paths = [""/user/echo""]
+                    cluster {
+                        enabled = on
+                        max-nr-of-instances-per-node = 1
+                        allow-local-routees = false #no one to route to!
+                    }
+                }
+            }
+        }
+        
+        remote.helios.tcp.port = 0
+    }")
+        {
+        }
+
+        
+        [Fact]
+        public async Task Should_Ask_Clustered_Pool_Router_and_forward_ask_to_routee()
+        {
+            var router = Sys.ActorOf(EchoActor.Props(this, true).WithRouter(FromConfig.Instance), "router1");
+            Assert.IsType<RoutedActorRef>(router);
+
+            var result = await router.Ask<string>("foo");
+            ExpectMsg<string>().ShouldBe(result);
+        }
+
+        [Fact]
+        public async Task Should_Ask_Clustered_Group_Router_and_forward_ask_to_routee()
+        {
+            var echo = Sys.ActorOf(EchoActor.Props(this, true), "echo");
+            var router = Sys.ActorOf(Props.Empty.WithRouter(FromConfig.Instance), "router2");
+            Assert.IsType<RoutedActorRef>(router);
+
+            var result = await router.Ask<string>("foo");
+            ExpectMsg<string>().ShouldBe(result);
+        }
+
+        [Fact]
+        public async Task Should_Ask_Clustered_Group_Router_and_with_no_routees_and_timeout()
+        {
+            var router = Sys.ActorOf(Props.Empty.WithRouter(FromConfig.Instance), "router3");
+            Assert.IsType<RoutedActorRef>(router);
+
+            try
+            {
+                var result = await router.Ask<string>("foo");
+            }
+            catch (Exception ex)
+            {
+                Assert.IsType<TaskCanceledException>(ex);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added some specs to verify if #1343 is an issue or not; was not able to reproduce the runtime error, but I want to keep these specs in the Akka.Cluster.Tests project anyway (they verify that Asks get forwarded to routees, which is helpful.)