### PR TITLE
Replaced Receive(Func<T, Task> handler) by ReceiveAsync(...)

### DIFF
--- a/src/benchmark/PingPong/ClientAsyncActor.cs
+++ b/src/benchmark/PingPong/ClientAsyncActor.cs
@@ -19,7 +19,7 @@ namespace PingPong
         {
             var received = 0L;
             var sent = 0L;
-            Receive<Messages.Msg>(async m =>
+            ReceiveAsync<Messages.Msg>(async m =>
             {
                 received++;
                 if (sent < repeat)

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -1318,6 +1318,7 @@ namespace Akka.Actor
         protected void Become(System.Action configure, bool discardOld = True) { }
         protected void BecomeStacked(System.Action configure) { }
         protected virtual void OnReceive(object message) { }
+        [System.ObsoleteAttribute("Use ReceiveAsync instead. This method will be removed in future versions")]
         protected void Receive<T>(System.Func<T, System.Threading.Tasks.Task> handler) { }
         protected void Receive<T>(System.Action<T> handler, System.Predicate<T> shouldHandle = null) { }
         protected void Receive<T>(System.Predicate<T> shouldHandle, System.Action<T> handler) { }
@@ -1326,6 +1327,11 @@ namespace Akka.Actor
         protected void Receive<T>(System.Func<T, bool> handler) { }
         protected void Receive(System.Type messageType, System.Func<object, bool> handler) { }
         protected void ReceiveAny(System.Action<object> handler) { }
+        protected void ReceiveAnyAsync(System.Func<object, System.Threading.Tasks.Task> handler) { }
+        protected void ReceiveAsync<T>(System.Func<T, System.Threading.Tasks.Task> handler, System.Predicate<T> shouldHandle = null) { }
+        protected void ReceiveAsync<T>(System.Predicate<T> shouldHandle, System.Func<T, System.Threading.Tasks.Task> handler) { }
+        protected void ReceiveAsync(System.Type messageType, System.Func<object, System.Threading.Tasks.Task> handler, System.Predicate<object> shouldHandle = null) { }
+        protected void ReceiveAsync(System.Type messageType, System.Predicate<object> shouldHandle, System.Func<object, System.Threading.Tasks.Task> handler) { }
     }
     public class ReceiveTimeout : Akka.Actor.IPossiblyHarmful
     {

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Reporting/TestRunCoordinator.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Reporting/TestRunCoordinator.cs
@@ -112,11 +112,11 @@ namespace Akka.MultiNodeTestRunner.Shared.Reporting
                 _currentSpecRunActor.Forward(message);
             });
             Receive<BeginNewSpec>(spec => ReceiveBeginSpecRun(spec));
-            Receive<EndSpec>(spec => ReceiveEndSpecRun(spec));
+            ReceiveAsync<EndSpec>(spec => ReceiveEndSpecRun(spec));
             Receive<RequestTestRunState>(state => Sender.Tell(TestRunData.Copy(TestRunPassed(TestRunData))));
             Receive<SubscribeFactCompletionMessages>(messages => AddSubscriber(messages));
             Receive<UnsubscribeFactCompletionMessages>(messages => RemoveSubscriber(messages));
-            Receive<EndTestRun>(async run =>
+            ReceiveAsync<EndTestRun>(async run =>
             {
                 //clean up the current spec, if it hasn't been done already
                 if (_currentSpecRunActor != null)

--- a/src/core/Akka.Remote/EndpointManager.cs
+++ b/src/core/Akka.Remote/EndpointManager.cs
@@ -470,18 +470,21 @@ namespace Akka.Remote
             * those results will then be piped back to Remoting, who waits for the results of
             * listen.AddressPromise.
             * */
-            Receive<Listen>(listen => Listens.ContinueWith<INoSerializationVerificationNeeded>(listens =>
+            Receive<Listen>(listen =>
             {
-                if (listens.IsFaulted)
+                Listens.ContinueWith<INoSerializationVerificationNeeded>(listens =>
                 {
-                    return new ListensFailure(listen.AddressesPromise, listens.Exception);
-                }
-                else
-                {
-                    return new ListensResult(listen.AddressesPromise, listens.Result);
-                }
-            }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default)
-                    .PipeTo(Self));
+                    if (listens.IsFaulted)
+                    {
+                        return new ListensFailure(listen.AddressesPromise, listens.Exception);
+                    }
+                    else
+                    {
+                        return new ListensResult(listen.AddressesPromise, listens.Result);
+                    }
+                }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default)
+                    .PipeTo(Self);
+            });
 
             Receive<ListensResult>(listens =>
             {

--- a/src/core/Akka.Tests/Actor/ActorCellSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorCellSpec.cs
@@ -32,7 +32,7 @@ namespace Akka.Tests.Actor
         {
             public DummyAsyncActor(AutoResetEvent autoResetEvent)
             {
-                Receive<string>(async m =>
+                ReceiveAsync<string>(async m =>
                 {
                     await Task.Delay(500);
                     autoResetEvent.Set();

--- a/src/core/Akka.Tests/Routing/TailChoppingSpec.cs
+++ b/src/core/Akka.Tests/Routing/TailChoppingSpec.cs
@@ -25,7 +25,7 @@ namespace Akka.Tests.Routing
 
             public TailChopTestActor(int sleepTime)
             {
-                Receive<string>(async command =>
+                ReceiveAsync<string>(async command =>
                 {
                     switch (command)
                     {

--- a/src/core/Akka/Actor/ReceiveActor.cs
+++ b/src/core/Akka/Actor/ReceiveActor.cs
@@ -110,14 +110,96 @@ namespace Akka.Actor
             return newHandler;
         }
 
-        protected void Receive<T>(Func<T,Task> handler)
+        [Obsolete("Use ReceiveAsync instead. This method will be removed in future versions")]
+        protected void Receive<T>(Func<T, Task> handler)
         {
-            EnsureMayConfigureMessageHandlers();
-            _matchHandlerBuilders.Peek().Match<T>( m =>
+            ReceiveAsync(handler);
+        }
+
+        private Action<T> WrapAsyncHandler<T>(Func<T, Task> asyncHandler)
+        {
+            return m =>
             {
-                Func<Task> wrap = () => handler(m);
+                Func<Task> wrap = () => asyncHandler(m);
                 ActorTaskScheduler.RunTask(wrap);
-            });
+            };
+        }
+
+        /// <summary>
+        /// Registers an asynchronous handler for incoming messages of the specified type <typeparamref name="T"/>.
+        /// If <paramref name="shouldHandle"/>!=<c>null</c> then it must return true before a message is passed to <paramref name="handler"/>.
+        /// <remarks>The actor will be suspended until the task returned by <paramref name="handler"/> completes.</remarks>
+        /// <remarks>This method may only be called when constructing the actor or from <see cref="Become(System.Action)"/> or <see cref="BecomeStacked"/>.</remarks>
+        /// <remarks>Note that handlers registered prior to this may have handled the message already. 
+        /// In that case, this handler will not be invoked.</remarks>
+        /// </summary>
+        /// <typeparam name="T">The type of the message</typeparam>
+        /// <param name="handler">The message handler that is invoked for incoming messages of the specified type <typeparamref name="T"/></param>
+        /// <param name="shouldHandle">When not <c>null</c> it is used to determine if the message matches.</param>
+        protected void ReceiveAsync<T>(Func<T,Task> handler, Predicate<T> shouldHandle = null)
+        {
+            Receive(WrapAsyncHandler(handler), shouldHandle);
+        }
+
+        /// <summary>
+        /// Registers an asynchronous handler for incoming messages of the specified type <typeparamref name="T"/>.
+        /// If <paramref name="shouldHandle"/>!=<c>null</c> then it must return true before a message is passed to <paramref name="handler"/>.
+        /// <remarks>The actor will be suspended until the task returned by <paramref name="handler"/> completes.</remarks>
+        /// <remarks>This method may only be called when constructing the actor or from <see cref="Become(System.Action)"/> or <see cref="BecomeStacked"/>.</remarks>
+        /// <remarks>Note that handlers registered prior to this may have handled the message already. 
+        /// In that case, this handler will not be invoked.</remarks>
+        /// </summary>
+        /// <typeparam name="T">The type of the message</typeparam>
+        /// <param name="shouldHandle">When not <c>null</c> it is used to determine if the message matches.</param>
+        /// <param name="handler">The message handler that is invoked for incoming messages of the specified type <typeparamref name="T"/></param>
+        protected void ReceiveAsync<T>(Predicate<T> shouldHandle, Func<T, Task> handler)
+        {
+            Receive(WrapAsyncHandler(handler), shouldHandle);
+        }
+
+        /// <summary>
+        /// Registers an asynchronous handler for incoming messages of the specified <paramref name="messageType"/>.
+        /// If <paramref name="shouldHandle"/>!=<c>null</c> then it must return true before a message is passed to <paramref name="handler"/>.
+        /// <remarks>The actor will be suspended until the task returned by <paramref name="handler"/> completes.</remarks>
+        /// <remarks>This method may only be called when constructing the actor or from <see cref="Become(Action)"/> or <see cref="BecomeStacked"/>.</remarks>
+        /// <remarks>Note that handlers registered prior to this may have handled the message already. 
+        /// In that case, this handler will not be invoked.</remarks>
+        /// </summary>
+        /// <param name="messageType">The type of the message</param>
+        /// <param name="handler">The message handler that is invoked for incoming messages of the specified <paramref name="messageType"/></param>
+        /// <param name="shouldHandle">When not <c>null</c> it is used to determine if the message matches.</param>
+        protected void ReceiveAsync(Type messageType, Func<object, Task> handler, Predicate<object> shouldHandle = null)
+        {
+            Receive(messageType, WrapAsyncHandler(handler), shouldHandle);
+        }
+
+        /// <summary>
+        /// Registers an asynchronous handler for incoming messages of the specified <paramref name="messageType"/>.
+        /// If <paramref name="shouldHandle"/>!=<c>null</c> then it must return true before a message is passed to <paramref name="handler"/>.
+        /// <remarks>The actor will be suspended until the task returned by <paramref name="handler"/> completes.</remarks>
+        /// <remarks>This method may only be called when constructing the actor or from <see cref="Become(Action)"/> or <see cref="BecomeStacked"/>.</remarks>
+        /// <remarks>Note that handlers registered prior to this may have handled the message already. 
+        /// In that case, this handler will not be invoked.</remarks>
+        /// </summary>
+        /// <param name="messageType">The type of the message</param>
+        /// <param name="shouldHandle">When not <c>null</c> it is used to determine if the message matches.</param>
+        /// <param name="handler">The message handler that is invoked for incoming messages of the specified <paramref name="messageType"/></param>
+        protected void ReceiveAsync(Type messageType, Predicate<object> shouldHandle, Func<object, Task> handler)
+        {
+            Receive(messageType, WrapAsyncHandler(handler), shouldHandle);
+        }
+
+        /// <summary>
+        /// Registers an asynchronous handler for incoming messages of any type.
+        /// <remarks>The actor will be suspended until the task returned by <paramref name="handler"/> completes.</remarks>
+        /// <remarks>This method may only be called when constructing the actor or from <see cref="Become(Action)"/> or <see cref="BecomeStacked"/>.</remarks>
+        /// <remarks>Note that handlers registered prior to this may have handled the message already. 
+        /// In that case, this handler will not be invoked.</remarks>
+        /// </summary>
+        /// <param name="handler">The message handler that is invoked for all</param>
+        protected void ReceiveAnyAsync(Func<object, Task> handler)
+        {
+            ReceiveAny(WrapAsyncHandler(handler));
         }
 
         /// <summary>


### PR DESCRIPTION
Marked Receive(Func<T, Task> handler) as obsolete and replaced it by ReceiveAsync.

This prevents from calling the asynchronous Receive by mistake (e.g. EndpointManager)