### PR TITLE
Lazy Remote Sender WIP

### DIFF
--- a/src/core/Akka.Remote/RemoteActorRef.cs
+++ b/src/core/Akka.Remote/RemoteActorRef.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using Akka.Actor;
 using Akka.Dispatch.SysMsg;
+using Akka.Util;
 
 namespace Akka.Remote
 {
@@ -176,6 +177,43 @@ namespace Akka.Remote
             if (_props != null && _deploy != null)
                 Remote.Provider.UseActorOnNode(this, _props, _deploy, _parent);
         }
+    }
+
+    public class LazyActorRef : IActorRef
+    {
+        private readonly Lazy<IActorRef> _lazyActorRef;
+
+        public LazyActorRef(RemoteActorRefProvider provider,Address address, string path)
+        {
+            _lazyActorRef = new Lazy<IActorRef>(() => provider.ResolveActorRefWithLocalAddress(path,address));
+        }
+
+        public void Tell(object message, IActorRef sender)
+        {
+            _lazyActorRef.Value.Tell(message, sender);
+        }
+
+        public bool Equals(IActorRef other)
+        {
+            return _lazyActorRef.Value.Equals(other);
+        }
+
+        public int CompareTo(IActorRef other)
+        {
+            return _lazyActorRef.Value.CompareTo(other);
+        }
+
+        public ISurrogate ToSurrogate(ActorSystem system)
+        {
+            return _lazyActorRef.Value.ToSurrogate(system);
+        }
+
+        public int CompareTo(object obj)
+        {
+            return _lazyActorRef.Value.CompareTo(obj);
+        }
+
+        public ActorPath Path => _lazyActorRef.Value.Path;
     }
 }
 

--- a/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
+++ b/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
@@ -226,7 +226,7 @@ namespace Akka.Remote.Transport
                     IActorRef senderOption = null;
                     if (envelopeContainer.HasSender)
                     {
-                        senderOption = provider.ResolveActorRefWithLocalAddress(envelopeContainer.Sender.Path, localAddress);
+                        senderOption = new LazyActorRef(provider,localAddress, envelopeContainer.Sender.Path);
                     }
                     SeqNo seqOption = null;
                     if (envelopeContainer.HasSeq)


### PR DESCRIPTION
This is an experiment to see if we can lazily resolve Remote senders.
Instead of resolving the remote sender directly, we instead pack the remote path inside a new `LazyActorRef` which will resolve the remote actor once any members have been touched.

This could potentially have a positive performance impact on Akka.Remote as most actor code never touch the Sender property. 

cc @JeffCyr