### PR TITLE
added initial performance specs using NBench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ bld/
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*
 
+# NBench results
+[Pp]erf[Rr]esult*/
+
 #NUNIT
 *.VisualState.xml
 TestResult.xml

--- a/build.cmd
+++ b/build.cmd
@@ -28,6 +28,7 @@ src\.nuget\NuGet.exe install FAKE -ConfigFile src\.nuget\Nuget.Config -OutputDir
 
 src\.nuget\NuGet.exe install xunit.runner.console -ConfigFile src\.nuget\Nuget.Config -OutputDirectory src\packages\FAKE -ExcludeVersion -Version 2.0.0
 src\.nuget\NuGet.exe install nunit.runners -ConfigFile src\.nuget\Nuget.Config -OutputDirectory src\packages\FAKE -ExcludeVersion -Version 2.6.4
+src\.nuget\NuGet.exe install NBench.Runner -OutputDirectory src\packages -ExcludeVersion
 
 if not exist src\packages\SourceLink.Fake\tools\SourceLink.fsx (
   src\.nuget\nuget.exe install SourceLink.Fake -ConfigFile src\.nuget\Nuget.Config -OutputDirectory src\packages -ExcludeVersion

--- a/build.sh
+++ b/build.sh
@@ -32,6 +32,9 @@ mono $SCRIPT_PATH/src/.nuget/NuGet.exe install FAKE -OutputDirectory $SCRIPT_PAT
 mono $SCRIPT_PATH/src/.nuget/NuGet.exe install xunit.runners -OutputDirectory $SCRIPT_PATH/src/packages/FAKE -ExcludeVersion -Version 2.0.0
 mono $SCRIPT_PATH/src/.nuget/NuGet.exe install nunit.runners -OutputDirectory $SCRIPT_PATH/src/packages/FAKE -ExcludeVersion -Version 2.6.4
 
+mono $SCRIPT_PATH/src/.nuget/NuGet.exe install NBench.Runner -OutputDirectory $SCRIPT_PATH/src/packages -ExcludeVersion
+ 
+
 if ! [ -e $SCRIPT_PATH/src/packages/SourceLink.Fake/tools/SourceLink.fsx ] ; then
 	mono $SCRIPT_PATH/src/.nuget/NuGet.exe install SourceLink.Fake -OutputDirectory $SCRIPT_PATH/src/packages -ExcludeVersion
 

--- a/src/Akka.sln
+++ b/src/Akka.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24606.1
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{69279534-1DBA-4115-BF8B-03F77FC8125E}"
 EndProject
@@ -234,6 +234,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Serialization.WireTests", "contrib\serializers\Akka.Serialization.WireTests\Akka.Serialization.WireTests.csproj", "{402FA351-D6C6-40FD-8868-F07156035919}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Logger.log4net", "contrib\loggers\Akka.Logger.log4net\Akka.Logger.log4net.csproj", "{DAEC9503-CA75-433F-83DE-E28965D94D56}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Tests.Performance", "core\Akka.Tests.Performance\Akka.Tests.Performance.csproj", "{B17DEDCB-D2AA-472D-82A0-D242B711F488}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -864,6 +866,14 @@ Global
 		{DAEC9503-CA75-433F-83DE-E28965D94D56}.Release Mono|Any CPU.Build.0 = Release|Any CPU
 		{DAEC9503-CA75-433F-83DE-E28965D94D56}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DAEC9503-CA75-433F-83DE-E28965D94D56}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B17DEDCB-D2AA-472D-82A0-D242B711F488}.Debug Mono|Any CPU.ActiveCfg = Debug|Any CPU
+		{B17DEDCB-D2AA-472D-82A0-D242B711F488}.Debug Mono|Any CPU.Build.0 = Debug|Any CPU
+		{B17DEDCB-D2AA-472D-82A0-D242B711F488}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B17DEDCB-D2AA-472D-82A0-D242B711F488}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B17DEDCB-D2AA-472D-82A0-D242B711F488}.Release Mono|Any CPU.ActiveCfg = Release|Any CPU
+		{B17DEDCB-D2AA-472D-82A0-D242B711F488}.Release Mono|Any CPU.Build.0 = Release|Any CPU
+		{B17DEDCB-D2AA-472D-82A0-D242B711F488}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B17DEDCB-D2AA-472D-82A0-D242B711F488}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -968,5 +978,6 @@ Global
 		{CAA97041-CFC0-4081-9BD2-8B139E62A611} = {0E55F1F8-E212-43D7-A0C0-ACEA9794B0D7}
 		{402FA351-D6C6-40FD-8868-F07156035919} = {0E55F1F8-E212-43D7-A0C0-ACEA9794B0D7}
 		{DAEC9503-CA75-433F-83DE-E28965D94D56} = {FFEC736B-EDA3-433C-8564-7C14676601A1}
