### PR TITLE
A logger that logs using the System.Diagnostics.Debugger

### DIFF
--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -227,6 +227,7 @@
     <Compile Include="Event\LogLevel.cs" />
     <Compile Include="Event\LogMessage.cs" />
     <Compile Include="Event\StandardOutLogger.cs" />
+    <Compile Include="Event\DebugLogger.cs" />
     <Compile Include="Helios.Concurrency.DedicatedThreadPool.cs" />
     <Compile Include="Pattern\BackoffSupervisor.cs" />
     <Compile Include="IO\DatagramChannel.cs" />

--- a/src/core/Akka/Event/DebugLogger.cs
+++ b/src/core/Akka/Event/DebugLogger.cs
@@ -1,0 +1,56 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="DebugLogger.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Diagnostics;
+using Akka.Actor;
+
+namespace Akka.Event
+{
+    /// <summary>
+    /// Represents a logger that logs using System.Diagnostics.Debug and breaks attached debuggers on errors.
+    /// </summary>
+    public class DebugLogger : ReceiveActor
+    {
+        private readonly ILoggingAdapter _log = Context.GetLogger();
+
+        private static void Log(LogEvent logEvent)
+        {
+            System.Diagnostics.Debug.WriteLine(
+                logEvent.ToString(),
+                logEvent.LogLevel().ToString());
+
+            if (Debugger.IsAttached)
+            {
+                if (Debugger.IsLogging())
+                {
+                    Debugger.Log(
+                        (int)logEvent.LogLevel(),
+                        logEvent.LogLevel().ToString(),
+                        logEvent.ToString());
+                }
+
+                if (logEvent.LogLevel() == LogLevel.ErrorLevel)
+                {
+                    Debugger.Break();
+                }
+            }
+        }
+
+        public DebugLogger()
+        {
+            Receive<Error>(m => Log(m));
+            Receive<Warning>(m => Log(m));
+            Receive<Info>(m => Log(m));
+            Receive<Akka.Event.Debug>(m => Log(m));
+            Receive<InitializeLogger>(m =>
+            {
+                _log.Info("DebugLogger started");
+                Sender.Tell(new LoggerInitialized());
+            });
+        }
+    }
+}


### PR DESCRIPTION
During the development of my applications, I've found it very useful for log entries to output to the standard debugger output and break on errors. This has made my development errors easier to find and fix, compared to the other loggers I've tried.