### PR TITLE
Warning about JSON.NET obsolete in v1.5

### DIFF
--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -26,6 +26,10 @@ akka {
   # as they have been started; before that, see "stdout-loglevel"
   # Options: OFF, ERROR, WARNING, INFO, DEBUG
   loglevel = "INFO"
+
+  # Suppresses warning about usage of the default (JSON.NET) serializer
+  # which is going to be obsoleted at v1.5
+  suppress-json-serializer-warning = off
  
   # Log level for the very basic logger activated during AkkaApplication startup
   # Options: OFF, ERROR, WARNING, INFO, DEBUG


### PR DESCRIPTION
This PR includes information about obsoleting JSON.NET as the default serializer in Akka.NET version 1.5. (see #1695). Warning contains link to manual informing, how to change default serializer to Wire and info about how to suppress this warning message by setting `suppress-json-serializer-warning` config key to on.