### PR TITLE
Add lower bounds to SnapshotSelectionCriteria API Approval

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
@@ -637,9 +637,11 @@ namespace Akka.Persistence
         public static readonly Akka.Persistence.SnapshotSelectionCriteria Latest;
         public readonly long MaxSequenceNr;
         public readonly System.DateTime MaxTimeStamp;
+        public readonly long MinSequenceNr;
+        public readonly System.Nullable<System.DateTime> MinTimestamp;
         public static readonly Akka.Persistence.SnapshotSelectionCriteria None;
         [Newtonsoft.Json.JsonConstructorAttribute()]
-        public SnapshotSelectionCriteria(long maxSequenceNr, System.DateTime maxTimeStamp) { }
+        public SnapshotSelectionCriteria(long maxSequenceNr, System.DateTime maxTimeStamp, long minSequenceNr = 0, System.Nullable<System.DateTime> minTimestamp = null) { }
         public SnapshotSelectionCriteria(long maxSequenceNr) { }
         public bool Equals(Akka.Persistence.SnapshotSelectionCriteria other) { }
         public override bool Equals(object obj) { }

--- a/src/core/Akka.Persistence/SnapshotProtocol.cs
+++ b/src/core/Akka.Persistence/SnapshotProtocol.cs
@@ -431,22 +431,22 @@ namespace Akka.Persistence
         /// <summary>
         /// Upper bound for a selected snapshot's sequence number.
         /// </summary>
-        public long MaxSequenceNr { get; }
+        public readonly long MaxSequenceNr;
 
         /// <summary>
         /// Upper bound for a selected snapshot's timestamp.
         /// </summary>
-        public DateTime MaxTimeStamp { get; }
+        public readonly DateTime MaxTimeStamp;
 
         /// <summary>
         /// Lower bound for a selected snapshot's sequence number
         /// </summary>
-        public long MinSequenceNr { get; set; }
+        public readonly long MinSequenceNr;
 
         /// <summary>
         /// Lower bound for a selected snapshot's timestamp
         /// </summary>
-        public DateTime? MinTimestamp { get; set; }
+        public readonly DateTime? MinTimestamp;
 
         internal SnapshotSelectionCriteria Limit(long toSequenceNr)
         {


### PR DESCRIPTION
Linked commit: https://github.com/akkadotnet/akka.net/commit/4a95a1e02da0041cbc9f89787328fa395c5c7d9c

Fixed that: https://github.com/akkadotnet/akka.net/issues/2203