### PR TITLE
Fixes handling of messages intended for another node

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubMediator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubMediator.cs
@@ -148,23 +148,20 @@ namespace Akka.Cluster.Tools.PublishSubscribe
                 var routees = new List<Routee>();
 
                 Bucket bucket;
-                if (_registry.TryGetValue(_cluster.SelfAddress, out bucket))
+                ValueHolder valueHolder;
+                if (_registry.TryGetValue(_cluster.SelfAddress, out bucket) && bucket.Content.TryGetValue(send.Path, out valueHolder) && send.LocalAffinity)
                 {
-                    ValueHolder valueHolder;
-                    if (bucket.Content.TryGetValue(send.Path, out valueHolder) && send.LocalAffinity)
+                    var routee = valueHolder.Routee;
+                    if (routee != null) routees.Add(routee);
+                }
+                else
+                {
+                    foreach (var entry in _registry)
                     {
-                        var routee = valueHolder.Routee;
-                        if (routee != null) routees.Add(routee);
-                    }
-                    else
-                    {
-                        foreach (var entry in _registry)
+                        if (entry.Value.Content.TryGetValue(send.Path, out valueHolder))
                         {
-                            if (entry.Value.Content.TryGetValue(send.Path, out valueHolder))
-                            {
-                                var routee = valueHolder.Routee;
-                                if (routee != null) routees.Add(routee);
-                            }
+                            var routee = valueHolder.Routee;
+                            if (routee != null) routees.Add(routee);
                         }
                     }
                 }


### PR DESCRIPTION
Given the following setup:
- Node: client (cluster client using remoting)
- Node: lighthouse (seed node for cluster)
- Node: worker (cluster member)

where both `lighthouse` and `worker` start `ClusterClientReceptionist`
but only the `worker` node registers a service (`/user/worker`).

If the `client` node uses the `lighthouse` node as the only value in
`initial-contacts` and attempts to send a message to `/user/worker`, the
log on the `lighthouse` node indicates that it received the message, but
the `worker` node never does.

With this change, the `worker` node will now receive the message.