### PR TITLE
Make FutureActorRef call _unregister() in a task continuation.

### DIFF
--- a/src/core/Akka.Tests/Actor/AskTimeoutSpec.cs
+++ b/src/core/Akka.Tests/Actor/AskTimeoutSpec.cs
@@ -50,5 +50,25 @@ namespace Akka.Tests.Actor
             }
         }
 
+        [Fact]
+        public async Task TimedOut_ask_should_remove_temp_actor()
+        {
+            var actor = Sys.ActorOf<SleepyActor>();
+
+            var actorCell = actor as ActorRefWithCell;
+            var container = actorCell.Provider.TempContainer as VirtualPathContainer;
+            try
+            {
+                await actor.Ask<string>("should time out");
+            }
+            catch (Exception)
+            {
+                var childCounter = 0;
+                container.ForEachChild(x => childCounter++);
+                Assert.True(childCounter==0,"Number of children in temp container should be 0.");
+            }
+
+        }
+
     }
 }

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -66,6 +66,7 @@ namespace Akka.Actor
             _result = result;
             _unregister = unregister;
             _path = path;
+            _result.Task.ContinueWith(_ => _unregister());
         }
 
         public override ActorPath Path
@@ -96,7 +97,6 @@ namespace Akka.Actor
                 if (Interlocked.Exchange(ref status, COMPLETED) == INITIATED)
                 {
                     _result.TrySetResult(message);
-                    _unregister();
                 }
             }
         }


### PR DESCRIPTION
This takes eisendle's idea of dealing with the temp actor unregistration issue on cancelled ask requests in #2380 and cherry-picks his test spec commit from PR #2381 , but handles it by calling the `unregister` action in a continuation inside of `FutureActorRef`. This should make the unregistration more consistent with `FutureActorRef` - ensuring that we clean up our resources once regardless of how the task turns out. I'm assuming there might be some back and forth in case it hits the same issue that caused the revert in #2399. Following up with this PR as a lot of people asked about #2381 when rebasing code in #2349.

It also adds two specs to make sure we clean up if we're basing the ask requests around cancellation requests or both timeouts and cancellation requests instead of just timeouts. It makes me nervous to just assume that it'll work the same in all three instances forever, so there's some extra tests.