### PR TITLE
v1.5 - NetworkStreamTransport implementation

### DIFF
--- a/src/Akka.sln
+++ b/src/Akka.sln
@@ -243,6 +243,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.API.Tests", "core\Akka
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Cluster.TestKit", "core\Akka.Cluster.TestKit\Akka.Cluster.TestKit.csproj", "{B32850D2-E9CB-4638-83A4-164907595E56}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RemoteBenchmark", "benchmark\RemoteBenchmark\RemoteBenchmark.csproj", "{4D9650CC-5E43-472D-91FC-B9B2FBCD29D5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug Mono|Any CPU = Debug Mono|Any CPU
@@ -900,6 +902,14 @@ Global
 		{B32850D2-E9CB-4638-83A4-164907595E56}.Release Mono|Any CPU.Build.0 = Release|Any CPU
 		{B32850D2-E9CB-4638-83A4-164907595E56}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B32850D2-E9CB-4638-83A4-164907595E56}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4D9650CC-5E43-472D-91FC-B9B2FBCD29D5}.Debug Mono|Any CPU.ActiveCfg = Debug|Any CPU
+		{4D9650CC-5E43-472D-91FC-B9B2FBCD29D5}.Debug Mono|Any CPU.Build.0 = Debug|Any CPU
+		{4D9650CC-5E43-472D-91FC-B9B2FBCD29D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4D9650CC-5E43-472D-91FC-B9B2FBCD29D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4D9650CC-5E43-472D-91FC-B9B2FBCD29D5}.Release Mono|Any CPU.ActiveCfg = Release|Any CPU
+		{4D9650CC-5E43-472D-91FC-B9B2FBCD29D5}.Release Mono|Any CPU.Build.0 = Release|Any CPU
+		{4D9650CC-5E43-472D-91FC-B9B2FBCD29D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4D9650CC-5E43-472D-91FC-B9B2FBCD29D5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1008,5 +1018,6 @@ Global
 		{453DD4B1-64B8-4B50-BFDA-3489E32D30D8} = {01167D3C-49C4-4CDE-9787-C176D139ACDD}
 		{F72BE71A-2BE3-413D-A3D9-C7FDBB4E5F08} = {01167D3C-49C4-4CDE-9787-C176D139ACDD}
 		{B32850D2-E9CB-4638-83A4-164907595E56} = {01167D3C-49C4-4CDE-9787-C176D139ACDD}
+		{4D9650CC-5E43-472D-91FC-B9B2FBCD29D5} = {73108242-625A-4D7B-AA09-63375DBAE464}
 	EndGlobalSection
 EndGlobal

--- a/src/benchmark/RemoteBenchmark/App.config
+++ b/src/benchmark/RemoteBenchmark/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/src/benchmark/RemoteBenchmark/Program.cs
+++ b/src/benchmark/RemoteBenchmark/Program.cs
@@ -22,7 +22,7 @@ namespace RemoteBenchmark
             ManualResetEventSlim start = new ManualResetEventSlim(false);
 
             if (args.Length == 1)
-                messageCount = int.Parse(args[0]);
+                concurrency = int.Parse(args[0]);
 
             var workers = new List<Task>();
             for (int i = 1; i <= concurrency; i++)

--- a/src/benchmark/RemoteBenchmark/Program.cs
+++ b/src/benchmark/RemoteBenchmark/Program.cs
@@ -1,0 +1,238 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+
+namespace RemoteBenchmark
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var actorSystemProvider = new NetworkStreamActorSystemProvider();
+            var system1 = actorSystemProvider.CreateSystem(8080);
+            var system2 = actorSystemProvider.CreateSystem(8081);
+
+            int concurrency = Environment.ProcessorCount;
+            int messageCount = 20000;
+            SemaphoreSlim ready = new SemaphoreSlim(0);
+            ManualResetEventSlim start = new ManualResetEventSlim(false);
+
+            if (args.Length == 1)
+                messageCount = int.Parse(args[0]);
+
+            var workers = new List<Task>();
+            for (int i = 1; i <= concurrency; i++)
+            {
+                int index = i;
+                workers.Add(RunThread(() =>
+                {
+                    var receiver = system1.ActorOf<ReceiverActor>("Receiver_" + index);
+                    system2.ActorOf<EchoActor>("EchoActor_" + index);
+
+                    string echoActorPath = actorSystemProvider.GetBaseAddress(8081) + "EchoActor_" + index;
+
+                    var remoteEchoRef = system1.ActorSelection(echoActorPath).ResolveOne(Timeout.InfiniteTimeSpan).Result;
+
+                    receiver.Ask(new ReceiverActor.Init(remoteEchoRef)).Wait();
+
+                    ready.Release();
+
+                    start.Wait();
+
+                    var task = receiver.Ask(new ReceiverActor.PerformanceRun(messageCount));
+
+                    for (int j = 0; j < messageCount; j++)
+                    {
+                        remoteEchoRef.Tell("a", ActorRefs.NoSender);
+                    }
+
+                    task.Wait();
+                }));
+            }
+
+            for (int i = 0; i < concurrency; i++)
+                ready.Wait();
+
+            start.Set();
+            Stopwatch sw = Stopwatch.StartNew();
+
+            Task.WaitAll(workers.ToArray());
+
+            Console.WriteLine("Message per seconds: " + messageCount * concurrency * 2 / sw.Elapsed.TotalSeconds);
+        }
+
+        private static Task RunThread(Action action)
+        {
+            return Task.Factory.StartNew(action, TaskCreationOptions.LongRunning);
+        }
+    }
+
+    public abstract class ActorSystemProvider
+    {
+        public const string SystemName = "System";
+
+        protected Config BaseConfig
+        {
+            get
+            {
+                return ConfigurationFactory.ParseString(@"
+akka {
+    stdout-loglevel = off
+    loglevel = off
+    actor {
+        provider = ""Akka.Remote.RemoteActorRefProvider, Akka.Remote""
+        serializers {
+            wire = ""Akka.Serialization.WireSerializer, Akka.Serialization.Wire""
+        }
+        serialization-bindings {
+            ""System.Object"" = wire
+        }
+    }
+    remote {
+        log-received-messages = off
+        log-sent-messages = off
+    }
+}
+");
+            }
+        }
+
+        protected abstract Config GetConfig(int port);
+
+        public ActorSystem CreateSystem(int port)
+        {
+            return ActorSystem.Create(SystemName, GetConfig(port).WithFallback(BaseConfig));
+        }
+
+        public abstract string GetBaseAddress(int port);
+    }
+
+    public class NetworkStreamActorSystemProvider : ActorSystemProvider
+    {
+        protected override Config GetConfig(int port)
+        {
+            return ConfigurationFactory.ParseString(@"
+akka {
+    remote {
+        enabled-transports = [""akka.remote.networkstream""]
+        networkstream {
+            transport-class = ""Akka.Remote.Transport.Streaming.NetworkStreamTransport, Akka.Remote""
+            hostname = ""localhost""
+            port = " + port + @"
+        }
+    }
+}
+");
+        }
+
+        public override string GetBaseAddress(int port)
+        {
+            return $"akka.tcp://{SystemName}@localhost:{port}/user/";
+        }
+    }
+
+    public class HeliosActorSystemProvider : ActorSystemProvider
+    {
+        protected override Config GetConfig(int port)
+        {
+            return ConfigurationFactory.ParseString(@"
+akka {
+    remote {
+        helios.tcp {
+            hostname = ""localhost""
+            port = " + port + @"
+        }
+    }
+}
+");
+        }
+
+        public override string GetBaseAddress(int port)
+        {
+            return $"akka.tcp://{SystemName}@localhost:{port}/user/";
+        }
+    }
+
+    public class ReceiverActor : UntypedActor
+    {
+        public class Init
+        {
+            public IActorRef EchoActor { get; private set; }
+
+            public Init(IActorRef echoActor)
+            {
+                EchoActor = echoActor;
+            }
+        }
+
+        public class PerformanceRun
+        {
+            public int MessageCount { get; private set; }
+
+            public PerformanceRun(int messageCount)
+            {
+                MessageCount = messageCount;
+            }
+        }
+
+        private IActorRef _init;
+        private IActorRef _request;
+        private int _total;
+        private int _received;
+
+        protected override void OnReceive(object message)
+        {
+            if (message is Init)
+            {
+                var init = (Init) message;
+                _init = Sender;
+                init.EchoActor.Tell("a");
+
+                Become(WaitingForEcho);
+            }
+        }
+
+        private void WaitingForEcho(object message)
+        {
+            _init.Tell("done");
+            Become(Ready);
+        }
+
+        private void Ready(object message)
+        {
+            if (message is PerformanceRun)
+            {
+                var request = (PerformanceRun)message;
+                _request = Sender;
+                _total = request.MessageCount;
+
+                Become(Running);
+            }
+        }
+
+        private void Running(object message)
+        {
+            ++_received;
+
+            if (_received >= _total)
+                _request.Tell("done");
+        }
+    }
+
+    public class EchoActor : UntypedActor
+    {
+        private IActorRef _sender;
+
+        protected override void OnReceive(object message)
+        {
+            if (_sender == null)
+                _sender = Sender;
+
+            _sender.Tell(message, ActorRefs.NoSender);
+        }
+    }
+}

--- a/src/benchmark/RemoteBenchmark/Properties/AssemblyInfo.cs
+++ b/src/benchmark/RemoteBenchmark/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Benchmarks")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Benchmarks")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("4d9650cc-5e43-472d-91fc-b9b2fbcd29d5")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/benchmark/RemoteBenchmark/RemoteBenchmark.csproj
+++ b/src/benchmark/RemoteBenchmark/RemoteBenchmark.csproj
@@ -1,0 +1,75 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4D9650CC-5E43-472D-91FC-B9B2FBCD29D5}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>RemoteBenchmark</RootNamespace>
+    <AssemblyName>RemoteBenchmark</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Akka.Serialization.Wire, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Akka.Serialization.Wire.1.0.6.17-beta\lib\net45\Akka.Serialization.Wire.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Wire, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Wire.0.0.6\lib\Wire.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\core\Akka.Remote\Akka.Remote.csproj">
+      <Project>{ea4ff8fd-7c53-49c8-b9aa-02e458b3e6a7}</Project>
+      <Name>Akka.Remote</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\core\Akka\Akka.csproj">
+      <Project>{5deddf90-37f0-48d3-a0b0-a5cbd8a7e377}</Project>
+      <Name>Akka</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/benchmark/RemoteBenchmark/packages.config
+++ b/src/benchmark/RemoteBenchmark/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Akka.Serialization.Wire" version="1.0.6.17-beta" targetFramework="net45" />
+  <package id="Wire" version="0.0.6" targetFramework="net45" />
+</packages>

