### PR TITLE
swapped out Wire references for Hyperion package

### DIFF
--- a/src/Akka.sln
+++ b/src/Akka.sln
@@ -186,7 +186,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Serialization.Wire", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Serialization.TestKit", "contrib\serializers\Akka.Serialization.TestKit\Akka.Serialization.TestKit.csproj", "{CAA97041-CFC0-4081-9BD2-8B139E62A611}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Serialization.WireTests", "contrib\serializers\Akka.Serialization.WireTests\Akka.Serialization.WireTests.csproj", "{402FA351-D6C6-40FD-8868-F07156035919}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Serialization.Wire.Tests", "contrib\serializers\Akka.Serialization.WireTests\Akka.Serialization.Wire.Tests.csproj", "{402FA351-D6C6-40FD-8868-F07156035919}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Cluster", "Cluster", "{76F58DC4-19F1-43EF-A6E2-EC1CC8395AC5}"
 EndProject

--- a/src/contrib/serializers/Akka.Serialization.Wire/Akka.Serialization.Wire.csproj
+++ b/src/contrib/serializers/Akka.Serialization.Wire/Akka.Serialization.Wire.csproj
@@ -32,8 +32,8 @@
     <DocumentationFile>bin\Release\Akka.Serialization.Wire.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Hyperion, Version=0.9.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Hyperion.0.9.0\lib\net45\Hyperion.dll</HintPath>
+    <Reference Include="Hyperion, Version=0.9.1.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Hyperion.0.9.1\lib\net45\Hyperion.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/contrib/serializers/Akka.Serialization.Wire/Akka.Serialization.Wire.csproj
+++ b/src/contrib/serializers/Akka.Serialization.Wire/Akka.Serialization.Wire.csproj
@@ -32,28 +32,24 @@
     <DocumentationFile>bin\Release\Akka.Serialization.Wire.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-    <Reference Include="Wire, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Wire.0.7.1\lib\net45\Wire.dll</HintPath>
+    <Reference Include="Hyperion, Version=0.9.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Hyperion.0.9.0\lib\net45\Hyperion.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="WireSerializer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Akka.Serialization.Wire.nuspec" />
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Akka\Akka.csproj">

--- a/src/contrib/serializers/Akka.Serialization.Wire/Akka.Serialization.Wire.csproj
+++ b/src/contrib/serializers/Akka.Serialization.Wire/Akka.Serialization.Wire.csproj
@@ -32,8 +32,8 @@
     <DocumentationFile>bin\Release\Akka.Serialization.Wire.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Hyperion, Version=0.9.1.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Hyperion.0.9.1\lib\net45\Hyperion.dll</HintPath>
