### PR TITLE
relaxed constraints for automatically downing previous incarnations of Cluster members

### DIFF
--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -1082,7 +1082,7 @@ namespace Akka.Cluster
                 {
                     _log.Info("New incarnation of existing member [{0}] is trying to join. " +
                         "Existing will be removed from the cluster and then new member will be allowed to join.", node);
-                    if (localMember.Status != MemberStatus.Down && localMember.Status != MemberStatus.Leaving && localMember.Status != MemberStatus.Exiting)
+                    if (localMember.Status != MemberStatus.Down)
                         Downing(localMember.Address);
                 }
                 else


### PR DESCRIPTION
When a new incarnation of a node joins a Cluster, i.e. restarting after becoming `Unreachable`, the `Cluster` will automatically `Down` the previous incarnation of that node was `MemberStatus.Up`. 

This change relaxes that constraint so it doesn't matter what the previous `MemberStatus` was - so if a node ends up becoming unreachable and restarting during the middle of leaving the cluster, a new incarnation can still successfully join.

I've noticed this issue from time to time in our MNTR logs, but also saw that the JVM had an issue for it earlier this year: https://github.com/akka/akka/issues/19859