### PR TITLE
Fixed sinks and sources

### DIFF
--- a/src/core/Akka.Streams.TestKit.Tests/Akka.Streams.TestKit.Tests.csproj
+++ b/src/core/Akka.Streams.TestKit.Tests/Akka.Streams.TestKit.Tests.csproj
@@ -42,6 +42,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/core/Akka.Streams.TestKit.Tests/ChainSetup.cs
+++ b/src/core/Akka.Streams.TestKit.Tests/ChainSetup.cs
@@ -24,7 +24,7 @@ namespace Akka.Streams.TestKit.Tests
             Upstream = TestPublisher.CreateManualProbe<TIn>(system);
             Downstream = TestSubscriber.CreateProbe<TOut>(system);
 
-            var s = Source.FromPublisher<TIn, Unit>(Upstream).Via(stream((Flow<TIn, TIn, Unit>)Flow.Identity<TIn>().Map(x => x).Named("buh")));
+            var s = Source.FromPublisher(Upstream).Via(stream((Flow<TIn, TIn, Unit>)Flow.Identity<TIn>().Map(x => x).Named("buh")));
             Publisher = toPublisher(s, materializer);
             UpstreamSubscription = Upstream.ExpectSubscription();
             Publisher.Subscribe(Downstream);

--- a/src/core/Akka.Streams.TestKit.Tests/TestPublisherSubscriberSpec.cs
+++ b/src/core/Akka.Streams.TestKit.Tests/TestPublisherSubscriberSpec.cs
@@ -30,7 +30,7 @@ namespace Akka.Streams.TestKit.Tests
             {
                 var upstream = TestPublisher.CreateManualProbe<int>(this);
                 var downstream = TestSubscriber.CreateManualProbe<int>(this);
-                Source.FromPublisher<int, Unit>(upstream)
+                Source.FromPublisher(upstream)
                     .RunWith(Sink.AsPublisher<int>(false), Materializer)
                     .Subscribe(downstream);
 

--- a/src/core/Akka.Streams.TestKit.Tests/TwoStreamsSetup.cs
+++ b/src/core/Akka.Streams.TestKit.Tests/TwoStreamsSetup.cs
@@ -30,14 +30,14 @@ namespace Akka.Streams.TestKit.Tests
 
         protected override TestSubscriber.Probe<TOutputs> Setup(IPublisher<int> p1, IPublisher<int> p2)
         {
-            var subscriber = TestSubscriber.CreateProbe<TOutputs>(this);
-            RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
+            var subscriber = this.CreateProbe<TOutputs>();
+            RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
             {
                 var f = CreateFixture(b);
 
-                b.From(Source.FromPublisher<int, Unit>(p1)).To(f.Left);
-                b.From(Source.FromPublisher<int, Unit>(p2)).To(f.Right);
-                b.From(f.Out).To(Sink.FromSubscriber<TOutputs, Unit>(subscriber));
+                b.From(Source.FromPublisher(p1)).To(f.Left);
+                b.From(Source.FromPublisher(p2)).To(f.Right);
+                b.From(f.Out).To(Sink.FromSubscriber(subscriber));
                 return ClosedShape.Instance;
             })).Run(Materializer);
 

--- a/src/core/Akka.Streams.TestKit.Tests/Utils.cs
+++ b/src/core/Akka.Streams.TestKit.Tests/Utils.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Reactive.Streams;
 using System.Threading;
