### PR TITLE
Configuration for default logger dispatcher

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -1498,6 +1498,7 @@ namespace Akka.Actor
         public int LogDeadLetters { get; }
         public bool LogDeadLettersDuringShutdown { get; }
         public System.Collections.Generic.IList<string> Loggers { get; }
+        public string LoggersDispatcher { get; }
         public System.TimeSpan LoggerStartTimeout { get; }
         public string LogLevel { get; }
         public string ProviderClass { get; }

--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -157,6 +157,7 @@
     <Compile Include="Event\EventBusSpec.cs" />
     <Compile Include="Event\EventStreamSpec.cs" />
     <Compile Include="Event\LoggerMailboxSpec.cs" />
+    <Compile Include="Event\LoggerSpec.cs" />
     <Compile Include="IO\SimpleDnsCacheSpec.cs" />
     <Compile Include="IO\TcpConnectionSpec.cs" />
     <Compile Include="IO\TcpIntegrationSpec.cs" />

--- a/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
+++ b/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
@@ -9,14 +9,62 @@ using System;
 using Akka.Configuration.Hocon;
 using System.Configuration;
 using System.Linq;
+using System.Threading;
+using Akka.Actor;
 using Akka.Configuration;
+using Akka.Dispatch;
+using Akka.Event;
 using Akka.TestKit;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Akka.Tests.Configuration
 {
     public class ConfigurationSpec : AkkaSpec
     {
+        public ConfigurationSpec() : base(ConfigurationFactory.Default())
+        {
+        }
+
+        [Fact]
+        public void The_default_configuration_file_contain_all_configuration_properties()
+        {
+            var settings = Sys.Settings;
+            var config = Sys.Settings.Config;
+
+            // settings.ConfigVersion.ShouldBe(ActorSystem.Version);
+            settings.Loggers.Count.ShouldBe(1);
+            settings.Loggers[0].ShouldBe(typeof(DefaultLogger).FullName);
+            // settings.LoggingFilter.ShouldBe(typeof(DefaultLoggingFilter));
+            settings.LoggersDispatcher.ShouldBe(Dispatchers.DefaultDispatcherId);
+            settings.LoggerStartTimeout.Seconds.ShouldBe(5);
+            settings.LogLevel.ShouldBe("INFO");
+            settings.StdoutLogLevel.ShouldBe("WARNING");
+            settings.LogConfigOnStart.ShouldBeFalse();
+            settings.LogDeadLetters.ShouldBe(10);
+            settings.LogDeadLettersDuringShutdown.ShouldBeTrue();
+
+            settings.ProviderClass.ShouldBe(typeof(LocalActorRefProvider).FullName);
+            settings.SupervisorStrategyClass.ShouldBe(typeof(DefaultSupervisorStrategy).FullName);
+            settings.CreationTimeout.Seconds.ShouldBe(20);
+            settings.AskTimeout.ShouldBe(Timeout.InfiniteTimeSpan);
+            settings.SerializeAllMessages.ShouldBeFalse();
+            settings.SerializeAllCreators.ShouldBeFalse();
+            settings.UnstartedPushTimeout.Seconds.ShouldBe(10);
+
+            settings.DefaultVirtualNodesFactor.ShouldBe(10);
+
+            settings.AddLoggingReceive.ShouldBeFalse();
+            settings.DebugAutoReceive.ShouldBeFalse();
+            settings.DebugLifecycle.ShouldBeFalse();
+            settings.FsmDebugEvent.ShouldBe(false);
+            settings.DebugEventStream.ShouldBeFalse();
+            settings.DebugUnhandledMessage.ShouldBeFalse();
+            settings.DebugRouterMisconfiguration.ShouldBeFalse();
+
+            settings.SchedulerClass.ShouldBe(typeof(DedicatedThreadScheduler).FullName);
+        }
+
         [Fact]
         public void Deserializes_hocon_configuration_from_net_config_file()
         {

--- a/src/core/Akka.Tests/Event/LoggerSpec.cs
+++ b/src/core/Akka.Tests/Event/LoggerSpec.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.TestKit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Tests.Event
+{
+    public class LoggerSpec : AkkaSpec
+    {
+        [Fact]
+        public async Task LoggingBus_should_stop_all_loggers_on_termination()
+        {
+            var system = ActorSystem.Create("TestSystem", ConfigurationFactory.Default());
+
+            system.EventStream.Subscribe(TestActor, typeof(Debug));
+            await system.Terminate();
+
+            var loggerStarted = ExpectMsg<Debug>(TestKitSettings.DefaultTimeout);
+            loggerStarted.Message.ShouldBe("Shutting down: StandardOutLogger started");
+            loggerStarted.LogClass.ShouldBe(typeof(EventStream));
+            loggerStarted.LogSource.ShouldBe(typeof(EventStream).Name);
+
+            var loggerStopped = ExpectMsg<Debug>(TestKitSettings.DefaultTimeout);
+            loggerStopped.Message.ShouldBe("All default loggers stopped");
+            loggerStopped.LogClass.ShouldBe(typeof(EventStream));
+            loggerStopped.LogSource.ShouldBe(typeof(EventStream).Name);
+
+            ExpectNoMsg(TimeSpan.FromSeconds(1));
+        }
+    }
+}

--- a/src/core/Akka/Actor/Settings.cs
+++ b/src/core/Akka/Actor/Settings.cs
@@ -78,7 +78,7 @@ namespace Akka.Actor
             LogLevel = Config.GetString("akka.loglevel");
             StdoutLogLevel = Config.GetString("akka.stdout-loglevel");
             Loggers = Config.GetStringList("akka.loggers");
-
+            LoggersDispatcher = Config.GetString("akka.loggers-dispatcher");
             LoggerStartTimeout = Config.GetTimeSpan("akka.logger-startup-timeout");
 
             //handled
@@ -195,6 +195,12 @@ namespace Akka.Actor
         /// </summary>
         /// <value>The loggers.</value>
         public IList<string> Loggers { get; private set; }
+
+        /// <summary>
+        ///     Gets the default loggers dispatcher.
+        /// </summary>
+        /// <value>The loggers dispatcher.</value>
+        public string LoggersDispatcher { get; private set; }
 
         /// <summary>
         ///     Gets the logger start timeout.

--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -16,6 +16,9 @@ akka {
   # Loggers to register at boot time (akka.event.Logging$DefaultLogger logs
   # to STDOUT)
   loggers = ["Akka.Event.DefaultLogger"]
+
+  # Specifies the default loggers dispatcher
+  loggers-dispatcher = "akka.actor.default-dispatcher"
  
   # Loggers are created and registered synchronously during ActorSystem
   # start-up, and since they are actors, this timeout is used to bound the
@@ -95,7 +98,7 @@ akka {
     # Timeout for send operations to top-level actors which are in the process
     # of being started. This is only relevant if using a bounded mailbox or the
     # CallingThreadDispatcher for a top-level actor.
-    unstarted-push-timeout = 10
+    unstarted-push-timeout = 10s
 
     # Default timeout for IActorRef.Ask.
     ask-timeout = infinite

--- a/src/core/Akka/Event/LoggingBus.cs
+++ b/src/core/Akka/Event/LoggingBus.cs
@@ -130,13 +130,33 @@ namespace Akka.Event
 
         internal void StopDefaultLoggers(ActorSystem system)
         {
-            //TODO: Implement stopping loggers
+            var level = LogLevel; // volatile access before reading loggers
+            if (!_loggers.Any(c => c is StandardOutLogger))
+            {
+                SetUpStdoutLogger(system.Settings);
+                Publish(new Debug(SimpleName(this), GetType(), "Shutting down: StandardOutLogger started"));
+            }
+
+            foreach (var logger in _loggers)
+            {
+                if (!(logger is StandardOutLogger))
+                {
+                    Unsubscribe(logger);
+                    var internalActorRef = logger as IInternalActorRef;
+                    if (internalActorRef != null)
+                    {
+                        internalActorRef.Stop();
+                    }
+                }
+            }
+
+            Publish(new Debug(SimpleName(this), GetType(), "All default loggers stopped"));
         }
 
         private void AddLogger(ActorSystemImpl system, Type loggerType, LogLevel logLevel, string loggingBusName, TimeSpan timeout)
         {
             var loggerName = CreateLoggerName(loggerType);
-            var logger = system.SystemActorOf(Props.Create(loggerType), loggerName);
+            var logger = system.SystemActorOf(Props.Create(loggerType).WithDispatcher(system.Settings.LoggersDispatcher), loggerName);
             var askTask = logger.Ask(new InitializeLogger(this));
 
             if (!askTask.Wait(timeout))


### PR DESCRIPTION
added configuration for default logger dispatcher (from Akka 2.4.3)
added configuration specs
implemented StopDefaultLoggers method
fixed default value for UnstartedPushTimeout