### PR TITLE
Exposed API for for materialized graph builder and at-least-once-delivery semantic messages

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
@@ -62,6 +62,24 @@ namespace Akka.Persistence
         public Akka.Persistence.AtLeastOnceDeliverySnapshot GetDeliverySnapshot() { }
         public void OnReplaySuccess() { }
         public void SetDeliverySnapshot(Akka.Persistence.AtLeastOnceDeliverySnapshot snapshot) { }
+        public sealed class Delivery : System.IEquatable<Akka.Persistence.AtLeastOnceDeliverySemantic.Delivery>
+        {
+            public readonly int Attempt;
+            public readonly Akka.Actor.ActorPath Destination;
+            public readonly object Message;
+            public readonly System.DateTime Timestamp;
+            public Delivery(Akka.Actor.ActorPath destination, object message, System.DateTime timestamp, int attempt) { }
+            public bool Equals(Akka.Persistence.AtLeastOnceDeliverySemantic.Delivery other) { }
+            public override bool Equals(object obj) { }
+            public override int GetHashCode() { }
+            public Akka.Persistence.AtLeastOnceDeliverySemantic.Delivery IncrementedCopy() { }
+            public override string ToString() { }
+        }
+        public sealed class RedeliveryTick
+        {
+            public static readonly Akka.Persistence.AtLeastOnceDeliverySemantic.RedeliveryTick Instance;
+            public override bool Equals(object obj) { }
+        }
     }
     public sealed class AtLeastOnceDeliverySnapshot : Akka.Persistence.Serialization.IMessage, System.IEquatable<Akka.Persistence.AtLeastOnceDeliverySnapshot>
     {

--- a/src/core/Akka.Persistence/AtLeastOnceDeliverySemantic.cs
+++ b/src/core/Akka.Persistence/AtLeastOnceDeliverySemantic.cs
@@ -193,7 +193,7 @@ namespace Akka.Persistence
     {
 
         [Serializable]
-        internal sealed class Delivery : IEquatable<Delivery>
+        public sealed class Delivery : IEquatable<Delivery>
         {
             public readonly int Attempt;
             public readonly ActorPath Destination;
@@ -250,7 +250,7 @@ namespace Akka.Persistence
         }
 
         [Serializable]
-        internal sealed class RedeliveryTick
+        public sealed class RedeliveryTick
         {
             public static readonly RedeliveryTick Instance = new RedeliveryTick();
 

--- a/src/core/Akka.Streams/CodeGen/Dsl/GraphApply.cs
+++ b/src/core/Akka.Streams/CodeGen/Dsl/GraphApply.cs
@@ -15,14 +15,19 @@ namespace Akka.Streams.Dsl
 		/// <summary>
 		/// Creates a new <see cref="IGraph{TShape, TMat}"/> by passing a <see cref="Builder{TMat}"/> to the given create function.
 		/// </summary>
-		public static IGraph<TShape, NotUsed> Create<TShape>(Func<Builder<NotUsed>, TShape> buildBlock) where TShape: Shape
+		public static IGraph<TShape, TMat> CreateMaterialized<TShape, TMat>(Func<Builder<TMat>, TShape> buildBlock) where TShape: Shape
 		{
-			var builder = new Builder<NotUsed>();
+			var builder = new Builder<TMat>();
 			var shape = buildBlock(builder);
 			var module = builder.Module.ReplaceShape(shape);
 
-			return new GraphImpl<TShape, NotUsed>(shape, module);
+			return new GraphImpl<TShape, TMat>(shape, module);
 		}
+
+        /// <summary>
+        /// Creates a new <see cref="IGraph{TShape}"/> by passing a <see cref="Builder{NotUsed}"/> to the given create function.
+        /// </summary>
+        public static IGraph<TShape, NotUsed> Create<TShape>(Func<Builder<NotUsed>, TShape> buildBlock) where TShape : Shape => CreateMaterialized(buildBlock);
 		
 		/// <summary>
 		/// Creates a new <see cref="IGraph{TShape, TMat}"/> by importing the given graph <paramref name="g1"/> 


### PR DESCRIPTION
- New method: `Graph.CreateMaterialized` which allows to use GraphDsl.Builder with custom generic type parameter. This is necessary, because currently there is no way to use Graph API returning graphs with custom materializer type. 
- Changed signatures of internal `AtLeastOnceDeliverySemantic` messages to public. This is also necessary, since using this object as separate component (instead of internal field of `AtLeastOnceDeliveryActor`) causes problems when internal messages, such as `RedeliveryTick`, arrive to user actors.