### PR TITLE
[api-docs] Documentation cleanup

### DIFF
--- a/src/contrib/dependencyInjection/Akka.DI.AutoFac/AutoFacDependencyResolver.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.AutoFac/AutoFacDependencyResolver.cs
@@ -103,8 +103,7 @@ namespace Akka.DI.AutoFac
         }
 
         /// <summary>
-        /// Signals the DI container to release it's reference to the actor.
-        /// <see href="http://www.amazon.com/Dependency-Injection-NET-Mark-Seemann/dp/1935182501/ref=sr_1_1?ie=UTF8&qid=1425861096&sr=8-1&keywords=mark+seemann">HERE</see> 
+        /// Signals the container to release it's reference to the actor.
         /// </summary>
         /// <param name="actor">The actor to remove from the container</param>
         public void Release(ActorBase actor)

--- a/src/contrib/dependencyInjection/Akka.DI.CastleWindsor/WindsorDependencyResolver.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.CastleWindsor/WindsorDependencyResolver.cs
@@ -93,8 +93,7 @@ namespace Akka.DI.CastleWindsor
         }
 
         /// <summary>
-        /// Signals the DI container to release it's reference to the actor.
-        /// <see href="http://www.amazon.com/Dependency-Injection-NET-Mark-Seemann/dp/1935182501/ref=sr_1_1?ie=UTF8&qid=1425861096&sr=8-1&keywords=mark+seemann">HERE</see> 
+        /// Signals the container to release it's reference to the actor.
         /// </summary>
         /// <param name="actor">The actor to remove from the container</param>
         public void Release(ActorBase actor)

--- a/src/contrib/dependencyInjection/Akka.DI.Core/DIActorProducer.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.Core/DIActorProducer.cs
@@ -47,17 +47,13 @@ namespace Akka.DI.Core
         }
 
         /// <summary>
-        /// This method is used to signal the DI Container that it can
-        /// release it's reference to the actor.  <see href="http://www.amazon.com/Dependency-Injection-NET-Mark-Seemann/dp/1935182501/ref=sr_1_1?ie=UTF8&qid=1425861096&sr=8-1&keywords=mark+seemann">HERE</see> 
+        /// This method is used to signal the container that it can release it's reference to the actor.
         /// </summary>
-        /// <param name="actor"></param>
-
+        /// <param name="actor">The actor to remove from the container</param>
         public void Release(ActorBase actor)
         {
             dependencyResolver.Release(actor);
         }
-
-        
     }
 }
 

--- a/src/contrib/dependencyInjection/Akka.DI.Core/IDependencyResolver.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.Core/IDependencyResolver.cs
@@ -40,8 +40,7 @@ namespace Akka.DI.Core
         /// <returns>The configuration object for the given actor type</returns>
         Props Create(Type actorType);
         /// <summary>
-        /// Signals the DI container to release it's reference to the actor.
-        /// <see href="http://www.amazon.com/Dependency-Injection-NET-Mark-Seemann/dp/1935182501/ref=sr_1_1?ie=UTF8&qid=1425861096&sr=8-1&keywords=mark+seemann">HERE</see> 
+        /// Signals the container to release it's reference to the actor.
         /// </summary>
         /// <param name="actor">The actor to remove from the container</param>
         void Release(ActorBase actor);

