### PR TITLE
Made JournalEntry.Payload an object and AtLeastOnceDeliverySemantic public

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/JournalDbEngine.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/JournalDbEngine.cs
@@ -29,9 +29,9 @@ namespace Akka.Persistence.Sql.Common.Journal
         public readonly bool IsDeleted;
         public readonly string Manifest;
         public readonly DateTime Timestamp;
-        public readonly byte[] Payload;
+        public readonly object Payload;
 
-        public JournalEntry(string persistenceId, long sequenceNr, bool isDeleted, string manifest, DateTime timestamp, byte[] payload)
+        public JournalEntry(string persistenceId, long sequenceNr, bool isDeleted, string manifest, DateTime timestamp, object payload)
         {
             PersistenceId = persistenceId;
             SequenceNr = sequenceNr;

--- a/src/core/Akka.Persistence/AtLeastOnceDeliverySemantic.cs
+++ b/src/core/Akka.Persistence/AtLeastOnceDeliverySemantic.cs
@@ -222,7 +222,7 @@ namespace Akka.Persistence
 
     #endregion
 
-    internal class AtLeastOnceDeliverySemantic
+    public class AtLeastOnceDeliverySemantic
     {
         /// <summary>
         ///     This exception is thrown when the <see cref="MaxUnconfirmedMessages" /> threshold has been exceeded.


### PR DESCRIPTION
This PR contains two changes:

- `JournalEntry.Payload` field from `Akka.Persistence.Sql.Common` has been made public. The reason behind it is that some database specific features (PostgreSQL JSON data type to be specific) expect from ADO.NET to pass column data in `string` format instead of `byte[]`.
- `AtLeastOnceDeliverySemantic` class has been made public, so it can be encapsulated by any other actor (not only persistent actors) to enhance them with at-least-once-delivery semantic.

None of these changes should break existing API.