### PR TITLE
ActorPath UID fix

### DIFF
--- a/src/contrib/serializers/Akka.Serialization.TestKit/AkkaSerializationSpec.cs
+++ b/src/contrib/serializers/Akka.Serialization.TestKit/AkkaSerializationSpec.cs
@@ -353,6 +353,15 @@ akka.actor {
         }
 
         [Fact]
+        public void CanSerializeActorRefWithUID()
+        {
+            var aref = ActorOf<BlackHoleActor>();
+            var surrogate = aref.ToSurrogate(Sys) as ActorRefBase.Surrogate;
+            var uid = aref.Path.Uid;
+            Assert.True(surrogate.Path.Contains("#" + uid));
+        }
+
+        [Fact]
         public void CanSerializeDecider()
         {
             var decider = Decider.From(

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -172,6 +172,7 @@ namespace Akka.Actor
         public static bool IsValidPathElement(string s) { }
         public static Akka.Actor.ActorPath Parse(string path) { }
         public string ToSerializationFormat() { }
+        public string ToSerializationFormatWithAddress(Akka.Actor.Address address) { }
         public override string ToString() { }
         public string ToStringWithAddress() { }
         public string ToStringWithAddress(Akka.Actor.Address address) { }

--- a/src/core/Akka.Remote.Tests/RemoteMessageLocalDeliverySpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteMessageLocalDeliverySpec.cs
@@ -86,7 +86,6 @@ namespace Akka.Remote.Tests
                     var ai =
                         Sys.ActorSelection(actorPath).Ask<ActorIdentity>(new Identify(null), TimeSpan.FromSeconds(3)).Result;
 
-                   
                     remoteActorRef.Tell(PoisonPill.Instance); // WATCH should be applied first
                     ExpectTerminated(remoteActorRef);
                 });

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -60,7 +60,7 @@ namespace Akka.Remote
             IActorRef senderOption = null)
         {
             var payload = MessageSerializer.Deserialize(system, message);
-            Type payloadClass = payload == null ? null : payload.GetType();
+            Type payloadClass = payload?.GetType();
             var sender = senderOption ?? system.DeadLetters;
             var originalReceiver = recipient.Path;
 
@@ -72,7 +72,7 @@ namespace Akka.Remote
                 {
                     if (settings.LogReceive)
                     {
-                        var msgLog = string.Format("RemoteMessage: {0} to {1}<+{2} from {3}", payload, recipient, originalReceiver,sender);
+                        var msgLog = $"RemoteMessage: {payload} to {recipient}<+{originalReceiver} from {sender}";
                         log.Debug("received daemon message [{0}]", msgLog);
                     }
                     remoteDaemon.Tell(payload);
@@ -84,7 +84,7 @@ namespace Akka.Remote
             {
                 if (settings.LogReceive)
                 {
-                    var msgLog = string.Format("RemoteMessage: {0} to {1}<+{2} from {3}", payload, recipient, originalReceiver,sender);
+                    var msgLog = $"RemoteMessage: {payload} to {recipient}<+{originalReceiver} from {sender}";
                     log.Debug("received local message [{0}]", msgLog);
                 }
                 if (payload is ActorSelectionMessage)
@@ -121,7 +121,6 @@ namespace Akka.Remote
                 {
                     recipient.Tell(payload, sender);
                 }
-
             }
 
             // message is intended for a remote-deployed recipient

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -323,24 +323,21 @@ namespace Akka.Remote
             {
                 return _local.ResolveActorRef(RootGuardian, actorPath.Elements);
             }
-            else
+            try
             {
-                try
-                {
-                    return new RemoteActorRef(Transport,
-                        Transport.LocalAddressForRemote(actorPath.Address),
-                        actorPath,
-                        ActorRefs.Nobody,
-                        Props.None,
-                        Deploy.None);
-                }
-                catch (Exception ex)
-                {
-                    _log.Warning("Error while resolving address [{0}] due to [{1}]", actorPath.Address, ex.Message);
-                    return new EmptyLocalActorRef(this, RootPath, _local.EventStream);
-                }
+                var rootPath = new RootActorPath(actorPath.Address)/actorPath.Elements;
+                return new RemoteActorRef(Transport,
+                    Transport.LocalAddressForRemote(actorPath.Address),
+                    rootPath, 
+                    ActorRefs.Nobody,
+                    Props.None,
+                    Deploy.None);
             }
-
+            catch (Exception ex)
+            {
+                _log.Warning("Error while resolving address [{0}] due to [{1}]", actorPath.Address, ex.Message);
+                return new EmptyLocalActorRef(this, RootPath, _local.EventStream);
+            }
         }
 
         public Address GetExternalAddressFor(Address address)

--- a/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
+++ b/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
@@ -158,7 +158,7 @@ namespace Akka.Remote.Transport
             try
             {
                 var pdu = AkkaProtocolMessage.ParseFrom(raw);
-                if(pdu.HasPayload) return new Payload(pdu.Payload);
+                if (pdu.HasPayload) return new Payload(pdu.Payload);
                 else if (pdu.HasInstruction) return DecodeControlPdu(pdu.Instruction);
                 else throw new PduCodecException("Error decoding Akka PDU: Neither message nor control message were contained");
             }
@@ -239,7 +239,7 @@ namespace Akka.Remote.Transport
                     messageOption = new Message(recipient, recipientAddress, serializedMessage, senderOption, seqOption);
                 }
             }
