### PR TITLE
spec for verifying that DistributedPubSub mediator can be spawned from within child actor in testkit

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Akka.Cluster.Tools.Tests.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Akka.Cluster.Tools.Tests.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PublishSubscribe\DistributedPubSubConfigSpec.cs" />
     <Compile Include="PublishSubscribe\DistributedPubSubMediatorRouterSpec.cs" />
+    <Compile Include="PublishSubscribe\DistributedPubSubMediatorSpec.cs" />
     <Compile Include="PublishSubscribe\DistributedPubSubMessageSerializerSpec.cs" />
     <Compile Include="Singleton\ClusterSingletonConfigSpec.cs" />
     <Compile Include="Singleton\ClusterSingletonMessageSerializerSpec.cs" />

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubMediatorSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubMediatorSpec.cs
@@ -1,0 +1,57 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="DistributedPubSubMediatorSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Actor.Dsl;
+using Akka.Cluster.Tools.PublishSubscribe;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Cluster.Tools.Tests.PublishSubscribe
+{
+    public class DistributedPubSubMediatorSpec : AkkaSpec
+    {
+        public DistributedPubSubMediatorSpec() : base(GetConfig()) { }
+
+        public static Config GetConfig()
+        {
+            return ConfigurationFactory.ParseString("akka.actor.provider = \"Akka.Cluster.ClusterActorRefProvider, Akka.Cluster\"");
+        }
+
+        /// <summary>
+        /// Checks to see if http://stackoverflow.com/questions/41249465/how-to-test-distributedpubsub-with-the-testkit-in-akka-net is resolved
+        /// </summary>
+        [Fact]
+        public void DistributedPubSubMediator_can_be_activated_in_child_actor()
+        {
+            EventFilter.Exception<NullReferenceException>().Expect(0, () =>
+            {
+                var actor = Sys.ActorOf((dsl, context) =>
+                {
+                    IActorRef mediator = null;
+                    dsl.OnPreStart = actorContext =>
+                    {
+                        mediator = DistributedPubSub.Get(actorContext.System).Mediator;
+                    };
+
+                    dsl.Receive<string>(s => s.Equals("check"), (s, actorContext) =>
+                    {
+                        actorContext.Sender.Tell(mediator);
+                    });
+
+                }, "childActor");
+
+                actor.Tell("check");
+                var a = ExpectMsg<IActorRef>();
+                a.ShouldNotBe(ActorRefs.NoSender);
+                a.ShouldNotBe(ActorRefs.Nobody);
+            });
+        }
+    }
+}


### PR DESCRIPTION
http://stackoverflow.com/questions/41249465/how-to-test-distributedpubsub-with-the-testkit-in-akka-net - just wanted to verify if this bug exists or not. My guess is that the end user needed to specify the `ClusterActorRefProvider` in their HOCON configuration