### PR TITLE
Cluster specs update

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingFailureSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingFailureSpec.cs
@@ -31,7 +31,6 @@ namespace Akka.Cluster.Sharding.Tests
                 akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider""
                 akka.remote.log-remote-lifecycle-events = off
                 akka.cluster.auto-down-unreachable-after = 0s
-                akka.cluster.down-removal-margin = 5s
                 akka.cluster.roles = [""backend""]
                 akka.persistence.journal.plugin = ""akka.persistence.journal.in-mem""
                 akka.persistence.journal.in-mem {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingLeavingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingLeavingSpec.cs
@@ -33,7 +33,6 @@ namespace Akka.Cluster.Sharding.Tests
                 akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider""
                 akka.remote.log-remote-lifecycle-events = off
                 akka.cluster.auto-down-unreachable-after = 0s
-                akka.cluster.down-removal-margin = 5s
                 akka.persistence.journal.plugin = ""Akka.Persistence.Journal.in-mem""
                 akka.persistence.journal.in-mem {
                   timeout = 5s

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingSpec.cs
@@ -42,7 +42,6 @@ namespace Akka.Cluster.Sharding.Tests
                 akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider""
                 akka.remote.log-remote-lifecycle-events = off
                 akka.cluster.auto-down-unreachable-after = 0s
-                akka.cluster.down-removal-margin = 5s
                 akka.cluster.roles = [""backend""]
                 akka.persistence.journal.plugin = ""akka.persistence.journal.leveldb-shared""
                 akka.persistence.journal.leveldb-shared.store {

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonConfigSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonConfigSpec.cs
@@ -33,7 +33,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             clusterSingletonManagerSettings.SingletonName.ShouldBe("singleton");
             clusterSingletonManagerSettings.Role.ShouldBe(null);
             clusterSingletonManagerSettings.HandOverRetryInterval.TotalSeconds.ShouldBe(1);
-            clusterSingletonManagerSettings.RemovalMargin.TotalSeconds.ShouldBe(20);
+            clusterSingletonManagerSettings.RemovalMargin.TotalSeconds.ShouldBe(0);
 
             var config = Sys.Settings.Config.GetConfig("akka.cluster.singleton");
             config.GetInt("min-number-of-hand-over-retries").ShouldBe(10);

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -368,6 +368,8 @@ namespace Akka.Actor
     {
         public static readonly Akka.Actor.Address AllSystems;
         public Address(string protocol, string system, string host = null, System.Nullable<int> port = null) { }
+        public bool HasGlobalScope { get; }
+        public bool HasLocalScope { get; }
         public string Host { get; }
         public System.Nullable<int> Port { get; }
         public string Protocol { get; }

--- a/src/core/Akka.Cluster.Tests/AutoDownSpec.cs
+++ b/src/core/Akka.Cluster.Tests/AutoDownSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using Akka.Actor;
 using Akka.TestKit;
+using FluentAssertions;
 using Xunit;
 
 namespace Akka.Cluster.Tests
@@ -113,7 +114,7 @@ namespace Akka.Cluster.Tests
             var a = AutoDownActor(TimeSpan.FromSeconds(2));
             a.Tell(new ClusterEvent.LeaderChanged(MemberA.Address));
             a.Tell(new ClusterEvent.UnreachableMember(MemberB));
-            ExpectNoMsg(TimeSpan.FromSeconds(1));
+            ExpectNoMsg(1.Seconds());
             ExpectMsg(new DownCalled(MemberB.Address));
         }
 
@@ -124,7 +125,7 @@ namespace Akka.Cluster.Tests
             a.Tell(new ClusterEvent.LeaderChanged(MemberB.Address));
             a.Tell(new ClusterEvent.UnreachableMember(MemberC));
             a.Tell(new ClusterEvent.LeaderChanged(MemberA.Address));
-            ExpectNoMsg(TimeSpan.FromSeconds(1));
+            ExpectNoMsg(1.Seconds());
             ExpectMsg(new DownCalled(MemberC.Address));
         }
 
@@ -135,7 +136,7 @@ namespace Akka.Cluster.Tests
             a.Tell(new ClusterEvent.LeaderChanged(MemberA.Address));
             a.Tell(new ClusterEvent.UnreachableMember(MemberC));
             a.Tell(new ClusterEvent.LeaderChanged(MemberB.Address));
-            ExpectNoMsg(TimeSpan.FromSeconds(3));
+            ExpectNoMsg(3.Seconds());
         }
 
         [Fact]
@@ -145,9 +146,8 @@ namespace Akka.Cluster.Tests
             a.Tell(new ClusterEvent.LeaderChanged(MemberA.Address));
             a.Tell(new ClusterEvent.UnreachableMember(MemberB));
             a.Tell(new ClusterEvent.ReachableMember(MemberB));
-            ExpectNoMsg(TimeSpan.FromSeconds(3));
+            ExpectNoMsg(3.Seconds());
         }
-
 
         [Fact]
         public void AutoDown_must_not_down_unreachable_is_removed_inbetween_detection_and_specified_duration()
@@ -156,7 +156,7 @@ namespace Akka.Cluster.Tests
             a.Tell(new ClusterEvent.LeaderChanged(MemberA.Address));
             a.Tell(new ClusterEvent.UnreachableMember(MemberB));
             a.Tell(new ClusterEvent.MemberRemoved(MemberB.Copy(MemberStatus.Removed), MemberStatus.Exiting));
-            ExpectNoMsg(TimeSpan.FromSeconds(3));
+            ExpectNoMsg(3.Seconds());
         }
 
         [Fact]
@@ -165,9 +165,7 @@ namespace Akka.Cluster.Tests
             var a = AutoDownActor(TimeSpan.Zero);
             a.Tell(new ClusterEvent.LeaderChanged(MemberA.Address));
             a.Tell(new ClusterEvent.UnreachableMember(MemberB.Copy(MemberStatus.Down)));
-            ExpectNoMsg(TimeSpan.FromSeconds(1));
+            ExpectNoMsg(1.Seconds());
         }
-
     }
 }
-

--- a/src/core/Akka.Cluster.Tests/ClusterConfigSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterConfigSpec.cs
@@ -8,10 +8,12 @@
 using System;
 using System.Collections.Immutable;
 using Akka.Actor;
+using Akka.Dispatch;
 using Akka.Remote;
 using Akka.TestKit;
 using Xunit;
 using Assert = Xunit.Assert;
