### PR TITLE
adding Akka.DI.SimpleInjector with tests

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -181,6 +181,7 @@ Target "CopyOutput" <| fun _ ->
       "contrib/dependencyinjection/Akka.DI.AutoFac"
       "contrib/dependencyinjection/Akka.DI.CastleWindsor"
       "contrib/dependencyinjection/Akka.DI.Ninject"
+      "contrib/dependencyinjection/Akka.DI.SimpleInjector"
       "contrib/dependencyinjection/Akka.DI.Unity"
       "contrib/dependencyinjection/Akka.DI.TestKit"
       "contrib/testkits/Akka.TestKit.Xunit" 

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -25,6 +25,8 @@ nuget xunit.abstractions 2.0.0 framework: >= net45
 nuget xunit.assert 2.0.0 framework: >= net45
 nuget xunit.core 2.0.0 framework: >= net45
 nuget xunit.extensibility.core 2.0.0 framework: >= net45
+nuget SimpleInjector 3.1.0 framework: >= net45
+nuget SimpleInjector.Extensions.ExecutionContextScoping 3.1.0 framework: >= net45
 
 group Test
 source https://www.nuget.org/api/v2/

--- a/paket.lock
+++ b/paket.lock
@@ -20,6 +20,9 @@ NUGET
     NuGet.CommandLine (2.8.6)
     qdfeed (1.1.0)
     Serilog (1.5.11)
+    SimpleInjector (3.1.1)
+    SimpleInjector.Extensions.ExecutionContextScoping (3.1.1)
+      SimpleInjector (>= 3.1.1)
     slf4net (0.1.32.1)
     structuremap (3.1.6.186)
     System.Collections (4.0.10) - framework: dnxcore50

--- a/src/Akka.sln
+++ b/src/Akka.sln
@@ -223,6 +223,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Persistence.Sqlite", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Persistence.Sqlite.Tests", "contrib\persistence\Akka.Persistence.Sqlite.Tests\Akka.Persistence.Sqlite.Tests.csproj", "{7A832BBF-053E-4E9F-BD83-D988A0130CC8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.DI.SimpleInjector", "contrib\dependencyInjection\Akka.DI.SimpleInjector\Akka.DI.SimpleInjector.csproj", "{C7745DC9-E4A7-4BFB-BF03-8A7A5CD92C97}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.DI.SimpleInjector.Tests", "contrib\dependencyInjection\Akka.DI.SimpleInjector.Tests\Akka.DI.SimpleInjector.Tests.csproj", "{6A1A6BB2-BA2C-4474-BA2E-298228C0A9BA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug Mono|Any CPU = Debug Mono|Any CPU
@@ -820,6 +824,22 @@ Global
 		{7A832BBF-053E-4E9F-BD83-D988A0130CC8}.Release Mono|Any CPU.Build.0 = Release|Any CPU
 		{7A832BBF-053E-4E9F-BD83-D988A0130CC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7A832BBF-053E-4E9F-BD83-D988A0130CC8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C7745DC9-E4A7-4BFB-BF03-8A7A5CD92C97}.Debug Mono|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7745DC9-E4A7-4BFB-BF03-8A7A5CD92C97}.Debug Mono|Any CPU.Build.0 = Debug|Any CPU
