### PR TITLE
Fixed ordering issues for tagged persistence query (SQL)

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Query.Sql/EventsByTagPublisher.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.Sql/EventsByTagPublisher.cs
@@ -101,7 +101,7 @@ namespace Akka.Persistence.Query.Sql
                         sequenceNr: replayed.Persistent.SequenceNr,
                         @event: replayed.Persistent.Payload));
 
-                    CurrentOffset = replayed.Offset + 1;
+                    CurrentOffset = replayed.Offset;
                     Buffer.DeliverBuffer(TotalDemand);
                 })
                 .With<RecoverySuccess>(success =>

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryExecutor.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryExecutor.cs
@@ -88,6 +88,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         public readonly string ManifestColumnName;
         public readonly string TimestampColumnName;
         public readonly string IsDeletedColumnName;
+        public readonly string OrderingColumnName;
 
         public readonly TimeSpan Timeout;
 
@@ -102,6 +103,7 @@ namespace Akka.Persistence.Sql.Common.Journal
             string timestampColumnName,
             string isDeletedColumnName,
             string tagsColumnName,
+            string orderingColumnName,
             TimeSpan timeout)
         {
             SchemaName = schemaName;
@@ -115,6 +117,7 @@ namespace Akka.Persistence.Sql.Common.Journal
             IsDeletedColumnName = isDeletedColumnName;
             Timeout = timeout;
             TagsColumnName = tagsColumnName;
+            OrderingColumnName = orderingColumnName;
         }
 
         public string FullJournalTableName => string.IsNullOrEmpty(SchemaName) ? JournalEventsTableName : SchemaName + "." + JournalEventsTableName;
@@ -131,6 +134,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         protected const int IsDeletedIndex = 3;
         protected const int ManifestIndex = 4;
         protected const int PayloadIndex = 5;
+        protected const int OrderingIndex = 6;
 
         protected static readonly string LongTypeName = typeof(long).FullName;
 
@@ -180,10 +184,10 @@ namespace Akka.Persistence.Sql.Common.Journal
 
             ByTagSql =
                 $@"
-                SELECT {allEventColumnNames}
+                SELECT {allEventColumnNames}, e.{Configuration.OrderingColumnName} as Ordering
                 FROM {Configuration.FullJournalTableName} e
