### PR TITLE
Fix CircuitBreaker swallowing exceptions cased it to open

### DIFF
--- a/src/core/Akka/Pattern/CircuitBreaker.cs
+++ b/src/core/Akka/Pattern/CircuitBreaker.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Util.Internal;
@@ -156,7 +157,7 @@ namespace Akka.Pattern
             }
             if (cbTask.Exception != null)
             {
-                throw cbTask.Exception;
+                ExceptionDispatchInfo.Capture(cbTask.Exception).Throw();
             }
         }
 


### PR DESCRIPTION
CircuitBreaker swallowing stack trace of exception cased it to become Open. 
It makes debug harder 