### PR TITLE
Completed port of ActorGraphInterpreterSpec

### DIFF
--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/ActorGraphInterpreterSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/ActorGraphInterpreterSpec.cs
@@ -2,11 +2,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Streams;
+using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Streams.Dsl;
-using Akka.Streams.Dsl.Internal;
 using Akka.Streams.Implementation.Fusing;
 using Akka.Streams.Stage;
+using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
 using FluentAssertions;
 using Xunit;
@@ -102,7 +104,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                     .Grouped(200)
                     .ToMaterialized(Sink.First<IEnumerable<int>>(), Keep.Right);
 
-                var g = RunnableGraph<Tuple<Task<IEnumerable<int>>, Task<IEnumerable<int>>>>.FromGraph(
+                var result = RunnableGraph<Tuple<Task<IEnumerable<int>>, Task<IEnumerable<int>>>>.FromGraph(
                     GraphDsl.Create(takeAll, takeAll, Keep.Both, (builder, shape1, shape2) =>
                     {
                         var bidi = builder.Add(rotatedBidi);
@@ -117,8 +119,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                             .To(shape1.Inlet).From(bidi.Outlet1);
 
                         return ClosedShape.Instance;
-                    }));
-                var result = g.Run(_materializer);
+                    })).Run(_materializer);
 
                 var f1 = await result.Item1;
                 var f2 = await result.Item2;
@@ -126,6 +127,73 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                 f1.Should().Equal(Enumerable.Range(1, 100));
                 f2.Should().Equal(Enumerable.Range(1, 10));
             }, _materializer);
+        }
+
+        [Fact]
+        public void ActorGraphInterpreter_should_be_able_to_report_errors_if_an_error_happens_for_an_already_completed_stage()
+        {
+            var failyStage = new FailyGraphStage();
+
+            EventFilter.Exception<ArgumentException>(new Regex("Error in stage.*")).ExpectOne(async () =>
+            {
+                await Source.FromGraph(failyStage).RunWith(Sink.Ignore<int>(), _materializer);
+            });
+        }
+
+        [Fact]
+        public void ActorGraphInterpreter_should_be_able_to_properly_handle_case_where_a_stage_fails_before_subscription_happens()
+        {
+            // Fuzzing needs to be off, so that the failure can propagate to the output boundary
+            // before the ExposedPublisher message.
+            var noFuzzMaterializer = ActorMaterializer.Create(Sys,
+                ActorMaterializerSettings.Create(Sys).WithFuzzingMode(false));
+            this.AssertAllStagesStopped(() =>
+            {
+
+                var evilLatch = new CountdownEvent(1);
+
+                // This is a somewhat tricky test setup. We need the following conditions to be met:
+                //  - the stage should fail its output port before the ExposedPublisher message is processed
+                //  - the enclosing actor (and therefore the stage) should be kept alive until a stray SubscribePending arrives
+                //    that has been enqueued after ExposedPublisher message has been enqueued, but before it has been processed
+                //
+                // To achieve keeping alive the stage for long enough, we use an extra input and output port and instead
+                // of failing the stage, we fail only the output port under test.
+                //
+                // To delay the startup long enough, so both ExposedPublisher and SubscribePending are enqueued, we use an evil
+                // latch to delay the preStart() (which in turn delays the enclosing actor's preStart).
+                var failyStage = new FailyInPreStartGraphStage(evilLatch);
+
+                var downstream0 = TestSubscriber.CreateProbe<int>(this);
+                var downstream1 = TestSubscriber.CreateProbe<int>(this);
+
+                var upstream = TestPublisher.CreateProbe<int>(this);
+
+                RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
+                {
+                    var faily = b.Add(failyStage);
+
+                    b.From(Source.FromPublisher<int, Unit>(upstream)).To(faily.In);
+                    b.From(faily.Out0).To(Sink.FromSubscriber<int, Unit>(downstream0));
+                    b.From(faily.Out1).To(Sink.FromSubscriber<int, Unit>(downstream1));
+
+                    return ClosedShape.Instance;
+                })).Run(noFuzzMaterializer);
+
+                evilLatch.Signal();
+                var ex = downstream0.ExpectSubscriptionAndError();
+                ex.Should().BeOfType<Utils.TE>();
+                ex.Message.Should().Be("Test failure in PreStart");
+
+                // if an NRE would happen due to unset exposedPublisher (see #19338), this would receive a failure instead
+                // of the actual element
+                downstream1.Request(1);
+                upstream.SendNext(42);
+                downstream1.ExpectNext(42);
+
+                upstream.SendComplete();
+                downstream1.ExpectComplete();
+            }, noFuzzMaterializer);
         }
 
         public class IdentityBidiGraphStage : GraphStage<BidiShape<int, int, int, int>>
