### PR TITLE
Much better UnboundedMailboxQueue

### DIFF
--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -204,6 +204,7 @@
     <Compile Include="TestUtils\Supervisor.cs" />
     <Compile Include="Util\ByteStringSpec.cs" />
     <Compile Include="Util\CollectionExtensionsSpec.cs" />
+    <Compile Include="Util\ConcurrentEnvelopeQueueTests.cs" />
     <Compile Include="Util\ContinuousEnumeratorSpec.cs" />
     <Compile Include="Util\IndexSpec.cs" />
     <Compile Include="Util\Internal\Collections\IteratorTests.cs" />

--- a/src/core/Akka.Tests/Util/ConcurrentEnvelopeQueueTests.cs
+++ b/src/core/Akka.Tests/Util/ConcurrentEnvelopeQueueTests.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using Akka.Actor;
+using Akka.Dispatch.SysMsg;
+using Akka.IO;
+using Akka.TestKit;
+using Akka.Util;
+using Xunit;
+
+namespace Akka.Tests.Util
+{
+    public class ConcurrentEnvelopeQueueTests
+    {
+        [Fact]
+        public void When_empty_Should_not_dequeue()
+        {
+            var queue = new ConcurrentEnvelopeQueue();
+
+            Envelope result;
+            queue.TryDequeue(out result).ShouldBeFalse();
+            result.Sender.ShouldBe(null);
+            result.Message.ShouldBe(null);
+        }
+
+        [Fact]
+        public void When_empty_Should_look_like_empty()
+        {
+            var queue = new ConcurrentEnvelopeQueue();
+
+            queue.Count.ShouldBe(0);
+            queue.IsEmpty.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void When_enqueued_Should_be_able_to_dequeue()
+        {
+            var queue = new ConcurrentEnvelopeQueue();
+            var message = new object();
+
+            var envelope = new Envelope
+            {
+                Sender = ActorRefs.NoSender,
+                Message = message
+            };
+
+            queue.Enqueue(ref envelope);
+
+            Envelope result;
+            queue.TryDequeue(out result).ShouldBeTrue();
+
+            result.Message.ShouldBe(message);
+
+            ReferenceEquals(result.Sender, ActorRefs.NoSender).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void When_enqueued_from_multiple_producers_should_be_dequeued_in_fifo_way()
+        {
+            const int messagesToSendPerThread = 1 << 16;
+            const int producerCount = 2;
+            const int expectedMessages = messagesToSendPerThread*producerCount;
+
+            var startEvent = new ManualResetEventSlim(false);
+            var producers = new Thread[producerCount];
+            var endEvent = new CountdownEvent(producers.Length);
+            var lastSeenMessagePerProducer = new int[producerCount];
+
+            var queue = new ConcurrentEnvelopeQueue();
+
+            var messages = new[] {new object(), new object(), new object(), new object(),};
+            var envelopes = messages.Select(m => new Envelope {Message = m}).ToArray();
+
+            for (var i = 0; i < producers.Length; i++)
+            {
+                producers[i] = new Thread(msgs =>
+                {
+                    var toSend = (Envelope[]) msgs;
+                    startEvent.Wait();
+                    for (var j = 0; j < messagesToSendPerThread; j++)
+                    {
+                        queue.Enqueue(ref toSend[(j + 1)%2]);
+                    }
+                    endEvent.Signal();
+                })
+                {
+                    IsBackground = true,
+                    Name = "Producer #" + i
+                };
+                producers[i].Start(envelopes.Skip(i*2).Take(2).ToArray());
+            }
+
+            startEvent.Set();
+            var count = 0;
+            while (count < expectedMessages)
+            {
+                Envelope result;
+                if (queue.TryDequeue(out result))
+                {
+                    var index = Array.IndexOf(messages, result.Message);
+                    var producerIndex = index >> 1;
+                    var messageIndex = index & 1;
+
+                    lastSeenMessagePerProducer[producerIndex].ShouldNotBe(messageIndex);
+                    lastSeenMessagePerProducer[producerIndex] = messageIndex;
+
+                    count += 1;
+                }
+            }
+
+            endEvent.Wait(TimeSpan.FromSeconds(1)).ShouldBeTrue();
+        }
+    }
+}

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -269,6 +269,7 @@
     <Compile Include="NotUsed.cs" />
     <Compile Include="Util\ByteIterator.cs" />
     <Compile Include="Util\ByteString.cs" />
+    <Compile Include="Util\ConcurrentEnvelopeQueue.cs" />
     <Compile Include="Util\ContinuousEnumerator.cs" />
     <Compile Include="Util\FastLazy.cs" />
     <Compile Include="Util\Index.cs" />

--- a/src/core/Akka/Dispatch/MessageQueues/UnboundedMailboxQueue.cs
+++ b/src/core/Akka/Dispatch/MessageQueues/UnboundedMailboxQueue.cs
@@ -26,7 +26,12 @@ namespace Akka.Dispatch.MessageQueues
 
         public bool HasMessages
         {
+#if MONO
             get { return _queue.Count > 0; }
+#else
+            get { return !_queue.IsEmpty; }
+
+#endif
         }
 
         public int Count

--- a/src/core/Akka/Dispatch/MessageQueues/UnboundedMailboxQueue.cs
+++ b/src/core/Akka/Dispatch/MessageQueues/UnboundedMailboxQueue.cs
@@ -5,11 +5,15 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
 using Akka.Actor;
 #if MONO
 using TQueue = Akka.Util.MonoConcurrentQueue<Akka.Actor.Envelope>;
 #else
-using TQueue = System.Collections.Concurrent.ConcurrentQueue<Akka.Actor.Envelope>;
+using TQueue = Akka.Util.ConcurrentEnvelopeQueue;
 
 #endif
 
@@ -32,7 +36,11 @@ namespace Akka.Dispatch.MessageQueues
 
         public void Enqueue(IActorRef receiver, Envelope envelope)
         {
+#if MONO
             _queue.Enqueue(envelope);
+#else
+            _queue.Enqueue(ref envelope);
+#endif
         }
 
         public bool TryDequeue(out Envelope envelope)
@@ -50,4 +58,3 @@ namespace Akka.Dispatch.MessageQueues
         }
     }
 }