@@ -37,7 +38,7 @@ namespace Akka.Streams.TestKit.Tests
 
             probe.Within(TimeSpan.FromSeconds(5), () =>
             {
-                ISet<IActorRef> children = new HashSet<IActorRef>();
+                IImmutableSet<IActorRef> children = ImmutableHashSet<IActorRef>.Empty;
                 try
                 {
                     probe.AwaitAssert(() =>

--- a/src/core/Akka.Streams.TestKit.Tests/Utils.cs
+++ b/src/core/Akka.Streams.TestKit.Tests/Utils.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Streams;
+using System.Threading;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Streams.Implementation;

--- a/src/core/Akka.Streams.Tests/Actor/ActorSubscriberSpec.cs
+++ b/src/core/Akka.Streams.Tests/Actor/ActorSubscriberSpec.cs
@@ -48,7 +48,7 @@ namespace Akka.Streams.Tests.Actor
             // creating actor with default supervision, because stream supervisor default strategy is to 
             var actorRef = Sys.ActorOf(ManualSubscriber.Props(TestActor));
             Source.From(Enumerable.Range(1, 7))
-                .RunWith(Sink.FromSubscriber<int, Unit>(new ActorSubscriberImpl<int>(actorRef)), Sys.Materializer());
+                .RunWith(Sink.FromSubscriber(new ActorSubscriberImpl<int>(actorRef)), Sys.Materializer());
             actorRef.Tell("ready");
             ExpectMsg<OnNext>().Element.Should().Be(1);
             ExpectMsg<OnNext>().Element.Should().Be(2);

--- a/src/core/Akka.Streams.Tests/Dsl/ActorRefBackpressureSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/ActorRefBackpressureSinkSpec.cs
@@ -189,7 +189,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var fw = CreateActor<Fw2>();
                 var publisher =
-                    RunnableGraph<TestPublisher.Probe<int>>.FromGraph(
+                    RunnableGraph.FromGraph(
                         this.SourceProbe<int>()
                             .To(Sink.ActorRefWithAck<int>(fw, InitMessage, AckMessage, CompleteMessage))
                             .WithAttributes(Attributes.CreateInputBuffer(1, 1))).Run(Materializer);

--- a/src/core/Akka.Streams.Tests/Dsl/ActorRefSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/ActorRefSourceSpec.cs
@@ -21,8 +21,7 @@ namespace Akka.Streams.Tests.Dsl
             var settings = ActorMaterializerSettings.Create(Sys);
             Materializer = ActorMaterializer.Create(Sys, settings);
         }
-
-
+        
         [Fact]
         public void A_ActorRefSource_must_emit_received_messages_to_the_stream()
         {

--- a/src/core/Akka.Streams.Tests/Dsl/ActorRefSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/ActorRefSourceSpec.cs
@@ -28,7 +28,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             var s = TestSubscriber.CreateManualProbe<int>(this);
             var actorRef = Source.ActorRef<int>(10, OverflowStrategy.Fail)
-                .To(Sink.FromSubscriber<int, Unit>(s))
+                .To(Sink.FromSubscriber(s))
                 .Run(Materializer);
             var sub = s.ExpectSubscription();
             sub.Request(2);
@@ -45,7 +45,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             var s = TestSubscriber.CreateManualProbe<int>(this);
             var actorRef = Source.ActorRef<int>(100, OverflowStrategy.DropHead)
-                .To(Sink.FromSubscriber<int, Unit>(s))
+                .To(Sink.FromSubscriber(s))
                 .Run(Materializer);
             var sub = s.ExpectSubscription();
             Enumerable.Range(1, 20).ForEach(x => actorRef.Tell(x));
@@ -86,7 +86,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var s = TestSubscriber.CreateManualProbe<int>(this);
                 var actorRef = Source.ActorRef<int>(0, OverflowStrategy.Fail)
-                    .To(Sink.FromSubscriber<int, Unit>(s))
+                    .To(Sink.FromSubscriber(s))
                     .Run(Materializer);
                 Watch(actorRef);
                 var sub = s.ExpectSubscription();
@@ -102,7 +102,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var s = TestSubscriber.CreateManualProbe<int>(this);
                 var actorRef = Source.ActorRef<int>(0, OverflowStrategy.DropHead)
-                    .To(Sink.FromSubscriber<int, Unit>(s))
+                    .To(Sink.FromSubscriber(s))
                     .Run(Materializer);
                 Watch(actorRef);
                 var sub = s.ExpectSubscription();
@@ -119,7 +119,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var s = TestSubscriber.CreateManualProbe<int>(this);
                 var actorRef = Source.ActorRef<int>(10, OverflowStrategy.Fail)
-                    .To(Sink.FromSubscriber<int, Unit>(s))
+                    .To(Sink.FromSubscriber(s))
                     .Run(Materializer);
                 s.ExpectSubscription();
                 actorRef.Tell(PoisonPill.Instance);
@@ -134,7 +134,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var s = TestSubscriber.CreateManualProbe<int>(this);
                 var actorRef = Source.ActorRef<int>(10, OverflowStrategy.Fail)
-                    .To(Sink.FromSubscriber<int, Unit>(s))
+                    .To(Sink.FromSubscriber(s))
                     .Run(Materializer);
                 var sub = s.ExpectSubscription();
                 actorRef.Tell(1);
@@ -154,7 +154,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var s = TestSubscriber.CreateManualProbe<int>(this);
                 var actorRef = Source.ActorRef<int>(3, OverflowStrategy.DropBuffer)
-                    .To(Sink.FromSubscriber<int, Unit>(s))
+                    .To(Sink.FromSubscriber(s))
                     .Run(Materializer);
                 var sub = s.ExpectSubscription();
                 actorRef.Tell(1);
@@ -178,7 +178,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var s = TestSubscriber.CreateManualProbe<int>(this);
                 var actorRef = Source.ActorRef<int>(3, OverflowStrategy.DropBuffer)
-                    .To(Sink.FromSubscriber<int, Unit>(s))
+                    .To(Sink.FromSubscriber(s))
                     .Run(Materializer);
                 var sub = s.ExpectSubscription();
                 actorRef.Tell(1);
@@ -199,7 +199,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var s = TestSubscriber.CreateManualProbe<int>(this);
                 var actorRef = Source.ActorRef<int>(10, OverflowStrategy.Fail)
-                    .To(Sink.FromSubscriber<int, Unit>(s))
+                    .To(Sink.FromSubscriber(s))
                     .Run(Materializer);
                 s.ExpectSubscription();
                 var ex = new TestException("testfailure");
@@ -217,7 +217,7 @@ namespace Akka.Streams.Tests.Dsl
                 const string name = "SomeCustomName";
                 var actorRef = Source.ActorRef<int>(10, OverflowStrategy.Fail)
                     .WithAttributes(Attributes.CreateName(name))
-                    .To(Sink.FromSubscriber<int, Unit>(s))
+                    .To(Sink.FromSubscriber(s))
                     .Run(Materializer);
                 actorRef.Path.ToString().Should().Contain(name);
                 actorRef.Tell(PoisonPill.Instance);

--- a/src/core/Akka.Streams.Tests/Dsl/AttributesSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/AttributesSpec.cs
@@ -38,7 +38,7 @@ namespace Akka.Streams.Tests.Dsl
         public void Attributes_must_keep_the_outermost_attribute_as_the_least_specific()
         {
             var runnable =
-                RunnableGraph<Task<Attributes>>.FromGraph(
+                RunnableGraph.FromGraph(
                     Source.Empty<Unit>()
                         .ToMaterialized(AttributesSink.Create(), Keep.Right)
                         .WithAttributes(Attributes.CreateName("new-name")));

--- a/src/core/Akka.Streams.Tests/Dsl/BidiFlowSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/BidiFlowSpec.cs
@@ -61,7 +61,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void A_BidiFlow_must_work_top_and_bottom_in_isolation()
         {
-            var t = RunnableGraph<Tuple<Task<long>,Task<string>>>.FromGraph(GraphDsl.Create(Sink.First<long>(), Sink.First<string>(), Keep.Both,
+            var t = RunnableGraph.FromGraph(GraphDsl.Create(Sink.First<long>(), Sink.First<string>(), Keep.Both,
                 (b, st, sb) =>
                 {
                     var s = b.Add(Bidi());
@@ -132,7 +132,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void A_BidiFlow_must_materialize_its_value()
         {
-            var f = RunnableGraph<Task<int>>.FromGraph(GraphDsl.Create(BidiMaterialized(), (b, bidi) =>
+            var f = RunnableGraph.FromGraph(GraphDsl.Create(BidiMaterialized(), (b, bidi) =>
             {
                 var flow1 = b.Add(Flow.Create<string>().Map(int.Parse).MapMaterializedValue(_ => Task.FromResult(0)));
                 var flow2 =

--- a/src/core/Akka.Streams.Tests/Dsl/FlowAppendSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowAppendSpec.cs
@@ -29,7 +29,7 @@ namespace Akka.Streams.Tests.Dsl
             RiverOf<string>((subscriber, otherFlow, elements) =>
             {
                 var flow = Flow.Create<int>().Via(otherFlow);
-                Source.From(elements).Via(flow).To(Sink.FromSubscriber<string, Unit>(subscriber)).Run(Materializer);
+                Source.From(elements).Via(flow).To(Sink.FromSubscriber(subscriber)).Run(Materializer);
             }, this);
         }
 
@@ -38,7 +38,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             RiverOf<string>((subscriber, otherFlow, elements) =>
             {
-                Source.From(elements).To(otherFlow.To(Sink.FromSubscriber<string, Unit>(subscriber))).Run(Materializer);
+                Source.From(elements).To(otherFlow.To(Sink.FromSubscriber(subscriber))).Run(Materializer);
             }, this);
         }
 
@@ -47,7 +47,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             RiverOf<string>((subscriber, otherFlow, elements) =>
             {
-                Source.From(elements).Via(otherFlow).To(Sink.FromSubscriber<string, Unit>(subscriber)).Run(Materializer);
+                Source.From(elements).Via(otherFlow).To(Sink.FromSubscriber(subscriber)).Run(Materializer);
             }, this);
         }
 
@@ -56,7 +56,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             RiverOf<string>((subscriber, otherFlow, elements) =>
             {
-                Source.From(elements).To(otherFlow.To(Sink.FromSubscriber<string, Unit>(subscriber))).Run(Materializer);
+                Source.From(elements).To(otherFlow.To(Sink.FromSubscriber(subscriber))).Run(Materializer);
             }, this);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowBatchSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowBatchSpec.cs
@@ -30,9 +30,9 @@ namespace Akka.Streams.Tests.Dsl
             var publisher = TestPublisher.CreateProbe<int>(this);
             var subscriber = TestSubscriber.CreateProbe<int>(this);
 
-            Source.FromPublisher<int, Unit>(publisher)
+            Source.FromPublisher(publisher)
                 .Batch(max: 2, seed: i => i, aggregate: (sum, i) => sum + i)
-                .To(Sink.FromSubscriber<int, Unit>(subscriber))
+                .To(Sink.FromSubscriber(subscriber))
                 .Run(Materializer);
 
             var sub = subscriber.ExpectSubscription();
@@ -53,11 +53,11 @@ namespace Akka.Streams.Tests.Dsl
             var publisher = TestPublisher.CreateProbe<int>(this);
             var subscriber = TestSubscriber.CreateProbe<List<int>>(this);
 
-            Source.FromPublisher<int, Unit>(publisher).Batch(long.MaxValue, i => new List<int> {i}, (ints, i) =>
+            Source.FromPublisher(publisher).Batch(long.MaxValue, i => new List<int> {i}, (ints, i) =>
             {
                 ints.Add(i);
                 return ints;
-            }).To(Sink.FromSubscriber<List<int>, Unit>(subscriber)).Run(Materializer);
+            }).To(Sink.FromSubscriber(subscriber)).Run(Materializer);
             var sub = subscriber.ExpectSubscription();
 
             for (var i = 1; i <= 10; i++)
@@ -88,9 +88,9 @@ namespace Akka.Streams.Tests.Dsl
             var publisher = TestPublisher.CreateProbe<int>(this);
             var subscriber = TestSubscriber.CreateProbe<int>(this);
 
-            Source.FromPublisher<int, Unit>(publisher)
+            Source.FromPublisher(publisher)
                 .Batch(2, i => i, (sum, i) => sum + i)
-                .To(Sink.FromSubscriber<int, Unit>(subscriber))
+                .To(Sink.FromSubscriber(subscriber))
                 .Run(Materializer);
             var sub = subscriber.EnsureSubscription();
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowBatchWeightedSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowBatchWeightedSpec.cs
@@ -25,9 +25,9 @@ namespace Akka.Streams.Tests.Dsl
             var publisher = TestPublisher.CreateProbe<int>(this);
             var subscriber = TestSubscriber.CreateProbe<int>(this);
 
-            Source.FromPublisher<int, Unit>(publisher)
+            Source.FromPublisher(publisher)
                 .BatchWeighted(3, _ => 4, i => i, (sum, i) => sum + i)
-                .To(Sink.FromSubscriber<int, Unit>(subscriber))
+                .To(Sink.FromSubscriber(subscriber))
                 .Run(Materializer);
             var sub = subscriber.EnsureSubscription();
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowBufferSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowBufferSpec.cs
@@ -72,9 +72,9 @@ namespace Akka.Streams.Tests.Dsl
             var publisher = TestPublisher.CreateProbe<int>(this);
             var subscriber = TestSubscriber.CreateManualProbe<int>(this);
 
-            Source.FromPublisher<int, Unit>(publisher)
+            Source.FromPublisher(publisher)
                 .Buffer(100, OverflowStrategy.Backpressure)
-                .To(Sink.FromSubscriber<int, Unit>(subscriber))
+                .To(Sink.FromSubscriber(subscriber))
                 .Run(Materializer);
 
             var sub = subscriber.ExpectSubscription();
@@ -98,9 +98,9 @@ namespace Akka.Streams.Tests.Dsl
             var publisher = TestPublisher.CreateProbe<int>(this);
             var subscriber = TestSubscriber.CreateManualProbe<int>(this);
 
-            Source.FromPublisher<int, Unit>(publisher)
+            Source.FromPublisher(publisher)
                 .Buffer(100, OverflowStrategy.DropHead)
-                .To(Sink.FromSubscriber<int, Unit>(subscriber))
+                .To(Sink.FromSubscriber(subscriber))
                 .Run(Materializer);
 
             var sub = subscriber.ExpectSubscription();
@@ -134,9 +134,9 @@ namespace Akka.Streams.Tests.Dsl
             var publisher = TestPublisher.CreateProbe<int>(this);
             var subscriber = TestSubscriber.CreateManualProbe<int>(this);
 
-            Source.FromPublisher<int, Unit>(publisher)
+            Source.FromPublisher(publisher)
                 .Buffer(100, OverflowStrategy.DropTail)
-                .To(Sink.FromSubscriber<int, Unit>(subscriber))
+                .To(Sink.FromSubscriber(subscriber))
                 .Run(Materializer);
 
             var sub = subscriber.ExpectSubscription();
@@ -173,9 +173,9 @@ namespace Akka.Streams.Tests.Dsl
             var publisher = TestPublisher.CreateProbe<int>(this);
             var subscriber = TestSubscriber.CreateManualProbe<int>(this);
 
-            Source.FromPublisher<int, Unit>(publisher)
+            Source.FromPublisher(publisher)
                 .Buffer(100, OverflowStrategy.DropBuffer)
-                .To(Sink.FromSubscriber<int, Unit>(subscriber))
+                .To(Sink.FromSubscriber(subscriber))
                 .Run(Materializer);
 
             var sub = subscriber.ExpectSubscription();
@@ -243,9 +243,9 @@ namespace Akka.Streams.Tests.Dsl
                 var publisher = TestPublisher.CreateProbe<int>(this);
                 var subscriber = TestSubscriber.CreateManualProbe<int>(this);
 
-                Source.FromPublisher<int, Unit>(publisher)
+                Source.FromPublisher(publisher)
                     .Buffer(100, OverflowStrategy.Fail)
-                    .To(Sink.FromSubscriber<int, Unit>(subscriber))
+                    .To(Sink.FromSubscriber(subscriber))
                     .Run(Materializer);
 
                 var sub = subscriber.ExpectSubscription();
@@ -281,9 +281,9 @@ namespace Akka.Streams.Tests.Dsl
             var publisher = TestPublisher.CreateProbe<int>(this);
             var subscriber = TestSubscriber.CreateManualProbe<int>(this);
 
-            Source.FromPublisher<int, Unit>(publisher)
+            Source.FromPublisher(publisher)
                 .Buffer(1, strategy)
-                .To(Sink.FromSubscriber<int, Unit>(subscriber))
+                .To(Sink.FromSubscriber(subscriber))
                 .Run(Materializer);
 
             var sub = subscriber.ExpectSubscription();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowConcatAllSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowConcatAllSpec.cs
@@ -35,7 +35,7 @@ namespace Akka.Streams.Tests.Dsl
                 var main = Source.From(new[] {s1, s2, s3, s4, s5});
 
                 var subscriber = TestSubscriber.CreateManualProbe<int>(this);
-                main.FlatMapConcat(s => s).To(Sink.FromSubscriber<int, Unit>(subscriber)).Run(Materializer);
+                main.FlatMapConcat(s => s).To(Sink.FromSubscriber(subscriber)).Run(Materializer);
                 var subscription = subscriber.ExpectSubscription();
                 subscription.Request(10);
                 for (var i = 1; i <= 10; i++)
@@ -74,9 +74,9 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var publisher = TestPublisher.CreateManualProbe<Source<int, Unit>>(this);
                 var subscriber = TestSubscriber.CreateManualProbe<int>(this);
-                Source.FromPublisher<Source<int, Unit>, Unit>(publisher)
+                Source.FromPublisher(publisher)
                     .FlatMapConcat(x => x)
-                    .To(Sink.FromSubscriber<int, Unit>(subscriber))
+                    .To(Sink.FromSubscriber(subscriber))
                     .Run(Materializer);
 
                 var upstream = publisher.ExpectSubscription();
@@ -84,7 +84,7 @@ namespace Akka.Streams.Tests.Dsl
                 downstream.Request(1000);
 
                 var substreamPublisher = TestPublisher.CreateManualProbe<int>(this);
-                var substreamFlow = Source.FromPublisher<int, Unit>(substreamPublisher);
+                var substreamFlow = Source.FromPublisher(substreamPublisher);
                 upstream.ExpectRequest();
                 upstream.SendNext(substreamFlow);
                 var subUpstream = substreamPublisher.ExpectSubscription();
@@ -102,9 +102,9 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var publisher = TestPublisher.CreateManualProbe<Source<int, Unit>>(this);
                 var subscriber = TestSubscriber.CreateManualProbe<int>(this);
-                Source.FromPublisher<Source<int, Unit>, Unit>(publisher)
+                Source.FromPublisher(publisher)
                     .FlatMapConcat(x => x)
-                    .To(Sink.FromSubscriber<int, Unit>(subscriber))
+                    .To(Sink.FromSubscriber(subscriber))
                     .Run(Materializer);
 
                 var upstream = publisher.ExpectSubscription();
@@ -112,7 +112,7 @@ namespace Akka.Streams.Tests.Dsl
                 downstream.Request(1000);
 
                 var substreamPublisher = TestPublisher.CreateManualProbe<int>(this, false);
-                var substreamFlow = Source.FromPublisher<int, Unit>(substreamPublisher);
+                var substreamFlow = Source.FromPublisher(substreamPublisher);
                 upstream.ExpectRequest();
                 upstream.SendNext(substreamFlow);
                 var subUpstream = substreamPublisher.ExpectSubscription();
@@ -133,9 +133,9 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var publisher = TestPublisher.CreateManualProbe<Source<int, Unit>>(this);
                 var subscriber = TestSubscriber.CreateManualProbe<int>(this);
-                Source.FromPublisher<Source<int, Unit>, Unit>(publisher)
+                Source.FromPublisher(publisher)
                     .FlatMapConcat<Source<int,Unit>,int,Unit>(x => { throw TestException; })
-                    .To(Sink.FromSubscriber<int, Unit>(subscriber))
+                    .To(Sink.FromSubscriber(subscriber))
                     .Run(Materializer);
 
                 var upstream = publisher.ExpectSubscription();
@@ -143,7 +143,7 @@ namespace Akka.Streams.Tests.Dsl
                 downstream.Request(1000);
 
                 var substreamPublisher = TestPublisher.CreateManualProbe<int>(this);
-                var substreamFlow = Source.FromPublisher<int, Unit>(substreamPublisher);
+                var substreamFlow = Source.FromPublisher(substreamPublisher);
                 upstream.ExpectRequest();
                 upstream.SendNext(substreamFlow);
                 subscriber.ExpectError().Should().Be(TestException);
@@ -158,9 +158,9 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var publisher = TestPublisher.CreateManualProbe<Source<int, Unit>>(this);
                 var subscriber = TestSubscriber.CreateManualProbe<int>(this);
-                Source.FromPublisher<Source<int, Unit>, Unit>(publisher)
+                Source.FromPublisher(publisher)
                     .FlatMapConcat(x => x)
-                    .To(Sink.FromSubscriber<int, Unit>(subscriber))
+                    .To(Sink.FromSubscriber(subscriber))
                     .Run(Materializer);
 
                 var upstream = publisher.ExpectSubscription();
@@ -168,7 +168,7 @@ namespace Akka.Streams.Tests.Dsl
                 downstream.Request(1000);
 
                 var substreamPublisher = TestPublisher.CreateManualProbe<int>(this);
-                var substreamFlow = Source.FromPublisher<int, Unit>(substreamPublisher);
+                var substreamFlow = Source.FromPublisher(substreamPublisher);
                 upstream.ExpectRequest();
                 upstream.SendNext(substreamFlow);
 
@@ -186,9 +186,9 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var publisher = TestPublisher.CreateManualProbe<Source<int, Unit>>(this);
                 var subscriber = TestSubscriber.CreateManualProbe<int>(this);
-                Source.FromPublisher<Source<int, Unit>, Unit>(publisher)
+                Source.FromPublisher(publisher)
                     .FlatMapConcat(x => x)
-                    .To(Sink.FromSubscriber<int, Unit>(subscriber))
+                    .To(Sink.FromSubscriber(subscriber))
                     .Run(Materializer);
 
                 var upstream = publisher.ExpectSubscription();
@@ -196,7 +196,7 @@ namespace Akka.Streams.Tests.Dsl
                 downstream.Request(1000);
 
                 var substreamPublisher = TestPublisher.CreateManualProbe<int>(this);
-                var substreamFlow = Source.FromPublisher<int, Unit>(substreamPublisher);
+                var substreamFlow = Source.FromPublisher(substreamPublisher);
                 upstream.ExpectRequest();
                 upstream.SendNext(substreamFlow);
                 var subUpstream = substreamPublisher.ExpectSubscription();
@@ -215,9 +215,9 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var publisher = TestPublisher.CreateManualProbe<Source<int, Unit>>(this);
                 var subscriber = TestSubscriber.CreateManualProbe<int>(this);
-                Source.FromPublisher<Source<int, Unit>, Unit>(publisher)
+                Source.FromPublisher(publisher)
                     .FlatMapConcat(x => x)
-                    .To(Sink.FromSubscriber<int, Unit>(subscriber))
+                    .To(Sink.FromSubscriber(subscriber))
                     .Run(Materializer);
 
                 var upstream = publisher.ExpectSubscription();
@@ -225,7 +225,7 @@ namespace Akka.Streams.Tests.Dsl
                 downstream.Request(1000);
 
                 var substreamPublisher = TestPublisher.CreateManualProbe<int>(this, false);
-                var substreamFlow = Source.FromPublisher<int, Unit>(substreamPublisher);
+                var substreamFlow = Source.FromPublisher(substreamPublisher);
                 upstream.ExpectRequest();
                 upstream.SendNext(substreamFlow);
                 var subUpstream = substreamPublisher.ExpectSubscription();
@@ -249,7 +249,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 //var flowSubscriber = Source.AsSubscriber<Source<int, Unit>>()
                 //    .FlatMapConcat(x => x)
-                //    .To(Sink.FromSubscriber<int, Unit>(down))
+                //    .To(Sink.FromSubscriber(down))
                 //    .Run(Materializer);
 
                 //var downstream = down.ExpectSubscription();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowConcatSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowConcatSpec.cs
@@ -23,9 +23,9 @@ namespace Akka.Streams.Tests.Dsl
         protected override TestSubscriber.Probe<int> Setup(IPublisher<int> p1, IPublisher<int> p2)
         {
             var subscriber = TestSubscriber.CreateProbe<int>(this);
-            Source.FromPublisher<int, Unit>(p1)
-                .Concat(Source.FromPublisher<int, Unit>(p2))
-                .RunWith(Sink.FromSubscriber<int, Unit>(subscriber), Materializer);
+            Source.FromPublisher(p1)
+                .Concat(Source.FromPublisher(p2))
+                .RunWith(Sink.FromSubscriber(subscriber), Materializer);
             return subscriber;
         }
 
@@ -145,7 +145,7 @@ namespace Akka.Streams.Tests.Dsl
                 var subscriber = TestSubscriber.CreateManualProbe<int>(this);
                 Source.From(Enumerable.Range(1, 3))
                     .Concat(Source.FromTask(promise.Task))
-                    .RunWith(Sink.FromSubscriber<int, Unit>(subscriber), Materializer);
+                    .RunWith(Sink.FromSubscriber(subscriber), Materializer);
 
                 var subscription = subscriber.ExpectSubscription();
                 subscription.Request(4);
@@ -238,8 +238,8 @@ namespace Akka.Streams.Tests.Dsl
                 var publisher1 = TestPublisher.CreateProbe<int>(this);
                 var publisher2 = TestPublisher.CreateProbe<int>(this);
                 var probeSink =
-                    Source.FromPublisher<int, Unit>(publisher1)
-                        .Concat(Source.FromPublisher<int, Unit>(publisher2))
+                    Source.FromPublisher(publisher1)
+                        .Concat(Source.FromPublisher(publisher2))
                         .RunWith(this.SinkProbe<int>(), Materializer);
 
                 var sub1 = publisher1.ExpectSubscription();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowConflateSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowConflateSpec.cs
@@ -3,9 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Streams;
 using System.Threading;
-using System.Threading.Tasks;
 using Akka.Streams.Dsl;
-using Akka.Streams.Dsl.Internal;
 using Akka.Streams.Supervision;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -34,9 +32,9 @@ namespace Akka.Streams.Tests.Dsl
             var publisher = TestPublisher.CreateProbe<int>(this);
             var subscriber = TestSubscriber.CreateManualProbe<int>(this);
 
-            Source.FromPublisher<int, Unit>(publisher)
+            Source.FromPublisher(publisher)
                 .ConflateWithSeed(i => i, (sum, i) => sum + i)
-                .To(Sink.FromSubscriber<int, Unit>(subscriber))
+                .To(Sink.FromSubscriber(subscriber))
                 .Run(Materializer);
             var sub = subscriber.ExpectSubscription();
 
@@ -56,9 +54,9 @@ namespace Akka.Streams.Tests.Dsl
             var publisher = TestPublisher.CreateProbe<int>(this);
             var subscriber = TestSubscriber.CreateManualProbe<int>(this);
 
-            Source.FromPublisher<int, Unit>(publisher)
+            Source.FromPublisher(publisher)
                 .Conflate((sum, i) => sum + i)
-                .To(Sink.FromSubscriber<int, Unit>(subscriber))
+                .To(Sink.FromSubscriber(subscriber))
                 .Run(Materializer);
             var sub = subscriber.ExpectSubscription();
 
@@ -78,9 +76,9 @@ namespace Akka.Streams.Tests.Dsl
             var publisher = TestPublisher.CreateProbe<int>(this);
             var subscriber = TestSubscriber.CreateManualProbe<int>(this);
 
-            Source.FromPublisher<int, Unit>(publisher)
+            Source.FromPublisher(publisher)
                 .ConflateWithSeed(i=>i,(sum, i) => sum + i)
-                .To(Sink.FromSubscriber<int, Unit>(subscriber))
+                .To(Sink.FromSubscriber(subscriber))
                 .Run(Materializer);
             var sub = subscriber.ExpectSubscription();
 
@@ -100,9 +98,9 @@ namespace Akka.Streams.Tests.Dsl
             var publisher = TestPublisher.CreateProbe<int>(this);
             var subscriber = TestSubscriber.CreateManualProbe<int>(this);
 
-            Source.FromPublisher<int, Unit>(publisher)
+            Source.FromPublisher(publisher)
                 .Conflate((sum, i) => sum + i)
-                .To(Sink.FromSubscriber<int, Unit>(subscriber))
+                .To(Sink.FromSubscriber(subscriber))
                 .Run(Materializer);
             var sub = subscriber.ExpectSubscription();
 
@@ -148,9 +146,9 @@ namespace Akka.Streams.Tests.Dsl
             var publisher = TestPublisher.CreateProbe<int>(this);
             var subscriber = TestSubscriber.CreateManualProbe<int>(this);
 
-            Source.FromPublisher<int, Unit>(publisher)
+            Source.FromPublisher(publisher)
                 .ConflateWithSeed(i=>i, (sum, i) => sum + i)
-                .To(Sink.FromSubscriber<int, Unit>(subscriber))
+                .To(Sink.FromSubscriber(subscriber))
                 .Run(Materializer);
             var sub = subscriber.ExpectSubscription();
 
@@ -194,7 +192,7 @@ namespace Akka.Streams.Tests.Dsl
             var sinkProbe = TestSubscriber.CreateManualProbe<int>(this);
             var exceptionlath = new TestLatch();
 
-            var graph = Source.FromPublisher<int, Unit>(sourceProbe).ConflateWithSeed(i =>
+            var graph = Source.FromPublisher(sourceProbe).ConflateWithSeed(i =>
             {
                 if (i%2 == 0)
                 {
@@ -204,9 +202,9 @@ namespace Akka.Streams.Tests.Dsl
                 return i;
             }, (sum, i) => sum + i)
                 .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.RestartingDecider))
-                .To(Sink.FromSubscriber<int, Unit>(sinkProbe))
+                .To(Sink.FromSubscriber(sinkProbe))
                 .WithAttributes(Attributes.CreateInputBuffer(1, 1));
-            RunnableGraph<Unit>.FromGraph(graph).Run(Materializer);
+            RunnableGraph.FromGraph(graph).Run(Materializer);
 
             var sub = sourceProbe.ExpectSubscription();
             var sinkSub = sinkProbe.ExpectSubscription();
@@ -253,11 +251,11 @@ namespace Akka.Streams.Tests.Dsl
                 return state + elem;
             }).WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.RestartingDecider));
 
-            var graph = Source.FromPublisher<string, Unit>(sourceProbe)
+            var graph = Source.FromPublisher(sourceProbe)
                 .Via(conflate)
-                .To(Sink.FromSubscriber<string, Unit>(sinkProbe))
+                .To(Sink.FromSubscriber(sinkProbe))
                 .WithAttributes(Attributes.CreateInputBuffer(4, 4));
-            RunnableGraph<Unit>.FromGraph(graph).Run(Materializer);
+            RunnableGraph.FromGraph(graph).Run(Materializer);
 
             var sub = sourceProbe.ExpectSubscription();
 
@@ -279,7 +277,7 @@ namespace Akka.Streams.Tests.Dsl
             var sinkProbe = TestSubscriber.CreateManualProbe<List<int>>(this);
             var saw4Latch = new TestLatch();
 
-            var graph = Source.FromPublisher<int, Unit>(sourceProbe).ConflateWithSeed(i => new List<int> { i },
+            var graph = Source.FromPublisher(sourceProbe).ConflateWithSeed(i => new List<int> { i },
                 (state, elem) =>
                 {
                     if (elem == 2)
@@ -292,9 +290,9 @@ namespace Akka.Streams.Tests.Dsl
                     return state;
                 })
                 .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider))
-                .To(Sink.FromSubscriber<List<int>, Unit>(sinkProbe))
+                .To(Sink.FromSubscriber(sinkProbe))
                 .WithAttributes(Attributes.CreateInputBuffer(1, 1));
-            RunnableGraph<Unit>.FromGraph(graph).Run(Materializer);
+            RunnableGraph.FromGraph(graph).Run(Materializer);
 
             var sub = sourceProbe.ExpectSubscription();
             var sinkSub = sinkProbe.ExpectSubscription();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowDelaySpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowDelaySpec.cs
@@ -73,9 +73,9 @@ namespace Akka.Streams.Tests.Dsl
                 var c = TestSubscriber.CreateManualProbe<int>(this);
                 var p = TestPublisher.CreateManualProbe<int>(this);
 
-                Source.FromPublisher<int, Unit>(p)
+                Source.FromPublisher(p)
                     .Delay(TimeSpan.FromMilliseconds(300))
-                    .To(Sink.FromSubscriber<int, Unit>(c))
+                    .To(Sink.FromSubscriber(c))
                     .Run(Materializer);
                 var cSub = c.ExpectSubscription();
                 var pSub = p.ExpectSubscription();
@@ -184,10 +184,10 @@ namespace Akka.Streams.Tests.Dsl
                 var c = TestSubscriber.CreateManualProbe<int>(this);
                 var p = TestPublisher.CreateManualProbe<int>(this);
 
-                Source.FromPublisher<int, Unit>(p)
+                Source.FromPublisher(p)
                     .Delay(TimeSpan.FromSeconds(10), DelayOverflowStrategy.EmitEarly)
                     .WithAttributes(Attributes.CreateInputBuffer(16, 16))
-                    .To(Sink.FromSubscriber<int, Unit>(c))
+                    .To(Sink.FromSubscriber(c))
                     .Run(Materializer);
                 var cSub = c.ExpectSubscription();
                 var pSub = p.ExpectSubscription();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowDropSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowDropSpec.cs
@@ -41,7 +41,7 @@ namespace Akka.Streams.Tests.Dsl
         public void A_Drop_must_not_drop_anything_for_negative_n()
         {
             var probe = TestSubscriber.CreateManualProbe<int>(this);
-            Source.From(new[] {1, 2, 3}).Drop(-1).To(Sink.FromSubscriber<int, Unit>(probe)).Run(Materializer);
+            Source.From(new[] {1, 2, 3}).Drop(-1).To(Sink.FromSubscriber(probe)).Run(Materializer);
             probe.ExpectSubscription().Request(10);
             probe.ExpectNext(1);
             probe.ExpectNext(2);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowDropWhithinSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowDropWhithinSpec.cs
@@ -27,9 +27,9 @@ namespace Akka.Streams.Tests.Dsl
             var input = Enumerable.Range(1, 200).GetEnumerator();
             var p = TestPublisher.CreateManualProbe<int>(this);
             var c = TestSubscriber.CreateManualProbe<int>(this);
-            Source.FromPublisher<int, Unit>(p)
+            Source.FromPublisher(p)
                 .DropWithin(TimeSpan.FromSeconds(1))
-                .To(Sink.FromSubscriber<int, Unit>(c))
+                .To(Sink.FromSubscriber(c))
                 .Run(Materializer);
             var pSub = p.ExpectSubscription();
             var cSub = c.ExpectSubscription();
@@ -66,9 +66,9 @@ namespace Akka.Streams.Tests.Dsl
             var upstream = TestPublisher.CreateProbe<int>(this);
             var downstream = TestSubscriber.CreateProbe<int>(this);
 
-            Source.FromPublisher<int, Unit>(upstream)
+            Source.FromPublisher(upstream)
                 .DropWithin(TimeSpan.FromDays(1))
-                .RunWith(Sink.FromSubscriber<int, Unit>(downstream), Materializer);
+                .RunWith(Sink.FromSubscriber(downstream), Materializer);
 
             upstream.SendComplete();
             downstream.ExpectSubscriptionAndComplete();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowExpandSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowExpandSpec.cs
@@ -35,9 +35,9 @@ namespace Akka.Streams.Tests.Dsl
             var subscriber = TestSubscriber.CreateProbe<int>(this);
 
             // Simply repeat the last element as an extrapolation step
-            Source.FromPublisher<int, Unit>(publisher)
+            Source.FromPublisher(publisher)
                 .Expand(i => Enumerable.Repeat(i, 200).GetEnumerator())
-                .To(Sink.FromSubscriber<int, Unit>(subscriber))
+                .To(Sink.FromSubscriber(subscriber))
                 .Run(materializer);
 
             for (var i = 1; i <= 100; i++)
@@ -57,9 +57,9 @@ namespace Akka.Streams.Tests.Dsl
             var subscriber = TestSubscriber.CreateProbe<int>(this);
 
             // Simply repeat the last element as an extrapolation step
-            Source.FromPublisher<int, Unit>(publisher)
+            Source.FromPublisher(publisher)
                 .Expand(i => Enumerable.Repeat(i, 200).GetEnumerator())
-                .To(Sink.FromSubscriber<int, Unit>(subscriber))
+                .To(Sink.FromSubscriber(subscriber))
                 .Run(Materializer);
 
             publisher.SendNext(42);
@@ -83,9 +83,9 @@ namespace Akka.Streams.Tests.Dsl
             var subscriber = TestSubscriber.CreateProbe<int>(this);
 
             // Simply repeat the last element as an extrapolation step
-            Source.FromPublisher<int, Unit>(publisher)
+            Source.FromPublisher(publisher)
                 .Expand(i => Enumerable.Repeat(i, 200).GetEnumerator())
-                .To(Sink.FromSubscriber<int, Unit>(subscriber))
+                .To(Sink.FromSubscriber(subscriber))
                 .Run(Materializer);
 
             publisher.SendNext(1);
@@ -129,9 +129,9 @@ namespace Akka.Streams.Tests.Dsl
             var subscriber = TestSubscriber.CreateProbe<int>(this);
 
             // Simply repeat the last element as an extrapolation step
-            Source.FromPublisher<int, Unit>(publisher)
+            Source.FromPublisher(publisher)
                 .Expand(i => Enumerable.Repeat(i, 200).GetEnumerator())
-                .To(Sink.FromSubscriber<int, Unit>(subscriber))
+                .To(Sink.FromSubscriber(subscriber))
                 .Run(Materializer);
 
             publisher.SendNext(1);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowFilterSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowFilterSpec.cs
@@ -44,7 +44,7 @@ namespace Akka.Streams.Tests.Dsl
             var probe = TestSubscriber.CreateManualProbe<int>(this);
             Source.From(Enumerable.Repeat(0, 1000).Concat(new[] {1}))
                 .Filter(x => x != 0)
-                .RunWith(Sink.FromSubscriber<int, Unit>(probe), materializer);
+                .RunWith(Sink.FromSubscriber(probe), materializer);
 
             var subscription = probe.ExpectSubscription();
             for (var i = 1; i <= 1000; i++)

--- a/src/core/Akka.Streams.Tests/Dsl/FlowFlattenMergeSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowFlattenMergeSpec.cs
@@ -131,7 +131,7 @@ namespace Akka.Streams.Tests.Dsl
             var p = new TaskCompletionSource<Source<int, Unit>>();
 
             Source.Combine(
-                Source.From(new[] {Source.FromPublisher<int, Unit>(p1), Source.FromPublisher<int, Unit>(p2)}),
+                Source.From(new[] {Source.FromPublisher(p1), Source.FromPublisher(p2)}),
                 Source.FromTask(p.Task), i => new Merge<Source<int, Unit>>(i))
                 .FlatMapMerge(5, x => x)
                 .RunWith(Sink.First<int>(), Materializer);
@@ -153,7 +153,7 @@ namespace Akka.Streams.Tests.Dsl
 
 
             Source.From(new[]
-            {Source.FromPublisher<int, Unit>(p1), Source.FromPublisher<int, Unit>(p2), Source.FromTask(p.Task)})
+            {Source.FromPublisher(p1), Source.FromPublisher(p2), Source.FromTask(p.Task)})
                 .FlatMapMerge(5, x => x)
                 .RunWith(Sink.First<int>(), Materializer);
 
@@ -176,7 +176,7 @@ namespace Akka.Streams.Tests.Dsl
             Source.From(Enumerable.Range(1, 3)).FlatMapMerge(10, i =>
             {
                 if (i == 1)
-                    return Source.FromPublisher<int, Unit>(p);
+                    return Source.FromPublisher(p);
 
                 latch.Ready(TimeSpan.FromSeconds(3));
                 throw ex;
@@ -192,7 +192,7 @@ namespace Akka.Streams.Tests.Dsl
             var p1 = TestPublisher.CreateProbe<int>(this);
             var p2 = TestPublisher.CreateProbe<int>(this);
 
-            var sink = Source.From(new[] {Source.FromPublisher<int, Unit>(p1), Source.FromPublisher<int, Unit>(p2)})
+            var sink = Source.From(new[] {Source.FromPublisher(p1), Source.FromPublisher(p2)})
                 .FlatMapMerge(5, x => x)
                 .RunWith(this.SinkProbe<int>(), Materializer);
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowForeachSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowForeachSpec.cs
@@ -60,7 +60,7 @@ namespace Akka.Streams.Tests.Dsl
             this.AssertAllStagesStopped(() =>
             {
                 var p = TestPublisher.CreateManualProbe<int>(this);
-                Source.FromPublisher<int, Unit>(p).RunForeach(i => TestActor.Tell(i), Materializer).ContinueWith(task =>
+                Source.FromPublisher(p).RunForeach(i => TestActor.Tell(i), Materializer).ContinueWith(task =>
                 {
                     if (task.Exception != null)
                         TestActor.Tell(task.Exception.InnerException);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowGraphCompileSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowGraphCompileSpec.cs
@@ -74,7 +74,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void A_Graph_should_build_simple_merge()
         {
-            RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
+            RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
             {
                 var merge = b.Add(new Merge<string>(2));
                 b.From(In1).Via(F1).To(merge.In(0));
@@ -87,7 +87,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void A_Graph_should_build_simple_broadcast()
         {
-            RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
+            RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
             {
                 var broadcast = b.Add(new Broadcast<string>(2));
                 b.From(In1).Via(F1).To(broadcast.In);
@@ -100,7 +100,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void A_Graph_should_build_simple_merge_broadcast()
         {
-            RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
+            RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
             {
                 var merge = b.Add(new Merge<string>(2));
                 var broadcast = b.Add(new Broadcast<string>(2));
@@ -116,7 +116,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void A_Graph_should_build_simple_merge_broadcast_with_implicits()
         {
-            RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
+            RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
             {
                 var merge = b.Add(new Merge<string>(2));
                 var broadcast = b.Add(new Broadcast<string>(2));
@@ -147,7 +147,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact(Skip = "FIXME needs cycle detection capability")]
         public void A_Graph_should_detect_cycle_in()
         {
-            RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
+            RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
             {
                 var merge = b.Add(new Merge<string>(2));
                 var broadcast1 = b.Add(new Broadcast<string>(2));
@@ -168,7 +168,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void A_Graph_should_express_complex_topologies_in_a_readable_way()
         {
-            RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
+            RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
             {
                 var merge = b.Add(new Merge<string>(2));
                 var broadcast1 = b.Add(new Broadcast<string>(2));
@@ -189,7 +189,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void A_Graph_should_build_broadcast_merge()
         {
-            RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
+            RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
             {
                 var merge = b.Add(new Merge<string>(2));
                 var broadcast = b.Add(new Broadcast<string>(2));
@@ -205,7 +205,7 @@ namespace Akka.Streams.Tests.Dsl
         public void A_Graph_should_build_wikipedia_Topological_sorting()
         {
             // see https://en.wikipedia.org/wiki/Topological_sorting#mediaviewer/File:Directed_acyclic_graph.png
-            RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
+            RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
             {
                 var b3 = b.Add(new Broadcast<string>(2));
                 var b7 = b.Add(new Broadcast<string>(2));
@@ -237,7 +237,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void A_Graph_should_make_it_optional_to_specify_flows()
         {
-            RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
+            RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
             {
                 var merge = b.Add(new Merge<string>(2));
                 var broadcast = b.Add(new Broadcast<string>(2));
@@ -253,7 +253,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void A_Graph_should_build_unzip_zip()
         {
-            RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
+            RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
             {
                 var zip = b.Add(new Zip<int, string>());
                 var unzip = b.Add(new UnZip<int, string>());
@@ -280,7 +280,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             Action action = () =>
             {
-                RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(builder =>
+                RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(builder =>
                 {
                     var zip = builder.Add(new Zip<int, string>());
                     var unzip = builder.Add(new UnZip<int, string>());
@@ -323,7 +323,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact(Skip = "FIXME Covariance  is not supported")]
         public void A_Graph_should_build_with_variance()
         {
-            RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
+            RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
             {
                 var merge = b.Add(new Merge<IFruit>(2));
                 var s1 = Source.FromEnumerator<IFruit>(Apples);
@@ -334,7 +334,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 b.From(merge.Out)
                     .Via(Flow.Create<IFruit>().Map(x => x))
-                    .To(Sink.FromSubscriber<IFruit, Unit>(TestSubscriber.CreateManualProbe<IFruit>(this)));
+                    .To(Sink.FromSubscriber(TestSubscriber.CreateManualProbe<IFruit>(this)));
 
                 return ClosedShape.Instance;
             })).Run(Materializer);
@@ -422,43 +422,43 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void A_Graph_should_build_with_plain_flow_without_junctions()
         {
-            RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape,Unit>(b =>
+            RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape,Unit>(b =>
             {
                 b.From(In1).Via(F1).To(Out1);
                 return ClosedShape.Instance;
             })).Run(Materializer);
 
-            RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
+            RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
             {
                 b.From(In1).Via(F1).Via(F2).To(Out1);
                 return ClosedShape.Instance;
             })).Run(Materializer);
 
-            RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
+            RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
             {
                 b.From(In1.Via(F1)).Via(F2).To(Out1);
                 return ClosedShape.Instance;
             })).Run(Materializer);
 
-            RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
+            RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
             {
                 b.From(In1).To(Out1);
                 return ClosedShape.Instance;
             })).Run(Materializer);
 
-            RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
+            RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
             {
                 b.From(In1).To(F1.To(Out1));
                 return ClosedShape.Instance;
             })).Run(Materializer);
 
-            RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
+            RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
             {
                 b.From(In1.Via(F1)).To(Out1);
                 return ClosedShape.Instance;
             })).Run(Materializer);
 
-            RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
+            RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
             {
                 b.From(In1.Via(F1)).To(F2.To(Out1));
                 return ClosedShape.Instance;

--- a/src/core/Akka.Streams.Tests/Dsl/FlowGroupedWithinSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowGroupedWithinSpec.cs
@@ -36,9 +36,9 @@ namespace Akka.Streams.Tests.Dsl
                 var p = TestPublisher.CreateManualProbe<int>(this);
                 var c = TestSubscriber.CreateManualProbe<IEnumerable<int>>(this);
 
-                Source.FromPublisher<int, Unit>(p)
+                Source.FromPublisher(p)
                     .GroupedWithin(1000, TimeSpan.FromSeconds(1))
-                    .To(Sink.FromSubscriber<IEnumerable<int>, Unit>(c))
+                    .To(Sink.FromSubscriber(c))
                     .Run(Materializer);
 
                 var pSub = p.ExpectSubscription();
@@ -83,7 +83,7 @@ namespace Akka.Streams.Tests.Dsl
 
             Source.From(Enumerable.Range(1, 3))
                 .GroupedWithin(1000, TimeSpan.FromSeconds(10))
-                .To(Sink.FromSubscriber<IEnumerable<int>, Unit>(c))
+                .To(Sink.FromSubscriber(c))
                 .Run(Materializer);
 
             var cSub = c.ExpectSubscription();
@@ -101,9 +101,9 @@ namespace Akka.Streams.Tests.Dsl
             var p = TestPublisher.CreateManualProbe<int>(this);
             var c = TestSubscriber.CreateManualProbe<IEnumerable<int>>(this);
 
-            Source.FromPublisher<int, Unit>(p)
+            Source.FromPublisher(p)
                 .GroupedWithin(1000, TimeSpan.FromSeconds(1))
-                .To(Sink.FromSubscriber<IEnumerable<int>, Unit>(c))
+                .To(Sink.FromSubscriber(c))
                 .Run(Materializer);
 
             var pSub = p.ExpectSubscription();
@@ -134,9 +134,9 @@ namespace Akka.Streams.Tests.Dsl
             var p = TestPublisher.CreateManualProbe<int>(this);
             var c = TestSubscriber.CreateManualProbe<IEnumerable<int>>(this);
 
-            Source.FromPublisher<int, Unit>(p)
+            Source.FromPublisher(p)
                 .GroupedWithin(1000, TimeSpan.FromMilliseconds(500))
-                .To(Sink.FromSubscriber<IEnumerable<int>, Unit>(c))
+                .To(Sink.FromSubscriber(c))
                 .Run(Materializer);
 
             var pSub = p.ExpectSubscription();
@@ -165,9 +165,9 @@ namespace Akka.Streams.Tests.Dsl
             var upstream = TestPublisher.CreateProbe<int>(this);
             var downstream = TestSubscriber.CreateProbe<IEnumerable<int>>(this);
 
-            Source.FromPublisher<int, Unit>(upstream)
+            Source.FromPublisher(upstream)
                 .GroupedWithin(3, TimeSpan.FromSeconds(2))
-                .To(Sink.FromSubscriber<IEnumerable<int>, Unit>(downstream))
+                .To(Sink.FromSubscriber(downstream))
                 .Run(Materializer);
 
             downstream.Request(2);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowIdleInjectSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowIdleInjectSpec.cs
@@ -65,9 +65,9 @@ namespace Akka.Streams.Tests.Dsl
             var upstream = TestPublisher.CreateProbe<int>(this);
             var downstream = TestSubscriber.CreateProbe<int>(this);
 
-            Source.FromPublisher<int, Unit>(upstream)
+            Source.FromPublisher(upstream)
                 .KeepAlive(TimeSpan.FromSeconds(1), () => 0)
-                .RunWith(Sink.FromSubscriber<int, Unit>(downstream), Materializer);
+                .RunWith(Sink.FromSubscriber(downstream), Materializer);
 
             downstream.Request(1);
 
@@ -84,10 +84,10 @@ namespace Akka.Streams.Tests.Dsl
             var upstream = TestPublisher.CreateProbe<int>(this);
             var downstream = TestSubscriber.CreateProbe<int>(this);
 
-            Source.Combine(Source.From(Enumerable.Range(1, 10)), Source.FromPublisher<int, Unit>(upstream),
+            Source.Combine(Source.From(Enumerable.Range(1, 10)), Source.FromPublisher(upstream),
                 i => new Merge<int, int>(i))
                 .KeepAlive(TimeSpan.FromSeconds(1), () => 0)
-                .RunWith(Sink.FromSubscriber<int, Unit>(downstream), Materializer);
+                .RunWith(Sink.FromSubscriber(downstream), Materializer);
 
             downstream.Request(10);
             downstream.ExpectNextN(10).ShouldAllBeEquivalentTo(Enumerable.Range(1, 10));
@@ -107,9 +107,9 @@ namespace Akka.Streams.Tests.Dsl
             var upstream = TestPublisher.CreateProbe<int>(this);
             var downstream = TestSubscriber.CreateProbe<int>(this);
 
-            Source.FromPublisher<int, Unit>(upstream)
+            Source.FromPublisher(upstream)
                 .KeepAlive(TimeSpan.FromSeconds(1), () => 0)
-                .RunWith(Sink.FromSubscriber<int, Unit>(downstream), Materializer);
+                .RunWith(Sink.FromSubscriber(downstream), Materializer);
 
             downstream.EnsureSubscription();
             downstream.ExpectNoMsg(TimeSpan.FromSeconds(1.5));
@@ -126,10 +126,10 @@ namespace Akka.Streams.Tests.Dsl
             var upstream = TestPublisher.CreateProbe<int>(this);
             var downstream = TestSubscriber.CreateProbe<int>(this);
 
-            Source.Combine(Source.From(Enumerable.Range(1, 10)), Source.FromPublisher<int, Unit>(upstream),
+            Source.Combine(Source.From(Enumerable.Range(1, 10)), Source.FromPublisher(upstream),
                 i => new Merge<int, int>(i))
                 .KeepAlive(TimeSpan.FromSeconds(1), () => 0)
-                .RunWith(Sink.FromSubscriber<int, Unit>(downstream), Materializer);
+                .RunWith(Sink.FromSubscriber(downstream), Materializer);
 
             downstream.Request(10);
             downstream.ExpectNextN(Enumerable.Range(1, 10));
@@ -148,9 +148,9 @@ namespace Akka.Streams.Tests.Dsl
             var upstream = TestPublisher.CreateProbe<int>(this);
             var downstream = TestSubscriber.CreateProbe<int>(this);
 
-            Source.FromPublisher<int, Unit>(upstream)
+            Source.FromPublisher(upstream)
                 .KeepAlive(TimeSpan.FromSeconds(1), () => 0)
-                .RunWith(Sink.FromSubscriber<int, Unit>(downstream), Materializer);
+                .RunWith(Sink.FromSubscriber(downstream), Materializer);
 
             downstream.EnsureSubscription();
             downstream.ExpectNoMsg(TimeSpan.FromSeconds(1.5));
@@ -170,10 +170,10 @@ namespace Akka.Streams.Tests.Dsl
             var upstream = TestPublisher.CreateProbe<int>(this);
             var downstream = TestSubscriber.CreateProbe<int>(this);
 
-            Source.Combine(Source.From(Enumerable.Range(1, 10)), Source.FromPublisher<int, Unit>(upstream),
+            Source.Combine(Source.From(Enumerable.Range(1, 10)), Source.FromPublisher(upstream),
                 i => new Merge<int, int>(i))
                 .KeepAlive(TimeSpan.FromSeconds(1), () => 0)
-                .RunWith(Sink.FromSubscriber<int, Unit>(downstream), Materializer);
+                .RunWith(Sink.FromSubscriber(downstream), Materializer);
 
             downstream.Request(10);
             downstream.ExpectNextN(Enumerable.Range(1, 10));
@@ -195,9 +195,9 @@ namespace Akka.Streams.Tests.Dsl
             var upstream = TestPublisher.CreateProbe<int>(this);
             var downstream = TestSubscriber.CreateProbe<int>(this);
 
-            Source.FromPublisher<int, Unit>(upstream)
+            Source.FromPublisher(upstream)
                 .KeepAlive(TimeSpan.FromSeconds(1), () => 0)
-                .RunWith(Sink.FromSubscriber<int, Unit>(downstream), Materializer);
+                .RunWith(Sink.FromSubscriber(downstream), Materializer);
 
             downstream.Request(2);
             downstream.ExpectNoMsg(TimeSpan.FromMilliseconds(500));

--- a/src/core/Akka.Streams.Tests/Dsl/FlowInitialDelaySpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowInitialDelaySpec.cs
@@ -58,7 +58,7 @@ namespace Akka.Streams.Tests.Dsl
                 var probe = TestSubscriber.CreateProbe<int>(this);
                 Source.From(Enumerable.Range(1, 10))
                     .InitialDelay(TimeSpan.FromSeconds(0.5))
-                    .RunWith(Sink.FromSubscriber<int, Unit>(probe), Materializer);
+                    .RunWith(Sink.FromSubscriber(probe), Materializer);
 
                 probe.EnsureSubscription();
                 probe.ExpectNoMsg(TimeSpan.FromSeconds(1.5));

--- a/src/core/Akka.Streams.Tests/Dsl/FlowInterleaveSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowInterleaveSpec.cs
@@ -18,9 +18,9 @@ namespace Akka.Streams.Tests.Dsl
         protected override TestSubscriber.Probe<int> Setup(IPublisher<int> p1, IPublisher<int> p2)
         {
             var subscriber = TestSubscriber.CreateProbe<int>(this);
-            Source.FromPublisher<int, Unit>(p1)
-                .Interleave(Source.FromPublisher<int, Unit>(p2), 2)
-                .RunWith(Sink.FromSubscriber<int, Unit>(subscriber), Materializer);
+            Source.FromPublisher(p1)
+                .Interleave(Source.FromPublisher(p2), 2)
+                .RunWith(Sink.FromSubscriber(subscriber), Materializer);
             return subscriber;
         }
 
@@ -34,7 +34,7 @@ namespace Akka.Streams.Tests.Dsl
                 Source.From(Enumerable.Range(0, 4))
                     .Interleave(Source.From(Enumerable.Range(4, 3)), 2)
                     .Interleave(Source.From(Enumerable.Range(7, 5)), 3)
-                    .RunWith(Sink.FromSubscriber<int, Unit>(probe), Materializer);
+                    .RunWith(Sink.FromSubscriber(probe), Materializer);
 
                 var subscription = probe.ExpectSubscription();
 
@@ -59,7 +59,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 Source.From(Enumerable.Range(0, 3))
                     .Interleave(Source.From(Enumerable.Range(3, 3)), 2)
-                    .RunWith(Sink.FromSubscriber<int, Unit>(probe), Materializer);
+                    .RunWith(Sink.FromSubscriber(probe), Materializer);
 
                 probe.ExpectSubscription().Request(10);
                 probe.ExpectNext(0, 1, 3, 4, 2, 5);
@@ -76,7 +76,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 Source.From(Enumerable.Range(0, 3))
                     .Interleave(Source.From(Enumerable.Range(3, 3)), 1)
-                    .RunWith(Sink.FromSubscriber<int, Unit>(probe), Materializer);
+                    .RunWith(Sink.FromSubscriber(probe), Materializer);
 
                 probe.ExpectSubscription().Request(10);
                 probe.ExpectNext(0, 3, 1, 4, 2, 5);
@@ -103,7 +103,7 @@ namespace Akka.Streams.Tests.Dsl
                 var probe = TestSubscriber.CreateManualProbe<int>(this);
                 Source.From(Enumerable.Range(0, 3))
                     .Interleave(Source.From(Enumerable.Range(3, 13)), 10)
-                    .RunWith(Sink.FromSubscriber<int, Unit>(probe), Materializer);
+                    .RunWith(Sink.FromSubscriber(probe), Materializer);
 
                 probe.ExpectSubscription().Request(25);
                 Enumerable.Range(0, 16).ForEach(i => probe.ExpectNext(i));
@@ -112,7 +112,7 @@ namespace Akka.Streams.Tests.Dsl
                 var probe2 = TestSubscriber.CreateManualProbe<int>(this);
                 Source.From(Enumerable.Range(1, 20))
                     .Interleave(Source.From(Enumerable.Range(21, 5)), 10)
-                    .RunWith(Sink.FromSubscriber<int, Unit>(probe2), Materializer);
+                    .RunWith(Sink.FromSubscriber(probe2), Materializer);
 
                 probe2.ExpectSubscription().Request(100);
                 Enumerable.Range(1, 10).ForEach(i => probe2.ExpectNext(i));
@@ -212,7 +212,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 var t = Source.AsSubscriber<int>()
                     .InterleaveMaterialized(Source.AsSubscriber<int>(), 2, Tuple.Create)
-                    .ToMaterialized(Sink.FromSubscriber<int, Unit>(down), Keep.Left)
+                    .ToMaterialized(Sink.FromSubscriber(down), Keep.Left)
                     .Run(Materializer);
                 var graphSubscriber1 = t.Item1;
                 var graphSubscriber2 = t.Item2;

--- a/src/core/Akka.Streams.Tests/Dsl/FlowJoinSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowJoinSpec.cs
@@ -44,7 +44,7 @@ namespace Akka.Streams.Tests.Dsl
                     b.From(merge.Out).To(broadcast.In);
                     b.From(broadcast.Out(0))
                         .Via(Flow.Create<int>().Grouped(1000))
-                        .To(Sink.FromSubscriber<IEnumerable<int>, Unit>(probe));
+                        .To(Sink.FromSubscriber(probe));
                     return new FlowShape<int, int>(merge.In(1), broadcast.Out(1));
                 }));
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowMapAsyncSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowMapAsyncSpec.cs
@@ -40,7 +40,7 @@ namespace Akka.Streams.Tests.Dsl
                 var c = TestSubscriber.CreateManualProbe<int>(this);
                 Source.From(Enumerable.Range(1, 3))
                     .MapAsync(4, Task.FromResult)
-                    .RunWith(Sink.FromSubscriber<int, Unit>(c), Materializer);
+                    .RunWith(Sink.FromSubscriber(c), Materializer);
                 var sub = c.ExpectSubscription();
 
                 sub.Request(2);
@@ -64,7 +64,7 @@ namespace Akka.Streams.Tests.Dsl
                     Thread.Sleep(ThreadLocalRandom.Current.Next(1, 10));
                     return i;
                 }))
-                .RunWith(Sink.FromSubscriber<int, Unit>(c), Materializer);
+                .RunWith(Sink.FromSubscriber(c), Materializer);
             var sub = c.ExpectSubscription();
             sub.Request(1000);
             Enumerable.Range(1, 50).ForEach(n => c.ExpectNext(n));
@@ -82,7 +82,7 @@ namespace Akka.Streams.Tests.Dsl
                     probe.Ref.Tell(n);
                     return n;
                 }))
-                .RunWith(Sink.FromSubscriber<int, Unit>(c), Materializer);
+                .RunWith(Sink.FromSubscriber(c), Materializer);
             var sub = c.ExpectSubscription();
             probe.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
             sub.Request(1);
@@ -115,7 +115,7 @@ namespace Akka.Streams.Tests.Dsl
                         latch.Ready(TimeSpan.FromSeconds(10));
                         return n;
                     }))
-                    .To(Sink.FromSubscriber<int, Unit>(c)).Run(Materializer);
+                    .To(Sink.FromSubscriber(c)).Run(Materializer);
                 var sub = c.ExpectSubscription();
                 sub.Request(10);
                 c.ExpectError().InnerException.Message.Should().Be("err1");
@@ -142,7 +142,7 @@ namespace Akka.Streams.Tests.Dsl
                             return n;
                         });
                     })
-                    .RunWith(Sink.FromSubscriber<int, Unit>(c), Materializer);
+                    .RunWith(Sink.FromSubscriber(c), Materializer);
                 var sub = c.ExpectSubscription();
                 sub.Request(10);
                 c.ExpectError().Message.Should().Be("err2");
@@ -166,7 +166,7 @@ namespace Akka.Streams.Tests.Dsl
                             return n;
                         }))
                         .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider))
-                        .RunWith(Sink.FromSubscriber<int, Unit>(c), Materializer);
+                        .RunWith(Sink.FromSubscriber(c), Materializer);
                     var sub = c.ExpectSubscription();
                     sub.Request(10);
                     new[] {1, 2, 4, 5}.ForEach(i => c.ExpectNext(i));
@@ -233,7 +233,7 @@ namespace Akka.Streams.Tests.Dsl
                     return Task.FromResult(n);
                 })
                 .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider))
-                .RunWith(Sink.FromSubscriber<int, Unit>(c), Materializer);
+                .RunWith(Sink.FromSubscriber(c), Materializer);
             var sub = c.ExpectSubscription();
             sub.Request(10);
             new[] {1, 2, 4, 5}.ForEach(i => c.ExpectNext(i));
@@ -247,7 +247,7 @@ namespace Akka.Streams.Tests.Dsl
 
             Source.From(new[] {"a", "b"})
                 .MapAsync(4, _ => Task.FromResult(null as string))
-                .To(Sink.FromSubscriber<string, Unit>(c)).Run(Materializer);
+                .To(Sink.FromSubscriber(c)).Run(Materializer);
 
             var sub = c.ExpectSubscription();
             sub.Request(10);
@@ -261,7 +261,7 @@ namespace Akka.Streams.Tests.Dsl
             Source.From(new[] { "a", "b", "c" })
                 .MapAsync(4, s => s.Equals("b") ? Task.FromResult(null as string) : Task.FromResult(s))
                 .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider))
-                .To(Sink.FromSubscriber<string, Unit>(c)).Run(Materializer);
+                .To(Sink.FromSubscriber(c)).Run(Materializer);
             var sub = c.ExpectSubscription();
             sub.Request(10);
             c.ExpectNext("a");
@@ -277,9 +277,9 @@ namespace Akka.Streams.Tests.Dsl
                 var pub = TestPublisher.CreateManualProbe<int>(this);
                 var sub = TestSubscriber.CreateManualProbe<int>(this);
 
-                Source.FromPublisher<int, Unit>(pub)
+                Source.FromPublisher(pub)
                     .MapAsync(4, _ => Task.FromResult(0))
-                    .RunWith(Sink.FromSubscriber<int, Unit>(sub), Materializer);
+                    .RunWith(Sink.FromSubscriber(sub), Materializer);
 
                 var upstream = pub.ExpectSubscription();
                 upstream.ExpectRequest();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowMapAsyncUnorderedSpec .cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowMapAsyncUnorderedSpec .cs
@@ -43,7 +43,7 @@ namespace Akka.Streams.Tests.Dsl
                 {
                     latch[n].Ready(TimeSpan.FromSeconds(5));
                     return n;
-                })).To(Sink.FromSubscriber<int, Unit>(c)).Run(Materializer);
+                })).To(Sink.FromSubscriber(c)).Run(Materializer);
                 var sub = c.ExpectSubscription();
                 sub.Request(5);
 
@@ -75,7 +75,7 @@ namespace Akka.Streams.Tests.Dsl
                     probe.Ref.Tell(n);
                     return n;
                 }))