--- a/src/contrib/dependencyInjection/Akka.DI.Core/Readme.md
+++ b/src/contrib/dependencyInjection/Akka.DI.Core/Readme.md
@@ -2,6 +2,8 @@
 
 **Actor Producer Extension** library used to create Dependency Injection Container for the [Akka.NET](https://github.com/akkadotnet/akka.net) framework.
 
+To learn more about using Dependency Injection in .NET, see [here]( http://www.amazon.com/Dependency-Injection-NET-Mark-Seemann/dp/1935182501/ref=sr_1_1?ie=UTF8&qid=1425861096&sr=8-1&keywords=mark+seemann).
+
 #What is it?
 
 **Akka.DI.Core** is an **ActorSystem extension** library for the Akka.NET framework that provides a simple way to create an Actor Dependency Resolver that can be used as an alternative to the basic capabilities of [Props](http://getakka.net/docs/Props) when you have actors with multiple dependencies.  

--- a/src/contrib/dependencyInjection/Akka.DI.Ninject/NinjectDependencyResolver.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.Ninject/NinjectDependencyResolver.cs
@@ -93,8 +93,7 @@ namespace Akka.DI.Ninject
         }
 
         /// <summary>
-        /// Signals the DI container to release it's reference to the actor.
-        /// <see href="http://www.amazon.com/Dependency-Injection-NET-Mark-Seemann/dp/1935182501/ref=sr_1_1?ie=UTF8&qid=1425861096&sr=8-1&keywords=mark+seemann">HERE</see> 
+        /// Signals the container to release it's reference to the actor.
         /// </summary>
         /// <param name="actor">The actor to remove from the container</param>
         public void Release(ActorBase actor)

--- a/src/contrib/dependencyInjection/Akka.DI.StructureMap/StructureMapDependencyResolver.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.StructureMap/StructureMapDependencyResolver.cs
@@ -95,8 +95,7 @@ namespace Akka.DI.StructureMap
         }
 
         /// <summary>
-        /// Signals the DI container to release it's reference to the actor.
-        /// <see href="http://www.amazon.com/Dependency-Injection-NET-Mark-Seemann/dp/1935182501/ref=sr_1_1?ie=UTF8&qid=1425861096&sr=8-1&keywords=mark+seemann">HERE</see> 
+        /// Signals the container to release it's reference to the actor.
         /// </summary>
         /// <param name="actor">The actor to remove from the container</param>
         public void Release(ActorBase actor)

--- a/src/contrib/dependencyInjection/Akka.DI.Unity/UnityDependencyResolver.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.Unity/UnityDependencyResolver.cs
@@ -93,8 +93,7 @@ namespace Akka.DI.Unity
         }
 
         /// <summary>
-        /// Signals the DI container to release it's reference to the actor.
-        /// <see href="http://www.amazon.com/Dependency-Injection-NET-Mark-Seemann/dp/1935182501/ref=sr_1_1?ie=UTF8&qid=1425861096&sr=8-1&keywords=mark+seemann">HERE</see> 
+        /// Signals the container to release it's reference to the actor.
         /// </summary>
         /// <param name="actor">The actor to remove from the container</param>
         public void Release(ActorBase actor)

--- a/src/core/Akka.Remote.TestKit/Conductor.cs
+++ b/src/core/Akka.Remote.TestKit/Conductor.cs
@@ -24,8 +24,8 @@ namespace Akka.Remote.TestKit
     /// The conductor is the one orchestrating the test: it governs the
     /// <see cref="Akka.Remote.TestKit.Controller"/>'s ports to which all
     /// Players connect, it issues commands to their
-    /// <see cref="Akka.Remote.TestKit.NetworkFailureInjector"></see> and provides support
-    /// for barriers using the <see cref="Akka.Remote.TestKit.BarrierCoordinator"></see>.
+    /// <see cref="Akka.Remote.TestKit.NetworkFailureInjector"/> and provides support
+    /// for barriers using the <see cref="Akka.Remote.TestKit.BarrierCoordinator"/>.
     /// All of this is bundled inside the <see cref="TestConductor"/>
     /// </summary>
     partial class TestConductor //Conductor trait in JVM version

