### PR TITLE
AtomicModule, optimized StreamLayout.Compose and minor IO spec fixes

### DIFF
--- a/src/core/Akka.Streams.Tests/IO/InputStreamSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/InputStreamSinkSpec.cs
@@ -21,7 +21,7 @@ namespace Akka.Streams.Tests.IO
         private readonly ActorMaterializer _materializer;
         private readonly ByteString _byteString = RandomByteString(3);
 
-        public InputStreamSinkSpec()
+        public InputStreamSinkSpec() : base(Utils.UnboundedMailboxConfig)
         {
             Sys.Settings.InjectTopLevelFallback(ActorMaterializer.DefaultConfig());
             var settings = ActorMaterializerSettings.Create(Sys).WithDispatcher("akka.actor.default-dispatcher");

--- a/src/core/Akka.Streams.Tests/IO/OutputStreamSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/OutputStreamSourceSpec.cs
@@ -31,9 +31,9 @@ namespace Akka.Streams.Tests.IO
 
             _bytesArray = new[]
             {
-                Convert.ToByte(new Random().Next(1024)),
-                Convert.ToByte(new Random().Next(1024)),
-                Convert.ToByte(new Random().Next(1024))
+                Convert.ToByte(new Random().Next(256)),
+                Convert.ToByte(new Random().Next(256)),
+                Convert.ToByte(new Random().Next(256))
             };
 
             _byteString = ByteString.Create(_bytesArray);

--- a/src/core/Akka.Streams.Tests/IO/TcpHelper.cs
+++ b/src/core/Akka.Streams.Tests/IO/TcpHelper.cs
@@ -15,7 +15,7 @@ namespace Akka.Streams.Tests.IO
         protected TcpHelper(string config) : base(config)
         {
             Settings = ActorMaterializerSettings.Create(Sys).WithInputBuffer(4, 4);
-            Materializer = ActorMaterializer.Create(this, Settings);
+            Materializer = Sys.Materializer(Settings);
         }
 
         protected ActorMaterializerSettings Settings { get; }

--- a/src/core/Akka.Streams/Implementation/ActorMaterializerImpl.cs
+++ b/src/core/Akka.Streams/Implementation/ActorMaterializerImpl.cs
@@ -239,7 +239,8 @@ namespace Akka.Streams.Implementation
 
             var session = new ActorMaterializerSession(this, runnableGraph.Module, InitialAttributes, subFlowFuser);
 
-            return (TMat)session.Materialize();
+            var matVal = session.Materialize();
+            return (TMat) matVal;
         }
 
         private readonly Lazy<MessageDispatcher> _executionContext;