-            
+
 
             return new AckAndMessage(ackOption, messageOption);
         }
@@ -247,9 +247,9 @@ namespace Akka.Remote.Transport
         private AcknowledgementInfo.Builder AckBuilder(Ack ack)
         {
             var ackBuilder = AcknowledgementInfo.CreateBuilder();
-            ackBuilder = ackBuilder.SetCumulativeAck((ulong) ack.CumulativeAck.RawValue);
+            ackBuilder = ackBuilder.SetCumulativeAck((ulong)ack.CumulativeAck.RawValue);
 
-            return ack.Nacks.Aggregate(ackBuilder, (current, nack) => current.AddNacks((ulong) nack.RawValue));
+            return ack.Nacks.Aggregate(ackBuilder, (current, nack) => current.AddNacks((ulong)nack.RawValue));
         }
 
         public override ByteString ConstructMessage(Address localAddress, IActorRef recipient, SerializedMessage serializedMessage,
@@ -336,7 +336,7 @@ namespace Akka.Remote.Transport
             return ActorRefData.CreateBuilder()
                 .SetPath((!string.IsNullOrEmpty(actorRef.Path.Address.Host))
                     ? actorRef.Path.ToSerializationFormat()
-                    : actorRef.Path.ToStringWithAddress(defaultAddress))
+                    : actorRef.Path.ToSerializationFormatWithAddress(defaultAddress))
                 .Build();
         }
 

--- a/src/core/Akka.TestKit/TestKitBase_Expect.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Expect.cs
@@ -135,7 +135,10 @@ namespace Akka.TestKit
         public Terminated ExpectTerminated(IActorRef target, TimeSpan? timeout = null, string hint = null)
         {
             var msg = string.Format("Terminated {0}. {1}", target.Path, hint ?? "");
-            return InternalExpectMsg<Terminated>(RemainingOrDilated(timeout), terminated => _assertions.AssertEqual(target, terminated.ActorRef, msg), msg);
+            return InternalExpectMsg<Terminated>(RemainingOrDilated(timeout), terminated =>
+            {
+                _assertions.AssertEqual(target, terminated.ActorRef, msg);
+            }, msg);
         }
 
 

--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Akka.Util;
 using Newtonsoft.Json;
+using static System.String;
 
 namespace Akka.Actor
 {
@@ -37,7 +38,7 @@ namespace Akka.Actor
                 Path = path;
             }
 
-            public string Path { get; private set; }
+            public string Path { get; }
 
             public ISurrogated FromSurrogate(ActorSystem system)
             {
@@ -49,22 +50,6 @@ namespace Akka.Actor
 
                 return null;
             }
-
-            #region Implicit conversion operators
-
-            public static implicit operator ActorPath(Surrogate surrogate)
-            {
-                ActorPath parse;
-                TryParse(surrogate.Path, out parse);
-                return parse;
-            }
-
-            public static implicit operator Surrogate(ActorPath path)
-            {
-                return (Surrogate)path.ToSurrogate(null);
-            }
-
-            #endregion
 
             #region Equality
 
