### PR TITLE
eliminated allocations with StandardOutWriter

### DIFF
--- a/src/core/Akka.FSharp/Properties/AssemblyInfo.fs
+++ b/src/core/Akka.FSharp/Properties/AssemblyInfo.fs
@@ -1,11 +1,4 @@
-﻿//-----------------------------------------------------------------------
-// <copyright file="AssemblyInfo.fs" company="Akka.NET Project">
-//     Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
-//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
-// </copyright>
-//-----------------------------------------------------------------------
-
-namespace System
+﻿namespace System
 open System
 open System.Reflection
 open System.Runtime.InteropServices

--- a/src/core/Akka.Tests.Performance/Akka.Tests.Performance.csproj
+++ b/src/core/Akka.Tests.Performance/Akka.Tests.Performance.csproj
@@ -34,6 +34,10 @@
       <HintPath>..\..\packages\NBench.0.2.1\lib\net45\NBench.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="NBench.PerformanceCounters, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NBench.PerformanceCounters.0.2.1\lib\net45\NBench.PerformanceCounters.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
@@ -53,6 +57,7 @@
     <Compile Include="Dispatch\MailboxMemoryFootprintSpec.cs" />
     <Compile Include="Actor\ActorThroughputSpecBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Util\StandardOutWriterMemoryBenchmark.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Akka.TestKit\Akka.TestKit.csproj">

--- a/src/core/Akka.Tests.Performance/Util/StandardOutWriterMemoryBenchmark.cs
+++ b/src/core/Akka.Tests.Performance/Util/StandardOutWriterMemoryBenchmark.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Util;
+using NBench;
+using NBench.PerformanceCounters;
+
+namespace Akka.Tests.Performance.Util
+{
+    /// <summary>
+    /// Testing to see if the use of delegates inside <see cref="StandardOutWriter"/>
+    /// results in allocations.
+    /// </summary>
+    public class StandardOutWriterMemoryBenchmark
+    {
+        private Counter _consoleWriteThroughputCounter;
+        private const string ConsoleWriteThroughputCounterName = "StandardOutWrites";
+        private const string InputStr = "W"; // want to avoid string allocations for this spec
+
+        [PerfSetup]
+        public void SetUp(BenchmarkContext context)
+        {
+            _consoleWriteThroughputCounter = context.GetCounter(ConsoleWriteThroughputCounterName);
+        }
+
+        [PerfBenchmark(Description = "Testing to see if the design of the StandardOutWriter produces allocations",
+            RunMode = RunMode.Throughput,
+            NumberOfIterations = 13, TestMode = TestMode.Measurement, RunTimeMilliseconds = 1000)]
+        [CounterMeasurement(ConsoleWriteThroughputCounterName)]
+        [MemoryAssertion(MemoryMetric.TotalBytesAllocated, MustBe.LessThan, ByteConstants.SixtyFourKb)]
+        [GcMeasurement(GcMetric.TotalCollections, GcGeneration.AllGc)]
+        [PerformanceCounterMeasurement(".NET CLR Memory", "# of Pinned Objects", InstanceName = NBenchPerformanceCounterConstants.CurrentProcessName, UnitName = "objects")]
+        [PerformanceCounterMeasurement(".NET CLR Memory", "# Bytes in all Heaps", InstanceName = NBenchPerformanceCounterConstants.CurrentProcessName, UnitName = "bytes")]
+        [PerformanceCounterMeasurement(".NET CLR Memory", "# GC Handles", InstanceName = NBenchPerformanceCounterConstants.CurrentProcessName, UnitName = "handles")]
+        public void StressTestStandardOutWriter(BenchmarkContext context)
+        {
+            StandardOutWriter.WriteLine(InputStr, ConsoleColor.Black, ConsoleColor.DarkGreen);
+            _consoleWriteThroughputCounter.Increment();
+        }
+    }
+}

--- a/src/core/Akka.Tests.Performance/packages.config
+++ b/src/core/Akka.Tests.Performance/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NBench" version="0.2.1" targetFramework="net45" />
+  <package id="NBench.PerformanceCounters" version="0.2.1" targetFramework="net45" />
 </packages>

--- a/src/core/Akka/Util/StandardOutWriter.cs
+++ b/src/core/Akka/Util/StandardOutWriter.cs
@@ -24,9 +24,10 @@ namespace Akka.Util
         /// <param name="message">The <see cref="string"/> value to write</param>
         /// <param name="foregroundColor">Optional: The foreground color</param>
         /// <param name="backgroundColor">Optional: The background color</param>
-        public static void Write(string message, ConsoleColor? foregroundColor = null, ConsoleColor? backgroundColor = null)
+        public static void Write(string message, ConsoleColor? foregroundColor = null,
+            ConsoleColor? backgroundColor = null)
         {
-            WriteToConsole(() => Console.Write(message), foregroundColor, backgroundColor);
+            WriteToConsole(message, foregroundColor, backgroundColor, false);
         }
 
         /// <summary>
@@ -37,33 +38,38 @@ namespace Akka.Util
         /// <param name="foregroundColor">Optional: The foreground color</param>
         /// <param name="backgroundColor">Optional: The background color</param>
 
-        public static void WriteLine(string message, ConsoleColor? foregroundColor = null, ConsoleColor? backgroundColor = null)
+        public static void WriteLine(string message, ConsoleColor? foregroundColor = null,
+            ConsoleColor? backgroundColor = null)
         {
-            WriteToConsole(() => Console.WriteLine(message), foregroundColor, backgroundColor);
+            WriteToConsole(message, foregroundColor, backgroundColor);
         }
 
-        private static void WriteToConsole(Action write, ConsoleColor? foregroundColor = null, ConsoleColor? backgroundColor = null)
+        private static void WriteToConsole(string message, ConsoleColor? foregroundColor = null,
+            ConsoleColor? backgroundColor = null, bool line = true)
         {
-            lock(_lock)
+            lock (_lock)
             {
                 ConsoleColor? fg = null;
-                if(foregroundColor.HasValue)
+                if (foregroundColor.HasValue)
                 {
                     fg = Console.ForegroundColor;
                     Console.ForegroundColor = foregroundColor.Value;
                 }
                 ConsoleColor? bg = null;
-                if(backgroundColor.HasValue)
+                if (backgroundColor.HasValue)
                 {
                     bg = Console.BackgroundColor;
                     Console.BackgroundColor = backgroundColor.Value;
                 }
-                write();
-                if(fg.HasValue)
+                if (line)
+                    Console.WriteLine(message);
+                else
+                    Console.Write(message);
+                if (fg.HasValue)
                 {
                     Console.ForegroundColor = fg.Value;
                 }
-                if(bg.HasValue)
+                if (bg.HasValue)
                 {
                     Console.BackgroundColor = bg.Value;
                 }
@@ -71,4 +77,3 @@ namespace Akka.Util
         }
     }
 }
-


### PR DESCRIPTION
Found some memory leaks in Helios which revolve around the use of delegates with context closures - realized it might explain some of the memory leak reports we've had around logging in Akka.NET. Found some code inside the `StandardOutWriter` that uses delegates similarly and profiled it.

Added `NBench.PerformanceCounters` to get some more detailed metrics.