### PR TITLE
Changed CopyAlways files to CopyIfNewer

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Akka.Persistence.Sqlite.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Akka.Persistence.Sqlite.csproj
@@ -61,7 +61,7 @@
     <None Include="Akka.Persistence.Sqlite.nuspec" />
     <None Include="packages.config" />
     <EmbeddedResource Include="sqlite.conf">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -215,7 +215,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="App.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <ItemGroup>

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -377,7 +377,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Akka.ExternalAnnotations.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <ItemGroup />


### PR DESCRIPTION
Some files had the CopyAlways options, this marked the projects as dirty after each build preventing to skip unchanged projects when rebuilding.

Now when you build the solution twice you get a nice instantaneous:
`========== Build: 0 succeeded, 0 failed, 71 up-to-date, 0 skipped ==========`