### PR TITLE
Recovered default journal & snapshot store to default config

### DIFF
--- a/src/core/Akka.Persistence.Tests/Akka.Persistence.Tests.csproj
+++ b/src/core/Akka.Persistence.Tests/Akka.Persistence.Tests.csproj
@@ -85,6 +85,7 @@
     <Compile Include="LoadPluginSpec.cs" />
     <Compile Include="MemoryEventAdapterSpec.cs" />
     <Compile Include="PerformanceSpec.cs" />
+    <Compile Include="PersistenceConfigSpec.cs" />
     <Compile Include="PersistenceSpec.cs" />
     <Compile Include="PersistentActorBoundedStashingSpec.cs" />
     <Compile Include="PersistentActorDeleteFailureSpec.cs" />

--- a/src/core/Akka.Persistence.Tests/AtLeastOnceDeliveryCrashSpec.cs
+++ b/src/core/Akka.Persistence.Tests/AtLeastOnceDeliveryCrashSpec.cs
@@ -117,7 +117,7 @@ namespace Akka.Persistence.Tests
         #endregion
 
         public AtLeastOnceDeliveryCrashSpec()
-            : base(PersistenceSpec.Configuration("inmem", "AtLeastOnceDeliveryCrashSpec", serialization: "off"))
+            : base(PersistenceSpec.Configuration("AtLeastOnceDeliveryCrashSpec", serialization: "off"))
         {
         }
 

--- a/src/core/Akka.Persistence.Tests/AtLeastOnceDeliveryReceiveActorSpec.cs
+++ b/src/core/Akka.Persistence.Tests/AtLeastOnceDeliveryReceiveActorSpec.cs
@@ -354,7 +354,7 @@ namespace Akka.Persistence.Tests
         #endregion
 
         public AtLeastOnceDeliveryReceiveActorSpec()
-            : base(Configuration("inmem", "AtLeastOnceDeliveryReceiveActorSpec"))
+            : base(Configuration("AtLeastOnceDeliveryReceiveActorSpec"))
         {
         }
 

--- a/src/core/Akka.Persistence.Tests/AtLeastOnceDeliverySpec.cs
+++ b/src/core/Akka.Persistence.Tests/AtLeastOnceDeliverySpec.cs
@@ -327,7 +327,7 @@ namespace Akka.Persistence.Tests
         #endregion
 
         public AtLeastOnceDeliverySpec()
-            : base(PersistenceSpec.Configuration("inmem", "AtLeastOnceDeliverySpec"))
+            : base(Configuration("AtLeastOnceDeliverySpec"))
         {
         }
 

--- a/src/core/Akka.Persistence.Tests/EndToEndEventAdapterSpec.cs
+++ b/src/core/Akka.Persistence.Tests/EndToEndEventAdapterSpec.cs
@@ -19,7 +19,7 @@ namespace Akka.Persistence.Tests
     public class MemoryEndToEndAdapterSpec : EndToEndEventAdapterSpec
     {
         private static readonly Config Config = ConfigurationFactory.ParseString(@"akka.persistence.journal.inmem.class = ""Akka.Persistence.Journal.SharedMemoryJournal, Akka.Persistence""");
-        public MemoryEndToEndAdapterSpec() : base("inmem", Configuration("inmem", "MemoryEndToEndAdapterSpec").WithFallback(Config))
+        public MemoryEndToEndAdapterSpec() : base("inmem", Configuration("MemoryEndToEndAdapterSpec").WithFallback(Config))
         {
         }
     }
@@ -292,7 +292,7 @@ namespace Akka.Persistence.Tests
             }}";
 
         protected EndToEndEventAdapterSpec(string journalName, Config journalConfig)
-            : base(PersistenceSpec.Configuration("inmem", "EndToEndEventAdapterSpec"))
+            : base(Configuration("EndToEndEventAdapterSpec"))
         {
             _journalName = journalName;
             _journalConfig = journalConfig;

--- a/src/core/Akka.Persistence.Tests/Fsm/PersistentFSMSpec.cs
+++ b/src/core/Akka.Persistence.Tests/Fsm/PersistentFSMSpec.cs
@@ -19,7 +19,7 @@ namespace Akka.Persistence.Tests.Fsm
         private readonly Random _random = new Random();
 
         public PersistentFSMSpec()
-            : base(Configuration("inmem", "PersistentFSMSpec"))
+            : base(Configuration("PersistentFSMSpec"))
         {
         }
 

--- a/src/core/Akka.Persistence.Tests/LoadPluginSpec.cs
+++ b/src/core/Akka.Persistence.Tests/LoadPluginSpec.cs
@@ -40,7 +40,7 @@ namespace Akka.Persistence.Tests
             }
         }
 
