### PR TITLE
Renamed internal exceptions to follow .NET standard

### DIFF
--- a/src/core/Akka.Remote.TestKit.Tests/BarrierSpec.cs
+++ b/src/core/Akka.Remote.TestKit.Tests/BarrierSpec.cs
@@ -93,7 +93,7 @@ namespace Akka.Remote.TestKit.Tests
             //EventFilter<BarrierCoordinator.BarrierEmpty>(1, () => b.Tell(new BarrierCoordinator.RemoveClient(A), TestActor)); //appears to be a bug in the testfilter
             b.Tell(new BarrierCoordinator.RemoveClient(A));
             ExpectMsg(new Failed(b,
-                new BarrierCoordinator.BarrierEmpty(
+                new BarrierCoordinator.BarrierEmptyException(
                     new BarrierCoordinator.Data(ImmutableHashSet.Create<Controller.NodeInfo>(), "", null, null),
                     "cannot remove RoleName(a): no client to remove")));
         }
@@ -208,12 +208,12 @@ namespace Akka.Remote.TestKit.Tests
             //TODO: EventFilter?
             barrier.Tell(new Controller.ClientDisconnected(B));
             var msg = ExpectMsg<Failed>();
-            Assert.Equal(new BarrierCoordinator.ClientLost(
+            Assert.Equal(new BarrierCoordinator.ClientLostException(
                 new BarrierCoordinator.Data(
                     ImmutableHashSet.Create(nodeA),
                     "bar6", 
                     ImmutableHashSet.Create(a.Ref),
-                    ((BarrierCoordinator.ClientLost) msg.Exception).BarrierData.Deadline)
+                    ((BarrierCoordinator.ClientLostException) msg.Exception).BarrierData.Deadline)
                 , B), msg.Exception);
         }
 
@@ -234,12 +234,12 @@ namespace Akka.Remote.TestKit.Tests
             //TODO: Event filter?
             barrier.Tell(new Controller.ClientDisconnected(B));
             var msg = ExpectMsg<Failed>();
-            Assert.Equal(new BarrierCoordinator.ClientLost(
+            Assert.Equal(new BarrierCoordinator.ClientLostException(
                 new BarrierCoordinator.Data(
                     ImmutableHashSet.Create(nodeA, nodeC),
                     "bar7", 
                     ImmutableHashSet.Create(a.Ref),
-                    ((BarrierCoordinator.ClientLost)msg.Exception).BarrierData.Deadline)
+                    ((BarrierCoordinator.ClientLostException)msg.Exception).BarrierData.Deadline)
                 , B), msg.Exception);
 
         }
@@ -258,14 +258,14 @@ namespace Akka.Remote.TestKit.Tests
             //TODO: Event filter
             b.Send(barrier, new EnterBarrier("foo", null));
             var msg = ExpectMsg<Failed>();
-            Assert.Equal(new BarrierCoordinator.WrongBarrier(
+            Assert.Equal(new BarrierCoordinator.WrongBarrierException(
                 "foo",
                 b.Ref,
                 new BarrierCoordinator.Data(
                     ImmutableHashSet.Create(nodeA, nodeB),
                     "bar8",
                     ImmutableHashSet.Create(a.Ref),
-                    ((BarrierCoordinator.WrongBarrier)msg.Exception).BarrierData.Deadline)
+                    ((BarrierCoordinator.WrongBarrierException)msg.Exception).BarrierData.Deadline)
                 ), msg.Exception);
         }
         
@@ -277,12 +277,12 @@ namespace Akka.Remote.TestKit.Tests
             //TODO: EventFilter
             barrier.Tell(new BarrierCoordinator.RemoveClient(A));
             var msg = ExpectMsg<Failed>();
