### PR TITLE
Updated batching journal behavior

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/BatchingSqliteJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/BatchingSqliteJournal.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Data;
 using System.Data.Common;
 using System.Data.SQLite;
 using Akka.Configuration;
@@ -34,8 +35,8 @@ namespace Akka.Persistence.Sqlite.Journal
         }
 
         public BatchingSqliteJournalSetup(string connectionString, int maxConcurrentOperations, int maxBatchSize, int maxBufferSize, bool autoInitialize, 
-            TimeSpan connectionTimeout, CircuitBreakerSettings circuitBreakerSettings, ReplayFilterSettings replayFilterSettings, QueryConfiguration namingConventions) 
-            : base(connectionString, maxConcurrentOperations, maxBatchSize, maxBufferSize, autoInitialize, connectionTimeout, circuitBreakerSettings, replayFilterSettings, namingConventions)
+            TimeSpan connectionTimeout, IsolationLevel isolationLevel, CircuitBreakerSettings circuitBreakerSettings, ReplayFilterSettings replayFilterSettings, QueryConfiguration namingConventions) 
+            : base(connectionString, maxConcurrentOperations, maxBatchSize, maxBufferSize, autoInitialize, connectionTimeout, isolationLevel, circuitBreakerSettings, replayFilterSettings, namingConventions)
         {
         }
     }


### PR DESCRIPTION
1. Now database exceptions for SQL batching journals are treated as write failures not rejections (as they should be).
2. Additional setting, `IsolationLevel`, that allows user to specify transaction isolation level used during query execution.