### PR TITLE
meta-table-name replaced with metadata-table-name

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteAllPersistenceIdsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteAllPersistenceIdsSpec.cs
@@ -23,7 +23,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                 class = ""Akka.Persistence.Sqlite.Journal.SqliteJournal, Akka.Persistence.Sqlite""
                 plugin-dispatcher = ""akka.actor.default-dispatcher""
                 table-name = event_journal
-                meta-table-name = journal_metadata
+                metadata-table-name = journal_metadata
                 auto-initialize = on
                 connection-string = ""FullUri=file:memdb-journal-{id}.db?mode=memory&cache=shared;""
                 refresh-interval = 1s

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteEventsByPersistenceIdSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteEventsByPersistenceIdSpec.cs
@@ -23,7 +23,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                 class = ""Akka.Persistence.Sqlite.Journal.SqliteJournal, Akka.Persistence.Sqlite""
                 plugin-dispatcher = ""akka.actor.default-dispatcher""
                 table-name = event_journal
-                meta-table-name = journal_metadata
+                metadata-table-name = journal_metadata
                 auto-initialize = on
                 connection-string = ""FullUri=file:memdb-journal-{id}.db?mode=memory&cache=shared;""
                 refresh-interval = 1s

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteEventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteEventsByTagSpec.cs
@@ -29,7 +29,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                 class = ""Akka.Persistence.Sqlite.Journal.SqliteJournal, Akka.Persistence.Sqlite""
                 plugin-dispatcher = ""akka.actor.default-dispatcher""
                 table-name = event_journal
-                meta-table-name = journal_metadata
+                metadata-table-name = journal_metadata
                 auto-initialize = on
                 connection-string = ""FullUri=file:memdb-journal-{id}.db?mode=memory&cache=shared;""
                 refresh-interval = 1s

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteJournalQuerySpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteJournalQuerySpec.cs
@@ -33,7 +33,7 @@ namespace Akka.Persistence.Sqlite.Tests
                             class = ""Akka.Persistence.Sqlite.Journal.SqliteJournal, Akka.Persistence.Sqlite""
                             plugin-dispatcher = ""akka.actor.default-dispatcher""
                             table-name = event_journal
-                            meta-table-name = journal_metadata
+                            metadata-table-name = journal_metadata
                             auto-initialize = on
                             connection-string = """ + connectionString + @"""
                         }

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteJournalSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteJournalSpec.cs
@@ -35,7 +35,7 @@ namespace Akka.Persistence.Sqlite.Tests
                             class = ""Akka.Persistence.Sqlite.Journal.SqliteJournal, Akka.Persistence.Sqlite""
                             plugin-dispatcher = ""akka.actor.default-dispatcher""
                             table-name = event_journal
-                            meta-table-name = journal_metadata
+                            metadata-table-name = journal_metadata
                             auto-initialize = on
                             connection-string = """ + connectionString + @"""
                         }

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/SqliteJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/SqliteJournal.cs
@@ -22,7 +22,7 @@ namespace Akka.Persistence.Sqlite.Journal
             QueryExecutor = new SqliteQueryExecutor(new QueryConfiguration(
                 schemaName: null,
                 journalEventsTableName: config.GetString("table-name"),
-                metaTableName: config.GetString("meta-table-name"),
+                metaTableName: config.GetString("metadata-table-name"),
                 persistenceIdColumnName: "persistence_id",
                 sequenceNrColumnName: "sequence_nr",
                 payloadColumnName: "payload",


### PR DESCRIPTION
The Persistence.Sql.Common code and sqlite.conf referred to a variable called metadata-table-name.  SqliteJournal.cs and many unit tests referred to meta-table-name.  

The unit tests passed before because the default value of metadata-table-name in sqllite.conf plus their manually configured meta-table-name variables defined in test worked out to cover both cases (and set them to the same name), but if you were to create a new project and assume the default name would cover all bases, you'd be wrong.  To get a sqlite persistence working in a new app I found I had to set both metadata-table-name and meta-table-name to the same value to get things to work.  Out of the box, following the sqlite modules directions, the sqlite persistence engine would not work right.

This PR standardizes all places to use metadata-table-name, as that is what the core persistence module uses and is what is set by default by sqlite.conf.  This should allow someone to use the sqlite persistence module with no error out of the box.

