### PR TITLE
increased NodeTestRunner max wait timeout

### DIFF
--- a/src/core/Akka.NodeTestRunner/Program.cs
+++ b/src/core/Akka.NodeTestRunner/Program.cs
@@ -24,7 +24,7 @@ namespace Akka.NodeTestRunner
         /// If it takes longer than this value for the <see cref="Sink"/> to get back to us
         /// about a particular test passing or failing, throw loudly.
         /// </summary>
-        private static readonly TimeSpan MaxProcessWaitTimeout = TimeSpan.FromMinutes(1.5);
+        private static readonly TimeSpan MaxProcessWaitTimeout = TimeSpan.FromMinutes(5);
         private static IActorRef _logger;
 
         static int Main(string[] args)


### PR DESCRIPTION
Reason why NodeChurn spec was failing: it's a long running spec and can run longer than the 90 seconds currently used as the maximum timeout.

This spec increases the timeout to 5 minutes - a better solution would be to make this configurable per-spec but with the way we use XUnit2 I can't access any of those properties from the NodeTestRunner directly.