### PR TITLE
[WIP] Implemented missed tests in Akka.Persistence.Sql.Common

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/JournalDbEngine.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/JournalDbEngine.cs
@@ -207,6 +207,22 @@ namespace Akka.Persistence.Sql.Common.Journal
         }
 
         /// <summary>
+        /// Saves the highest sequence number when messages was deleted from journal.
+        /// </summary>
+        public async Task UpdateSequenceNr(string persistenceId, long highestSequenceNr)
+        {
+            using (var connection = CreateDbConnection())
+            {
+                await connection.OpenAsync();
+
+                var sqlCommand = QueryBuilder.UpdateHighestSequenceNr(persistenceId, highestSequenceNr);
+                CompleteCommand(sqlCommand, connection);
+
+                await sqlCommand.ExecuteNonQueryAsync();
+            }
+        }
+
+        /// <summary>
         /// Asynchronously writes all persistent <paramref name="messages"/> inside SQL Server database.
         /// 
         /// Specific table used for message persistence may be defined through configuration within 

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryBuilder.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryBuilder.cs
@@ -32,6 +32,11 @@ namespace Akka.Persistence.Sql.Common.Journal
         DbCommand SelectHighestSequenceNr(string persistenceId);
 
         /// <summary>
+        /// Saves the highest sequence number when messages was deleted from journal.
+        /// </summary>
+        DbCommand UpdateHighestSequenceNr(string persistenceId, long highestSequenceNr);
+
+        /// <summary>
         /// Returns a non-query command used to insert collection of <paramref name="messages"/> in journal table.
         /// </summary>
         DbCommand InsertBatchMessages(IPersistentRepresentation[] messages);

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Settings.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Settings.cs
@@ -42,6 +42,11 @@ namespace Akka.Persistence.Sql.Common
         public string TableName { get; private set; }
 
         /// <summary>
+        /// Name of the metadata table.
+        /// </summary>
+        public string MetadataTableName { get; private set; }
+
+        /// <summary>
         /// Fully qualified type name for <see cref="ITimestampProvider"/> used to generate journal timestamps.
         /// </summary>
         public string TimestampProvider { get; set; }
@@ -56,6 +61,7 @@ namespace Akka.Persistence.Sql.Common
             SchemaName = config.GetString("schema-name");
             TableName = config.GetString("table-name");
             TimestampProvider = config.GetString("timestamp-provider");
