### PR TITLE
#1255 Remote redeployment spec

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -651,6 +651,7 @@ namespace Akka.Actor
         public abstract Akka.Actor.IInternalActorRef LookupRoot { get; }
         public abstract Akka.Actor.IActorRefProvider Provider { get; }
         public abstract Akka.Actor.IInternalActorRef SystemGuardian { get; }
+        public abstract void Abort();
         public abstract Akka.Actor.IActorRef SystemActorOf(Akka.Actor.Props props, string name = null);
         public abstract Akka.Actor.IActorRef SystemActorOf<TActor>(string name = null)
             where TActor : Akka.Actor.ActorBase, new ();
@@ -1767,6 +1768,7 @@ namespace Akka.Actor.Internal
         [System.ObsoleteAttribute("Use WhenTerminated instead. This property will be removed in future versions")]
         public override System.Threading.Tasks.Task TerminationTask { get; }
         public override System.Threading.Tasks.Task WhenTerminated { get; }
+        public override void Abort() { }
         public override Akka.Actor.IActorRef ActorOf(Akka.Actor.Props props, string name = null) { }
         public override Akka.Actor.ActorSelection ActorSelection(Akka.Actor.ActorPath actorPath) { }
         public override Akka.Actor.ActorSelection ActorSelection(string actorPath) { }