-                .To(Sink.FromSubscriber<int, Unit>(c)).Run(Materializer);
+                .To(Sink.FromSubscriber(c)).Run(Materializer);
             var sub = c.ExpectSubscription();
             c.ExpectNoMsg(TimeSpan.FromMilliseconds(200));
             probe.ExpectNoMsg(TimeSpan.Zero);
@@ -110,7 +110,7 @@ namespace Akka.Streams.Tests.Dsl
                         latch.Ready(TimeSpan.FromSeconds(10));
                         return n;
                     }))
-                    .To(Sink.FromSubscriber<int, Unit>(c)).Run(Materializer);
+                    .To(Sink.FromSubscriber(c)).Run(Materializer);
                 var sub = c.ExpectSubscription();
                 sub.Request(10);
                 c.ExpectError().InnerException.Message.Should().Be("err1");
@@ -137,7 +137,7 @@ namespace Akka.Streams.Tests.Dsl
                             return n;
                         });
                     })
-                    .RunWith(Sink.FromSubscriber<int, Unit>(c), Materializer);
+                    .RunWith(Sink.FromSubscriber(c), Materializer);
                 var sub = c.ExpectSubscription();
                 sub.Request(10);
                 c.ExpectError().Message.Should().Be("err2");
@@ -238,7 +238,7 @@ namespace Akka.Streams.Tests.Dsl
 
             Source.From(new[] {"a", "b"})
                 .MapAsyncUnordered(4, _ => Task.FromResult(null as string))