-        public LoadPluginSpec() : base(Configuration("inmem", "LoadPluginSpec", extraConfig:
+        public LoadPluginSpec() : base(Configuration("LoadPluginSpec", extraConfig:
   @"akka.persistence.journal.inmem.class = ""Akka.Persistence.Tests.LoadPluginSpec+JournalWithConfig, Akka.Persistence.Tests""
   akka.persistence.journal.inmem.extra-property = 17"))
         {

--- a/src/core/Akka.Persistence.Tests/MemoryEventAdapterSpec.cs
+++ b/src/core/Akka.Persistence.Tests/MemoryEventAdapterSpec.cs
@@ -287,7 +287,7 @@ namespace Akka.Persistence.Tests
             typeof(LoggingAdapter).FullName + ", Akka.Persistence.Tests");
 
         public MemoryEventAdapterSpec()
-            : this("inmem", PersistenceSpec.Configuration("inmem", "MemoryEventAdapterSpec"), ConfigurationFactory.ParseString(AdapterSpecConfig))
+            : this("inmem", Configuration("MemoryEventAdapterSpec"), ConfigurationFactory.ParseString(AdapterSpecConfig))
         {
 
         }

--- a/src/core/Akka.Persistence.Tests/OptionalSnapshotStoreSpec.cs
+++ b/src/core/Akka.Persistence.Tests/OptionalSnapshotStoreSpec.cs
@@ -65,19 +65,11 @@ namespace Akka.Persistence.Tests
     akka.persistence.journal.plugin = ""akka.persistence.journal.inmem""
 
     # snapshot store plugin is NOT defined, things should still work
+    akka.persistence.snapshot-store.plugin = ""akka.persistence.no-snapshot-store""
     akka.persistence.snapshot-store.local.dir = ""target/snapshots-" + typeof(OptionalSnapshotStoreSpec).FullName + "/"))
         {
         }
-
-        [Fact]
-        public void Persistence_extension_should_initialize_properly_even_in_absence_of_configured_snapshot_store()
-        {
-            Sys.ActorOf(Props.Create(() => new AnyPersistentActor(Name)));
-            Sys.EventStream.Subscribe(TestActor, typeof (Warning));
-            var message = ExpectMsg<Warning>().Message.ToString();
-            message.ShouldStartWith("No default snapshot store configured");
-        }
-
+        
         [Fact]
         public void Persistence_extension_should_fail_if_PersistentActor_tries_to_SaveSnapshot_without_snapshot_store_available()
         {

--- a/src/core/Akka.Persistence.Tests/PersistenceConfigSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistenceConfigSpec.cs
@@ -1,0 +1,30 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="PersistenceConfigSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Persistence.Tests
+{
+    public class PersistenceConfigSpec : AkkaSpec
+    {
+        [Fact]
+        public void Persistence_should_use_inmem_journal_by_default()
+        {
+            var persistence = Persistence.Instance.Apply(Sys);
+            var journal = persistence.JournalFor(string.Empty); // get the default journal
+            journal.Path.Name.ShouldBe("akka.persistence.journal.inmem");
+        }
+
+        [Fact]
+        public void Persistence_should_use_local_snapshot_store_by_default()
+        {
+            var persistence = Persistence.Instance.Apply(Sys);
+            var journal = persistence.SnapshotStoreFor(string.Empty); // get the default snapshot store
+            journal.Path.Name.ShouldBe("akka.persistence.snapshot-store.local");
+        }
+    }
+}

--- a/src/core/Akka.Persistence.Tests/PersistenceSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistenceSpec.cs
@@ -18,7 +18,7 @@ namespace Akka.Persistence.Tests
 {
     public abstract class PersistenceSpec : AkkaSpec
     {
-        public static Config Configuration(string plugin, string test, string serialization = null,
+        public static Config Configuration(string test, string serialization = null,
             string extraConfig = null)
         {
             var c = extraConfig == null
@@ -28,10 +28,8 @@ namespace Akka.Persistence.Tests
                 akka.actor.serialize-creators = {0}
                 akka.actor.serialize-messages = {0}
                 akka.persistence.publish-plugin-commands = on
-                akka.persistence.journal.plugin = ""akka.persistence.journal.{1}""
-                akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.local""
-                akka.persistence.snapshot-store.local.dir = ""target/snapshots-{2}/""
-                akka.test.single-expect-default = 10s", serialization ?? "on", plugin, test);
+                akka.persistence.snapshot-store.local.dir = ""target/snapshots-{1}/""
+                akka.test.single-expect-default = 10s", serialization ?? "on", test);
 
             return c.WithFallback(ConfigurationFactory.ParseString(configString));
         }

--- a/src/core/Akka.Persistence.Tests/PersistentActorDeleteFailureSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorDeleteFailureSpec.cs
@@ -104,7 +104,7 @@ namespace Akka.Persistence.Tests
             }
         }
 
-        public PersistentActorDeleteFailureSpec() : base(Configuration("inmem", "PersistentActorDeleteFailureSpec",
+        public PersistentActorDeleteFailureSpec() : base(Configuration("PersistentActorDeleteFailureSpec",
             serialization: "off",
             extraConfig: "akka.persistence.journal.inmem.class = \"Akka.Persistence.Tests.PersistentActorDeleteFailureSpec+DeleteFailingMemoryJournal, Akka.Persistence.Tests\""))
         {

--- a/src/core/Akka.Persistence.Tests/PersistentActorFailureSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorFailureSpec.cs
@@ -280,7 +280,7 @@ namespace Akka.Persistence.Tests
         #endregion
 
         public PersistentActorFailureSpec()
-            : base(Configuration("inmem", "PersistentActorFailureSpec",
+            : base(Configuration("PersistentActorFailureSpec",
                 extraConfig:
                     @"akka.persistence.journal.inmem.class = ""Akka.Persistence.Tests.PersistentActorFailureSpec+FailingMemoryJournal, Akka.Persistence.Tests""
                     akka.actor.serialize-messages=off"))

--- a/src/core/Akka.Persistence.Tests/PersistentActorSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorSpec.cs
@@ -19,7 +19,7 @@ namespace Akka.Persistence.Tests
     {
         private readonly Random _random = new Random();
         public PersistentActorSpec()
-            : base(Configuration("inmem", "PersistentActorSpec"))
+            : base(Configuration("PersistentActorSpec"))
         {
             var pref = ActorOf(Props.Create(() => new BehaviorOneActor(Name)));
             pref.Tell(new Cmd("a"));

--- a/src/core/Akka.Persistence.Tests/PersistentActorStashingSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorStashingSpec.cs
@@ -268,7 +268,7 @@ namespace Akka.Persistence.Tests
         }
 
         public PersistentActorStashingSpec()
-            : base(Configuration("inmem", "PersistentActorStashingSpec"))
+            : base(Configuration("PersistentActorStashingSpec"))
         {
         }
 
@@ -438,7 +438,7 @@ namespace Akka.Persistence.Tests
         }
 
         public SteppingMemoryPersistentActorStashingSpec()
-            : base(SteppingMemoryJournal.Config("persistence-stash").WithFallback(Configuration("stepping-inmem", "SteppingMemoryPersistentActorStashingSpec")))
+            : base(SteppingMemoryJournal.Config("persistence-stash").WithFallback(Configuration("SteppingMemoryPersistentActorStashingSpec")))
         {
         }
 

--- a/src/core/Akka.Persistence.Tests/PersistentViewSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentViewSpec.cs
@@ -20,7 +20,7 @@ namespace Akka.Persistence.Tests
         protected TestProbe _viewProbe;
 
         public PersistentViewSpec()
-            : base(Configuration("inmem", "PersistentViewSpec"))
+            : base(Configuration("PersistentViewSpec"))
         {
             _prefProbe = CreateTestProbe();
             _viewProbe = CreateTestProbe();

--- a/src/core/Akka.Persistence.Tests/SnapshotDirectoryFailureSpec.cs
+++ b/src/core/Akka.Persistence.Tests/SnapshotDirectoryFailureSpec.cs
@@ -50,7 +50,7 @@ namespace Akka.Persistence.Tests
 
         FileInfo file = new FileInfo(InUseSnapshotPath);
 
-        public SnapshotDirectoryFailureSpec() : base(Configuration("inmem", "SnapshotDirectoryFailureSpec",
+        public SnapshotDirectoryFailureSpec() : base(Configuration("SnapshotDirectoryFailureSpec",
             extraConfig: "akka.persistence.snapshot-store.local.dir = \"" + InUseSnapshotPath + "\""))
         {
         }

--- a/src/core/Akka.Persistence.Tests/SnapshotFailureRobustnessSpec.cs
+++ b/src/core/Akka.Persistence.Tests/SnapshotFailureRobustnessSpec.cs
@@ -181,7 +181,7 @@ namespace Akka.Persistence.Tests
             }
         }
 
-        public SnapshotFailureRobustnessSpec() : base(Configuration("inmem", "SnapshotFailureRobustnessSpec", serialization: "off",
+        public SnapshotFailureRobustnessSpec() : base(Configuration("SnapshotFailureRobustnessSpec", serialization: "off",
             extraConfig: @"
 akka.persistence.snapshot-store.local.class = ""Akka.Persistence.Tests.SnapshotFailureRobustnessSpec+FailingLocalSnapshotStore, Akka.Persistence.Tests""
 akka.persistence.snapshot-store.local-delete-fail.class = ""Akka.Persistence.Tests.SnapshotFailureRobustnessSpec+DeleteFailingLocalSnapshotStore, Akka.Persistence.Tests""

--- a/src/core/Akka.Persistence.Tests/SnapshotRecoveryLocalStoreSpec.cs
+++ b/src/core/Akka.Persistence.Tests/SnapshotRecoveryLocalStoreSpec.cs
@@ -74,7 +74,7 @@ namespace Akka.Persistence.Tests
             }
         }
 
-        public SnapshotRecoveryLocalStoreSpec() : base(Configuration("inmem", "SnapshotRecoveryLocalStoreSpec")) { }
+        public SnapshotRecoveryLocalStoreSpec() : base(Configuration("SnapshotRecoveryLocalStoreSpec")) { }
 
         [Fact]
         public void PersistentActor_which_is_persisted_at_the_same_time_as_another_actor_whose_PersistenceId_is_an_extension_of_the_first_should_recover_state_only_from_its_own_correct_snapshot_file()

--- a/src/core/Akka.Persistence.Tests/SnapshotSerializationSpec.cs
+++ b/src/core/Akka.Persistence.Tests/SnapshotSerializationSpec.cs
@@ -133,7 +133,7 @@ namespace Akka.Persistence.Tests
             }
         }
 
-        public SnapshotSerializationSpec() : base(Configuration("inmem", "SnapshotSerializationSpec", serialization: "off", extraConfig:
+        public SnapshotSerializationSpec() : base(Configuration("SnapshotSerializationSpec", serialization: "off", extraConfig:
             @"
     akka.actor {
       serializers {

--- a/src/core/Akka.Persistence.Tests/SnapshotSpec.cs
+++ b/src/core/Akka.Persistence.Tests/SnapshotSpec.cs
@@ -145,7 +145,7 @@ namespace Akka.Persistence.Tests
         #endregion
 
         public SnapshotSpec()
-            : base(Configuration("inmem", "SnapshotSpec"))
+            : base(Configuration("SnapshotSpec"))
         {
             var pref = ActorOf(() => new SaveSnapshotTestActor(Name, TestActor));
             pref.Tell("a");

--- a/src/core/Akka.Persistence/persistence.conf
+++ b/src/core/Akka.Persistence/persistence.conf
@@ -19,7 +19,7 @@ akka.persistence {
         # persistent actor or view by default.
         # Persistent actor or view can override `journalPluginId` method
         # in order to rely on a different journal plugin.
-        plugin = ""
+        plugin = "akka.persistence.journal.inmem"
         # List of journal plugins to start automatically. Use "" for the default journal plugin.
         auto-start-journals = []
     }
@@ -32,7 +32,7 @@ akka.persistence {
         # If you don't use snapshots you don't have to configure it.
         # Note that Cluster Sharding is using snapshots, so if you
         # use Cluster Sharding you need to define a snapshot store plugin.
-        plugin = ""
+        plugin = "akka.persistence.snapshot-store.local"
         # List of snapshot stores to start automatically. Use "" for the default snapshot store.
         auto-start-snapshot-stores = []
     }


### PR DESCRIPTION
See #1861

- Default config journal plugin id is restored to point at in-memory journal (was none, causing an error).
- Default config snapshot store plugin id is restored to point at local file system one (was none with warning log message, which didn't cause any explicit error, but was breaking change in API behavior).

EDIT:
- All persistence specs are now running on default config settings, making sure that default journal and snapshot store have been initialized.