--- a/src/core/Akka.Remote/Akka.Remote.csproj
+++ b/src/core/Akka.Remote/Akka.Remote.csproj
@@ -118,6 +118,12 @@
     <Compile Include="Transport\FailureInjectorTransportAdapter.cs" />
     <Compile Include="Transport\Helios\HeliosHelpers.cs" />
     <Compile Include="Transport\Helios\HeliosTcpTransport.cs" />
+    <Compile Include="Transport\Streaming\AsyncQueue.cs" />
+    <Compile Include="Transport\Streaming\NamedPipeTransport.cs" />
+    <Compile Include="Transport\Streaming\NetworkStreamTransport.cs" />
+    <Compile Include="Transport\Streaming\SslStreamTransport.cs" />
+    <Compile Include="Transport\Streaming\StreamAssociationHandle.cs" />
+    <Compile Include="Transport\Streaming\StreamTransport.cs" />
     <Compile Include="Transport\ThrottleTransportAdapter.cs" />
     <Compile Include="Transport\TransportAdapters.cs" />
     <Compile Include="Transport\AkkaProtocolTransport.cs" />

--- a/src/core/Akka.Remote/Configuration/Remote.conf
+++ b/src/core/Akka.Remote/Configuration/Remote.conf
@@ -587,6 +587,14 @@ akka {
 
       # Enables TCP Keepalive, subject to the O/S kernel's configuration
       tcp-keepalive = on
+
+      # Messages larger than this threshold will be read by chunk
+      # if the data is not already available in the buffer.
+      chunked-read-threshold = 4096b
+
+      # Messages larger than this limit will make the connection drop.
+      # Default 64MB.
+      frame-size-hard-limit = 67108864b
     }
 
     ### Default configuration for the failure injector transport adapter

--- a/src/core/Akka.Remote/Configuration/Remote.conf
+++ b/src/core/Akka.Remote/Configuration/Remote.conf
@@ -488,6 +488,107 @@ akka {
       }
     }
 
