### PR TITLE
Change doc comment references to Duration.Inf

### DIFF
--- a/src/core/Akka/Actor/SupervisorStrategy.cs
+++ b/src/core/Akka/Actor/SupervisorStrategy.cs
@@ -241,7 +241,7 @@ namespace Akka.Actor
         ///     the number of times a child actor is allowed to be restarted, negative value means no limit,
         ///     if the limit is exceeded the child actor is stopped.
         /// </param>
-        /// <param name="withinTimeRange">duration of the time window for maxNrOfRetries, Duration.Inf means no window.</param>
+        /// <param name="withinTimeRange">duration of the time window for maxNrOfRetries, System.Threading.Timeout.InfiniteTimeSpan means no window.</param>
         /// <param name="localOnlyDecider">mapping from Exception to <see cref="Directive" /></param>
         public OneForOneStrategy(int? maxNrOfRetries, TimeSpan? withinTimeRange, Func<Exception, Directive> localOnlyDecider)
             : this(maxNrOfRetries.GetValueOrDefault(-1), (int) withinTimeRange.GetValueOrDefault(Timeout.InfiniteTimeSpan).TotalMilliseconds, localOnlyDecider)
@@ -258,7 +258,7 @@ namespace Akka.Actor
         ///     the number of times a child actor is allowed to be restarted, negative value means no limit,
         ///     if the limit is exceeded the child actor is stopped.
         /// </param>
-        /// <param name="withinTimeRange">duration of the time window for maxNrOfRetries, Duration.Inf means no window.</param>
+        /// <param name="withinTimeRange">duration of the time window for maxNrOfRetries, System.Threading.Timeout.InfiniteTimeSpan means no window.</param>
         /// <param name="decider">mapping from Exception to <see cref="Directive" /></param>
         public OneForOneStrategy(int? maxNrOfRetries, TimeSpan? withinTimeRange, IDecider decider)
             : this(maxNrOfRetries.GetValueOrDefault(-1), (int) withinTimeRange.GetValueOrDefault(Timeout.InfiniteTimeSpan).TotalMilliseconds, decider)


### PR DESCRIPTION
Reference System.Threading.Timeout.InfiniteTimeSpan which is used by the internal code instead of Duration.Inf which appears to be a Java Akka specific constant.