### PR TITLE
Fix of #2226. DistributedPubSubMediator.NextVersion will use ticks

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubMediator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubMediator.cs
@@ -611,7 +611,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         private long _version = 0L;
         private long NextVersion()
         {
-            var current = Math.Max(0L, (long)DateTime.UtcNow.TimeOfDay.TotalMilliseconds);
+            var current = DateTime.UtcNow.Ticks / 10000;
             _version = current > _version ? current : _version + 1;
             return _version;
         }


### PR DESCRIPTION
Solution of https://github.com/akkadotnet/akka.net/issues/2226
Handles the midnight issue and I don't think that timestamp point of start is a problem.