-            Assert.Equal(new BarrierCoordinator.BarrierEmpty(
+            Assert.Equal(new BarrierCoordinator.BarrierEmptyException(
                 new BarrierCoordinator.Data(
                     ImmutableHashSet.Create<Controller.NodeInfo>(),
                     "",
                     ImmutableHashSet.Create<IActorRef>(),
-                    ((BarrierCoordinator.BarrierEmpty)msg.Exception).BarrierData.Deadline)
+                    ((BarrierCoordinator.BarrierEmptyException)msg.Exception).BarrierData.Deadline)
                 , "cannot remove RoleName(a): no client to remove"), msg.Exception);
             barrier.Tell(new Controller.NodeInfo(A, Address.Parse("akka://sys"), a.Ref));
             a.Send(barrier, new EnterBarrier("bar9", null));
@@ -300,15 +300,15 @@ namespace Akka.Remote.TestKit.Tests
             barrier.Tell(nodeA);
             barrier.Tell(nodeB);
             a.Send(barrier, new EnterBarrier("bar10", null));
-            EventFilter.Exception<BarrierCoordinator.BarrierTimeout>().ExpectOne(() =>
+            EventFilter.Exception<BarrierCoordinator.BarrierTimeoutException>().ExpectOne(() =>
             {
                 var msg = ExpectMsg<Failed>(TimeSpan.FromSeconds(7));
-                Assert.Equal(new BarrierCoordinator.BarrierTimeout(
+                Assert.Equal(new BarrierCoordinator.BarrierTimeoutException(
                     new BarrierCoordinator.Data(
                         ImmutableHashSet.Create(nodeA, nodeB),
                         "bar10",
                         ImmutableHashSet.Create(a.Ref),
-                        ((BarrierCoordinator.BarrierTimeout)msg.Exception).BarrierData.Deadline)
+                        ((BarrierCoordinator.BarrierTimeoutException)msg.Exception).BarrierData.Deadline)
                     ), msg.Exception);
             });
         }
@@ -325,12 +325,12 @@ namespace Akka.Remote.TestKit.Tests
             //TODO: Event filter
             barrier.Tell(nodeB);
             var msg = ExpectMsg<Failed>();
-            Assert.Equal(new BarrierCoordinator.DuplicateNode(
+            Assert.Equal(new BarrierCoordinator.DuplicateNodeException(
                 new BarrierCoordinator.Data(
                     ImmutableHashSet.Create(nodeA),
                     "",
                     ImmutableHashSet.Create<IActorRef>(),
-                    ((BarrierCoordinator.DuplicateNode)msg.Exception).BarrierData.Deadline)
+                    ((BarrierCoordinator.DuplicateNodeException)msg.Exception).BarrierData.Deadline)
                 , nodeB), msg.Exception);
         }
 

--- a/src/core/Akka.Remote.TestKit/BarrierCoordinator.cs
+++ b/src/core/Akka.Remote.TestKit/BarrierCoordinator.cs
@@ -121,9 +121,9 @@ namespace Akka.Remote.TestKit
             }
         }
 
-        public sealed class BarrierTimeout : Exception
+        public sealed class BarrierTimeoutException : Exception
         {
-            public BarrierTimeout(Data barrierData)
+            public BarrierTimeoutException(Data barrierData)
                 : base(string.Format("timeout while waiting for barrier '{0}'", barrierData.Barrier))
             {
                 BarrierData = barrierData;
@@ -131,7 +131,7 @@ namespace Akka.Remote.TestKit
 
             public Data BarrierData { get; private set; }
 
-            private bool Equals(BarrierTimeout other)
+            private bool Equals(BarrierTimeoutException other)
             {
                 return Equals(BarrierData, other.BarrierData);
             }
@@ -140,7 +140,7 @@ namespace Akka.Remote.TestKit
             {
                 if (ReferenceEquals(null, obj)) return false;
                 if (ReferenceEquals(this, obj)) return true;
-                return obj is BarrierTimeout && Equals((BarrierTimeout) obj);
+                return obj is BarrierTimeoutException && Equals((BarrierTimeoutException) obj);
             }
 
             public override int GetHashCode()
@@ -148,20 +148,20 @@ namespace Akka.Remote.TestKit
                 return (BarrierData != null ? BarrierData.GetHashCode() : 0);
             }
 
-            public static bool operator ==(BarrierTimeout left, BarrierTimeout right)
+            public static bool operator ==(BarrierTimeoutException left, BarrierTimeoutException right)
             {
                 return Equals(left, right);
             }
 
-            public static bool operator !=(BarrierTimeout left, BarrierTimeout right)
+            public static bool operator !=(BarrierTimeoutException left, BarrierTimeoutException right)
             {
                 return !Equals(left, right);
             }
         }
 
