### PR TITLE
Revert "Unregister temp actor if ask operation got canceled."

### DIFF
--- a/src/core/Akka.Tests/Actor/AskTimeoutSpec.cs
+++ b/src/core/Akka.Tests/Actor/AskTimeoutSpec.cs
@@ -50,25 +50,5 @@ namespace Akka.Tests.Actor
             }
         }
 
-        [Fact]
-        public async Task TimedOut_ask_should_remove_temp_actor()
-        {
-            var actor = Sys.ActorOf<SleepyActor>();
-
-            var actorCell = actor as ActorRefWithCell;
-            var container = actorCell.Provider.TempContainer as VirtualPathContainer;
-            try
-            {
-                await actor.Ask<string>("should time out");
-            }
-            catch (Exception)
-            {
-                var childCounter = 0;
-                container.ForEachChild(x => childCounter++);
-                Assert.True(childCounter==0,"Number of children in temp container should be 0.");
-            }
-
-        }
-
     }
 }

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -66,20 +66,15 @@ namespace Akka.Actor
 
             timeout = timeout ?? provider.Settings.AskTimeout;
 
-            //create a new tempcontainer path
-            ActorPath path = provider.TempPath();
-
             if (timeout != Timeout.InfiniteTimeSpan && timeout.Value > default(TimeSpan))
             {
                 timeoutCancellation = new CancellationTokenSource();
-                timeoutCancellation.Token.Register(() =>
-                {
-                    result.TrySetCanceled();
-                    provider.UnregisterTempActor(path);
-                });
+                timeoutCancellation.Token.Register(() => result.TrySetCanceled());
                 timeoutCancellation.CancelAfter(timeout.Value);
             }
 
+            //create a new tempcontainer path
+            ActorPath path = provider.TempPath();
             //callback to unregister from tempcontainer
             Action unregister =
                 () =>


### PR DESCRIPTION
Reverts akkadotnet/akka.net#2381

Have to revert this. Causes enormous, like hundreds of MBs worth of "unregister temp actor spam" in all of our logs. Can't ship it like this. Need to address that logging issue first.