+		{C7745DC9-E4A7-4BFB-BF03-8A7A5CD92C97}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7745DC9-E4A7-4BFB-BF03-8A7A5CD92C97}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7745DC9-E4A7-4BFB-BF03-8A7A5CD92C97}.Release Mono|Any CPU.ActiveCfg = Release|Any CPU
+		{C7745DC9-E4A7-4BFB-BF03-8A7A5CD92C97}.Release Mono|Any CPU.Build.0 = Release|Any CPU
+		{C7745DC9-E4A7-4BFB-BF03-8A7A5CD92C97}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C7745DC9-E4A7-4BFB-BF03-8A7A5CD92C97}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A1A6BB2-BA2C-4474-BA2E-298228C0A9BA}.Debug Mono|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A1A6BB2-BA2C-4474-BA2E-298228C0A9BA}.Debug Mono|Any CPU.Build.0 = Debug|Any CPU
+		{6A1A6BB2-BA2C-4474-BA2E-298228C0A9BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A1A6BB2-BA2C-4474-BA2E-298228C0A9BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A1A6BB2-BA2C-4474-BA2E-298228C0A9BA}.Release Mono|Any CPU.ActiveCfg = Release|Any CPU
+		{6A1A6BB2-BA2C-4474-BA2E-298228C0A9BA}.Release Mono|Any CPU.Build.0 = Release|Any CPU
+		{6A1A6BB2-BA2C-4474-BA2E-298228C0A9BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A1A6BB2-BA2C-4474-BA2E-298228C0A9BA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -919,5 +939,7 @@ Global
 		{E7BC4F35-B9FB-49CB-B12C-CD00F6A08EA2} = {264C22A4-CAFC-41F6-B82C-4DDC5C196767}
 		{453EFD22-7C53-4887-9DBF-FCFC9172E909} = {264C22A4-CAFC-41F6-B82C-4DDC5C196767}
 		{7A832BBF-053E-4E9F-BD83-D988A0130CC8} = {264C22A4-CAFC-41F6-B82C-4DDC5C196767}
+		{C7745DC9-E4A7-4BFB-BF03-8A7A5CD92C97} = {B1D10183-8FAE-4506-B935-403FCED89BDB}
+		{6A1A6BB2-BA2C-4474-BA2E-298228C0A9BA} = {B1D10183-8FAE-4506-B935-403FCED89BDB}
 	EndGlobalSection
 EndGlobal

--- a/src/contrib/dependencyInjection/Akka.DI.SimpleInjector.Tests/Akka.DI.SimpleInjector.Tests.csproj
+++ b/src/contrib/dependencyInjection/Akka.DI.SimpleInjector.Tests/Akka.DI.SimpleInjector.Tests.csproj
@@ -1,0 +1,116 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{6A1A6BB2-BA2C-4474-BA2E-298228C0A9BA}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Akka.DI.SimpleInjector.Tests</RootNamespace>
+    <AssemblyName>Akka.DI.SimpleInjector.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Practices.Unity">
+      <HintPath>..\..\..\..\packages\Unity\lib\net45\Microsoft.Practices.Unity.dll</HintPath>
+    </Reference>
+    <Reference Include="SimpleInjector">
+      <HintPath>..\..\..\..\packages\SimpleInjector\lib\net45\SimpleInjector.dll</HintPath>
+    </Reference>
+    <Reference Include="SimpleInjector.Extensions.ExecutionContextScoping">
+      <HintPath>..\..\..\..\packages\SimpleInjector.Extensions.ExecutionContextScoping\lib\net45\SimpleInjector.Extensions.ExecutionContextScoping.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="SimpleInjectorDependencyResolverSpecs.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\core\Akka.TestKit\Akka.TestKit.csproj">
+      <Project>{0d3cbad0-bbdb-43e5-afc4-ed1d3ecdc224}</Project>
+      <Name>Akka.TestKit</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\core\Akka\Akka.csproj">
+      <Project>{5deddf90-37f0-48d3-a0b0-a5cbd8a7e377}</Project>
+      <Name>Akka</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\testkits\Akka.TestKit.Xunit2\Akka.TestKit.Xunit2.csproj">
+      <Project>{7dbd5c17-5e9d-40c4-9201-d092751532a7}</Project>
+      <Name>Akka.TestKit.Xunit2</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Akka.DI.Core\Akka.DI.Core.csproj">
+      <Project>{fdf09d18-b68e-4b95-b1f6-b89d9c6c3ae9}</Project>
+      <Name>Akka.DI.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Akka.DI.SimpleInjector\Akka.DI.SimpleInjector.csproj">
+      <Project>{c7745dc9-e4a7-4bfb-bf03-8a7a5cd92c97}</Project>
+      <Name>Akka.DI.SimpleInjector</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Akka.DI.TestKit\Akka.DI.TestKit.csproj">
+      <Project>{d8db14a5-6147-4512-bf5c-683fdca6190c}</Project>
+      <Name>Akka.DI.TestKit</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="paket.references" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <Import Project="..\..\..\..\.paket\paket.targets" />
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="SimpleInjector">
+          <HintPath>..\..\..\..\packages\SimpleInjector\lib\net45\SimpleInjector.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="SimpleInjector.Extensions.ExecutionContextScoping">
+          <HintPath>..\..\..\..\packages\SimpleInjector.Extensions.ExecutionContextScoping\lib\net45\SimpleInjector.Extensions.ExecutionContextScoping.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+</Project>

--- a/src/contrib/dependencyInjection/Akka.DI.SimpleInjector.Tests/Properties/AssemblyInfo.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.SimpleInjector.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,34 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Akka.DI.SimpleInjector.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")] 
+[assembly: AssemblyProduct("Akka.DI.SimpleInjector.Tests")] 
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("6a1a6bb2-ba2c-4474-ba2e-298228c0a9ba")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/contrib/dependencyInjection/Akka.DI.SimpleInjector.Tests/SimpleInjectorDependencyResolverSpecs.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.SimpleInjector.Tests/SimpleInjectorDependencyResolverSpecs.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Akka.Actor;
+using Akka.DI.Core;
+using Akka.DI.TestKit;
+using SimpleInjector;
+using SimpleInjector.Extensions.ExecutionContextScoping;
+
+namespace Akka.DI.SimpleInjector.Tests
+{
+    public class SimpleInjectorDependencyResolverSpecs : DiResolverSpec
+    {
+        protected override object NewDiContainer()
+        {
+            var container = new Container();
+            container.Options.DefaultScopedLifestyle = new ExecutionContextScopeLifestyle();           
+            return container;
+        }
+
+        protected override IDependencyResolver NewDependencyResolver(object diContainer, ActorSystem system)
+        {
+            var container = diContainer as Container;
+            return new SimpleInjectorDependencyResolver(container, system);
+        }
+
+        protected override void Bind<T>(object diContainer, Func<T> generator)
+        {
+            var container = diContainer as Container;
+            container.Register(generator, Lifestyle.Scoped);
+        }
+
+        protected override void Bind<T>(object diContainer)
+        {
+            var container = diContainer as Container;
+            container.Register<T>(Lifestyle.Scoped);
+        }
+    }
+}

--- a/src/contrib/dependencyInjection/Akka.DI.SimpleInjector.Tests/paket.references
+++ b/src/contrib/dependencyInjection/Akka.DI.SimpleInjector.Tests/paket.references
@@ -1,0 +1,2 @@
+SimpleInjector
+SimpleInjector.Extensions.ExecutionContextScoping

--- a/src/contrib/dependencyInjection/Akka.DI.SimpleInjector/Akka.DI.SimpleInjector.csproj
+++ b/src/contrib/dependencyInjection/Akka.DI.SimpleInjector/Akka.DI.SimpleInjector.csproj
@@ -1,0 +1,103 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C7745DC9-E4A7-4BFB-BF03-8A7A5CD92C97}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Akka.DI.SimpleInjector</RootNamespace>
+    <AssemblyName>Akka.DI.SimpleInjector</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="SimpleInjector, Version=3.1.0.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\packages\SimpleInjector\lib\net45\SimpleInjector.dll</HintPath>
+    </Reference>
+    <Reference Include="SimpleInjector.Extensions.ExecutionContextScoping, Version=3.1.0.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\packages\SimpleInjector.Extensions.ExecutionContextScoping\lib\net45\SimpleInjector.Extensions.ExecutionContextScoping.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="SimpleInjectorDependencyResolver.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Akka.DI.SimpleInjector.nuspec" />
+    <None Include="paket.references" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\core\Akka\Akka.csproj">
+      <Project>{5deddf90-37f0-48d3-a0b0-a5cbd8a7e377}</Project>
+      <Name>Akka</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Akka.DI.Core\Akka.DI.Core.csproj">
+      <Project>{fdf09d18-b68e-4b95-b1f6-b89d9c6c3ae9}</Project>
+      <Name>Akka.DI.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <Import Project="..\..\..\..\.paket\paket.targets" />
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="SimpleInjector">
+          <HintPath>..\..\..\..\packages\SimpleInjector\lib\net45\SimpleInjector.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="SimpleInjector.Extensions.ExecutionContextScoping">
+          <HintPath>..\..\..\..\packages\SimpleInjector.Extensions.ExecutionContextScoping\lib\net45\SimpleInjector.Extensions.ExecutionContextScoping.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+</Project>

