### PR TITLE
A persistent view replays events during the recovery despite the fact…

### DIFF
--- a/src/core/Akka.Persistence.Tests/PersistentViewSpec.Actors.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentViewSpec.Actors.cs
@@ -293,6 +293,36 @@ namespace Akka.Persistence.Tests
         }
 
         #endregion
+
+        internal class RecoveryTestPersistentView : PersistentView
+        {
+            private readonly string _name;
+            private readonly IActorRef _probe;
+
+            public RecoveryTestPersistentView(string name, IActorRef probe)
+            {
+                _name = name;
+                _probe = probe;
+            }
+
+            protected override bool Receive(object message)
+            {
+                _probe.Tell(string.Format("replicated-{0}-{1}", message, LastSequenceNr));
+                return true;
+            }
+
+            public override Recovery Recovery
+            {
+                get
+                {
+                    return Recovery.None; 
+                }
+            }
+
+            public override string ViewId { get { return _name + "-view"; } }
+            public override string PersistenceId { get { return _name; } }
+
+        }
     }
 }
 

--- a/src/core/Akka.Persistence.Tests/PersistentViewSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentViewSpec.cs
@@ -223,6 +223,16 @@ namespace Akka.Persistence.Tests
             _viewProbe.ExpectMsg("other-2");
         }
 
+        [Fact]
+        public void PersistentView_should_send_zero_fromSequenceNr_to_journal_if_recovery_none()
+        {
+            var replayProbe = CreateTestProbe();
+            SubscribeToReplay(replayProbe);
+            _view = ActorOf(() => new RecoveryTestPersistentView(Name, _viewProbe.Ref));
+
+            replayProbe.ExpectMsg<ReplayMessages>(m => m.FromSequenceNr == 0L && m.ToSequenceNr == 0L);
+        }
+
         private void SubscribeToReplay(TestProbe probe)
         {
             Sys.EventStream.Subscribe(probe.Ref, typeof(ReplayMessages));

--- a/src/core/Akka.Persistence/PersistentView.Recovery.cs
+++ b/src/core/Akka.Persistence/PersistentView.Recovery.cs
@@ -56,7 +56,9 @@ namespace Akka.Persistence
                         base.AroundReceive(receive, new SnapshotOffer(selectedSnapshot.Metadata, selectedSnapshot.Snapshot));
                     }
                     ChangeState(ReplayStarted(true));
-                    Journal.Tell(new ReplayMessages(LastSequenceNr + 1, loadResult.ToSequenceNr, replayMax, PersistenceId, Self));
+
+                    long fromSequenceNumber = loadResult.ToSequenceNr == 0 ? 0 : LastSequenceNr + 1;
+                    Journal.Tell(new ReplayMessages(fromSequenceNumber, loadResult.ToSequenceNr, replayMax, PersistenceId, Self));
                 }
                 else _internalStash.Stash();
             });


### PR DESCRIPTION
A persistent view replays events during the recovery despite the fact, that Recovery property is overriden and returns Recovery.None