### PR TITLE
Remove NuGet -self restore

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -2,23 +2,6 @@
 
 pushd %~dp0
 
-SETLOCAL
-SET CACHED_NUGET=%LocalAppData%\NuGet\NuGet.exe
-
-IF EXIST %CACHED_NUGET% goto copynuget
-echo Downloading latest version of NuGet.exe...
-IF NOT EXIST %LocalAppData%\NuGet md %LocalAppData%\NuGet
-@powershell -NoProfile -ExecutionPolicy unrestricted -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://www.nuget.org/nuget.exe' -OutFile '%CACHED_NUGET%'"
-
-:copynuget
-IF EXIST src\.nuget\nuget.exe goto restore
-md src\.nuget
-copy %CACHED_NUGET% src\.nuget\nuget.exe > nul
-
-:restore
-
-src\.nuget\NuGet.exe update -self
-
 cls
 
 .paket\paket.bootstrapper.exe

--- a/build.fsx
+++ b/build.fsx
@@ -56,7 +56,7 @@ let testOutput = FullName "TestResults"
 let nugetDir = binDir @@ "nuget"
 let workingDir = binDir @@ "build"
 let libDir = workingDir @@ @"lib\net45\"
-let nugetExe = FullName @"src\.nuget\NuGet.exe"
+let nugetExe = FullName @"./packages/NuGet.CommandLine/tools/NuGet.exe"
 let docDir = "bin" @@ "doc"
 
 

--- a/build.sh
+++ b/build.sh
@@ -8,13 +8,6 @@ cd `dirname ${SCRIPT_PATH}` > /dev/null
 SCRIPT_PATH=`pwd`;
 popd  > /dev/null
 
-if ! [ -f $SCRIPT_PATH/src/.nuget/nuget.exe ] 
-    then
-        wget "https://www.nuget.org/nuget.exe" -P $SCRIPT_PATH/src/.nuget/
-fi
-
-mono $SCRIPT_PATH/src/.nuget/nuget.exe update -self
-
 if test "$OS" = "Windows_NT"
 then
   # use .Net


### PR DESCRIPTION
Not sure why this was still in place. AFAIK we use NuGet.CommandLine package to pack new nupkgs.