### PR TITLE
'Ask' memory leak

### DIFF
--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -95,8 +95,8 @@ namespace Akka.Actor
             {
                 if (Interlocked.Exchange(ref status, COMPLETED) == INITIATED)
                 {
-                    _unregister();
                     _result.TrySetResult(message);
+                    _unregister();
                 }
             }
         }


### PR DESCRIPTION
cancelling timeout CancellationToken in Ask in order to prevent memory leaks -- a reference to 'result' variable is stored in CancellationToken's callback which prevents it from garbage collection. it's a huge problem when your timeout value is more or less big and your actor returns big data:

```csharp
 public sealed class LeakActor : ReceiveActor
 {
     public LeakActor()
     {
         Receive<GetDataMessage>(message => Sender.Tell(new byte[10000]));
     }
    
    public sealed class GetDataMessage { }
}
```
then call it somewhere:
```csharp
for (var index = 0; index < 10000; index += 1)
{
    await greeter.Ask<byte[]>(new LeakActor.GetDataMessage(), TimeSpan.FromSeconds(10));
}
```

the next calls were rearranged because a future actor should set result before _unregister() cancels Token:

```csharp
_result.TrySetResult(message);
_unregister();
``` 