--- a/src/contrib/dependencyInjection/Akka.DI.SimpleInjector/Akka.DI.SimpleInjector.nuspec
+++ b/src/contrib/dependencyInjection/Akka.DI.SimpleInjector/Akka.DI.SimpleInjector.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <id>@project@</id>
+    <title>@project@@title@</title>
+    <version>@build.number@</version>
+    <authors>@authors@</authors>
+    <owners>@authors@</owners>
+    <description>SimpleInjector Dependency Injection (DI) support for Akka.NET</description>
+    <licenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/akkadotnet/akka.net</projectUrl>
+    <iconUrl>http://getakka.net/images/AkkaNetLogo.Normal.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes>@releaseNotes@</releaseNotes>
+    <copyright>@copyright@</copyright>
+    <tags>@tags@ DI SimpleInjector</tags>
+    @dependencies@
+    @references@
+  </metadata>
+</package>

--- a/src/contrib/dependencyInjection/Akka.DI.SimpleInjector/Properties/AssemblyInfo.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.SimpleInjector/Properties/AssemblyInfo.cs
@@ -1,0 +1,28 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AssemblyInfo.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Akka.DI.SimpleInjector")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyProduct("Akka.DI.SimpleInjector")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("c7745dc9-e4a7-4bfb-bf03-8a7a5cd92c97")]
+ 

