### PR TITLE
Removed all usage of AttachedToParent

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/SqlJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/SqlJournal.cs
@@ -57,7 +57,7 @@ namespace Akka.Persistence.Sql.Common.Journal
             })
             .ContinueWith(task => 
                 task.IsFaulted || task.IsCanceled ? (IQueryReply)new QueryFailure(queryId, task.Exception) : new QuerySuccess(queryId), 
-                TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.AttachedToParent)
+                TaskContinuationOptions.ExecuteSynchronously)
             .PipeTo(Context.Sender);
         }
 

--- a/src/core/Akka.FSharp/FsApi.fs
+++ b/src/core/Akka.FSharp/FsApi.fs
@@ -84,7 +84,7 @@ module Actors =
     /// tracked by actorRef and awaits for response send back from corresponding actor. 
     /// </summary>
     let (<?) (tell : #ICanTell) (msg : obj) : Async<'Message> = 
-        tell.Ask(msg).ContinueWith(Func<_,'Message>(tryCast), TaskContinuationOptions.AttachedToParent|||TaskContinuationOptions.ExecuteSynchronously)
+        tell.Ask(msg).ContinueWith(Func<_,'Message>(tryCast), TaskContinuationOptions.ExecuteSynchronously)
         |> Async.AwaitTask
 
     /// Pipes an output of asynchronous expression directly to the recipients mailbox.

--- a/src/core/Akka.Persistence.Tests/Journal/SteppingMemoryJournal.cs
+++ b/src/core/Akka.Persistence.Tests/Journal/SteppingMemoryJournal.cs
@@ -43,7 +43,7 @@ namespace Akka.Persistence.Tests.Journal
             private TokenConsumed() { }
         }
 
-        private static readonly TaskContinuationOptions _continuationOptions = TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.AttachedToParent;
+        private static readonly TaskContinuationOptions _continuationOptions = TaskContinuationOptions.ExecuteSynchronously;
         // keep it in a thread safe global so that tests can get their hand on the actor ref and send Steps to it
         private static readonly ConcurrentDictionary<string, IActorRef> _current = new ConcurrentDictionary<string, IActorRef>();
         private readonly string _instanceId;

--- a/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
@@ -17,7 +17,7 @@ namespace Akka.Persistence.Journal
 {
     public abstract class AsyncWriteJournal : WriteJournalBase, IAsyncRecovery
     {
-        private static readonly TaskContinuationOptions _continuationOptions = TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.AttachedToParent;
+        private static readonly TaskContinuationOptions _continuationOptions = TaskContinuationOptions.ExecuteSynchronously;
         protected readonly bool CanPublish;
         private readonly CircuitBreaker _breaker;
         private readonly ReplayFilterMode _replayFilterMode;

--- a/src/core/Akka.Persistence/Snapshot/SnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/SnapshotStore.cs
@@ -14,8 +14,7 @@ namespace Akka.Persistence.Snapshot
 {
     public abstract class SnapshotStore : ActorBase
     {
-        private readonly TaskContinuationOptions _continuationOptions = TaskContinuationOptions.ExecuteSynchronously |
-                                                                        TaskContinuationOptions.AttachedToParent;
+        private readonly TaskContinuationOptions _continuationOptions = TaskContinuationOptions.ExecuteSynchronously;
         private readonly bool _publish;
         private readonly CircuitBreaker _breaker;
 

--- a/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
+++ b/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
@@ -892,7 +892,7 @@ namespace Akka.Remote.Transport
         private void ListenForListenerRegistration(TaskCompletionSource<IHandleEventListener> readHandlerSource)
         {
             readHandlerSource.Task.ContinueWith(rh => new HandleListenerRegistered(rh.Result),
-                TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.AttachedToParent).PipeTo(Self);
+                TaskContinuationOptions.ExecuteSynchronously).PipeTo(Self);
         }
 
         private Task<IHandleEventListener> NotifyOutboundHandler(AssociationHandle wrappedHandle,

--- a/src/core/Akka.Remote/Transport/ThrottleTransportAdapter.cs
+++ b/src/core/Akka.Remote/Transport/ThrottleTransportAdapter.cs
@@ -433,7 +433,7 @@ namespace Akka.Remote.Transport
                 //        internalTarget.Tell(new Unwatch(target, promiseRef));
                 //       return SetThrottleAck.Instance;
                 //    }
-                //}, TaskContinuationOptions.AttachedToParent & TaskContinuationOptions.ExecuteSynchronously);
+                //}, TaskContinuationOptions.ExecuteSynchronously);
 
             }
         }

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -64,7 +64,7 @@ namespace Akka.Actor
         private static Task<object> Ask(ICanTell self, object message, IActorRefProvider provider,
             TimeSpan? timeout)
         {
-            var result = new TaskCompletionSource<object>(TaskContinuationOptions.AttachedToParent);
+            var result = new TaskCompletionSource<object>();
 
             timeout = timeout ?? provider.Settings.AskTimeout;
 


### PR DESCRIPTION
This flag could be harmful by making the outer task waits until the inner tasks complete.