+using FluentAssertions;
 
 namespace Akka.Cluster.Tests
 {
@@ -23,40 +25,49 @@ namespace Akka.Cluster.Tests
         public void Clustering_must_be_able_to_parse_generic_cluster_config_elements()
         {
             var settings = new ClusterSettings(Sys.Settings.Config, Sys.Name);
-            Assert.True(settings.LogInfo);
-            Assert.Equal(8, settings.FailureDetectorConfig.GetDouble("threshold"));
-            Assert.Equal(1000, settings.FailureDetectorConfig.GetInt("max-sample-size"));
-            Assert.Equal(TimeSpan.FromMilliseconds(100), settings.FailureDetectorConfig.GetTimeSpan("min-std-deviation"));
-            Assert.Equal(TimeSpan.FromSeconds(3), settings.FailureDetectorConfig.GetTimeSpan("acceptable-heartbeat-pause"));
-            Assert.Equal(typeof(PhiAccrualFailureDetector), Type.GetType(settings.FailureDetectorImplementationClass));
-            Assert.Equal(ImmutableList.Create<Address>(), settings.SeedNodes);
-            Assert.Equal(TimeSpan.FromSeconds(5), settings.SeedNodeTimeout);
-            Assert.Equal(TimeSpan.FromSeconds(10), settings.RetryUnsuccessfulJoinAfter);
-            Assert.Equal(TimeSpan.FromSeconds(1), settings.PeriodicTasksInitialDelay);
-            Assert.Equal(TimeSpan.FromSeconds(1), settings.GossipInterval);
-            Assert.Equal(TimeSpan.FromSeconds(2), settings.GossipTimeToLive);
-            Assert.Equal(TimeSpan.FromSeconds(1), settings.HeartbeatInterval);
-            Assert.Equal(5, settings.MonitoredByNrOfMembers);
-            Assert.Equal(TimeSpan.FromSeconds(5), settings.HeartbeatExpectedResponseAfter);
-            Assert.Equal(TimeSpan.FromSeconds(1), settings.LeaderActionsInterval);
-            Assert.Equal(TimeSpan.FromSeconds(1), settings.UnreachableNodesReaperInterval);
-            Assert.Null(settings.PublishStatsInterval);
-            Assert.Null(settings.AutoDownUnreachableAfter);
-            Assert.Equal(1, settings.MinNrOfMembers);
-            //TODO:
-            //Assert.AreEqual(ImmutableDictionary.Create<string, int>(), settings.);
-            Assert.Equal(ImmutableHashSet.Create<string>(), settings.Roles);
-            Assert.Equal("akka.cluster.default-cluster-dispatcher", settings.UseDispatcher);
-            Assert.Equal(.8, settings.GossipDifferentViewProbability);
-            Assert.Equal(400, settings.ReduceGossipDifferentViewProbability);
-            Assert.Equal(TimeSpan.FromMilliseconds(33), settings.SchedulerTickDuration);
-            Assert.Equal(512, settings.SchedulerTicksPerWheel);
-            Assert.True(settings.MetricsEnabled);
-            //TODO:
-            //Assert.AreEqual(typeof(SigarMetricsCollector).FullName, settings.MetricsCollectorClass);
-            Assert.Equal(TimeSpan.FromSeconds(3), settings.MetricsGossipInterval);
-            Assert.Equal(TimeSpan.FromSeconds(12), settings.MetricsMovingAverageHalfLife);
-            Assert.Equal(false, settings.VerboseHeartbeatLogging);
+            settings.LogInfo.Should().BeTrue();
+
+            settings.SeedNodes.Should().BeEquivalentTo(ImmutableList.Create<Address>());
+            settings.SeedNodeTimeout.Should().Be(5.Seconds());
+            settings.RetryUnsuccessfulJoinAfter.Should().Be(10.Seconds());
+            settings.PeriodicTasksInitialDelay.Should().Be(1.Seconds());
+            settings.GossipInterval.Should().Be(1.Seconds());
+            settings.GossipTimeToLive.Should().Be(2.Seconds());
+            settings.HeartbeatInterval.Should().Be(1.Seconds());
+            settings.MonitoredByNrOfMembers.Should().Be(5);
+            settings.HeartbeatExpectedResponseAfter.Should().Be(1.Seconds());
+            settings.LeaderActionsInterval.Should().Be(1.Seconds());
+            settings.UnreachableNodesReaperInterval.Should().Be(1.Seconds());
+            settings.PublishStatsInterval.Should().NotHaveValue();
+            settings.AutoDownUnreachableAfter.Should().NotHaveValue();
+            settings.DownRemovalMargin.Should().Be(TimeSpan.Zero);
+            settings.MinNrOfMembers.Should().Be(1);
+            settings.MinNrOfMembersOfRole.Should().Equal(ImmutableDictionary<string, int>.Empty);
+            settings.Roles.Should().BeEquivalentTo(ImmutableHashSet<string>.Empty);
+            // settings.UseDispatcher.Should().Be(Dispatchers.DefaultDispatcherId);
+            settings.GossipDifferentViewProbability.Should().Be(0.8);
+            settings.ReduceGossipDifferentViewProbability.Should().Be(400);
+
+            Type.GetType(settings.FailureDetectorImplementationClass).Should().Be(typeof(PhiAccrualFailureDetector));
+            settings.FailureDetectorConfig.GetTimeSpan("heartbeat-interval").Should().Be(1.Seconds());
+            settings.FailureDetectorConfig.GetDouble("threshold").Should().Be(8.0d);
+            settings.FailureDetectorConfig.GetInt("max-sample-size").Should().Be(1000);
+            settings.FailureDetectorConfig.GetTimeSpan("min-std-deviation").Should().Be(100.Milliseconds());
+            settings.FailureDetectorConfig.GetTimeSpan("acceptable-heartbeat-pause").Should().Be(3.Seconds());
+            settings.FailureDetectorConfig.GetInt("monitored-by-nr-of-members").Should().Be(5);
+            settings.FailureDetectorConfig.GetTimeSpan("expected-response-after").Should().Be(1.Seconds());
+
+            // TODO remove metrics
+            settings.MetricsEnabled.Should().BeTrue();
+            Type.GetType(settings.MetricsCollectorClass).Should().Be(typeof(PerformanceCounterMetricsCollector));
+            settings.MetricsInterval.Should().Be(3.Seconds());
+            settings.MetricsGossipInterval.Should().Be(3.Seconds());
+            settings.MetricsMovingAverageHalfLife.Should().Be(12.Seconds());
+
+            settings.SchedulerTickDuration.Should().Be(33.Milliseconds());
+            settings.SchedulerTicksPerWheel.Should().Be(512);
+
+            settings.VerboseHeartbeatLogging.Should().BeFalse();
         }
 
         [Fact]

--- a/src/core/Akka.Cluster.Tests/ClusterDeployerSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterDeployerSpec.cs
@@ -13,58 +13,57 @@ using Akka.Routing;
 using Akka.TestKit;
 using Akka.Util.Internal;
 using Xunit;
+using FluentAssertions;
 
 namespace Akka.Cluster.Tests
 {
     public class ClusterDeployerSpec : AkkaSpec
     {
-        public static readonly Config deployConf = ConfigurationFactory.ParseString(@"
-        akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""
-      akka.actor.deployment {
-        /user/service1 {
-          router = round-robin-pool
-          nr-of-instances = 20
-          cluster.enabled = on
-          cluster.max-nr-of-instances-per-node = 3
-          cluster.max-total-nr-of-instances = 20
-          cluster.allow-local-routees = off
-        }
-        /user/service2 {
-          dispatcher = mydispatcher
-          mailbox = mymailbox
-          router = round-robin-group
-          nr-of-instances = 20
-          routees.paths = [""/user/myservice""]
-          cluster.enabled = on
-          cluster.max-total-nr-of-instances = 20
-          cluster.allow-local-routees = off
-          cluster.use-role = backend
-        }
-      }
-      akka.remote.helios.tcp.port = 0
+        public static readonly Config deployerConf = ConfigurationFactory.ParseString(@"
+          akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""
+          akka.actor.deployment {
+            /user/service1 {
+              router = round-robin-pool
+              cluster.enabled = on
+              cluster.max-nr-of-instances-per-node = 3
+              cluster.max-total-nr-of-instances = 20
+              cluster.allow-local-routees = off
+            }
+            /user/service2 {
+              dispatcher = mydispatcher
+              mailbox = mymailbox
+              router = round-robin-group
+              nr-of-instances = 20
+              routees.paths = [""/user/myservice""]
+              cluster.enabled = on
+              cluster.max-total-nr-of-instances = 20
+              cluster.allow-local-routees = off
+            }
+          }
+          akka.remote.helios.tcp.port = 0");
 
-");
-
-        public ClusterDeployerSpec() : base(deployConf) { }
+        public ClusterDeployerSpec() : base(deployerConf) { }
 
         [Fact]
         public void RemoteDeployer_must_be_able_to_parse_akka_actor_deployment_with_specified_cluster_pool()
         {
             var service = "/user/service1";
             var deployment = Sys.AsInstanceOf<ActorSystemImpl>().Provider.Deployer.Lookup(service.Split('/').Drop(1));
-            deployment.ShouldNotBe(null);
+            deployment.Should().NotBeNull();
 
-            deployment.Path.ShouldBe(service);
-            deployment.RouterConfig.GetType().ShouldBe(typeof(ClusterRouterPool));
-            deployment.RouterConfig.AsInstanceOf<ClusterRouterPool>().Local.GetType().ShouldBe(typeof(RoundRobinPool));
-            deployment.RouterConfig.AsInstanceOf<ClusterRouterPool>().Local.AsInstanceOf<RoundRobinPool>().NrOfInstances.ShouldBe(20);
-            deployment.RouterConfig.AsInstanceOf<ClusterRouterPool>().Settings.TotalInstances.ShouldBe(20);
-            deployment.RouterConfig.AsInstanceOf<ClusterRouterPool>().Settings.AllowLocalRoutees.ShouldBe(false);
-            deployment.RouterConfig.AsInstanceOf<ClusterRouterPool>().Settings.UseRole.ShouldBe(string.Empty);
-            deployment.RouterConfig.AsInstanceOf<ClusterRouterPool>().Settings.AsInstanceOf<ClusterRouterPoolSettings>().MaxInstancesPerNode.ShouldBe(3);
-            deployment.Scope.ShouldBe(ClusterScope.Instance);
-            deployment.Mailbox.ShouldBe(Deploy.NoMailboxGiven);
-            deployment.Dispatcher.ShouldBe(Deploy.NoDispatcherGiven);
+            deployment.Path.Should().Be(service);
+            deployment.RouterConfig.Should().BeOfType<ClusterRouterPool>();
+
+            var routerConfig = deployment.RouterConfig.AsInstanceOf<ClusterRouterPool>();
+            routerConfig.Local.Should().BeOfType<RoundRobinPool>();
+            routerConfig.Local.AsInstanceOf<RoundRobinPool>().NrOfInstances.Should().Be(20);
+            routerConfig.Settings.TotalInstances.Should().Be(20);
+            routerConfig.Settings.AllowLocalRoutees.Should().BeFalse();
+            routerConfig.Settings.UseRole.Should().BeNull();
+            routerConfig.Settings.AsInstanceOf<ClusterRouterPoolSettings>().MaxInstancesPerNode.Should().Be(3);
+            deployment.Scope.Should().Be(ClusterScope.Instance);
+            deployment.Mailbox.Should().Be(Deploy.NoMailboxGiven);
+            deployment.Dispatcher.Should().Be(Deploy.NoDispatcherGiven);
         }
 
         [Fact]
@@ -72,22 +71,22 @@ namespace Akka.Cluster.Tests
         {
             var service = "/user/service2";
             var deployment = Sys.AsInstanceOf<ActorSystemImpl>().Provider.Deployer.Lookup(service.Split('/').Drop(1));
-            deployment.ShouldNotBe(null);
+            deployment.Should().NotBeNull();
 
-            deployment.Path.ShouldBe(service);
-            deployment.RouterConfig.GetType().ShouldBe(typeof(ClusterRouterGroup));
-            deployment.RouterConfig.AsInstanceOf<ClusterRouterGroup>().Local.GetType().ShouldBe(typeof(RoundRobinGroup));
-            deployment.RouterConfig.AsInstanceOf<ClusterRouterGroup>().Local.AsInstanceOf<RoundRobinGroup>().Paths.ShouldBe(new[]{ "/user/myservice" });
-            deployment.RouterConfig.AsInstanceOf<ClusterRouterGroup>().Settings.TotalInstances.ShouldBe(20);
-            deployment.RouterConfig.AsInstanceOf<ClusterRouterGroup>().Settings.AllowLocalRoutees.ShouldBe(false);
-            deployment.RouterConfig.AsInstanceOf<ClusterRouterGroup>().Settings.UseRole.ShouldBe("backend");
-            deployment.RouterConfig.AsInstanceOf<ClusterRouterGroup>().Settings.AsInstanceOf<ClusterRouterGroupSettings>().RouteesPaths.ShouldBe(new[] { "/user/myservice" });
-            deployment.Scope.ShouldBe(ClusterScope.Instance);
-            deployment.Mailbox.ShouldBe("mymailbox");
-            deployment.Dispatcher.ShouldBe("mydispatcher");
+            deployment.Path.Should().Be(service);
+            deployment.RouterConfig.Should().BeOfType<ClusterRouterGroup>();
+
+            var routerConfig = deployment.RouterConfig.AsInstanceOf<ClusterRouterGroup>();
+            routerConfig.Local.Should().BeOfType<RoundRobinGroup>();
+            routerConfig.Local.AsInstanceOf<RoundRobinGroup>().Paths.Should().BeEquivalentTo("/user/myservice");
+            routerConfig.Settings.TotalInstances.Should().Be(20);
+            routerConfig.Settings.AllowLocalRoutees.Should().BeFalse();
+            routerConfig.Settings.UseRole.Should().BeNull();
+            routerConfig.Settings.AsInstanceOf<ClusterRouterGroupSettings>().RouteesPaths.Should().BeEquivalentTo("/user/myservice");
+            deployment.Scope.Should().Be(ClusterScope.Instance);
+            deployment.Mailbox.Should().Be("mymailbox");
+            deployment.Dispatcher.Should().Be("mydispatcher");
         }
-
-        //todo: implement "have correct router mappings" test for adaptive load-balancing routers (not yet implemented)
     }
 }
 

--- a/src/core/Akka.Cluster.Tests/ClusterDomainEventPublisherSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterDomainEventPublisherSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Immutable;
 using Akka.Actor;
 using Akka.TestKit;
+using FluentAssertions;
 using Xunit;
 
 namespace Akka.Cluster.Tests
@@ -16,13 +17,8 @@ namespace Akka.Cluster.Tests
     public class ClusterDomainEventPublisherSpec : AkkaSpec
     {
         const string Config = @"    
-        akka.cluster {
-            auto-down-unreachable-after = 0s
-            periodic-tasks-initial-delay = 120 s // turn off scheduled tasks
-            publish-stats-interval = 0 s # always, when it happens
-        }
-        akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""
-        akka.remote.helios.tcp.port = 0";
+            akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""
+            akka.remote.helios.tcp.port = 0";
 
         readonly IActorRef _publisher;
         static readonly Member aUp = TestMember.Create(new Address("akka.tcp", "sys", "a", 2552), MemberStatus.Up);
@@ -38,11 +34,11 @@ namespace Akka.Cluster.Tests
         static readonly Member dUp = TestMember.Create(new Address("akka.tcp", "sys", "d", 2552), MemberStatus.Up, ImmutableHashSet.Create("GRP"));
 
         static readonly Gossip g0 = new Gossip(ImmutableSortedSet.Create(aUp)).Seen(aUp.UniqueAddress);
-        static readonly Gossip g1 = new Gossip(ImmutableSortedSet.Create(aUp, cJoining)).Seen(aUp.UniqueAddress).Seen(bExiting.UniqueAddress).Seen(cJoining.UniqueAddress);
+        static readonly Gossip g1 = new Gossip(ImmutableSortedSet.Create(aUp, cJoining)).Seen(aUp.UniqueAddress).Seen(cJoining.UniqueAddress);
         static readonly Gossip g2 = new Gossip(ImmutableSortedSet.Create(aUp, bExiting, cUp)).Seen(aUp.UniqueAddress);
         static readonly Gossip g3 = g2.Seen(bExiting.UniqueAddress).Seen(cUp.UniqueAddress);
         static readonly Gossip g4 = new Gossip(ImmutableSortedSet.Create(a51Up, aUp, bExiting, cUp)).Seen(aUp.UniqueAddress);
-        static readonly Gossip g5 = new Gossip(ImmutableSortedSet.Create(a51Up, aUp, bExiting, cUp)).Seen(aUp.UniqueAddress).Seen(bExiting.UniqueAddress).Seen(cUp.UniqueAddress).Seen(a51Up.UniqueAddress);
+        static readonly Gossip g5 = new Gossip(ImmutableSortedSet.Create(a51Up, aUp, bExiting, cUp)).Seen(aUp.UniqueAddress).Seen(bExiting.UniqueAddress).Seen(cUp.UniqueAddress);
         static readonly Gossip g6 = new Gossip(ImmutableSortedSet.Create(aLeaving, bExiting, cUp)).Seen(aUp.UniqueAddress);
         static readonly Gossip g7 = new Gossip(ImmutableSortedSet.Create(aExiting, bExiting, cUp)).Seen(aUp.UniqueAddress);
         static readonly Gossip g8 = new Gossip(ImmutableSortedSet.Create(aUp, bExiting, cUp, dUp), new GossipOverview(Reachability.Empty.Unreachable(aUp.UniqueAddress, dUp.UniqueAddress))).Seen(aUp.UniqueAddress);
@@ -57,21 +53,20 @@ namespace Akka.Cluster.Tests
             Sys.EventStream.Subscribe(_memberSubscriber.Ref, typeof(ClusterEvent.ClusterShuttingDown));
 
             _publisher = Sys.ActorOf(Props.Create<ClusterDomainEventPublisher>());
-            //TODO: If parent told of exception then test should fail (if not expected in some way)?
             _publisher.Tell(new InternalClusterAction.PublishChanges(g0));
             _memberSubscriber.ExpectMsg(new ClusterEvent.MemberUp(aUp));
             _memberSubscriber.ExpectMsg(new ClusterEvent.LeaderChanged(aUp.Address));
         }
 
         [Fact]
-        public void ClusterDomainEventPublisher_must_publish_member_joined()
+        public void ClusterDomainEventPublisher_must_publish_MemberJoined()
         {
             _publisher.Tell(new InternalClusterAction.PublishChanges(g1));
             _memberSubscriber.ExpectMsg(new ClusterEvent.MemberJoined(cJoining));
         }
 
         [Fact]
-        public void ClusterDomainEventPublisher_must_publish_member_up()
+        public void ClusterDomainEventPublisher_must_publish_MemberUp()
         {
             _publisher.Tell(new InternalClusterAction.PublishChanges(g2));
             _publisher.Tell(new InternalClusterAction.PublishChanges(g3));
@@ -87,7 +82,7 @@ namespace Akka.Cluster.Tests
             _memberSubscriber.ExpectMsg(new ClusterEvent.MemberExited(bExiting));
             _memberSubscriber.ExpectMsg(new ClusterEvent.MemberUp(cUp));
             _memberSubscriber.ExpectMsg(new ClusterEvent.LeaderChanged(a51Up.Address));
-            _memberSubscriber.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
+            _memberSubscriber.ExpectNoMsg(500.Milliseconds());
         }
 
         [Fact]
@@ -101,13 +96,12 @@ namespace Akka.Cluster.Tests
             _publisher.Tell(new InternalClusterAction.PublishChanges(g7));
             _memberSubscriber.ExpectMsg(new ClusterEvent.MemberExited(aExiting));
             _memberSubscriber.ExpectMsg(new ClusterEvent.LeaderChanged(cUp.Address));
-            _memberSubscriber.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
+            _memberSubscriber.ExpectNoMsg(500.Milliseconds());
             // at the removed member a an empty gossip is the last thing
             _publisher.Tell(new InternalClusterAction.PublishChanges(Gossip.Empty));
             _memberSubscriber.ExpectMsg(new ClusterEvent.MemberRemoved(aRemoved, MemberStatus.Exiting));
             _memberSubscriber.ExpectMsg(new ClusterEvent.MemberRemoved(bRemoved, MemberStatus.Exiting));
             _memberSubscriber.ExpectMsg(new ClusterEvent.MemberRemoved(cRemoved, MemberStatus.Up));
-            //TODO: Null leader stuff is messy. Better approach?
             _memberSubscriber.ExpectMsg(new ClusterEvent.LeaderChanged(null));
         }
 
@@ -121,7 +115,7 @@ namespace Akka.Cluster.Tests
             _memberSubscriber.ExpectMsg(new ClusterEvent.LeaderChanged(a51Up.Address));
 
             _publisher.Tell(new InternalClusterAction.PublishChanges(g5));
-            _memberSubscriber.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
+            _memberSubscriber.ExpectNoMsg(500.Milliseconds());
         }
 
         [Fact]
@@ -130,18 +124,20 @@ namespace Akka.Cluster.Tests
             var subscriber = CreateTestProbe();
             _publisher.Tell(new InternalClusterAction.Subscribe(subscriber.Ref, ClusterEvent.SubscriptionInitialStateMode.InitialStateAsSnapshot, ImmutableHashSet.Create(typeof(ClusterEvent.RoleLeaderChanged))));
             subscriber.ExpectMsg<ClusterEvent.CurrentClusterState>();
-            // but only to the new subscriber
-            _memberSubscriber.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
+            _publisher.Tell(new InternalClusterAction.PublishChanges(new Gossip(ImmutableSortedSet.Create(cJoining, dUp))));
+            subscriber.ExpectMsg(new ClusterEvent.RoleLeaderChanged("GRP", dUp.Address));
+            _publisher.Tell(new InternalClusterAction.PublishChanges(new Gossip(ImmutableSortedSet.Create(cUp, dUp))));
+            subscriber.ExpectMsg(new ClusterEvent.RoleLeaderChanged("GRP", cUp.Address));
         }
 
         [Fact]
