### PR TITLE
Member.UpNumber fix

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
@@ -92,8 +92,8 @@ namespace Akka.Cluster.Sharding
 
             public int Compare(Member x, Member y)
             {
-                if (y.IsOlderThan(x)) return -1;
-                return x.IsOlderThan(y) ? 1 : 0;
+                if (x.IsOlderThan(y)) return -1;
+                return y.IsOlderThan(x) ? 1 : 0;
             }
         }
 

--- a/src/core/Akka.Cluster.Tests/TestMember.cs
+++ b/src/core/Akka.Cluster.Tests/TestMember.cs
@@ -19,7 +19,7 @@ namespace Akka.Cluster.Tests
 
         public static Member Create(Address address, MemberStatus status, ImmutableHashSet<string> roles)
         {
-            return Member.Create(new UniqueAddress(address, 0), status, roles);
+            return Member.Create(new UniqueAddress(address, 0), 0, status, roles);
         }
     }
 }

--- a/src/core/Akka.Cluster/Member.cs
+++ b/src/core/Akka.Cluster/Member.cs
@@ -52,9 +52,9 @@ namespace Akka.Cluster
         readonly ImmutableHashSet<string> _roles;
         public ImmutableHashSet<string> Roles { get { return _roles; } }
 
-        public static Member Create(UniqueAddress uniqueAddress, MemberStatus status, ImmutableHashSet<string> roles)
+        public static Member Create(UniqueAddress uniqueAddress, int upNumber, MemberStatus status, ImmutableHashSet<string> roles)
         {
-            return new Member(uniqueAddress, 0, status, roles);
+            return new Member(uniqueAddress, upNumber, status, roles);
         }
 
         Member(UniqueAddress uniqueAddress, int upNumber, MemberStatus status, ImmutableHashSet<string> roles)

--- a/src/core/Akka.Cluster/Proto/ClusterMessageSerializer.cs
+++ b/src/core/Akka.Cluster/Proto/ClusterMessageSerializer.cs
@@ -456,7 +456,7 @@ namespace Akka.Cluster.Proto
                 return new Reachability(recordBuilder.ToImmutable(), versionsBuilder.ToImmutable());
             };
 
-            Func<Msg.Member, Member> memberFromProto = member => Member.Create(addressMapping[member.AddressIndex], MemberStatusFromProto[member.Status],
+            Func<Msg.Member, Member> memberFromProto = member => Member.Create(addressMapping[member.AddressIndex], member.HasUpNumber ? member.UpNumber : 0, MemberStatusFromProto[member.Status],
                 member.RolesIndexesList.Select(x => roleMapping[x]).ToImmutableHashSet());
 
             var members = gossip.MembersList.Select(memberFromProto).ToImmutableSortedSet(Member.Ordering);

--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -254,7 +254,8 @@ namespace Akka.Actor
             var a = path;
             foreach (string element in name)
             {
-                a = a / element;
+                if(!string.IsNullOrEmpty(element))
+                    a = a / element;
             }
             return a;
         }


### PR DESCRIPTION
Fixes issue #1784.

Member.UpNumber is not being propagated across cluster
MemberAgeComparer is sorting in a reverse order then it should