### PR TITLE
rewrote ActorPath.TryParseAddrss to now test Uris by use Uri.TryCreate instead of try / catch

### DIFF
--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -297,14 +297,10 @@ namespace Akka.Actor
             //This code corresponds to AddressFromURIString.unapply
             uri = null;
             address = null;
-            try
-            {
-                uri = new Uri(path);
-            }
-            catch (UriFormatException)
-            {
+
+            if (!Uri.TryCreate(path, UriKind.Absolute, out uri))
                 return false;
-            }
+
             var protocol = uri.Scheme; //Typically "akka"
             if (!protocol.StartsWith("akka", StringComparison.OrdinalIgnoreCase))
             {


### PR DESCRIPTION
I get a flurry of handled `UriFormatException`s whenever I run Akka.NET specs, and that's been by design. Rewrote that code to use `Uri.TryCreate` instead so it no longer throws period.