### PR TITLE
External ActorSystem for Testkit event filters.

### DIFF
--- a/src/core/Akka.TestKit.Tests/Xunit2/TestEventListenerTests/AllTestForEventFilterBase_Instances.cs
+++ b/src/core/Akka.TestKit.Tests/Xunit2/TestEventListenerTests/AllTestForEventFilterBase_Instances.cs
@@ -13,9 +13,29 @@ namespace Akka.TestKit.Tests.Xunit2.TestEventListenerTests
     {
         public EventFilterDebugTests() : base("akka.loglevel=DEBUG"){}
 
+        protected override EventFilterFactory CreateTestingEventFilter()
+        {
+            return EventFilter;
+        }
+
         protected override void PublishMessage(object message, string source)
         {
             Sys.EventStream.Publish(new Debug(source,GetType(),message));
+        }
+    }
+
+    public class CustomEventFilterDebugTests : AllTestForEventFilterBase<Debug>
+    {
+        public CustomEventFilterDebugTests() : base("akka.loglevel=DEBUG") { }
+
+        protected override EventFilterFactory CreateTestingEventFilter()
+        {
+            return CreateEventFilter(Sys);
+        }
+
+        protected override void PublishMessage(object message, string source)
+        {
+            Sys.EventStream.Publish(new Debug(source, GetType(), message));
         }
     }
 
@@ -23,15 +43,56 @@ namespace Akka.TestKit.Tests.Xunit2.TestEventListenerTests
     {
         public EventFilterInfoTests() : base("akka.loglevel=INFO") { }
 
+        protected override EventFilterFactory CreateTestingEventFilter()
+        {
+            return EventFilter;
+        }
+
         protected override void PublishMessage(object message, string source)
         {
             Sys.EventStream.Publish(new Info(source, GetType(), message));
         }
     }
 
