### PR TITLE
Implemented ActorRef caching in Akka.Remote

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -177,6 +177,7 @@ namespace Akka.Actor
         public string ToStringWithUid() { }
         public Akka.Util.ISurrogate ToSurrogate(Akka.Actor.ActorSystem system) { }
         public static bool TryParse(string path, out Akka.Actor.ActorPath actorPath) { }
+        [System.ObsoleteAttribute()]
         public static bool TryParseAddress(string path, out Akka.Actor.Address address) { }
         public abstract Akka.Actor.ActorPath WithUid(long uid);
         public class Surrogate : Akka.Util.ISurrogate, System.IEquatable<Akka.Actor.ActorPath.Surrogate>, System.IEquatable<Akka.Actor.ActorPath>

--- a/src/core/Akka.Remote.Tests.Performance/InboundMessageDispatcherSpec.cs
+++ b/src/core/Akka.Remote.Tests.Performance/InboundMessageDispatcherSpec.cs
@@ -93,7 +93,7 @@ namespace Akka.Remote.Tests.Performance
         [CounterMeasurement(MessageDispatcherThroughputCounterName)]
         public void DispatchThroughput(BenchmarkContext context)
         {
-            _dispatcher.Dispatch(_targetActorRef, _systemAddress, _message);
+            _dispatcher.Dispatch(_targetActorRef, _message);
         }
 
         [PerfCleanup]

