### PR TITLE
Akka.Persistence.Query core plugin

### DIFF
--- a/src/Akka.sln
+++ b/src/Akka.sln
@@ -257,6 +257,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StreamsExamples", "examples
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Cluster.TestKit", "core\Akka.Cluster.TestKit\Akka.Cluster.TestKit.csproj", "{B32850D2-E9CB-4638-83A4-164907595E56}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Persistence.Query", "core\Akka.Persistence.Query\Akka.Persistence.Query.csproj", "{92AB2788-E008-40D0-8B54-0C95B3CF3404}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Persistence.Query.Tests", "core\Akka.Persistence.Query.Tests\Akka.Persistence.Query.Tests.csproj", "{C01FE575-10B5-4072-8EF9-66FA7CD86F6F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug Mono|Any CPU = Debug Mono|Any CPU
@@ -962,6 +966,22 @@ Global
 		{B32850D2-E9CB-4638-83A4-164907595E56}.Release Mono|Any CPU.Build.0 = Release|Any CPU
 		{B32850D2-E9CB-4638-83A4-164907595E56}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B32850D2-E9CB-4638-83A4-164907595E56}.Release|Any CPU.Build.0 = Release|Any CPU
+		{92AB2788-E008-40D0-8B54-0C95B3CF3404}.Debug Mono|Any CPU.ActiveCfg = Debug|Any CPU
+		{92AB2788-E008-40D0-8B54-0C95B3CF3404}.Debug Mono|Any CPU.Build.0 = Debug|Any CPU
+		{92AB2788-E008-40D0-8B54-0C95B3CF3404}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{92AB2788-E008-40D0-8B54-0C95B3CF3404}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{92AB2788-E008-40D0-8B54-0C95B3CF3404}.Release Mono|Any CPU.ActiveCfg = Release|Any CPU
+		{92AB2788-E008-40D0-8B54-0C95B3CF3404}.Release Mono|Any CPU.Build.0 = Release|Any CPU
+		{92AB2788-E008-40D0-8B54-0C95B3CF3404}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{92AB2788-E008-40D0-8B54-0C95B3CF3404}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C01FE575-10B5-4072-8EF9-66FA7CD86F6F}.Debug Mono|Any CPU.ActiveCfg = Debug|Any CPU
+		{C01FE575-10B5-4072-8EF9-66FA7CD86F6F}.Debug Mono|Any CPU.Build.0 = Debug|Any CPU
+		{C01FE575-10B5-4072-8EF9-66FA7CD86F6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C01FE575-10B5-4072-8EF9-66FA7CD86F6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C01FE575-10B5-4072-8EF9-66FA7CD86F6F}.Release Mono|Any CPU.ActiveCfg = Release|Any CPU
+		{C01FE575-10B5-4072-8EF9-66FA7CD86F6F}.Release Mono|Any CPU.Build.0 = Release|Any CPU
+		{C01FE575-10B5-4072-8EF9-66FA7CD86F6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C01FE575-10B5-4072-8EF9-66FA7CD86F6F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1077,5 +1097,7 @@ Global
 		{CACEBC5C-76D5-4286-B0EB-D6AC32961F52} = {69279534-1DBA-4115-BF8B-03F77FC8125E}
 		{66F23146-44BB-4928-89CB-3ED9D20BC4D2} = {CACEBC5C-76D5-4286-B0EB-D6AC32961F52}
 		{B32850D2-E9CB-4638-83A4-164907595E56} = {01167D3C-49C4-4CDE-9787-C176D139ACDD}
+		{92AB2788-E008-40D0-8B54-0C95B3CF3404} = {01167D3C-49C4-4CDE-9787-C176D139ACDD}
+		{C01FE575-10B5-4072-8EF9-66FA7CD86F6F} = {01167D3C-49C4-4CDE-9787-C176D139ACDD}
 	EndGlobalSection
 EndGlobal

--- a/src/core/Akka.Persistence.Query.Tests/Akka.Persistence.Query.Tests.csproj
+++ b/src/core/Akka.Persistence.Query.Tests/Akka.Persistence.Query.Tests.csproj
@@ -1,0 +1,113 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C01FE575-10B5-4072-8EF9-66FA7CD86F6F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Akka.Persistence.Query.Tests</RootNamespace>
+    <AssemblyName>Akka.Persistence.Query.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="DummyReadJournal.cs" />
+    <Compile Include="PersistenceQuerySpec.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\contrib\testkits\Akka.TestKit.Xunit2\Akka.TestKit.Xunit2.csproj">
+      <Project>{7dbd5c17-5e9d-40c4-9201-d092751532a7}</Project>
+      <Name>Akka.TestKit.Xunit2</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\System.Reactive.Streams\System.Reactive.Streams.csproj">
+      <Project>{68FBB4DF-6D83-4CF1-8105-A1D41912852F}</Project>
+      <Name>System.Reactive.Streams</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Akka.Persistence.Query\Akka.Persistence.Query.csproj">
+      <Project>{92ab2788-e008-40d0-8b54-0c95b3cf3404}</Project>
+      <Name>Akka.Persistence.Query</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Akka.Persistence\Akka.Persistence.csproj">
+      <Project>{fca84dea-c118-424b-9eb8-34375dfef18a}</Project>
+      <Name>Akka.Persistence</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Akka.Streams\Akka.Streams.csproj">
+      <Project>{6180A876-AE4A-41E2-A08F-84FDEA0C8A0E}</Project>
+      <Name>Akka.Streams</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Akka.TestKit\Akka.TestKit.csproj">
+      <Project>{0d3cbad0-bbdb-43e5-afc4-ed1d3ecdc224}</Project>
+      <Name>Akka.TestKit</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Akka\Akka.csproj">
+      <Project>{5deddf90-37f0-48d3-a0b0-a5cbd8a7e377}</Project>
+      <Name>Akka</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/core/Akka.Persistence.Query.Tests/DummyReadJournal.cs
+++ b/src/core/Akka.Persistence.Query.Tests/DummyReadJournal.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reactive.Streams;
+using Akka.Configuration;
+using Akka.Streams.Dsl;
+
+namespace Akka.Persistence.Query.Tests
+{
+    /// <summary>
+    /// Use for tests only!
+    /// Emits infinite stream of strings (representing queried for events).
+    /// </summary>
+    public class DummyReadJournal : IAllPersistenceIdsQuery
+    {
+        public static readonly string Identifier = "akka.persistence.query.journal.dummy";
+
+        public Source<string, Unit> AllPersistenceIds => Source.From(Iterate(0)).Map(i => i.ToString());
+
+        private IEnumerable<int> Iterate(int start)
+        {
+            while (true) yield return start++;
+        }
+    }
+
+    public class DummyReadJournalProvider : IReadJournalProvider
+    {
+        public static Config Config => ConfigurationFactory.ParseString(
+            $@"{DummyReadJournal.Identifier} {{ class = ""{typeof (DummyReadJournalProvider).FullName}, Akka.Persistence.Query.Tests"" }}");
+
+        public IReadJournal GetReadJournal()
+        {
+            return new DummyReadJournal();
+        }
+    }
+}

--- a/src/core/Akka.Persistence.Query.Tests/PersistenceQuerySpec.cs
+++ b/src/core/Akka.Persistence.Query.Tests/PersistenceQuerySpec.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Akka.Configuration;
+using Akka.TestKit.Xunit2;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Query.Tests
+{
+    public class PersistenceQuerySpec : TestKit.Xunit2.TestKit
+    {
+        public static readonly Config Config = DummyReadJournalProvider.Config.WithFallback(ConfigurationFactory.Default());
+
+        public PersistenceQuerySpec(ITestOutputHelper output) : base(Config, output: output)
+        {
+        }
+
+        [Fact]
+        public void ReadJournal_should_be_found_by_full_config_key()
+        {
+            PersistenceQuery.Get(Sys).ReadJournalFor<DummyReadJournal>(DummyReadJournal.Identifier);
+        }
+
+        [Fact]
+        public void ReadJournal_should_throw_if_unable_to_find_query_journal_by_config_key()
+        {
+            Assert.Throws<ArgumentException>(() => 
+                PersistenceQuery.Get(Sys).ReadJournalFor<DummyReadJournal>(DummyReadJournal.Identifier + "-fail"));
+        }
+    }
+}

--- a/src/core/Akka.Persistence.Query.Tests/Properties/AssemblyInfo.cs
+++ b/src/core/Akka.Persistence.Query.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Akka.Persistence.Query.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Akka.Persistence.Query.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("c01fe575-10b5-4072-8ef9-66fa7cd86f6f")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/core/Akka.Persistence.Query.Tests/packages.config
+++ b/src/core/Akka.Persistence.Query.Tests/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xunit" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
+</packages>

--- a/src/core/Akka.Persistence.Query/Akka.Persistence.Query.csproj
+++ b/src/core/Akka.Persistence.Query/Akka.Persistence.Query.csproj
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{92AB2788-E008-40D0-8B54-0C95B3CF3404}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Akka.Persistence.Query</RootNamespace>
+    <AssemblyName>Akka.Persistence.Query</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="EventEnvelope.cs" />
+    <Compile Include="Interfaces.cs" />
+    <Compile Include="IReadJournalProvider.cs" />
+    <Compile Include="PersistenceQuery.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\System.Reactive.Streams\System.Reactive.Streams.csproj">
+      <Project>{68FBB4DF-6D83-4CF1-8105-A1D41912852F}</Project>
+      <Name>System.Reactive.Streams</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Akka.Persistence\Akka.Persistence.csproj">
+      <Project>{fca84dea-c118-424b-9eb8-34375dfef18a}</Project>
+      <Name>Akka.Persistence</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Akka.Streams\Akka.Streams.csproj">
+      <Project>{6180a876-ae4a-41e2-a08f-84fdea0c8a0e}</Project>
+      <Name>Akka.Streams</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Akka\Akka.csproj">
+      <Project>{5deddf90-37f0-48d3-a0b0-a5cbd8a7e377}</Project>
+      <Name>Akka</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/core/Akka.Persistence.Query/EventEnvelope.cs
+++ b/src/core/Akka.Persistence.Query/EventEnvelope.cs
@@ -1,0 +1,53 @@
+﻿using System;
+
+namespace Akka.Persistence.Query
+{
+    /// <summary>
+    /// Event wrapper adding meta data for the events in the result stream of
+    /// <see cref="IEventsByTagQuery"/> query, or similar queries.
+    /// </summary>
+    [Serializable]
+    public sealed class EventEnvelope : IEquatable<EventEnvelope>
+    {
+        public readonly long Offset;
+        public readonly string PersistenceId;
+        public readonly long SequenceNr;
+        public readonly object Event;
+
+        public EventEnvelope(long offset, string persistenceId, long sequenceNr, object @event)
+        {
+            Offset = offset;
+            PersistenceId = persistenceId;
+            SequenceNr = sequenceNr;
+            Event = @event;
+        }
+
+        public bool Equals(EventEnvelope other)
+        {
+            if (ReferenceEquals(this, other)) return true;
+            if (ReferenceEquals(other, null)) return false;
+
+            return Offset == other.Offset
+                   && PersistenceId == other.PersistenceId
+                   && SequenceNr == other.SequenceNr
+                   && Equals(Event, other.Event);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is EventEnvelope && Equals((EventEnvelope) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Offset.GetHashCode();
+                hashCode = (hashCode*397) ^ (PersistenceId != null ? PersistenceId.GetHashCode() : 0);
+                hashCode = (hashCode*397) ^ SequenceNr.GetHashCode();
+                hashCode = (hashCode*397) ^ (Event != null ? Event.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
+    }
+}

--- a/src/core/Akka.Persistence.Query/IReadJournalProvider.cs
+++ b/src/core/Akka.Persistence.Query/IReadJournalProvider.cs
@@ -1,0 +1,14 @@
+﻿namespace Akka.Persistence.Query
+{
+    /// <summary>
+    /// A query plugin must implement a class that implements this interface. 
+    /// A read journal plugin must provide implementations for <see cref="IReadJournal"/>.
+    /// </summary> 
+    public interface IReadJournalProvider
+    {
+        /// <summary>
+        /// This corresponds to the instance that is returned by <see cref="PersistenceQuery.ReadJournalFor{TJournal}"/>
+        /// </summary>
+        IReadJournal GetReadJournal();
+    }
+}

--- a/src/core/Akka.Persistence.Query/Interfaces.cs
+++ b/src/core/Akka.Persistence.Query/Interfaces.cs
@@ -1,0 +1,133 @@
+﻿using System.Reactive.Streams;
+using Akka.Streams.Dsl;
+
+namespace Akka.Persistence.Query
+{
+    /// <summary>
+    /// API for reading persistent events and information derived
+    /// from stored persistent events.
+    /// <para>
+    /// The purpose of the API is not to enforce compatibility between different
+    /// journal implementations, because the technical capabilities may be very different.
+    /// The interface is very open so that different journals may implement specific queries.
+    /// </para>
+    /// There are a few pre-defined queries that a query implementation may implement,
+    /// such as <see cref="IEventsByPersistenceIdQuery"/>, <see cref="IAllPersistenceIdsQuery"/> and <see cref="IEventsByTagQuery"/>
+    /// Implementation of these queries are optional and query (journal) plugins may define
+    /// their own specialized queries by implementing other methods.
+    /// <example>
+    /// var journal = PersistenceQuery.Get(system).ReadJournalFor&lt;SomeCoolReadJournal&gt;(queryPluginConfigPath)
+    /// var events = journal.Query(new EventsByTag("mytag", 0L))
+    /// </example>
+    /// </summary>
+    public interface IReadJournal
+    {
+    }
+
+    /// <summary>
+    /// A plugin may optionally support this query by implementing this trait.
+    /// </summary>
+    public interface IEventsByTagQuery : IReadJournal
+    {
+        /// <summary>
+        /// Query events that have a specific tag. A tag can for example correspond to an
+        /// aggregate root type (in DDD terminology).
+        /// <para>
+        /// The consumer can keep track of its current position in the event stream by storing the
+        /// <paramref name="offset"/> and restart the query from a given <paramref name="offset"/> after a crash/restart.
+        /// </para>
+        /// The exact meaning of the <paramref name="offset"/> depends on the journal and must be documented by the
+        /// read journal plugin. It may be a sequential id number that uniquely identifies the
+        /// position of each event within the event stream. Distributed data stores cannot easily
+        /// support those semantics and they may use a weaker meaning. For example it may be a
+        /// timestamp (taken when the event was created or stored). Timestamps are not unique and
+        /// not strictly ordered, since clocks on different machines may not be synchronized.
+        /// <para>
+        /// The returned event stream should be ordered by <paramref name="offset"/> if possible, but this can also be
+        /// difficult to fulfill for a distributed data store. The order must be documented by the
+        /// read journal plugin.
+        /// </para>
+        /// The stream is not completed when it reaches the end of the currently stored events,
+        /// but it continues to push new events when new events are persisted.
+        /// Corresponding query that is completed when it reaches the end of the currently
+        /// stored events is provided by <see cref="ICurrentEventsByTagQuery.CurrentEventsByTag"/>.
+        /// </summary>
+        Source<EventEnvelope, Unit> EventsByTag(string tag, long offset);
+    }
+
+    /// <summary>
+    /// A plugin may optionally support this query by implementing this trait.
+    /// </summary>
+    public interface ICurrentEventsByTagQuery : IReadJournal
+    {
+        /// <summary>
+        /// Same type of query as <see cref="IEventsByTagQuery.EventsByTag"/> but the event stream
+        /// is completed immediately when it reaches the end of the "result set". Events that are
+        /// stored after the query is completed are not included in the event stream.
+        /// </summary>
+        Source<EventEnvelope, Unit> CurrentEventsByTag(string tag, long offset);
+    }
+
+    /// <summary>
+    /// A plugin may optionally support this query by implementing this trait.
+    /// </summary>
+    public interface IEventsByPersistenceIdQuery : IReadJournal
+    {
+        /// <summary>
+        /// Query events for a specific <see cref="PersistentActor"/> identified by <paramref name="persistenceId"/>.
+        /// <para>
+        /// You can retrieve a subset of all events by specifying <paramref name="fromSequenceNr"/> and <paramref name="toSequenceNr"/>
+        /// or use <see cref="0L"/> and <see cref="long.MaxValue"/> respectively to retrieve all events.
+        /// </para>
+        /// The returned event stream should be ordered by sequence number.
+        /// <para>
+        /// The stream is not completed when it reaches the end of the currently stored events,
+        /// but it continues to push new events when new events are persisted.
+        /// Corresponding query that is completed when it reaches the end of the currently
+        /// stored events is provided by <see cref="ICurrentEventsByPersistenceIdQuery.CurrentEventsByPersistenceId"/>.
+        /// </para>
+        /// </summary>
+        Source<EventEnvelope, Unit> EventsByPersistenceId(string persistenceId, long fromSequenceNr, long toSequenceNr);
+    }
+
+    /// <summary>
+    /// A plugin may optionally support this query by implementing this trait.
+    /// </summary>
+    public interface ICurrentEventsByPersistenceIdQuery : IReadJournal
+    {
+        /// <summary>
+        /// Same type of query as <see cref="IEventsByPersistenceIdQuery.EventsByPersistenceId"/>
+        /// but the event stream is completed immediately when it reaches the end of
+        /// the "result set". Events that are stored after the query is completed are
+        /// not included in the event stream.
+        /// </summary>
+        Source<EventEnvelope, Unit> CurrentEventsByPersistenceId(string persistenceId, long fromSequenceNr, long toSequenceNr);
+    }
+
+    /// <summary>
+    /// A plugin may optionally support this query by implementing this trait.
+    /// </summary>
+    public interface ICurrentPersistenceIdsQuery : IReadJournal
+    {
+        /// <summary>
+        /// Same type of query as <see cref="IAllPersistenceIdsQuery.AllPersistenceIds"/> but the stream
+        /// is completed immediately when it reaches the end of the "result set". Persistent
+        /// actors that are created after the query is completed are not included in the stream.
+        /// </summary>
+        Source<string, Unit> CurrentPersistenceIds { get; }
+    }
+
+    public interface IAllPersistenceIdsQuery : IReadJournal
+    {
+        /// <summary>
+        /// Query all <see cref="PersistentActor"/> identifiers, i.e. as defined by the
+        /// `persistenceId` of the <see cref="PersistentActor"/>.
+        /// 
+        /// The stream is not completed when it reaches the end of the currently used `persistenceIds`,
+        /// but it continues to push new `persistenceIds` when new persistent actors are created.
+        /// Corresponding query that is completed when it reaches the end of the currently
+        /// currently used `persistenceIds` is provided by <see cref="ICurrentPersistenceIdsQuery.CurrentPersistenceIds"/>.
+        /// </summary>
+        Source<string, Unit> AllPersistenceIds { get; }
+    }
+}

--- a/src/core/Akka.Persistence.Query/PersistenceQuery.cs
+++ b/src/core/Akka.Persistence.Query/PersistenceQuery.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Concurrent;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+
+namespace Akka.Persistence.Query
+{
+    public sealed class PersistenceQuery : IExtension
+    {
+        private readonly ExtendedActorSystem _system;
+        private readonly ConcurrentDictionary<string, IReadJournal> _readJournalPluginExtensionIds = new ConcurrentDictionary<string, IReadJournal>();
+        private ILoggingAdapter _log;
+
+        public static PersistenceQuery Get(ActorSystem system)
+        {
+            return system.WithExtension<PersistenceQuery, PersistenceQueryProvider>();
+        }
+
+        public ILoggingAdapter Log => _log ?? (_log = _system.Log);
+
+        public PersistenceQuery(ExtendedActorSystem system)
+        {
+            _system = system;
+        }
+
+        public TJournal ReadJournalFor<TJournal>(string readJournalPluginId) where TJournal : IReadJournal
+        {
+            var plugin = _readJournalPluginExtensionIds.GetOrAdd(readJournalPluginId, path => CreatePlugin(path).GetReadJournal());
+            return (TJournal) plugin;
+        }
+
+        private IReadJournalProvider CreatePlugin(string configPath)
+        {
+            if (string.IsNullOrEmpty(configPath) || !_system.Settings.Config.HasPath(configPath))
+                throw new ArgumentException("HOCON config is missing persistence read journal plugin config path: " + configPath);
+
+            var pluginConfig = _system.Settings.Config.GetConfig(configPath);
+            var pluginTypeName = pluginConfig.GetString("class");
+            var pluginType = Type.GetType(pluginTypeName, true);
+
+            return CreateType(pluginType, new object[] { _system, pluginConfig });
+        }
+
+        private IReadJournalProvider CreateType(Type pluginType, object[] parameters)
+        {
+            var ctor = pluginType.GetConstructor(new Type[] {typeof (ExtendedActorSystem), typeof (Config)});
+            if (ctor != null) return (IReadJournalProvider)ctor.Invoke(parameters);
+
+            ctor = pluginType.GetConstructor(new Type[] { typeof(ExtendedActorSystem) });
+            if (ctor != null) return (IReadJournalProvider)ctor.Invoke(new [] { parameters[0] });
+
+            ctor = pluginType.GetConstructor(new Type[0]);
+            if (ctor != null) return (IReadJournalProvider)ctor.Invoke(new object[0]);
+
+            throw new ArgumentException($"Unable to create read journal plugin instance type {pluginType}!");
+        }
+    }
+
+    public class PersistenceQueryProvider : ExtensionIdProvider<PersistenceQuery>
+    {
+        public override PersistenceQuery CreateExtension(ExtendedActorSystem system)
+        {
+            return new PersistenceQuery(system);
+        }
+    }
+
+    public static class PersistenceQueryExtensions
+    {
+        public static TJournal ReadJournalFor<TJournal>(this ActorSystem system, string readJournalPluginId)
+            where TJournal : IReadJournal
+        {
+            return PersistenceQuery.Get(system).ReadJournalFor<TJournal>(readJournalPluginId);
+        }
+    }
+}

--- a/src/core/Akka.Persistence.Query/Properties/AssemblyInfo.cs
+++ b/src/core/Akka.Persistence.Query/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Akka.Persistence.Query")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Akka.Persistence.Query")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("92ab2788-e008-40d0-8b54-0c95b3cf3404")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
This PR contains core lib for Akka.Persistence.Query - persistent backend implementation must use it in order to support akka streams of their side.

Example usage:

```csharp
var journal = system.ReadJournalFor<SomeCoolReadJournal>(queryPluginConfigPath);
var events = journal.Query(new EventsByTag("mytag", 0L));
```