### PR TITLE
GetNode do not lookups fallback config; config produced by WithFallbck contains all values from provided fallback

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -2042,7 +2042,7 @@ namespace Akka.Configuration
         public System.Collections.Generic.IEnumerable<Akka.Configuration.Hocon.HoconSubstitution> Substitutions { get; set; }
         [System.Runtime.CompilerServices.IteratorStateMachineAttribute(typeof(Akka.Configuration.Config.<AsEnumerable>d__46))]
         public virtual System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, Akka.Configuration.Hocon.HoconValue>> AsEnumerable() { }
-        protected Akka.Configuration.Config Copy() { }
+        protected Akka.Configuration.Config Copy(Akka.Configuration.Config fallback = null) { }
         public virtual bool GetBoolean(string path, bool default = False) { }
         public virtual System.Collections.Generic.IList<bool> GetBooleanList(string path) { }
         public virtual System.Collections.Generic.IList<byte> GetByteList(string path) { }
@@ -2217,6 +2217,7 @@ namespace Akka.Configuration.Hocon
     public class HoconValue : Akka.Configuration.Hocon.IMightBeAHoconObject
     {
         public HoconValue() { }
+        public HoconValue(System.Collections.Generic.List<Akka.Configuration.Hocon.IHoconElement> values, bool adoptedFromFallback = True) { }
         public bool IsEmpty { get; }
         public System.Collections.Generic.List<Akka.Configuration.Hocon.IHoconElement> Values { get; }
         public void AppendValue(Akka.Configuration.Hocon.IHoconElement value) { }

--- a/src/core/Akka.Tests/Actor/ActorSystemTests.cs
+++ b/src/core/Akka.Tests/Actor/ActorSystemTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Akka.Tests
 {
-    
+
     public class ActorSystemTests
     {
         public class TestActor : UntypedActor
@@ -35,7 +35,7 @@ namespace Akka.Tests
             //assert
             var children = system.Provider.Guardian.Children;
             Assert.True(children.Any(c => c == child));
-        }        
+        }
 
         [Fact]
         public void ActorOf_gives_child_unique_name_if_not_specified()

--- a/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
+++ b/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
@@ -34,7 +34,7 @@ namespace Akka.Tests.Configuration
 
             // settings.ConfigVersion.ShouldBe(ActorSystem.Version);
             settings.Loggers.Count.ShouldBe(1);
-            settings.Loggers[0].ShouldBe(typeof(DefaultLogger).FullName);
+            settings.Loggers[0].ShouldBe(typeof (DefaultLogger).FullName);
             // settings.LoggingFilter.ShouldBe(typeof(DefaultLoggingFilter));
             settings.LoggersDispatcher.ShouldBe(Dispatchers.DefaultDispatcherId);
             settings.LoggerStartTimeout.Seconds.ShouldBe(5);
@@ -44,8 +44,8 @@ namespace Akka.Tests.Configuration
             settings.LogDeadLetters.ShouldBe(10);
             settings.LogDeadLettersDuringShutdown.ShouldBeTrue();
 
-            settings.ProviderClass.ShouldBe(typeof(LocalActorRefProvider).FullName);
-            settings.SupervisorStrategyClass.ShouldBe(typeof(DefaultSupervisorStrategy).FullName);
+            settings.ProviderClass.ShouldBe(typeof (LocalActorRefProvider).FullName);
+            settings.SupervisorStrategyClass.ShouldBe(typeof (DefaultSupervisorStrategy).FullName);
             settings.CreationTimeout.Seconds.ShouldBe(20);
             settings.AskTimeout.ShouldBe(Timeout.InfiniteTimeSpan);
             settings.SerializeAllMessages.ShouldBeFalse();
@@ -62,13 +62,13 @@ namespace Akka.Tests.Configuration
             settings.DebugUnhandledMessage.ShouldBeFalse();
             settings.DebugRouterMisconfiguration.ShouldBeFalse();
 
-            settings.SchedulerClass.ShouldBe(typeof(HashedWheelTimerScheduler).FullName);
+            settings.SchedulerClass.ShouldBe(typeof (HashedWheelTimerScheduler).FullName);
         }
 
         [Fact]
         public void Deserializes_hocon_configuration_from_net_config_file()
         {
-            var section = (AkkaConfigurationSection)ConfigurationManager.GetSection("akka");
+            var section = (AkkaConfigurationSection) ConfigurationManager.GetSection("akka");
             Assert.NotNull(section);
             Assert.False(string.IsNullOrEmpty(section.Hocon.Content));
             var akkaConfig = section.AkkaConfig;
@@ -82,7 +82,7 @@ namespace Akka.Tests.Configuration
             {
                 StringProperty = "aaa",
                 BoolProperty = true,
-                IntergerArray = new[]{1,2,3,4 }
+                IntergerArray = new[] {1, 2, 3, 4}
             };
 
             var config = ConfigurationFactory.FromObject(source);
@@ -90,7 +90,7 @@ namespace Akka.Tests.Configuration
             Assert.Equal("aaa", config.GetString("StringProperty"));
             Assert.Equal(true, config.GetBoolean("BoolProperty"));
 
-            Assert.Equal(new[] { 1, 2, 3, 4 }, config.GetIntList("IntergerArray").ToArray());
+            Assert.Equal(new[] {1, 2, 3, 4}, config.GetIntList("IntergerArray").ToArray());
         }
 
         [Fact]