@@ -78,7 +63,7 @@ namespace Akka.Actor
             public bool Equals(ActorPath other)
             {
                 if (other == null) return false;
-                return Equals(other.ToSurrogate(null));
+                return Equals(other.ToSurrogate(null)); //TODO: not so sure if this is OK
             }
 
             public override bool Equals(object obj)
@@ -86,8 +71,8 @@ namespace Akka.Actor
                 if (ReferenceEquals(null, obj)) return false;
                 if (ReferenceEquals(this, obj)) return true;
                 var actorPath = obj as ActorPath;
-
-                return Equals(actorPath);
+                if (actorPath != null) return Equals(actorPath);
+                return Equals(obj as Surrogate);
             }
 
             public override int GetHashCode()
@@ -98,7 +83,7 @@ namespace Akka.Actor
             #endregion
         }
 
-         /** INTERNAL API */
+        /** INTERNAL API */
         internal static char[] ValidSymbols = @"""-_.*$+:@&=,!~';""()".ToCharArray();
 
         /// <summary> 
@@ -108,7 +93,7 @@ namespace Akka.Actor
         /// </summary>
         public static bool IsValidPathElement(string s)
         {
-            if (String.IsNullOrEmpty(s))
+            if (IsNullOrEmpty(s))
             {
                 return false;
             }
@@ -139,8 +124,6 @@ namespace Akka.Actor
             return true;
         }
 
-        private readonly string _name;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ActorPath" /> class.
         /// </summary>
@@ -148,7 +131,7 @@ namespace Akka.Actor
         /// <param name="name"> The name. </param>
         protected ActorPath(Address address, string name)
         {
-            _name = name;
+            Name = name;
             Address = address;
         }
 
@@ -162,14 +145,14 @@ namespace Akka.Actor
         {
             Address = parentPath.Address;
             Uid = uid;
-            _name = name;
+            Name = name;
         }
 
         /// <summary>
         /// Gets the uid.
         /// </summary>
         /// <value> The uid. </value>
-        public long Uid { get; private set; }
+        public long Uid { get; }
 
         /// <summary>
         /// Gets the elements.
@@ -195,17 +178,14 @@ namespace Akka.Actor
         /// Gets the name.
         /// </summary>
         /// <value> The name. </value>
-        public string Name
-        {
-            get { return _name; }
-        }
+        public string Name { get; }
 
         /// <summary>
         /// The Address under which this path can be reached; walks up the tree to
         /// the RootActorPath.
         /// </summary>
         /// <value> The address. </value>
-        public Address Address { get; private set; }
+        public Address Address { get; }
 
         public abstract ActorPath Root { get; }
         public abstract ActorPath Parent { get; }
@@ -254,8 +234,7 @@ namespace Akka.Actor
             var a = path;
             foreach (string element in name)
             {
-                if(!string.IsNullOrEmpty(element))
-                    a = a / element;
+                a = a / element;
             }
             return a;
         }
@@ -284,6 +263,11 @@ namespace Akka.Actor
             if (!TryParseAddress(path, out address, out uri)) return false;
             var pathElements = uri.AbsolutePath.Split('/');
             actorPath = new RootActorPath(address) / pathElements.Skip(1);
+            if (uri.Fragment.StartsWith("#"))
+            {
+                var uid = int.Parse(uri.Fragment.Substring(1));
+                actorPath = actorPath.WithUid(uid);
+            }
             return true;
         }
 
@@ -296,12 +280,9 @@ namespace Akka.Actor
         private static bool TryParseAddress(string path, out Address address, out Uri uri)
         {
             //This code corresponds to AddressFromURIString.unapply
-            uri = null;
             address = null;
-
             if (!Uri.TryCreate(path, UriKind.Absolute, out uri))
                 return false;
-
             var protocol = uri.Scheme; //Typically "akka"
             if (!protocol.StartsWith("akka", StringComparison.OrdinalIgnoreCase))
             {
@@ -313,7 +294,7 @@ namespace Akka.Actor
             string systemName;
             string host = null;
             int? port = null;
-            if (string.IsNullOrEmpty(uri.UserInfo))
+            if (IsNullOrEmpty(uri.UserInfo))
             {
                 //  protocol://SystemName/Path1/Path2
                 if (uri.Port > 0)
@@ -347,7 +328,7 @@ namespace Akka.Actor
         /// <returns> System.String. </returns>
         private string Join()
         {
-            var joined = string.Join("/", Elements);
+            var joined = String.Join("/", Elements);
             return "/" + joined;
         }
 
@@ -416,12 +397,6 @@ namespace Akka.Actor
             return Equals(other);
         }
 
-        //public bool Equals(Surrogate other)
-        //{
-        //    if (other == null) return false;
-        //    return other.Equals(ToSurrogate(null));
-        //}
-
         public static bool operator ==(ActorPath left, ActorPath right)
         {
             return Equals(left, right);
@@ -446,6 +421,20 @@ namespace Akka.Actor
             return ToStringWithAddress();
         }
 
+        public string ToSerializationFormatWithAddress(Address address)
+        {
+            var withAddress = ToStringWithAddress(address);
+            var result = AppendUidFragment(withAddress);
+            return result;
+        }
+
+        private string AppendUidFragment(string withAddress)
+        {
+            if (Uid == ActorCell.UndefinedUid)
+                return withAddress;
+
+            return withAddress + "#" + Uid;
+        }
         /// <summary>
         /// Generate String representation, replacing the Address in the RootActorPath
         /// with the given one unless this path’s address includes host and port
@@ -456,9 +445,9 @@ namespace Akka.Actor
         public string ToStringWithAddress(Address address)
         {
             if (Address.Host != null && Address.Port.HasValue)
-                return string.Format("{0}{1}", Address, Join());
+                return $"{Address}{Join()}";
 
-            return string.Format("{0}{1}", address, Join());
+            return $"{address}{Join()}";
         }
 
         public static string FormatPathElements(IEnumerable<string> pathElements)
@@ -468,7 +457,7 @@ namespace Akka.Actor
 
         public ISurrogate ToSurrogate(ActorSystem system)
         {
-            return new Surrogate(ToSerializationFormat());
+            return new Surrogate(AppendUidFragment(ToSerializationFormat()));
         }
     }
 
@@ -487,16 +476,10 @@ namespace Akka.Actor
         {
         }
 
-        public override ActorPath Parent
-        {
-            get { return null; }
-        }
+        public override ActorPath Parent => null;
 
         [JsonIgnore]
-        public override ActorPath Root
-        {
-            get { return this; }
-        }
+        public override ActorPath Root => this;
 
         /// <summary>
         /// Withes the uid.
@@ -514,7 +497,7 @@ namespace Akka.Actor
         public override int CompareTo(ActorPath other)
         {
             if (other is ChildActorPath) return 1;
-            return String.Compare(ToString(), other.ToString(), StringComparison.Ordinal);
+            return Compare(ToString(), other.ToString(), StringComparison.Ordinal);
         }
     }
 
@@ -539,10 +522,7 @@ namespace Akka.Actor
             _parent = parentPath;
         }
 
-        public override ActorPath Parent
-        {
-            get { return _parent; }
-        }
+        public override ActorPath Parent => _parent;
 
         public override ActorPath Root
         {
@@ -583,11 +563,10 @@ namespace Akka.Actor
             var rightRoot = right as RootActorPath;
             if (rightRoot != null)
                 return -rightRoot.CompareTo(left);
-            var nameCompareResult = String.Compare(left.Name, right.Name, StringComparison.Ordinal);
+            var nameCompareResult = Compare(left.Name, right.Name, StringComparison.Ordinal);
             if (nameCompareResult != 0)
                 return nameCompareResult;
             return InternalCompareTo(left.Parent, right.Parent);
         }
     }
 }
-

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -162,7 +162,7 @@ namespace Akka.Actor
                 Path = path;
             }
 
-            public string Path { get; private set; }
+            public string Path { get; }
 
             public ISurrogated FromSurrogate(ActorSystem system)
             {

--- a/src/core/Akka/Serialization/Serialization.cs
+++ b/src/core/Akka/Serialization/Serialization.cs
@@ -22,7 +22,8 @@ namespace Akka.Serialization
 
     public class Serialization
     {
-        [ThreadStatic] private static Information _currentTransportInformation;
+        [ThreadStatic]
+        private static Information _currentTransportInformation;
 
         public static T SerializeWithTransport<T>(ActorSystem system, Address address, Func<T> action)
         {
@@ -46,7 +47,7 @@ namespace Akka.Serialization
             System = system;
 
             _nullSerializer = new NullSerializer(system);
-            _serializers.Add(_nullSerializer.Identifier,_nullSerializer);
+            _serializers.Add(_nullSerializer.Identifier, _nullSerializer);
 
             var serializersConfig = system.Settings.Config.GetConfig("akka.actor.serializers").AsEnumerable().ToList();
             var serializerBindingConfig = system.Settings.Config.GetConfig("akka.actor.serialization-bindings").AsEnumerable().ToList();
@@ -57,13 +58,13 @@ namespace Akka.Serialization
                 var serializerType = Type.GetType(serializerTypeName);
                 if (serializerType == null)
                 {
-                    system.Log.Warning("The type name for serializer '{0}' did not resolve to an actual Type: '{1}'",kvp.Key, serializerTypeName);
+                    system.Log.Warning("The type name for serializer '{0}' did not resolve to an actual Type: '{1}'", kvp.Key, serializerTypeName);
                     continue;
                 }
 
-                var serializer = (Serializer)Activator.CreateInstance(serializerType,system);
+                var serializer = (Serializer)Activator.CreateInstance(serializerType, system);
                 _serializers.Add(serializer.Identifier, serializer);
-                namedSerializers.Add(kvp.Key,serializer);
+                namedSerializers.Add(kvp.Key, serializer);
             }
 
             foreach (var kvp in serializerBindingConfig)
@@ -75,7 +76,7 @@ namespace Akka.Serialization
                 if (messageType == null)
                 {
 
-                    system.Log.Warning("The type name for message/serializer binding '{0}' did not resolve to an actual Type: '{1}'",serializerName, typename);
+                    system.Log.Warning("The type name for message/serializer binding '{0}' did not resolve to an actual Type: '{1}'", serializerName, typename);
                     continue;
                 }
 
@@ -85,7 +86,7 @@ namespace Akka.Serialization
                     system.Log.Warning("Serialization binding to non existing serializer: '{0}'", serializerName);
                     continue;
                 }
-                _serializerMap.Add(messageType,serializer);
+                _serializerMap.Add(messageType, serializer);
             }
         }
 
@@ -146,7 +147,7 @@ namespace Akka.Serialization
         }
 
         //cache to eliminate lots of typeof operator calls
-        private readonly Type _objectType = typeof (object);
+        private readonly Type _objectType = typeof(object);
         public Serializer FindSerializerForType(Type objectType)
         {
             Type type = objectType;
@@ -167,7 +168,7 @@ namespace Akka.Serialization
 
         public static string SerializedActorPath(IActorRef actorRef)
         {
-            if (Equals(actorRef, ActorRefs.NoSender)) 
+            if (Equals(actorRef, ActorRefs.NoSender))
                 return String.Empty;
 
             var path = actorRef.Path;
@@ -187,7 +188,7 @@ namespace Akka.Serialization
                 else
                 {
                     var defaultAddress = originalSystem.Provider.DefaultAddress;
-                    var res = path.ToStringWithAddress(defaultAddress);
+                    var res = path.ToSerializationFormatWithAddress(defaultAddress);
                     return res;
                 }
             }
@@ -197,14 +198,14 @@ namespace Akka.Serialization
             var address = _currentTransportInformation.Address;
             if (originalSystem == null || originalSystem == system)
             {
-                var res = path.ToStringWithAddress(address);
+                var res = path.ToSerializationFormatWithAddress(address);
                 return res;
             }
             else
             {
                 var provider = originalSystem.Provider;
                 var res =
-                    path.ToStringWithAddress(provider.GetExternalAddressFor(address).GetOrElse(provider.DefaultAddress));
+                    path.ToSerializationFormatWithAddress(provider.GetExternalAddressFor(address).GetOrElse(provider.DefaultAddress));
                 return res;
             }
         }


### PR DESCRIPTION
This PR fixes the issue with missing UID tags when using remote actorrefs..
There was a missing method in `ActorPath` `ToSerializationFormatWithAddress`, our code instead used the `ToStringWithAddress` which omits the UID.

This corrects the most immediate issues in Akka.Remote.
However there are a lot of uses of `ToStringWithAddress` inside Akka.Cluster and other modules, that probably should use the new method. (imo out of scope for this PR)