+    public class CustomEventFilterInfoTests : AllTestForEventFilterBase<Info>
+    {
+        public CustomEventFilterInfoTests() : base("akka.loglevel=INFO") { }
+
+        protected override EventFilterFactory CreateTestingEventFilter()
+        {
+            return CreateEventFilter(Sys);
+        }
+
+        protected override void PublishMessage(object message, string source)
+        {
+            Sys.EventStream.Publish(new Info(source, GetType(), message));
+        }
+    }
+
+
     public class EventFilterWarningTests : AllTestForEventFilterBase<Warning>
     {
         public EventFilterWarningTests() : base("akka.loglevel=WARNING") { }
+
+        protected override EventFilterFactory CreateTestingEventFilter()
+        {
+            return EventFilter;
+        }
+
+        protected override void PublishMessage(object message, string source)
+        {
+            Sys.EventStream.Publish(new Warning(source, GetType(), message));
+        }
+    }
+
+    public class CustomEventFilterWarningTests : AllTestForEventFilterBase<Warning>
+    {
+        public CustomEventFilterWarningTests() : base("akka.loglevel=WARNING") { }
+
+        protected override EventFilterFactory CreateTestingEventFilter()
+        {
+            return CreateEventFilter(Sys);
+        }
 
         protected override void PublishMessage(object message, string source)
         {
@@ -42,6 +103,26 @@ namespace Akka.TestKit.Tests.Xunit2.TestEventListenerTests
     public class EventFilterErrorTests : AllTestForEventFilterBase<Error>
     {
         public EventFilterErrorTests() : base("akka.loglevel=ERROR") { }
+
+        protected override EventFilterFactory CreateTestingEventFilter()
+        {
+            return EventFilter;
+        }
+
+        protected override void PublishMessage(object message, string source)
+        {
+            Sys.EventStream.Publish(new Error(null, source, GetType(), message));
+        }
+    }
+
+    public class CustomEventFilterErrorTests : AllTestForEventFilterBase<Error>
+    {
+        public CustomEventFilterErrorTests() : base("akka.loglevel=ERROR") { }
+
+        protected override EventFilterFactory CreateTestingEventFilter()
+        {
+            return CreateEventFilter(Sys);
+        }
 
         protected override void PublishMessage(object message, string source)
         {

--- a/src/core/Akka.TestKit.Tests/Xunit2/TestEventListenerTests/DeadLettersEventFilterTests.cs
+++ b/src/core/Akka.TestKit.Tests/Xunit2/TestEventListenerTests/DeadLettersEventFilterTests.cs
@@ -12,11 +12,12 @@ using Xunit;
 
 namespace Akka.TestKit.Tests.Xunit2.TestEventListenerTests
 {
-    public class DeadLettersEventFilterTests : EventFilterTestBase
+    public abstract class DeadLettersEventFilterTestsBase : EventFilterTestBase
     {
         private readonly IActorRef _deadActor;
+
         // ReSharper disable ConvertToLambdaExpression
-        public DeadLettersEventFilterTests() : base("akka.loglevel=ERROR")
+        protected DeadLettersEventFilterTestsBase() : base("akka.loglevel=ERROR")
         {
             _deadActor = Sys.ActorOf(BlackHoleActor.Props, "dead-actor");
             Watch(_deadActor);
@@ -29,10 +30,13 @@ namespace Akka.TestKit.Tests.Xunit2.TestEventListenerTests
             Sys.EventStream.Publish(new Error(null, "DeadLettersEventFilterTests", GetType(), message));
         }
 
+        protected abstract EventFilterFactory CreateTestingEventFilter();
+
         [Fact]
         public void Should_be_able_to_filter_dead_letters()
         {
-            EventFilter.DeadLetter().ExpectOne(() =>
+            var eventFilter = CreateTestingEventFilter();
+            eventFilter.DeadLetter().ExpectOne(() =>
             {
                 _deadActor.Tell("whatever");
             });
@@ -40,6 +44,22 @@ namespace Akka.TestKit.Tests.Xunit2.TestEventListenerTests
 
 
         // ReSharper restore ConvertToLambdaExpression
+    }
+
+    public class DeadLettersEventFilterTests : DeadLettersEventFilterTestsBase
+    {
+        protected override EventFilterFactory CreateTestingEventFilter()
+        {
+            return EventFilter;
+        }
+    }
+
+    public class DeadLettersCustomEventFilterTests : DeadLettersEventFilterTestsBase
+    {
+        protected override EventFilterFactory CreateTestingEventFilter()
+        {
+            return CreateEventFilter(Sys);
+        }
     }
 }
 

--- a/src/core/Akka.TestKit/EventFilter/EventFilterFactory_Generated.cs
+++ b/src/core/Akka.TestKit/EventFilter/EventFilterFactory_Generated.cs
@@ -15,6 +15,7 @@
 //------------------------------------------------------------------------------
 using System;
 using System.Text.RegularExpressions;
+using Akka.Actor;
 using Akka.TestKit;
 using Akka.TestKit.Internal;
 using Akka.TestKit.Internal.StringMatcher;
@@ -55,9 +56,8 @@ namespace Akka.TestKit
             var messageMatcher = CreateMessageMatcher(message, start, contains);   //This file has been auto generated. Do NOT modify this file directly
             var sourceMatcher = source == null ? null : new EqualsStringAndPathMatcher(source);
             var filter = new ErrorFilter(messageMatcher, sourceMatcher);
-            return CreateApplier(filter);
+            return CreateApplier(filter, _system);
         }
-
 
         /// <summary>
         /// Create a filter for <see cref="Akka.Event.Error"/> events. Events must match the specified pattern to be filtered.
@@ -75,7 +75,7 @@ namespace Akka.TestKit
         {
             var sourceMatcher = source == null ? null : new EqualsStringAndPathMatcher(source);
             var filter = new ErrorFilter(new RegexMatcher(pattern), sourceMatcher);
-            return CreateApplier(filter);
+            return CreateApplier(filter, _system);
         }
 
 
@@ -112,7 +112,7 @@ namespace Akka.TestKit
             var messageMatcher = CreateMessageMatcher(message, start, contains);   //This file has been auto generated. Do NOT modify this file directly
             var sourceMatcher = source == null ? null : new EqualsStringAndPathMatcher(source);
             var filter = new WarningFilter(messageMatcher, sourceMatcher);
-            return CreateApplier(filter);
+            return CreateApplier(filter, _system);
         }
 
 
@@ -132,7 +132,7 @@ namespace Akka.TestKit
         {
             var sourceMatcher = source == null ? null : new EqualsStringAndPathMatcher(source);
             var filter = new WarningFilter(new RegexMatcher(pattern), sourceMatcher);
-            return CreateApplier(filter);
+            return CreateApplier(filter, _system);
         }
 
 
@@ -169,7 +169,7 @@ namespace Akka.TestKit
             var messageMatcher = CreateMessageMatcher(message, start, contains);   //This file has been auto generated. Do NOT modify this file directly
             var sourceMatcher = source == null ? null : new EqualsStringAndPathMatcher(source);
             var filter = new InfoFilter(messageMatcher, sourceMatcher);
-            return CreateApplier(filter);
+            return CreateApplier(filter, _system);
         }
 
 
@@ -189,7 +189,7 @@ namespace Akka.TestKit
         {
             var sourceMatcher = source == null ? null : new EqualsStringAndPathMatcher(source);
             var filter = new InfoFilter(new RegexMatcher(pattern), sourceMatcher);
-            return CreateApplier(filter);
+            return CreateApplier(filter, _system);
         }
 
 
@@ -226,7 +226,7 @@ namespace Akka.TestKit
             var messageMatcher = CreateMessageMatcher(message, start, contains);   //This file has been auto generated. Do NOT modify this file directly
             var sourceMatcher = source == null ? null : new EqualsStringAndPathMatcher(source);
             var filter = new DebugFilter(messageMatcher, sourceMatcher);
-            return CreateApplier(filter);
+            return CreateApplier(filter, _system);
         }
 
 
@@ -246,7 +246,7 @@ namespace Akka.TestKit
         {
             var sourceMatcher = source == null ? null : new EqualsStringAndPathMatcher(source);
             var filter = new DebugFilter(new RegexMatcher(pattern), sourceMatcher);
-            return CreateApplier(filter);
+            return CreateApplier(filter, _system);
         }
 
 

--- a/src/core/Akka.TestKit/EventFilter/Internal/EventFilterApplier.cs
+++ b/src/core/Akka.TestKit/EventFilter/Internal/EventFilterApplier.cs
@@ -21,76 +21,69 @@ namespace Akka.TestKit.Internal
     {
         private readonly IReadOnlyList<EventFilterBase> _filters;
         private readonly TestKitBase _testkit;
+        private readonly ActorSystem _actorSystem;
 
-        public InternalEventFilterApplier(TestKitBase testkit, IReadOnlyList<EventFilterBase> filters)
+        public InternalEventFilterApplier(TestKitBase testkit, ActorSystem system, IReadOnlyList<EventFilterBase> filters)
         {
             _filters = filters;
             _testkit = testkit;
+            _actorSystem = system;
         }
-
 
         public void ExpectOne(Action action)
         {
-            InternalExpect(action, 1);
+            InternalExpect(action, _actorSystem, 1);
         }
 
         public void ExpectOne(TimeSpan timeout, Action action)
         {
-            InternalExpect(action, 1, timeout);
+            InternalExpect(action, _actorSystem, 1, timeout);
         }
 
         public void Expect(int expectedCount, Action action)
         {
-            InternalExpect(action, expectedCount, null);
+            InternalExpect(action, _actorSystem, expectedCount, null);
         }
 
         public void Expect(int expectedCount, TimeSpan timeout, Action action)
         {
-            InternalExpect(action, expectedCount, timeout);
+            InternalExpect(action, _actorSystem, expectedCount, timeout);
         }
-
-        private void InternalExpect(Action action, int expectedCount, TimeSpan? timeout = null)
-        {
-            Intercept<object>(() => { action(); return null; }, _testkit.Sys, timeout, expectedCount);
-        }
-
 
         public T ExpectOne<T>(Func<T> func)
         {
-            return Intercept(func, _testkit.Sys, null, 1);
+            return Intercept(func, _actorSystem, null, 1);
         }
 
         public T ExpectOne<T>(TimeSpan timeout, Func<T> func)
         {
-            return Intercept(func, _testkit.Sys, timeout, 1);
+            return Intercept(func, _actorSystem, timeout, 1);
         }
 
         public T Expect<T>(int expectedCount, Func<T> func)
         {
-            return Intercept(func, _testkit.Sys, null, expectedCount);
+            return Intercept(func, _actorSystem, null, expectedCount);
         }
 
         public T Expect<T>(int expectedCount, TimeSpan timeout, Func<T> func)
         {
-            return Intercept(func, _testkit.Sys, timeout, expectedCount);
+            return Intercept(func, _actorSystem, timeout, expectedCount);
         }
-
-
 
         public T Mute<T>(Func<T> func)
         {
-            return Intercept(func, _testkit.Sys, null, null);
+            return Intercept(func, _actorSystem, null, null);
         }
 
         public void Mute(Action action)
         {
-            Intercept<object>(() => { action(); return null; }, _testkit.Sys, null, null);
+            Intercept<object>(() => { action(); return null; }, _actorSystem, null, null);
         }
 
         public IUnmutableFilter Mute()
         {
-            _testkit.Sys.EventStream.Publish(new Mute(_filters));
-            return new InternalUnmutableFilter(_filters, _testkit.Sys);
+            _actorSystem.EventStream.Publish(new Mute(_filters));
+            return new InternalUnmutableFilter(_filters, _actorSystem);
         }
 
 
@@ -98,13 +91,17 @@ namespace Akka.TestKit.Internal
         {
             get
             {
-                return new EventFilterFactory(_testkit,_filters);
+                return new EventFilterFactory(_testkit, _actorSystem, _filters);
             }
         }
 
         protected T Intercept<T>(Func<T> func, ActorSystem system, TimeSpan? timeout, int? expectedOccurrences, MatchedEventHandler matchedEventHandler = null)
         {
-            var timeoutValue = timeout.HasValue ? _testkit.Dilated(timeout.Value) : TestKitExtension.For(system).TestEventFilterLeeway;
+            var leeway = system.HasExtension<TestKitSettings>()
+                ? TestKitExtension.For(system).TestEventFilterLeeway
+                : _testkit.TestKitSettings.TestEventFilterLeeway;
+
+            var timeoutValue = timeout.HasValue ? _testkit.Dilated(timeout.Value) : leeway;
             matchedEventHandler = matchedEventHandler ?? new MatchedEventHandler();
             system.EventStream.Publish(new Mute(_filters));
             try
@@ -133,8 +130,10 @@ namespace Akka.TestKit.Internal
                     else
                         msg = string.Format("Timeout ({0}) while waiting for messages that matched filter [{1}]", timeoutValue, _filters);
 
-                    var testKitAssertionsProvider = TestKitAssertionsExtension.For(system);
-                    testKitAssertionsProvider.Assertions.Fail(msg);
+                    var assertionsProvider = system.HasExtension<TestKitAssertionsProvider>()
+                        ? TestKitAssertionsExtension.For(system)
+                        : TestKitAssertionsExtension.For(_testkit.Sys);
+                    assertionsProvider.Assertions.Fail(msg);
                 }
                 return result;
             }
@@ -162,6 +161,11 @@ namespace Akka.TestKit.Internal
         protected static string GetMessageString(int number)
         {
             return number == 1 ? "message" : "messages";
+        }
+
+        private void InternalExpect(Action action, ActorSystem actorSystem, int expectedCount, TimeSpan? timeout = null)
+        {
+            Intercept<object>(() => { action(); return null; }, actorSystem, timeout, expectedCount);
         }
 
         protected class MatchedEventHandler

--- a/src/core/Akka.TestKit/TestKitBase.cs
+++ b/src/core/Akka.TestKit/TestKitBase.cs
@@ -173,6 +173,15 @@ namespace Akka.TestKit
         /// </summary>
         public EventFilterFactory EventFilter { get { return _testState.EventFilterFactory; } }
 
+        /// <summary>
+        /// Creates a new event filter for the specified actor system.
+        /// </summary>
+        /// <param name="system">Actor system.</param>
+        /// <returns>A new instance of <see cref="EventFilterFactory"/>.</returns>
+        public EventFilterFactory CreateEventFilter(ActorSystem system)
+        {
+            return new EventFilterFactory(this, system);
+        }
 
         /// <summary>
         /// Returns <c>true</c> if messages are available.


### PR DESCRIPTION
This commit resolves issue described in #1630. EventFilters now can be
created for user-defined actor systems, not only TestKit.Sys.