### PR TITLE
Excludes DeadLetter from serialization verification

### DIFF
--- a/src/core/Akka/Event/DeadLetter.cs
+++ b/src/core/Akka/Event/DeadLetter.cs
@@ -13,7 +13,7 @@ namespace Akka.Event
     /// Represents a message that could not be delivered to it's recipient. 
     /// This message wraps the original message, the sender and the intended recipient of the message.
     /// </summary>
-    public class DeadLetter
+    public class DeadLetter : INoSerializationVerificationNeeded
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DeadLetter"/> class.


### PR DESCRIPTION
Serialization verification in combination with Wire serializer causes ```StackOverflowException``` to be thrown as ```DeadLetter``` deserialization forces ActorSystem to send another ```DeadLetter```.