### PR TITLE
[build system bug fix] locked the NBench runner version used to performance tests

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -27,7 +27,7 @@ src\.nuget\NuGet.exe update -self
 src\.nuget\NuGet.exe install FAKE -ConfigFile src\.nuget\Nuget.Config -OutputDirectory src\packages -ExcludeVersion -Version 4.16.1
 
 src\.nuget\NuGet.exe install xunit.runner.console -ConfigFile src\.nuget\Nuget.Config -OutputDirectory src\packages\FAKE -ExcludeVersion -Version 2.0.0
-src\.nuget\NuGet.exe install NBench.Runner -OutputDirectory src\packages -ExcludeVersion
+src\.nuget\NuGet.exe install NBench.Runner -OutputDirectory src\packages -ExcludeVersion -Version 0.1.5
 
 if not exist src\packages\SourceLink.Fake\tools\SourceLink.fsx (
   src\.nuget\nuget.exe install SourceLink.Fake -ConfigFile src\.nuget\Nuget.Config -OutputDirectory src\packages -ExcludeVersion

--- a/build.sh
+++ b/build.sh
@@ -32,7 +32,7 @@ mono $SCRIPT_PATH/src/.nuget/NuGet.exe install FAKE -OutputDirectory $SCRIPT_PAT
 mono $SCRIPT_PATH/src/.nuget/NuGet.exe install xunit.runners -OutputDirectory $SCRIPT_PATH/src/packages/FAKE -ExcludeVersion -Version 2.0.0
 mono $SCRIPT_PATH/src/.nuget/NuGet.exe install nunit.runners -OutputDirectory $SCRIPT_PATH/src/packages/FAKE -ExcludeVersion -Version 2.6.4
 
-mono $SCRIPT_PATH/src/.nuget/NuGet.exe install NBench.Runner -OutputDirectory $SCRIPT_PATH/src/packages -ExcludeVersion
+mono $SCRIPT_PATH/src/.nuget/NuGet.exe install NBench.Runner -OutputDirectory $SCRIPT_PATH/src/packages -ExcludeVersion -Version 0.1.5
  
 
 if ! [ -e $SCRIPT_PATH/src/packages/SourceLink.Fake/tools/SourceLink.fsx ] ; then


### PR DESCRIPTION
The release of NBench v0.1.6 yesterday introduced a redesign of how tests are loaded (isolated AppDomains) and that broke compatibility between the runner and the test dll. This locks the runner version to the version we're using in our tests and is needed in order to get CI to pass.