@@ -117,7 +117,7 @@ a {
 }
 ";
 
-            var root1 = Parser.Parse(hocon1,null);
+            var root1 = Parser.Parse(hocon1, null);
             var root2 = Parser.Parse(hocon2, null);
 
             var obj1 = root1.Value.GetObject();
@@ -134,6 +134,35 @@ a {
             Assert.Equal(123, config.GetInt("a.sub.aa"));
             Assert.Equal(456, config.GetInt("a.sub.bb"));
 
+        }
+
+        [Fact(DisplayName = @"Scalar value should not be overriden by an object during merge")]
+        public void Scalar_value_should_not_be_overriden_by_an_object_during_merge()
+        {
+            var hocon1 = @"
+a {
+    b = 1
+}
+";
+            var hocon2 = @"
+a {
+    b {
+        c = 2
+    }
+}
+";
+
+            var root1 = Parser.Parse(hocon1, null);
+            var root2 = Parser.Parse(hocon2, null);
+
+            var obj1 = root1.Value.GetObject();
+            var obj2 = root2.Value.GetObject();
+            obj1.Merge(obj2);
+
+            var config = new Config(root1);
+
+            Assert.Equal(1, config.GetInt("a.b"));
+            Assert.Throws<NullReferenceException>(() => config.GetInt("a.b.c"));
         }
 
         public class MyObjectConfig
@@ -155,6 +184,5 @@ a {
         {
             ConfigurationFactory.Empty.IsEmpty.ShouldBeTrue();
         }
-   }
+    }
 }
-

--- a/src/core/Akka.Tests/Configuration/HoconTests.cs
+++ b/src/core/Akka.Tests/Configuration/HoconTests.cs
@@ -546,6 +546,55 @@ foo {
             config.GetInt("foo.bar.borkbork").ShouldBe(-1);
         }
 