--- a/src/core/Akka.Streams/Implementation/FlowModule.cs
+++ b/src/core/Akka.Streams/Implementation/FlowModule.cs
@@ -3,7 +3,7 @@ using System.Collections.Immutable;
 
 namespace Akka.Streams.Implementation
 {
-    internal abstract class FlowModule<TIn, TOut, TMat> : Module
+    internal abstract class FlowModule<TIn, TOut, TMat> : AtomicModule
     {
         public readonly Inlet<TIn> In = new Inlet<TIn>("Flow.in");
         public readonly Outlet<TOut> Out = new Outlet<TOut>("Flow.out");
@@ -14,7 +14,6 @@ namespace Akka.Streams.Implementation
         }
         
         public override Shape Shape { get; }
-        public override ImmutableArray<IModule> SubModules => ImmutableArray<IModule>.Empty;
 
         public override IModule ReplaceShape(Shape shape)
         {

--- a/src/core/Akka.Streams/Implementation/Fusing/ActorGraphInterpreter.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/ActorGraphInterpreter.cs
@@ -14,7 +14,7 @@ using Akka.Util.Internal;
 // ReSharper disable MemberHidesStaticFromOuterClass
 namespace Akka.Streams.Implementation.Fusing
 {
-    internal class GraphModule : Module
+    internal class GraphModule : AtomicModule
     {
         public readonly IModule[] MaterializedValueIds;
         public readonly GraphAssembly Assembly;
@@ -29,9 +29,7 @@ namespace Akka.Streams.Implementation.Fusing
 
         public override Shape Shape { get; }
         public override Attributes Attributes { get; }
-
-        public override ImmutableArray<IModule> SubModules => ImmutableArray<IModule>.Empty;
-
+        
         public override IModule WithAttributes(Attributes attributes)
         {
             return new GraphModule(Assembly, Shape, attributes, MaterializedValueIds);

--- a/src/core/Akka.Streams/Implementation/Fusing/GraphStages.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/GraphStages.cs
@@ -43,7 +43,7 @@ namespace Akka.Streams.Implementation.Fusing
         }
     }
 
-    internal class GraphStageModule : Module
+    internal class GraphStageModule : AtomicModule
     {
         public readonly IGraphStageWithMaterializedValue Stage;
 
@@ -60,9 +60,7 @@ namespace Akka.Streams.Implementation.Fusing
         {
             return new CopiedModule(shape, Attributes.None, this);
         }
-
-        public override ImmutableArray<IModule> SubModules => ImmutableArray<IModule>.Empty;
-
+        
         public override IModule CarbonCopy()
         {
             return ReplaceShape(Shape.DeepCopy());

--- a/src/core/Akka.Streams/Implementation/IO/InputStreamSinkStage.cs
+++ b/src/core/Akka.Streams/Implementation/IO/InputStreamSinkStage.cs
@@ -214,7 +214,7 @@ namespace Akka.Streams.Implementation.IO
                 throw new ArgumentException("offset must be >= 0");
             if (count <= 0)
                 throw new ArgumentException("count must be > 0");
-            if (offset + count <= buffer.Length)
+            if (offset + count > buffer.Length)
                 throw new AggregateException("offset + count must be smaller or equal to the array length");
 
             return ExecuteIfNotClosed(() =>
@@ -283,7 +283,7 @@ namespace Akka.Streams.Implementation.IO
             var size = chunk.Count;
             if (size <= count)
             {
-                chunk.ToArray().CopyTo(buffer, count);
+                Array.Copy(chunk.ToArray(), 0, buffer, offset, Math.Min(size, count));
                 _detachedChunk = null;
                 if (size == count)
                     return gotBytes + size;

--- a/src/core/Akka.Streams/Implementation/Modules.cs
+++ b/src/core/Akka.Streams/Implementation/Modules.cs
@@ -13,7 +13,7 @@ namespace Akka.Streams.Implementation
         IPublisher Create(MaterializationContext context, out object materializer);
     }
 
-    internal abstract class SourceModule<TOut, TMat> : Module, ISourceModule
+    internal abstract class SourceModule<TOut, TMat> : AtomicModule, ISourceModule
     {
         private readonly SourceShape<TOut> _shape;
 
@@ -46,9 +46,7 @@ namespace Akka.Streams.Implementation
         {
             return NewInstance(new SourceShape<TOut>(Outlet.Create<TOut>(_shape.Outlet.CarbonCopy())));
         }
-
-        public override ImmutableArray<IModule> SubModules => ImmutableArray<IModule>.Empty;
-
+        
         protected SourceShape<TOut> AmendShape(Attributes attributes)
         {
             var thisN = Attributes.GetNameOrDefault(null);

--- a/src/core/Akka.Streams/Implementation/Sinks.cs
+++ b/src/core/Akka.Streams/Implementation/Sinks.cs
@@ -16,7 +16,7 @@ namespace Akka.Streams.Implementation
         ISubscriber Create(MaterializationContext context, out object materializer);
     }
 
-    public abstract class SinkModule<TIn, TMat> : Module, ISinkModule
+    public abstract class SinkModule<TIn, TMat> : AtomicModule, ISinkModule
     {
         private readonly SinkShape<TIn> _shape;
 
@@ -26,7 +26,6 @@ namespace Akka.Streams.Implementation
         }
 
         public override Shape Shape => _shape;
-        public override ImmutableArray<IModule> SubModules => ImmutableArray<IModule>.Empty;
 
         protected abstract SinkModule<TIn, TMat> NewInstance(SinkShape<TIn> shape);
 

--- a/src/core/Akka/Util/ByteString.cs
+++ b/src/core/Akka/Util/ByteString.cs
@@ -371,7 +371,7 @@ namespace Akka.IO
     /// when concatenating and slicing sequences of bytes,
     /// and also providing a thread safe way of working with bytes.
     /// </summary>
-    public abstract partial class ByteString : IReadOnlyList<byte>
+    public abstract partial class ByteString : IReadOnlyList<byte>, IEquatable<ByteString>
     {
         public abstract byte this[int index] { get; }
 
@@ -521,6 +521,23 @@ namespace Akka.IO
         public static ByteString Create(byte[] buffer)
         {
             return Create(buffer, 0, buffer.Length);
+        }
+
+        public bool Equals(ByteString other)
+        {
+            if (ReferenceEquals(other, null)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            if (Count != other.Count) return false;
+            for (int i = 0; i < Count; i++)
+            {
+                if (this[i] != other[i]) return false;
+            }
+            return true;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is ByteString && Equals((ByteString) obj);
         }
     }
 


### PR DESCRIPTION
- Implemented AtomicModule and introduced it in inheriting classes.
- ByteString equality method (for spec asserts)
- Optimization step for compose working on two materialized values - now Keep.Left / Keep.Right check is made to minimize unnecessary steps.