### PR TITLE
Add wire back as contrib package + Serialization TestKit

### DIFF
--- a/src/Akka.sln
+++ b/src/Akka.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.24606.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{69279534-1DBA-4115-BF8B-03F77FC8125E}"
 EndProject
@@ -224,6 +224,14 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Persistence.Sqlite", "contrib\persistence\Akka.Persistence.Sqlite\Akka.Persistence.Sqlite.csproj", "{453EFD22-7C53-4887-9DBF-FCFC9172E909}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Persistence.Sqlite.Tests", "contrib\persistence\Akka.Persistence.Sqlite.Tests\Akka.Persistence.Sqlite.Tests.csproj", "{7A832BBF-053E-4E9F-BD83-D988A0130CC8}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Serializers", "Serializers", "{0E55F1F8-E212-43D7-A0C0-ACEA9794B0D7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Serialization.Wire", "contrib\serializers\Akka.Serialization.Wire\Akka.Serialization.Wire.csproj", "{B47CA568-40CF-48DE-B87E-31BD400EBB08}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Serialization.TestKit", "contrib\serializers\Akka.Serialization.TestKit\Akka.Serialization.TestKit.csproj", "{CAA97041-CFC0-4081-9BD2-8B139E62A611}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Serialization.WireTests", "contrib\serializers\Akka.Serialization.WireTests\Akka.Serialization.WireTests.csproj", "{402FA351-D6C6-40FD-8868-F07156035919}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -822,6 +830,30 @@ Global
 		{7A832BBF-053E-4E9F-BD83-D988A0130CC8}.Release Mono|Any CPU.Build.0 = Release|Any CPU
 		{7A832BBF-053E-4E9F-BD83-D988A0130CC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7A832BBF-053E-4E9F-BD83-D988A0130CC8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B47CA568-40CF-48DE-B87E-31BD400EBB08}.Debug Mono|Any CPU.ActiveCfg = Debug|Any CPU
+		{B47CA568-40CF-48DE-B87E-31BD400EBB08}.Debug Mono|Any CPU.Build.0 = Debug|Any CPU
+		{B47CA568-40CF-48DE-B87E-31BD400EBB08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B47CA568-40CF-48DE-B87E-31BD400EBB08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B47CA568-40CF-48DE-B87E-31BD400EBB08}.Release Mono|Any CPU.ActiveCfg = Release|Any CPU
+		{B47CA568-40CF-48DE-B87E-31BD400EBB08}.Release Mono|Any CPU.Build.0 = Release|Any CPU
+		{B47CA568-40CF-48DE-B87E-31BD400EBB08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B47CA568-40CF-48DE-B87E-31BD400EBB08}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CAA97041-CFC0-4081-9BD2-8B139E62A611}.Debug Mono|Any CPU.ActiveCfg = Debug|Any CPU
+		{CAA97041-CFC0-4081-9BD2-8B139E62A611}.Debug Mono|Any CPU.Build.0 = Debug|Any CPU
+		{CAA97041-CFC0-4081-9BD2-8B139E62A611}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CAA97041-CFC0-4081-9BD2-8B139E62A611}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CAA97041-CFC0-4081-9BD2-8B139E62A611}.Release Mono|Any CPU.ActiveCfg = Release|Any CPU
+		{CAA97041-CFC0-4081-9BD2-8B139E62A611}.Release Mono|Any CPU.Build.0 = Release|Any CPU
+		{CAA97041-CFC0-4081-9BD2-8B139E62A611}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CAA97041-CFC0-4081-9BD2-8B139E62A611}.Release|Any CPU.Build.0 = Release|Any CPU
+		{402FA351-D6C6-40FD-8868-F07156035919}.Debug Mono|Any CPU.ActiveCfg = Debug|Any CPU
+		{402FA351-D6C6-40FD-8868-F07156035919}.Debug Mono|Any CPU.Build.0 = Debug|Any CPU
+		{402FA351-D6C6-40FD-8868-F07156035919}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{402FA351-D6C6-40FD-8868-F07156035919}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{402FA351-D6C6-40FD-8868-F07156035919}.Release Mono|Any CPU.ActiveCfg = Release|Any CPU
+		{402FA351-D6C6-40FD-8868-F07156035919}.Release Mono|Any CPU.Build.0 = Release|Any CPU
+		{402FA351-D6C6-40FD-8868-F07156035919}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{402FA351-D6C6-40FD-8868-F07156035919}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -921,5 +953,9 @@ Global
 		{E7BC4F35-B9FB-49CB-B12C-CD00F6A08EA2} = {264C22A4-CAFC-41F6-B82C-4DDC5C196767}
 		{453EFD22-7C53-4887-9DBF-FCFC9172E909} = {264C22A4-CAFC-41F6-B82C-4DDC5C196767}
 		{7A832BBF-053E-4E9F-BD83-D988A0130CC8} = {264C22A4-CAFC-41F6-B82C-4DDC5C196767}