@@ -231,6 +299,98 @@ namespace Akka.Streams.Tests.Implementation.Fusing
             public override string ToString()
             {
                 return "IdentityBidi";
+            }
+        }
+
+        public class FailyGraphStage : GraphStage<SourceShape<int>>
+        {
+            private class Logic : GraphStageLogic
+            {
+                public Logic(SourceShape<int> shape) : base(shape)
+                {
+                    SetHandler(shape.Outlet,
+                        onPull: () =>
+                        {
+                            CompleteStage();
+                            // This cannot be propagated now since the stage is already closed
+                            Push(shape.Outlet, -1);
+                        });
+                }
+            }
+
+            public Outlet<int> Out { get; }
+
+            public FailyGraphStage()
+            {
+                Out = new Outlet<int>("test.out");
+                Shape = new SourceShape<int>(Out);
+            }
+
+            public override SourceShape<int> Shape { get; }
+
+            protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes)
+            {
+                return new Logic(Shape);
+            }
+
+            public override string ToString()
+            {
+                return "Faily";
+            }
+        }
+
+        /// <summary>
+        /// </summary>
+        public class FailyInPreStartGraphStage : GraphStage<FanOutShape<int, int, int>>
+        {
+            private readonly CountdownEvent _evilLatch;
+
+            private class Logic : GraphStageLogic
+            {
+                private readonly CountdownEvent _evilLatch;
+                private readonly FanOutShape<int, int, int> _shape;
+
+                public Logic(FanOutShape<int, int, int> shape, CountdownEvent evilLatch) : base(shape)
+                {
+                    _shape = shape;
+                    _evilLatch = evilLatch;
+
+                    SetHandler(shape.Out0, IgnoreTerminateOutput); // We fail in PreStart anyway
+                    SetHandler(shape.Out1, IgnoreTerminateOutput); // We fail in PreStart anyway
+                    PassAlong(shape.In, shape.Out1);
+                }
+
+                public override void PreStart()
+                {
+                    Pull(_shape.In);
+                    _evilLatch.Wait(TimeSpan.FromSeconds(3));
+                    Fail(_shape.Out0, new Utils.TE("Test failure in PreStart"));
+                }
+            }
+
+            public Inlet<int> In { get; }
+            public Outlet<int> Out0 { get; }
+            public Outlet<int> Out1 { get; }
+
+            public FailyInPreStartGraphStage(CountdownEvent evilLatch)
+            {
+                _evilLatch = evilLatch;
+                In = new Inlet<int>("test.in");
+                Out0 = new Outlet<int>("test.out0");
+                Out1 = new Outlet<int>("test.out1");
+                Shape = new FanOutShape<int, int, int>(In, Out0, Out1);
+            }
+
+            public override FanOutShape<int, int, int> Shape { get; }
+
+            protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes)
+            {
+                return new Logic(Shape, _evilLatch);
+            }
+
+            public override string ToString()
+            {
+                return "Faily";
             }
         }
     }