-        public void ClusterDomainEventPublisher_must_send_current_cluster_state_when_subscribe()
+        public void ClusterDomainEventPublisher_must_send_CurrentClusterState_when_subscribe()
         {
             var subscriber = CreateTestProbe();
             _publisher.Tell(new InternalClusterAction.Subscribe(subscriber.Ref, ClusterEvent.SubscriptionInitialStateMode.InitialStateAsSnapshot, ImmutableHashSet.Create(typeof(ClusterEvent.IClusterDomainEvent))));
             subscriber.ExpectMsg<ClusterEvent.CurrentClusterState>();
             // but only to the new subscriber
-            _memberSubscriber.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
+            _memberSubscriber.ExpectNoMsg(500.Milliseconds());
         }
 
         [Fact]
@@ -150,15 +146,15 @@ namespace Akka.Cluster.Tests
             var subscriber = CreateTestProbe();
             _publisher.Tell(new InternalClusterAction.PublishChanges(g8));
             _publisher.Tell(new InternalClusterAction.Subscribe(subscriber.Ref, ClusterEvent.SubscriptionInitialStateMode.InitialStateAsEvents, ImmutableHashSet.Create(typeof(ClusterEvent.IMemberEvent), typeof(ClusterEvent.ReachabilityEvent))));
-            var received = subscriber.ReceiveN(4);
-            XAssert.Equivalent(
-                new object[]
-                {
-                    new ClusterEvent.MemberUp(aUp), new ClusterEvent.MemberUp(cUp), new ClusterEvent.MemberUp(dUp),
-                    new ClusterEvent.MemberExited(bExiting)
-                }, received );
+
+            subscriber.ReceiveN(4).Should().BeEquivalentTo(
+                new ClusterEvent.MemberUp(aUp),
+                new ClusterEvent.MemberUp(cUp),
+                new ClusterEvent.MemberUp(dUp),
+                new ClusterEvent.MemberExited(bExiting));
+
             subscriber.ExpectMsg(new ClusterEvent.UnreachableMember(dUp));
-            subscriber.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
+            subscriber.ExpectNoMsg(500.Milliseconds());
         }
 
         [Fact]
@@ -169,7 +165,8 @@ namespace Akka.Cluster.Tests
             subscriber.ExpectMsg<ClusterEvent.CurrentClusterState>();
             _publisher.Tell(new InternalClusterAction.Unsubscribe(subscriber.Ref, typeof(ClusterEvent.IMemberEvent)));
             _publisher.Tell(new InternalClusterAction.PublishChanges(g3));
-            subscriber.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
+            subscriber.ExpectNoMsg(500.Milliseconds());
+            // but memberSubscriber is still subscriber
             _memberSubscriber.ExpectMsg(new ClusterEvent.MemberExited(bExiting));
             _memberSubscriber.ExpectMsg(new ClusterEvent.MemberUp(cUp));
         }
@@ -182,10 +179,10 @@ namespace Akka.Cluster.Tests
             subscriber.ExpectMsg<ClusterEvent.CurrentClusterState>();
             _publisher.Tell(new InternalClusterAction.PublishChanges(g2));
             subscriber.ExpectMsg<ClusterEvent.SeenChanged>();
-            subscriber.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
+            subscriber.ExpectNoMsg(500.Milliseconds());
             _publisher.Tell(new InternalClusterAction.PublishChanges(g3));
             subscriber.ExpectMsg<ClusterEvent.SeenChanged>();
-            subscriber.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
+            subscriber.ExpectNoMsg(500.Milliseconds());
         }
 
         [Fact]

--- a/src/core/Akka.Cluster.Tests/ClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterSpec.cs
@@ -13,19 +13,21 @@ using Akka.Configuration;
 using Akka.TestKit;
 using Akka.Util.Internal;
 using Xunit;
