### PR TITLE
[build] Removed duplicate entries

### DIFF
--- a/src/core/Akka.Remote.TestKit/Akka.Remote.TestKit.csproj
+++ b/src/core/Akka.Remote.TestKit/Akka.Remote.TestKit.csproj
@@ -120,7 +120,6 @@
       <Name>Akka</Name>
     </ProjectReference>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <EmbeddedResource Include="Internals\Reference.conf" />
   </ItemGroup>

--- a/src/core/Akka.Streams.TestKit.Tests/Akka.Streams.TestKit.Tests.csproj
+++ b/src/core/Akka.Streams.TestKit.Tests/Akka.Streams.TestKit.Tests.csproj
@@ -113,7 +113,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
   </Target>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
This PR removes duplicate target entries, ```Microsoft.CSharp.targets```, inside a couple of the csproj  files.