--- a/src/contrib/dependencyInjection/Akka.DI.SimpleInjector/SimpleInjectorDependencyResolver.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.SimpleInjector/SimpleInjectorDependencyResolver.cs
@@ -1,0 +1,121 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SimpleInjectorDependencyResolver.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Akka.Actor;
+using Akka.DI.Core;
+using SimpleInjector;
+using SimpleInjector.Extensions.ExecutionContextScoping;
+using Scope = SimpleInjector.Scope;
+
+namespace Akka.DI.SimpleInjector
+{
+    /// <summary>
+    /// Provides services to the <see cref="ActorSystem "/> extension _system
+    /// used to create actors using the SimpleInject IoC _container.
+    /// </summary>
+    public class SimpleInjectorDependencyResolver : IDependencyResolver
+    {
+        private readonly Container _container;
+        private readonly ConcurrentDictionary<string, Type> _typeCache;
+        private readonly ActorSystem _system;
+        private readonly ConditionalWeakTable<ActorBase, Scope> _references;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SimpleInjectorDependencyResolver"/> class.
+        /// </summary>
+        /// <param name="container">The _container used to resolve _references</param>
+        /// <param name="system">The actor _system to plug into</param>
+        /// <exception cref="ArgumentNullException">
+        /// Either the <paramref name="container"/> or the <paramref name="system"/> was null.
+        /// </exception>
+        public SimpleInjectorDependencyResolver(Container container, ActorSystem system)
+        {
+            if (system == null) throw new ArgumentNullException("system");
+            if (container == null) throw new ArgumentNullException("container");
+            this._container = container;
+            _typeCache = new ConcurrentDictionary<string, Type>(StringComparer.InvariantCultureIgnoreCase);
+            this._system = system;
+            this._system.AddDependencyResolver(this);
+            this._references = new ConditionalWeakTable<ActorBase, Scope>();
+        }
+
+        /// <summary>
+        /// Retrieves an actor's type with the specified name
+        /// </summary>
+        /// <param name="actorName">The name of the actor to retrieve</param>
+        /// <returns>The type with the specified actor name</returns>
+        public Type GetType(string actorName)
+        {
+            _typeCache.
+                TryAdd(actorName,
+                  //     actorName.GetTypeValue() ??
+                       _container.GetRootRegistrations().
+                       Where(registration => registration.ServiceType
+                                 .Name.Equals(actorName, StringComparison.InvariantCultureIgnoreCase)).
+                        Select(registration => registration.ServiceType).
+                        FirstOrDefault());
+
+            return _typeCache[actorName];
+        }
+
+        /// <summary>
+        /// Creates a delegate factory used to create actors based on their type
+        /// </summary>
+        /// <param name="actorType">The type of actor that the factory builds</param>
+        /// <returns>A delegate factory used to create actors</returns>
+        public Func<ActorBase> CreateActorFactory(Type actorType)
+        {
+            return () =>
+            {               
+                var scope =_container.BeginExecutionContextScope();
+                
+                var actor = (ActorBase) _container.GetInstance(actorType);
+
+                _references.Add(actor, scope);
+                return actor;
+            };
+        }
+
+        /// <summary>
+        /// Used to register the configuration for an actor of the specified type <typeparamref name="TActor"/>
+        /// </summary>
+        /// <typeparam name="TActor">The type of actor the configuration is based</typeparam>
+        /// <returns>The configuration object for the given actor type</returns>
+        public Props Create<TActor>() where TActor : ActorBase
+        {
+            return Create(typeof(TActor));
+        }
+
+        /// <summary>
+        /// Used to register the configuration for an actor of the specified type <paramref name="actorType"/> 
+        /// </summary>
+        /// <param name="actorType">The <see cref="Type"/> of actor the configuration is based</param>
+        /// <returns>The configuration object for the given actor type</returns>
+        public virtual Props Create(Type actorType)
+        {
+            return _system.GetExtension<DIExt>().Props(actorType);
+        }
+
+        /// <summary>
+        /// Signals the _container to release it's reference to the actor.
+        /// </summary>
+        /// <param name="actor">The actor to remove from the _container</param>
+        public void Release(ActorBase actor)
+        {
+            Scope scope;
+
+            if (_references.TryGetValue(actor, out scope))
+
+                _references.Remove(actor);
+                scope.Dispose();
+            }
+        }
+}