+using FluentAssertions;
 
 namespace Akka.Cluster.Tests
 {
     public class ClusterSpec : AkkaSpec
     {
         const string Config = @"    
-        akka.cluster {
-            auto-down-unreachable-after = 0s
-            periodic-tasks-initial-delay = 120 s // turn off scheduled tasks
-            publish-stats-interval = 0 s # always, when it happens
-        }
-        akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""
-        akka.remote.helios.tcp.port = 0";
+            akka.cluster {
+              auto-down-unreachable-after = 0s
+              periodic-tasks-initial-delay = 120 s
+              publish-stats-interval = 0 s # always, when it happens
+            }
+            akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""
+            akka.remote.log-remote-lifecycle-events = off
+            akka.remote.helios.tcp.port = 0";
 
         public IActorRef Self { get { return TestActor; } }
 
@@ -49,19 +51,20 @@ namespace Akka.Cluster.Tests
         [Fact]
         public void A_cluster_must_use_the_address_of_the_remote_transport()
         {
-            Assert.Equal(_selfAddress, _cluster.SelfAddress);
+            _cluster.SelfAddress.Should().Be(_selfAddress);
         }
 
         [Fact]
         public void A_cluster_must_initially_become_singleton_cluster_when_joining_itself_and_reach_convergence()
         {
-            Assert.Equal(0, ClusterView.Members.Count);
+            ClusterView.Members.Count.Should().Be(0);
             _cluster.Join(_selfAddress);
             LeaderActions(); // Joining -> Up
             AwaitCondition(() => ClusterView.IsSingletonCluster);
-            Assert.Equal(_selfAddress, ClusterView.Self.Address);
-            Assert.Equal(ImmutableHashSet.Create(_selfAddress), ClusterView.Members.Select(m => m.Address).ToImmutableHashSet());
-            AwaitAssert(() => Assert.Equal(MemberStatus.Up, ClusterView.Status));
+            ClusterView.Self.Address.Should().Be(_selfAddress);
+            ClusterView.Members.Select(m => m.Address).ToImmutableHashSet()
+                .Should().BeEquivalentTo(ImmutableHashSet.Create(_selfAddress));
+            AwaitAssert(() => ClusterView.Status.Should().Be(MemberStatus.Up));
         }
 
         [Fact]
@@ -83,8 +86,10 @@ namespace Akka.Cluster.Tests
         {
             try
             {
+                // TODO: this should be removed
                 _cluster.Join(_selfAddress);
                 LeaderActions(); // Joining -> Up
+
                 _cluster.Subscribe(TestActor, ClusterEvent.InitialStateAsEvents, new[] { typeof(ClusterEvent.IMemberEvent) });
                 ExpectMsg<ClusterEvent.MemberUp>();
             }
@@ -105,6 +110,7 @@ namespace Akka.Cluster.Tests
         [Fact]
         public void A_cluster_must_publish_member_removed_when_shutdown()
         {
+            // TODO: this should be removed
             _cluster.Join(_selfAddress);
             LeaderActions(); // Joining -> Up
 
@@ -119,25 +125,12 @@ namespace Akka.Cluster.Tests
             ExpectMsg<ClusterEvent.CurrentClusterState>();
 
             _cluster.Shutdown();
-            var memberRemoved = ExpectMsg<ClusterEvent.MemberRemoved>();
-            Assert.Equal(_selfAddress, memberRemoved.Member.Address);
+            ExpectMsg<ClusterEvent.MemberRemoved>().Member.Address.Should().Be(_selfAddress);
 
             callbackProbe.ExpectMsg("OnMemberRemoved");
         }
 
         [Fact]
-        public void A_ActorSystem_with_Cluster_must_be_able_to_terminate()
-        {
-            _cluster.Join(_selfAddress);
-            LeaderActions(); // Joining -> Up
-            AwaitCondition(() => ClusterView.IsSingletonCluster);
-
-            var remainingTime = RemainingOrDefault;
-            Assert.True(Sys.Terminate().Wait(RemainingOrDefault), $"Expected actor system to terminate in {RemainingOrDefault}, but did not");
-        }
-
-        // TODO: https://github.com/akkadotnet/akka.net/issues/1983
-        [Fact(Skip = "fails for now - will need to implement https://github.com/akkadotnet/akka.net/issues/1983")]
         public void A_cluster_must_be_allowed_to_join_and_leave_with_local_address()
         {
             var sys2 = ActorSystem.Create("ClusterSpec2", ConfigurationFactory.ParseString(@"akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""
@@ -145,24 +138,24 @@ namespace Akka.Cluster.Tests
 
             try
             {
-                var ref2 = sys2.ActorOf(Props.Empty);
-                Cluster.Get(sys2).Join(ref2.Path.Address); // address doesn't contain full address information
-                Within(TimeSpan.FromSeconds(5), () =>
+                var @ref = sys2.ActorOf(Props.Empty);
+                Cluster.Get(sys2).Join(@ref.Path.Address); // address doesn't contain full address information
+                Within(5.Seconds(), () =>
                 {
                     AwaitAssert(() =>
                     {
-                        Cluster.Get(sys2).State.Members.Count.ShouldBe(1);
-                        Cluster.Get(sys2).State.Members.First().Status.ShouldBe(MemberStatus.Up);
+                        Cluster.Get(sys2).State.Members.Count.Should().Be(1);
+                        Cluster.Get(sys2).State.Members.First().Status.Should().Be(MemberStatus.Up);
                     });
                 });
 
-                Cluster.Get(sys2).Leave(ref2.Path.Address);
+                Cluster.Get(sys2).Leave(@ref.Path.Address);
 
-                Within(TimeSpan.FromSeconds(5), () =>
+                Within(5.Seconds(), () =>
                 {
                     AwaitAssert(() =>
                     {
-                        Cluster.Get(sys2).IsTerminated.ShouldBe(true);
+                        Cluster.Get(sys2).IsTerminated.Should().BeTrue();
                     });
                 });
             }
@@ -170,6 +163,16 @@ namespace Akka.Cluster.Tests
             {
                 Shutdown(sys2);
             }
+        }
+
+        [Fact]
+        public void A_cluster_must_allow_to_resolve_RemotePathOf_any_actor()
+        {
+            var remotePath = _cluster.RemotePathOf(TestActor);
+
+            TestActor.Path.Address.Host.Should().BeNull();
+            _cluster.RemotePathOf(TestActor).Uid.Should().Be(TestActor.Path.Uid);
+            _cluster.RemotePathOf(TestActor).Address.Should().Be(_selfAddress);
         }
     }
 }

--- a/src/core/Akka.Cluster.Tests/GossipSpec.cs
+++ b/src/core/Akka.Cluster.Tests/GossipSpec.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using Akka.Actor;
 using Akka.TestKit;
 using Xunit;
+using FluentAssertions;
 
 namespace Akka.Cluster.Tests
 {
@@ -31,7 +32,65 @@ namespace Akka.Cluster.Tests
         [Fact]
         public void A_gossip_must_reach_convergence_when_its_empty()
         {
-            Assert.True(Gossip.Empty.Convergence(a1.UniqueAddress));
+            Gossip.Empty.Convergence(a1.UniqueAddress).Should().BeTrue();
+        }
+
+        [Fact]
+        public void A_gossip_must_reach_convergence_for_one_node()
+        {
+            var g1 = new Gossip(ImmutableSortedSet.Create(a1)).Seen(a1.UniqueAddress);
+            g1.Convergence(a1.UniqueAddress).Should().BeTrue();
+        }
+
+        [Fact]
+        public void A_gossip_must_not_reach_convergence_until_all_have_seen_version()
+        {
+            var g1 = new Gossip(ImmutableSortedSet.Create(a1, b1)).Seen(a1.UniqueAddress);
+            g1.Convergence(a1.UniqueAddress).Should().BeFalse();
+        }
+
+        [Fact]
+        public void A_gossip_must_not_reach_reach_convergence_for_two_nodes()
+        {
+            var g1 = new Gossip(ImmutableSortedSet.Create(a1, b1)).Seen(a1.UniqueAddress).Seen(b1.UniqueAddress);
+            g1.Convergence(a1.UniqueAddress).Should().BeTrue();
+        }
+
+        [Fact]
+        public void A_gossip_must_reach_convergence_skipping_joining()
+        {
+            // e1 is joining
+            var g1 = new Gossip(ImmutableSortedSet.Create(a1, b1, e1)).Seen(a1.UniqueAddress).Seen(b1.UniqueAddress);
+            g1.Convergence(a1.UniqueAddress).Should().BeTrue();
+        }
+
+        [Fact]
+        public void A_gossip_must_reach_convergence_skipping_down()
+        {
+            // e3 is down
+            var g1 = new Gossip(ImmutableSortedSet.Create(a1, b1, e3)).Seen(a1.UniqueAddress).Seen(b1.UniqueAddress);
+            g1.Convergence(a1.UniqueAddress).Should().BeTrue();
+        }
+
+        [Fact]
+        public void A_gossip_must_not_reach_convergence_when_unreachable()
+        {
+            var r1 = Reachability.Empty.Unreachable(b1.UniqueAddress, a1.UniqueAddress);
+            var g1 = new Gossip(ImmutableSortedSet.Create(a1, b1), new GossipOverview(r1))
+                .Seen(a1.UniqueAddress).Seen(b1.UniqueAddress);
+            g1.Convergence(b1.UniqueAddress).Should().BeFalse();
+            // but from a1's point of view (it knows that itself is not unreachable)
+            g1.Convergence(a1.UniqueAddress).Should().BeTrue();
+        }
+
+        [Fact]
+        public void A_gossip_must_reach_convergence_when_downed_node_has_observed_unreachable()
+        {
+            // e3 is Down
+            var r1 = Reachability.Empty.Unreachable(e3.UniqueAddress, a1.UniqueAddress);
+            var g1 = new Gossip(ImmutableSortedSet.Create(a1, b1, e3), new GossipOverview(r1))
+                .Seen(a1.UniqueAddress).Seen(b1.UniqueAddress).Seen(e3.UniqueAddress);
+            g1.Convergence(b1.UniqueAddress).Should().BeTrue();
         }
 
         [Fact]
@@ -41,32 +100,33 @@ namespace Akka.Cluster.Tests
             var g2 = Gossip.Create(ImmutableSortedSet.Create(a2, c2, e2));
 
             var merged1 = g1.Merge(g2);
-            Assert.Equal(ImmutableSortedSet.Create(a2, c1, e1), merged1.Members);
-            Assert.Equal(new []{MemberStatus.Up, MemberStatus.Leaving, MemberStatus.Up}, merged1.Members.Select(m => m.Status).ToArray());
+            merged1.Members.Should().BeEquivalentTo(ImmutableSortedSet.Create(a2, c1, e1));
+            merged1.Members.Select(c => c.Status).ToImmutableList().Should()
+                .BeEquivalentTo(ImmutableList.Create(MemberStatus.Up, MemberStatus.Leaving, MemberStatus.Up));
 
             var merged2 = g2.Merge(g1);
-            Assert.Equal(ImmutableSortedSet.Create(a2, c1, e1), merged2.Members);
-            Assert.Equal(new []{MemberStatus.Up, MemberStatus.Leaving, MemberStatus.Up}, merged2.Members.Select(m => m.Status).ToArray());
+            merged2.Members.Should().BeEquivalentTo(ImmutableSortedSet.Create(a2, c1, e1));
+            merged2.Members.Select(c => c.Status).ToImmutableList().Should()
+                .BeEquivalentTo(ImmutableList.Create(MemberStatus.Up, MemberStatus.Leaving, MemberStatus.Up));
         }
 
         [Fact]
         public void A_gossip_must_merge_unreachable()
         {
-            var r1 = Reachability.Empty.Unreachable(b1.UniqueAddress, a1.UniqueAddress)
-                .Unreachable(b1.UniqueAddress, c1.UniqueAddress);
+            var r1 = Reachability.Empty.
+                Unreachable(b1.UniqueAddress, a1.UniqueAddress).
+                Unreachable(b1.UniqueAddress, c1.UniqueAddress);
             var g1 = new Gossip(ImmutableSortedSet.Create(a1, b1, c1), new GossipOverview(r1));
             var r2 = Reachability.Empty.Unreachable(a1.UniqueAddress, d1.UniqueAddress);
             var g2 = new Gossip(ImmutableSortedSet.Create(a1, b1, c1, d1), new GossipOverview(r2));
 
             var merged1 = g1.Merge(g2);
+            merged1.Overview.Reachability.AllUnreachable.Should()
+                .BeEquivalentTo(ImmutableHashSet.Create(a1.UniqueAddress, c1.UniqueAddress, d1.UniqueAddress));
             
-            XAssert.Equivalent(ImmutableHashSet.Create(a1.UniqueAddress, c1.UniqueAddress, d1.UniqueAddress),
-                merged1.Overview.Reachability.AllUnreachable);
-
             var merged2 = g2.Merge(g1);
-            XAssert.Equivalent(merged1.Overview.Reachability.AllUnreachable,
-                merged2.Overview.Reachability.AllUnreachable
-                );
+            merged2.Overview.Reachability.AllUnreachable.Should()
+                .BeEquivalentTo(merged1.Overview.Reachability.AllUnreachable);
         }
 
         [Fact]
@@ -79,47 +139,46 @@ namespace Akka.Cluster.Tests
             var g2 = new Gossip(ImmutableSortedSet.Create(a1, b1, c3), new GossipOverview(r2));
 
             var merged1 = g1.Merge(g2);
-            Assert.Equal(ImmutableHashSet.Create(a1, b1), merged1.Members);
-            Assert.Equal(ImmutableHashSet.Create(a1.UniqueAddress), merged1.Overview.Reachability.AllUnreachable);
-
+            merged1.Members.Should().BeEquivalentTo(ImmutableHashSet.Create(a1, b1));
+            merged1.Overview.Reachability.AllUnreachable.Should()
+                .BeEquivalentTo(ImmutableHashSet.Create(a1.UniqueAddress));
 
             var merged2 = g2.Merge(g1);
-            Assert.Equal(merged2.Overview.Reachability.AllUnreachable, merged1.Overview.Reachability.AllUnreachable);
-            Assert.Equal(merged1.Members, merged2.Members);
+            merged2.Overview.Reachability.AllUnreachable.Should()
+                .BeEquivalentTo(merged1.Overview.Reachability.AllUnreachable);
+            merged2.Members.Should().BeEquivalentTo(merged1.Members);
         }
 
         [Fact]
         public void A_gossip_must_have_leader_as_first_member_based_on_ordering_except_exiting_status()
         {
-            Assert.Equal(c2.UniqueAddress, new Gossip(ImmutableSortedSet.Create(c2, e2)).Leader(c2.UniqueAddress));
-            Assert.Equal(e2.UniqueAddress, new Gossip(ImmutableSortedSet.Create(c3, e2)).Leader(e2.UniqueAddress));
-            Assert.Equal(c3.UniqueAddress, new Gossip(ImmutableSortedSet.Create(c3)).Leader(c3.UniqueAddress));
+            new Gossip(ImmutableSortedSet.Create(c2, e2)).Leader(c2.UniqueAddress).Should().Be(c2.UniqueAddress);
+            new Gossip(ImmutableSortedSet.Create(c3, e2)).Leader(c3.UniqueAddress).Should().Be(e2.UniqueAddress);
+            new Gossip(ImmutableSortedSet.Create(c3)).Leader(c3.UniqueAddress).Should().Be(c3.UniqueAddress);
         }
 
         [Fact]
         public void A_gossip_must_merge_seen_table_correctly()
         {
             var vclockNode = VectorClock.Node.Create("something");
-            var g1 =
-                new Gossip(ImmutableSortedSet.Create(a1, b1, c1, d1)).Increment(vclockNode)
+            var g1 = new Gossip(ImmutableSortedSet.Create(a1, b1, c1, d1)).Increment(vclockNode)
                     .Seen(a1.UniqueAddress)
                     .Seen(b1.UniqueAddress);
-            var g2 =
-                new Gossip(ImmutableSortedSet.Create(a1, b1, c1, d1)).Increment(vclockNode)
+            var g2 = new Gossip(ImmutableSortedSet.Create(a1, b1, c1, d1)).Increment(vclockNode)
                     .Seen(a1.UniqueAddress)
                     .Seen(c1.UniqueAddress);
             var g3 = g1.Copy(version: g2.Version).Seen(d1.UniqueAddress);
 
-            Action<Gossip> checkMerge = (m) =>
+            Action<Gossip> checkMerge = merged =>
             {
-                var seen = m.Overview.Seen;
-                Assert.Equal(0, seen.Count());
+                var seen = merged.Overview.Seen;
+                seen.Count.Should().Be(0);
 
-                Assert.False(m.SeenByNode(a1.UniqueAddress));
-                Assert.False(m.SeenByNode(b1.UniqueAddress));
-                Assert.False(m.SeenByNode(c1.UniqueAddress));
-                Assert.False(m.SeenByNode(d1.UniqueAddress));
-                Assert.False(m.SeenByNode(e1.UniqueAddress));
+                merged.SeenByNode(a1.UniqueAddress).Should().BeFalse();
+                merged.SeenByNode(b1.UniqueAddress).Should().BeFalse();
+                merged.SeenByNode(c1.UniqueAddress).Should().BeFalse();
+                merged.SeenByNode(d1.UniqueAddress).Should().BeFalse();
+                merged.SeenByNode(e1.UniqueAddress).Should().BeFalse();
             };
 
             checkMerge(g3.Merge(g2));
@@ -132,12 +191,12 @@ namespace Akka.Cluster.Tests
             // a2 and e1 is Joining
             var g1 = new Gossip(ImmutableSortedSet.Create(a2, b1.CopyUp(3), e1),
                 new GossipOverview(Reachability.Empty.Unreachable(a2.UniqueAddress, e1.UniqueAddress)));
-            Assert.Equal(b1, g1.YoungestMember);
+            g1.YoungestMember.Should().Be(b1);
             var g2 = new Gossip(ImmutableSortedSet.Create(a2, b1.CopyUp(3), e1),
                 new GossipOverview(Reachability.Empty.Unreachable(a2.UniqueAddress, b1.UniqueAddress).Unreachable(a2.UniqueAddress, e1.UniqueAddress)));
-            Assert.Equal(b1, g2.YoungestMember);
+            g2.YoungestMember.Should().Be(b1);
             var g3 = new Gossip(ImmutableSortedSet.Create(a2, b1.CopyUp(3), e2.CopyUp(4)));
-            Assert.Equal(e2, g3.YoungestMember);
+            g3.YoungestMember.Should().Be(e2);
         }
     }
 }

--- a/src/core/Akka.Cluster.Tests/MemberOrderingSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MemberOrderingSpec.cs
@@ -10,6 +10,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Akka.Actor;
 using System;
+using FluentAssertions;
 using Xunit;
 
 namespace Akka.Cluster.Tests
@@ -19,26 +20,24 @@ namespace Akka.Cluster.Tests
         [Fact]
         public void MemberOrdering_must_order_members_by_host_and_port()
         {
-            var sortedSet = new SortedSet<Member>         
+            var members = new SortedSet<Member>         
             {
                 TestMember.Create(Address.Parse("akka://sys@darkstar:1112"), MemberStatus.Up),
                 TestMember.Create(Address.Parse("akka://sys@darkstar:1113"), MemberStatus.Joining),
                 TestMember.Create(Address.Parse("akka://sys@darkstar:1111"), MemberStatus.Up),
             };;
 
-            var expected = new List<Member>
-            {
-                TestMember.Create(Address.Parse("akka://sys@darkstar:1111"), MemberStatus.Up),
-                TestMember.Create(Address.Parse("akka://sys@darkstar:1112"), MemberStatus.Up),
-                TestMember.Create(Address.Parse("akka://sys@darkstar:1113"), MemberStatus.Joining),
-            };
-
-            Assert.Equal(expected, sortedSet.ToList());
+            var seq = members.ToList();
+            seq.Count.Should().Be(3);
+            seq[0].Should().Be(TestMember.Create(Address.Parse("akka://sys@darkstar:1111"), MemberStatus.Up));
+            seq[1].Should().Be(TestMember.Create(Address.Parse("akka://sys@darkstar:1112"), MemberStatus.Up));
+            seq[2].Should().Be(TestMember.Create(Address.Parse("akka://sys@darkstar:1113"), MemberStatus.Joining));
         }
 
         [Fact]
         public void MemberOrdering_must_be_sorted_by_address_correctly()
         {
+            // sorting should be done on host and port, only
             var m1 = TestMember.Create(new Address("akka.tcp", "sys1", "host1", 9000), MemberStatus.Up);
             var m2 = TestMember.Create(new Address("akka.tcp", "sys1", "host1", 10000), MemberStatus.Up);
             var m3 = TestMember.Create(new Address("cluster", "sys2", "host2", 8000), MemberStatus.Up);
@@ -46,12 +45,9 @@ namespace Akka.Cluster.Tests
             var m5 = TestMember.Create(new Address("cluster", "sys1", "host2", 10000), MemberStatus.Up);
 
             var expected = new List<Member> { m1, m2, m3, m4, m5 };
-
-            var shuffled = expected.Shuffle();
-            Assert.Equal(expected, new SortedSet<Member>(shuffled));
-
-            shuffled.Sort();
-            Assert.Equal(expected, shuffled);
+            var shuffled = expected.Shuffle().ToImmutableList();
+            new SortedSet<Member>(shuffled).Should().BeEquivalentTo(expected);
+            shuffled.Sort().Should().BeEquivalentTo(expected);
         }
 
         [Fact]
@@ -59,18 +55,23 @@ namespace Akka.Cluster.Tests
         {
             var address = new Address("akka.tcp", "sys1", "host1", 9000);
             var m1 = TestMember.Create(address, MemberStatus.Joining);
-            var m11 = Member.Create(new UniqueAddress(address, -3), ImmutableHashSet.Create<string>());
+            var m11 = Member.Create(new UniqueAddress(address, -3), ImmutableHashSet<string>.Empty);
             var m2 = m1.Copy(status: MemberStatus.Up);
             var m22 = m11.Copy(status: MemberStatus.Up);
             var m3 = TestMember.Create(address.WithPort(10000), MemberStatus.Up);
 
-            Assert.Equal(m1, m2);
-            Assert.Equal(m1.GetHashCode(), m2.GetHashCode());
-            Assert.NotEqual(m3, m2);
-            Assert.NotEqual(m3, m1);
-            Assert.Equal(m11, m22);
-            Assert.NotEqual(m1, m11);
-            Assert.NotEqual(m2, m22);
+            m1.Should().Be(m2);
+            m1.GetHashCode().Should().Be(m2.GetHashCode());
+
+            m3.Should().NotBe(m2);
+            m3.Should().NotBe(m1);
+
+            m11.Should().Be(m22);
+            m11.GetHashCode().Should().Be(m22.GetHashCode());
+
+            // different uid
+            m1.Should().NotBe(m11);
+            m2.Should().NotBe(m22);
         }
 
         [Fact]
@@ -82,14 +83,14 @@ namespace Akka.Cluster.Tests
             var x = TestMember.Create(address1, MemberStatus.Exiting);
             var y = TestMember.Create(address1, MemberStatus.Removed);
             var z = TestMember.Create(address2, MemberStatus.Up);
-            Assert.Equal(0, Member.Ordering.Compare(x,y));
-            Assert.Equal(Member.Ordering.Compare(y, z), Member.Ordering.Compare(x, z));
+            Member.Ordering.Compare(x, y).Should().Be(0);
+            Member.Ordering.Compare(x, z).Should().Be(Member.Ordering.Compare(y, z));
 
             //different uid
             var a = TestMember.Create(address1, MemberStatus.Joining);
-            var b = Member.Create(new UniqueAddress(address1, -3), ImmutableHashSet.Create<string>());
-            Assert.Equal(1, Member.Ordering.Compare(a, b));
-            Assert.Equal(-1, Member.Ordering.Compare(b, a));
+            var b = Member.Create(new UniqueAddress(address1, -3), ImmutableHashSet<string>.Empty);
+            Member.Ordering.Compare(a, b).Should().Be(1);
+            Member.Ordering.Compare(b, a).Should().Be(-1);
         }
 
         [Fact]
@@ -99,39 +100,31 @@ namespace Akka.Cluster.Tests
             var address2 = address1.WithPort(9002);
             var address3 = address1.WithPort(9003);
 
-            var set = new SortedSet<Member>
-            {
-                TestMember.Create(address1, MemberStatus.Joining)
-            };
-            set.Remove(TestMember.Create(address1, MemberStatus.Up));
-            Assert.Equal(new SortedSet<Member>(), set);
+            ImmutableSortedSet
+                .Create(TestMember.Create(address1, MemberStatus.Joining))
+                .Remove(TestMember.Create(address1, MemberStatus.Up))
+                .Should().BeEmpty();
 
-            set = new SortedSet<Member>
-            {
-                TestMember.Create(address1, MemberStatus.Exiting)
-            };
-            set.Remove(TestMember.Create(address1, MemberStatus.Removed));
-            Assert.Equal(new SortedSet<Member>(), set);
+            ImmutableSortedSet
+                .Create(TestMember.Create(address1, MemberStatus.Exiting))
+                .Remove(TestMember.Create(address1, MemberStatus.Removed))
+                .Should().BeEmpty();
 
-            set = new SortedSet<Member>
-            {
-                TestMember.Create(address1, MemberStatus.Up)
-            };
-            set.Remove(TestMember.Create(address1, MemberStatus.Exiting));
-            Assert.Equal(new SortedSet<Member>(), set);
+            ImmutableSortedSet
+                .Create(TestMember.Create(address1, MemberStatus.Up))
+                .Remove(TestMember.Create(address1, MemberStatus.Exiting))
+                .Should().BeEmpty();
 
-            set = new SortedSet<Member>
-            {
-                TestMember.Create(address2, MemberStatus.Up),
-                TestMember.Create(address3, MemberStatus.Joining),
-                TestMember.Create(address3, MemberStatus.Exiting)
-            };
-            set.Remove(TestMember.Create(address1, MemberStatus.Removed));
-            Assert.Equal(new SortedSet<Member>
-            {
-                TestMember.Create(address2, MemberStatus.Up),
-                TestMember.Create(address3, MemberStatus.Joining)                
-            }, set);
+            ImmutableSortedSet
+                .Create(
+                    TestMember.Create(address2, MemberStatus.Up),
+                    TestMember.Create(address3, MemberStatus.Joining),
+                    TestMember.Create(address1, MemberStatus.Exiting))
+                .Remove(
+                    TestMember.Create(address1, MemberStatus.Removed))
+                .Should().BeEquivalentTo(
+                    TestMember.Create(address2, MemberStatus.Up),
+                    TestMember.Create(address3, MemberStatus.Joining));
         }
 
         [Fact]