-        public sealed class FailedBarrier : Exception
+        public sealed class FailedBarrierException : Exception
         {
-            public FailedBarrier(Data barrierData)
+            public FailedBarrierException(Data barrierData)
                 : base(string.Format("failing barrier '{0}'", barrierData.Barrier))
             {
                 BarrierData = barrierData;
@@ -169,7 +169,7 @@ namespace Akka.Remote.TestKit
 
             public Data BarrierData { get; private set; }
 
-            private bool Equals(FailedBarrier other)
+            private bool Equals(FailedBarrierException other)
             {
                 return Equals(BarrierData, other.BarrierData);
             }
@@ -178,7 +178,7 @@ namespace Akka.Remote.TestKit
             {
                 if (ReferenceEquals(null, obj)) return false;
                 if (ReferenceEquals(this, obj)) return true;
-                return obj is FailedBarrier && Equals((FailedBarrier) obj);
+                return obj is FailedBarrierException && Equals((FailedBarrierException) obj);
             }
 
             public override int GetHashCode()
@@ -186,20 +186,20 @@ namespace Akka.Remote.TestKit
                 return (BarrierData != null ? BarrierData.GetHashCode() : 0);
             }
 
-            public static bool operator ==(FailedBarrier left, FailedBarrier right)
+            public static bool operator ==(FailedBarrierException left, FailedBarrierException right)
             {
                 return Equals(left, right);
             }
 
-            public static bool operator !=(FailedBarrier left, FailedBarrier right)
+            public static bool operator !=(FailedBarrierException left, FailedBarrierException right)
             {
                 return !Equals(left, right);
             }
         }
 
-        public sealed class DuplicateNode : Exception
+        public sealed class DuplicateNodeException : Exception
         {
-            public DuplicateNode(Data barrierData, Controller.NodeInfo node)
+            public DuplicateNodeException(Data barrierData, Controller.NodeInfo node)
                 : base(string.Format(node.ToString()))
             {
                 Node = node;
@@ -210,7 +210,7 @@ namespace Akka.Remote.TestKit
 
             public Controller.NodeInfo Node { get; private set; }
 
-            private bool Equals(DuplicateNode other)
+            private bool Equals(DuplicateNodeException other)
             {
                 return Equals(BarrierData, other.BarrierData) && Equals(Node, other.Node);
             }
@@ -219,7 +219,7 @@ namespace Akka.Remote.TestKit
             {
                 if (ReferenceEquals(null, obj)) return false;
                 if (ReferenceEquals(this, obj)) return true;
-                return obj is DuplicateNode && Equals((DuplicateNode) obj);
+                return obj is DuplicateNodeException && Equals((DuplicateNodeException) obj);
             }
 
             public override int GetHashCode()
@@ -230,20 +230,20 @@ namespace Akka.Remote.TestKit
                 }
             }
 
-            public static bool operator ==(DuplicateNode left, DuplicateNode right)
+            public static bool operator ==(DuplicateNodeException left, DuplicateNodeException right)
             {
                 return Equals(left, right);
             }
 
-            public static bool operator !=(DuplicateNode left, DuplicateNode right)
+            public static bool operator !=(DuplicateNodeException left, DuplicateNodeException right)
             {
                 return !Equals(left, right);
             }
         }
 
