### PR TITLE
disabled Test mode for all Akka.Streams.Tests.Performance benchmarks

### DIFF
--- a/src/core/Akka.Streams.Tests.Performance/FlowSelectBenchmark.cs
+++ b/src/core/Akka.Streams.Tests.Performance/FlowSelectBenchmark.cs
@@ -45,6 +45,8 @@ akka {
 }
 ");
 
+        private const TestMode CurrentTestMode = TestMode.Measurement;
+
         private ActorSystem _actorSystem;
         private ActorMaterializer _materializer8;
         private ActorMaterializer _materializer32;
@@ -73,7 +75,7 @@ akka {
 
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3,
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3,
             Description ="Test the performance of a Select flow with InputBufferSize of 8, 1 Select and without GraphStages.Identity")]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 300)]
@@ -81,7 +83,7 @@ akka {
             => Execute(_materializer8, 1, false);
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3,
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3,
             Description = "Test the performance of a Select flow with InputBufferSize of 32, 1 Select and without GraphStages.Identity")]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 300)]
@@ -89,7 +91,7 @@ akka {
             => Execute(_materializer32, 1, false);
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3,
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3,
             Description = "Test the performance of a Select flow with InputBufferSize of 128, 1 Select and without GraphStages.Identity")]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 300)]
@@ -98,7 +100,7 @@ akka {
 
         
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3,
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3,
             Description = "Test the performance of a Select flow with InputBufferSize of 8, 1 Select and with GraphStages.Identity")]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 200)]
@@ -106,7 +108,7 @@ akka {
             => Execute(_materializer8, 1, true);
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3,
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3,
             Description = "Test the performance of a Select flow with InputBufferSize of 32, 1 Select and with GraphStages.Identity")]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 200)]
@@ -114,7 +116,7 @@ akka {
             => Execute(_materializer32, 1, true);
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3,
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3,
             Description = "Test the performance of a Select flow with InputBufferSize of 128, 1 Select and with GraphStages.Identity")]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 200)]
@@ -126,7 +128,7 @@ akka {
 
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3,
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3,
             Description = "Test the performance of a Select flow with InputBufferSize of 8, 5 Selects and without GraphStages.Identity")]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 700)]
@@ -134,7 +136,7 @@ akka {
             => Execute(_materializer8, 5, false);
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3,
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3,
             Description = "Test the performance of a Select flow with InputBufferSize of 32, 5 Selects and without GraphStages.Identity")]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 700)]
@@ -142,7 +144,7 @@ akka {
             => Execute(_materializer32, 5, false);
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3,
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3,
             Description = "Test the performance of a Select flow with InputBufferSize of 128, 5 Selects and without GraphStages.Identity")]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 700)]
@@ -151,7 +153,7 @@ akka {
 
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3,
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3,
             Description = "Test the performance of a Select flow with InputBufferSize of 8, 5 Selects and with GraphStages.Identity")]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 200)]
@@ -159,7 +161,7 @@ akka {
             => Execute(_materializer8, 5, true);
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3,
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3,
             Description = "Test the performance of a Select flow with InputBufferSize of 32, 5 Selects and with GraphStages.Identity")]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 200)]
@@ -167,7 +169,7 @@ akka {
             => Execute(_materializer32, 5, true);
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3,
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3,
             Description = "Test the performance of a Select flow with InputBufferSize of 128, 5 Selects and with GraphStages.Identity")]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 200)]
@@ -179,7 +181,7 @@ akka {
 
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3,
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3,
             Description = "Test the performance of a Select flow with InputBufferSize of 8, 10 Selects and without GraphStages.Identity")]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 1200)]
@@ -187,7 +189,7 @@ akka {
             => Execute(_materializer8, 10, false);
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3,
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3,
             Description = "Test the performance of a Select flow with InputBufferSize of 32, 10 Selects and without GraphStages.Identity")]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 1200)]
@@ -195,7 +197,7 @@ akka {
             => Execute(_materializer32, 10, false);
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3,
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3,
             Description = "Test the performance of a Select flow with InputBufferSize of 128, 10 Selects and without GraphStages.Identity")]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 1200)]
@@ -204,7 +206,7 @@ akka {
 
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3,
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3,
             Description = "Test the performance of a Select flow with InputBufferSize of 8, 10 Selects and with GraphStages.Identity")]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 200)]
