### PR TITLE
#1365 added untrustedspec

### DIFF
--- a/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
+++ b/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Transport\TestTransportSpec.cs" />
     <Compile Include="Transport\ThrottleModeSpec.cs" />
     <Compile Include="Transport\ThrottlerTransportAdapterSpec.cs" />
+    <Compile Include="UntrustedSpec.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\contrib\testkits\Akka.TestKit.Xunit2\Akka.TestKit.Xunit2.csproj">

--- a/src/core/Akka.Remote.Tests/UntrustedSpec.cs
+++ b/src/core/Akka.Remote.Tests/UntrustedSpec.cs
@@ -1,0 +1,295 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RemoteWatcherSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.TestKit;
+using Akka.Util.Internal;
+using Xunit;
+
+namespace Akka.Remote.Tests
+{
+    public class UntrustedSpec : AkkaSpec
+    {
+        private readonly ActorSystem _client;
+        private readonly Address _address;
+        private readonly IActorRef _receptionist;
+        private readonly Lazy<IActorRef> _remoteDaemon;
+        private readonly Lazy<IActorRef> _target2;
+
+
+        public UntrustedSpec()
+            : base(@"
+            akka.actor.provider = ""Akka.Remote.RemoteActorRefProvider, Akka.Remote""
+            akka.remote.untrusted-mode = on
+            akka.remote.trusted-selection-paths = [""/user/receptionist"", ]    
+            akka.remote.helios.tcp = {
+                port = 0
+                hostname = localhost
+            }
+            akka.loglevel = DEBUG
+            ")
+        {
+            _client = ActorSystem.Create("UntrustedSpec-client", ConfigurationFactory.ParseString(@"
+                akka.actor.provider =  ""Akka.Remote.RemoteActorRefProvider, Akka.Remote""
+                 akka.remote.helios.tcp = {
+                    port = 0
+                    hostname = localhost
+                }                
+            ").WithFallback(Sys.Settings.Config));
+
+            _address = Sys.AsInstanceOf<ExtendedActorSystem>().Provider.DefaultAddress;
+            _receptionist = Sys.ActorOf(Props.Create(() => new Receptionist(TestActor)), "receptionist");
+
+            _remoteDaemon = new Lazy<IActorRef>(() =>
+            {
+                var p = CreateTestProbe(_client);
+                _client.ActorSelection(new RootActorPath(_address)/_receptionist.Path.Elements)
+                    .Tell(new IdentifyReq("/remote"), p.Ref);
+                return p.ExpectMsg<ActorIdentity>().Subject;
+            });
+
+            _target2 = new Lazy<IActorRef>(() =>
+            {
+                var p = CreateTestProbe(_client);
+                _client.ActorSelection(new RootActorPath(_address)/_receptionist.Path.Elements)
+                    .Tell(new IdentifyReq("child2"), p.Ref);
+
+                var actorRef = p.ExpectMsg<ActorIdentity>().Subject;
+                return actorRef;
+            });
+
+
+            EventFilter.Debug().Mute();
+        }
+
+
+        protected override void AfterTermination()
+        {
+            Shutdown(_client);
+        }
+
+
+        [Fact]
+        public void UntrustedModeMustAllowActorSelectionToConfiguredWhiteList()
+        {
+            var sel = _client.ActorSelection(new RootActorPath(_address)/_receptionist.Path.Elements);
+            sel.Tell("hello");
+            ExpectMsg("hello");
+        }
+
+        [Fact]
+        public void UntrustedModeMustDiscardHarmfulMessagesToSlashRemote()
+        {
+            var logProbe = CreateTestProbe();
+            // but instead install our own listener
+            Sys.EventStream.Subscribe(
+                Sys.ActorOf(Props.Create(() => new DebugSniffer(logProbe)).WithDeploy(Deploy.Local), "debugSniffer"),
+                typeof (Debug));
+
+            _remoteDaemon.Value.Tell("hello");
+            logProbe.ExpectMsg<Debug>();
+        }
+
+        [Fact]
+        public void UntrustedModeMustDiscardHarmfulMessagesToTestActor()
+        {
+            var target2 = _target2.Value;
+
+            target2.Tell(new Terminated(_remoteDaemon.Value, true, false));
+            target2.Tell(PoisonPill.Instance);
+            _client.Stop(target2);
+            target2.Tell("blech");
+            ExpectMsg("blech");
+        }
+
+        [Fact]
+        public void UntrustedModeMustDiscardWatchMessages()
+        {
+            var target2 = _target2.Value;
+            _client.ActorOf(Props.Create(() => new Target2Watch(target2, TestActor)).WithDeploy(Deploy.Local));
+            _receptionist.Tell(new StopChild1("child2"));
+            ExpectMsg("child2 stopped");
+            // no Terminated msg, since watch was discarded
+            ExpectNoMsg(TimeSpan.FromSeconds(1));
+        }
+
+        [Fact]
+        public void UntrustedModeMustDiscardActorSelection()
+        {
+            var sel = _client.ActorSelection(new RootActorPath(_address)/TestActor.Path.Elements);
+            sel.Tell("hello");
+            ExpectNoMsg(TimeSpan.FromSeconds(1));
+        }
+
+        [Fact]
+        public void UntrustedModeMustDiscardActorSelectionToChildOfMatchingWhiteList()
+        {
+            var sel = _client.ActorSelection(new RootActorPath(_address)/_receptionist.Path.Elements/"child1");
+            sel.Tell("hello");
+            ExpectNoMsg(TimeSpan.FromSeconds(1));
+        }
+
+        [Fact]
+        public void UntrustedModeMustDiscardActorSelectionWithWildcard()
+        {
+            var sel = _client.ActorSelection(new RootActorPath(_address)/_receptionist.Path.Elements/"*");
+            sel.Tell("hello");
+            ExpectNoMsg(TimeSpan.FromSeconds(1));
+        }
+
+        [Fact]
+        public void UntrustedModeMustDiscardActorSelectionContainingHarmfulMessage()
+        {
+            var sel = _client.ActorSelection(new RootActorPath(_address)/_receptionist.Path.Elements);
+            sel.Tell(PoisonPill.Instance);
+            ExpectNoMsg(TimeSpan.FromSeconds(1));
+        }
+
+
+        [Fact]
+        public void UntrustedModeMustDiscardActorSelectionWithNonRootAnchor()
+        {
+            var p = CreateTestProbe(_client);
+            _client.ActorSelection(new RootActorPath(_address)/_receptionist.Path.Elements).Tell(
+                new Identify(null), p.Ref);
+            var clientReceptionistRef = p.ExpectMsg<ActorIdentity>().Subject;
+
+            var sel = ActorSelection(clientReceptionistRef, _receptionist.Path.ToStringWithoutAddress());
+            sel.Tell("hello");
+            ExpectNoMsg(TimeSpan.FromSeconds(1));
+        }
+
+
+        private class IdentifyReq
+        {
+            public IdentifyReq(string path)
+            {
+                Path = path;
+            }
+
+            public string Path { get; }
+        }
+
+        private class StopChild1
+        {
+            public StopChild1(string name)
+            {
+                Name = name;
+            }
+
+            public string Name { get; }
+        }
+
+
+        private class Receptionist : ActorBase
+        {
+            private readonly IActorRef _testActor;
+
+            public Receptionist(IActorRef testActor)
+            {
+                _testActor = testActor;
+                Context.ActorOf(Props.Create(() => new Child(testActor)), "child1");
+                Context.ActorOf(Props.Create(() => new Child(testActor)), "child2");
+                Context.ActorOf(Props.Create(() => new FakeUser(testActor)), "user");
+            }
+
+
+            protected override bool Receive(object message)
+            {
+                return message.Match().With<IdentifyReq>(req =>
+                {
+                    var actorSelection = Context.ActorSelection(req.Path);
+                    actorSelection.Tell(new Identify(null), Sender);
+                })
+                    .With<StopChild1>(child => { Context.Stop(Context.Child(child.Name)); })
+                    .Default(o => { _testActor.Forward(o); })
+                    .WasHandled;
+            }
+        }
+
+        private class Child : ActorBase
+        {
+            private readonly IActorRef _testActor;
+
+            public Child(IActorRef testActor)
+            {
+                _testActor = testActor;
+            }
+
+            protected override bool Receive(object message)
+            {
+                _testActor.Forward(message);
+                return true;
+            }
+
+            protected override void PostStop()
+            {
+                _testActor.Tell(string.Format("{0} stopped", Self.Path.Name));
+                base.PostStop();
+            }
+        }
+
+        private class FakeUser : ActorBase
+        {
+            private readonly IActorRef _testActor;
+
+            public FakeUser(IActorRef testActor)
+            {
+                _testActor = testActor;
+                Context.ActorOf(Props.Create(() => new Child(testActor)), "receptionist");
+            }
+
+            protected override bool Receive(object message)
+            {
+                _testActor.Forward(message);
+                return true;
+            }
+        }
+
+        private class DebugSniffer : ActorBase
+        {
+            private readonly TestProbe _testProbe;
+
+            public DebugSniffer(TestProbe testProbe)
+            {
+                _testProbe = testProbe;
+            }
+
+            protected override bool Receive(object message)
+            {
+                return message.Match().With<Debug>(debug =>
+                {
+                    if (((string) debug.Message).Contains("dropping"))
+                    {
+                        _testProbe.Ref.Tell(debug);
+                    }
+                }).WasHandled;
+            }
+        }
+
+        private class Target2Watch : ActorBase
+        {
+            private readonly IActorRef _testActor;
+
+
+            public Target2Watch(IActorRef target2, IActorRef testActor)
+            {
+                _testActor = testActor;
+                Context.Watch(target2);
+            }
+
+            protected override bool Receive(object message)
+            {
+                _testActor.Forward(message);
+                return true;
+            }
+        }
+    }
+}

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -78,42 +78,46 @@ namespace Akka.Remote
             else if ((recipient is ILocalRef || recipient is RepointableActorRef) && recipient.IsLocal)
             {
                 if (settings.LogReceive) log.Debug("received local message [{0}]", msgLog);
-                payload.Match()
-                    .With<ActorSelectionMessage>(sel =>
-                    {
-                        var actorPath = "/" + string.Join("/", sel.Elements.Select(x => x.ToString()));
-                        if (settings.UntrustedMode
-                            && (!settings.TrustedSelectionPaths.Contains(actorPath)
+                if (payload is ActorSelectionMessage)
+                {
+                    var sel = (ActorSelectionMessage) payload;
+
+                    var actorPath = "/" + string.Join("/", sel.Elements.Select(x => x.ToString()));
+                    if (settings.UntrustedMode
+                        && (!settings.TrustedSelectionPaths.Contains(actorPath)
                             || sel.Message is IPossiblyHarmful
-                            || recipient != provider.Guardian))
-                        {
-                            log.Debug(
-                                "operating in UntrustedMode, dropping inbound actor selection to [{0}], allow it" +
-                                "by adding the path to 'akka.remote.trusted-selection-paths' in configuration",
-                                actorPath);
-                        }
-                        else
-                        {
-                            //run the receive logic for ActorSelectionMessage here to make sure it is not stuck on busy user actor
-                            ActorSelection.DeliverSelection(recipient, sender, sel);
-                        }
-                    })
-                    .With<IPossiblyHarmful>(msg =>
+                            || recipient != provider.RootGuardian))
                     {
-                        if (settings.UntrustedMode)
-                        {
-                            log.Debug("operating in UntrustedMode, dropping inbound IPossiblyHarmful message of type {0}", msg.GetType());
-                        }
-                    })
-                    .With<ISystemMessage>(msg => { recipient.Tell(msg); })
-                    .Default(msg =>
+                        log.Debug(
+                            "operating in UntrustedMode, dropping inbound actor selection to [{0}], allow it" +
+                            "by adding the path to 'akka.remote.trusted-selection-paths' in configuration",
+                            actorPath);
+                    }
+                    else
                     {
-                        recipient.Tell(msg, sender);
-                    });
+                        //run the receive logic for ActorSelectionMessage here to make sure it is not stuck on busy user actor
+                        ActorSelection.DeliverSelection(recipient, sender, sel);
+                    }
+                }
+                else if (payload is IPossiblyHarmful && settings.UntrustedMode)
+                {
+                    log.Debug("operating in UntrustedMode, dropping inbound IPossiblyHarmful message of type {0}",
+                        payload.GetType());
+                }
+                else if (payload is ISystemMessage)
+                {
+                    recipient.Tell(payload);
+                }
+                else
+                {
+                    recipient.Tell(payload, sender);
+                }
+
             }
 
             // message is intended for a remote-deployed recipient
-            else if ((recipient is IRemoteRef || recipient is RepointableActorRef) && !recipient.IsLocal && !settings.UntrustedMode)
+            else if ((recipient is IRemoteRef || recipient is RepointableActorRef) && !recipient.IsLocal &&
+                     !settings.UntrustedMode)
             {
                 if (settings.LogReceive) log.Debug("received remote-destined message {0}", msgLog);
                 if (provider.Transport.Addresses.Contains(recipientAddress))
@@ -131,8 +135,8 @@ namespace Akka.Remote
             else
             {
                 log.Error(
-                        "Dropping message [{0}] for non-local recipient [{1}] arriving at [{2}] inbound addresses [{3}]",
-                        payloadClass, recipient, recipientAddress, string.Join(",", provider.Transport.Addresses));
+                    "Dropping message [{0}] for non-local recipient [{1}] arriving at [{2}] inbound addresses [{3}]",
+                    payloadClass, recipient, recipientAddress, string.Join(",", provider.Transport.Addresses));
             }
         }
     }

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -45,13 +45,16 @@ namespace Akka.Remote
 
         private Internals RemoteInternals
         {
-            get
-            {
-                return _internals ??
-                       (_internals =
-                           new Internals(new Remoting(_system, this), _system.Serialization,
-                               new RemoteSystemDaemon(_system, RootPath / "remote", SystemGuardian, _remotingTerminator, _log)));
-            }
+            get { return _internals ?? (_internals = CreateInternals()); }
+        }
+
+        private Internals CreateInternals()
+        {
+            var internals =
+                new Internals(new Remoting(_system, this), _system.Serialization,
+                    new RemoteSystemDaemon(_system, RootPath/"remote", SystemGuardian, _remotingTerminator, _log));
+            _local.RegisterExtraName("remote", internals.RemoteDaemon);
+            return internals;
         }
 
         public IInternalActorRef RemoteDaemon { get { return RemoteInternals.RemoteDaemon; } }