-        public sealed class WrongBarrier : Exception
+        public sealed class WrongBarrierException : Exception
         {
-            public WrongBarrier(string barrier, IActorRef client, Data barrierData)
+            public WrongBarrierException(string barrier, IActorRef client, Data barrierData)
                 : base(string.Format("tried"))
             {
                 BarrierData = barrierData;
@@ -257,7 +257,7 @@ namespace Akka.Remote.TestKit
 
             public Data BarrierData { get; private set; }
 
-            private bool Equals(WrongBarrier other)
+            private bool Equals(WrongBarrierException other)
             {
                 return string.Equals(Barrier, other.Barrier) && Equals(Client, other.Client) && Equals(BarrierData, other.BarrierData);
             }
@@ -266,7 +266,7 @@ namespace Akka.Remote.TestKit
             {
                 if (ReferenceEquals(null, obj)) return false;
                 if (ReferenceEquals(this, obj)) return true;
-                return obj is WrongBarrier && Equals((WrongBarrier) obj);
+                return obj is WrongBarrierException && Equals((WrongBarrierException) obj);
             }
 
             public override int GetHashCode()
@@ -280,20 +280,20 @@ namespace Akka.Remote.TestKit
                 }
             }
 
-            public static bool operator ==(WrongBarrier left, WrongBarrier right)
+            public static bool operator ==(WrongBarrierException left, WrongBarrierException right)
             {
                 return Equals(left, right);
             }
 
-            public static bool operator !=(WrongBarrier left, WrongBarrier right)
+            public static bool operator !=(WrongBarrierException left, WrongBarrierException right)
             {
                 return !Equals(left, right);
             }
         }
 
-        public sealed class BarrierEmpty : Exception
+        public sealed class BarrierEmptyException : Exception
         {
-            public BarrierEmpty(Data barrierData, string message)
+            public BarrierEmptyException(Data barrierData, string message)
                 : base(message)
             {
                 BarrierData = barrierData;
@@ -301,7 +301,7 @@ namespace Akka.Remote.TestKit
 
             public Data BarrierData { get; private set; }
 
-            private bool Equals(BarrierEmpty other)
+            private bool Equals(BarrierEmptyException other)
             {
                 return Equals(BarrierData, other.BarrierData);
             }
@@ -310,7 +310,7 @@ namespace Akka.Remote.TestKit
             {
                 if (ReferenceEquals(null, obj)) return false;
                 if (ReferenceEquals(this, obj)) return true;
-                return obj is BarrierEmpty && Equals((BarrierEmpty) obj);
+                return obj is BarrierEmptyException && Equals((BarrierEmptyException) obj);
             }
 
             public override int GetHashCode()
@@ -318,20 +318,20 @@ namespace Akka.Remote.TestKit
                 return (BarrierData != null ? BarrierData.GetHashCode() : 0);
             }
 
-            public static bool operator ==(BarrierEmpty left, BarrierEmpty right)
+            public static bool operator ==(BarrierEmptyException left, BarrierEmptyException right)
             {
                 return Equals(left, right);
             }
 
-            public static bool operator !=(BarrierEmpty left, BarrierEmpty right)
+            public static bool operator !=(BarrierEmptyException left, BarrierEmptyException right)
             {
                 return !Equals(left, right);
             }
         }
 
-        public sealed class ClientLost : Exception
+        public sealed class ClientLostException : Exception
         {
-            public ClientLost(Data barrierData, RoleName client)
+            public ClientLostException(Data barrierData, RoleName client)
                 : base(string.Format("unannounced disconnect of {0}", client))
             {
                 Client = client;
@@ -342,7 +342,7 @@ namespace Akka.Remote.TestKit
 
             public RoleName Client { get; private set; }
 
-            private bool Equals(ClientLost other)
+            private bool Equals(ClientLostException other)
             {
                 return Equals(BarrierData, other.BarrierData) && Equals(Client, other.Client);
             }
@@ -351,7 +351,7 @@ namespace Akka.Remote.TestKit
             {
                 if (ReferenceEquals(null, obj)) return false;
                 if (ReferenceEquals(this, obj)) return true;
-                return obj is ClientLost && Equals((ClientLost) obj);
+                return obj is ClientLostException && Equals((ClientLostException) obj);
             }
 
             public override int GetHashCode()
@@ -363,12 +363,12 @@ namespace Akka.Remote.TestKit
                 }
             }
 
