### PR TITLE
added Akka.NET v1.0.8 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,25 @@
-#### 1.0.8 April 5 2016 ####
-Placeholder for next release
+#### 1.0.8 April 26 2016 ####
+**Maintenance release for Akka.NET v1.0.7**
+
+Fixes an issue with the 1.0.7 release where the default settings for Akka.Persistence changed and caused potential breaking changes for Akka.Persistence users. Those changes have been reverted back to the same values as previous versions.
+
+General fixes:
+* [Recovered default journal & snapshot store to default config](https://github.com/akkadotnet/akka.net/pull/1864)
+* [EndpointRegistry fixes](https://github.com/akkadotnet/akka.net/pull/1862)
+* [eliminated allocations with StandardOutWriter](https://github.com/akkadotnet/akka.net/pull/1881)
+* [ClusterSingletonManager - settings update](https://github.com/akkadotnet/akka.net/pull/1878)
+* [Implement spec for standard mailbox combinations in Akka.NET](https://github.com/akkadotnet/akka.net/pull/1897)
+
+**Commit Stats for v1.0.8**
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 4 | 240 | 59 | Aaron Stannard |
+| 3 | 268 | 1 | Danthar |
+| 3 | 189 | 2810 | Silv3rcircl3 |
+| 2 | 204 | 4 | Willem Meints |
+| 2 | 161 | 108 | Bartosz Sypytkowski |
+| 2 | 101 | 24 | Sean Gilliam |
+| 1 | 25 | 16 | zbynek001 |
 
 #### 1.0.7 April 4 2016 ####
 **Maintenance release for Akka.NET v1.0.6**


### PR DESCRIPTION
#### 1.0.8 April 26 2016 ####
**Maintenance release for Akka.NET v1.0.7**

Fixes an issue with the 1.0.7 release where the default settings for Akka.Persistence changed and caused potential breaking changes for Akka.Persistence users. Those changes have been reverted back to the same values as previous versions.

General fixes:
* [Recovered default journal & snapshot store to default config](https://github.com/akkadotnet/akka.net/pull/1864)
* [EndpointRegistry fixes](https://github.com/akkadotnet/akka.net/pull/1862)
* [eliminated allocations with StandardOutWriter](https://github.com/akkadotnet/akka.net/pull/1881)
* [ClusterSingletonManager - settings update](https://github.com/akkadotnet/akka.net/pull/1878)
* [Implement spec for standard mailbox combinations in Akka.NET](https://github.com/akkadotnet/akka.net/pull/1897)

**Commit Stats for v1.0.8**
| COMMITS | LOC+ | LOC- | AUTHOR |
| --- | --- | --- | --- |
| 4 | 240 | 59 | Aaron Stannard |
| 3 | 268 | 1 | Danthar |
| 3 | 189 | 2810 | Silv3rcircl3 |
| 2 | 204 | 4 | Willem Meints |
| 2 | 161 | 108 | Bartosz Sypytkowski |
| 2 | 101 | 24 | Sean Gilliam |
| 1 | 25 | 16 | zbynek001 |