### PR TITLE
Added NonInfluenceReceiveTimeout

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -1036,6 +1036,7 @@ namespace Akka.Actor
         public Akka.Actor.IActorRef Watch(Akka.Actor.IActorRef subject) { }
     }
     public interface INoSerializationVerificationNeeded { }
+    public interface INotInfluenceReceiveTimeout { }
     public abstract class InternalActorRefBase : Akka.Actor.ActorRefBase, Akka.Actor.IActorRef, Akka.Actor.IActorRefScope, Akka.Actor.ICanTell, Akka.Actor.IInternalActorRef, Akka.Util.ISurrogated, System.IComparable, System.IComparable<Akka.Actor.IActorRef>, System.IEquatable<Akka.Actor.IActorRef>
     {
         protected InternalActorRefBase() { }

--- a/src/core/Akka.Tests/Actor/ReceiveTimeoutSpec.cs
+++ b/src/core/Akka.Tests/Actor/ReceiveTimeoutSpec.cs
@@ -9,6 +9,7 @@ using System;
 using Akka.Actor;
 using Akka.Event;
 using Akka.TestKit;
+using Akka.Util.Internal;
 using Xunit;
 
 
@@ -16,7 +17,9 @@ namespace Akka.Tests.Actor
 {
     public class ReceiveTimeoutSpec : AkkaSpec
     {
-        private static readonly object Tick = new object();
+        public class Tick { }
+
+        public class TransperentTick : INotInfluenceReceiveTimeout { }
 
         public class TimeoutActor : ActorBase
         {
@@ -32,6 +35,7 @@ namespace Akka.Tests.Actor
                 _timeoutLatch = timeoutLatch;
                 Context.SetReceiveTimeout(timeout.GetValueOrDefault());
             }
+
             protected override bool Receive(object message)
             {
                 if (message is ReceiveTimeout)
@@ -39,10 +43,48 @@ namespace Akka.Tests.Actor
                     _timeoutLatch.Open();
                     return true;
                 }
-                if (message == Tick)
+
+                if (message is Tick)
                 {
                     return true;
                 }
+
+                if (message is TransperentTick)
+                {
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        public class TurnOffTimeoutActor : ActorBase
+        {
+            private TestLatch _timeoutLatch;
+            private readonly AtomicCounter _counter;
+
+            public TurnOffTimeoutActor(TestLatch timeoutLatch, AtomicCounter counter)
+            {
+                _timeoutLatch = timeoutLatch;
+                _counter = counter;
+                Context.SetReceiveTimeout(TimeSpan.FromMilliseconds(500));
+            }
+
+            protected override bool Receive(object message)
+            {
+                if (message is ReceiveTimeout)
+                {
+                    _counter.IncrementAndGet();
+                    _timeoutLatch.Open();
+                    Context.SetReceiveTimeout(null);
+                    return true;
+                }
+
+                if (message is Tick)
+                {
+                    return true;
+                }
+
                 return false;
             }
         }
@@ -55,6 +97,7 @@ namespace Akka.Tests.Actor
             {
                 _timeoutLatch = timeoutLatch;
             }
+
             protected override bool Receive(object message)
             {
                 if (message is ReceiveTimeout)
@@ -62,46 +105,78 @@ namespace Akka.Tests.Actor
                     _timeoutLatch.Open();
                     return true;
                 }
-                if (message == Tick)
+
+                if (message is Tick)
                 {
                     return true;
                 }
+
                 return false;
             }
         }
 
-        [Fact(DisplayName="An actor with receive timeout must get timeout")]
-        public void Get_timeout()
+        [Fact]
+        public void An_actor_with_receive_timeout_must_get_timeout()
         {
             var timeoutLatch = new TestLatch();
-            var timeoutActor = Sys.ActorOf(Props.Create(() => new TimeoutActor(timeoutLatch)));
+            var timeoutActor = Sys.ActorOf(Props.Create(() => new TimeoutActor(timeoutLatch, TimeSpan.FromMilliseconds(500))));
 
-            timeoutLatch.Ready(TestLatch.DefaultTimeout);
-            Sys.Stop(timeoutActor);
-        }
-
-        //TODO: how does this prove that there was a reschedule?? see ReceiveTimeoutSpec.scala 
-        [Fact(DisplayName = "An actor with receive timeout must reschedule timeout after regular receive")]
-        public void Reschedule_timeout()
-        {
-            var timeoutLatch = new TestLatch();
-            var timeoutActor = Sys.ActorOf(Props.Create(() => new TimeoutActor(timeoutLatch)));
-            timeoutActor.Tell(Tick);
-            timeoutLatch.Ready(TestLatch.DefaultTimeout);
-            Sys.Stop(timeoutActor);
-        }
-
-        [Fact(DisplayName = "An actor with receive timeout must not receive timeout message when not specified")]
-        public void Not_get_timeout()
-        {
-            var timeoutLatch = new TestLatch();
-            var timeoutActor = Sys.ActorOf(Props.Create(() => new NoTimeoutActor(timeoutLatch)));
-            Assert.Throws<TimeoutException>(() => timeoutLatch.Ready(TestLatch.DefaultTimeout));
+            timeoutLatch.Ready(TestKitSettings.DefaultTimeout);
             Sys.Stop(timeoutActor);
         }
 
         [Fact]
-        public void Cancel_ReceiveTimeout_When_terminated()
+        public void An_actor_with_receive_timeout_must_reschedule_timeout_after_regular_receive()
+        {
+            var timeoutLatch = new TestLatch();
+            var timeoutActor = Sys.ActorOf(Props.Create(() => new TimeoutActor(timeoutLatch, TimeSpan.FromMilliseconds(500))));
+
+            timeoutActor.Tell(new Tick());
+            timeoutLatch.Ready(TestKitSettings.DefaultTimeout);
+
+            Sys.Stop(timeoutActor);
+        }
+
+        [Fact]
+        public void An_actor_with_receive_timeout_must_be_able_to_turn_off_timeout_if_desired()
+        {
+            var count = new AtomicCounter(0);
+
+            var timeoutLatch = new TestLatch();
+            var timeoutActor = Sys.ActorOf(Props.Create(() => new TurnOffTimeoutActor(timeoutLatch, count)));
+
+            timeoutActor.Tell(new Tick());
+            timeoutLatch.Ready(TestKitSettings.DefaultTimeout);
+            count.Current.ShouldBe(1);
+            Sys.Stop(timeoutActor);
+        }
+
+        [Fact]
+        public void An_actor_with_receive_timeout_must_not_receive_timeout_message_when_not_specified()
+        {
+            var timeoutLatch = new TestLatch();
+            var timeoutActor = Sys.ActorOf(Props.Create(() => new NoTimeoutActor(timeoutLatch)));
+
+            Intercept<TimeoutException>(() => timeoutLatch.Ready(TestKitSettings.DefaultTimeout));
+            Sys.Stop(timeoutActor);
+        }
+
+        [Fact]
+        public void An_actor_with_receive_timeout_must_get_timeout_while_receiving_NotInfluenceReceiveTimeout_messages()
+        {
+            var timeoutLatch = new TestLatch();
+            var timeoutActor = Sys.ActorOf(Props.Create(() => new TimeoutActor(timeoutLatch, TimeSpan.FromSeconds(1))));
+
+            var ticks = Sys.Scheduler.ScheduleTellRepeatedlyCancelable(TimeSpan.FromMilliseconds(100),
+                TimeSpan.FromMilliseconds(100), timeoutActor, new TransperentTick(), TestActor);
+
+            timeoutLatch.Ready(TestKitSettings.DefaultTimeout);
+            ticks.Cancel();
+            Sys.Stop(timeoutActor);
+        }
+
+        [Fact]
+        public void Issue469_An_actor_with_receive_timeout_must_cancel_receive_timeout_when_terminated()
         {
             //This test verifies that bug #469 "ReceiveTimeout isn't cancelled when actor terminates" has been fixed
             var timeoutLatch = CreateTestLatch();

--- a/src/core/Akka/Actor/ActorCell.ReceiveTimeout.cs
+++ b/src/core/Akka/Actor/ActorCell.ReceiveTimeout.cs
@@ -8,7 +8,11 @@
 using System;
 
 namespace Akka.Actor
-{	
+{
+    public interface INotInfluenceReceiveTimeout
+    {
+    }
+
     public partial class ActorCell
     {
         private TimeSpan? _receiveTimeoutDuration = null;


### PR DESCRIPTION
Messages marked with NotInfluenceReceiveTimeout will not reset the timer. This can be useful when ReceiveTimeout should be fired by external inactivity but not influenced by internal activity, e.g. scheduled tick messages.