### PR TITLE
added Cluster.LeaveAsync for graceful exit

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCluster.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCluster.approved.txt
@@ -28,6 +28,7 @@ namespace Akka.Cluster
         public void Join(Akka.Actor.Address address) { }
         public void JoinSeedNodes(System.Collections.Generic.IEnumerable<Akka.Actor.Address> seedNodes) { }
         public void Leave(Akka.Actor.Address address) { }
+        public System.Threading.Tasks.Task LeaveAsync() { }
         public void RegisterOnMemberRemoved(System.Action callback) { }
         public void RegisterOnMemberUp(System.Action callback) { }
         public Akka.Actor.ActorPath RemotePathOf(Akka.Actor.IActorRef actorRef) { }

--- a/src/core/Akka.Cluster.Tests/ClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterSpec.cs
@@ -143,12 +143,11 @@ namespace Akka.Cluster.Tests
 
             var leaveTask = _cluster.LeaveAsync();
 
-            Within(TimeSpan.FromSeconds(10), () =>
-            {
-                // current node should be marked as leaving, but not removed yet
-                AwaitCondition(() => _cluster.State.Members
-                    .Single(x => x.Address.Equals(_cluster.SelfAddress)).Status == MemberStatus.Leaving);
-            });
+            // current node should be marked as leaving, but not removed yet
+            AwaitCondition(() => _cluster.State.Members
+                .Single(x => x.Address.Equals(_cluster.SelfAddress)).Status == MemberStatus.Leaving, 
+                TimeSpan.FromSeconds(10), 
+                message: "Failed to observe node as Leaving.");
 
             // can't run this inside Within block
             ExpectNoMsg();
@@ -159,7 +158,8 @@ namespace Akka.Cluster.Tests
 
                 LeaderActions(); // Leaving --> Exiting
                 AwaitCondition(() => _cluster.State.Members
-                   .Single(x => x.Address.Equals(_cluster.SelfAddress)).Status == MemberStatus.Exiting);
+                   .Single(x => x.Address.Equals(_cluster.SelfAddress)).Status == MemberStatus.Exiting, 
+                   TimeSpan.FromSeconds(10), message: "Failed to observe node as Exiting.");
 
                 LeaderActions(); // Exiting --> Removed
                 ExpectMsg<ClusterEvent.MemberRemoved>().Member.Address.Should().Be(_selfAddress);

--- a/src/core/Akka.Cluster.Tests/ClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterSpec.cs
@@ -131,6 +131,37 @@ namespace Akka.Cluster.Tests
         }
 
         [Fact]
+        public void A_cluster_must_complete_LeaveAsync_task_upon_being_removed()
+        {
+            _cluster.Join(_selfAddress);
+            LeaderActions(); // Joining -> Up
+
+            _cluster.Subscribe(TestActor, new[] { typeof(ClusterEvent.MemberRemoved) });
+
+            // first, is in response to the subscription
+            ExpectMsg<ClusterEvent.CurrentClusterState>();
+
+            var leaveTask = _cluster.LeaveAsync();
+
+            // current node should be marked as leaving, but not removed yet
+            AwaitCondition(() => _cluster.State.Members
+                .Single(x => x.Address.Equals(_cluster.SelfAddress)).Status == MemberStatus.Leaving);
+            ExpectNoMsg();
+            leaveTask.IsCompleted.Should().BeFalse();
+
+            LeaderActions(); // Leaving --> Exiting
+            AwaitCondition(() => _cluster.State.Members
+               .Single(x => x.Address.Equals(_cluster.SelfAddress)).Status == MemberStatus.Exiting);
+
+            LeaderActions(); // Exiting --> Removed
+            ExpectMsg<ClusterEvent.MemberRemoved>().Member.Address.Should().Be(_selfAddress);
+            leaveTask.IsCompleted.Should().BeTrue();
+
+            // A second call for LeaveAsync should complete immediately
+            _cluster.LeaveAsync().IsCompleted.Should().BeTrue();
+        }
+
+        [Fact]
         public void A_cluster_must_be_allowed_to_join_and_leave_with_local_address()
         {
             var sys2 = ActorSystem.Create("ClusterSpec2", ConfigurationFactory.ParseString(@"akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""

--- a/src/core/Akka.Cluster.Tests/ClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterSpec.cs
@@ -148,7 +148,13 @@ namespace Akka.Cluster.Tests
                 // current node should be marked as leaving, but not removed yet
                 AwaitCondition(() => _cluster.State.Members
                     .Single(x => x.Address.Equals(_cluster.SelfAddress)).Status == MemberStatus.Leaving);
-                ExpectNoMsg();
+            });
+
+            // can't run this inside Within block
+            ExpectNoMsg();
+
+            Within(TimeSpan.FromSeconds(10), () =>
+            {
                 leaveTask.IsCompleted.Should().BeFalse();
 
                 LeaderActions(); // Leaving --> Exiting


### PR DESCRIPTION
close #2280 

Also tried to implement the `leave-on-termination` feature in HOCON, but unfortunately the `TerminationHooks` implemented in `ActorSystem` don't support this - they always run *after* the actors have shut down. We'd need something that runs *before* the ActorSystem has shut down the actors to implement this correctly.

Therefore, I think the smartest thing to do is when developing an Akka.Cluster application, always call `Cluster.LeaveAsync` -> `ActorSystem.Terminate` in that order when you're ready to shut down. 
