### PR TITLE
Fixes to serialization errors for serialized-messages=on

### DIFF
--- a/src/core/Akka.Streams/Actors/ActorPublisher.cs
+++ b/src/core/Akka.Streams/Actors/ActorPublisher.cs
@@ -18,8 +18,7 @@ namespace Akka.Streams.Actors
 {
     #region Internal messages
 
-    [Serializable]
-    public sealed class Subscribe<T>
+    public sealed class Subscribe<T> : INoSerializationVerificationNeeded
     {
         public readonly ISubscriber<T> Subscriber;
         public Subscribe(ISubscriber<T> subscriber)


### PR DESCRIPTION
For now this fixes the Cassandra plugin issues, will run the streams tests with serialize-messages=on shortly