-                WHERE e.{Configuration.TagsColumnName} LIKE @Tag
-                ORDER BY {Configuration.PersistenceIdColumnName}, {Configuration.SequenceNrColumnName}";
+                WHERE e.{Configuration.OrderingColumnName} > @Ordering AND e.{Configuration.TagsColumnName} LIKE @Tag
+                ORDER BY {Configuration.OrderingColumnName} ASC";
 
             InsertEventSql = $@"
                 INSERT INTO {Configuration.FullJournalTableName} (
@@ -266,10 +270,9 @@ namespace Akka.Persistence.Sql.Common.Journal
         {
             using (var command = GetCommand(connection, ByTagSql))
             {
-                fromOffset = Math.Max(1, fromOffset);
                 var take = Math.Min(toOffset - fromOffset, max);
                 AddParameter(command, "@Tag", DbType.String, "%;" + tag + ";%");
-                AddParameter(command, "@Skip", DbType.Int64, fromOffset - 1);
+                AddParameter(command, "@Ordering", DbType.Int64, fromOffset);
                 AddParameter(command, "@Take", DbType.Int64, take);
 
                 using (var reader = await command.ExecuteReaderAsync(cancellationToken))
@@ -278,9 +281,9 @@ namespace Akka.Persistence.Sql.Common.Journal
                     while (await reader.ReadAsync(cancellationToken))
                     {
                         var persistent = ReadEvent(reader);
+                        var ordering = reader.GetInt64(OrderingIndex);
                         maxSequenceNr = Math.Max(maxSequenceNr, persistent.SequenceNr);
-                        callback(new ReplayedTaggedMessage(persistent, tag, fromOffset));
-                        fromOffset++;
+                        callback(new ReplayedTaggedMessage(persistent, tag, ordering));
                     }
 
                     return maxSequenceNr;

--- a/src/contrib/persistence/Akka.Persistence.Sql.TestKit/EventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.TestKit/EventsByTagSpec.cs
@@ -58,17 +58,17 @@ namespace Akka.Persistence.Sql.TestKit
             var greenSrc = _queries.CurrentEventsByTag("green", offset: 0);
             var probe = greenSrc.RunWith(this.SinkProbe<EventEnvelope>(), _materializer);
             probe.Request(2)
-                .ExpectNext(new EventEnvelope(1, "a", 2, "a green apple"))
-                .ExpectNext(new EventEnvelope(2, "a", 3, "a green banana"));
+                .ExpectNext(new EventEnvelope(2, "a", 2, "a green apple"))
+                .ExpectNext(new EventEnvelope(4, "a", 3, "a green banana"));
             probe.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
             probe.Request(2)
-                .ExpectNext(new EventEnvelope(3, "b", 2, "a green leaf"))
+                .ExpectNext(new EventEnvelope(5, "b", 2, "a green leaf"))
                 .ExpectComplete();
 
             var blackSrc = _queries.CurrentEventsByTag("black", offset: 0);
             probe = blackSrc.RunWith(this.SinkProbe<EventEnvelope>(), _materializer);
             probe.Request(5)
-                .ExpectNext(new EventEnvelope(1, "b", 1, "a black car"))
+                .ExpectNext(new EventEnvelope(3, "b", 1, "a black car"))
                 .ExpectComplete();
         }
 
@@ -81,8 +81,8 @@ namespace Akka.Persistence.Sql.TestKit
             var greenSrc = _queries.CurrentEventsByTag("green", offset: 0);
             var probe = greenSrc.RunWith(this.SinkProbe<EventEnvelope>(), _materializer);
             probe.Request(2)
-                .ExpectNext(new EventEnvelope(1, "a", 2, "a green apple"))
-                .ExpectNext(new EventEnvelope(2, "a", 3, "a green banana"))
+                .ExpectNext(new EventEnvelope(2, "a", 2, "a green apple"))
+                .ExpectNext(new EventEnvelope(4, "a", 3, "a green banana"))
                 .ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
             c.Tell("a green cucumber");
@@ -90,7 +90,7 @@ namespace Akka.Persistence.Sql.TestKit
 
             probe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
             probe.Request(5)
-                .ExpectNext(new EventEnvelope(3, "b", 2, "a green leaf"))
+                .ExpectNext(new EventEnvelope(5, "b", 2, "a green leaf"))
                 .ExpectComplete();
         }
 
@@ -102,9 +102,9 @@ namespace Akka.Persistence.Sql.TestKit
             var greenSrc = _queries.CurrentEventsByTag("green", offset: 2);
             var probe = greenSrc.RunWith(this.SinkProbe<EventEnvelope>(), _materializer);
             probe.Request(10)
-                .ExpectNext(new EventEnvelope(2, "a", 3, "a green banana"))
-                .ExpectNext(new EventEnvelope(3, "b", 2, "a green leaf"))
-                .ExpectNext(new EventEnvelope(4, "c", 1, "a green cucumber"))
+                .ExpectNext(new EventEnvelope(4, "a", 3, "a green banana"))
+                .ExpectNext(new EventEnvelope(5, "b", 2, "a green leaf"))
+                .ExpectNext(new EventEnvelope(6, "c", 1, "a green cucumber"))
                 .ExpectComplete();
         }
 
@@ -118,7 +118,7 @@ namespace Akka.Persistence.Sql.TestKit
             var blackSrc = _queries.EventsByTag("black", offset: 0);
             var probe = blackSrc.RunWith(this.SinkProbe<EventEnvelope>(), _materializer);
             probe.Request(2)
-                .ExpectNext(new EventEnvelope(1, "b", 1, "a black car"))
+                .ExpectNext(new EventEnvelope(3, "b", 1, "a black car"))
                 .ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
             d.Tell("a black dog");
@@ -126,10 +126,10 @@ namespace Akka.Persistence.Sql.TestKit
             d.Tell("a black night");
             ExpectMsg("a black night-done");
 
-            probe.ExpectNext(new EventEnvelope(2, "d", 1, "a black dog"))
+            probe.ExpectNext(new EventEnvelope(7, "d", 1, "a black dog"))
                 .ExpectNoMsg(TimeSpan.FromMilliseconds(100));
             probe.Request(10)
-                .ExpectNext(new EventEnvelope(3, "d", 2, "a black night"));
+                .ExpectNext(new EventEnvelope(8, "d", 2, "a black night"));
         }
 
         [Fact]
