### PR TITLE
WIP Actor DSL

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -123,6 +123,20 @@ namespace Akka.Actor
         public Akka.Actor.IActorRef Watch(Akka.Actor.IActorRef subject) { }
         protected void WatchedActorTerminated(Akka.Actor.IActorRef actor, bool existenceConfirmed, bool addressTerminated) { }
     }
+    public class static ActorDsl
+    {
+        public static Akka.Actor.ActorSystem ActorSystem(string name, Akka.Configuration.Config config) { }
+        public static Akka.Actor.ActorSystem ActorSystem(string name) { }
+        public static Akka.Actor.Status.Failure Failure(System.Exception cause) { }
+        public static Akka.Routing.FromConfig FromConfig() { }
+        public static Akka.Actor.Identify Identify(object messageId) { }
+        public static Akka.Actor.PoisonPill PoisonPill() { }
+        public static Akka.Actor.Props Props<T>()
+            where T : Akka.Actor.ActorBase, new () { }
+        public static Akka.Actor.Props Props<T>(System.Linq.Expressions.Expression<System.Func<T>> factory)
+            where T : Akka.Actor.ActorBase { }
+        public static Akka.Actor.Status.Success Success(object status) { }
+    }
     public sealed class ActorIdentity
     {
         public ActorIdentity(object messageId, Akka.Actor.IActorRef subject) { }

--- a/src/core/Akka/Actor/ActorDsl.cs
+++ b/src/core/Akka/Actor/ActorDsl.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Linq.Expressions;
+using Akka.Configuration;
+using Akka.Routing;
+
+namespace Akka.Actor
+{
+    public static class ActorDsl
+    {
+        public static ActorSystem ActorSystem(string name, Config config)
+        {
+            return Actor.ActorSystem.Create(name, config);
+        }
+
+        public static ActorSystem ActorSystem(string name)
+        {
+            return Actor.ActorSystem.Create(name);
+        }
+
+        public static Props Props<T>() where T : ActorBase, new()
+        {
+            return Actor.Props.Create<T>();
+        }
+
+        public static Props Props<T>(Expression<Func<T>> factory) where T : ActorBase
+        {
+            return Actor.Props.Create(factory);
+        }
+
+        public static FromConfig FromConfig()
+        {
+            return Routing.FromConfig.Instance;
+        }
+
+        public static Identify Identify(object messageId) => new Identify(messageId);
+        public static PoisonPill PoisonPill() => Actor.PoisonPill.Instance;
+
+        public static Status.Success Success(object status)
+        {
+            return new Status.Success(status);
+        }
+
+        public static Status.Failure Failure(Exception cause)
+        {
+            return new Status.Failure(cause);
+        }
+    }
+}

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -70,6 +70,7 @@
     </Compile>
     <Compile Include="ActorState.cs" />
     <Compile Include="Actor\ActorCell.DeathWatch.cs" />
+    <Compile Include="Actor\ActorDsl.cs" />
     <Compile Include="Actor\ActorProducerPipeline.cs" />
     <Compile Include="Actor\ChildrenContainer\Internal\ChildrenContainer.cs" />
     <Compile Include="Actor\ChildrenContainer\Internal\ChildrenContainerBase.cs" />

--- a/src/examples/RemoteDeploy/System1/Program.cs
+++ b/src/examples/RemoteDeploy/System1/Program.cs
@@ -10,6 +10,7 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.Routing;
 using Shared;
+using static Akka.Actor.ActorDsl;
 
 namespace System1
 {
@@ -61,14 +62,14 @@ akka {
     }
 }
 ");
-            using (var system = ActorSystem.Create("system1", config))
+            using (var system = ActorSystem("system1", config))
             {
                 var reply = system.ActorOf<ReplyActor>("reply");
                 //create a local group router (see config)
-                var local = system.ActorOf(Props.Create(() => new SomeActor("hello", 123)).WithRouter(FromConfig.Instance), "localactor");
+                var local = system.ActorOf(Props(() => new SomeActor("hello", 123)).WithRouter(FromConfig()), "localactor");
 
                 //create a remote deployed actor
-                var remote = system.ActorOf(Props.Create(() => new SomeActor(null, 123)).WithRouter(FromConfig.Instance), "remoteactor");
+                var remote = system.ActorOf(Props(() => new SomeActor(null, 123)).WithRouter(FromConfig()), "remoteactor");
 
                 //these messages should reach the workers via the routed local ref
                 local.Tell("Local message 1", reply);


### PR DESCRIPTION
PoC of #1277

This adds some initial DSL support by using the new C#6 `using static` feature.

We can get our API closer to Scala and it is completely opt-in.. if you don't use `using static Akka.Actor.ActorDsl` then everything behaves exactly as before.

When the DSL is enabled, we get convenience features such as:

`ActorSystem(name,config)` instead of `ActorSystem.Create`
`Props<T>()` instead of `Props.Create<T>()`
`FromConfig()` instead of `FromConfig.Instance`
`Success(status)` instead of `new Status.Success(status)`
`Failure(cause)` instead of `new Status.Failure(cause)`

This can ofcourse be improved upon.
I just wanted to submit a PoC to show how it could look and start a discussion around it.
