### PR TITLE
Added Iterator.Continually support

### DIFF
--- a/src/core/Akka.Streams/Util/Iterator.cs
+++ b/src/core/Akka.Streams/Util/Iterator.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Akka.Streams.Util {
+    public abstract class Iterator
+    {
+        public static IEnumerator<T> Continually<T>(Func<T> getNext)
+        {
+            return new InfiniteIterator<T>(getNext);
+        }
+    }
+
+    /// <summary>
+    /// Iterator to support scala Iterator.Continually type of iterators
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class InfiniteIterator<T> : IEnumerator<T>
+    {
+        private readonly Func<T> getNext;
+        private bool disposed = false;
+
+        public InfiniteIterator(Func<T> getNext)
+        {
+            this.getNext = getNext;
+            Current = default(T);
+        }
+
+        public void Dispose()
+        {
+            Current = default(T);
+            disposed = true;
+        }
+
+        public bool MoveNext()
+        {
+            if (!disposed)
+                Current = getNext();
+
+            return !disposed;
+        }
+
+        public void Reset()
+        {
+
+        }
+
+        public T Current { get; private set; }
+
+        object IEnumerator.Current => Current;
+    }
+}


### PR DESCRIPTION
I have added a custom Iterator to support the scala style Iterator.Continually concept.
This was inspired by following scala snippet

```
    val lastFlow = Flow[Double]
      .expand(Iterator.continually(_))
```

and using this PR could be translated to
```
 double current = 0;
Func<double> next = () => current++;

var lastFlow = Flow.Create<double>()
     .Expand(_ => Iterator.Continually(next));
```

We could add more overloads to simplify/reduce the sample even more. However this would mean adding explicit overloads for each type you would want to support. 

/cc @akkadotnet/core what are your thoughts on this?