-                .To(Sink.FromSubscriber<string, Unit>(c)).Run(Materializer);
+                .To(Sink.FromSubscriber(c)).Run(Materializer);
 
             var sub = c.ExpectSubscription();
             sub.Request(10);
@@ -252,7 +252,7 @@ namespace Akka.Streams.Tests.Dsl
             Source.From(new[] { "a", "b", "c" })
                 .MapAsyncUnordered(4, s => s.Equals("b") ? Task.FromResult(null as string) : Task.FromResult(s))
                 .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider))
-                .To(Sink.FromSubscriber<string, Unit>(c)).Run(Materializer);
+                .To(Sink.FromSubscriber(c)).Run(Materializer);
             var sub = c.ExpectSubscription();
             sub.Request(10);
             c.ExpectNextUnordered("a", "c");
@@ -267,9 +267,9 @@ namespace Akka.Streams.Tests.Dsl
                 var pub = TestPublisher.CreateManualProbe<int>(this);
                 var sub = TestSubscriber.CreateManualProbe<int>(this);
 
-                Source.FromPublisher<int, Unit>(pub)
+                Source.FromPublisher(pub)
                     .MapAsyncUnordered(4, _ => Task.FromResult(0))
-                    .RunWith(Sink.FromSubscriber<int, Unit>(sub), Materializer);
+                    .RunWith(Sink.FromSubscriber(sub), Materializer);
 
                 var upstream = pub.ExpectSubscription();
                 upstream.ExpectRequest();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowMapConcatSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowMapConcatSpec.cs
@@ -60,7 +60,7 @@ namespace Akka.Streams.Tests.Dsl
                     Thread.Sleep(10);
                     return x;
                 })
-                .RunWith(Sink.FromSubscriber<int,Unit>(subscriber), materializer);
+                .RunWith(Sink.FromSubscriber(subscriber), materializer);
 
             var subscription = subscriber.ExpectSubscription();
             subscription.Request(100);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowMergeSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowMergeSpec.cs
@@ -17,9 +17,9 @@ namespace Akka.Streams.Tests.Dsl
         protected override TestSubscriber.Probe<int> Setup(IPublisher<int> p1, IPublisher<int> p2)
         {
             var subscriber = TestSubscriber.CreateProbe<int>(this);
-            Source.FromPublisher<int, Unit>(p1)
-                .Merge(Source.FromPublisher<int, Unit>(p2))
-                .RunWith(Sink.FromSubscriber<int, Unit>(subscriber), Materializer);
+            Source.FromPublisher(p1)
+                .Merge(Source.FromPublisher(p2))
+                .RunWith(Sink.FromSubscriber(subscriber), Materializer);
             return subscriber;
         }
 
@@ -40,7 +40,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Map(i => i*2)
                     .Map(i => i/2)
                     .Map(i => i + 1)
-                    .RunWith(Sink.FromSubscriber<int, Unit>(probe), Materializer);
+                    .RunWith(Sink.FromSubscriber(probe), Materializer);
 
                 var subscription = probe.ExpectSubscription();
 
@@ -116,7 +116,7 @@ namespace Akka.Streams.Tests.Dsl
                 var t =
                     Source.AsSubscriber<int>()
                         .MergeMaterialized(Source.AsSubscriber<int>(), Tuple.Create)
-                        .ToMaterialized(Sink.FromSubscriber<int, Unit>(down), Keep.Left)
+                        .ToMaterialized(Sink.FromSubscriber(down), Keep.Left)
                         .Run(Materializer);
                 var graphSubscriber1 = t.Item1;
                 var graphSubscriber2 = t.Item2;

--- a/src/core/Akka.Streams.Tests/Dsl/FlowOnCompleteSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowOnCompleteSpec.cs
@@ -26,7 +26,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var onCompleteProbe = CreateTestProbe();
                 var p = TestPublisher.CreateManualProbe<int>(this);
-                Source.FromPublisher<int, Unit>(p)
+                Source.FromPublisher(p)
                     .To(Sink.OnComplete<int>(() => onCompleteProbe.Ref.Tell("done"), _ => { }))
                     .Run(Materializer);
                 var proc = p.ExpectSubscription();
@@ -45,7 +45,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var onCompleteProbe = CreateTestProbe();
                 var p = TestPublisher.CreateManualProbe<int>(this);
-                Source.FromPublisher<int, Unit>(p)
+                Source.FromPublisher(p)
                     .To(Sink.OnComplete<int>(() => {}, ex => onCompleteProbe.Ref.Tell(ex)))
                     .Run(Materializer);
                 var proc = p.ExpectSubscription();
@@ -64,7 +64,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var onCompleteProbe = CreateTestProbe();
                 var p = TestPublisher.CreateManualProbe<int>(this);
-                Source.FromPublisher<int, Unit>(p)
+                Source.FromPublisher(p)
                     .To(Sink.OnComplete<int>(() => onCompleteProbe.Ref.Tell("done"), _ => {}))
                     .Run(Materializer);
                 var proc = p.ExpectSubscription();
@@ -83,7 +83,7 @@ namespace Akka.Streams.Tests.Dsl
                 var onCompleteProbe = CreateTestProbe();
                 var p = TestPublisher.CreateManualProbe<int>(this);
                 var foreachSink = Sink.ForEach<int>(x => onCompleteProbe.Ref.Tell("foreach-" + x));
-                var future = Source.FromPublisher<int, Unit>(p).Map(x =>
+                var future = Source.FromPublisher(p).Map(x =>
                 {
                     onCompleteProbe.Ref.Tell("map-" + x);
                     return x;

--- a/src/core/Akka.Streams.Tests/Dsl/FlowPrefixAndTailSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowPrefixAndTailSpec.cs
@@ -42,7 +42,7 @@ namespace Akka.Streams.Tests.Dsl
                 fut.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
                 var tailFlow = fut.Result.Item2;
                 var tailSubscriber = TestSubscriber.CreateManualProbe<int>(this);
-                tailFlow.To(Sink.FromSubscriber<int, Unit>(tailSubscriber)).Run(Materializer);
+                tailFlow.To(Sink.FromSubscriber(tailSubscriber)).Run(Materializer);
                 tailSubscriber.ExpectSubscriptionAndComplete();
             }, Materializer);
         }
@@ -58,7 +58,7 @@ namespace Akka.Streams.Tests.Dsl
                 fut.Result.Item1.ShouldAllBeEquivalentTo(new[] {1, 2, 3});
                 var tailFlow = fut.Result.Item2;
                 var tailSubscriber = TestSubscriber.CreateManualProbe<int>(this);
-                tailFlow.To(Sink.FromSubscriber<int, Unit>(tailSubscriber)).Run(Materializer);
+                tailFlow.To(Sink.FromSubscriber(tailSubscriber)).Run(Materializer);
                 tailSubscriber.ExpectSubscriptionAndComplete();
             }, Materializer);
         }
@@ -129,7 +129,7 @@ namespace Akka.Streams.Tests.Dsl
                 fut.Result.Item1.ShouldAllBeEquivalentTo(Enumerable.Range(1, 10));
                 var tail = fut.Result.Item2;
                 var subscriber = TestSubscriber.CreateManualProbe<int>(this);
-                tail.To(Sink.FromSubscriber<int, Unit>(subscriber)).Run(Materializer);
+                tail.To(Sink.FromSubscriber(subscriber)).Run(Materializer);
                 subscriber.ExpectSubscriptionAndComplete();
             }, Materializer);
         }
@@ -146,10 +146,10 @@ namespace Akka.Streams.Tests.Dsl
                 var tail = fut.Result.Item2;
 
                 var subscriber1 = TestSubscriber.CreateProbe<int>(this);
-                tail.To(Sink.FromSubscriber<int, Unit>(subscriber1)).Run(Materializer);
+                tail.To(Sink.FromSubscriber(subscriber1)).Run(Materializer);
 
                 var subscriber2 = TestSubscriber.CreateProbe<int>(this);
-                tail.To(Sink.FromSubscriber<int, Unit>(subscriber2)).Run(Materializer);
+                tail.To(Sink.FromSubscriber(subscriber2)).Run(Materializer);
 
                 subscriber2.ExpectSubscriptionAndError()
                     .Message.Should()
@@ -178,7 +178,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 var subscriber = TestSubscriber.CreateProbe<int>(this);
                 Thread.Sleep(1000);
-                tail.To(Sink.FromSubscriber<int, Unit>(subscriber)).Run(tightTimeoutMaterializer);
+                tail.To(Sink.FromSubscriber(subscriber)).Run(tightTimeoutMaterializer);
                 subscriber.ExpectSubscriptionAndError()
                     .Message.Should()
                     .Be("Substream Source has not been materialized in 00:00:00.5000000");
@@ -205,9 +205,9 @@ namespace Akka.Streams.Tests.Dsl
                 var publisher = TestPublisher.CreateManualProbe<int>(this);
                 var subscriber = TestSubscriber.CreateManualProbe<Tuple<IImmutableList<int>, Source<int, Unit>>>(this);
 
-                Source.FromPublisher<int, Unit>(publisher)
+                Source.FromPublisher(publisher)
                     .PrefixAndTail(3)
-                    .To(Sink.FromSubscriber<Tuple<IImmutableList<int>, Source<int, Unit>>, Unit>(subscriber))
+                    .To(Sink.FromSubscriber(subscriber))
                     .Run(Materializer);
 
                 var upstream = publisher.ExpectSubscription();
@@ -231,9 +231,9 @@ namespace Akka.Streams.Tests.Dsl
                 var publisher = TestPublisher.CreateManualProbe<int>(this);
                 var subscriber = TestSubscriber.CreateManualProbe<Tuple<IImmutableList<int>, Source<int, Unit>>>(this);
 
-                Source.FromPublisher<int, Unit>(publisher)
+                Source.FromPublisher(publisher)
                     .PrefixAndTail(1)
-                    .To(Sink.FromSubscriber<Tuple<IImmutableList<int>, Source<int, Unit>>, Unit>(subscriber))
+                    .To(Sink.FromSubscriber(subscriber))
                     .Run(Materializer);
 
                 var upstream = publisher.ExpectSubscription();
@@ -250,7 +250,7 @@ namespace Akka.Streams.Tests.Dsl
                 subscriber.ExpectComplete();
 
                 var substreamSubscriber = TestSubscriber.CreateManualProbe<int>(this);
-                tail.To(Sink.FromSubscriber<int, Unit>(substreamSubscriber)).Run(Materializer);
+                tail.To(Sink.FromSubscriber(substreamSubscriber)).Run(Materializer);
                 substreamSubscriber.ExpectSubscription();
                 upstream.SendError(TestException);
                 substreamSubscriber.ExpectError().Should().Be(TestException);
@@ -265,9 +265,9 @@ namespace Akka.Streams.Tests.Dsl
                 var publisher = TestPublisher.CreateManualProbe<int>(this);
                 var subscriber = TestSubscriber.CreateManualProbe<Tuple<IImmutableList<int>, Source<int, Unit>>>(this);
 
-                Source.FromPublisher<int, Unit>(publisher)
+                Source.FromPublisher(publisher)
                     .PrefixAndTail(3)
-                    .To(Sink.FromSubscriber<Tuple<IImmutableList<int>, Source<int, Unit>>, Unit>(subscriber))
+                    .To(Sink.FromSubscriber(subscriber))
                     .Run(Materializer);
 
                 var upstream = publisher.ExpectSubscription();
