### PR TITLE
Add optional PipeTo completion handlers

### DIFF
--- a/src/core/Akka.Tests/Actor/PipeToSupportSpec.cs
+++ b/src/core/Akka.Tests/Actor/PipeToSupportSpec.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Event;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Tests.Actor
+{
+    public class PipeToSupportSpec : AkkaSpec
+    {
+        private TaskCompletionSource<string> _taskCompletionSource;
+        private Task<string> _task;
+
+        public PipeToSupportSpec()
+        {
+            _taskCompletionSource = new TaskCompletionSource<string>();
+            _task = _taskCompletionSource.Task;
+            Sys.EventStream.Subscribe(TestActor, typeof(DeadLetter));
+        }
+
+        [Fact]
+        public void Should_by_default_send_task_result_as_message()
+        {
+            _task.PipeTo(TestActor);
+            _taskCompletionSource.SetResult("Hello");
+            ExpectMsg("Hello");
+        }
+
+        [Fact]
+        public void Should_by_default_send_task_exception_as_status_failure_message()
+        {
+            _task.PipeTo(TestActor);
+            _taskCompletionSource.SetException(new Exception("Boom"));
+            ExpectMsg<Status.Failure>(x => x.Cause.InnerException.Message == "Boom");
+        }
+
+        [Fact]
+        public void Should_use_success_handling_to_transform_task_result()
+        {
+            _task.PipeTo(TestActor, success: x => "Hello " + x);
+            _taskCompletionSource.SetResult("World");
+            ExpectMsg("Hello World");
+        }
+
+        [Fact]
+        public void Should_use_failure_handling_to_transform_task_exception()
+        {
+            _task.PipeTo(TestActor, failure: e => "Such a " + e.InnerException.Message);
+            _taskCompletionSource.SetException(new Exception("failure..."));
+            ExpectMsg("Such a failure...");
+        }
+    }
+}

--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Actor\Cancellation\CancelableTests.cs" />
     <Compile Include="Actor\InboxSpec.cs" />
     <Compile Include="Actor\LocalActorRefProviderSpec.cs" />
+    <Compile Include="Actor\PipeToSupportSpec.cs" />
     <Compile Include="Actor\PropsSpec.cs" />
     <Compile Include="Actor\ReceiveActorTests.cs" />
     <Compile Include="Actor\ActorRefProviderSpec.cs" />


### PR DESCRIPTION
Added an optional success and failure handler to PipeTo, to simplify
use of Tasks. PipeTo falls back to original behavior when not supplied.

Added test for both default handlers and the new handlers.