### PR TITLE
Naming conventions

### DIFF
--- a/src/core/Akka.Persistence.Query.Tests/DummyReadJournal.cs
+++ b/src/core/Akka.Persistence.Query.Tests/DummyReadJournal.cs
@@ -20,7 +20,7 @@ namespace Akka.Persistence.Query.Tests
     {
         public static readonly string Identifier = "akka.persistence.query.journal.dummy";
 
-        public Source<string, Unit> AllPersistenceIds() => Source.From(Iterate(0)).Map(i => i.ToString());
+        public Source<string, Unit> AllPersistenceIds() => Source.From(Iterate(0)).Select(i => i.ToString());
 
         private IEnumerable<int> Iterate(int start)
         {

--- a/src/core/Akka.Streams.TestKit.Tests/ChainSetup.cs
+++ b/src/core/Akka.Streams.TestKit.Tests/ChainSetup.cs
@@ -31,7 +31,7 @@ namespace Akka.Streams.TestKit.Tests
             Upstream = TestPublisher.CreateManualProbe<TIn>(system);
             Downstream = TestSubscriber.CreateProbe<TOut>(system);
 
-            var s = Source.FromPublisher(Upstream).Via(stream((Flow<TIn, TIn, Unit>)Flow.Identity<TIn>().Map(x => x).Named("buh")));
+            var s = Source.FromPublisher(Upstream).Via(stream((Flow<TIn, TIn, Unit>)Flow.Identity<TIn>().Select(x => x).Named("buh")));
             Publisher = toPublisher(s, materializer);
             UpstreamSubscription = Upstream.ExpectSubscription();
             Publisher.Subscribe(Downstream);

--- a/src/core/Akka.Streams.Tests/Actor/ActorPublisherSpec.cs
+++ b/src/core/Akka.Streams.Tests/Actor/ActorPublisherSpec.cs
@@ -322,9 +322,9 @@ my-dispatcher1 {
                     builder.From(source1).To(merge.In(0));
                     builder.From(source2.Outlet).To(merge.In(1));
                     
-                    builder.From(merge.Out).Via(Flow.Create<int>().Map(i => i.ToString())).To(bcast.In);
+                    builder.From(merge.Out).Via(Flow.Create<int>().Select(i => i.ToString())).To(bcast.In);
                     
-                    builder.From(bcast.Out(0)).Via(Flow.Create<string>().Map(s => s + "mark")).To(sink1);
+                    builder.From(bcast.Out(0)).Via(Flow.Create<string>().Select(s => s + "mark")).To(sink1);
                     builder.From(bcast.Out(1)).To(sink2);
 
                     return ClosedShape.Instance;

--- a/src/core/Akka.Streams.Tests/Actor/ActorSubscriberSpec.cs
+++ b/src/core/Akka.Streams.Tests/Actor/ActorSubscriberSpec.cs
@@ -128,7 +128,7 @@ namespace Akka.Streams.Tests.Actor
         {
             var n = 117;
             Source.From(Enumerable.Range(1, n))
-                .Map(i => new Msg(i, TestActor))
+                .Select(i => new Msg(i, TestActor))
                 .RunWith(Sink.ActorSubscriber<Msg>(Streamer.Props), Sys.Materializer());
             ReceiveN(n).ShouldAllBeEquivalentTo(Enumerable.Range(1, n).Select(i => new Done(i)));
         }

--- a/src/core/Akka.Streams.Tests/ActorMaterializerSpec.cs
+++ b/src/core/Akka.Streams.Tests/ActorMaterializerSpec.cs
@@ -39,7 +39,7 @@ namespace Akka.Streams.Tests
         public void ActorMaterializer_should_properly_shut_down_actors_associated_with_it()
         {
             var m = Sys.Materializer();
-            var f = Source.Maybe<int>().RunFold(0, (x, y) => x + y, m);
+            var f = Source.Maybe<int>().RunAggregate(0, (x, y) => x + y, m);
 
             m.Shutdown();
 

--- a/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
+++ b/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
@@ -97,7 +97,7 @@
     <Compile Include="Dsl\FlowLimitWeightedSpec.cs" />
     <Compile Include="Dsl\FlowLogSpec.cs" />
     <Compile Include="Dsl\FlowMapAsyncUnorderedSpec .cs" />
-    <Compile Include="Dsl\FlowMapAsyncSpec.cs" />
+    <Compile Include="Dsl\FlowSelectAsyncSpec.cs" />
     <Compile Include="Dsl\FlowMergeSpec.cs" />
     <Compile Include="Dsl\FlowOnCompleteSpec.cs" />
     <Compile Include="Dsl\FlowPrefixAndTailSpec.cs" />

--- a/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
+++ b/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
@@ -103,7 +103,7 @@
     <Compile Include="Dsl\FlowPrefixAndTailSpec.cs" />
     <Compile Include="Dsl\FlowRecoverSpec.cs" />
     <Compile Include="Dsl\FlowRecoverWithSpec.cs" />
-    <Compile Include="Dsl\FlowReduceSpec.cs" />
+    <Compile Include="Dsl\FlowSumSpec.cs" />
     <Compile Include="Dsl\FlowScanSpec.cs" />
     <Compile Include="Dsl\FlowSectionSpec.cs" />
     <Compile Include="Dsl\FlowSlidingSpec.cs" />

--- a/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
+++ b/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
@@ -138,7 +138,7 @@
     <Compile Include="Dsl\FlowBufferSpec.cs" />
     <Compile Include="Dsl\FlowDropWhithinSpec.cs" />
     <Compile Include="Dsl\FlowSkipWhileSpec.cs" />
-    <Compile Include="Dsl\FlowDropSpec.cs" />
+    <Compile Include="Dsl\FlowSkipSpec.cs" />
     <Compile Include="Dsl\FlowMapConcatSpec.cs" />
     <Compile Include="Dsl\FlowSelectSpec.cs" />
     <Compile Include="Dsl\FlowSupervisionSpec.cs" />

--- a/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
+++ b/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
@@ -136,7 +136,7 @@
     <Compile Include="Dsl\ActorRefBackpressureSinkSpec.cs" />
     <Compile Include="Dsl\ActorRefSinkSpec.cs" />
     <Compile Include="Dsl\FlowBufferSpec.cs" />
-    <Compile Include="Dsl\FlowDropWhithinSpec.cs" />
+    <Compile Include="Dsl\FlowSkipWhithinSpec.cs" />
     <Compile Include="Dsl\FlowSkipWhileSpec.cs" />
     <Compile Include="Dsl\FlowSkipSpec.cs" />
     <Compile Include="Dsl\FlowMapConcatSpec.cs" />

--- a/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
+++ b/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
@@ -96,7 +96,7 @@
     <Compile Include="Dsl\FlowLimitSpec.cs" />
     <Compile Include="Dsl\FlowLimitWeightedSpec.cs" />
     <Compile Include="Dsl\FlowLogSpec.cs" />
-    <Compile Include="Dsl\FlowMapAsyncUnorderedSpec .cs" />
+    <Compile Include="Dsl\FlowSelectAsyncUnorderedSpec .cs" />
     <Compile Include="Dsl\FlowSelectAsyncSpec.cs" />
     <Compile Include="Dsl\FlowMergeSpec.cs" />
     <Compile Include="Dsl\FlowOnCompleteSpec.cs" />

--- a/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
+++ b/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
@@ -80,7 +80,7 @@
     <Compile Include="Dsl\FlowExpandSpec.cs" />
     <Compile Include="Dsl\FlowWhereSpec.cs" />
     <Compile Include="Dsl\FlowFlattenMergeSpec.cs" />
-    <Compile Include="Dsl\FlowFoldSpec.cs" />
+    <Compile Include="Dsl\FlowAggregateSpec.cs" />
     <Compile Include="Dsl\FlowForeachSpec.cs" />
     <Compile Include="Dsl\FlowFromFutureSpec.cs" />
     <Compile Include="Dsl\FlowGraphCompileSpec.cs" />

--- a/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
+++ b/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
@@ -110,7 +110,7 @@
     <Compile Include="Dsl\FlowSpec.cs" />
     <Compile Include="Dsl\FlowSplitAfterSpec.cs" />
     <Compile Include="Dsl\FlowSplitWhenSpec.cs" />
-    <Compile Include="Dsl\FlowStatefulMapConcatSpec.cs" />
+    <Compile Include="Dsl\FlowStatefulSelectManySpec.cs" />
     <Compile Include="Dsl\FramingSpec.cs" />
     <Compile Include="Dsl\GraphBackedFlowSpec.cs" />
     <Compile Include="Dsl\GraphBalanceSpec.cs" />
@@ -139,7 +139,7 @@
     <Compile Include="Dsl\FlowSkipWhithinSpec.cs" />
     <Compile Include="Dsl\FlowSkipWhileSpec.cs" />
     <Compile Include="Dsl\FlowSkipSpec.cs" />
-    <Compile Include="Dsl\FlowMapConcatSpec.cs" />
+    <Compile Include="Dsl\FlowSelectManySpec.cs" />
     <Compile Include="Dsl\FlowSelectSpec.cs" />
     <Compile Include="Dsl\FlowSupervisionSpec.cs" />
     <Compile Include="Dsl\FlowTakeSpec.cs" />

--- a/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
+++ b/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
@@ -82,7 +82,7 @@
     <Compile Include="Dsl\FlowFlattenMergeSpec.cs" />
     <Compile Include="Dsl\FlowAggregateSpec.cs" />
     <Compile Include="Dsl\FlowForeachSpec.cs" />
-    <Compile Include="Dsl\FlowFromFutureSpec.cs" />
+    <Compile Include="Dsl\FlowFromTaskSpec.cs" />
     <Compile Include="Dsl\FlowGraphCompileSpec.cs" />
     <Compile Include="Dsl\FlowGroupBySpec.cs" />
     <Compile Include="Dsl\FlowGroupedSpec.cs" />

--- a/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
+++ b/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
@@ -78,7 +78,7 @@
     <Compile Include="Dsl\FlowDetacherSpec.cs" />
     <Compile Include="Dsl\FlowDispatcherSpec.cs" />
     <Compile Include="Dsl\FlowExpandSpec.cs" />
-    <Compile Include="Dsl\FlowFilterSpec.cs" />
+    <Compile Include="Dsl\FlowWhereSpec.cs" />
     <Compile Include="Dsl\FlowFlattenMergeSpec.cs" />
     <Compile Include="Dsl\FlowFoldSpec.cs" />
     <Compile Include="Dsl\FlowForeachSpec.cs" />

--- a/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
+++ b/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
@@ -137,7 +137,7 @@
     <Compile Include="Dsl\ActorRefSinkSpec.cs" />
     <Compile Include="Dsl\FlowBufferSpec.cs" />
     <Compile Include="Dsl\FlowDropWhithinSpec.cs" />
-    <Compile Include="Dsl\FlowDropWhileSpec.cs" />
+    <Compile Include="Dsl\FlowSkipWhileSpec.cs" />
     <Compile Include="Dsl\FlowDropSpec.cs" />
     <Compile Include="Dsl\FlowMapConcatSpec.cs" />
     <Compile Include="Dsl\FlowSelectSpec.cs" />

--- a/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
+++ b/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
@@ -140,7 +140,7 @@
     <Compile Include="Dsl\FlowDropWhileSpec.cs" />
     <Compile Include="Dsl\FlowDropSpec.cs" />
     <Compile Include="Dsl\FlowMapConcatSpec.cs" />
-    <Compile Include="Dsl\FlowMapSpec.cs" />
+    <Compile Include="Dsl\FlowSelectSpec.cs" />
     <Compile Include="Dsl\FlowSupervisionSpec.cs" />
     <Compile Include="Dsl\FlowTakeSpec.cs" />
     <Compile Include="Dsl\FlowTakeWhileSpec.cs" />

--- a/src/core/Akka.Streams.Tests/Dsl/FlowAggregateSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowAggregateSpec.cs
@@ -35,7 +35,7 @@ namespace Akka.Streams.Tests.Dsl
             InputSource.Aggregate(0, (sum, i) => sum + i).Where(_ => true).Select(x => x);
 
         private static Flow<int, int, Unit> FoldFlow =>
-            FlowOperations.Select(Flow.Create<int>().Where(_ => true).Select(x => x).Aggregate(0, (sum, i) => sum + i).Where(_ => true), x => x);
+            Flow.Create<int>().Where(_ => true).Select(x => x).Aggregate(0, (sum, i) => sum + i).Where(_ => true).Select(x => x);
 
         private static Sink<int, Task<int>> FoldSink => Sink.Aggregate<int, int>(0, (sum, i) => sum + i);
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowAggregateSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowAggregateSpec.cs
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------
-// <copyright file="FlowFoldSpec.cs" company="Akka.NET Project">
+// <copyright file="FlowAggregateSpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>
@@ -18,11 +18,11 @@ using Xunit.Abstractions;
 
 namespace Akka.Streams.Tests.Dsl
 {
-    public class FlowFoldSpec : AkkaSpec
+    public class FlowAggregateSpec : AkkaSpec
     {
         private ActorMaterializer Materializer { get; }
 
-        public FlowFoldSpec(ITestOutputHelper helper) : base(helper)
+        public FlowAggregateSpec(ITestOutputHelper helper) : base(helper)
         {
             Materializer = ActorMaterializer.Create(Sys);
         }
@@ -32,15 +32,15 @@ namespace Akka.Streams.Tests.Dsl
         private static Source<int, Unit> InputSource => Source.From(Input).Where(_ => true).Select(x => x);
 
         private static Source<int, Unit> FoldSource =>
-            InputSource.Fold(0, (sum, i) => sum + i).Where(_ => true).Select(x => x);
+            InputSource.Aggregate(0, (sum, i) => sum + i).Where(_ => true).Select(x => x);
 
         private static Flow<int, int, Unit> FoldFlow =>
-            FlowOperations.Select(Flow.Create<int>().Where(_ => true).Select(x => x).Fold(0, (sum, i) => sum + i).Where(_ => true), x => x);
+            FlowOperations.Select(Flow.Create<int>().Where(_ => true).Select(x => x).Aggregate(0, (sum, i) => sum + i).Where(_ => true), x => x);
 
-        private static Sink<int, Task<int>> FoldSink => Sink.Fold<int, int>(0, (sum, i) => sum + i);
+        private static Sink<int, Task<int>> FoldSink => Sink.Aggregate<int, int>(0, (sum, i) => sum + i);
 
         [Fact]
-        public void A_Fold_must_work_when_using_Source_RunFold()
+        public void A_Aggregate_must_work_when_using_Source_RunFold()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -51,7 +51,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Fold_must_work_when_using_Source_Fold()
+        public void A_Aggregate_must_work_when_using_Source_Fold()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -62,7 +62,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Fold_must_work_when_using_Sink_Fold()
+        public void A_Aggregate_must_work_when_using_Sink_Fold()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -74,7 +74,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Fold_must_work_when_using_Flow_Fold()
+        public void A_Aggregate_must_work_when_using_Flow_Fold()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -86,7 +86,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Fold_must_work_when_using__Source_Fold_and_Flow_Fold_and_Sink_Fold()
+        public void A_Aggregate_must_work_when_using__Source_Aggregate_and_Flow_Aggregate_and_Sink_Fold()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -98,7 +98,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Fold_must_propagate_an_error()
+        public void A_Aggregate_must_propagate_an_error()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -119,7 +119,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Fold_must_complete_future_with_failure_when_folding_functions_throws()
+        public void A_Aggregate_must_complete_future_with_failure_when_folding_functions_throws()
         {
             this.AssertAllStagesStopped(() =>
             {

--- a/src/core/Akka.Streams.Tests/Dsl/FlowAggregateSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowAggregateSpec.cs
@@ -44,7 +44,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             this.AssertAllStagesStopped(() =>
             {
-                var task = InputSource.RunFold(0, (sum, i) => sum + i, Materializer);
+                var task = InputSource.RunAggregate(0, (sum, i) => sum + i, Materializer);
                 task.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
                 task.Result.Should().Be(Expected);
             }, Materializer);
@@ -108,7 +108,7 @@ namespace Akka.Streams.Tests.Dsl
                     if (x > 50)
                         throw error;
                     return x;
-                }).RunFold(Unit.Instance, Keep.None, Materializer);
+                }).RunAggregate(Unit.Instance, Keep.None, Materializer);
 
                 future.Invoking(f => f.Wait(TimeSpan.FromSeconds(3)))
                     .ShouldThrow<TestException>()
@@ -124,7 +124,7 @@ namespace Akka.Streams.Tests.Dsl
             this.AssertAllStagesStopped(() =>
             {
                 var error = new TestException("buh");
-                var future = InputSource.RunFold(0, (x,y) =>
+                var future = InputSource.RunAggregate(0, (x,y) =>
                 {
                     if (x > 50)
                         throw error;

--- a/src/core/Akka.Streams.Tests/Dsl/FlowAppendSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowAppendSpec.cs
@@ -69,7 +69,7 @@ namespace Akka.Streams.Tests.Dsl
 
         internal static class River
         {
-            private static readonly Flow<int, string, Unit> OtherFlow = Flow.Create<int>().Map(i => i.ToString());
+            private static readonly Flow<int, string, Unit> OtherFlow = Flow.Create<int>().Select(i => i.ToString());
             
             public static void RiverOf<T>(Action<ISubscriber<T>, Flow<int, string, Unit>, IEnumerable<int>> flowConstructor, TestKitBase kit)
             {

--- a/src/core/Akka.Streams.Tests/Dsl/FlowBatchSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowBatchSpec.cs
@@ -123,7 +123,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Batch_must_work_with_a_buffer_and_fold()
+        public void Batch_must_work_with_a_buffer_and_aggregate()
         {
             var future =
                 Source.From(Enumerable.Range(1, 50))

--- a/src/core/Akka.Streams.Tests/Dsl/FlowBatchSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowBatchSpec.cs
@@ -84,7 +84,7 @@ namespace Akka.Streams.Tests.Dsl
                 if (ThreadLocalRandom.Current.Next(1, 3) == 1)
                     Thread.Sleep(10);
                 return i;
-            }).RunFold(0, (i, i1) => i + i1, Materializer);
+            }).RunAggregate(0, (i, i1) => i + i1, Materializer);
             future.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
             future.Result.Should().Be(500500);
         }
@@ -129,7 +129,7 @@ namespace Akka.Streams.Tests.Dsl
                 Source.From(Enumerable.Range(1, 50))
                     .Batch(long.MaxValue, i => i, (sum, i) => sum + i)
                     .Buffer(50, OverflowStrategy.Backpressure)
-                    .RunFold(0, (sum, i) => sum + i, Materializer);
+                    .RunAggregate(0, (sum, i) => sum + i, Materializer);
             future.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
             future.Result.Should().Be(Enumerable.Range(1, 50).Sum());
         }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowBatchSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowBatchSpec.cs
@@ -79,7 +79,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Batch_must_work_on_a_variable_rate_chain()
         {
-            var future = Source.From(Enumerable.Range(1, 1000)).Batch(100, i => i, (sum, i) => sum + i).Map(i =>
+            var future = Source.From(Enumerable.Range(1, 1000)).Batch(100, i => i, (sum, i) => sum + i).Select(i =>
             {
                 if (ThreadLocalRandom.Current.Next(1, 3) == 1)
                     Thread.Sleep(10);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowCompileSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowCompileSpec.cs
@@ -47,8 +47,8 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Flow_should_append_Flow()
         {
-            var open1 = Flow.Create<int>().Map(x => x.ToString());
-            var open2 = Flow.Create<string>().Map(x => x.GetHashCode());
+            var open1 = Flow.Create<int>().Select(x => x.ToString());
+            var open2 = Flow.Create<string>().Select(x => x.GetHashCode());
             dynamic open3 = open1.Via(open2);
             Action compiler = () => open3.Run(Materializer);
             compiler.ShouldThrow<RuntimeBinderException>();
@@ -68,8 +68,8 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Flow_should_append_Sink()
         {
-            var open = Flow.Create<int>().Map(x => x.ToString());
-            var closedSink = Flow.Create<string>().Map(x => x.GetHashCode()).To(Sink.AsPublisher<int>(false));
+            var open = Flow.Create<int>().Select(x => x.ToString());
+            var closedSink = Flow.Create<string>().Select(x => x.GetHashCode()).To(Sink.AsPublisher<int>(false));
             dynamic appended = open.To(closedSink);
             Action compiler = () => appended.Run(Materializer);
             compiler.ShouldThrow<RuntimeBinderException>();
@@ -81,8 +81,8 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Flow_should_append_Source()
         {
-            var open = Flow.Create<int>().Map(x => x.ToString());
-            var closedSource = StringSeq.Via(Flow.Create<string>().Map(x => x.GetHashCode()));
+            var open = Flow.Create<int>().Select(x => x.ToString());
+            var closedSource = StringSeq.Via(Flow.Create<string>().Select(x => x.GetHashCode()));
             dynamic closedSource2 = closedSource.Via(open);
             Action compiler = () => closedSource2.Run(Materializer);
             compiler.ShouldThrow<RuntimeBinderException>();
@@ -93,7 +93,7 @@ namespace Akka.Streams.Tests.Dsl
 
 
         private Sink<int, Unit> OpenSink
-            => Flow.Create<int>().Map(x => x.ToString()).To(Sink.AsPublisher<string>(false));
+            => Flow.Create<int>().Select(x => x.ToString()).To(Sink.AsPublisher<string>(false));
 
         [Fact]
         public void Sink_should_accept_Source() => IntSeq.To(OpenSink);
@@ -115,7 +115,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
 
-        private Source<string, Unit> OpenSource => Source.From(new[] {1, 2, 3}).Map(x => x.ToString());
+        private Source<string, Unit> OpenSource => Source.From(new[] {1, 2, 3}).Select(x => x.ToString());
 
         [Fact]
         public void Source_should_accept_Sink() => OpenSource.To(Sink.AsPublisher<string>(false));
@@ -140,7 +140,7 @@ namespace Akka.Streams.Tests.Dsl
         private IRunnableGraph<IPublisher<string>> Closed
             =>
                 Source.From(new[] {1, 2, 3})
-                    .Map(x => x.ToString())
+                    .Select(x => x.ToString())
                     .ToMaterialized(Sink.AsPublisher<string>(false), Keep.Right);
 
         [Fact]

--- a/src/core/Akka.Streams.Tests/Dsl/FlowConcatAllSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowConcatAllSpec.cs
@@ -44,7 +44,7 @@ namespace Akka.Streams.Tests.Dsl
                 var main = Source.From(new[] {s1, s2, s3, s4, s5});
 
                 var subscriber = TestSubscriber.CreateManualProbe<int>(this);
-                main.FlatMapConcat(s => s).To(Sink.FromSubscriber(subscriber)).Run(Materializer);
+                main.ConcatMany(s => s).To(Sink.FromSubscriber(subscriber)).Run(Materializer);
                 var subscription = subscriber.ExpectSubscription();
                 subscription.Request(10);
                 for (var i = 1; i <= 10; i++)
@@ -60,7 +60,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             var subscriber = TestSubscriber.CreateProbe<int>(this);
             var subflow = Source.From(Enumerable.Range(1, 10)).SplitWhen(x => x%2 == 0).PrefixAndTail(0).Select(x => x.Item2);
-            var source = ((SubFlow<Source<int, Unit>, Unit, IRunnableGraph<Unit>>) subflow).ConcatSubstream().FlatMapConcat(x => x);
+            var source = ((SubFlow<Source<int, Unit>, Unit, IRunnableGraph<Unit>>) subflow).ConcatSubstream().ConcatMany(x => x);
             ((Source<int, Unit>) source).RunWith(Sink.FromSubscriber(subscriber), Materializer);
 
             for (var i = 1; i <= 10; i++)
@@ -77,7 +77,7 @@ namespace Akka.Streams.Tests.Dsl
                 var publisher = TestPublisher.CreateManualProbe<Source<int, Unit>>(this);
                 var subscriber = TestSubscriber.CreateManualProbe<int>(this);
                 Source.FromPublisher(publisher)
-                    .FlatMapConcat(x => x)
+                    .ConcatMany(x => x)
                     .To(Sink.FromSubscriber(subscriber))
                     .Run(Materializer);
 
@@ -105,7 +105,7 @@ namespace Akka.Streams.Tests.Dsl
                 var publisher = TestPublisher.CreateManualProbe<Source<int, Unit>>(this);
                 var subscriber = TestSubscriber.CreateManualProbe<int>(this);
                 Source.FromPublisher(publisher)
-                    .FlatMapConcat(x => x)
+                    .ConcatMany(x => x)
                     .To(Sink.FromSubscriber(subscriber))
                     .Run(Materializer);
 
@@ -136,7 +136,7 @@ namespace Akka.Streams.Tests.Dsl
                 var publisher = TestPublisher.CreateManualProbe<Source<int, Unit>>(this);
                 var subscriber = TestSubscriber.CreateManualProbe<int>(this);
                 Source.FromPublisher(publisher)
-                    .FlatMapConcat<Source<int,Unit>,int,Unit>(x => { throw TestException; })
+                    .ConcatMany<Source<int,Unit>,int,Unit>(x => { throw TestException; })
                     .To(Sink.FromSubscriber(subscriber))
                     .Run(Materializer);
 
@@ -161,7 +161,7 @@ namespace Akka.Streams.Tests.Dsl
                 var publisher = TestPublisher.CreateManualProbe<Source<int, Unit>>(this);
                 var subscriber = TestSubscriber.CreateManualProbe<int>(this);
                 Source.FromPublisher(publisher)
-                    .FlatMapConcat(x => x)
+                    .ConcatMany(x => x)
                     .To(Sink.FromSubscriber(subscriber))
                     .Run(Materializer);
 
@@ -189,7 +189,7 @@ namespace Akka.Streams.Tests.Dsl
                 var publisher = TestPublisher.CreateManualProbe<Source<int, Unit>>(this);
                 var subscriber = TestSubscriber.CreateManualProbe<int>(this);
                 Source.FromPublisher(publisher)
-                    .FlatMapConcat(x => x)
+                    .ConcatMany(x => x)
                     .To(Sink.FromSubscriber(subscriber))
                     .Run(Materializer);
 
@@ -218,7 +218,7 @@ namespace Akka.Streams.Tests.Dsl
                 var publisher = TestPublisher.CreateManualProbe<Source<int, Unit>>(this);
                 var subscriber = TestSubscriber.CreateManualProbe<int>(this);
                 Source.FromPublisher(publisher)
-                    .FlatMapConcat(x => x)
+                    .ConcatMany(x => x)
                     .To(Sink.FromSubscriber(subscriber))
                     .Run(Materializer);
 
@@ -250,7 +250,7 @@ namespace Akka.Streams.Tests.Dsl
                 var down = TestSubscriber.CreateManualProbe<int>(this);
 
                 var flowSubscriber = Source.AsSubscriber<Source<int, Unit>>()
-                    .FlatMapConcat(x => x.MapMaterializedValue<ISubscriber<Source<int, Unit>>>(_ => null))
+                    .ConcatMany(x => x.MapMaterializedValue<ISubscriber<Source<int, Unit>>>(_ => null))
                     .To(Sink.FromSubscriber(down))
                     .Run(Materializer);
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowConcatAllSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowConcatAllSpec.cs
@@ -59,7 +59,7 @@ namespace Akka.Streams.Tests.Dsl
         public void ConcatAll_must_work_together_with_SplitWhen()
         {
             var subscriber = TestSubscriber.CreateProbe<int>(this);
-            var subflow = Source.From(Enumerable.Range(1, 10)).SplitWhen(x => x%2 == 0).PrefixAndTail(0).Map(x => x.Item2);
+            var subflow = Source.From(Enumerable.Range(1, 10)).SplitWhen(x => x%2 == 0).PrefixAndTail(0).Select(x => x.Item2);
             var source = ((SubFlow<Source<int, Unit>, Unit, IRunnableGraph<Unit>>) subflow).ConcatSubstream().FlatMapConcat(x => x);
             ((Source<int, Unit>) source).RunWith(Sink.FromSubscriber(subscriber), Materializer);
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowConcatSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowConcatSpec.cs
@@ -39,9 +39,9 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void A_Concat_for_Flow_must_be_able_to_concat_Flow_with_Source()
         {
-            var f1 = Flow.Create<int>().Map(x => x + "-s");
+            var f1 = Flow.Create<int>().Select(x => x + "-s");
             var s1 = Source.From(new[] {1, 2, 3});
-            var s2 = Source.From(new[] { 4,5,6 }).Map(x=> x + "-s");
+            var s2 = Source.From(new[] { 4,5,6 }).Select(x=> x + "-s");
 
             var subs = TestSubscriber.CreateManualProbe<string>(this);
             var subSink = Sink.AsPublisher<string>(false);
@@ -58,9 +58,9 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void A_Concat_for_Flow_must_be_able_to_prepend_a_Source_to_a_Flow()
         {
-            var s1 = Source.From(new[] { 1, 2, 3 }).Map(x => x + "-s");
+            var s1 = Source.From(new[] { 1, 2, 3 }).Select(x => x + "-s");
             var s2 = Source.From(new[] { 4, 5, 6 });
-            var f2 = Flow.Create<int>().Map(x => x + "-s");
+            var f2 = Flow.Create<int>().Select(x => x + "-s");
 
             var subs = TestSubscriber.CreateManualProbe<string>(this);
             var subSink = Sink.AsPublisher<string>(false);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowConflateSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowConflateSpec.cs
@@ -124,7 +124,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Conflate_must_work_on_a_variable_rate_chain()
         {
-            var future = Source.From(Enumerable.Range(1, 1000)).ConflateWithSeed(i => i, (sum, i) => sum + i).Map(i =>
+            var future = Source.From(Enumerable.Range(1, 1000)).ConflateWithSeed(i => i, (sum, i) => sum + i).Select(i =>
             {
                 if (ThreadLocalRandom.Current.Next(1, 3) == 2)
                     Thread.Sleep(10);
@@ -137,7 +137,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Conflate_must_work_on_a_variable_rate_chain_simple_conflate()
         {
-            var future = Source.From(Enumerable.Range(1, 1000)).Conflate((sum, i) => sum + i).Map(i =>
+            var future = Source.From(Enumerable.Range(1, 1000)).Conflate((sum, i) => sum + i).Select(i =>
             {
                 if (ThreadLocalRandom.Current.Next(1, 3) == 2)
                     Thread.Sleep(10);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowConflateSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowConflateSpec.cs
@@ -181,7 +181,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Conflate_must_work_with_a_buffer_and_fold()
+        public void Conflate_must_work_with_a_buffer_and_aggregate()
         {
             var future =
                 Source.From(Enumerable.Range(1, 50))

--- a/src/core/Akka.Streams.Tests/Dsl/FlowConflateSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowConflateSpec.cs
@@ -129,7 +129,7 @@ namespace Akka.Streams.Tests.Dsl
                 if (ThreadLocalRandom.Current.Next(1, 3) == 2)
                     Thread.Sleep(10);
                 return i;
-            }).RunFold(0, (sum, i) => sum + i, Materializer);
+            }).RunAggregate(0, (sum, i) => sum + i, Materializer);
             future.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
             future.Result.Should().Be(500500);
         }
@@ -142,7 +142,7 @@ namespace Akka.Streams.Tests.Dsl
                 if (ThreadLocalRandom.Current.Next(1, 3) == 2)
                     Thread.Sleep(10);
                 return i;
-            }).RunFold(0, (sum, i) => sum + i, Materializer);
+            }).RunAggregate(0, (sum, i) => sum + i, Materializer);
             future.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
             future.Result.Should().Be(500500);
         }
@@ -187,7 +187,7 @@ namespace Akka.Streams.Tests.Dsl
                 Source.From(Enumerable.Range(1, 50))
                     .ConflateWithSeed(i => i, (sum, i) => sum + i)
                     .Buffer(50, OverflowStrategy.Backpressure)
-                    .RunFold(0, (sum, i) => sum + i, Materializer);
+                    .RunAggregate(0, (sum, i) => sum + i, Materializer);
             future.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
             future.Result.Should().Be(Enumerable.Range(1, 50).Sum());
         }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowDetacherSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowDetacherSpec.cs
@@ -43,7 +43,7 @@ namespace Akka.Streams.Tests.Dsl
             this.AssertAllStagesStopped(() =>
             {
                 var ex = new TestException("buh");
-                var result = Source.From(Enumerable.Range(1, 100)).Map(x =>
+                var result = Source.From(Enumerable.Range(1, 100)).Select(x =>
                 {
                     if (x == 50)
                         throw ex;

--- a/src/core/Akka.Streams.Tests/Dsl/FlowExpandSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowExpandSpec.cs
@@ -112,7 +112,7 @@ namespace Akka.Streams.Tests.Dsl
         public void Expand_must_work_on_a_variable_rate_chain()
         {
             var future = Source.From(Enumerable.Range(1, 100))
-                .Map(x =>
+                .Select(x =>
                 {
                     if (ThreadLocalRandom.Current.Next(1, 3) == 2)
                         Thread.Sleep(10);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowExpandSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowExpandSpec.cs
@@ -119,7 +119,7 @@ namespace Akka.Streams.Tests.Dsl
                     return x;
                 })
                 .Expand(i => Enumerable.Repeat(i, 200).GetEnumerator())
-                .RunFold(new HashSet<int>(), (agg, elem) =>
+                .RunAggregate(new HashSet<int>(), (agg, elem) =>
                 {
                     agg.Add(elem);
                     return agg;

--- a/src/core/Akka.Streams.Tests/Dsl/FlowFlattenMergeSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowFlattenMergeSpec.cs
@@ -41,7 +41,7 @@ namespace Akka.Streams.Tests.Dsl
         private Sink<int, Task<ImmutableHashSet<int>>> ToSet =>
                 Flow.Create<int>()
                     .Grouped(1000)
-                    .Map(x => x.ToImmutableHashSet())
+                    .Select(x => x.ToImmutableHashSet())
                     .ToMaterialized(Sink.First<ImmutableHashSet<int>>(), Keep.Right);
 
         [Fact]

--- a/src/core/Akka.Streams.Tests/Dsl/FlowFlattenMergeSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowFlattenMergeSpec.cs
@@ -48,7 +48,7 @@ namespace Akka.Streams.Tests.Dsl
         public void A_FlattenMerge_must_work_in_the_nominal_case()
         {
             var task = Source.From(new[] {Src10(0), Src10(10), Src10(20), Src10(30)})
-                .FlatMapMerge(4, s => s)
+                .MergeMany(4, s => s)
                 .RunWith(ToSet, Materializer);
             task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
             task.Result.ShouldAllBeEquivalentTo(Enumerable.Range(0, 40));
@@ -58,7 +58,7 @@ namespace Akka.Streams.Tests.Dsl
         public void A_FlattenMerge_must_not_be_held_back_by_one_slow_stream()
         {
             var task = Source.From(new[] { Src10(0), Src10(10), Blocked, Src10(20), Src10(30) })
-                .FlatMapMerge(3, s => s)
+                .MergeMany(3, s => s)
                 .Take(40)
                 .RunWith(ToSet, Materializer);
             task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
@@ -69,7 +69,7 @@ namespace Akka.Streams.Tests.Dsl
         public void A_FlattenMerge_must_respect_breadth()
         {
             var task = Source.From(new[] { Src10(0), Src10(10), Src10(20), Blocked, Blocked, Src10(30) })
-                .FlatMapMerge(3, s => s)
+                .MergeMany(3, s => s)
                 .Take(40)
                 .RunWith(ToSeq, Materializer);
             task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
@@ -83,7 +83,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             var ex = new TestException("buh");
             var future = Source.Failed<Source<int, Unit>>(ex)
-                .FlatMapMerge(1, x => x)
+                .MergeMany(1, x => x)
                 .RunWith(Sink.First<int>(), Materializer);
 
             future.Invoking(f => f.Wait(TimeSpan.FromSeconds(1))).ShouldThrow<TestException>().And.Should().Be(ex);
@@ -96,7 +96,7 @@ namespace Akka.Streams.Tests.Dsl
 
             var future = Source.Combine(Source.From(new[] {Blocked, Blocked}), Source.Failed<Source<int, Unit>>(ex),
                 i => new Merge<Source<int, Unit>>(i))
-                .FlatMapMerge(10, x => x)
+                .MergeMany(10, x => x)
                 .RunWith(Sink.First<int>(), Materializer);
 
             future.Invoking(f => f.Wait(TimeSpan.FromSeconds(1))).ShouldThrow<TestException>().And.Should().Be(ex);
@@ -107,7 +107,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             var ex = new TestException("buh");
             var future = Source.From(Enumerable.Range(1, 3))
-                .FlatMapMerge(10, x =>
+                .MergeMany(10, x =>
                 {
                     if (x == 3)
                         throw ex;
@@ -123,7 +123,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             var ex = new TestException("buh");
             var future = Source.From(new[] { Blocked, Blocked, Source.Failed<int>(ex) })
-                .FlatMapMerge(10, x => x)
+                .MergeMany(10, x => x)
                 .RunWith(Sink.First<int>(), Materializer);
 
             future.Invoking(f => f.Wait(TimeSpan.FromSeconds(1))).ShouldThrow<TestException>().And.Should().Be(ex);
@@ -140,7 +140,7 @@ namespace Akka.Streams.Tests.Dsl
             Source.Combine(
                 Source.From(new[] {Source.FromPublisher(p1), Source.FromPublisher(p2)}),
                 Source.FromTask(p.Task), i => new Merge<Source<int, Unit>>(i))
-                .FlatMapMerge(5, x => x)
+                .MergeMany(5, x => x)
                 .RunWith(Sink.First<int>(), Materializer);
 
             p1.ExpectRequest();
@@ -161,7 +161,7 @@ namespace Akka.Streams.Tests.Dsl
 
             Source.From(new[]
             {Source.FromPublisher(p1), Source.FromPublisher(p2), Source.FromTask(p.Task)})
-                .FlatMapMerge(5, x => x)
+                .MergeMany(5, x => x)
                 .RunWith(Sink.First<int>(), Materializer);
 
             p1.ExpectRequest();
@@ -180,7 +180,7 @@ namespace Akka.Streams.Tests.Dsl
             var ex = new TestException("buh");
             var latch = new TestLatch();
 
-            Source.From(Enumerable.Range(1, 3)).FlatMapMerge(10, i =>
+            Source.From(Enumerable.Range(1, 3)).MergeMany(10, i =>
             {
                 if (i == 1)
                     return Source.FromPublisher(p);
@@ -200,7 +200,7 @@ namespace Akka.Streams.Tests.Dsl
             var p2 = TestPublisher.CreateProbe<int>(this);
 
             var sink = Source.From(new[] {Source.FromPublisher(p1), Source.FromPublisher(p2)})
-                .FlatMapMerge(5, x => x)
+                .MergeMany(5, x => x)
                 .RunWith(this.SinkProbe<int>(), Materializer);
 
             sink.Request(1);
@@ -216,7 +216,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             const int noOfSources = 100;
             var p = Source.From(Enumerable.Range(0, noOfSources).Select(i => Src10(10*i)))
-                .FlatMapMerge(int.MaxValue, x => x)
+                .MergeMany(int.MaxValue, x => x)
                 .RunWith(this.SinkProbe<int>(), Materializer);
 
             p.EnsureSubscription();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowFoldSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowFoldSpec.cs
@@ -29,13 +29,13 @@ namespace Akka.Streams.Tests.Dsl
 
         private static IEnumerable<int> Input => Enumerable.Range(1, 100);
         private static int Expected => Input.Sum();
-        private static Source<int, Unit> InputSource => Source.From(Input).Filter(_ => true).Select(x => x);
+        private static Source<int, Unit> InputSource => Source.From(Input).Where(_ => true).Select(x => x);
 
         private static Source<int, Unit> FoldSource =>
-            InputSource.Fold(0, (sum, i) => sum + i).Filter(_ => true).Select(x => x);
+            InputSource.Fold(0, (sum, i) => sum + i).Where(_ => true).Select(x => x);
 
         private static Flow<int, int, Unit> FoldFlow =>
-            FlowOperations.Select(Flow.Create<int>().Filter(_ => true).Select(x => x).Fold(0, (sum, i) => sum + i).Filter(_ => true), x => x);
+            FlowOperations.Select(Flow.Create<int>().Where(_ => true).Select(x => x).Fold(0, (sum, i) => sum + i).Where(_ => true), x => x);
 
         private static Sink<int, Task<int>> FoldSink => Sink.Fold<int, int>(0, (sum, i) => sum + i);
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowFoldSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowFoldSpec.cs
@@ -29,13 +29,13 @@ namespace Akka.Streams.Tests.Dsl
 
         private static IEnumerable<int> Input => Enumerable.Range(1, 100);
         private static int Expected => Input.Sum();
-        private static Source<int, Unit> InputSource => Source.From(Input).Filter(_ => true).Map(x => x);
+        private static Source<int, Unit> InputSource => Source.From(Input).Filter(_ => true).Select(x => x);
 
         private static Source<int, Unit> FoldSource =>
-            InputSource.Fold(0, (sum, i) => sum + i).Filter(_ => true).Map(x => x);
+            InputSource.Fold(0, (sum, i) => sum + i).Filter(_ => true).Select(x => x);
 
         private static Flow<int, int, Unit> FoldFlow =>
-            Flow.Create<int>().Filter(_ => true).Map(x => x).Fold(0, (sum, i) => sum + i).Filter(_ => true).Map(x => x);
+            FlowOperations.Select(Flow.Create<int>().Filter(_ => true).Select(x => x).Fold(0, (sum, i) => sum + i).Filter(_ => true), x => x);
 
         private static Sink<int, Task<int>> FoldSink => Sink.Fold<int, int>(0, (sum, i) => sum + i);
 
@@ -103,7 +103,7 @@ namespace Akka.Streams.Tests.Dsl
             this.AssertAllStagesStopped(() =>
             {
                 var error = new TestException("buh");
-                var future = InputSource.Map(x =>
+                var future = InputSource.Select(x =>
                 {
                     if (x > 50)
                         throw error;

--- a/src/core/Akka.Streams.Tests/Dsl/FlowFromTaskSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowFromTaskSpec.cs
@@ -44,7 +44,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_based_on_a_Task_must_produce_error_from_already_failed_Future()
+        public void A_Flow_based_on_a_Task_must_produce_error_from_already_failed_Task()
         {
             this.AssertAllStagesStopped(() =>
             {

--- a/src/core/Akka.Streams.Tests/Dsl/FlowFromTaskSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowFromTaskSpec.cs
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------
-// <copyright file="FlowFromFutureSpec.cs" company="Akka.NET Project">
+// <copyright file="FlowFromTaskSpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>
@@ -17,18 +17,18 @@ using Xunit.Abstractions;
 
 namespace Akka.Streams.Tests.Dsl
 {
-    public class FlowFromFutureSpec : AkkaSpec
+    public class FlowFromTaskSpec : AkkaSpec
     {
         private ActorMaterializer Materializer { get; }
 
-        public FlowFromFutureSpec(ITestOutputHelper helper) : base(helper)
+        public FlowFromTaskSpec(ITestOutputHelper helper) : base(helper)
         {
             var settings = ActorMaterializerSettings.Create(Sys);
             Materializer = ActorMaterializer.Create(Sys, settings);
         }
 
         [Fact]
-        public void A_Flow_based_on_a_Future_must_produce_one_element_from_already_successful_Future()
+        public void A_Flow_based_on_a_Task_must_produce_one_element_from_already_successful_Future()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -44,7 +44,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_based_on_a_Future_must_produce_error_from_already_failed_Future()
+        public void A_Flow_based_on_a_Task_must_produce_error_from_already_failed_Future()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -59,7 +59,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_based_on_a_Future_must_produce_one_element_when_Future_is_completed()
+        public void A_Flow_based_on_a_Task_must_produce_one_element_when_Task_is_completed()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -78,7 +78,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_based_on_a_Future_must_produce_one_element_when_Future_is_completed_but_not_before_request()
+        public void A_Flow_based_on_a_Task_must_produce_one_element_when_Task_is_completed_but_not_before_request()
         {
             var promise = new TaskCompletionSource<int>();
             var c = TestSubscriber.CreateManualProbe<int>(this);
@@ -93,7 +93,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_based_on_a_Future_must_produce_elements_with_multiple_subscribers()
+        public void A_Flow_based_on_a_Task_must_produce_elements_with_multiple_subscribers()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -116,7 +116,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_based_on_a_Future_must_allow_cancel_before_receiving_element()
+        public void A_Flow_based_on_a_Task_must_allow_cancel_before_receiving_element()
         {
             var promise = new TaskCompletionSource<int>();
             var c = TestSubscriber.CreateManualProbe<int>(this);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowGraphCompileSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowGraphCompileSpec.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------
 // <copyright file="FlowGraphCompileSpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
@@ -274,7 +274,7 @@ namespace Akka.Streams.Tests.Dsl
 
 
                 b.From(source).To(unzip.In);
-                b.From(unzip.Out0).Via(Flow.Create<int>().Map(x => x * 2)).To(zip.In0);
+                b.From(unzip.Out0).Via(Flow.Create<int>().Select(x => x * 2)).To(zip.In0);
                 b.From(unzip.Out1).To(zip.In1);
                 b.From(zip.Out).To(sink);
 
@@ -340,7 +340,7 @@ namespace Akka.Streams.Tests.Dsl
                 //b.From(s2).Via(Flow.Create<Apple>()).To(merge.In(1));
 
                 b.From(merge.Out)
-                    .Via(Flow.Create<IFruit>().Map(x => x))
+                    .Via(Flow.Create<IFruit>().Select(x => x))
                     .To(Sink.FromSubscriber(TestSubscriber.CreateManualProbe<IFruit>(this)));
 
                 return ClosedShape.Instance;

--- a/src/core/Akka.Streams.Tests/Dsl/FlowIntersperseSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowIntersperseSpec.cs
@@ -46,7 +46,7 @@ namespace Akka.Streams.Tests.Dsl
                 Source.From(new[] { 1, 2, 3 })
                     .Select(x => x.ToString())
                     .Intersperse(",")
-                    .RunFold("", (s, s1) => s + s1, Materializer);
+                    .RunAggregate("", (s, s1) => s + s1, Materializer);
 
             concated.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
             concated.Result.Should().Be("1,2,3");

--- a/src/core/Akka.Streams.Tests/Dsl/FlowIntersperseSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowIntersperseSpec.cs
@@ -31,7 +31,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             var probe =
                 Source.From(new[] { 1, 2, 3 })
-                    .Map(x => x.ToString())
+                    .Select(x => x.ToString())
                     .Intersperse(",")
                     .RunWith(this.SinkProbe<string>(), Materializer);
 
@@ -44,7 +44,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             var concated =
                 Source.From(new[] { 1, 2, 3 })
-                    .Map(x => x.ToString())
+                    .Select(x => x.ToString())
                     .Intersperse(",")
                     .RunFold("", (s, s1) => s + s1, Materializer);
 
@@ -57,7 +57,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             var probe =
                 Source.From(new[] { 1, 2, 3 })
-                    .Map(x => x.ToString())
+                    .Select(x => x.ToString())
                     .Intersperse("[", ",", "]")
                     .RunWith(this.SinkProbe<string>(), Materializer);
 
@@ -81,7 +81,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             var probe =
        Source.Empty<string>()
-           .Map(x => x.ToString())
+           .Select(x => x.ToString())
            .Intersperse("[", ",", "]")
            .RunWith(this.SinkProbe<string>(), Materializer);
 
@@ -94,7 +94,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             var probe =
                 Source.From(new[] {1})
-                    .Map(x => x.ToString())
+                    .Select(x => x.ToString())
                     .Intersperse("[", ",", "]")
                     .RunWith(this.SinkProbe<string>(), Materializer);
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowIntersperseSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowIntersperseSpec.cs
@@ -40,7 +40,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Intersperse_must_inject_element_between_existing_elements_when_downstream_is_fold()
+        public void A_Intersperse_must_inject_element_between_existing_elements_when_downstream_is_aggregate()
         {
             var concated =
                 Source.From(new[] { 1, 2, 3 })

--- a/src/core/Akka.Streams.Tests/Dsl/FlowIteratorSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowIteratorSpec.cs
@@ -264,7 +264,7 @@ namespace Akka.Streams.Tests.Dsl
             this.AssertAllStagesStopped(() =>
             {
                 var p = CreateSource(4)
-                    .Filter(x => x%2 == 0)
+                    .Where(x => x%2 == 0)
                     .Select(x => x*2)
                     .RunWith(Sink.AsPublisher<int>(false), Materializer);
                 var c = TestSubscriber.CreateManualProbe<int>(this);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowIteratorSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowIteratorSpec.cs
@@ -243,7 +243,7 @@ namespace Akka.Streams.Tests.Dsl
             this.AssertAllStagesStopped(() =>
             {
                 var p = CreateSource(3)
-                    .Map(x => x*2)
+                    .Select(x => x*2)
                     .RunWith(Sink.AsPublisher<int>(false), Materializer);
                 var c = TestSubscriber.CreateManualProbe<int>(this);
 
@@ -265,7 +265,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var p = CreateSource(4)
                     .Filter(x => x%2 == 0)
-                    .Map(x => x*2)
+                    .Select(x => x*2)
                     .RunWith(Sink.AsPublisher<int>(false), Materializer);
                 var c = TestSubscriber.CreateManualProbe<int>(this);
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowJoinSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowJoinSpec.cs
@@ -58,7 +58,7 @@ namespace Akka.Streams.Tests.Dsl
                 var flow2 =
                     Flow.Create<int>()
                         .Filter(x => x%2 == 1)
-                        .Map(x => x*10)
+                        .Select(x => x*10)
                         .Buffer((end + 1)/2, OverflowStrategy.Backpressure)
                         .Take((end + 1)/2);
 
@@ -142,7 +142,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 var feedback = Flow.FromGraph(GraphDsl.Create(Source.Single("ignition"), (b, ignition) =>
                 {
-                    var f = b.Add(Flow.Create<Tuple<string, string>>().Map(t => t.Item1));
+                    var f = b.Add(Flow.Create<Tuple<string, string>>().Select(t => t.Item1));
                     var merge = b.Add(new Merge<string>(2));
 
                     b.From(ignition).To(merge.In(0));

--- a/src/core/Akka.Streams.Tests/Dsl/FlowJoinSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowJoinSpec.cs
@@ -57,7 +57,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 var flow2 =
                     Flow.Create<int>()
-                        .Filter(x => x%2 == 1)
+                        .Where(x => x%2 == 1)
                         .Select(x => x*10)
                         .Buffer((end + 1)/2, OverflowStrategy.Backpressure)
                         .Take((end + 1)/2);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowLogSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowLogSpec.cs
@@ -155,7 +155,7 @@ namespace Akka.Streams.Tests.Dsl
             var future = Source.From(Enumerable.Range(1, 5))
                 .Log("hi", n => { throw ex; })
                 .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider))
-                .RunWith(Sink.Fold<int, int>(0, (i, i1) => i + i1), Materializer);
+                .RunWith(Sink.Aggregate<int, int>(0, (i, i1) => i + i1), Materializer);
 
             future.Wait(TimeSpan.FromMilliseconds(500)).Should().BeTrue();
             future.Result.Should().Be(0);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowMapConcatSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowMapConcatSpec.cs
@@ -62,7 +62,7 @@ namespace Akka.Streams.Tests.Dsl
             Source
                 .From(input)
                 .MapConcat(x => x)
-                .Map(x =>
+                .Select(x =>
                 {
                     Thread.Sleep(10);
                     return x;

--- a/src/core/Akka.Streams.Tests/Dsl/FlowMergeSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowMergeSpec.cs
@@ -41,12 +41,13 @@ namespace Akka.Streams.Tests.Dsl
                 var source3 = Source.From(Enumerable.Range(4, 6));
                 var probe = TestSubscriber.CreateManualProbe<int>(this);
 
-                SourceOperations.Select(source1
-                        .Merge(source2)
-                        .Merge(source3)
-                        .Select(i => i*2)
-                        .Select(i => i/2), i => i + 1)
-                    .RunWith(Sink.FromSubscriber(probe), Materializer);
+                source1
+                    .Merge(source2)
+                    .Merge(source3)
+                    .Select(i => i*2)
+                    .Select(i => i/2)
+                    .Select(i => i+1)
+                .RunWith(Sink.FromSubscriber(probe), Materializer);
 
                 var subscription = probe.ExpectSubscription();
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowMergeSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowMergeSpec.cs
@@ -41,12 +41,11 @@ namespace Akka.Streams.Tests.Dsl
                 var source3 = Source.From(Enumerable.Range(4, 6));
                 var probe = TestSubscriber.CreateManualProbe<int>(this);
 
-                source1
-                    .Merge(source2)
-                    .Merge(source3)
-                    .Map(i => i*2)
-                    .Map(i => i/2)
-                    .Map(i => i + 1)
+                SourceOperations.Select(source1
+                        .Merge(source2)
+                        .Merge(source3)
+                        .Select(i => i*2)
+                        .Select(i => i/2), i => i + 1)
                     .RunWith(Sink.FromSubscriber(probe), Materializer);
 
                 var subscription = probe.ExpectSubscription();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowOnCompleteSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowOnCompleteSpec.cs
@@ -90,7 +90,7 @@ namespace Akka.Streams.Tests.Dsl
                 var onCompleteProbe = CreateTestProbe();
                 var p = TestPublisher.CreateManualProbe<int>(this);
                 var foreachSink = Sink.ForEach<int>(x => onCompleteProbe.Ref.Tell("foreach-" + x));
-                var future = Source.FromPublisher(p).Map(x =>
+                var future = Source.FromPublisher(p).Select(x =>
                 {
                     onCompleteProbe.Ref.Tell("map-" + x);
                     return x;

--- a/src/core/Akka.Streams.Tests/Dsl/FlowRecoverSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowRecoverSpec.cs
@@ -33,14 +33,14 @@ namespace Akka.Streams.Tests.Dsl
         {
             this.AssertAllStagesStopped(() =>
             {
-                Source.From(Enumerable.Range(1, 4)).Map(x =>
+                Source.From(Enumerable.Range(1, 4)).Select(x =>
                 {
                     if (x == 3)
                         throw Ex;
                     return x;
                 })
                     .Recover(_ => new Option<int>(0))
-                    .Map(x => x.Value)
+                    .Select(x => x.Value)
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .RequestNext(1)
                     .RequestNext(2)
@@ -56,14 +56,14 @@ namespace Akka.Streams.Tests.Dsl
         {
             this.AssertAllStagesStopped(() =>
             {
-                Source.From(Enumerable.Range(1, 3)).Map(x =>
+                Source.From(Enumerable.Range(1, 3)).Select(x =>
                 {
                     if (x == 2)
                         throw Ex;
                     return x;
                 })
                     .Recover(_ => Option<int>.None)
-                    .Map(x=>x.Value)
+                    .Select(x=>x.Value)
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .RequestNext(1)
                     .Request(1)
@@ -77,9 +77,9 @@ namespace Akka.Streams.Tests.Dsl
             this.AssertAllStagesStopped(() =>
             {
                 Source.From(Enumerable.Range(1, 3))
-                    .Map(x => x)
+                    .Select(x => x)
                     .Recover(_ => new Option<int>(0))
-                    .Map(x => x.Value)
+                    .Select(x => x.Value)
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(3)
                     .ExpectNext(1, 2, 3)
@@ -93,9 +93,9 @@ namespace Akka.Streams.Tests.Dsl
             this.AssertAllStagesStopped(() =>
             {
                 Source.Empty<int>()
-                    .Map(x => x)
+                    .Select(x => x)
                     .Recover(_ => new Option<int>(0))
-                    .Map(x=>x.Value)
+                    .Select(x=>x.Value)
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(1)
                     .ExpectComplete();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowRecoverWithSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowRecoverWithSpec.cs
@@ -33,7 +33,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             this.AssertAllStagesStopped(() =>
             {
-                var probe = Source.From(Enumerable.Range(1, 4)).Map(x =>
+                var probe = Source.From(Enumerable.Range(1, 4)).Select(x =>
                 {
                     if (x == 3)
                         throw Ex;
@@ -61,7 +61,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             this.AssertAllStagesStopped(() =>
             {
-                var probe = Source.From(Enumerable.Range(1, 4)).Map(x =>
+                var probe = Source.From(Enumerable.Range(1, 4)).Select(x =>
                 {
                     if (x == 3)
                         throw Ex;
@@ -85,7 +85,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             this.AssertAllStagesStopped(() =>
             {
-                var probe = Source.From(Enumerable.Range(1, 3)).Map(x =>
+                var probe = Source.From(Enumerable.Range(1, 3)).Select(x =>
                 {
                     if (x == 2)
                         throw Ex;
@@ -107,7 +107,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             this.AssertAllStagesStopped(() =>
             {
-                var src = Source.From(Enumerable.Range(1, 3)).Map(x =>
+                var src = Source.From(Enumerable.Range(1, 3)).Select(x =>
                 {
                     if (x == 3)
                         throw Ex;
@@ -137,7 +137,7 @@ namespace Akka.Streams.Tests.Dsl
             this.AssertAllStagesStopped(() =>
             {
                 Source.From(Enumerable.Range(1, 3))
-                    .Map(x => x)
+                    .Select(x => x)
                     .RecoverWith(_ => Source.Single(0))
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(3)
@@ -152,7 +152,7 @@ namespace Akka.Streams.Tests.Dsl
             this.AssertAllStagesStopped(() =>
             {
                 Source.Empty<int>()
-                    .Map(x => x)
+                    .Select(x => x)
                     .RecoverWith(_ => Source.Single(0))
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(3)
@@ -165,7 +165,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             this.AssertAllStagesStopped(() =>
             {
-                var probe = Source.From(Enumerable.Range(1, 3)).Map(x =>
+                var probe = Source.From(Enumerable.Range(1, 3)).Select(x =>
                 {
                     if (x == 3)
                         throw new IndexOutOfRangeException();
@@ -173,7 +173,7 @@ namespace Akka.Streams.Tests.Dsl
                 }).RecoverWith(ex =>
                 {
                     if (ex is IndexOutOfRangeException)
-                        return Source.From(new [] {11,22}).Map(x =>
+                        return Source.From(new [] {11,22}).Select(x =>
                         {
                             if (x == 22)
                                 throw new ArgumentException();
@@ -205,7 +205,7 @@ namespace Akka.Streams.Tests.Dsl
             this.AssertAllStagesStopped(() =>
             {
                 var probe = Source.From(Enumerable.Range(1, 3))
-                    .Map(x =>
+                    .Select(x =>
                     {
                         if(x==3)
                             throw new IndexOutOfRangeException();
@@ -214,7 +214,7 @@ namespace Akka.Streams.Tests.Dsl
                     .RecoverWith(ex =>
                     {
                         if (ex is IndexOutOfRangeException)
-                            return Source.From(new[] {11, 22}).Map(x =>
+                            return Source.From(new[] {11, 22}).Select(x =>
                             {
                                 if (x == 22)
                                     throw Ex;

--- a/src/core/Akka.Streams.Tests/Dsl/FlowReduceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowReduceSpec.cs
@@ -29,13 +29,13 @@ namespace Akka.Streams.Tests.Dsl
 
         private static IEnumerable<int> Input => Enumerable.Range(1, 100);
         private static int Expected => Input.Sum();
-        private static Source<int, Unit> InputSource => Source.From(Input).Filter(_ => true).Map(x => x);
+        private static Source<int, Unit> InputSource => Source.From(Input).Filter(_ => true).Select(x => x);
 
         private static Source<int, Unit> ReduceSource
-            => InputSource.Reduce((i, i1) => i + i1).Filter(_ => true).Map(x => x);
+            => InputSource.Reduce((i, i1) => i + i1).Filter(_ => true).Select(x => x);
 
         private static Flow<int, int, Unit> ReduceFlow
-            => Flow.Create<int>().Filter(_ => true).Map(x => x).Reduce((i, i1) => i + i1).Filter(_ => true).Map(x => x);
+            => Flow.Create<int>().Filter(_ => true).Select(x => x).Reduce((i, i1) => i + i1).Filter(_ => true).Select(x => x);
 
         private static Sink<int, Task<int>> ReduceSink => Sink.Reduce<int>((i, i1) => i + i1);
 
@@ -101,7 +101,7 @@ namespace Akka.Streams.Tests.Dsl
             this.AssertAllStagesStopped(() =>
             {
                 var error = new TestException("test");
-                var task = InputSource.Map(x =>
+                var task = InputSource.Select(x =>
                 {
                     if (x > 50)
                         throw error;

--- a/src/core/Akka.Streams.Tests/Dsl/FlowReduceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowReduceSpec.cs
@@ -29,13 +29,13 @@ namespace Akka.Streams.Tests.Dsl
 
         private static IEnumerable<int> Input => Enumerable.Range(1, 100);
         private static int Expected => Input.Sum();
-        private static Source<int, Unit> InputSource => Source.From(Input).Filter(_ => true).Select(x => x);
+        private static Source<int, Unit> InputSource => Source.From(Input).Where(_ => true).Select(x => x);
 
         private static Source<int, Unit> ReduceSource
-            => InputSource.Reduce((i, i1) => i + i1).Filter(_ => true).Select(x => x);
+            => InputSource.Reduce((i, i1) => i + i1).Where(_ => true).Select(x => x);
 
         private static Flow<int, int, Unit> ReduceFlow
-            => Flow.Create<int>().Filter(_ => true).Select(x => x).Reduce((i, i1) => i + i1).Filter(_ => true).Select(x => x);
+            => Flow.Create<int>().Where(_ => true).Select(x => x).Reduce((i, i1) => i + i1).Where(_ => true).Select(x => x);
 
         private static Sink<int, Task<int>> ReduceSink => Sink.Reduce<int>((i, i1) => i + i1);
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowScanSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowScanSpec.cs
@@ -35,7 +35,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             duration = duration ?? TimeSpan.FromSeconds(5);
 
-            var t = source.Scan(0, (i, i1) => i + i1).RunFold(new List<int>(), (list, i) =>
+            var t = source.Scan(0, (i, i1) => i + i1).RunAggregate(new List<int>(), (list, i) =>
             {
                 list.Add(i);
                 return list;

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSectionSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSectionSpec.cs
@@ -50,7 +50,7 @@ namespace Akka.Streams.Tests.Dsl
         public void A_Flow_can_have_an_op_with_a_different_dispatcher()
         {
             var flow = Flow.Create<int>()
-                .Map(x => SentThreadNameTo(TestActor, x))
+                .Select(x => SentThreadNameTo(TestActor, x))
                 .WithAttributes(ActorAttributes.CreateDispatcher("my-dispatcher1"));
 
             Source.Single(1).Via(flow).To(Sink.Ignore<int>()).Run(Materializer);
@@ -64,7 +64,7 @@ namespace Akka.Streams.Tests.Dsl
             Source.Single(1)
                 .Via(
                     Flow.Create<int>()
-                        .Map(x => SentThreadNameTo(TestActor, x))
+                        .Select(x => SentThreadNameTo(TestActor, x))
                         .WithAttributes(ActorAttributes.CreateDispatcher("my-dispatcher")))
                 .To(Sink.Ignore<int>())
                 .Run(Materializer);
@@ -80,12 +80,12 @@ namespace Akka.Streams.Tests.Dsl
 
             var flow1 =
                 Flow.Create<int>()
-                    .Map(x => SentThreadNameTo(probe1.Ref, x))
+                    .Select(x => SentThreadNameTo(probe1.Ref, x))
                     .WithAttributes(ActorAttributes.CreateDispatcher("my-dispatcher1"));
 
             var flow2 =
                 Flow.FromGraph(flow1)
-                    .Via(Flow.Create<int>().Map(x => SentThreadNameTo(probe2.Ref, x)))
+                    .Via(Flow.Create<int>().Select(x => SentThreadNameTo(probe2.Ref, x)))
                     .WithAttributes(ActorAttributes.CreateDispatcher("my-dispatcher2"));
 
             Source.Single(1).Via(flow2).To(Sink.Ignore<int>()).Run(Materializer);
@@ -98,13 +98,13 @@ namespace Akka.Streams.Tests.Dsl
         public void A_Flow_can_include_name_in_ToString()
         {
             var n = "Uppercase reverser";
-            var f1 = Flow.Create<string>().Map(c => c.ToLower());
+            var f1 = Flow.Create<string>().Select(c => c.ToLower());
             var graph =
                 Flow.Create<string>()
-                    .Map(c => c.ToUpper())
-                    .Map(s => s.Reverse().Aggregate("", (agg, c) => agg + c))
+                    .Select(c => c.ToUpper())
+                    .Select(s => s.Reverse().Aggregate("", (agg, c) => agg + c))
                     .Named(n);
-            var f2 = Flow.FromGraph(graph).Map(c => c.ToLower());
+            var f2 = Flow.FromGraph(graph).Select(c => c.ToLower());
 
             f1.Via(f2).ToString().Should().Contain(n);
         }
@@ -115,11 +115,11 @@ namespace Akka.Streams.Tests.Dsl
             var defaultDispatcher = CreateTestProbe();
             var customDispatcher = CreateTestProbe();
 
-            var f1 = Flow.Create<int>().Map(x => SentThreadNameTo(defaultDispatcher.Ref, x));
+            var f1 = Flow.Create<int>().Select(x => SentThreadNameTo(defaultDispatcher.Ref, x));
             var f2 =
                 Flow.Create<int>()
-                    .Map(x => SentThreadNameTo(defaultDispatcher.Ref, x))
-                    .Map(x => x)
+                    .Select(x => SentThreadNameTo(defaultDispatcher.Ref, x))
+                    .Select(x => x)
                     .WithAttributes(
                         ActorAttributes.CreateDispatcher("my-dispatcher")
                             .And(Attributes.CreateName("seperate-dispatcher")));

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncSpec.cs
@@ -40,7 +40,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsync_must_produce_future_elements()
+        public void A_Flow_with_SelectAsync_must_produce_task_elements()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -62,7 +62,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsync_must_produce_future_elements_in_order()
+        public void A_Flow_with_SelectAsync_must_produce_task_elements_in_order()
         {
             var c = TestSubscriber.CreateManualProbe<int>(this);
             Source.From(Enumerable.Range(1, 50))
@@ -107,7 +107,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsync_must_signal_future_failure()
+        public void A_Flow_with_SelectAsync_must_signal_task_failure()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -158,7 +158,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsync_must_resume_after_future_failure()
+        public void A_Flow_with_SelectAsync_must_resume_after_task_failure()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -208,7 +208,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsync_must_finish_after_future_failure()
+        public void A_Flow_with_SelectAsync_must_finish_after_task_failure()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -248,7 +248,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsync_must_signal_NPE_when_future_is_completed_with_null()
+        public void A_Flow_with_SelectAsync_must_signal_NPE_when_task_is_completed_with_null()
         {
             var c = TestSubscriber.CreateManualProbe<string>(this);
 
@@ -262,7 +262,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsync_must_resume_when_future_is_completed_with_null()
+        public void A_Flow_with_SelectAsync_must_resume_when_task_is_completed_with_null()
         {
             var c = TestSubscriber.CreateManualProbe<string>(this);
             Source.From(new[] { "a", "b", "c" })

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncSpec.cs
@@ -349,7 +349,7 @@ namespace Akka.Streams.Tests.Dsl
                     const int n = 10000;
                     var task = Source.From(Enumerable.Range(1, n))
                         .SelectAsync(parallelism, _ => deferred())
-                        .RunFold(0, (c, _) => c + 1, Materializer);
+                        .RunAggregate(0, (c, _) => c + 1, Materializer);
 
                     task.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
                     task.Result.Should().Be(n);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncUnorderedSpec .cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncUnorderedSpec .cs
@@ -39,7 +39,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsyncUnordered_must_produce_future_elements_in_the_order_they_are_ready()
+        public void A_Flow_with_SelectAsyncUnordered_must_produce_task_elements_in_the_order_they_are_ready()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -102,7 +102,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsyncUnordered_must_signal_future_failure()
+        public void A_Flow_with_SelectAsyncUnordered_must_signal_task_failure()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -126,7 +126,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsyncUnordered_must_signal_error_from_MapAsyncUnordered()
+        public void A_Flow_with_SelectAsyncUnordered_must_signal_error_from_SelectAsyncUnordered()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -153,7 +153,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsyncUnordered_must_resume_after_future_failure()
+        public void A_Flow_with_SelectAsyncUnordered_must_resume_after_task_failure()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -201,7 +201,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsyncUnordered_must_finish_after_future_failure()
+        public void A_Flow_with_SelectAsyncUnordered_must_finish_after_task_failure()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -239,7 +239,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsyncUnordered_must_signal_NPE_when_future_is_completed_with_null()
+        public void A_Flow_with_SelectAsyncUnordered_must_signal_NPE_when_task_is_completed_with_null()
         {
             var c = TestSubscriber.CreateManualProbe<string>(this);
 
@@ -253,7 +253,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsyncUnordered_must_resume_when_future_is_completed_with_null()
+        public void A_Flow_with_SelectAsyncUnordered_must_resume_when_task_is_completed_with_null()
         {
             var c = TestSubscriber.CreateManualProbe<string>(this);
             Source.From(new[] { "a", "b", "c" })

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncUnorderedSpec .cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncUnorderedSpec .cs
@@ -338,7 +338,7 @@ namespace Akka.Streams.Tests.Dsl
                     const int n = 10000;
                     var task = Source.From(Enumerable.Range(1, n))
                         .SelectAsyncUnordered(parallelism, _ => deferred())
-                        .RunFold(0, (c, _) => c + 1, Materializer);
+                        .RunAggregate(0, (c, _) => c + 1, Materializer);
 
                     task.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
                     task.Result.Should().Be(n);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSelectManySpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSelectManySpec.cs
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------
-// <copyright file="FlowMapConcatSpec.cs" company="Akka.NET Project">
+// <copyright file="FlowSelectManySpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>
@@ -20,19 +20,19 @@ using Xunit.Abstractions;
 
 namespace Akka.Streams.Tests.Dsl
 {
-    public class FlowMapConcatSpec : ScriptedTest
+    public class FlowSelectManySpec : ScriptedTest
     {
         private readonly ActorMaterializerSettings settings;
         private readonly ActorMaterializer materializer;
 
-        public FlowMapConcatSpec(ITestOutputHelper output) : base(output)
+        public FlowSelectManySpec(ITestOutputHelper output) : base(output)
         {
             settings = ActorMaterializerSettings.Create(Sys).WithInputBuffer(initialSize: 2, maxSize: 16);
             materializer = Sys.Materializer();
         }
 
         [Fact]
-        public void MapConcat_should_map_and_concat()
+        public void SelectMany_should_map_and_concat()
         {
             var script = Script.Create(
                 Tuple.Create<ICollection<int>, ICollection<int>>(new[] { 0 }, new int[0]),
@@ -44,11 +44,11 @@ namespace Akka.Streams.Tests.Dsl
 
             var random = ThreadLocalRandom.Current.Next(1, 10);
             for (int i = 0; i < random; i++)
-                RunScript(script, settings, a => a.MapConcat(x => Enumerable.Range(1, x).Select(_ => x)));
+                RunScript(script, settings, a => a.SelectMany(x => Enumerable.Range(1, x).Select(_ => x)));
         }
 
         [Fact]
-        public void MapConcat_should_map_and_concat_grouping_with_slow_downstream()
+        public void SelectMany_should_map_and_concat_grouping_with_slow_downstream()
         {
             var subscriber = this.CreateManualProbe<int>();
             var input = new[]
@@ -61,7 +61,7 @@ namespace Akka.Streams.Tests.Dsl
 
             Source
                 .From(input)
-                .MapConcat(x => x)
+                .SelectMany(x => x)
                 .Select(x =>
                 {
                     Thread.Sleep(10);
@@ -78,13 +78,13 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void MapConcat_should_be_able_to_resume()
+        public void SelectMany_should_be_able_to_resume()
         {
             var exception = new Exception("TEST");
 
             Source
                 .From(Enumerable.Range(1, 5))
-                .MapConcat(x =>
+                .SelectMany(x =>
                 {
                     if (x == 3) throw exception;
                     else return new[] {x};

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSelectSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSelectSpec.cs
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------
-// <copyright file="FlowMapSpec.cs" company="Akka.NET Project">
+// <copyright file="FlowSelectSpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>
@@ -17,12 +17,12 @@ using Xunit.Abstractions;
 
 namespace Akka.Streams.Tests.Dsl
 {
-    public class FlowMapSpec : ScriptedTest
+    public class FlowSelectSpec : ScriptedTest
     {
         private readonly ActorMaterializerSettings _settings;
         private readonly ActorMaterializer _materializer;
 
-        public FlowMapSpec(ITestOutputHelper output) : base(output)
+        public FlowSelectSpec(ITestOutputHelper output) : base(output)
         {
             Sys.Settings.InjectTopLevelFallback(ActorMaterializer.DefaultConfig());
             _settings = ActorMaterializerSettings.Create(Sys)
@@ -32,7 +32,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Map_should_map()
+        public void Select_should_map()
         {
 
             var script = Script.Create(Enumerable.Range(1, ThreadLocalRandom.Current.Next(1, 10)).Select(_ =>
@@ -44,21 +44,21 @@ namespace Akka.Streams.Tests.Dsl
             var n = ThreadLocalRandom.Current.Next(10);
             for (int i = 0; i < n; i++)
             {
-                RunScript(script, _settings, x => x.Map(y => y.ToString()));
+                RunScript(script, _settings, x => x.Select(y => y.ToString()));
             }
         }
 
         [Fact]
-        public void Map_should_not_blow_up_with_high_request_counts()
+        public void Select_should_not_blow_up_with_high_request_counts()
         {
             var probe = this.CreateManualProbe<int>();
 
             Source.From(new [] {1})
-                .Map(x => x + 1)
-                .Map(x => x + 1)
-                .Map(x => x + 1)
-                .Map(x => x + 1)
-                .Map(x => x + 1)
+                .Select(x => x + 1)
+                .Select(x => x + 1)
+                .Select(x => x + 1)
+                .Select(x => x + 1)
+                .Select(x => x + 1)
                 .RunWith(Sink.AsPublisher<int>(false), _materializer)
                 .Subscribe(probe);
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSelectSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSelectSpec.cs
@@ -32,7 +32,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Select_should_map()
+        public void Select_should_select()
         {
 
             var script = Script.Create(Enumerable.Range(1, ThreadLocalRandom.Current.Next(1, 10)).Select(_ =>

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSkipSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSkipSpec.cs
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------
-// <copyright file="FlowDropSpec.cs" company="Akka.NET Project">
+// <copyright file="FlowSkipSpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>
@@ -18,19 +18,19 @@ using static Akka.Streams.Tests.Dsl.TestConfig;
 
 namespace Akka.Streams.Tests.Dsl
 {
-    public class FlowDropSpec : ScriptedTest
+    public class FlowSkipSpec : ScriptedTest
     {
         private ActorMaterializerSettings Settings { get; }
         private ActorMaterializer Materializer { get; }
 
-        public FlowDropSpec(ITestOutputHelper helper) : base(helper)
+        public FlowSkipSpec(ITestOutputHelper helper) : base(helper)
         {
             Settings = ActorMaterializerSettings.Create(Sys).WithInputBuffer(2, 16);
             Materializer = ActorMaterializer.Create(Sys, Settings);
         }
 
         [Fact]
-        public void A_Drop_must_drop()
+        public void A_Skip_must_drop()
         {
             Func<long, Script<int, int>> script =
                 d => Script.Create(RandomTestRange(Sys)
@@ -40,15 +40,15 @@ namespace Akka.Streams.Tests.Dsl
             foreach (var _ in RandomTestRange(Sys))
             {
                 var d = Math.Min(Math.Max(random.Next(-10, 60), 0), 50);
-                RunScript(script(d), Settings, f => f.Drop(d));
+                RunScript(script(d), Settings, f => f.Skip(d));
             }
         }
 
         [Fact]
-        public void A_Drop_must_not_drop_anything_for_negative_n()
+        public void A_Skip_must_not_drop_anything_for_negative_n()
         {
             var probe = TestSubscriber.CreateManualProbe<int>(this);
-            Source.From(new[] {1, 2, 3}).Drop(-1).To(Sink.FromSubscriber(probe)).Run(Materializer);
+            Source.From(new[] {1, 2, 3}).Skip(-1).To(Sink.FromSubscriber(probe)).Run(Materializer);
             probe.ExpectSubscription().Request(10);
             probe.ExpectNext(1);
             probe.ExpectNext(2);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSkipSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSkipSpec.cs
@@ -30,7 +30,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Skip_must_drop()
+        public void A_Skip_must_skip()
         {
             Func<long, Script<int, int>> script =
                 d => Script.Create(RandomTestRange(Sys)
@@ -45,7 +45,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Skip_must_not_drop_anything_for_negative_n()
+        public void A_Skip_must_not_skip_anything_for_negative_n()
         {
             var probe = TestSubscriber.CreateManualProbe<int>(this);
             Source.From(new[] {1, 2, 3}).Skip(-1).To(Sink.FromSubscriber(probe)).Run(Materializer);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSkipWhileSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSkipWhileSpec.cs
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------
-// <copyright file="FlowDropWhileSpec.cs" company="Akka.NET Project">
+// <copyright file="FlowSkipWhileSpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>
@@ -16,23 +16,23 @@ using Xunit.Abstractions;
 
 namespace Akka.Streams.Tests.Dsl
 {
-    public class FlowDropWhileSpec : AkkaSpec
+    public class FlowSkipWhileSpec : AkkaSpec
     {
         private ActorMaterializer Materializer { get; }
 
-        public FlowDropWhileSpec(ITestOutputHelper helper) : base(helper)
+        public FlowSkipWhileSpec(ITestOutputHelper helper) : base(helper)
         {
             var settings = ActorMaterializerSettings.Create(Sys);
             Materializer = ActorMaterializer.Create(Sys, settings);
         }
 
         [Fact]
-        public void A_DropWhile_must_drop_while_predicate_is_true()
+        public void A_SkipWhile_must_drop_while_predicate_is_true()
         {
             this.AssertAllStagesStopped(() =>
             {
                 Source.From(Enumerable.Range(1, 4))
-                    .DropWhile(x => x < 3)
+                    .SkipWhile(x => x < 3)
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(2)
                     .ExpectNext(3, 4)
@@ -41,12 +41,12 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_DropWhile_must_complete_the_future_for_an_empty_stream()
+        public void A_SkipWhile_must_complete_the_future_for_an_empty_stream()
         {
             this.AssertAllStagesStopped(() =>
             {
                 Source.Empty<int>()
-                    .DropWhile(x => x < 2)
+                    .SkipWhile(x => x < 2)
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(1)
                     .ExpectComplete();
@@ -54,12 +54,12 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_DropWhile_must_continue_if_error()
+        public void A_SkipWhile_must_continue_if_error()
         {
             this.AssertAllStagesStopped(() =>
             {
                 var testException = new Exception("test");
-                Source.From(Enumerable.Range(1, 4)).DropWhile(x =>
+                Source.From(Enumerable.Range(1, 4)).SkipWhile(x =>
                 {
                     if (x < 3)
                         return true;

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSkipWhileSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSkipWhileSpec.cs
@@ -27,7 +27,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_SkipWhile_must_drop_while_predicate_is_true()
+        public void A_SkipWhile_must_skip_while_predicate_is_true()
         {
             this.AssertAllStagesStopped(() =>
             {

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSkipWhithinSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSkipWhithinSpec.cs
@@ -19,23 +19,23 @@ using Xunit.Abstractions;
 
 namespace Akka.Streams.Tests.Dsl
 {
-    public class FlowDropWithinSpec : AkkaSpec
+    public class FlowSkipWithinSpec : AkkaSpec
     {
         private ActorMaterializer Materializer { get; }
 
-        public FlowDropWithinSpec(ITestOutputHelper helper) : base(helper)
+        public FlowSkipWithinSpec(ITestOutputHelper helper) : base(helper)
         {
             Materializer = ActorMaterializer.Create(Sys);
         }
 
         [Fact]
-        public void A_DropWithin_must_deliver_elements_after_the_duration_but_not_before()
+        public void A_SkipWithin_must_deliver_elements_after_the_duration_but_not_before()
         {
             var input = Enumerable.Range(1, 200).GetEnumerator();
             var p = TestPublisher.CreateManualProbe<int>(this);
             var c = TestSubscriber.CreateManualProbe<int>(this);
             Source.FromPublisher(p)
-                .DropWithin(TimeSpan.FromSeconds(1))
+                .SkipWithin(TimeSpan.FromSeconds(1))
                 .To(Sink.FromSubscriber(c))
                 .Run(Materializer);
             var pSub = p.ExpectSubscription();
@@ -68,13 +68,13 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_DropWithin_must_deliver_completion_even_before_the_duration()
+        public void A_SkipWithin_must_deliver_completion_even_before_the_duration()
         {
             var upstream = TestPublisher.CreateProbe<int>(this);
             var downstream = TestSubscriber.CreateProbe<int>(this);
 
             Source.FromPublisher(upstream)
-                .DropWithin(TimeSpan.FromDays(1))
+                .SkipWithin(TimeSpan.FromDays(1))
                 .RunWith(Sink.FromSubscriber(downstream), Materializer);
 
             upstream.SendComplete();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSlidingSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSlidingSpec.cs
@@ -37,7 +37,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 var af = Source.FromEnumerator(() => Enumerable.Range(0, int.MaxValue).Take(len).GetEnumerator())
                     .Sliding(win, step)
-                    .RunFold(new List<IEnumerable<int>>(), (ints, e) =>
+                    .RunAggregate(new List<IEnumerable<int>>(), (ints, e) =>
                     {
                         ints.Add(e);
                         return ints;
@@ -45,7 +45,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 var input = Enumerable.Range(0, int.MaxValue).Take(len).ToList();
                 var cf = Source.FromEnumerator(() => Sliding(input, win, step).GetEnumerator())
-                    .RunFold(new List<IEnumerable<int>>(), (ints, e) =>
+                    .RunAggregate(new List<IEnumerable<int>>(), (ints, e) =>
                     {
                         ints.Add(e);
                         return ints;

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSplitAfterSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSplitAfterSpec.cs
@@ -146,7 +146,7 @@ namespace Akka.Streams.Tests.Dsl
                 var task = Source.From(Enumerable.Range(1, 10))
                     .SplitAfter(_ => true)
                     .Lift()
-                    .MapAsync(1, s => s.RunWith(Sink.First<int>(), Materializer))
+                    .SelectAsync(1, s => s.RunWith(Sink.First<int>(), Materializer))
                     .Grouped(10)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
                 task.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSplitWhenSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSplitWhenSpec.cs
@@ -373,7 +373,7 @@ namespace Akka.Streams.Tests.Dsl
                     var task =
                         testSource.Lift()
                             .Delay(TimeSpan.FromSeconds(1))
-                            .FlatMapConcat(s => s.MapMaterializedValue<TaskCompletionSource<int>>(_ => null))
+                            .ConcatMany(s => s.MapMaterializedValue<TaskCompletionSource<int>>(_ => null))
                             .RunWith(Sink.Ignore<int>(), tightTimeoutMaterializer);
                     task.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
                 };

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSplitWhenSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSplitWhenSpec.cs
@@ -195,7 +195,7 @@ namespace Akka.Streams.Tests.Dsl
                 Source.FromPublisher(inputs)
                     .SplitWhen(x => x == 2)
                     .Lift()
-                    .Map(x => x.RunWith(Sink.FromSubscriber(substream), Materializer))
+                    .Select(x => x.RunWith(Sink.FromSubscriber(substream), Materializer))
                     .RunWith(Sink.FromSubscriber(masterStream), Materializer);
 
                 masterStream.Request(1);
@@ -212,7 +212,7 @@ namespace Akka.Streams.Tests.Dsl
                 Source.FromPublisher(inputs2)
                     .SplitWhen(x => x == 2)
                     .Lift()
-                    .Map(x => x.RunWith(Sink.Cancelled<int>(), Materializer))
+                    .Select(x => x.RunWith(Sink.Cancelled<int>(), Materializer))
                     .RunWith(Sink.Cancelled<Unit>(), Materializer);
                 inputs2.ExpectCancellation();
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSplitWhenSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSplitWhenSpec.cs
@@ -127,7 +127,7 @@ namespace Akka.Streams.Tests.Dsl
                     Source.Empty<int>()
                         .SplitWhen(_ => true)
                         .Lift()
-                        .MapAsync(1, s => s.RunWith(Sink.FirstOrDefault<int>(), Materializer))
+                        .SelectAsync(1, s => s.RunWith(Sink.FirstOrDefault<int>(), Materializer))
                         .Grouped(10)
                         .RunWith(Sink.FirstOrDefault<IEnumerable<int>>(),
                     Materializer);
@@ -321,7 +321,7 @@ namespace Akka.Streams.Tests.Dsl
                 var task = Source.From(Enumerable.Range(1, 100))
                     .SplitWhen(_ => true)
                     .Lift()
-                    .MapAsync(1, s => s.RunWith(Sink.First<int>(), Materializer)) // Please note that this line *also* implicitly asserts nonempty substreams
+                    .SelectAsync(1, s => s.RunWith(Sink.First<int>(), Materializer)) // Please note that this line *also* implicitly asserts nonempty substreams
                     .Grouped(200)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
                 task.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
@@ -335,7 +335,7 @@ namespace Akka.Streams.Tests.Dsl
             this.AssertAllStagesStopped(() =>
             {
                 var task = Source.Single(1).SplitWhen(_ => true).Lift()
-                    .MapAsync(1, source =>
+                    .SelectAsync(1, source =>
                     {
                         source.RunWith(Sink.Ignore<int>(), Materializer);
                         // Sink.ignore+mapAsync pipes error back

--- a/src/core/Akka.Streams.Tests/Dsl/FlowStatefulSelectManySpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowStatefulSelectManySpec.cs
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------
-// <copyright file="FlowStatefulMapConcatSpec.cs" company="Akka.NET Project">
+// <copyright file="FlowStatefulSelectManySpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>
@@ -19,11 +19,11 @@ using static Akka.Streams.Tests.Dsl.TestConfig;
 
 namespace Akka.Streams.Tests.Dsl
 {
-    public class FlowStatefulMapConcatSpec : ScriptedTest
+    public class FlowStatefulSelectManySpec : ScriptedTest
     {
         private ActorMaterializer Materializer { get; }
 
-        public FlowStatefulMapConcatSpec()
+        public FlowStatefulSelectManySpec()
         {
             var settings = ActorMaterializerSettings.Create(Sys).WithInputBuffer(2, 16);
             Materializer = ActorMaterializer.Create(Sys, settings);
@@ -32,7 +32,7 @@ namespace Akka.Streams.Tests.Dsl
         private static readonly Exception Ex = new TestException("Test");
 
         [Fact]
-        public void A_StatefulMapConcat_must_work_in_happy_case()
+        public void A_StatefulSelectMany_must_work_in_happy_case()
         {
             Func<Script<int, int>> script = () =>
             {
@@ -48,7 +48,7 @@ namespace Akka.Streams.Tests.Dsl
 
             RandomTestRange(Sys).ForEach(_ =>
             {
-                RunScript(script(), Materializer.Settings, flow => flow.StatefulMapConcat<int,int,int, Unit>(() =>
+                RunScript(script(), Materializer.Settings, flow => flow.StatefulSelectMany<int,int,int, Unit>(() =>
                 {
                     int? prev = null;
                     return (x =>
@@ -68,9 +68,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_StatefulMapConcat_must_be_able_to_restart()
+        public void A_StatefulSelectMany_must_be_able_to_restart()
         {
-            var probe = Source.From(new[] {2, 1, 3, 4, 1}).StatefulMapConcat<int, int, Unit>(() =>
+            var probe = Source.From(new[] {2, 1, 3, 4, 1}).StatefulSelectMany<int, int, Unit>(() =>
             {
                 int? prev = null;
 
@@ -99,9 +99,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_StatefulMapConcat_must_be_able_to_resume()
+        public void A_StatefulSelectMany_must_be_able_to_resume()
         {
-            var probe = Source.From(new[] { 2, 1, 3, 4, 1 }).StatefulMapConcat<int, int, Unit>(() =>
+            var probe = Source.From(new[] { 2, 1, 3, 4, 1 }).StatefulSelectMany<int, int, Unit>(() =>
             {
                 int? prev = null;
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSumSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSumSpec.cs
@@ -31,16 +31,16 @@ namespace Akka.Streams.Tests.Dsl
         private static int Expected => Input.Sum();
         private static Source<int, Unit> InputSource => Source.From(Input).Where(_ => true).Select(x => x);
 
-        private static Source<int, Unit> ReduceSource
+        private static Source<int, Unit> SumSource
             => InputSource.Sum((i, i1) => i + i1).Where(_ => true).Select(x => x);
 
-        private static Flow<int, int, Unit> ReduceFlow
+        private static Flow<int, int, Unit> SumFlow
             => Flow.Create<int>().Where(_ => true).Select(x => x).Sum((i, i1) => i + i1).Where(_ => true).Select(x => x);
 
-        private static Sink<int, Task<int>> ReduceSink => Sink.Sum<int>((i, i1) => i + i1);
+        private static Sink<int, Task<int>> SumSink => Sink.Sum<int>((i, i1) => i + i1);
 
         [Fact]
-        public void A_Sum_must_work_when_using_Source_RunReduce()
+        public void A_Sum_must_work_when_using_Source_RunSum()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -51,21 +51,21 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Sum_must_work_when_using_Source_Reduce()
+        public void A_Sum_must_work_when_using_Source_Sum()
         {
             this.AssertAllStagesStopped(() =>
             {
-                var t = ReduceSource.RunWith(Sink.First<int>(), Materializer);
+                var t = SumSource.RunWith(Sink.First<int>(), Materializer);
                 t.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
                 t.Result.Should().Be(Expected);
             }, Materializer);
         }
         [Fact]
-        public void A_Sum_must_work_when_using_Sink_Reduce()
+        public void A_Sum_must_work_when_using_Sink_Sum()
         {
             this.AssertAllStagesStopped(() =>
             {
-                var t = InputSource.RunWith(ReduceSink, Materializer);
+                var t = InputSource.RunWith(SumSink, Materializer);
                 t.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
                 t.Result.Should().Be(Expected);
 
@@ -73,22 +73,22 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Sum_must_work_when_using_Flow_Reduce()
+        public void A_Sum_must_work_when_using_Flow_Sum()
         {
             this.AssertAllStagesStopped(() =>
             {
-                var t = InputSource.Via(ReduceFlow).RunWith(Sink.First<int>(), Materializer);
+                var t = InputSource.Via(SumFlow).RunWith(Sink.First<int>(), Materializer);
                 t.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
                 t.Result.Should().Be(Expected);
             }, Materializer);
         }
 
         [Fact]
-        public void A_Sum_must_work_when_using_Source_Sum_and_Flow_Sum_and_Sink_Reduce()
+        public void A_Sum_must_work_when_using_Source_Sum_and_Flow_Sum_and_Sink_Sum()
         {
             this.AssertAllStagesStopped(() =>
             {
-                var t = ReduceSource.Via(ReduceFlow).RunWith(ReduceSink, Materializer);
+                var t = SumSource.Via(SumFlow).RunWith(SumSink, Materializer);
                 t.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
                 t.Result.Should().Be(Expected);
 
@@ -113,7 +113,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Sum_must_complete_future_with_failure_when_reducing_function_throws()
+        public void A_Sum_must_complete_task_with_failure_when_reducing_function_throws()
         {
             this.AssertAllStagesStopped(() =>
             {

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSumSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSumSpec.cs
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------
-// <copyright file="FlowReduceSpec.cs" company="Akka.NET Project">
+// <copyright file="FlowSumSpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>
@@ -18,11 +18,11 @@ using Xunit.Abstractions;
 
 namespace Akka.Streams.Tests.Dsl
 {
-    public class FlowReduceSpec : AkkaSpec
+    public class FlowSumSpec : AkkaSpec
     {
         private ActorMaterializer Materializer { get; }
 
-        public FlowReduceSpec(ITestOutputHelper helper):base(helper)
+        public FlowSumSpec(ITestOutputHelper helper):base(helper)
         {
             Materializer = ActorMaterializer.Create(Sys);
         }
@@ -32,26 +32,26 @@ namespace Akka.Streams.Tests.Dsl
         private static Source<int, Unit> InputSource => Source.From(Input).Where(_ => true).Select(x => x);
 
         private static Source<int, Unit> ReduceSource
-            => InputSource.Reduce((i, i1) => i + i1).Where(_ => true).Select(x => x);
+            => InputSource.Sum((i, i1) => i + i1).Where(_ => true).Select(x => x);
 
         private static Flow<int, int, Unit> ReduceFlow
-            => Flow.Create<int>().Where(_ => true).Select(x => x).Reduce((i, i1) => i + i1).Where(_ => true).Select(x => x);
+            => Flow.Create<int>().Where(_ => true).Select(x => x).Sum((i, i1) => i + i1).Where(_ => true).Select(x => x);
 
-        private static Sink<int, Task<int>> ReduceSink => Sink.Reduce<int>((i, i1) => i + i1);
+        private static Sink<int, Task<int>> ReduceSink => Sink.Sum<int>((i, i1) => i + i1);
 
         [Fact]
-        public void A_Reduce_must_work_when_using_Source_RunReduce()
+        public void A_Sum_must_work_when_using_Source_RunReduce()
         {
             this.AssertAllStagesStopped(() =>
             {
-                var t = InputSource.RunReduce((i, i1) => i + i1, Materializer);
+                var t = InputSource.RunSum((i, i1) => i + i1, Materializer);
                 t.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
                 t.Result.Should().Be(Expected);
             }, Materializer);
         }
 
         [Fact]
-        public void A_Reduce_must_work_when_using_Source_Reduce()
+        public void A_Sum_must_work_when_using_Source_Reduce()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -61,7 +61,7 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
         [Fact]
-        public void A_Reduce_must_work_when_using_Sink_Reduce()
+        public void A_Sum_must_work_when_using_Sink_Reduce()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -73,7 +73,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Reduce_must_work_when_using_Flow_Reduce()
+        public void A_Sum_must_work_when_using_Flow_Reduce()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -84,7 +84,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Reduce_must_work_when_using_Source_Reduce_and_Flow_Reduce_and_Sink_Reduce()
+        public void A_Sum_must_work_when_using_Source_Sum_and_Flow_Sum_and_Sink_Reduce()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -96,7 +96,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Reduce_must_propagate_an_error()
+        public void A_Sum_must_propagate_an_error()
         {
             this.AssertAllStagesStopped(() =>
             {
@@ -106,19 +106,19 @@ namespace Akka.Streams.Tests.Dsl
                     if (x > 50)
                         throw error;
                     return x;
-                }).RunReduce((i, i1) => 0, Materializer);
+                }).RunSum((i, i1) => 0, Materializer);
 
                 task.Invoking(t => t.Wait(TimeSpan.FromSeconds(3))).ShouldThrow<TestException>().WithMessage("test");
             }, Materializer);
         }
 
         [Fact]
-        public void A_Reduce_must_complete_future_with_failure_when_reducing_function_throws()
+        public void A_Sum_must_complete_future_with_failure_when_reducing_function_throws()
         {
             this.AssertAllStagesStopped(() =>
             {
                 var error = new TestException("test");
-                var task = InputSource.RunReduce((x, y) =>
+                var task = InputSource.RunSum((x, y) =>
                 {
                     if (x > 50)
                         throw error;

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSupervisionSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSupervisionSpec.cs
@@ -22,7 +22,7 @@ namespace Akka.Streams.Tests.Dsl
     public class FlowSupervisionSpec : AkkaSpec
     {
         private static readonly SystemException Exception = new SystemException("simulated exception");
-        private static Flow<int, int, Unit> FailingMap => Flow.Create<int>().Map(n =>
+        private static Flow<int, int, Unit> FailingMap => Flow.Create<int>().Select(n =>
         {
             if (n == 3)
                 throw Exception;
@@ -76,7 +76,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Stream_supervision_must_complete_stream_with_ArgumentNullException_when_null_is_emitted()
         {
-            var task = Source.From(new[] {"a", "b"}).Map(x => null as string).Limit(1000).RunWith(Sink.Seq<string>(), Materializer);
+            var task = Source.From(new[] {"a", "b"}).Select(x => null as string).Limit(1000).RunWith(Sink.Seq<string>(), Materializer);
 
             task.Invoking(t => t.Wait(TimeSpan.FromSeconds(3)))
                 .ShouldThrow<ArgumentNullException>()
@@ -86,7 +86,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Stream_supervision_must_resume_stream_when_null_is_emitted()
         {
-            var nullMap = Flow.Create<string>().Map(element =>
+            var nullMap = Flow.Create<string>().Select(element =>
             {
                 if (element == "b")
                     return null;

--- a/src/core/Akka.Streams.Tests/Dsl/FlowWhereSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowWhereSpec.cs
@@ -71,7 +71,7 @@ namespace Akka.Streams.Tests.Dsl
                 return new Tuple<ICollection<int>, ICollection<int>>(new[] { x }, (x & 1) == 1 ? new[] { x } : new int[] { });
             }).ToArray());
 
-            RandomTestRange(Sys).ForEach(_ => RunScript(script, Settings, flow => flow.FilterNot(x => x % 2 == 0)));
+            RandomTestRange(Sys).ForEach(_ => RunScript(script, Settings, flow => flow.WhereNot(x => x % 2 == 0)));
         }
     }
 }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowWhereSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowWhereSpec.cs
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------
-// <copyright file="FlowFilterSpec.cs" company="Akka.NET Project">
+// <copyright file="FlowWhereSpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>
@@ -20,17 +20,17 @@ using static Akka.Streams.Tests.Dsl.TestConfig;
 
 namespace Akka.Streams.Tests.Dsl
 {
-    public class FlowFilterSpec : ScriptedTest
+    public class FlowWhereSpec : ScriptedTest
     {
         private ActorMaterializerSettings Settings { get; }
 
-        public FlowFilterSpec(ITestOutputHelper helper) : base(helper)
+        public FlowWhereSpec(ITestOutputHelper helper) : base(helper)
         {
             Settings = ActorMaterializerSettings.Create(Sys).WithInputBuffer(2, 16);
         }
 
         [Fact]
-        public void A_Filter_must_filter()
+        public void A_Where_must_filter()
         {
             var random = new Random();
             Script<int, int> script = Script.Create(RandomTestRange(Sys).Select(_ =>
@@ -39,18 +39,18 @@ namespace Akka.Streams.Tests.Dsl
                 return new Tuple<ICollection<int>, ICollection<int>>(new[] {x}, (x & 1) == 0 ? new[] {x} : new int[] {});
             }).ToArray());
 
-            RandomTestRange(Sys).ForEach(_ => RunScript(script, Settings, flow => flow.Filter(x => x%2 == 0)));
+            RandomTestRange(Sys).ForEach(_ => RunScript(script, Settings, flow => flow.Where(x => x%2 == 0)));
         }
 
         [Fact]
-        public void A_Filter_must_not_blow_up_with_high_request_counts()
+        public void A_Where_must_not_blow_up_with_high_request_counts()
         {
             var settings = ActorMaterializerSettings.Create(Sys).WithInputBuffer(1, 1);
             var materializer = ActorMaterializer.Create(Sys, settings);
 
             var probe = TestSubscriber.CreateManualProbe<int>(this);
             Source.From(Enumerable.Repeat(0, 1000).Concat(new[] {1}))
-                .Filter(x => x != 0)
+                .Where(x => x != 0)
                 .RunWith(Sink.FromSubscriber(probe), materializer);
 
             var subscription = probe.ExpectSubscription();

--- a/src/core/Akka.Streams.Tests/Dsl/FramingSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FramingSpec.cs
@@ -128,7 +128,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void Delimiter_bytes_based_framing_must_work_with_empty_streams()
         {
-            var task = Source.Empty<ByteString>().Via(SimpleLines("\n", 256)).RunFold(new List<string>(), (list, s) =>
+            var task = Source.Empty<ByteString>().Via(SimpleLines("\n", 256)).RunAggregate(new List<string>(), (list, s) =>
             {
                 list.Add(s);
                 return list;
@@ -243,7 +243,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             var task = Source.Empty<ByteString>()
                 .Via(Framing.LengthField(4, int.MaxValue, 0, ByteOrder.BigEndian))
-                .RunFold(new List<ByteString>(), (list, s) =>
+                .RunAggregate(new List<ByteString>(), (list, s) =>
                 {
                     list.Add(s);
                     return list;
@@ -258,7 +258,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             var task1 = Source.Single(Encode(ReferenceChunk.Take(100), 0, 1, ByteOrder.BigEndian))
                 .Via(Framing.LengthField(1, 99, 0, ByteOrder.BigEndian))
-                .RunFold(new List<ByteString>(), (list, s) =>
+                .RunAggregate(new List<ByteString>(), (list, s) =>
                 {
                     list.Add(s);
                     return list;
@@ -267,7 +267,7 @@ namespace Akka.Streams.Tests.Dsl
 
             var task2 = Source.Single(Encode(ReferenceChunk.Take(100), 49, 1, ByteOrder.BigEndian))
                 .Via(Framing.LengthField(1, 100, 0, ByteOrder.BigEndian))
-                .RunFold(new List<ByteString>(), (list, s) =>
+                .RunAggregate(new List<ByteString>(), (list, s) =>
                 {
                     list.Add(s);
                     return list;

--- a/src/core/Akka.Streams.Tests/Dsl/FramingSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FramingSpec.cs
@@ -76,7 +76,7 @@ namespace Akka.Streams.Tests.Dsl
         private static Flow<ByteString, string, Unit> SimpleLines(string delimiter, int maximumBytes, bool allowTruncation = true)
         {
             return  Flow.FromGraph(Framing.Delimiter(ByteString.FromString(delimiter), maximumBytes, allowTruncation)
-                .Map(x => x.DecodeString(Encoding.UTF8)).Named("LineFraming"));
+                .Select(x => x.DecodeString(Encoding.UTF8)).Named("LineFraming"));
         }
 
         private static IEnumerable<ByteString> CompleteTestSequence(ByteString delimiter)
@@ -94,7 +94,7 @@ namespace Akka.Streams.Tests.Dsl
                 foreach (var delimiter in DelimiterBytes)
                 {
                     var task = Source.From(CompleteTestSequence(delimiter))
-                        .Map(x => x + delimiter)
+                        .Select(x => x + delimiter)
                         .Via(Rechunk)
                         .Via(Framing.Delimiter(delimiter, 256))
                         .Grouped(1000)

--- a/src/core/Akka.Streams.Tests/Dsl/GraphBalanceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphBalanceSpec.cs
@@ -151,7 +151,7 @@ namespace Akka.Streams.Tests.Dsl
 
                     b.From(source).To(balance.In);
                     return new SourceShape<int>(balance.Out(0));
-                })).RunFold(new List<int>(), (list, i) =>
+                })).RunAggregate(new List<int>(), (list, i) =>
                 {
                     list.Add(i);
                     return list;

--- a/src/core/Akka.Streams.Tests/Dsl/GraphBalanceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphBalanceSpec.cs
@@ -194,7 +194,7 @@ namespace Akka.Streams.Tests.Dsl
             this.AssertAllStagesStopped(() =>
             {
                 const int numElementsForSink = 10000;
-                var outputs = Sink.Fold<int, int>(0, (sum, i) => sum + i);
+                var outputs = Sink.Aggregate<int, int>(0, (sum, i) => sum + i);
                 var t = RunnableGraph.FromGraph(GraphDsl.Create(outputs, outputs, outputs, Tuple.Create,
                     (b, o1, o2, o3) =>
                     {

--- a/src/core/Akka.Streams.Tests/Dsl/GraphBroadcastSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphBroadcastSpec.cs
@@ -79,7 +79,7 @@ namespace Akka.Streams.Tests.Dsl
                     b.From(source).To(broadcast.In);
 
                     return new SourceShape<int>(broadcast.Out(0));
-                })).RunFold(new List<int>(), (list, i) =>
+                })).RunAggregate(new List<int>(), (list, i) =>
                 {
                     list.Add(i);
                     return list;

--- a/src/core/Akka.Streams.Tests/Dsl/GraphMatValueSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphMatValueSpec.cs
@@ -94,7 +94,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             var t =
                 FoldFeedbackSource.MapAsync(4, x => x)
-                    .Map(x => x + 100)
+                    .Select(x => x + 100)
                     .ToMaterialized(Sink.First<int>(), Keep.Both)
                     .Run(Materializer);
             var f1 = t.Item1;
@@ -110,7 +110,7 @@ namespace Akka.Streams.Tests.Dsl
         public void A_Graph_with_materialized_value_must_allow_exposing_the_materialized_values_as_port_even_if_wrapped_and_the_final_materialized_value_is_unit()
         {
             var noMatSource =
-                FoldFeedbackSource.MapAsync(4, x => x).Map(x => x + 100).MapMaterializedValue(_ => Unit.Instance);
+                FoldFeedbackSource.MapAsync(4, x => x).Select(x => x + 100).MapMaterializedValue(_ => Unit.Instance);
             var t = noMatSource.RunWith(Sink.First<int>(), Materializer);
             t.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
             t.Result.Should().Be(155);
@@ -125,7 +125,7 @@ namespace Akka.Streams.Tests.Dsl
                     var zip = b.Add(new ZipWith<int, int, int>((i, i1) => i + i1));
 
                     b.From(s1.Outlet).Via(Flow.Create<Task<int>>().MapAsync(4, x => x)).To(zip.In0);
-                    b.From(s2.Outlet).Via(Flow.Create<Task<int>>().MapAsync(4, x => x).Map(x => x*100)).To(zip.In1);
+                    b.From(s2.Outlet).Via(Flow.Create<Task<int>>().MapAsync(4, x => x).Select(x => x*100)).To(zip.In1);
                     
                     return new SourceShape<int>(zip.Out);
                 }));
@@ -136,7 +136,7 @@ namespace Akka.Streams.Tests.Dsl
                     var zip = b.Add(new ZipWith<int, int, int>((i, i1) => i + i1));
 
                     b.From(s1.Outlet).To(zip.In0);
-                    b.From(s2.Outlet).Via(Flow.Create<int>().Map(x => x*10000)).To(zip.In1);
+                    b.From(s2.Outlet).Via(Flow.Create<int>().Select(x => x*10000)).To(zip.In1);
 
                     return new SourceShape<int>(zip.Out);
                 }));

--- a/src/core/Akka.Streams.Tests/Dsl/GraphMatValueSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphMatValueSpec.cs
@@ -29,7 +29,7 @@ namespace Akka.Streams.Tests.Dsl
             Materializer = ActorMaterializer.Create(Sys, settings);
         }
 
-        private static Sink<int, Task<int>> FoldSink => Sink.Fold<int,int>(0, (sum, i) => sum + i);
+        private static Sink<int, Task<int>> FoldSink => Sink.Aggregate<int,int>(0, (sum, i) => sum + i);
 
         [Fact]
         public void A_Graph_with_materialized_value_must_expose_the_materialized_value_as_source()
@@ -154,7 +154,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void A_Graph_with_materialized_value_must_work_also_when_the_sources_module_is_copied()
         {
-            var foldFlow = Flow.FromGraph(GraphDsl.Create(Sink.Fold<int, int>(0, (sum, i) => sum + i), (b, fold) =>
+            var foldFlow = Flow.FromGraph(GraphDsl.Create(Sink.Aggregate<int, int>(0, (sum, i) => sum + i), (b, fold) =>
             {
                 var o = b.From(b.MaterializedValue).Via(Flow.Create<Task<int>>().SelectAsync(4, x => x));
                 return new FlowShape<int,int>(fold.Inlet, o.Out);

--- a/src/core/Akka.Streams.Tests/Dsl/GraphMergeSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphMergeSpec.cs
@@ -94,7 +94,7 @@ namespace Akka.Streams.Tests.Dsl
                 b.From(source).To(merge.In(0));
 
                 return new SourceShape<int>(merge.Out);
-            })).RunFold(new List<int>(), (list, i) =>
+            })).RunAggregate(new List<int>(), (list, i) =>
             {
                 list.Add(i);
                 return list;

--- a/src/core/Akka.Streams.Tests/Dsl/GraphMergeSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphMergeSpec.cs
@@ -62,8 +62,8 @@ namespace Akka.Streams.Tests.Dsl
                     var sink = Sink.FromSubscriber(probe);
 
                     b.From(source1).To(m1.In(0));
-                    b.From(m1.Out).Via(Flow.Create<int>().Map(x => x*2)).To(m2.In(0));
-                    b.From(m2.Out).Via(Flow.Create<int>().Map(x => x / 2).Map(x=>x+1)).To(sink);
+                    b.From(m1.Out).Via(Flow.Create<int>().Select(x => x*2)).To(m2.In(0));
+                    b.From(m2.Out).Via(Flow.Create<int>().Select(x => x / 2).Select(x=>x+1)).To(sink);
                     b.From(source2).To(m1.In(1));
                     b.From(source3).To(m2.In(1));
 

--- a/src/core/Akka.Streams.Tests/Dsl/GraphOpsIntegrationSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphOpsIntegrationSpec.cs
@@ -100,7 +100,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 b.From(source).To(broadcast.In);
                 b.From(broadcast.Out(0)).To(merge.In(0));
-                b.From(broadcast.Out(1)).Via(Flow.Create<int>().Map(x => x + 3)).To(merge.In(1));
+                b.From(broadcast.Out(1)).Via(Flow.Create<int>().Select(x => x + 3)).To(merge.In(1));
                 b.From(merge.Out).Via(Flow.Create<int>().Grouped(10)).To(sink.Inlet);
 
                 return ClosedShape.Instance;
@@ -202,9 +202,9 @@ namespace Akka.Streams.Tests.Dsl
                 var merge = b.Add(new Merge<int>(2));
                 var source = Source.From(Enumerable.Range(1,3)).MapMaterializedValue<Task<IEnumerable<int>>>(_ => null);
 
-                b.From(source.Map(x => x*2)).To(broadcast.In);
+                b.From(source.Select(x => x*2)).To(broadcast.In);
                 b.From(broadcast.Out(0)).To(merge.In(0));
-                b.From(broadcast.Out(1)).Via(Flow.Create<int>().Map(x => x + 3)).To(merge.In(1));
+                b.From(broadcast.Out(1)).Via(Flow.Create<int>().Select(x => x + 3)).To(merge.In(1));
                 b.From(merge.Out).Via(Flow.Create<int>().Grouped(10)).To(sink.Inlet);
                 
                 return ClosedShape.Instance;
@@ -219,7 +219,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             var p = Source.From(Enumerable.Range(1, 3)).RunWith(Sink.AsPublisher<int>(false), Materializer);
             var s = TestSubscriber.CreateManualProbe<int>(this);
-            var flow = Flow.Create<int>().Map(x => x*2);
+            var flow = Flow.Create<int>().Select(x => x*2);
 
             RunnableGraph.FromGraph(GraphDsl.Create<ClosedShape, Unit>(b =>
             {
@@ -239,7 +239,7 @@ namespace Akka.Streams.Tests.Dsl
                 i =>
                     Source.From(Enumerable.Range(i, 3))
                         .MapMaterializedValue<Tuple<Unit, Unit, Unit, Task<IEnumerable<int>>>>(_ => null);
-            var shuffler = Shuffle.Create(Flow.Create<int>().Map(x => x + 1));
+            var shuffler = Shuffle.Create(Flow.Create<int>().Select(x => x + 1));
 
             var task =
                 RunnableGraph.FromGraph(GraphDsl.Create(shuffler, shuffler, shuffler, Sink.First<IEnumerable<int>>(),

--- a/src/core/Akka.Streams.Tests/Dsl/GraphPartialSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphPartialSpec.cs
@@ -102,7 +102,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void FlowFlowGraph_Partial_must_be_able_to_build_and_reuse_complex_materializing_partial_graphs()
         {
-            var summer = Sink.Fold<int, int>(0, (i, i1) => i + i1);
+            var summer = Sink.Aggregate<int, int>(0, (i, i1) => i + i1);
 
             var doubler = GraphDsl.Create(summer, summer, Tuple.Create, (b, s1,s2) =>
             {

--- a/src/core/Akka.Streams.Tests/Dsl/GraphPartialSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphPartialSpec.cs
@@ -145,7 +145,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void FlowFlowGraph_Partial_must_be_able_to_expose_the_ports_of_imported_graphs()
         {
-            var p = GraphDsl.Create(Flow.Create<int>().Map(x => x + 1),
+            var p = GraphDsl.Create(Flow.Create<int>().Select(x => x + 1),
                 (b, flow) => new FlowShape<int, int>(flow.Inlet, flow.Outlet));
 
             var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink.First<int>(), p, Keep.Left,

--- a/src/core/Akka.Streams.Tests/Dsl/GraphUnzipSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphUnzipSpec.cs
@@ -48,7 +48,7 @@ namespace Akka.Streams.Tests.Dsl
                     
                     b.From(source).To(unzip.In);
                     b.From(unzip.Out0)
-                        .Via(Flow.Create<int>().Buffer(16, OverflowStrategy.Backpressure).Map(x => x*2))
+                        .Via(Flow.Create<int>().Buffer(16, OverflowStrategy.Backpressure).Select(x => x*2))
                         .To(Sink.FromSubscriber(c1));
                     b.From(unzip.Out1)
                         .Via(Flow.Create<string>().Buffer(16, OverflowStrategy.Backpressure))

--- a/src/core/Akka.Streams.Tests/Dsl/HeadSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/HeadSinkSpec.cs
@@ -32,7 +32,7 @@ namespace Akka.Streams.Tests.Dsl
             this.AssertAllStagesStopped(() =>
             {
                 var p = TestPublisher.CreateManualProbe<int>(this);
-                var task = Source.FromPublisher(p).Map(x=>x).RunWith(Sink.First<int>(), Materializer);
+                var task = Source.FromPublisher(p).Select(x=>x).RunWith(Sink.First<int>(), Materializer);
                 var proc = p.ExpectSubscription();
                 proc.ExpectRequest();
                 proc.SendNext(42);
@@ -95,7 +95,7 @@ namespace Akka.Streams.Tests.Dsl
             this.AssertAllStagesStopped(() =>
             {
                 var p = TestPublisher.CreateManualProbe<int>(this);
-                var task = Source.FromPublisher(p).Map(x => x).RunWith(Sink.FirstOrDefault<int>(), Materializer);
+                var task = Source.FromPublisher(p).Select(x => x).RunWith(Sink.FirstOrDefault<int>(), Materializer);
                 var proc = p.ExpectSubscription();
                 proc.ExpectRequest();
                 proc.SendNext(42);

--- a/src/core/Akka.Streams.Tests/Dsl/LastSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/LastSinkSpec.cs
@@ -30,7 +30,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             this.AssertAllStagesStopped(() =>
             {
-                var task = Source.From(Enumerable.Range(1,42)).Map(x=>x).RunWith(Sink.Last<int>(), Materializer);
+                var task = Source.From(Enumerable.Range(1,42)).Select(x=>x).RunWith(Sink.Last<int>(), Materializer);
                 task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
                 task.Result.Should().Be(42);
             }, Materializer);
@@ -68,7 +68,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             this.AssertAllStagesStopped(() =>
             {
-                var task = Source.From(Enumerable.Range(1, 42)).Map(x => x).RunWith(Sink.LastOrDefault<int>(), Materializer);
+                var task = Source.From(Enumerable.Range(1, 42)).Select(x => x).RunWith(Sink.LastOrDefault<int>(), Materializer);
                 task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
                 task.Result.Should().Be(42);
             }, Materializer);

--- a/src/core/Akka.Streams.Tests/Dsl/LiftExtensions.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/LiftExtensions.cs
@@ -19,7 +19,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             return
                 (Source<Source<int, Unit>, TMat>)
-                    ((SubFlow<Source<int, Unit>, TMat, IRunnableGraph<TMat>>) source.PrefixAndTail(0).Map(x => x.Item2))
+                    ((SubFlow<Source<int, Unit>, TMat, IRunnableGraph<TMat>>) source.PrefixAndTail(0).Select(x => x.Item2))
                         .ConcatSubstream();
         }
 
@@ -27,7 +27,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             return
                 (Source<Tuple<int, Source<int, Unit>>, TMat>)
-                ((SubFlow<Tuple<int, Source<int, Unit>>, TMat, IRunnableGraph<TMat>>)source.PrefixAndTail(1).Map(p => Tuple.Create(key(p.Item1.First()), Source.Single(p.Item1.First()).Concat(p.Item2)))).ConcatSubstream();
+                ((SubFlow<Tuple<int, Source<int, Unit>>, TMat, IRunnableGraph<TMat>>)source.PrefixAndTail(1).Select(p => Tuple.Create(key(p.Item1.First()), Source.Single(p.Item1.First()).Concat(p.Item2)))).ConcatSubstream();
         }
     }
 }

--- a/src/core/Akka.Streams.Tests/Dsl/PublisherSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/PublisherSinkSpec.cs
@@ -50,8 +50,8 @@ namespace Akka.Streams.Tests.Dsl
                 var pub1 = t.Item1;
                 var pub2 = t.Item2;
 
-                var f1 = Source.FromPublisher(pub1).Select(x => x).RunFold(0, (sum, i) => sum + i, Materializer);
-                var f2 = Source.FromPublisher(pub2).Select(x => x).RunFold(0, (sum, i) => sum + i, Materializer);
+                var f1 = Source.FromPublisher(pub1).Select(x => x).RunAggregate(0, (sum, i) => sum + i, Materializer);
+                var f2 = Source.FromPublisher(pub2).Select(x => x).RunAggregate(0, (sum, i) => sum + i, Materializer);
 
                 f1.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
                 f2.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
@@ -83,7 +83,7 @@ namespace Akka.Streams.Tests.Dsl
                 .RunWith(
                     Sink.AsPublisher<int>(false)
                         .MapMaterializedValue(
-                            p => Source.FromPublisher(p).RunFold(0, (sum, i) => sum + i, Materializer)),
+                            p => Source.FromPublisher(p).RunAggregate(0, (sum, i) => sum + i, Materializer)),
                     Materializer);
             f.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
             f.Result.Should().Be(6);

--- a/src/core/Akka.Streams.Tests/Dsl/PublisherSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/PublisherSinkSpec.cs
@@ -42,7 +42,7 @@ namespace Akka.Streams.Tests.Dsl
                                     Source.From(Enumerable.Range(0, 6))
                                         .MapMaterializedValue<Tuple<IPublisher<int>, IPublisher<int>>>(_ => null);
                                 b.From(source).To(broadcast.In);
-                                b.From(broadcast.Out(0)).Via(Flow.Create<int>().Map(i => i * 2)).To(p1.Inlet);
+                                b.From(broadcast.Out(0)).Via(Flow.Create<int>().Select(i => i * 2)).To(p1.Inlet);
                                 b.From(broadcast.Out(1)).To(p2.Inlet);
                                 return ClosedShape.Instance;
                             })).Run(Materializer);
@@ -50,8 +50,8 @@ namespace Akka.Streams.Tests.Dsl
                 var pub1 = t.Item1;
                 var pub2 = t.Item2;
 
-                var f1 = Source.FromPublisher(pub1).Map(x => x).RunFold(0, (sum, i) => sum + i, Materializer);
-                var f2 = Source.FromPublisher(pub2).Map(x => x).RunFold(0, (sum, i) => sum + i, Materializer);
+                var f1 = Source.FromPublisher(pub1).Select(x => x).RunFold(0, (sum, i) => sum + i, Materializer);
+                var f2 = Source.FromPublisher(pub2).Select(x => x).RunFold(0, (sum, i) => sum + i, Materializer);
 
                 f1.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
                 f2.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();

--- a/src/core/Akka.Streams.Tests/Dsl/ReverseArrowSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/ReverseArrowSpec.cs
@@ -275,7 +275,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 b.Invoking(builder => builder.To(s).Via(f).From(src))
                     .ShouldThrow<ArgumentException>()
-                    .WithMessage("The output port [StatefulMapConcat.out] is already connected");
+                    .WithMessage("The output port [StatefulSelectMany.out] is already connected");
 
                 return ClosedShape.Instance;
             })).Run(Materializer);

--- a/src/core/Akka.Streams.Tests/Dsl/SinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SinkSpec.cs
@@ -46,7 +46,7 @@ namespace Akka.Streams.Tests.Dsl
                 {
                     var closure = i;
                     b.From(broadcast.Out(i))
-                        .Via(Flow.Create<int>().Filter(x => x == closure))
+                        .Via(Flow.Create<int>().Where(x => x == closure))
                         .To(Sink.FromSubscriber(probes[i]));
                 }
                 return new SinkShape<int>(broadcast.In);
@@ -67,12 +67,12 @@ namespace Akka.Streams.Tests.Dsl
             var sink = Sink.FromGraph(GraphDsl.Create(Sink.FromSubscriber(probes[0]), (b, shape) =>
             {
                 var broadcast = b.Add(new Broadcast<int>(3));
-                b.From(broadcast.Out(0)).Via(Flow.Create<int>().Filter(x => x == 0)).To(shape.Inlet);
+                b.From(broadcast.Out(0)).Via(Flow.Create<int>().Where(x => x == 0)).To(shape.Inlet);
                 b.From(broadcast.Out(1))
-                    .Via(Flow.Create<int>().Filter(x => x == 1))
+                    .Via(Flow.Create<int>().Where(x => x == 1))
                     .To(Sink.FromSubscriber(probes[1]));
                 b.From(broadcast.Out(2))
-                    .Via(Flow.Create<int>().Filter(x => x == 2))
+                    .Via(Flow.Create<int>().Where(x => x == 2))
                     .To(Sink.FromSubscriber(probes[2]));
                 return new SinkShape<int>(broadcast.In);
             }));
@@ -94,10 +94,10 @@ namespace Akka.Streams.Tests.Dsl
                     Sink.FromSubscriber(probes[1]), (_, __) => Unit.Instance, (b, shape0, shape1) =>
                     {
                         var broadcast = b.Add(new Broadcast<int>(3));
-                        b.From(broadcast.Out(0)).Via(Flow.Create<int>().Filter(x => x == 0)).To(shape0.Inlet);
-                        b.From(broadcast.Out(1)).Via(Flow.Create<int>().Filter(x => x == 1)).To(shape1.Inlet);
+                        b.From(broadcast.Out(0)).Via(Flow.Create<int>().Where(x => x == 0)).To(shape0.Inlet);
+                        b.From(broadcast.Out(1)).Via(Flow.Create<int>().Where(x => x == 1)).To(shape1.Inlet);
                         b.From(broadcast.Out(2))
-                            .Via(Flow.Create<int>().Filter(x => x == 2))
+                            .Via(Flow.Create<int>().Where(x => x == 2))
                             .To(Sink.FromSubscriber(probes[2]));
                         return new SinkShape<int>(broadcast.In);
                     }));
@@ -120,9 +120,9 @@ namespace Akka.Streams.Tests.Dsl
                     (_, __, ___) => Unit.Instance, (b, shape0, shape1, shape2) =>
                     {
                         var broadcast = b.Add(new Broadcast<int>(3));
-                        b.From(broadcast.Out(0)).Via(Flow.Create<int>().Filter(x => x == 0)).To(shape0.Inlet);
-                        b.From(broadcast.Out(1)).Via(Flow.Create<int>().Filter(x => x == 1)).To(shape1.Inlet);
-                        b.From(broadcast.Out(2)).Via(Flow.Create<int>().Filter(x => x == 2)).To(shape2.Inlet);
+                        b.From(broadcast.Out(0)).Via(Flow.Create<int>().Where(x => x == 0)).To(shape0.Inlet);
+                        b.From(broadcast.Out(1)).Via(Flow.Create<int>().Where(x => x == 1)).To(shape1.Inlet);
+                        b.From(broadcast.Out(2)).Via(Flow.Create<int>().Where(x => x == 2)).To(shape2.Inlet);
                         return new SinkShape<int>(broadcast.In);
                     }));
             Source.From(new[] { 0, 1, 2 }).RunWith(sink, Materializer);

--- a/src/core/Akka.Streams.Tests/Dsl/SourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SourceSpec.cs
@@ -292,7 +292,7 @@ namespace Akka.Streams.Tests.Dsl
                 if (a > 10000000)
                     return null;
                 return Tuple.Create(Tuple.Create(b, a + b), a);
-            }).RunFold(new LinkedList<int>(), (ints, i) =>
+            }).RunAggregate(new LinkedList<int>(), (ints, i) =>
             {
                 ints.AddFirst(i);
                 return ints;
@@ -311,7 +311,7 @@ namespace Akka.Streams.Tests.Dsl
                     if (a > 10000000)
                         throw new SystemException("expected");
                     return Tuple.Create(Tuple.Create(b, a + b), a);
-                }).RunFold(new LinkedList<int>(), (ints, i) =>
+                }).RunAggregate(new LinkedList<int>(), (ints, i) =>
                 {
                     ints.AddFirst(i);
                     return ints;
@@ -332,7 +332,7 @@ namespace Akka.Streams.Tests.Dsl
                 if (a > 10000000)
                     return Task.FromResult<Tuple<Tuple<int, int>, int>>(null);
                 return Task.FromResult(Tuple.Create(Tuple.Create(b, a + b), a));
-            }).RunFold(new LinkedList<int>(), (ints, i) =>
+            }).RunAggregate(new LinkedList<int>(), (ints, i) =>
             {
                 ints.AddFirst(i);
                 return ints;
@@ -349,7 +349,7 @@ namespace Akka.Streams.Tests.Dsl
                 return Tuple.Create(Tuple.Create(b, a + b), a);
             })
             .Take(36)
-            .RunFold(new LinkedList<int>(), (ints, i) =>
+            .RunAggregate(new LinkedList<int>(), (ints, i) =>
             {
                 ints.AddFirst(i);
                 return ints;

--- a/src/core/Akka.Streams.Tests/Dsl/SourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SourceSpec.cs
@@ -116,7 +116,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             this.AssertAllStagesStopped(() =>
             {
-                var neverSource = Source.Maybe<int>().Filter(_ => false);
+                var neverSource = Source.Maybe<int>().Where(_ => false);
                 var counterSink = Sink.Fold<int, int>(0, (acc, _) => acc + 1);
 
                 var t = neverSource.ToMaterialized(counterSink, Keep.Both).Run(Materializer);

--- a/src/core/Akka.Streams.Tests/Dsl/SourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SourceSpec.cs
@@ -117,7 +117,7 @@ namespace Akka.Streams.Tests.Dsl
             this.AssertAllStagesStopped(() =>
             {
                 var neverSource = Source.Maybe<int>().Where(_ => false);
-                var counterSink = Sink.Fold<int, int>(0, (acc, _) => acc + 1);
+                var counterSink = Sink.Aggregate<int, int>(0, (acc, _) => acc + 1);
 
                 var t = neverSource.ToMaterialized(counterSink, Keep.Both).Run(Materializer);
                 var neverPromise = t.Item1;

--- a/src/core/Akka.Streams.Tests/Dsl/SubscriberSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SubscriberSourceSpec.cs
@@ -31,7 +31,7 @@ namespace Akka.Streams.Tests.Dsl
             var f = Source.AsSubscriber<int>()
                 .MapMaterializedValue(
                     s => Source.From(Enumerable.Range(1, 3)).RunWith(Sink.FromSubscriber(s), Materializer))
-                .RunWith(Sink.Fold<int, int>(0, (sum, i) => sum + i), Materializer);
+                .RunWith(Sink.Aggregate<int, int>(0, (sum, i) => sum + i), Materializer);
 
             f.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
             f.Result.Should().Be(6);

--- a/src/core/Akka.Streams.Tests/Dsl/TickSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/TickSourceSpec.cs
@@ -104,7 +104,7 @@ namespace Akka.Streams.Tests.Dsl
                     b.From(Source.Tick(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), "tick")
                         .MapMaterializedValue(_ => Unit.Instance)).To(zip.In1);
                     b.From(zip.Out)
-                        .Via(Flow.Create<Tuple<int, string>>().Map(t => t.Item1))
+                        .Via(Flow.Create<Tuple<int, string>>().Select(t => t.Item1))
                         .To(Sink.FromSubscriber(c));
                     return ClosedShape.Instance;
                 })).Run(Materializer);

--- a/src/core/Akka.Streams.Tests/Extra/FlowTimedSpec.cs
+++ b/src/core/Akka.Streams.Tests/Extra/FlowTimedSpec.cs
@@ -55,7 +55,7 @@ namespace Akka.Streams.Tests.Extra
             testRuns.ForEach(
                 _ =>
                     RunScript(script(), Materializer.Settings,
-                        flow =>flow.Map(x => x)
+                        flow =>flow.Select(x => x)
                                 .TimedIntervalBetween(i => i%measureBetweenEvery == 0, printInfo)));
 
             var expectedNrOfOnIntervalCalls = testRuns.Length*((n/measureBetweenEvery) - 1); // first time has no value to compare to, so skips calling onInterval
@@ -82,7 +82,7 @@ namespace Akka.Streams.Tests.Extra
                             .Select(x => new Tuple<ICollection<int>, ICollection<int>>(new[] {x}, new[] {x})).ToArray());
 
             testRuns.ForEach(
-                _ => RunScript(script(), Materializer.Settings, flow => flow.Timed(f => f.Map(x => x), printInfo)));
+                _ => RunScript(script(), Materializer.Settings, flow => flow.Timed(f => f.Select(x => x), printInfo)));
             testRuns.ForEach(_ => testActor.ExpectMsg<TimeSpan>());
             testActor.ExpectNoMsg(TimeSpan.FromSeconds(1));
         }
@@ -96,7 +96,7 @@ namespace Akka.Streams.Tests.Extra
                 var probe = CreateTestProbe();
 
                 var flow =
-                    Flow.Create<int>().Map(x => (long) x).TimedIntervalBetween(i => i%2 == 1, d => probe.Tell(d));
+                    Flow.Create<int>().Select(x => (long) x).TimedIntervalBetween(i => i%2 == 1, d => probe.Tell(d));
 
                 var c1 = TestSubscriber.CreateManualProbe<long>(this);
                 Source.From(Enumerable.Range(1, 3)).Via(flow).RunWith(Sink.FromSubscriber(c1), Materializer);
@@ -122,9 +122,9 @@ namespace Akka.Streams.Tests.Extra
 
                 var flow =
                     Flow.Create<int>()
-                        .Timed(f => f.Map(x => (double)x).Map(x => (int)x).Map(x => x.ToString()),
+                        .Timed(f => f.Select(x => (double)x).Select(x => (int)x).Select(x => x.ToString()),
                             d => probe.Tell(d))
-                        .Map(s => s + "!");
+                        .Select(s => s + "!");
 
                 var t = flow.RunWith(Source.AsSubscriber<int>(), Sink.AsPublisher<string>(false), Materializer);
                 var flowIn = t.Item1;

--- a/src/core/Akka.Streams.Tests/FusingSpec.cs
+++ b/src/core/Akka.Streams.Tests/FusingSpec.cs
@@ -39,10 +39,10 @@ namespace Akka.Streams.Tests
                     .Where(x => x%2 == 1)
                     .AlsoTo(
                         Flow.Create<int>()
-                            .Fold(0, (sum, i) => sum + i)
+                            .Aggregate(0, (sum, i) => sum + i)
                             .To(Sink.First<int>().Named("otherSink"))
                             .AddAttributes(async ? Attributes.CreateAsyncBoundary() : Attributes.None))
-                    .Via(Flow.Create<int>().Fold(1, (sum, i) => sum + i).Named("mainSink"));
+                    .Via(Flow.Create<int>().Aggregate(1, (sum, i) => sum + i).Named("mainSink"));
         }
 
         private static void SinglePath<TShape, TMat>(Fusing.FusedGraph<TShape, TMat> fusedGraph,

--- a/src/core/Akka.Streams.Tests/FusingSpec.cs
+++ b/src/core/Akka.Streams.Tests/FusingSpec.cs
@@ -132,9 +132,9 @@ namespace Akka.Streams.Tests
         [Fact]
         public void A_SubFusingActorMaterializer_must_work_with_asynchronous_boundaries_in_the_subflows()
         {
-            var async = Flow.Create<int>().Map(x => x*2).Async();
+            var async = Flow.Create<int>().Select(x => x*2).Async();
             var t = Source.From(Enumerable.Range(0, 10))
-                .Map(x => x*10)
+                .Select(x => x*10)
                 .FlatMapMerge(5, i => Source.From(Enumerable.Range(i, 10)).Via(async))
                 .Grouped(1000)
                 .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
@@ -152,13 +152,13 @@ namespace Akka.Streams.Tests
                 return GetInstanceField(typeof(BusLogging), bus, "_logSource") as string;
             };
 
-            var async = Flow.Create<int>().Map(x =>
+            var async = Flow.Create<int>().Select(x =>
             {
                 TestActor.Tell(refFunc());
                 return x;
             }).Async();
             var t = Source.From(Enumerable.Range(0, 10))
-                .Map(x =>
+                .Select(x =>
                 {
                     TestActor.Tell(refFunc());
                     return x;
@@ -184,13 +184,13 @@ namespace Akka.Streams.Tests
                 return GetInstanceField(typeof(BusLogging), bus, "_logSource") as string;
             };
 
-            var flow = Flow.Create<int>().Map(x =>
+            var flow = Flow.Create<int>().Select(x =>
             {
                 TestActor.Tell(refFunc());
                 return x;
             });
             var t = Source.From(Enumerable.Range(0, 10))
-                .Map(x =>
+                .Select(x =>
                 {
                     TestActor.Tell(refFunc());
                     return x;

--- a/src/core/Akka.Streams.Tests/FusingSpec.cs
+++ b/src/core/Akka.Streams.Tests/FusingSpec.cs
@@ -36,7 +36,7 @@ namespace Akka.Streams.Tests
         {
             return
                 Source.Unfold(1, x => Tuple.Create(x, x))
-                    .Filter(x => x%2 == 1)
+                    .Where(x => x%2 == 1)
                     .AlsoTo(
                         Flow.Create<int>()
                             .Fold(0, (sum, i) => sum + i)

--- a/src/core/Akka.Streams.Tests/FusingSpec.cs
+++ b/src/core/Akka.Streams.Tests/FusingSpec.cs
@@ -135,7 +135,7 @@ namespace Akka.Streams.Tests
             var async = Flow.Create<int>().Select(x => x*2).Async();
             var t = Source.From(Enumerable.Range(0, 10))
                 .Select(x => x*10)
-                .FlatMapMerge(5, i => Source.From(Enumerable.Range(i, 10)).Via(async))
+                .MergeMany(5, i => Source.From(Enumerable.Range(i, 10)).Via(async))
                 .Grouped(1000)
                 .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
@@ -163,7 +163,7 @@ namespace Akka.Streams.Tests
                     TestActor.Tell(refFunc());
                     return x;
                 })
-                .FlatMapMerge(5, i => Source.Single(i).Via(async))
+                .MergeMany(5, i => Source.Single(i).Via(async))
                 .Grouped(1000)
                 .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
@@ -195,7 +195,7 @@ namespace Akka.Streams.Tests
                     TestActor.Tell(refFunc());
                     return x;
                 })
-                .FlatMapMerge(5, i => Source.Single(i).Via(flow.Async()))
+                .MergeMany(5, i => Source.Single(i).Via(flow.Async()))
                 .Grouped(1000)
                 .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 

--- a/src/core/Akka.Streams.Tests/IO/FileSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/FileSinkSpec.cs
@@ -91,7 +91,7 @@ namespace Akka.Streams.Tests.IO
                 TargetFile(f =>
                 {
                     Func<IEnumerable<string>, Task<IOResult>> write = lines => Source.From(lines)
-                        .Map(ByteString.FromString)
+                        .Select(ByteString.FromString)
                         .RunWith(FileIO.ToFile(f), _materializer);
 
                     var completion1 = write(_testLines);
@@ -121,7 +121,7 @@ namespace Akka.Streams.Tests.IO
                 TargetFile(f =>
                 {
                     Func<List<string>, Task<IOResult>> write = lines => Source.From(lines)
-                        .Map(ByteString.FromString)
+                        .Select(ByteString.FromString)
                         .RunWith(FileIO.ToFile(f, fileMode: FileMode.Append), _materializer);
 
                     var completion1 = write(_testLines);

--- a/src/core/Akka.Streams.Tests/IO/FileSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/FileSourceSpec.cs
@@ -173,7 +173,7 @@ namespace Akka.Streams.Tests.IO
             var s = FileIO.FromFile(ManyLines(), chunkSize)
                 .WithAttributes(Attributes.CreateInputBuffer(readAhead, readAhead));
             var f = s.RunWith(
-                Sink.Fold<ByteString, int>(0, (acc, l) => acc + l.DecodeString(Encoding.UTF8).Count(c => c == '\n')),
+                Sink.Aggregate<ByteString, int>(0, (acc, l) => acc + l.DecodeString(Encoding.UTF8).Count(c => c == '\n')),
                 _materializer);
 
             f.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();

--- a/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
@@ -83,7 +83,7 @@ namespace Akka.Streams.Tests.IO
             var resultFuture =
                 Source.FromPublisher(idle.PublisherProbe)
                     .Via(Sys.TcpStream().OutgoingConnection(server.Address))
-                    .RunFold(ByteString.Empty, (acc, input) => acc + input, Materializer);
+                    .RunAggregate(ByteString.Empty, (acc, input) => acc + input, Materializer);
             var serverConnection = server.WaitAccept();
 
             foreach (var input in testInput)
@@ -435,7 +435,7 @@ namespace Akka.Streams.Tests.IO
             var result = Source.From(Enumerable.Repeat(0, 1000)
                 .Select(i => ByteString.Create(new[] {Convert.ToByte(i)})))
                 .Via(Sys.TcpStream().OutgoingConnection(serverAddress))
-                .RunFold(0, (i, s) => i + s.Count, Materializer);
+                .RunAggregate(0, (i, s) => i + s.Count, Materializer);
 
             result.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
             result.Result.Should().Be(1000);
@@ -455,7 +455,7 @@ namespace Akka.Streams.Tests.IO
 
             var result = Source.Maybe<ByteString>()
                 .Via(system2.TcpStream().OutgoingConnection(serverAddress))
-                .RunFold(0, (i, s) => i + s.Count, mat2);
+                .RunAggregate(0, (i, s) => i + s.Count, mat2);
 
             // Getting rid of existing connection actors by using a blunt instrument
             system2.ActorSelection(system2.Tcp().Path/"selectors"/"$b"/"*").Tell(Kill.Instance);
@@ -497,7 +497,7 @@ namespace Akka.Streams.Tests.IO
             var resultFuture =
                 Source.From(testInput)
                     .Via(Sys.TcpStream().OutgoingConnection(serverAddress))
-                    .RunFold(ByteString.Empty, (agg, b) => agg.Concat(b), Materializer);
+                    .RunAggregate(ByteString.Empty, (agg, b) => agg.Concat(b), Materializer);
 
             resultFuture.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
             resultFuture.Result.ShouldBeEquivalentTo(expectedOutput);
@@ -530,7 +530,7 @@ namespace Akka.Streams.Tests.IO
                 .Via(echoConnection)
                 .Via(echoConnection)
                 .Via(echoConnection)
-                .RunFold(ByteString.Empty, (agg, b) => agg.Concat(b), Materializer);
+                .RunAggregate(ByteString.Empty, (agg, b) => agg.Concat(b), Materializer);
 
             resultFuture.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
             resultFuture.Result.ShouldBeEquivalentTo(expectedOutput);
@@ -597,7 +597,7 @@ namespace Akka.Streams.Tests.IO
                 var total = Source.From(
                     Enumerable.Range(0, 1000).Select(_ => ByteString.Create(new byte[] {0})))
                     .Via(Sys.TcpStream().OutgoingConnection(serverAddress))
-                    .RunFold(0, (i, s) => i + s.Count, Materializer);
+                    .RunAggregate(0, (i, s) => i + s.Count, Materializer);
 
                 total.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
                 total.Result.Should().Be(1000);

--- a/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
@@ -404,7 +404,7 @@ namespace Akka.Streams.Tests.IO
 
                 var t = Source.Maybe<ByteString>()
                     .Via(Sys.TcpStream().OutgoingConnection(serverAddress.Address.ToString(), serverAddress.Port))
-                    .ToMaterialized(Sink.Fold<ByteString, ByteString>(ByteString.Empty, (s, s1) => s + s1), Keep.Both)
+                    .ToMaterialized(Sink.Aggregate<ByteString, ByteString>(ByteString.Empty, (s, s1) => s + s1), Keep.Both)
                     .Run(Materializer);
                 var promise = t.Item1;
                 var result = t.Item2;
@@ -624,7 +624,7 @@ namespace Akka.Streams.Tests.IO
 
                 var folder = Source.From(Enumerable.Range(0, 100).Select(_ => ByteString.Create(new byte[] {0})))
                     .Via(Sys.TcpStream().OutgoingConnection(serverAddress))
-                    .Fold(0, (i, s) => i + s.Count)
+                    .Aggregate(0, (i, s) => i + s.Count)
                     .ToMaterialized(Sink.First<int>(), Keep.Right);
 
                 var total = folder.Run(Materializer);

--- a/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
@@ -611,11 +611,11 @@ namespace Akka.Streams.Tests.IO
             {
                 var serverAddress = TestUtils.TemporaryServerAddress();
                 var firstClientConnected = new TaskCompletionSource<Unit>();
-                var takeTwoAndDropSecond = Flow.Create<Tcp.IncomingConnection>().Map(c =>
+                var takeTwoAndDropSecond = Flow.Create<Tcp.IncomingConnection>().Select(c =>
                 {
                     firstClientConnected.TrySetResult(Unit.Instance);
                     return c;
-                }).Grouped(2).Take(1).Map(e => e.First());
+                }).Grouped(2).Take(1).Select(e => e.First());
 
                 Sys.TcpStream()
                     .Bind(serverAddress.Address.ToString(), serverAddress.Port)

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/ActorGraphInterpreterSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/ActorGraphInterpreterSpec.cs
@@ -74,7 +74,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
             this.AssertAllStagesStopped(() =>
             {
                 var identityBidi = new IdentityBidiGraphStage();
-                var identity = BidiFlow.FromGraph(identityBidi).Join(Flow.Identity<int>().Map(x => x));
+                var identity = BidiFlow.FromGraph(identityBidi).Join(Flow.Identity<int>().Select(x => x));
 
                 var task = Source.From(Enumerable.Range(1, 10))
                     .Via(identity)
@@ -93,7 +93,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
             {
                 var identityBidi = new IdentityBidiGraphStage();
                 var identityBidiFlow = BidiFlow.FromGraph(identityBidi);
-                var identity = identityBidiFlow.Atop(identityBidiFlow).Atop(identityBidiFlow).Join(Flow.Identity<int>().Map(x => x));
+                var identity = identityBidiFlow.Atop(identityBidiFlow).Atop(identityBidiFlow).Join(Flow.Identity<int>().Select(x => x));
 
                 var task = Source.From(Enumerable.Range(1, 10))
                     .Via(identity)

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/InterpreterSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/InterpreterSpec.cs
@@ -116,7 +116,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
             WithOneBoundedSetup(new IStage<int, int>[]
             {
                 new Doubler<int>(),
-                new Filter<int>(x => x != 0, Deciders.StoppingDecider)
+                new Where<int>(x => x != 0, Deciders.StoppingDecider)
             },
                 (lastEvents, upstream, downstream) =>
                 {
@@ -147,7 +147,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         {
             WithOneBoundedSetup(new IStage<int, int>[]
             {
-                new Filter<int>(x => x != 0, Deciders.StoppingDecider),
+                new Where<int>(x => x != 0, Deciders.StoppingDecider),
                 new Doubler<int>()
             },
                 (lastEvents, upstream, downstream) =>
@@ -204,7 +204,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         {
             WithOneBoundedSetup(new IStage<int, int>[]
             {
-                new Filter<int>(x => x != 0, Deciders.StoppingDecider),
+                new Where<int>(x => x != 0, Deciders.StoppingDecider),
                 new Take<int>(2),
                 new Select<int, int>(x => x + 1, Deciders.StoppingDecider)
             },

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/InterpreterSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/InterpreterSpec.cs
@@ -39,7 +39,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         [Fact]
         public void Interpreter_should_implement_map_correctly()
         {
-            WithOneBoundedSetup(new Map<int, int>(x => x + 1, Deciders.StoppingDecider),
+            WithOneBoundedSetup(new Select<int, int>(x => x + 1, Deciders.StoppingDecider),
                 (lastEvents, upstream, downstream) =>
                 {
                     lastEvents().Should().BeEmpty();
@@ -66,9 +66,9 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         {
             WithOneBoundedSetup(new IStage<int, int>[]
             {
-                new Map<int, int>(x => x + 1, Deciders.StoppingDecider),
-                new Map<int, int>(x => x * 2, Deciders.StoppingDecider),
-                new Map<int, int>(x => x + 1, Deciders.StoppingDecider)
+                new Select<int, int>(x => x + 1, Deciders.StoppingDecider),
+                new Select<int, int>(x => x * 2, Deciders.StoppingDecider),
+                new Select<int, int>(x => x + 1, Deciders.StoppingDecider)
             },
                 (lastEvents, upstream, downstream) =>
                 {
@@ -206,7 +206,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
             {
                 new Filter<int>(x => x != 0, Deciders.StoppingDecider),
                 new Take<int>(2),
-                new Map<int, int>(x => x + 1, Deciders.StoppingDecider)
+                new Select<int, int>(x => x + 1, Deciders.StoppingDecider)
             },
                 (lastEvents, upstream, downstream) =>
                 {
@@ -547,11 +547,11 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         {
             WithOneBoundedSetup(new IStage<int, int>[]
             {
-                new Map<int, int>(x => x, Deciders.StoppingDecider),
-                new Map<int, int>(x => x, Deciders.StoppingDecider),
+                new Select<int, int>(x => x, Deciders.StoppingDecider),
+                new Select<int, int>(x => x, Deciders.StoppingDecider),
                 new KeepGoing<int>(),
-                new Map<int, int>(x => x, Deciders.StoppingDecider),
-                new Map<int, int>(x => x, Deciders.StoppingDecider)
+                new Select<int, int>(x => x, Deciders.StoppingDecider),
+                new Select<int, int>(x => x, Deciders.StoppingDecider)
             },
                 (lastEvents, upstream, downstream) =>
                 {
@@ -601,9 +601,9 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         {
             WithOneBoundedSetup(new IStage<int, int>[]
             {
-                new Map<int, int>(x => x, Deciders.StoppingDecider),
+                new Select<int, int>(x => x, Deciders.StoppingDecider),
                 new PushFinishStage<int>(),
-                new Map<int, int>(x => x, Deciders.StoppingDecider)
+                new Select<int, int>(x => x, Deciders.StoppingDecider)
             },
                 (lastEvents, upstream, downstream) =>
                 {

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/InterpreterSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/InterpreterSpec.cs
@@ -234,7 +234,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         {
             WithOneBoundedSetup(new IStage<int, int>[]
             {
-                new Fold<int, int>(0, (agg, x) => agg + x, Deciders.StoppingDecider)
+                new Aggregate<int, int>(0, (agg, x) => agg + x, Deciders.StoppingDecider)
             },
                 (lastEvents, upstream, downstream) =>
                 {
@@ -262,7 +262,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         {
             WithOneBoundedSetup(new IStage<int, int>[]
             {
-                new Fold<int, int>(0, (agg, x) => agg + x, Deciders.StoppingDecider)
+                new Aggregate<int, int>(0, (agg, x) => agg + x, Deciders.StoppingDecider)
             },
                 (lastEvents, upstream, downstream) =>
                 {
@@ -290,7 +290,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         {
             WithOneBoundedSetup(new IStage<int, int>[]
             {
-                new Fold<int, int>(0, (agg, x) => agg + x, Deciders.StoppingDecider)
+                new Aggregate<int, int>(0, (agg, x) => agg + x, Deciders.StoppingDecider)
             },
                 (lastEvents, upstream, downstream) =>
                 {
@@ -623,7 +623,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
             WithOneBoundedSetup(new IStage<int, int>[]
             {
                 new PushFinishStage<int>(),
-                new Fold<int, int>(0, (x, y) => x + y, Deciders.StoppingDecider)
+                new Aggregate<int, int>(0, (x, y) => x + y, Deciders.StoppingDecider)
             },
                 (lastEvents, upstream, downstream) =>
                 {

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/InterpreterStressSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/InterpreterStressSpec.cs
@@ -29,7 +29,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
 
         private readonly ITestOutputHelper _helper;
 
-        private readonly Map<int,int> _map = new Map<int, int>(x=>x+1, Deciders.StoppingDecider);
+        private readonly Select<int,int> _select = new Select<int, int>(x=>x+1, Deciders.StoppingDecider);
 
         public InterpreterStressSpec(ITestOutputHelper helper = null) : base(helper)
         {
@@ -40,7 +40,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         [Fact]
         public void Interpreter_must_work_with_a_massive_chain_of_maps()
         {
-            var ops = Enumerable.Range(1, ChainLength).Select(_ => _map)
+            var ops = Enumerable.Range(1, ChainLength).Select(_ => _select)
                 .Cast<IStage<int, int>>().ToArray();
             WithOneBoundedSetup(ops, (lastEvents, upstream, downstream) =>
                 {
@@ -72,9 +72,9 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         [Fact]
         public void Interpreter_must_work_with_a_massive_chain_of_maps_with_early_complete()
         {
-            var ops = Enumerable.Range(1, HalfLength).Select(_ => _map).ToList<IStage<int, int>>();
+            var ops = Enumerable.Range(1, HalfLength).Select(_ => _select).ToList<IStage<int, int>>();
             ops.Add(new Take<int>(Repetition/2));
-            ops.AddRange(Enumerable.Range(1, HalfLength).Select(_ => _map));
+            ops.AddRange(Enumerable.Range(1, HalfLength).Select(_ => _select));
 
             WithOneBoundedSetup(ops.ToArray(), (lastEvents, upstream, downstream) =>
             {

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/InterpreterSupervisionSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/InterpreterSupervisionSpec.cs
@@ -38,7 +38,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         [Fact]
         public void Interpreter_error_handling_should_handle_external_failure()
         {
-            WithOneBoundedSetup(new Map<int, int>(x => x + 1, stoppingDecider),
+            WithOneBoundedSetup(new Select<int, int>(x => x + 1, stoppingDecider),
                 (lastEvents, upstream, downstream) =>
                 {
                     lastEvents().Should().BeEmpty();
@@ -51,7 +51,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         [Fact]
         public void Interpreter_error_handling_should_emit_failure_when_op_throws()
         {
-            WithOneBoundedSetup(new Map<int, int>(x => { if (x == 0) throw TE(); return x; }, stoppingDecider),
+            WithOneBoundedSetup(new Select<int, int>(x => { if (x == 0) throw TE(); return x; }, stoppingDecider),
                 (lastEvents, upstream, downstream) =>
                 {
                     downstream.RequestOne();
@@ -70,9 +70,9 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         public void Interpreter_error_handling_should_emit_failure_when_op_throws_in_middle_of_chain()
         {
             WithOneBoundedSetup(new IStage<int, int>[] {
-                new Map<int, int>(x => x + 1, stoppingDecider),
-                new Map<int, int>(x => { if (x == 0) throw TE(); return x + 10; }, stoppingDecider),
-                new Map<int, int>(x => x + 100, stoppingDecider)
+                new Select<int, int>(x => x + 1, stoppingDecider),
+                new Select<int, int>(x => { if (x == 0) throw TE(); return x + 10; }, stoppingDecider),
+                new Select<int, int>(x => x + 100, stoppingDecider)
             },
                 (lastEvents, upstream, downstream) =>
                 {
@@ -92,9 +92,9 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         public void Interpreter_error_handling_should_resume_when_Map_throws_in_middle_of_chain()
         {
             WithOneBoundedSetup(new IStage<int, int>[] {
-                new Map<int, int>(x => x + 1, resumingDecider),
-                new Map<int, int>(x => { if (x == 0) throw TE(); return x + 10; }, resumingDecider),
-                new Map<int, int>(x => x + 100, resumingDecider)
+                new Select<int, int>(x => x + 1, resumingDecider),
+                new Select<int, int>(x => { if (x == 0) throw TE(); return x + 10; }, resumingDecider),
+                new Select<int, int>(x => x + 100, resumingDecider)
             },
                 (lastEvents, upstream, downstream) =>
                 {
@@ -117,8 +117,8 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         public void Interpreter_error_handling_should_resume_when_Map_throws_before_Grouped()
         {
             WithOneBoundedSetup<int>(new IGraphStageWithMaterializedValue<Shape, object>[] {
-                ToGraphStage(new Map<int, int>(x => x + 1, resumingDecider)),
-                ToGraphStage(new Map<int, int>(x => { if (x == 0) throw TE(); return x + 10; }, resumingDecider)),
+                ToGraphStage(new Select<int, int>(x => x + 1, resumingDecider)),
+                ToGraphStage(new Select<int, int>(x => { if (x == 0) throw TE(); return x + 10; }, resumingDecider)),
                 ToGraphStage(new Grouped<int>(3))
             },
                 (lastEvents, upstream, downstream) =>
@@ -143,8 +143,8 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         public void Interpreter_error_handling_should_complete_after_resume_when_Map_throws_before_Grouped()
         {
             WithOneBoundedSetup<int>(new IGraphStageWithMaterializedValue<Shape, object>[] {
-                ToGraphStage(new Map<int, int>(x => x + 1, resumingDecider)),
-                ToGraphStage(new Map<int, int>(x => { if (x == 0) throw TE(); return x + 10; }, resumingDecider)),
+                ToGraphStage(new Select<int, int>(x => x + 1, resumingDecider)),
+                ToGraphStage(new Select<int, int>(x => { if (x == 0) throw TE(); return x + 10; }, resumingDecider)),
                 ToGraphStage(new Grouped<int>(1000))
             },
                 (lastEvents, upstream, downstream) =>
@@ -174,9 +174,9 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                 return null;
             });
             WithOneBoundedSetup(new IStage<int, int>[] {
-                new Map<int, int>(x => x + 1, resumingDecider),
+                new Select<int, int>(x => x + 1, resumingDecider),
                 stage,
-                new Map<int, int>(x => x + 100, resumingDecider)
+                new Select<int, int>(x => x + 100, resumingDecider)
             },
                 (lastEvents, upstream, downstream) =>
                 {
@@ -205,9 +205,9 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                 return result;
             });
             WithOneBoundedSetup(new IStage<int, int>[] {
-                new Map<int, int>(x => x + 1, resumingDecider),
+                new Select<int, int>(x => x + 1, resumingDecider),
                 stage,
-                new Map<int, int>(x => x + 100, resumingDecider)
+                new Select<int, int>(x => x + 100, resumingDecider)
             },
                 (lastEvents, upstream, downstream) =>
                 {
@@ -239,9 +239,9 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                 return null;
             });
             WithOneBoundedSetup(new IStage<int, int>[] {
-                new Map<int, int>(x => x + 1, resumingDecider),
+                new Select<int, int>(x => x + 1, resumingDecider),
                 stage,
-                new Map<int, int>(x => x + 100, resumingDecider)
+                new Select<int, int>(x => x + 100, resumingDecider)
             },
                 (lastEvents, upstream, downstream) =>
                 {

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/InterpreterSupervisionSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/InterpreterSupervisionSpec.cs
@@ -263,7 +263,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         [Fact]
         public void Interpreter_error_handling_should_resume_when_Filter_throws()
         {
-            WithOneBoundedSetup(new Filter<int>(x => { if (x == 0) throw TE(); return true; }, resumingDecider),
+            WithOneBoundedSetup(new Where<int>(x => { if (x == 0) throw TE(); return true; }, resumingDecider),
                 (lastEvents, upstream, downstream) =>
                 {
                     downstream.RequestOne();

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/LifecycleInterpreterSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/LifecycleInterpreterSpec.cs
@@ -324,7 +324,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
             var ops = new IStage<string, string>[]
             {
                 new PushFinishStage<string>(() => TestActor.Tell("stop")),
-                new Fold<string, string>("", (x, y) => x+y, Deciders.StoppingDecider) 
+                new Aggregate<string, string>("", (x, y) => x+y, Deciders.StoppingDecider) 
             };
 
             WithOneBoundedSetup(ops, (lastEvents, upstream, downstream) =>

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/LifecycleInterpreterSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/LifecycleInterpreterSpec.cs
@@ -242,12 +242,12 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         {
             var ops = new IStage<string, string>[]
             {
-                new Map<string, string>(x => x, Deciders.StoppingDecider),
+                new Select<string, string>(x => x, Deciders.StoppingDecider),
                 new PreStartFailer<string>(() =>
                 {
                     throw new TestException("Boom!");
                 }),
-                new Map<string, string>(x => x, Deciders.StoppingDecider),
+                new Select<string, string>(x => x, Deciders.StoppingDecider),
             };
 
             WithOneBoundedSetup(ops, (lastEvents, upstream, downstream) =>
@@ -300,9 +300,9 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         {
             var ops = new IStage<string, string>[]
             {
-                new Map<string, string>(x => x, Deciders.StoppingDecider),
+                new Select<string, string>(x => x, Deciders.StoppingDecider),
                 new PushFinishStage<string>(() => TestActor.Tell("stop")), 
-                new Map<string, string>(x => x, Deciders.StoppingDecider)
+                new Select<string, string>(x => x, Deciders.StoppingDecider)
             };
 
             WithOneBoundedSetup(ops, (lastEvents, upstream, downstream) =>

--- a/src/core/Akka.Streams.Tests/Implementation/GraphStageLogicSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/GraphStageLogicSpec.cs
@@ -266,7 +266,7 @@ namespace Akka.Streams.Tests.Implementation
             {
                 var error = new ArgumentException("Don't argue like that!");
                 Source.From(Enumerable.Range(1, 5))
-                    .Map(x =>
+                    .Select(x =>
                     {
                         if (x > 3)
                             throw error;

--- a/src/core/Akka.Streams.Tests/Implementation/StreamLayoutSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/StreamLayoutSpec.cs
@@ -244,7 +244,7 @@ namespace Akka.Streams.Tests.Implementation
         public void StreamLayout_should_not_fail_materialization_when_building_a_large_graph_with_simple_computation_when_starting_from_a_Source()
         {
             var g = Enumerable.Range(1, TooDeepForStack)
-                .Aggregate(Source.Single(42).MapMaterializedValue(_ => 1), (source, i) => source.Map(x => x));
+                .Aggregate(Source.Single(42).MapMaterializedValue(_ => 1), (source, i) => source.Select(x => x));
 
             var t = g.ToMaterialized(Sink.Seq<int>(), Keep.Both).Run(materializer);
             var materialized = t.Item1;
@@ -259,7 +259,7 @@ namespace Akka.Streams.Tests.Implementation
         public void StreamLayout_should_not_fail_materialization_when_building_a_large_graph_with_simple_computation_when_starting_from_a_Flow()
         {
             var g = Enumerable.Range(1, TooDeepForStack)
-                .Aggregate(Flow.Create<int>().MapMaterializedValue(_ => 1), (source, i) => source.Map(x => x));
+                .Aggregate(Flow.Create<int>().MapMaterializedValue(_ => 1), (source, i) => source.Select(x => x));
 
             var t = g.RunWith(Source.Single(42).MapMaterializedValue(_ => 1), Sink.Seq<int>(), materializer);
             var materialized = t.Item1;
@@ -274,7 +274,7 @@ namespace Akka.Streams.Tests.Implementation
         public void StreamLayout_should_not_fail_materialization_when_building_a_large_graph_with_simple_computation_when_using_Via()
         {
             var g = Enumerable.Range(1, TooDeepForStack)
-                .Aggregate(Source.Single(42).MapMaterializedValue(_ => 1), (source, i) => source.Map(x => x));
+                .Aggregate(Source.Single(42).MapMaterializedValue(_ => 1), (source, i) => source.Select(x => x));
 
             var t = g.ToMaterialized(Sink.Seq<int>(), Keep.Both).Run(materializer);
             var materialized = t.Item1;
@@ -289,7 +289,7 @@ namespace Akka.Streams.Tests.Implementation
         public void StreamLayout_should_not_fail_fusing_and_materialization_when_building_a_large_graph_with_simple_computation_when_starting_from_a_Source()
         {
             var g = Source.FromGraph(Fuse.Aggressive(Enumerable.Range(1, TooDeepForStack)
-                .Aggregate(Source.Single(42).MapMaterializedValue(_ => 1), (source, i) => source.Map(x => x))));
+                .Aggregate(Source.Single(42).MapMaterializedValue(_ => 1), (source, i) => source.Select(x => x))));
 
             var m = g.ToMaterialized(Sink.Seq<int>(), Keep.Both);
             var t = m.Run(materializer);
@@ -305,7 +305,7 @@ namespace Akka.Streams.Tests.Implementation
         public void StreamLayout_should_not_fail_fusing_and_materialization_when_building_a_large_graph_with_simple_computation_when_starting_from_a_Flow()
         {
             var g = Flow.FromGraph(Fuse.Aggressive(Enumerable.Range(1, TooDeepForStack)
-                .Aggregate(Flow.Create<int>().MapMaterializedValue(_ => 1), (source, i) => source.Map(x => x))));
+                .Aggregate(Flow.Create<int>().MapMaterializedValue(_ => 1), (source, i) => source.Select(x => x))));
 
             var t = g.RunWith(Source.Single(42).MapMaterializedValue(_ => 1), Sink.Seq<int>(), materializer);
             var materialized = t.Item1;
@@ -320,7 +320,7 @@ namespace Akka.Streams.Tests.Implementation
         public void StreamLayout_should_not_fail_fusing_and_materialization_when_building_a_large_graph_with_simple_computation_when_using_Via()
         {
             var g = Source.FromGraph(Fuse.Aggressive(Enumerable.Range(1, TooDeepForStack)
-                .Aggregate(Source.Single(42).MapMaterializedValue(_ => 1), (source, i) => source.Map(x => x))));
+                .Aggregate(Source.Single(42).MapMaterializedValue(_ => 1), (source, i) => source.Select(x => x))));
 
             var t = g.ToMaterialized(Sink.Seq<int>(), Keep.Both).Run(materializer);
             var materialized = t.Item1;

--- a/src/core/Akka.Streams.Tests/Sample.cs
+++ b/src/core/Akka.Streams.Tests/Sample.cs
@@ -28,7 +28,7 @@ namespace Akka.Streams.Tests
             {
                 await Source
                     .From(text)
-                    .Map(char.ToUpper) 
+                    .Select(char.ToUpper) 
                     .RunForeach(Console.WriteLine, materializer);
             }
         }

--- a/src/core/Akka.Streams/Dsl/BidiFlow.cs
+++ b/src/core/Akka.Streams/Dsl/BidiFlow.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------
 // <copyright file="BidiFlow.cs" company="Akka.NET Project">
 //     Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
@@ -83,7 +83,7 @@ namespace Akka.Streams.Dsl
         /// </summary>
         public static BidiFlow<TIn1, TOut1, TIn2, TOut2, Unit> FromFunction<TIn1, TOut1, TIn2, TOut2>(Func<TIn1, TOut1> outbound, Func<TIn2, TOut2> inbound)
         {
-            return FromFlows(Flow.Create<TIn1>().Map(outbound), Flow.Create<TIn2>().Map(inbound));
+            return FromFlows(Flow.Create<TIn1>().Select(outbound), Flow.Create<TIn2>().Select(inbound));
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/FLow.cs
+++ b/src/core/Akka.Streams/Dsl/FLow.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------
 // <copyright file="FLow.cs" company="Akka.NET Project">
 //     Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
@@ -282,7 +282,7 @@ namespace Akka.Streams.Dsl
         /// </summary>
         public static Flow<TIn, TOut, Unit> FromFunction<TIn, TOut>(Func<TIn, TOut> function)
         {
-            return Create<TIn>().Map(function);
+            return Create<TIn>().Select(function);
         } 
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/FlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/FlowOperations.cs
@@ -149,7 +149,7 @@ namespace Akka.Streams.Dsl
         /// Transform this stream by applying the given function <paramref name="asyncMapper"/> to each of the elements
         /// as they pass through this processing step. The function returns a <see cref="Task{TOut}"/> and the
         /// value of that task will be emitted downstream. The number of tasks
-        /// that shall run in parallel is given as the first argument to <see cref="MapAsync{T,TIn,TOut,TMat}"/>.
+        /// that shall run in parallel is given as the first argument to <see cref="SelectAsync{T,TIn,TOut,TMat}"/>.
         /// These tasks may complete in any order, but the elements that
         /// are emitted downstream are in the same order as received from upstream.
         /// 
@@ -175,9 +175,9 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// </summary>
         /// <seealso cref="MapAsyncUnordered{T,TIn,TOut,TMat}"/>
-        public static Flow<T, TOut, TMat> MapAsync<T, TIn, TOut, TMat>(this Flow<T, TIn, TMat> flow, int parallelism, Func<TIn, Task<TOut>> asyncMapper)
+        public static Flow<T, TOut, TMat> SelectAsync<T, TIn, TOut, TMat>(this Flow<T, TIn, TMat> flow, int parallelism, Func<TIn, Task<TOut>> asyncMapper)
         {
-            return (Flow<T, TOut, TMat>)InternalFlowOperations.MapAsync(flow, parallelism, asyncMapper);
+            return (Flow<T, TOut, TMat>)InternalFlowOperations.SelectAsync(flow, parallelism, asyncMapper);
         }
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace Akka.Streams.Dsl
         /// Cancels when downstream cancels
         /// </para>
         /// </summary>
-        /// <seealso cref="MapAsync{T,TIn,TOut,TMat}"/>
+        /// <seealso cref="SelectAsync{T,TIn,TOut,TMat}"/>
         public static Flow<T, TOut, TMat> MapAsyncUnordered<T, TIn, TOut, TMat>(this Flow<T, TIn, TMat> flow, int parallelism, Func<TIn, Task<TOut>> asyncMapper)
         {
             return (Flow<T, TOut, TMat>)InternalFlowOperations.MapAsyncUnordered(flow, parallelism, asyncMapper);

--- a/src/core/Akka.Streams/Dsl/FlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/FlowOperations.cs
@@ -596,9 +596,9 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static Flow<TIn, TOut, TMat> DropWithin<TIn, TOut, TMat>(this Flow<TIn, TOut, TMat> flow, TimeSpan duration)
+        public static Flow<TIn, TOut, TMat> SkipWithin<TIn, TOut, TMat>(this Flow<TIn, TOut, TMat> flow, TimeSpan duration)
         {
-            return (Flow<TIn, TOut, TMat>)InternalFlowOperations.DropWithin(flow, duration);
+            return (Flow<TIn, TOut, TMat>)InternalFlowOperations.SkipWithin(flow, duration);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/FlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/FlowOperations.cs
@@ -284,9 +284,9 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static Flow<TIn, TOut, TMat> DropWhile<TIn, TOut, TMat>(this Flow<TIn, TOut, TMat> flow, Predicate<TOut> predicate)
+        public static Flow<TIn, TOut, TMat> SkipWhile<TIn, TOut, TMat>(this Flow<TIn, TOut, TMat> flow, Predicate<TOut> predicate)
         {
-            return (Flow<TIn, TOut, TMat>)InternalFlowOperations.DropWhile(flow, predicate);
+            return (Flow<TIn, TOut, TMat>)InternalFlowOperations.SkipWhile(flow, predicate);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/FlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/FlowOperations.cs
@@ -174,7 +174,7 @@ namespace Akka.Streams.Dsl
         /// Cancels when downstream cancels
         /// </para>
         /// </summary>
-        /// <seealso cref="MapAsyncUnordered{T,TIn,TOut,TMat}"/>
+        /// <seealso cref="SelectAsyncUnordered{T,TIn,TOut,TMat}"/>
         public static Flow<T, TOut, TMat> SelectAsync<T, TIn, TOut, TMat>(this Flow<T, TIn, TMat> flow, int parallelism, Func<TIn, Task<TOut>> asyncMapper)
         {
             return (Flow<T, TOut, TMat>)InternalFlowOperations.SelectAsync(flow, parallelism, asyncMapper);
@@ -209,9 +209,9 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// </summary>
         /// <seealso cref="SelectAsync{T,TIn,TOut,TMat}"/>
-        public static Flow<T, TOut, TMat> MapAsyncUnordered<T, TIn, TOut, TMat>(this Flow<T, TIn, TMat> flow, int parallelism, Func<TIn, Task<TOut>> asyncMapper)
+        public static Flow<T, TOut, TMat> SelectAsyncUnordered<T, TIn, TOut, TMat>(this Flow<T, TIn, TMat> flow, int parallelism, Func<TIn, Task<TOut>> asyncMapper)
         {
-            return (Flow<T, TOut, TMat>)InternalFlowOperations.MapAsyncUnordered(flow, parallelism, asyncMapper);
+            return (Flow<T, TOut, TMat>)InternalFlowOperations.SelectAsyncUnordered(flow, parallelism, asyncMapper);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/FlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/FlowOperations.cs
@@ -108,9 +108,9 @@ namespace Akka.Streams.Dsl
         /// Cancels when downstream cancels
         /// </para>
         /// </summary>
-        public static Flow<T, TOut, TMat> MapConcat<T, TIn, TOut, TMat>(this Flow<T, TIn, TMat> flow, Func<TIn, IEnumerable<TOut>> mapConcater)
+        public static Flow<T, TOut, TMat> SelectMany<T, TIn, TOut, TMat>(this Flow<T, TIn, TMat> flow, Func<TIn, IEnumerable<TOut>> mapConcater)
         {
-            return (Flow<T, TOut, TMat>)InternalFlowOperations.MapConcat(flow, mapConcater);
+            return (Flow<T, TOut, TMat>)InternalFlowOperations.SelectMany(flow, mapConcater);
         }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace Akka.Streams.Dsl
         /// then flattened into the output stream. The transformation is meant to be stateful,
         /// which is enabled by creating the transformation function <paramref name="mapConcaterFactory"/> a new for every materialization —
         /// the returned function will typically close over mutable objects to store state between
-        /// invocations. For the stateless variant see <see cref="FlowOperations.MapConcat{T,TIn,TOut,TMat}"/>.
+        /// invocations. For the stateless variant see <see cref="SelectMany{T,TIn,TOut,TMat}"/>.
         /// 
         /// The returned Enumerable MUST NOT contain null values,
         /// as they are illegal as stream elements - according to the Reactive Streams specification.
@@ -137,12 +137,12 @@ namespace Akka.Streams.Dsl
         /// <para>
         /// Cancels when downstream cancels
         /// </para>
-        /// See also <see cref="FlowOperations.MapConcat{T,TIn,TOut,TMat}"/>
+        /// See also <see cref="SelectMany{T,TIn,TOut,TMat}"/>
         /// </summary>
-        public static Flow<T, TOut, TMat> StatefulMapConcat<T, TIn, TOut, TMat>(this Flow<T, TIn, TMat> flow,
+        public static Flow<T, TOut, TMat> StatefulSelectMany<T, TIn, TOut, TMat>(this Flow<T, TIn, TMat> flow,
             Func<Func<TIn, IEnumerable<TOut>>> mapConcaterFactory)
         {
-            return (Flow<T, TOut, TMat>) InternalFlowOperations.StatefulMapConcat(flow, mapConcaterFactory);
+            return (Flow<T, TOut, TMat>) InternalFlowOperations.StatefulSelectMany(flow, mapConcaterFactory);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/FlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/FlowOperations.cs
@@ -227,9 +227,9 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static Flow<TIn, TOut, TMat> Filter<TIn, TOut, TMat>(this Flow<TIn, TOut, TMat> flow, Predicate<TOut> predicate)
+        public static Flow<TIn, TOut, TMat> Where<TIn, TOut, TMat>(this Flow<TIn, TOut, TMat> flow, Predicate<TOut> predicate)
         {
-            return (Flow<TIn, TOut, TMat>)InternalFlowOperations.Filter(flow, predicate);
+            return (Flow<TIn, TOut, TMat>)InternalFlowOperations.Where(flow, predicate);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/FlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/FlowOperations.cs
@@ -1009,9 +1009,9 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static Flow<TIn, TOut2, TMat> FlatMapConcat<TIn, TOut1, TOut2, TMat>(this Flow<TIn, TOut1, TMat> flow, Func<TOut1, IGraph<SourceShape<TOut2>, TMat>> flatten)
+        public static Flow<TIn, TOut2, TMat> ConcatMany<TIn, TOut1, TOut2, TMat>(this Flow<TIn, TOut1, TMat> flow, Func<TOut1, IGraph<SourceShape<TOut2>, TMat>> flatten)
         {
-            return (Flow<TIn, TOut2, TMat>)InternalFlowOperations.FlatMapConcat(flow, flatten);
+            return (Flow<TIn, TOut2, TMat>)InternalFlowOperations.ConcatMany(flow, flatten);
         }
 
         /// <summary>
@@ -1027,9 +1027,9 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static Flow<TIn, TOut2, TMat> FlatMapMerge<TIn, TOut1, TOut2, TMat>(this Flow<TIn, TOut1, TMat> flow, int breadth, Func<TOut1, IGraph<SourceShape<TOut2>, TMat>> flatten)
+        public static Flow<TIn, TOut2, TMat> MergeMany<TIn, TOut1, TOut2, TMat>(this Flow<TIn, TOut1, TMat> flow, int breadth, Func<TOut1, IGraph<SourceShape<TOut2>, TMat>> flatten)
         {
-            return (Flow<TIn, TOut2, TMat>)InternalFlowOperations.FlatMapMerge(flow, breadth, flatten);
+            return (Flow<TIn, TOut2, TMat>)InternalFlowOperations.MergeMany(flow, breadth, flatten);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/FlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/FlowOperations.cs
@@ -462,9 +462,9 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static Flow<TIn, TOut, TMat> Reduce<TIn, TOut, TMat>(this Flow<TIn, TOut, TMat> flow, Func<TOut, TOut, TOut> reduce)
+        public static Flow<TIn, TOut, TMat> Sum<TIn, TOut, TMat>(this Flow<TIn, TOut, TMat> flow, Func<TOut, TOut, TOut> reduce)
         {
-            return (Flow<TIn, TOut, TMat>) InternalFlowOperations.Reduce(flow, reduce);
+            return (Flow<TIn, TOut, TMat>) InternalFlowOperations.Sum(flow, reduce);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/FlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/FlowOperations.cs
@@ -82,9 +82,9 @@ namespace Akka.Streams.Dsl
         /// Cancels when downstream cancels
         /// </para>
         /// </summary>
-        public static Flow<T, TOut, TMat> Map<T, TIn, TOut, TMat>(this Flow<T, TIn, TMat> flow, Func<TIn, TOut> mapper)
+        public static Flow<T, TOut, TMat> Select<T, TIn, TOut, TMat>(this Flow<T, TIn, TMat> flow, Func<TIn, TOut> mapper)
         {
-            return (Flow<T, TOut, TMat>)InternalFlowOperations.Map(flow, mapper);
+            return (Flow<T, TOut, TMat>)InternalFlowOperations.Select(flow, mapper);
         }
         
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/FlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/FlowOperations.cs
@@ -580,9 +580,9 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static Flow<TIn, TOut, TMat> Drop<TIn, TOut, TMat>(this Flow<TIn, TOut, TMat> flow, long n)
+        public static Flow<TIn, TOut, TMat> Skip<TIn, TOut, TMat>(this Flow<TIn, TOut, TMat> flow, long n)
         {
-            return (Flow<TIn, TOut, TMat>)InternalFlowOperations.Drop(flow, n);
+            return (Flow<TIn, TOut, TMat>)InternalFlowOperations.Skip(flow, n);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/FlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/FlowOperations.cs
@@ -245,9 +245,9 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static Flow<TIn, TOut, TMat> FilterNot<TIn, TOut, TMat>(this Flow<TIn, TOut, TMat> flow, Predicate<TOut> predicate)
+        public static Flow<TIn, TOut, TMat> WhereNot<TIn, TOut, TMat>(this Flow<TIn, TOut, TMat> flow, Predicate<TOut> predicate)
         {
-            return (Flow<TIn, TOut, TMat>)InternalFlowOperations.FilterNot(flow, predicate);
+            return (Flow<TIn, TOut, TMat>)InternalFlowOperations.WhereNot(flow, predicate);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/FlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/FlowOperations.cs
@@ -405,7 +405,7 @@ namespace Akka.Streams.Dsl
         }
 
         /// <summary>
-        /// Similar to <see cref="Fold{TIn,TOut}"/> but is not a terminal operation,
+        /// Similar to <see cref="Aggregate{TIn,TOut1,TOut2,TMat}"/> but is not a terminal operation,
         /// emits its current value which starts at <paramref name="zero"/> and then
         /// applies the current and next value to the given function <paramref name="scan"/>,
         /// emitting the next current value.
@@ -444,13 +444,13 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static Flow<TIn, TOut2, TMat> Fold<TIn, TOut1, TOut2, TMat>(this Flow<TIn, TOut1, TMat> flow, TOut2 zero, Func<TOut2, TOut1, TOut2> fold)
+        public static Flow<TIn, TOut2, TMat> Aggregate<TIn, TOut1, TOut2, TMat>(this Flow<TIn, TOut1, TMat> flow, TOut2 zero, Func<TOut2, TOut1, TOut2> fold)
         {
-            return (Flow<TIn, TOut2, TMat>)InternalFlowOperations.Fold(flow, zero, fold);
+            return (Flow<TIn, TOut2, TMat>)InternalFlowOperations.Aggregate(flow, zero, fold);
         }
 
         /// <summary>
-        /// Similar to <see cref="Fold{TIn,TOut1,TOut2,TMat}"/> but uses first element as zero element.
+        /// Similar to <see cref="Aggregate{TIn,TOut1,TOut2,TMat}"/> but uses first element as zero element.
         /// Applies the given function <paramref name="reduce"/> towards its current and next value,
         /// yielding the next current value. 
         /// <para>

--- a/src/core/Akka.Streams/Dsl/Framing.cs
+++ b/src/core/Akka.Streams/Dsl/Framing.cs
@@ -81,7 +81,7 @@ namespace Akka.Streams.Dsl
         /// <returns></returns>
         public static BidiFlow<ByteString, ByteString, ByteString, ByteString, Unit> SimpleFramingProtocol(int maximumMessageLength)
         {
-            var decoder = LengthField(4, maximumMessageLength + 4, 0, ByteOrder.BigEndian).Map(b => b.Drop(4));
+            var decoder = LengthField(4, maximumMessageLength + 4, 0, ByteOrder.BigEndian).Select(b => b.Drop(4));
             var encoder = Flow.Create<ByteString>().Transform(() => new FramingDecoderStage(maximumMessageLength));
 
             return BidiFlow.FromFlowsMat(encoder, decoder, Keep.Left);

--- a/src/core/Akka.Streams/Dsl/GraphDsl.cs
+++ b/src/core/Akka.Streams/Dsl/GraphDsl.cs
@@ -85,7 +85,7 @@ namespace Akka.Streams.Dsl
             /// the outlets will emit the materialized value.
             /// 
             /// Be careful to not to feed the result of this outlet to a stage that produces the materialized value itself (for
-            /// example to a <see cref="Sink.Fold{TIn,TOut}"/> that contributes to the materialized value) since that might lead to an unresolvable
+            /// example to a <see cref="Sink.Aggregate{TIn,TOut}"/> that contributes to the materialized value) since that might lead to an unresolvable
             /// dependency cycle.
             /// </summary> 
             public Outlet<T> MaterializedValue

--- a/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
@@ -240,9 +240,9 @@ namespace Akka.Streams.Dsl.Internal
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static IFlow<T, TMat> Filter<T, TMat>(this IFlow<T, TMat> flow, Predicate<T> predicate)
+        public static IFlow<T, TMat> Where<T, TMat>(this IFlow<T, TMat> flow, Predicate<T> predicate)
         {
-            return flow.AndThen(new Filter<T>(predicate));
+            return flow.AndThen(new Where<T>(predicate));
         }
 
         /// <summary>
@@ -260,7 +260,7 @@ namespace Akka.Streams.Dsl.Internal
         /// </summary>
         public static IFlow<T, TMat> FilterNot<T, TMat>(this IFlow<T, TMat> flow, Predicate<T> predicate)
         {
-            return flow.AndThen(new Filter<T>(e => !predicate(e)));
+            return flow.AndThen(new Where<T>(e => !predicate(e)));
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
@@ -258,7 +258,7 @@ namespace Akka.Streams.Dsl.Internal
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static IFlow<T, TMat> FilterNot<T, TMat>(this IFlow<T, TMat> flow, Predicate<T> predicate)
+        public static IFlow<T, TMat> WhereNot<T, TMat>(this IFlow<T, TMat> flow, Predicate<T> predicate)
         {
             return flow.AndThen(new Where<T>(e => !predicate(e)));
         }

--- a/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
@@ -418,7 +418,7 @@ namespace Akka.Streams.Dsl.Internal
         }
 
         /// <summary>
-        /// Similar to <see cref="Fold{TIn,TOut}"/> but is not a terminal operation,
+        /// Similar to <see cref="Aggregate{TIn,TOut,TMat}"/> but is not a terminal operation,
         /// emits its current value which starts at <paramref name="zero"/> and then
         /// applies the current and next value to the given function <paramref name="scan"/>,
         /// emitting the next current value.
@@ -458,14 +458,14 @@ namespace Akka.Streams.Dsl.Internal
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static IFlow<TOut, TMat> Fold<TIn, TOut, TMat>(this IFlow<TIn, TMat> flow, TOut zero,
+        public static IFlow<TOut, TMat> Aggregate<TIn, TOut, TMat>(this IFlow<TIn, TMat> flow, TOut zero,
             Func<TOut, TIn, TOut> fold)
         {
-            return flow.AndThen(new Fold<TIn, TOut>(zero, fold));
+            return flow.AndThen(new Aggregate<TIn, TOut>(zero, fold));
         }
 
         /// <summary>
-        /// Similar to <see cref="Fold{TIn,TOut,TMat}"/> but uses first element as zero element.
+        /// Similar to <see cref="Aggregate{TIn,TOut,TMat}"/> but uses first element as zero element.
         /// Applies the given function <paramref name="reduce"/> towards its current and next value,
         /// yielding the next current value. 
         /// <para>

--- a/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
@@ -118,10 +118,10 @@ namespace Akka.Streams.Dsl.Internal
         /// Cancels when downstream cancels
         /// </para>
         /// </summary>
-        public static IFlow<TOut, TMat> MapConcat<TIn, TOut, TMat>(this IFlow<TIn, TMat> flow,
+        public static IFlow<TOut, TMat> SelectMany<TIn, TOut, TMat>(this IFlow<TIn, TMat> flow,
             Func<TIn, IEnumerable<TOut>> mapConcater)
         {
-            return StatefulMapConcat(flow, () => mapConcater);
+            return StatefulSelectMany(flow, () => mapConcater);
         }
 
         /// <summary>
@@ -129,7 +129,7 @@ namespace Akka.Streams.Dsl.Internal
         /// then flattened into the output stream. The transformation is meant to be stateful,
         /// which is enabled by creating the transformation function <paramref name="mapConcaterFactory"/> a new for every materialization —
         /// the returned function will typically close over mutable objects to store state between
-        /// invocations. For the stateless variant see <see cref="MapConcat{TIn,TOut,TMat}"/>.
+        /// invocations. For the stateless variant see <see cref="SelectMany{TIn,TOut,TMat}"/>.
         /// 
         /// The returned Enumerable MUST NOT contain null values,
         /// as they are illegal as stream elements - according to the Reactive Streams specification.
@@ -148,12 +148,12 @@ namespace Akka.Streams.Dsl.Internal
         /// <para>
         /// Cancels when downstream cancels
         /// </para>
-        /// See also <see cref="MapConcat{TIn,TOut,TMat}"/>
+        /// See also <see cref="SelectMany{TIn,TOut,TMat}"/>
         /// </summary>
-        public static IFlow<TOut, TMat> StatefulMapConcat<TIn, TOut, TMat>(this IFlow<TIn, TMat> flow,
+        public static IFlow<TOut, TMat> StatefulSelectMany<TIn, TOut, TMat>(this IFlow<TIn, TMat> flow,
             Func<Func<TIn, IEnumerable<TOut>>> mapConcaterFactory)
         {
-            return flow.Via(new Fusing.StatefulMapConcat<TIn, TOut>(mapConcaterFactory));
+            return flow.Via(new Fusing.StatefulSelectMany<TIn, TOut>(mapConcaterFactory));
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
@@ -606,9 +606,9 @@ namespace Akka.Streams.Dsl.Internal
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static IFlow<T, TMat> Drop<T, TMat>(this IFlow<T, TMat> flow, long n)
+        public static IFlow<T, TMat> Skip<T, TMat>(this IFlow<T, TMat> flow, long n)
         {
-            return flow.AndThen(new Drop<T>(n));
+            return flow.AndThen(new Skip<T>(n));
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
@@ -622,9 +622,9 @@ namespace Akka.Streams.Dsl.Internal
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static IFlow<T, TMat> DropWithin<T, TMat>(this IFlow<T, TMat> flow, TimeSpan duration)
+        public static IFlow<T, TMat> SkipWithin<T, TMat>(this IFlow<T, TMat> flow, TimeSpan duration)
         {
-            return flow.Via(new Fusing.DropWithin<T>(duration).WithAttributes(Attributes.CreateName("dropWithin")));
+            return flow.Via(new Fusing.SkipWithin<T>(duration).WithAttributes(Attributes.CreateName("skipWithin")));
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
@@ -1118,7 +1118,7 @@ namespace Akka.Streams.Dsl.Internal
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static IFlow<TOut, TMat> FlatMapConcat<TIn, TOut, TMat>(this IFlow<TIn, TMat> flow,
+        public static IFlow<TOut, TMat> ConcatMany<TIn, TOut, TMat>(this IFlow<TIn, TMat> flow,
             Func<TIn, IGraph<SourceShape<TOut>, TMat>> flatten)
         {
             return flow.Select(flatten).Via(new Fusing.FlattenMerge<IGraph<SourceShape<TOut>, TMat>, TOut, TMat>(1));
@@ -1137,7 +1137,7 @@ namespace Akka.Streams.Dsl.Internal
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static IFlow<TOut, TMat> FlatMapMerge<TIn, TOut, TMat>(this IFlow<TIn, TMat> flow, int breadth,
+        public static IFlow<TOut, TMat> MergeMany<TIn, TOut, TMat>(this IFlow<TIn, TMat> flow, int breadth,
             Func<TIn, IGraph<SourceShape<TOut>, TMat>> flatten)
         {
             return flow.Select(flatten).Via(new Fusing.FlattenMerge<IGraph<SourceShape<TOut>, TMat>, TOut, TMat>(breadth));

--- a/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------
 // <copyright file="InternalFlowOperations.cs" company="Akka.NET Project">
 //     Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
@@ -92,9 +92,9 @@ namespace Akka.Streams.Dsl.Internal
         /// Cancels when downstream cancels
         /// </para>
         /// </summary>
-        public static IFlow<TOut, TMat> Map<TIn, TOut, TMat>(this IFlow<TIn, TMat> flow, Func<TIn, TOut> mapper)
+        public static IFlow<TOut, TMat> Select<TIn, TOut, TMat>(this IFlow<TIn, TMat> flow, Func<TIn, TOut> mapper)
         {
-            return flow.AndThen(new Map<TIn, TOut>(mapper));
+            return flow.AndThen(new Select<TIn, TOut>(mapper));
         }
 
         /// <summary>
@@ -932,7 +932,7 @@ namespace Akka.Streams.Dsl.Internal
             public IFlow<T, TMat> Apply<T>(Flow<TOut, T, TMat> flow, int breadth)
             {
                 return _deprecatedAndThenFunc(_self, new GroupBy<TOut, TKey>(_maxSubstreams, o => _groupingFunc(o)))
-                    .Map(f => f.Via(flow))
+                    .Select(f => f.Via(flow))
                     .Via(new Fusing.FlattenMerge<Source<T, Unit>, T, Unit>(breadth));
             }
         }
@@ -1021,7 +1021,7 @@ namespace Akka.Streams.Dsl.Internal
             public IFlow<T, TMat> Apply<T>(Flow<TOut, T, TMat> flow, int breadth)
             {
                 return _self.Via(Fusing.Split.When(_predicate, _substreamCancelStrategy))
-                    .Map(f => f.Via(flow))
+                    .Select(f => f.Via(flow))
                     .Via(new Fusing.FlattenMerge<Source<T, Unit>, T, Unit>(breadth));
             }
         }
@@ -1100,7 +1100,7 @@ namespace Akka.Streams.Dsl.Internal
             public IFlow<T, TMat> Apply<T>(Flow<TOut, T, TMat> flow, int breadth)
             {
                 return _self.Via(Fusing.Split.After(_predicate, _substreamCancelStrategy))
-                    .Map(f => f.Via(flow))
+                    .Select(f => f.Via(flow))
                     .Via(new Fusing.FlattenMerge<Source<T, Unit>, T, Unit>(breadth));
             }
         }
@@ -1121,7 +1121,7 @@ namespace Akka.Streams.Dsl.Internal
         public static IFlow<TOut, TMat> FlatMapConcat<TIn, TOut, TMat>(this IFlow<TIn, TMat> flow,
             Func<TIn, IGraph<SourceShape<TOut>, TMat>> flatten)
         {
-            return flow.Map(flatten).Via(new Fusing.FlattenMerge<IGraph<SourceShape<TOut>, TMat>, TOut, TMat>(1));
+            return flow.Select(flatten).Via(new Fusing.FlattenMerge<IGraph<SourceShape<TOut>, TMat>, TOut, TMat>(1));
         }
 
         /// <summary>
@@ -1140,7 +1140,7 @@ namespace Akka.Streams.Dsl.Internal
         public static IFlow<TOut, TMat> FlatMapMerge<TIn, TOut, TMat>(this IFlow<TIn, TMat> flow, int breadth,
             Func<TIn, IGraph<SourceShape<TOut>, TMat>> flatten)
         {
-            return flow.Map(flatten).Via(new Fusing.FlattenMerge<IGraph<SourceShape<TOut>, TMat>, TOut, TMat>(breadth));
+            return flow.Select(flatten).Via(new Fusing.FlattenMerge<IGraph<SourceShape<TOut>, TMat>, TOut, TMat>(breadth));
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
@@ -297,9 +297,9 @@ namespace Akka.Streams.Dsl.Internal
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static IFlow<T, TMat> DropWhile<T, TMat>(this IFlow<T, TMat> flow, Predicate<T> predicate)
+        public static IFlow<T, TMat> SkipWhile<T, TMat>(this IFlow<T, TMat> flow, Predicate<T> predicate)
         {
-            return flow.AndThen(new DropWhile<T>(predicate));
+            return flow.AndThen(new SkipWhile<T>(predicate));
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
@@ -185,7 +185,7 @@ namespace Akka.Streams.Dsl.Internal
         /// Cancels when downstream cancels
         /// </para>
         /// </summary>
-        /// <seealso cref="MapAsyncUnordered{TIn,TOut,TMat}"/>
+        /// <seealso cref="SelectAsyncUnordered{TIn,TOut,TMat}"/>
         public static IFlow<TOut, TMat> SelectAsync<TIn, TOut, TMat>(this IFlow<TIn, TMat> flow, int parallelism,
             Func<TIn, Task<TOut>> asyncMapper)
         {
@@ -221,10 +221,10 @@ namespace Akka.Streams.Dsl.Internal
         /// </para>
         /// </summary>
         /// <seealso cref="SelectAsync{TIn,TOut,TMat}"/>
-        public static IFlow<TOut, TMat> MapAsyncUnordered<TIn, TOut, TMat>(this IFlow<TIn, TMat> flow, int parallelism,
+        public static IFlow<TOut, TMat> SelectAsyncUnordered<TIn, TOut, TMat>(this IFlow<TIn, TMat> flow, int parallelism,
             Func<TIn, Task<TOut>> asyncMapper)
         {
-            return flow.Via(new Fusing.MapAsyncUnordered<TIn, TOut>(parallelism, asyncMapper));
+            return flow.Via(new Fusing.SelectAsyncUnordered<TIn, TOut>(parallelism, asyncMapper));
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
@@ -160,7 +160,7 @@ namespace Akka.Streams.Dsl.Internal
         /// Transform this stream by applying the given function <paramref name="asyncMapper"/> to each of the elements
         /// as they pass through this processing step. The function returns a <see cref="Task{TOut}"/> and the
         /// value of that task will be emitted downstream. The number of tasks
-        /// that shall run in parallel is given as the first argument to <see cref="MapAsync{TIn,TOut,TMat}"/>.
+        /// that shall run in parallel is given as the first argument to <see cref="SelectAsync{TIn,TOut,TMat}"/>.
         /// These tasks may complete in any order, but the elements that
         /// are emitted downstream are in the same order as received from upstream.
         /// 
@@ -186,10 +186,10 @@ namespace Akka.Streams.Dsl.Internal
         /// </para>
         /// </summary>
         /// <seealso cref="MapAsyncUnordered{TIn,TOut,TMat}"/>
-        public static IFlow<TOut, TMat> MapAsync<TIn, TOut, TMat>(this IFlow<TIn, TMat> flow, int parallelism,
+        public static IFlow<TOut, TMat> SelectAsync<TIn, TOut, TMat>(this IFlow<TIn, TMat> flow, int parallelism,
             Func<TIn, Task<TOut>> asyncMapper)
         {
-            return flow.Via(new Fusing.MapAsync<TIn, TOut>(parallelism, asyncMapper));
+            return flow.Via(new Fusing.SelectAsync<TIn, TOut>(parallelism, asyncMapper));
         }
 
         /// <summary>
@@ -220,7 +220,7 @@ namespace Akka.Streams.Dsl.Internal
         /// Cancels when downstream cancels
         /// </para>
         /// </summary>
-        /// <seealso cref="MapAsync{TIn,TOut,TMat}"/>
+        /// <seealso cref="SelectAsync{TIn,TOut,TMat}"/>
         public static IFlow<TOut, TMat> MapAsyncUnordered<TIn, TOut, TMat>(this IFlow<TIn, TMat> flow, int parallelism,
             Func<TIn, Task<TOut>> asyncMapper)
         {

--- a/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
@@ -477,9 +477,9 @@ namespace Akka.Streams.Dsl.Internal
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static IFlow<TIn, TMat> Reduce<TIn, TMat>(this IFlow<TIn, TMat> flow, Func<TIn, TIn, TIn> reduce)
+        public static IFlow<TIn, TMat> Sum<TIn, TMat>(this IFlow<TIn, TMat> flow, Func<TIn, TIn, TIn> reduce)
         {
-            return flow.Via(new Fusing.Reduce<TIn>(reduce));
+            return flow.Via(new Fusing.Sum<TIn>(reduce));
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/Sink.cs
+++ b/src/core/Akka.Streams/Dsl/Sink.cs
@@ -256,7 +256,7 @@ namespace Akka.Streams.Dsl
             var fold = Flow.Create<TIn>()
                 .Aggregate(zero, aggregate)
                 .ToMaterialized(First<TOut>(), Keep.Right)
-                .Named("FoldSink");
+                .Named("AggregateSink");
 
             return FromGraph(fold);
         }
@@ -268,12 +268,12 @@ namespace Akka.Streams.Dsl
         /// function evaluation when the input stream ends, or completed with `Failure`
         /// if there is a failure signaled in the stream.
         /// </summary>
-        public static Sink<TIn, Task<TIn>> Reduce<TIn>(Func<TIn, TIn, TIn> reduce)
+        public static Sink<TIn, Task<TIn>> Sum<TIn>(Func<TIn, TIn, TIn> reduce)
         {
             var graph = Flow.Create<TIn>()
-                .Reduce(reduce)
+                .Sum(reduce)
                 .ToMaterialized(First<TIn>(), Keep.Right)
-                .Named("ReduceSink");
+                .Named("SumSink");
 
             return FromGraph(graph);
         }

--- a/src/core/Akka.Streams/Dsl/Sink.cs
+++ b/src/core/Akka.Streams/Dsl/Sink.cs
@@ -251,10 +251,10 @@ namespace Akka.Streams.Dsl
         /// function evaluation when the input stream ends, or completed with the streams exception
         /// if there is a failure signaled in the stream.
         /// </summary>
-        public static Sink<TIn, Task<TOut>> Fold<TIn, TOut>(TOut zero, Func<TOut, TIn, TOut> aggregate)
+        public static Sink<TIn, Task<TOut>> Aggregate<TIn, TOut>(TOut zero, Func<TOut, TIn, TOut> aggregate)
         {
             var fold = Flow.Create<TIn>()
-                .Fold(zero, aggregate)
+                .Aggregate(zero, aggregate)
                 .ToMaterialized(First<TOut>(), Keep.Right)
                 .Named("FoldSink");
 

--- a/src/core/Akka.Streams/Dsl/Sink.cs
+++ b/src/core/Akka.Streams/Dsl/Sink.cs
@@ -232,12 +232,12 @@ namespace Akka.Streams.Dsl
         /// element is dropped and the stream continues. 
         /// 
         ///  <para/>
-        /// See also <seealso cref="MapAsyncUnordered{TIn,TOut}"/> 
+        /// See also <seealso cref="SelectAsyncUnordered{TIn,TOut}"/> 
         /// </summary>
         public static Sink<TIn, Task> ForEachParallel<TIn>(int parallelism, Action<TIn> action)
         {
             return Flow.Create<TIn>()
-                .MapAsyncUnordered(parallelism, input => Task.Run(() =>
+                .SelectAsyncUnordered(parallelism, input => Task.Run(() =>
                 {
                     action(input);
                     return Unit.Instance;

--- a/src/core/Akka.Streams/Dsl/Sink.cs
+++ b/src/core/Akka.Streams/Dsl/Sink.cs
@@ -191,7 +191,7 @@ namespace Akka.Streams.Dsl
         /// </summary>
         public static Sink<TIn, Task> ForEach<TIn>(Action<TIn> action)
         {
-            var forEach = Flow.Create<TIn>().Map(input =>
+            var forEach = Flow.Create<TIn>().Select(input =>
             {
                 action(input);
                 return Unit.Instance;

--- a/src/core/Akka.Streams/Dsl/Source.cs
+++ b/src/core/Akka.Streams/Dsl/Source.cs
@@ -170,7 +170,7 @@ namespace Akka.Streams.Dsl
         /// </summary>
         public Task<TOut2> RunFold<TOut2>(TOut2 zero, Func<TOut2, TOut, TOut2> aggregate, IMaterializer materializer)
         {
-            return RunWith(Sink.Fold(zero, aggregate), materializer);
+            return RunWith(Sink.Aggregate(zero, aggregate), materializer);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/Source.cs
+++ b/src/core/Akka.Streams/Dsl/Source.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------
 // <copyright file="Source.cs" company="Akka.NET Project">
 //     Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
@@ -262,7 +262,7 @@ namespace Akka.Streams.Dsl
         /// </summary>
         public static Source<T, Unit> From<T>(IEnumerable<T> enumerable)
         {
-            return Single(enumerable).MapConcat(x => x).WithAttributes(DefaultAttributes.EnumerableSource);
+            return Single(enumerable).SelectMany(x => x).WithAttributes(DefaultAttributes.EnumerableSource);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/Source.cs
+++ b/src/core/Akka.Streams/Dsl/Source.cs
@@ -168,7 +168,7 @@ namespace Akka.Streams.Dsl
         /// function evaluation when the input stream ends, or completed with Failure
         /// if there is a failure signaled in the stream.
         /// </summary>
-        public Task<TOut2> RunFold<TOut2>(TOut2 zero, Func<TOut2, TOut, TOut2> aggregate, IMaterializer materializer)
+        public Task<TOut2> RunAggregate<TOut2>(TOut2 zero, Func<TOut2, TOut, TOut2> aggregate, IMaterializer materializer)
         {
             return RunWith(Sink.Aggregate(zero, aggregate), materializer);
         }
@@ -181,9 +181,9 @@ namespace Akka.Streams.Dsl
         /// function evaluation when the input stream ends, or completed with Failure
         /// if there is a failure signaled in the stream.
         /// </summary>
-        public Task<TOut> RunReduce(Func<TOut, TOut, TOut> reduce, IMaterializer materializer)
+        public Task<TOut> RunSum(Func<TOut, TOut, TOut> reduce, IMaterializer materializer)
         {
-            return RunWith(Sink.Reduce(reduce), materializer);
+            return RunWith(Sink.Sum(reduce), materializer);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/SourceOperations.cs
+++ b/src/core/Akka.Streams/Dsl/SourceOperations.cs
@@ -107,9 +107,9 @@ namespace Akka.Streams.Dsl
         /// Cancels when downstream cancels
         /// </para>
         /// </summary>
-        public static Source<TOut2, TMat> MapConcat<TOut1, TOut2, TMat>(this Source<TOut1, TMat> flow, Func<TOut1, IEnumerable<TOut2>> mapConcater)
+        public static Source<TOut2, TMat> SelectMany<TOut1, TOut2, TMat>(this Source<TOut1, TMat> flow, Func<TOut1, IEnumerable<TOut2>> mapConcater)
         {
-            return (Source<TOut2, TMat>)InternalFlowOperations.MapConcat(flow, mapConcater);
+            return (Source<TOut2, TMat>)InternalFlowOperations.SelectMany(flow, mapConcater);
         }
 
         /// <summary>
@@ -117,7 +117,7 @@ namespace Akka.Streams.Dsl
         /// then flattened into the output stream. The transformation is meant to be stateful,
         /// which is enabled by creating the transformation function <paramref name="mapConcaterFactory"/> a new for every materialization —
         /// the returned function will typically close over mutable objects to store state between
-        /// invocations. For the stateless variant see <see cref="MapConcat{TIn,TOut,TMat}"/>.
+        /// invocations. For the stateless variant see <see cref="SelectMany{TIn,TOut,TMat}"/>.
         /// 
         /// The returned Enumerable MUST NOT contain null values,
         /// as they are illegal as stream elements - according to the Reactive Streams specification.
@@ -136,12 +136,12 @@ namespace Akka.Streams.Dsl
         /// <para>
         /// Cancels when downstream cancels
         /// </para>
-        /// See also <see cref="MapConcat{TIn,TOut,TMat}"/>
+        /// See also <see cref="SelectMany{TIn,TOut,TMat}"/>
         /// </summary>
-        public static Source<TOut2, TMat> StatefulMapConcat<TOut1, TOut2, TMat>(this Source<TOut1, TMat> flow,
+        public static Source<TOut2, TMat> StatefulSelectMany<TOut1, TOut2, TMat>(this Source<TOut1, TMat> flow,
             Func<Func<TOut1, IEnumerable<TOut2>>> mapConcaterFactory)
         {
-            return (Source<TOut2, TMat>)InternalFlowOperations.StatefulMapConcat(flow, mapConcaterFactory);
+            return (Source<TOut2, TMat>)InternalFlowOperations.StatefulSelectMany(flow, mapConcaterFactory);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/SourceOperations.cs
+++ b/src/core/Akka.Streams/Dsl/SourceOperations.cs
@@ -461,9 +461,9 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static Source<TOut, TMat> Reduce<TOut, TMat>(this Source<TOut, TMat> flow, Func<TOut, TOut, TOut> reduce)
+        public static Source<TOut, TMat> Sum<TOut, TMat>(this Source<TOut, TMat> flow, Func<TOut, TOut, TOut> reduce)
         {
-            return (Source<TOut, TMat>)InternalFlowOperations.Reduce(flow, reduce);
+            return (Source<TOut, TMat>)InternalFlowOperations.Sum(flow, reduce);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/SourceOperations.cs
+++ b/src/core/Akka.Streams/Dsl/SourceOperations.cs
@@ -244,9 +244,9 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static Source<TOut, TMat> FilterNot<TOut, TMat>(this Source<TOut, TMat> flow, Predicate<TOut> predicate)
+        public static Source<TOut, TMat> WhereNot<TOut, TMat>(this Source<TOut, TMat> flow, Predicate<TOut> predicate)
         {
-            return (Source<TOut, TMat>)InternalFlowOperations.FilterNot(flow, predicate);
+            return (Source<TOut, TMat>)InternalFlowOperations.WhereNot(flow, predicate);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/SourceOperations.cs
+++ b/src/core/Akka.Streams/Dsl/SourceOperations.cs
@@ -404,7 +404,7 @@ namespace Akka.Streams.Dsl
         }
 
         /// <summary>
-        /// Similar to <see cref="Fold{TOut1,TOut2,TMat}"/> but is not a terminal operation,
+        /// Similar to <see cref="Aggregate{TOut1,TOut2,TMat}"/> but is not a terminal operation,
         /// emits its current value which starts at <paramref name="zero"/> and then
         /// applies the current and next value to the given function <paramref name="scan"/>,
         /// emitting the next current value.
@@ -443,13 +443,13 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static Source<TOut2, TMat> Fold<TOut1, TOut2, TMat>(this Source<TOut1, TMat> flow, TOut2 zero, Func<TOut2, TOut1, TOut2> fold)
+        public static Source<TOut2, TMat> Aggregate<TOut1, TOut2, TMat>(this Source<TOut1, TMat> flow, TOut2 zero, Func<TOut2, TOut1, TOut2> fold)
         {
-            return (Source<TOut2, TMat>)InternalFlowOperations.Fold(flow, zero, fold);
+            return (Source<TOut2, TMat>)InternalFlowOperations.Aggregate(flow, zero, fold);
         }
 
         /// <summary>
-        /// Similar to <see cref="Fold{TIn,TOut,TMat}"/> but uses first element as zero element.
+        /// Similar to <see cref="Aggregate{TIn,TOut,TMat}"/> but uses first element as zero element.
         /// Applies the given function <paramref name="reduce"/> towards its current and next value,
         /// yielding the next current value. 
         /// <para>

--- a/src/core/Akka.Streams/Dsl/SourceOperations.cs
+++ b/src/core/Akka.Streams/Dsl/SourceOperations.cs
@@ -1008,9 +1008,9 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static Source<TOut2, TMat> FlatMapConcat<TOut1, TOut2, TMat>(this Source<TOut1, TMat> flow, Func<TOut1, IGraph<SourceShape<TOut2>, TMat>> flatten)
+        public static Source<TOut2, TMat> ConcatMany<TOut1, TOut2, TMat>(this Source<TOut1, TMat> flow, Func<TOut1, IGraph<SourceShape<TOut2>, TMat>> flatten)
         {
-            return (Source<TOut2, TMat>)InternalFlowOperations.FlatMapConcat(flow, flatten);
+            return (Source<TOut2, TMat>)InternalFlowOperations.ConcatMany(flow, flatten);
         }
 
         /// <summary>
@@ -1026,9 +1026,9 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static Source<TOut2, TMat> FlatMapMerge<TOut1, TOut2, TMat>(this Source<TOut1, TMat> flow, int breadth, Func<TOut1, IGraph<SourceShape<TOut2>, TMat>> flatten)
+        public static Source<TOut2, TMat> MergeMany<TOut1, TOut2, TMat>(this Source<TOut1, TMat> flow, int breadth, Func<TOut1, IGraph<SourceShape<TOut2>, TMat>> flatten)
         {
-            return (Source<TOut2, TMat>)InternalFlowOperations.FlatMapMerge(flow, breadth, flatten);
+            return (Source<TOut2, TMat>)InternalFlowOperations.MergeMany(flow, breadth, flatten);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/SourceOperations.cs
+++ b/src/core/Akka.Streams/Dsl/SourceOperations.cs
@@ -283,9 +283,9 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static Source<TOut, TMat> DropWhile<TOut, TMat>(this Source<TOut, TMat> flow, Predicate<TOut> predicate)
+        public static Source<TOut, TMat> SkipWhile<TOut, TMat>(this Source<TOut, TMat> flow, Predicate<TOut> predicate)
         {
-            return (Source<TOut, TMat>)InternalFlowOperations.DropWhile(flow, predicate);
+            return (Source<TOut, TMat>)InternalFlowOperations.SkipWhile(flow, predicate);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/SourceOperations.cs
+++ b/src/core/Akka.Streams/Dsl/SourceOperations.cs
@@ -173,7 +173,7 @@ namespace Akka.Streams.Dsl
         /// Cancels when downstream cancels
         /// </para>
         /// </summary>
-        /// <seealso cref="MapAsyncUnordered{TIn,TOut,TMat}"/>
+        /// <seealso cref="SelectAsyncUnordered{TIn,TOut,TMat}"/>
         public static Source<TOut, TMat> SelectAsync<TIn, TOut, TMat>(this Source<TIn, TMat> flow, int parallelism, Func<TIn, Task<TOut>> asyncMapper)
         {
             return (Source<TOut, TMat>)InternalFlowOperations.SelectAsync(flow, parallelism, asyncMapper);
@@ -208,9 +208,9 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// </summary>
         /// <seealso cref="SelectAsync{TIn,TOut,TMat}"/>
-        public static Source<TOut, TMat> MapAsyncUnordered<TIn, TOut, TMat>(this Source<TIn, TMat> flow, int parallelism, Func<TIn, Task<TOut>> asyncMapper)
+        public static Source<TOut, TMat> SelectAsyncUnordered<TIn, TOut, TMat>(this Source<TIn, TMat> flow, int parallelism, Func<TIn, Task<TOut>> asyncMapper)
         {
-            return (Source<TOut, TMat>)InternalFlowOperations.MapAsyncUnordered(flow, parallelism, asyncMapper);
+            return (Source<TOut, TMat>)InternalFlowOperations.SelectAsyncUnordered(flow, parallelism, asyncMapper);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/SourceOperations.cs
+++ b/src/core/Akka.Streams/Dsl/SourceOperations.cs
@@ -226,9 +226,9 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static Source<TOut, TMat> Filter<TOut, TMat>(this Source<TOut, TMat> flow, Predicate<TOut> predicate)
+        public static Source<TOut, TMat> Where<TOut, TMat>(this Source<TOut, TMat> flow, Predicate<TOut> predicate)
         {
-            return (Source<TOut, TMat>)InternalFlowOperations.Filter(flow, predicate);
+            return (Source<TOut, TMat>)InternalFlowOperations.Where(flow, predicate);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/SourceOperations.cs
+++ b/src/core/Akka.Streams/Dsl/SourceOperations.cs
@@ -81,9 +81,9 @@ namespace Akka.Streams.Dsl
         /// Cancels when downstream cancels
         /// </para>
         /// </summary>
-        public static Source<TOut, TMat> Map<TIn, TOut, TMat>(this Source<TIn, TMat> flow, Func<TIn, TOut> mapper)
+        public static Source<TOut, TMat> Select<TIn, TOut, TMat>(this Source<TIn, TMat> flow, Func<TIn, TOut> mapper)
         {
-            return (Source<TOut, TMat>)InternalFlowOperations.Map(flow, mapper);
+            return (Source<TOut, TMat>)InternalFlowOperations.Select(flow, mapper);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/SourceOperations.cs
+++ b/src/core/Akka.Streams/Dsl/SourceOperations.cs
@@ -579,9 +579,9 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static Source<TOut, TMat> Drop<TOut, TMat>(this Source<TOut, TMat> flow, long n)
+        public static Source<TOut, TMat> Skip<TOut, TMat>(this Source<TOut, TMat> flow, long n)
         {
-            return (Source<TOut, TMat>)InternalFlowOperations.Drop(flow, n);
+            return (Source<TOut, TMat>)InternalFlowOperations.Skip(flow, n);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/SourceOperations.cs
+++ b/src/core/Akka.Streams/Dsl/SourceOperations.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------
 // <copyright file="SourceOperations.cs" company="Akka.NET Project">
 //     Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
@@ -148,7 +148,7 @@ namespace Akka.Streams.Dsl
         /// Transform this stream by applying the given function <paramref name="asyncMapper"/> to each of the elements
         /// as they pass through this processing step. The function returns a <see cref="Task{TOut}"/> and the
         /// value of that task will be emitted downstream. The number of tasks
-        /// that shall run in parallel is given as the first argument to <see cref="MapAsync{TIn,TOut,TMat}"/>.
+        /// that shall run in parallel is given as the first argument to <see cref="SelectAsync{TIn,TOut,TMat}"/>.
         /// These tasks may complete in any order, but the elements that
         /// are emitted downstream are in the same order as received from upstream.
         /// 
@@ -174,9 +174,9 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// </summary>
         /// <seealso cref="MapAsyncUnordered{TIn,TOut,TMat}"/>
-        public static Source<TOut, TMat> MapAsync<TIn, TOut, TMat>(this Source<TIn, TMat> flow, int parallelism, Func<TIn, Task<TOut>> asyncMapper)
+        public static Source<TOut, TMat> SelectAsync<TIn, TOut, TMat>(this Source<TIn, TMat> flow, int parallelism, Func<TIn, Task<TOut>> asyncMapper)
         {
-            return (Source<TOut, TMat>)InternalFlowOperations.MapAsync(flow, parallelism, asyncMapper);
+            return (Source<TOut, TMat>)InternalFlowOperations.SelectAsync(flow, parallelism, asyncMapper);
         }
 
         /// <summary>
@@ -207,7 +207,7 @@ namespace Akka.Streams.Dsl
         /// Cancels when downstream cancels
         /// </para>
         /// </summary>
-        /// <seealso cref="MapAsync{TIn,TOut,TMat}"/>
+        /// <seealso cref="SelectAsync{TIn,TOut,TMat}"/>
         public static Source<TOut, TMat> MapAsyncUnordered<TIn, TOut, TMat>(this Source<TIn, TMat> flow, int parallelism, Func<TIn, Task<TOut>> asyncMapper)
         {
             return (Source<TOut, TMat>)InternalFlowOperations.MapAsyncUnordered(flow, parallelism, asyncMapper);

--- a/src/core/Akka.Streams/Dsl/SourceOperations.cs
+++ b/src/core/Akka.Streams/Dsl/SourceOperations.cs
@@ -595,9 +595,9 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        public static Source<TOut, TMat> DropWithin<TOut, TMat>(this Source<TOut, TMat> flow, TimeSpan duration)
+        public static Source<TOut, TMat> SkipWithin<TOut, TMat>(this Source<TOut, TMat> flow, TimeSpan duration)
         {
-            return (Source<TOut, TMat>)InternalFlowOperations.DropWithin(flow, duration);
+            return (Source<TOut, TMat>)InternalFlowOperations.SkipWithin(flow, duration);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
@@ -21,12 +21,12 @@ using Akka.Util;
 
 namespace Akka.Streams.Implementation.Fusing
 {
-    internal sealed class Map<TIn, TOut> : PushStage<TIn, TOut>
+    internal sealed class Select<TIn, TOut> : PushStage<TIn, TOut>
     {
         private readonly Func<TIn, TOut> _func;
         private readonly Decider _decider;
 
-        public Map(Func<TIn, TOut> func, Decider decider)
+        public Select(Func<TIn, TOut> func, Decider decider)
         {
             _func = func;
             _decider = decider;

--- a/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
@@ -1018,19 +1018,19 @@ namespace Akka.Streams.Implementation.Fusing
         protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes) => new Logic(inheritedAttributes, this);
     }
 
-    internal sealed class MapAsyncUnordered<TIn, TOut> : GraphStage<FlowShape<TIn, TOut>>
+    internal sealed class SelectAsyncUnordered<TIn, TOut> : GraphStage<FlowShape<TIn, TOut>>
     {
         #region internal classes
 
         private sealed class Logic : GraphStageLogic
         {
-            private readonly MapAsyncUnordered<TIn, TOut> _stage;
+            private readonly SelectAsyncUnordered<TIn, TOut> _stage;
             private readonly Decider _decider;
             private IBuffer<TOut> _buffer;
             private readonly Action<Result<TOut>> _taskCallback;
             private int _inFlight;
 
-            public Logic(Attributes inheritedAttributes, MapAsyncUnordered<TIn, TOut> stage) : base(stage.Shape)
+            public Logic(Attributes inheritedAttributes, SelectAsyncUnordered<TIn, TOut> stage) : base(stage.Shape)
             {
                 _stage = stage;
                 var attr = inheritedAttributes.GetAttribute<ActorAttributes.SupervisionStrategy>(null);
@@ -1113,14 +1113,14 @@ namespace Akka.Streams.Implementation.Fusing
         public readonly Inlet<TIn> In = new Inlet<TIn>("in");
         public readonly Outlet<TOut> Out = new Outlet<TOut>("out");
 
-        public MapAsyncUnordered(int parallelism, Func<TIn, Task<TOut>> mapFunc)
+        public SelectAsyncUnordered(int parallelism, Func<TIn, Task<TOut>> mapFunc)
         {
             _parallelism = parallelism;
             _mapFunc = mapFunc;
             Shape = new FlowShape<TIn, TOut>(In, Out);
         }
 
-        protected override Attributes InitialAttributes { get; } = Attributes.CreateName("MapAsyncUnordered");
+        protected override Attributes InitialAttributes { get; } = Attributes.CreateName("selectAsyncUnordered");
 
         public override FlowShape<TIn, TOut> Shape { get; }
 

--- a/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
@@ -1550,7 +1550,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes) => new Logic(this);
     }
 
-    internal sealed class Reduce<T> : SimpleLinearGraphStage<T>
+    internal sealed class Sum<T> : SimpleLinearGraphStage<T>
     {
         #region internal classes
 
@@ -1558,7 +1558,7 @@ namespace Akka.Streams.Implementation.Fusing
         {
             private T _aggregator;
 
-            public Logic(Reduce<T> stage) : base(stage.Shape)
+            public Logic(Sum<T> stage) : base(stage.Shape)
             {
                 var rest = new LambdaInHandler(onPush: () =>
                 {
@@ -1587,16 +1587,16 @@ namespace Akka.Streams.Implementation.Fusing
 
         private readonly Func<T, T, T> _reduce;
 
-        public Reduce(Func<T,T,T> reduce)
+        public Sum(Func<T,T,T> reduce)
         {
             _reduce = reduce;
         }
 
-        protected override Attributes InitialAttributes { get; } = DefaultAttributes.Reduce;
+        protected override Attributes InitialAttributes { get; } = DefaultAttributes.Sum;
 
         protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes) => new Logic(this);
 
-        public override string ToString() => "Reduce";
+        public override string ToString() => "Sum";
     }
 
     internal sealed class RecoverWith<TOut, TMat> : SimpleLinearGraphStage<TOut>

--- a/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
@@ -71,13 +71,13 @@ namespace Akka.Streams.Implementation.Fusing
         public override Directive Decide(Exception cause) => _decider(cause);
     }
 
-    internal sealed class DropWhile<T> : PushStage<T, T>
+    internal sealed class SkipWhile<T> : PushStage<T, T>
     {
         private readonly Predicate<T> _predicate;
         private readonly Decider _decider;
         private bool _taking;
 
-        public DropWhile(Predicate<T> predicate, Decider decider)
+        public SkipWhile(Predicate<T> predicate, Decider decider)
         {
             _predicate = predicate;
             _decider = decider;

--- a/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
@@ -37,12 +37,12 @@ namespace Akka.Streams.Implementation.Fusing
         public override Directive Decide(Exception cause) => _decider(cause);
     }
 
-    internal sealed class Filter<T> : PushStage<T, T>
+    internal sealed class Where<T> : PushStage<T, T>
     {
         private readonly Predicate<T> _predicate;
         private readonly Decider _decider;
 
-        public Filter(Predicate<T> predicate, Decider decider)
+        public Where(Predicate<T> predicate, Decider decider)
         {
             _predicate = predicate;
             _decider = decider;

--- a/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
@@ -232,14 +232,14 @@ namespace Akka.Streams.Implementation.Fusing
         public override IStage<TIn, TOut> Restart() => new Scan<TIn, TOut>(_zero, _aggregate, _decider);
     }
 
-    internal sealed class Fold<TIn, TOut> : PushPullStage<TIn, TOut>
+    internal sealed class Aggregate<TIn, TOut> : PushPullStage<TIn, TOut>
     {
         private readonly TOut _zero;
         private readonly Func<TOut, TIn, TOut> _aggregate;
         private readonly Decider _decider;
         private TOut _aggregator;
 
-        public Fold(TOut zero, Func<TOut, TIn, TOut> aggregate, Decider decider)
+        public Aggregate(TOut zero, Func<TOut, TIn, TOut> aggregate, Decider decider)
         {
             _zero = _aggregator = zero;
             _aggregate = aggregate;
@@ -259,7 +259,7 @@ namespace Akka.Streams.Implementation.Fusing
 
         public override Directive Decide(Exception cause) => _decider(cause);
 
-        public override IStage<TIn, TOut> Restart() => new Fold<TIn, TOut>(_zero, _aggregate, _decider);
+        public override IStage<TIn, TOut> Restart() => new Aggregate<TIn, TOut>(_zero, _aggregate, _decider);
     }
 
     internal sealed class Intersperse<T> : GraphStage<FlowShape<T, T>>

--- a/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
@@ -1511,7 +1511,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes) => new Logic(this);
     }
 
-    internal sealed class DropWithin<T> : SimpleLinearGraphStage<T>
+    internal sealed class SkipWithin<T> : SimpleLinearGraphStage<T>
     {
         private readonly TimeSpan _timeout;
 
@@ -1519,10 +1519,10 @@ namespace Akka.Streams.Implementation.Fusing
 
         private sealed class Logic : TimerGraphStageLogic
         {
-            private readonly DropWithin<T> _stage;
+            private readonly SkipWithin<T> _stage;
             private bool _allow;
 
-            public Logic(DropWithin<T> stage) : base(stage.Shape)
+            public Logic(SkipWithin<T> stage) : base(stage.Shape)
             {
                 _stage = stage;
                 SetHandler(_stage.Inlet, onPush: () =>
@@ -1542,7 +1542,7 @@ namespace Akka.Streams.Implementation.Fusing
 
         #endregion
 
-        public DropWithin(TimeSpan timeout)
+        public SkipWithin(TimeSpan timeout)
         {
             _timeout = timeout;
         }

--- a/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
@@ -1677,18 +1677,18 @@ namespace Akka.Streams.Implementation.Fusing
         public override string ToString() => "RecoverWith";
     }
 
-    internal sealed class StatefulMapConcat<TIn, TOut> : GraphStage<FlowShape<TIn, TOut>>
+    internal sealed class StatefulSelectMany<TIn, TOut> : GraphStage<FlowShape<TIn, TOut>>
     {
         #region internal classes
 
         private sealed class Logic : GraphStageLogic
         {
-            private readonly StatefulMapConcat<TIn, TOut> _stage;
+            private readonly StatefulSelectMany<TIn, TOut> _stage;
             private IteratorAdapter<TOut> _currentIterator;
             private readonly Decider _decider;
             private Func<TIn, IEnumerable<TOut>> _plainConcat;
 
-            public Logic(StatefulMapConcat<TIn, TOut> stage, Attributes inheritedAttributes) : base(stage.Shape)
+            public Logic(StatefulSelectMany<TIn, TOut> stage, Attributes inheritedAttributes) : base(stage.Shape)
             {
                 _stage = stage;
                 _decider = inheritedAttributes.GetAttribute(new ActorAttributes.SupervisionStrategy(Deciders.StoppingDecider)).Decider;
@@ -1758,22 +1758,22 @@ namespace Akka.Streams.Implementation.Fusing
 
         private readonly Func<Func<TIn, IEnumerable<TOut>>> _concatFactory;
 
-        private readonly Inlet<TIn> _in = new Inlet<TIn>("StatefulMapConcat.in");
-        private readonly Outlet<TOut> _out = new Outlet<TOut>("StatefulMapConcat.out");
+        private readonly Inlet<TIn> _in = new Inlet<TIn>("StatefulSelectMany.in");
+        private readonly Outlet<TOut> _out = new Outlet<TOut>("StatefulSelectMany.out");
 
-        public StatefulMapConcat(Func<Func<TIn, IEnumerable<TOut>>> concatFactory)
+        public StatefulSelectMany(Func<Func<TIn, IEnumerable<TOut>>> concatFactory)
         {
             _concatFactory = concatFactory;
 
             Shape = new FlowShape<TIn, TOut>(_in, _out);
         }
 
-        protected override Attributes InitialAttributes { get; } = DefaultAttributes.StatefulMapConcat;
+        protected override Attributes InitialAttributes { get; } = DefaultAttributes.StatefulSelectMany;
 
         public override FlowShape<TIn, TOut> Shape { get; }
 
         protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes) => new Logic(this, inheritedAttributes);
 
-        public override string ToString() => "StatefulMapConcat";
+        public override string ToString() => "StatefulSelectMany";
     }
 }

--- a/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
@@ -882,7 +882,7 @@ namespace Akka.Streams.Implementation.Fusing
         public override string ToString() => "Expand";
     }
 
-    internal sealed class MapAsync<TIn, TOut> : GraphStage<FlowShape<TIn, TOut>>
+    internal sealed class SelectAsync<TIn, TOut> : GraphStage<FlowShape<TIn, TOut>>
     {
         #region internal classes
 
@@ -895,12 +895,12 @@ namespace Akka.Streams.Implementation.Fusing
 
             private static readonly Result<TOut> NotYetThere = Result.Failure<TOut>(new Exception());
 
-            private readonly MapAsync<TIn, TOut> _stage;
+            private readonly SelectAsync<TIn, TOut> _stage;
             private readonly Decider _decider;
             private IBuffer<Holder<TOut>> _buffer;
             private readonly Action<Tuple<Holder<TOut>, Result<TOut>>> _taskCallback;
 
-            public Logic(Attributes inheritedAttributes, MapAsync<TIn, TOut> stage) : base(stage.Shape)
+            public Logic(Attributes inheritedAttributes, SelectAsync<TIn, TOut> stage) : base(stage.Shape)
             {
                 _stage = stage;
                 var attr = inheritedAttributes.GetAttribute<ActorAttributes.SupervisionStrategy>(null);
@@ -1004,14 +1004,14 @@ namespace Akka.Streams.Implementation.Fusing
         public readonly Inlet<TIn> In = new Inlet<TIn>("in");
         public readonly Outlet<TOut> Out = new Outlet<TOut>("out");
 
-        public MapAsync(int parallelism, Func<TIn, Task<TOut>> mapFunc)
+        public SelectAsync(int parallelism, Func<TIn, Task<TOut>> mapFunc)
         {
             _parallelism = parallelism;
             _mapFunc = mapFunc;
             Shape = new FlowShape<TIn, TOut>(In, Out);
         }
 
-        protected override Attributes InitialAttributes { get; } = Attributes.CreateName("MapAsync");
+        protected override Attributes InitialAttributes { get; } = Attributes.CreateName("selectAsync");
 
         public override FlowShape<TIn, TOut> Shape { get; }
 

--- a/src/core/Akka.Streams/Implementation/Stages/Stages.cs
+++ b/src/core/Akka.Streams/Implementation/Stages/Stages.cs
@@ -46,7 +46,7 @@ namespace Akka.Streams.Implementation.Stages
         public static readonly Attributes BatchWeighted = Attributes.CreateName("batchWeighted");
         public static readonly Attributes Conflate = Attributes.CreateName("conflate");
         public static readonly Attributes Expand = Attributes.CreateName("expand");
-        public static readonly Attributes StatefulMapConcat = Attributes.CreateName("statefulMapConcat");
+        public static readonly Attributes StatefulSelectMany = Attributes.CreateName("statefulSelectMany");
         public static readonly Attributes GroupBy = Attributes.CreateName("groupBy");
         public static readonly Attributes PrefixAndTail = Attributes.CreateName("prefixAndTail");
         public static readonly Attributes Split = Attributes.CreateName("split");

--- a/src/core/Akka.Streams/Implementation/Stages/Stages.cs
+++ b/src/core/Akka.Streams/Implementation/Stages/Stages.cs
@@ -38,7 +38,7 @@ namespace Akka.Streams.Implementation.Stages
         public static readonly Attributes Take = Attributes.CreateName("take");
         public static readonly Attributes Drop = Attributes.CreateName("drop");
         public static readonly Attributes TakeWhile = Attributes.CreateName("takeWhile");
-        public static readonly Attributes DropWhile = Attributes.CreateName("dropWhile");
+        public static readonly Attributes SkipWhile = Attributes.CreateName("skipWhile");
         public static readonly Attributes Scan = Attributes.CreateName("scan");
         public static readonly Attributes Fold = Attributes.CreateName("fold");
         public static readonly Attributes Buffer = Attributes.CreateName("buffer");
@@ -301,17 +301,17 @@ namespace Akka.Streams.Implementation.Stages
             => new Fusing.TakeWhile<T>(_predicate, Supervision(effectiveAttributes));
     }
 
-    internal sealed class DropWhile<T> : SymbolicStage<T, T>
+    internal sealed class SkipWhile<T> : SymbolicStage<T, T>
     {
         private readonly Predicate<T> _predicate;
 
-        public DropWhile(Predicate<T> predicate, Attributes attributes = null) : base(attributes ?? DefaultAttributes.DropWhile)
+        public SkipWhile(Predicate<T> predicate, Attributes attributes = null) : base(attributes ?? DefaultAttributes.SkipWhile)
         {
             _predicate = predicate;
         }
 
         public override IStage<T, T> Create(Attributes effectiveAttributes)
-            => new Fusing.DropWhile<T>(_predicate, Supervision(effectiveAttributes));
+            => new Fusing.SkipWhile<T>(_predicate, Supervision(effectiveAttributes));
     }
 
     internal sealed class Scan<TIn, TOut> : SymbolicStage<TIn, TOut>

--- a/src/core/Akka.Streams/Implementation/Stages/Stages.cs
+++ b/src/core/Akka.Streams/Implementation/Stages/Stages.cs
@@ -36,7 +36,7 @@ namespace Akka.Streams.Implementation.Stages
         public static readonly Attributes LimitWeighted = Attributes.CreateName("limitWeighted");
         public static readonly Attributes Sliding = Attributes.CreateName("sliding");
         public static readonly Attributes Take = Attributes.CreateName("take");
-        public static readonly Attributes Drop = Attributes.CreateName("drop");
+        public static readonly Attributes Skip = Attributes.CreateName("skip");
         public static readonly Attributes TakeWhile = Attributes.CreateName("takeWhile");
         public static readonly Attributes SkipWhile = Attributes.CreateName("skipWhile");
         public static readonly Attributes Scan = Attributes.CreateName("scan");
@@ -276,11 +276,11 @@ namespace Akka.Streams.Implementation.Stages
         public override IStage<T, T> Create(Attributes effectiveAttributes) => new Fusing.Take<T>(_count);
     }
 
-    internal sealed class Drop<T> : SymbolicStage<T, T>
+    internal sealed class Skip<T> : SymbolicStage<T, T>
     {
         private readonly long _count;
 
-        public Drop(long count, Attributes attributes = null) : base(attributes ?? DefaultAttributes.Drop)
+        public Skip(long count, Attributes attributes = null) : base(attributes ?? DefaultAttributes.Skip)
         {
             _count = count;
         }

--- a/src/core/Akka.Streams/Implementation/Stages/Stages.cs
+++ b/src/core/Akka.Streams/Implementation/Stages/Stages.cs
@@ -26,7 +26,7 @@ namespace Akka.Streams.Implementation.Stages
         public static readonly Attributes Log = Attributes.CreateName("log");
         public static readonly Attributes Where = Attributes.CreateName("where");
         public static readonly Attributes Collect = Attributes.CreateName("collect");
-        public static readonly Attributes Reduce = Attributes.CreateName("reduce");
+        public static readonly Attributes Sum = Attributes.CreateName("sum");
         public static readonly Attributes Recover = Attributes.CreateName("recover");
         public static readonly Attributes RecoverWith = Attributes.CreateName("recoverWith");
         public static readonly Attributes MapAsync = Attributes.CreateName("mapAsync");

--- a/src/core/Akka.Streams/Implementation/Stages/Stages.cs
+++ b/src/core/Akka.Streams/Implementation/Stages/Stages.cs
@@ -22,7 +22,7 @@ namespace Akka.Streams.Implementation.Stages
         public static readonly Attributes IODispatcher = ActorAttributes.CreateDispatcher("akka.stream.default-blocking-io-dispatcher");
 
         public static readonly Attributes Fused = Attributes.CreateName("fused");
-        public static readonly Attributes Map = Attributes.CreateName("map");
+        public static readonly Attributes Select = Attributes.CreateName("select");
         public static readonly Attributes Log = Attributes.CreateName("log");
         public static readonly Attributes Filter = Attributes.CreateName("filter");
         public static readonly Attributes Collect = Attributes.CreateName("collect");
@@ -152,17 +152,17 @@ namespace Akka.Streams.Implementation.Stages
             => attributes.GetAttribute(new ActorAttributes.SupervisionStrategy(Deciders.StoppingDecider)).Decider;
     }
 
-    internal sealed class Map<TIn, TOut> : SymbolicStage<TIn, TOut>
+    internal sealed class Select<TIn, TOut> : SymbolicStage<TIn, TOut>
     {
         private readonly Func<TIn, TOut> _mapper;
 
-        public Map(Func<TIn, TOut> mapper, Attributes attributes = null) : base(attributes ?? DefaultAttributes.Map)
+        public Select(Func<TIn, TOut> mapper, Attributes attributes = null) : base(attributes ?? DefaultAttributes.Select)
         {
             _mapper = mapper;
         }
 
         public override IStage<TIn, TOut> Create(Attributes effectiveAttributes)
-            => new Fusing.Map<TIn, TOut>(_mapper, Supervision(effectiveAttributes));
+            => new Fusing.Select<TIn, TOut>(_mapper, Supervision(effectiveAttributes));
     }
 
     internal sealed class Log<T> : SymbolicStage<T, T>

--- a/src/core/Akka.Streams/Implementation/Stages/Stages.cs
+++ b/src/core/Akka.Streams/Implementation/Stages/Stages.cs
@@ -40,7 +40,7 @@ namespace Akka.Streams.Implementation.Stages
         public static readonly Attributes TakeWhile = Attributes.CreateName("takeWhile");
         public static readonly Attributes SkipWhile = Attributes.CreateName("skipWhile");
         public static readonly Attributes Scan = Attributes.CreateName("scan");
-        public static readonly Attributes Fold = Attributes.CreateName("fold");
+        public static readonly Attributes Aggregate = Attributes.CreateName("aggregate");
         public static readonly Attributes Buffer = Attributes.CreateName("buffer");
         public static readonly Attributes Batch = Attributes.CreateName("batch");
         public static readonly Attributes BatchWeighted = Attributes.CreateName("batchWeighted");
@@ -329,19 +329,19 @@ namespace Akka.Streams.Implementation.Stages
             => new Fusing.Scan<TIn, TOut>(_zero, _aggregate, Supervision(effectiveAttributes));
     }
 
-    internal sealed class Fold<TIn, TOut> : SymbolicStage<TIn, TOut>
+    internal sealed class Aggregate<TIn, TOut> : SymbolicStage<TIn, TOut>
     {
         private readonly TOut _zero;
         private readonly Func<TOut, TIn, TOut> _aggregate;
 
-        public Fold(TOut zero, Func<TOut, TIn, TOut> aggregate, Attributes attributes = null) : base(attributes ?? DefaultAttributes.Fold)
+        public Aggregate(TOut zero, Func<TOut, TIn, TOut> aggregate, Attributes attributes = null) : base(attributes ?? DefaultAttributes.Aggregate)
         {
             _zero = zero;
             _aggregate = aggregate;
         }
 
         public override IStage<TIn, TOut> Create(Attributes effectiveAttributes)
-            => new Fusing.Fold<TIn, TOut>(_zero, _aggregate, Supervision(effectiveAttributes));
+            => new Fusing.Aggregate<TIn, TOut>(_zero, _aggregate, Supervision(effectiveAttributes));
     }
 
     internal sealed class Buffer<T> : SymbolicStage<T, T>

--- a/src/core/Akka.Streams/Implementation/Stages/Stages.cs
+++ b/src/core/Akka.Streams/Implementation/Stages/Stages.cs
@@ -24,7 +24,7 @@ namespace Akka.Streams.Implementation.Stages
         public static readonly Attributes Fused = Attributes.CreateName("fused");
         public static readonly Attributes Select = Attributes.CreateName("select");
         public static readonly Attributes Log = Attributes.CreateName("log");
-        public static readonly Attributes Filter = Attributes.CreateName("filter");
+        public static readonly Attributes Where = Attributes.CreateName("where");
         public static readonly Attributes Collect = Attributes.CreateName("collect");
         public static readonly Attributes Reduce = Attributes.CreateName("reduce");
         public static readonly Attributes Recover = Attributes.CreateName("recover");
@@ -182,17 +182,17 @@ namespace Akka.Streams.Implementation.Stages
             => new Fusing.Log<T>(_name, _extract, _loggingAdapter, Supervision(effectiveAttributes));
     }
 
-    internal sealed class Filter<T> : SymbolicStage<T, T>
+    internal sealed class Where<T> : SymbolicStage<T, T>
     {
         private readonly Predicate<T> _predicate;
 
-        public Filter(Predicate<T> predicate, Attributes attributes = null) : base(attributes ?? DefaultAttributes.Filter)
+        public Where(Predicate<T> predicate, Attributes attributes = null) : base(attributes ?? DefaultAttributes.Where)
         {
             _predicate = predicate;
         }
 
         public override IStage<T, T> Create(Attributes effectiveAttributes)
-            => new Fusing.Filter<T>(_predicate, Supervision(effectiveAttributes));
+            => new Fusing.Where<T>(_predicate, Supervision(effectiveAttributes));
     }
 
 

--- a/src/examples/Streams/StreamsExamples/Program.cs
+++ b/src/examples/Streams/StreamsExamples/Program.cs
@@ -14,7 +14,7 @@ namespace StreamsExamples
             {
                 var flow = Source
                     .From(new[] {1, 2, 3})
-                    .Map(x => x + 1);
+                    .Select(x => x + 1);
 
                 var result = flow
                     .RunForeach(x =>


### PR DESCRIPTION
Changed Akka.Stream DSL naming conventions to closer match LINQ/RxNet:

- Map -> Select
- MapAsync -> SelectAsync
- MapAsyncUnordered -> SelectAsyncUnordered
- Filter -> Where
- FilterNot -> WhereNot
- DropWhile -> SkipWhile
- Drop -> Skip
- DropWithin -> SkipWithin
- MapConcat -> SelectMany
- Fold -> Aggregate
- Reduce -> Sum
- FlatMapConcat -> ConcatMany 
- FlatMapMerge -> MergeMany
- Future -> Task