+    <Reference Include="Hyperion, Version=0.9.2.2, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Hyperion.0.9.2\lib\net45\Hyperion.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/contrib/serializers/Akka.Serialization.Wire/Properties/AssemblyInfo.cs
+++ b/src/contrib/serializers/Akka.Serialization.Wire/Properties/AssemblyInfo.cs
@@ -15,10 +15,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Akka.Serialization.Wire")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Akka.Serialization.Wire")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
-[assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -28,16 +25,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("b47ca568-40cf-48de-b87e-31bd400ebb08")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/contrib/serializers/Akka.Serialization.Wire/WireSerializer.cs
+++ b/src/contrib/serializers/Akka.Serialization.Wire/WireSerializer.cs
@@ -9,7 +9,7 @@ using System;
 using System.IO;
 using Akka.Actor;
 using Akka.Util;
-using Wire;
+using Hyperion;
 
 // ReSharper disable once CheckNamespace
 namespace Akka.Serialization
@@ -19,7 +19,7 @@ namespace Akka.Serialization
     /// </summary>
     public class WireSerializer : Serializer
     {
-        private readonly Wire.Serializer _serializer;
+        private readonly Hyperion.Serializer _serializer;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WireSerializer"/> class.
@@ -34,7 +34,7 @@ namespace Akka.Serialization
                 to => to.FromSurrogate(system));
 
             _serializer =
-                new Wire.Serializer(new SerializerOptions(
+                new Hyperion.Serializer(new SerializerOptions(
                     preserveObjectReferences: true, 
                     versionTolerance: true,
                     surrogates: new[]

--- a/src/contrib/serializers/Akka.Serialization.Wire/packages.config
+++ b/src/contrib/serializers/Akka.Serialization.Wire/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Wire" version="0.7.1" targetFramework="net45" />
+  <package id="Hyperion" version="0.9.0" targetFramework="net45" />
 </packages>

--- a/src/contrib/serializers/Akka.Serialization.Wire/packages.config
+++ b/src/contrib/serializers/Akka.Serialization.Wire/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Hyperion" version="0.9.0" targetFramework="net45" />
+  <package id="Hyperion" version="0.9.1" targetFramework="net45" />
 </packages>

--- a/src/contrib/serializers/Akka.Serialization.Wire/packages.config
+++ b/src/contrib/serializers/Akka.Serialization.Wire/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Hyperion" version="0.9.1" targetFramework="net45" />
+  <package id="Hyperion" version="0.9.2" targetFramework="net45" />
 </packages>

--- a/src/contrib/serializers/Akka.Serialization.WireTests/Akka.Serialization.Wire.Tests.csproj
+++ b/src/contrib/serializers/Akka.Serialization.WireTests/Akka.Serialization.Wire.Tests.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{402FA351-D6C6-40FD-8868-F07156035919}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Akka.Serialization.WireTests</RootNamespace>
-    <AssemblyName>Akka.Serialization.WireTests</AssemblyName>
+    <RootNamespace>Akka.Serialization.Wire.Tests</RootNamespace>
+    <AssemblyName>Akka.Serialization.Wire.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
@@ -32,6 +32,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Hyperion, Version=0.9.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Hyperion.0.9.0\lib\net45\Hyperion.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -40,10 +44,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Wire, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Wire.0.7.1\lib\net45\Wire.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>

--- a/src/contrib/serializers/Akka.Serialization.WireTests/Akka.Serialization.Wire.Tests.csproj
+++ b/src/contrib/serializers/Akka.Serialization.WireTests/Akka.Serialization.Wire.Tests.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Hyperion, Version=0.9.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Hyperion.0.9.0\lib\net45\Hyperion.dll</HintPath>
+    <Reference Include="Hyperion, Version=0.9.1.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Hyperion.0.9.1\lib\net45\Hyperion.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/contrib/serializers/Akka.Serialization.WireTests/Akka.Serialization.Wire.Tests.csproj
+++ b/src/contrib/serializers/Akka.Serialization.WireTests/Akka.Serialization.Wire.Tests.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Hyperion, Version=0.9.1.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Hyperion.0.9.1\lib\net45\Hyperion.dll</HintPath>
+    <Reference Include="Hyperion, Version=0.9.2.2, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Hyperion.0.9.2\lib\net45\Hyperion.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/contrib/serializers/Akka.Serialization.WireTests/WireTests.cs
+++ b/src/contrib/serializers/Akka.Serialization.WireTests/WireTests.cs
@@ -7,7 +7,7 @@
 
 using Akka.Tests.Serialization;
 
-namespace Akka.Serialization.WireTests
+namespace Akka.Serialization.Wire.Tests
 {
     public class WireTests : AkkaSerializationSpec
     {

--- a/src/contrib/serializers/Akka.Serialization.WireTests/packages.config
+++ b/src/contrib/serializers/Akka.Serialization.WireTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Hyperion" version="0.9.0" targetFramework="net45" />
+  <package id="Hyperion" version="0.9.1" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/src/contrib/serializers/Akka.Serialization.WireTests/packages.config
+++ b/src/contrib/serializers/Akka.Serialization.WireTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Wire" version="0.7.1" targetFramework="net45" />
+  <package id="Hyperion" version="0.9.0" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/src/contrib/serializers/Akka.Serialization.WireTests/packages.config
+++ b/src/contrib/serializers/Akka.Serialization.WireTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Hyperion" version="0.9.1" targetFramework="net45" />
+  <package id="Hyperion" version="0.9.2" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
@@ -228,7 +228,7 @@ namespace Akka.Actor.Internal
                 Serialization.FindSerializerForType(typeof (object)) is NewtonSoftJsonSerializer)
             {
                 Log.Warning($"NewtonSoftJsonSerializer has been detected as a default serializer. " +
-                            $"It will be obsoleted in Akka.NET starting from version 1.5 in the favor of Wire " +
+                            $"It will be obsoleted in Akka.NET starting from version 1.5 in the favor of Hyperion " +
                             $"(for more info visit: http://getakka.net/docs/Serialization#how-to-setup-wire-as-default-serializer ). " +
                             $"If you want to suppress this message set HOCON `{configPath}` config flag to on.");
             }

--- a/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/ClusterSharding.Node.csproj
+++ b/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/ClusterSharding.Node.csproj
@@ -66,10 +66,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Wire, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Wire.0.7.1\lib\net45\Wire.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AutomaticJoin\AutomaticCluster.cs" />

--- a/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/packages.config
+++ b/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/packages.config
@@ -5,5 +5,4 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
   <package id="System.Data.SQLite.Core" version="1.0.98.1" targetFramework="net45" />
-  <package id="Wire" version="0.7.1" targetFramework="net45" />
 </packages>

--- a/src/examples/Cluster/ClusterTools/ClusterToolsExample.Node/ClusterToolsExample.Node.csproj
+++ b/src/examples/Cluster/ClusterTools/ClusterToolsExample.Node/ClusterToolsExample.Node.csproj
@@ -60,10 +60,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Wire, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Wire.0.7.1\lib\net45\Wire.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/src/examples/Cluster/ClusterTools/ClusterToolsExample.Node/packages.config
+++ b/src/examples/Cluster/ClusterTools/ClusterToolsExample.Node/packages.config
@@ -4,5 +4,4 @@
   <package id="Helios" version="2.1.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
-  <package id="Wire" version="0.7.1" targetFramework="net45" />
 </packages>

--- a/src/examples/Cluster/ClusterTools/ClusterToolsExample.Seed/ClusterToolsExample.Seed.csproj
+++ b/src/examples/Cluster/ClusterTools/ClusterToolsExample.Seed/ClusterToolsExample.Seed.csproj
@@ -60,10 +60,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Wire, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Wire.0.7.1\lib\net45\Wire.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/src/examples/Cluster/ClusterTools/ClusterToolsExample.Seed/packages.config
+++ b/src/examples/Cluster/ClusterTools/ClusterToolsExample.Seed/packages.config
@@ -4,5 +4,4 @@
   <package id="Helios" version="2.1.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
-  <package id="Wire" version="0.7.1" targetFramework="net45" />
 </packages>

--- a/src/examples/Cluster/ClusterTools/ClusterToolsExample.Shared/ClusterToolsExample.Shared.csproj
+++ b/src/examples/Cluster/ClusterTools/ClusterToolsExample.Shared/ClusterToolsExample.Shared.csproj
@@ -58,10 +58,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Wire, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Wire.0.7.1\lib\net45\Wire.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Echo.cs" />

--- a/src/examples/Cluster/ClusterTools/ClusterToolsExample.Shared/packages.config
+++ b/src/examples/Cluster/ClusterTools/ClusterToolsExample.Shared/packages.config
@@ -4,5 +4,4 @@
   <package id="Helios" version="2.1.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
-  <package id="Wire" version="0.7.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This PR swaps out the underlying Wire dependencies for Hyperion, in order to stop our users from getting GPL'd by upgrading to a new version of Wire.

I propose doing this across two releases

1. Release the current Akka.Serailization.Wire, complete with Hyperion dependencies, to move net new users onto the latest Hyperion version.
2. Deprecate the Akka.Serialization.Wire package and replace it with a Akka.Serialization.Hyperion package and update the necessary documentation in a subsequent release.

Any thoughts on the above?