@@ -146,11 +139,11 @@ namespace Akka.Cluster.Tests
             };
 
             var seq = addresses.ToList();
-            Assert.Equal(4, seq.Count);
-            Assert.Equal(Address.Parse("akka://sys@darkstar:1110"), seq[0]);
-            Assert.Equal(Address.Parse("akka://sys@darkstar:1111"), seq[1]);
-            Assert.Equal(Address.Parse("akka://sys@darkstar:1112"), seq[2]);
-            Assert.Equal(Address.Parse("akka://sys@darkstar:1113"), seq[3]);
+            seq.Count.Should().Be(4);
+            seq[0].Should().Be(Address.Parse("akka://sys@darkstar:1110"));
+            seq[1].Should().Be(Address.Parse("akka://sys@darkstar:1111"));
+            seq[2].Should().Be(Address.Parse("akka://sys@darkstar:1112"));
+            seq[3].Should().Be(Address.Parse("akka://sys@darkstar:1113"));
         }
 
         [Fact]
@@ -165,11 +158,11 @@ namespace Akka.Cluster.Tests
             };
 
             var seq = addresses.ToList();
-            Assert.Equal(4, seq.Count);
-            Assert.Equal(Address.Parse("akka://sys@darkstar0:1110"), seq[0]);
-            Assert.Equal(Address.Parse("akka://sys@darkstar1:1110"), seq[1]);
-            Assert.Equal(Address.Parse("akka://sys@darkstar2:1110"), seq[2]);
-            Assert.Equal(Address.Parse("akka://sys@darkstar3:1110"), seq[3]);
+            seq.Count.Should().Be(4);
+            seq[0].Should().Be(Address.Parse("akka://sys@darkstar0:1110"));
+            seq[1].Should().Be(Address.Parse("akka://sys@darkstar1:1110"));
+            seq[2].Should().Be(Address.Parse("akka://sys@darkstar2:1110"));
+            seq[3].Should().Be(Address.Parse("akka://sys@darkstar3:1110"));
         }
 
         [Fact]
@@ -184,13 +177,12 @@ namespace Akka.Cluster.Tests
             };
 
             var seq = addresses.ToList();
