### PR TITLE
Using supported IsEmtpy for non-mono UnboundedMailboxQueue.

### DIFF
--- a/src/core/Akka/Dispatch/MessageQueues/UnboundedMailboxQueue.cs
+++ b/src/core/Akka/Dispatch/MessageQueues/UnboundedMailboxQueue.cs
@@ -22,7 +22,11 @@ namespace Akka.Dispatch.MessageQueues
 
         public bool HasMessages
         {
+#if MONO
             get { return _queue.Count > 0; }
+#else
+            get { return !_queue.IsEmpty; }
+#endif
         }
 
         public int Count
@@ -50,4 +54,3 @@ namespace Akka.Dispatch.MessageQueues
         }
     }
 }
-


### PR DESCRIPTION
For queues that are longer than one segment (32 messages) this may reduce the check.