### PR TITLE
Removed F# hack over JSON.NET serializer

### DIFF
--- a/src/core/Akka.FSharp.Tests/ApiTests.fs
+++ b/src/core/Akka.FSharp.Tests/ApiTests.fs
@@ -40,13 +40,16 @@ type TestUnion2 =
     | D of int
 
 [<Fact>]
-let ``can serialize and deserialize discriminated unions over remote nodes`` () =     
+let ``can serialize and deserialize discriminated unions over remote nodes using wire serializer`` () =     
     let remoteConfig port = 
         sprintf """
         akka { 
             actor {
                 ask-timeout = 5s
                 provider = "Akka.Remote.RemoteActorRefProvider, Akka.Remote"
+                serialization-bindings {
+                    "System.Object" = wire
+                }
             }
             remote {
                 helios.tcp {

--- a/src/core/Akka.FSharp/FsApi.fs
+++ b/src/core/Akka.FSharp/FsApi.fs
@@ -307,11 +307,7 @@ module Actors =
             | Func f -> 
                 match msg with
                 | :? 'Message as m -> state <- f m
-                | _ -> 
-                    let serializer = UntypedActor.Context.System.Serialization.FindSerializerForType typeof<obj> :?> Akka.Serialization.NewtonSoftJsonSerializer
-                    match Serialization.tryDeserializeJObject serializer.Serializer msg with
-                    | Some(m) -> state <- f m
-                    | None -> x.Unhandled msg
+                | _ -> x.Unhandled msg
             | Return _ -> x.PostStop()
         override x.PostStop() =
             base.PostStop ()
@@ -319,7 +315,7 @@ module Actors =
             
 
     /// Builds an actor message handler using an actor expression syntax.
-    let actor = ActorBuilder()                
+    let actor = ActorBuilder()    
     
 [<AutoOpen>]
 module Logging = 


### PR DESCRIPTION
This PR removes an JSON.NET hack hardcoded inside F# API. Also existing end2end discriminated union serialization test between remote nodes has been updated by replacing JSON.NET with Wire.