@@ -291,9 +291,9 @@ namespace Akka.Streams.Tests.Dsl
                 var publisher = TestPublisher.CreateManualProbe<int>(this);
                 var subscriber = TestSubscriber.CreateManualProbe<Tuple<IImmutableList<int>, Source<int, Unit>>>(this);
 
-                Source.FromPublisher<int, Unit>(publisher)
+                Source.FromPublisher(publisher)
                     .PrefixAndTail(1)
-                    .To(Sink.FromSubscriber<Tuple<IImmutableList<int>, Source<int, Unit>>, Unit>(subscriber))
+                    .To(Sink.FromSubscriber(subscriber))
                     .Run(Materializer);
 
                 var upstream = publisher.ExpectSubscription();
@@ -310,7 +310,7 @@ namespace Akka.Streams.Tests.Dsl
                 subscriber.ExpectComplete();
 
                 var substreamSubscriber = TestSubscriber.CreateManualProbe<int>(this);
-                tail.To(Sink.FromSubscriber<int, Unit>(substreamSubscriber)).Run(Materializer);
+                tail.To(Sink.FromSubscriber(substreamSubscriber)).Run(Materializer);
                 substreamSubscriber.ExpectSubscription().Cancel();
 
                 upstream.ExpectCancellation();
@@ -327,7 +327,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 var flowSubscriber = Source.AsSubscriber<int>()
                     .PrefixAndTail(1)
-                    .To(Sink.FromSubscriber<Tuple<IImmutableList<int>, Source<int, Unit>>, Unit>(down))
+                    .To(Sink.FromSubscriber(down))
                     .Run(Materializer);
 
                 var downstream = down.ExpectSubscription();
@@ -345,7 +345,7 @@ namespace Akka.Streams.Tests.Dsl
             var sub = TestSubscriber.CreateManualProbe<int>(this);
 
             var f =
-                Source.FromPublisher<int, Unit>(pub)
+                Source.FromPublisher(pub)
                     .PrefixAndTail(1)
                     .RunWith(Sink.First<Tuple<IImmutableList<int>, Source<int, Unit>>>(), Materializer);
             var s = pub.ExpectSubscription();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSpec.cs
@@ -208,9 +208,9 @@ namespace Akka.Streams.Tests.Dsl
         {
             var flow = Flow.Create<string>();
             var c1 = TestSubscriber.CreateManualProbe<string>(this);
-            var sink = flow.To(Sink.FromSubscriber<string, Unit>(c1));
+            var sink = flow.To(Sink.FromSubscriber(c1));
             var publisher = Source.From(new[] { "1", "2", "3" }).RunWith(Sink.AsPublisher<string>(false), Materializer);
-            Source.FromPublisher<string, Unit>(publisher).To(sink).Run(Materializer);
+            Source.FromPublisher(publisher).To(sink).Run(Materializer);
 
             var sub1 = c1.ExpectSubscription();
             sub1.Request(3);
@@ -229,7 +229,7 @@ namespace Akka.Streams.Tests.Dsl
                 return i.ToString();
             });
             var publisher = Source.From(new[] { 1, 2, 3 }).RunWith(Sink.AsPublisher<int>(false), Materializer);
-            Source.FromPublisher<int, Unit>(publisher).Via(flow).To(Sink.Ignore<string>()).Run(Materializer);
+            Source.FromPublisher(publisher).Via(flow).To(Sink.Ignore<string>()).Run(Materializer);
 
             ExpectMsg("1");
             ExpectMsg("2");
@@ -241,9 +241,9 @@ namespace Akka.Streams.Tests.Dsl
         {
             var flow = Flow.Create<int>().Map(i => i.ToString());
             var c1 = TestSubscriber.CreateManualProbe<string>(this);
-            var sink = flow.To(Sink.FromSubscriber<string, Unit>(c1));
+            var sink = flow.To(Sink.FromSubscriber(c1));
             var publisher = Source.From(new[] { 1, 2, 3 }).RunWith(Sink.AsPublisher<int>(false), Materializer);
-            Source.FromPublisher<int, Unit>(publisher).To(sink).Run(Materializer);
+            Source.FromPublisher(publisher).To(sink).Run(Materializer);
 
             var sub1 = c1.ExpectSubscription();
             sub1.Request(3);
@@ -699,8 +699,8 @@ namespace Akka.Streams.Tests.Dsl
 
                 impl.Tell(new ActorGraphInterpreter.ExposedPublisher(shell, 0, publisher));
 
-                return Flow.FromSinkAndSource(Sink.FromSubscriber<TOut, Unit>(subscriber),
-                    Source.FromPublisher<TOut2, Unit>(publisher));
+                return Flow.FromSinkAndSource(Sink.FromSubscriber(subscriber),
+                    Source.FromPublisher(publisher));
             };
 
             return flow.Via(createGraph());

--- a/src/core/Akka.Streams.Tests/Dsl/FlowTakeSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowTakeSpec.cs
@@ -46,7 +46,7 @@ namespace Akka.Streams.Tests.Dsl
             var probe = TestSubscriber.CreateManualProbe<int>(this);
             Source.From(Enumerable.Range(1, 3))
                 .Take(-1)
-                .To(Sink.FromSubscriber<int, Unit>(probe))
+                .To(Sink.FromSubscriber(probe))
                 .Run(Materializer);
             probe.ExpectSubscription().Request(10);
             probe.ExpectComplete();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowTakeWithinSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowTakeWithinSpec.cs
@@ -25,9 +25,9 @@ namespace Akka.Streams.Tests.Dsl
             var input = 1;
             var p = TestPublisher.CreateManualProbe<int>(this);
             var c = TestSubscriber.CreateManualProbe<int>(this);
-            Source.FromPublisher<int, Unit>(p)
+            Source.FromPublisher(p)
                 .TakeWithin(TimeSpan.FromSeconds(1))
-                .To(Sink.FromSubscriber<int, Unit>(c))
+                .To(Sink.FromSubscriber(c))
                 .Run(Materializer);
             var pSub = p.ExpectSubscription();
             var cSub = c.ExpectSubscription();
@@ -52,7 +52,7 @@ namespace Akka.Streams.Tests.Dsl
                 var c = TestSubscriber.CreateManualProbe<int>(this);
                 Source.From(Enumerable.Range(1, 3))
                     .TakeWithin(TimeSpan.FromSeconds(1))
-                    .To(Sink.FromSubscriber<int, Unit>(c))
+                    .To(Sink.FromSubscriber(c))
                     .Run(Materializer);
                 var cSub = c.ExpectSubscription();
                 c.ExpectNoMsg(TimeSpan.FromMilliseconds(200));

--- a/src/core/Akka.Streams.Tests/Dsl/FlowThrottleSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowThrottleSpec.cs
@@ -57,9 +57,9 @@ namespace Akka.Streams.Tests.Dsl
                 var upstream = TestPublisher.CreateProbe<int>(this);
                 var downstream = TestSubscriber.CreateProbe<int>(this);
 
-                Source.FromPublisher<int, Unit>(upstream)
+                Source.FromPublisher(upstream)
                     .Throttle(1, TimeSpan.FromMilliseconds(300), 0, ThrottleMode.Shaping)
-                    .RunWith(Sink.FromSubscriber<int, Unit>(downstream), Materializer);
+                    .RunWith(Sink.FromSubscriber(downstream), Materializer);
 
                 downstream.Request(2);
                 upstream.SendNext(1);
@@ -83,9 +83,9 @@ namespace Akka.Streams.Tests.Dsl
                 var upstream = TestPublisher.CreateProbe<int>(this);
                 var downstream = TestSubscriber.CreateProbe<int>(this);
 
-                Source.FromPublisher<int, Unit>(upstream)
+                Source.FromPublisher(upstream)
                     .Throttle(1, TimeSpan.FromMilliseconds(300), 0, ThrottleMode.Shaping)
-                    .RunWith(Sink.FromSubscriber<int, Unit>(downstream), Materializer);
+                    .RunWith(Sink.FromSubscriber(downstream), Materializer);
 
                 downstream.Request(2);
                 upstream.SendNext(1);
@@ -108,7 +108,7 @@ namespace Akka.Streams.Tests.Dsl
                 var downstream = TestSubscriber.CreateProbe<int>(this);
                 Source.From(Enumerable.Range(1, 10))
                     .Throttle(1, TimeSpan.FromMilliseconds(300), 0, ThrottleMode.Shaping)
-                    .RunWith(Sink.FromSubscriber<int, Unit>(downstream), Materializer);
+                    .RunWith(Sink.FromSubscriber(downstream), Materializer);
                 downstream.Cancel();
             }, Materializer);
         }
@@ -142,9 +142,9 @@ namespace Akka.Streams.Tests.Dsl
                 var upstream = TestPublisher.CreateProbe<int>(this);
                 var downstream = TestSubscriber.CreateProbe<int>(this);
 
-                Source.FromPublisher<int, Unit>(upstream)
+                Source.FromPublisher(upstream)
                     .Throttle(1, TimeSpan.FromMilliseconds(200), 5, ThrottleMode.Shaping)
-                    .RunWith(Sink.FromSubscriber<int, Unit>(downstream), Materializer);
+                    .RunWith(Sink.FromSubscriber(downstream), Materializer);
 
                 downstream.Request(1);
                 upstream.SendNext(1);
@@ -173,9 +173,9 @@ namespace Akka.Streams.Tests.Dsl
                 var upstream = TestPublisher.CreateProbe<int>(this);
                 var downstream = TestSubscriber.CreateProbe<int>(this);
 
-                Source.FromPublisher<int, Unit>(upstream)
+                Source.FromPublisher(upstream)
                     .Throttle(1, TimeSpan.FromMilliseconds(200), 5, ThrottleMode.Shaping)
-                    .RunWith(Sink.FromSubscriber<int, Unit>(downstream), Materializer);
+                    .RunWith(Sink.FromSubscriber(downstream), Materializer);
 
                 downstream.Request(1);
                 upstream.SendNext(1);
@@ -271,9 +271,9 @@ namespace Akka.Streams.Tests.Dsl
                 var upstream = TestPublisher.CreateProbe<int>(this);
                 var downstream = TestSubscriber.CreateProbe<int>(this);
 
-                Source.FromPublisher<int, Unit>(upstream)
+                Source.FromPublisher(upstream)
                     .Throttle(1, TimeSpan.FromMilliseconds(300), 0, x => x, ThrottleMode.Shaping)
-                    .RunWith(Sink.FromSubscriber<int, Unit>(downstream), Materializer);
+                    .RunWith(Sink.FromSubscriber(downstream), Materializer);
 
                 downstream.Request(2);
                 upstream.SendNext(1);
@@ -296,7 +296,7 @@ namespace Akka.Streams.Tests.Dsl
                 var downstream = TestSubscriber.CreateProbe<int>(this);
                 Source.From(Enumerable.Range(1, 10))
                     .Throttle(2, TimeSpan.FromMilliseconds(200), 0, x => x, ThrottleMode.Shaping)
-                    .RunWith(Sink.FromSubscriber<int, Unit>(downstream), Materializer);
+                    .RunWith(Sink.FromSubscriber(downstream), Materializer);
                 downstream.Cancel();
             }, Materializer);
         }
@@ -330,9 +330,9 @@ namespace Akka.Streams.Tests.Dsl
                 var upstream = TestPublisher.CreateProbe<int>(this);
                 var downstream = TestSubscriber.CreateProbe<int>(this);
 
-                Source.FromPublisher<int, Unit>(upstream)
+                Source.FromPublisher(upstream)
                     .Throttle(2, TimeSpan.FromMilliseconds(400), 5, x => 1, ThrottleMode.Shaping)
-                    .RunWith(Sink.FromSubscriber<int, Unit>(downstream), Materializer);
+                    .RunWith(Sink.FromSubscriber(downstream), Materializer);
 
                 downstream.Request(1);
                 upstream.SendNext(1);
@@ -361,9 +361,9 @@ namespace Akka.Streams.Tests.Dsl
                 var upstream = TestPublisher.CreateProbe<int>(this);
                 var downstream = TestSubscriber.CreateProbe<int>(this);
 
-                Source.FromPublisher<int, Unit>(upstream)
+                Source.FromPublisher(upstream)
                     .Throttle(2, TimeSpan.FromMilliseconds(400), 5, e => e < 4 ? 1 : 20, ThrottleMode.Shaping)
-                    .RunWith(Sink.FromSubscriber<int, Unit>(downstream), Materializer);
+                    .RunWith(Sink.FromSubscriber(downstream), Materializer);
 
                 downstream.Request(1);
                 upstream.SendNext(1);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowZipSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowZipSpec.cs
@@ -19,9 +19,9 @@ namespace Akka.Streams.Tests.Dsl
         protected override TestSubscriber.Probe<Tuple<int, int>> Setup(IPublisher<int> p1, IPublisher<int> p2)
         {
             var subscriber = TestSubscriber.CreateProbe<Tuple<int, int>>(this);
-            Source.FromPublisher<int, Unit>(p1)
-                .Zip(Source.FromPublisher<int, Unit>(p2))
-                .RunWith(Sink.FromSubscriber<Tuple<int, int>, Unit>(subscriber), Materializer);
+            Source.FromPublisher(p1)
+                .Zip(Source.FromPublisher(p2))
+                .RunWith(Sink.FromSubscriber(subscriber), Materializer);
             return subscriber;
         }
 
@@ -33,7 +33,7 @@ namespace Akka.Streams.Tests.Dsl
                 var probe = TestSubscriber.CreateManualProbe<Tuple<int, string>>(this);
                 Source.From(Enumerable.Range(1, 4))
                     .Zip(Source.From(new[] {"A", "B", "C", "D", "E", "F"}))
-                    .RunWith(Sink.FromSubscriber<Tuple<int, string>, Unit>(probe), Materializer);
+                    .RunWith(Sink.FromSubscriber(probe), Materializer);
                 var subscription = probe.ExpectSubscription();
 
                 subscription.Request(2);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowZipWithSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowZipWithSpec.cs
@@ -19,9 +19,9 @@ namespace Akka.Streams.Tests.Dsl
         protected override TestSubscriber.Probe<int> Setup(IPublisher<int> p1, IPublisher<int> p2)
         {
             var subscriber = TestSubscriber.CreateProbe<int>(this);
-            Source.FromPublisher<int, Unit>(p1)
-                .ZipWith(Source.FromPublisher<int, Unit>(p2), (i, i1) => i + i1)
-                .RunWith(Sink.FromSubscriber<int, Unit>(subscriber), Materializer);
+            Source.FromPublisher(p1)
+                .ZipWith(Source.FromPublisher(p2), (i, i1) => i + i1)
+                .RunWith(Sink.FromSubscriber(subscriber), Materializer);
             return subscriber;
         }
 
@@ -31,7 +31,7 @@ namespace Akka.Streams.Tests.Dsl
             var probe = TestSubscriber.CreateManualProbe<int>(this);
             Source.From(Enumerable.Range(1, 4))
                 .ZipWith(Source.From(new[] {10, 20, 30, 40}.AsEnumerable()), (i, i1) => i + i1)
-                .RunWith(Sink.FromSubscriber<int, Unit>(probe), Materializer);
+                .RunWith(Sink.FromSubscriber(probe), Materializer);
 
             var subscription = probe.ExpectSubscription();
 
@@ -53,7 +53,7 @@ namespace Akka.Streams.Tests.Dsl
             var probe = TestSubscriber.CreateManualProbe<int>(this);
             Source.From(Enumerable.Range(1, 4))
                 .ZipWith(Source.From(Enumerable.Range(-2, 4)), (i, i1) => i/i1)
-                .RunWith(Sink.FromSubscriber<int, Unit>(probe), Materializer);
+                .RunWith(Sink.FromSubscriber(probe), Materializer);
 
             var subscription = probe.ExpectSubscription();
 

