### PR TITLE
Issue #1766 - Lazy evaluation of ChildrenContainer.Children and ChildrenContainer.Stats

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -1769,11 +1769,11 @@ namespace Akka.Actor.Internal
     public abstract class ChildrenContainerBase : Akka.Actor.Internal.IChildrenContainer
     {
         protected ChildrenContainerBase(System.Collections.Immutable.IImmutableDictionary<string, Akka.Actor.Internal.IChildStats> children) { }
-        public System.Collections.Generic.IReadOnlyList<Akka.Actor.IInternalActorRef> Children { get; }
+        public System.Collections.Generic.IReadOnlyCollection<Akka.Actor.IInternalActorRef> Children { get; }
         protected System.Collections.Immutable.IImmutableDictionary<string, Akka.Actor.Internal.IChildStats> InternalChildren { get; }
         public virtual bool IsNormal { get; }
         public virtual bool IsTerminating { get; }
-        public System.Collections.Generic.IReadOnlyList<Akka.Actor.Internal.ChildRestartStats> Stats { get; }
+        public System.Collections.Generic.IReadOnlyCollection<Akka.Actor.Internal.ChildRestartStats> Stats { get; }
         public abstract Akka.Actor.Internal.IChildrenContainer Add(string name, Akka.Actor.Internal.ChildRestartStats stats);
         protected void ChildStatsAppender(System.Text.StringBuilder sb, System.Collections.Generic.KeyValuePair<string, Akka.Actor.Internal.IChildStats> kvp, int index) { }
         public bool Contains(Akka.Actor.IActorRef actor) { }
@@ -1796,11 +1796,11 @@ namespace Akka.Actor.Internal
     public class EmptyChildrenContainer : Akka.Actor.Internal.IChildrenContainer
     {
         protected EmptyChildrenContainer() { }
-        public System.Collections.Generic.IReadOnlyList<Akka.Actor.IInternalActorRef> Children { get; }
+        public System.Collections.Generic.IReadOnlyCollection<Akka.Actor.IInternalActorRef> Children { get; }
         public static Akka.Actor.Internal.IChildrenContainer Instance { get; }
         public virtual bool IsNormal { get; }
         public virtual bool IsTerminating { get; }
-        public System.Collections.Generic.IReadOnlyList<Akka.Actor.Internal.ChildRestartStats> Stats { get; }
+        public System.Collections.Generic.IReadOnlyCollection<Akka.Actor.Internal.ChildRestartStats> Stats { get; }
         public virtual Akka.Actor.Internal.IChildrenContainer Add(string name, Akka.Actor.Internal.ChildRestartStats stats) { }
         public bool Contains(Akka.Actor.IActorRef actor) { }
         public Akka.Actor.Internal.IChildrenContainer Remove(Akka.Actor.IActorRef child) { }
@@ -1813,10 +1813,10 @@ namespace Akka.Actor.Internal
     }
     public interface IChildrenContainer
     {
-        System.Collections.Generic.IReadOnlyList<Akka.Actor.IInternalActorRef> Children { get; }
+        System.Collections.Generic.IReadOnlyCollection<Akka.Actor.IInternalActorRef> Children { get; }
         bool IsNormal { get; }
         bool IsTerminating { get; }
-        System.Collections.Generic.IReadOnlyList<Akka.Actor.Internal.ChildRestartStats> Stats { get; }
+        System.Collections.Generic.IReadOnlyCollection<Akka.Actor.Internal.ChildRestartStats> Stats { get; }
         Akka.Actor.Internal.IChildrenContainer Add(string name, Akka.Actor.Internal.ChildRestartStats stats);
         bool Contains(Akka.Actor.IActorRef actor);
         Akka.Actor.Internal.IChildrenContainer Remove(Akka.Actor.IActorRef child);

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainer.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainer.cs
@@ -15,8 +15,8 @@ namespace Akka.Actor.Internal
         IChildrenContainer Remove(IActorRef child);
         bool TryGetByName(string name, out IChildStats stats);
         bool TryGetByRef(IActorRef actor, out ChildRestartStats stats);
-        IReadOnlyList<IInternalActorRef> Children { get; }
-        IReadOnlyList<ChildRestartStats> Stats { get; }
+        IReadOnlyCollection<IInternalActorRef> Children { get; }
+        IReadOnlyCollection<ChildRestartStats> Stats { get; }
         IChildrenContainer ShallDie(IActorRef actor);
         IChildrenContainer Reserve(string name);
         IChildrenContainer Unreserve(string name);

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainerBase.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainerBase.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -15,6 +16,41 @@ namespace Akka.Actor.Internal
 {
     public abstract class ChildrenContainerBase : IChildrenContainer
     {
+        private class LazyReadOnlyCollection<T> : IReadOnlyCollection<T>
+        {
+            private readonly IEnumerable<T> _enumerable;
+            private int _lazyCount;
+
+            public int Count
+            {
+                get
+                {
+                    int count = _lazyCount;
+
+                    if (count == -1)
+                        _lazyCount = count = _enumerable.Count();
+
+                    return count;
+                }
+            }
+
+            public LazyReadOnlyCollection(IEnumerable<T> enumerable)
+            {
+                _enumerable = enumerable;
+                _lazyCount = -1;
+            }
+
+            public IEnumerator<T> GetEnumerator()
+            {
+                return _enumerable.GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+
         private readonly IImmutableDictionary<string, IChildStats> _children;
 
         protected ChildrenContainerBase(IImmutableDictionary<string, IChildStats> children)
@@ -30,25 +66,26 @@ namespace Akka.Actor.Internal
         public abstract IChildrenContainer ShallDie(IActorRef actor);
         public abstract IChildrenContainer Unreserve(string name);
 
-        public IReadOnlyList<IInternalActorRef> Children
+        public IReadOnlyCollection<IInternalActorRef> Children
         {
             get
             {
-                return (from stat in InternalChildren.Values
-                        let childRestartStats = stat as ChildRestartStats
-                        where childRestartStats != null
-                        select childRestartStats.Child).ToList();
+                var children = InternalChildren.Values
+                    .OfType<ChildRestartStats>()
+                    .Select(item => item.Child);
+
+                // The children collection must stay lazy evaluated
+                return new LazyReadOnlyCollection<IInternalActorRef>(children);
             }
         }
 
-        public IReadOnlyList<ChildRestartStats> Stats
+        public IReadOnlyCollection<ChildRestartStats> Stats
         {
             get
             {
-                return (from stat in InternalChildren.Values
-                        let childRestartStats = stat as ChildRestartStats
-                        where childRestartStats != null
-                        select childRestartStats).ToList();
+                var children = InternalChildren.Values.OfType<ChildRestartStats>();
+
+                return new LazyReadOnlyCollection<ChildRestartStats>(children);
             }
         }
 

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/EmptyChildrenContainer.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/EmptyChildrenContainer.cs
@@ -54,9 +54,9 @@ namespace Akka.Actor.Internal
             return false;
         }
 
-        public IReadOnlyList<IInternalActorRef> Children { get { return ImmutableList<IInternalActorRef>.Empty; } }
+        public IReadOnlyCollection<IInternalActorRef> Children { get { return ImmutableList<IInternalActorRef>.Empty; } }
 
-        public IReadOnlyList<ChildRestartStats> Stats { get { return ImmutableList<ChildRestartStats>.Empty; } }
+        public IReadOnlyCollection<ChildRestartStats> Stats { get { return ImmutableList<ChildRestartStats>.Empty; } }
 
         public IChildrenContainer ShallDie(IActorRef actor)
         {


### PR DESCRIPTION
ChildrenContainer.Children was returning a copy of all its child. This PR change the Children and Stats property to return the lazy evaluated LINQ expression instead of a copy.

- This is safe because the underlying collection is immutable
- This is more efficient because:
  - No memory is allocated
  - Enumerating the children from the ImmutableDictionary is not expensive
  - The returned IReadOnlyCollection is not iterated in most case

The performance problem of issue #1766 was caused by this line:
https://github.com/akkadotnet/akka.net/blob/d00159ee8be45babecc7d20b935559df1415f49f/src/core/Akka/Actor/ActorCell.FaultHandling.cs#L422

(Note that the implementation of HandleChildTerminated is not touching the children parameter)

With this PR, GetChildren is lazy evaluated, so calling this method is not expensive anymore.