### PR TITLE
[api-docs] Documentation cleanup

### DIFF
--- a/src/core/Akka.Cluster/Configuration/ClusterConfigFactory.cs
+++ b/src/core/Akka.Cluster/Configuration/ClusterConfigFactory.cs
@@ -12,24 +12,26 @@ using Akka.Configuration;
 namespace Akka.Cluster.Configuration
 {
     /// <summary>
-    /// Internal class used for loading akka-cluster configuration values
+    /// This class contains methods used to retrieve cluster configuration options from this assembly's resources.
+    ///
+    /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
     /// </summary>
     internal static class ClusterConfigFactory
     {
         /// <summary>
-        /// Defaults this instance.
+        /// Retrieves the default cluster options that Akka.NET uses when no configuration has been defined.
         /// </summary>
-        /// <returns>Config.</returns>
+        /// <returns>The configuration that contains default values for all cluster options.</returns>
         public static Config Default()
         {
             return FromResource("Akka.Cluster.Configuration.Cluster.conf");
         }
 
         /// <summary>
-        /// Froms the resource.
+        /// Retrieves a configuration defined in a resource of the current executing assembly.
         /// </summary>
-        /// <param name="resourceName">Name of the resource.</param>
-        /// <returns>Config.</returns>
+        /// <param name="resourceName">The name of the resource that contains the configuration.</param>
+        /// <returns>The configuration defined in the current executing assembly.</returns>
         internal static Config FromResource(string resourceName)
         {
             var assembly = typeof(ClusterConfigFactory).Assembly;
@@ -47,4 +49,3 @@ namespace Akka.Cluster.Configuration
         }
     }
 }
-

--- a/src/core/Akka.Persistence/AtLeastOnceDelivery.cs
+++ b/src/core/Akka.Persistence/AtLeastOnceDelivery.cs
@@ -229,15 +229,25 @@ namespace Akka.Persistence
     #endregion
 
     /// <summary>
-    /// An exception thrown, when <see cref="AtLeastOnceDeliveryActor.MaxUnconfirmedMessages"/> threshold has been exceeded.
+    /// This exception is thrown when the <see cref="AtLeastOnceDeliveryActor.MaxUnconfirmedMessages"/> threshold has been exceeded.
     /// </summary>
     public class MaxUnconfirmedMessagesExceededException : AkkaException
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MaxUnconfirmedMessagesExceededException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="cause">The exception that is the cause of the current exception.</param>
         public MaxUnconfirmedMessagesExceededException(string message, Exception cause = null)
             : base(message, cause)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MaxUnconfirmedMessagesExceededException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
         protected MaxUnconfirmedMessagesExceededException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/core/Akka.Persistence/Journal/AsyncWriteProxy.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteProxy.cs
@@ -14,18 +14,33 @@ using System.Runtime.Serialization;
 
 namespace Akka.Persistence.Journal
 {
+    /// <summary>
+    /// This exception is thrown when the replay inactivity exceeds a specified timeout.
+    /// </summary>
     [Serializable]
     public class AsyncReplayTimeoutException : AkkaException
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncReplayTimeoutException"/> class.
+        /// </summary>
         public AsyncReplayTimeoutException()
         {
         }
 
-        public AsyncReplayTimeoutException(string msg)
-            : base(msg)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncReplayTimeoutException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public AsyncReplayTimeoutException(string message)
+            : base(message)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncReplayTimeoutException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
         protected AsyncReplayTimeoutException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/core/Akka.Remote.TestKit/Controller.cs
+++ b/src/core/Akka.Remote.TestKit/Controller.cs
@@ -71,10 +71,22 @@ namespace Akka.Remote.TestKit
             }
         }
 
