### PR TITLE
Get events from sql journal db in right sequence

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryExecutor.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryExecutor.cs
@@ -180,7 +180,8 @@ namespace Akka.Persistence.Sql.Common.Journal
                 SELECT {allEventColumnNames}
                 FROM {Configuration.FullJournalTableName} e
                 WHERE e.{Configuration.PersistenceIdColumnName} = @PersistenceId
-                AND e.{Configuration.SequenceNrColumnName} BETWEEN @FromSequenceNr AND @ToSequenceNr;";
+                AND e.{Configuration.SequenceNrColumnName} BETWEEN @FromSequenceNr AND @ToSequenceNr
+				ORDER BY {Configuration.SequenceNrColumnName} ASC;";
 
             ByTagSql =
                 $@"

--- a/src/core/Akka/Pattern/CircuitBreaker.cs
+++ b/src/core/Akka/Pattern/CircuitBreaker.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Util.Internal;
@@ -156,7 +157,7 @@ namespace Akka.Pattern
             }
             if (cbTask.Exception != null)
             {
-                throw cbTask.Exception;
+                ExceptionDispatchInfo.Capture(cbTask.Exception).Throw();
             }
         }
 


### PR DESCRIPTION
After Akka.Persistence upgrade to 1.1.2 sql journal started to fetch events with undetermined order, 
not caring about SequenceNr column. 

After we changed PK from (PersistenceId, SequenceNr) to (Ordering) raws in table no longer ordered by SequenceNr, so ordering should be declared explicitly

