### PR TITLE
Player closure fix

### DIFF
--- a/src/core/Akka.Remote.TestKit/Player.cs
+++ b/src/core/Akka.Remote.TestKit/Player.cs
@@ -447,12 +447,13 @@ namespace Akka.Remote.TestKit
                                 .Transport.ManagementCommand(new SetThrottle(throttleMsg.Target, throttleMsg.Direction,
                                     mode));
 
+                        var self = Self;
                         cmdTask.ContinueWith(t =>
                         {
                             if (t.IsFaulted)
                                 throw new ConfigurationException("Throttle was requested from the TestConductor, but no transport " +
                                     "adapters available that support throttling. Specify 'testTransport(on=true)' in your MultiNodeConfig");
-                            Self.Tell(new ToServer<Done>(Done.Instance));
+                            self.Tell(new ToServer<Done>(Done.Instance));
                         });
                         return Stay();
                     }


### PR DESCRIPTION
This PR fixes a non closed over Self reference in the Remote.TestKit Player.
`Self` is not safe to use in continuations as the `Self` property is pointing to the currently active context.

From ActorBase.cs
```csharp
protected IActorRef Self { get { return HasBeenCleared ? _clearedSelf : Context.Self; } }

protected static IActorContext Context
{
      get
      {
         var context = InternalCurrentActorCellKeeper.Current;
         if (context == null)
            throw new NotSupportedException(
                        "There is no active ActorContext, this is most likely due to use of async operations from within this actor.");

         return context.ActorHasBeenCleared ? null : context;
     }
}
```