+        /// <summary>
+        /// This exception is thrown when a client has disconnected.
+        /// </summary>
         public class ClientDisconnectedException : AkkaException
         {
-            public ClientDisconnectedException(string msg) : base(msg){}
+            /// <summary>
+            /// Initializes a new instance of the <see cref="ClientDisconnectedException"/> class.
+            /// </summary>
+            /// <param name="message">The message that describes the error.</param>
+            public ClientDisconnectedException(string message) : base(message){}
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="ClientDisconnectedException"/> class.
+            /// </summary>
+            /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+            /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
             protected ClientDisconnectedException(SerializationInfo info, StreamingContext context) : base(info, context)
             {
             }

--- a/src/core/Akka.Remote.TestKit/Internals/TestConductorConfigFactory.cs
+++ b/src/core/Akka.Remote.TestKit/Internals/TestConductorConfigFactory.cs
@@ -12,25 +12,27 @@ using Akka.Configuration;
 namespace Akka.Remote.TestKit.Internals
 {
     /// <summary>
-    /// Loads required Multi-Node TestKit configuration values embedded into the assembly
+    /// This class contains methods used to retrieve Multi-Node TestKit configuration options from this assembly's resources
     /// and injects them in relevant tests.
+    ///
+    /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
     /// </summary>
     internal static class TestConductorConfigFactory
     {
         /// <summary>
-        /// Defaults this instance.
+        /// Retrieves the default Multi-Node TestKit options that Akka.NET uses when no configuration has been defined.
         /// </summary>
-        /// <returns>Config.</returns>
+        /// <returns>The configuration that contains default values for all Multi-Node TestKit options.</returns>
         public static Config Default()
         {
             return FromResource("Akka.Remote.TestKit.Internals.Reference.conf");
         }
 
         /// <summary>
-        /// Froms the resource.
+        /// Retrieves a configuration defined in a resource of the current executing assembly.
         /// </summary>
-        /// <param name="resourceName">Name of the resource.</param>
-        /// <returns>Config.</returns>
+        /// <param name="resourceName">The name of the resource that contains the configuration.</param>
+        /// <returns>The configuration defined in the current executing assembly.</returns>
         internal static Config FromResource(string resourceName)
         {
             var assembly = typeof(TestConductorConfigFactory).Assembly;

--- a/src/core/Akka.Remote/AckedDelivery.cs
+++ b/src/core/Akka.Remote/AckedDelivery.cs
@@ -219,21 +219,39 @@ namespace Akka.Remote
         }
     }
 
+    /// <summary>
+    /// This exception is thrown when the Resent buffer is filled beyond its capacity.
+    /// </summary>
     class ResendBufferCapacityReachedException : AkkaException
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResendBufferCapacityReachedException"/> class.
+        /// </summary>
+        /// <param name="c">The capacity of the buffer</param>
         public ResendBufferCapacityReachedException(int c)
             : base(string.Format("Resent buffer capacity of {0} has been reached.", c))
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResendBufferCapacityReachedException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
         protected ResendBufferCapacityReachedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
     }
 
+    /// <summary>
+    /// This exception is thrown when the system is unable to fulfill a resend request since negatively acknowledged payload is no longer in buffer.
+    /// </summary>
     class ResendUnfulfillableException : AkkaException
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResendUnfulfillableException"/> class.
+        /// </summary>
         public ResendUnfulfillableException()
             : base("Unable to fulfill resend request since negatively acknowledged payload is no longer in buffer. " +
                 "The resend states between two systems are compromised and cannot be recovered") { }

--- a/src/core/Akka.Remote/Configuration/RemoteConfigFactory.cs
+++ b/src/core/Akka.Remote/Configuration/RemoteConfigFactory.cs
@@ -12,24 +12,26 @@ using Akka.Configuration;
 namespace Akka.Remote.Configuration
 {
     /// <summary>
-    /// Internal class used for loading remote configuration values
+    /// This class contains methods used to retrieve remote configuration options from this assembly's resources.
+    ///
+    /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
     /// </summary>
     internal static class RemoteConfigFactory
     {
         /// <summary>
-        /// Defaults this instance.
+        /// Retrieves the default remote options that Akka.NET uses when no configuration has been defined.
         /// </summary>
-        /// <returns>Config.</returns>
+        /// <returns>The configuration that contains default values for all remote options.</returns>
         public static Config Default()
         {
             return FromResource("Akka.Remote.Configuration.Remote.conf");
         }
 
         /// <summary>
-        /// Froms the resource.
+        /// Retrieves a configuration defined in a resource of the current executing assembly.
         /// </summary>
-        /// <param name="resourceName">Name of the resource.</param>
-        /// <returns>Config.</returns>
+        /// <param name="resourceName">The name of the resource that contains the configuration.</param>
+        /// <returns>The configuration defined in the current executing assembly.</returns>
         internal static Config FromResource(string resourceName)
         {
             var assembly = typeof (RemoteConfigFactory).Assembly;
@@ -47,4 +49,3 @@ namespace Akka.Remote.Configuration
         }
     }
 }
-

--- a/src/core/Akka.Remote/RemoteSystemDaemon.cs
+++ b/src/core/Akka.Remote/RemoteSystemDaemon.cs
@@ -73,7 +73,7 @@ namespace Akka.Remote
     /// 
     /// Internal system "daemon" actor for remote internal communication.
     /// 
-    /// It acts as the brain of the remote that response to system remote messages and executes actions accordingly.
+    /// It acts as the brain of the remote that responds to system remote messages and executes actions accordingly.
     /// </summary>
     internal class RemoteSystemDaemon : VirtualPathContainer
     {

--- a/src/core/Akka.Remote/RemoteTransport.cs
+++ b/src/core/Akka.Remote/RemoteTransport.cs
@@ -97,16 +97,26 @@ namespace Akka.Remote
     }
 
     /// <summary>
-    /// Represents a general failure within a <see cref="RemoteTransport"/>, such as
+    /// This exception is thrown when a general failure within a <see cref="RemoteTransport"/> occurs, such as
     /// the inability to start, wrong configuration, etc...
     /// </summary>
     public class RemoteTransportException : AkkaException
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RemoteTransportException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="cause">The exception that is the cause of the current exception.</param>
         public RemoteTransportException(string message, Exception cause = null)
             : base(message, cause)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RemoteTransportException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
         protected RemoteTransportException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/core/Akka.Remote/Serialization/MessageContainerSerializer.cs
+++ b/src/core/Akka.Remote/Serialization/MessageContainerSerializer.cs
@@ -13,22 +13,42 @@ using Google.ProtocolBuffers;
 
 namespace Akka.Remote.Serialization
 {
+    /// <summary>
+    /// This is a special <see cref="Serializer"/> that serializes and deserializes <see cref="ActorSelectionMessage"/> only.
+    /// </summary>
     public class MessageContainerSerializer : Serializer
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessageContainerSerializer"/> class.
+        /// </summary>
+        /// <param name="system">The actor system to associate with this serializer. </param>
         public MessageContainerSerializer(ExtendedActorSystem system) : base(system)
         {
         }
 
+        /// <summary>
+        /// Completely unique value to identify this implementation of Serializer, used to optimize network traffic
+        /// Values from 0 to 16 is reserved for Akka internal usage
+        /// </summary>
         public override int Identifier
         {
             get { return 6; }
         }
 
+        /// <summary>
+        /// Returns whether this serializer needs a manifest in the fromBinary method
+        /// </summary>
         public override bool IncludeManifest
         {
             get { return false; }
         }
 
+        /// <summary>
+        /// Serializes the given object into a byte array
+        /// </summary>
+        /// <param name="obj">The object to serialize </param>
+        /// <returns>A byte array containing the serialized object</returns>
+        /// <exception cref="ArgumentException">Object must be of type <see cref="ActorSelectionMessage"/></exception>
         public override byte[] ToBinary(object obj)
         {
             if (!(obj is ActorSelectionMessage))
@@ -84,6 +104,13 @@ namespace Akka.Remote.Serialization
             return builder.Build().ToByteArray();
         }
 
+        /// <summary>
+        /// Deserializes a byte array into an object of type <paramref name="type"/>.
+        /// </summary>
+        /// <param name="bytes">The array containing the serialized object</param>
+        /// <param name="type">The type of object contained in the array</param>
+        /// <returns>The object contained in the array</returns>
+        /// <exception cref="NotSupportedException">Unknown SelectionEnvelope.Elements.Type</exception>
         public override object FromBinary(byte[] bytes, Type type)
         {
             SelectionEnvelope selectionEnvelope = SelectionEnvelope.ParseFrom(bytes);
@@ -108,4 +135,3 @@ namespace Akka.Remote.Serialization
         }
     }
 }
