### PR TITLE
Removed redundant type parameters from PersistentFSMBase.State

### DIFF
--- a/src/core/Akka.Persistence/Fsm/PersistentFSM.cs
+++ b/src/core/Akka.Persistence/Fsm/PersistentFSM.cs
@@ -35,7 +35,7 @@ namespace Akka.Persistence.Fsm
 
         protected abstract TData ApplyEvent(TEvent e, TData data);
 
-        protected override void ApplyState(State<TState, TData, TEvent> upcomingState)
+        protected override void ApplyState(State upcomingState)
         {
             var eventsToPersist = new List<object>();
             if (upcomingState.DomainEvents != null)


### PR DESCRIPTION
As I've described in https://github.com/akkadotnet/akka.net/issues/1952. With backward compatibility support.