+            MetadataTableName = config.GetString("metadata-table-name");
         }
     }
 

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Akka.Persistence.Sqlite.Tests.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Akka.Persistence.Sqlite.Tests.csproj
@@ -60,6 +60,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SqliteConfigSpec.cs" />
     <Compile Include="SqliteJournalQuerySpec.cs" />
     <Compile Include="SqliteJournalSpec.cs" />
     <Compile Include="SqliteSnapshotStoreSpec.cs" />

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteConfigSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteConfigSpec.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Xunit;
+
+namespace Akka.Persistence.Sqlite.Tests
+{
+    public class SqliteConfigSpec : Akka.TestKit.Xunit2.TestKit
+    {
+        [Fact]
+        public void Should_sqlite_journal_has_default_config()
+        {
+            SqlitePersistence.Get(Sys);
+
+            var config = Sys.Settings.Config.GetConfig("akka.persistence.journal.sqlite");
+            
+            Assert.NotNull(config);
+            Assert.Equal("Akka.Persistence.Sqlite.Journal.SqliteJournal, Akka.Persistence.Sqlite", config.GetString("class"));
+            Assert.Equal("akka.actor.default-dispatcher", config.GetString("plugin-dispatcher"));
+            Assert.Equal(string.Empty, config.GetString("connection-string"));
+            Assert.Equal(string.Empty, config.GetString("connection-string-name"));
+            Assert.Equal(TimeSpan.FromSeconds(30), config.GetTimeSpan("connection-timeout"));
+            Assert.Equal("event_journal", config.GetString("table-name"));
+            Assert.Equal("metadata", config.GetString("metadata-table-name"));
+            Assert.Equal(false, config.GetBoolean("auto-initialize"));
+            Assert.Equal("Akka.Persistence.Sql.Common.Journal.DefaultTimestampProvider, Akka.Persistence.Sql.Common", config.GetString("timestamp-provider"));
+        }
+
+        [Fact]
+        public void Should_sqlite_snapshot_has_default_config()
+        {
+            SqlitePersistence.Get(Sys);
+
+            var config = Sys.Settings.Config.GetConfig("akka.persistence.snapshot-store.sqlite");
+
+            Assert.NotNull(config);
+            Assert.Equal("Akka.Persistence.Sqlite.Snapshot.SqliteSnapshotStore, Akka.Persistence.Sqlite", config.GetString("class"));
+            Assert.Equal("akka.actor.default-dispatcher", config.GetString("plugin-dispatcher"));
+            Assert.Equal(string.Empty, config.GetString("connection-string"));
+            Assert.Equal(string.Empty, config.GetString("connection-string-name"));
+            Assert.Equal(TimeSpan.FromSeconds(30), config.GetTimeSpan("connection-timeout"));
+            Assert.Equal("snapshot_store", config.GetString("table-name"));
+            Assert.Equal(false, config.GetBoolean("auto-initialize"));
+       }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/DbHelper.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/DbHelper.cs
@@ -23,6 +23,13 @@ namespace Akka.Persistence.Sqlite
                     PRIMARY KEY (persistence_id, sequence_nr)
                 );";
 
+        private const string MetadataFormat = @"
+                CREATE TABLE IF NOT EXISTS {0} (
+	                persistence_id VARCHAR(255) NOT NULL,
+                    sequence_nr INTEGER(8) NOT NULL,
+                    PRIMARY KEY (persistence_id, sequence_nr)
+                );";
+
         private const string SnapshotStoreFormat = @"
                 CREATE TABLE IF NOT EXISTS {0} (
                     persistence_id VARCHAR(255) NOT NULL,
@@ -40,6 +47,19 @@ namespace Akka.Persistence.Sqlite
 
             using (var connection = new SQLiteConnection(connectionString))
             using (var command = new SQLiteCommand(string.Format(JournalFormat, tableName), connection))
+            {
+                connection.Open();
+                command.ExecuteNonQuery();
+            }
+        }
+
+        public static void CreateMetadataTable(string connectionString, string metadataTableName)
+        {
+            if (string.IsNullOrEmpty(connectionString)) throw new ArgumentNullException("connectionString", "SqlitePersistence requires connection string to be provided");
+            if (string.IsNullOrEmpty(metadataTableName)) throw new ArgumentNullException("metadataTableName", "SqlitePersistence requires metadata table name to be provided");
+
+            using (var connection = new SQLiteConnection(connectionString))
+            using (var command = new SQLiteCommand(string.Format(MetadataFormat, metadataTableName), connection))
             {
                 connection.Open();
                 command.ExecuteNonQuery();

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Extension.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Extension.cs
@@ -80,7 +80,10 @@ namespace Akka.Persistence.Sqlite
                 system.WhenTerminated.ContinueWith(t => ConnectionContext.Forget(JournalSettings.ConnectionString));
 
                 if (JournalSettings.AutoInitialize)
+                {
                     DbHelper.CreateJournalTable(JournalSettings.ConnectionString, JournalSettings.TableName);
+                    DbHelper.CreateMetadataTable(JournalSettings.ConnectionString, JournalSettings.MetadataTableName);
+                }
             }
 
             if (!string.IsNullOrEmpty(SnapshotSettings.ConnectionString))

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/SqliteJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/SqliteJournal.cs
@@ -17,7 +17,7 @@ namespace Akka.Persistence.Sqlite.Journal
         public SqliteJournalEngine(ActorSystem system)
             : base(system)
         {
-            QueryBuilder = new SqliteQueryBuilder(Settings.TableName);
+            QueryBuilder = new SqliteQueryBuilder(Settings.TableName, Settings.MetadataTableName);
         }
 
         protected override string JournalConfigPath { get { return SqliteJournalSettings.ConfigPath; } }

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Snapshot/QueryBuilder.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Snapshot/QueryBuilder.cs
@@ -23,9 +23,13 @@ namespace Akka.Persistence.Sqlite.Snapshot
         public QueryBuilder(SqliteSnapshotSettings settings)
         {
             _deleteSql = string.Format(@"DELETE FROM {0} WHERE persistence_id = ? ", settings.TableName);
-            _insertSql = string.Format(@"INSERT INTO {0} (persistence_id, sequence_nr, created_at, manifest, snapshot) VALUES (@PersistenceId, @SequenceNr, @Timestamp, @Manifest, @Snapshot)", settings.TableName);
+
+            _insertSql = string.Format(@"
+            UPDATE {0} SET created_at = @Timestamp, manifest = @Manifest, snapshot = @Snapshot WHERE persistence_id = @PersistenceId AND sequence_nr = @SequenceNr;
+            INSERT OR IGNORE INTO {0} (persistence_id, sequence_nr, created_at, manifest, snapshot) VALUES (@PersistenceId, @SequenceNr, @Timestamp, @Manifest, @Snapshot)", settings.TableName);
+
             _selectSql = string.Format(@"SELECT persistence_id, sequence_nr, created_at, manifest, snapshot FROM {0} WHERE persistence_id = ? ", settings.TableName);
-        }
+       }
 
         public DbCommand DeleteOne(string persistenceId, long sequenceNr, DateTime timestamp)
         {

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/sqlite.conf
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/sqlite.conf
@@ -19,11 +19,11 @@
 			# default SQLite commands timeout
 			connection-timeout = 30s
 
-			# SQLite schema name to table corresponding with persistent journal
-			schema-name = dbo
-
 			# SQLite table corresponding with persistent journal
 			table-name = event_journal
+
+			# metadata table
+			metadata-table-name = metadata
 
 			# should corresponding journal table be initialized automatically
 			auto-initialize = off
@@ -52,9 +52,6 @@
 
 			# default SQLite commands timeout
 			connection-timeout = 30s
-
-			# SQLite schema name to table corresponding with persistent journal
-			schema-name = dbo
 
 			# SQLite table corresponding with persistent journal
 			table-name = snapshot_store

--- a/src/core/Akka.Persistence.TestKit/Journal/JournalSpec.cs
+++ b/src/core/Akka.Persistence.TestKit/Journal/JournalSpec.cs
@@ -261,7 +261,7 @@ namespace Akka.Persistence.TestKit.Journal
             _receiverProbe.ExpectMsg<RecoverySuccess>(m => m.HighestSequenceNr == 5L);
         }
 
-        [Fact(Skip = "This is not yet supported by the journals")]
+        [Fact]
         public void Journal_should_not_reset_HighestSequenceNr_after_journal_cleanup()
         {
             Journal.Tell(new ReplayMessages(0, long.MaxValue, long.MaxValue, Pid, _receiverProbe.Ref));

--- a/src/core/Akka.Persistence.TestKit/Snapshot/SnapshotStoreSpec.cs
+++ b/src/core/Akka.Persistence.TestKit/Snapshot/SnapshotStoreSpec.cs
@@ -211,7 +211,7 @@ namespace Akka.Persistence.TestKit.Snapshot
                 && result.Snapshot.Snapshot.ToString() == "s-4");
         }
 
-        [Fact(Skip = "This is not yet supported by the snapshot stores")]
+        [Fact]
         public void SnapshotStore_should_save_and_overwrite_snapshot_with_same_sequence_number()
         {
             var md = Metadata[4];


### PR DESCRIPTION
Implemented suggestions from this PR: https://github.com/akkadotnet/Akka.Persistence.SqlServer/pull/24
- Put MetadataTableName property to JournalSettings class
- Added a method UpdateSequenceNr to IJournalQueryBuilder
- Method DeleteMessagesToAsync updates sequence number in the metadata table
- Fixed 2 tests for Sqlite provider
- Fixed 1 test for MemoryJournal
- Sqlite configuration specs

All MNTK specs passed locally