### PR TITLE
Rewrite of the AtomicReference

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -4518,12 +4518,14 @@ namespace Akka.Util
         public Akka.Util.ILinearSeq<T> Tail() { }
     }
     public class AtomicReference<T>
+        where T :  class
     {
         protected T atomicValue;
         public AtomicReference(T originalValue) { }
         public AtomicReference() { }
         public T Value { get; set; }
         public bool CompareAndSet(T expected, T newValue) { }
+        public T GetAndSet(T newValue) { }
     }
     public class static Base64Encoding
     {

--- a/src/core/Akka.Cluster.Tests.MultiNode/FailureDetectorPuppet.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/FailureDetectorPuppet.cs
@@ -5,10 +5,10 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Threading;
 using Akka.Configuration;
 using Akka.Event;
 using Akka.Remote;
-using Akka.Util;
 
 namespace Akka.Cluster.Tests.MultiNode
 {
@@ -68,6 +68,97 @@ namespace Akka.Cluster.Tests.MultiNode
         public override void HeartBeat()
         {
             _status.CompareAndSet(Status.Unknown, Status.Up);
+        }
+
+
+        //This version was replaced with a new version which is restricted to reference types, 
+        //therefore we use the old version here.
+        private class AtomicReference<T>
+        {
+            /// <summary>
+            /// Sets the initial value of this <see cref="AtomicReference{T}"/> to <paramref name="originalValue"/>.
+            /// </summary>
+            public AtomicReference(T originalValue)
+            {
+                atomicValue = originalValue;
+            }
+
+            /// <summary>
+            /// Default constructor
+            /// </summary>
+            public AtomicReference()
+            {
+                atomicValue = default(T);
+            }
+
+            // ReSharper disable once InconsistentNaming
+            protected T atomicValue;
+
+            /// <summary>
+            /// The current value of this <see cref="AtomicReference{T}"/>
+            /// </summary>
+            public T Value
+            {
+                get
+                {
+                    Interlocked.MemoryBarrier();
+                    return atomicValue;
+                }
+                set
+                {
+                    Interlocked.MemoryBarrier();
+                    atomicValue = value;
+                    Interlocked.MemoryBarrier();
+                }
+            }
+
+            /// <summary>
+            /// If <see cref="Value"/> equals <paramref name="expected"/>, then set the Value to
+            /// <paramref name="newValue"/>.
+            /// </summary>
+            /// <returns><c>true</c> if <paramref name="newValue"/> was set</returns>
+            public bool CompareAndSet(T expected, T newValue)
+            {
+                //special handling for null values
+                if (Value == null)
+                {
+                    if (expected == null)
+                    {
+                        Value = newValue;
+                        return true;
+                    }
+                    return false;
+                }
+
+                if (Value.Equals(expected))
+                {
+                    Value = newValue;
+                    return true;
+                }
+                return false;
+            }
+
+            #region Conversion operators
+
+            /// <summary>
+            /// Implicit conversion operator = automatically casts the <see cref="AtomicReference{T}"/> to an instance of <typeparamref name="T"/>.
+            /// </summary>
+            public static implicit operator T(AtomicReference<T> aRef)
+            {
+                return aRef.Value;
+            }
+
+            /// <summary>
+            /// Implicit conversion operator = allows us to cast any type directly into a <see cref="AtomicReference{T}"/> instance.
+            /// </summary>
+            /// <param name="newValue"></param>
+            /// <returns></returns>
+            public static implicit operator AtomicReference<T>(T newValue)
+            {
+                return new AtomicReference<T>(newValue);
+            }
+
+            #endregion
         }
     }
 }

--- a/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
@@ -403,7 +403,7 @@ namespace Akka.Actor.Internal
     class TerminationCallbacks
     {
         private Task _terminationTask;
-        private AtomicReference<Task> _atomicRef;
+        private readonly AtomicReference<Task> _atomicRef;
 
         public TerminationCallbacks(Task upStreamTerminated)
         {
@@ -411,7 +411,7 @@ namespace Akka.Actor.Internal
 
             upStreamTerminated.ContinueWith(_ =>
             {
-                _terminationTask = Interlocked.Exchange(ref _atomicRef, new AtomicReference<Task>(null)).Value;
+                _terminationTask = _atomicRef.GetAndSet(null);
                 _terminationTask.Start();
             });
         }

--- a/src/core/Akka/Util/AtomicReference.cs
+++ b/src/core/Akka/Util/AtomicReference.cs
@@ -12,11 +12,12 @@ namespace Akka.Util
     /// <summary>
     /// Implementation of the java.concurrent.util AtomicReference type.
     /// 
-    /// Uses <see cref="Interlocked.MemoryBarrier"/> internally to enforce ordering of writes
+    /// Uses <see cref="Volatile"/> internally to enforce ordering of writes
     /// without any explicit locking. .NET's strong memory on write guarantees might already enforce
-    /// this ordering, but the addition of the MemoryBarrier guarantees it.
+    /// this ordering, but the addition of the Volatile guarantees it.
     /// </summary>
     public class AtomicReference<T>
+        where T : class
     {
         /// <summary>
         /// Sets the initial value of this <see cref="AtomicReference{T}"/> to <paramref name="originalValue"/>.
@@ -42,17 +43,8 @@ namespace Akka.Util
         /// </summary>
         public T Value
         {
-            get
-            {
-                Interlocked.MemoryBarrier();
-                return atomicValue;
-            }
-            set
-            {
-                Interlocked.MemoryBarrier();
-                atomicValue = value;
-                Interlocked.MemoryBarrier();
-            }
+            get { return Volatile.Read(ref atomicValue); }
+            set { Volatile.Write(ref atomicValue, value); }
         }
 
         /// <summary>
@@ -62,23 +54,18 @@ namespace Akka.Util
         /// <returns><c>true</c> if <paramref name="newValue"/> was set</returns>
         public bool CompareAndSet(T expected, T newValue)
         {
-            //special handling for null values
-            if (Value == null)
-            {
-                if (expected == null)
-                {
-                    Value = newValue;
-                    return true;
-                }
-                return false;
-            }
+            var previous = Interlocked.CompareExchange(ref atomicValue, newValue, expected);
+            return ReferenceEquals(previous, expected);
+        }
 
-            if (Value.Equals(expected))
-            {
-                Value = newValue;
-                return true;
-            }
-            return false;
+        /// <summary>
+        /// Atomically sets the <see cref="Value"/> to <paramref name="newValue"/> and returns the old <see cref="Value"/>.
+        /// </summary>
+        /// <param name="newValue">The new value</param>
+        /// <returns>The old value</returns>
+        public T GetAndSet(T newValue)
+        {
+            return Interlocked.Exchange(ref atomicValue, newValue);
         }
 
         #region Conversion operators


### PR DESCRIPTION
Based on the gitter discussion I have rewritten the AtomicReference based on the DotNetty version.

- it is now restricted to reference types
- it uses Volatile Read/Write instead of Interlocked.MemoryBarrier for the Value property
- it has a new method to atomically get the current value and replace it with a new one