### PR TITLE
DeadLetter should implement INoSerializationVerificationNeeded

### DIFF
--- a/src/core/Akka.Tests/Actor/SupervisorStrategyConfiguratorSpec.cs
+++ b/src/core/Akka.Tests/Actor/SupervisorStrategyConfiguratorSpec.cs
@@ -1,0 +1,31 @@
+﻿using Akka.Actor;
+using Xunit;
+
+namespace Akka.Tests.Actor
+{
+    public class DefaultSupervisorStrategySpec
+    {
+        [Fact]
+        public void DefaultSupervisorStrategy_returns_default_strategy_as_a_guardian_strategy()
+        {
+            var defaultStrategyConfigurator = new DefaultSupervisorStrategy();
+
+            var result = defaultStrategyConfigurator.Create();
+
+            Assert.Equal(SupervisorStrategy.DefaultStrategy, result);
+        }
+    }
+
+    public class StoppingSupervisorStrategySpec
+    {
+        [Fact]
+        public void StoppingSupervisorStrategy_returns_stopping_strategy_as_a_guardian_strategy()
+        {
+            var defaultStrategyConfigurator = new StoppingSupervisorStrategy();
+
+            var result = defaultStrategyConfigurator.Create();
+
+            Assert.Equal(SupervisorStrategy.StoppingStrategy, result);
+        }
+    }
+}

--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Actor\StashMailboxSpec.cs" />
     <Compile Include="Actor\Stash\ActorWithStashSpec.cs" />
     <Compile Include="Actor\SupervisorHierarchySpec.cs" />
+    <Compile Include="Actor\SupervisorStrategyConfiguratorSpec.cs" />
     <Compile Include="Actor\SupervisorStrategySpecs.cs" />
     <Compile Include="Actor\SystemGuardianTests.cs" />
     <Compile Include="Configuration\ConfigurationSpec.cs" />

--- a/src/core/Akka/Actor/DefaultSupervisorStrategy.cs
+++ b/src/core/Akka/Actor/DefaultSupervisorStrategy.cs
@@ -1,0 +1,17 @@
+﻿namespace Akka.Actor
+{
+    /// <summary>
+    /// Default guardian supervision strategy.
+    /// </summary>
+    public sealed class DefaultSupervisorStrategy : ISupervisorStrategyConfigurator
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="SupervisorStrategy"/>. 
+        /// </summary>
+        /// <returns>An instance of <see cref="SupervisorStrategy"/>.</returns>
+        public SupervisorStrategy Create()
+        {
+            return SupervisorStrategy.DefaultStrategy;
+        }
+    }
+}

--- a/src/core/Akka/Actor/ISupervisorStrategyConfigurator.cs
+++ b/src/core/Akka/Actor/ISupervisorStrategyConfigurator.cs
@@ -1,0 +1,16 @@
+﻿namespace Akka.Actor
+{
+    /// <summary>
+    /// Implement this interface in order to configure the supervisorStrategy for
+    /// the top-level guardian actor (`/user`). An instance of this class must be
+    /// instantiable using a no-arg constructor.
+    /// </summary>
+    public interface ISupervisorStrategyConfigurator
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="SupervisorStrategy"/>. 
+        /// </summary>
+        /// <returns>An instance of <see cref="SupervisorStrategy"/>.</returns>
+        SupervisorStrategy Create();
+    }
+}

--- a/src/core/Akka/Actor/StoppingSupervisorStrategy.cs
+++ b/src/core/Akka/Actor/StoppingSupervisorStrategy.cs
@@ -1,0 +1,17 @@
+﻿namespace Akka.Actor
+{
+    /// <summary>
+    /// Stopping guardian supervision strategy.
+    /// </summary>
+    public sealed class StoppingSupervisorStrategy : ISupervisorStrategyConfigurator
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="SupervisorStrategy"/>. 
+        /// </summary>
+        /// <returns>An instance of <see cref="SupervisorStrategy"/>.</returns>
+        public SupervisorStrategy Create()
+        {
+            return SupervisorStrategy.StoppingStrategy;
+        }
+    }
+}

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -83,12 +83,14 @@
     <Compile Include="Actor\Cancellation\AlreadyCanceledCancelable.cs" />
     <Compile Include="Actor\Cancellation\CancelableExtensions.cs" />
     <Compile Include="Actor\Cancellation\Cancelable.cs" />
+    <Compile Include="Actor\DefaultSupervisorStrategy.cs" />
     <Compile Include="Actor\Dsl\Act.cs" />
     <Compile Include="Actor\Cancellation\ICancellable.cs" />
     <Compile Include="Actor\Inbox.Actor.cs" />
     <Compile Include="Actor\Internal\InternalCurrentActorCellKeeper.cs" />
     <Compile Include="Actor\Internal\InternalSupportsTestFSMRef.cs" />
     <Compile Include="Actor\Internal\InitializableActor.cs" />
+    <Compile Include="Actor\ISupervisorStrategyConfigurator.cs" />
     <Compile Include="Actor\Scheduler\DateTimeNowTimeProvider.cs" />
     <Compile Include="Actor\Scheduler\DedicatedThreadScheduler.cs" />
     <Compile Include="Actor\Scheduler\IDateTimeNowTimeProvider.cs" />
@@ -152,6 +154,7 @@
     <Compile Include="Actor\Stash\UntypedActorWithUnboundedStash.cs" />
     <Compile Include="Actor\Stash\IWithBoundedStash.cs" />
     <Compile Include="Actor\Stash\IWithUnboundedStash.cs" />
+    <Compile Include="Actor\StoppingSupervisorStrategy.cs" />
     <Compile Include="Configuration\ConfigurationException.cs" />
     <Compile Include="Configuration\ConfigurationFactory.cs" />
     <Compile Include="Configuration\Config.cs" />

--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -70,7 +70,7 @@ akka {
     # The guardian "/user" will use this class to obtain its supervisorStrategy.
     # It needs to be a subclass of akka.actor.SupervisorStrategyConfigurator.
     # In addition to the default there is akka.actor.StoppingSupervisorStrategy.
-    guardian-supervisor-strategy = "akka.actor.DefaultSupervisorStrategy"
+    guardian-supervisor-strategy = "Akka.Actor.DefaultSupervisorStrategy"
  
     # Timeout for ActorSystem.actorOf
     creation-timeout = 20s

--- a/src/core/Akka/Event/DeadLetter.cs
+++ b/src/core/Akka/Event/DeadLetter.cs
@@ -13,7 +13,7 @@ namespace Akka.Event
     /// Represents a message that could not be delivered to it's recipient. 
     /// This message wraps the original message, the sender and the intended recipient of the message.
     /// </summary>
-    public class DeadLetter
+    public class DeadLetter : INoSerializationVerificationNeeded
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DeadLetter"/> class.


### PR DESCRIPTION
This PR marks ```DeadLetter``` message with ```INoSerializationVerificationNeeded```. Without it, a StackOverflowException is thrown when using Wire serializer and serialization verification is enabled.