### PR TITLE
Named log format

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -1482,11 +1482,13 @@ namespace Akka.Actor
         public System.Collections.Generic.IList<string> Loggers { get; }
         public System.TimeSpan LoggerStartTimeout { get; }
         public string LogLevel { get; }
+        public string LogTemplate { get; }
         public string ProviderClass { get; }
         public string SchedulerClass { get; }
         public bool SerializeAllCreators { get; }
         public bool SerializeAllMessages { get; }
         public string StdoutLogLevel { get; }
+        public string StdoutLogTemplate { get; }
         public string SupervisorStrategyClass { get; }
         public Akka.Actor.ActorSystem System { get; }
         public System.TimeSpan UnstartedPushTimeout { get; }
@@ -2664,6 +2666,7 @@ namespace Akka.Event
         public System.Exception Cause { get; }
         public override Akka.Event.LogLevel LogLevel() { }
         public override string ToString() { }
+        public new string ToString(string template) { }
     }
     public abstract class EventBus<TEvent, TClassifier, TSubscriber>
     {
@@ -2731,8 +2734,10 @@ namespace Akka.Event
         public object Message { get; set; }
         public System.Threading.Thread Thread { get; }
         public System.DateTime Timestamp { get; }
+        protected static string GetOrAddTemplate(string template, System.Func<string, string> body) { }
         public abstract Akka.Event.LogLevel LogLevel();
         public override string ToString() { }
+        public string ToString(string template) { }
     }
     public class LoggerInitialized : Akka.Actor.INoSerializationVerificationNeeded
     {
@@ -2803,6 +2808,7 @@ namespace Akka.Event
         public static System.ConsoleColor DebugColor { get; set; }
         public static System.ConsoleColor ErrorColor { get; set; }
         public static System.ConsoleColor InfoColor { get; set; }
+        public static string LogTemplate { get; set; }
         public override Akka.Actor.ActorPath Path { get; }
         public override Akka.Actor.IActorRefProvider Provider { get; }
         public static bool UseColors { get; set; }

--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -154,6 +154,7 @@
     <Compile Include="Dispatch\XUnitAsyncTestsSanityCheck.cs" />
     <Compile Include="Event\EventBusSpec.cs" />
     <Compile Include="Event\EventStreamSpec.cs" />
+    <Compile Include="Event\LoggingSpec.cs" />
     <Compile Include="IO\SimpleDnsCacheSpec.cs" />
     <Compile Include="IO\TcpConnectionSpec.cs" />
     <Compile Include="IO\TcpIntegrationSpec.cs" />

--- a/src/core/Akka.Tests/Event/LoggingSpec.cs
+++ b/src/core/Akka.Tests/Event/LoggingSpec.cs
@@ -1,0 +1,43 @@
+﻿using Akka.Event;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Tests.Event
+{
+    public class LoggingSpec : AkkaSpec
+    {
+        public LoggingSpec() : base(GetConfig())
+        {
+            
+        }
+
+        private static string GetConfig()
+        {
+            return @"
+akka.stdout-logtemplate = ""TestConfig [{LogLevel}][{Timestamp}][Thread {ThreadId}][{LogSource}] {Message}""
+";
+        }        
+
+        [Fact]
+        public void Default_stdout_logging_template_is_read_from_config()
+        {
+            Sys.Settings.StdoutLogTemplate.ShouldBe("TestConfig [{LogLevel}][{Timestamp}][Thread {ThreadId}][{LogSource}] {Message}");
+        }
+
+        [Fact]
+        public void LogEvent_can_be_rendered_with_custom_templates()
+        {
+            var debug = new Debug("abc",typeof(string),123);
+            var res = debug.ToString("{LogSource}{Message}");
+            res.ShouldBe("abc123");
+        }
+
+        [Fact]
+        public void LogEvent_can_be_rendered_with_formatters()
+        {
+            var debug = new Debug("abc", typeof(string), 123);
+            var res = debug.ToString("{Timestamp:yyyy}");
+            res.Length.ShouldBe(4);
+        }
+    }
+}

--- a/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
@@ -55,6 +55,7 @@ namespace Akka.Actor.Internal
 
             _name = name;            
             ConfigureSettings(config);
+            ConfigureStandardOutLogger();
             ConfigureEventStream();
             ConfigureProvider();
             ConfigureTerminationCallbacks();
@@ -128,6 +129,11 @@ namespace Akka.Actor.Internal
         public override ActorSelection ActorSelection(string actorPath)
         {
             return ActorRefFactoryShared.ActorSelection(actorPath, this, _provider.RootGuardian);
+        }
+
+        private void ConfigureStandardOutLogger()
+        {
+            StandardOutLogger.LogTemplate = Settings.StdoutLogTemplate;
         }
 
         private void ConfigureScheduler()

--- a/src/core/Akka/Actor/Settings.cs
+++ b/src/core/Akka/Actor/Settings.cs
@@ -76,11 +76,18 @@ namespace Akka.Actor
             SerializeAllCreators = Config.GetBoolean("akka.actor.serialize-creators");
 
             LogLevel = Config.GetString("akka.loglevel");
+            LogTemplate = Config.GetString("akka.stdout-logtemplate");
             StdoutLogLevel = Config.GetString("akka.stdout-loglevel");
+            StdoutLogTemplate = Config.GetString("akka.stdout-logtemplate");
+
+            //use base template as fallback if missing
+            if (string.IsNullOrWhiteSpace(StdoutLogTemplate))
+                StdoutLogTemplate = LogTemplate;
+
             Loggers = Config.GetStringList("akka.loggers");
 
             LoggerStartTimeout = Config.GetTimeSpan("akka.logger-startup-timeout");
-
+            
             //handled
             LogConfigOnStart = Config.GetBoolean("akka.log-config-on-start");
             LogDeadLetters = 0;
@@ -117,6 +124,16 @@ namespace Akka.Actor
                 final val DefaultVirtualNodesFactor: Int = getInt("akka.actor.deployment.default.virtual-nodes-factor")
              */
         }
