### PR TITLE
#1365 added untrustedspec

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -250,11 +250,13 @@ namespace Akka.Actor
     {
         public static Akka.Actor.IActorRef ActorOf<TActor>(this Akka.Actor.IActorRefFactory factory, string name = null)
             where TActor : Akka.Actor.ActorBase, new () { }
+        public static Akka.Actor.ActorSelection ActorSelection(this Akka.Actor.IActorRefFactory factory, Akka.Actor.IActorRef anchorRef, string actorPath) { }
     }
     public class static ActorRefFactoryShared
     {
         public static Akka.Actor.ActorSelection ActorSelection(Akka.Actor.ActorPath actorPath, Akka.Actor.ActorSystem system) { }
         public static Akka.Actor.ActorSelection ActorSelection(string path, Akka.Actor.ActorSystem system, Akka.Actor.IActorRef lookupRoot) { }
+        public static Akka.Actor.ActorSelection ActorSelection(Akka.Actor.IActorRef anchorActorRef, string path) { }
     }
     public class static ActorRefImplicitSenderExtensions
     {
@@ -1235,7 +1237,7 @@ namespace Akka.Actor
         public static System.Threading.Tasks.Task PipeTo<T>(this System.Threading.Tasks.Task<T> taskToPipe, Akka.Actor.ICanTell recipient, Akka.Actor.IActorRef sender = null, System.Func<T, object> success = null, System.Func<System.Exception, object> failure = null) { }
         public static System.Threading.Tasks.Task PipeTo(this System.Threading.Tasks.Task taskToPipe, Akka.Actor.ICanTell recipient, Akka.Actor.IActorRef sender = null) { }
     }
-    public sealed class PoisonPill : Akka.Actor.IAutoReceivedMessage, Akka.Actor.INoSerializationVerificationNeeded
+    public sealed class PoisonPill : Akka.Actor.IAutoReceivedMessage, Akka.Actor.INoSerializationVerificationNeeded, Akka.Actor.IPossiblyHarmful
     {
         public static Akka.Actor.PoisonPill Instance { get; }
         public override string ToString() { }
@@ -2569,7 +2571,7 @@ namespace Akka.Dispatch.SysMsg
         public static Akka.Dispatch.SysMsg.Suspend Instance { get; }
         public override string ToString() { }
     }