@@ -212,7 +214,7 @@ akka {
             => Execute(_materializer8, 10, true);
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3,
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3,
             Description = "Test the performance of a Select flow with InputBufferSize of 32, 10 Selects and with GraphStages.Identity")]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 200)]
@@ -220,7 +222,7 @@ akka {
             => Execute(_materializer32, 10, true);
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3,
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3,
             Description = "Test the performance of a Select flow with InputBufferSize of 128, 10 Selects and with GraphStages.Identity")]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 200)]

--- a/src/core/Akka.Streams.Tests.Performance/FusedGraphsBenchmark.cs
+++ b/src/core/Akka.Streams.Tests.Performance/FusedGraphsBenchmark.cs
@@ -10,6 +10,7 @@ namespace Akka.Streams.Tests.Performance
 {
     public class FusedGraphsBenchmark
     {
+        private const TestMode CurrentTestMode = TestMode.Measurement;
         private const int ElementCount = 100 * 1000;
 
         private sealed class MutableElement
@@ -265,61 +266,61 @@ namespace Akka.Streams.Tests.Performance
 
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 50)]
         public void SingleIdentity() => _singleIdentity.Run(_materializer).Ready();
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 100)]
         public void ChainOfIdentities() => _chainOfIdentities.Run(_materializer).Ready();
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 50)]
         public void SingleSelect() => _singleSelect.Run(_materializer).Ready();
 
         
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 110)]
         public void ChainOfSelects() => _chainOfSelects.Run(_materializer).Ready();
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 60)]
         public void SingleBuffer() => _singleBuffer.Run(_materializer).Ready();
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 350)]
         public void ChainOfBuffers() => _chainOfBuffers.Run(_materializer).Ready();
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 3500)]
         public void RepeatTakeSelectAndAggregate() => _repeatTakeSelectAndAggregate.Run(_materializer).Ready();
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 100)]
         public void BroadcastZip() => _broadcastZip.Run(_materializer).Ready();
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 50)]
         public void BalanceMerge() => _balanceMerge.Run(_materializer).Ready();
 
 
-        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+        [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 100)]
         public void BroadcastZipBalanceMerge() => _broadcastZipBalanceMerge.Run(_materializer).Ready();

