### PR TITLE
added Ask performance benchmark

### DIFF
--- a/src/core/Akka.Tests.Performance/Actor/Pattern/AskSpec.cs
+++ b/src/core/Akka.Tests.Performance/Actor/Pattern/AskSpec.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Akka.Actor;
+using NBench;
+
+namespace Akka.Tests.Performance.Actor.Pattern
+{
+    /// <summary>
+    /// Benchmark and performance test for <see cref="Ask"/>
+    /// </summary>
+    public class AskSpec
+    {
+        class EmptyActor : ReceiveActor
+        {
+            public EmptyActor()
+            {
+                ReceiveAny(o => Sender.Tell(o));
+            }
+        }
+
+        public const string AskThroughputCounterName = "AskReplies";
+        private Counter _askThroughputCounter;
+
+        private ActorSystem _sys;
+        private IActorRef _target;
+        private static readonly Identify Msg = new Identify(null);
+        private static readonly TimeSpan AskTimeout = TimeSpan.FromSeconds(1);
+
+        [PerfSetup]
+        public void Setup(BenchmarkContext context)
+        {
+            _sys = ActorSystem.Create("AskSpec");
+            _target = _sys.ActorOf(Props.Create(() => new EmptyActor()));
+            _askThroughputCounter = context.GetCounter(AskThroughputCounterName);
+        }
+
+        [PerfBenchmark(Description = "Tests how quickly ICanTell.Ask operations can be performed, and with how much memory", RunMode = RunMode.Throughput,
+            RunTimeMilliseconds = 5000, NumberOfIterations = 3)]
+        [CounterMeasurement(AskThroughputCounterName)]
+        [MemoryMeasurement(MemoryMetric.TotalBytesAllocated)]
+        public void AskThroughput(BenchmarkContext context)
+        {
+            _target.Ask<ActorIdentity>(Msg, AskTimeout).Wait();
+            _askThroughputCounter.Increment();
+        }
+
+        [PerfCleanup]
+        public void TearDown(BenchmarkContext context)
+        {
+            var shutdownTimeout = TimeSpan.FromSeconds(5);
+            try
+            {
+                _sys?.Terminate().Wait(shutdownTimeout);
+            }
+            catch (Exception ex)
+            {
+                context.Trace.Error(ex, $"failed to shutdown actorsystem within {shutdownTimeout}");
+            }
+        }
+    }
+}

--- a/src/core/Akka.Tests.Performance/Akka.Tests.Performance.csproj
+++ b/src/core/Akka.Tests.Performance/Akka.Tests.Performance.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Actor\ActorSystemShutdownSpec.cs" />
     <Compile Include="Actor\AddressSpec.cs" />
     <Compile Include="Actor\MinimalActorRefThroughputSpec.cs" />
+    <Compile Include="Actor\Pattern\AskSpec.cs" />
     <Compile Include="Actor\ReceiveActorThroughputSpec.cs" />
     <Compile Include="Actor\UntypedActorThroughputSpec.cs" />
     <Compile Include="Dispatch\DefaultDispatcherColdThroughputSpec.cs" />


### PR DESCRIPTION
Testing the throughput and memory allocation of `ICanTell.Ask`.

Uses a simple blocking implementation to do it.

Going to be making some modifications to this in a subsequent PR. Wanted the data now as a baseline.