### PR TITLE
PersistentFSM Removes events duplication on stacked Applying

### DIFF
--- a/src/core/Akka.Persistence/Fsm/PersistentFSMBase.cs
+++ b/src/core/Akka.Persistence/Fsm/PersistentFSMBase.cs
@@ -955,7 +955,7 @@ namespace Akka.Persistence.Fsm
                 var events = new List<TEvent>();
                 events.AddRange(DomainEvents);
                 events.Add(e);
-                return Copy(null, null, null, new ArrayLinearSeq<TEvent>(DomainEvents.Concat(events).ToArray()));
+                return Copy(null, null, null, new ArrayLinearSeq<TEvent>(events.ToArray()));
             }
 
 


### PR DESCRIPTION
We have this problem in PersistentFSM.
'''
return this.GoTo(newState).Applying(event1).Applying(event2).Applying(event3);
'''
In this case `event1` will be applied 3 times, `event2` 2 times and `event3` 1 time.
This PR fixes it.