-            Assert.Equal(4, seq.Count);
-            Assert.Equal(Address.Parse("akka://sys@darkstar0:1110"), seq[0]);
-            Assert.Equal(Address.Parse("akka://sys@darkstar0:1111"), seq[1]);
-            Assert.Equal(Address.Parse("akka://sys@darkstar2:1110"), seq[2]);
-            Assert.Equal(Address.Parse("akka://sys@darkstar2:1111"), seq[3]);
+            seq.Count.Should().Be(4);
+            seq[0].Should().Be(Address.Parse("akka://sys@darkstar0:1110"));
+            seq[1].Should().Be(Address.Parse("akka://sys@darkstar0:1111"));
+            seq[2].Should().Be(Address.Parse("akka://sys@darkstar2:1110"));
+            seq[3].Should().Be(Address.Parse("akka://sys@darkstar2:1111"));
         }
-
 
         [Fact]
         public void LeaderOrdering_must_order_members_with_status_joining_exiting_down_last()
@@ -206,9 +198,8 @@ namespace Akka.Cluster.Tests
             var m8 = TestMember.Create(address.WithPort(9000), MemberStatus.Up);
 
             var expected = new List<Member> {m7, m8, m1, m2, m3, m4, m5, m6};
-            var shuffled = expected.Shuffle();
-            shuffled.Sort(Member.LeaderStatusOrdering);
-            Assert.Equal(expected, shuffled);
+            var shuffled = expected.Shuffle().ToImmutableList();
+            shuffled.Sort(Member.LeaderStatusOrdering).Should().BeEquivalentTo(expected);
         }
     }
 

--- a/src/core/Akka.Cluster.Tests/ReachabilitySpec.cs
+++ b/src/core/Akka.Cluster.Tests/ReachabilitySpec.cs
@@ -7,7 +7,6 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using Akka.Actor;
 using FluentAssertions;
 using Xunit;
@@ -26,8 +25,8 @@ namespace Akka.Cluster.Tests
         public void ReachabilityTable_must_be_reachable_when_empty()
         {
             var r = Reachability.Empty;
-            Assert.True(r.IsReachable(nodeA));
-            Assert.Equal(ImmutableHashSet.Create<UniqueAddress>(), r.AllUnreachable);
+            r.IsReachable(nodeA).Should().BeTrue();
+            r.AllUnreachable.Should().BeEquivalentTo(ImmutableHashSet.Create<UniqueAddress>());
         }
 
         [Fact]
@@ -42,41 +41,56 @@ namespace Akka.Cluster.Tests
         public void ReachabilityTable_must_not_be_reachable_when_terminated()
         {
             var r = Reachability.Empty.Terminated(nodeB, nodeA);
-            Assert.False(r.IsReachable(nodeA));
+            r.IsReachable(nodeA).Should().BeFalse();
             // allUnreachable doesn't include terminated
-            Assert.Equal(ImmutableHashSet.Create<UniqueAddress>(), r.AllUnreachable);
-            Assert.Equal(ImmutableHashSet.Create(nodeA), r.AllUnreachableOrTerminated);
+            r.AllUnreachable.Should().BeEquivalentTo(ImmutableHashSet.Create<UniqueAddress>());
+            r.AllUnreachableOrTerminated.Should().BeEquivalentTo(ImmutableHashSet.Create(nodeA));
         }
 
         [Fact]
         public void ReachabilityTable_must_not_change_terminated_entry()
         {
             var r = Reachability.Empty.Terminated(nodeB, nodeA);
-            Assert.True(r == r.Reachable(nodeB, nodeA));
-            Assert.True(r == r.Unreachable(nodeB, nodeA));
+            r.Reachable(nodeB, nodeA).Should().BeSameAs(r);
+            r.Unreachable(nodeB, nodeA).Should().BeSameAs(r);
         }
 
         [Fact]
         public void ReachabilityTable_must_not_change_when_same_status()
         {
             var r = Reachability.Empty.Unreachable(nodeB, nodeA);
-            Assert.True(r == r.Unreachable(nodeB, nodeA));
+            r.Unreachable(nodeB, nodeA).Should().BeSameAs(r);
         }
 
         [Fact]
         public void ReachabilityTable_must_be_unreachable_when_some_observed_unreachable_and_other_reachable()
         {
             var r = Reachability.Empty.Unreachable(nodeB, nodeA).Unreachable(nodeC, nodeA).Reachable(nodeD, nodeA);
-            Assert.False(r.IsReachable(nodeA));
+            r.IsReachable(nodeA).Should().BeFalse();
         }
 
         [Fact]
-        public void ReachabilityTable_must_reachable_when_all_observed_reachable_again()
+        public void ReachabilityTable_must_be_reachable_when_all_observed_reachable_again()
         {
             var r = Reachability.Empty.Unreachable(nodeB, nodeA).Unreachable(nodeC, nodeA).
                 Reachable(nodeB, nodeA).Reachable(nodeC, nodeA).
                 Unreachable(nodeB, nodeC).Unreachable(nodeC, nodeB);
-            Assert.True(r.IsReachable(nodeA));
+            r.IsReachable(nodeA).Should().BeTrue();
+        }
+
+        [Fact]
+        public void ReachabilityTable_must_exclude_observations_from_specific_downed_nodes()
+        {
+            var r = Reachability.Empty.
+                Unreachable(nodeC, nodeA).Reachable(nodeC, nodeA).
+                Unreachable(nodeC, nodeB).
+                Unreachable(nodeB, nodeA).Unreachable(nodeB, nodeC);
+
+            r.IsReachable(nodeA).Should().BeFalse();
+            r.IsReachable(nodeB).Should().BeFalse();
+            r.IsReachable(nodeC).Should().BeFalse();
+            r.AllUnreachableOrTerminated.Should().BeEquivalentTo(ImmutableHashSet.Create(nodeA, nodeB, nodeC));
+            r.RemoveObservers(ImmutableHashSet.Create(nodeB)).AllUnreachableOrTerminated.Should().BeEquivalentTo(ImmutableHashSet.Create(nodeB));
         }
 
         [Fact]
@@ -86,22 +100,21 @@ namespace Akka.Cluster.Tests
                 Unreachable(nodeB, nodeA).Unreachable(nodeB, nodeC).
                 Unreachable(nodeD, nodeC).
                 Reachable(nodeB, nodeA).Reachable(nodeB, nodeC);
-            Assert.True(r.IsReachable(nodeA));
-            Assert.False(r.IsReachable(nodeC));
-            var expected1 = ImmutableList.Create(new Reachability.Record(
-                nodeD,
-                nodeC,
-                Reachability.ReachabilityStatus.Unreachable,
-                1));
-            Assert.Equal(expected1, r.Records);
+
+            r.IsReachable(nodeA).Should().BeTrue();
+            r.IsReachable(nodeC).Should().BeFalse();
+
+            var expected1 = ImmutableList.Create(
+                new Reachability.Record(nodeD, nodeC, Reachability.ReachabilityStatus.Unreachable, 1));
+            r.Records.Should().BeEquivalentTo(expected1);
 
             var r2 = r.Unreachable(nodeB, nodeD).Unreachable(nodeB, nodeE);
             var expected2 = ImmutableHashSet.Create(
                 new Reachability.Record(nodeD, nodeC, Reachability.ReachabilityStatus.Unreachable, 1),
                 new Reachability.Record(nodeB, nodeD, Reachability.ReachabilityStatus.Unreachable, 5),
-                new Reachability.Record(nodeB, nodeE, Reachability.ReachabilityStatus.Unreachable, 6)
-                );
-            Assert.Equal(expected2, r2.Records.ToImmutableHashSet());
+                new Reachability.Record(nodeB, nodeE, Reachability.ReachabilityStatus.Unreachable, 6));
+
+            r2.Records.ToImmutableHashSet().Should().BeEquivalentTo(expected2);
         }
 
         [Fact]
@@ -111,8 +124,8 @@ namespace Akka.Cluster.Tests
                 new Reachability.Record(nodeA, nodeB, Reachability.ReachabilityStatus.Reachable, 2),
                 new Reachability.Record(nodeC, nodeB, Reachability.ReachabilityStatus.Unreachable, 2),
                 new Reachability.Record(nodeA, nodeD, Reachability.ReachabilityStatus.Unreachable, 3),
-                new Reachability.Record(nodeD, nodeB, Reachability.ReachabilityStatus.Terminated, 4)
-                );
+                new Reachability.Record(nodeD, nodeB, Reachability.ReachabilityStatus.Terminated, 4));
+
             var versions = ImmutableDictionary.CreateRange(new[]
             {
                 new KeyValuePair<UniqueAddress, long>(nodeA, 3),
@@ -120,9 +133,9 @@ namespace Akka.Cluster.Tests
                 new KeyValuePair<UniqueAddress, long>(nodeD, 4)
             });
             var r = new Reachability(records, versions);
-            Assert.Equal(Reachability.ReachabilityStatus.Reachable, r.Status(nodeA));
-            Assert.Equal(Reachability.ReachabilityStatus.Terminated, r.Status(nodeB));
-            Assert.Equal(Reachability.ReachabilityStatus.Unreachable, r.Status(nodeD));
+            r.Status(nodeA).Should().Be(Reachability.ReachabilityStatus.Reachable);
+            r.Status(nodeB).Should().Be(Reachability.ReachabilityStatus.Terminated);
+            r.Status(nodeD).Should().Be(Reachability.ReachabilityStatus.Unreachable);
         }
 
         [Fact]
@@ -135,27 +148,27 @@ namespace Akka.Cluster.Tests
                 Reachable(nodeE, nodeD).
                 Unreachable(nodeA, nodeE).Terminated(nodeB, nodeE);
 
-            Assert.Equal(Reachability.ReachabilityStatus.Unreachable, r.Status(nodeB, nodeA));
-            Assert.Equal(Reachability.ReachabilityStatus.Unreachable, r.Status(nodeC, nodeA));
-            Assert.Equal(Reachability.ReachabilityStatus.Unreachable, r.Status(nodeD, nodeA));
+            r.Status(nodeB, nodeA).Should().Be(Reachability.ReachabilityStatus.Unreachable);
+            r.Status(nodeC, nodeA).Should().Be(Reachability.ReachabilityStatus.Unreachable);
+            r.Status(nodeD, nodeA).Should().Be(Reachability.ReachabilityStatus.Unreachable);
 
-            Assert.Equal(Reachability.ReachabilityStatus.Reachable, r.Status(nodeC, nodeB));
-            Assert.Equal(Reachability.ReachabilityStatus.Unreachable, r.Status(nodeD, nodeB));
+            r.Status(nodeC, nodeB).Should().Be(Reachability.ReachabilityStatus.Reachable);
+            r.Status(nodeD, nodeB).Should().Be(Reachability.ReachabilityStatus.Unreachable);
 
-            Assert.Equal(Reachability.ReachabilityStatus.Unreachable, r.Status(nodeA, nodeE));
-            Assert.Equal(Reachability.ReachabilityStatus.Terminated, r.Status(nodeB, nodeE));
+            r.Status(nodeA, nodeE).Should().Be(Reachability.ReachabilityStatus.Unreachable);
+            r.Status(nodeB, nodeE).Should().Be(Reachability.ReachabilityStatus.Terminated);
 
-            Assert.False(r.IsReachable(nodeA));
-            Assert.False(r.IsReachable(nodeB));
-            Assert.True(r.IsReachable(nodeC));
-            Assert.True(r.IsReachable(nodeD));
-            Assert.False(r.IsReachable(nodeE));
+            r.IsReachable(nodeA).Should().BeFalse();
+            r.IsReachable(nodeB).Should().BeFalse();
+            r.IsReachable(nodeC).Should().BeTrue();
+            r.IsReachable(nodeD).Should().BeTrue();
+            r.IsReachable(nodeE).Should().BeFalse();
 
