### PR TITLE
The log-config-on-start option fixed to log with INFO level.

### DIFF
--- a/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
@@ -135,7 +135,7 @@ namespace Akka.Actor.Internal
 
                 if (_settings.LogConfigOnStart)
                 {
-                    _log.Warning(Settings.ToString());
+                    _log.Info(Settings.ToString());
                 }
             }
             catch (Exception)


### PR DESCRIPTION
It's a bit confusing seeing warning which prints akka configuration on staging machine .

I was confused and tried to figure out if there are any problems with this configuration, because it is WARNING.

In the original akka it logs it with INFO level instead. And it's fine.
http://doc.akka.io/docs/akka/2.4/scala/logging.html#Auxiliary_logging_options

> Log the complete configuration at INFO level when the actor system is started.
> This is useful when you are uncertain of what configuration is used.
> log-config-on-start = on

Here is the scala source code:
https://github.com/akka/akka/blob/master/akka-actor/src/main/scala/akka/actor/ActorSystem.scala#L572
https://github.com/akka/akka/blob/master/akka-actor/src/main/scala/akka/actor/ActorSystem.scala#L662

Here is the net source code:
https://github.com/akkadotnet/akka.net/blob/dev/src/core/Akka/Actor/Internal/ActorSystemImpl.cs#L136-L139