### PR TITLE
Issue1202 boekabart

### DIFF
--- a/src/core/Akka.Tests/Util/Internal/Collections/ImmutableAvlTreeTests.cs
+++ b/src/core/Akka.Tests/Util/Internal/Collections/ImmutableAvlTreeTests.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Linq;
 using Akka.TestKit;
 using Akka.Util.Internal.Collections;
@@ -167,6 +168,83 @@ namespace Akka.Tests.Util.Internal.Collections
             Assert.Equal(62, newTree.Root.Right.Left.Key);
             Assert.Equal(88, newTree.Root.Right.Right.Key);
 
+        }
+
+        private static int TreeImbalance(ImmutableAvlTree<int, int> tree)
+        {
+            var lh = NodeHeight(tree.Root.Left);
+            var rh = NodeHeight(tree.Root.Right);
+            return lh - rh;
+        }
+
+        private static int NodeHeight(IBinaryTreeNode<int, int> tree)
+        {
+            if (tree == null) return 0;
+            return Math.Max(NodeHeight(tree.Left), NodeHeight(tree.Right)) + 1;
+        }
+
+        [Fact]
+        public void WhenRemovingNodeThatCausesLeftThenRightHeavyUnbalanceTheTreeIsRebalanced()
+        {
+            var tree = ImmutableAvlTree<int, int>.Empty
+                .Add(60, 6)
+                .Add(20, 2)
+                .Add(80, 8)
+                .Add(10, 1)
+                .Add(70, 7)
+                .Add(40, 4)
+                .Add(30, 3)
+                .Add(50, 5);
+            Assert.Equal(60, tree.Root.Key);
+            Assert.Equal(20, tree.Root.Left.Key);
+            Assert.Equal(10, tree.Root.Left.Left.Key);
+            Assert.Equal(40, tree.Root.Left.Right.Key);
+            Assert.Equal(80, tree.Root.Right.Key);
+            Assert.Equal(70, tree.Root.Right.Left.Key);
+            Assert.Null(tree.Root.Right.Right);
+            tree = tree.Remove(70);
+
+            Assert.InRange(TreeImbalance(tree), -1, 1);
+
+            Assert.Equal(40, tree.Root.Key);
+            Assert.Equal(20, tree.Root.Left.Key);
+            Assert.Equal(60, tree.Root.Right.Key);
+            Assert.Equal(10, tree.Root.Left.Left.Key);
+            Assert.Equal(30, tree.Root.Left.Right.Key);
+            Assert.Equal(50, tree.Root.Right.Left.Key);
+            Assert.Equal(80, tree.Root.Right.Right.Key);
+        }
+
+        [Fact]
+        public void WhenRemovingNodeThatCausesRightThenLeftHeavyUnbalanceTheTreeIsRebalanced()
+        {
+            var tree = ImmutableAvlTree<int, int>.Empty
+                .Add(-60, 6)
+                .Add(-20, 2)
+                .Add(-80, 8)
+                .Add(-10, 1)
+                .Add(-70, 7)
+                .Add(-40, 4)
+                .Add(-30, 3)
+                .Add(-50, 5);
+            Assert.Equal(-60, tree.Root.Key);
+            Assert.Equal(-20, tree.Root.Right.Key);
+            Assert.Equal(-10, tree.Root.Right.Right.Key);
+            Assert.Equal(-40, tree.Root.Right.Left.Key);
+            Assert.Equal(-80, tree.Root.Left.Key);
+            Assert.Equal(-70, tree.Root.Left.Right.Key);
+            Assert.Null(tree.Root.Left.Left);
+            tree = tree.Remove(-70);
+
+            Assert.InRange(TreeImbalance(tree), -1, 1);
+
+            Assert.Equal(-40, tree.Root.Key);
+            Assert.Equal(-20, tree.Root.Right.Key);
+            Assert.Equal(-60, tree.Root.Left.Key);
+            Assert.Equal(-10, tree.Root.Right.Right.Key);
+            Assert.Equal(-30, tree.Root.Right.Left.Key);
+            Assert.Equal(-50, tree.Root.Left.Right.Key);
+            Assert.Equal(-80, tree.Root.Left.Left.Key);
         }
 
         [Fact]

--- a/src/core/Akka/Util/Internal/Collections/ImmutableAvlTreeBase.cs
+++ b/src/core/Akka/Util/Internal/Collections/ImmutableAvlTreeBase.cs
@@ -439,11 +439,11 @@ namespace Akka.Util.Internal.Collections
 		private Node MakeBalanced(Node tree)
 		{
 			Node result;
-			if (IsRightHeavy(tree))
+			if (IsRightHeavyAndUnbalanced(tree))
 			{
 				result = IsLeftHeavy(tree.Right) ? DoubleLeftRotation(tree) : RotateLeft(tree);
 			}
-			else if (IsLeftHeavy(tree))
+			else if (IsLeftHeavyAndUnbalanced(tree))
 			{
 				result = IsRightHeavy(tree.Left) ? DoubleRightRotation(tree) : RotateRight(tree);
 			}
@@ -452,8 +452,10 @@ namespace Akka.Util.Internal.Collections
 			return result;
 		}
 
-		private bool IsRightHeavy(Node tree) { return Balance(tree) >= 2; }
-		private bool IsLeftHeavy(Node tree) { return Balance(tree) <= -2; }
+		private bool IsRightHeavyAndUnbalanced(Node tree) { return Balance(tree) >= 2; }
+		private bool IsLeftHeavyAndUnbalanced(Node tree) { return Balance(tree) <= -2; }
+		private bool IsRightHeavy(Node tree) { return Balance(tree) >= 1; }
+		private bool IsLeftHeavy(Node tree) { return Balance(tree) <= -1; }
 
 		private int Balance(Node tree)
 		{


### PR DESCRIPTION
This fixes #1202 which was caused by Remove sometimes returning an unbalanced tree. This happened in after the 'core' remove, node X became unbalanced, and either X.L.R was higher than X.L.L  or X.R.L was higher than X.R.R .

This has been reproduced in 2 unit tests.

Mostly this would not lead to a problem: a next remove or add would fix it, but in some cases (haven't been able to reproduce in a Unit Test, though) doing adds close to this tree (not to the tree itself!) would lead to a NullReferenceException when Rotating the now-unbalanced tree.

The fix is trivial: DoubleRotate should be done when the tree-after-remove is left (resp right) heavy - not only when it's left/right imbalanced. The helper functions were incorrectly named.