### PR TITLE
Updated Ask user cancellation rebase

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -837,7 +837,11 @@ namespace Akka.Actor
     public class static Futures
     {
         public static System.Threading.Tasks.Task<object> Ask(this Akka.Actor.ICanTell self, object message, System.Nullable<System.TimeSpan> timeout = null) { }
+        public static System.Threading.Tasks.Task<object> Ask(this Akka.Actor.ICanTell self, object message, System.Threading.CancellationToken cancellationToken) { }
+        public static System.Threading.Tasks.Task<object> Ask(this Akka.Actor.ICanTell self, object message, System.Nullable<System.TimeSpan> timeout, System.Threading.CancellationToken cancellationToken) { }
         public static System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, object message, System.Nullable<System.TimeSpan> timeout = null) { }
+        public static System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, object message, System.Threading.CancellationToken cancellationToken) { }
+        public static System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, object message, System.Nullable<System.TimeSpan> timeout, System.Threading.CancellationToken cancellationToken) { }
     }
     public class static GracefulStopSupport
     {

--- a/src/core/Akka.Tests/Actor/AskSpec.cs
+++ b/src/core/Akka.Tests/Actor/AskSpec.cs
@@ -86,6 +86,15 @@ namespace Akka.Tests.Actor
             Assert.Throws<AggregateException>(() => { actor.Ask<string>("timeout", TimeSpan.FromSeconds(3)).Wait(); });
         }
 
+        [Fact]
+        public void CanCancelWhenAskingActor()
+        {            
+            var actor = Sys.ActorOf<SomeActor>();
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+            Assert.Throws<AggregateException>(() => { actor.Ask<string>("timeout", Timeout.InfiniteTimeSpan, cts.Token).Wait(); });
+            Assert.True(cts.IsCancellationRequested);
+        }
+
         /// <summary>
         /// Tests to ensure that if we wait on the result of an Ask inside an actor's receive loop
         /// that we don't deadlock

--- a/src/core/Akka.Tests/Actor/AskSpec.cs
+++ b/src/core/Akka.Tests/Actor/AskSpec.cs
@@ -87,7 +87,7 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
-        public void CanCancelWhenAskingActor()
+        public void Can_cancel_when_asking_actor()
         {            
             var actor = Sys.ActorOf<SomeActor>();
             var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -91,10 +91,14 @@ namespace Akka.Actor
                 timeoutCancellation = new CancellationTokenSource();
                 timeoutCancellation.Token.Register(() => result.TrySetCanceled());
                 timeoutCancellation.CancelAfter(timeout.Value);
+                result.Task.ContinueWith(_ => timeoutCancellation.Dispose());
             }
 
             if (cancellationToken.CanBeCanceled)
-                cancellationToken.Register(() => result.TrySetCanceled());
+            {
+                var ctr = cancellationToken.Register(() => result.TrySetCanceled());
+                result.Task.ContinueWith(_ => ctr.Dispose());
+            }                
         
             //create a new tempcontainer path
             ActorPath path = provider.TempPath();

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -91,13 +91,15 @@ namespace Akka.Actor
                 timeoutCancellation = new CancellationTokenSource();
                 timeoutCancellation.Token.Register(() => result.TrySetCanceled());
                 timeoutCancellation.CancelAfter(timeout.Value);
-                result.Task.ContinueWith(_ => timeoutCancellation.Dispose());
+                result.Task.ContinueWith(_ => timeoutCancellation.Dispose(),
+                    CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
             }
 
             if (cancellationToken.CanBeCanceled)
             {
                 var ctr = cancellationToken.Register(() => result.TrySetCanceled());
-                result.Task.ContinueWith(_ => ctr.Dispose());
+                result.Task.ContinueWith(_ => ctr.Dispose(), 
+                    CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
             }                
         
             //create a new tempcontainer path

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -27,20 +27,40 @@ namespace Akka.Actor
         //when asking from outside of an actor, we need to pass a system, so the FutureActor can register itself there and be resolvable for local and remote calls
         public static Task<object> Ask(this ICanTell self, object message, TimeSpan? timeout = null)
         {
-            return self.Ask<object>(message, timeout);
+            return self.Ask<object>(message, timeout, CancellationToken.None);
+        }
+
+        public static Task<object> Ask(this ICanTell self, object message, CancellationToken cancellationToken)
+        {
+            return self.Ask<object>(message, null, cancellationToken);
+        }
+
+        public static Task<object> Ask(this ICanTell self, object message, TimeSpan? timeout, CancellationToken cancellationToken)
+        {
+            return self.Ask<object>(message, timeout, cancellationToken);
+        }
+
+        public static Task<T> Ask<T>(this ICanTell self, object message, TimeSpan? timeout = null)
+        {
+            return self.Ask<T>(message, timeout, CancellationToken.None);
+        }
+
+        public static Task<T> Ask<T>(this ICanTell self, object message, CancellationToken cancellationToken)
+        {
+            return self.Ask<T>(message, null, cancellationToken);
         }
 
         /// <summary></summary>
         /// <exception cref="ArgumentException">
         /// This exception is thrown if the system can't resolve the target provider.
         /// </exception>
-        public static Task<T> Ask<T>(this ICanTell self, object message, TimeSpan? timeout = null)
+        public static Task<T> Ask<T>(this ICanTell self, object message, TimeSpan? timeout, CancellationToken cancellationToken)
         {
             IActorRefProvider provider = ResolveProvider(self);
             if (provider == null)
                 throw new ArgumentException("Unable to resolve the target Provider", nameof(self));
 
-            return Ask(self, message, provider, timeout).CastTask<object, T>();
+            return Ask(self, message, provider, timeout, cancellationToken).CastTask<object, T>();
         }
 
         internal static IActorRefProvider ResolveProvider(ICanTell self)
@@ -58,7 +78,7 @@ namespace Akka.Actor
         }
 
         private static Task<object> Ask(ICanTell self, object message, IActorRefProvider provider,
-            TimeSpan? timeout)
+            TimeSpan? timeout, CancellationToken cancellationToken)
         {
             var result = new TaskCompletionSource<object>();
 
@@ -73,6 +93,9 @@ namespace Akka.Actor
                 timeoutCancellation.CancelAfter(timeout.Value);
             }
 
+            if (cancellationToken.CanBeCanceled)
+                cancellationToken.Register(() => result.TrySetCanceled());
+        
             //create a new tempcontainer path
             ActorPath path = provider.TempPath();
             //callback to unregister from tempcontainer


### PR DESCRIPTION
This is taking Zetanova's commits from [PR #1632](https://github.com/akkadotnet/akka.net/pull/1632) in January, rebasing and doing all the merging to keep them current against the dev branch, and adding in the [changes](https://github.com/akkadotnet/akka.net/pull/1632#issuecomment-193860389) necessary to make the public API tests pass. [Additionally](https://github.com/akkadotnet/akka.net/pull/1632#issuecomment-253962723), one untested optimization was left out in the merge, and a test was renamed to follow adjustments to naming conventions.

The purpose is to allow the `Ask` extensions on `ICanTell` to be cancelled externally beyond just waiting for timeouts.