--- a/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
+++ b/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
@@ -588,7 +588,7 @@ namespace Akka.Remote.TestKit
 
         protected void InjectDeployments(ActorSystem system, RoleName role)
         {
-            var deployer = Sys.AsInstanceOf<ExtendedActorSystem>().Provider.Deployer;
+            var deployer = system.AsInstanceOf<ExtendedActorSystem>().Provider.Deployer;
             foreach (var str in _deployments(role))
             {
                 var deployString = _replacements.Values.Aggregate(str, (@base, r) =>
@@ -631,7 +631,7 @@ namespace Akka.Remote.TestKit
         protected ActorSystem StartNewSystem()
         {
             var sb =
-                new StringBuilder("helios.tcp{").AppendLine()
+                new StringBuilder("akka.remote.helios.tcp{").AppendLine()
                     .AppendFormat("port={0}", _myAddress.Port)
                     .AppendLine()
                     .AppendFormat(@"hostname=""{0}""", _myAddress.Host)

--- a/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
+++ b/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
@@ -12,6 +12,8 @@ using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Text;
+
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Configuration.Hocon;
@@ -628,11 +630,15 @@ namespace Akka.Remote.TestKit
 
         protected ActorSystem StartNewSystem()
         {
+            var sb =
+                new StringBuilder("helios.tcp{").AppendLine()
+                    .AppendFormat("port={0}", _myAddress.Port)
+                    .AppendLine()
+                    .AppendFormat(@"hostname=""{0}""", _myAddress.Host)
+                    .AppendLine("}");
             var config =
                 ConfigurationFactory
-                .ParseString(String.Format(@"helios.tcp{port={0}\nhostname=""{1}""",
-                    _myAddress.Host,
-                    _myAddress.Port))
+                .ParseString(sb.ToString())
                 .WithFallback(Sys.Settings.Config);
 
             var system = ActorSystem.Create(Sys.Name, config);

--- a/src/core/Akka.Remote.TestKit/Player.cs
+++ b/src/core/Akka.Remote.TestKit/Player.cs
@@ -13,11 +13,13 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Actor.Internal;
 using Akka.Configuration;
 using Akka.Event;
 using Akka.Pattern;
 using Akka.Remote.Transport;
 using Akka.Util;
+using Akka.Util.Internal;
 using Helios.Channels;
 
 namespace Akka.Remote.TestKit
@@ -474,9 +476,7 @@ namespace Akka.Remote.TestKit
                         }
                         if (terminateMsg.ShutdownOrExit.IsLeft && terminateMsg.ShutdownOrExit.ToLeft().Value == true)
                         {
-                            //TODO: terminate more aggressively with Abort
-                            //Context.System.AsInstanceOf<ActorSystemImpl>().Abort();
-                            Context.System.Terminate();
+                            Context.System.AsInstanceOf<ActorSystemImpl>().Abort();
                             return Stay();
                         }
                         if (terminateMsg.ShutdownOrExit.IsRight)

--- a/src/core/Akka.Remote.Tests.MultiNode/Akka.Remote.Tests.MultiNode.csproj
+++ b/src/core/Akka.Remote.Tests.MultiNode/Akka.Remote.Tests.MultiNode.csproj
@@ -74,6 +74,7 @@
     <Compile Include="PiercingShouldKeepQuarantineSpec.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RemoteDeliverySpec.cs" />
+    <Compile Include="RemoteReDeploymentSpec.cs" />
     <Compile Include="RemoteGatePiercingSpec.cs" />
     <Compile Include="RemoteNodeDeathWatchSpec.cs" />
     <Compile Include="RemoteNodeRestartDeathWatchSpec.cs" />

--- a/src/core/Akka.Remote.Tests.MultiNode/RemoteReDeploymentSpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/RemoteReDeploymentSpec.cs
@@ -1,0 +1,305 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RemoteRoundRobinSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.Remote.TestKit;
+using Akka.Remote.Transport;
+
+namespace Akka.Remote.Tests.MultiNode
+{
+    public class RemoteReDeploymentSpecConfig : MultiNodeConfig
+    {
+        public RemoteReDeploymentSpecConfig()
+        {
+            First = Role("first");
+            Second = Role("second");
+
+            CommonConfig = ConfigurationFactory.ParseString(@"
+    akka.remote.transport-failure-detector {
+         threshold=0.1
+         heartbeat-interval=0.1s
+         acceptable-heartbeat-pause=1s
+       }
+       akka.remote.watch-failure-detector {
+         threshold=0.1
+         heartbeat-interval=0.1s
+         acceptable-heartbeat-pause=2.5s
+       }").WithFallback(DebugConfig(false));
+
+            DeployOn(Second, "/parent/hello.remote = \"@first@\"");
+
+            TestTransport = true;
+        }
+
+        public RoleName First { get; }
+        public RoleName Second { get; }
+    }
+
+
+    public abstract class RemoteReDeploymentSpec : MultiNodeSpec
+    {
+        private readonly RemoteReDeploymentSpecConfig _config;
+        private readonly Func<RoleName, string, IActorRef> _identify;
+
+        protected RemoteReDeploymentSpec() : this(new RemoteReDeploymentSpecConfig())
+        {
+        }
+
+        protected RemoteReDeploymentSpec(RemoteReDeploymentSpecConfig config) : base(config)
+        {
+            _config = config;
+        }
+
+        protected abstract bool ExpectQuarantine { get; }
+        protected abstract TimeSpan SleepAfterKill { get; }
+
+        protected override int InitialParticipantsValueFactory
+        {
+            get { return Roles.Count; }
+        }
+
+        [MultiNodeFact]
+        public void RemoteReDeployment_must_terminate_the_child_when_its_parent_system_is_replaced_by_a_new_one()
+        {
+            var echo = Sys.ActorOf(EchoProps(TestActor), "echo");
+            EnterBarrier("echo-started");
+
+            RunOn(() =>
+            {
+                Sys.ActorOf(Props.Create(() => new Parent()), "parent")
+                    .Tell(new ParentMessage(Props.Create(() => new Hello()), "hello"));
+
+                ExpectMsg<string>("HelloParent", TimeSpan.FromSeconds(15));
+            }, _config.Second);
+
+            RunOn(() =>
+            {
+                ExpectMsg<string>("PreStart", TimeSpan.FromSeconds(15));
+                
+            }, _config.First);
+
+            EnterBarrier("first-deployed");
+
+            RunOn(() =>
+            {
+                TestConductor.Blackhole(_config.Second, _config.First, ThrottleTransportAdapter.Direction.Both)
+                    .Wait();
+                TestConductor.Shutdown(_config.Second, true).Wait();
+                if (ExpectQuarantine)
+                {
+                    Within(SleepAfterKill, () =>
+                    {
+                        ExpectMsg("PostStop");
+                        ExpectNoMsg();
+                    });
+                }
+                else
+                {
+                    ExpectNoMsg(SleepAfterKill);
+                }
+                AwaitAssert(() => Node(_config.Second), TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(100));
+            }, _config.First);
+
+            ActorSystem tempSys = null;
+
+            RunOn(() =>
+            {
+                Sys.WhenTerminated.Wait(TimeSpan.FromSeconds(30));
+                ExpectNoMsg(SleepAfterKill);
+                tempSys = StartNewSystem();
+            }, _config.Second);
+
+            EnterBarrier("cable-cut");
+
+            RunOn(() =>
+            {
+                var p = CreateTestProbe(tempSys);
+                tempSys.ActorOf(EchoProps(p), "echo");
+                p.Send(tempSys.ActorOf(Props.Create(() => new Parent()), "parent"),
+                    new ParentMessage(Props.Create(() => new Hello()), "hello"));
+                p.ExpectMsg("HelloParent", TimeSpan.FromSeconds(15));
+            }, _config.Second);
+
+            EnterBarrier("re-deployed");
+
+            RunOn(() =>
+            {
+                Within(TimeSpan.FromSeconds(15), () =>
+                {
+                    if (ExpectQuarantine)
+                    {
+                        ExpectMsg("PreStart");
+                    }
+                    else
+                    {
+                        ExpectMsgAllOf("PostStop", "PreStart");
+                    }
+                });
+            }, _config.First);
+
+            EnterBarrier("the-end");
+
+            ExpectNoMsg(TimeSpan.FromSeconds(1));
+        }
+
+        private Props EchoProps(IActorRef target)
+        {
+            return Props.Create(() => new Echo(target));
+        }
+
+        private sealed class Parent : ActorBase
+        {
+            private readonly ActorSelection _monitor;
+
+            public Parent()
+            {
+                _monitor = Context.ActorSelection("/user/echo");
+            }
+
+            protected override bool Receive(object message)
+            {
+                return message.Match().With<ParentMessage>(_ => Context.ActorOf(_.Props, _.Name)).Default(m =>
+                    _monitor.Tell(m)).WasHandled;
+            }
+        }
+
+        private sealed class Echo : ActorBase
+        {
+            private readonly IActorRef _target;
+
+            public Echo(IActorRef target)
+            {
+                _target = target;
+            }
+
+            protected override bool Receive(object message)
+            {
+                //Context.GetLogger().Info("received {0} from {1}", message, Sender);
+                _target.Tell(message);
+                return true;
+            }
+        }
+
+        private sealed class Hello : ActorBase
+        {
+            private readonly ActorSelection _monitor;
+
+            public Hello()
+            {
+                Context.Parent.Tell("HelloParent");
+                _monitor = Context.ActorSelection("/user/echo");
+            }
+
+            protected override bool Receive(object message)
+            {
+                return true;
+            }
+
+            protected override void PreStart()
+            {
+                _monitor.Tell("PreStart");
+            }
+
+            protected override void PostStop()
+            {
+                _monitor.Tell("PostStop");
+            }
+        }
+
+        private sealed class ParentMessage
+        {
+            public ParentMessage(Props props, string name)
+            {
+                Props = props;
+                Name = name;
+            }
+
+            public Props Props { get; }
+            public string Name { get; }
+        }
+    }
+
+    #region specs
+
+   public  class RemoteReDeploymentFastMultiNetNode1 : RemoteReDeploymentFastMultiNetSpec
+    {
+        
+    }
+
+    public class RemoteReDeploymentFastMultiNetNode2 : RemoteReDeploymentFastMultiNetSpec
+    {
+        
+    }
+
+    public abstract class RemoteReDeploymentFastMultiNetSpec : RemoteReDeploymentSpec
+    {
+        // new association will come in while old is still “healthy”
+        protected override bool ExpectQuarantine
+        {
+            get { return false; }
+        }
+
+        protected override TimeSpan SleepAfterKill
+        {
+            get { return TimeSpan.FromSeconds(0); }
+        }
+    }
+
+    public class RemoteReDeploymentMediumMultiNetNode1 : RemoteReDeploymentMediumMultiNetSpec
+    {
+        
+    }
+
+    public class RemoteReDeploymentMediumMultiNetNode2 : RemoteReDeploymentMediumMultiNetSpec
+    {
+        
+    }
+
+    public abstract class RemoteReDeploymentMediumMultiNetSpec : RemoteReDeploymentSpec
+    {
+        // new association will come in while old is gated in ReliableDeliverySupervisor
+        protected override bool ExpectQuarantine
+        {
+            get { return false; }
+        }
+
+        protected override TimeSpan SleepAfterKill
+        {
+            get { return TimeSpan.FromSeconds(1); }
+        }
+    }
+
+    public class RemoteReDeploymentSlowMultiNetNode1 : RemoteReDeploymentSlowMultiNetSpec
+    {
+        
+    }
+
+    public class RemoteReDeploymentSlowMultiNetNode2 : RemoteReDeploymentSlowMultiNetSpec
+    {
+        
+    }
+
+    public abstract class RemoteReDeploymentSlowMultiNetSpec : RemoteReDeploymentSpec
+    {
+        // new association will come in after old has been quarantined
+        protected override bool ExpectQuarantine
+        {
+            get { return true; }
+        }
+
+        protected override TimeSpan SleepAfterKill
+        {
+            get { return TimeSpan.FromSeconds(10); }
+        }
+
+    }
+
+    #endregion
+}

--- a/src/core/Akka/Actor/ActorCell.FaultHandling.cs
+++ b/src/core/Akka/Actor/ActorCell.FaultHandling.cs
@@ -215,14 +215,15 @@ namespace Akka.Actor
             // stop all children, which will turn childrenRefs into TerminatingChildrenContainer (if there are children)
             StopChildren();
 
-            //TODO: Implement when we have ActorSystem.Abort
-            //    if (systemImpl.aborting) {
-            //      // separate iteration because this is a very rare case that should not penalize normal operation
-            //      children foreach {
-            //        case ref: ActorRefScope if !ref.isLocal ⇒ self.sendSystemMessage(DeathWatchNotification(ref, true, false))
-            //        case _                                  ⇒
-            //      }
-            //    }
+            if (SystemImpl.Aborting)
+            {
+                // separate iteration because this is a very rare case that should not penalize normal operation
+                foreach (var child in Children)
+                {
+                    if(!child.AsInstanceOf<IActorRefScope>().IsLocal) // send ourselves a deathwatch notification pre-emptively for non-local children
+                        Self.AsInstanceOf<IInternalActorRef>().SendSystemMessage(new DeathWatchNotification(child, true, false));
+                }
+            }
             var wasTerminating = IsTerminating;
             if (SetChildrenTerminationReason(SuspendReason.Termination.Instance))
             {

--- a/src/core/Akka/Actor/ExtendedActorSystem.cs
+++ b/src/core/Akka/Actor/ExtendedActorSystem.cs
@@ -53,12 +53,17 @@ namespace Akka.Actor
         /// terminated.</summary>
         public abstract IActorRef SystemActorOf<TActor>(string name = null) where TActor : ActorBase, new();
 
+        /// <summary>
+        /// Aggressively terminates an <see cref="ActorSystem"/> without waiting for the normal shutdown process to run as-is.
+        /// </summary>
+        public abstract void Abort();
+
         //TODO: Missing threadFactory, dynamicAccess, printTree
         //  /**
         //  * A ThreadFactory that can be used if the transport needs to create any Threads
         //  */
         //  def threadFactory: ThreadFactory
-  
+
         //  /**
         //  * ClassLoader wrapper which is used for reflective accesses internally. This is set
         //  * to use the context class loader, if one is set, or the class loader which
@@ -67,7 +72,7 @@ namespace Akka.Actor
         //  * creation.
         //  */
         //  def dynamicAccess: DynamicAccess
-  
+
         //  /**
         //  * For debugging: traverse actor hierarchy and make string representation.
         //  * Careful, this may OOM on large actor systems, and it is only meant for

--- a/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
@@ -98,6 +98,14 @@ namespace Akka.Actor.Internal
             return _provider.SystemGuardian.Cell.AttachChild(Props.Create<TActor>(), true, name);
         }
 
+        internal volatile bool Aborting = false;
+
+        public override void Abort()
+        {
+            Aborting = true;
+            Terminate();
+        }
+
         /// <summary>Starts this system</summary>
         public void Start()
         {


### PR DESCRIPTION
Fixed some bugs with the Akka.Remote.TestKit that caused this spec not to pass. Also implemented `ActorSystemImpl.Abort`.