### PR TITLE
enabled additional debugging for troubleshooting RemoteRoundRobinSpec

### DIFF
--- a/src/core/Akka.Remote.Tests.MultiNode/RemoteRoundRobinSpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/RemoteRoundRobinSpec.cs
@@ -33,7 +33,7 @@ namespace Akka.Remote.Tests.MultiNode
             Third = Role("third");
             Fourth = Role("fourth");
 
-            CommonConfig = DebugConfig(false);
+            CommonConfig = DebugConfig(true);
 
             DeployOnAll(@"
       /service-hello {
@@ -244,7 +244,7 @@ namespace Akka.Remote.Tests.MultiNode
             var runOnFourth = new Action(() =>
             {
                 EnterBarrier("start");
-                var actor = Sys.ActorOf(Props.Create<BlackHoleActor>().WithRouter(FromConfig.Instance), "service-hello3");
+                var actor = Sys.ActorOf(Props.Empty.WithRouter(FromConfig.Instance), "service-hello3");
 
                 Assert.IsType<RoutedActorRef>(actor);
 
@@ -271,6 +271,8 @@ namespace Akka.Remote.Tests.MultiNode
                         });
 
                 EnterBarrier("end");
+                Log.Debug("Counts for RemoteRoundRobinSpec nodes. First: {0}, Second: {1}, Third: {2}", replies[Node(_config.First).Address],
+                    replies[Node(_config.Second).Address], replies[Node(_config.Third).Address]);
                 replies.Values.ForEach(x => Assert.Equal(x, iterationCount));
                 Assert.False(replies.ContainsKey(Node(_config.Fourth).Address));
             });

--- a/src/core/Akka.Remote.Tests.MultiNode/RemoteRoundRobinSpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/RemoteRoundRobinSpec.cs
@@ -168,6 +168,8 @@ namespace Akka.Remote.Tests.MultiNode
                 actor.Tell(new Broadcast(PoisonPill.Instance));
 
                 EnterBarrier("end");
+                Log.Debug("Counts for RemoteRoundRobinSpec nodes. First: {0}, Second: {1}, Third: {2}", replies[Node(_config.First).Address],
+                   replies[Node(_config.Second).Address], replies[Node(_config.Third).Address]);
                 replies.Values.ForEach(x => Assert.Equal(x, iterationCount));
                 Assert.False(replies.ContainsKey(Node(_config.Fourth).Address));
 


### PR DESCRIPTION
Per #1628 - turning on some additional logging so I can get a clearer picture of what's going on inside the spec.