### PR TITLE
Become and BecomeStacked for ReceivePersistentActor

### DIFF
--- a/src/core/Akka.Persistence.Tests/Akka.Persistence.Tests.csproj
+++ b/src/core/Akka.Persistence.Tests/Akka.Persistence.Tests.csproj
@@ -72,6 +72,9 @@
     <Compile Include="PersistentViewSpec.cs" />
     <Compile Include="PersistentViewSpec.Actors.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ReceivePersistentActorTests.cs" />
+    <Compile Include="ReceivePersistentActorTests_Become.cs" />
+    <Compile Include="ReceivePersistentActorTests_LifeCycle.cs" />
     <Compile Include="SnapshotSpec.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/core/Akka.Persistence.Tests/ReceivePersistentActorTests.cs
+++ b/src/core/Akka.Persistence.Tests/ReceivePersistentActorTests.cs
@@ -1,0 +1,262 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ReceivePersistentActorTests.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Akka.Actor;
+using Akka.Event;
+using Akka.TestKit;
+using Akka.Util.Internal;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Tests
+{
+
+    public partial class ReceivePersistentActorTests : AkkaSpec
+    {
+        public ReceivePersistentActorTests(ITestOutputHelper output = null) : base(output: output)
+        {
+        }
+
+        [Fact]
+        public void Given_persistent_actor_with_no_receive_command_specified_When_receiving_message_Then_it_should_be_unhandled()
+        {
+            //Given
+            var pid = "p-1";
+            WriteEvents(pid, 1, 2, 3);
+            var actor = Sys.ActorOf(Props.Create(() => new NoCommandActor(pid)), "no-receive-specified");
+            Sys.EventStream.Subscribe(TestActor, typeof(UnhandledMessage));
+
+            //When
+            actor.Tell("Something");
+
+            //Then
+            ExpectMsg<UnhandledMessage>(m => ((string)m.Message) == "Something" && Equals(m.Recipient, actor));
+            Sys.EventStream.Unsubscribe(TestActor, typeof(UnhandledMessage));
+        }
+
+        [Fact]
+        public void Given_persistent_actor_with_no_receive_event_specified_When_receiving_message_Then_it_should_be_unhandled()
+        {
+            //Given
+            var pid = "p-2";
+            WriteEvents(pid, "Something");
+
+            // when
+            var actor = Sys.ActorOf(Props.Create(() => new NoEventActor(pid)), "no-receive-specified");
+            Sys.EventStream.Subscribe(TestActor, typeof(UnhandledMessage));
+            
+            //Then
+            ExpectMsg<UnhandledMessage>(m => ((string)m.Message) == "Something" && Equals(m.Recipient, actor));
+            Sys.EventStream.Unsubscribe(TestActor, typeof(UnhandledMessage));
+        }
+
+        [Fact]
+        public void Test_that_persistent_actor_cannot_call_receive_command_or_receive_event_out_of_construction_and_become()
+        {
+            //Given
+            var pid = "p-3";
+            WriteEvents(pid, 1, 2, 3);
+            var actor = Sys.ActorOf(Props.Create(() => new CallReceiveWhenHandlingMessageActor(pid)),"receive-on-handling-message");
+
+            //When
+            actor.Tell("Something that will trigger the actor do call Receive", TestActor);
+
+            //Then
+            //We expect a exception was thrown when the actor called Receive, and that it was sent back to us
+            ExpectMsg<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void Given_a_persistent_actor_which_uses_predicates_When_sending_different_messages_Then_correct_handler_should_be_invoked()
+        {
+            //Given
+            var pid = "p-4";
+            WriteEvents(pid, 1, 2, 3);
+            var actor = Sys.ActorOf(Props.Create(() => new IntPredicatesActor(pid)) , "predicates");
+
+            //When
+            actor.Tell(0, TestActor);
+            actor.Tell(5, TestActor);
+            actor.Tell(10, TestActor);
+            actor.Tell(15, TestActor);
+
+            //Then
+            ExpectMsg((object) "int<5:0");
+            ExpectMsg((object) "int<10:5");
+            ExpectMsg((object) "int<15:10");
+            ExpectMsg((object) "int:15");
+        }
+
+        [Fact]
+        public void Given_a_persistent_actor_that_uses_non_generic_and_predicates_When_sending_different_messages_Then_correct_handler_should_be_invoked()
+        {
+            //Given
+            var pid = "p-5";
+            WriteEvents(pid, 1, 2, 3);
+            var actor = Sys.ActorOf(Props.Create(() => new TypePredicatesActor(pid)) , "predicates");
+
+            //When
+            actor.Tell(0, TestActor);
+            actor.Tell(5, TestActor);
+            actor.Tell(10, TestActor);
+            actor.Tell(15, TestActor);
+            actor.Tell("hello", TestActor);
+
+            //Then
+            ExpectMsg((object) "int<5:0");
+            ExpectMsg((object) "int<10:5");
+            ExpectMsg((object) "int<15:10");
+            ExpectMsg((object) "int:15");
+            ExpectMsg((object) "string:hello");
+        }
+
+
+        [Fact]
+        public void Given_a_persistent_actor_with_ReceiveAnyCommand_When_sending_different_messages_Then_correct_handler_should_be_invoked()
+        {
+            //Given
+            var pid = "p-6";
+            WriteEvents(pid, 1, 2, 3);
+            var actor = Sys.ActorOf(Props.Create(() => new ReceiveAnyActor(pid)) , "matchany");
+
+            //When
+            actor.Tell(4711, TestActor);
+            actor.Tell("hello", TestActor);
+
+            //Then
+            ExpectMsg((object)"int:4711");
+            ExpectMsg((object)"any:hello");
+        }
+        
+        private readonly AtomicCounterLong _seqNrCounter = new AtomicCounterLong(1L);
+        /// <summary>
+        /// Initialize test journal using provided events.
+        /// </summary>
+        private void WriteEvents(string pid, params object[] events)
+        {
+            var journalRef = Persistence.Instance.Apply(Sys).JournalFor(string.Empty);
+            var persistents = events
+                .Select(e => new Persistent(e, _seqNrCounter.GetAndIncrement(), e.GetType().FullName, pid))
+                .ToArray();
+            journalRef.Tell(new WriteMessages(persistents, TestActor, 1));
+
+            ExpectMsg<WriteMessagesSuccessful>();
+            foreach (var p in persistents)
+                ExpectMsg(new WriteMessageSuccess(p, 1));
+        }
+
+        private abstract class TestReceivePersistentActor : ReceivePersistentActor
+        {
+            public readonly LinkedList<object> State = new LinkedList<object>();
+            private readonly string _persistenceId;
+
+            protected TestReceivePersistentActor(string persistenceId)
+            {
+                _persistenceId = persistenceId;
+            }
+
+            public override string PersistenceId { get { return _persistenceId; } }
+        }
+
+        private class NoCommandActor : TestReceivePersistentActor
+        {
+            public NoCommandActor(string pid) : base(pid)
+            {
+                RecoverAny(o => State.AddLast(o));
+                // no command here
+            }
+        }
+
+        private class NoEventActor : TestReceivePersistentActor
+        {
+            public NoEventActor(string pid) : base(pid)
+            {
+                CommandAny(msg => Sender.Tell(msg, Self));
+                // no recover here
+            }
+        }
+
+        private class CallReceiveWhenHandlingMessageActor : TestReceivePersistentActor
+        {
+            public CallReceiveWhenHandlingMessageActor(string pid) : base(pid)
+            {
+                Recover<int>(i => State.AddLast(i));
+                Command<object>(m =>
+                {
+                    try
+                    {
+                        Command<int>(i => Sender.Tell(i, Self));
+                        Sender.Tell(null, Self);
+                    }
+                    catch(Exception e)
+                    {
+                        Sender.Tell(e, Self);
+                    }
+                });
+            }
+        }
+
+        private class IntPredicatesActor : TestReceivePersistentActor
+        {
+            public IntPredicatesActor(string pid) : base(pid)
+            {
+                Recover<int>(i => State.AddLast(i));
+                Command<int>(i => i < 5, i => Sender.Tell("int<5:" + i, Self));     //Predicate first, when i < 5
+                Command<int>(i => Sender.Tell("int<10:" + i, Self), i => i < 10);   //Predicate after, when 5 <= i < 10
+                Command<int>(i =>
+                {
+                    if(i < 15)
+                    {
+                        Sender.Tell("int<15:" + i, Self);
+                        return true;
+                    }
+                    return false;
+                });                                                                 //Func,            when 10 <= i < 15
+                Command<int>(i => Sender.Tell("int:" + i, Self), null);             //Null predicate,  when i >= 15
+                Command<int>(i => Sender.Tell("ShouldNeverMatch:" + i, Self));      //The handler above should never be invoked
+            }
+        }
+
+        private class TypePredicatesActor : TestReceivePersistentActor
+        {
+            public TypePredicatesActor(string pid) : base(pid)
+            {
+                Recover<int>(i => State.AddLast(i));
+                Command(typeof(int), i => (int)i < 5, i => Sender.Tell("int<5:" + i, Self));     //Predicate first, when i < 5
+                Command(typeof(int), i => Sender.Tell("int<10:" + i, Self), i => (int)i < 10);   //Predicate after, when 5 <= i < 10
+                Command(typeof(int), o =>
+                {
+                    var i = (int) o;
+                    if(i < 15)
+                    {
+                        Sender.Tell("int<15:" + i, Self);
+                        return true;
+                    }
+                    return false;
+                });                                                                              //Func,            when 10 <= i < 15
+                Command(typeof(int), i => Sender.Tell("int:" + i, Self), null);                  //Null predicate,  when i >= 15
+                Command(typeof(int), i => Sender.Tell("ShouldNeverMatch:" + i, Self));           //The handler above should never be invoked
+                Command(typeof(string), i => Sender.Tell("string:" + i));
+            }
+        }
+
+
+        private class ReceiveAnyActor : TestReceivePersistentActor
+        {
+            public ReceiveAnyActor(string pid) : base(pid)
+            {
+                Command<int>(i => Sender.Tell("int:" + i, Self));
+                CommandAny(o => Sender.Tell("any:" + o, Self));
+            }
+        }
+
+    }
+}
+

--- a/src/core/Akka.Persistence.Tests/ReceivePersistentActorTests_Become.cs
+++ b/src/core/Akka.Persistence.Tests/ReceivePersistentActorTests_Become.cs
@@ -1,0 +1,146 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ReceivePersistentActorTests_Become.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Actor;
+using Akka.Event;
+using Xunit;
+
+namespace Akka.Persistence.Tests
+{
+    public partial class ReceivePersistentActorTests
+    {
+        [Fact]
+        public void Given_persistent_actor_When_it_calls_Become_Then_it_switches_command_handler()
+        {
+            //Given
+            var pid = "p-21";
+            WriteEvents(pid, 1, 2, 3);
+            var actor = Sys.ActorOf(Props.Create(() => new BecomeActor(pid)), "become");
+            Sys.EventStream.Subscribe(TestActor, typeof(UnhandledMessage));
+
+            //When
+            actor.Tell("BECOME", TestActor);    //Switch to state2   
+            actor.Tell("hello", TestActor);
+            actor.Tell(4711, TestActor);
+            //Then
+            ExpectMsg((object) "string2:hello");
+            ExpectMsg<UnhandledMessage>( m => ((int)m.Message) == 4711 && m.Recipient == actor);
+
+            //When
+            actor.Tell("BECOME", TestActor);    //Switch to state3
+            actor.Tell("hello", TestActor);
+            actor.Tell(4711, TestActor);
+            //Then
+            ExpectMsg((object) "string3:hello");
+            ExpectMsg<UnhandledMessage>(m => ((int)m.Message) == 4711 && m.Recipient == actor);
+        }
+
+        [Fact(Skip = "FIXME: stash dedupes based on reference equality causes this to fail")]
+        public void Given_persistent_actor_that_has_called_Become_When_it_calls_Unbecome_Then_it_switches_back_command_handler()
+        {
+            //Given
+            var pid = "p-22";
+            WriteEvents(pid, 1, 2, 3);
+            var actor = Sys.ActorOf(Props.Create(() => new BecomeActor(pid)), "become");
+            actor.Tell("BECOME", TestActor);    //Switch to state2
+            actor.Tell("BECOME", TestActor);    //Switch to state3
+
+            //When
+            actor.Tell("UNBECOME", TestActor);  //Switch back to state2
+            actor.Tell("hello", TestActor);
+
+            //Then
+            ExpectMsg((object) "string2:hello");
+        }
+
+        [Fact]
+        public void Given_persistent_actor_that_has_called_Become_at_construction_time_When_it_calls_Unbecome_Then_it_switches_back_command_handler()
+        {
+            //Given
+            var pid = "p-23";
+            WriteEvents(pid, 1, 2, 3);
+            var actor = Sys.ActorOf(Props.Create(() => new BecomeDirectlyInConstructorActor(pid)), "become");
+
+            //When
+            actor.Tell("hello", TestActor);
+            //Then
+            ExpectMsg((object) "string3:hello");
+
+            //When
+            actor.Tell("UNBECOME", TestActor);  //Switch back to state2
+            actor.Tell("hello", TestActor);
+            //Then
+            ExpectMsg((object) "string2:hello");
+
+            //When
+            actor.Tell("UNBECOME", TestActor);  //Switch back to state1
+            actor.Tell("hello", TestActor);
+            //Then
+            ExpectMsg((object) "string1:hello");
+
+            //When
+            actor.Tell("UNBECOME", TestActor);  //should still be in state1
+            actor.Tell("hello", TestActor);
+            //Then
+            ExpectMsg((object) "string1:hello");
+        }
+
+        private class BecomeActor : TestReceivePersistentActor
+        {
+            public BecomeActor(string pid) : base(pid)
+            {
+                Recover<int>(i => State.AddLast(i));
+                Command<string>(s => s == "UNBECOME", _ => UnbecomeStacked());
+                Command<string>(s => s == "BECOME", _ => BecomeStacked(State2));
+                Command<string>(s => Sender.Tell("string1:" + s, Self));
+                Command<int>(i => Sender.Tell("int1:" + i, Self));
+            }
+
+            private void State2()
+            {
+                Command<string>(s => s == "UNBECOME", __ => UnbecomeStacked());
+                Command<string>(s => s == "BECOME", _ => BecomeStacked(State3));
+                Command<string>(s => Sender.Tell("string2:" + s, Self));
+            }
+
+            private void State3()
+            {
+                Command<string>(s => s == "UNBECOME", __ => UnbecomeStacked());
+                Command<string>(s => Sender.Tell("string3:" + s, Self));
+            }
+        }
+
+        private class BecomeDirectlyInConstructorActor : TestReceivePersistentActor
+        {
+            public BecomeDirectlyInConstructorActor(string pid) : base(pid)
+            {
+                Recover<int>(i => State.AddLast(i));
+                Command<string>(s => s == "UNBECOME", __ => UnbecomeStacked());
+                Command<string>(s => s == "BECOME", _ => BecomeStacked(State2));
+                Command<string>(s => Sender.Tell("string1:" + s, Self));
+                Command<int>(i => Sender.Tell("int1:" + i, Self));
+                BecomeStacked(State2);
+                BecomeStacked(State3);
+            }
+
+            private void State2()
+            {
+                Command<string>(s => s == "UNBECOME", __ => UnbecomeStacked());
+                Command<string>(s => s == "BECOME", _ => BecomeStacked(State3));
+                Command<string>(s => Sender.Tell("string2:" + s, Self));
+            }
+
+            private void State3()
+            {
+                Command<string>(s => s == "UNBECOME", __ => UnbecomeStacked());
+                Command<string>(s => Sender.Tell("string3:" + s, Self));
+            }
+        }
+
+    }
+}
+

--- a/src/core/Akka.Persistence.Tests/ReceivePersistentActorTests_LifeCycle.cs
+++ b/src/core/Akka.Persistence.Tests/ReceivePersistentActorTests_LifeCycle.cs
@@ -1,0 +1,87 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ReceivePersistentActorTests_LifeCycle.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Xunit;
+
+namespace Akka.Persistence.Tests
+{
+    public partial class ReceivePersistentActorTests
+    {
+        [Fact]
+        public void Given_persistent_actor_When_it_restarts_Then_uses_the_handler()
+        {
+            //Given
+            var pid = "p-11";
+            WriteEvents(pid, 1, 2, 3);
+            var actor = Sys.ActorOf(Props.Create(() => new CrashActor(pid)), "crash");
+            
+            //When
+            actor.Tell("CRASH");
+
+            //Then
+            actor.Tell("hello", TestActor);
+            ExpectMsg((object) "1:hello");
+        }
+
+        [Fact]
+        public void Given_persistent_actor_that_has_replaced_its_initial_handler_When_it_restarts_Then_uses_the_initial_handler()
+        {
+            //Given
+            var pid = "p-12";
+            WriteEvents(pid, 1, 2, 3);
+            var actor = Sys.ActorOf(Props.Create(() => new CrashActor(pid)), "crash");
+            actor.Tell("BECOME-DISCARD");
+
+            //When
+            actor.Tell("CRASH", TestActor);
+
+            //Then
+            actor.Tell("hello", TestActor);
+            ExpectMsg((object) "1:hello");
+        }
+
+
+        [Fact]
+        public void Given_persistent_actor_that_has_pushed_a_new_handler_When_it_restarts_Then_uses_the_initial_handler()
+        {
+            //Given
+            var pid = "p-13";
+            WriteEvents(pid, 1, 2, 3);
+            var actor = Sys.ActorOf(Props.Create(() => new CrashActor(pid)), "crash");
+            actor.Tell("BECOME");
+
+            //When
+            actor.Tell("CRASH", TestActor);
+
+            //Then
+            actor.Tell("hello", TestActor);
+            ExpectMsg((object) "1:hello");
+        }
+
+        private class CrashActor : TestReceivePersistentActor
+        {
+            public CrashActor(string pid) : base(pid)
+            {
+                Recover<int>(i => State.AddLast(i));
+
+                Command<string>(s => s == "CRASH", s => { throw new Exception("Crash!"); });
+                Command<string>(s => s == "BECOME", _ => BecomeStacked(State2));
+                Command<string>(s => s == "BECOME-DISCARD", _ => BecomeStacked(State2));
+                Command<string>(s => Sender.Tell("1:"+s));
+            }
+
+            private void State2()
+            {
+                Command<string>(s => s == "CRASH", s => { throw new Exception("Crash!"); });
+                Command<string>(s => Sender.Tell("2:" + s));
+            }
+        }
+    }
+}
+

--- a/src/core/Akka.Persistence/PersistentActor.cs
+++ b/src/core/Akka.Persistence/PersistentActor.cs
@@ -227,6 +227,29 @@ namespace Akka.Persistence
             _matchRecoverBuilders.Push(new MatchBuilder(CachedMatchCompiler<object>.Instance));
         }
 