--- a/src/core/Akka.Streams/CodeGen/Dsl/GraphApply.cs
+++ b/src/core/Akka.Streams/CodeGen/Dsl/GraphApply.cs
@@ -1,8 +1,5 @@
 ﻿// --- auto generated: 05.02.2016 09:30:42 --- //
 using System;
-using System.Linq;
-using System.Reactive.Streams;
-using Akka.Streams.Implementation;
 using Akka.Streams.Dsl.Internal;
 
 namespace Akka.Streams.Dsl
@@ -12,9 +9,9 @@ namespace Akka.Streams.Dsl
 		/// <summary>
 		/// Creates a new <see cref="IGraph{TShape, TMat}"/> by passing a <see cref="GraphDsl.Builder{TMat}"/> to the given create function.
 		/// </summary>
-		public static IGraph<TShape, TMat> Create<TShape, TMat>(Func<GraphDsl.Builder<TMat>, TShape> buildBlock) where TShape: Shape
+		public static IGraph<TShape, TMat> Create<TShape, TMat>(Func<Builder<TMat>, TShape> buildBlock) where TShape: Shape
 		{
-			var builder = new GraphDsl.Builder<TMat>();
+			var builder = new Builder<TMat>();
 			var shape = buildBlock(builder);
 			var module = builder.Module.Nest().ReplaceShape(shape);
 
@@ -25,11 +22,11 @@ namespace Akka.Streams.Dsl
 		/// Creates a new <see cref="IGraph{TShape, TMat}"/> by importing the given graph <paramref name="g1"/> 
 		/// and passing its <see cref="Shape"/> along with the <see cref="GraphDsl.Builder{TMat}"/> to the given create function.
 		/// </summary>
-		public static IGraph<TShapeOut, TMat> Create<TShapeOut, TMat, TShape1>(IGraph<TShape1, TMat> g1, Func<GraphDsl.Builder<TMat>, TShape1, TShapeOut> buildBlock) 
+		public static IGraph<TShapeOut, TMat> Create<TShapeOut, TMat, TShape1>(IGraph<TShape1, TMat> g1, Func<Builder<TMat>, TShape1, TShapeOut> buildBlock) 
 			where TShapeOut: Shape
 			where TShape1: Shape
 		{
-			var builder = new GraphDsl.Builder<TMat>();
+			var builder = new Builder<TMat>();
 			var shape1 = builder.Add(g1);
 			var shape = buildBlock(builder, shape1);
 			var module = builder.Module.Nest().ReplaceShape(shape);
@@ -44,16 +41,16 @@ namespace Akka.Streams.Dsl
 		public static IGraph<TShapeOut, TMatOut> Create<TShapeOut, TMatOut, TMat0, TMat1, TShape0, TShape1>(
 			IGraph<TShape0, TMat0> g0, IGraph<TShape1, TMat1> g1, 
 			Func<TMat0, TMat1, TMatOut> combineMaterializers,
-			Func<GraphDsl.Builder<TMatOut>, TShape0, TShape1, TShapeOut> buildBlock) 
+			Func<Builder<TMatOut>, TShape0, TShape1, TShapeOut> buildBlock) 
 			where TShapeOut: Shape
 			where TShape0: Shape
 			where TShape1: Shape
 			
 		{
-			var builder = new GraphDsl.Builder<TMatOut>();
+			var builder = new Builder<TMatOut>();
 			
-			var shape0 = builder.Add(g0);
-			var shape1 = builder.Add(g1);
+			var shape0 = builder.Add<TShape0, TMat0, Func<TMat1, TMatOut>>(g0, m0 => (m1 => combineMaterializers(m0, m1)));
+			var shape1 = builder.Add<TShape1, Func<TMat1, TMatOut>, TMat1, TMatOut>(g1, (f, m1) => f(m1));
 			
 			var shape = buildBlock(builder, shape0, shape1);
 			var module = builder.Module.Nest().ReplaceShape(shape);
@@ -68,18 +65,18 @@ namespace Akka.Streams.Dsl
 		public static IGraph<TShapeOut, TMatOut> Create<TShapeOut, TMatOut, TMat0, TMat1, TMat2, TShape0, TShape1, TShape2>(
 			IGraph<TShape0, TMat0> g0, IGraph<TShape1, TMat1> g1, IGraph<TShape2, TMat2> g2, 
 			Func<TMat0, TMat1, TMat2, TMatOut> combineMaterializers,
-			Func<GraphDsl.Builder<TMatOut>, TShape0, TShape1, TShape2, TShapeOut> buildBlock) 
+			Func<Builder<TMatOut>, TShape0, TShape1, TShape2, TShapeOut> buildBlock) 
 			where TShapeOut: Shape
 			where TShape0: Shape
 			where TShape1: Shape
 			where TShape2: Shape
 			
 		{
-			var builder = new GraphDsl.Builder<TMatOut>();
+			var builder = new Builder<TMatOut>();
 			
-			var shape0 = builder.Add(g0);
-			var shape1 = builder.Add(g1);
-			var shape2 = builder.Add(g2);
+			var shape0 = builder.Add<TShape0, TMat0, Func<TMat1, TMat2, TMatOut>>(g0, m0 => ((m1, m2) => combineMaterializers(m0, m1, m2)));
+			var shape1 = builder.Add<TShape1, Func<TMat1, TMatOut>, TMat1, TMatOut>(g1, (f, m1) => f(m1));
+			var shape2 = builder.Add<TShape2, Func<TMat2, TMatOut>, TMat2, TMatOut>(g2, (f, m2) => f(m2));
 			
 			var shape = buildBlock(builder, shape0, shape1, shape2);
 			var module = builder.Module.Nest().ReplaceShape(shape);
@@ -94,7 +91,7 @@ namespace Akka.Streams.Dsl
 		public static IGraph<TShapeOut, TMatOut> Create<TShapeOut, TMatOut, TMat0, TMat1, TMat2, TMat3, TShape0, TShape1, TShape2, TShape3>(
 			IGraph<TShape0, TMat0> g0, IGraph<TShape1, TMat1> g1, IGraph<TShape2, TMat2> g2, IGraph<TShape3, TMat3> g3, 
 			Func<TMat0, TMat1, TMat2, TMat3, TMatOut> combineMaterializers,
-			Func<GraphDsl.Builder<TMatOut>, TShape0, TShape1, TShape2, TShape3, TShapeOut> buildBlock) 
+			Func<Builder<TMatOut>, TShape0, TShape1, TShape2, TShape3, TShapeOut> buildBlock) 
 			where TShapeOut: Shape
 			where TShape0: Shape
 			where TShape1: Shape
@@ -102,12 +99,12 @@ namespace Akka.Streams.Dsl
 			where TShape3: Shape
 			
 		{
-			var builder = new GraphDsl.Builder<TMatOut>();
+			var builder = new Builder<TMatOut>();
 			
-			var shape0 = builder.Add(g0);
-			var shape1 = builder.Add(g1);
-			var shape2 = builder.Add(g2);
-			var shape3 = builder.Add(g3);
+			var shape0 = builder.Add<TShape0, TMat0, Func<TMat1, TMat2, TMat3, TMatOut>>(g0, m0 => ((m1, m2, m3) => combineMaterializers(m0, m1, m2, m3)));
+			var shape1 = builder.Add<TShape1, Func<TMat1, TMatOut>, TMat1, TMatOut>(g1, (f, m1) => f(m1));
+			var shape2 = builder.Add<TShape2, Func<TMat2, TMatOut>, TMat2, TMatOut>(g2, (f, m2) => f(m2));
+			var shape3 = builder.Add<TShape3, Func<TMat3, TMatOut>, TMat3, TMatOut>(g3, (f, m3) => f(m3));
 			
 			var shape = buildBlock(builder, shape0, shape1, shape2, shape3);
 			var module = builder.Module.Nest().ReplaceShape(shape);
@@ -122,7 +119,7 @@ namespace Akka.Streams.Dsl
 		public static IGraph<TShapeOut, TMatOut> Create<TShapeOut, TMatOut, TMat0, TMat1, TMat2, TMat3, TMat4, TShape0, TShape1, TShape2, TShape3, TShape4>(
 			IGraph<TShape0, TMat0> g0, IGraph<TShape1, TMat1> g1, IGraph<TShape2, TMat2> g2, IGraph<TShape3, TMat3> g3, IGraph<TShape4, TMat4> g4, 
 			Func<TMat0, TMat1, TMat2, TMat3, TMat4, TMatOut> combineMaterializers,
-			Func<GraphDsl.Builder<TMatOut>, TShape0, TShape1, TShape2, TShape3, TShape4, TShapeOut> buildBlock) 
+			Func<Builder<TMatOut>, TShape0, TShape1, TShape2, TShape3, TShape4, TShapeOut> buildBlock) 
 			where TShapeOut: Shape
 			where TShape0: Shape
 			where TShape1: Shape
@@ -131,13 +128,13 @@ namespace Akka.Streams.Dsl
 			where TShape4: Shape
 			
 		{
-			var builder = new GraphDsl.Builder<TMatOut>();
+			var builder = new Builder<TMatOut>();
 			
-			var shape0 = builder.Add(g0);
-			var shape1 = builder.Add(g1);
-			var shape2 = builder.Add(g2);
-			var shape3 = builder.Add(g3);
-			var shape4 = builder.Add(g4);
+			var shape0 = builder.Add<TShape0, TMat0, Func<TMat1, TMat2, TMat3, TMat4, TMatOut>>(g0, m0 => ((m1, m2, m3, m4) => combineMaterializers(m0, m1, m2, m3, m4)));
+			var shape1 = builder.Add<TShape1, Func<TMat1, TMatOut>, TMat1, TMatOut>(g1, (f, m1) => f(m1));
+			var shape2 = builder.Add<TShape2, Func<TMat2, TMatOut>, TMat2, TMatOut>(g2, (f, m2) => f(m2));
+			var shape3 = builder.Add<TShape3, Func<TMat3, TMatOut>, TMat3, TMatOut>(g3, (f, m3) => f(m3));
+			var shape4 = builder.Add<TShape4, Func<TMat4, TMatOut>, TMat4, TMatOut>(g4, (f, m4) => f(m4));
 			
 			var shape = buildBlock(builder, shape0, shape1, shape2, shape3, shape4);
 			var module = builder.Module.Nest().ReplaceShape(shape);

--- a/src/core/Akka.Streams/Dsl/GraphDsl.cs
+++ b/src/core/Akka.Streams/Dsl/GraphDsl.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Streams;
 using Akka.Streams.Implementation;
 using Akka.Streams.Implementation.Fusing;
-using Akka.Streams.Implementation.Stages;
-using Akka.Streams.Stage;
 
 namespace Akka.Streams.Dsl
 {
@@ -41,7 +38,7 @@ namespace Akka.Streams.Dsl
             /// This is only used by the materialization-importing apply methods of Source,
             /// Flow, Sink and Graph.
             /// </summary>
-            internal TShape Add<TShape, TMat1, TMat2, TMat3>(IGraph<TShape, TMat1> graph, Func<TMat1, TMat2, TMat3> combine) where TShape : Shape
+            internal TShape Add<TShape, TMat1, TMat2, TMat3>(IGraph<TShape> graph, Func<TMat1, TMat2, TMat3> combine) where TShape : Shape
             {
                 var copy = graph.Module.CarbonCopy();
                 _moduleInProgress = _moduleInProgress.Compose(copy, combine);
@@ -85,7 +82,7 @@ namespace Akka.Streams.Dsl
                 }
             }
 
-            public IModule Module { get { return _moduleInProgress; } }
+            public IModule Module => _moduleInProgress;
 
             public ForwardOps<TOut, T> From<TOut>(Outlet<TOut> outlet)
             {

--- a/src/core/Akka.Streams/FanOutShape.cs
+++ b/src/core/Akka.Streams/FanOutShape.cs
@@ -54,13 +54,14 @@ namespace Akka.Streams
         #endregion
 
         private readonly string _name;
-        private ImmutableArray<Outlet> _outlets = new ImmutableArray<Outlet>();
+        private ImmutableArray<Outlet> _outlets;
         private readonly IEnumerator<Outlet> _registered;
 
         protected FanOutShape(Inlet<TIn> inlet, IEnumerable<Outlet> registered, string name)
         {
             In = inlet;
             Inlets = ImmutableArray.Create<Inlet>(inlet);
+            _outlets = ImmutableArray<Outlet>.Empty;
             _name = name;
             _registered = registered.GetEnumerator();
         }

--- a/src/core/Akka.Streams/Graph.cs
+++ b/src/core/Akka.Streams/Graph.cs
@@ -5,8 +5,7 @@ namespace Akka.Streams
     /// <summary>
     /// </summary>
     /// <typeparam name="TShape">Type-level accessor for the shape parameter of this graph.</typeparam>
-    /// <typeparam name="TMaterializer"></typeparam>
-    public interface IGraph<out TShape, TMaterializer> where TShape : Shape
+    public interface IGraph<out TShape> where TShape : Shape
     {
         /// <summary>
         /// The shape of a graph is all that is externally visible: its inlets and outlets.
@@ -17,7 +16,14 @@ namespace Akka.Streams
         /// INTERNAL API: Every materializable element must be backed by a stream layout module
         /// </summary>
         IModule Module { get; }
+    }
 
+    /// <summary>
+    /// </summary>
+    /// <typeparam name="TShape">Type-level accessor for the shape parameter of this graph.</typeparam>
+    /// <typeparam name="TMaterializer"></typeparam>
+    public interface IGraph<out TShape, TMaterializer> : IGraph<TShape> where TShape : Shape
+    {
         IGraph<TShape, TMaterializer> WithAttributes(Attributes attributes);
         IGraph<TShape, TMaterializer> Named(string name);
     }

--- a/src/core/Akka.Streams/Implementation/Fusing/GraphAssembly.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/GraphAssembly.cs
@@ -73,7 +73,6 @@ namespace Akka.Streams.Implementation.Fusing
             foreach (var t in seq)
             {
                 array[idx++] = t;
-                idx++;
             }
             return array;
         }

--- a/src/core/Akka.Streams/Implementation/Fusing/GraphStages.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/GraphStages.cs
@@ -262,7 +262,7 @@ namespace Akka.Streams.Implementation.Fusing
         void SetValue(object result);
     }
 
-    internal class MaterializedValueSource<T> : GraphStage<SourceShape<T>>, IMaterializedValueSource
+    internal sealed class MaterializedValueSource<T> : GraphStage<SourceShape<T>>, IMaterializedValueSource
     {
         #region internal classes
         internal sealed class MaterializedValueGraphStageLogic : GraphStageLogic
@@ -299,7 +299,7 @@ namespace Akka.Streams.Implementation.Fusing
             Shape = new SourceShape<T>(Outlet);
         }
 
-        public MaterializedValueSource(StreamLayout.IMaterializedValueNode computation) : this(computation, new Outlet<T>("MaterializedValue.out")) { }
+        public MaterializedValueSource(StreamLayout.IMaterializedValueNode computation) : this(computation, new Outlet<T>("matValue")) { }
 
         protected override Attributes InitialAttributes { get { return Name; } }
         public override SourceShape<T> Shape { get; }


### PR DESCRIPTION
Included are:
* Update to Graph Dsl to use `combineMaterializers` func
* Bug fix in `GraphAssembly` contructor
* Bug fix `StreamLayout.MaterializeModule`
* Bug fix in `GraphStageLogic.PassAlong`
* Bug fix in `FanOutShape` constructor
