### PR TITLE
#1694 Added safe check in InboxActor when receive timeout is already expired

### DIFF
--- a/src/core/Akka.Tests/Actor/InboxSpec.cs
+++ b/src/core/Akka.Tests/Actor/InboxSpec.cs
@@ -151,6 +151,14 @@ namespace Akka.Tests.Actor
             updatedSelect.Client.ShouldBe(updatedActorRef);
         }
 
+        [Fact]
+        public void Inbox_Receive_will_timeout_gracefully_if_timeout_is_already_expired()
+        {
+            var task = _inbox.ReceiveAsync(TimeSpan.FromSeconds(-1));
+
+            Assert.True(task.Wait(1000), "Receive did not complete in time.");
+            Assert.IsType<Status.Failure>(task.Result);
+        }
     }
 }
 

--- a/src/core/Akka/Actor/Inbox.Actor.cs
+++ b/src/core/Akka/Actor/Inbox.Actor.cs
@@ -168,10 +168,21 @@ namespace Akka.Actor
                     if (_currentDeadline != null)
                     {
                         _currentDeadline.Item2.Cancel();
+                        _currentDeadline = null;
                     }
-                    var cancelable = Context.System.Scheduler.ScheduleTellOnceCancelable(next.Deadline - Context.System.Scheduler.MonotonicClock, Self, new Kick(), Self);
 
-                    _currentDeadline = Tuple.Create(next.Deadline, cancelable);
+                    TimeSpan delay = next.Deadline - Context.System.Scheduler.MonotonicClock;
+
+                    if (delay > TimeSpan.Zero)
+                    {
+                        var cancelable = Context.System.Scheduler.ScheduleTellOnceCancelable(delay, Self, new Kick(), Self);
+                        _currentDeadline = Tuple.Create(next.Deadline, cancelable);
+                    }
+                    else
+                    {
+                        // The client already timed out, Kick immediately
+                        Self.Tell(new Kick(), ActorRefs.NoSender);
+                    }
                 }
             }
 


### PR DESCRIPTION
The InboxActor could crash when scheduling a query timeout if that timeout was already expired.

I added a safety check to send a Kick to self immediately if the timeout is already expired.