-    public sealed class Terminate : Akka.Actor.INoSerializationVerificationNeeded, Akka.Dispatch.SysMsg.ISystemMessage
+    public sealed class Terminate : Akka.Actor.INoSerializationVerificationNeeded, Akka.Actor.IPossiblyHarmful, Akka.Dispatch.SysMsg.ISystemMessage
     {
         public static Akka.Dispatch.SysMsg.Terminate Instance { get; }
         public override string ToString() { }

--- a/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
+++ b/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Transport\TestTransportSpec.cs" />
     <Compile Include="Transport\ThrottleModeSpec.cs" />
     <Compile Include="Transport\ThrottlerTransportAdapterSpec.cs" />
+    <Compile Include="UntrustedSpec.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\contrib\testkits\Akka.TestKit.Xunit2\Akka.TestKit.Xunit2.csproj">

--- a/src/core/Akka.Remote.Tests/UntrustedSpec.cs
+++ b/src/core/Akka.Remote.Tests/UntrustedSpec.cs
@@ -1,0 +1,295 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RemoteWatcherSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.TestKit;
+using Akka.Util.Internal;
+using Xunit;
+
+namespace Akka.Remote.Tests
+{
+    public class UntrustedSpec : AkkaSpec
+    {
+        private readonly ActorSystem _client;
+        private readonly Address _address;
+        private readonly IActorRef _receptionist;
+        private readonly Lazy<IActorRef> _remoteDaemon;
+        private readonly Lazy<IActorRef> _target2;
+
+
+        public UntrustedSpec()
+            : base(@"
+            akka.actor.provider = ""Akka.Remote.RemoteActorRefProvider, Akka.Remote""
+            akka.remote.untrusted-mode = on
+            akka.remote.trusted-selection-paths = [""/user/receptionist"", ]    
+            akka.remote.helios.tcp = {
+                port = 0
+                hostname = localhost
+            }
+            akka.loglevel = DEBUG
+            ")
+        {
+            _client = ActorSystem.Create("UntrustedSpec-client", ConfigurationFactory.ParseString(@"
+                akka.actor.provider =  ""Akka.Remote.RemoteActorRefProvider, Akka.Remote""
+                 akka.remote.helios.tcp = {
+                    port = 0
+                    hostname = localhost
+                }                
+            ").WithFallback(Sys.Settings.Config));
+
+            _address = Sys.AsInstanceOf<ExtendedActorSystem>().Provider.DefaultAddress;
+            _receptionist = Sys.ActorOf(Props.Create(() => new Receptionist(TestActor)), "receptionist");
+
+            _remoteDaemon = new Lazy<IActorRef>(() =>
+            {
+                var p = CreateTestProbe(_client);
+                _client.ActorSelection(new RootActorPath(_address)/_receptionist.Path.Elements)
+                    .Tell(new IdentifyReq("/remote"), p.Ref);
+                return p.ExpectMsg<ActorIdentity>().Subject;
+            });
+
+            _target2 = new Lazy<IActorRef>(() =>
+            {
+                var p = CreateTestProbe(_client);
+                _client.ActorSelection(new RootActorPath(_address)/_receptionist.Path.Elements)
+                    .Tell(new IdentifyReq("child2"), p.Ref);
+
+                var actorRef = p.ExpectMsg<ActorIdentity>().Subject;
+                return actorRef;
+            });
+
+
+            EventFilter.Debug().Mute();
+        }
+
+
+        protected override void AfterTermination()
+        {
+            Shutdown(_client);
+        }
+
+
+        [Fact]
+        public void UntrustedModeMustAllowActorSelectionToConfiguredWhiteList()
+        {
+            var sel = _client.ActorSelection(new RootActorPath(_address)/_receptionist.Path.Elements);
+            sel.Tell("hello");
+            ExpectMsg("hello");
+        }
+
+        [Fact]
+        public void UntrustedModeMustDiscardHarmfulMessagesToSlashRemote()
+        {
+            var logProbe = CreateTestProbe();
+            // but instead install our own listener
+            Sys.EventStream.Subscribe(
+                Sys.ActorOf(Props.Create(() => new DebugSniffer(logProbe)).WithDeploy(Deploy.Local), "debugSniffer"),
+                typeof (Debug));
+
+            _remoteDaemon.Value.Tell("hello");
+            logProbe.ExpectMsg<Debug>();
+        }
+
+        [Fact]
+        public void UntrustedModeMustDiscardHarmfulMessagesToTestActor()
+        {
+            var target2 = _target2.Value;
+
+            target2.Tell(new Terminated(_remoteDaemon.Value, true, false));
+            target2.Tell(PoisonPill.Instance);
+            _client.Stop(target2);
+            target2.Tell("blech");
+            ExpectMsg("blech");
+        }
+
+        [Fact]
+        public void UntrustedModeMustDiscardWatchMessages()
+        {
+            var target2 = _target2.Value;
+            _client.ActorOf(Props.Create(() => new Target2Watch(target2, TestActor)).WithDeploy(Deploy.Local));
+            _receptionist.Tell(new StopChild1("child2"));
+            ExpectMsg("child2 stopped");
+            // no Terminated msg, since watch was discarded
+            ExpectNoMsg(TimeSpan.FromSeconds(1));
+        }
+
+        [Fact]
+        public void UntrustedModeMustDiscardActorSelection()
+        {
+            var sel = _client.ActorSelection(new RootActorPath(_address)/TestActor.Path.Elements);
+            sel.Tell("hello");
+            ExpectNoMsg(TimeSpan.FromSeconds(1));
+        }
+
+        [Fact]
+        public void UntrustedModeMustDiscardActorSelectionToChildOfMatchingWhiteList()
+        {
+            var sel = _client.ActorSelection(new RootActorPath(_address)/_receptionist.Path.Elements/"child1");
+            sel.Tell("hello");
+            ExpectNoMsg(TimeSpan.FromSeconds(1));
+        }
+
+        [Fact]
+        public void UntrustedModeMustDiscardActorSelectionWithWildcard()
+        {
+            var sel = _client.ActorSelection(new RootActorPath(_address)/_receptionist.Path.Elements/"*");
+            sel.Tell("hello");
+            ExpectNoMsg(TimeSpan.FromSeconds(1));
+        }
+
+        [Fact]
+        public void UntrustedModeMustDiscardActorSelectionContainingHarmfulMessage()
+        {
+            var sel = _client.ActorSelection(new RootActorPath(_address)/_receptionist.Path.Elements);
+            sel.Tell(PoisonPill.Instance);
+            ExpectNoMsg(TimeSpan.FromSeconds(1));
+        }
+
+
+        [Fact]
+        public void UntrustedModeMustDiscardActorSelectionWithNonRootAnchor()
+        {
+            var p = CreateTestProbe(_client);
+            _client.ActorSelection(new RootActorPath(_address)/_receptionist.Path.Elements).Tell(
+                new Identify(null), p.Ref);
+            var clientReceptionistRef = p.ExpectMsg<ActorIdentity>().Subject;
+
+            var sel = ActorSelection(clientReceptionistRef, _receptionist.Path.ToStringWithoutAddress());
+            sel.Tell("hello");
+            ExpectNoMsg(TimeSpan.FromSeconds(1));
+        }
+
+
+        private class IdentifyReq
+        {
+            public IdentifyReq(string path)
+            {
+                Path = path;
+            }
+
+            public string Path { get; }
+        }
+
+        private class StopChild1
+        {
+            public StopChild1(string name)
+            {
+                Name = name;
+            }
+
+            public string Name { get; }
+        }
+
+
+        private class Receptionist : ActorBase
+        {
+            private readonly IActorRef _testActor;
+
+            public Receptionist(IActorRef testActor)
+            {
+                _testActor = testActor;
+                Context.ActorOf(Props.Create(() => new Child(testActor)), "child1");
+                Context.ActorOf(Props.Create(() => new Child(testActor)), "child2");
+                Context.ActorOf(Props.Create(() => new FakeUser(testActor)), "user");
+            }
+
+
+            protected override bool Receive(object message)
+            {
+                return message.Match().With<IdentifyReq>(req =>
+                {
+                    var actorSelection = Context.ActorSelection(req.Path);
+                    actorSelection.Tell(new Identify(null), Sender);
+                })
+                    .With<StopChild1>(child => { Context.Stop(Context.Child(child.Name)); })
+                    .Default(o => { _testActor.Forward(o); })
+                    .WasHandled;
+            }
+        }
+
+        private class Child : ActorBase
+        {
+            private readonly IActorRef _testActor;
+
+            public Child(IActorRef testActor)
+            {
+                _testActor = testActor;
+            }
+
+            protected override bool Receive(object message)
+            {
+                _testActor.Forward(message);
+                return true;
+            }
+
+            protected override void PostStop()
+            {
+                _testActor.Tell(string.Format("{0} stopped", Self.Path.Name));
+                base.PostStop();
+            }
+        }
+
+        private class FakeUser : ActorBase
+        {
+            private readonly IActorRef _testActor;
+
+            public FakeUser(IActorRef testActor)
+            {
+                _testActor = testActor;
+                Context.ActorOf(Props.Create(() => new Child(testActor)), "receptionist");
+            }
+
+            protected override bool Receive(object message)
+            {
+                _testActor.Forward(message);
+                return true;
+            }
+        }
+
+        private class DebugSniffer : ActorBase
+        {
+            private readonly TestProbe _testProbe;
+
+            public DebugSniffer(TestProbe testProbe)
+            {
+                _testProbe = testProbe;
+            }
+
+            protected override bool Receive(object message)
+            {
+                return message.Match().With<Debug>(debug =>
+                {
+                    if (((string) debug.Message).Contains("dropping"))
+                    {
+                        _testProbe.Ref.Tell(debug);
+                    }
+                }).WasHandled;
+            }
+        }
+
+        private class Target2Watch : ActorBase
+        {
+            private readonly IActorRef _testActor;
+
+
+            public Target2Watch(IActorRef target2, IActorRef testActor)
+            {
+                _testActor = testActor;
+                Context.Watch(target2);
+            }
+
+            protected override bool Receive(object message)
+            {
+                _testActor.Forward(message);
+                return true;
+            }
+        }
+    }
+}

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -45,13 +45,16 @@ namespace Akka.Remote
 
         private Internals RemoteInternals
         {
-            get
-            {
-                return _internals ??
-                       (_internals =
-                           new Internals(new Remoting(_system, this), _system.Serialization,
-                               new RemoteSystemDaemon(_system, RootPath / "remote", SystemGuardian, _remotingTerminator, _log)));
-            }
+            get { return _internals ?? (_internals = CreateInternals()); }
+        }
+
+        private Internals CreateInternals()
+        {
+            var internals =
+                new Internals(new Remoting(_system, this), _system.Serialization,
+                    new RemoteSystemDaemon(_system, RootPath/"remote", SystemGuardian, _remotingTerminator, _log));
+            _local.RegisterExtraName("remote", internals.RemoteDaemon);
+            return internals;
         }
 
         public IInternalActorRef RemoteDaemon { get { return RemoteInternals.RemoteDaemon; } }

--- a/src/core/Akka.TestKit/TestKitBase_ActorOf.cs
+++ b/src/core/Akka.TestKit/TestKitBase_ActorOf.cs
@@ -131,6 +131,11 @@ namespace Akka.TestKit
         }
 
 
+        public ActorSelection ActorSelection(IActorRef anchorRef, string actorPath)
+        {
+            return Sys.ActorSelection(anchorRef, actorPath);
+        }
+
         /// <summary>
         /// Create a new actor as child of specified supervisor and returns it as <see cref="TestActorRef{TActor}"/>
         /// to enable access to the underlying actor instance via <see cref="TestActorRefBase{TActor}.UnderlyingActor"/>.

--- a/src/core/Akka/Actor/ActorRefFactoryExtensions.cs
+++ b/src/core/Akka/Actor/ActorRefFactoryExtensions.cs
@@ -14,6 +14,17 @@ namespace Akka.Actor
             return factory.ActorOf(Props.Create<TActor>(), name: name);
         }
 
+        /// <summary>
+        ///     Construct an <see cref="Akka.Actor.ActorSelection"/> from the given string representing a path
+        ///     relative to the given target. This operation has to create all the
+        ///     matching magic, so it is preferable to cache its result if the
+        ///     intention is to send messages frequently.
+        /// </summary>
+        public static ActorSelection ActorSelection(this IActorRefFactory factory, IActorRef anchorRef, string actorPath)
+        {
+            return ActorRefFactoryShared.ActorSelection(anchorRef, actorPath);
+        }
+
     }
 }
 