--- a/src/core/Akka.Remote.Tests/ActorRefCacheSpec.cs
+++ b/src/core/Akka.Remote.Tests/ActorRefCacheSpec.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using System.Threading;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.TestKit;
+using Akka.TestKit.TestActors;
+using Xunit;
+
+namespace Akka.Remote.Tests
+{
+    public class ActorRefCacheSpec : AkkaSpec
+    {
+        private static Config _config = ConfigurationFactory.ParseString(@"
+akka.scheduler.implementation = ""Akka.TestKit.TestScheduler, Akka.TestKit""
+
+akka.remote {
+    actorref-cache {
+        enabled = true
+        maximum-remote-cache-size = 4
+        remote-cache-expiration = 1s
+    }
+}
+");
+        private ActorRefCache Cache { get; set; }
+
+        private IActorRef CacheActor { get; set; }
+
+        public TestScheduler Scheduler
+        {
+            get { return (TestScheduler)Sys.Scheduler; }
+        }
+
+        public ActorRefCacheSpec()
+            : base(_config)
+        { }
+
+        protected override void AtStartup()
+        {
+            base.AtStartup();
+
+            Cache = ActorRefCache.Create((ExtendedActorSystem)Sys);
+            CacheActor = Sys.ActorSelection("/system/actorref-cache").ResolveOne(TimeSpan.FromSeconds(1)).Result;
+        }
+
+        [Fact]
+        public void LocalActorRef_should_be_added_and_cleared()
+        {
+            var actorRef = (IInternalActorRef)ActorOf<DummyActor>("a");
+
+            string path = actorRef.Path.ToString();
+
+            Cache.Add(path, actorRef);
+
+            AssertLocalCacheSize(1);
+
+            Watch(actorRef);
+            actorRef.Tell(PoisonPill.Instance);
+            ExpectTerminated(actorRef, TimeSpan.FromSeconds(1));
+
+            AssertLocalCacheSize(0);
+        }
+
+        [Fact]
+        public void Temp_actors_should_not_be_cached()
+        {
+            var system = (ExtendedActorSystem)Sys;
+
+            var actorPath = system.Provider.TempPath();
+            var actorRef = new DummyActorRef(actorPath);
+
+            string path = actorPath.ToString();
+
+            Cache.Add(path, actorRef);
+
+            AssertLocalCacheSize(0);
+        }
+
+        [Fact]
+        public void RemoteActorRef_should_be_added_and_expired()
+        {
+            var actorRef = new DummyActorRef(new RootActorPath(Address.AllSystems) / "remote" / "a");
+
+            string path = actorRef.Path.ToString();
+
+            Cache.Add(path, actorRef);
+
+            AssertRemoteCacheSize(1);
+
+            // Trigger the cache expiration
+            AdvanceOneSecond();
+
+            AssertRemoteCacheSize(0);
+        }
+
+        [Fact]
+        public void Cache_should_be_limited_by_max_size()
+        {
+            IInternalActorRef actorRef;
+            ActorPath basePath = new RootActorPath(Address.AllSystems) / "remote";
+
+            // Fill the cache
+            actorRef = new DummyActorRef(basePath / "1");
+            Cache.Add(actorRef.Path.ToString(), actorRef);
+
+            actorRef = new DummyActorRef(basePath / "2");
+            Cache.Add(actorRef.Path.ToString(), actorRef);
+
+            actorRef = new DummyActorRef(basePath / "3");
+            Cache.Add(actorRef.Path.ToString(), actorRef);
+
+            actorRef = new DummyActorRef(basePath / "4");
+            Cache.Add(actorRef.Path.ToString(), actorRef);
+
+            AssertRemoteCacheSize(4);
+
+            // Make a cache hit for actor 1, it will move to the front of the LRU
+            Assert.True(Cache.TryGetActorRef((basePath / "1").ToString(), out actorRef));
+
+            actorRef = new DummyActorRef(basePath / "5");
+            Cache.Add(actorRef.Path.ToString(), actorRef);
+
+            // Actor 2 should have been cleared from cache
+            AssertRemoteCacheSize(4);
+
+            Assert.False(Cache.TryGetActorRef((basePath / "2").ToString(), out actorRef));
+
+            AdvanceOneSecond();
+            AssertRemoteCacheSize(0);
+        }
+
+        private void AdvanceOneSecond()
+        {
+            Scheduler.Advance(TimeSpan.FromSeconds(1));
+        }
+
+        private void AssertLocalCacheSize(int expected)
+        {
+            var cacheSize = GetCacheSize();
+
+            Assert.Equal(expected, cacheSize.LocalActorRefCount);
+        }
+
+        private void AssertRemoteCacheSize(int expected)
+        {
+            var cacheSize = GetCacheSize();
+
+            Assert.Equal(expected, cacheSize.RemoteActorRefCount);
+        }
+
+        private ActorRefCacheController.CacheSize GetCacheSize()
+        {
+            return CacheActor.Ask<ActorRefCacheController.CacheSize>(new ActorRefCacheController.GetCacheSize(), TimeSpan.FromSeconds(1)).Result;
+        }
+    }
+
+    public class DummyActor : ReceiveActor
+    { }
+
+    public class DummyActorRef : MinimalActorRef
+    {
+
+        public override ActorPath Path { get; }
+
+        public override IActorRefProvider Provider
+        {
+            get { return null; }
+        }
+
+        public DummyActorRef(ActorPath path)
+        {
+            Path = path;
+        }
+    }
+}

--- a/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
+++ b/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
@@ -94,6 +94,7 @@
   <ItemGroup>
     <Compile Include="AccrualFailureDetectorSpec.cs" />
     <Compile Include="AckedDeliverySpec.cs" />
+    <Compile Include="ActorRefCacheSpec.cs" />
     <Compile Include="DeadlineFailureDetectorSpec.cs" />
     <Compile Include="EndpointRegistrySpec.cs" />
     <Compile Include="FailureDetectorRegistrySpec.cs" />

--- a/src/core/Akka.Remote/ActorRefCache.cs
+++ b/src/core/Akka.Remote/ActorRefCache.cs
@@ -1,0 +1,276 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Akka.Actor;
+using Akka.Actor.Internal;
+using Akka.Configuration;
+using Akka.Util.Internal;
+using System.Threading;
+
+namespace Akka.Remote
+{
+    internal class ActorRefCacheController : ReceiveActor
+    {
+        #region Messages
+
+        public class Init
+        {
+            public ActorRefCache Cache { get; }
+
+            public Init(ActorRefCache cache)
+            {
+                Cache = cache;
+            }
+        }
+
+        public class AddCacheEntry
+        {
+            public LinkedListNode<ActorRefCacheEntry> CacheEntry { get; }
+
+            public AddCacheEntry(LinkedListNode<ActorRefCacheEntry> cacheEntry)
+            {
+                CacheEntry = cacheEntry;
+            }
+        }
+
+        public class CacheHit
+        {
+            public LinkedListNode<ActorRefCacheEntry> CacheEntry { get; }
+
+            public CacheHit(LinkedListNode<ActorRefCacheEntry> cacheEntry)
+            {
+                CacheEntry = cacheEntry;
+            }
+        }
+
+        public class CheckCacheExpiration
+        {
+            public static readonly CheckCacheExpiration Instance = new CheckCacheExpiration();
+        }
+
+        public class GetCacheSize
+        { }
+
+        public class CacheSize
+        {
+            public int LocalActorRefCount { get; }
+            public int RemoteActorRefCount { get; }
+
+            public CacheSize(int localActorRefCount, int remoteActorRefCount)
+            {
+                LocalActorRefCount = localActorRefCount;
+                RemoteActorRefCount = remoteActorRefCount;
+            }
+        }
+
+        #endregion
+
+        private static readonly TimeSpan CacheExpirationDelay = TimeSpan.FromSeconds(1);
+
+        private ActorRefCache _cache;
+        private readonly ActorRefCacheSettings _settings;
+        private readonly Dictionary<IActorRef, string> _localActorRefs;
+        private readonly LinkedList<ActorRefCacheEntry> _remoteActorRefs;
+        private int _remoteActorRefCount;
+        
+        public ActorRefCacheController(ActorRefCacheSettings settings)
+        {
+            _settings = settings;
+            _localActorRefs = new Dictionary<IActorRef, string>(RefEqualityComparer<IActorRef>.Default);
+            _remoteActorRefs = new LinkedList<ActorRefCacheEntry>();
+
+            Receive<Init>(msg =>
+            {
+                _cache = msg.Cache;
+                Become(Ready);
+            });
+        }
+
+        public void Ready()
+        {
+            if (_settings.RemoteCacheExpiration != Timeout.InfiniteTimeSpan)
+                Context.System.Scheduler.ScheduleTellOnce(CacheExpirationDelay, Self, CheckCacheExpiration.Instance, ActorRefs.NoSender);
+
+            Receive<AddCacheEntry>(msg =>
+            {
+                var node = msg.CacheEntry;
+                var actorRef = node.Value.ActorRef;
+
+                if (actorRef is ActorRefWithCell)
+                {
+                    if (!_localActorRefs.ContainsKey(actorRef))
+                    {
+                        _localActorRefs.Add(actorRef, node.Value.Path);
+                        Context.Watch(actorRef);
+                    }
+                }
+                else
+                {
+                    node.Value.LastCacheHit = Context.System.Scheduler.HighResMonotonicClock;
+                    _remoteActorRefs.AddFirst(node);
+
+                    if (_remoteActorRefCount >= _settings.MaximumCacheSize)
+                    {
+                        var last = _remoteActorRefs.Last;
+                        _remoteActorRefs.Remove(last);
+                        _cache.Remove(last.Value.Path);
+                    }
+                    else
+                    {
+                        ++_remoteActorRefCount;
+                    }
+                }
+            });
+
+            Receive<Terminated>(msg =>
+            {
+                string path;
+
+                if (_localActorRefs.TryGetValue(msg.ActorRef, out path))
+                {
+                    _localActorRefs.Remove(msg.ActorRef);
+                    _cache.Remove(path);
+                }
+            });
+
+            Receive<CacheHit>(msg =>
+            {
+                LinkedListNode<ActorRefCacheEntry> node = msg.CacheEntry;
+
+                node.Value.LastCacheHit = Context.System.Scheduler.HighResMonotonicClock;
+
+                if (_remoteActorRefs.First != node)
+                {
+                    _remoteActorRefs.Remove(node);
+                    _remoteActorRefs.AddFirst(node);
+                }
+            });
+
+            Receive<CheckCacheExpiration>(msg =>
+            {
+                var expirationTime = Context.System.Scheduler.HighResMonotonicClock - _settings.RemoteCacheExpiration;
+
+                var node = _remoteActorRefs.Last;
+                while (node != null && node.Value.LastCacheHit <= expirationTime)
+                {
+                    _remoteActorRefs.Remove(node);
+                    _cache.Remove(node.Value.Path);
+                    --_remoteActorRefCount;
+
+                    node = _remoteActorRefs.Last;
+                }
+
+                Context.System.Scheduler.ScheduleTellOnce(CacheExpirationDelay, Self, CheckCacheExpiration.Instance, ActorRefs.NoSender);
+            });
+
+            Receive<GetCacheSize>(msg =>
+            {
+                Sender.Tell(new CacheSize(_localActorRefs.Count, _remoteActorRefCount));
+            });
+        }
+    }
+
+    internal class ActorRefCacheEntry
+    {
+        public string Path { get; }
+        public IInternalActorRef ActorRef { get; }
+        public TimeSpan LastCacheHit { get; set; }
+
+        public ActorRefCacheEntry(string path, IInternalActorRef actorRef)
+        {
+            Path = path;
+            ActorRef = actorRef;
+        }
+    }
+
+    internal class ActorRefCacheSettings
+    {
+        public bool Enabled { get; }
+        public int MaximumCacheSize { get; }
+        public TimeSpan RemoteCacheExpiration { get; }
+
+        public ActorRefCacheSettings(Config config)
+        {
+            Enabled = config.GetBoolean("enabled");
+            MaximumCacheSize = config.GetInt("maximum-remote-cache-size");
+            RemoteCacheExpiration = config.GetTimeSpan("remote-cache-expiration");
+        }
+    }
+
+    internal class ActorRefCache
+    {
+        private readonly ActorRefCacheSettings _settings;
+        private readonly IActorRef _cacheController;
+        private readonly ConcurrentDictionary<string, LinkedListNode<ActorRefCacheEntry>> _pathToRefMap;
+
+        public ActorRefCache(ActorRefCacheSettings settings, IActorRef cacheController)
+        {
+            _settings = settings;
+            _cacheController = cacheController;
+            _pathToRefMap = new ConcurrentDictionary<string, LinkedListNode<ActorRefCacheEntry>>(StringComparer.Ordinal);
+        }
+
+        public bool TryGetActorRef(string path, out IInternalActorRef actorRef)
+        {
+            LinkedListNode<ActorRefCacheEntry> node;
+            if (_settings.Enabled && _pathToRefMap.TryGetValue(path, out node))
+            {
+                actorRef = node.Value.ActorRef;
+
+                if (!(actorRef is ActorRefWithCell))
+                    _cacheController.Tell(new ActorRefCacheController.CacheHit(node));
+
+                return true;
+            }
+
+            actorRef = null;
+            return false;
+        }
+
+        public void Add(string path, IInternalActorRef actorRef)
+        {
+            if (!_settings.Enabled)
+                return;
+
+            // Don't cache temp actors, they are most likely only used onced so it's not worth caching
+            var actorPath = actorRef.Path;
+            if (actorPath.Elements.Count > 0 && actorPath.Elements[0] == "temp")
+                return;
+
+            var node = new LinkedListNode<ActorRefCacheEntry>(new ActorRefCacheEntry(path, actorRef));
+            if (_pathToRefMap.TryAdd(path, node))
+                _cacheController.Tell(new ActorRefCacheController.AddCacheEntry(node));
+        }
+
+        /// <summary>
+        /// Do not call directly
+        /// </summary>
+        internal void Remove(string path)
+        {
+            LinkedListNode<ActorRefCacheEntry> node;
+            _pathToRefMap.TryRemove(path, out node);
+        }
+
+        public static ActorRefCache Create(ExtendedActorSystem system, RemoteSettings remoteSettings = null)
+        {
+            var config = system.Settings.Config.GetConfig("akka.remote.actorref-cache");
+            ActorRefCacheSettings settings = new ActorRefCacheSettings(config);
+
+            if (!settings.Enabled)
+                return new ActorRefCache(settings, system.DeadLetters);
+
+            Props props;
+
+            if (remoteSettings == null)
+                props = Props.Create(() => new ActorRefCacheController(settings));
+            else
+                props = remoteSettings.ConfigureDispatcher(Props.Create(() => new ActorRefCacheController(settings)));
+
+            IActorRef cacheController = system.SystemActorOf(props, "actorref-cache");
+            var actorRefCache = new ActorRefCache(settings, cacheController);
+            cacheController.Tell(new ActorRefCacheController.Init(actorRefCache));
+
+            return actorRefCache;
+        }
+    }
+}

--- a/src/core/Akka.Remote/Akka.Remote.csproj
+++ b/src/core/Akka.Remote/Akka.Remote.csproj
@@ -76,6 +76,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="AckedDelivery.cs" />
+    <Compile Include="ActorRefCache.cs" />
     <Compile Include="AddressUidExtension.cs" />
     <Compile Include="AkkaProtocolSettings.cs" />
     <Compile Include="AssociationEvent.cs" />

--- a/src/core/Akka.Remote/Configuration/Remote.conf
+++ b/src/core/Akka.Remote/Configuration/Remote.conf
@@ -90,6 +90,12 @@ akka {
     # every module will respect this setting.
     use-dispatcher = "akka.remote.default-remote-dispatcher"
 
+    actorref-cache {
+        enabled = true
+        maximum-remote-cache-size = 4096
+        remote-cache-expiration = 30s
+    }
+
     ### Security settings
 
     # Enable untrusted mode for full security of server managed actors, prevents

--- a/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
+++ b/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
@@ -64,18 +64,15 @@ namespace Akka.Remote.Transport
 
     internal sealed class Message : IAkkaPdu, IHasSequenceNumber
     {
-        public Message(IInternalActorRef recipient, Address recipientAddress, SerializedMessage serializedMessage, IActorRef senderOptional = null, SeqNo seq = null)
+        public Message(IInternalActorRef recipient, SerializedMessage serializedMessage, IActorRef senderOptional = null, SeqNo seq = null)
         {
             Seq = seq;
             SenderOptional = senderOptional;
             SerializedMessage = serializedMessage;
-            RecipientAddress = recipientAddress;
             Recipient = recipient;
         }
 
         public IInternalActorRef Recipient { get; private set; }
-
-        public Address RecipientAddress { get; private set; }
 
         public SerializedMessage SerializedMessage { get; private set; }
 
@@ -220,8 +217,6 @@ namespace Akka.Remote.Transport
                 if (envelopeContainer != null)
                 {
                     var recipient = provider.ResolveActorRefWithLocalAddress(envelopeContainer.Recipient.Path, localAddress);
-                    Address recipientAddress;
-                    ActorPath.TryParseAddress(envelopeContainer.Recipient.Path, out recipientAddress);
                     var serializedMessage = envelopeContainer.Message;
                     IActorRef senderOption = null;
                     if (envelopeContainer.HasSender)
@@ -236,7 +231,7 @@ namespace Akka.Remote.Transport
                             seqOption = new SeqNo((long)envelopeContainer.Seq); //proto takes a ulong
                         }
                     }
-                    messageOption = new Message(recipient, recipientAddress, serializedMessage, senderOption, seqOption);
+                    messageOption = new Message(recipient, serializedMessage, senderOption, seqOption);
                 }
             }
             