@@ -137,12 +137,12 @@ namespace Akka.Persistence.Sql.TestKit
         {
             Sql_live_query_EventsByTag_should_find_new_events();
 
-            var greenSrc = _queries.EventsByTag("green", offset: 2L);
+            var greenSrc = _queries.EventsByTag("green", offset: 2);
             var probe = greenSrc.RunWith(this.SinkProbe<EventEnvelope>(), _materializer);
             probe.Request(10)
-                .ExpectNext(new EventEnvelope(2L, "a", 3L, "a green banana"))
-                .ExpectNext(new EventEnvelope(3L, "b", 2L, "a green leaf"))
-                .ExpectNext(new EventEnvelope(4L, "c", 1L, "a green cucumber"))
+                .ExpectNext(new EventEnvelope(4, "a", 3L, "a green banana"))
+                .ExpectNext(new EventEnvelope(5, "b", 2L, "a green leaf"))
+                .ExpectNext(new EventEnvelope(6, "c", 1L, "a green cucumber"))
                 .ExpectNoMsg(TimeSpan.FromMilliseconds(100));
         }
 

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteConfigSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteConfigSpec.cs
@@ -6,12 +6,18 @@
 //-----------------------------------------------------------------------
 
 using System;
+using Akka.Actor;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Akka.Persistence.Sqlite.Tests
 {
     public class SqliteConfigSpec : Akka.TestKit.Xunit2.TestKit
     {
+        public SqliteConfigSpec(ITestOutputHelper output) : base(output: output)
+        {
+        }
+
         [Fact]
         public void Should_sqlite_journal_has_default_config()
         {

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/SqliteJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/SqliteJournal.cs
@@ -30,6 +30,7 @@ namespace Akka.Persistence.Sqlite.Journal
                 timestampColumnName: "timestamp",
                 isDeletedColumnName: "is_deleted",
                 tagsColumnName: "tags",
+                orderingColumnName: "ordering",
                 timeout: config.GetTimeSpan("connection-timeout")), 
                     Context.System.Serialization, 
                     GetTimestampProvider(config.GetString("timestamp-provider")));

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/SqliteQueryExecutor.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/SqliteQueryExecutor.cs
@@ -16,10 +16,11 @@ namespace Akka.Persistence.Sqlite.Journal
         public SqliteQueryExecutor(QueryConfiguration configuration, Akka.Serialization.Serialization serialization, ITimestampProvider timestampProvider) 
             : base(configuration, serialization, timestampProvider)
         {
-            ByTagSql = base.ByTagSql + " LIMIT @Take OFFSET @Skip";
+            ByTagSql = base.ByTagSql + " LIMIT @Take";
 
             CreateEventsJournalSql = $@"
                 CREATE TABLE IF NOT EXISTS {configuration.FullJournalTableName} (
+                    {configuration.OrderingColumnName} INTEGER PRIMARY KEY NOT NULL,
                     {configuration.PersistenceIdColumnName} VARCHAR(255) NOT NULL,
                     {configuration.SequenceNrColumnName} INTEGER(8) NOT NULL,
                     {configuration.IsDeletedColumnName} INTEGER(1) NOT NULL,
@@ -27,7 +28,7 @@ namespace Akka.Persistence.Sqlite.Journal
                     {configuration.TimestampColumnName} INTEGER NOT NULL,
                     {configuration.PayloadColumnName} BLOB NOT NULL,
                     {configuration.TagsColumnName} VARCHAR(2000) NULL,
-                    PRIMARY KEY ({configuration.PersistenceIdColumnName}, {configuration.SequenceNrColumnName})
+                    UNIQUE ({configuration.PersistenceIdColumnName}, {configuration.SequenceNrColumnName})
                 );";
 
             CreateMetaTableSql = $@"

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/README.md
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/README.md
@@ -50,11 +50,11 @@ SQLite persistence plugin defines a default table schema used for both journal a
 
 **EventJournal table**:
 
-    +----------------+-------------+------------+----------------+------------+---------+
-    | persistence_id | sequence_nr | is_deleted |    manifest    | timestamp  | payload |
-    +----------------+-------------+------------+----------------+------------+---------+
-    |  varchar(255)  | integer(8)  | integer(1) |  varchar(255)  | integer(8) |   blob  |
-    +----------------+-------------+------------+----------------+------------+---------+
+    +------------+----------------+-------------+------------+----------------+------------+---------+
+    |  ordering  | persistence_id | sequence_nr | is_deleted |    manifest    | timestamp  | payload |
+    +------------+----------------+-------------+------------+----------------+------------+---------+
+    | integer(8) |  varchar(255)  | integer(8)  | integer(1) |  varchar(255)  | integer(8) |   blob  |
+    +------------+----------------+-------------+------------+----------------+------------+---------+
 
 **SnapshotStore table**:
 


### PR DESCRIPTION
This PR introduces new Ordering column to journal. It's used for ordering persistent queries operating on event tags. It fixed problem mentioned in #2257 . It should be followed by the PRs on the SqlServer and PostgreSQL implementations.