+        /// <summary>
+        /// Changes the actor's command behavior and replaces the current receive command handler with the specified handler.
+        /// </summary>
+        /// <param name="configure">Configures the new handler by calling the different Receive overloads.</param>
+        protected void Become(Action configure)
+        {
+            var newHandler = CreateNewHandler(configure);
+            base.Become(m => ExecutePartialMessageHandler(m, newHandler));
+        }
+
+        /// <summary>
+        /// Changes the actor's command behavior and replaces the current receive command handler with the specified handler.
+        /// The current handler is stored on a stack, and you can revert to it by calling <see cref="ActorBase.UnbecomeStacked"/>
+        /// <remarks>Please note, that in order to not leak memory, make sure every call to <see cref="BecomeStacked"/>
+        /// is matched with a call to <see cref="ActorBase.UnbecomeStacked"/>.</remarks>
+        /// </summary>
+        /// <param name="configure">Configures the new handler by calling the different Command overloads.</param>
+        protected void BecomeStacked(Action configure)
+        {
+            var newHandler = CreateNewHandler(configure);
+            base.BecomeStacked(m => ExecutePartialMessageHandler(m, newHandler));
+        }
+
         protected sealed override void OnCommand(object message)
         {
             ExecutePartialMessageHandler(message, _partialReceiveCommand);
@@ -340,6 +363,20 @@ namespace Akka.Persistence
         {
             EnsureMayConfigureCommandHandlers();
             _matchCommandBuilders.Peek().MatchAny(handler);
+        }
+
+        protected void CommandAny(Action<object> handler)
+        {
+            EnsureMayConfigureCommandHandlers();
+            _matchCommandBuilders.Peek().MatchAny(handler);
+        }
+
+        private PartialAction<object> CreateNewHandler(Action configure)
+        {
+            _matchCommandBuilders.Push(new MatchBuilder(CachedMatchCompiler<object>.Instance));
+            configure();
+            var newHandler = BuildNewReceiveHandler(_matchCommandBuilders.Pop());
+            return newHandler;
         }
 
         #endregion

--- a/src/core/Akka/Actor/ActorBase.cs
+++ b/src/core/Akka/Actor/ActorBase.cs
@@ -199,7 +199,7 @@ namespace Akka.Actor
         }
 
         /// <summary>
-        /// Changes the actor's behavior and replaces the current receive handler with the specified handler.
+        /// Changes the actor's command behavior and replaces the current receive handler with the specified handler.
         /// </summary>
         /// <param name="receive">The new message handler.</param>
         protected void Become(Receive receive)


### PR DESCRIPTION
See #1395

This part adds missing API parts to `ReceivePersistentActor` as well as the battery of tests to verify it's behavior:

- Two methods have been created -`Become` and `BecomeStacked`. They works with `Command`, `CommandAny`, `Recover` and `RecoverAny` handlers in the similar way as in case of `Receive` method in `ReceiveActor`.
- New method `UnbecomeStacked` reverts the behavior of `BecomeStacked` applied previously.
- `CommandAny` method matching any incoming command was missing and has been added.

NOTE: one of the test is skipped until some decisions will be made for issue described in #1400 .