### PR TITLE
fix for DNS resolution issues

### DIFF
--- a/src/core/Akka.Remote.TestKit.Tests/Akka.Remote.TestKit.Tests.csproj
+++ b/src/core/Akka.Remote.TestKit.Tests/Akka.Remote.TestKit.Tests.csproj
@@ -34,8 +34,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Helios, Version=2.1.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Helios.2.1.1\lib\net45\Helios.dll</HintPath>
+    <Reference Include="Helios, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Helios.2.1.2\lib\net45\Helios.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/core/Akka.Remote.TestKit.Tests/packages.config
+++ b/src/core/Akka.Remote.TestKit.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Helios" version="2.1.1" targetFramework="net45" />
+  <package id="Helios" version="2.1.2" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />

--- a/src/core/Akka.Remote.TestKit/Akka.Remote.TestKit.csproj
+++ b/src/core/Akka.Remote.TestKit/Akka.Remote.TestKit.csproj
@@ -43,8 +43,8 @@
       <HintPath>..\..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.Serialization.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Helios, Version=2.1.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Helios.2.1.1\lib\net45\Helios.dll</HintPath>
+    <Reference Include="Helios, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Helios.2.1.2\lib\net45\Helios.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/src/core/Akka.Remote.TestKit/packages.config
+++ b/src/core/Akka.Remote.TestKit/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Google.ProtocolBuffers" version="2.4.1.555" targetFramework="net45" />
-  <package id="Helios" version="2.1.1" targetFramework="net45" />
+  <package id="Helios" version="2.1.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />

--- a/src/core/Akka.Remote.Tests/RemoteConfigSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteConfigSpec.cs
@@ -97,6 +97,7 @@ namespace Akka.Remote.Tests
             Assert.Equal(2, s.ServerSocketWorkerPoolSize);
             Assert.Equal(2, s.ClientSocketWorkerPoolSize);
             Assert.False(s.BackwardsCompatibilityModeEnabled);
+            Assert.False(s.DnsUseIpv6);
         }
 
         [Fact]

--- a/src/core/Akka.Remote/Akka.Remote.csproj
+++ b/src/core/Akka.Remote/Akka.Remote.csproj
@@ -59,8 +59,8 @@
       <HintPath>..\..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.Serialization.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Helios, Version=2.1.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Helios.2.1.1\lib\net45\Helios.dll</HintPath>