-            public static bool operator ==(ClientLost left, ClientLost right)
+            public static bool operator ==(ClientLostException left, ClientLostException right)
             {
                 return Equals(left, right);
             }
 
-            public static bool operator !=(ClientLost left, ClientLost right)
+            public static bool operator !=(ClientLostException left, ClientLostException right)
             {
                 return !Equals(left, right);
             }
@@ -403,7 +403,7 @@ namespace Akka.Remote.TestKit
                 @event.FsmEvent.Match()
                     .With<Controller.NodeInfo>(node =>
                     {
-                        if (clients.Any(x => x.Name == node.Name)) throw new DuplicateNode(@event.StateData, node);
+                        if (clients.Any(x => x.Name == node.Name)) throw new DuplicateNodeException(@event.StateData, node);
                         nextState = Stay().Using(@event.StateData.Copy(clients.Add(node)));
                     })
                     .With<Controller.ClientDisconnected>(disconnected =>
@@ -419,7 +419,7 @@ namespace Akka.Remote.TestKit
                             if (client == null) nextState = Stay();
                             else
                             {
-                                throw new ClientLost(@event.StateData.Copy(clients.Remove(client), arrived:arrived.Where(x => x != client.FSM).ToImmutableHashSet()), disconnected.Name);
+                                throw new ClientLostException(@event.StateData.Copy(clients.Remove(client), arrived:arrived.Where(x => x != client.FSM).ToImmutableHashSet()), disconnected.Name);
                             }
                         }
                     });