-            Assert.Equal(ImmutableHashSet.Create(nodeA, nodeB), r.AllUnreachable);
-            Assert.Equal(ImmutableHashSet.Create(nodeE), r.AllUnreachableFrom(nodeA));
-            Assert.Equal(ImmutableHashSet.Create(nodeA), r.AllUnreachableFrom(nodeB));
-            Assert.Equal(ImmutableHashSet.Create(nodeA), r.AllUnreachableFrom(nodeC));
-            Assert.Equal(ImmutableHashSet.Create(nodeA, nodeB), r.AllUnreachableFrom(nodeD));
+            r.AllUnreachable.Should().BeEquivalentTo(ImmutableHashSet.Create(nodeA, nodeB));
+            r.AllUnreachableFrom(nodeA).Should().BeEquivalentTo(ImmutableHashSet.Create(nodeE));
+            r.AllUnreachableFrom(nodeB).Should().BeEquivalentTo(ImmutableHashSet.Create(nodeA));
+            r.AllUnreachableFrom(nodeC).Should().BeEquivalentTo(ImmutableHashSet.Create(nodeA));
+            r.AllUnreachableFrom(nodeD).Should().BeEquivalentTo(ImmutableHashSet.Create(nodeA, nodeB));
 
             var expected = new Dictionary<UniqueAddress, ImmutableHashSet<UniqueAddress>>
             {
@@ -164,14 +177,31 @@ namespace Akka.Cluster.Tests
                 {nodeE, ImmutableHashSet.Create(nodeA)}
             }.ToImmutableDictionary();
 
-            r.ObserversGroupedByUnreachable
-                .Should()
-                .HaveCount(3);
+            r.ObserversGroupedByUnreachable.Should().HaveCount(3);
+            r.ObserversGroupedByUnreachable[nodeA].Should().BeEquivalentTo(expected[nodeA]);
+            r.ObserversGroupedByUnreachable[nodeB].Should().BeEquivalentTo(expected[nodeB]);
+            r.ObserversGroupedByUnreachable[nodeE].Should().BeEquivalentTo(expected[nodeE]);
+        }
 
-            foreach (var pair in r.ObserversGroupedByUnreachable)
-            {
-                pair.Value.ShouldBeEquivalentTo(expected[pair.Key]);
-            }
+        [Fact]
+        public void ReachabilityTable_must_merge_by_picking_latest_version_of_each_record()
+        {
+            var r1 = Reachability.Empty.Unreachable(nodeB, nodeA).Unreachable(nodeC, nodeD);
+            var r2 = r1.Reachable(nodeB, nodeA).Unreachable(nodeD, nodeE).Unreachable(nodeC, nodeA);
+            var merged = r1.Merge(ImmutableHashSet.Create(nodeA, nodeB, nodeC, nodeD, nodeE), r2);
+
+            merged.Status(nodeB, nodeA).Should().Be(Reachability.ReachabilityStatus.Reachable);
+            merged.Status(nodeC, nodeA).Should().Be(Reachability.ReachabilityStatus.Unreachable);
+            merged.Status(nodeC, nodeD).Should().Be(Reachability.ReachabilityStatus.Unreachable);
+            merged.Status(nodeD, nodeE).Should().Be(Reachability.ReachabilityStatus.Unreachable);
+            merged.Status(nodeE, nodeA).Should().Be(Reachability.ReachabilityStatus.Reachable);
+
+            merged.IsReachable(nodeA).Should().BeFalse();
+            merged.IsReachable(nodeD).Should().BeFalse();
+            merged.IsReachable(nodeE).Should().BeFalse();
+
+            var merged2 = r2.Merge(ImmutableHashSet.Create(nodeA, nodeB, nodeC, nodeD, nodeE), r1);
+            merged2.Records.ToImmutableHashSet().Should().BeEquivalentTo(merged.Records.ToImmutableHashSet());
         }
 
         [Fact]
@@ -183,21 +213,21 @@ namespace Akka.Cluster.Tests
             var allowed = ImmutableHashSet.Create(nodeA, nodeB, nodeC, nodeE);
             var merged = r1.Merge(allowed, r2);
 
-            Assert.Equal(Reachability.ReachabilityStatus.Reachable, merged.Status(nodeB, nodeA));
-            Assert.Equal(Reachability.ReachabilityStatus.Unreachable, merged.Status(nodeC, nodeA));
-            Assert.Equal(Reachability.ReachabilityStatus.Reachable, merged.Status(nodeC, nodeD));
-            Assert.Equal(Reachability.ReachabilityStatus.Reachable, merged.Status(nodeD, nodeE));
-            Assert.Equal(Reachability.ReachabilityStatus.Reachable, merged.Status(nodeE, nodeA));
+            merged.Status(nodeB, nodeA).Should().Be(Reachability.ReachabilityStatus.Reachable);
+            merged.Status(nodeC, nodeA).Should().Be(Reachability.ReachabilityStatus.Unreachable);
+            merged.Status(nodeC, nodeD).Should().Be(Reachability.ReachabilityStatus.Reachable);
+            merged.Status(nodeD, nodeE).Should().Be(Reachability.ReachabilityStatus.Reachable);
+            merged.Status(nodeE, nodeA).Should().Be(Reachability.ReachabilityStatus.Reachable);
 
-            Assert.False(merged.IsReachable(nodeA));
-            Assert.True(merged.IsReachable(nodeD));
-            Assert.True(merged.IsReachable(nodeE));
+            merged.IsReachable(nodeA).Should().BeFalse();
+            merged.IsReachable(nodeD).Should().BeTrue();
+            merged.IsReachable(nodeE).Should().BeTrue();
 
-            Assert.Equal(ImmutableHashSet.Create(nodeB, nodeC), merged.Versions.Keys.ToImmutableHashSet());
+            merged.Versions.Keys.Should().BeEquivalentTo(ImmutableHashSet.Create(nodeB, nodeC));
 
             var merged2 = r2.Merge(allowed, r1);
-            Assert.Equal(merged.Records.ToImmutableHashSet(), merged2.Records.ToImmutableHashSet());
-            Assert.Equal(merged.Versions, merged2.Versions);
+            merged2.Records.ToImmutableHashSet().Should().BeEquivalentTo(merged.Records.ToImmutableHashSet());
+            merged2.Versions.Should().Equal(merged.Versions);
         }
 
         [Fact]
@@ -208,29 +238,44 @@ namespace Akka.Cluster.Tests
             var r3 = r1.Reachable(nodeB, nodeA); //nodeB pruned
             var merged = r2.Merge(ImmutableHashSet.Create(nodeA, nodeB, nodeC, nodeD, nodeE), r3);
 
-            Assert.Equal(ImmutableHashSet.Create(
+            var expected = ImmutableHashSet.Create(
                 new Reachability.Record(nodeA, nodeE, Reachability.ReachabilityStatus.Unreachable, 1),
-                new Reachability.Record(nodeC, nodeD, Reachability.ReachabilityStatus.Unreachable, 1))
-                , merged.Records.ToImmutableHashSet());
+                new Reachability.Record(nodeC, nodeD, Reachability.ReachabilityStatus.Unreachable, 1));
+            merged.Records.ToImmutableHashSet().Should().BeEquivalentTo(expected);
 
             var merged3 = r3.Merge(ImmutableHashSet.Create(nodeA, nodeB, nodeC, nodeD, nodeE), r2);
-            Assert.Equal(merged.Records.ToImmutableHashSet(), merged3.Records.ToImmutableHashSet());
+            merged3.Records.ToImmutableHashSet().Should().BeEquivalentTo(merged.Records.ToImmutableHashSet());
         }
 
         [Fact]
         public void ReachabilityTable_must_merge_versions_correctly()
         {
-            var r1 = new Reachability(ImmutableList.Create<Reachability.Record>(),
-                new Dictionary<UniqueAddress, long> {{nodeA, 3}, {nodeB, 5}, {nodeC, 7}}.ToImmutableDictionary());
-            var r2 = new Reachability(ImmutableList.Create<Reachability.Record>(),
-                new Dictionary<UniqueAddress, long> { { nodeA, 6 }, { nodeB, 2 }, { nodeD, 1 } }.ToImmutableDictionary());
+            var r1 = new Reachability(ImmutableList.Create<Reachability.Record>(), new Dictionary<UniqueAddress, long>
+            {
+                { nodeA, 3 },
+                { nodeB, 5 },
+                { nodeC, 7 }
+            }.ToImmutableDictionary());
+
+            var r2 = new Reachability(ImmutableList.Create<Reachability.Record>(), new Dictionary<UniqueAddress, long>
+            {
+                { nodeA, 6 },
+                { nodeB, 2 },
+                { nodeD, 1 }
+            }.ToImmutableDictionary());
             var merged = r1.Merge(ImmutableHashSet.Create(nodeA, nodeB, nodeC, nodeD, nodeE), r2);
 
-            var expected = new Dictionary<UniqueAddress, long> { { nodeA, 6 }, { nodeB, 5 }, { nodeC, 7 }, { nodeD, 1} }.ToImmutableDictionary();
-            Assert.Equal(expected, merged.Versions);
+            var expected = new Dictionary<UniqueAddress, long>
+            {
+                { nodeA, 6 },
+                { nodeB, 5 },
+                { nodeC, 7 },
+                { nodeD, 1 }
+            }.ToImmutableDictionary();
+            merged.Versions.Should().Equal(expected);
 
             var merged2 = r2.Merge(ImmutableHashSet.Create(nodeA, nodeB, nodeC, nodeD, nodeE), r1);
-            Assert.Equal(expected, merged2.Versions);
+            merged2.Versions.Should().Equal(expected);
         }
 
         [Fact]
@@ -243,11 +288,10 @@ namespace Akka.Cluster.Tests
                 Unreachable(nodeB, nodeE).
                 Remove(ImmutableHashSet.Create(nodeA, nodeB));
 
-            Assert.Equal(Reachability.ReachabilityStatus.Reachable, r.Status(nodeB, nodeA));
-            Assert.Equal(Reachability.ReachabilityStatus.Unreachable, r.Status(nodeC, nodeD));
-            Assert.Equal(Reachability.ReachabilityStatus.Reachable, r.Status(nodeB, nodeC));
-            Assert.Equal(Reachability.ReachabilityStatus.Reachable, r.Status(nodeB, nodeE));
+            r.Status(nodeB, nodeA).Should().Be(Reachability.ReachabilityStatus.Reachable);
+            r.Status(nodeC, nodeD).Should().Be(Reachability.ReachabilityStatus.Unreachable);
+            r.Status(nodeB, nodeC).Should().Be(Reachability.ReachabilityStatus.Reachable);
+            r.Status(nodeB, nodeE).Should().Be(Reachability.ReachabilityStatus.Reachable);
         }
     }
 }
-

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -1211,8 +1211,8 @@ namespace Akka.Cluster
                 var newOverview = localGossip.Overview.Copy(reachability: newReachability);
                 var newGossip = localGossip.Copy(overview: newOverview);
                 UpdateLatestGossip(newGossip);
-                _log.Warning("Cluster Node [{0}] - Marking node as TERMINATED [{1}], due to quarantine",
-                    Self, node.Address);
+                _log.Warning("Cluster Node [{0}] - Marking node as TERMINATED [{1}], due to quarantine. Node roles [{2}]",
+                    Self, node.Address, string.Join(",", _cluster.SelfRoles));
                 Publish(_latestGossip);
                 Downing(node.Address);
             }