-

--- a/src/core/Akka/Util/ConcurrentEnvelopeQueue.cs
+++ b/src/core/Akka/Util/ConcurrentEnvelopeQueue.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Threading;
+using Akka.Actor;
+
+namespace Akka.Util
+{
+    /// <summary>
+    /// A lighter replacement for <see cref="System.Collections.Concurrent.ConcurrentQueue{Envelope}"/>
+    /// </summary>
+    /// <remarks>
+    /// This implemenatation is aware of the <see cref="Envelope"/> structure using its two fields <see cref="Envelope.Message"/> and <see cref="Envelope.Sender"/> to persist data 
+    /// without additional overhead of the status field. Writing and reading every <see cref="Segment._messages"/> item with <see cref="Volatile"/> ensures proper ordering without the burden of maintaining the envelope's struct status.
+    /// </remarks>
+    public sealed class ConcurrentEnvelopeQueue
+    {
+        private volatile Segment _head;
+        private volatile Segment _tail;
+
+        private const int SegmentSize = 32;
+        private const int SegmentSizeMask = SegmentSize - 1;
+
+        /// <summary>
+        /// Inititalizes this queue.
+        /// </summary>
+        public ConcurrentEnvelopeQueue()
+        {
+            _head = _tail = new Segment(0L, this);
+        }
+
+        /// <summary>
+        /// Returns true if the queue is empty.
+        /// </summary>
+        public bool IsEmpty
+        {
+            get
+            {
+                var segment = _head;
+                if (!segment.IsEmpty)
+                    return false;
+                if (segment.Next == null)
+                    return true;
+                var spinWait = new SpinWait();
+                for (; segment.IsEmpty; segment = _head)
+                {
+                    if (segment.Next == null)
+                        return true;
+                    spinWait.SpinOnce();
+                }
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Counts elements in the queue.
+        /// </summary>
+        public int Count
+        {
+            get
+            {
+                Segment head;
+                Segment tail;
+                int headLow;
+                int tailHigh;
+                this.GetHeadTailPositions(out head, out tail, out headLow, out tailHigh);
+                if (head == tail)
+                    return tailHigh - headLow + 1;
+                return 32 - headLow + 32*(int) (tail.Index - head.Index - 1L) + (tailHigh + 1);
+            }
+        }
+
+        private void GetHeadTailPositions(out Segment head, out Segment tail, out int headLow, out int tailHigh)
+        {
+            head = _head;
+            tail = _tail;
+            headLow = head.Low;
+            tailHigh = tail.High;
+            var spinWait = new SpinWait();
+            while (head != _head || tail != _tail || (headLow != head.Low || tailHigh != tail.High) ||
+                   head.Index > tail.Index)
+            {
+                spinWait.SpinOnce();
+                head = _head;
+                tail = _tail;
+                headLow = head.Low;
+                tailHigh = tail.High;
+            }
+        }
+
+        /// <summary>
+        /// Enqueues <paramref name="item"/>.
+        /// </summary>
+        public void Enqueue(ref Envelope item)
+        {
+            var spinWait = new SpinWait();
+            while (!_tail.TryAppend(ref item))
+                spinWait.SpinOnce();
+        }
+
+        /// <summary>
+        /// Tries to dequeue an envelope.
+        /// </summary>
+        /// <returns>If dequeue succeeded.</returns>
+        public bool TryDequeue(out Envelope result)
+        {
+            while (!IsEmpty)
+            {
+                if (_head.TryRemove(out result))
+                    return true;
+            }
+            result = default(Envelope);
+            return false;
+        }
+
+        private class Segment
+        {
+            internal readonly long Index;
+            private volatile IActorRef[] _senders;
+            private volatile object[] _messages;
+            private volatile Segment _next;
+            private volatile int _low;
+            private volatile int _high;
+            private volatile ConcurrentEnvelopeQueue _source;
+
+            internal Segment Next => _next;
+
+            internal bool IsEmpty => Low > High;
+
+            internal int Low => Math.Min(_low, SegmentSize);
+
+            internal int High => Math.Min(_high, SegmentSizeMask);
+
+            internal Segment(long index, ConcurrentEnvelopeQueue source)
+            {
+                _senders = new IActorRef[SegmentSize];
+                _messages = new object[SegmentSize];
+                _high = -1;
+                Index = index;
+                _source = source;
+            }
+
+            void Grow()
+            {
+                _next = new Segment(Index + 1L, _source);
+                _source._tail = _next;
+            }
+
+            internal bool TryAppend(ref Envelope value)
+            {
+                if (_high >= SegmentSizeMask)
+                    return false;
+                int index;
+                try
+                {
+                }
+                finally
+                {
+                    index = Interlocked.Increment(ref _high);
+                    if (index <= SegmentSizeMask)
+                    {
+                        _senders[index] = value.Sender;
+                        Volatile.Write(ref _messages[index], value.Message);
+                    }
+                    if (index == SegmentSizeMask)
+                        this.Grow();
+                }
+                return index <= SegmentSizeMask;
+            }
+
+            internal bool TryRemove(out Envelope result)
+            {
+                var sw1 = new SpinWait();
+                var low = Low;
+                for (var high = High; low <= high; high = High)
+                {
+                    if (Interlocked.CompareExchange(ref _low, low + 1, low) == low)
+                    {
+                        var sw2 = new SpinWait();
+                        object msg;
+                        while ((msg = Volatile.Read(ref _messages[low])) == null)
+                            sw2.SpinOnce();
+                        var sender = _senders[low];
+
+                        _senders[low] = null;
+                        _messages[low] = null;
+
+                        if (low + 1 >= SegmentSize)
+                        {
+                            var sw3 = new SpinWait();
+                            while (_next == null)
+                                sw3.SpinOnce();
+                            _source._head = _next;
+                        }
+
+                        result = new Envelope {Message = msg, Sender = sender};
+
+                        return true;
+                    }
+                    sw1.SpinOnce();
+                    low = Low;
+                }
+                result = default(Envelope);
+                return false;
+            }
+        }
+    }
+}

--- a/src/core/Akka/Util/ConcurrentEnvelopeQueue.cs
+++ b/src/core/Akka/Util/ConcurrentEnvelopeQueue.cs
@@ -11,7 +11,7 @@ namespace Akka.Util
     /// This implemenatation is aware of the <see cref="Envelope"/> structure using its two fields <see cref="Envelope.Message"/> and <see cref="Envelope.Sender"/> to persist data 
     /// without additional overhead of the status field. Writing and reading every <see cref="Segment._messages"/> item with <see cref="Volatile"/> ensures proper ordering without the burden of maintaining the envelope's struct status.
     /// </remarks>
-    public sealed class ConcurrentEnvelopeQueue
+    internal sealed class ConcurrentEnvelopeQueue
     {
         private volatile Segment _head;
         private volatile Segment _tail;


### PR DESCRIPTION
This PR provides a much better concurrent collection for `UnboundedMailboxQueue` than `ConcurrentQueue{T}`. The new structure called `ConcurrentEnvelopeQueue` has been written to store `Envelope` structs only. I checked the following performance tests repeatedly, still obtaining a meaningful positive difference.

1. `Akka.Tests.Performance.Dispatch.MailboxMemoryFootprintSpec+UnboundedMailbox` (Average result of total bytes allocated)
1. `Akka.Tests.Performance.Dispatch.MailboxBenchmarks+MailboxBatchRunPerf` (Average # of operations / s)

|Branch | Average msg/s | TotalBytesAllocated |
| --- | --- | --- |
| this PR | 6,501,868.72 | 7,274,546.46 bytes |
| dev| 6,145,230.66 | 7,756,292.31 bytes |
