### PR TITLE
added testcase for unescaped filepaths

### DIFF
--- a/src/core/Akka.Tests/Configuration/HoconTests.cs
+++ b/src/core/Akka.Tests/Configuration/HoconTests.cs
@@ -393,7 +393,13 @@ a.b.e.f=3
             Assert.Equal("hello\\y\\o\\u", ConfigurationFactory.ParseString(hocon).GetString("a"));
         }
 
-
+        [Fact]
+        public void Can_assign_unescaped_path_like_variable_to_field()
+        {
+            var hocon = @"a=""""""C:\Dev\somepath\to\a\file.txt""""""";
+            Assert.Equal("C:\\Dev\\somepath\\to\\a\\file.txt", ConfigurationFactory.ParseString(hocon).GetString("a"));
+        }
+        
         [Fact]
         public void Can_use_fallback()
         {


### PR DESCRIPTION
Added a testcase for the scenario i ran into as described towards the end in https://github.com/akkadotnet/akka.net/issues/1687

Im not sure this is a valid scenario for hocon. I haven't found anything explicit in the hocon docs about this.
The way i ran into this is by building a filepath to a sqllite db in code, using `Path.Combine` and putting it in hocon as is. 

So is it valid for the hocon parser to throw in this scenario, and should a user always supply escaped path strings? Or does hocon need to handle this transparently.

If its the former, ill update the testcase to verify it does. If its the latter, then the testcase is fine as is now, and we have a failing test for the hocon parser.

/cc @rogeralsing 

