### PR TITLE
Bugfix: Assert.All takes an 'Action' and not a 'Func', so it won't ch…

### DIFF
--- a/src/core/Akka.Remote.Tests.MultiNode/Router/RemoteRoundRobinSpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/Router/RemoteRoundRobinSpec.cs
@@ -223,7 +223,7 @@ namespace Akka.Remote.Tests.MultiNode.Router
                         .Select(x => x.Address);
 
                     // check if they have same elements (ignoring order)
-                    Assert.All(repliesFromAddresses, x => expectedAddresses.Contains(x));
+                    Assert.All(repliesFromAddresses, x => Assert.Contains(x, expectedAddresses));
                     Assert.True(repliesFromAddresses.Count() == expectedAddresses.Count());
 
                     Sys.Stop(actor);


### PR DESCRIPTION
…eck the return value of a 'Func<?, bool>'

`Assert.All` simply executes the action on all elements of the collection inside a try catch block. So unless `Exception`s are being checked, it typically contains an `Assert` statement.