+    networkstream {
+      # The class given here must implement the akka.remote.transport.Transport
+      # interface and offer a public constructor which takes two arguments:
+      #  1) akka.actor.ExtendedActorSystem
+      #  2) com.typesafe.config.Config
+      transport-class = "Akka.Remote.Transport.Streaming.NetworkStreamTransport, Akka.Remote"
+
+      # Transport drivers can be augmented with adapters by adding their
+      # name to the applied-adapters list. The last adapter in the
+      # list is the adapter immediately above the driver, while
+      # the first one is the top of the stack below the standard
+      # Akka protocol
+      applied-adapters = []
+
+      # The default remote server port clients should connect to.
+      # Default is 2552 (AKKA), use 0 if you want a random available port
+      # This port needs to be unique for each actor system on the same machine.
+      port = 2552
+
+      # The hostname or ip clients should connect to.
+      hostname = "localhost"
+
+      # Use this setting to bind a network interface to a different port
+      # than remoting protocol expects messages at. This may be used
+      # when running akka nodes in a separated networks (under NATs or docker containers).
+      # Use 0 if you want a random available port. Examples:
+      #
+      # akka.remote.networkstream.port = 2552
+      # akka.remote.networkstream.bind-port = 2553
+      # Network interface will be bound to the 2553 port, but remoting protocol will
+      # expect messages sent to port 2552.
+      #
+      # akka.remote.networkstream.port = 0
+      # akka.remote.networkstream.bind-port = 0
+      # Network interface will be bound to a random port, and remoting protocol will
+      # expect messages sent to the bound port.
+      #
+      # akka.remote.networkstream.port = 2552
+      # akka.remote.networkstream.bind-port = 0
+      # Network interface will be bound to a random port, but remoting protocol will
+      # expect messages sent to port 2552.
+      #
+      # akka.remote.networkstream.port = 0
+      # akka.remote.networkstream.bind-port = 2553
+      # Network interface will be bound to the 2553 port, and remoting protocol will
+      # expect messages sent to the bound port.
+      #
+      # akka.remote.networkstream.port = 2552
+      # akka.remote.networkstream.bind-port = ""
+      # Network interface will be bound to the 2552 port, and remoting protocol will
+      # expect messages sent to the bound port.
+      #
+      # akka.remote.networkstream.port if empty
+      bind-port = ""
+
+      # Use this setting to bind to a specific ip
+      # than remoting protocol expects messages at.
+      # Use "0.0.0.0" to bind to all interfaces.
+      # akka.remote.networkstream.hostname if empty
+      bind-hostname = ""
+
+      # Sets the connectTimeoutMillis of all outbound connections,
+      # i.e. how long a connect may take until it is timed out
+      connection-timeout = 15s
+
+      # Sets the send buffer size of the Sockets.
+      send-buffer-size = 256000b
+
+      # Sets the receive buffer size of the Sockets.
+      receive-buffer-size = 256000b
+
+      # Sets the write buffer size of the Stream.
+      # This is the buffer that is given to Socket.BeginSend.
+      # Setting a higher value might cause send delays, only modify if you know what you are doing
+      stream-write-buffer-size = 4096b
+
+      # Sets the read buffer size of the Stream.
+      # This is the buffer that is given to Socket.BeginReceive.
+      stream-read-buffer-size = 65536b
+
+      # The time to wait for pending writes before closing the connection
+      flush-wait-on-shutdown = 2s
+
+      # Maximum message size the transport will accept, but at least
+      # 32000 bytes.
+      # Please note that UDP does not support arbitrary large datagrams,
+      # so this setting has to be chosen carefully when using UDP.
+      # Both send-buffer-size and receive-buffer-size settings has to
+      # be adjusted to be able to buffer messages of maximum size.
+      maximum-frame-size = 128000b
+
+      # Sets the size of the connection backlog
+      backlog = 4096
+
+      # Enables the TCP_NODELAY flag, i.e. disables Nagle's algorithm
+      tcp-nodelay = on
+
+      # Enables TCP Keepalive, subject to the O/S kernel's configuration
+      tcp-keepalive = on
+    }
+
     ### Default configuration for the failure injector transport adapter
 
     gremlin {

--- a/src/core/Akka.Remote/Transport/Streaming/AsyncQueue.cs
+++ b/src/core/Akka.Remote/Transport/Streaming/AsyncQueue.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Akka.Remote.Transport.Streaming
+{
+    //TODO This queue can be optimized by making it single reader
+    // and using a custom awaiter instead of TaskCompletionSource
+    internal sealed class AsyncQueue<T> : IDisposable
+    {
+        private class Waiter
+        {
+            private readonly TaskCompletionSource<T> _completion;
+
+            public Task<T> Task
+            {
+                get { return _completion.Task; }
+            }
+
+            public Waiter()
+            {
+                _completion = new TaskCompletionSource<T>();
+            }
+
+            public void SetResult(T item)
+            {
+                _completion.TrySetResult(item);
+            }
+
+            public void SetCanceled()
+            {
+                _completion.TrySetCanceled();
+            }
+        }
+
+        private readonly Queue<T> _queue;
+        private readonly Queue<Waiter> _waiters;
+
+        public bool IsDisposed { get; private set; }
+
+        public int Count
+        {
+            get
+            {
+                lock (_queue)
+                {
+                    return _queue.Count;
+                }
+            }
+        }
+
+        public AsyncQueue()
+        {
+            _queue = new Queue<T>();
+            _waiters = new Queue<Waiter>();
+        }
+
+        public bool Enqueue(T item)
+        {
+            Waiter completedWaiter = null;
+
+            lock (_queue)
+            {
+                if (IsDisposed)
+                    return true;
+
+                if (_waiters.Count > 0)
+                {
+                    completedWaiter = _waiters.Dequeue();
+                }
+                else
+                {
+                    _queue.Enqueue(item);
+                }
+            }
+
+            if (completedWaiter != null)
+                ThreadPool.QueueUserWorkItem(_ => completedWaiter.SetResult(item));
+
+            return true;
+        }
+
+        public Task<T> Dequeue()
+        {
+            Waiter waiter = new Waiter();
+
+            lock (_queue)
+            {
+                if (IsDisposed)
+                {
+                    waiter.SetCanceled();
+                }
+                else if (_queue.Count > 0)
+                {
+                    T value = _queue.Dequeue();
+                    waiter.SetResult(value);
+                }
+                else
+                {
+                    _waiters.Enqueue(waiter);
+                }
+            }
+
+            return waiter.Task;
+        }
+
+        public void Dispose()
+        {
+            List<Waiter> waiters;
+            lock (_queue)
+            {
+                if (IsDisposed)
+                    return;
+
+                IsDisposed = true;
+
+                waiters = _waiters.ToList();
+            }
+
+            Task.Run(() =>
+            {
+                foreach (Waiter waiter in waiters)
+                    waiter.SetCanceled();
+            });
+        }
+    }
+}

--- a/src/core/Akka.Remote/Transport/Streaming/NamedPipeTransport.cs
+++ b/src/core/Akka.Remote/Transport/Streaming/NamedPipeTransport.cs
@@ -8,11 +8,11 @@ using Akka.Configuration;
 namespace Akka.Remote.Transport.Streaming
 {
     //TODO Work in progress
-    public class NamedPipeTranspotSettings : StreamTransportSettings
+    public class NamedPipeTransportSettings : StreamTransportSettings
     {
         public string PipeName { get; private set; }
 
-        public NamedPipeTranspotSettings(Config config)
+        public NamedPipeTransportSettings(Config config)
             : base(config)
         {
             PipeName = config.GetString("pipe-name");
@@ -26,7 +26,7 @@ namespace Akka.Remote.Transport.Streaming
     {
         public const string ProtocolName = "pipe";
 
-        public new NamedPipeTranspotSettings Settings { get;  }
+        public new NamedPipeTransportSettings Settings { get;  }
 
         public override string SchemeIdentifier
         {
@@ -34,12 +34,12 @@ namespace Akka.Remote.Transport.Streaming
         }
 
         public NamedPipeTransport(ActorSystem system, Config config)
-            : base(system, new NamedPipeTranspotSettings(config))
+            : base(system, new NamedPipeTransportSettings(config))
         {
             
         }
 
-        public NamedPipeTransport(ActorSystem system, NamedPipeTranspotSettings settings)
+        public NamedPipeTransport(ActorSystem system, NamedPipeTransportSettings settings)
             : base(system, settings)
         {
             Settings = settings;

--- a/src/core/Akka.Remote/Transport/Streaming/NamedPipeTransport.cs
+++ b/src/core/Akka.Remote/Transport/Streaming/NamedPipeTransport.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Google.ProtocolBuffers;
+
+namespace Akka.Remote.Transport.Streaming
+{
+    public class NamedPipeTranspotSettings
+    {
+        public string PipeName { get; private set; }
+
+        public NamedPipeTranspotSettings(Config config)
+        {
+            PipeName = config.GetString("pipe-name");
+        }
+    }
+
+    //TODO Find a way to make it work without port
+    // Otherwise it might be ok to set the actual pipe name to {PipeName}_{port}
+
+    public class NamedPipeTransport : StreamTransport
+    {
+        public const string ProtocolName = "pipe";
+
+        public NamedPipeTranspotSettings Settings { get; private set; }
+
+        public override string SchemeIdentifier
+        {
+            get { return ProtocolName; }
+        }
+
+        public NamedPipeTransport(ActorSystem system, Config config)
+            : base(system, config)
+        {
+            Settings = new NamedPipeTranspotSettings(config);
+        }
+
+        protected override Address Initialize()
+        {
+            return new Address(ProtocolName, System.Name, Settings.PipeName, 1);
+        }
+
+        protected override void StartAcceptingConnections(IAssociationEventListener listener)
+        {
+            Task.Run(() => ListenLoop(listener));
+        }
+
+        public override void Cleanup()
+        {
+            //TODO
+        }
+
+        private async Task ListenLoop(IAssociationEventListener listener)
+        {
+            while (!CancelToken.IsCancellationRequested)
+            {
+                NamedPipeServerStream stream = new NamedPipeServerStream(Settings.PipeName, PipeDirection.InOut, NamedPipeServerStream.MaxAllowedServerInstances, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+
+                //TODO Catch exceptions appropriately
+                await Task.Factory.FromAsync(stream.BeginWaitForConnection, stream.EndWaitForConnection, null);
+
+                string uniqueId = Guid.NewGuid().ToString("N");
+                var remoteAddress = new Address(ProtocolName, System.Name, Settings.PipeName + "_" + uniqueId, 1);
+
+                var association = CreateInboundAssociation(stream, remoteAddress);
+
+                listener.Notify(new InboundAssociation(association));
+            }
+        }
+
+        public override Task<AssociationHandle> Associate(Address remoteAddress)
+        {
+            var association = CreateOutboundAssociation(remoteAddress);
+
+            return Task.FromResult(association);
+        }
+
+        public AssociationHandle CreateInboundAssociation(NamedPipeServerStream stream, Address remoteAddress)
+        {
+            var association = new StreamAssociationHandle(stream, InboundAddress, remoteAddress);
+
+            association.ReadHandlerSource.Task.ContinueWith(task => association.Initialize(task.Result),
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnRanToCompletion,
+                TaskScheduler.Default);
+
+            return association;
+        }
+
+        public AssociationHandle CreateOutboundAssociation(Address remoteAddress)
+        {
+            NamedPipeClientStream stream = new NamedPipeClientStream(".", remoteAddress.Host, PipeDirection.InOut, PipeOptions.Asynchronous);
+
+            // Should not block, the server listens for `MaxAllowedServerInstances`
+            // Connect will throw if the server is not listening
+            stream.Connect();
+
+            string uniqueId = Guid.NewGuid().ToString("N");
+            var localAddress = new Address(ProtocolName, System.Name, Settings.PipeName + "_" + uniqueId, 1);
+
+            var association = new StreamAssociationHandle(stream, localAddress, remoteAddress.WithPort(1));
+
+            association.ReadHandlerSource.Task.ContinueWith(task => association.Initialize(task.Result),
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnRanToCompletion,
+                TaskScheduler.Default);
+
+            return association;
+        }
+    }
+}

--- a/src/core/Akka.Remote/Transport/Streaming/NetworkStreamTransport.cs
+++ b/src/core/Akka.Remote/Transport/Streaming/NetworkStreamTransport.cs
@@ -1,0 +1,204 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Util.Internal;
+
+namespace Akka.Remote.Transport.Streaming
+{
+    public class NetworkStreamTransportSettings
+    {
+        private const int DefaultSendBufferSize = 128 * 1024;
+        private const int DefaultReceiveBufferSize = 128 * 1024;
+
+        public string Hostname { get; }
+
+        public int Port { get; }
+
+        public int SendBufferSize { get; }
+
+        public int ReceiveBufferSize { get; }
+
+        public NetworkStreamTransportSettings(Config config)
+        {
+            Hostname = config.GetString("hostname");
+            Port = config.GetInt("port");
+            SendBufferSize = config.GetInt("send-buffer-size", DefaultSendBufferSize);
+            ReceiveBufferSize = config.GetInt("receive-buffer-size", DefaultReceiveBufferSize);
+        }
+
+        public void ConfigureSocket(Socket s)
+        {
+            s.NoDelay = true;
+
+            s.SendBufferSize = SendBufferSize;
+            s.ReceiveBufferSize = ReceiveBufferSize;
+        }
+    }
+
+    public class NetworkStreamTransport : StreamTransport
+    {
+        public const string ProtocolName = "tcp";
+
+        private readonly Socket _listener;
+
+        private readonly NetworkStreamTransportSettings _settings;
+
+        public override string SchemeIdentifier
+        {
+            get { return ProtocolName; }
+        }
+
+        public NetworkStreamTransport(ActorSystem system, Config config)
+            : base(system, config)
+        {
+            _settings = new NetworkStreamTransportSettings(config);
+
+            _listener = new Socket(SocketType.Stream, ProtocolType.Tcp);
+        }
+
+        protected override Address Initialize()
+        {
+            _listener.Bind(new IPEndPoint(IPAddress.IPv6Any, _settings.Port));
+            _listener.Listen(int.MaxValue);
+
+            return new Address(ProtocolName, System.Name, _settings.Hostname, ((IPEndPoint)_listener.LocalEndPoint).Port);
+        }
+
+        protected override void StartAcceptingConnections(IAssociationEventListener listener)
+        {
+            Task.Run(() => ListenLoop(listener));
+        }
+
+        private async Task ListenLoop(IAssociationEventListener listener)
+        {
+            // Accept will throw when _listener is closed
+            while (!CancelToken.IsCancellationRequested)
+            {
+                try
+                {
+                    var socket = await Task<Socket>.Factory.FromAsync(_listener.BeginAccept, _listener.EndAccept, null);
+
+                    _settings.ConfigureSocket(socket);
+
+                    IPEndPoint remoteEndPoint = (IPEndPoint)socket.RemoteEndPoint;
+                    string host = GetAddressString(remoteEndPoint.Address);
+
+                    var remoteAddress = new Address(ProtocolName, System.Name, host, remoteEndPoint.Port);
+
+                    var networkStream = new NetworkStream(socket, true);
+
+#pragma warning disable 4014
+                    CreateInboundAssociation(networkStream, remoteAddress)
+                        .ContinueWith(task =>
+                        {
+                            //TODO Do we need to notify a failure?
+
+                            if (task.Status == TaskStatus.RanToCompletion)
+                                listener.Notify(new InboundAssociation(task.Result));
+                        });
+#pragma warning restore 4014
+                }
+                catch (Exception)
+                {
+                    //TODO Log and shutdown if fatal exception
+                }
+            }
+        }
+
+        private static string GetAddressString(IPAddress ip)
+        {
+            if (ip.AddressFamily == AddressFamily.InterNetworkV6)
+                return ip.ToString();
+
+            if (ip.IsIPv4MappedToIPv6)
+                return SafeMapToIPv4(ip).ToString();
+
+            // IPv6 must be wrapped inside bracket in uri
+            return "[" + ip.ToString() + "]";
+        }
+
+        /// <summary>
+        /// IPAddress.MapToIPv4 is bugged.
+        /// http://stackoverflow.com/questions/23608829/why-does-ipaddress-maptoipv4-throw-argumentoutofrangeexception
+        /// </summary>
+        public static IPAddress SafeMapToIPv4(IPAddress address)
+        {
+            if (address.AddressFamily == AddressFamily.InterNetwork)
+                return address;
+
+            byte[] bytes = address.GetAddressBytes();
+            ushort[] numbers = new ushort[8];
+
+            for (int i = 0; i < 8; i++)
+                numbers[i] = (ushort)(bytes[i * 2] * 256 + bytes[i * 2 + 1]);
+
+            // Cast the ushort values to a uint and mask with unsigned literal before bit shifting.
+            // Otherwise, we can end up getting a negative value for any IPv4 address that ends with
+            // a byte higher than 127 due to sign extension of the most significant 1 bit.
+            long addressValue = ((((uint)numbers[6] & 0x0000FF00u) >> 8) | (((uint)numbers[6] & 0x000000FFu) << 8)) |
+                (((((uint)numbers[7] & 0x0000FF00u) >> 8) | (((uint)numbers[7] & 0x000000FFu) << 8)) << 16);
+
+            return new IPAddress(addressValue);
+        }
+
+        public override Task<AssociationHandle> Associate(Address remoteAddress)
+        {
+            return CreateOutboundAssociation(remoteAddress);
+        }
+
+        public override void Cleanup()
+        {
+            _listener.Close();
+        }
+
+        public virtual Task<AssociationHandle> CreateInboundAssociation(Stream stream, Address remoteAddress)
+        {
+            var association = new StreamAssociationHandle(stream, InboundAddress, remoteAddress);
+
+            // TODO Can ReadHandlerSource.Task fail? If so what do we do
+
+            association.ReadHandlerSource.Task.ContinueWith(task => association.Initialize(task.Result),
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnRanToCompletion,
+                TaskScheduler.Default);
+
+            return Task.FromResult((AssociationHandle)association);
+        }
+
+        public async Task<AssociationHandle> CreateOutboundAssociation(Address remoteAddress)
+        {
+            Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+
+            _settings.ConfigureSocket(socket);
+
+            int port = remoteAddress.Port ?? 2552;
+
+            await Task.Factory.FromAsync(socket.BeginConnect, socket.EndConnect, remoteAddress.Host, port, null);
+
+            NetworkStream stream = new NetworkStream(socket, true);
+
+            return await CreateOutboundAssociation(stream, InboundAddress, remoteAddress);
+        }
+
+        public virtual Task<AssociationHandle> CreateOutboundAssociation(Stream stream, Address localAddress, Address remoteAddress)
+        {
+            var association = new StreamAssociationHandle(stream, localAddress, remoteAddress);
+
+            // TODO Can ReadHandlerSource.Task fail? If so what do we do
+
+#pragma warning disable CS4014
+            association.ReadHandlerSource.Task.ContinueWith(task => association.Initialize(task.Result),
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnRanToCompletion,
+                TaskScheduler.Default);
+#pragma warning restore CS4014
+
+            return Task.FromResult((AssociationHandle)association);
+        }
+    }
+}

--- a/src/core/Akka.Remote/Transport/Streaming/NetworkStreamTransport.cs
+++ b/src/core/Akka.Remote/Transport/Streaming/NetworkStreamTransport.cs
@@ -41,9 +41,6 @@ namespace Akka.Remote.Transport.Streaming
 
             Port = config.GetInt("port");
 
-            Hostname = config.GetString("hostname");
-            Port = config.GetInt("port");
-
             string bindHostname = config.GetString("bind-hostname");
 
             if (string.IsNullOrEmpty(bindHostname))
@@ -210,8 +207,10 @@ namespace Akka.Remote.Transport.Streaming
             Socket socket = CreateDualModeTcpSocket();
             Settings.ConfigureSocket(socket);
 
-            //TODO Does it even work if the port is not set?
-            int port = remoteAddress.Port ?? 2552;
+            if (remoteAddress.Port == null)
+                throw new ArgumentException("Port must be specified.", nameof(remoteAddress));
+
+            int port = remoteAddress.Port.Value;
 
             var connectTask = Task.Factory.FromAsync(socket.BeginConnect, socket.EndConnect, remoteAddress.Host, port, null);
 

--- a/src/core/Akka.Remote/Transport/Streaming/SslStreamTransport.cs
+++ b/src/core/Akka.Remote/Transport/Streaming/SslStreamTransport.cs
@@ -128,7 +128,7 @@ certificate {
 
         public override string SchemeIdentifier
         {
-            get { return "ssl"; }
+            get { return "ssl.tcp"; }
         }
 
         public SslStreamTransport(ActorSystem system, Config config)

--- a/src/core/Akka.Remote/Transport/Streaming/SslStreamTransport.cs
+++ b/src/core/Akka.Remote/Transport/Streaming/SslStreamTransport.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+
+namespace Akka.Remote.Transport.Streaming
+{
+    // TODO Work in progress
+    public class SslStreamTransportSettings
+    {
+        private static readonly Config DefaultConfig = ConfigurationFactory.ParseString(@"
+enabled-ssl-protocols = [Tls ,Tls11, Tls12]
+check-server-certificate-revocation = true
+
+certificate {
+    store-location = LocalMachine
+    //md5-thumbprint = ...
+    //subject-name = ...
+}");
+
+        public X509Certificate Certificate { get; }
+
+        public SslProtocols EnabledSslProtocols { get; }
+
+        public bool CheckServerCertificateRevocation { get; }
+
+        public RemoteCertificateValidationCallback CertificateValidationCallback { get; }
+
+        public SslStreamTransportSettings(Config config)
+        {
+            string enabledProtocolsParameter = "enabled-ssl-protocols";
+            IList<string> enabledProtocols = config.GetStringList(enabledProtocolsParameter);
+
+            foreach (string protocol in enabledProtocols)
+            {
+                SslProtocols flag;
+                if (!Enum.TryParse(protocol, true, out flag))
+                    throw new ArgumentException($"Invalid SslProtocol '{protocol}'", enabledProtocolsParameter);
+
+                EnabledSslProtocols |= flag;
+            }
+
+            bool allowUntrusted = config.GetBoolean("insecure-allow-untrusted-server-certificate");
+            if (allowUntrusted)
+            {
+                CheckServerCertificateRevocation = false;
+                CertificateValidationCallback = (sender, certificate, chain, errors) => true;
+            }
+            else
+            {
+                CheckServerCertificateRevocation = config.GetBoolean("check-server-certificate-revocation", true);
+                CertificateValidationCallback = null;
+            }
+
+
+            StoreLocation location;
+            string storeLocationParameter = "store-location";
+            string storeLocationString = config.GetString(storeLocationParameter);
+            if (!Enum.TryParse(storeLocationString, out location))
+                throw new ArgumentException($"Invalid StoreLocation '{storeLocationString}'", storeLocationParameter);
+
+            
+        }
+
+        public static X509Certificate2 GetCertificateFromThumbprint(StoreLocation location, string thumbprint)
+        {
+            if (thumbprint == null)
+                return null;
+
+            // When copy pasting from the Certificate UI, it often start with the Left-to-right mark
+            // Remove it or we won't find the certificate.
+            if (thumbprint[0] == 0x200E)
+                thumbprint = thumbprint.Substring(1);
+
+            X509Store store = new X509Store(StoreName.My, location);
+
+            store.Open(OpenFlags.ReadOnly);
+
+            var certificates = store.Certificates.Find(X509FindType.FindByThumbprint, thumbprint, false);
+
+            X509Certificate2 result = null;
+
+            if (certificates.Count > 0)
+                result = certificates[0];
+
+            store.Close();
+
+            return result;
+        }
+
+        public static X509Certificate2 GetCertificateFromSubjectName(StoreLocation location, string subjectName)
+        {
+            X509Store store = new X509Store(StoreName.My, location);
+
+            store.Open(OpenFlags.ReadOnly);
+
+            var certificates = store.Certificates.Find(X509FindType.FindBySubjectName, subjectName, false);
+
+            X509Certificate2 result = null;
+
+            if (certificates.Count == 1)
+            {
+                result = certificates[0];
+            }
+            else if (certificates.Count > 1)
+            {
+                result = certificates.Cast<X509Certificate2>()
+                                     .OrderByDescending(item => item.NotAfter)
+                                     .First();
+            }
+
+            store.Close();
+
+            return result;
+        }
+    }
+
+    public class SslStreamTransport : NetworkStreamTransport
+    {
+        private readonly SslStreamTransportSettings _settings;
+
+        public override string SchemeIdentifier
+        {
+            get { return "ssl"; }
+        }
+
+        public SslStreamTransport(ActorSystem system, Config config)
+            : base(system, config)
+        {
+            _settings = new SslStreamTransportSettings(config);
+        }
+
+        public override async Task<AssociationHandle> CreateInboundAssociation(Stream stream, Address remoteAddress)
+        {
+            SslStream sslStream = new SslStream(stream, true);
+
+            await sslStream.AuthenticateAsServerAsync(_settings.Certificate, false, _settings.EnabledSslProtocols, false);
+
+            return await base.CreateInboundAssociation(sslStream, remoteAddress);
+        }
+
+        public override async Task<AssociationHandle> CreateOutboundAssociation(Stream stream, Address localAddress, Address remoteAddress)
+        {
+            SslStream sslStream = new SslStream(stream, true, _settings.CertificateValidationCallback);
+
+            await sslStream.AuthenticateAsClientAsync(remoteAddress.Host, null, _settings.EnabledSslProtocols, _settings.CheckServerCertificateRevocation);
+
+            return await base.CreateOutboundAssociation(stream, localAddress, remoteAddress);
+        }
+    }
+}

--- a/src/core/Akka.Remote/Transport/Streaming/StreamAssociationHandle.cs
+++ b/src/core/Akka.Remote/Transport/Streaming/StreamAssociationHandle.cs
@@ -1,0 +1,194 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Google.ProtocolBuffers;
+
+namespace Akka.Remote.Transport.Streaming
+{
+    public class StreamAssociationHandle : AssociationHandle
+    {
+        private const int UserBufferSize = 1024*8;
+
+        private readonly Stream _stream;
+        private readonly AsyncQueue<ByteString> _writeQueue;
+        private IHandleEventListener _eventListener;
+
+        private byte[] _readBuffer;
+        private byte[] _writeBuffer;
+
+        public StreamAssociationHandle(Stream stream, Address localAddress, Address remoteAddress)
+            : base(localAddress, remoteAddress)
+        {
+            _stream = stream;
+            _writeQueue = new AsyncQueue<ByteString>();
+        }
+
+        internal void Initialize(IHandleEventListener eventListener)
+        {
+            _readBuffer = new byte[UserBufferSize];
+            _writeBuffer = new byte[UserBufferSize];
+
+            _eventListener = eventListener;
+            Task.Run(() => ReadLoop())
+                .ContinueWith(_ =>
+                {
+                    _eventListener.Notify(new Disassociated(DisassociateInfo.Unknown));
+                }, TaskContinuationOptions.OnlyOnFaulted);
+
+            Task.Run(() => WriteLoop())
+                .ContinueWith(_ =>
+                {
+                    _eventListener.Notify(new Disassociated(DisassociateInfo.Unknown));
+                }, TaskContinuationOptions.OnlyOnFaulted);
+        }
+
+        private async Task ReadLoop()
+        {
+            //TODO Add 100% test coverage for this
+
+            byte[] readBuffer = _readBuffer;
+            int bufferLength = readBuffer.Length;
+
+            int readBytes = 0;
+            int readIndex = 0;
+
+            while (true)
+            {
+                int available = readBytes - readIndex;
+                if (available < sizeof(int))
+                {
+                    // To simplify the message length read logic, we enforce the length bytes be whole in the buffer
+
+                    // Copy the partial length at the start of the buffer
+                    if (available != 0)
+                        Buffer.BlockCopy(readBuffer, readIndex, readBuffer, 0, available);
+
+                    readIndex = 0;
+                    readBytes = await _stream.ReadAsync(readBuffer, available, bufferLength - available).ConfigureAwait(false);
+
+                    if (readBytes == 0)
+                    {
+                        _eventListener.Notify(new Disassociated(DisassociateInfo.Unknown));
+                        return;
+                    }
+
+                    // Adjust readBytes to include the partial length that we copied earlier
+                    readBytes += available;
+                }
+
+                int payloadLength = BitConverter.ToInt32(readBuffer, readIndex);
+                readIndex += sizeof(int);
+
+                byte[] payloadBuffer = new byte[payloadLength];
+                int payloadOffset = 0;
+
+                while (payloadOffset < payloadLength)
+                {
+                    if (readIndex == readBytes)
+                    {
+                        readIndex = 0;
+                        readBytes = await _stream.ReadAsync(readBuffer, 0, bufferLength).ConfigureAwait(false);
+
+                        if (readBytes == 0)
+                        {
+                            _eventListener.Notify(new Disassociated(DisassociateInfo.Unknown));
+                            return;
+                        }
+                    }
+
+                    available = Math.Min(readBytes - readIndex, payloadLength - payloadOffset);
+
+                    Buffer.BlockCopy(readBuffer, readIndex, payloadBuffer, payloadOffset, available);
+                    readIndex += available;
+                    payloadOffset += available;
+                }
+
+                var payload = new InboundPayload(ByteString.Unsafe.FromBytes(payloadBuffer));
+                _eventListener.Notify(payload);
+            }
+        }
+
+        public override bool Write(ByteString payload)
+        {
+            _writeQueue.Enqueue(payload);
+
+            return true;
+        }
+
+        private async Task WriteLoop()
+        {
+            //TODO Add 100% test coverage for this
+
+            byte[] writeBuffer = _writeBuffer;
+            int bufferLength = writeBuffer.Length;
+            int bufferOffset = 0;
+
+            try
+            {
+                while (true)
+                {
+                    var dequeueTask = _writeQueue.Dequeue();
+
+                    ByteString payload;
+
+                    if (dequeueTask.IsCompleted)
+                        payload = dequeueTask.Result;
+                    else
+                    {
+                        if (bufferOffset > 0)
+                        {
+                            // We are about to wait for data, flush the buffer
+                            await _stream.WriteAsync(writeBuffer, 0, bufferOffset).ConfigureAwait(false);
+                            bufferOffset = 0;
+                        }
+
+                        payload = await dequeueTask.ConfigureAwait(false);
+                    }
+
+
+                    if (bufferLength - bufferOffset < sizeof (int))
+                    {
+                        // Not enough space to write payload length, flush the buffer
+                        await _stream.WriteAsync(writeBuffer, 0, bufferOffset).ConfigureAwait(false);
+                        bufferOffset = 0;
+                    }
+
+                    // Copy the length
+                    // We can assume that the write buffer length will always be greater than sizeof(int)!
+                    int payloadLength = payload.Length;
+                    byte[] lengthBuffer = BitConverter.GetBytes(payloadLength);
+                    Buffer.BlockCopy(lengthBuffer, 0, writeBuffer, bufferOffset, sizeof(int));
+                    bufferOffset += 4;
+
+                    byte[] payloadBuffer = ByteString.Unsafe.GetBuffer(payload);
+                    int payloadOffset = 0;
+
+                    while (payloadOffset < payloadLength)
+                    {
+                        if (bufferLength == bufferOffset)
+                        {
+                            // Flush the buffer
+                            await _stream.WriteAsync(writeBuffer, 0, bufferOffset).ConfigureAwait(false);
+                            bufferOffset = 0;
+                        }
+
+                        int available = Math.Min(bufferLength - bufferOffset, payloadLength - payloadOffset);
+
+                        Buffer.BlockCopy(payloadBuffer, payloadOffset, writeBuffer, bufferOffset, available);
+                        payloadOffset += available;
+                        bufferOffset += available;
+                    }
+                }
+            }
+            catch (TaskCanceledException)
+            { }
+        }
+
+        public override void Disassociate()
+        {
+            _writeQueue.Dispose();
+            _stream.Close();
+        }
+    }
+}

--- a/src/core/Akka.Remote/Transport/Streaming/StreamTransport.cs
+++ b/src/core/Akka.Remote/Transport/Streaming/StreamTransport.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+
+namespace Akka.Remote.Transport.Streaming
+{
+    public abstract class StreamTransport : Transport
+    {
+        private readonly CancellationTokenSource _cancellation;
+        private string _responsibleProtocol;
+
+        protected Address InboundAddress { get; private set; }
+
+        protected CancellationToken CancelToken
+        {
+            get { return _cancellation.Token; }
+        }
+
+        public override long MaximumPayloadBytes
+        {
+            get { return int.MaxValue; }
+        }
+
+        protected StreamTransport(ActorSystem system, Config config)
+        {
+            _cancellation = new CancellationTokenSource();
+
+            System = system;
+            Config = config;
+        }
+
+        public sealed override Task<Tuple<Address, TaskCompletionSource<IAssociationEventListener>>> Listen()
+        {
+            TaskCompletionSource<IAssociationEventListener> completion = new TaskCompletionSource<IAssociationEventListener>();
+
+            InboundAddress = Initialize();
+
+            _responsibleProtocol = "akka." + SchemeIdentifier;
+
+            completion.Task.ContinueWith(task =>
+            {
+                StartAcceptingConnections(task.Result);
+            }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Default);
+
+            return Task.FromResult(Tuple.Create(InboundAddress, completion));
+        }
+
+        protected abstract Address Initialize();
+
+        protected abstract void StartAcceptingConnections(IAssociationEventListener listener);
+
+        public override bool IsResponsibleFor(Address remote)
+        {
+            return string.Equals(_responsibleProtocol, remote.Protocol, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public sealed override Task<bool> Shutdown()
+        {
+            // TODO Close all connections and flush writes?
+
+            _cancellation.Cancel();
+            Cleanup();
+            return Task.FromResult(true);
+        }
+
+        public abstract void Cleanup();
+    }
+}

--- a/src/core/Akka.Remote/Transport/Streaming/StreamTransport.cs
+++ b/src/core/Akka.Remote/Transport/Streaming/StreamTransport.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
@@ -6,29 +8,66 @@ using Akka.Configuration;
 
 namespace Akka.Remote.Transport.Streaming
 {
+    public class StreamTransportSettings
+    {
+        public Config Config { get; }
+
+        public int StreamWriteBufferSize { get; }
+
+        public int StreamReadBufferSize { get; }
+
+        public int MaximumFrameSize { get; }
+
+        public TimeSpan FlushWaitTimeout { get; }
+
+        public StreamTransportSettings(Config config)
+        {
+            Config = config;
+
+            StreamWriteBufferSize = GetByteSize(config, "stream-write-buffer-size");
+            StreamReadBufferSize = GetByteSize(config, "stream-read-buffer-size");
+            MaximumFrameSize = GetByteSize(config, "maximum-frame-size", 32000);
+            FlushWaitTimeout = config.GetTimeSpan("flush-wait-on-shutdown");
+        }
+
+        protected static int GetByteSize(Config config, string path, int minValue = 0, int maxValue = int.MaxValue)
+        {
+            long? option = config.GetByteSize(path);
+
+            if (option == null)
+                throw new ConfigurationException($"Setting '{path}' is missing.");
+
+            long size = option.Value;
+            if (size < minValue)
+                throw new ConfigurationException($"Setting '{path}' must be at least '{minValue}'.");
+
+            if (size > maxValue)
+                throw new ConfigurationException($"Setting '{path}' must be smaller than '{maxValue}'.");
+
+            return (int)size;
+        }
+    }
+
     public abstract class StreamTransport : Transport
     {
         private readonly CancellationTokenSource _cancellation;
-        private string _responsibleProtocol;
+        private readonly HashSet<StreamAssociationHandle> _associations = new HashSet<StreamAssociationHandle>();
+
+        protected StreamTransportSettings Settings { get; }
 
         protected Address InboundAddress { get; private set; }
 
-        protected CancellationToken CancelToken
-        {
-            get { return _cancellation.Token; }
-        }
+        protected CancellationToken ShutdownToken => _cancellation.Token;
 
-        public override long MaximumPayloadBytes
-        {
-            get { return int.MaxValue; }
-        }
+        public override long MaximumPayloadBytes => Settings.MaximumFrameSize;
 
-        protected StreamTransport(ActorSystem system, Config config)
+        protected StreamTransport(ActorSystem system, StreamTransportSettings settings)
         {
             _cancellation = new CancellationTokenSource();
 
             System = system;
-            Config = config;
+            Config = settings.Config;
+            Settings = settings;
         }
 
         public sealed override Task<Tuple<Address, TaskCompletionSource<IAssociationEventListener>>> Listen()
@@ -36,8 +75,6 @@ namespace Akka.Remote.Transport.Streaming
             TaskCompletionSource<IAssociationEventListener> completion = new TaskCompletionSource<IAssociationEventListener>();
 
             InboundAddress = Initialize();
-
-            _responsibleProtocol = "akka." + SchemeIdentifier;
 
             completion.Task.ContinueWith(task =>
             {
@@ -53,18 +90,48 @@ namespace Akka.Remote.Transport.Streaming
 
         public override bool IsResponsibleFor(Address remote)
         {
-            return string.Equals(_responsibleProtocol, remote.Protocol, StringComparison.OrdinalIgnoreCase);
+            return true;
         }
 
-        public sealed override Task<bool> Shutdown()
+        public sealed override async Task<bool> Shutdown()
         {
-            // TODO Close all connections and flush writes?
-
             _cancellation.Cancel();
+            bool gracefulShutdown = await ShutdownAssociations();
             Cleanup();
-            return Task.FromResult(true);
+            return gracefulShutdown;
         }
 
-        public abstract void Cleanup();
+        public void RegisterAssociation(StreamAssociationHandle association)
+        {
+            lock (_associations)
+            {
+                _associations.Add(association);
+            }
+
+            association.Stopped.ContinueWith(_ =>
+            {
+                lock (_associations)
+                {
+                    _associations.Remove(association);
+                }
+            }, ShutdownToken);
+        }
+
+        private async Task<bool> ShutdownAssociations()
+        {
+            StreamAssociationHandle[] associations;
+            lock (_associations)
+            {
+                associations = _associations.ToArray();
+                _associations.Clear();
+            }
+
+            var tasks = associations.Select(item => item.Stopped).ToArray();
+            var results = await Task.WhenAll(tasks);
+
+            return results.All(flushSucceeded => flushSucceeded);
+        }
+
+        protected abstract void Cleanup();
     }
 }

--- a/src/core/Akka.Remote/Transport/Streaming/StreamTransport.cs
+++ b/src/core/Akka.Remote/Transport/Streaming/StreamTransport.cs
@@ -20,6 +20,10 @@ namespace Akka.Remote.Transport.Streaming
 
         public TimeSpan FlushWaitTimeout { get; }
 
+        public int ChunkedReadThreshold { get; }
+
+        public int FrameSizeHardLimit { get; }
+
         public StreamTransportSettings(Config config)
         {
             Config = config;
@@ -28,6 +32,8 @@ namespace Akka.Remote.Transport.Streaming
             StreamReadBufferSize = GetByteSize(config, "stream-read-buffer-size");
             MaximumFrameSize = GetByteSize(config, "maximum-frame-size", 32000);
             FlushWaitTimeout = config.GetTimeSpan("flush-wait-on-shutdown");
+            ChunkedReadThreshold = GetByteSize(config, "chunked-read-threshold");
+            FrameSizeHardLimit = GetByteSize(config, "frame-size-hard-limit", 32000);
         }
 
         protected static int GetByteSize(Config config, string path, int minValue = 0, int maxValue = int.MaxValue)


### PR DESCRIPTION
This pull request includes a new Remoting Transport based on a NetworkStream.

This Transport aims to get the lowest overhead possible on top of .Net Sockets.

A sub-goal is to be able to support easily any Transport based on System.IO.Stream. The PR include two other transports (SslStreamTransport and NamedPipeTransport), but it is still a work in progress.

Initial results are promising, the transport is able to achieve 120K msg/sec on a quad core workstation, compared to ~6K msg/sec with Helios.

The happy path is working, but the code remain largely untested. Other PRs will includes spec until there is 100% code & feature coverage.

(This PR does not include the ActorPath cache to achieve 120K msg/sec, without the patch it is doing ~70K msg/sec)