+
+        /// <summary>
+        /// Gets the base template used for all loggers
+        /// </summary>
+        public string LogTemplate { get; private set; }
+
+        /// <summary>
+        /// Gets the log template used for Stdout logging
+        /// </summary>
+        public string StdoutLogTemplate { get;private set; }
 
         /// <summary>
         ///     Gets the system.

--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -30,6 +30,12 @@ akka {
   # Log level for the very basic logger activated during AkkaApplication startup
   # Options: OFF, ERROR, WARNING, INFO, DEBUG
   stdout-loglevel = "WARNING"
+
+  # Template used for logging
+  logtemplate = "[{LogLevel}][{Timestamp}][Thread {ThreadId}][{LogSource}] {Message}"
+
+  # Template used for stdout logging
+  # stdout-logtemplate = "[{LogLevel}][{Timestamp}][Thread {ThreadId}][{LogSource}] {Message}"
  
   # Log the complete configuration at INFO level when the actor system is started.
   # This is useful when you are uncertain of what configuration is used.

--- a/src/core/Akka/Event/Error.cs
+++ b/src/core/Akka/Event/Error.cs
@@ -47,12 +47,24 @@ namespace Akka.Event
         /// <returns></returns>
         public override string ToString()
         {
-            var cause = Cause;
-            var causeStr = cause == null ? "Unknown" : cause.ToString();
-            var errorStr = string.Format("[{0}][{1}][Thread {2}][{3}] {4}{5}Cause: {6}",
-                LogLevel().ToString().Replace("Level", "").ToUpperInvariant(), Timestamp,
-                Thread.ManagedThreadId.ToString().PadLeft(4, '0'), LogSource, Message, Environment.NewLine, causeStr);
-            return errorStr;
+            return ToString("[{LogLevel}][{Timestamp}][Thread {ThreadId}][{LogSource}] {Message}\r\n{Cause}");
+        }
+
+        public string ToString(string template)
+        {
+            var format = GetOrAddTemplate(template, t => template
+                .Replace("{LogLevel", "{0")
+                .Replace("{Timestamp", "{1")
+                .Replace("{ThreadId", "{2")
+                .Replace("{LogSource", "{3")
+                .Replace("{LogClass", "{4")
+                .Replace("{Message", "{5")
+                .Replace("{Cause","{6"));            
+
+            var logLevel = LogLevel().ToString().Replace("Level", "").ToUpperInvariant();
+            var threadId = Thread.ManagedThreadId.ToString().PadLeft(4, '0');
+            var causeStr = Cause == null ? "Unknown" : Cause.ToString();
+            return String.Format(format, logLevel, Timestamp, threadId, LogSource, LogClass, Message,causeStr);
         }
     }
 }

--- a/src/core/Akka/Event/StandardOutLogger.cs
+++ b/src/core/Akka/Event/StandardOutLogger.cs
@@ -88,6 +88,11 @@ namespace Akka.Event
         public static ConsoleColor ErrorColor { get; set; }
 
         /// <summary>
+        /// Gets or Sets the log template of the events.
+        /// </summary>
+        public static string LogTemplate { get; set; }
+
+        /// <summary>
         /// Gets or Sets whether or not to use colors when printing events.
         /// </summary>
         public static bool UseColors { get; set; }
@@ -120,7 +125,10 @@ namespace Akka.Event
                 }
             }
 
-            StandardOutWriter.WriteLine(logEvent.ToString(), color);
+            //use built in template if no template is provided
+            var message = LogTemplate == null? logEvent.ToString() : logEvent.ToString(LogTemplate);
+
+            StandardOutWriter.WriteLine(message, color);
         }
     }
 }

--- a/src/examples/RemoteDeploy/System1/Program.cs
+++ b/src/examples/RemoteDeploy/System1/Program.cs
@@ -29,7 +29,7 @@ namespace System1
 akka {  
     log-config-on-start = on
     stdout-loglevel = DEBUG
-    loglevel = DEBUG
+    loglevel = ERROR
     actor {
         provider = ""Akka.Remote.RemoteActorRefProvider, Akka.Remote""
         

--- a/src/examples/RemoteDeploy/System2/Program.cs
+++ b/src/examples/RemoteDeploy/System2/Program.cs
@@ -18,8 +18,8 @@ namespace System2
             var config = ConfigurationFactory.ParseString(@"
 akka {  
     log-config-on-start = on
-    stdout-loglevel = DEBUG
-    loglevel = DEBUG
+    stdout-loglevel = ERROR
+    loglevel = ERROR
     actor {
         provider = ""Akka.Remote.RemoteActorRefProvider, Akka.Remote""
         


### PR DESCRIPTION
This is a PoC for #1358, introducing `LogEvent` format templates.
This is just to get a feel for how a template _could_ look.
I went for the standard .NET string format approach, but with named arguments. 
It is somewhat on the hackish side of things, but you would still have to make an effort to actually break the templates.

Are we OK with this format?

There are still room for improvement in terms of perf and GC, we could easily cache the parsed templates in a concurrent dictionary if translating names turns out to be on the heavy side.
