### PR TITLE
v1.5 - Replaced HeliosTcpTransport by NetworkStreamTransport

### DIFF
--- a/src/core/Akka.Remote.Tests/RemoteConfigSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteConfigSpec.cs
@@ -92,7 +92,7 @@ namespace Akka.Remote.Tests
             Assert.Equal(4096, s.Backlog);
             Assert.True(s.TcpNoDelay);
             Assert.True(s.TcpKeepAlive);
-            Assert.True(s.TcpReuseAddr);
+            Assert.False(s.TcpReuseAddr);
             Assert.True(string.IsNullOrEmpty(c.GetString("hostname")));
             Assert.Equal(1, s.ServerSocketWorkerPoolSize);
             Assert.Equal(1, s.ClientSocketWorkerPoolSize);

--- a/src/core/Akka.Remote.Tests/RemotingSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemotingSpec.cs
@@ -42,7 +42,7 @@ namespace Akka.Remote.Tests
         private static string GetConfig()
         {
             return @"
-            common-helios-settings {
+            common-transport-settings {
               port = 0
               hostname = ""localhost""
             }
@@ -51,19 +51,15 @@ namespace Akka.Remote.Tests
               actor.provider = ""Akka.Remote.RemoteActorRefProvider,Akka.Remote""
 
               remote {
-                transport = ""Akka.Remote.Remoting,Akka.Remote""
-
                 retry-gate-closed-for = 1 s
                 log-remote-lifecycle-events = on
 
                 enabled-transports = [
                   ""akka.remote.test"",
-                  ""akka.remote.helios.tcp"",
-#""akka.remote.helios.udp""
+                  ""akka.remote.networkstream""
                 ]
 
-                helios.tcp = ${common-helios-settings}
-                helios.udp = ${common-helios-settings}
+                networkstream = ${common-transport-settings}
 
                 test {
                   transport-class = ""Akka.Remote.Transport.TestTransport,Akka.Remote""
@@ -89,7 +85,7 @@ namespace Akka.Remote.Tests
         protected string GetOtherRemoteSysConfig()
         {
             return @"
-            common-helios-settings {
+            common-transport-settings {
               port = 0
               hostname = ""localhost""
             }
@@ -98,19 +94,16 @@ namespace Akka.Remote.Tests
               actor.provider = ""Akka.Remote.RemoteActorRefProvider,Akka.Remote""
 
               remote {
-                transport = ""Akka.Remote.Remoting,Akka.Remote""
 
                 retry-gate-closed-for = 1 s
                 log-remote-lifecycle-events = on
 
                 enabled-transports = [
                   ""akka.remote.test"",
-                  ""akka.remote.helios.tcp"",
-#""akka.remote.helios.udp""
+                  ""akka.remote.networkstream""
                 ]
 
-                helios.tcp = ${common-helios-settings}
-                helios.udp = ${common-helios-settings}
+                networkstream = ${common-transport-settings}
 
                 test {
                   transport-class = ""Akka.Remote.Transport.TestTransport,Akka.Remote""

--- a/src/core/Akka.Remote.Tests/Transport/AkkaProtocolStressTest.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaProtocolStressTest.cs
@@ -178,7 +178,7 @@ namespace Akka.Remote.Tests.Transport
 
         #region Tests
 
-        [Fact(Skip = "Still have intermittent timeouts")]
+        [Fact]
         public void AkkaProtocolTransport_must_guarantee_at_most_once_delivery_and_message_ordering_despite_packet_loss()
         {
             //todo mute both systems for deadletters for any type of message

--- a/src/core/Akka.Remote/Configuration/Remote.conf
+++ b/src/core/Akka.Remote/Configuration/Remote.conf
@@ -395,7 +395,7 @@ akka {
       # Valid values are "on", "off" and "off-for-windows"
       # due to the following Windows bug: http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4476378
       # "off-for-windows" of course means that it's "on" for all other platforms
-      tcp-reuse-addr = on
+      tcp-reuse-addr = off
 
       # Used to configure the number of I/O worker threads on server sockets
       server-socket-worker-pool {
@@ -425,66 +425,6 @@ akka {
 
         # Max number of threads to cap factor-based number to
         pool-size-max = 1
-      }
-
-
-    }
-
-    helios.udp = ${akka.remote.helios.tcp}
-    helios.udp {
-      transport-protocol = udp
-    }
-
-    helios.ssl = ${akka.remote.helios.tcp}
-    helios.ssl = {
-      # Enable SSL/TLS encryption.
-      # This must be enabled on both the client and server to work.
-      enable-ssl = true
-
-      security {
-        # This is the Java Key Store used by the server connection
-        key-store = "keystore"
-
-        # This password is used for decrypting the key store
-        key-store-password = "changeme"
-
-        # This password is used for decrypting the key
-        key-password = "changeme"
-
-        # This is the Java Key Store used by the client connection
-        trust-store = "truststore"
-
-        # This password is used for decrypting the trust store
-        trust-store-password = "changeme"
-
-        # Protocol to use for SSL encryption, choose from:
-        # Java 6 & 7:
-        #   'SSLv3', 'TLSv1'
-        # Java 7:
-        #   'TLSv1.1', 'TLSv1.2'
-        protocol = "TLSv1"
-
-        # Example: ["TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA"]
-        # You need to install the JCE Unlimited Strength Jurisdiction Policy
-        # Files to use AES 256.
-        # More info here:
-        # http://docs.oracle.com/javase/7/docs/technotes/guides/security/SunProviders.html#SunJCEProvider
-        enabled-algorithms = ["TLS_RSA_WITH_AES_128_CBC_SHA"]
-
-        # There are three options, in increasing order of security:
-        # "" or SecureRandom => (default)
-        # "SHA1PRNG" => Can be slow because of blocking issues on Linux
-        # "AES128CounterSecureRNG" => fastest startup and based on AES encryption
-        # algorithm
-        # "AES256CounterSecureRNG"
-        # The following use one of 3 possible seed sources, depending on
-        # availability: /dev/random, random.org and SecureRandom (provided by Java)
-        # "AES128CounterInetRNG"
-        # "AES256CounterInetRNG" (Install JCE Unlimited Strength Jurisdiction
-        # Policy Files first)
-        # Setting a value here may require you to supply the appropriate cipher
-        # suite (see enabled-algorithms section above)
-        random-number-generator = ""
       }
     }
 

--- a/src/core/Akka.Remote/Transport/Helios/HeliosTcpTransport.cs
+++ b/src/core/Akka.Remote/Transport/Helios/HeliosTcpTransport.cs
@@ -10,6 +10,7 @@ using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
+using Akka.Remote.Transport.Streaming;
 using Google.ProtocolBuffers;
 using Helios.Exceptions;
 using Helios.Net;
@@ -230,9 +231,9 @@ namespace Akka.Remote.Transport.Helios
     /// additional bookkeeping when transports are disposed or opened.
     /// </remarks>
     /// </summary>
-    class HeliosTcpTransport : HeliosTransport
+    class HeliosTcpTransport_v1_0 : HeliosTransport
     {
-        public HeliosTcpTransport(ActorSystem system, Config config)
+        public HeliosTcpTransport_v1_0(ActorSystem system, Config config)
             : base(system, config)
         {
         }
@@ -245,6 +246,21 @@ namespace Akka.Remote.Transport.Helios
             client.Open();
 
             return ((TcpClientHandler)client).StatusFuture;
+        }
+    }
+
+    // In v1.5, the Helios config is translated to use NetworkStreamTransport instead.
+    class HeliosTcpTransport : NetworkStreamTransport
+    {
+        public HeliosTcpTransport(ActorSystem system, Config config)
+            : base(system, GetSettings(config))
+        { }
+
+        private static NetworkStreamTransportSettings GetSettings(Config config)
+        {
+            var heliosSettings = new HeliosTransportSettings(config);
+
+            return new NetworkStreamTransportSettings(heliosSettings);
         }
     }
 }

--- a/src/core/Akka.Remote/Transport/Streaming/AsyncQueue.cs
+++ b/src/core/Akka.Remote/Transport/Streaming/AsyncQueue.cs
@@ -85,6 +85,7 @@ namespace Akka.Remote.Transport.Streaming
             {
                 _isCompleted = true;
 
+                //TODO Queue on IO ThreadPool or Remote's DedicatedThreadPool
                 if (_continuation != null)
                     ThreadPool.QueueUserWorkItem(state => ((Action)state).Invoke(), _continuation);
             }
@@ -114,6 +115,7 @@ namespace Akka.Remote.Transport.Streaming
                         alreadyCompleted = true;
                 }
 
+                //TODO Queue on IO ThreadPool or Remote's DedicatedThreadPool
                 if (alreadyCompleted)
                     ThreadPool.QueueUserWorkItem(state => ((Action)state).Invoke(), continuation);
             }

--- a/src/core/Akka.Remote/Transport/Streaming/StreamTransport.cs
+++ b/src/core/Akka.Remote/Transport/Streaming/StreamTransport.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
+using Akka.Remote.Transport.Helios;
 
 namespace Akka.Remote.Transport.Streaming
 {
@@ -34,6 +35,18 @@ namespace Akka.Remote.Transport.Streaming
             FlushWaitTimeout = config.GetTimeSpan("flush-wait-on-shutdown");
             ChunkedReadThreshold = GetByteSize(config, "chunked-read-threshold");
             FrameSizeHardLimit = GetByteSize(config, "frame-size-hard-limit", 32000);
+        }
+
+        internal StreamTransportSettings(HeliosTransportSettings heliosSettings)
+        {
+            Config = heliosSettings.Config;
+
+            StreamWriteBufferSize = 4096;
+            StreamReadBufferSize = 65536;
+            MaximumFrameSize = heliosSettings.MaxFrameSize;
+            FlushWaitTimeout = TimeSpan.FromSeconds(2);
+            ChunkedReadThreshold = 4096;
+            FrameSizeHardLimit = 67108864;
         }
 
         protected static int GetByteSize(Config config, string path, int minValue = 0, int maxValue = int.MaxValue)


### PR DESCRIPTION
This PR makes the default helios config to use NetworkStreamTransport instead of HeliosTcpTransport.

This is to see how things goes with the unit tests.

We'll need to discuss the upgrade path from 1.0 to 1.5, like if we want to introduce a configuration breaking change (cleaner solution) or if we want to make things work with the same 1.0 config (better experience but ugly).