+		{B17DEDCB-D2AA-472D-82A0-D242B711F488} = {01167D3C-49C4-4CDE-9787-C176D139ACDD}
 	EndGlobalSection
 EndGlobal

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -4,5 +4,5 @@ using System.Reflection;
 [assembly: AssemblyCompanyAttribute("Akka.NET Team")]
 [assembly: AssemblyCopyrightAttribute("Copyright © 2013-2015 Akka.NET Team")]
 [assembly: AssemblyTrademarkAttribute("")]
-[assembly: AssemblyVersionAttribute("1.0.5.0")]
-[assembly: AssemblyFileVersionAttribute("1.0.5.0")]
+[assembly: AssemblyVersionAttribute("1.0.6.0")]
+[assembly: AssemblyFileVersionAttribute("1.0.6.0")]

--- a/src/core/Akka.FSharp/Properties/AssemblyInfo.fs
+++ b/src/core/Akka.FSharp/Properties/AssemblyInfo.fs
@@ -10,9 +10,9 @@ open System.Runtime.InteropServices
 [<assembly: AssemblyCompanyAttribute("Akka.NET Team")>]
 [<assembly: ComVisibleAttribute(false)>]
 [<assembly: CLSCompliantAttribute(true)>]
-[<assembly: AssemblyVersionAttribute("1.0.5.0")>]
-[<assembly: AssemblyFileVersionAttribute("1.0.5.0")>]
+[<assembly: AssemblyVersionAttribute("1.0.6.0")>]
+[<assembly: AssemblyFileVersionAttribute("1.0.6.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "1.0.5.0"
+    let [<Literal>] Version = "1.0.6.0"

--- a/src/core/Akka.Remote/Akka.Remote.csproj
+++ b/src/core/Akka.Remote/Akka.Remote.csproj
@@ -51,9 +51,6 @@
     <Optimize>false</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="CHANGES.txt">
-      <Paket>True</Paket>
-    </Content>
     <Content Include="licenses\license.txt">
       <Paket>True</Paket>
     </Content>

--- a/src/core/Akka.Tests.Performance/Actor/ActorMemoryFootprintSpec.cs
+++ b/src/core/Akka.Tests.Performance/Actor/ActorMemoryFootprintSpec.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using Akka.Actor;
+using Akka.Util.Internal;
+using NBench;
+
+namespace Akka.Tests.Performance.Actor
+{
+    /// <summary>
+    /// Tests the default memory footprint of an Akka.NET actor
+    /// </summary>
+    public class ActorMemoryFootprintSpec
+    {
+        class MemoryUntypedActor : UntypedActor {
+            protected override void OnReceive(object message)
+            {
+                if (message is string) return;
+                if (message is int) return;
+                if (message is bool) return;
+                Unhandled(message);
+            }
+        }
+
+        class MemoryReceiveActor : ReceiveActor
+        {
+            public MemoryReceiveActor()
+            {
+                Receive<string>(s => { });
+                Receive<int>(i => { });
+                Receive<bool>(b => { });
+            }
+        }
+
+        private static readonly AtomicCounter Counter = new AtomicCounter(0);
+        private ActorSystem _system;
+        private Counter _createActorThroughput;
+
+        private const string CreateThroughputCounter = "ActorCreateThroughput";
+        private const int ActorCreateNumber = 10000;
+
+        private static readonly Props UntypedActorProps = Props.Create(() => new MemoryUntypedActor());
+        private static readonly Props ReceiveActorProps = Props.Create(() => new MemoryReceiveActor());
+        
+        [PerfSetup]
+        public void Setup(BenchmarkContext context)
+        {
+            _system = ActorSystem.Create("ActorMemoryFootprintSpec" + Counter.GetAndIncrement());
+            _createActorThroughput = context.GetCounter(CreateThroughputCounter);
+        }
+
+        [PerfBenchmark(Description = "Measures the amount of memory used by 10,000 UntypedActors", RunMode = RunMode.Iterations, NumberOfIterations = 13, TestMode = TestMode.Measurement)]
+        [MemoryMeasurement(MemoryMetric.TotalBytesAllocated)]
+        [CounterMeasurement(CreateThroughputCounter)]
+        public void UntypedActorMemoryFootprint(BenchmarkContext context)
+        {
+            for (var i = 0; i < ActorCreateNumber; i++)
+            {
+                _system.ActorOf(UntypedActorProps);
+                _createActorThroughput.Increment();
+            }
+        }
+
+        [PerfBenchmark(Description = "Measures the amount of memory used by 10,000 ReceiveActors", RunMode = RunMode.Iterations, NumberOfIterations = 13, TestMode = TestMode.Measurement)]
+        [MemoryMeasurement(MemoryMetric.TotalBytesAllocated)]
+        [CounterMeasurement(CreateThroughputCounter)]
+        public void ReceiveActorMemoryFootprint(BenchmarkContext context)
+        {
+            for (var i = 0; i < ActorCreateNumber; i++)
+            {
+                _system.ActorOf(ReceiveActorProps);
+                _createActorThroughput.Increment();
+            }
+        }
+
+        [PerfCleanup]
+        public void Teardown(BenchmarkContext context)
+        {
+            _system.Shutdown();
+            _system.AwaitTermination(TimeSpan.FromSeconds(2.0d));
+            _system = null;
+        }
+    }
+}

--- a/src/core/Akka.Tests.Performance/Akka.Tests.Performance.csproj
+++ b/src/core/Akka.Tests.Performance/Akka.Tests.Performance.csproj
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B17DEDCB-D2AA-472D-82A0-D242B711F488}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Akka.Tests.Performance</RootNamespace>
+    <AssemblyName>Akka.Tests.Performance</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="NBench, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NBench.0.1.3\lib\net45\NBench.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Actor\ActorMemoryFootprintSpec.cs" />
+    <Compile Include="Dispatch\MailboxMemoryFootprintSpec.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Akka.TestKit\Akka.TestKit.csproj">
+      <Project>{0d3cbad0-bbdb-43e5-afc4-ed1d3ecdc224}</Project>
+      <Name>Akka.TestKit</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Akka\Akka.csproj">
+      <Project>{5deddf90-37f0-48d3-a0b0-a5cbd8a7e377}</Project>
+      <Name>Akka</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/core/Akka.Tests.Performance/Dispatch/ConcurrentQueueMailboxThroughputSpec.cs
+++ b/src/core/Akka.Tests.Performance/Dispatch/ConcurrentQueueMailboxThroughputSpec.cs
@@ -1,0 +1,12 @@
+﻿using Akka.Dispatch;
+
+namespace Akka.Tests.Performance.Dispatch
+{
+    public class ConcurrentQueueMailboxThroughputSpec : MailboxThroughputSpecBase
+    {
+        protected override Mailbox CreateMailbox()
+        {
+            return new ConcurrentQueueMailbox();
+        }
+    }
+}

--- a/src/core/Akka.Tests.Performance/Dispatch/MailboxMemoryFootprintSpec.cs
+++ b/src/core/Akka.Tests.Performance/Dispatch/MailboxMemoryFootprintSpec.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+using Akka.Dispatch;
+using NBench;
+
+namespace Akka.Tests.Performance.Dispatch
+{
+    public class MailboxMemoryFootprintSpec
+    {
+        private Counter _createMailboxThroughput;
+
+        private const string CreateThroughputCounter = "MailboxCreateThroughput";
+        private const int MailboxCreateNumber = 10000;
+
+        private List<Mailbox> _mailboxes;
+        
+        [PerfSetup]
+        public void Setup(BenchmarkContext context)
+        {
+            _createMailboxThroughput = context.GetCounter(CreateThroughputCounter);
+            _mailboxes = new List<Mailbox>(MailboxCreateNumber);
+        }
+
+        [PerfBenchmark(Description = "Measures the amount of memory used by 10,000 ConcurrentQueueMailboxes", RunMode = RunMode.Iterations, NumberOfIterations = 13, TestMode = TestMode.Measurement)]
+        [MemoryMeasurement(MemoryMetric.TotalBytesAllocated)]
+        [CounterMeasurement(CreateThroughputCounter)]
+        public void ConcurrentQueueMailbox()
+        {
+            for (var i = 0; i < MailboxCreateNumber; i++)
+            {
+                _mailboxes.Add(new ConcurrentQueueMailbox());
+                _createMailboxThroughput.Increment();
+            }
+        }
+
+        [PerfBenchmark(Description = "Measures the amount of memory used by 10,000 UnboundedDequeBasedMailboxes", RunMode = RunMode.Iterations, NumberOfIterations = 13, TestMode = TestMode.Measurement)]
+        [MemoryMeasurement(MemoryMetric.TotalBytesAllocated)]
+        [CounterMeasurement(CreateThroughputCounter)]
+        public void UnboundedDequeBasedMailbox()
+        {
+            for (var i = 0; i < MailboxCreateNumber; i++)
+            {
+                _mailboxes.Add(new UnboundedDequeBasedMailbox());
+                _createMailboxThroughput.Increment();
+            }
+        }
+
+        [PerfBenchmark(Description = "Measures the amount of memory used by 10,000 BoundedDequeBasedMailboxes", RunMode = RunMode.Iterations, NumberOfIterations = 13, TestMode = TestMode.Measurement)]
+        [MemoryMeasurement(MemoryMetric.TotalBytesAllocated)]
+        [CounterMeasurement(CreateThroughputCounter)]
+        public void BoundedDequeBasedMailbox()
+        {
+            for (var i = 0; i < MailboxCreateNumber; i++)
+            {
+                _mailboxes.Add(new BoundedDequeBasedMailbox());
+                _createMailboxThroughput.Increment();
+            }
+        }
+
+        [PerfCleanup]
+        public void Teardown()
+        {
+            _mailboxes.Clear();
+            _mailboxes = null;
+        }
+    }
+}

--- a/src/core/Akka.Tests.Performance/Dispatch/MailboxThroughputSpecBase.cs
+++ b/src/core/Akka.Tests.Performance/Dispatch/MailboxThroughputSpecBase.cs
@@ -1,0 +1,68 @@
+﻿using Akka.Actor;
+using Akka.Actor.Internal;
+using Akka.Configuration;
+using Akka.Dispatch;
+using Akka.TestKit;
+using Akka.Util.Internal;
+using NBench;
+
+namespace Akka.Tests.Performance.Dispatch
+{
+    /// <summary>
+    ///     Base class used to test the performance of different <see cref="Mailbox" /> implementations
+    /// </summary>
+    public abstract class MailboxThroughputSpecBase
+    {
+        private const string MailboxCounterName = "MessageReceived";
+        private static readonly Envelope TestEnvelope = new Envelope {Message = "", Sender = ActorRefs.NoSender};
+        private ActorCell _actorCell;
+        private MessageDispatcher _dispatcher;
+        private Mailbox _mailbox;
+        private Counter _mailboxThroughput;
+        private IActorRef _receiver;
+        protected abstract Mailbox CreateMailbox();
+
+        private static readonly AtomicCounter Counter = new AtomicCounter(0);
+        private ActorSystem _system;
+
+        class BenchmarkActor : UntypedActor
+        {
+            private Counter _counter;
+
+            public BenchmarkActor(Counter counter)
+            {
+                _counter = counter;
+            }
+
+            protected override void OnReceive(object message)
+            {
+                _counter.Increment();
+            }
+        }
+
+        [PerfSetup]
+        public void Setup(BenchmarkContext context)
+        {
+            _mailboxThroughput = context.GetCounter(MailboxCounterName);
+            _mailbox = CreateMailbox();
+            _system = ActorSystem.Create("MailboxThroughputSpecBase" + Counter.GetAndIncrement());
+            _receiver = _system.ActorOf(Props.Create(() => new BenchmarkActor(_mailboxThroughput)));
+            _actorCell = _receiver.AsInstanceOf<ActorRefWithCell>().Underlying.AsInstanceOf<ActorCell>();
+            _dispatcher = _actorCell.Dispatcher;
+            _mailbox.Setup(_actorCell.Dispatcher);
+            _mailbox.SetActor(_actorCell);
+            _mailbox.Start();
+        }
+
+        [PerfBenchmark(
+            Description =
+                "Measures the raw message throughput of a mailbox implementation with no additional configuration options",
+            RunMode = RunMode.Throughput, NumberOfIterations = 13, TestMode = TestMode.Measurement,
+            RunTimeMilliseconds = 1000)]
+        [CounterMeasurement(MailboxCounterName)]
+        public void Benchmark(BenchmarkContext context)
+        {
+            _receiver.Tell(string.Empty);
+        }
+    }
+}

--- a/src/core/Akka.Tests.Performance/Properties/AssemblyInfo.cs
+++ b/src/core/Akka.Tests.Performance/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Akka.Tests.Performance")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Akka.Tests.Performance")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("b17dedcb-d2aa-472d-82a0-d242b711f488")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/core/Akka.Tests.Performance/packages.config
+++ b/src/core/Akka.Tests.Performance/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NBench" version="0.1.3" targetFramework="net45" />
+</packages>

--- a/src/core/Akka/Properties/AssemblyInfo.cs
+++ b/src/core/Akka/Properties/AssemblyInfo.cs
@@ -28,6 +28,7 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("1a5cab08-b032-49ca-8db3-9428c5a9db14")]
 [assembly: InternalsVisibleTo("Akka.Tests")]
+[assembly: InternalsVisibleTo("Akka.Tests.Performance")]
 [assembly: InternalsVisibleTo("Akka.TestKit")]
 [assembly: InternalsVisibleTo("Akka.TestKit.Tests")]
 [assembly: InternalsVisibleTo("Akka.Remote")]


### PR DESCRIPTION
Uses [NBench](https://github.com/petabridge/nbench) for performing some simple, but automated benchmarks on each build.

Adding this and actually uses it requires me to change the build process on the server, so I wanted to ship a minimal performance testing footprint immediately and expand it later - that way this commit can begin making it into every other contributor's dev branch going forward.

I'll link to some of the results this PR produces....