### PR TITLE
close #1399 - modified build script to download NuGet for package publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,6 +210,7 @@ FakesAssemblies/
 /src/.Akka.boltdata/TestResults.json
 resetdev.bat
 /src/packages/repositories.config
+/src/.nuget
 
 # FAKE build folder
 .fake/

--- a/build.cmd
+++ b/build.cmd
@@ -1,4 +1,24 @@
 @echo off
+
+pushd %~dp0
+
+SETLOCAL
+SET CACHED_NUGET=%LocalAppData%\NuGet\NuGet.exe
+
+IF EXIST %CACHED_NUGET% goto copynuget
+echo Downloading latest version of NuGet.exe...
+IF NOT EXIST %LocalAppData%\NuGet md %LocalAppData%\NuGet
+@powershell -NoProfile -ExecutionPolicy unrestricted -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://www.nuget.org/nuget.exe' -OutFile '%CACHED_NUGET%'"
+
+:copynuget
+IF EXIST src\.nuget\nuget.exe goto restore
+md src\.nuget
+copy %CACHED_NUGET% src\.nuget\nuget.exe > nul
+
+:restore
+
+src\.nuget\NuGet.exe update -self
+
 cls
 
 .paket\paket.bootstrapper.exe

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,20 @@
 #!/usr/bin/env bash
+SCRIPT_PATH="${BASH_SOURCE[0]}";
+if ([ -h "${SCRIPT_PATH}" ]) then
+  while([ -h "${SCRIPT_PATH}" ]) do SCRIPT_PATH=`readlink "${SCRIPT_PATH}"`; done
+fi
+pushd . > /dev/null
+cd `dirname ${SCRIPT_PATH}` > /dev/null
+SCRIPT_PATH=`pwd`;
+popd  > /dev/null
+
+if ! [ -f $SCRIPT_PATH/src/.nuget/nuget.exe ] 
+    then
+        wget "https://www.nuget.org/nuget.exe" -P $SCRIPT_PATH/src/.nuget/
+fi
+
+mono $SCRIPT_PATH/src/.nuget/nuget.exe update -self
+
 if test "$OS" = "Windows_NT"
 then
   # use .Net


### PR DESCRIPTION
Modifies just the `build.cmd` and `build.sh` files to download Nuget.exe to where it's expected for package publishing.