### PR TITLE
hocon-empty

### DIFF
--- a/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
+++ b/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
@@ -94,6 +94,19 @@ a {
             public bool BoolProperty { get; set; }
             public int[] IntergerArray { get; set; }
         }
+
+        [Fact]
+        public void ParsingEmptyStringShouldProduceEmptyHoconRoot()
+        {
+            var value = Parser.Parse(string.Empty, null).Value;
+            value.IsEmpty.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Config_Empty_is_Empty()
+        {
+            ConfigurationFactory.Empty.IsEmpty.ShouldBeTrue();
+        }
    }
 }
 

--- a/src/core/Akka/Configuration/Hocon/HoconValue.cs
+++ b/src/core/Akka/Configuration/Hocon/HoconValue.cs
@@ -32,7 +32,19 @@ namespace Akka.Configuration.Hocon
         /// </summary>
         public bool IsEmpty
         {
-            get { return Values.Count == 0; }
+            get
+            {
+                if (Values.Count == 0)
+                    return true;
+
+                var first = Values[0] as HoconObject;
+                if (first != null)
+                {
+                    if (first.Items.Count == 0)
+                        return true;
+                }
+                return false;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fix for `Hocon.Value.IsEmpty` bug