### PR TITLE
Persistent actor stops on recovery failures

### DIFF
--- a/src/core/Akka.Persistence/Persistence.cs
+++ b/src/core/Akka.Persistence/Persistence.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Threading;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Dispatch;
@@ -52,14 +53,14 @@ namespace Akka.Persistence
                 var configPath = _config.GetString("journal.plugin");
                 if (string.IsNullOrEmpty(configPath)) throw new NullReferenceException("Default journal plugin is not configured");
                 return configPath;
-            });
+            }, LazyThreadSafetyMode.ExecutionAndPublication);
 
             _defaultSnapshotPluginId = new Lazy<string>(() =>
             {
                 var configPath = _config.GetString("snapshot-store.plugin");
                 if (string.IsNullOrEmpty(configPath)) throw new NullReferenceException("Default snapshot-store plugin is not configured");
                 return configPath;
-            });
+            }, LazyThreadSafetyMode.ExecutionAndPublication);
 
             Settings = new PersistenceSettings(_system, _config);
         }
@@ -81,7 +82,7 @@ namespace Akka.Persistence
             Lazy<PluginHolder> pluginContainer;
             if (!_snapshotPluginExtensionIds.TryGetValue(configPath, out pluginContainer))
             {
-                var plugin = new Lazy<PluginHolder>(() => CreatePlugin(configPath, _ => DefaultPluginDispatcherId));
+                var plugin = new Lazy<PluginHolder>(() => CreatePlugin(configPath, _ => DefaultPluginDispatcherId), LazyThreadSafetyMode.ExecutionAndPublication);
                 pluginContainer = _snapshotPluginExtensionIds.AddOrUpdate(configPath, plugin, (key, old) => plugin);
             }
 
@@ -101,7 +102,8 @@ namespace Akka.Persistence
                 var plugin = new Lazy<PluginHolder>(() => CreatePlugin(configPath, type =>
                     typeof (AsyncWriteJournal).IsAssignableFrom(type)
                         ? Dispatchers.DefaultDispatcherId
-                        : DefaultPluginDispatcherId));
+                        : DefaultPluginDispatcherId), 
+                        LazyThreadSafetyMode.ExecutionAndPublication);
                 pluginContainer = _journalPluginExtensionIds.AddOrUpdate(configPath, plugin, (key, old) => plugin);
             }
 
@@ -124,7 +126,8 @@ namespace Akka.Persistence
                 var plugin = new Lazy<PluginHolder>(() =>
                     CreatePlugin(configPath, type => typeof (AsyncWriteJournal).IsAssignableFrom(type)
                         ? Dispatchers.DefaultDispatcherId
-                        : DefaultPluginDispatcherId));
+                        : DefaultPluginDispatcherId), 
+                        LazyThreadSafetyMode.ExecutionAndPublication);
                 pluginContainer = _journalPluginExtensionIds.AddOrUpdate(configPath, plugin, (key, old) => plugin);
             }
 


### PR DESCRIPTION
This PR contains two changes:

1. It attaches `LazyThreadSafetyMode.ExecutionAndPublication` in order to make lazy journal/snapshot store creation more thread safe (see issue #1397).
2. It changes behavior of persistent actor in case of failure during recovery - now it causes actor to stop. This is desired behavior in sync with canonical akka-persistence from version 2.4 (see issue #1403). Also it changes singature of method `OnReplayFailure(Exception reason)` to `OnReplayFailure(Exception reason, object message = null)` - now it will not only pass an exception that caused an error but also responsible event. Another change is that default implementation will log this cause on Error level - therefore all persistent actors contain logging adapters by default.