--- a/src/core/Akka.Remote.TestKit/Extension.cs
+++ b/src/core/Akka.Remote.TestKit/Extension.cs
@@ -15,7 +15,7 @@ using Akka.Util.Internal;
 namespace Akka.Remote.TestKit
 {
     /// <summary>
-    /// Access to the <see cref="TestConductor"></see> extension:
+    /// Access to the <see cref="TestConductor"/> extension:
     /// 
     /// {{{
     /// var tc = TestConductor(system)

--- a/src/core/Akka.TestKit/EventFilter/IEventFilterApplier.cs
+++ b/src/core/Akka.TestKit/EventFilter/IEventFilterApplier.cs
@@ -123,7 +123,7 @@ namespace Akka.TestKit
 
         /// <summary>
         /// Prevents events from being logged from now on. To allow events to be logged again, call 
-        /// <see cref="IUnmutableFilter.Unmute">Unmute</see> on the returned object.
+        /// <see cref="IUnmutableFilter.Unmute"/> on the returned object.
         /// <example>
         /// <code>
         /// var filter = EventFilter.Debug().Mute();

--- a/src/core/Akka.TestKit/INoImplicitSender.cs
+++ b/src/core/Akka.TestKit/INoImplicitSender.cs
@@ -10,8 +10,8 @@ using Akka.Actor;
 namespace Akka.TestKit
 {
     /// <summary>
-    /// Normally test classes has <see cref="TestKitBase.TestActor">TestActor</see> as implicit sender.
-    /// So when no sender is specified when sending messages, <see cref="TestKitBase.TestActor">TestActor</see>
+    /// Normally test classes has <see cref="TestKitBase.TestActor"/> as implicit sender.
+    /// So when no sender is specified when sending messages, <see cref="TestKitBase.TestActor"/>
     /// is used.
     /// When a a test class implements <see cref="INoImplicitSender"/> this behavior is removed and the normal
     /// behavior is restored, i.e. <see cref="ActorRefs.NoSender"/> is used as sender when no sender has been specified.

--- a/src/core/Akka.TestKit/TestActorRef.cs
+++ b/src/core/Akka.TestKit/TestActorRef.cs
@@ -14,7 +14,7 @@ namespace Akka.TestKit
     /// overrides the dispatcher to <see cref="CallingThreadDispatcher"/> and sets the receiveTimeout to None. Otherwise,
     /// it acts just like a normal ActorRef. You may retrieve a reference to the underlying actor to test internal logic.
     /// A <see cref="TestActorRef{TActor}"/> can be implicitly casted to an <see cref="IActorRef"/> or you can get the actual
-    /// <see cref="IActorRef"/> from the <see cref="TestActorRefBase{TActor}.Ref">Ref</see> property.
+    /// <see cref="IActorRef"/> from the <see cref="TestActorRefBase{TActor}.Ref"/> property.
     /// </summary>
     /// <typeparam name="TActor">The type of actor</typeparam>
     public class TestActorRef<TActor> : TestActorRefBase<TActor> where TActor : ActorBase

--- a/src/core/Akka.TestKit/TestActors/EchoActor.cs
+++ b/src/core/Akka.TestKit/TestActors/EchoActor.cs
@@ -11,9 +11,9 @@ namespace Akka.TestKit.TestActors
 {
     /// <summary>
     /// An <see cref="EchoActor"/> is an actor that echoes whatever is sent to it, to the
-    /// TestKit's <see cref="TestKitBase.TestActor">TestActor</see>.
-    /// By default it also echoes back to the sender, unless the sender is the TestActor
-    /// (in this case the TestActor will only receive one message).
+    /// TestKit's <see cref="TestKitBase.TestActor"/>.
+    /// By default it also echoes back to the sender, unless the sender is the <see cref="TestKitBase.TestActor"/>
+    /// (in this case the <see cref="TestKitBase.TestActor"/> will only receive one message).
     /// </summary>
     public class EchoActor : ReceiveActor
     {
@@ -32,9 +32,9 @@ namespace Akka.TestKit.TestActors
         /// <summary>
         /// Returns a <see cref="Props"/> object that can be used to create an <see cref="EchoActor"/>.
         /// The  <see cref="EchoActor"/> echoes whatever is sent to it, to the
-        /// TestKit's <see cref="TestKitBase.TestActor">TestActor</see>.
-        /// By default it also echoes back to the sender, unless the sender is the TestActor
-        /// (in this case the TestActor will only receive one message) or unless 
+        /// TestKit's <see cref="TestKitBase.TestActor"/>.
+        /// By default it also echoes back to the sender, unless the sender is the <see cref="TestKitBase.TestActor"/>
+        /// (in this case the <see cref="TestKitBase.TestActor"/> will only receive one message) or unless 
         /// <paramref name="echoBackToSenderAsWell"/> has been set to <c>false</c>.
         /// </summary>
         public static Props Props(TestKitBase testkit, bool echoBackToSenderAsWell = true)

--- a/src/core/Akka.TestKit/TestKitSettings.cs
+++ b/src/core/Akka.TestKit/TestKitSettings.cs
@@ -64,7 +64,7 @@ namespace Akka.TestKit
 
         /// <summary>
         /// If set to <c>true</c> calls to testkit will be logged.
-        /// This is enabled by seting configuration "akka.test.testkit.debug" value to a true.
+        /// This is enabled by setting the configuration value "akka.test.testkit.debug" to a true.
         /// </summary>
         public bool LogTestKitCalls { get { return _logTestKitCalls; } }
     }

--- a/src/core/Akka/Actor/Exceptions.cs
+++ b/src/core/Akka/Actor/Exceptions.cs
@@ -11,52 +11,72 @@ using System.Runtime.Serialization;
 namespace Akka.Actor
 {
     /// <summary>
-    ///     Class AkkaException.
+    /// This exception provides the base for all Akka.NET specific exceptions within the system.
     /// </summary>
     public abstract class AkkaException : Exception
     {
         /// <summary>
-        ///     Initializes a new instance of the <see cref="AkkaException" /> class.
+        /// Initializes a new instance of the <see cref="AkkaException"/> class.
         /// </summary>
         protected AkkaException()
         {
         }
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="T:System.Exception" /> class with a specified error message.
+        /// Initializes a new instance of the <see cref="AkkaException"/> class.
         /// </summary>
         /// <param name="message">The message that describes the error.</param>
-        /// <param name="cause">An inner exception responsible for this error.</param>
+        /// <param name="cause">The exception that is the cause of the current exception.</param>
         protected AkkaException(string message, Exception cause = null)
             : base(message, cause)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AkkaException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
         protected AkkaException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
 
+        /// <summary>
+        /// The exception that is the cause of the current exception.
+        /// </summary>
         protected Exception Cause { get { return InnerException; } }
     }
 
     /// <summary>
-    /// An InvalidActorNameException is thrown when the actor name is invalid
+    /// This exception is thrown when the actor name is invalid.
     /// </summary>
     public class InvalidActorNameException : AkkaException
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidActorNameException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
         public InvalidActorNameException(string message)
             : base(message)
         {
-            //Intentionally left blank
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidActorNameException"/> class.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception.</param>
         public InvalidActorNameException(string message, Exception innerException)
             : base(message, innerException)
         {
-            //Intentionally left blank
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidActorNameException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
         protected InvalidActorNameException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -64,16 +84,24 @@ namespace Akka.Actor
     }
 
     /// <summary>
-    /// Thrown when an Ask operation times out
+    /// This exception is thrown when an Ask operation times out.
     /// </summary>
     public class AskTimeoutException : AkkaException
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AskTimeoutException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
         public AskTimeoutException(string message)
             : base(message)
         {
-            //Intentionally left blank
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AskTimeoutException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
         protected AskTimeoutException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -81,27 +109,72 @@ namespace Akka.Actor
     }
 
     /// <summary>
+    /// This exception is thrown when the initialization logic for an Actor fails.
     /// </summary>
     public class ActorInitializationException : AkkaException
     {
         private readonly IActorRef _actor;
-        protected ActorInitializationException() : base(){}
 
-        public ActorInitializationException(string message) : base(message) { }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActorInitializationException"/> class.
+        /// </summary>
+        protected ActorInitializationException()
+            : base()
+        {
+        }
 
-        public ActorInitializationException(string message, Exception cause) : base(message, cause) { }
-        public ActorInitializationException(IActorRef actor, string message, Exception cause = null) : base(message, cause)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActorInitializationException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public ActorInitializationException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActorInitializationException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="cause">The exception that is the cause of the current exception.</param>
+        public ActorInitializationException(string message, Exception cause)
+            : base(message, cause)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActorInitializationException"/> class.
+        /// </summary>
+        /// <param name="actor">The actor whose initialization logic failed.</param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="cause">The exception that is the cause of the current exception.</param>
+        public ActorInitializationException(IActorRef actor, string message, Exception cause = null)
+            : base(message, cause)
         {
             _actor = actor;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActorInitializationException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
         protected ActorInitializationException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
 
+        /// <summary>
+        /// Retrieves the actor whose initialization logic failed.
+        /// </summary>
         public IActorRef Actor { get { return _actor; } }
 
+        /// <summary>
+        /// Returns a <see cref="String" /> that represents this instance.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="String" /> that represents this instance.
+        /// </returns>
         public override string ToString()
         {
             if (_actor == null) return base.ToString();
@@ -110,37 +183,68 @@ namespace Akka.Actor
     }
 
     /// <summary>
-    ///     Class LoggerInitializationException is thrown to indicate that there was a problem initializing a logger.
+    /// This exception is thrown when there was a problem initializing a logger.
     /// </summary>
     public class LoggerInitializationException : AkkaException
     {
-        public LoggerInitializationException() : base() { }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoggerInitializationException"/> class.
+        /// </summary>
+        public LoggerInitializationException()
+            : base()
+        {
+        }
 
-        public LoggerInitializationException(string message) : base(message) { }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoggerInitializationException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public LoggerInitializationException(string message)
+            : base(message)
+        {
+        }
 
-        public LoggerInitializationException(string message, Exception cause = null) : base(message, cause) { }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoggerInitializationException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="cause">The exception that is the cause of the current exception.</param>
+        public LoggerInitializationException(string message, Exception cause = null)
+            : base(message, cause)
+        {
+        }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoggerInitializationException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
         protected LoggerInitializationException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
     }
 
-
-
     /// <summary>
-    /// Thrown when a <see cref="Kill"/> message has been sent to an actor. <see cref="SupervisorStrategy.DefaultDecider"/> will by default stop the actor.
+    /// This exception is thrown when a <see cref="Kill"/> message has been sent to an Actor.
+    /// <see cref="SupervisorStrategy.DefaultDecider"/> will by default stop the actor.
     /// </summary>
     public class ActorKilledException : AkkaException
     {
         /// <summary>
-        ///     Initializes a new instance of the <see cref="ActorKilledException" /> class.
+        /// Initializes a new instance of the <see cref="ActorKilledException"/> class.
         /// </summary>
-        /// <param name="message">The message.</param>
-        public ActorKilledException(string message) : base(message)
+        /// <param name="message">The message that describes the error.</param>
+        public ActorKilledException(string message)
+            : base(message)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActorKilledException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
         protected ActorKilledException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -148,13 +252,25 @@ namespace Akka.Actor
     }
 
     /// <summary>
-    /// IllegalActorStateException is thrown when a core invariant in the Actor implementation has been violated.
-    /// For instance, if you try to create an Actor that doesn't inherit from <see cref="ActorBase"/>.
+    /// This exception is thrown when a core invariant in the Actor implementation has been violated.
+    /// For instance, if you try to create an Actor that doesn't inherit from <see cref="ActorBase" />.
     /// </summary>
     public class IllegalActorStateException : AkkaException
     {
-        public IllegalActorStateException(string msg) : base(msg) { }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IllegalActorStateException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public IllegalActorStateException(string message)
+            : base(message)
+        {
+        }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IllegalActorStateException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
         protected IllegalActorStateException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -162,12 +278,24 @@ namespace Akka.Actor
     }
 
     /// <summary>
-    /// IllegalActorNameException is thrown when an Actor with an invalid name is deployed our bound.
+    /// This exception is thrown when an Actor with an invalid name is deployed.
     /// </summary>
     public class IllegalActorNameException : AkkaException
     {
-        public IllegalActorNameException(string msg) : base(msg) { }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IllegalActorNameException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public IllegalActorNameException(string message)
+            : base(message)
+        {
+        }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IllegalActorNameException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
         protected IllegalActorNameException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -175,24 +303,36 @@ namespace Akka.Actor
     }
 
     /// <summary>
-    /// A DeathPactException is thrown by an Actor that receives a Terminated(someActor) message
+    /// This exception is thrown by an Actor that receives a Terminated(someActor) message
     /// that it doesn't handle itself, effectively crashing the Actor and escalating to the supervisor.
     /// </summary>
     public class DeathPactException : AkkaException
     {
         private readonly IActorRef _deadActor;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeathPactException"/> class.
+        /// </summary>
+        /// <param name="deadActor">The actor that has been terminated.</param>
         public DeathPactException(IActorRef deadActor)
             : base("Monitored actor [" + deadActor + "] terminated")
         {
             _deadActor = deadActor;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeathPactException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
         protected DeathPactException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
 
+        /// <summary>
+        /// Retrieves the actor that has been terminated.
+        /// </summary>
         public IActorRef DeadActor
         {
             get { return _deadActor; }
@@ -200,7 +340,12 @@ namespace Akka.Actor
     }
 
     /// <summary>
-    ///     Class PreRestartException.
+    /// This exception is thrown when the <see cref="ActorBase.PreRestart"/> method fails during a restart attempt.
+    ///
+    /// <note>
+    /// This exception is not propagated to the supervisor, as it originates from the already failed instance,
+    /// hence it is only visible as log entry on the event stream.
+    /// </note>
     /// </summary>
     public class PreRestartException : AkkaException
     {
@@ -209,8 +354,14 @@ namespace Akka.Actor
         private Exception exception;
         private object optionalMessage;
 
-        public PreRestartException(IActorRef actor, Exception restartException, Exception cause,
-            object optionalMessage)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PreRestartException"/> class.
+        /// </summary>
+        /// <param name="actor">The actor whose <see cref="ActorBase.PreRestart"/> hook failed.</param>
+        /// <param name="restartException">The exception thrown by the <paramref name="actor"/> within <see cref="ActorBase.PreRestart"/>.</param>
+        /// <param name="cause">The exception which caused the restart in the first place.</param>
+        /// <param name="optionalMessage">The message which was optionally passed into <see cref="ActorBase.PreRestart"/>.</param>
+        public PreRestartException(IActorRef actor, Exception restartException, Exception cause, object optionalMessage)
         {
             Actor = actor;
             e = restartException;
@@ -218,6 +369,11 @@ namespace Akka.Actor
             this.optionalMessage = optionalMessage;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PreRestartException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
         protected PreRestartException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -225,11 +381,8 @@ namespace Akka.Actor
     }
 
     /// <summary>
-    /// A PostRestartException is thrown when constructor or postRestart() method
+    /// This exception is thrown when the Actor constructor or <see cref="ActorBase.PostRestart"/> method
     /// fails during a restart attempt.
-    /// <para><see cref="PostRestartException.Actor"/>: actor is the actor whose constructor or postRestart() hook failed.</para>
-    /// <para><see cref="PostRestartException.Cause"/>: cause is the exception thrown by that actor within preRestart()</para>
-    /// <para><see cref="OriginalCause"/>: originalCause is the exception which caused the restart in the first place</para>
     /// </summary>
     public class PostRestartException : ActorInitializationException
     {
@@ -238,8 +391,8 @@ namespace Akka.Actor
         /// <summary>
         /// Initializes a new instance of the <see cref="PostRestartException"/> class.
         /// </summary>
-        /// <param name="actor">The actor whose constructor or postRestart() hook failed.</param>
-        /// <param name="cause">Cause is the exception thrown by that actor within preRestart().</param>
+        /// <param name="actor">The actor whose constructor or <see cref="ActorBase.PostRestart"/> hook failed.</param>
+        /// <param name="cause">The exception thrown by the <paramref name="actor"/> within <see cref="ActorBase.PostRestart"/>.</param>
         /// <param name="originalCause">The original cause is the exception which caused the restart in the first place.</param>
         public PostRestartException(IActorRef actor, Exception cause, Exception originalCause)
             :base(actor,"Exception post restart (" + (originalCause == null ?"null" : originalCause.GetType().ToString()) + ")", cause)
@@ -247,22 +400,40 @@ namespace Akka.Actor
             _originalCause = originalCause;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PostRestartException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
         protected PostRestartException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
 
+        ///<summary>
+        /// Retrieves the exception which caused the restart in the first place.
+        /// </summary>
         public Exception OriginalCause { get { return _originalCause; } }
     }
 
-
     /// <summary>
-    /// Class ActorNotFoundException.
+    /// This exception is thrown when an Actor can not be found.
     /// </summary>
     public class ActorNotFoundException : AkkaException
     {
-        public ActorNotFoundException() : base() { }
-        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActorNotFoundException"/> class.
+        /// </summary>
+        public ActorNotFoundException()
+            : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActorNotFoundException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
         protected ActorNotFoundException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -270,19 +441,36 @@ namespace Akka.Actor
     }
 
     /// <summary>
-    /// InvalidMessageException is thrown when an invalid message is sent to an Actor.
+    /// This exception is thrown when an invalid message is sent to an Actor.
+    ///
+    /// <note>
     /// Currently only <c>null</c> is an invalid message.
+    /// </note>
     /// </summary>
     public class InvalidMessageException : AkkaException
     {
-        public InvalidMessageException() : this("Message is null")
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidMessageException"/> class.
+        /// </summary>
+        public InvalidMessageException()
+            : this("Message is null")
         {
         }
 
-        public InvalidMessageException(string message):base(message)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidMessageException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public InvalidMessageException(string message)
+            : base(message)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidMessageException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
         protected InvalidMessageException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/core/Akka/Dispatch/DequeBasedMailbox.cs
+++ b/src/core/Akka/Dispatch/DequeBasedMailbox.cs
@@ -6,24 +6,25 @@
 //-----------------------------------------------------------------------
 
 using Akka.Actor;
+using Akka.Dispatch.MessageQueues;
 
 namespace Akka.Dispatch
 {
     /// <summary>
-    /// Used for <see cref="MessageQueue"/> instances that support double-ended queues.
+    /// Used for <see cref="IMessageQueue"/> instances that support double-ended queues.
     /// </summary>
     public interface IDequeBasedMailbox
     {
         /// <summary>
         /// Enqueues an <see cref="Envelope"/> to the front of
-        /// the <see cref="MessageQueue"/>. Typically called during
+        /// the <see cref="IMessageQueue"/>. Typically called during
         /// a <see cref="IStash.Unstash"/> or <see cref="IStash.UnstashAll()"/>operation.
         /// </summary>
         /// <param name="envelope">The message that will be prepended to the queue.</param>
         void EnqueueFirst(Envelope envelope);
 
         /// <summary>
-        /// Posts a message to the back of the <see cref="MessageQueue"/>
+        /// Posts a message to the back of the <see cref="IMessageQueue"/>
         /// </summary>
         /// <param name="receiver">The intended recipient of the message.</param>
         /// <param name="envelope">The message that will be appended to the queue.</param>

--- a/src/core/Akka/Dispatch/MessageQueues/DequeWrapperMessageQueue.cs
+++ b/src/core/Akka/Dispatch/MessageQueues/DequeWrapperMessageQueue.cs
@@ -20,7 +20,7 @@ namespace Akka.Dispatch.MessageQueues
         private readonly Stack<Envelope> _prependBuffer = new Stack<Envelope>();
         private readonly IMessageQueue _messageQueue;
         /// <summary>
-        /// Takes another <see cref="MessageQueue"/> as an argument - wraps <paramref name="messageQueue"/>
+        /// Takes another <see cref="IMessageQueue"/> as an argument - wraps <paramref name="messageQueue"/>
         /// in order to provide it with prepend (<see cref="EnqueueFirst"/>) semantics.
         /// </summary>
         /// <param name="messageQueue"></param>
@@ -47,7 +47,7 @@ namespace Akka.Dispatch.MessageQueues
         }
 
         /// <summary>
-        /// Enqueue a message to the back of the <see cref="MessageQueue"/>
+        /// Enqueue a message to the back of the <see cref="IMessageQueue"/>
         /// </summary>
         /// <param name="envelope"></param>
         public void Enqueue(Envelope envelope)
@@ -59,7 +59,7 @@ namespace Akka.Dispatch.MessageQueues
         /// Attempt to dequeue a message from the front of the prepend buffer.
         /// 
         /// If the prepend buffer is empty, dequeue a message from the normal
-        /// <see cref="MessageQueue"/> wrapped but this wrapper.
+        /// <see cref="IMessageQueue"/> wrapped but this wrapper.
         /// </summary>
         /// <param name="envelope">The message to return, if any</param>
         /// <returns><c>true</c> if a message was available, <c>false</c> otherwise.</returns>

--- a/src/core/Akka/Dispatch/SysMsg/ISystemMessage.cs
+++ b/src/core/Akka/Dispatch/SysMsg/ISystemMessage.cs
@@ -19,7 +19,6 @@ namespace Akka.Dispatch.SysMsg
     /// <summary>
     ///     Class ISystemMessage.
     /// </summary>
-    /// **
     public interface ISystemMessage : INoSerializationVerificationNeeded
     {
     }

--- a/src/core/Akka/Util/MatchHandler/IPartialActionBuilder.cs
+++ b/src/core/Akka/Util/MatchHandler/IPartialActionBuilder.cs
@@ -12,7 +12,7 @@ namespace Akka.Tools.MatchHandler
     public interface IPartialActionBuilder
     {
         /// <summary>
-        /// Builds the specified delegate and arguments to a <see cref="PartialAction{T}">PartialAction&lt;<typeparamref name="T"/>&gt;</see>
+        /// Builds the specified delegate and arguments to a <see cref="PartialAction{T}"/>
         /// <para>If the number of arguments are 0, the delegate should be a <see cref="Func{T}">Func&lt;<typeparamref name="T"/>,bool&gt;</see></para>
         /// <para>If the number of arguments are 1, the delegate should be a <see cref="Func{T,T1}">Func&lt;<typeparamref name="T"/>,T1,bool&gt;</see></para>
         /// <para>...</para>

--- a/src/core/Akka/Util/MatchHandler/MatchBuilder.cs
+++ b/src/core/Akka/Util/MatchHandler/MatchBuilder.cs
@@ -125,9 +125,9 @@ namespace Akka.Tools.MatchHandler
 
 
         /// <summary>
-        /// Builds all added handlers and returns a <see cref="PartialAction{T}">PartialAction&lt;object&gt;</see>.
+        /// Builds all added handlers and returns a <see cref="PartialAction{TItem}"/>.
         /// </summary>
-        /// <returns>Returns a <see cref="PartialAction{T}">PartialAction&lt;object&gt;</see></returns>
+        /// <returns>Returns a <see cref="PartialAction{TItem}"/></returns>
         public PartialAction<TItem> Build()
         {
             var partialAction = _compiler.Compile(_typeHandlers, _arguments, new MatchBuilderSignature(_signature));


### PR DESCRIPTION
This PR cleans up a bit of documentation.

- Fleshed out the api docs for the various Akka exceptions.

- Fixed a couple of x-references.

- Moved the link in the various dependency resolvers Release method to
the DI Core readme. That link didn't really relate to that method.

- Replaced some extraneous tags with self-closing tabs.