### PR TITLE
Fix Serialization KeyNotFoundException when looking up serializers

### DIFF
--- a/src/core/Akka/Serialization/Serialization.cs
+++ b/src/core/Akka/Serialization/Serialization.cs
@@ -80,7 +80,10 @@ namespace Akka.Serialization
                     continue;
                 }
 
-                var serializer = namedSerializers[serializerName];
+                Serializer serializer;
+
+                namedSerializers.TryGetValue(serializerName, out serializer);
+
                 if (serializer == null)
                 {
                     system.Log.Warning("Serialization binding to non existing serializer: '{0}'", serializerName);

--- a/src/core/Akka/Serialization/Serialization.cs
+++ b/src/core/Akka/Serialization/Serialization.cs
@@ -82,13 +82,12 @@ namespace Akka.Serialization
 
                 Serializer serializer;
 
-                namedSerializers.TryGetValue(serializerName, out serializer);
-
-                if (serializer == null)
+                if (!namedSerializers.TryGetValue(serializerName, out serializer))
                 {
                     system.Log.Warning("Serialization binding to non existing serializer: '{0}'", serializerName);
                     continue;
                 }
+
                 _serializerMap.Add(messageType, serializer);
             }
         }


### PR DESCRIPTION
A `KeyNotFoundException` can occur if the serializer dll is not present in the search paths for binaries. This can occur when there is a proj A that depends on B and B depends on Akka. There is no direct reference to any of the serializers in either A or B besides being referenced in HOCON. MSBuild likes to optimize dlls out of the output if they are not directly referenced in code.