--- a/src/core/Akka/Actor/ActorRefFactoryShared.cs
+++ b/src/core/Akka/Actor/ActorRefFactoryShared.cs
@@ -67,6 +67,17 @@ namespace Akka.Actor
             
             return new ActorSelection(lookupRoot, path);
         }
+
+        /// <summary>
+        ///     Construct an <see cref="Akka.Actor.ActorSelection"/> from the given string representing a path
+        ///     relative to the given target. This operation has to create all the
+        ///     matching magic, so it is preferable to cache its result if the
+        ///     intention is to send messages frequently.
+        /// </summary>
+        public static ActorSelection ActorSelection(IActorRef anchorActorRef, string path)
+        {
+            return new ActorSelection(anchorActorRef, path);
+        }
     }
 }
 

--- a/src/core/Akka/Actor/IAutoReceivedMessage.cs
+++ b/src/core/Akka/Actor/IAutoReceivedMessage.cs
@@ -78,7 +78,7 @@ namespace Akka.Actor
     /// it processes the message, which gets handled using the normal supervisor mechanism, and
     /// <see cref="IActorContext.Stop"/> which causes the actor to stop without processing any more messages. </para>
     /// </summary>
-    public sealed class PoisonPill : IAutoReceivedMessage
+    public sealed class PoisonPill : IAutoReceivedMessage , IPossiblyHarmful
     {
         private PoisonPill() { }
         private static readonly PoisonPill _instance = new PoisonPill();

--- a/src/core/Akka/Dispatch/SysMsg/ISystemMessage.cs
+++ b/src/core/Akka/Dispatch/SysMsg/ISystemMessage.cs
@@ -451,7 +451,7 @@ namespace Akka.Dispatch.SysMsg
     /// <summary>
     ///     Class Terminate.
     /// </summary>
-    public sealed class Terminate : ISystemMessage
+    public sealed class Terminate : ISystemMessage, IPossiblyHarmful
     {
         private Terminate() { }
         private static readonly Terminate _instance = new Terminate();


### PR DESCRIPTION
fixed dropping inbound actor selection in the untrusted mode 
https://github.com/akka/akka/blob/master/akka-remote/src/main/scala/akka/remote/Endpoint.scala#L79

fixed dropping inbound PossiblyHarmful message
https://github.com/akka/akka/blob/master/akka-remote/src/main/scala/akka/remote/Endpoint.scala#L86

added path to remote daemon
https://github.com/akka/akka/blob/master/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala#L167

added actor selection by given target

replaced type matching to if else , for doing complicated conditions