### PR TITLE
DistributedPubSub: Use TypeQualifiedNameForManifest with Manifest required Serializers

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Serialization/DistributedPubSubMessageSerializer.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Serialization/DistributedPubSubMessageSerializer.cs
@@ -275,7 +275,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
             else
             {
                 if (serializer.IncludeManifest)
-                    builder.SetMessageManifest(ByteString.CopyFromUtf8(message.GetType().FullName));
+                    builder.SetMessageManifest(ByteString.CopyFromUtf8(TypeQualifiedNameForManifest(message.GetType())));
             }
 
             return builder.Build();


### PR DESCRIPTION
Instead of `.FullName`.