### PR TITLE
Sync Unix build script with Windows build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,10 +27,11 @@ popd  > /dev/null
 
 mono $SCRIPT_PATH/src/.nuget/NuGet.exe update -self
 
-mono $SCRIPT_PATH/src/.nuget/NuGet.exe install FAKE -OutputDirectory $SCRIPT_PATH/src/packages -ExcludeVersion -Version 3.28.8
+mono $SCRIPT_PATH/src/.nuget/NuGet.exe install FAKE -OutputDirectory $SCRIPT_PATH/src/packages -ExcludeVersion -Version 4.16.1
 
 mono $SCRIPT_PATH/src/.nuget/NuGet.exe install xunit.runners -OutputDirectory $SCRIPT_PATH/src/packages/FAKE -ExcludeVersion -Version 2.0.0
 mono $SCRIPT_PATH/src/.nuget/NuGet.exe install nunit.runners -OutputDirectory $SCRIPT_PATH/src/packages/FAKE -ExcludeVersion -Version 2.6.4
+mono $SCRIPT_PATH/src/.nuget/NuGet.exe install NUnit.Console -OutputDirectory $SCRIPT_PATH/src/packages/FAKE -ExcludeVersion -Version 3.0.0
 
 mono $SCRIPT_PATH/src/.nuget/NuGet.exe install NBench.Runner -OutputDirectory $SCRIPT_PATH/src/packages -ExcludeVersion -Version 0.1.5
  


### PR DESCRIPTION
The build failed, because of the outdated FAKE assembly:

```
> [Loading /home/juergen/akka.net/build.fsx]
/home/juergen/software/akka.net/build.fsx(223,11): error FS0039: The namespace 'Testing' is not defined
```