### PR TITLE
Print out contributors since release

### DIFF
--- a/tools/contributors.sh
+++ b/tools/contributors.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [ -z ${1} ]; then
+  # no version number passed in, get last release tag from github
+  release_tag=`git describe --tags $(git rev-list --tags --max-count=1)`
+else
+  # can pass a target release tag e.g. bash tools/contributors.sh v1.0.2
+  # must include the "v" at the front of the version number e.g. "v1.0.2" NOT "1.0.2"
+  release_tag=$1
+fi
+
+function report_contributions {
+  echo `count_contributors` contributors since release $release_tag
+  printf "\n| COMMITS | LOC+ | LOC- | AUTHOR |\n| --- | --- | --- | --- |\n"
+  print_contributions
+}
+
+function print_contributions {
+  git log $release_tag..HEAD --oneline --numstat --pretty=format:%an --no-merges --abbrev-commit | awk 'author == "" { author = $0; commits[author] += 1; next } /^$/ { author = ""; next} {added[author] += $1; removed[author] +=$2 } END { for(author in added) { printf "| %s | %s | %s | %s |\n", commits[author], added[author], removed[author], author } }' | sort -n -k2 -r
+}
+
+function count_contributors {
+  print_contributions | wc -l
+}
+
+
+report_contributions


### PR DESCRIPTION
Call bash tools/contributors.sh to get contribs since last release. Thx @Horusiath for the formatting suggestions.

Example usage below.

```
>> bash tools/contributors.sh
```

6 contributors since release v1.0.5

| COMMITS | LOC+ | LOC- | AUTHOR |
| --- | --- | --- | --- |
| 4 | 83 | 24470 | Aaron Stannard |
| 2 | 24475 | 43 | Bartosz Sypytkowski |
| 2 | 1136 | 7 | rogeralsing |
| 1 | 364 | 113 | JeffCyr |
| 1 | 27 | 0 | Andrew Skotzko |
| 1 | 2 | 2 | easuter |

or:

```
>> bash tools/contributors.sh v1.0.4
```
32 contributors since release v1.0.4

| COMMITS | LOC+ | LOC- | AUTHOR |
| --- | --- | --- | --- |
| 18 | 5410 | 42582 | Aaron Stannard |
| 17 | 4637 | 1394 | maxim.salamatko |
| 12 | 1506 | 343 | rogeralsing |
| 11 | 40804 | 2541 | Bartosz Sypytkowski |
| 8 | 1667 | 320 | Graeme Bradbury |
| 7 | 576 | 40 | Marek Kadek |
| 6 | 1149 | 407 | Sean Gilliam |
| 4 | 208 | 72 | willieferguson |
| 3 | 39 | 21 | Alexander Pantyukhin |
| 2 | 9496 | 2498 | Steffen Forkmann |
| 2 | 71 | 6 | Emil Ingerslev |
| 2 | 5 | 496 | Alex Koshelev |
| 2 | 30 | 6 | evertmulder |
| 2 | 26 | 16 | Silv3rcircl3 |
| 2 | 19 | 14 | Filip Malachowicz |
| 2 | 11 | 2 | Suhas Chatekar |
| 1 | 98 | 52 | Christian Palmstierna |
| 1 | 63 | 22 | Willie Ferguson |
| 1 | 61 | 5 | Grover Jackson |
| 1 | 6 | 1 | tintoy |
| 1 | 54 | 1 | rdavisau |
| 1 | 364 | 113 | JeffCyr |
| 1 | 33 | 23 | Uladzimir Makarau |
| 1 | 27 | 0 | Andrew Skotzko |
| 1 | 269 | 108 | Jeff Cyr |
| 1 | 2 | 2 | easuter |
| 1 | 2 | 2 | Jonathan |
| 1 | 18 | 33 | alex-kondrashov |
| 1 | 1118 | 0 | moliver |
| 1 | 1 | 1 | neekgreen |
| 1 | 1 | 1 | Christopher Martin |
| 1 | 1 | 1 | Artem Borzilov |