### PR TITLE
Revert "prevent nuget from self-upgrading"

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -17,12 +17,12 @@ copy %CACHED_NUGET% src\.nuget\nuget.exe > nul
 
 :restore
 
-REM src\.nuget\NuGet.exe update -self
+src\.nuget\NuGet.exe update -self
 
 
 pushd %~dp0
 
-REM src\.nuget\NuGet.exe update -self
+src\.nuget\NuGet.exe update -self
 
 src\.nuget\NuGet.exe install FAKE -ConfigFile src\.nuget\Nuget.Config -OutputDirectory src\packages -ExcludeVersion -Version 4.1.0
 

--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ if ! [ -f $SCRIPT_PATH/src/.nuget/nuget.exe ]
         wget "https://www.nuget.org/nuget.exe" -P $SCRIPT_PATH/src/.nuget/
 fi
 
-#mono $SCRIPT_PATH/src/.nuget/nuget.exe update -self
+mono $SCRIPT_PATH/src/.nuget/nuget.exe update -self
 
 
 SCRIPT_PATH="${BASH_SOURCE[0]}";
@@ -25,7 +25,7 @@ cd `dirname ${SCRIPT_PATH}` > /dev/null
 SCRIPT_PATH=`pwd`;
 popd  > /dev/null
 
-#mono $SCRIPT_PATH/src/.nuget/NuGet.exe update -self
+mono $SCRIPT_PATH/src/.nuget/NuGet.exe update -self
 
 mono $SCRIPT_PATH/src/.nuget/NuGet.exe install FAKE -OutputDirectory $SCRIPT_PATH/src/packages -ExcludeVersion -Version 3.28.8
 


### PR DESCRIPTION
Reverts akkadotnet/akka.net#1511

Based on the discussion on the https://github.com/NuGet/Home/issues/1813, looks like this may have been an intermittent issue with symbolsource errors occurring silently. Suggestion is to upload symbol packages in a separate command from the main NuGet package upload, which should be easy to do.