### PR TITLE
Implement enumerator for Composite ByteString.

### DIFF
--- a/src/core/Akka/Util/ByteString.cs
+++ b/src/core/Akka/Util/ByteString.cs
@@ -273,7 +273,12 @@ namespace Akka.IO
                         _byteStrings.Select(x => (ByteIterator.ByteArrayIterator) x.Iterator()).ToArray());
             }
 
-            public override ByteString Concat(ByteString that)
+			public override IEnumerator<byte> GetEnumerator()
+			{
+				return _byteStrings.SelectMany(byteString => byteString).GetEnumerator();
+			}
+
+			public override ByteString Concat(ByteString that)
             {
                 if (that.IsEmpty)
                 {


### PR DESCRIPTION
Hi. I ran into this while working with Akka I/O (specifically, concatenated `ByteString`s can't be enumerated). I was going to add a couple of tests for this, but I see that the existing spec for `ByteString` doesn't currently cover IEnumerable at all. I'm wondering if this is because there's a separate "iterator" implemented on `ByteString` (a Scala artefact, perhaps?)...

Anyway, let me know if some tests would be helpful, I don't mind writing them.