### PR TITLE
Resolves 1475 - reliable error capture and logging system for MultiNodeTests

### DIFF
--- a/src/core/Akka.MultiNodeTestRunner.Shared/Akka.MultiNodeTestRunner.Shared.csproj
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Akka.MultiNodeTestRunner.Shared.csproj
@@ -60,6 +60,7 @@
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Sinks\ConsoleMessageSinkActor.cs" />
+    <Compile Include="Sinks\FileSystemAppenderActor.cs" />
     <Compile Include="Sinks\FileSystemMessageSinkActor.cs" />
     <Compile Include="Sinks\IMessageSink.cs" />
     <Compile Include="Reporting\MultiNodeMessage.cs" />

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/FileSystemAppenderActor.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/FileSystemAppenderActor.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using Akka.Actor;
+
+namespace Akka.MultiNodeTestRunner.Shared.Sinks
+{
+    /// <summary>
+    /// Actor that just writes dumb messages to the file system - used for capturing
+    /// raw logs from individual nodes.
+    /// </summary>
+    public class FileSystemAppenderActor : ReceiveActor
+    {
+        private readonly string _fullFilePath;
+
+        public FileSystemAppenderActor(string fullFilePath)
+        {
+            _fullFilePath = fullFilePath;
+
+            ReceiveAny(o =>
+            {
+                File.AppendAllText(_fullFilePath, o.ToString() + Environment.NewLine);
+            });
+        }
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/FileSystemMessageSinkActor.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/FileSystemMessageSinkActor.cs
@@ -61,7 +61,15 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
         protected override void HandleTestRunTree(TestRunTree tree)
         {
             Console.WriteLine("Writing test state to: {0}", Path.GetFullPath(FileName));
-            FileStore.SaveTestRun(FileName, tree);
+            try
+            {
+                FileStore.SaveTestRun(FileName, tree);
+            }
+            catch (Exception ex) //avoid throwing exception back to parent - just continue
+            {
+                Console.WriteLine("Failed to write test state to {0}. Cause: {1}", Path.GetFullPath(FileName), ex);
+            }
+            Console.WriteLine("Finished.");
         }
 
         protected override void ReceiveFactData(FactData data)

--- a/src/core/Akka.MultiNodeTestRunner/Program.cs
+++ b/src/core/Akka.MultiNodeTestRunner/Program.cs
@@ -15,6 +15,7 @@ using System.Net;
 using System.Reflection;
 using System.Threading;
 using Akka.Actor;
+using Akka.Event;
 using Akka.IO;
 using Akka.MultiNodeTestRunner.Shared;
 using Akka.MultiNodeTestRunner.Shared.Persistence;
@@ -33,7 +34,10 @@ namespace Akka.MultiNodeTestRunner
 
         protected static IActorRef SinkCoordinator;
 
-
+        /// <summary>
+        /// file output directory
+        /// </summary>
+        protected static string OutputDirectory;
 
         /// <summary>
         /// MultiNodeTestRunner takes the following <see cref="args"/>:
@@ -67,15 +71,39 @@ namespace Akka.MultiNodeTestRunner
         ///                  as the test binary.
         ///     </description>
         /// </item>
+        /// <item>
+        ///     <term>-Dmultinode.listen-address={ip}</term>
+        ///     <description>
+        ///             Determines the address that this multi-node test runner will use to listen for log messages from
+        ///             individual NodeTestRunner.exe processes.
+        /// 
+        ///             Defaults to 127.0.0.1
+        ///     </description>
+        /// </item>
+        /// <item>
+        ///     <term>-Dmultinode.listen-port={port}</term>
+        ///     <description>
+        ///             Determines the port number that this multi-node test runner will use to listen for log messages from
+        ///             individual NodeTestRunner.exe processes.
+        /// 
+        ///             Defaults to 6577
+        ///     </description>
+        /// </item>
         /// </list>
         /// </summary>
         static void Main(string[] args)
         {
+            OutputDirectory = CommandLine.GetProperty("multinode.output-directory") ?? string.Empty;
             TestRunSystem = ActorSystem.Create("TestRunnerLogging");
             SinkCoordinator = TestRunSystem.ActorOf(Props.Create<SinkCoordinator>(), "sinkCoordinator");
 
-            var tcpLogger = TestRunSystem.ActorOf<TcpLoggingServer>();
-            TestRunSystem.Tcp().Tell(new Tcp.Bind(tcpLogger, new IPEndPoint(IPAddress.Any, 5678)));
+
+            var listenAddress = IPAddress.Parse(CommandLine.GetPropertyOrDefault("multinode.listen-address", "127.0.0.1"));
+            var listenPort = CommandLine.GetInt32OrDefault("multinode.listen-port", 6577);
+            var listenEndpoint = new IPEndPoint(listenAddress, listenPort);
+
+            var tcpLogger = TestRunSystem.ActorOf(Props.Create(() => new TcpLoggingServer(SinkCoordinator)), "TcpLogger");
+            TestRunSystem.Tcp().Tell(new Tcp.Bind(tcpLogger, listenEndpoint));
 
             var assemblyName = Path.GetFullPath(args[0]);
             EnableAllSinks(assemblyName);
@@ -101,7 +129,6 @@ namespace Akka.MultiNodeTestRunner
                         var processes = new List<Process>();
 
                         StartNewSpec(test.Value);
-
                         foreach (var nodeTest in test.Value)
                         {
                             //Loop through each test, work out number of nodes to run on and kick off process
@@ -110,22 +137,23 @@ namespace Akka.MultiNodeTestRunner
                             process.StartInfo.UseShellExecute = false;
                             process.StartInfo.RedirectStandardOutput = true;
                             process.StartInfo.FileName = "Akka.NodeTestRunner.exe";
-                            process.StartInfo.Arguments = String.Format(@"-Dmultinode.test-assembly=""{0}"" -Dmultinode.test-class=""{1}"" -Dmultinode.test-method=""{2}"" -Dmultinode.max-nodes={3} -Dmultinode.server-host=""{4}"" -Dmultinode.host=""{5}"" -Dmultinode.index={6}",
-                                assemblyName, nodeTest.TypeName, nodeTest.MethodName, test.Value.Count, "localhost", "localhost", nodeTest.Node - 1);
+                            process.StartInfo.Arguments =
+                                $@"-Dmultinode.test-assembly=""{assemblyName}"" -Dmultinode.test-class=""{
+                                    nodeTest.TypeName}"" -Dmultinode.test-method=""{nodeTest.MethodName
+                                    }"" -Dmultinode.max-nodes={test.Value.Count} -Dmultinode.server-host=""{"localhost"
+                                    }"" -Dmultinode.host=""{"localhost"}"" -Dmultinode.index={nodeTest.Node - 1
+                                    } -Dmultinode.listen-address={listenAddress} -Dmultinode.listen-port={listenPort}";
                             var nodeIndex = nodeTest.Node;
-                            process.OutputDataReceived +=
-                                (sender, line) =>
-                                {
-                                    //ignore any trailing whitespace
-                                    if (string.IsNullOrEmpty(line.Data) || string.IsNullOrWhiteSpace(line.Data)) return;
-                                    string message = line.Data;
-                                    if (!message.StartsWith("[NODE", true, CultureInfo.InvariantCulture))
-                                    {
-                                        message = "[NODE" + nodeIndex + "]" + message;
-                                    }
-                                    PublishToAllSinks(message);
-                                };
-
+                            //TODO: might need to do some validation here to avoid the 260 character max path error on Windows
+                            var folder = Directory.CreateDirectory(Path.Combine(OutputDirectory, nodeTest.MethodName));
+                            var logFilePath = Path.Combine(folder.FullName, "node" + nodeIndex + ".txt");
+                            var fileActor =
+                                TestRunSystem.ActorOf(Props.Create(() => new FileSystemAppenderActor(logFilePath)));
+                            process.OutputDataReceived += (sender, eventArgs) =>
+                            {
+                                if(eventArgs?.Data != null)
+                                    fileActor.Tell(eventArgs.Data);
+                            };
                             var closureTest = nodeTest;
                             process.Exited += (sender, eventArgs) =>
                             {
@@ -134,8 +162,8 @@ namespace Akka.MultiNodeTestRunner
                                     ReportSpecPassFromExitCode(nodeIndex, closureTest.TestName);
                                 }
                             };
+                            
                             process.Start();
-
                             process.BeginOutputReadLine();
                             PublishRunnerMessage(string.Format("Started node {0} on pid {1}", nodeTest.Node, process.Id));
                         }
@@ -171,7 +199,7 @@ namespace Akka.MultiNodeTestRunner
 
             // if multinode.output-directory wasn't specified, the results files will be written
             // to the same directory as the test assembly.
-            var outputDirectory = CommandLine.GetProperty("multinode.output-directory");
+            var outputDirectory = OutputDirectory;
 
             Func<MessageSink> createJsonFileSink = () =>
                 {
@@ -234,24 +262,26 @@ namespace Akka.MultiNodeTestRunner
 
     class TcpLoggingServer : ReceiveActor
     {
-        public TcpLoggingServer()
+        private readonly IActorRef _sinkCoordinator;
+        private readonly ILoggingAdapter _log = Context.GetLogger();
+
+        public TcpLoggingServer(IActorRef sinkCoordinator)
         {
-            var currentDirectory = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
-            var logFilePath = Path.Combine(currentDirectory, "TcpLog.txt");
+            _sinkCoordinator = sinkCoordinator;
 
             Receive<Tcp.Connected>(connected =>
             {
-                File.AppendAllText(logFilePath, $"Node connected on {Sender}{Environment.NewLine}");
+                _log.Info($"Node connected on {Sender}");
                 Sender.Tell(new Tcp.Register(Self));
             });
 
             Receive<Tcp.ConnectionClosed>(
-                closed => File.AppendAllText(logFilePath, $"Node disconnected on {Sender}{Environment.NewLine}"));
+                closed => _log.Info($"Node disconnected on {Sender}{Environment.NewLine}"));
 
             Receive<Tcp.Received>(received =>
             {
                 var message = received.Data.DecodeString();
-                File.AppendAllText(logFilePath, message + Environment.NewLine);
+                _sinkCoordinator.Tell(message);
             });
         }
     }

--- a/src/core/Akka.NodeTestRunner/Akka.NodeTestRunner.csproj
+++ b/src/core/Akka.NodeTestRunner/Akka.NodeTestRunner.csproj
@@ -79,6 +79,10 @@
       <Project>{E5957C3E-2B1E-469F-A680-7953B4DEA31B}</Project>
       <Name>Akka.Remote.TestKit</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Akka\Akka.csproj">
+      <Project>{5deddf90-37f0-48d3-a0b0-a5cbd8a7e377}</Project>
+      <Name>Akka</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.5">

--- a/src/core/Akka.Remote.TestKit/CommandLine.cs
+++ b/src/core/Akka.Remote.TestKit/CommandLine.cs
@@ -43,9 +43,19 @@ namespace Akka.Remote.TestKit
             return Values.Value[key];
         }
 
+        public static string GetPropertyOrDefault(string key, string defaultStr)
+        {
+            return Values.Value.ContainsKey(key) ? Values.Value[key] : defaultStr;
+        }
+
         public static int GetInt32(string key)
         {
             return Convert.ToInt32(GetProperty(key));
+        }
+
+        public static int GetInt32OrDefault(string key, int defaultInt)
+        {
+            return Values.Value.ContainsKey(key) ? GetInt32(key) : defaultInt;
         }
     }
 }


### PR DESCRIPTION
Builds on the work by @Silv3rcircl3 and uses a combination of STD OUT redirection and TCP logging to capture a complete picture of what actually happened inside a multi-node test.