### PR TITLE
added an independent performance spec for InboundMessageDispatcher

### DIFF
--- a/src/core/Akka.Remote.Tests.Performance/Akka.Remote.Tests.Performance.csproj
+++ b/src/core/Akka.Remote.Tests.Performance/Akka.Remote.Tests.Performance.csproj
@@ -30,6 +30,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Google.ProtocolBuffers, Version=2.4.1.521, Culture=neutral, PublicKeyToken=55f7125234beb589, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Google.ProtocolBuffers.2.4.1.521\lib\net40\Google.ProtocolBuffers.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Google.ProtocolBuffers.Serialization, Version=2.4.1.521, Culture=neutral, PublicKeyToken=55f7125234beb589, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Google.ProtocolBuffers.2.4.1.521\lib\net40\Google.ProtocolBuffers.Serialization.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NBench, Version=0.1.5.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NBench.0.1.5\lib\net45\NBench.dll</HintPath>
       <Private>True</Private>
@@ -47,6 +55,7 @@
     <Compile Include="Transports\TestTransportAssociationStressSpec.cs" />
     <Compile Include="Transports\TestTransportRemoteMessagingThroughputSpec.cs" />
     <Compile Include="ThreadPoolDispatcherRemoteMessagingThroughputSpec.cs" />
+    <Compile Include="InboundMessageDispatcherSpec.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Akka.Remote\Akka.Remote.csproj">

--- a/src/core/Akka.Remote.Tests.Performance/InboundMessageDispatcherSpec.cs
+++ b/src/core/Akka.Remote.Tests.Performance/InboundMessageDispatcherSpec.cs
@@ -1,0 +1,97 @@
+﻿using System.Threading;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Util.Internal;
+using Google.ProtocolBuffers;
+using NBench;
+
+namespace Akka.Remote.Tests.Performance
+{
+    /// <summary>
+    /// Specs used to verify the performance of the <see cref="IInboundMessageDispatcher"/>,
+    /// one of the potential bottlenecks inside the remoting system
+    /// </summary>
+    public class InboundMessageDispatcherSpec
+    {
+        private const string MessageDispatcherThroughputCounterName = "InboundMessageDispatch";
+        private SerializedMessage _message;
+
+        private Counter _inboundMessageDispatcherCounter;
+        private static readonly AtomicCounter Counter = new AtomicCounter(0);
+
+        private ActorSystem _actorSystem;
+        private Address _systemAddress;
+        private IInboundMessageDispatcher _dispatcher;
+
+        private IInternalActorRef _targetActorRef;
+
+        /// <summary>
+        /// Not thread-safe, but called by a single thread in the benchmark
+        /// </summary>
+        private class BenchmarkActorRef : MinimalActorRef
+        {
+            private readonly Counter _counter;
+
+            public BenchmarkActorRef(Counter counter)
+            {
+                _counter = counter;
+            }
+
+            protected override void TellInternal(object message, IActorRef sender)
+            {
+                _counter.Increment();
+            }
+
+            public override ActorPath Path { get { return null; } }
+            public override IActorRefProvider Provider { get { return null; } }
+        }
+
+        private static readonly Config RemoteHocon = ConfigurationFactory.ParseString(@"
+             akka {
+              actor.provider = ""Akka.Remote.RemoteActorRefProvider,Akka.Remote""
+
+              remote {
+                log-remote-lifecycle-events = off
+
+                enabled-transports = [
+                  ""akka.remote.test"",
+                ]
+
+                test {
+                  transport-class = ""Akka.Remote.Transport.TestTransport,Akka.Remote""
+                  applied-adapters = []
+                  registry-key = aX33k12WKg
+                  maximum-payload-bytes = 128000b
+                  scheme-identifier = test
+                  local-address = ""test://MessageDispatcher@0.0.0.0:1111""
+                }
+              }
+        ");
+
+        [PerfSetup]
+        public void Setup(BenchmarkContext context)
+        {
+            _actorSystem = ActorSystem.Create("MessageDispatcher" + Counter.GetAndIncrement(), RemoteHocon);
+            _systemAddress = RARP.For(_actorSystem).Provider.DefaultAddress;
+            _inboundMessageDispatcherCounter = context.GetCounter(MessageDispatcherThroughputCounterName);
+            _message = SerializedMessage.CreateBuilder().SetSerializerId(0).SetMessage(ByteString.CopyFromUtf8("foo")).Build();
+            _dispatcher = new DefaultMessageDispatcher(_actorSystem, RARP.For(_actorSystem).Provider, _actorSystem.Log);
+            _targetActorRef = new BenchmarkActorRef(_inboundMessageDispatcherCounter);
+        }
+
+        [PerfBenchmark(Description = "Tests the performance of the Default", RunMode = RunMode.Throughput, NumberOfIterations = 13, TestMode = TestMode.Measurement)]
+        [CounterMeasurement(MessageDispatcherThroughputCounterName)]
+        public void DispatchThroughput(BenchmarkContext context)
+        {
+            _dispatcher.Dispatch(_targetActorRef, _systemAddress, _message);
+        }
+
+        [PerfCleanup]
+        public void Cleanup()
+        {
+            _actorSystem.Shutdown();
+            _actorSystem.TerminationTask.Wait();
+            _actorSystem = null;
+        }
+    }
+}

--- a/src/core/Akka.Remote.Tests.Performance/packages.config
+++ b/src/core/Akka.Remote.Tests.Performance/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Google.ProtocolBuffers" version="2.4.1.521" targetFramework="net45" />
   <package id="NBench" version="0.1.5" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Makes it possible to test performance improvements made to the read side of Akka.Remote independently from the rest of the message processing pipeline. Great for changes such as #1540.