@@ -1494,7 +1494,7 @@ namespace Akka.Cluster
                 else
                 {
                     _leaderActionCounter += 1;
-                    if (_leaderActionCounter == firstNotice || _leaderActionCounter%periodicNotice == 0)
+                    if (_leaderActionCounter == firstNotice || _leaderActionCounter % periodicNotice == 0)
                     {
                         _log.Info(
                             "Leader can currently not perform its duties, reachability status: [{0}], member status: [{1}]",
@@ -1674,15 +1674,15 @@ namespace Akka.Cluster
                         var nonExiting = partitioned.Item2;
 
                         if (nonExiting.Any())
-                            _log.Warning("Cluster Node [{0}] - Marking node(s) as UNREACHABLE [{1}]",
-                                _cluster.SelfAddress, nonExiting.Select(m => m.ToString()).Aggregate((a, b) => a + ", " + b));
+                            _log.Warning("Cluster Node [{0}] - Marking node(s) as UNREACHABLE [{1}]. Node roles [{2}]",
+                                _cluster.SelfAddress, nonExiting.Select(m => m.ToString()).Aggregate((a, b) => a + ", " + b), string.Join(",", _cluster.SelfRoles));
 
                         if (exiting.Any())
                             _log.Warning("Marking exiting node(s) as UNREACHABLE [{0}]. This is expected and they will be removed.",
                                 _cluster.SelfAddress, exiting.Select(m => m.ToString()).Aggregate((a, b) => a + ", " + b));
 
                         if (newlyDetectedReachableMembers.Any())
-                            _log.Info("Marking node(s) as REACHABLE [{0}]", newlyDetectedReachableMembers.Select(m => m.ToString()).Aggregate((a, b) => a + ", " + b));
+                            _log.Info("Marking node(s) as REACHABLE [{0}]. Node roles [{1}]", newlyDetectedReachableMembers.Select(m => m.ToString()).Aggregate((a, b) => a + ", " + b), string.Join(",", _cluster.SelfRoles));
 
                         Publish(_latestGossip);
                     }

--- a/src/core/Akka.Cluster/ClusterSettings.cs
+++ b/src/core/Akka.Cluster/ClusterSettings.cs
@@ -68,7 +68,11 @@ namespace Akka.Cluster
             _leaderActionsInterval = cc.GetTimeSpan("leader-actions-interval");
             _unreachableNodesReaperInterval = cc.GetTimeSpan("unreachable-nodes-reaper-interval");
             _publishStatsInterval = cc.GetTimeSpanWithOffSwitch("publish-stats-interval");
-            _downRemovalMargin = cc.GetTimeSpan("down-removal-margin");
+
+            var key = "down-removal-margin";
+            _downRemovalMargin = cc.GetString(key).ToLowerInvariant().Equals("off") 
+                ? TimeSpan.Zero
+                : cc.GetTimeSpan("down-removal-margin");
 
             _autoDownUnreachableAfter = cc.GetTimeSpanWithOffSwitch("auto-down-unreachable-after");
 
@@ -76,7 +80,6 @@ namespace Akka.Cluster
             _minNrOfMembers = cc.GetInt("min-nr-of-members");
             //TODO:
             //_minNrOfMembersOfRole = cc.GetConfig("role").Root.GetArray().ToImmutableDictionary(o => o. )
-            //TODO: Ignored jmx
             _useDispatcher = cc.GetString("use-dispatcher");
             if (String.IsNullOrEmpty(_useDispatcher)) _useDispatcher = Dispatchers.DefaultDispatcherId;
             _gossipDifferentViewProbability = cc.GetDouble("gossip-different-view-probability");

--- a/src/core/Akka.Cluster/Configuration/Cluster.conf
+++ b/src/core/Akka.Cluster/Configuration/Cluster.conf
@@ -29,11 +29,16 @@ akka {
     # Disable with "off" or specify a duration to enable auto-down.
     auto-down-unreachable-after = off
 	
-    # Margin until shards or singletons that belonged to a downed/removed
+    # Time margin after which shards or singletons that belonged to a downed/removed
     # partition are created in surviving partition. The purpose of this margin is that 
     # in case of a network partition the persistent actors in the non-surviving partitions
     # must be stopped before corresponding persistent actors are started somewhere else.
-    down-removal-margin = 20s
+    # This is useful if you implement downing strategies that handle network partitions,
+    # e.g. by keeping the larger side of the partition and shutting down the smaller side.
+    # It will not add any extra safety for auto-down-unreachable-after, since that is not
+    # handling network partitions. 
+    # Disable with "off" or specify a duration to enable.
+    down-removal-margin = off
         
     # The roles of this member. List of strings, e.g. roles = ["A", "B"].
     # The roles are part of the membership information and can be used by
@@ -60,9 +65,6 @@ akka {
 
     # Enable/disable info level logging of cluster events
     log-info = on
-
-    # Enable or disable JMX MBeans for management of the cluster
-    jmx.enabled = on
 
     # how long should the node wait before starting the periodic tasks
     # maintenance tasks?
@@ -109,7 +111,7 @@ akka {
       # It must implement akka.remote.FailureDetector and have
       # a public constructor with a com.typesafe.config.Config and
       # akka.actor.EventStream parameter.
-      implementation-class = "Akka.Remote.PhiAccrualFailureDetector,Akka.Remote"
+      implementation-class = "Akka.Remote.PhiAccrualFailureDetector, Akka.Remote"
 
       # How often keep-alive heartbeat messages should be sent to each connection.
       heartbeat-interval = 1 s
@@ -145,7 +147,7 @@ akka {
       # After the heartbeat request has been sent the first failure detection
       # will start after this period, even though no heartbeat mesage has
       # been received.
-      expected-response-after = 5 s
+      expected-response-after = 1 s
 
     }
 

--- a/src/core/Akka.Cluster/Reachability.cs
+++ b/src/core/Akka.Cluster/Reachability.cs
@@ -268,11 +268,38 @@ namespace Akka.Cluster
 
         public Reachability Remove(IEnumerable<UniqueAddress> nodes)
         {
-            var newRecords = _records.FindAll(r => !nodes.Contains(r.Observer) && !nodes.Contains(r.Subject));
-            if (newRecords.Count == _records.Count) return this;
- 
-            var newVersions = _versions.RemoveRange(nodes);
-            return new Reachability(newRecords, newVersions);
+            var nodesSet = nodes.ToImmutableHashSet();
+            var newRecords = _records.FindAll(r => !nodesSet.Contains(r.Observer) && !nodesSet.Contains(r.Subject));
+            if (newRecords.Count == _records.Count)
+            {
+                return this;
+            }
+            else
+            {
+                var newVersions = _versions.RemoveRange(nodes);
+                return new Reachability(newRecords, newVersions);
+            }
+        }
+
+        public Reachability RemoveObservers(ImmutableHashSet<UniqueAddress> nodes)
+        {
+            if (nodes.Count == 0)
+            {
+                return this;
+            }
+            else
+            {
+                var newRecords = _records.FindAll(r => !nodes.Contains(r.Observer));
+                if (newRecords.Count == _records.Count)
+                {
+                    return this;
+                }
+                else
+                {
+                    var newVersions = _versions.RemoveRange(nodes);
+                    return new Reachability(newRecords, newVersions);
+                }
+            }
         }
 
         public ReachabilityStatus Status(UniqueAddress observer, UniqueAddress subject)

--- a/src/core/Akka.Cluster/Routing/ClusterRoutingConfig.cs
+++ b/src/core/Akka.Cluster/Routing/ClusterRoutingConfig.cs
@@ -25,7 +25,7 @@ namespace Akka.Cluster.Routing
         {
         }
 
-        public ClusterRouterGroupSettings(int totalInstances, bool allowLocalRoutees, string useRole, ImmutableHashSet<string> routeesPaths) : base(totalInstances, allowLocalRoutees, useRole)
+        public ClusterRouterGroupSettings(int totalInstances, bool allowLocalRoutees, string useRole, ImmutableHashSet<string> routeesPaths) : base(totalInstances, allowLocalRoutees, UseRoleOption(useRole))
         {
             RouteesPaths = routeesPaths;
             if(routeesPaths == null || routeesPaths.IsEmpty || string.IsNullOrEmpty(routeesPaths.First())) throw new ArgumentException("routeesPaths must be defined", "routeesPaths");
@@ -45,7 +45,7 @@ namespace Akka.Cluster.Routing
             return new ClusterRouterGroupSettings(
                 GetMaxTotalNrOfInstances(config),
                 config.GetBoolean("cluster.allow-local-routees"),
-                config.GetString("cluster.use-role"),
+                UseRoleOption(config.GetString("cluster.use-role")),
                 ImmutableHashSet.Create(config.GetStringList("routees.paths").ToArray()));
         }
     }
@@ -61,7 +61,7 @@ namespace Akka.Cluster.Routing
         {
         }
 
-        public ClusterRouterPoolSettings(int totalInstances, bool allowLocalRoutees, string useRole, int maxInstancesPerNode) : base(totalInstances, allowLocalRoutees, useRole)
+        public ClusterRouterPoolSettings(int totalInstances, bool allowLocalRoutees, string useRole, int maxInstancesPerNode) : base(totalInstances, allowLocalRoutees, UseRoleOption(useRole))
         {
             MaxInstancesPerNode = maxInstancesPerNode;
             if(MaxInstancesPerNode <= 0) throw new ArgumentOutOfRangeException("maxInstancesPerNode", "maxInstancesPerNode of cluster pool router must be > 0");
@@ -74,7 +74,7 @@ namespace Akka.Cluster.Routing
             return new ClusterRouterPoolSettings(
                 GetMaxTotalNrOfInstances(config),
                 config.GetBoolean("cluster.allow-local-routees"),
-                config.GetString("cluster.use-role"),
+                UseRoleOption(config.GetString("cluster.use-role")),
                 config.GetInt("cluster.max-nr-of-instances-per-node"));
         }
     }
@@ -102,6 +102,14 @@ namespace Akka.Cluster.Routing
         public bool AllowLocalRoutees { get; private set; }
 
         public string UseRole { get; private set; }
+
+        protected static string UseRoleOption(string role)
+        {
+            if (string.IsNullOrEmpty(role))
+                return null;
+
+            return role;
+        }
 
         protected static int GetMaxTotalNrOfInstances(Config config)
         {

--- a/src/core/Akka.Remote.Tests/RemoteConfigSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteConfigSpec.cs
@@ -52,7 +52,7 @@ namespace Akka.Remote.Tests
             Assert.Equal(typeof(HeliosTcpTransport), Type.GetType(remoteSettings.Transports.Head().TransportClass));
             Assert.Equal(typeof(PhiAccrualFailureDetector), Type.GetType(remoteSettings.WatchFailureDetectorImplementationClass));
             Assert.Equal(TimeSpan.FromSeconds(1), remoteSettings.WatchHeartBeatInterval);
-            Assert.Equal(TimeSpan.FromSeconds(3), remoteSettings.WatchHeartbeatExpectedResponseAfter);
+            Assert.Equal(TimeSpan.FromSeconds(1), remoteSettings.WatchHeartbeatExpectedResponseAfter);
             Assert.Equal(TimeSpan.FromSeconds(1), remoteSettings.WatchUnreachableReaperInterval);
             Assert.Equal(10, remoteSettings.WatchFailureDetectorConfig.GetDouble("threshold"));
             Assert.Equal(200, remoteSettings.WatchFailureDetectorConfig.GetDouble("max-sample-size"));

--- a/src/core/Akka.Remote/Configuration/Remote.conf
+++ b/src/core/Akka.Remote/Configuration/Remote.conf
@@ -214,7 +214,7 @@ akka {
       # After the heartbeat request has been sent the first failure detection
       # will start after this period, even though no heartbeat mesage has
       # been received.
-      expected-response-after = 3 s
+      expected-response-after = 1 s
 
     }
 

--- a/src/core/Akka/Actor/Address.cs
+++ b/src/core/Akka/Actor/Address.cs
@@ -64,6 +64,25 @@ namespace Akka.Actor
             get { return _protocol; }
         }
 
+        /// <summary>
+        /// Returns true if this Address is only defined locally. It is not safe to send locally scoped addresses to remote
+        ///  hosts. See also <see cref="HasGlobalScope"/>
+        /// </summary>
+        public bool HasLocalScope
+        {
+            get { return string.IsNullOrEmpty(Host); }
+        }
+
+        /// <summary>
+        /// Returns true if this Address is usable globally. Unlike locally defined addresses <see cref="HasLocalScope"/>
+        /// addresses of global scope are safe to sent to other hosts, as they globally and uniquely identify an addressable
+        /// entity.
+        /// </summary>
+        public bool HasGlobalScope
+        {
+            get { return !string.IsNullOrEmpty(Host); }
+        }
+
         private Lazy<string> CreateLazyToString()
         {
             return new Lazy<string>(() =>


### PR DESCRIPTION
Implemented these stories
- Exclude unreachable observations from downed node: https://github.com/akka/akka/issues/13875
- Investigate if expected-response-after can be removed: https://github.com/akka/akka/issues/17750
- Cluster: need to be able to perform self-join using local address: https://github.com/akkadotnet/akka.net/issues/1983
- logging selfRoles during node unreachable and quarantined: https://github.com/akka/akka/issues/20613
- Add a helper method to Cluster extension to get full ActorPath: https://github.com/akka/akka/issues/19086
- disable down-removal-margin by default https://github.com/akka/akka/issues/18337
- used FluentAssertions everywhere

Reviewed these cluster specs
- ClusterDomainEventSpec
- GossipSpec
- ReachabilitySpec
- AutoDownSpec
- ClusterConfigSpec
- ClusterDeployerSpec
- ClusterDomainEventPublisherSpec
- ClusterSpec
- MemberOrderingSpec