--- a/src/core/Akka.TestKit/TestKitBase_ActorOf.cs
+++ b/src/core/Akka.TestKit/TestKitBase_ActorOf.cs
@@ -130,6 +130,11 @@ namespace Akka.TestKit
             return Sys.ActorSelection(actorPath);
         }
 
+        public ActorSelection ActorSelection(IActorRef anchorActorRef, string path)
+        {
+            return Sys.ActorSelection(path);
+        }
+
 
         /// <summary>
         /// Create a new actor as child of specified supervisor and returns it as <see cref="TestActorRef{TActor}"/>

--- a/src/core/Akka/Actor/ActorRefFactoryShared.cs
+++ b/src/core/Akka/Actor/ActorRefFactoryShared.cs
@@ -32,6 +32,17 @@ namespace Akka.Actor
         }
 
         /// <summary>
+        ///     Construct an <see cref="Akka.Actor.ActorSelection"/> from the given string representing a path
+        ///     relative to the given target. This operation has to create all the
+        ///     matching magic, so it is preferable to cache its result if the
+        ///     intention is to send messages frequently.
+        /// </summary>
+        public static ActorSelection ActorSelection(IActorRef anchorActorRef, string path)
+        {
+            return new ActorSelection(anchorActorRef, path);
+        }
+
+        /// <summary>
         ///     Construct an <see cref="Akka.Actor.ActorSelection"/> from the given path, which is
         ///     parsed for wildcards (these are replaced by regular expressions
         ///     internally). No attempt is made to verify the existence of any part of

