### PR TITLE
fixed racy spec behaviour

### DIFF
--- a/src/core/Akka.Remote.Tests.MultiNode/RemoteNodeShutdownAndComesBackSpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/RemoteNodeShutdownAndComesBackSpec.cs
@@ -24,6 +24,8 @@ namespace Akka.Remote.Tests.MultiNode
                   akka.remote.transport-failure-detector.acceptable-heartbeat-pause = 3 s
                   ## the acceptable pause is too long and therefore the test will fail, it pass when we use a lower value like the default one
                   ## akka.remote.watch-failure-detector.acceptable-heartbeat-pause = 60 s
+                  ## wee need to set this value because the default configuration isn't used as fallback and therefore a default TimeSpan is returned instead of 10 s
+                  akka.remote.watch-failure-detector.acceptable-heartbeat-pause = 10 s
             "));
 
             TestTransport = true;


### PR DESCRIPTION
We need to run the multinode tests multiple times on this PR to see if the racy behavior described in #1804 is fixed with this setting.