### PR TITLE
enabled concurrency mode for NBench; activated Helios 1.4 benchmarks

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -333,6 +333,7 @@ Target "NBench" <| fun _ ->
         let args = new StringBuilder()
                 |> append assembly
                 |> append (sprintf "output-directory=\"%s\"" perfOutput)
+                |> append (sprintf "concurrent=\"%b\"" true)
                 |> toText
 
         let result = ExecProcess(fun info -> 

--- a/src/core/Akka.Remote.Tests.Performance/Transports/HeliosRemoteMessagingThroughputSpec.cs
+++ b/src/core/Akka.Remote.Tests.Performance/Transports/HeliosRemoteMessagingThroughputSpec.cs
@@ -5,62 +5,64 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using Akka.Configuration;
+using Akka.Remote.Tests.Performance.Transports;
+
 namespace Akka.Remote.Tests.Performance.Transports
 {
-    // todo: SKIP FOR NOW - BUGS
-    //public class HeliosRemoteMessagingThroughputSpec : RemoteMessagingThroughputSpecBase
-    //{
-    //    public override Config CreateActorSystemConfig(string actorSystemName, string ipOrHostname, int port)
-    //    {
-    //        var baseConfig = ConfigurationFactory.ParseString(@"
-    //            akka {
-    //          actor.provider = ""Akka.Remote.RemoteActorRefProvider,Akka.Remote""
+    public class HeliosRemoteMessagingThroughputSpec : RemoteMessagingThroughputSpecBase
+    {
+        public override Config CreateActorSystemConfig(string actorSystemName, string ipOrHostname, int port)
+        {
+            var baseConfig = ConfigurationFactory.ParseString(@"
+                akka {
+              actor.provider = ""Akka.Remote.RemoteActorRefProvider,Akka.Remote""
 
-    //          remote {
-    //            log-remote-lifecycle-events = off
+              remote {
+                log-remote-lifecycle-events = off
 
-    //            helios.tcp {
-    //                port = 0
-    //                hostname = ""localhost""
+                helios.tcp {
+                    port = 0
+                    hostname = ""localhost""
 
-    //                # Used to configure the number of I/O worker threads on server sockets
-    //  server-socket-worker-pool {
-    //    # Min number of threads to cap factor-based number to
-    //    pool-size-min = 1
+                    # Used to configure the number of I/O worker threads on server sockets
+      server-socket-worker-pool {
+        # Min number of threads to cap factor-based number to
+        pool-size-min = 1
 
-    //    # The pool size factor is used to determine thread pool size
-    //    # using the following formula: ceil(available processors * factor).
-    //    # Resulting size is then bounded by the pool-size-min and
-    //    # pool-size-max values.
-    //    pool-size-factor = 1.0
+        # The pool size factor is used to determine thread pool size
+        # using the following formula: ceil(available processors * factor).
+        # Resulting size is then bounded by the pool-size-min and
+        # pool-size-max values.
+        pool-size-factor = 1.0
 
-    //    # Max number of threads to cap factor-based number to
-    //    pool-size-max = 1
-    //  }
+        # Max number of threads to cap factor-based number to
+        pool-size-max = 1
+      }
 
-    //  # Used to configure the number of I/O worker threads on client sockets
-    //  client-socket-worker-pool {
-    //    # Min number of threads to cap factor-based number to
-    //    pool-size-min = 1
+      # Used to configure the number of I/O worker threads on client sockets
+      client-socket-worker-pool {
+        # Min number of threads to cap factor-based number to
+        pool-size-min = 1
 
-    //    # The pool size factor is used to determine thread pool size
-    //    # using the following formula: ceil(available processors * factor).
-    //    # Resulting size is then bounded by the pool-size-min and
-    //    # pool-size-max values.
-    //    pool-size-factor = 1.0
+        # The pool size factor is used to determine thread pool size
+        # using the following formula: ceil(available processors * factor).
+        # Resulting size is then bounded by the pool-size-min and
+        # pool-size-max values.
+        pool-size-factor = 1.0
 
-    //    # Max number of threads to cap factor-based number to
-    //    pool-size-max = 1
-    //  }
-    //            }
-    //          }
-    //        ");
+        # Max number of threads to cap factor-based number to
+        pool-size-max = 1
+      }
+                }
+              }
+            ");
 
-    //        var bindingConfig =
-    //            ConfigurationFactory.ParseString(@"akka.remote.helios.tcp.hostname = """ + ipOrHostname + @"""")
-    //            .WithFallback(ConfigurationFactory.ParseString(@"akka.remote.helios.tcp.port = " + port));
+            var bindingConfig =
+                ConfigurationFactory.ParseString(@"akka.remote.helios.tcp.hostname = """ + ipOrHostname + @"""")
+                .WithFallback(ConfigurationFactory.ParseString(@"akka.remote.helios.tcp.port = " + port));
 
-    //        return bindingConfig.WithFallback(baseConfig);
-    //    }
-    //}
+            return bindingConfig.WithFallback(baseConfig);
+        }
+    }
 }

--- a/src/core/Akka.Tests.Performance/Util/StandardOutWriterMemoryBenchmark.cs
+++ b/src/core/Akka.Tests.Performance/Util/StandardOutWriterMemoryBenchmark.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -21,6 +22,8 @@ namespace Akka.Tests.Performance.Util
         [PerfSetup]
         public void SetUp(BenchmarkContext context)
         {
+            // disable SO so we don't fill up the build log with garbage
+            Console.SetOut(new StreamWriter(Stream.Null));
             _consoleWriteThroughputCounter = context.GetCounter(ConsoleWriteThroughputCounterName);
         }
 
@@ -35,6 +38,13 @@ namespace Akka.Tests.Performance.Util
         {
             StandardOutWriter.WriteLine(InputStr, ConsoleColor.Black, ConsoleColor.DarkGreen);
             _consoleWriteThroughputCounter.Increment();
+        }
+
+        [PerfCleanup]
+        public void CleanUp()
+        {
+            // cleanup SO
+            Console.SetOut(new StreamWriter(Console.OpenStandardOutput()));
         }
     }
 }


### PR DESCRIPTION
This PR does a couple of things:

1. Enables concurrency mode for NBench, which allows all cores to be utilized. You will notice a significant increase in performance for any multi-threaded NBench spec and an increase in standard deviation size for non-multi-threaded specs possibly.
2. Activates the benchmark for the current Helios Akka.Remote transport. This will be used to compare it to the Helios 2.0 implementation.
3. Disables and then restores Console.Out for the duration our `StandardOutWriter` specs, so we don't fill up the build log with garbage.