@@ -455,7 +455,7 @@ namespace Akka.Remote.TestKit
                     .With<RemoveClient>(client =>
                     {
                         if (clients.Count == 0)
-                            throw new BarrierEmpty(@event.StateData,
+                            throw new BarrierEmptyException(@event.StateData,
                                 string.Format("cannot remove {0}: no client to remove", client.Name));
                         nextState =
                             Stay().Using(@event.StateData.Copy(clients.Where(x => x.Name != client.Name).ToImmutableHashSet()));
@@ -474,7 +474,7 @@ namespace Akka.Remote.TestKit
                     .With<EnterBarrier>(barrier =>
                     {
                         if (barrier.Name != currentBarrier)
-                            throw new WrongBarrier(barrier.Name, Sender, @event.StateData);
+                            throw new WrongBarrierException(barrier.Name, Sender, @event.StateData);
                         var together = clients.Any(x => x.FSM == Sender)
                             ? @event.StateData.Arrived.Add(Sender)
                             : @event.StateData.Arrived;
@@ -503,12 +503,12 @@ namespace Akka.Remote.TestKit
                     })
                     .With<FailBarrier>(barrier =>
                     {
-                        if(barrier.Name != currentBarrier) throw new WrongBarrier(barrier.Name, Sender, @event.StateData);
-                        throw new FailedBarrier(@event.StateData);
+                        if(barrier.Name != currentBarrier) throw new WrongBarrierException(barrier.Name, Sender, @event.StateData);
+                        throw new FailedBarrierException(@event.StateData);
                     })
                     .With<StateTimeout>(() =>
                     {
-                        throw new BarrierTimeout(@event.StateData);
+                        throw new BarrierTimeoutException(@event.StateData);
                     });
 
                 return nextState;

--- a/src/core/Akka.Remote.TestKit/Controller.cs
+++ b/src/core/Akka.Remote.TestKit/Controller.cs
@@ -219,21 +219,21 @@ namespace Akka.Remote.TestKit
         {
             return new OneForOneStrategy(e =>
             {
-                var barrierTimeout = e as BarrierCoordinator.BarrierTimeout;
+                var barrierTimeout = e as BarrierCoordinator.BarrierTimeoutException;
                 if (barrierTimeout != null) return FailBarrier(barrierTimeout.BarrierData);
-                var failedBarrier = e as BarrierCoordinator.FailedBarrier;
+                var failedBarrier = e as BarrierCoordinator.FailedBarrierException;
                 if (failedBarrier != null) return FailBarrier(failedBarrier.BarrierData);
-                var barrierEmpty = e as BarrierCoordinator.BarrierEmpty;
+                var barrierEmpty = e as BarrierCoordinator.BarrierEmptyException;
                 if(barrierEmpty != null) return Directive.Resume;
-                var wrongBarrier = e as BarrierCoordinator.WrongBarrier;
+                var wrongBarrier = e as BarrierCoordinator.WrongBarrierException;
                 if (wrongBarrier != null)
                 {
                     wrongBarrier.Client.Tell(new ToClient<BarrierResult>(new BarrierResult(wrongBarrier.Barrier, false)));
                     return FailBarrier(wrongBarrier.BarrierData);
                 }
-                var clientLost = e as BarrierCoordinator.ClientLost;
+                var clientLost = e as BarrierCoordinator.ClientLostException;
                 if (clientLost != null) return FailBarrier(clientLost.BarrierData);
-                var duplicateNode = e as BarrierCoordinator.DuplicateNode;
+                var duplicateNode = e as BarrierCoordinator.DuplicateNodeException;
                 if (duplicateNode != null) return FailBarrier(duplicateNode.BarrierData);
                 throw new InvalidOperationException(String.Format("Cannot process exception of type {0}", e.GetType()));
             });

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -160,9 +160,9 @@ namespace Akka.Remote
     /// <summary>
     /// INTERNAL API
     /// </summary>
-    internal sealed class ShutDownAssociation : EndpointException, IAssociationProblem
+    internal sealed class ShutDownAssociationException : EndpointException, IAssociationProblem
     {
-        public ShutDownAssociation(Address localAddress, Address remoteAddress, Exception cause = null)
+        public ShutDownAssociationException(Address localAddress, Address remoteAddress, Exception cause = null)
             : base(string.Format("Shut down address: {0}", remoteAddress), cause)
         {
             RemoteAddress = remoteAddress;
@@ -174,9 +174,9 @@ namespace Akka.Remote
         public Address RemoteAddress { get; private set; }
     }
 
-    internal sealed class InvalidAssociation : EndpointException, IAssociationProblem
+    internal sealed class InvalidAddressAssociationException : EndpointException, IAssociationProblem
     {
-        public InvalidAssociation(Address localAddress, Address remoteAddress, Exception cause = null)
+        public InvalidAddressAssociationException(Address localAddress, Address remoteAddress, Exception cause = null)
             : base(string.Format("Invalid address: {0}", remoteAddress), cause)
         {
             RemoteAddress = remoteAddress;
@@ -191,9 +191,9 @@ namespace Akka.Remote
     /// <summary>
     /// INTERNAL API
     /// </summary>
-    internal sealed class HopelessAssociation : EndpointException, IAssociationProblem
+    internal sealed class HopelessAssociationException : EndpointException, IAssociationProblem
     {
-        public HopelessAssociation(Address localAddress, Address remoteAddress, int? uid = null, Exception cause = null)
+        public HopelessAssociationException(Address localAddress, Address remoteAddress, int? uid = null, Exception cause = null)
             : base("Catastrophic association error.", cause)
         {
             RemoteAddress = remoteAddress;
@@ -488,7 +488,7 @@ namespace Akka.Remote
                         // In other words, this action is safe.
                         if (!UidConfirmed && BailoutAt.IsOverdue)
                         {
-                            throw new InvalidAssociation(_localAddress, _remoteAddress,
+                            throw new InvalidAddressAssociationException(_localAddress, _remoteAddress,
                                 new TimeoutException("Delivery of system messages timed out and they were dropped"));
                         }
 
@@ -628,7 +628,7 @@ namespace Akka.Remote
             }
             catch (Exception ex)
             {
-                throw new HopelessAssociation(_localAddress, _remoteAddress, Uid, ex);
+                throw new HopelessAssociationException(_localAddress, _remoteAddress, Uid, ex);
             }
         }
 
@@ -913,7 +913,7 @@ namespace Akka.Remote
                 var failure = message as Status.Failure;
                 if (failure.Cause is InvalidAssociationException)
                 {
-                    PublishAndThrow(new InvalidAssociation(LocalAddress, RemoteAddress, failure.Cause),
+                    PublishAndThrow(new InvalidAddressAssociationException(LocalAddress, RemoteAddress, failure.Cause),
                         LogLevel.WarningLevel);
                 }
                 else
@@ -1685,10 +1685,10 @@ namespace Akka.Remote
             switch (info)
             {
                 case DisassociateInfo.Quarantined:
-                    throw new InvalidAssociation(LocalAddress, RemoteAddress, new InvalidAssociationException("The remote system has quarantined this system. No further associations " +
+                    throw new InvalidAddressAssociationException(LocalAddress, RemoteAddress, new InvalidAssociationException("The remote system has quarantined this system. No further associations " +
                                                                                                               "to the remote system are possible until this system is restarted."));
                 case DisassociateInfo.Shutdown:
-                    throw new ShutDownAssociation(LocalAddress, RemoteAddress, new InvalidAssociationException("The remote system terminated the association because it is shutting down."));
+                    throw new ShutDownAssociationException(LocalAddress, RemoteAddress, new InvalidAssociationException("The remote system terminated the association because it is shutting down."));
                 case DisassociateInfo.Unknown:
                 default:
                     Context.Stop(Self);

--- a/src/core/Akka.Remote/EndpointManager.cs
+++ b/src/core/Akka.Remote/EndpointManager.cs
@@ -340,7 +340,7 @@ namespace Akka.Remote
                 var directive = Directive.Stop;
 
                 ex.Match()
-                    .With<InvalidAssociation>(ia =>
+                    .With<InvalidAddressAssociationException>(ia =>
                     {
                         log.Warning("Tried to associate with unreachable remote address [{0}]. Address is now gated for {1} ms, all messages to this address will be delivered to dead letters. Reason: [{2}]",
                                  ia.RemoteAddress, settings.RetryGateClosedFor.TotalMilliseconds, ia.Message);
@@ -348,7 +348,7 @@ namespace Akka.Remote
                         AddressTerminatedTopic.Get(Context.System).Publish(new AddressTerminated(ia.RemoteAddress));
                         directive = Directive.Stop;
                     })
-                    .With<ShutDownAssociation>(shutdown =>
+                    .With<ShutDownAssociationException>(shutdown =>
                     {
                         log.Debug("Remote system with address [{0}] has shut down. Address is now gated for {1}ms, all messages to this address will be delivered to dead letters.",
                                   shutdown.RemoteAddress, settings.RetryGateClosedFor.TotalMilliseconds);
@@ -356,7 +356,7 @@ namespace Akka.Remote
                         AddressTerminatedTopic.Get(Context.System).Publish(new AddressTerminated(shutdown.RemoteAddress));
                         directive = Directive.Stop;
                     })
-                    .With<HopelessAssociation>(hopeless =>
+                    .With<HopelessAssociationException>(hopeless =>
                     {
                         if (settings.QuarantineDuration.HasValue && hopeless.Uid.HasValue)
                         {


### PR DESCRIPTION
Closes #1192.

This PR renames various internal exceptions to follow the .NET standard
of suffixing exceptions with "Exception". Since these are internal and
not public it shouldn't break the public API.