### PR TITLE
[api-docs] Fixed various x-references

### DIFF
--- a/src/contrib/dependencyInjection/Akka.DI.AutoFac/AutoFacDependencyResolver.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.AutoFac/AutoFacDependencyResolver.cs
@@ -83,7 +83,7 @@ namespace Akka.DI.AutoFac
         }
 
         /// <summary>
-        /// Used to register the configuration for an actor of the specified type <typeparam name="TActor"/>
+        /// Used to register the configuration for an actor of the specified type <typeparamref name="TActor"/>
         /// </summary>
         /// <typeparam name="TActor">The type of actor the configuration is based</typeparam>
         /// <returns>The configuration object for the given actor type</returns>

--- a/src/contrib/dependencyInjection/Akka.DI.CastleWindsor/WindsorDependencyResolver.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.CastleWindsor/WindsorDependencyResolver.cs
@@ -73,7 +73,7 @@ namespace Akka.DI.CastleWindsor
         }
 
         /// <summary>
-        /// Used to register the configuration for an actor of the specified type <typeparam name="TActor"/>
+        /// Used to register the configuration for an actor of the specified type <typeparamref name="TActor"/>
         /// </summary>
         /// <typeparam name="TActor">The type of actor the configuration is based</typeparam>
         /// <returns>The configuration object for the given actor type</returns>

--- a/src/contrib/dependencyInjection/Akka.DI.Core/IDependencyResolver.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.Core/IDependencyResolver.cs
@@ -28,7 +28,7 @@ namespace Akka.DI.Core
         /// <returns>A delegate factory used to create actors</returns>
         Func<ActorBase> CreateActorFactory(Type actorType);
         /// <summary>
-        /// Used to register the configuration for an actor of the specified type <typeparam name="TActor"/>
+        /// Used to register the configuration for an actor of the specified type <typeparamref name="TActor"/>
         /// </summary>
         /// <typeparam name="TActor">The type of actor the configuration is based</typeparam>
         /// <returns>The configuration object for the given actor type</returns>

--- a/src/contrib/dependencyInjection/Akka.DI.Ninject/NinjectDependencyResolver.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.Ninject/NinjectDependencyResolver.cs
@@ -73,7 +73,7 @@ namespace Akka.DI.Ninject
         }
 
         /// <summary>
-        /// Used to register the configuration for an actor of the specified type <typeparam name="TActor"/>
+        /// Used to register the configuration for an actor of the specified type <typeparamref name="TActor"/>
         /// </summary>
         /// <typeparam name="TActor">The type of actor the configuration is based</typeparam>
         /// <returns>The configuration object for the given actor type</returns>

--- a/src/core/Akka.Cluster/Cluster.cs
+++ b/src/core/Akka.Cluster/Cluster.cs
@@ -111,7 +111,7 @@ namespace Akka.Cluster
         /// </summary>
         /// <param name="subscriber">The actor who'll receive the cluster domain events</param>
         /// <param name="to"><see cref="ClusterEvent.IClusterDomainEvent"/> subclasses</param>
-        /// <remarks>A snapshot of <see cref="ClusterEvent.CurrentClusterState"/> will be sent to <see cref="subscriber"/> as the first message</remarks>
+        /// <remarks>A snapshot of <see cref="ClusterEvent.CurrentClusterState"/> will be sent to <paramref name="subscriber"/> as the first message</remarks>
         public void Subscribe(IActorRef subscriber, Type[] to)
         {
             Subscribe(subscriber, ClusterEvent.SubscriptionInitialStateMode.InitialStateAsSnapshot, to);
@@ -123,10 +123,10 @@ namespace Akka.Cluster
         /// <param name="subscriber">The actor who'll receive the cluster domain events</param>
         /// <param name="initialStateMode">
         /// If set to <see cref="ClusterEvent.SubscriptionInitialStateMode.InitialStateAsEvents"/> the events corresponding to the current state
-        /// will be sent to <see cref="subscriber"/> to mimic what it would have seen if it were listening to the events when they occurred in the past.
+        /// will be sent to <paramref name="subscriber"/> to mimic what it would have seen if it were listening to the events when they occurred in the past.
         /// 
         /// If set to <see cref="ClusterEvent.SubscriptionInitialStateMode.InitialStateAsSnapshot"/> 
-        /// a snapshot of <see cref="ClusterEvent.CurrentClusterState"/> will be sent to <see cref="subscriber"/> as the first message. </param>
+        /// a snapshot of <see cref="ClusterEvent.CurrentClusterState"/> will be sent to <paramref name="subscriber"/> as the first message. </param>
         /// <param name="to"><see cref="ClusterEvent.IClusterDomainEvent"/> subclasses</param>
         public void Subscribe(IActorRef subscriber, ClusterEvent.SubscriptionInitialStateMode initialStateMode, Type[] to)
         {
@@ -161,7 +161,7 @@ namespace Akka.Cluster
         }
 
         /// <summary>
-        /// Try to join this cluster node specified by <see cref="address"/>.
+        /// Try to join this cluster node specified by <paramref name="address"/>.
         /// A <see cref="Join"/> command is sent to the node to join.
         /// 
         /// An actor system can only join a cluster once. Additional attempts will be ignored.
@@ -187,7 +187,7 @@ namespace Akka.Cluster
         }
 
         /// <summary>
