### PR TITLE
fixes issue with Helios message ordering

### DIFF
--- a/src/core/Akka.Remote.Tests/RemoteConfigSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteConfigSpec.cs
@@ -94,8 +94,8 @@ namespace Akka.Remote.Tests
             Assert.True(s.TcpKeepAlive);
             Assert.True(s.TcpReuseAddr);
             Assert.True(string.IsNullOrEmpty(c.GetString("hostname")));
-            Assert.Equal(2, s.ServerSocketWorkerPoolSize);
-            Assert.Equal(2, s.ClientSocketWorkerPoolSize);
+            Assert.Equal(1, s.ServerSocketWorkerPoolSize);
+            Assert.Equal(1, s.ClientSocketWorkerPoolSize);
         }
 
         [Fact]
@@ -106,17 +106,17 @@ namespace Akka.Remote.Tests
             // server-socket-worker-pool
             {
                 var pool = c.GetConfig("server-socket-worker-pool");
-                Assert.Equal(2, pool.GetInt("pool-size-min"));
+                Assert.Equal(1, pool.GetInt("pool-size-min"));
                 Assert.Equal(1.0d, pool.GetDouble("pool-size-factor"));
-                Assert.Equal(2, pool.GetInt("pool-size-max"));
+                Assert.Equal(1, pool.GetInt("pool-size-max"));
             }
 
             //client-socket-worker-pool
             {
                 var pool = c.GetConfig("client-socket-worker-pool");
-                Assert.Equal(2, pool.GetInt("pool-size-min"));
+                Assert.Equal(1, pool.GetInt("pool-size-min"));
                 Assert.Equal(1.0d, pool.GetDouble("pool-size-factor"));
-                Assert.Equal(2, pool.GetInt("pool-size-max"));
+                Assert.Equal(1, pool.GetInt("pool-size-max"));
             }
         }
 

--- a/src/core/Akka.Remote/Configuration/Remote.conf
+++ b/src/core/Akka.Remote/Configuration/Remote.conf
@@ -400,7 +400,7 @@ akka {
       # Used to configure the number of I/O worker threads on server sockets
       server-socket-worker-pool {
         # Min number of threads to cap factor-based number to
-        pool-size-min = 2
+        pool-size-min = 1
 
         # The pool size factor is used to determine thread pool size
         # using the following formula: ceil(available processors * factor).
@@ -409,13 +409,13 @@ akka {
         pool-size-factor = 1.0
 
         # Max number of threads to cap factor-based number to
-        pool-size-max = 2
+        pool-size-max = 1
       }
 
       # Used to configure the number of I/O worker threads on client sockets
       client-socket-worker-pool {
         # Min number of threads to cap factor-based number to
-        pool-size-min = 2
+        pool-size-min = 1
 
         # The pool size factor is used to determine thread pool size
         # using the following formula: ceil(available processors * factor).
@@ -424,7 +424,7 @@ akka {
         pool-size-factor = 1.0
 
         # Max number of threads to cap factor-based number to
-        pool-size-max = 2
+        pool-size-max = 1
       }
 
 


### PR DESCRIPTION
Resolves #1628 - the enhanced MNTR logs revealed that Helios delivering messages for a remotely deployed actor before the remotely deployed actor was created were the problem.

This will hurt throughput to some extent in Helios, but it's more important to be functionally correct. I would like to make this part of the v1.0.6 release as it fixes what is a critical issue in my opinion.