-

--- a/src/core/Akka.Remote/Serialization/ProtobufSerializer.cs
+++ b/src/core/Akka.Remote/Serialization/ProtobufSerializer.cs
@@ -11,22 +11,42 @@ using Akka.Serialization;
 
 namespace Akka.Remote.Serialization
 {
+    /// <summary>
+    /// This is a special <see cref="Serializer"/> that serializes and deserializes Google protobuf messages only.
+    /// </summary>
     public class ProtobufSerializer : Serializer
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProtobufSerializer"/> class.
+        /// </summary>
+        /// <param name="system">The actor system to associate with this serializer. </param>
         public ProtobufSerializer(ExtendedActorSystem system) : base(system)
         {
         }
 
-        public override bool IncludeManifest
-        {
-            get { return true; }
-        }
-
+        /// <summary>
+        /// Completely unique value to identify this implementation of Serializer, used to optimize network traffic
+        /// Values from 0 to 16 is reserved for Akka internal usage
+        /// </summary>
         public override int Identifier
         {
             get { return 2; }
         }
 
+        /// <summary>
+        /// Returns whether this serializer needs a manifest in the fromBinary method
+        /// </summary>
+        public override bool IncludeManifest
+        {
+            get { return true; }
+        }
+
+        /// <summary>
+        /// Serializes the given object into a byte array
+        /// </summary>
+        /// <param name="obj">The object to serialize </param>
+        /// <returns>A byte array containing the serialized object</returns>
+        /// <exception cref="NotImplementedException">This method is not currently implemented.</exception>
         public override byte[] ToBinary(object obj)
         {
             throw new NotImplementedException();
@@ -37,6 +57,13 @@ namespace Akka.Remote.Serialization
             //}
         }
 
+        /// <summary>
+        /// Deserializes a byte array into an object of type <paramref name="type"/>.
+        /// </summary>
+        /// <param name="bytes">The array containing the serialized object</param>
+        /// <param name="type">The type of object contained in the array</param>
+        /// <returns>The object contained in the array</returns>
+        /// <exception cref="NotImplementedException">This method is not currently implemented.</exception>
         public override object FromBinary(byte[] bytes, Type type)
         {
             throw new NotImplementedException();
@@ -47,4 +74,3 @@ namespace Akka.Remote.Serialization
         }
     }
 }