--- a/src/core/Akka/Actor/ActorSystem.cs
+++ b/src/core/Akka/Actor/ActorSystem.cs
@@ -251,6 +251,8 @@ namespace Akka.Actor
         public abstract ActorSelection ActorSelection(ActorPath actorPath);
         public abstract ActorSelection ActorSelection(string actorPath);
 
+        public abstract ActorSelection ActorSelection(IActorRef anchorRef, string actorPath);
+
         /// <summary>
         /// Block and prevent the main application thread from exiting unless
         /// the actor system is shut down.

--- a/src/core/Akka/Actor/IAutoReceivedMessage.cs
+++ b/src/core/Akka/Actor/IAutoReceivedMessage.cs
@@ -78,7 +78,7 @@ namespace Akka.Actor
     /// it processes the message, which gets handled using the normal supervisor mechanism, and
     /// <see cref="IActorContext.Stop"/> which causes the actor to stop without processing any more messages. </para>
     /// </summary>
-    public sealed class PoisonPill : IAutoReceivedMessage
+    public sealed class PoisonPill : IAutoReceivedMessage , IPossiblyHarmful
     {
         private PoisonPill() { }
         private static readonly PoisonPill _instance = new PoisonPill();

--- a/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
@@ -130,6 +130,11 @@ namespace Akka.Actor.Internal
             return ActorRefFactoryShared.ActorSelection(actorPath, this, _provider.RootGuardian);
         }
 