--- a/src/core/Akka.Streams.Tests.Performance/GraphBuilderBenchmark.cs
+++ b/src/core/Akka.Streams.Tests.Performance/GraphBuilderBenchmark.cs
@@ -11,29 +11,31 @@ namespace Akka.Streams.Tests.Performance
 {
     public class GraphBuilderBenchmark
     {
+        private const TestMode CurrentTestMode = TestMode.Measurement;
+
         [PerfBenchmark(Description = "Test the performance of the GraphBuilder for a flow with 1 map stage",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 2)]
         public void Flow_with_1_map() => MaterializationBenchmark.FlowWithMapBuilder(1);
 
 
         [PerfBenchmark(Description = "Test the performance of the GraphBuilder for a flow with 10 map stages",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 2)]
         public void Flow_with_10_map() => MaterializationBenchmark.FlowWithMapBuilder(10);
 
 
         [PerfBenchmark(Description = "Test the performance of the GraphBuilder for a flow with 100 map stages",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 5)]
         public void Flow_with_100_map() => MaterializationBenchmark.FlowWithMapBuilder(100);
 
 
         [PerfBenchmark(Description = "Test the performance of the GraphBuilder for a flow with 1000 map stages",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 150)]
         public void Flow_with_1000_map() => MaterializationBenchmark.FlowWithMapBuilder(1000);
@@ -41,28 +43,28 @@ namespace Akka.Streams.Tests.Performance
 
 
         [PerfBenchmark(Description = "Test the performance of the GraphBuilder for a graph with 1 junction",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 2)]
         public void Graph_with_1_junction() => MaterializationBenchmark.GraphWithJunctionsBuilder(1);
 
 
         [PerfBenchmark(Description = "Test the performance of the GraphBuilder for a graph with 10 junctions",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 5)]
         public void Graph_with_10_junction() => MaterializationBenchmark.GraphWithJunctionsBuilder(10);
 
 
         [PerfBenchmark(Description = "Test the performance of the GraphBuilder for a graph with 100 junctions",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 20)]
         public void Graph_with_100_junction() => MaterializationBenchmark.GraphWithJunctionsBuilder(100);
 
 
         [PerfBenchmark(Description = "Test the performance of the GraphBuilder for a graph with 1000 junctions",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 1000)]
         public void Graph_with_1000_junction() => MaterializationBenchmark.GraphWithJunctionsBuilder(1000);
@@ -70,28 +72,28 @@ namespace Akka.Streams.Tests.Performance
 
 
         [PerfBenchmark(Description = "Test the performance of the GraphBuilder for a graph with 1 nested import",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 2)]
         public void Graph_with_1_nested_imports() => MaterializationBenchmark.GraphWithNestedImportsBuilder(1);
 
 
         [PerfBenchmark(Description = "Test the performance of the GraphBuilder for a graph with 10 nested imports",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 2)]
         public void Graph_with_10_nested_imports() => MaterializationBenchmark.GraphWithNestedImportsBuilder(10);
 
 
         [PerfBenchmark(Description = "Test the performance of the GraphBuilder for a graph with 100 nested imports",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 5)]
         public void Graph_with_100_nested_imports() => MaterializationBenchmark.GraphWithNestedImportsBuilder(100);
 
 
         [PerfBenchmark(Description = "Test the performance of the GraphBuilder for a graph with 1000 nested imports",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 5)]
         public void Graph_with_1000_nested_imports() => MaterializationBenchmark.GraphWithNestedImportsBuilder(1000);
@@ -99,28 +101,28 @@ namespace Akka.Streams.Tests.Performance
 
 
         [PerfBenchmark(Description = "Test the performance of the GraphBuilder for a graph with 1 imported flow",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 2)]
         public void Graph_with_1_imported_flow() => MaterializationBenchmark.GraphWithImportedFlowBuilder(1);
 
 
         [PerfBenchmark(Description = "Test the performance of the GraphBuilder for a graph with 10 imported flows",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 2)]
         public void Graph_with_10_imported_flows() => MaterializationBenchmark.GraphWithImportedFlowBuilder(10);
 
 
         [PerfBenchmark(Description = "Test the performance of the GraphBuilder for a graph with 100 imported flows",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 5)]
         public void Graph_with_100_imported_flows() => MaterializationBenchmark.GraphWithImportedFlowBuilder(100);
 
 
         [PerfBenchmark(Description = "Test the performance of the GraphBuilder for a graph with 1000 imported flows",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 100)]
         public void Graph_with_1000_imported_flows() => MaterializationBenchmark.GraphWithImportedFlowBuilder(1000);

--- a/src/core/Akka.Streams.Tests.Performance/IO/FileSourcesBenchmark.cs
+++ b/src/core/Akka.Streams.Tests.Performance/IO/FileSourcesBenchmark.cs
@@ -20,6 +20,8 @@ namespace Akka.Streams.Tests.Performance.IO
 {
     public class FileSourcesBenchmark
     {
+        private const TestMode CurrentTestMode = TestMode.Measurement;
+
         private const int BufferSize = 2048;
         private ActorSystem _actorSystem;
         private ActorMaterializer _materializer;
@@ -68,7 +70,7 @@ namespace Akka.Streams.Tests.Performance.IO
 
 
         [PerfBenchmark(Description = "Test the performance of a FileSource using a file channel",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 1)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 1)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 2500)]
         public void FileChannel()
@@ -78,7 +80,7 @@ namespace Akka.Streams.Tests.Performance.IO
 
 
         [PerfBenchmark(Description = "Test the performance of a FileSource using a file channel without read ahead",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 1)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 1)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 2000)]
         public void FileChannel_without_read_ahead()
@@ -89,7 +91,7 @@ namespace Akka.Streams.Tests.Performance.IO
 
 
         [PerfBenchmark(Description = "Test the performance of a FileSource using a file stream",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 1)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 1)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 2000)]
         public void FileStream()
@@ -99,7 +101,7 @@ namespace Akka.Streams.Tests.Performance.IO
 
 
         [PerfBenchmark(Description = "Test the performance of a FileSource using File.ReadLines enumerator",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 1)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 1)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 8000)]
         public void Naive_IO_lines_enumerator()

--- a/src/core/Akka.Streams.Tests.Performance/InterpreterBenchmark.cs
+++ b/src/core/Akka.Streams.Tests.Performance/InterpreterBenchmark.cs
@@ -19,15 +19,17 @@ namespace Akka.Streams.Tests.Performance
 {
     public class InterpreterBenchmark
     {
+        private const TestMode CurrentTestMode = TestMode.Measurement;
+
         [PerfBenchmark(Description = "Test the performance of the graph interpreter with 1 identity",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 200)]
         public void Graph_interpreter_100k_elements_with_1_identity() => Execute(1);
 
 
         [PerfBenchmark(Description = "Test the performance of the graph interpreter with 5 identities",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3,
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3,
             Skip = "FIXME Port is pulled twice")]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 1000)]