-

--- a/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
+++ b/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
@@ -105,7 +105,7 @@ namespace Akka.Remote.Transport
     /// <summary>
     /// INTERNAL API
     /// 
-    /// A Codec that is able to convert Akka PDUs from and to <see cref="ByteString"/>
+    /// A codec that is able to convert Akka PDUs from and to <see cref="ByteString"/>
     /// </summary>
     internal abstract class AkkaPduCodec
     {

--- a/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
+++ b/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
@@ -37,17 +37,22 @@ namespace Akka.Remote.Transport
     }
 
     /// <summary>
-    /// An <see cref="AkkaException"/> that can occur during the course of an Akka Protocol handshake.
+    /// This exception is thrown when an error occurred during the Akka protocol handshake.
     /// </summary>
     public class AkkaProtocolException : AkkaException
     {
         /// <summary>
-        /// Constructor.
+        /// Initializes a new instance of the <see cref="AkkaProtocolException"/> class.
         /// </summary>
-        /// <param name="message">The error message.</param>
-        /// <param name="cause">The internal exception (null by default.)</param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="cause">The exception that is the cause of the current exception.</param>
         public AkkaProtocolException(string message, Exception cause = null) : base(message, cause) { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AkkaProtocolException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
         protected AkkaProtocolException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/core/Akka.Remote/Transport/FailureInjectorTransportAdapter.cs
+++ b/src/core/Akka.Remote/Transport/FailureInjectorTransportAdapter.cs
@@ -29,20 +29,32 @@ namespace Akka.Remote.Transport
     }
 
     /// <summary>
-    /// The failure we're going to inject into a transport, of course :)
+    /// This exception is used to indicate a simulated failure in an association.
     /// </summary>
     public sealed class FailureInjectorException : AkkaException
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FailureInjectorException"/> class.
+        /// </summary>
+        /// <param name="msg">The message that describes the error.</param>
         public FailureInjectorException(string msg)
         {
             Msg = msg;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FailureInjectorException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
         private FailureInjectorException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
 
+        /// <summary>
+        /// Retrieves the message of the simulated failure.
+        /// </summary>
         public string Msg { get; private set; }
     }
 

--- a/src/core/Akka.Remote/Transport/Transport.cs
+++ b/src/core/Akka.Remote/Transport/Transport.cs
@@ -60,15 +60,25 @@ namespace Akka.Remote.Transport
     }
 
     /// <summary>
