### PR TITLE
PublicHostname defaults to IPAddress.Any when hostname is blank

### DIFF
--- a/src/core/Akka.Remote.Tests/RemoteConfigSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteConfigSpec.cs
@@ -12,6 +12,7 @@ using Akka.Remote.Transport.Helios;
 using Akka.TestKit;
 using Akka.Util.Internal;
 using Xunit;
+using System.Net;
 
 namespace Akka.Remote.Tests
 {
@@ -113,6 +114,17 @@ namespace Akka.Remote.Tests
                 Assert.Equal(2, pool.GetInt("pool-size-max"));
             }
         }
-    }
+
+        [Fact]
+        public void Remoting_should_contain_correct_hostname_values_in_ReferenceConf()
+        {
+           var c = ((RemoteActorRefProvider)((ActorSystemImpl)Sys).Provider).RemoteSettings.Config.GetConfig("akka.remote.helios.tcp");
+           var s = new HeliosTransportSettings(c);
+
+           //Non-specified hostnames should default to IPAddress.Any
+           Assert.Equal(IPAddress.Any.ToString(), s.Hostname);
+           Assert.Equal(IPAddress.Any.ToString(), s.PublicHostname);
+      }
+   }
 }
 

--- a/src/core/Akka.Remote/Transport/Helios/HeliosTransport.cs
+++ b/src/core/Akka.Remote/Transport/Helios/HeliosTransport.cs
@@ -84,6 +84,7 @@ namespace Akka.Remote.Transport.Helios
             var publicConfigHost = Config.GetString("public-hostname");
             Hostname = string.IsNullOrEmpty(configHost) ? IPAddress.Any.ToString() : configHost;
             PublicHostname = string.IsNullOrEmpty(publicConfigHost) ? configHost : publicConfigHost;
+            PublicHostname = string.IsNullOrEmpty(publicConfigHost) ? Hostname : publicConfigHost;
             ServerSocketWorkerPoolSize = ComputeWps(Config.GetConfig("server-socket-worker-pool"));
             ClientSocketWorkerPoolSize = ComputeWps(Config.GetConfig("client-socket-worker-pool"));
             Port = Config.GetInt("port");


### PR DESCRIPTION
Previously, the fallback for PublicHostname was the Hostname from the
config, now it's the Hostname which has the IPAddress.Any fallback.
Also, added a test to cover this