### PR TITLE
made Akka.MultiNodeTestRunner, Akka.Cluster.TestKit, and Akka.Remote.TestKit available as NuGet packages.

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingConfigSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingConfigSpec.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Akka.Cluster.Sharding.Tests
 {
-    public class ClusterShardingConfigSpec : TestKit.Xunit2.TestKit
+    public class ClusterShardingConfigSpec : Akka.TestKit.Xunit2.TestKit
     {
         public ClusterShardingConfigSpec() : base(GetConfig())
         {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingFailureSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingFailureSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.IO;
 using System.Linq;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Cluster.Tests.MultiNode;
 using Akka.Configuration;
 using Akka.Persistence.Journal;

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingGracefulShutdownSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingGracefulShutdownSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.IO;
 using System.Linq;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Cluster.Tests.MultiNode;
 using Akka.Configuration;
 using Akka.Persistence.Journal;

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingLeavingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingLeavingSpec.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Cluster.Tests.MultiNode;
 using Akka.Configuration;
 using Akka.Persistence.Journal;

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingSpec.cs
@@ -13,6 +13,7 @@ using Akka.Configuration;
 using Akka.Persistence;
 using Akka.Remote.TestKit;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Cluster.Tests.MultiNode;
 using Akka.Cluster.Tools.Singleton;
 using Akka.Pattern;

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Akka.Cluster.Tools.Tests.MultiNode.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Akka.Cluster.Tools.Tests.MultiNode.csproj
@@ -113,10 +113,6 @@
       <Project>{0D3CBAD0-BBDB-43E5-AFC4-ED1D3ECDC224}</Project>
       <Name>Akka.TestKit</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\core\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj">
-      <Project>{e636d23c-3432-4aa9-9a5d-5f29d33d3399}</Project>
-      <Name>Akka.Tests.Shared.Internals</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\..\core\Akka\Akka.csproj">
       <Project>{5DEDDF90-37F0-48D3-A0B0-A5CBD8A7E377}</Project>
       <Name>Akka</Name>

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/ClusterClient/ClusterClientSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/ClusterClient/ClusterClientSpec.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Cluster.Tests.MultiNode;
 using Akka.Cluster.Tools.Client;
 using Akka.Cluster.Tools.PublishSubscribe;

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubMediatorSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubMediatorSpec.cs
@@ -10,6 +10,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Cluster.Tests.MultiNode;
 using Akka.Cluster.Tools.PublishSubscribe;
 using Akka.Cluster.Tools.PublishSubscribe.Internal;

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerChaos2Spec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerChaos2Spec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Linq;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Cluster.Tests.MultiNode;
 using Akka.Cluster.Tools.Singleton;
 using Akka.Configuration;

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerChaosSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerChaosSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Linq;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Cluster.Tests.MultiNode;
 using Akka.Cluster.Tools.Singleton;
 using Akka.Configuration;

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerLeaveSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerLeaveSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Linq;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Cluster.Tests.MultiNode;
 using Akka.Cluster.Tools.Singleton;
 using Akka.Configuration;

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Linq;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Cluster.Tests.MultiNode;
 using Akka.Cluster.Tools.Singleton;
 using Akka.Configuration;

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerStartupSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerStartupSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Linq;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Cluster.Tests.MultiNode;
 using Akka.Cluster.Tools.Singleton;
 using Akka.Configuration;

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Akka.Cluster.Tools.Tests.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Akka.Cluster.Tools.Tests.csproj
@@ -88,10 +88,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\core\Akka.Cluster.TestKit\Akka.Cluster.TestKit.csproj">
-      <Project>{b32850d2-e9cb-4638-83a4-164907595e56}</Project>
-      <Name>Akka.Cluster.TestKit</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\..\core\Akka.Cluster\Akka.Cluster.csproj">
       <Project>{6ab00f61-269a-4501-b06a-026707f000a7}</Project>
       <Name>Akka.Cluster</Name>

--- a/src/core/Akka.Cluster.TestKit/Akka.Cluster.TestKit.csproj
+++ b/src/core/Akka.Cluster.TestKit/Akka.Cluster.TestKit.csproj
@@ -62,6 +62,9 @@
     <Compile Include="..\..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="..\Akka.Tests.Shared.Internals\AkkaSpecExtensions.cs">
+      <Link>AkkaSpecExtensions.cs</Link>
+    </Compile>
     <Compile Include="FailureDetectorPuppet.cs" />
     <Compile Include="MultiNodeClusterSpec.cs" />
     <Compile Include="MultiNodeLoggingConfig.cs" />
@@ -88,16 +91,13 @@
       <Project>{0d3cbad0-bbdb-43e5-afc4-ed1d3ecdc224}</Project>
       <Name>Akka.TestKit</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj">
-      <Project>{e636d23c-3432-4aa9-9a5d-5f29d33d3399}</Project>
-      <Name>Akka.Tests.Shared.Internals</Name>
-    </ProjectReference>
     <ProjectReference Include="..\Akka\Akka.csproj">
       <Project>{5deddf90-37f0-48d3-a0b0-a5cbd8a7e377}</Project>
       <Name>Akka</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="Akka.Cluster.TestKit.nuspec" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/core/Akka.Cluster.TestKit/Akka.Cluster.TestKit.nuspec
+++ b/src/core/Akka.Cluster.TestKit/Akka.Cluster.TestKit.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <id>@project@</id>
+    <title>@project@@title@</title>
+    <version>@build.number@</version>
+    <authors>@authors@</authors>
+    <owners>@authors@</owners>
+    <description>Helper classes for combining the Akka.Remote.TestKit with Akka.Cluster</description>
+    <licenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/akkadotnet/akka.net</projectUrl>
+    <iconUrl>http://getakka.net/images/AkkaNetLogo.Normal.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes>@releaseNotes@</releaseNotes>
+    <copyright>@copyright@</copyright>
+    <tags>@tags@</tags>
+    @dependencies@
+    @references@
+  </metadata>
+</package>

--- a/src/core/Akka.Cluster.TestKit/MultiNodeClusterSpec.cs
+++ b/src/core/Akka.Cluster.TestKit/MultiNodeClusterSpec.cs
@@ -12,7 +12,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Akka.Actor;
-using Akka.Cluster;
+using Akka.Cluster.Tests.MultiNode;
 using Akka.Configuration;
 using Akka.Dispatch.SysMsg;
 using Akka.Remote.TestKit;
@@ -22,7 +22,7 @@ using Akka.TestKit.Xunit2;
 using Akka.Util.Internal;
 using Xunit;
 
-namespace Akka.Cluster.Tests.MultiNode
+namespace Akka.Cluster.TestKit
 {
     //TODO: WatchedByCoroner?
     //@Aaronontheweb: Coroner is a JVM-specific instrument used to report deadlocks and other fun stuff.

--- a/src/core/Akka.Cluster.TestKit/MultiNodeLoggingConfig.cs
+++ b/src/core/Akka.Cluster.TestKit/MultiNodeLoggingConfig.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
 

--- a/src/core/Akka.Cluster.Tests.MultiNode/Akka.Cluster.Tests.MultiNode.csproj
+++ b/src/core/Akka.Cluster.Tests.MultiNode/Akka.Cluster.Tests.MultiNode.csproj
@@ -125,10 +125,6 @@
       <Project>{0d3cbad0-bbdb-43e5-afc4-ed1d3ecdc224}</Project>
       <Name>Akka.TestKit</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj">
-      <Project>{e636d23c-3432-4aa9-9a5d-5f29d33d3399}</Project>
-      <Name>Akka.Tests.Shared.Internals</Name>
-    </ProjectReference>
     <ProjectReference Include="..\Akka\Akka.csproj">
       <Project>{5deddf90-37f0-48d3-a0b0-a5cbd8a7e377}</Project>
       <Name>Akka</Name>

--- a/src/core/Akka.Cluster.Tests.MultiNode/ClientDowningNodeThatIsUnreachableSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/ClientDowningNodeThatIsUnreachableSpec.cs
@@ -7,6 +7,7 @@
 
 using System.Collections.Immutable;
 using System.Linq;
+using Akka.Cluster.TestKit;
 using Akka.Cluster.Tests.MultiNode;
 using Akka.Remote.TestKit;
 using Akka.TestKit;

--- a/src/core/Akka.Cluster.Tests.MultiNode/ClusterAccrualFailureDetectorSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/ClusterAccrualFailureDetectorSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Threading;
+using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
 using Akka.Remote.Transport;

--- a/src/core/Akka.Cluster.Tests.MultiNode/ClusterDeathWatchSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/ClusterDeathWatchSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Linq;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.Remote;
 using Akka.Remote.TestKit;

--- a/src/core/Akka.Cluster.Tests.MultiNode/ConvergenceSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/ConvergenceSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
 using Akka.TestKit;

--- a/src/core/Akka.Cluster.Tests.MultiNode/DisallowJoinOfTwoClustersSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/DisallowJoinOfTwoClustersSpec.cs
@@ -7,6 +7,7 @@
 
 using System.Linq;
 using System.Threading;
+using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
 using Akka.TestKit;

--- a/src/core/Akka.Cluster.Tests.MultiNode/InitialHeartbeatSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/InitialHeartbeatSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
 using Akka.Remote.Transport;

--- a/src/core/Akka.Cluster.Tests.MultiNode/JoinInProgressSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/JoinInProgressSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Threading;
+using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.Remote;
 using Akka.Remote.TestKit;

--- a/src/core/Akka.Cluster.Tests.MultiNode/JoinSeedNodeSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/JoinSeedNodeSpec.cs
@@ -8,6 +8,7 @@
 using System.Collections.Immutable;
 using System.Threading;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
 

--- a/src/core/Akka.Cluster.Tests.MultiNode/LeaderDowningNodeThatIsUnreachableSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/LeaderDowningNodeThatIsUnreachableSpec.cs
@@ -11,6 +11,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
 using FluentAssertions;

--- a/src/core/Akka.Cluster.Tests.MultiNode/LeaderElectionSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/LeaderElectionSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using Akka.Cluster.TestKit;
 using Akka.Remote.TestKit;
 using Akka.TestKit;
 

--- a/src/core/Akka.Cluster.Tests.MultiNode/LeaderLeavingSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/LeaderLeavingSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Linq;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Remote.TestKit;
 using Akka.TestKit;
 

--- a/src/core/Akka.Cluster.Tests.MultiNode/MembershipChangeListenerExitingSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/MembershipChangeListenerExitingSpec.cs
@@ -7,6 +7,7 @@
 
 using System.Linq;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Remote.TestKit;
 using Akka.TestKit;
 

--- a/src/core/Akka.Cluster.Tests.MultiNode/MembershipChangeListenerUpSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/MembershipChangeListenerUpSpec.cs
@@ -8,6 +8,7 @@
 using System.Collections.Immutable;
 using System.Linq;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Remote.TestKit;
 using Akka.TestKit;
 

--- a/src/core/Akka.Cluster.Tests.MultiNode/MinMembersBeforeUpSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/MinMembersBeforeUpSpec.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
 using Akka.TestKit;

--- a/src/core/Akka.Cluster.Tests.MultiNode/NodeDowningAndBeingRemovedSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/NodeDowningAndBeingRemovedSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
 using FluentAssertions;

--- a/src/core/Akka.Cluster.Tests.MultiNode/NodeLeavingAndExitingAndBeingRemovedSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/NodeLeavingAndExitingAndBeingRemovedSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
 using FluentAssertions;

--- a/src/core/Akka.Cluster.Tests.MultiNode/NodeLeavingAndExitingSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/NodeLeavingAndExitingSpec.cs
@@ -7,6 +7,7 @@
 
 using System.Linq;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Remote.TestKit;
 using Akka.TestKit;
 

--- a/src/core/Akka.Cluster.Tests.MultiNode/NodeMembershipSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/NodeMembershipSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System.Linq;
+using Akka.Cluster.TestKit;
 using Akka.Remote.TestKit;
 using Akka.TestKit;
 

--- a/src/core/Akka.Cluster.Tests.MultiNode/NodeUpSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/NodeUpSpec.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Remote.TestKit;
 using Akka.TestKit;
 using Akka.Util;

--- a/src/core/Akka.Cluster.Tests.MultiNode/RestartFirstSeedNodeSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/RestartFirstSeedNodeSpec.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
 using FluentAssertions;

--- a/src/core/Akka.Cluster.Tests.MultiNode/RestartNode2Spec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/RestartNode2Spec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
 using FluentAssertions;

--- a/src/core/Akka.Cluster.Tests.MultiNode/RestartNode3Spec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/RestartNode3Spec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.Event;
 using Akka.Remote.TestKit;

--- a/src/core/Akka.Cluster.Tests.MultiNode/RestartNodeSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/RestartNodeSpec.cs
@@ -13,6 +13,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Dsl;
+using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
 using Xunit;

--- a/src/core/Akka.Cluster.Tests.MultiNode/Routing/ClusterConsistentHashingGroupSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/Routing/ClusterConsistentHashingGroupSpec.cs
@@ -10,6 +10,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Akka.Actor;
 using Akka.Cluster.Routing;
+using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
 using Akka.Routing;

--- a/src/core/Akka.Cluster.Tests.MultiNode/Routing/ClusterConsistentHashingRouterSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/Routing/ClusterConsistentHashingRouterSpec.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Akka.Actor;
 using Akka.Cluster.Routing;
+using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
 using Akka.Routing;

--- a/src/core/Akka.Cluster.Tests.MultiNode/SingletonClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/SingletonClusterSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Immutable;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
 using Akka.TestKit;

--- a/src/core/Akka.Cluster.Tests.MultiNode/SplitBrainSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/SplitBrainSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
 using Akka.Remote.Transport;

--- a/src/core/Akka.Cluster.Tests.MultiNode/SunnyWeatherSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/SunnyWeatherSpec.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
 using Akka.Util;

--- a/src/core/Akka.Cluster.Tests.MultiNode/UnreachableNodeJoinsAgainSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/UnreachableNodeJoinsAgainSpec.cs
@@ -11,6 +11,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using Akka.Actor;
+using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
 using Akka.Remote.Transport;

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Akka.MultiNodeTestRunner.Shared.csproj
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Akka.MultiNodeTestRunner.Shared.csproj
@@ -42,6 +42,9 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="ExitCodeContainer.cs" />
     <Compile Include="NodeTest.cs" />
     <Compile Include="Persistence\EnumerableExtensions.cs" />

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Properties/AssemblyInfo.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Properties/AssemblyInfo.cs
@@ -14,10 +14,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Akka.MultiNodeTestRunner.Shared")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Akka.MultiNodeTestRunner.Shared")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
-[assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -27,17 +24,4 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("3830bade-088e-4cdb-828f-68f194b6458f")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
 

--- a/src/core/Akka.MultiNodeTestRunner/Akka.MultiNodeTestRunner.csproj
+++ b/src/core/Akka.MultiNodeTestRunner/Akka.MultiNodeTestRunner.csproj
@@ -45,12 +45,15 @@
     <Reference Include="xunit.core">
       <HintPath>..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.runner.utility.desktop, Version=2.1.0.2981, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\xunit.runner.utility.2.1.0-beta2-build2981\lib\net35\xunit.runner.utility.desktop.dll</HintPath>
+    <Reference Include="xunit.runner.utility.desktop, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.runner.utility.2.0.0\lib\net35\xunit.runner.utility.desktop.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="..\Akka.Remote.TestKit\CommandLine.cs">
       <Link>CommandLine.cs</Link>
     </Compile>
@@ -59,6 +62,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="Akka.MultiNodeTestRunner.nuspec" />
     <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>

--- a/src/core/Akka.MultiNodeTestRunner/Akka.MultiNodeTestRunner.nuspec
+++ b/src/core/Akka.MultiNodeTestRunner/Akka.MultiNodeTestRunner.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <id>@project@</id>
+    <title>@project@@title@</title>
+    <version>@build.number@</version>
+    <authors>@authors@</authors>
+    <owners>@authors@</owners>
+    <description>Akka.NET Multi-node Test Runner; used for executing tests written with Akka.Remote.TestKit</description>
+    <licenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/akkadotnet/akka.net</projectUrl>
+    <iconUrl>http://getakka.net/images/AkkaNetLogo.Normal.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes>@releaseNotes@</releaseNotes>
+    <copyright>@copyright@</copyright>
+    <tags>@tags@</tags>
+    @dependencies@
+    @references@
+  </metadata>
+</package>

--- a/src/core/Akka.MultiNodeTestRunner/Program.cs
+++ b/src/core/Akka.MultiNodeTestRunner/Program.cs
@@ -113,7 +113,7 @@ namespace Akka.MultiNodeTestRunner
             var tcpLogger = TestRunSystem.ActorOf(Props.Create(() => new TcpLoggingServer(SinkCoordinator)), "TcpLogger");
             TestRunSystem.Tcp().Tell(new Tcp.Bind(tcpLogger, listenEndpoint));
 
-            var assemblyName = Path.GetFullPath(args[0]);
+            var assemblyName = Path.GetFullPath(args[0].Trim('"')); //unquote the string first
             EnableAllSinks(assemblyName);
             PublishRunnerMessage(String.Format("Running MultiNodeTests for {0}", assemblyName));
 

--- a/src/core/Akka.MultiNodeTestRunner/Properties/AssemblyInfo.cs
+++ b/src/core/Akka.MultiNodeTestRunner/Properties/AssemblyInfo.cs
@@ -14,10 +14,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Akka.MultiNodeTestRunner")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Akka.MultiNodeTestRunner")]
-[assembly: AssemblyCopyright("Copyright ©  2014")]
-[assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -27,17 +24,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("4442771d-674d-45ad-8e13-ffdc6b442716")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-

--- a/src/core/Akka.MultiNodeTestRunner/packages.config
+++ b/src/core/Akka.MultiNodeTestRunner/packages.config
@@ -3,5 +3,5 @@
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.core" version="2.0.0" targetFramework="net45" />
   <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.runner.utility" version="2.1.0-beta2-build2981" targetFramework="net45" />
+  <package id="xunit.runner.utility" version="2.0.0" targetFramework="net45" />
 </packages>

--- a/src/core/Akka.NodeTestRunner/Akka.NodeTestRunner.csproj
+++ b/src/core/Akka.NodeTestRunner/Akka.NodeTestRunner.csproj
@@ -55,12 +55,15 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.runner.utility.desktop, Version=2.1.0.2981, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\xunit.runner.utility.2.1.0-beta2-build2981\lib\net35\xunit.runner.utility.desktop.dll</HintPath>
+    <Reference Include="xunit.runner.utility.desktop, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.runner.utility.2.0.0\lib\net35\xunit.runner.utility.desktop.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Discovery.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/core/Akka.NodeTestRunner/Properties/AssemblyInfo.cs
+++ b/src/core/Akka.NodeTestRunner/Properties/AssemblyInfo.cs
@@ -14,10 +14,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Akka.NodeTestRunner")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Akka.NodeTestRunner")]
-[assembly: AssemblyCopyright("Copyright ©  2014")]
-[assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -27,17 +24,4 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("9bcfd143-9720-46e3-b7dd-39e04b34fc9f")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
 

--- a/src/core/Akka.NodeTestRunner/packages.config
+++ b/src/core/Akka.NodeTestRunner/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.runner.utility" version="2.1.0-beta2-build2981" targetFramework="net45" />
+  <package id="xunit.runner.utility" version="2.0.0" targetFramework="net45" />
 </packages>

--- a/src/core/Akka.Remote.TestKit/Akka.Remote.TestKit.csproj
+++ b/src/core/Akka.Remote.TestKit/Akka.Remote.TestKit.csproj
@@ -125,6 +125,7 @@
     <EmbeddedResource Include="Internals\Reference.conf" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="Akka.Remote.TestKit.nuspec" />
     <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>

--- a/src/core/Akka.Remote.TestKit/Akka.Remote.TestKit.nuspec
+++ b/src/core/Akka.Remote.TestKit/Akka.Remote.TestKit.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <id>@project@</id>
+    <title>@project@@title@</title>
+    <version>@build.number@</version>
+    <authors>@authors@</authors>
+    <owners>@authors@</owners>
+    <description>TestKit for Testing Distributed Akka.NET Applications</description>
+    <licenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/akkadotnet/akka.net</projectUrl>
+    <iconUrl>http://getakka.net/images/AkkaNetLogo.Normal.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes>@releaseNotes@</releaseNotes>
+    <copyright>@copyright@</copyright>
+    <tags>@tags@</tags>
+    @dependencies@
+    @references@
+  </metadata>
+</package>

--- a/src/core/Akka.Remote.TestKit/CommandLine.cs
+++ b/src/core/Akka.Remote.TestKit/CommandLine.cs
@@ -26,7 +26,7 @@ namespace Akka.Remote.TestKit
     /// </summary>
     public class CommandLine
     {
-        private readonly static Lazy<StringDictionary> Values = new Lazy<StringDictionary>(() =>
+        private static readonly Lazy<StringDictionary> Values = new Lazy<StringDictionary>(() =>
         {
             var dictionary = new StringDictionary();
             foreach (var arg in Environment.GetCommandLineArgs())


### PR DESCRIPTION
closes #2071 
Updated namespace of Akka.Cluster.TestKit classes to reflect the name of the assembly.

Tested the packages in an external project and everything worked, although there's some major "user friendliness" issues with the MNTR that should be addressed.