+    <Reference Include="Helios, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Helios.2.1.2\lib\net45\Helios.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/core/Akka.Remote/Configuration/Remote.conf
+++ b/src/core/Akka.Remote/Configuration/Remote.conf
@@ -342,6 +342,10 @@ akka {
 	  # this is designed to make it easy to support private / public addressing schemes
 	  public-hostname = ""
 
+	  # If set to true, we will use IPV6 addresses upon DNS resolution for host names.
+	  # Otherwise, we will use IPV4.
+	  dns-use-ipv6 = false
+
       # Enables SSL support on this transport
       enable-ssl = false
 

--- a/src/core/Akka.Remote/packages.config
+++ b/src/core/Akka.Remote/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Google.ProtocolBuffers" version="2.4.1.555" targetFramework="net45" />
-  <package id="Helios" version="2.1.1" targetFramework="net45" />
+  <package id="Helios" version="2.1.2" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
 </packages>

--- a/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/ClusterSharding.Node.csproj
+++ b/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/ClusterSharding.Node.csproj
@@ -42,8 +42,8 @@
       <HintPath>..\..\..\..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.Serialization.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Helios, Version=2.1.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Helios.2.1.1\lib\net45\Helios.dll</HintPath>
+    <Reference Include="Helios, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Helios.2.1.2\lib\net45\Helios.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/packages.config
+++ b/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Google.ProtocolBuffers" version="2.4.1.555" targetFramework="net45" />
-  <package id="Helios" version="2.1.1" targetFramework="net45" />
+  <package id="Helios" version="2.1.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
   <package id="System.Data.SQLite.Core" version="1.0.98.1" targetFramework="net45" />

--- a/src/examples/Cluster/ClusterTools/ClusterToolsExample.Node/ClusterToolsExample.Node.csproj
+++ b/src/examples/Cluster/ClusterTools/ClusterToolsExample.Node/ClusterToolsExample.Node.csproj
@@ -40,8 +40,8 @@
       <HintPath>..\..\..\..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.Serialization.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Helios, Version=2.1.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Helios.2.1.1\lib\net45\Helios.dll</HintPath>
+    <Reference Include="Helios, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Helios.2.1.2\lib\net45\Helios.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/src/examples/Cluster/ClusterTools/ClusterToolsExample.Node/packages.config
+++ b/src/examples/Cluster/ClusterTools/ClusterToolsExample.Node/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Google.ProtocolBuffers" version="2.4.1.555" targetFramework="net45" />
-  <package id="Helios" version="2.1.1" targetFramework="net45" />
+  <package id="Helios" version="2.1.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
   <package id="Wire" version="0.0.6" targetFramework="net45" />

--- a/src/examples/Cluster/ClusterTools/ClusterToolsExample.Seed/ClusterToolsExample.Seed.csproj
+++ b/src/examples/Cluster/ClusterTools/ClusterToolsExample.Seed/ClusterToolsExample.Seed.csproj
@@ -40,8 +40,8 @@
       <HintPath>..\..\..\..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.Serialization.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Helios, Version=2.1.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Helios.2.1.1\lib\net45\Helios.dll</HintPath>
+    <Reference Include="Helios, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Helios.2.1.2\lib\net45\Helios.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/src/examples/Cluster/ClusterTools/ClusterToolsExample.Seed/packages.config
+++ b/src/examples/Cluster/ClusterTools/ClusterToolsExample.Seed/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Google.ProtocolBuffers" version="2.4.1.555" targetFramework="net45" />
-  <package id="Helios" version="2.1.1" targetFramework="net45" />
+  <package id="Helios" version="2.1.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
   <package id="Wire" version="0.0.6" targetFramework="net45" />

--- a/src/examples/Cluster/ClusterTools/ClusterToolsExample.Shared/ClusterToolsExample.Shared.csproj
+++ b/src/examples/Cluster/ClusterTools/ClusterToolsExample.Shared/ClusterToolsExample.Shared.csproj
@@ -38,8 +38,8 @@
       <HintPath>..\..\..\..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.Serialization.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Helios, Version=2.1.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Helios.2.1.1\lib\net45\Helios.dll</HintPath>
+    <Reference Include="Helios, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Helios.2.1.2\lib\net45\Helios.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/src/examples/Cluster/ClusterTools/ClusterToolsExample.Shared/packages.config
+++ b/src/examples/Cluster/ClusterTools/ClusterToolsExample.Shared/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Google.ProtocolBuffers" version="2.4.1.555" targetFramework="net45" />
-  <package id="Helios" version="2.1.1" targetFramework="net45" />
+  <package id="Helios" version="2.1.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
   <package id="Wire" version="0.0.6" targetFramework="net45" />

--- a/src/examples/TimeServer/TimeClient/App.config
+++ b/src/examples/TimeServer/TimeClient/App.config
@@ -42,8 +42,9 @@
 		            applied-adapters = []
 		            transport-protocol = tcp
 		            port = 0 #bind to any available port
-		            hostname = 0.0.0.0 #listens on ALL ips for this machine
-                    public-hostname = localhost #but only accepts connections on localhost (usually 127.0.0.1)
+		              hostname = 0.0.0.0 #listens on ALL ips for this machine
+                  public-hostname = localhost #but only accepts connections on localhost (usually 127.0.0.1)
+                  dns-use-ipv6 = true
                 }
                 log-remote-lifecycle-events = INFO
             }

--- a/src/examples/TimeServer/TimeClient/TimeClient.csproj
+++ b/src/examples/TimeServer/TimeClient/TimeClient.csproj
@@ -34,8 +34,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Helios, Version=2.1.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Helios.2.1.1\lib\net45\Helios.dll</HintPath>
+    <Reference Include="Helios, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Helios.2.1.2\lib\net45\Helios.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/examples/TimeServer/TimeClient/packages.config
+++ b/src/examples/TimeServer/TimeClient/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Helios" version="2.1.1" targetFramework="net45" />
+  <package id="Helios" version="2.1.2" targetFramework="net45" />
 </packages>

--- a/src/examples/TimeServer/TimeServer/TimeServer.csproj
+++ b/src/examples/TimeServer/TimeServer/TimeServer.csproj
@@ -34,8 +34,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Helios, Version=2.1.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Helios.2.1.1\lib\net45\Helios.dll</HintPath>
+    <Reference Include="Helios, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Helios.2.1.2\lib\net45\Helios.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/examples/TimeServer/TimeServer/packages.config
+++ b/src/examples/TimeServer/TimeServer/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Helios" version="2.1.1" targetFramework="net45" />
+  <package id="Helios" version="2.1.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Resolves #2161

upgraded to Helios 2.1.2; set default DNS resolution target to IPV4; made DNS resolution configurable via HOCON.