-        /// Send command to issue state transition to LEAVING for the node specified by <see cref="address"/>.
+        /// Send command to issue state transition to LEAVING for the node specified by <paramref name="address"/>.
         /// The member will go through the status changes <see cref="MemberStatus.Leaving"/> (not published to 
         /// subscribers) followed by <see cref="MemberStatus.Exiting"/> and finally <see cref="MemberStatus.Removed"/>.
         /// 
@@ -205,7 +205,7 @@ namespace Akka.Cluster
         }
 
         /// <summary>
-        /// Send command to DOWN the node specified by <see cref="address"/>.
+        /// Send command to DOWN the node specified by <paramref name="address"/>.
         /// 
         /// When a member is considered by the failure detector to be unreachable the leader is not
         /// allowed to perform its duties, such as changing status of new joining members to <see cref="MemberStatus.Up"/>.

--- a/src/core/Akka.Cluster/ClusterMetricsCollector.cs
+++ b/src/core/Akka.Cluster/ClusterMetricsCollector.cs
@@ -223,7 +223,7 @@ namespace Akka.Cluster
         }
 
         /// <summary>
-        /// Only the nodes that are in the <see cref="includeNodes"/> set.
+        /// Only the nodes that are in the <paramref name="includeNodes"/> set.
         /// </summary>
         public MetricsGossip Filter(ImmutableHashSet<Address> includeNodes)
         {
@@ -355,7 +355,7 @@ namespace Akka.Cluster
         public NodeMetrics(Address address, long timestamp) : this(address, timestamp, ImmutableHashSet.Create<Metric>()) { }
 
         /// <summary>
-        /// Return the metric that matches <see cref="key"/>. Returns null if not found.
+        /// Return the metric that matches <paramref name="key"/>. Returns null if not found.
         /// </summary>
         public Metric Metric(string key)
         {
@@ -478,7 +478,7 @@ namespace Akka.Cluster
         #region Static methods
 
         /// <summary>
-        /// Creates a new <see cref="Metric"/> instance if <see cref="value"/> is valid, otherwise
+        /// Creates a new <see cref="Metric"/> instance if <paramref name="value"/> is valid, otherwise
         /// returns null. Invalid numeric values are negative and NaN/Infinite.
         /// </summary>
         public static Metric Create(string name, double value, double? decayFactor = null)
@@ -747,17 +747,17 @@ namespace Akka.Cluster
         private PerformanceCounter _systemLoadAverageCounter = new PerformanceCounter("Processor", "% Processor Time", "_Total", true);
         private PerformanceCounter _systemAvailableMemory = new PerformanceCounter("Memory", "Available MBytes", true);
 
-	    private static readonly bool IsRunningOnMono = Type.GetType("Mono.Runtime") != null;
+        private static readonly bool IsRunningOnMono = Type.GetType("Mono.Runtime") != null;
 
 
-		// Mono doesn't support Microsoft.VisualBasic, so need an alternative way of sampling this value
-		// see http://stackoverflow.com/questions/105031/how-do-you-get-total-amount-of-ram-the-computer-has
-	    private PerformanceCounter _monoSystemMaxMemory = IsRunningOnMono
-		    ? new PerformanceCounter("Mono Memory", "Total Physical Memory")
-		    : null;
+        // Mono doesn't support Microsoft.VisualBasic, so need an alternative way of sampling this value
+        // see http://stackoverflow.com/questions/105031/how-do-you-get-total-amount-of-ram-the-computer-has
+        private PerformanceCounter _monoSystemMaxMemory = IsRunningOnMono
+            ? new PerformanceCounter("Mono Memory", "Total Physical Memory")
+            : null;
 
 
-		#endregion
+        #endregion
 
         public Address Address { get; private set; }
 
@@ -817,20 +817,20 @@ namespace Akka.Cluster
         /// </summary>
         public Metric SystemMaxMemory()
         {
-	        return Metric.Create(StandardMetrics.SystemMemoryMax,
-		        IsRunningOnMono
-			        ? _monoSystemMaxMemory.RawValue
-			        : GetVbTotalPhysicalMemory());
+            return Metric.Create(StandardMetrics.SystemMemoryMax,
+                IsRunningOnMono
+                    ? _monoSystemMaxMemory.RawValue
+                    : GetVbTotalPhysicalMemory());
         }
 
-	    double GetVbTotalPhysicalMemory()
-	    {
+        double GetVbTotalPhysicalMemory()
+        {
 #if __MonoCS__
-			throw new NotImplementedException();
+            throw new NotImplementedException();
 #else
-		    return new Microsoft.VisualBasic.Devices.ComputerInfo().TotalPhysicalMemory;
+            return new Microsoft.VisualBasic.Devices.ComputerInfo().TotalPhysicalMemory;
 #endif
-	    }
+        }
 
         #endregion
 

--- a/src/core/Akka.Cluster/Gossip.cs
+++ b/src/core/Akka.Cluster/Gossip.cs
@@ -205,7 +205,6 @@ namespace Akka.Cluster
             return new Gossip(mergedMembers, new GossipOverview(mergedSeen, mergedReachability), mergedVClock);
         }
 
-        /// <summary>
         // First check that:
         //   1. we don't have any members that are unreachable, or
         //   2. all unreachable members in the set have status DOWN or EXITING
@@ -213,7 +212,6 @@ namespace Akka.Cluster
         // When that is done we check that all members with a convergence
         // status is in the seen table and has the latest vector clock
         // version
-        /// </summary>
         public bool Convergence(UniqueAddress selfUniqueAddress)
         {
             var unreachable = _overview.Reachability.AllUnreachableOrTerminated

--- a/src/core/Akka.Persistence/AtLeastOnceDelivery.cs
+++ b/src/core/Akka.Persistence/AtLeastOnceDelivery.cs
@@ -190,9 +190,9 @@ namespace Akka.Persistence
         public int UnconfirmedCount { get { return _unconfirmed.Count; } }
 
         /// <summary>
-        /// Send the message created with <paramref name="deliveryMessageMapper"/> function to the <see cref="destination"/>
+        /// Send the message created with <paramref name="deliveryMessageMapper"/> function to the <paramref name="destination"/>
         /// actor. It will retry sending the message until the delivery is confirmed with <see cref="ConfirmDelivery"/>.
-        /// Correlation between these two methods is performed by delivery id - parameter of <see cref="deliveryMessageMapper"/>.
+        /// Correlation between these two methods is performed by delivery id - parameter of <paramref name="deliveryMessageMapper"/>.
         /// Usually it's passed inside the message to the destination, which replies with the message having the same id.
         /// 
         /// During recovery this method won't send out any message, but it will be sent later until corresponding 

--- a/src/core/Akka.Remote/AckedDelivery.cs
+++ b/src/core/Akka.Remote/AckedDelivery.cs
@@ -196,7 +196,7 @@ namespace Akka.Remote
         /// Class representing an acknowledgement with select negative acknowledgements.
         /// </summary>
         /// <param name="cumulativeAck">Represents the highest sequence number received</param>
-        /// <param name="nacks">Set of sequence numbers between the last delivered one and <see cref="cumulativeAck"/> that has not been received.</param>
+        /// <param name="nacks">Set of sequence numbers between the last delivered one and <paramref name="cumulativeAck"/> that has not been received.</param>
         public Ack(SeqNo cumulativeAck, IEnumerable<SeqNo> nacks)
         {
             Nacks = new SortedSet<SeqNo>(nacks, SeqNo.Comparer);

--- a/src/core/Akka.Remote/RemoteDeployer.cs
+++ b/src/core/Akka.Remote/RemoteDeployer.cs
@@ -47,7 +47,7 @@ namespace Akka.Remote
         }
 
         /// <summary>
-        /// Used to determine if a given <see cref="deploy"/> is an instance of <see cref="RemoteRouterConfig"/>.
+        /// Used to determine if a given <paramref name="deploy"/> is an instance of <see cref="RemoteRouterConfig"/>.
         /// </summary>
         private static Deploy CheckRemoteRouterConfig(Deploy deploy)
         {

--- a/src/core/Akka.Remote/RemoteSystemDaemon.cs
+++ b/src/core/Akka.Remote/RemoteSystemDaemon.cs
@@ -102,7 +102,8 @@ namespace Akka.Remote
         /// <summary>
         ///     Called when [receive].
         /// </summary>
-        /// <param name="message">The message.</param>
+        /// <param name="message">The message that was received.</param>
+        /// <param name="sender">The actor that sent the message.</param>
         protected void OnReceive(object message, IActorRef sender)
         {
             //note: RemoteDaemon does not handle ActorSelection messages - those are handled directly by the RemoteActorRefProvider.

--- a/src/core/Akka.Remote/RemoteTransport.cs
+++ b/src/core/Akka.Remote/RemoteTransport.cs
@@ -68,7 +68,7 @@ namespace Akka.Remote
         public abstract Task Shutdown();
 
         /// <summary>
-        /// Sends the given message to the recipient, supplying <see cref="sender"/> if any.
+        /// Sends the given message to the recipient, supplying <paramref name="sender"/> if any.
         /// </summary>
         public abstract void Send(object message, IActorRef sender, RemoteActorRef recipient);
 

--- a/src/core/Akka.Remote/Transport/TestTransport.cs
+++ b/src/core/Akka.Remote/Transport/TestTransport.cs
@@ -333,7 +333,7 @@ namespace Akka.Remote.Transport
         /// <summary>
         /// Changes the current behavior to the provided one
         /// </summary>
-        /// <param name="behavior">Function that takes a parameter type <typeparam name="TIn"/> and returns a Task<typeparam name="TOut"></typeparam></param>
+        /// <param name="behavior">Function that takes a parameter type <typeparamref name="TIn"/> and returns a Task<typeparamref name="TOut"/>.</param>
         public void Push(Func<TIn, Task<TOut>> behavior)
         {
             _behaviorStack.Push(behavior);
@@ -484,7 +484,7 @@ namespace Akka.Remote.Transport
         /// </summary>
         /// <param name="key">Ordered pair of addresses representing an association. First element must be the address of the initiator.</param>
         /// <param name="listeners">A pair of listeners that will be responsible for handling the events of the two endpoints
-        /// of the association. Elements in the Tuple must be in the same order as the addresses in <see cref="key"/>.</param>
+        /// of the association. Elements in the Tuple must be in the same order as the addresses in <paramref name="key"/>.</param>
         public void RegisterListenerPair(Tuple<Address, Address> key,
             Tuple<IHandleEventListener, IHandleEventListener> listeners)
         {

--- a/src/core/Akka.Remote/Transport/Transport.cs
+++ b/src/core/Akka.Remote/Transport/Transport.cs
@@ -245,7 +245,7 @@ namespace Akka.Remote.Transport
         public TaskCompletionSource<IHandleEventListener> ReadHandlerSource { get; protected set; }
 
         /// <summary>
-        /// Asynchronously sends the specified <see cref="payload"/> to the remote endpoint. This method's implementation MUST be thread-safe
+        /// Asynchronously sends the specified <paramref name="payload"/> to the remote endpoint. This method's implementation MUST be thread-safe
         /// as it might be called from different threads. This method MUST NOT block.
         /// 
         /// Writes guarantee ordering of messages, but not their reception. The call to write returns with a boolean indicating if the

--- a/src/core/Akka.TestKit/TestKitBase_Receive.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Receive.cs
@@ -246,7 +246,7 @@ namespace Akka.TestKit
 
         /// <summary>
         /// Receive a series of messages.
-        /// It will continue to receive messages until the <see cref="shouldIgnore"/> predicate returns <c>false</c> or the idle 
+        /// It will continue to receive messages until the <paramref name="shouldIgnore"/> predicate returns <c>false</c> or the idle 
         /// timeout is met (disabled by default) or the overall
         /// maximum duration is elapsed or expected messages count is reached.
         /// If a message that isn't of type <typeparamref name="T"/> the parameter <paramref name="shouldIgnoreOtherMessageTypes"/> 

--- a/src/core/Akka.TestKit/TestKitBase_Within.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Within.cs
@@ -15,7 +15,7 @@ namespace Akka.TestKit
     {
 
         /// <summary>
-        /// Execute code block while bounding its execution time between 0 seconds and <see cref="max"/>.
+        /// Execute code block while bounding its execution time between 0 seconds and <paramref name="max"/>.
         /// <para>`within` blocks may be nested. All methods in this class which take maximum wait times 
         /// are available in a version which implicitly uses the remaining time governed by 
         /// the innermost enclosing `within` block.</para>
@@ -27,7 +27,7 @@ namespace Akka.TestKit
         }
 
         /// <summary>
-        /// Execute code block while bounding its execution time between <see cref="min"/> and <see cref="max"/>.
+        /// Execute code block while bounding its execution time between <paramref name="min"/> and <paramref name="max"/>.
         /// <para>`within` blocks may be nested. All methods in this class which take maximum wait times 
         /// are available in a version which implicitly uses the remaining time governed by 
         /// the innermost enclosing `within` block.</para>
@@ -40,7 +40,7 @@ namespace Akka.TestKit
 
 
         /// <summary>
-        /// Execute code block while bounding its execution time between 0 seconds and <see cref="max"/>.
+        /// Execute code block while bounding its execution time between 0 seconds and <paramref name="max"/>.
         /// <para>`within` blocks may be nested. All methods in this class which take maximum wait times 
         /// are available in a version which implicitly uses the remaining time governed by 
         /// the innermost enclosing `within` block.</para>
@@ -52,7 +52,7 @@ namespace Akka.TestKit
         }
 
         /// <summary>
-        /// Execute code block while bounding its execution time between <see cref="min"/> and <see cref="max"/>.
+        /// Execute code block while bounding its execution time between <paramref name="min"/> and <paramref name="max"/>.
         /// <para>`within` blocks may be nested. All methods in this class which take maximum wait times 
         /// are available in a version which implicitly uses the remaining time governed by 
         /// the innermost enclosing `within` block.</para>

--- a/src/core/Akka/Actor/ActorProducerPipeline.cs
+++ b/src/core/Akka/Actor/ActorProducerPipeline.cs
@@ -65,7 +65,7 @@ namespace Akka.Actor
     public abstract class ActorProducerPluginBase<TActor> : IActorProducerPlugin where TActor : ActorBase
     {
         /// <summary>
-        /// By default derivatives of this plugin will be applied to all actors inheriting from <typeparam name="TActor">actor generic type</typeparam>.
+        /// By default derivatives of this plugin will be applied to all actors inheriting from <typeparamref name="TActor">actor generic type</typeparamref>.
         /// </summary>
         public virtual bool CanBeAppliedTo(Type actorType)
         {

--- a/src/core/Akka/Actor/FSM.cs
+++ b/src/core/Akka/Actor/FSM.cs
@@ -729,8 +729,8 @@ namespace Akka.Actor
         /// See http://scalachina.com/api/scala/PartialFunction.html
         /// </summary>
         /// <param name="original">The original <see cref="StateFunction"/> to be called</param>
-        /// <param name="fallback">The <see cref="StateFunction"/> to be called if <see cref="original"/> returns null</param>
-        /// <returns>A <see cref="StateFunction"/> which combines both the results of <see cref="original"/> and <see cref="fallback"/></returns>
+        /// <param name="fallback">The <see cref="StateFunction"/> to be called if <paramref name="original"/> returns null</param>
+        /// <returns>A <see cref="StateFunction"/> which combines both the results of <paramref name="original"/> and <paramref name="fallback"/></returns>
         private static StateFunction OrElse(StateFunction original, StateFunction fallback)
         {
             StateFunction chained = delegate(Event<TData> @event)

--- a/src/core/Akka/Actor/PipeToSupport.cs
+++ b/src/core/Akka/Actor/PipeToSupport.cs
@@ -16,7 +16,7 @@ namespace Akka.Actor
     public static class PipeToSupport
     {
         /// <summary>
-        /// Pipes the output of a Task directly to the <see cref="recipient"/>'s mailbox once
+        /// Pipes the output of a Task directly to the <paramref name="recipient"/>'s mailbox once
         /// the task completes
         /// </summary>
         public static Task PipeTo<T>(this Task<T> taskToPipe, ICanTell recipient, IActorRef sender = null)
@@ -32,8 +32,8 @@ namespace Akka.Actor
         }
 
         /// <summary>
-        /// Pipes the output of a Task directly to the <see cref="recipient"/>'s mailbox once
-        /// the task completes.  As this task has no result, only exceptions will be piped to the <see cref="recipient"/>
+        /// Pipes the output of a Task directly to the <paramref name="recipient"/>'s mailbox once
+        /// the task completes.  As this task has no result, only exceptions will be piped to the <paramref name="recipient"/>
         /// </summary>
         public static Task PipeTo(this Task taskToPipe, ICanTell recipient, IActorRef sender = null)
         {

--- a/src/core/Akka/Actor/ReceiveActor.cs
+++ b/src/core/Akka/Actor/ReceiveActor.cs
@@ -122,7 +122,7 @@ namespace Akka.Actor
 
         /// <summary>
         /// Registers a handler for incoming messages of the specified type <typeparamref name="T"/>.
-        /// If <paramref name="shouldHandle"/>!=<c>null</c> then it must return true before a message is passed to <paramref name="handler"/>.        
+        /// If <paramref name="shouldHandle"/>!=<c>null</c> then it must return true before a message is passed to <paramref name="handler"/>.
         /// <remarks>This method may only be called when constructing the actor or from <see cref="Become(System.Action)"/> or <see cref="BecomeStacked"/>.</remarks>
         /// <remarks>Note that handlers registered prior to this may have handled the message already. 
         /// In that case, this handler will not be invoked.</remarks>
@@ -138,8 +138,8 @@ namespace Akka.Actor
 
         /// <summary>
         /// Registers a handler for incoming messages of the specified type <typeparamref name="T"/>.
-        /// If <paramref name="shouldHandle"/>!=<c>null</c> then it must return true before a message is passed to <paramref name="handler"/>.        
-        /// <remarks>This method may only be called when constructing the actor or from <see cref="Become(System.Action)"/> or <see cref="BecomeStacked"/>.</remarks>
+        /// If <paramref name="shouldHandle"/>!=<c>null</c> then it must return true before a message is passed to <paramref name="handler"/>.
+        /// <remarks>This method may only be called when constructing the actor or from <see cref="Become(Action)"/> or <see cref="BecomeStacked"/>.</remarks>
         /// <remarks>Note that handlers registered prior to this may have handled the message already. 
         /// In that case, this handler will not be invoked.</remarks>
         /// </summary>
@@ -153,14 +153,14 @@ namespace Akka.Actor
 
 
         /// <summary>
-        /// Registers a handler for incoming messages of the specified <see cref="messageType"/>.
-        /// If <paramref name="shouldHandle"/>!=<c>null</c> then it must return true before a message is passed to <paramref name="handler"/>.        
-        /// <remarks>This method may only be called when constructing the actor or from <see cref="Become(System.Action)"/> or <see cref="BecomeStacked"/>.</remarks>
+        /// Registers a handler for incoming messages of the specified <paramref name="messageType"/>.
+        /// If <paramref name="shouldHandle"/>!=<c>null</c> then it must return true before a message is passed to <paramref name="handler"/>.
+        /// <remarks>This method may only be called when constructing the actor or from <see cref="Become(Action)"/> or <see cref="BecomeStacked"/>.</remarks>
         /// <remarks>Note that handlers registered prior to this may have handled the message already. 
         /// In that case, this handler will not be invoked.</remarks>
         /// </summary>
         /// <param name="messageType">The type of the message</param>
-        /// <param name="handler">The message handler that is invoked for incoming messages of the specified <see cref="messageType"/></param>
+        /// <param name="handler">The message handler that is invoked for incoming messages of the specified <paramref name="messageType"/></param>
         /// <param name="shouldHandle">When not <c>null</c> it is used to determine if the message matches.</param>
         protected void Receive(Type messageType, Action<object> handler, Predicate<object> shouldHandle = null)
         {
@@ -170,14 +170,14 @@ namespace Akka.Actor
 
 
         /// <summary>
-        /// Registers a handler for incoming messages of the specified <see cref="messageType"/>.
-        /// If <paramref name="shouldHandle"/>!=<c>null</c> then it must return true before a message is passed to <paramref name="handler"/>.        
-        /// <remarks>This method may only be called when constructing the actor or from <see cref="Become(System.Action)"/> or <see cref="BecomeStacked"/>.</remarks>
+        /// Registers a handler for incoming messages of the specified <paramref name="messageType"/>.
+        /// If <paramref name="shouldHandle"/>!=<c>null</c> then it must return true before a message is passed to <paramref name="handler"/>.
+        /// <remarks>This method may only be called when constructing the actor or from <see cref="Become(Action)"/> or <see cref="BecomeStacked"/>.</remarks>
         /// <remarks>Note that handlers registered prior to this may have handled the message already. 
         /// In that case, this handler will not be invoked.</remarks>
         /// </summary>
         /// <param name="messageType">The type of the message</param>
-        /// <param name="handler">The message handler that is invoked for incoming messages of the specified <see cref="messageType"/></param>
+        /// <param name="handler">The message handler that is invoked for incoming messages of the specified <paramref name="messageType"/></param>
         /// <param name="shouldHandle">When not <c>null</c> it is used to determine if the message matches.</param>
         protected void Receive(Type messageType, Predicate<object> shouldHandle, Action<object> handler)
         {
@@ -192,7 +192,7 @@ namespace Akka.Actor
         /// Registers a handler for incoming messages of the specified type <typeparamref name="T"/>.
         /// The handler should return <c>true</c> if it has handled the message. 
         /// If the handler returns true no more handlers will be tried; otherwise the next registered handler will be tried.
-        /// <remarks>This method may only be called when constructing the actor or from <see cref="Become(System.Action)"/> or <see cref="BecomeStacked"/>.</remarks>
+        /// <remarks>This method may only be called when constructing the actor or from <see cref="Become(Action)"/> or <see cref="BecomeStacked"/>.</remarks>
         /// <remarks>Note that handlers registered prior to this may have handled the message already. 
         /// In that case, this handler will not be invoked.</remarks>
         /// </summary>
@@ -207,16 +207,16 @@ namespace Akka.Actor
         }
 
         /// <summary>
-        /// Registers a handler for incoming messages of the specified <see cref="messageType"/>.
+        /// Registers a handler for incoming messages of the specified <paramref name="messageType"/>.
         /// The handler should return <c>true</c> if it has handled the message. 
         /// If the handler returns true no more handlers will be tried; otherwise the next registered handler will be tried.
-        /// <remarks>This method may only be called when constructing the actor or from <see cref="Become(System.Action)"/> or <see cref="BecomeStacked"/>.</remarks>
+        /// <remarks>This method may only be called when constructing the actor or from <see cref="Become(Action)"/> or <see cref="BecomeStacked"/>.</remarks>
         /// <remarks>Note that handlers registered prior to this may have handled the message already. 
         /// In that case, this handler will not be invoked.</remarks>
         /// </summary>
         /// <param name="messageType">The type of the message</param>
         /// <param name="handler">The message handler that is invoked for incoming messages of the 
-        /// specified type <see cref="messageType"/>. It should return <c>true</c>if it handled/matched 
+        /// specified type <paramref name="messageType"/>. It should return <c>true</c>if it handled/matched 
         /// the message; <c>false</c> otherwise.</param>
         protected void Receive(Type messageType, Func<object, bool> handler)
         {
@@ -230,7 +230,7 @@ namespace Akka.Actor
 
         /// <summary>
         /// Registers a handler for incoming messages of any type.
-        /// <remarks>This method may only be called when constructing the actor or from <see cref="Become(System.Action)"/> or <see cref="BecomeStacked"/>.</remarks>
+        /// <remarks>This method may only be called when constructing the actor or from <see cref="Become(Action)"/> or <see cref="BecomeStacked"/>.</remarks>
         /// <remarks>Note that handlers registered prior to this may have handled the message already. 
         /// In that case, this handler will not be invoked.</remarks>
         /// </summary>

--- a/src/core/Akka/Actor/SupervisorStrategy.cs
+++ b/src/core/Akka/Actor/SupervisorStrategy.cs
@@ -78,7 +78,6 @@ namespace Akka.Actor
         ///     thrown. It will be restarted for other `Exception` types.
         ///     The error is escalated if it's a `Exception`, i.e. `Error`.
         /// </summary>
-        /// <param name="exception">The exception.</param>
         /// <returns>Directive.</returns>
         public static IDecider DefaultDecider = Decider.From(Directive.Restart,
             Directive.Stop.When<ActorInitializationException>(),

--- a/src/core/Akka/Dispatch/Dispatchers.cs
+++ b/src/core/Akka/Dispatch/Dispatchers.cs
@@ -226,7 +226,7 @@ namespace Akka.Dispatch
         /// </summary>
         /// <param name="cfg">The provided configuration section.</param>
         /// <returns>An instance of the <see cref="MessageDispatcher"/>, if valid.</returns>
-        /// <exception cref="ConfigurationException">if the `id` property is missing from <see cref="cfg"/></exception>
+        /// <exception cref="ConfigurationException">if the `id` property is missing from <paramref name="cfg"/></exception>
         /// <exception cref="NotSupportedException">thrown if the dispatcher path or type cannot be resolved.</exception>
         internal MessageDispatcher From(Config cfg)
         {

--- a/src/core/Akka/Dispatch/MessageQueues/DequeWrapperMessageQueue.cs
+++ b/src/core/Akka/Dispatch/MessageQueues/DequeWrapperMessageQueue.cs
@@ -20,7 +20,7 @@ namespace Akka.Dispatch.MessageQueues
         private readonly Stack<Envelope> _prependBuffer = new Stack<Envelope>();
         private readonly IMessageQueue _messageQueue;
         /// <summary>
-        /// Takes another <see cref="MessageQueue"/> as an argument - wraps <see cref="messageQueue"/>
+        /// Takes another <see cref="MessageQueue"/> as an argument - wraps <paramref name="messageQueue"/>
         /// in order to provide it with prepend (<see cref="EnqueueFirst"/>) semantics.
         /// </summary>
         /// <param name="messageQueue"></param>

--- a/src/core/Akka/Event/LoggingAdapterBase.cs
+++ b/src/core/Akka/Event/LoggingAdapterBase.cs
@@ -31,15 +31,21 @@ namespace Akka.Event
         /// Creates an instance of the LoggingAdapterBase.
         /// </summary>
         /// <param name="logMessageFormatter">The log message formatter used by this logging adapter.</param>
-        /// <exception cref="ArgumentException"></exception>
+        /// <exception cref="ArgumentNullException">This exception is thrown when the supplied message formatter is null.</exception>
         protected LoggingAdapterBase(ILogMessageFormatter logMessageFormatter)
         {
             if(logMessageFormatter == null)
-                throw new ArgumentException("logMessageFormatter");
+                throw new ArgumentNullException("logMessageFormatter", "The message formatter must not be null.");
 
             _logMessageFormatter = logMessageFormatter;
         }
-        
+
+        /// <summary>
+        /// Checks the logging adapter to see if the supplied <paramref name="logLevel"/> is enabled.
+        /// </summary>
+        /// <param name="logLevel">The log level to check if it is enabled in this logging adapter.</param>
+        /// <returns><c>true</c> if the supplied log level is enabled; otherwise <c>false</c></returns>
+        /// <exception cref="NotSupportedException">This exception is thrown when the supplied log level is unknown.</exception>
         public bool IsEnabled(LogLevel logLevel)
         {
             switch(logLevel)
@@ -62,7 +68,7 @@ namespace Akka.Event
         /// </summary>
         /// <param name="logLevel">The log level of the log event.</param>
         /// <param name="message">The log message of the log event.</param>
-        /// <exception cref="NotSupportedException"></exception>
+        /// <exception cref="NotSupportedException">This exception is thrown when the supplied log level is unknown.</exception>
         protected void NotifyLog(LogLevel logLevel, object message)
         {
             switch(logLevel)

--- a/src/core/Akka/Pattern/CircuitBreaker.cs
+++ b/src/core/Akka/Pattern/CircuitBreaker.cs
@@ -162,7 +162,7 @@ namespace Akka.Pattern
 
         /// <summary>
         /// Wraps invocations of asynchronous calls that need to be protected
-        /// If this does not complete within the time allotted, it should return default(<typeparam name="T"></typeparam>)
+        /// If this does not complete within the time allotted, it should return default(<typeparamref name="T"/>)
         /// 
         /// <code>
         ///  Await.result(
@@ -173,7 +173,7 @@ namespace Akka.Pattern
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="body"></param>
-        /// <returns><typeparam name="T"></typeparam> or default(<typeparam name="T"></typeparam>)</returns>
+        /// <returns><typeparamref name="T"/> or default(<typeparamref name="T"/>)</returns>
         public T WithSyncCircuitBreaker<T>( Func<T> body )
         {
             var cbTask = WithCircuitBreaker( () => Task.Factory.StartNew( body ) );

--- a/src/core/Akka/Util/AtomicBoolean.cs
+++ b/src/core/Akka/Util/AtomicBoolean.cs
@@ -23,7 +23,7 @@ namespace Akka.Util
 
         private int _value;
         /// <summary>
-        /// Sets the initial value of this <see cref="AtomicBoolean"/> to <see cref="initialValue"/>.
+        /// Sets the initial value of this <see cref="AtomicBoolean"/> to <paramref name="initialValue"/>.
         /// </summary>
         public AtomicBoolean(bool initialValue = false)
         {
@@ -47,10 +47,10 @@ namespace Akka.Util
         }
 
         /// <summary>
-        /// If <see cref="Value"/> equals <see cref="expected"/>, then set the Value to
-        /// <see cref="newValue"/>.
+        /// If <see cref="Value"/> equals <paramref name="expected"/>, then set the Value to
+        /// <paramref name="newValue"/>.
         /// </summary>
-        /// <returns><c>true</c> if <see cref="newValue"/> was set</returns>
+        /// <returns><c>true</c> if <paramref name="newValue"/> was set</returns>
         public bool CompareAndSet(bool expected, bool newValue)
         {
             var expectedInt = expected ? _trueValue : _falseValue;

--- a/src/core/Akka/Util/AtomicReference.cs
+++ b/src/core/Akka/Util/AtomicReference.cs
@@ -19,7 +19,7 @@ namespace Akka.Util
     public class AtomicReference<T>
     {
         /// <summary>
-        /// Sets the initial value of this <see cref="AtomicReference{T}"/> to <see cref="originalValue"/>.
+        /// Sets the initial value of this <see cref="AtomicReference{T}"/> to <paramref name="originalValue"/>.
         /// </summary>
         public AtomicReference(T originalValue)
         {
@@ -56,10 +56,10 @@ namespace Akka.Util
         }
 
         /// <summary>
-        /// If <see cref="Value"/> equals <see cref="expected"/>, then set the Value to
-        /// <see cref="newValue"/>.
+        /// If <see cref="Value"/> equals <paramref name="expected"/>, then set the Value to
+        /// <paramref name="newValue"/>.
         /// </summary>
-        /// <returns><c>true</c> if <see cref="newValue"/> was set</returns>
+        /// <returns><c>true</c> if <paramref name="newValue"/> was set</returns>
         public bool CompareAndSet(T expected, T newValue)
         {
             //special handling for null values
@@ -84,7 +84,7 @@ namespace Akka.Util
         #region Conversion operators
 
         /// <summary>
-        /// Implicit conversion operator = automatically casts the <see cref="AtomicReference{T}"/> to an instance of <typeparam name="T"></typeparam>
+        /// Implicit conversion operator = automatically casts the <see cref="AtomicReference{T}"/> to an instance of <typeparamref name="T"/>.
         /// </summary>
         public static implicit operator T(AtomicReference<T> aRef)
         {

--- a/src/core/Akka/Util/ContinuousEnumerator.cs
+++ b/src/core/Akka/Util/ContinuousEnumerator.cs
@@ -63,9 +63,9 @@ namespace Akka.Util
     internal static class ContinuousEnumeratorExtensions
     {
         /// <summary>
-        /// Provides a <see cref="ContinuousEnumerator{T}"/> instance for <see cref="collection"/>.
+        /// Provides a <see cref="ContinuousEnumerator{T}"/> instance for <paramref name="collection"/>.
         /// 
-        /// Internally, it just wraps <see cref="collection"/>'s internal iterator with circular iteration behavior.
+        /// Internally, it just wraps <paramref name="collection"/>'s internal iterator with circular iteration behavior.
         /// </summary>
         public static ContinuousEnumerator<T> GetContinuousEnumerator<T>(this IEnumerable<T> collection)
         {

--- a/src/core/Akka/Util/Internal/ArrayExtensions.cs
+++ b/src/core/Akka/Util/Internal/ArrayExtensions.cs
@@ -80,17 +80,19 @@ namespace Akka.Util.Internal
         /// <param name="items">The array of items to slice</param>
         /// <param name="startIndex">The starting position to begin the slice</param>
         /// <param name="count">The number of items to take</param>
-        /// <returns>A slice of size <see cref="count"/> beginning from position <see cref="startIndex"/> in <see cref="items"/>.</returns>
+        /// <returns>A slice of size <paramref name="count"/> beginning from position <sparamref name="startIndex"/> in <paramref name="items"/>.</returns>
         internal static IEnumerable<T> Slice<T>(this IEnumerable<T> items, int startIndex, int count)
         {
             return items.Skip(startIndex).Take(count);
         }
 
         /// <summary>
-        /// Select all the items in this array beginning with <see cref="startingItem"/> and up until the end of the array.
+        /// Select all the items in this array beginning with <paramref name="startingItem"/> and up until the end of the array.
         /// 
-        /// If <see cref="startingItem"/> is not found in the array, From will return an empty set.
-        /// If <see cref="startingItem"/> is found at the end of the array, From will return the entire original array.
+        /// <note>
+        /// If <paramref name="startingItem"/> is not found in the array, From will return an empty set.
+        /// If <paramref name="startingItem"/> is found at the end of the array, From will return the entire original array.
+        /// </note>
         /// </summary>
         internal static IEnumerable<T> From<T>(this IEnumerable<T> items, T startingItem)
         {
@@ -103,10 +105,11 @@ namespace Akka.Util.Internal
         }
 
         /// <summary>
-        /// Select all the items in this array from the beginning until (but not including) <see cref="startingItem"/>
-        /// 
-        /// If <see cref="startingItem"/> is not found in the array, Until will select all items.
-        /// If <see cref="startingItem"/> is the first item in the array, an empty array will be returned.
+        /// Select all the items in this array from the beginning until (but not including) <paramref name="startingItem"/>
+        /// <note>
+        /// If <paramref name="startingItem"/> is not found in the array, Until will select all items.
+        /// If <paramref name="startingItem"/> is the first item in the array, an empty array will be returned.
+        /// </note>
         /// </summary>
         internal static IEnumerable<T> Until<T>(this IEnumerable<T> items, T startingItem)
         {

--- a/src/core/Akka/Util/MatchHandler/PartialAction.cs
+++ b/src/core/Akka/Util/MatchHandler/PartialAction.cs
@@ -8,11 +8,11 @@
 namespace Akka.Tools.MatchHandler
 {
     /// <summary>
-    /// An action that returns <c>true</c> if the <param name="item"/> was handled.
+    /// An action that returns <c>true</c> if the <paramref name="item"/> was handled.
     /// </summary>
     /// <typeparam name="T">The type of the argument</typeparam>
     /// <param name="item">The argument.</param>
-    /// <returns>Returns <c>true</c> if the <param name="item"/> was handled</returns>
+    /// <returns>Returns <c>true</c> if the <paramref name="item"/> was handled</returns>
     public delegate bool PartialAction<in T>(T item);
 }
 

--- a/src/core/Akka/Util/MurmurHash.cs
+++ b/src/core/Akka/Util/MurmurHash.cs
@@ -125,7 +125,7 @@ namespace Akka.Util
         #region Internal 32-bit hashing helpers
 
         /// <summary>
-        /// Rotate a 32-bit unsigned integer to the left by <see cref="shift"/> bits
+        /// Rotate a 32-bit unsigned integer to the left by <paramref name="shift"/> bits
         /// </summary>
         /// <param name="original">Original value</param>
         /// <param name="shift">The shift value</param>
@@ -136,7 +136,7 @@ namespace Akka.Util
         }
 
         /// <summary>
-        /// Rotate a 64-bit unsigned integer to the left by <see cref="shift"/> bits
+        /// Rotate a 64-bit unsigned integer to the left by <paramref name="shift"/> bits
         /// </summary>
         /// <param name="original">Original value</param>
         /// <param name="shift">The shift value</param>


### PR DESCRIPTION
This PR fixes various x-reference issues in the xmldocs.

Most of these are in the form of replacing ```<param name="method parameter"/>``` with ```<paramref name="method parameter"/>``` when included in the ```<summary/>```. 

Sandcastle misinterprets the former when in a summary and puts a placeholder **[!parameter name]** instead of the correct reference *parameter name*. See this for an [example](http://api.getakka.net/docs/stable/html/F9E07D50.htm) of what it does when referencing the *address* parameter.