### PR TITLE
[WIP] Activating bounded stashing

### DIFF
--- a/src/core/Akka/Actor/Stash/IWithBoundedStash.cs
+++ b/src/core/Akka/Actor/Stash/IWithBoundedStash.cs
@@ -16,8 +16,7 @@ namespace Akka.Actor
     /// You need to add the property:
     /// <code>public IStash Stash { get; set; }</code>
     /// </summary>
-    // ReSharper disable once InconsistentNaming
-    [Obsolete("Bounded stashing is not yet implemented. Unbounded stashing will be used instead")]
+    // ReSharper disable once InconsistentNaming    
     public interface IWithBoundedStash : IActorStash, IRequiresMessageQueue<IBoundedDequeBasedMessageQueueSemantics>
     { }
 }

--- a/src/core/Akka/Dispatch/ISemantics.cs
+++ b/src/core/Akka/Dispatch/ISemantics.cs
@@ -73,7 +73,7 @@ namespace Akka.Dispatch
     /// Semantics for message queues that are Double-Ended and bounded
     /// </summary>
     public interface IBoundedDequeBasedMessageQueueSemantics : IDequeBasedMessageQueueSemantics,
-        IUnboundedMessageQueueSemantics //TODO: make this Bounded once we have BoundedMessageQueues
+        IBoundedMessageQueueSemantics 
     {
     }
 }

--- a/src/core/Akka/Dispatch/MessageQueues/UnboundedDequeMessageQueue.cs
+++ b/src/core/Akka/Dispatch/MessageQueues/UnboundedDequeMessageQueue.cs
@@ -5,6 +5,8 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
+
 namespace Akka.Dispatch.MessageQueues
 {
     public class UnboundedDequeMessageQueue : DequeWrapperMessageQueue, IUnboundedDequeBasedMessageQueueSemantics
@@ -19,6 +21,8 @@ namespace Akka.Dispatch.MessageQueues
             : base(new BoundedMessageQueue())
         {
         }
+
+        public TimeSpan PushTimeOut { get; set; }
     }
 }
 


### PR DESCRIPTION
Enabling Bounded stashing as we now have bounded message queues.

This will of course need some tests before pulling it in.
I could use some help remembering how this interface galore setup works.
It's not clear how the `DequeWrapperMessageQueue` can interact with the push timeout on the `IBoundedDequeBasedMessageQueueSemantics`

Related to #453