-    /// Indicates that the association setup request is invalid and it is impossible to recover (malformed IP address, unknown hostname, etc...)
+    /// This exception is thrown when an association setup request is invalid and it is impossible to recover (malformed IP address, unknown hostname, etc...).
     /// </summary>
     public class InvalidAssociationException : AkkaException
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidAssociationException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="cause">The exception that is the cause of the current exception.</param>
         public InvalidAssociationException(string message, Exception cause = null)
             : base(message, cause)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidAssociationException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
         protected InvalidAssociationException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -139,22 +149,37 @@ namespace Akka.Remote.Transport
     /// </summary>
     public interface IHandleEventListener
     {
+        /// <summary>
+        /// Notify the listener about an <see cref="IHandleEvent"/>.
+        /// </summary>
+        /// <param name="ev">The <see cref="IHandleEvent"/> to notify the listener about</param>
         void Notify(IHandleEvent ev);
     }
 
     /// <summary>
-    /// Converts an <see cref="IActorRef"/> instance into an <see cref="IHandleEventListener"/>, so <see cref="IHandleEvent"/> messages
+    /// Converts an <see cref="IActorRef"/> into an <see cref="IHandleEventListener"/>, so <see cref="IHandleEvent"/> messages
     /// can be passed directly to the Actor.
     /// </summary>
     public sealed class ActorHandleEventListener : IHandleEventListener
     {
+        /// <summary>
+        /// The Actor to notify about <see cref="IHandleEvent"/> messages.
+        /// </summary>
         public readonly IActorRef Actor;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActorHandleEventListener"/> class.
+        /// </summary>
+        /// <param name="actor">The Actor to notify about <see cref="IHandleEvent"/> messages.</param>
         public ActorHandleEventListener(IActorRef actor)
         {
             Actor = actor;
         }
 
+        /// <summary>
+        /// Notify the Actor about an <see cref="IHandleEvent"/> message.
+        /// </summary>
+        /// <param name="ev">The <see cref="IHandleEvent"/> message to notify the Actor about</param>
         public void Notify(IHandleEvent ev)
         {
             Actor.Tell(ev);
@@ -189,22 +214,37 @@ namespace Akka.Remote.Transport
     /// </summary>
     public interface IAssociationEventListener
     {
+        /// <summary>
+        /// Notify the listener about an <see cref="IAssociationEvent"/> message.
+        /// </summary>
+        /// <param name="ev">The <see cref="IAssociationEvent"/> message to notify the listener about</param>
         void Notify(IAssociationEvent ev);
     }
 
     /// <summary>
-    /// Converts an <see cref="IActorRef"/> instance into an <see cref="IAssociationEventListener"/>, so <see cref="IAssociationEvent"/> messages
+    /// Converts an <see cref="IActorRef"/> into an <see cref="IAssociationEventListener"/>, so <see cref="IAssociationEvent"/> messages
     /// can be passed directly to the Actor.
     /// </summary>
     public sealed class ActorAssociationEventListener : IAssociationEventListener
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActorAssociationEventListener"/> class.
+        /// </summary>
+        /// <param name="actor">The Actor to notify about <see cref="IAssociationEvent"/> messages.</param>
         public ActorAssociationEventListener(IActorRef actor)
         {
             Actor = actor;
         }
 
+        /// <summary>
+        /// The Actor to notify about <see cref="IAssociationEvent"/> messages.
+        /// </summary>
         public IActorRef Actor { get; private set; }
 
+        /// <summary>
+        /// Notify the Actor about an <see cref="IAssociationEvent"/>.
+        /// </summary>
+        /// <param name="ev">The <see cref="IAssociationEvent"/> message to notify the Actor about</param>
         public void Notify(IAssociationEvent ev)
         {
             Actor.Tell(ev);

--- a/src/core/Akka/Actor/Stash/StashOverflowException.cs
+++ b/src/core/Akka/Actor/Stash/StashOverflowException.cs
@@ -11,16 +11,25 @@ using System.Runtime.Serialization;
 namespace Akka.Actor
 {
     /// <summary>
-    /// Is thrown when the size of the Stash exceeds the capacity of the stash
+    /// This exception is thrown when the size of the Stash exceeds the capacity of the stash.
     /// </summary>
     public class StashOverflowException : AkkaException
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StashOverflowException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="cause">The exception that is the cause of the current exception.</param>
         public StashOverflowException(string message, Exception cause = null) : base(message, cause) { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StashOverflowException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
         protected StashOverflowException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
     }
 }
-

--- a/src/core/Akka/Pattern/IllegalStateException.cs
+++ b/src/core/Akka/Pattern/IllegalStateException.cs
@@ -11,21 +11,26 @@ using Akka.Actor;
 namespace Akka.Pattern
 {
     /// <summary>
-    /// Signals that a method has been invoked at an illegal or
-    /// inappropriate time.
+    /// This exception is thrown when a method has been invoked at an illegal or inappropriate time.
     /// </summary>
     public class IllegalStateException : AkkaException
     {
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IllegalStateException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
         public IllegalStateException(string message) : base(message)
         {
-
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IllegalStateException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
         protected IllegalStateException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
     }
 }
-

--- a/src/core/Akka/Pattern/OpenCircuitException.cs
+++ b/src/core/Akka/Pattern/OpenCircuitException.cs
@@ -12,24 +12,41 @@ using Akka.Actor;
 namespace Akka.Pattern
 {
     /// <summary>
-    /// Exception throws when CircuitBreaker is open
+    /// This exception is thrown when the CircuitBreaker is open.
     /// </summary>
     public class OpenCircuitException : AkkaException
     {
-        public OpenCircuitException( ) : base( "Circuit Breaker is open; calls are failing fast" ) { }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenCircuitException"/> class.
+        /// </summary>
+        public OpenCircuitException() : base("Circuit Breaker is open; calls are failing fast") { }
 
-        public OpenCircuitException( string message )
-            : base( message )
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenCircuitException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public OpenCircuitException(string message)
+            : base(message)
         {
         }
 
-        public OpenCircuitException( string message, Exception innerException )
-            : base( message, innerException )
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenCircuitException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="cause">The exception that is the cause of the current exception.</param>
+        public OpenCircuitException(string message, Exception cause)
+            : base(message, cause)
         {
         }
 
-        protected OpenCircuitException( SerializationInfo info, StreamingContext context )
-            : base( info, context )
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenCircuitException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
+        protected OpenCircuitException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }


### PR DESCRIPTION
This PR cleans up a bit of the documentation.

- Fleshed out the api docs for various Akka exceptions.

- Cleaned up auto-generated api docs for configuration factory classes.

- Added api docs for a couple of the serializers.

- Added api docs for a couple of event listeners.