### PR TITLE
modified XUnit code to run each assembly individually

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -264,9 +264,13 @@ Target "RunTests" <| fun _ ->
    
     let xunitToolPath = findToolInSubPath "xunit.console.exe" "src/packages/xunit.runner.console*/tools"
     printfn "Using XUnit runner: %s" xunitToolPath
-    xUnit2
-        (fun p -> { p with XmlOutputPath = Some (testOutput + @"\XUnitTestResults.xml"); HtmlOutputPath = Some (testOutput + @"\XUnitTestResults.HTML"); ToolPath = xunitToolPath; TimeOut = System.TimeSpan.FromMinutes 30.0; Parallel = ParallelMode.NoParallelization })
-        xunitTestAssemblies
+    let runSingleAssembly assembly =
+        let assemblyName = Path.GetFileNameWithoutExtension(assembly)
+        xUnit2
+            (fun p -> { p with XmlOutputPath = Some (testOutput + @"\" + assemblyName + "_xunit.xml"); HtmlOutputPath = Some (testOutput + @"\" + assemblyName + "_xunit.HTML"); ToolPath = xunitToolPath; TimeOut = System.TimeSpan.FromMinutes 30.0; Parallel = ParallelMode.NoParallelization }) 
+            (Seq.singleton assembly)
+
+    xunitTestAssemblies |> Seq.iter (runSingleAssembly)
 
 Target "RunTestsMono" <| fun _ ->  
     let xunitTestAssemblies = !! "src/**/bin/Release Mono/*.Tests.dll"
@@ -275,9 +279,13 @@ Target "RunTestsMono" <| fun _ ->
 
     let xunitToolPath = findToolInSubPath "xunit.console.exe" "src/packages/xunit.runner.console*/tools"
     printfn "Using XUnit runner: %s" xunitToolPath
-    xUnit2
-        (fun p -> { p with XmlOutputPath = Some (testOutput + @"\XUnitTestResults.xml"); HtmlOutputPath = Some (testOutput + @"\XUnitTestResults.HTML"); ToolPath = xunitToolPath; TimeOut = System.TimeSpan.FromMinutes 30.0; Parallel = ParallelMode.NoParallelization })
-        xunitTestAssemblies
+    let runSingleAssembly assembly =
+        let assemblyName = Path.GetFileNameWithoutExtension(assembly)
+        xUnit2
+            (fun p -> { p with XmlOutputPath = Some (testOutput + @"\" + assemblyName + "_xunit.xml"); HtmlOutputPath = Some (testOutput + @"\" + assemblyName + "_xunit.HTML"); ToolPath = xunitToolPath; TimeOut = System.TimeSpan.FromMinutes 30.0; Parallel = ParallelMode.NoParallelization }) 
+            (Seq.singleton assembly)
+
+    xunitTestAssemblies |> Seq.iter (runSingleAssembly)
 
 Target "MultiNodeTests" <| fun _ ->
     let testSearchPath =

--- a/src/core/Akka.FSharp/Properties/AssemblyInfo.fs
+++ b/src/core/Akka.FSharp/Properties/AssemblyInfo.fs
@@ -6,7 +6,7 @@ open System.Runtime.InteropServices
 [<assembly: AssemblyTitleAttribute("Akka.FSharp")>]
 [<assembly: AssemblyProductAttribute("Akka.NET")>]
 [<assembly: AssemblyDescriptionAttribute("Akka.NET is a port of the popular Java/Scala framework Akka to .NET")>]
-[<assembly: AssemblyCopyrightAttribute("Copyright © 2013-2015 Akka.NET Team")>]
+[<assembly: AssemblyCopyrightAttribute("Copyright © 2013-2016 Akka.NET Team")>]
 [<assembly: AssemblyCompanyAttribute("Akka.NET Team")>]
 [<assembly: ComVisibleAttribute(false)>]
 [<assembly: CLSCompliantAttribute(true)>]


### PR DESCRIPTION
Used this to spot a problem in my repository that's similar to what's happening in #1730.

This will make it so a new XUnit process is spawned for each test assembly and all reporting / logging is done individually per-assembly now, rather than globbed together.