@@ -35,7 +37,7 @@ namespace Akka.Streams.Tests.Performance
 
 
         [PerfBenchmark(Description = "Test the performance of the graph interpreter with 10 identities",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3,
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3,
             Skip = "FIXME Port is pulled twice")]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 1000)]

--- a/src/core/Akka.Streams.Tests.Performance/JsonFramingBenchmark.cs
+++ b/src/core/Akka.Streams.Tests.Performance/JsonFramingBenchmark.cs
@@ -6,6 +6,7 @@ namespace Akka.Streams.Tests.Performance
 {
     public class JsonFramingBenchmark
     {
+        private const TestMode CurrentTestMode = TestMode.Measurement;
         private const string BracketThroughputCounterName = "Bracket";
 
         private const string Input = @"{""fname"":""Frank"",""name"":""Smith"",""age"":42,""id"":1337,""boardMember"":false},
@@ -28,7 +29,7 @@ namespace Akka.Streams.Tests.Performance
 
         [PerfBenchmark(Description = "Testing throughput for an Offer and a single Poll call",
             RunMode = RunMode.Throughput,
-            NumberOfIterations = 13, TestMode = TestMode.Test, RunTimeMilliseconds = 1000)]
+            NumberOfIterations = 13, TestMode = CurrentTestMode, RunTimeMilliseconds = 1000)]
         [CounterThroughputAssertion(BracketThroughputCounterName, MustBe.GreaterThan, 150000)]
         public void Counting_1()
         {
@@ -40,7 +41,7 @@ namespace Akka.Streams.Tests.Performance
 
         [PerfBenchmark(Description = "Testing throughput for an Offer and 6 Poll calls",
             RunMode = RunMode.Throughput,
-            NumberOfIterations = 13, TestMode = TestMode.Test, RunTimeMilliseconds = 1000)]
+            NumberOfIterations = 13, TestMode = CurrentTestMode, RunTimeMilliseconds = 1000)]
         [CounterThroughputAssertion(BracketThroughputCounterName, MustBe.GreaterThan, 20000)]
         public void Counting_offer_5()
         {

--- a/src/core/Akka.Streams.Tests.Performance/MaterializationBenchmark.cs
+++ b/src/core/Akka.Streams.Tests.Performance/MaterializationBenchmark.cs
@@ -16,6 +16,8 @@ namespace Akka.Streams.Tests.Performance
 {
     public class MaterializationBenchmark
     {
+        private const TestMode CurrentTestMode = TestMode.Measurement;
+
         private ActorSystem _actorSystem;
         private ActorMaterializerSettings _materializerSettings;
         private ActorMaterializer _materializer;
@@ -35,7 +37,7 @@ namespace Akka.Streams.Tests.Performance
         public void Shutdown() => _actorSystem.Terminate().Wait(TimeSpan.FromSeconds(5));
 
         [PerfBenchmark(Description = "Test the performance of the materialization phase for a flow with 1 map stage",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 2)]
         public void Flow_with_1_map() => FlowWithMapBuilder(1).Run(_materializer);
@@ -49,14 +51,14 @@ namespace Akka.Streams.Tests.Performance
 
 
         [PerfBenchmark(Description = "Test the performance of the materialization phase for a flow with 100 map stages",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 10)]
         public void Flow_with_100_map() => FlowWithMapBuilder(100).Run(_materializer);
 
 
         [PerfBenchmark(Description = "Test the performance of the materialization phase for a flow with 1000 map stages",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 150)]
         public void Flow_with_1000_map() => FlowWithMapBuilder(1000).Run(_materializer);
@@ -64,28 +66,28 @@ namespace Akka.Streams.Tests.Performance
 
 
         [PerfBenchmark(Description = "Test the performance of the materialization phase for a graph with 1 junction",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 2)]
         public void Graph_with_1_junction() => GraphWithJunctionsBuilder(1).Run(_materializer);
 
 
         [PerfBenchmark(Description = "Test the performance of the materialization phase for a graph with 10 junctions",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 5)]
         public void Graph_with_10_junction() => GraphWithJunctionsBuilder(10).Run(_materializer);
 
 
         [PerfBenchmark(Description = "Test the performance of the materialization phase for a graph with 100 junctions",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 20)]
         public void Graph_with_100_junction() => GraphWithJunctionsBuilder(100).Run(_materializer);
 
 
         [PerfBenchmark(Description = "Test the performance of the materialization phase for a graph with 1000 junctions",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 1000)]
         public void Graph_with_1000_junction() => GraphWithJunctionsBuilder(1000).Run(_materializer);
@@ -93,28 +95,28 @@ namespace Akka.Streams.Tests.Performance
 
 
         [PerfBenchmark(Description = "Test the performance of the materialization phase for a graph with 1 nested import",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 2)]
         public void Graph_with_1_nested_imports() => GraphWithNestedImportsBuilder(1).Run(_materializer);
 
 
         [PerfBenchmark(Description = "Test the performance of the materialization phase for a graph with 10 nested imports",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 5)]
         public void Graph_with_10_nested_imports() => GraphWithNestedImportsBuilder(10).Run(_materializer);
 
 
         [PerfBenchmark(Description = "Test the performance of the materialization phase for a graph with 100 nested imports",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 5)]
         public void Graph_with_100_nested_imports() => GraphWithNestedImportsBuilder(100).Run(_materializer);
 
 
         [PerfBenchmark(Description = "Test the performance of the materialization phase for a graph with 1000 nested imports",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3,
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3,
             Skip = "Throws StackOverflowException by around 200 nested imports")]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 1000)]
@@ -123,28 +125,28 @@ namespace Akka.Streams.Tests.Performance
 
 
         [PerfBenchmark(Description = "Test the performance of the materialization phase for a graph with 1 imported flow",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 2)]
         public void Graph_with_1_imported_flow() => GraphWithImportedFlowBuilder(1).Run(_materializer);
 
 
         [PerfBenchmark(Description = "Test the performance of the materialization phase for a graph with 10 imported flows",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 5)]
         public void Graph_with_10_imported_flows() => GraphWithImportedFlowBuilder(10).Run(_materializer);
 
 
         [PerfBenchmark(Description = "Test the performance of the materialization phase for a graph with 100 imported flows",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 10)]
         public void Graph_with_100_imported_flows() => GraphWithImportedFlowBuilder(100).Run(_materializer);
 
 
         [PerfBenchmark(Description = "Test the performance of the materialization phase for a graph with 1000 imported flows",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 100)]
         public void Graph_with_1000_imported_flows() => GraphWithImportedFlowBuilder(1000).Run(_materializer);

--- a/src/core/Akka.Streams.Tests.Performance/MergeManyBenchmark.cs
+++ b/src/core/Akka.Streams.Tests.Performance/MergeManyBenchmark.cs
@@ -18,6 +18,8 @@ namespace Akka.Streams.Tests.Performance
     // JVM : FlatMapMergeBenchmark
     public class MergeManyBenchmark
     {
+        private const TestMode CurrentTestMode = TestMode.Measurement;
+
         private ActorSystem _actorSystem;
         private ActorMaterializerSettings _materializerSettings;
         private ActorMaterializer _materializer;
@@ -60,21 +62,21 @@ namespace Akka.Streams.Tests.Performance
 
 
         [PerfBenchmark(Description = "Test the performance of a single source without using MergeMany",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 200)]
         public void Take_100k_elements() => _takeGraph.Run(_materializer).Wait();
 
 
         [PerfBenchmark(Description = "Test the performance of a single source using MergeMany",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 500)]
         public void Select_many_from_1_Source_100k_elements() => _singleGraph.Run(_materializer).Wait();
 
 
         [PerfBenchmark(Description = "Test the performance from 10 sources using MergeMany",
-            RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
+            RunMode = RunMode.Iterations, TestMode = CurrentTestMode, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 600)]
         public void Select_many_from_10_Sources_10k_elements_each() => _tenGraph.Run(_materializer).Wait();


### PR DESCRIPTION
closes #2397

This is a temporary solution to a bigger problem. The relativistic / historical benchmarking tools I've planned to add for NBench are really the right solution to this problem, but for the time being: we're having a **TON** of false negatives on our Akka.Streams performance assertions due to small variances that are totally within normal ranges (i.e. being off by a few MS.) Benchmarking concurrent code is a dark art, and doing it with hard limits is predictably erroneous.

For the time being, I've disabled assertions on the benchmarks themselves via the use of constants on the classes. This can easily be toggled on and by changing the constant value `CurrentTestMode` on each individual benchmark class.

CC @Silv3rcircl3 @Horusiath @Danthar any issues with this?