### PR TITLE
Enabling some tests where the problem have been solved.

### DIFF
--- a/src/core/Akka.Tests/Actor/FSMTimingSpec.cs
+++ b/src/core/Akka.Tests/Actor/FSMTimingSpec.cs
@@ -194,7 +194,7 @@ namespace Akka.Tests.Actor
         /// <summary>
         /// receiveWhile is currently broken
         /// </summary>
-        [Fact(Skip = "receiveWhile is currently broken")]
+        [Fact]
         public void FSM_must_receive_and_cancel_a_repeated_timer()
         {
             fsm.Tell(State.TestRepeatedTimer, Self);

--- a/src/core/Akka.Tests/Actor/RootGuardianActorRef_Tests.cs
+++ b/src/core/Akka.Tests/Actor/RootGuardianActorRef_Tests.cs
@@ -78,7 +78,7 @@ namespace Akka.Tests.Actor
             Assert.Same(extraNameChild, actorRef);
         }
 
-        [Fact(Skip = "Ignored")]
+        [Fact]
         public void Getting_an_unknown_child_that_exists_in_extraNames_Should_return_nobody()
         {
             var props = Props.Create<GuardianActor>(new OneForOneStrategy(e => Directive.Stop));

--- a/src/core/Akka.Tests/Event/EventStreamSpec.cs
+++ b/src/core/Akka.Tests/Event/EventStreamSpec.cs
@@ -239,7 +239,7 @@ namespace Akka.Tests.Event
             }
         }
 
-        [Fact(Skip = "TODO: this test hangs, why?")]
+        [Fact]
         public void ManageLogLevels()
         {
             var bus = new EventStream(false);


### PR DESCRIPTION
There are a few issues that have been fixed that makes it possible to re-enable these tests.
Not sure about the status of ManageLogLevels, it runs good on local machine. going to give it a few runs on the build server.