--- a/src/core/Akka.Streams.Tests/Dsl/HeadSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/HeadSinkSpec.cs
@@ -25,7 +25,7 @@ namespace Akka.Streams.Tests.Dsl
             this.AssertAllStagesStopped(() =>
             {
                 var p = TestPublisher.CreateManualProbe<int>(this);
-                var task = Source.FromPublisher<int, Unit>(p).Map(x=>x).RunWith(Sink.First<int>(), Materializer);
+                var task = Source.FromPublisher(p).Map(x=>x).RunWith(Sink.First<int>(), Materializer);
                 var proc = p.ExpectSubscription();
                 proc.ExpectRequest();
                 proc.SendNext(42);
@@ -88,7 +88,7 @@ namespace Akka.Streams.Tests.Dsl
             this.AssertAllStagesStopped(() =>
             {
                 var p = TestPublisher.CreateManualProbe<int>(this);
-                var task = Source.FromPublisher<int, Unit>(p).Map(x => x).RunWith(Sink.FirstOrDefault<int>(), Materializer);
+                var task = Source.FromPublisher(p).Map(x => x).RunWith(Sink.FirstOrDefault<int>(), Materializer);
                 var proc = p.ExpectSubscription();
                 proc.ExpectRequest();
                 proc.SendNext(42);

--- a/src/core/Akka.Streams.Tests/Dsl/PublisherSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/PublisherSinkSpec.cs
@@ -25,7 +25,7 @@ namespace Akka.Streams.Tests.Dsl
             this.AssertAllStagesStopped(() =>
             {
                 var t =
-                    RunnableGraph<Tuple<IPublisher<int>, IPublisher<int>>>.FromGraph(
+                    RunnableGraph.FromGraph(
                         GraphDsl.Create(Sink.AsPublisher<int>(false),
                             Sink.AsPublisher<int>(false), Keep.Both,
                             (b, p1, p2) =>
@@ -43,8 +43,8 @@ namespace Akka.Streams.Tests.Dsl
                 var pub1 = t.Item1;
                 var pub2 = t.Item2;
 
-                var f1 = Source.FromPublisher<int, Unit>(pub1).Map(x => x).RunFold(0, (sum, i) => sum + i, Materializer);
-                var f2 = Source.FromPublisher<int, Unit>(pub2).Map(x => x).RunFold(0, (sum, i) => sum + i, Materializer);
+                var f1 = Source.FromPublisher(pub1).Map(x => x).RunFold(0, (sum, i) => sum + i, Materializer);
+                var f2 = Source.FromPublisher(pub2).Map(x => x).RunFold(0, (sum, i) => sum + i, Materializer);
 
                 f1.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
                 f2.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
@@ -61,9 +61,9 @@ namespace Akka.Streams.Tests.Dsl
             var sub = t.Item1;
             var pub = t.Item2;
 
-            Source.From(Enumerable.Range(1, 100)).To(Sink.FromSubscriber<int, Unit>(sub)).Run(Materializer);
+            Source.From(Enumerable.Range(1, 100)).To(Sink.FromSubscriber(sub)).Run(Materializer);
 
-            var task = Source.FromPublisher<int, Unit>(pub).Limit(1000).RunWith(Sink.Seq<int>(), Materializer);
+            var task = Source.FromPublisher(pub).Limit(1000).RunWith(Sink.Seq<int>(), Materializer);
             task.Wait(TimeSpan.FromSeconds(3));
             task.Result.ShouldAllBeEquivalentTo(Enumerable.Range(1, 100));
 
@@ -76,7 +76,7 @@ namespace Akka.Streams.Tests.Dsl
                 .RunWith(
                     Sink.AsPublisher<int>(false)
                         .MapMaterializedValue(
-                            p => Source.FromPublisher<int, Unit>(p).RunFold(0, (sum, i) => sum + i, Materializer)),
+                            p => Source.FromPublisher(p).RunFold(0, (sum, i) => sum + i, Materializer)),
                     Materializer);
             f.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
             f.Result.Should().Be(6);

--- a/src/core/Akka.Streams.Tests/Dsl/QueueSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/QueueSourceSpec.cs
@@ -37,7 +37,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             var s = this.CreateManualProbe<int>();
             var queue =
-                Source.Queue<int>(10, OverflowStrategy.Fail).To(Sink.FromSubscriber<int, Unit>(s)).Run(_materializer);
+                Source.Queue<int>(10, OverflowStrategy.Fail).To(Sink.FromSubscriber(s)).Run(_materializer);
             var sub = s.ExpectSubscription();
 
             sub.Request(2);
@@ -55,7 +55,7 @@ namespace Akka.Streams.Tests.Dsl
             var s = this.CreateManualProbe<int>();
             var queue =
                 Source.Queue<int>(100, OverflowStrategy.DropHead)
-                    .To(Sink.FromSubscriber<int, Unit>(s))
+                    .To(Sink.FromSubscriber(s))
                     .Run(_materializer);
             var sub = s.ExpectSubscription();
 
@@ -79,7 +79,7 @@ namespace Akka.Streams.Tests.Dsl
                 var s = this.CreateManualProbe<int>();
                 var queue =
                     Source.Queue<int>(0, OverflowStrategy.DropHead)
-                        .To(Sink.FromSubscriber<int, Unit>(s))
+                        .To(Sink.FromSubscriber(s))
                         .Run(_materializer);
                 var sub = s.ExpectSubscription();
 
@@ -98,7 +98,7 @@ namespace Akka.Streams.Tests.Dsl
                 var s = this.CreateManualProbe<int>();
                 var queue =
                     Source.Queue<int>(0, OverflowStrategy.DropHead)
-                        .To(Sink.FromSubscriber<int, Unit>(s))
+                        .To(Sink.FromSubscriber(s))
                         .Run(_materializer);
                 var sub = s.ExpectSubscription();
 
@@ -119,7 +119,7 @@ namespace Akka.Streams.Tests.Dsl
                 var s = this.CreateManualProbe<int>();
                 var queue =
                     Source.Queue<int>(0, OverflowStrategy.DropHead)
-                        .To(Sink.FromSubscriber<int, Unit>(s))
+                        .To(Sink.FromSubscriber(s))
                         .Run(_materializer);
                 var sub = s.ExpectSubscription();
 
@@ -143,7 +143,7 @@ namespace Akka.Streams.Tests.Dsl
                 var s = this.CreateManualProbe<int>();
                 var queue =
                     Source.Queue<int>(1, OverflowStrategy.Fail)
-                        .To(Sink.FromSubscriber<int, Unit>(s))
+                        .To(Sink.FromSubscriber(s))
                         .Run(_materializer);
                 s.ExpectSubscription();
 
@@ -162,7 +162,7 @@ namespace Akka.Streams.Tests.Dsl
                 var probe = CreateTestProbe();
                 var queue = TestSourceStage<int, ISourceQueue<int>>.Create(
                     new QueueSource<int>(1, OverflowStrategy.DropHead), probe)
-                    .To(Sink.FromSubscriber<int, Unit>(s))
+                    .To(Sink.FromSubscriber(s))
                     .Run(_materializer);
                 var sub = s.ExpectSubscription();
 
@@ -182,7 +182,7 @@ namespace Akka.Streams.Tests.Dsl
                 var s = this.CreateManualProbe<int>();
                 var queue =
                     Source.Queue<int>(5, OverflowStrategy.Backpressure)
-                        .To(Sink.FromSubscriber<int, Unit>(s))
+                        .To(Sink.FromSubscriber(s))
                         .Run(_materializer);
                 var sub = s.ExpectSubscription();
 
@@ -210,7 +210,7 @@ namespace Akka.Streams.Tests.Dsl
                 var s = this.CreateManualProbe<int>();
                 var queue =
                     Source.Queue<int>(1, OverflowStrategy.Fail)
-                        .To(Sink.FromSubscriber<int, Unit>(s))
+                        .To(Sink.FromSubscriber(s))
                         .Run(_materializer);
                 queue.WatchCompletionAsync().PipeTo(TestActor);
                 queue.OfferAsync(1); // need to wait when first offer is done as initialization can be done in this moment
@@ -227,7 +227,7 @@ namespace Akka.Streams.Tests.Dsl
                 var s = this.CreateManualProbe<int>();
                 var queue =
                     Source.Queue<int>(1, OverflowStrategy.DropNew)
-                        .To(Sink.FromSubscriber<int, Unit>(s))
+                        .To(Sink.FromSubscriber(s))
                         .Run(_materializer);
                 var sub = s.ExpectSubscription();
 
@@ -249,7 +249,7 @@ namespace Akka.Streams.Tests.Dsl
                 var s = this.CreateManualProbe<int>();
                 var queue =
                     Source.Queue<int>(1, OverflowStrategy.Backpressure)
-                        .To(Sink.FromSubscriber<int, Unit>(s))
+                        .To(Sink.FromSubscriber(s))
                         .Run(_materializer);
                 var sub = s.ExpectSubscription();
                 AssertSuccess(queue.OfferAsync(1));
@@ -276,7 +276,7 @@ namespace Akka.Streams.Tests.Dsl
                 var s = this.CreateManualProbe<int>();
                 var queue =
                     Source.Queue<int>(1, OverflowStrategy.DropNew)
-                        .To(Sink.FromSubscriber<int, Unit>(s))
+                        .To(Sink.FromSubscriber(s))
                         .Run(_materializer);
                 var sub = s.ExpectSubscription();
 

--- a/src/core/Akka.Streams.Tests/Dsl/ReverseArrowSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/ReverseArrowSpec.cs
@@ -36,7 +36,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Reverse_Arrows_in_the_GraphDsl_must_work_from_Inlets()
         {
-            var task = RunnableGraph<Task<IImmutableList<int>>>.FromGraph(GraphDsl.Create(Sink, (b, s) =>
+            var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
                 b.To(s.Inlet).From(Source);
                 return ClosedShape.Instance;
@@ -48,7 +48,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Reverse_Arrows_in_the_GraphDsl_must_work_from_SinkShape()
         {
-            var task = RunnableGraph<Task<IImmutableList<int>>>.FromGraph(GraphDsl.Create(Sink, (b, s) =>
+            var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
                 b.To(s).From(Source);
                 return ClosedShape.Instance;
@@ -61,9 +61,9 @@ namespace Akka.Streams.Tests.Dsl
         public void Reverse_Arrows_in_the_GraphDsl_must_work_from_Sink()
         {
             var sub = TestSubscriber.CreateManualProbe<int>(this);
-            RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
+            RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
             {
-                b.To(Streams.Dsl.Sink.FromSubscriber<int, Unit>(sub))
+                b.To(Streams.Dsl.Sink.FromSubscriber(sub))
                     .From(Streams.Dsl.Source.From(Enumerable.Range(1, 3)));
                 
                 return ClosedShape.Instance;
@@ -77,7 +77,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Reverse_Arrows_in_the_GraphDsl_must_not_work_from_Outlets()
         {
-            RunnableGraph<Task<IImmutableList<int>>>.FromGraph(
+            RunnableGraph.FromGraph(
                 GraphDsl.Create<ClosedShape, Task<IImmutableList<int>>>(b =>
                 {
                     var o = b.Add(Source).Outlet;
@@ -91,7 +91,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Reverse_Arrows_in_the_GraphDsl_must_not_work_from_SourceShape()
         {
-            RunnableGraph<Task<IImmutableList<int>>>.FromGraph(
+            RunnableGraph.FromGraph(
                 GraphDsl.Create<ClosedShape, Task<IImmutableList<int>>>(b =>
                 {
                     var o = b.Add(Source);
@@ -112,7 +112,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Reverse_Arrows_in_the_GraphDsl_must_work_from_FlowShape()
         {
-            var task = RunnableGraph<Task<IImmutableList<int>>>.FromGraph(GraphDsl.Create(Sink, (b, s) =>
+            var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
                 var f = b.Add(Flow.Create<int>());
                 b.To(f).From(Source);
@@ -126,7 +126,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Reverse_Arrows_in_the_GraphDsl_must_work_from_UniformFanInShape()
         {
-            var task = RunnableGraph<Task<IImmutableList<int>>>.FromGraph(GraphDsl.Create(Sink, (b, s) =>
+            var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
                 var f = b.Add(new Merge<int, int>(2));
                 b.To(f).From(Source);
@@ -141,7 +141,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Reverse_Arrows_in_the_GraphDsl_must_work_from_UniformFanOutShape()
         {
-            var task = RunnableGraph<Task<IImmutableList<int>>>.FromGraph(GraphDsl.Create(Sink, (b, s) =>
+            var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
                 var f = b.Add(new Broadcast<int>(2));
                 b.To(f).From(Source);
@@ -156,7 +156,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Reverse_Arrows_in_the_GraphDsl_must_work_towards_Outlets()
         {
-            var task = RunnableGraph<Task<IImmutableList<int>>>.FromGraph(GraphDsl.Create(Sink, (b, s) =>
+            var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
                 var o = b.Add(Source).Outlet;
                 b.To(s).From(o);
@@ -169,7 +169,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Reverse_Arrows_in_the_GraphDsl_must_work_towards_SourceShape()
         {
-            var task = RunnableGraph<Task<IImmutableList<int>>>.FromGraph(GraphDsl.Create(Sink, (b, s) =>
+            var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
                 var o = b.Add(Source);
                 b.To(s).From(o);
@@ -182,7 +182,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Reverse_Arrows_in_the_GraphDsl_must_work_towards_Source()
         {
-            var task = RunnableGraph<Task<IImmutableList<int>>>.FromGraph(GraphDsl.Create(Sink, (b, s) =>
+            var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
                 b.To(s).From(Source);
                 return ClosedShape.Instance;
@@ -194,7 +194,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Reverse_Arrows_in_the_GraphDsl_must_work_towards_FlowShape()
         {
-            var task = RunnableGraph<Task<IImmutableList<int>>>.FromGraph(GraphDsl.Create(Sink, (b, s) =>
+            var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
                 var f = b.Add(Flow.Create<int>());
                 b.To(s).From(f);
@@ -208,7 +208,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Reverse_Arrows_in_the_GraphDsl_must_work_towards_UniformFanInShape()
         {
-            var task = RunnableGraph<Task<IImmutableList<int>>>.FromGraph(GraphDsl.Create(Sink, (b, s) =>
+            var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
                 var f = b.Add(new Merge<int, int>(2));
                 b.To(s).From(f);
@@ -223,7 +223,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Reverse_Arrows_in_the_GraphDsl_must_fail_towards_already_full_UniformFanInShape()
         {
-            var task = RunnableGraph<Task<IImmutableList<int>>>.FromGraph(GraphDsl.Create(Sink, (b, s) =>
+            var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
                 var f = b.Add(new Merge<int, int>(2));
                 var src = b.Add(Source);
@@ -243,7 +243,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Reverse_Arrows_in_the_GraphDsl_must_work_towards_UniformFanOutShape()
         {
-            var task = RunnableGraph<Task<IImmutableList<int>>>.FromGraph(GraphDsl.Create(Sink, (b, s) =>
+            var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
                 var f = b.Add(new Broadcast<int>(2));
                 b.To(s).From(f);
@@ -258,7 +258,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Reverse_Arrows_in_the_GraphDsl_must_fail_towards_already_full_UniformFanOutShape()
         {
-            var task = RunnableGraph<Task<IImmutableList<int>>>.FromGraph(GraphDsl.Create(Sink, (b, s) =>
+            var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
                 var f = b.Add(new Broadcast<int>(2));
                 var sink2 = b.Add(Streams.Dsl.Sink.Ignore<int>().MapMaterializedValue(_ => MaterializedValue));
@@ -279,7 +279,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Reverse_Arrows_in_the_GraphDsl_must__work_across_a_Flow()
         {
-            var task = RunnableGraph<Task<IImmutableList<int>>>.FromGraph(GraphDsl.Create(Sink, (b, s) =>
+            var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
                 b.To(s).Via(Flow.Create<int>().MapMaterializedValue(_ => MaterializedValue)).From(Source);
                 return ClosedShape.Instance;
@@ -291,7 +291,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Reverse_Arrows_in_the_GraphDsl_must_work_across_a_FlowShape()
         {
-            var task = RunnableGraph<Task<IImmutableList<int>>>.FromGraph(GraphDsl.Create(Sink, (b, s) =>
+            var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
                 b.To(s).Via(b.Add(Flow.Create<int>().MapMaterializedValue(_ => MaterializedValue))).From(Source);
                 

--- a/src/core/Akka.Streams.Tests/Dsl/SinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SinkSpec.cs
@@ -40,7 +40,7 @@ namespace Akka.Streams.Tests.Dsl
                     var closure = i;
                     b.From(broadcast.Out(i))
                         .Via(Flow.Create<int>().Filter(x => x == closure))
-                        .To(Sink.FromSubscriber<int, Unit>(probes[i]));
+                        .To(Sink.FromSubscriber(probes[i]));
                 }
                 return new SinkShape<int>(broadcast.In);
             }));
@@ -57,16 +57,16 @@ namespace Akka.Streams.Tests.Dsl
         public void A_Sink_must_be_composable_with_importing_1_modules()
         {
             var probes = CreateProbes();
-            var sink = Sink.FromGraph(GraphDsl.Create(Sink.FromSubscriber<int, Unit>(probes[0]), (b, shape) =>
+            var sink = Sink.FromGraph(GraphDsl.Create(Sink.FromSubscriber(probes[0]), (b, shape) =>
             {
                 var broadcast = b.Add(new Broadcast<int>(3));
                 b.From(broadcast.Out(0)).Via(Flow.Create<int>().Filter(x => x == 0)).To(shape.Inlet);
                 b.From(broadcast.Out(1))
                     .Via(Flow.Create<int>().Filter(x => x == 1))
-                    .To(Sink.FromSubscriber<int, Unit>(probes[1]));
+                    .To(Sink.FromSubscriber(probes[1]));
                 b.From(broadcast.Out(2))
                     .Via(Flow.Create<int>().Filter(x => x == 2))
-                    .To(Sink.FromSubscriber<int, Unit>(probes[2]));
+                    .To(Sink.FromSubscriber(probes[2]));
                 return new SinkShape<int>(broadcast.In);
             }));
             Source.From(new[] { 0, 1, 2 }).RunWith(sink, Materializer);
@@ -83,15 +83,15 @@ namespace Akka.Streams.Tests.Dsl
         {
             var probes = CreateProbes();
             var sink =
-                Sink.FromGraph(GraphDsl.Create(Sink.FromSubscriber<int, Unit>(probes[0]),
-                    Sink.FromSubscriber<int, Unit>(probes[1]), (_, __) => Unit.Instance, (b, shape0, shape1) =>
+                Sink.FromGraph(GraphDsl.Create(Sink.FromSubscriber(probes[0]),
+                    Sink.FromSubscriber(probes[1]), (_, __) => Unit.Instance, (b, shape0, shape1) =>
                     {
                         var broadcast = b.Add(new Broadcast<int>(3));
                         b.From(broadcast.Out(0)).Via(Flow.Create<int>().Filter(x => x == 0)).To(shape0.Inlet);
                         b.From(broadcast.Out(1)).Via(Flow.Create<int>().Filter(x => x == 1)).To(shape1.Inlet);
                         b.From(broadcast.Out(2))
                             .Via(Flow.Create<int>().Filter(x => x == 2))
-                            .To(Sink.FromSubscriber<int, Unit>(probes[2]));
+                            .To(Sink.FromSubscriber(probes[2]));
                         return new SinkShape<int>(broadcast.In);
                     }));
             Source.From(new[] { 0, 1, 2 }).RunWith(sink, Materializer);
@@ -108,8 +108,8 @@ namespace Akka.Streams.Tests.Dsl
         {
             var probes = CreateProbes();
             var sink =
-                Sink.FromGraph(GraphDsl.Create(Sink.FromSubscriber<int, Unit>(probes[0]),
-                    Sink.FromSubscriber<int, Unit>(probes[1]), Sink.FromSubscriber<int, Unit>(probes[2]),
+                Sink.FromGraph(GraphDsl.Create(Sink.FromSubscriber(probes[0]),
+                    Sink.FromSubscriber(probes[1]), Sink.FromSubscriber(probes[2]),
                     (_, __, ___) => Unit.Instance, (b, shape0, shape1, shape2) =>
                     {
                         var broadcast = b.Add(new Broadcast<int>(3));
@@ -131,8 +131,8 @@ namespace Akka.Streams.Tests.Dsl
         public void A_Sink_must_combine_to_many_outputs_with_simplified_API()
         {
             var probes = CreateProbes();
-            var sink = Sink.Combine(i => new Broadcast<int>(i), Sink.FromSubscriber<int, Unit>(probes[0]),
-                Sink.FromSubscriber<int, Unit>(probes[1]), Sink.FromSubscriber<int, Unit>(probes[2]));
+            var sink = Sink.Combine(i => new Broadcast<int>(i), Sink.FromSubscriber(probes[0]),
+                Sink.FromSubscriber(probes[1]), Sink.FromSubscriber(probes[2]));
 
             Source.From(new[] { 0, 1, 2 }).RunWith(sink, Materializer);
 
@@ -151,8 +151,8 @@ namespace Akka.Streams.Tests.Dsl
         public void A_Sink_must_combine_to_two_sinks_with_simplified_API()
         {
             var probes = CreateProbes().Take(2).ToArray();
-            var sink = Sink.Combine(i => new Broadcast<int>(i), Sink.FromSubscriber<int, Unit>(probes[0]),
-                Sink.FromSubscriber<int, Unit>(probes[1]));
+            var sink = Sink.Combine(i => new Broadcast<int>(i), Sink.FromSubscriber(probes[0]),
+                Sink.FromSubscriber(probes[1]));
 
             Source.From(new[] { 0, 1, 2 }).RunWith(sink, Materializer);
 

--- a/src/core/Akka.Streams.Tests/Dsl/SourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SourceSpec.cs
@@ -183,7 +183,7 @@ namespace Akka.Streams.Tests.Dsl
                         b.From(i3.Outlet).To(m.In(3));
                         b.From(i4.Outlet).To(m.In(4));
                         return new SourceShape<int>(m.Out);
-                    })).To(Sink.FromSubscriber<int, Unit>(outProbe)).Run(Materializer);
+                    })).To(Sink.FromSubscriber(outProbe)).Run(Materializer);
 
             for (var i = 0; i < 5; i++)
                 probes[i].Subscribe(s[i]);
@@ -209,11 +209,11 @@ namespace Akka.Streams.Tests.Dsl
         public void Composite_Source_must_combine_from_many_inputs_with_simplified_API()
         {
             var probes = Enumerable.Range(1, 3).Select(_ => TestPublisher.CreateManualProbe<int>(this)).ToList();
-            var source = probes.Select(Source.FromPublisher<int, Unit>).ToList();
+            var source = probes.Select(Source.FromPublisher).ToList();
             var outProbe = TestSubscriber.CreateManualProbe<int>(this);
 
             Source.Combine(source[0], source[1], i => new Merge<int, int>(i), source[2])
-                .To(Sink.FromSubscriber<int, Unit>(outProbe))
+                .To(Sink.FromSubscriber(outProbe))
                 .Run(Materializer);
 
             var sub = outProbe.ExpectSubscription();
@@ -238,11 +238,11 @@ namespace Akka.Streams.Tests.Dsl
         public void Composite_Source_must_combine_from_two_inputs_with_simplified_API()
         {
             var probes = Enumerable.Range(1, 2).Select(_ => TestPublisher.CreateManualProbe<int>(this)).ToList();
-            var source = probes.Select(Source.FromPublisher<int, Unit>).ToList();
+            var source = probes.Select(Source.FromPublisher).ToList();
             var outProbe = TestSubscriber.CreateManualProbe<int>(this);
 
             Source.Combine(source[0], source[1], i => new Merge<int, int>(i))
-                .To(Sink.FromSubscriber<int, Unit>(outProbe))
+                .To(Sink.FromSubscriber(outProbe))
                 .Run(Materializer);
 
             var sub = outProbe.ExpectSubscription();

--- a/src/core/Akka.Streams.Tests/Dsl/SubscriberSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SubscriberSinkSpec.cs
@@ -24,7 +24,7 @@ namespace Akka.Streams.Tests.Dsl
             this.AssertAllStagesStopped(() =>
             {
                 var c = this.CreateManualProbe<int>();
-                Source.From(Enumerable.Range(1, 3)).To(Sink.FromSubscriber<int, Unit>(c)).Run(Materializer);
+                Source.From(Enumerable.Range(1, 3)).To(Sink.FromSubscriber(c)).Run(Materializer);
 
                 var s = c.ExpectSubscription();
                 s.Request(3);

--- a/src/core/Akka.Streams.Tests/Dsl/SubscriberSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SubscriberSourceSpec.cs
@@ -24,7 +24,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             var f = Source.AsSubscriber<int>()
                 .MapMaterializedValue(
-                    s => Source.From(Enumerable.Range(1, 3)).RunWith(Sink.FromSubscriber<int, Unit>(s), Materializer))
+                    s => Source.From(Enumerable.Range(1, 3)).RunWith(Sink.FromSubscriber(s), Materializer))
                 .RunWith(Sink.Fold<int, int>(0, (sum, i) => sum + i), Materializer);
 
             f.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();

--- a/src/core/Akka.Streams.Tests/Dsl/TickSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/TickSourceSpec.cs
@@ -26,7 +26,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var c = TestSubscriber.CreateManualProbe<string>(this);
                 Source.Tick(TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(500), "tick")
-                    .To(Sink.FromSubscriber<string, Unit>(c))
+                    .To(Sink.FromSubscriber(c))
                     .Run(Materializer);
                 var sub = c.ExpectSubscription();
                 sub.Request(3);
@@ -46,7 +46,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             var c = TestSubscriber.CreateManualProbe<string>(this);
             Source.Tick(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), "tick")
-                .To(Sink.FromSubscriber<string, Unit>(c))
+                .To(Sink.FromSubscriber(c))
                 .Run(Materializer);
             var sub = c.ExpectSubscription();
             sub.Request(2);
@@ -90,7 +90,7 @@ namespace Akka.Streams.Tests.Dsl
             this.AssertAllStagesStopped(() =>
             {
                 var c = TestSubscriber.CreateManualProbe<int>(this);
-                RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
+                RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
                 {
                     var zip = b.Add(new Zip<int, string>());
                     b.From(Source.From(Enumerable.Range(1, 100))).To(zip.In0);
@@ -98,7 +98,7 @@ namespace Akka.Streams.Tests.Dsl
                         .MapMaterializedValue(_ => Unit.Instance)).To(zip.In1);
                     b.From(zip.Out)
                         .Via(Flow.Create<Tuple<int, string>>().Map(t => t.Item1))
-                        .To(Sink.FromSubscriber<int, Unit>(c));
+                        .To(Sink.FromSubscriber(c));
                     return ClosedShape.Instance;
                 })).Run(Materializer);
                 var sub = c.ExpectSubscription();
@@ -118,7 +118,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var c = TestSubscriber.CreateManualProbe<string>(this);
                 var tickSource = Source.Tick(TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(500), "tick");
-                var cancelable = tickSource.To(Sink.FromSubscriber<string, Unit>(c)).Run(Materializer);
+                var cancelable = tickSource.To(Sink.FromSubscriber(c)).Run(Materializer);
                 var sub = c.ExpectSubscription();
                 sub.Request(3);
                 c.ExpectNoMsg(TimeSpan.FromMilliseconds(600));

--- a/src/core/Akka.Streams.Tests/IO/FileSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/FileSourceSpec.cs
@@ -141,7 +141,7 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void FileSource_should_onError_wen_trying_to_read_from_file_which_does_not_exist()
+        public void FileSource_should_onError_when_trying_to_read_from_file_which_does_not_exist()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -267,8 +267,8 @@ namespace Akka.Streams.Tests.IO
         {
             base.AfterAll();
 
-            _manyLinesPath.Delete();
-            _testFilePath.Delete();
+            _manyLinesPath?.Delete();
+            _testFilePath?.Delete();
         }
     }
 }

--- a/src/core/Akka.Streams.Tests/IO/TcpHelper.cs
+++ b/src/core/Akka.Streams.Tests/IO/TcpHelper.cs
@@ -88,7 +88,7 @@ namespace Akka.Streams.Tests.IO
             => Props.Create(() => new TestClient(connection)).WithDispatcher("akka.test.stream-dispatcher");
 
         protected static Props TestServerProps(EndPoint address, IActorRef probe)
-            => Props.Create(() => new TestSerer(address, probe)).WithDispatcher("akka.test.stream-dispatcher");
+            => Props.Create(() => new TestServer(address, probe)).WithDispatcher("akka.test.stream-dispatcher");
 
 
         protected class TestClient : UntypedActor
@@ -174,12 +174,12 @@ namespace Akka.Streams.Tests.IO
             private ServerClose() { }
         }
 
-        protected class TestSerer : UntypedActor
+        protected class TestServer : UntypedActor
         {
             private readonly IActorRef _probe;
             private IActorRef _listener = Nobody.Instance;
 
-            public TestSerer(EndPoint address, IActorRef probe)
+            public TestServer(EndPoint address, IActorRef probe)
             {
                 _probe = probe;
                 Context.System.Tcp().Tell(new Tcp.Bind(Self, address, 100, null, pullMode: true));
@@ -216,6 +216,7 @@ namespace Akka.Streams.Tests.IO
 
                 ServerProbe = testkit.CreateTestProbe();
                 ServerRef = testkit.ActorOf(TestServerProps(Address, ServerProbe.Ref));
+                ServerProbe.ExpectMsg<Tcp.Bound>();
             }
 
             public EndPoint Address { get; }

--- a/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
@@ -33,9 +33,9 @@ namespace Akka.Streams.Tests.IO
 
                 var tcpReadProbe = new TcpReadProbe(this);
                 var tcpWriteProbe = new TcpWriteProbe(this);
-                Source.FromPublisher<ByteString, ByteString>(tcpWriteProbe.PublisherProbe)
+                Source.FromPublisher(tcpWriteProbe.PublisherProbe)
                     .Via(new Tcp().CreateExtension(Sys as ExtendedActorSystem).OutgoingConnection(server.Address))
-                    .To(Sink.FromSubscriber<ByteString, Unit>(tcpReadProbe.SubscriberProbe))
+                    .To(Sink.FromSubscriber(tcpReadProbe.SubscriberProbe))
                     .Run(Materializer);
                 var serverConnection = server.WaitAccept();
 
@@ -69,7 +69,7 @@ namespace Akka.Streams.Tests.IO
 
             var idle = new TcpWriteProbe(this); //Just register an idle upstream
             var resultFuture =
-                Source.FromPublisher<ByteString, ByteString>(idle.PublisherProbe)
+                Source.FromPublisher(idle.PublisherProbe)
                     .Via(new Tcp().CreateExtension(Sys as ExtendedActorSystem).OutgoingConnection(server.Address))
                     .RunFold(ByteString.Empty, (acc, input) => acc + input, Materializer);
             var serverConnection = server.WaitAccept();
@@ -92,9 +92,9 @@ namespace Akka.Streams.Tests.IO
 
                 var tcpWriteProbe = new TcpWriteProbe(this);
                 var tcpReadProbe = new TcpReadProbe(this);
-                Source.FromPublisher<ByteString, ByteString>(tcpWriteProbe.PublisherProbe)
+                Source.FromPublisher(tcpWriteProbe.PublisherProbe)
                     .Via(new Tcp().CreateExtension(Sys as ExtendedActorSystem).OutgoingConnection(server.Address))
-                    .To(Sink.FromSubscriber<ByteString, ByteString>(tcpReadProbe.SubscriberProbe))
+                    .To(Sink.FromSubscriber(tcpReadProbe.SubscriberProbe))
                     .Run(Materializer);
                 var serverConnection = server.WaitAccept();
 
@@ -130,9 +130,9 @@ namespace Akka.Streams.Tests.IO
 
                 var tcpWriteProbe = new TcpWriteProbe(this);
                 var tcpReadProbe = new TcpReadProbe(this);
-                Source.FromPublisher<ByteString, ByteString>(tcpWriteProbe.PublisherProbe)
+                Source.FromPublisher(tcpWriteProbe.PublisherProbe)
                     .Via(new Tcp().CreateExtension(Sys as ExtendedActorSystem).OutgoingConnection(server.Address))
-                    .To(Sink.FromSubscriber<ByteString, ByteString>(tcpReadProbe.SubscriberProbe))
+                    .To(Sink.FromSubscriber(tcpReadProbe.SubscriberProbe))
                     .Run(Materializer);
                 var serverConnection = server.WaitAccept();
 
@@ -166,9 +166,9 @@ namespace Akka.Streams.Tests.IO
 
                 var tcpWriteProbe = new TcpWriteProbe(this);
                 var tcpReadProbe = new TcpReadProbe(this);
-                Source.FromPublisher<ByteString, ByteString>(tcpWriteProbe.PublisherProbe)
+                Source.FromPublisher(tcpWriteProbe.PublisherProbe)
                     .Via(new Tcp().CreateExtension(Sys as ExtendedActorSystem).OutgoingConnection(server.Address))
-                    .To(Sink.FromSubscriber<ByteString, ByteString>(tcpReadProbe.SubscriberProbe))
+                    .To(Sink.FromSubscriber(tcpReadProbe.SubscriberProbe))
                     .Run(Materializer);
                 var serverConnection = server.WaitAccept();
 
@@ -208,9 +208,9 @@ namespace Akka.Streams.Tests.IO
 
                 var tcpWriteProbe = new TcpWriteProbe(this);
                 var tcpReadProbe = new TcpReadProbe(this);
-                Source.FromPublisher<ByteString, ByteString>(tcpWriteProbe.PublisherProbe)
+                Source.FromPublisher(tcpWriteProbe.PublisherProbe)
                     .Via(new Tcp().CreateExtension(Sys as ExtendedActorSystem).OutgoingConnection(server.Address))
-                    .To(Sink.FromSubscriber<ByteString, ByteString>(tcpReadProbe.SubscriberProbe))
+                    .To(Sink.FromSubscriber(tcpReadProbe.SubscriberProbe))
                     .Run(Materializer);
                 var serverConnection = server.WaitAccept();
 
@@ -245,9 +245,9 @@ namespace Akka.Streams.Tests.IO
 
                 var tcpWriteProbe = new TcpWriteProbe(this);
                 var tcpReadProbe = new TcpReadProbe(this);
-                Source.FromPublisher<ByteString, ByteString>(tcpWriteProbe.PublisherProbe)
+                Source.FromPublisher(tcpWriteProbe.PublisherProbe)
                     .Via(new Tcp().CreateExtension(Sys as ExtendedActorSystem).OutgoingConnection(server.Address))
-                    .To(Sink.FromSubscriber<ByteString, ByteString>(tcpReadProbe.SubscriberProbe))
+                    .To(Sink.FromSubscriber(tcpReadProbe.SubscriberProbe))
                     .Run(Materializer);
                 var serverConnection = server.WaitAccept();
 
@@ -279,9 +279,9 @@ namespace Akka.Streams.Tests.IO
 
                 var tcpWriteProbe = new TcpWriteProbe(this);
                 var tcpReadProbe = new TcpReadProbe(this);
-                Source.FromPublisher<ByteString, ByteString>(tcpWriteProbe.PublisherProbe)
+                Source.FromPublisher(tcpWriteProbe.PublisherProbe)
                     .Via(new Tcp().CreateExtension(Sys as ExtendedActorSystem).OutgoingConnection(server.Address))
-                    .To(Sink.FromSubscriber<ByteString, ByteString>(tcpReadProbe.SubscriberProbe))
+                    .To(Sink.FromSubscriber(tcpReadProbe.SubscriberProbe))
                     .Run(Materializer);
                 var serverConnection = server.WaitAccept();
 
@@ -315,9 +315,9 @@ namespace Akka.Streams.Tests.IO
                 var tcpWriteProbe = new TcpWriteProbe(this);
                 var tcpReadProbe = new TcpReadProbe(this);
 
-                Source.FromPublisher<ByteString, ByteString>(tcpWriteProbe.PublisherProbe)
+                Source.FromPublisher(tcpWriteProbe.PublisherProbe)
                     .Via(new Tcp().CreateExtension(Sys as ExtendedActorSystem).OutgoingConnection(server.Address))
-                    .To(Sink.FromSubscriber<ByteString, ByteString>(tcpReadProbe.SubscriberProbe))
+                    .To(Sink.FromSubscriber(tcpReadProbe.SubscriberProbe))
                     .Run(Materializer);
                 var serverConnection = server.WaitAccept();
 
@@ -341,14 +341,14 @@ namespace Akka.Streams.Tests.IO
             var tcpReadProbe2 = new TcpReadProbe(this);
             var outgoingConnection = new Tcp().CreateExtension(Sys as ExtendedActorSystem).OutgoingConnection(server.Address);
 
-            var conn1F = Source.FromPublisher<ByteString, ByteString>(tcpWriteProbe1.PublisherProbe)
+            var conn1F = Source.FromPublisher(tcpWriteProbe1.PublisherProbe)
                     .ViaMaterialized(outgoingConnection, Keep.Both)
-                    .To(Sink.FromSubscriber<ByteString, ByteString>(tcpReadProbe1.SubscriberProbe))
+                    .To(Sink.FromSubscriber(tcpReadProbe1.SubscriberProbe))
                     .Run(Materializer).Item2;
             var serverConnection1 = server.WaitAccept();
-            var conn2F = Source.FromPublisher<ByteString, ByteString>(tcpWriteProbe2.PublisherProbe)
+            var conn2F = Source.FromPublisher(tcpWriteProbe2.PublisherProbe)
                     .ViaMaterialized(outgoingConnection, Keep.Both)
-                    .To(Sink.FromSubscriber<ByteString, ByteString>(tcpReadProbe2.SubscriberProbe))
+                    .To(Sink.FromSubscriber(tcpReadProbe2.SubscriberProbe))
                     .Run(Materializer).Item2;
             var serverConnection2 = server.WaitAccept();
 

--- a/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
@@ -34,7 +34,7 @@ namespace Akka.Streams.Tests.IO
                 var tcpReadProbe = new TcpReadProbe(this);
                 var tcpWriteProbe = new TcpWriteProbe(this);
                 Source.FromPublisher(tcpWriteProbe.PublisherProbe)
-                    .Via(new Tcp().CreateExtension(Sys as ExtendedActorSystem).OutgoingConnection(server.Address))
+                    .Via(Sys.TcpStream().OutgoingConnection(server.Address))
                     .To(Sink.FromSubscriber(tcpReadProbe.SubscriberProbe))
                     .Run(Materializer);
                 var serverConnection = server.WaitAccept();
@@ -51,7 +51,7 @@ namespace Akka.Streams.Tests.IO
             var expectedOutput = ByteString.Create(Enumerable.Range(0, 255).Select(Convert.ToByte).ToArray());
 
             Source.From(testInput)
-                .Via(new Tcp().CreateExtension(Sys as ExtendedActorSystem).OutgoingConnection(server.Address))
+                .Via(Sys.TcpStream().OutgoingConnection(server.Address))
                 .To(Sink.Ignore<ByteString>())
                 .Run(Materializer);
 
@@ -70,7 +70,7 @@ namespace Akka.Streams.Tests.IO
             var idle = new TcpWriteProbe(this); //Just register an idle upstream
             var resultFuture =
                 Source.FromPublisher(idle.PublisherProbe)
-                    .Via(new Tcp().CreateExtension(Sys as ExtendedActorSystem).OutgoingConnection(server.Address))
+                    .Via(Sys.TcpStream().OutgoingConnection(server.Address))
                     .RunFold(ByteString.Empty, (acc, input) => acc + input, Materializer);
             var serverConnection = server.WaitAccept();
 
@@ -93,7 +93,7 @@ namespace Akka.Streams.Tests.IO
                 var tcpWriteProbe = new TcpWriteProbe(this);
                 var tcpReadProbe = new TcpReadProbe(this);
                 Source.FromPublisher(tcpWriteProbe.PublisherProbe)
-                    .Via(new Tcp().CreateExtension(Sys as ExtendedActorSystem).OutgoingConnection(server.Address))
+                    .Via(Sys.TcpStream().OutgoingConnection(server.Address))
                     .To(Sink.FromSubscriber(tcpReadProbe.SubscriberProbe))
                     .Run(Materializer);
                 var serverConnection = server.WaitAccept();
@@ -131,7 +131,7 @@ namespace Akka.Streams.Tests.IO
                 var tcpWriteProbe = new TcpWriteProbe(this);
                 var tcpReadProbe = new TcpReadProbe(this);
                 Source.FromPublisher(tcpWriteProbe.PublisherProbe)
-                    .Via(new Tcp().CreateExtension(Sys as ExtendedActorSystem).OutgoingConnection(server.Address))
+                    .Via(Sys.TcpStream().OutgoingConnection(server.Address))
                     .To(Sink.FromSubscriber(tcpReadProbe.SubscriberProbe))
                     .Run(Materializer);
                 var serverConnection = server.WaitAccept();
@@ -167,7 +167,7 @@ namespace Akka.Streams.Tests.IO
                 var tcpWriteProbe = new TcpWriteProbe(this);
                 var tcpReadProbe = new TcpReadProbe(this);
                 Source.FromPublisher(tcpWriteProbe.PublisherProbe)
-                    .Via(new Tcp().CreateExtension(Sys as ExtendedActorSystem).OutgoingConnection(server.Address))
+                    .Via(Sys.TcpStream().OutgoingConnection(server.Address))
                     .To(Sink.FromSubscriber(tcpReadProbe.SubscriberProbe))
                     .Run(Materializer);
                 var serverConnection = server.WaitAccept();
@@ -209,7 +209,7 @@ namespace Akka.Streams.Tests.IO
                 var tcpWriteProbe = new TcpWriteProbe(this);
                 var tcpReadProbe = new TcpReadProbe(this);
                 Source.FromPublisher(tcpWriteProbe.PublisherProbe)
-                    .Via(new Tcp().CreateExtension(Sys as ExtendedActorSystem).OutgoingConnection(server.Address))
+                    .Via(Sys.TcpStream().OutgoingConnection(server.Address))
                     .To(Sink.FromSubscriber(tcpReadProbe.SubscriberProbe))
                     .Run(Materializer);
                 var serverConnection = server.WaitAccept();
@@ -246,7 +246,7 @@ namespace Akka.Streams.Tests.IO
                 var tcpWriteProbe = new TcpWriteProbe(this);
                 var tcpReadProbe = new TcpReadProbe(this);
                 Source.FromPublisher(tcpWriteProbe.PublisherProbe)
-                    .Via(new Tcp().CreateExtension(Sys as ExtendedActorSystem).OutgoingConnection(server.Address))
+                    .Via(Sys.TcpStream().OutgoingConnection(server.Address))
                     .To(Sink.FromSubscriber(tcpReadProbe.SubscriberProbe))
                     .Run(Materializer);
                 var serverConnection = server.WaitAccept();
@@ -280,7 +280,7 @@ namespace Akka.Streams.Tests.IO
                 var tcpWriteProbe = new TcpWriteProbe(this);
                 var tcpReadProbe = new TcpReadProbe(this);
                 Source.FromPublisher(tcpWriteProbe.PublisherProbe)
-                    .Via(new Tcp().CreateExtension(Sys as ExtendedActorSystem).OutgoingConnection(server.Address))
+                    .Via(Sys.TcpStream().OutgoingConnection(server.Address))
                     .To(Sink.FromSubscriber(tcpReadProbe.SubscriberProbe))
                     .Run(Materializer);
                 var serverConnection = server.WaitAccept();
@@ -316,7 +316,7 @@ namespace Akka.Streams.Tests.IO
                 var tcpReadProbe = new TcpReadProbe(this);
 
                 Source.FromPublisher(tcpWriteProbe.PublisherProbe)
-                    .Via(new Tcp().CreateExtension(Sys as ExtendedActorSystem).OutgoingConnection(server.Address))
+                    .Via(Sys.TcpStream().OutgoingConnection(server.Address))
                     .To(Sink.FromSubscriber(tcpReadProbe.SubscriberProbe))
                     .Run(Materializer);
                 var serverConnection = server.WaitAccept();
@@ -380,8 +380,8 @@ namespace Akka.Streams.Tests.IO
                 var writeButIgnoreRead = Flow.FromSinkAndSource(Sink.Ignore<ByteString>(),
                     Source.Single(ByteString.FromString("Early response")), Keep.Right);
 
-                var task = 
-                    new Tcp().CreateExtension(Sys as ExtendedActorSystem)
+                var task =
+                    Sys.TcpStream()
                         .Bind(serverAddress.Address.ToString(), serverAddress.Port, halfClose: false)
                         .ToMaterialized(
                             Sink.ForEach<Tcp.IncomingConnection>(conn => conn.Flow.Join(writeButIgnoreRead)),
@@ -411,8 +411,7 @@ namespace Akka.Streams.Tests.IO
         {
             var serverAddress = TestUtils.TemporaryServerAddress();
 
-            var task =
-                new Tcp().CreateExtension(Sys as ExtendedActorSystem)
+            var task = Sys.TcpStream()
                     .Bind(serverAddress.Address.ToString(), serverAddress.Port, halfClose: false)
                     .ToMaterialized(
                         Sink.ForEach<Tcp.IncomingConnection>(conn => conn.Flow.Join(Flow.Create<ByteString>())),
@@ -439,7 +438,7 @@ namespace Akka.Streams.Tests.IO
             var mat2 = ActorMaterializer.Create(system2);
 
             var serverAddress = TestUtils.TemporaryServerAddress();
-            var binding = new Tcp().CreateExtension(system2 as ExtendedActorSystem)
+            var binding = Sys.TcpStream()
                 .BindAndHandle(Flow.Create<ByteString>(), mat2, serverAddress.Address.ToString(), serverAddress.Port);
 
             var result = Source.Maybe<ByteString>()
@@ -464,11 +463,7 @@ namespace Akka.Streams.Tests.IO
             writeProbe.Write(testData);
             serverConnection.WaitRead().ShouldBeEquivalentTo(testData);
         }
-
-
-
-
-
+        
         private Sink<Tcp.IncomingConnection, Task> EchoHandler() =>
             Sink.ForEach<Tcp.IncomingConnection>(c => c.Flow.Join(Flow.Create<ByteString>()).Run(Materializer));
 
@@ -476,7 +471,7 @@ namespace Akka.Streams.Tests.IO
         public void Tcp_listen_stream_must_be_able_to_implement_echo()
         {
             var serverAddress = TestUtils.TemporaryServerAddress();
-            var t = new Tcp().CreateExtension(Sys as ExtendedActorSystem)
+            var t = Sys.TcpStream()
                 .Bind(serverAddress.Address.ToString(), serverAddress.Port)
                 .ToMaterialized(EchoHandler(), Keep.Both)
                 .Run(Materializer);
@@ -491,7 +486,7 @@ namespace Akka.Streams.Tests.IO
             var expectedOutput = testInput.Aggregate(ByteString.Empty, (agg, b) => agg.Concat(b));
             var resultFuture =
                 Source.From(testInput)
-                    .Via(new Tcp().CreateExtension(Sys as ExtendedActorSystem).OutgoingConnection(serverAddress))
+                    .Via(Sys.TcpStream().OutgoingConnection(serverAddress))
                     .RunFold(ByteString.Empty, (agg, b) => agg.Concat(b), Materializer);
 
             resultFuture.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
@@ -504,7 +499,7 @@ namespace Akka.Streams.Tests.IO
         public void Tcp_listen_stream_must_work_with_a_chain_of_echoes()
         {
             var serverAddress = TestUtils.TemporaryServerAddress();
-            var t = new Tcp().CreateExtension(Sys as ExtendedActorSystem)
+            var t = Sys.TcpStream()
                 .Bind(serverAddress.Address.ToString(), serverAddress.Port)
                 .ToMaterialized(EchoHandler(), Keep.Both)
                 .Run(Materializer);
@@ -515,7 +510,7 @@ namespace Akka.Streams.Tests.IO
             bindingFuture.Wait(100).Should().BeTrue();
             var binding = bindingFuture.Result;
 
-            var echoConnection = new Tcp().CreateExtension(Sys as ExtendedActorSystem).OutgoingConnection(serverAddress);
+            var echoConnection = Sys.TcpStream().OutgoingConnection(serverAddress);
 
             var testInput = Enumerable.Range(0, 255).Select(i => ByteString.Create(new[] { Convert.ToByte(i) })).ToList();
             var expectedOutput = testInput.Aggregate(ByteString.Empty, (agg, b) => agg.Concat(b));
@@ -581,7 +576,7 @@ namespace Akka.Streams.Tests.IO
             this.AssertAllStagesStopped(() =>
             {
                 var serverAddress = TestUtils.TemporaryServerAddress();
-                new Tcp().CreateExtension(Sys as ExtendedActorSystem)
+                Sys.TcpStream()
                     .Bind(serverAddress.Address.ToString(), serverAddress.Port)
                     .Take(1).RunForeach(c =>
                     {
@@ -591,7 +586,7 @@ namespace Akka.Streams.Tests.IO
 
                 var total = Source.From(
                     Enumerable.Range(0, 1000).Select(_ => ByteString.Create(new byte[] {0})))
-                    .Via(new Tcp().CreateExtension(Sys as ExtendedActorSystem).OutgoingConnection(serverAddress))
+                    .Via(Sys.TcpStream().OutgoingConnection(serverAddress))
                     .RunFold(0, (i, s) => i + s.Count, Materializer);
 
                 total.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
@@ -612,13 +607,13 @@ namespace Akka.Streams.Tests.IO
                     return c;
                 }).Grouped(2).Take(1).Map(e => e.First());
 
-                new Tcp().CreateExtension(Sys as ExtendedActorSystem)
+                Sys.TcpStream()
                     .Bind(serverAddress.Address.ToString(), serverAddress.Port)
                     .Via(takeTwoAndDropSecond)
                     .RunForeach(c => c.Flow.Join(Flow.Create<ByteString>()).Run(Materializer), Materializer);
 
                 var folder = Source.From(Enumerable.Range(0, 100).Select(_ => ByteString.Create(new byte[] {0})))
-                    .Via(new Tcp().CreateExtension(Sys as ExtendedActorSystem).OutgoingConnection(serverAddress))
+                    .Via(Sys.TcpStream().OutgoingConnection(serverAddress))
                     .Fold(0, (i, s) => i + s.Count)
                     .ToMaterialized(Sink.First<int>(), Keep.Right);
 

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/ActorGraphInterpreterSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/ActorGraphInterpreterSpec.cs
@@ -108,7 +108,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                     .Grouped(200)
                     .ToMaterialized(Sink.First<IEnumerable<int>>(), Keep.Right);
 
-                var tasks = RunnableGraph<Tuple<Task<IEnumerable<int>>, Task<IEnumerable<int>>>>.FromGraph(
+                var tasks = RunnableGraph.FromGraph(
                     GraphDsl.Create(takeAll, takeAll, Keep.Both, (builder, shape1, shape2) =>
                     {
                         var bidi = builder.Add(rotatedBidi);
@@ -173,13 +173,13 @@ namespace Akka.Streams.Tests.Implementation.Fusing
 
                 var upstream = TestPublisher.CreateProbe<int>(this);
 
-                RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
+                RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
                 {
                     var faily = b.Add(failyStage);
 
-                    b.From(Source.FromPublisher<int, Unit>(upstream)).To(faily.In);
-                    b.From(faily.Out0).To(Sink.FromSubscriber<int, Unit>(downstream0));
-                    b.From(faily.Out1).To(Sink.FromSubscriber<int, Unit>(downstream1));
+                    b.From(Source.FromPublisher(upstream)).To(faily.In);
+                    b.From(faily.Out0).To(Sink.FromSubscriber(downstream0));
+                    b.From(faily.Out1).To(Sink.FromSubscriber(downstream1));
 
                     return ClosedShape.Instance;
                 })).Run(noFuzzMaterializer);

--- a/src/core/Akka.Streams.Tests/Implementation/TimeoutsSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/TimeoutsSpec.cs
@@ -60,7 +60,7 @@ namespace Akka.Streams.Tests.Implementation
                 var downstreamProbe = this.CreateProbe<int>();
                 Source.Maybe<int>()
                 .InitialTimeout(TimeSpan.FromSeconds(1))
-                .RunWith(Sink.FromSubscriber<int, Unit>(downstreamProbe), Materializer);
+                .RunWith(Sink.FromSubscriber(downstreamProbe), Materializer);
 
                 downstreamProbe.ExpectSubscription();
                 downstreamProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
@@ -108,9 +108,9 @@ namespace Akka.Streams.Tests.Implementation
                 var upstreamProbe = TestPublisher.CreateProbe<int>(this);
                 var downstreamProbe = this.CreateProbe<int>();
 
-                Source.FromPublisher<int, Unit>(upstreamProbe)
+                Source.FromPublisher<int>(upstreamProbe)
                     .CompletionTimeout(TimeSpan.FromSeconds(2))
-                    .RunWith(Sink.FromSubscriber<int, Unit>(downstreamProbe), Materializer);
+                    .RunWith(Sink.FromSubscriber(downstreamProbe), Materializer);
 
 
                 upstreamProbe.SendNext(1);
@@ -164,9 +164,9 @@ namespace Akka.Streams.Tests.Implementation
                 var upstreamProbe = TestPublisher.CreateProbe<int>(this);
                 var downstreamProbe = this.CreateProbe<int>();
 
-                Source.FromPublisher<int, Unit>(upstreamProbe)
+                Source.FromPublisher<int>(upstreamProbe)
                     .IdleTimeout(TimeSpan.FromSeconds(1))
-                    .RunWith(Sink.FromSubscriber<int, Unit>(downstreamProbe), Materializer);
+                    .RunWith(Sink.FromSubscriber(downstreamProbe), Materializer);
 
                 // Two seconds in overall, but won't timeout until time between elements is large enough
                 // (i.e. this works differently from completionTimeout)
@@ -208,9 +208,9 @@ namespace Akka.Streams.Tests.Implementation
                 var downstreamWriter = TestPublisher.CreateProbe<string>(this);
 
                 var upstream = Flow.FromSinkAndSource(Sink.Ignore<string>(),
-                    Source.FromPublisher<int, Unit>(upstreamWriter), Keep.Left);
+                    Source.FromPublisher<int>(upstreamWriter), Keep.Left);
                 var downstream = Flow.FromSinkAndSource(Sink.Ignore<int>(),
-                    Source.FromPublisher<string, Unit>(downstreamWriter), Keep.Left);
+                    Source.FromPublisher<string>(downstreamWriter), Keep.Left);
 
                 var assembly = upstream.JoinMaterialized(
                     BidiFlow.BidirectionalIdleTimeout<int, string>(TimeSpan.FromSeconds(2)),
@@ -245,14 +245,14 @@ namespace Akka.Streams.Tests.Implementation
                 var downWrite = TestPublisher.CreateProbe<int>(this);
                 var downRead = TestSubscriber.CreateProbe<string>(this);
 
-                RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
+                RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
                 {
                     var timeoutStage = b.Add(BidiFlow.BidirectionalIdleTimeout<string, int>(TimeSpan.FromSeconds(2)));
 
-                    b.From(Source.FromPublisher<string, Unit>(upWrite)).To(timeoutStage.Inlet1);
-                    b.From(timeoutStage.Outlet1).To(Sink.FromSubscriber<string, Unit>(downRead));
-                    b.From(timeoutStage.Outlet2).To(Sink.FromSubscriber<int, Unit>(upRead));
-                    b.From(Source.FromPublisher<int, Unit>(downWrite)).To(timeoutStage.Inlet2);
+                    b.From(Source.FromPublisher<string>(upWrite)).To(timeoutStage.Inlet1);
+                    b.From(timeoutStage.Outlet1).To(Sink.FromSubscriber(downRead));
+                    b.From(timeoutStage.Outlet2).To(Sink.FromSubscriber(upRead));
+                    b.From(Source.FromPublisher<int>(downWrite)).To(timeoutStage.Inlet2);
 
                     return ClosedShape.Instance;
                 })).Run(Materializer);
@@ -300,14 +300,14 @@ namespace Akka.Streams.Tests.Implementation
                 var downWrite = TestPublisher.CreateProbe<int>(this);
                 var downRead = TestSubscriber.CreateProbe<string>(this);
 
-                RunnableGraph<Unit>.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
+                RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
                 {
                     var timeoutStage = b.Add(BidiFlow.BidirectionalIdleTimeout<string, int>(TimeSpan.FromSeconds(2)));
 
-                    b.From(Source.FromPublisher<string, Unit>(upWrite)).To(timeoutStage.Inlet1);
-                    b.From(timeoutStage.Outlet1).To(Sink.FromSubscriber<string, Unit>(downRead));
-                    b.From(timeoutStage.Outlet2).To(Sink.FromSubscriber<int, Unit>(upRead));
-                    b.From(Source.FromPublisher<int, Unit>(downWrite)).To(timeoutStage.Inlet2);
+                    b.From(Source.FromPublisher<string>(upWrite)).To(timeoutStage.Inlet1);
+                    b.From(timeoutStage.Outlet1).To(Sink.FromSubscriber(downRead));
+                    b.From(timeoutStage.Outlet2).To(Sink.FromSubscriber(upRead));
+                    b.From(Source.FromPublisher<int>(downWrite)).To(timeoutStage.Inlet2);
 
                     return ClosedShape.Instance;
                 })).Run(Materializer);

--- a/src/core/Akka.Streams/Actors/ActorPublisher.cs
+++ b/src/core/Akka.Streams/Actors/ActorPublisher.cs
@@ -360,7 +360,7 @@ namespace Akka.Streams.Actors
                 case LifecycleState.Active:
                 case LifecycleState.PreSubscriber:
                     _lifecycleState = LifecycleState.ErrorEmitted;
-                    _onError = new OnErrorBlock(cause, false);
+                    _onError = new OnErrorBlock(cause, stop: true);
                     if (_subscriber != null)
                     {
                         // otherwise onError will be called when the subscription arrives

--- a/src/core/Akka.Streams/Dsl/RunnableGraph.cs
+++ b/src/core/Akka.Streams/Dsl/RunnableGraph.cs
@@ -59,12 +59,15 @@ namespace Akka.Streams.Dsl
         {
             return materializer.Materialize(this);
         }
+    }
 
+    public static class RunnableGraph
+    {
         /// <summary>
         /// A graph with a closed shape is logically a runnable graph, this method makes
         /// it so also in type.
         /// </summary>
-        public static RunnableGraph<TMat> FromGraph(IGraph<ClosedShape, TMat> g)
+        public static RunnableGraph<TMat> FromGraph<TMat>(IGraph<ClosedShape, TMat> g)
             => g as RunnableGraph<TMat> ?? new RunnableGraph<TMat>(g.Module);
     }
 }

--- a/src/core/Akka.Streams/Dsl/Sink.cs
+++ b/src/core/Akka.Streams/Dsl/Sink.cs
@@ -362,9 +362,9 @@ namespace Akka.Streams.Dsl
         /// <summary>
         /// Helper to create <see cref="Sink{TIn,TMat}"/> from <see cref="ISubscriber{TIn}"/>.
         /// </summary>
-        public static Sink<TIn, TMat> FromSubscriber<TIn, TMat>(ISubscriber<TIn> subscriber)
+        public static Sink<TIn, Unit> FromSubscriber<TIn>(ISubscriber<TIn> subscriber)
         {
-            return new Sink<TIn, TMat>(new SubscriberSink<TIn>(subscriber, DefaultAttributes.SubscriberSink, Shape<TIn>("SubscriberSink")));
+            return new Sink<TIn, Unit>(new SubscriberSink<TIn>(subscriber, DefaultAttributes.SubscriberSink, Shape<TIn>("SubscriberSink")));
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/Source.cs
+++ b/src/core/Akka.Streams/Dsl/Source.cs
@@ -214,9 +214,9 @@ namespace Akka.Streams.Dsl
         /// that mediate the flow of elements downstream and the propagation of
         /// back-pressure upstream.
         /// </summary>
-        public static Source<T, TMat> FromPublisher<T, TMat>(IPublisher<T> publisher)
+        public static Source<T, Unit> FromPublisher<T>(IPublisher<T> publisher)
         {
-            return new Source<T, TMat>(new PublisherSource<T>(publisher, DefaultAttributes.PublisherSource, Shape<T>("PublisherSource")));
+            return new Source<T, Unit>(new PublisherSource<T>(publisher, DefaultAttributes.PublisherSource, Shape<T>("PublisherSource")));
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/Tcp.cs
+++ b/src/core/Akka.Streams/Dsl/Tcp.cs
@@ -149,7 +149,7 @@ namespace Akka.Streams.Dsl
         /// </summary>
         /// <param name="remoteAddress"> The remote address to connect to</param>
         /// <param name="localAddress">Optional local address for the connection</param>
-        /// <param name="options">TCP options for the connections, see <see cref="IO.Tcp"/> for details</param>
+        /// <param name="options">TCP options for the connections, see <see cref="Akka.IO.Tcp"/> for details</param>
         /// <param name="halfClose"> Controls whether the connection is kept open even after writing has been completed to the accepted TCP connections.
         /// If set to true, the connection will implement the TCP half-close mechanism, allowing the server to
         /// write to the connection even after the client has finished writing.The TCP socket is only closed
@@ -178,5 +178,13 @@ namespace Akka.Streams.Dsl
         /// </summary>
         public Flow<ByteString, ByteString, Task<Tcp.OutgoingConnection>> OutgoingConnection(string host, int port)
             => OutgoingConnection(new DnsEndPoint(host, port));
+    }
+
+    public static class TcpStreamExtensions
+    {
+        public static TcpExt TcpStream(this ActorSystem system)
+        {
+            return system.WithExtension<TcpExt, Tcp>();
+        }
     }
 }

--- a/src/core/Akka.Streams/Implementation/ActorMaterializerImpl.cs
+++ b/src/core/Akka.Streams/Implementation/ActorMaterializerImpl.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Reactive.Streams;
 using Akka.Actor;
@@ -372,8 +373,8 @@ namespace Akka.Streams.Implementation
         }
         public sealed class Children
         {
-            public readonly ISet<IActorRef> Refs;
-            public Children(ISet<IActorRef> refs)
+            public readonly IImmutableSet<IActorRef> Refs;
+            public Children(IImmutableSet<IActorRef> refs)
             {
                 Refs = refs;
             }
@@ -416,7 +417,7 @@ namespace Akka.Streams.Implementation
             }
             else if (message is GetChildren)
             {
-                Sender.Tell(new Children(new HashSet<IActorRef>(Context.GetChildren())));
+                Sender.Tell(new Children(Context.GetChildren().ToImmutableHashSet()));
             }
             else if (message is StopChildren)
             {

--- a/src/core/Akka.Streams/Implementation/GroupByProcessorImpl.cs
+++ b/src/core/Akka.Streams/Implementation/GroupByProcessorImpl.cs
@@ -101,7 +101,7 @@ namespace Akka.Streams.Implementation
                     if (_keyToSubstreamOutput.Count == _maxSubstreams)
                         throw new IllegalStateException(string.Format("Cannot open substream for key '{0}': too many substreams open", key));
                     var substreamOutput = CreateSubstreamOutput();
-                    var substreamFlow = Source.FromPublisher<object, Unit>(substreamOutput);
+                    var substreamFlow = Source.FromPublisher(substreamOutput);
                     PrimaryOutputs.EnqueueOutputElement(substreamFlow);
 
                     if (_keyToSubstreamOutput.ContainsKey(key)) _keyToSubstreamOutput[key] = substreamOutput;

--- a/src/core/Akka.Streams/Implementation/IO/FilePublisher.cs
+++ b/src/core/Akka.Streams/Implementation/IO/FilePublisher.cs
@@ -107,7 +107,7 @@ namespace Akka.Streams.Implementation.IO
                 return SignalOnNexts(chunks.RemoveAt(0));
             }
 
-            if (chunks.Count != 0 && EofEncountered)
+            if (chunks.Count == 0 && EofEncountered)
                 OnCompleteThenStop();
 
             return chunks;

--- a/src/core/Akka.Streams/Implementation/Modules.cs
+++ b/src/core/Akka.Streams/Implementation/Modules.cs
@@ -213,7 +213,7 @@ namespace Akka.Streams.Implementation
         public override IPublisher<TOut> Create(MaterializationContext context, out IActorRef materializer)
         {
             var mat = ActorMaterializer.Downcast(context.Materializer);
-            materializer = mat.ActorOf(context, ActorRefSourceActor.Props(_bufferSize, _overflowStrategy, mat.Settings));
+            materializer = mat.ActorOf(context, ActorRefSourceActor<TOut>.Props(_bufferSize, _overflowStrategy, mat.Settings));
             return new ActorPublisherImpl<TOut>(materializer);
         }
     }


### PR DESCRIPTION
- `FileSource` is fixed and fully operational.
- `ActorRefSource` is fixed and fully operational.
- `InputStreamsSink` is mostly fixed (1 unresolved test issue concerning ActorGraphInterpreter).
- Fixed issue inside `ActorPublisher`, which caused it not to stop when `OnError` message was arriving.
- Modified `Source.FromPublisher` and `Sink.FromSubscriber` generic parameters - as materialized value param was always (with 1 exception) equal to unit, moving is as default resulted in method invocation generic params being fully inferred from the usage :)

Current status of streams specs (with rerun on failing racy ones):
**845** total / **42** failing (10 of them in DSL, 32 in IO)