### PR TITLE
Fixes PersistentView_should_run_updates_again_on_failure_during_an_update_cycle test

### DIFF
--- a/src/core/Akka.Persistence.Tests/PersistentViewSpec.Actors.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentViewSpec.Actors.cs
@@ -67,6 +67,11 @@ namespace Akka.Persistence.Tests
             {
                 if (message.ToString() == "get") _probe.Tell(_last);
                 else if (message.ToString() == "boom") throw new TestException("boom");
+                else if (message is RecoveryFailure)
+                {
+                    var failure = message as RecoveryFailure;
+                    throw failure.Cause;
+                }
                 else if (IsPersistent && ShouldFail(message)) throw new TestException("boom");
                 else if (IsPersistent)
                 {

--- a/src/core/Akka.Persistence.Tests/PersistentViewSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentViewSpec.cs
@@ -108,7 +108,7 @@ namespace Akka.Persistence.Tests
             _viewProbe.ExpectMsg("replicated-b-2");
         }
 
-        [Fact(Skip = "FIXME")]
+        [Fact]
         public void PersistentView_should_run_updates_again_on_failure_during_an_update_cycle()
         {
             _pref.Tell("c");


### PR DESCRIPTION
This PR fixes the previously skipped test PersistentView_should_run_updates_again_on_failure_during_an_update_cycle.

There was a message that wasnt handled in the view which caused the test to fail.
Adding the message handler from scala fixed the test.

cc @Horusiath 