### PR TITLE
[api-docs]Enabled missing xmldoc output option

### DIFF
--- a/documentation/akkadoc.shfbproj
+++ b/documentation/akkadoc.shfbproj
@@ -60,22 +60,34 @@
       <DocumentationSource sourceFile="..\src\contrib\dependencyInjection\Akka.DI.Core\bin\Release\Akka.DI.Core.xml" />
       <DocumentationSource sourceFile="..\src\contrib\dependencyInjection\Akka.DI.Ninject\bin\Release\Akka.DI.Ninject.dll" />
       <DocumentationSource sourceFile="..\src\contrib\dependencyInjection\Akka.DI.Ninject\bin\Release\Akka.DI.Ninject.xml" />
+      <DocumentationSource sourceFile="..\src\contrib\dependencyInjection\Akka.DI.StructureMap\bin\Release\Akka.DI.StructureMap.dll" />
+      <DocumentationSource sourceFile="..\src\contrib\dependencyInjection\Akka.DI.StructureMap\bin\Release\Akka.DI.StructureMap.xml" />
+      <DocumentationSource sourceFile="..\src\contrib\dependencyInjection\Akka.DI.Unity\bin\Release\Akka.DI.Unity.dll" />
+      <DocumentationSource sourceFile="..\src\contrib\dependencyInjection\Akka.DI.Unity\bin\Release\Akka.DI.Unity.xml" />
       <DocumentationSource sourceFile="..\src\core\Akka\bin\Release\Akka.dll" />
       <DocumentationSource sourceFile="..\src\core\Akka\bin\Release\Akka.ExternalAnnotations.xml" />
       <DocumentationSource sourceFile="..\src\core\Akka.FSharp\bin\Release\Akka.FSharp.dll" />
       <DocumentationSource sourceFile="..\src\core\Akka.FSharp\bin\Release\Akka.FSharp.xml" />
+      <DocumentationSource sourceFile="..\src\contrib\loggers\Akka.Logger.log4net\bin\Release\Akka.Logger.log4net.dll" />
+      <DocumentationSource sourceFile="..\src\contrib\loggers\Akka.Logger.log4net\bin\Release\Akka.Logger.log4net.xml" />
       <DocumentationSource sourceFile="..\src\contrib\loggers\Akka.Logger.NLog\bin\Release\Akka.Logger.NLog.dll" />
       <DocumentationSource sourceFile="..\src\contrib\loggers\Akka.Logger.NLog\bin\Release\Akka.Logger.NLog.xml" />
       <DocumentationSource sourceFile="..\src\contrib\loggers\Akka.Logger.Serilog\bin\Release\Akka.Logger.Serilog.dll" />
       <DocumentationSource sourceFile="..\src\contrib\loggers\Akka.Logger.Serilog\bin\Release\Akka.Logger.Serilog.xml" />
       <DocumentationSource sourceFile="..\src\contrib\loggers\Akka.Logger.slf4net\bin\Release\Akka.Logger.slf4net.dll" />
       <DocumentationSource sourceFile="..\src\contrib\loggers\Akka.Logger.slf4net\bin\Release\Akka.Logger.slf4net.xml" />
+      <DocumentationSource sourceFile="..\src\contrib\serializers\Akka.Serialization.Wire\bin\Release\Akka.Serialization.Wire.dll" />
+      <DocumentationSource sourceFile="..\src\contrib\serializers\Akka.Serialization.Wire\bin\Release\Akka.Serialization.Wire.xml" />
       <DocumentationSource sourceFile="..\src\core\Akka.Persistence\bin\Release\Akka.Persistence.dll" />
       <DocumentationSource sourceFile="..\src\core\Akka.Persistence.FSharp\bin\Release\Akka.Persistence.FSharp.dll" />
       <DocumentationSource sourceFile="..\src\core\Akka.Persistence.FSharp\bin\Release\Akka.Persistence.FSharp.xml" />
       <DocumentationSource sourceFile="..\src\core\Akka.Persistence.TestKit\bin\Release\Akka.Persistence.TestKit.dll" />
       <DocumentationSource sourceFile="..\src\core\Akka.Persistence.TestKit\bin\Release\Akka.Persistence.TestKit.xml" />
       <DocumentationSource sourceFile="..\src\core\Akka.Persistence\bin\Release\Akka.Persistence.xml" />