+        [Fact(DisplayName = @"Scalar value should not be overriden by an object in fallback and vice versa")]
+        public void Scalar_value_should_not_be_overriden_by_an_object_in_fallback_and_vice_versa() {
+            var hocon1 = @"
+a {
+    b = 1
+}
+";
+            var hocon2 = @"
+a {
+    b {
+        c = 2
+    }
+}
+";
+
+            var config1 = ConfigurationFactory.ParseString(hocon1);
+            var config2 = ConfigurationFactory.ParseString(hocon2);
+
+            var config12 = config1.WithFallback(config2);
+            var config21 = config2.WithFallback(config1);
+
+            Assert.Equal(1, config12.GetInt("a.b"));
+            Assert.Equal(2, config21.GetInt("a.b.c"));
+        }
+
+        [Fact(DisplayName = "Config constructed from merging with fallback should not share state with origin")]
+        public void Config_constructed_from_merging_with_fallback_should_not_share_state_with_origin()
+        {
+            var hocon1 = @"
+a {
+    b = 1
+}
+";
+            var hocon2 = @"
+a {
+    c = 2
+}
+";
+
+            var config1 = ConfigurationFactory.ParseString(hocon1);
+            var config2 = ConfigurationFactory.ParseString(hocon2);
+
+            var config12 = config1.WithFallback(config2);
+
+            Assert.Equal(2, config12.GetInt("a.c"));
+            Assert.Equal(0, config1.GetInt("a.c"));
+            Assert.Equal(0, config2.GetInt("a.b"));
+        }
+
         [Fact]
         public void Can_parse_quoted_keys()
         {

--- a/src/core/Akka/Configuration/Config.cs
+++ b/src/core/Akka/Configuration/Config.cs
@@ -83,12 +83,12 @@ namespace Akka.Configuration
         /// Generates a deep clone of the current configuration.
         /// </summary>
         /// <returns>A deep clone of the current configuration</returns>
-        protected Config Copy()
+        protected Config Copy(Config fallback = null)
         {
             //deep clone
             return new Config
             {
-                Fallback = Fallback != null ? Fallback.Copy() : null,
+                Fallback = Fallback != null ? Fallback.Copy(fallback) : fallback,
                 Root = Root,
                 Substitutions = Substitutions
             };
@@ -96,22 +96,16 @@ namespace Akka.Configuration
 
         private HoconValue GetNode(string path)
         {
-            var elements = path.SplitDottedPathHonouringQuotes();
+            var parsedPath = path.SplitDottedPathHonouringQuotes();
             HoconValue currentNode = Root;
             if (currentNode == null)
             {
                 throw new InvalidOperationException("Current node should not be null");
             }
-            foreach (string key in elements)
+            foreach (string key in parsedPath)
             {
                 currentNode = currentNode.GetChildObject(key);
-                if (currentNode == null)
-                {
-                    if (Fallback != null)
-                        return Fallback.GetNode(path);
-
-                    return null;
-                }
+                if (currentNode == null) return null;
             }
             return currentNode;
         }
@@ -455,19 +449,15 @@ namespace Akka.Configuration
         {
             if (fallback == this)
                 throw new ArgumentException("Config can not have itself as fallback", nameof(fallback));
-
-            Config clone = Copy();
-
-            Config current = clone;
-            while (current.Fallback != null)
-            {
-                current = current.Fallback;
-            }
-            current.Fallback = fallback;
-
-            return clone;
+            if (fallback == null)
+                return this;
+            var mergedRoot = Root.GetObject().MergeImmutable(fallback.Root.GetObject());
+            var newRoot = new HoconValue();
+            newRoot.AppendValue(mergedRoot);
+            var mergedConfig = Copy(fallback);
+            mergedConfig.Root = newRoot;
+            return mergedConfig;
         }
-
 
         /// <summary>
         /// Determine if a HOCON configuration element exists at the specified location

--- a/src/core/Akka/Configuration/Hocon/HoconObject.cs
+++ b/src/core/Akka/Configuration/Hocon/HoconObject.cs
@@ -161,6 +161,7 @@ namespace Akka.Configuration.Hocon
             var sb = new StringBuilder();
             foreach (var kvp in Items)
             {
+                if (kvp.Value.AdoptedFromFallback) continue;
                 string key = QuoteIfNeeded(kvp.Key);
                 sb.AppendFormat("{0}{1} : {2}\r\n", i, key, kvp.Value.ToString(indent));
             }
@@ -202,9 +203,44 @@ namespace Akka.Configuration.Hocon
                 else
                 {
                     //other key was not present in this object, just copy it over
-                    Items.Add(otherItem.Key,otherItem.Value);
+                    Items.Add(otherItem.Key, otherItem.Value);
                 }
             }
+        }
+
+        /// <summary>
+        /// Merges the specified object with this instance producing new one.
+        /// </summary>
+        /// <param name="other">The object to merge into this instance.</param>
+        internal HoconObject MergeImmutable(HoconObject other)
+        {
+            var thisItems = new Dictionary<string, HoconValue>(Items);
+            var otherItems = other.Items;
+
+            foreach (var otherItem in otherItems)
+            {
+                if (thisItems.ContainsKey(otherItem.Key))
+                {
+                    //other key was present in this object.
+                    //if we have a value, just ignore the other value, unless it is an object
+                    var thisItem = thisItems[otherItem.Key];
+
+                    //if both values are objects, merge them
+                    if (thisItem.IsObject() && otherItem.Value.IsObject())
+                    {
+                        var mergedObject = thisItem.GetObject().MergeImmutable(otherItem.Value.GetObject());
+                        var mergedValue = new HoconValue();
+                        mergedValue.AppendValue(mergedObject);
+                        thisItems[otherItem.Key] = mergedValue;
+                    }
+                }
+                else
+                {
+                    //other key was not present in this object, just copy it over
+                    thisItems.Add(otherItem.Key, new HoconValue(otherItem.Value.Values));
+                }
+            }
+            return new HoconObject {Items = thisItems};
         }
     }
 }

--- a/src/core/Akka/Configuration/Hocon/HoconValue.cs
+++ b/src/core/Akka/Configuration/Hocon/HoconValue.cs
@@ -29,6 +29,17 @@ namespace Akka.Configuration.Hocon
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="HoconValue"/> class.
+        /// </summary>
+        /// <param name="values">The list of elements inside this HOCON value.</param>
+        /// <param name="adoptedFromFallback">Indicates whether this instance was constructed during association with fallback <see cref="Config"/>.</param>
+        public HoconValue(List<IHoconElement> values, bool adoptedFromFallback = true)
+        {
+            Values = values;
+            AdoptedFromFallback = adoptedFromFallback;
+        }
+
+        /// <summary>
         /// Returns true if this HOCON value doesn't contain any elements
         /// </summary>
         public bool IsEmpty
@@ -52,6 +63,12 @@ namespace Akka.Configuration.Hocon
         /// The list of elements inside this HOCON value
         /// </summary>
         public List<IHoconElement> Values { get; private set; }
+
+        /// <summary>
+        /// Marker for values were merged during fallback attaching
+        /// serving exclusively to skip rendering such values in <see cref="HoconObject.ToString()"/>
+        /// </summary>
+        internal bool AdoptedFromFallback { get; private set; }
 
         /// <summary>
         /// Wraps this <see cref="HoconValue"/> into a new <see cref="Config"/> object at the specified key.


### PR DESCRIPTION
Fix for [2404](https://github.com/akkadotnet/akka.net/issues/2404)
Note that configs logging on start producing more verbose output as a side effect of changes in implementation;
Also note that we may no more needing `public Config Fallback { get; private set; }`
I didn't removed it since its public, however its only used in Config.cs;
There is also room for optimisation [see here](https://github.com/akkadotnet/akka.net/issues/2404#issuecomment-266321385)