--- a/src/core/Akka.TestKit/TestScheduler.cs
+++ b/src/core/Akka.TestKit/TestScheduler.cs
@@ -17,17 +17,20 @@ namespace Akka.TestKit
                                  IAdvancedScheduler
     {
         private DateTimeOffset _now;
+        private TimeSpan _monotonicClock;
         private readonly ConcurrentDictionary<long, Queue<ScheduledItem>>  _scheduledWork; 
 
         public TestScheduler(ActorSystem system)
         {
             _now = DateTimeOffset.UtcNow;
+            _monotonicClock = new TimeSpan();
             _scheduledWork = new ConcurrentDictionary<long, Queue<ScheduledItem>>();
         }
 
         public void Advance(TimeSpan offset)
         {
             _now = _now.Add(offset);
+            _monotonicClock += offset;
 
             var tickItems = _scheduledWork.Where(s => s.Key <= _now.Ticks).OrderBy(s => s.Key).ToList();
 
@@ -127,8 +130,8 @@ namespace Akka.TestKit
 
         protected DateTimeOffset TimeNow { get { return _now; } }
         public DateTimeOffset Now { get { return _now; } }
-        public TimeSpan MonotonicClock { get { return Util.MonotonicClock.Elapsed; } }
-        public TimeSpan HighResMonotonicClock { get { return Util.MonotonicClock.ElapsedHighRes; } }
+        public TimeSpan MonotonicClock { get { return _monotonicClock; } }
+        public TimeSpan HighResMonotonicClock { get { return _monotonicClock; } }
 
         public IAdvancedScheduler Advanced
         {

--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -98,7 +98,7 @@ namespace Akka.Actor
             #endregion
         }
 
-         /** INTERNAL API */
+        /** INTERNAL API */
         internal static char[] ValidSymbols = @"""-_.*$+:@&=,!~';""()".ToCharArray();
 
         /// <summary> 
@@ -278,7 +278,6 @@ namespace Akka.Actor
         {
             actorPath = null;
 
-
             Address address;
             Uri uri;
             if (!TryParseAddress(path, out address, out uri)) return false;
@@ -287,6 +286,7 @@ namespace Akka.Actor
             return true;
         }
 
+        [Obsolete]
         public static bool TryParseAddress(string path, out Address address)
         {
             Uri uri;

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -283,6 +283,7 @@
     <Compile Include="Util\Internal\InterlockedSpin.cs" />
     <Compile Include="Util\Internal\Collections\IBinaryTreeNode.cs" />
     <Compile Include="Util\Internal\Collections\IKeyValuePair.cs" />
+    <Compile Include="Util\Internal\RefEqualityComparer.cs" />
     <Compile Include="Util\Internal\StringBuilderExtensions.cs" />
     <Compile Include="Util\Internal\TaskExtensions.cs" />
     <Compile Include="Util\ISurrogate.cs" />

--- a/src/core/Akka/Util/Internal/RefEqualityComparer.cs
+++ b/src/core/Akka/Util/Internal/RefEqualityComparer.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Akka.Util.Internal
+{
+    internal class RefEqualityComparer<T> : IEqualityComparer<T> where T : class
+    {
+        public static readonly RefEqualityComparer<T> Default = new RefEqualityComparer<T>();
+
+        public bool Equals(T x, T y)
+        {
+            return ReferenceEquals(x, y);
+        }
+
+        public int GetHashCode(T obj)
+        {
+            return RuntimeHelpers.GetHashCode(obj);
+        }
+    }
+}


### PR DESCRIPTION
This PR mitigates the current bottlenecks in Akka.Remote:
- ActorPath parsing
- ActorRef resolving

The cache is backed by a ConcurrentDictionary which maps the string path straight to the ActorRef. An actor is responsible for the handling of cache maximum size and expiration with an LRU list.

There is two modes of operation:
#####  Local ActorRefWithCell caching
This mode handles the caching of local actor refs backed with an ActorCell. It is bounded by the number of live actors in the system. The cache entries are cleared with DeathWatch notifications.

##### Remote ActorRef caching
This mode caches all the actor refs not backed with an ActorCell (e.g. RemoteActorRef). It is bounded by the `maximum-remote-cache-size` setting, the least recently used actor refs are removed first when the maximum capacity is reached.

The cache entries in this mode are also cleared by an expiration specified with the `remote-cache-expiration` setting.

##### Note
Actor refs under the /temp path are not cached since they will most likely not be reused. This means that Asks will not benefit from this optimization. A workaround would be to set the `Sender` of an Ask to a system actor that would forward the response to the FutureActorRef.