--- a/src/contrib/dependencyInjection/Akka.DI.SimpleInjector/paket.references
+++ b/src/contrib/dependencyInjection/Akka.DI.SimpleInjector/paket.references
@@ -1,0 +1,2 @@
+SimpleInjector
+SimpleInjector.Extensions.ExecutionContextScoping

--- a/src/contrib/dependencyInjection/Akka.DI.TestKit/DiResolverSpec.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.TestKit/DiResolverSpec.cs
@@ -119,7 +119,7 @@ namespace Akka.DI.TestKit
         class ConcreteDiSingleton : IDiSingleton
         {
             AtomicCounter _counter = new AtomicCounter(0);
-            public int CallCount { get { return _counter.Current; }}
+            public int CallCount { get { return _counter.Current; } }
 
             public void Call()
             {
@@ -201,7 +201,7 @@ namespace Akka.DI.TestKit
             : base(new XunitAssertions(), config, actorSystemName, testActorName)
         {
             _pid = "p-" + Counter.IncrementAndGet();
-// ReSharper disable once DoNotCallOverridableMethodsInConstructor
+            // ReSharper disable once DoNotCallOverridableMethodsInConstructor
             var resolver = ConfigureDependencyResolver(Sys);
         }
 
@@ -242,7 +242,7 @@ namespace Akka.DI.TestKit
         /// <typeparam name="T">The type we're binding onto the DI container.</typeparam>
         /// <param name="diContainer">The DI container.</param>
         /// <param name="generator">A generator function that yields new objects of type <typeparam name="T"/>.</param>
-        protected abstract void Bind<T>(object diContainer, Func<T> generator);
+        protected abstract void Bind<T>(object diContainer, Func<T> generator) where T : class;
 
         /// <summary>
         /// Create a binding for type <typeparam name="T"/> on the provided DI container.
@@ -252,7 +252,7 @@ namespace Akka.DI.TestKit
         /// </summary>
         /// <typeparam name="T">The type we're binding onto the DI container.</typeparam>
         /// <param name="diContainer">The DI container.</param>
-        protected abstract void Bind<T>(object diContainer);
+        protected abstract void Bind<T>(object diContainer) where T : class;
 
         #endregion
 
@@ -344,7 +344,7 @@ namespace Akka.DI.TestKit
             var stashActorProps = Sys.DI().Props<UnboundedStashActor>();
             var stashActor = Sys.ActorOf(stashActorProps);
 
-            var internalRef = (LocalActorRef) stashActor;
+            var internalRef = (LocalActorRef)stashActor;
 
             Assert.IsType<UnboundedDequeBasedMailbox>(internalRef.Cell.Mailbox);
         }


### PR DESCRIPTION
adding Akka.DI.SimpleInjector with tests SimpleInjector dependency resolver.
I have implemented it basing on other DI implementations, i have also included the Shared assembly info.

One point of attention i had to change the two base Bind<T> methods on DiResolverSpec so it could call Register<T> on SimpleInjector wich has a clause T:class