+      <DocumentationSource sourceFile="..\src\contrib\persistence\Akka.Persistence.Sql.Common\bin\Release\Akka.Persistence.Sql.Common.xml" />
+      <DocumentationSource sourceFile="..\src\contrib\persistence\Akka.Persistence.Sql.Common\bin\Release\Akka.Persistence.Sql.Common.dll" />
+      <DocumentationSource sourceFile="..\src\contrib\persistence\Akka.Persistence.Sqlite\bin\Release\Akka.Persistence.Sqlite.xml" />
+      <DocumentationSource sourceFile="..\src\contrib\persistence\Akka.Persistence.Sqlite\bin\Release\Akka.Persistence.Sqlite.dll" />
       <DocumentationSource sourceFile="..\src\core\Akka.Remote\bin\Release\Akka.Remote.dll" />
       <DocumentationSource sourceFile="..\src\core\Akka.Remote.TestKit\bin\Release\Akka.Remote.TestKit.dll" />
       <DocumentationSource sourceFile="..\src\core\Akka.Remote.TestKit\bin\Release\Akka.Remote.TestKit.xml" />
@@ -86,6 +98,8 @@
       <DocumentationSource sourceFile="..\src\core\Akka.TestKit\bin\Release\Akka.TestKit.xml" />
       <DocumentationSource sourceFile="..\src\contrib\testkits\Akka.TestKit.Xunit\bin\Release\Akka.TestKit.Xunit.dll" />
       <DocumentationSource sourceFile="..\src\contrib\testkits\Akka.TestKit.Xunit\bin\Release\Akka.TestKit.Xunit.xml" />
+      <DocumentationSource sourceFile="..\src\contrib\testkits\Akka.TestKit.NUnit\bin\Release\Akka.TestKit.NUnit.dll" />
+      <DocumentationSource sourceFile="..\src\contrib\testkits\Akka.TestKit.NUnit\bin\Release\Akka.TestKit.NUnit.xml" />
       <DocumentationSource sourceFile="..\src\core\Akka\bin\Release\Akka.xml" />
     </DocumentationSources>
     <NamespaceSummaries>
@@ -95,10 +109,10 @@
         Akka.NET is an open-source library for building concurrent, fault-tolerant and scalable systems using the actor model.
       </NamespaceSummaryItem>
       <NamespaceSummaryItem name="Akka.Actor" isDocumented="True">
-        The Akka.Actor namespace contains classes used to create and manage actors.
+        The Akka.Actor namespace contains classes used to create and manage actors including lifecycle, message receiving and handling.
       </NamespaceSummaryItem>
       <NamespaceSummaryItem name="Akka.Actor.Dsl" isDocumented="True">
-	    The Akka.Actor.Dsl namespace contains classes used to manage an actor including lifecycle, message receiving and handling.
+	    The Akka.Actor.Dsl namespace contains classes used to create and manage an actor using a custom domain specific language.
       </NamespaceSummaryItem>
       <NamespaceSummaryItem name="Akka.Actor.Internal" isDocumented="True">
         The Akka.Actor.Internal namespace contains classes used to create and manage actors within the system. These classes are part
@@ -135,6 +149,12 @@
       <NamespaceSummaryItem name="Akka.DI.Ninject" isDocumented="True">
         The Akka.DI.Ninject namespace contains classes used to perform dependency injection using the Ninject library.
       </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.DI.StructureMap" isDocumented="True">
+        The Akka.DI.StructureMap namespace contains classes used to perform dependency injection using the StructureMap library.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.DI.Unity" isDocumented="True">
+        The Akka.DI.Unity namespace contains classes used to perform dependency injection using the Unity library.
+      </NamespaceSummaryItem>
       <NamespaceSummaryItem name="Akka.Dispatch" isDocumented="True">
         The Akka.Dispatch namespace contains classes used to dispatch messages to the actors.
       </NamespaceSummaryItem>
@@ -150,6 +170,9 @@
       <NamespaceSummaryItem name="Akka.FSharp" isDocumented="True">
         The Akka.FSharp namespace contains an API used to interact and control the system via F#.
       </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.IO" isDocumented="True">
+        The Akka.IO namespace contains classes and methods used to interact directly with actors via TCP/UDP.
+      </NamespaceSummaryItem>
       <NamespaceSummaryItem name="Akka.Logger.NLog" isDocumented="True">
         The Akka.Logger.NLog namespace contains classes used to log messages using the NLog library.
       </NamespaceSummaryItem>
@@ -159,11 +182,17 @@
       <NamespaceSummaryItem name="Akka.Logger.slf4net" isDocumented="True">
         The Akka.Logger.slf4net namespace contains classes used to log messages using the slf4net library.
       </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Logger.log4net" isDocumented="True">
+        The Akka.Logger.log4net namespace contains classes used to log messages using the log4net library.
+      </NamespaceSummaryItem>
       <NamespaceSummaryItem name="Akka.Pattern" isDocumented="True">
-        TBD
+        The Akka.Pattern namespace contains classes containing common usage patterns when interacting with actors.
       </NamespaceSummaryItem>
       <NamespaceSummaryItem name="Akka.Persistence" isDocumented="True">
