### PR TITLE
Hocon Tripple quoted text - Fixes #1687

### DIFF
--- a/src/core/Akka.Tests/Configuration/HoconTests.cs
+++ b/src/core/Akka.Tests/Configuration/HoconTests.cs
@@ -387,6 +387,14 @@ a.b.e.f=3
         }
 
         [Fact]
+        public void CanAssignTripleQuotedStringWithUnescapedCharsToField()
+        {
+            var hocon = @"a=""""""hello\y\o\u""""""";
+            Assert.Equal("hello\\y\\o\\u", ConfigurationFactory.ParseString(hocon).GetString("a"));
+        }
+
+
+        [Fact]
         public void CanUseFallback()
         {
             var hocon1 = @"

--- a/src/core/Akka/Configuration/Hocon/HoconTokenizer.cs
+++ b/src/core/Akka/Configuration/Hocon/HoconTokenizer.cs
@@ -470,15 +470,8 @@ namespace Akka.Configuration.Hocon
             Take(3);
             while (!EoF && !Matches("\"\"\""))
             {
-                if (Matches("\\"))
-                {
-                    sb.Append(PullEscapeSequence());
-                }
-                else
-                {
-                    sb.Append(Peek());
-                    Take();
-                }
+                sb.Append(Peek());
+                Take();
             }
             Take(3);
             return Token.LiteralValue(sb.ToString());


### PR DESCRIPTION
This PR fixes #1687
There was special handling for escape sequences in the code that pulls tripple quoted text which should not be there.
Now any characters inside a tripple quoted string are parsed verbatim.