### PR TITLE
Fixed missing type registrations in DiResolverSpec

### DIFF
--- a/src/contrib/dependencyinjection/Akka.DI.TestKit/DiResolverSpec.cs
+++ b/src/contrib/dependencyinjection/Akka.DI.TestKit/DiResolverSpec.cs
@@ -219,6 +219,8 @@ namespace Akka.DI.TestKit
             Bind<DisposableActor>(container);
             Bind<DiPerRequestActor>(container);
             Bind<DiSingletonActor>(container);
+            Bind<BoundedStashActor>(container);
+            Bind<UnboundedStashActor>(container);
             return NewDependencyResolver(container, system);
         }
 


### PR DESCRIPTION
Added missing type registrations in DiResolverSpec to resolve an issue
where some DI libraries would fail tests because the actor being
resolved through the DI system was not registered (autofac to name one)