-        The Akka.Persistence namespace contains classes used to save/restore an actor's state into a persistence store.
+        The Akka.Persistence namespace contains classes used to save/restore an actor's state into a persist data store.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Persistence.Fsm" isDocumented="True">
+        The Akka.Persistence.Fsm namespace contains classes used to interact with actor persistence using a state machine.
       </NamespaceSummaryItem>
       <NamespaceSummaryItem name="Akka.Persistence.Journal" isDocumented="True">
         The Akka.Persistence.Journal namespace contains classes used to journal sequences of events the actor state.
@@ -185,6 +214,30 @@
       <NamespaceSummaryItem name="Akka.Persistence.TestKit.Snapshot" isDocumented="True">
         The Akka.Persistence.TestKit.Snapshot namespace contains classes that provide base testing functionality used to test
         snapshotting in new persistence extensions.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Persistence.Sql.Common" isDocumented="True">
+        The Akka.Persistence.Sql.Common namespace contains common classes used by the various SQL persistence extensions.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Persistence.Sql.Common.Journal" isDocumented="True">
+        The Akka.Persistence.Sql.Common.Journal namespace contains common classes used by the various SQL persistence extensions
+		when journalling.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Persistence.Sql.Common.Queries" isDocumented="True">
+        The Akka.Persistence.Sql.Common.Queries namespace contains common classes used by the various SQL persistence extensions
+		when performing queries.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Persistence.Sql.Common.Snapshot" isDocumented="True">
+        The Akka.Persistence.Sql.Common.snapshot namespace contains common classes used by the various SQL persistence extensions
+		when snapshotting.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Persistence.Sqlite" isDocumented="True">
+        The Akka.Persistence namespace contains classes used to save/restore an actor's state into a Sqlite data store.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Persistence.Sqlite.Journal" isDocumented="True">
+        The Akka.Persistence.Journal namespace contains classes used when interacting with the Sqlite implementation of persistence journalling.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.Persistence.Sqlite.Snapshot" isDocumented="True">
+        The Akka.Persistence.Snapshot namespace contains classes used when interacting with the Sqlite implementation of persistence snapshotting.
       </NamespaceSummaryItem>
       <NamespaceSummaryItem name="Akka.Remote" isDocumented="True">
         The Akka.Remote namespace contains classes that provide for interacting to remote actors.
@@ -217,6 +270,9 @@
         The Akka.TestKit namespace contains classes that provide base testing functionality used by the different testkit extensions.
         This functionality allows for writing tests in the extension's framework.
       </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.TestKit.Configs" isDocumented="True">
+        The Akka.TestKit.Configs namespace contains common classes used when configuring the different testkit extensions.
+      </NamespaceSummaryItem>
       <NamespaceSummaryItem name="Akka.TestKit.Internal" isDocumented="True">
         The Akka.TestKit.Internal namespace contains classes that provide base testing functionality used by the different testkit extensions.
         This functionality allows for writing tests in the extension's framework. These classes are part of an internal API.
@@ -232,6 +288,9 @@
       </NamespaceSummaryItem>
       <NamespaceSummaryItem name="Akka.TestKit.TestEvent" isDocumented="True">
         The Akka.TestKit.TestEvent namespace contains classes that provide basic events used for event-filtering testing purposes.
+      </NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Akka.TestKit.NUnit" isDocumented="True">
+        The Akka.TestKit.NUnit namespace contains classes that provide for writing tests in NUnit.
       </NamespaceSummaryItem>
       <NamespaceSummaryItem name="Akka.TestKit.VsTest" isDocumented="True">
         The Akka.TestKit.VsTest namespace contains classes that provide for writing tests in MSTest.

--- a/src/contrib/dependencyInjection/Akka.DI.StructureMap/Akka.DI.StructureMap.csproj
+++ b/src/contrib/dependencyInjection/Akka.DI.StructureMap/Akka.DI.StructureMap.csproj
@@ -30,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\Akka.DI.StructureMap.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="StructureMap, Version=3.1.5.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/contrib/dependencyInjection/Akka.DI.Unity/Akka.DI.Unity.csproj
+++ b/src/contrib/dependencyInjection/Akka.DI.Unity/Akka.DI.Unity.csproj
@@ -30,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\Akka.DI.Unity.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Practices.Unity">

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj
@@ -28,6 +28,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\Akka.Persistence.Sql.Common.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Akka.Persistence.Sqlite.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Akka.Persistence.Sqlite.csproj
@@ -30,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\Akka.Persistence.Sqlite.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/contrib/serializers/Akka.Serialization.Wire/Akka.Serialization.Wire.csproj
+++ b/src/contrib/serializers/Akka.Serialization.Wire/Akka.Serialization.Wire.csproj
@@ -29,6 +29,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\Akka.Serialization.Wire.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
Some of the newer assemblies forgot to enable this option when they were
merged in. This PR enables that option so that Sandcastle can generate
their respective documentation pages.

Also some of the newer namespaces were missing namespace documentation,
so this PR adds those docs as well.