### PR TITLE
[Ready] Modified Akka.Remote.Transport benchmarks to get more accurate readings

### DIFF
--- a/src/core/Akka.Remote.Tests.Performance/Akka.Remote.Tests.Performance.csproj
+++ b/src/core/Akka.Remote.Tests.Performance/Akka.Remote.Tests.Performance.csproj
@@ -39,10 +39,14 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="HeliosRemoteMessagingThroughputSpec.cs" />
+    <Compile Include="Transports\AssociationStressSpecBase.cs" />
+    <Compile Include="ForkJoinDispatcherRemoteMessagingThroughputSpec.cs" />
+    <Compile Include="Transports\HeliosRemoteMessagingThroughputSpec.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="RemoteMessagingThroughputSpecBase.cs" />
-    <Compile Include="TestTransportRemoteMessagingThroughputSpec.cs" />
+    <Compile Include="Transports\RemoteMessagingThroughputSpecBase.cs" />
+    <Compile Include="Transports\TestTransportAssociationStressSpec.cs" />
+    <Compile Include="Transports\TestTransportRemoteMessagingThroughputSpec.cs" />
+    <Compile Include="ThreadPoolDispatcherRemoteMessagingThroughputSpec.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Akka.Remote\Akka.Remote.csproj">

--- a/src/core/Akka.Remote.Tests.Performance/ForkJoinDispatcherRemoteMessagingThroughputSpec.cs
+++ b/src/core/Akka.Remote.Tests.Performance/ForkJoinDispatcherRemoteMessagingThroughputSpec.cs
@@ -1,0 +1,30 @@
+using Akka.Configuration;
+using Akka.Remote.Tests.Performance.Transports;
+
+namespace Akka.Remote.Tests.Performance
+{
+    public class ForkJoinDispatcherRemoteMessagingThroughputSpec : TestTransportRemoteMessagingThroughputSpec
+    {
+        public static Config ForkJoinDispatcherConfig => ConfigurationFactory.ParseString(@"
+            akka.remote.default-remote-dispatcher {
+              type = ForkJoinDispatcher
+              dedicated-thread-pool {
+                # Fixed number of threads to have in this threadpool
+                thread-count = 4
+              }
+            }
+    
+            akka.remote.backoff-remote-dispatcher {
+              type = ForkJoinDispatcher
+              dedicated-thread-pool {
+                # Fixed number of threads to have in this threadpool
+                thread-count = 4
+              }
+        ");
+
+        public override Config CreateActorSystemConfig(string actorSystemName, string ipOrHostname, int port)
+        {
+            return ForkJoinDispatcherConfig.WithFallback(base.CreateActorSystemConfig(actorSystemName, ipOrHostname, port));
+        }
+    }
+}

--- a/src/core/Akka.Remote.Tests.Performance/ThreadPoolDispatcherRemoteMessagingThroughputSpec.cs
+++ b/src/core/Akka.Remote.Tests.Performance/ThreadPoolDispatcherRemoteMessagingThroughputSpec.cs
@@ -1,0 +1,23 @@
+using Akka.Configuration;
+using Akka.Remote.Tests.Performance.Transports;
+
+namespace Akka.Remote.Tests.Performance
+{
+    public class ThreadPoolDispatcherRemoteMessagingThroughputSpec : TestTransportRemoteMessagingThroughputSpec
+    {
+        public static Config ThreadPoolDispatcherConfig => ConfigurationFactory.ParseString(@"
+            akka.remote.default-remote-dispatcher {
+              type = Dispatcher
+            }
+    
+            akka.remote.backoff-remote-dispatcher {
+              type = Dispatcher
+            }
+        ");
+
+        public override Config CreateActorSystemConfig(string actorSystemName, string ipOrHostname, int port)
+        {
+            return ThreadPoolDispatcherConfig.WithFallback(base.CreateActorSystemConfig(actorSystemName, ipOrHostname, port));
+        }
+    }
+}

--- a/src/core/Akka.Remote.Tests.Performance/Transports/AssociationStressSpecBase.cs
+++ b/src/core/Akka.Remote.Tests.Performance/Transports/AssociationStressSpecBase.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Remote.Transport;
+using Akka.Util.Internal;
+using NBench;
+
+namespace Akka.Remote.Tests.Performance.Transports
+{
+    /// <summary>
+    ///     Creates and shuts associations between two <see cref="ActorSystem" /> instances rapidly
+    ///     using pluggable transports. Designed to expose race conditions, deadlocks, and other
+    ///     faults with the <see cref="AssociationHandle" /> implementation specific to each transport.
+    /// </summary>
+    public abstract class AssociationStressSpecBase
+    {
+        private const string AssociationCounterName = "AssociationConfirmed";
+        private static readonly AtomicCounter ActorSystemNameCounter = new AtomicCounter(0);
+        protected readonly TimeSpan AssociationTimeout = TimeSpan.FromSeconds(2);
+        protected Counter AssociationCounter;
+
+        protected Props ActorProps = Props.Create(() => new EchoActor());
+
+        /// <summary>
+        ///     Used to create a HOCON <see cref="Config" /> object for each <see cref="ActorSystem" />
+        ///     participating in this throughput test.
+        ///     This method is responsible for selecting the correct <see cref="Transport" /> implementation.
+        /// </summary>
+        /// <param name="actorSystemName">The name of the <see cref="ActorSystem" />. Needed for <see cref="TestTransport" />.</param>
+        /// <param name="ipOrHostname">The address this system will be bound to</param>
+        /// <param name="port">The port this system will be bound to</param>
+        /// <param name="registryKey">
+        ///     The <see cref="AssociationRegistry" /> key. Only needed when using
+        ///     <see cref="TestTransport" />.
+        /// </param>
+        /// <returns>A populated <see cref="Config" /> object.</returns>
+        public abstract Config CreateActorSystemConfig(string actorSystemName, string ipOrHostname, int port,
+            string registryKey = null);
+
+        public virtual string CreateRegistryKey()
+        {
+            return null;
+        }
+
+        private class EchoActor : UntypedActor
+        {
+            protected override void OnReceive(object message)
+            {
+                Sender.Tell(message);
+            }
+        }
+
+        [PerfSetup]
+        public void Setup(BenchmarkContext context)
+        {
+            AssociationCounter = context.GetCounter(AssociationCounterName);
+        }
+
+        [PerfBenchmark(
+            Description =
+                "Tests how quickly and frequently we can make associations between two ActorSystems using the configured transport",
+            NumberOfIterations = 13, RunTimeMilliseconds = 2000, RunMode = RunMode.Throughput,
+            TestMode = TestMode.Measurement)]
+        [CounterMeasurement(AssociationCounterName)]
+        public void AssociationStress(BenchmarkContext context)
+        {
+            var registryKey = CreateRegistryKey();
+            using (
+                var system1 = ActorSystem.Create("SystemA" + ActorSystemNameCounter.Next(),
+                    CreateActorSystemConfig("SystemA" + ActorSystemNameCounter.Current, "127.0.0.1", 0, registryKey)))
+            using (
+                var system2 = ActorSystem.Create("SystemB" + ActorSystemNameCounter.Next(),
+                    CreateActorSystemConfig("SystemB" + ActorSystemNameCounter.Current, "127.0.0.1", 0, registryKey)))
+            {
+                var echo = system1.ActorOf(ActorProps, "echo");
+                var system1Address = RARP.For(system1).Provider.Transport.DefaultAddress;
+                var system1EchoActorPath = new RootActorPath(system1Address) / "user" / "echo";
+
+               var remoteActor = system2.ActorSelection(system1EchoActorPath)
+                   .Ask<ActorIdentity>(new Identify(null), TimeSpan.FromSeconds(2)).Result.Subject;
+                AssociationCounter.Increment();
+            }
+        }
+
+        [PerfCleanup]
+        public virtual void Cleanup()
+        {
+        }
+    }
+}

--- a/src/core/Akka.Remote.Tests.Performance/Transports/HeliosRemoteMessagingThroughputSpec.cs
+++ b/src/core/Akka.Remote.Tests.Performance/Transports/HeliosRemoteMessagingThroughputSpec.cs
@@ -1,6 +1,4 @@
-using Akka.Configuration;
-
-namespace Akka.Remote.Tests.Performance
+namespace Akka.Remote.Tests.Performance.Transports
 {
     // todo: SKIP FOR NOW - BUGS
     //public class HeliosRemoteMessagingThroughputSpec : RemoteMessagingThroughputSpecBase

--- a/src/core/Akka.Remote.Tests.Performance/Transports/TestTransportAssociationStressSpec.cs
+++ b/src/core/Akka.Remote.Tests.Performance/Transports/TestTransportAssociationStressSpec.cs
@@ -1,0 +1,52 @@
+using System;
+using Akka.Configuration;
+using Akka.Remote.Transport;
+
+namespace Akka.Remote.Tests.Performance.Transports
+{
+    public class TestTransportAssociationStressSpec : AssociationStressSpecBase
+    {
+        public override string CreateRegistryKey()
+        {
+            return Guid.NewGuid().ToString();
+        }
+
+        public override Config CreateActorSystemConfig(string actorSystemName, string ipOrHostname, int port, string registryKey = null)
+        {
+            var baseConfig = ConfigurationFactory.ParseString(@"
+                akka {
+              actor.provider = ""Akka.Remote.RemoteActorRefProvider,Akka.Remote""
+
+              remote {
+                log-remote-lifecycle-events = off
+
+                enabled-transports = [
+                  ""akka.remote.test"",
+                ]
+
+                test {
+                  transport-class = ""Akka.Remote.Transport.TestTransport,Akka.Remote""
+                  applied-adapters = []
+                  maximum-payload-bytes = 128000b
+                  scheme-identifier = test
+                }
+              }
+            ");
+
+            port = 10; //BUG: setting the port to 0 causes the DefaultAddress to report the port as -1
+            var remoteAddress = $"test://{actorSystemName}@{ipOrHostname}:{port}";
+            var bindingConfig =
+                ConfigurationFactory.ParseString(@"akka.remote.test.local-address = """ + remoteAddress + @"""");
+            var registryKeyConfig = ConfigurationFactory.ParseString($"akka.remote.test.registry-key = {registryKey}");
+
+            return registryKeyConfig.WithFallback(bindingConfig.WithFallback(baseConfig));
+        }
+
+        public override void Cleanup()
+        {
+            // nuke all registries
+            AssociationRegistry.Clear();
+            base.Cleanup();
+        }
+    }
+}

--- a/src/core/Akka.Remote.Tests.Performance/Transports/TestTransportRemoteMessagingThroughputSpec.cs
+++ b/src/core/Akka.Remote.Tests.Performance/Transports/TestTransportRemoteMessagingThroughputSpec.cs
@@ -1,9 +1,13 @@
+using System;
 using Akka.Configuration;
+using Akka.Remote.Transport;
 
-namespace Akka.Remote.Tests.Performance
+namespace Akka.Remote.Tests.Performance.Transports
 {
     public class TestTransportRemoteMessagingThroughputSpec : RemoteMessagingThroughputSpecBase
     {
+        private readonly string _registryKey = Guid.NewGuid().ToString();
+
         public override Config CreateActorSystemConfig(string actorSystemName, string ipOrHostname, int port)
         {
             var baseConfig = ConfigurationFactory.ParseString(@"
@@ -20,7 +24,6 @@ namespace Akka.Remote.Tests.Performance
                 test {
                   transport-class = ""Akka.Remote.Transport.TestTransport,Akka.Remote""
                   applied-adapters = []
-                  registry-key = aX33k12WKg
                   maximum-payload-bytes = 128000b
                   scheme-identifier = test
                 }
@@ -31,8 +34,17 @@ namespace Akka.Remote.Tests.Performance
             var remoteAddress = $"test://{actorSystemName}@{ipOrHostname}:{port}";
             var bindingConfig =
                 ConfigurationFactory.ParseString(@"akka.remote.test.local-address = """+ remoteAddress +@"""");
+            var registryKeyConfig = ConfigurationFactory.ParseString($"akka.remote.test.registry-key = {_registryKey}");
 
-            return bindingConfig.WithFallback(baseConfig);
+            return registryKeyConfig.WithFallback(bindingConfig.WithFallback(baseConfig));
+        }
+
+        public override void Cleanup()
+        {
+            base.Cleanup();
+
+            // force all content logged by the TestTransport to be released
+            AssociationRegistry.Get(_registryKey).Reset();
         }
     }
 }

--- a/src/core/Akka.Remote/Transport/TestTransport.cs
+++ b/src/core/Akka.Remote/Transport/TestTransport.cs
@@ -17,44 +17,42 @@ using Google.ProtocolBuffers;
 namespace Akka.Remote.Transport
 {
     /// <summary>
-    /// Transport implementation used for testing.
-    /// 
-    /// The TestTransport is basically shared memory between actor systems. It can be programmed to emulate
-    /// different failure modes of a <see cref="Transport"/> implementation. TestTransport keeps a log of the activities
-    /// it was requested to do. This class is not optimized for performance and MUST not be used in production systems.
+    ///     Transport implementation used for testing.
+    ///     The TestTransport is basically shared memory between actor systems. It can be programmed to emulate
+    ///     different failure modes of a <see cref="Transport" /> implementation. TestTransport keeps a log of the activities
+    ///     it was requested to do. This class is not optimized for performance and MUST not be used in production systems.
     /// </summary>
     public class TestTransport : Transport
     {
-
-
-        public readonly Address LocalAddress;
+        private readonly TaskCompletionSource<IAssociationEventListener> _associationListenerPromise =
+            new TaskCompletionSource<IAssociationEventListener>();
 
         private readonly AssociationRegistry _registry;
+        public readonly SwitchableLoggedBehavior<Address, AssociationHandle> AssociateBehavior;
+        public readonly SwitchableLoggedBehavior<TestAssociationHandle, bool> DisassociateBehavior;
+        /*
+         * Programmable behaviors
+         */
 
-        private TaskCompletionSource<IAssociationEventListener> _associationListenerPromise
-        {
-            get
-            {
-                return new TaskCompletionSource<IAssociationEventListener>();
-            }
-        }
+        public readonly SwitchableLoggedBehavior<bool, Tuple<Address, TaskCompletionSource<IAssociationEventListener>>>
+            ListenBehavior;
+
+        public readonly Address LocalAddress;
+        public readonly SwitchableLoggedBehavior<bool, bool> ShutdownBehavior;
+        public readonly SwitchableLoggedBehavior<Tuple<TestAssociationHandle, ByteString>, bool> WriteBehavior;
 
         public TestTransport(ActorSystem system, Config conf)
             : this(
-                Address.Parse(GetConfigString(conf, "local-address")), 
-                AssociationRegistry.Get(GetConfigString(conf,"registry-key")),
+                Address.Parse(GetConfigString(conf, "local-address")),
+                AssociationRegistry.Get(GetConfigString(conf, "registry-key")),
                 conf.GetByteSize("maximum-payload-bytes") ?? 32000,
-                GetConfigString(conf,"scheme-identifier")
-            ) { }
-
-        private static string GetConfigString(Config conf, string name)
+                GetConfigString(conf, "scheme-identifier")
+                )
         {
-            var value = conf.GetString(name);
-            if(value==null) throw new ConfigurationException("Please specify a value for config setting \""+name+"\"");
-            return value;
         }
 
-        public TestTransport(Address localAddress, AssociationRegistry registry, long maximumPayloadBytes = 32000, string schemeIdentifier = "test")
+        public TestTransport(Address localAddress, AssociationRegistry registry, long maximumPayloadBytes = 32000,
+            string schemeIdentifier = "test")
         {
             LocalAddress = localAddress;
             _registry = registry;
@@ -64,27 +62,25 @@ namespace Akka.Remote.Transport
                 new SwitchableLoggedBehavior<bool, Tuple<Address, TaskCompletionSource<IAssociationEventListener>>>(
                     x => DefaultListen(), x => _registry.LogActivity(new ListenAttempt(LocalAddress)));
             AssociateBehavior =
-                new SwitchableLoggedBehavior<Address, AssociationHandle>(DefaultAssociate, address => registry.LogActivity(new AssociateAttempt(LocalAddress, address)));
-            ShutdownBehavior = new SwitchableLoggedBehavior<bool, bool>(x => DefaultShutdown(), x => registry.LogActivity(new ShutdownAttempt(LocalAddress)));
-            DisassociateBehavior = new SwitchableLoggedBehavior<TestAssociationHandle, bool>(x =>
-            {
-                DefaultDisassociate(x);
-                return Task.Run(() => true);
-            }, remote => _registry.LogActivity(new DisassociateAttempt(remote.LocalAddress, remote.RemoteAddress)));
+                new SwitchableLoggedBehavior<Address, AssociationHandle>(DefaultAssociate,
+                    address => registry.LogActivity(new AssociateAttempt(LocalAddress, address)));
+            ShutdownBehavior = new SwitchableLoggedBehavior<bool, bool>(x => DefaultShutdown(),
+                x => registry.LogActivity(new ShutdownAttempt(LocalAddress)));
+            DisassociateBehavior = new SwitchableLoggedBehavior<TestAssociationHandle, bool>(DefaultDisassociate, remote => _registry.LogActivity(new DisassociateAttempt(remote.LocalAddress, remote.RemoteAddress)));
 
             WriteBehavior = new SwitchableLoggedBehavior<Tuple<TestAssociationHandle, ByteString>, bool>(
                 args => DefaultWriteBehavior(args.Item1, args.Item2),
-                data => _registry.LogActivity(new WriteAttempt(data.Item1.LocalAddress, data.Item1.RemoteAddress, data.Item2)));
+                data =>
+                    _registry.LogActivity(new WriteAttempt(data.Item1.LocalAddress, data.Item1.RemoteAddress, data.Item2)));
         }
 
-        /*
-         * Programmable behaviors
-         */
-        public readonly SwitchableLoggedBehavior<bool, Tuple<Address, TaskCompletionSource<IAssociationEventListener>>> ListenBehavior;
-        public readonly SwitchableLoggedBehavior<Address, AssociationHandle> AssociateBehavior;
-        public readonly SwitchableLoggedBehavior<bool, bool> ShutdownBehavior;
-        public readonly SwitchableLoggedBehavior<TestAssociationHandle, bool> DisassociateBehavior;
-        public readonly SwitchableLoggedBehavior<Tuple<TestAssociationHandle, ByteString>, bool> WriteBehavior;
+        private static string GetConfigString(Config conf, string name)
+        {
+            var value = conf.GetString(name);
+            if (value == null)
+                throw new ConfigurationException("Please specify a value for config setting \"" + name + "\"");
+            return value;
+        }
 
         public override bool IsResponsibleFor(Address remote)
         {
@@ -103,7 +99,7 @@ namespace Akka.Remote.Transport
             var promise = _associationListenerPromise;
             _registry.RegisterTransport(this, promise.Task);
             return
-                Task.Run(() => new Tuple<Address, TaskCompletionSource<IAssociationEventListener>>(LocalAddress, promise));
+                Task.FromResult(new Tuple<Address, TaskCompletionSource<IAssociationEventListener>>(LocalAddress, promise));
         }
 
         #endregion
@@ -128,27 +124,25 @@ namespace Akka.Remote.Transport
                 remoteHandle.Writeable = false;
 
                 //pass a non-writeable handle to remote first
-                var remoteAssociationListener = remoteAssociationListenerTask.Result;
+                var remoteAssociationListener = await remoteAssociationListenerTask.ConfigureAwait(false);
                 remoteAssociationListener.Notify(new InboundAssociation(remoteHandle));
                 var remoteHandlerTask = remoteHandle.ReadHandlerSource.Task;
 
                 //registration of reader at local finishes the registration and enables communication
-                await remoteHandlerTask;
-
-                var remoteListener = remoteHandlerTask.Result;
+                var remoteListener = await remoteHandlerTask.ConfigureAwait(false);
 
 #pragma warning disable 4014
                 localHandle.ReadHandlerSource.Task.ContinueWith(result =>
 #pragma warning restore 4014
                 {
                     var localListener = result.Result;
-                    _registry.RegisterListenerPair(localHandle.Key, new Tuple<IHandleEventListener, IHandleEventListener>(localListener, remoteListener));
+                    _registry.RegisterListenerPair(localHandle.Key,
+                        new Tuple<IHandleEventListener, IHandleEventListener>(localListener, remoteListener));
                     localHandle.Writeable = true;
                     remoteHandle.Writeable = true;
                 }, TaskContinuationOptions.ExecuteSynchronously);
 
-                return (AssociationHandle)localHandle;
-
+                return (AssociationHandle) localHandle;
             }
 
             throw new InvalidAssociationException(string.Format("No registered transport: {0}", remoteAddress));
@@ -172,13 +166,16 @@ namespace Akka.Remote.Transport
             return DisassociateBehavior.Apply(handle);
         }
 
-        public Task DefaultDisassociate(TestAssociationHandle handle)
+        public Task<bool> DefaultDisassociate(TestAssociationHandle handle)
         {
             var handlers = _registry.DeregisterAssociation(handle.Key);
-            handlers.Item1.Notify(new Disassociated(DisassociateInfo.Unknown));
-            handlers.Item2.Notify(new Disassociated(DisassociateInfo.Unknown));
+            if (handlers != null)
+            {
+                handlers.Item1.Notify(new Disassociated(DisassociateInfo.Unknown));
+                handlers.Item2.Notify(new Disassociated(DisassociateInfo.Unknown));
+            }
 
-            return Task.Run(() => { });
+            return Task.FromResult(true);
         }
 
         #endregion
@@ -192,7 +189,7 @@ namespace Akka.Remote.Transport
 
         private Task<bool> DefaultShutdown()
         {
-            return Task.Run(() => true);
+            return Task.FromResult(true);
         }
 
         #endregion
@@ -211,7 +208,7 @@ namespace Akka.Remote.Transport
             if (remoteReadHandler != null)
             {
                 remoteReadHandler.Notify(new InboundPayload(payload));
-                return Task.Run(() => true);
+                return Task.FromResult(true);
             }
 
             return Task.Run(() =>
@@ -227,9 +224,11 @@ namespace Akka.Remote.Transport
     }
 
     /// <summary>
-    /// Base trait for remote activities that are logged by <see cref="TestTransport"/>
+    ///     Base trait for remote activities that are logged by <see cref="TestTransport" />
     /// </summary>
-    public abstract class Activity { }
+    public abstract class Activity
+    {
+    }
 
     public sealed class ListenAttempt : Activity
     {
@@ -250,7 +249,6 @@ namespace Akka.Remote.Transport
         }
 
         public Address LocalAddress { get; private set; }
-
         public Address RemoteAddress { get; private set; }
     }
 
@@ -274,9 +272,7 @@ namespace Akka.Remote.Transport
         }
 
         public Address Sender { get; private set; }
-
         public Address Recipient { get; private set; }
-
         public ByteString Payload { get; private set; }
     }
 
@@ -289,26 +285,19 @@ namespace Akka.Remote.Transport
         }
 
         public Address Requestor { get; private set; }
-
         public Address Remote { get; private set; }
     }
 
     /// <summary>
-    /// Test utility to make behavior of functions that return some Task controllable form tests.
-    /// 
-    /// This tool is able to override default behavior with any generic behavior, including failure, and exposes
-    /// control to the timing of completion of the associated Task.
-    /// 
-    /// The utility is implemented as a stack of behaviors, where the behavior on the top of the stack represents the
-    /// currently active behavior. The bottom of the stack always contains the <see cref="DefaultBehavior"/> which
-    /// can not be popped out.
+    ///     Test utility to make behavior of functions that return some Task controllable form tests.
+    ///     This tool is able to override default behavior with any generic behavior, including failure, and exposes
+    ///     control to the timing of completion of the associated Task.
+    ///     The utility is implemented as a stack of behaviors, where the behavior on the top of the stack represents the
+    ///     currently active behavior. The bottom of the stack always contains the <see cref="DefaultBehavior" /> which
+    ///     can not be popped out.
     /// </summary>
     public class SwitchableLoggedBehavior<TIn, TOut>
     {
-        public Func<TIn, Task<TOut>> DefaultBehavior { get; private set; }
-
-        public Action<TIn> LogCallback { get; private set; }
-
         private readonly ConcurrentStack<Func<TIn, Task<TOut>>> _behaviorStack =
             new ConcurrentStack<Func<TIn, Task<TOut>>>();
 
@@ -318,6 +307,9 @@ namespace Akka.Remote.Transport
             DefaultBehavior = defaultBehavior;
             _behaviorStack.Push(DefaultBehavior);
         }
+
+        public Func<TIn, Task<TOut>> DefaultBehavior { get; }
+        public Action<TIn> LogCallback { get; }
 
         public Func<TIn, Task<TOut>> CurrentBehavior
         {
@@ -331,30 +323,33 @@ namespace Akka.Remote.Transport
         }
 
         /// <summary>
-        /// Changes the current behavior to the provided one
+        ///     Changes the current behavior to the provided one
         /// </summary>
-        /// <param name="behavior">Function that takes a parameter type <typeparamref name="TIn"/> and returns a Task<typeparamref name="TOut"/>.</param>
+        /// <param name="behavior">
+        ///     Function that takes a parameter type <typeparamref name="TIn" /> and returns a Task
+        ///     <typeparamref name="TOut" />.
+        /// </param>
         public void Push(Func<TIn, Task<TOut>> behavior)
         {
             _behaviorStack.Push(behavior);
         }
 
         /// <summary>
-        /// Changes the behavior to return a completed Task with the given constant value.
+        ///     Changes the behavior to return a completed Task with the given constant value.
         /// </summary>
         /// <param name="result">The constant the Task will be completed with.</param>
         public void PushConstant(TOut result)
         {
-            Push((x) => Task.Run(() => result));
+            Push(x => Task.FromResult(result));
         }
 
         /// <summary>
-        /// Changes the behavior to return a faulted Task with the given exception
+        ///     Changes the behavior to return a faulted Task with the given exception
         /// </summary>
         /// <param name="e">The exception responsible for faulting this task</param>
         public void PushError(Exception e)
         {
-            Push((x) => Task.Run(() =>
+            Push(x => Task.Run(() =>
             {
                 throw e;
 #pragma warning disable 162
@@ -364,14 +359,14 @@ namespace Akka.Remote.Transport
         }
 
         /// <summary>
-        /// Enables control of the completion of the previously active behavior. Wraps the previous behavior in
+        ///     Enables control of the completion of the previously active behavior. Wraps the previous behavior in
         /// </summary>
         /// <returns></returns>
         public TaskCompletionSource<bool> PushDelayed()
         {
             var controlPromise = new TaskCompletionSource<bool>();
             var originalBehavior = CurrentBehavior;
-            Push((x) =>
+            Push(x =>
             {
                 controlPromise.Task.Wait();
                 return originalBehavior.Invoke(x);
@@ -397,29 +392,65 @@ namespace Akka.Remote.Transport
     }
 
     /// <summary>
-    /// Shared state among <see cref="TestTransport"/> instances. Coordinates the transports and the means of
-    /// communication between them.
+    ///     Shared state among <see cref="TestTransport" /> instances. Coordinates the transports and the means of
+    ///     communication between them.
     /// </summary>
+    /// <remarks>
+    ///     NOTE: This is a global shared state between different actor systems. The purpose of this class is to allow
+    ///     dynamically
+    ///     loaded TestTransports to set up a shared AssociationRegistry.Extensions could not be used for this purpose, as the
+    ///     injection
+    ///     of the shared instance must happen during the startup time of the actor system. Association registries are looked
+    ///     up via a string key. Until we find a better way to inject an AssociationRegistry to multiple actor systems it is
+    ///     strongly recommended to use long, randomly generated strings to key the registry to avoid interference between
+    ///     tests.
+    /// </remarks>
     public class AssociationRegistry
     {
+        private static readonly ConcurrentDictionary<string, AssociationRegistry> registries =
+            new ConcurrentDictionary<string, AssociationRegistry>();
+
         private readonly ConcurrentStack<Activity> _activityLog = new ConcurrentStack<Activity>();
-        private readonly ConcurrentDictionary<Address, Tuple<TestTransport, Task<IAssociationEventListener>>> _transportTable = new ConcurrentDictionary<Address, Tuple<TestTransport, Task<IAssociationEventListener>>>();
-        private readonly ConcurrentDictionary<Tuple<Address, Address>, Tuple<IHandleEventListener, IHandleEventListener>> _listenersTable = new ConcurrentDictionary<Tuple<Address, Address>, Tuple<IHandleEventListener, IHandleEventListener>>();
 
-        private static ConcurrentDictionary<string, AssociationRegistry> registries = new ConcurrentDictionary<string, AssociationRegistry>();
+        private readonly
+            ConcurrentDictionary<Tuple<Address, Address>, Tuple<IHandleEventListener, IHandleEventListener>>
+            _listenersTable =
+                new ConcurrentDictionary<Tuple<Address, Address>, Tuple<IHandleEventListener, IHandleEventListener>>();
 
+        private readonly ConcurrentDictionary<Address, Tuple<TestTransport, Task<IAssociationEventListener>>>
+            _transportTable = new ConcurrentDictionary<Address, Tuple<TestTransport, Task<IAssociationEventListener>>>();
+
+        /// <summary>
+        /// Retrieves the specified <see cref="AssociationRegistry"/> associated with the <see cref="key"/>.
+        /// </summary>
+        /// <param name="key">The registry key - see the HOCON example for details.</param>
+        /// <returns>An existing or new <see cref="AssociationRegistry"/> instance.</returns>
+        /// <code>
+        ///     akka{
+        ///         remote{
+        ///             enabled-transports = ["akka.remote.test"]
+        ///             test{
+        ///                 registry-key = "SOME KEY"
+        ///             }
+        ///         }
+        ///     }
+        /// </code>
         public static AssociationRegistry Get(string key)
         {
             return registries.GetOrAdd(key, new AssociationRegistry());
         }
 
+        /// <summary>
+        /// Wipes out all of the <see cref="AssociationRegistry"/> instances retained by this process.
+        /// </summary>
         public static void Clear()
         {
             registries.Clear();
         }
 
         /// <summary>
-        /// Returns the remote endpoint for a pair of endpoints relative to the owner of the supplied <see cref="TestAssociationHandle"/>.
+        ///     Returns the remote endpoint for a pair of endpoints relative to the owner of the supplied
+        ///     <see cref="TestAssociationHandle" />.
         /// </summary>
         /// <param name="handle">The reference handle to determine the remote endpoint relative to</param>
         /// <param name="listenerPair">pair of listeners in initiator, receiver order</param>
@@ -433,7 +464,7 @@ namespace Akka.Remote.Transport
         }
 
         /// <summary>
-        /// Logs a transport activity
+        ///     Logs a transport activity
         /// </summary>
         /// <param name="activity">The activity to be logged</param>
         public void LogActivity(Activity activity)
@@ -442,7 +473,7 @@ namespace Akka.Remote.Transport
         }
 
         /// <summary>
-        /// Gets a snapshot of the current transport activity log
+        ///     Gets a snapshot of the current transport activity log
         /// </summary>
         /// <returns>A IList of activities ordered left-to-right in chronological order (element[0] is the oldest)</returns>
         public IList<Activity> LogSnapshot()
@@ -451,7 +482,7 @@ namespace Akka.Remote.Transport
         }
 
         /// <summary>
-        /// Clears the current contents of the log
+        ///     Clears the current contents of the log
         /// </summary>
         public void ClearLog()
         {
@@ -459,18 +490,23 @@ namespace Akka.Remote.Transport
         }
 
         /// <summary>
-        /// Records a mapping between an address and the corresponding (transport, associationEventListener) pair.
+        ///     Records a mapping between an address and the corresponding (transport, associationEventListener) pair.
         /// </summary>
         /// <param name="transport">The transport that is to be registered. The address of this transport will be used as a key.</param>
-        /// <param name="associationEventListenerTask">The Task that will be completed with the listener that will handle the events for the given transport.</param>
-        public void RegisterTransport(TestTransport transport, Task<IAssociationEventListener> associationEventListenerTask)
+        /// <param name="associationEventListenerTask">
+        ///     The Task that will be completed with the listener that will handle the
+        ///     events for the given transport.
+        /// </param>
+        public void RegisterTransport(TestTransport transport,
+            Task<IAssociationEventListener> associationEventListenerTask)
         {
-            _transportTable.TryAdd(transport.LocalAddress, new Tuple<TestTransport, Task<IAssociationEventListener>>(transport, associationEventListenerTask));
+            _transportTable.TryAdd(transport.LocalAddress,
+                new Tuple<TestTransport, Task<IAssociationEventListener>>(transport, associationEventListenerTask));
         }
 
         /// <summary>
-        /// Indicates if all given transports were successfully registered. No associations can be established between
-        /// transports that are not yet registered.
+        ///     Indicates if all given transports were successfully registered. No associations can be established between
+        ///     transports that are not yet registered.
         /// </summary>
         /// <param name="addresses">The listen addresses of transports that participate in the test case.</param>
         /// <returns>True if all transports are successfully registered.</returns>
@@ -480,21 +516,29 @@ namespace Akka.Remote.Transport
         }
 
         /// <summary>
-        /// Registers two event listeners corresponding to the two endpoints of an association.
+        ///     Registers two event listeners corresponding to the two endpoints of an association.
         /// </summary>
-        /// <param name="key">Ordered pair of addresses representing an association. First element must be the address of the initiator.</param>
-        /// <param name="listeners">A pair of listeners that will be responsible for handling the events of the two endpoints
-        /// of the association. Elements in the Tuple must be in the same order as the addresses in <paramref name="key"/>.</param>
+        /// <param name="key">
+        ///     Ordered pair of addresses representing an association. First element must be the address of the
+        ///     initiator.
+        /// </param>
+        /// <param name="listeners">
+        ///     A pair of listeners that will be responsible for handling the events of the two endpoints
+        ///     of the association. Elements in the Tuple must be in the same order as the addresses in <paramref name="key" />.
+        /// </param>
         public void RegisterListenerPair(Tuple<Address, Address> key,
             Tuple<IHandleEventListener, IHandleEventListener> listeners)
         {
-            _listenersTable.AddOrUpdate(key, x => listeners, (x,y) => listeners);
+            _listenersTable.AddOrUpdate(key, x => listeners, (x, y) => listeners);
         }
 
         /// <summary>
-        /// Removes an association.
+        ///     Removes an association.
         /// </summary>
-        /// <param name="key">Ordered pair of addresses representing an association. First element must be the address of the initiator.</param>
+        /// <param name="key">
+        ///     Ordered pair of addresses representing an association. First element must be the address of the
+        ///     initiator.
+        /// </param>
         /// <returns>The original entries, or null if the key wasn't found in the table.</returns>
         public Tuple<IHandleEventListener, IHandleEventListener> DeregisterAssociation(Tuple<Address, Address> key)
         {
@@ -504,7 +548,7 @@ namespace Akka.Remote.Transport
         }
 
         /// <summary>
-        /// Tests if an association was registered.
+        ///     Tests if an association was registered.
         /// </summary>
         /// <param name="initiatorAddress">The initiator of the association.</param>
         /// <param name="remoteAddress">The other address of the association.</param>
@@ -515,8 +559,9 @@ namespace Akka.Remote.Transport
         }
 
         /// <summary>
-        /// Returns the event handler corresponding to the remote endpoint of the given local handle. In other words
-        /// it returns the listener that will receive <see cref="InboundPayload"/> events when <seealso cref="AssociationHandle.Write"/> is called.
+        ///     Returns the event handler corresponding to the remote endpoint of the given local handle. In other words
+        ///     it returns the listener that will receive <see cref="InboundPayload" /> events when
+        ///     <seealso cref="AssociationHandle.Write" /> is called.
         /// </summary>
         /// <param name="localHandle">The handle</param>
         /// <returns>The option that contains the listener if it exists.</returns>
@@ -532,7 +577,7 @@ namespace Akka.Remote.Transport
         }
 
         /// <summary>
-        /// Returns the transport bound to the given address.
+        ///     Returns the transport bound to the given address.
         /// </summary>
         /// <param name="address">The address bound to the transport.</param>
         /// <returns>The transport, if it exists.</returns>
@@ -544,11 +589,10 @@ namespace Akka.Remote.Transport
         }
 
         /// <summary>
-        /// Clears the state of the entire registry.
-        /// 
-        /// <remarks>
-        /// This method is not atomic and does not use a critical section when clearing transports, listeners, and logs.
-        /// </remarks>
+        ///     Clears the state of the entire registry.
+        ///     <remarks>
+        ///         This method is not atomic and does not use a critical section when clearing transports, listeners, and logs.
+        ///     </remarks>
         /// </summary>
         public void Reset()
         {
@@ -560,6 +604,10 @@ namespace Akka.Remote.Transport
 
     public sealed class TestAssociationHandle : AssociationHandle
     {
+        private readonly TestTransport _transport;
+        public readonly bool Inbound;
+        internal volatile bool Writeable = true;
+
         public TestAssociationHandle(Address localAddress, Address remoteAddress, TestTransport transport, bool inbound)
             : base(localAddress, remoteAddress)
         {
@@ -567,21 +615,17 @@ namespace Akka.Remote.Transport
             _transport = transport;
         }
 
-        public readonly bool Inbound;
-
-        internal volatile bool Writeable = true;
-
-        private readonly TestTransport _transport;
-
         /// <summary>
-        /// Key used in <see cref="AssociationRegistry"/> to identify associations. Contains an ordered Tuple of addresses,
-        /// where the first address is always the initiator of the association.
+        ///     Key used in <see cref="AssociationRegistry" /> to identify associations. Contains an ordered Tuple of addresses,
+        ///     where the first address is always the initiator of the association.
         /// </summary>
         public Tuple<Address, Address> Key
         {
             get
             {
-                return !Inbound ? new Tuple<Address, Address>(LocalAddress, RemoteAddress) : new Tuple<Address, Address>(RemoteAddress, LocalAddress);
+                return !Inbound
+                    ? new Tuple<Address, Address>(LocalAddress, RemoteAddress)
+                    : new Tuple<Address, Address>(RemoteAddress, LocalAddress);
             }
         }
 
@@ -590,7 +634,7 @@ namespace Akka.Remote.Transport
             if (Writeable)
             {
                 var result = _transport.Write(this, payload);
-                result.Wait();
+                result.Wait(TimeSpan.FromSeconds(3));
                 return result.Result;
             }
 
@@ -603,4 +647,3 @@ namespace Akka.Remote.Transport
         }
     }
 }
-

--- a/src/core/Akka.Tests.Performance/Actor/ActorThroughputSpecBase.cs
+++ b/src/core/Akka.Tests.Performance/Actor/ActorThroughputSpecBase.cs
@@ -44,17 +44,15 @@ namespace Akka.Tests.Performance.Actor
                 _receiver.Tell(string.Empty);
                 ++i;
             }
-            _resetEvent.Wait(1000); //wait up to a second
+            _resetEvent.Wait(); //wait up to a second
         }
 
         [PerfCleanup]
         public void Cleanup()
         {
-            if (!_resetEvent.IsSet)
-                _resetEvent.Wait(); // wait indefinitely until the event is set
             _resetEvent.Dispose();
             System.Shutdown();
-            System.AwaitTermination(TimeSpan.FromSeconds(2));
+            System.TerminationTask.Wait();
         }
     }
 }


### PR DESCRIPTION
Modified Akka.Actor benchmarks to get more accurate reading
Added dispatcher-specific specs for Akka.Remote
close #1547 - fixed benchmarks that depend on `TestTransport`
close #1556 - memory leak caused by not clearing `TestTransport` logs