### PR TITLE
Fix for #2053

### DIFF
--- a/src/core/Akka/Event/EventStream.cs
+++ b/src/core/Akka/Event/EventStream.cs
@@ -56,12 +56,13 @@ namespace Akka.Event
             if (subscriber == null)
                 throw new ArgumentNullException("subscriber");
 
+            RegisterWithUnsubscriber(subscriber);
+            var res = base.Subscribe(subscriber, channel);
             if (_debug)
             {
                 Publish(new Debug(SimpleName(this), GetType(), "subscribing " + subscriber + " to channel " + channel));
             }
-            RegisterWithUnsubscriber(subscriber);
-            return base.Subscribe(subscriber, channel);
+            return res;
         }
 
         /// <summary>


### PR DESCRIPTION
Moved the subscribe debug-log message in such a way that the message is
published after the subscribe completes.