### PR TITLE
Store EventSequence events in list to permit duplicates

### DIFF
--- a/src/core/Akka.Persistence/Journal/EventSequences.cs
+++ b/src/core/Akka.Persistence/Journal/EventSequences.cs
@@ -25,7 +25,7 @@ namespace Akka.Persistence.Journal
 
         private EmptyEventSequence() { }
 
-        public IEnumerable<object> Events { get { return Enumerable.Empty<object>(); } }
+        public IEnumerable<object> Events => Enumerable.Empty<object>();
 
         public bool Equals(IEventSequence other)
         {
@@ -41,17 +41,17 @@ namespace Akka.Persistence.Journal
     [Serializable]
     public class EventSequence<T> : IEventSequence, IEquatable<IEventSequence>
     {
-        private readonly ISet<object> _events;
+        private readonly IList<object> _events;
         public EventSequence(IEnumerable<object> events)
         {
-            _events = new HashSet<object>(events);
+            _events = events.ToList();
         }
 
-        public IEnumerable<object> Events { get { return _events; } }
+        public IEnumerable<object> Events => _events;
 
         public bool Equals(IEventSequence other)
         {
-            return other != null && _events.SetEquals(other.Events);
+            return other != null && _events.SequenceEqual(other.Events);
         }
 
         public override bool Equals(object obj)
@@ -69,7 +69,7 @@ namespace Akka.Persistence.Journal
             _events = new[] { e };
         }
 
-        public IEnumerable<object> Events { get { return _events; } }
+        public IEnumerable<object> Events => _events;
 
         public bool Equals(IEventSequence other)
         {


### PR DESCRIPTION
JVM version also uses a list, and a test in the cassandra plugins tests that duplicates are properly emitted