+		{0E55F1F8-E212-43D7-A0C0-ACEA9794B0D7} = {588C1513-FAB6-42C3-B6FC-3485F13620CF}
+		{B47CA568-40CF-48DE-B87E-31BD400EBB08} = {0E55F1F8-E212-43D7-A0C0-ACEA9794B0D7}
+		{CAA97041-CFC0-4081-9BD2-8B139E62A611} = {0E55F1F8-E212-43D7-A0C0-ACEA9794B0D7}
+		{402FA351-D6C6-40FD-8868-F07156035919} = {0E55F1F8-E212-43D7-A0C0-ACEA9794B0D7}
 	EndGlobalSection
 EndGlobal

--- a/src/contrib/serializers/Akka.Serialization.TestKit/Akka.Serialization.TestKit.csproj
+++ b/src/contrib/serializers/Akka.Serialization.TestKit/Akka.Serialization.TestKit.csproj
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CAA97041-CFC0-4081-9BD2-8B139E62A611}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Akka.Serialization.TestKit</RootNamespace>
+    <AssemblyName>Akka.Serialization.TestKit</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AkkaSerializationSpec.cs" />
+    <Compile Include="ContainerMessage.cs" />
+    <Compile Include="EmptyActor.cs" />
+    <Compile Include="ImmutableMessage.cs" />
+    <Compile Include="ImmutableMessageWithPrivateCtor.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SomeMessage.cs" />
+    <Compile Include="UntypedContainerMessage.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\core\Akka.TestKit\Akka.TestKit.csproj">
+      <Project>{0d3cbad0-bbdb-43e5-afc4-ed1d3ecdc224}</Project>
+      <Name>Akka.TestKit</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\core\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj">
+      <Project>{e636d23c-3432-4aa9-9a5d-5f29d33d3399}</Project>
+      <Name>Akka.Tests.Shared.Internals</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\core\Akka\Akka.csproj">
+      <Project>{5deddf90-37f0-48d3-a0b0-a5cbd8a7e377}</Project>
+      <Name>Akka</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\testkits\Akka.TestKit.Xunit2\Akka.TestKit.Xunit2.csproj">
+      <Project>{7dbd5c17-5e9d-40c4-9201-d092751532a7}</Project>
+      <Name>Akka.TestKit.Xunit2</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/contrib/serializers/Akka.Serialization.TestKit/AkkaSerializationSpec.cs
+++ b/src/contrib/serializers/Akka.Serialization.TestKit/AkkaSerializationSpec.cs
@@ -1,0 +1,419 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SerializationSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Dispatch.SysMsg;
+using Akka.Routing;
+using Akka.TestKit.TestActors;
+using Xunit;
+
+namespace Akka.Tests.Serialization
+{
+    public abstract class AkkaSerializationSpec : TestKit.Xunit2.TestKit
+    {
+        protected AkkaSerializationSpec(Type serializerType):base(GetConfig(serializerType))
+        {
+        }
+
+        private static string GetConfig(Type serializerType)
+        {
+            return @"
+
+akka.actor {
+    serializers {
+        testserializer = """ + serializerType.AssemblyQualifiedName + @"""
+    }
+
+    serialization-bindings {
+      ""System.Object"" = testserializer
+    }
+}
+";
+        }
+
+        [Fact]
+        public void CanSerializeAddressMessage()
+        {
+            var message = new UntypedContainerMessage { Contents = new Address("abc", "def") };
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeDecimal()
+        {
+            var message = 123.456m;
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeDecimalMessage()
+        {
+            var message = new UntypedContainerMessage { Contents = 123.456m };
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeFloatMessage()
+        {
+            var message = new UntypedContainerMessage { Contents = 123.456f };
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeLongMessage()
+        {
+            var message = new UntypedContainerMessage { Contents = 123L };
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeDoubleMessage()
+        {
+            var message = new UntypedContainerMessage { Contents = 123.456d };
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeIntMessage()
+        {
+            var message = new UntypedContainerMessage { Contents = 123 };
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeLong()
+        {
+            var message = 123L;
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeDouble()
+        {
+            var message = 123.456d;
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeInt()
+        {
+            var message = 123;
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeFloat()
+        {
+            var message = 123.456f;
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeAddress()
+        {
+            var message = new Address("abc", "def", "ghi", 123);
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeImmutableMessages()
+        {
+            var message = new ImmutableMessage(Tuple.Create("aaa", "bbb"));
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeImmutableMessagesWithPrivateCtor()
+        {
+            var message = new ImmutableMessageWithPrivateCtor(Tuple.Create("aaa", "bbb"));
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeProps()
+        {
+            var message = Props.Create<BlackHoleActor>().WithMailbox("abc").WithDispatcher("def");
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeDeploy()
+        {
+            var message = new Deploy(RouterConfig.NoRouter).WithMailbox("abc");
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeRemoteScope()
+        {
+            var message = new RemoteScope(new Address("akka.tcp", "foo", "localhost", 8080));
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeLocalScope()
+        {
+            var message = LocalScope.Instance;
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeRoundRobinPool()
+        {
+            var decider = Decider.From(
+             Directive.Restart,
+             Directive.Stop.When<ArgumentException>(),
+             Directive.Stop.When<NullReferenceException>());
+
+            var supervisor = new OneForOneStrategy(decider);
+
+            var message = new RoundRobinPool(10, new DefaultResizer(0, 1), supervisor, "abc");
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeRoundRobinGroup()
+        {
+            var message = new RoundRobinGroup("abc");
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeRandomPool()
+        {
+            var decider = Decider.From(
+             Directive.Restart,
+             Directive.Stop.When<ArgumentException>(),
+             Directive.Stop.When<NullReferenceException>());
+
+            var supervisor = new OneForOneStrategy(decider);
+
+            var message = new RandomPool(10, new DefaultResizer(0, 1), supervisor, "abc");
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeRandomGroup()
+        {
+            var message = new RandomGroup("abc");
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeConsistentHashPool()
+        {
+            var decider = Decider.From(
+               Directive.Restart,
+               Directive.Stop.When<ArgumentException>(),
+               Directive.Stop.When<NullReferenceException>());
+
+            var supervisor = new OneForOneStrategy(decider);
+
+            var message = new ConsistentHashingPool(10, null, supervisor, "abc");
+            AssertEqual(message);
+        }
+
+
+        [Fact]
+        public void CanSerializeTailChoppingPool()
+        {
+            var decider = Decider.From(
+             Directive.Restart,
+             Directive.Stop.When<ArgumentException>(),
+             Directive.Stop.When<NullReferenceException>());
+
+            var supervisor = new OneForOneStrategy(decider);
+
+            var message = new TailChoppingPool(10, null, supervisor, "abc", TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(2));
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeScatterGatherFirstCompletedPool()
+        {
+            var decider = Decider.From(
+             Directive.Restart,
+             Directive.Stop.When<ArgumentException>(),
+             Directive.Stop.When<NullReferenceException>());
+
+            var supervisor = new OneForOneStrategy(decider);
+
+            var message = new ScatterGatherFirstCompletedPool(10, null, supervisor, "abc", TimeSpan.MaxValue);
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeSmallestMailboxPool()
+        {
+            var decider = Decider.From(
+             Directive.Restart,
+             Directive.Stop.When<ArgumentException>(),
+             Directive.Stop.When<NullReferenceException>());
+
+            var supervisor = new OneForOneStrategy(decider);
+
+            var message = new SmallestMailboxPool(10, null, supervisor, "abc");
+            AssertEqual(message);
+        }
+
+        [Fact]
+        public void CanSerializeResizer()
+        {
+            var message = new DefaultResizer(1, 20);
+            AssertEqual(message);
+        }
+
+        private void AssertEqual<T>(T message)
+        {
+            var serializer = Sys.Serialization.FindSerializerFor(message);
+            var serialized = serializer.ToBinary(message);
+            var result = serializer.FromBinary(serialized, typeof(T));
+            var deserialized = (T)result;
+
+            //     Assert.True(message.Equals(deserialized));
+            Assert.Equal(message, deserialized);
+        }
+
+
+        [Fact]
+        public void CanSerializeConfig()
+        {
+            var message = ConfigurationFactory.Default();
+            var serializer = Sys.Serialization.FindSerializerFor(message);
+            var serialized = serializer.ToBinary(message);
+            var deserialized = (Config)serializer.FromBinary(serialized, typeof(Config));
+
+            var config1 = message.ToString();
+            var config2 = deserialized.ToString();
+
+            Assert.Equal(config1, config2);
+        }
+
+
+        [Fact]
+        public void CanSerializeActorRef()
+        {
+            var message = new SomeMessage
+            {
+                ActorRef = TestActor,
+            };
+
+            var serializer = Sys.Serialization.FindSerializerFor(message);
+            var serialized = serializer.ToBinary(message);
+            var deserialized = (SomeMessage)serializer.FromBinary(serialized, typeof(SomeMessage));
+
+            Assert.Same(TestActor, deserialized.ActorRef);
+        }
+
+        [Fact]
+        public void CanSerializeActorPath()
+        {
+            var uri = "akka.tcp://sys@localhost:9000/user/actor";
+            var actorPath = ActorPath.Parse(uri);
+
+            AssertEqual(actorPath);
+        }
+
+        [Fact]
+        public void CanSerializeActorPathContainer()
+        {
+            var uri = "akka.tcp://sys@localhost:9000/user/actor";
+            var actorPath = ActorPath.Parse(uri);
+            var container = new ContainerMessage<ActorPath>(actorPath);
+            var serializer = Sys.Serialization.FindSerializerFor(container);
+            var serialized = serializer.ToBinary(container);
+            var deserialized = (ContainerMessage<ActorPath>)serializer.FromBinary(serialized, typeof(ContainerMessage<ActorPath>));
+
+            Assert.Equal(actorPath, deserialized.Contents);
+        }
+
+        [Fact]
+        public void CanSerializeSingletonMessages()
+        {
+            var message = Terminate.Instance;
+
+            var serializer = Sys.Serialization.FindSerializerFor(message);
+            var serialized = serializer.ToBinary(message);
+            var deserialized = (Terminate)serializer.FromBinary(serialized, typeof(Terminate));
+
+            Assert.NotNull(deserialized);
+        }
+
+        [Fact]
+        public void CanTranslateActorRefFromSurrogateType()
+        {
+            var aref = ActorOf<BlackHoleActor>();
+            AssertEqual(aref);
+        }
+
+        [Fact]
+        public void CanSerializeDecider()
+        {
+            var decider = Decider.From(
+                Directive.Restart,
+                Directive.Stop.When<ArgumentException>(),
+                Directive.Stop.When<NullReferenceException>());
+
+            var serializer = Sys.Serialization.FindSerializerFor(decider);
+            var bytes = serializer.ToBinary(decider);
+            var sref = (DeployableDecider)serializer.FromBinary(bytes, typeof(DeployableDecider));
+            Assert.NotNull(sref);
+            Assert.Equal(decider.Pairs[0], sref.Pairs[0]);
+            Assert.Equal(decider.Pairs[1], sref.Pairs[1]);
+            Assert.Equal(decider.DefaultDirective, sref.DefaultDirective);
+        }
+
+        [Fact]
+        public void CanSerializeSupervisor()
+        {
+            var decider = Decider.From(
+                Directive.Restart,
+                Directive.Stop.When<ArgumentException>(),
+                Directive.Stop.When<NullReferenceException>());
+
+            var supervisor = new OneForOneStrategy(decider);
+
+            var serializer = Sys.Serialization.FindSerializerFor(supervisor);
+            var bytes = serializer.ToBinary(supervisor);
+            var sref = (OneForOneStrategy)serializer.FromBinary(bytes, typeof(OneForOneStrategy));
+            Assert.NotNull(sref);
+            var sdecider = sref.Decider as DeployableDecider;
+            Assert.Equal(decider.Pairs[0], sdecider.Pairs[0]);
+            Assert.Equal(decider.Pairs[1], sdecider.Pairs[1]);
+            Assert.Equal(supervisor.MaxNumberOfRetries, sref.MaxNumberOfRetries);
+            Assert.Equal(supervisor.WithinTimeRangeMilliseconds, sref.WithinTimeRangeMilliseconds);
+            Assert.Equal(decider.DefaultDirective, sdecider.DefaultDirective);
+        }
+
+
+        //TODO: find out why this fails on build server
+
+        [Fact(Skip = "Fails on buildserver")]
+        public void CanSerializeFutureActorRef()
+        {
+            Sys.EventStream.Subscribe(TestActor, typeof(object));
+            var empty = Sys.ActorOf<EmptyActor>();
+            empty.Ask("hello");
+            var f = ExpectMsg<FutureActorRef>();
+
+
+            var message = new SomeMessage
+            {
+                ActorRef = f,
+            };
+
+            var serializer = Sys.Serialization.FindSerializerFor(message);
+            var serialized = serializer.ToBinary(message);
+            var deserialized = (SomeMessage)serializer.FromBinary(serialized, typeof(SomeMessage));
+
+            Assert.Same(f, deserialized.ActorRef);
+        }        
+    }
+}
+

--- a/src/contrib/serializers/Akka.Serialization.TestKit/ContainerMessage.cs
+++ b/src/contrib/serializers/Akka.Serialization.TestKit/ContainerMessage.cs
@@ -1,0 +1,11 @@
+namespace Akka.Tests.Serialization
+{
+    public class ContainerMessage<T>
+    {
+        public ContainerMessage(T contents)
+        {
+            Contents = contents;
+        }
+        public T Contents { get; private set; }
+    }
+}

--- a/src/contrib/serializers/Akka.Serialization.TestKit/EmptyActor.cs
+++ b/src/contrib/serializers/Akka.Serialization.TestKit/EmptyActor.cs
@@ -1,0 +1,12 @@
+using Akka.Actor;
+
+namespace Akka.Tests.Serialization
+{
+    public class EmptyActor : UntypedActor
+    {
+        protected override void OnReceive(object message)
+        {
+            Context.System.EventStream.Publish(Sender);
+        }
+    }
+}

--- a/src/contrib/serializers/Akka.Serialization.TestKit/ImmutableMessage.cs
+++ b/src/contrib/serializers/Akka.Serialization.TestKit/ImmutableMessage.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace Akka.Tests.Serialization
+{
+    public class ImmutableMessage
+    {
+        public string Foo { get; private set; }
+        public string Bar { get; private set; }
+
+        public ImmutableMessage()
+        {
+
+        }
+
+        protected bool Equals(ImmutableMessage other)
+        {
+            return string.Equals(Bar, other.Bar) && string.Equals(Foo, other.Foo);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return Equals((ImmutableMessage)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((Bar != null ? Bar.GetHashCode() : 0) * 397) ^ (Foo != null ? Foo.GetHashCode() : 0);
+            }
+        }
+
+        public ImmutableMessage(Tuple<string, string> nonConventionalArg)
+        {
+            Foo = nonConventionalArg.Item1;
+            Bar = nonConventionalArg.Item2;
+        }
+    }
+}

--- a/src/contrib/serializers/Akka.Serialization.TestKit/ImmutableMessageWithPrivateCtor.cs
+++ b/src/contrib/serializers/Akka.Serialization.TestKit/ImmutableMessageWithPrivateCtor.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace Akka.Tests.Serialization
+{
+    public class ImmutableMessageWithPrivateCtor
+    {
+        public string Foo { get; private set; }
+        public string Bar { get; private set; }
+
+        protected ImmutableMessageWithPrivateCtor()
+        {
+        }
+
+        protected bool Equals(ImmutableMessageWithPrivateCtor other)
+        {
+            return String.Equals(Bar, other.Bar) && String.Equals(Foo, other.Foo);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return Equals((ImmutableMessageWithPrivateCtor)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((Bar != null ? Bar.GetHashCode() : 0) * 397) ^ (Foo != null ? Foo.GetHashCode() : 0);
+            }
+        }
+
+        public ImmutableMessageWithPrivateCtor(Tuple<string, string> nonConventionalArg)
+        {
+            Foo = nonConventionalArg.Item1;
+            Bar = nonConventionalArg.Item2;
+        }
+    }
+}

--- a/src/contrib/serializers/Akka.Serialization.TestKit/Properties/AssemblyInfo.cs
+++ b/src/contrib/serializers/Akka.Serialization.TestKit/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Akka.Serialization.TestKit")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Akka.Serialization.TestKit")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("caa97041-cfc0-4081-9bd2-8b139e62a611")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/contrib/serializers/Akka.Serialization.TestKit/SomeMessage.cs
+++ b/src/contrib/serializers/Akka.Serialization.TestKit/SomeMessage.cs
@@ -1,0 +1,9 @@
+using Akka.Actor;
+
+namespace Akka.Tests.Serialization
+{
+    public class SomeMessage
+    {
+        public IActorRef ActorRef { get; set; }
+    }
+}

--- a/src/contrib/serializers/Akka.Serialization.TestKit/UntypedContainerMessage.cs
+++ b/src/contrib/serializers/Akka.Serialization.TestKit/UntypedContainerMessage.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace Akka.Tests.Serialization
+{
+    public class UntypedContainerMessage : IEquatable<UntypedContainerMessage>
+    {
+        public bool Equals(UntypedContainerMessage other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Equals(Contents, other.Contents);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((UntypedContainerMessage)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return (Contents != null ? Contents.GetHashCode() : 0);
+        }
+
+        public static bool operator ==(UntypedContainerMessage left, UntypedContainerMessage right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(UntypedContainerMessage left, UntypedContainerMessage right)
+        {
+            return !Equals(left, right);
+        }
+
+        public object Contents { get; set; }
+
+        public override string ToString()
+        {
+            return String.Format("<UntypedContainerMessage {0}>", Contents);
+        }
+    }
+}

--- a/src/contrib/serializers/Akka.Serialization.TestKit/packages.config
+++ b/src/contrib/serializers/Akka.Serialization.TestKit/packages.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+</packages>

--- a/src/contrib/serializers/Akka.Serialization.Wire/Akka.Serialization.Wire.csproj
+++ b/src/contrib/serializers/Akka.Serialization.Wire/Akka.Serialization.Wire.csproj
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B47CA568-40CF-48DE-B87E-31BD400EBB08}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Akka.Serialization.Wire</RootNamespace>
+    <AssemblyName>Akka.Serialization.Wire</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Wire, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Wire.0.0.6\lib\Wire.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="WireSerializer.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\core\Akka\Akka.csproj">
+      <Project>{5deddf90-37f0-48d3-a0b0-a5cbd8a7e377}</Project>
+      <Name>Akka</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/contrib/serializers/Akka.Serialization.Wire/Properties/AssemblyInfo.cs
+++ b/src/contrib/serializers/Akka.Serialization.Wire/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Akka.Serialization.Wire")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Akka.Serialization.Wire")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("b47ca568-40cf-48de-b87e-31bd400ebb08")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/contrib/serializers/Akka.Serialization.Wire/WireSerializer.cs
+++ b/src/contrib/serializers/Akka.Serialization.Wire/WireSerializer.cs
@@ -1,0 +1,69 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="WireSerializer.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.IO;
+using Akka.Actor;
+using Akka.Util;
+using Wire;
+
+// ReSharper disable once CheckNamespace
+namespace Akka.Serialization
+{
+    public class WireSerializer : Serializer
+    {
+        private readonly Wire.Serializer _seralizer;
+
+        public WireSerializer(ExtendedActorSystem system) : base(system)
+        {
+            var akkaSurrogate = 
+                Surrogate
+                .Create<ISurrogated, ISurrogate>(
+                from => from.ToSurrogate(system),
+                to => to.FromSurrogate(system));
+
+            _seralizer =
+                new Wire.Serializer(new SerializerOptions(
+                    preserveObjectReferences: true, 
+                    versionTolerance: true,
+                    surrogates: new[]
+                    {
+                        akkaSurrogate
+                    }));
+        }
+
+        public override int Identifier
+        {
+            get { return -4; }
+        }
+
+        public override bool IncludeManifest
+        {
+            get { return false; }
+        }
+
+        public override byte[] ToBinary(object obj)
+        {
+            using (var ms = new MemoryStream())
+            {
+                _seralizer.Serialize(obj, ms);
+                return ms.ToArray();
+            }
+        }
+
+        public override object FromBinary(byte[] bytes, Type type)
+        {
+            using (var ms = new MemoryStream())
+            {
+                ms.Write(bytes, 0, bytes.Length);
+                ms.Position = 0;
+                var res = _seralizer.Deserialize<object>(ms);
+                return res;
+            }
+        }
+    }
+}

--- a/src/contrib/serializers/Akka.Serialization.Wire/packages.config
+++ b/src/contrib/serializers/Akka.Serialization.Wire/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Wire" version="0.0.6" targetFramework="net45" />
+</packages>

--- a/src/contrib/serializers/Akka.Serialization.WireTests/Akka.Serialization.WireTests.csproj
+++ b/src/contrib/serializers/Akka.Serialization.WireTests/Akka.Serialization.WireTests.csproj
@@ -1,0 +1,102 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{402FA351-D6C6-40FD-8868-F07156035919}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Akka.Serialization.WireTests</RootNamespace>
+    <AssemblyName>Akka.Serialization.WireTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="WireTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\core\Akka.TestKit\Akka.TestKit.csproj">
+      <Project>{0d3cbad0-bbdb-43e5-afc4-ed1d3ecdc224}</Project>
+      <Name>Akka.TestKit</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\core\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj">
+      <Project>{e636d23c-3432-4aa9-9a5d-5f29d33d3399}</Project>
+      <Name>Akka.Tests.Shared.Internals</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\core\Akka\Akka.csproj">
+      <Project>{5deddf90-37f0-48d3-a0b0-a5cbd8a7e377}</Project>
+      <Name>Akka</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\testkits\Akka.TestKit.Xunit2\Akka.TestKit.Xunit2.csproj">
+      <Project>{7dbd5c17-5e9d-40c4-9201-d092751532a7}</Project>
+      <Name>Akka.TestKit.Xunit2</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Akka.Serialization.TestKit\Akka.Serialization.TestKit.csproj">
+      <Project>{caa97041-cfc0-4081-9bd2-8b139e62a611}</Project>
+      <Name>Akka.Serialization.TestKit</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Akka.Serialization.Wire\Akka.Serialization.Wire.csproj">
+      <Project>{b47ca568-40cf-48de-b87e-31bd400ebb08}</Project>
+      <Name>Akka.Serialization.Wire</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/contrib/serializers/Akka.Serialization.WireTests/Properties/AssemblyInfo.cs
+++ b/src/contrib/serializers/Akka.Serialization.WireTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Akka.Serialization.WireTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Akka.Serialization.WireTests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("402fa351-d6c6-40fd-8868-f07156035919")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/contrib/serializers/Akka.Serialization.WireTests/WireTests.cs
+++ b/src/contrib/serializers/Akka.Serialization.WireTests/WireTests.cs
@@ -1,0 +1,11 @@
+﻿using Akka.Tests.Serialization;
+
+namespace Akka.Serialization.WireTests
+{
+    public class WireTests : AkkaSerializationSpec
+    {
+        public WireTests() : base(typeof (WireSerializer))
+        {            
+        }
+    }
+}

--- a/src/contrib/serializers/Akka.Serialization.WireTests/packages.config
+++ b/src/contrib/serializers/Akka.Serialization.WireTests/packages.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+</packages>

--- a/src/core/Akka/Routing/RouterConfig.cs
+++ b/src/core/Akka/Routing/RouterConfig.cs
@@ -129,7 +129,7 @@ namespace Akka.Routing
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return Equals(_paths, other._paths);
+            return _paths.SequenceEqual(other._paths);
         }
 
         public override bool Equals(object obj)


### PR DESCRIPTION
Adding Wire back as a contrib package.

I've also added a Akka Serialization Testkit which can be inherited much like the Persistence spec.

The tests for the Wire serializer is implemented using the SerializationTestkit