+        public override ActorSelection ActorSelection(IActorRef anchorActorRef, string path)
+        {
+            return ActorRefFactoryShared.ActorSelection(anchorActorRef, path);
+        }
+
         private void ConfigureScheduler()
         {
             var schedulerType = Type.GetType(_settings.SchedulerClass, true);

--- a/src/core/Akka/Dispatch/SysMsg/ISystemMessage.cs
+++ b/src/core/Akka/Dispatch/SysMsg/ISystemMessage.cs
@@ -447,7 +447,7 @@ namespace Akka.Dispatch.SysMsg
     /// <summary>
     ///     Class Terminate.
     /// </summary>
-    public sealed class Terminate : ISystemMessage
+    public sealed class Terminate : ISystemMessage, IPossiblyHarmful
     {
         private Terminate() { }
         private static readonly Terminate _instance = new Terminate();


### PR DESCRIPTION
fixed dropping inbound actor selection in the untrusted mode 
https://github.com/akka/akka/blob/master/akka-remote/src/main/scala/akka/remote/Endpoint.scala#L79

fixed dropping inbound PossiblyHarmful message
https://github.com/akka/akka/blob/master/akka-remote/src/main/scala/akka/remote/Endpoint.scala#L86

added path to remote daemon
https://github.com/akka/akka/blob/master/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala#L167

added actor selection by given target

replaced type matching to `if else` , for doing complicated conditions 