### PR TITLE
Stashing fix

### DIFF
--- a/src/core/Akka.Remote.Tests/RemoteConsistentHashingRouterSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteConsistentHashingRouterSpec.cs
@@ -43,7 +43,7 @@ namespace Akka.Remote.Tests
             var keys = new List<string>(new [] { "A", "B", "C", "D", "E", "F", "G"});
             var result1 = keys.Select(k => consistentHash1.NodeFor(k).Routee);
             var result2 = keys.Select(k => consistentHash2.NodeFor(k).Routee);
-            result1.ShouldBeEquivalentTo(result2);
+            Assert.Equal(result2,result1);
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/Stash/ActorWithStashSpec.cs
+++ b/src/core/Akka.Tests/Actor/Stash/ActorWithStashSpec.cs
@@ -59,6 +59,17 @@ namespace Akka.Tests.Actor.Stash
         }
 
         [Fact]
+        public void An_actor_Should__not_throw_an_exception_if_the_same_message_is_received_and_stashed_twice()
+        {
+            _state.ExpectedException = new TestLatch();
+            var stasher = ActorOf<StashAndReplyActor>("stashing-actor");
+            stasher.Tell("hello");
+            ExpectMsg("bye");
+            stasher.Tell("hello");
+            ExpectMsg("bye");
+        }
+
+        [Fact]
         public void An_actor_must_unstash_all_messages_on_PostStop()
         {
             var stasher = ActorOf<StashEverythingActor>("stasher");
@@ -170,6 +181,20 @@ namespace Akka.Tests.Actor.Stash
                 ReceiveAny(_ => { }); //Do nothing
             }
 
+            public IStash Stash { get; set; }
+        }
+
+        private class StashAndReplyActor : ReceiveActor, IWithUnboundedStash
+        {
+            public StashAndReplyActor()
+            {
+                ReceiveAny(m =>
+                {
+                    Stash.Stash();
+                    Sender.Tell("bye");
+                }
+                );
+            }
             public IStash Stash { get; set; }
         }
 

--- a/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
+++ b/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
@@ -36,6 +36,12 @@ namespace Akka.Actor
             }
         }
 
+        private int _currentEnvelopeId;
+
+        public int CurrentEnvelopeId
+        {
+            get { return _currentEnvelopeId; }
+        }
         /// <summary>
         ///     Invokes the specified envelope.
         /// </summary>
@@ -44,6 +50,7 @@ namespace Akka.Actor
         {
             var message = envelope.Message;
             CurrentMessage = message;
+            _currentEnvelopeId ++;
             Sender = MatchSender(envelope);
 
             try

--- a/src/core/Akka/Actor/Stash/Internal/AbstractStash.cs
+++ b/src/core/Akka/Actor/Stash/Internal/AbstractStash.cs
@@ -51,6 +51,8 @@ An (unbounded) deque-based mailbox can be configured as follows:
 
         private IDequeBasedMailbox Mailbox { get { return (IDequeBasedMailbox)_actorCell.Mailbox; } }
 
+        private int _currentEnvelopeId;
+
         /// <summary>
         /// Stashes the current message in the actor's state.
         /// </summary>
@@ -61,12 +63,13 @@ An (unbounded) deque-based mailbox can be configured as follows:
         {
             var currMsg = _actorCell.CurrentMessage;
             var sender = _actorCell.Sender;
-            if(_theStash.Count > 0)
+
+            if (_actorCell.CurrentEnvelopeId == _currentEnvelopeId)
             {
-                var lastEnvelope = _theStash.Last.Value;
-                if(ReferenceEquals(lastEnvelope.Message,currMsg) && lastEnvelope.Sender == sender)
-                    throw new IllegalActorStateException(string.Format("Can't stash the same message {0} more than once", currMsg));
+                 throw new IllegalActorStateException(string.Format("Can't stash the same message {0} more than once", currMsg));
             }
+            _currentEnvelopeId = _actorCell.CurrentEnvelopeId;
+            
             if(_capacity <= 0 || _theStash.Count < _capacity)
                 _theStash.AddLast(new Envelope() { Message = currMsg, Sender = sender });
             else throw new StashOverflowException(string.Format("Couldn't enqueue message {0} to stash of {1}", currMsg, _actorCell.Self));


### PR DESCRIPTION
This is a suggestion on how to solve the stashing #1400 issue
The mechanics in this PR works by incrementing an envelopeId in the actorcell for each user message received.
Once you call `Stash` the stash plugin will check if it has already stashed this envelope Id.

This has minimal impact on performance and we can still keep our envelopes as structs.
The solution is also unaffected by async await features as the envelope ID is only touched when processing user messages.

Thoughts?