### PR TITLE
Fixed RandomLogic and RandomPool to work correctly.

### DIFF
--- a/src/core/Akka.Tests/Routing/RandomSpec.cs
+++ b/src/core/Akka.Tests/Routing/RandomSpec.cs
@@ -53,12 +53,12 @@ namespace Akka.Tests.Routing
             }
         }
 
-        private class BroadcastActor : ReceiveActor
+        private class RandomBroadcastActor : ReceiveActor
         {
             private readonly TestLatch _helloLatch;
             private readonly TestLatch _stopLatch;
 
-            public BroadcastActor(TestLatch helloLatch, TestLatch stopLatch)
+            public RandomBroadcastActor(TestLatch helloLatch, TestLatch stopLatch)
             {
                 _helloLatch = helloLatch;
                 _stopLatch = stopLatch;
@@ -70,6 +70,71 @@ namespace Akka.Tests.Routing
             {
                 _stopLatch.CountDown();
             }
+        }
+
+        private class EmptyBehaviorActor : UntypedActor
+        {
+            protected override void OnReceive(object message)
+            {
+            }
+        }
+
+        private class RandomGroupActor : ReceiveActor
+        {
+            private readonly TestLatch _doneLatch;
+
+            public RandomGroupActor(TestLatch doneLatch)
+            {
+                this._doneLatch = doneLatch;
+
+                Receive<string>(s => s == "hit", c => Sender.Tell(Self.Path.Name));
+                Receive<string>(s => s == "end", c => _doneLatch.CountDown());
+            }
+        }
+
+        private class RandomLogicActor : ReceiveActor
+        {
+            public RandomLogicActor()
+            {
+                var n = 0;
+                var router = new Router(new RandomLogic());
+
+                Receive<Props>(p =>
+                {
+                    n++;
+                    var c = Context.ActorOf(p, "child-" + n);
+                    Context.Watch(c);
+                    router = router.AddRoutee(c);
+                });
+
+                Receive<Terminated>(terminated =>
+                {
+                    router = router.RemoveRoutee(terminated.ActorRef);
+                    if (!router.Routees.Any())
+                    {
+                        Context.Stop(Self);
+                    }
+                });
+
+                ReceiveAny(other =>
+                {
+                    router.Route(other, Sender);
+                });
+            }
+        }
+
+        private class RandomLogicPropsActor : ReceiveActor
+        {
+            public RandomLogicPropsActor()
+            {
+                Receive<string>(s => s == "hit", c => Sender.Tell(Self.Path.Name));
+                Receive<string>(s => s == "end", c => Context.Stop(Self));
+            }
+        }
+
+        private int RouteeSize(IActorRef router)
+        {
+            return router.Ask<Routees>(new GetRoutees()).Result.Members.Count();
         }
 
         [Fact]
@@ -130,6 +195,7 @@ namespace Akka.Tests.Routing
             doneLatch.Ready(TimeSpan.FromSeconds(5));
 
             replies.Values.ForEach(c => c.Should().BeGreaterThan(0));
+            replies.Values.Any(c => c != iterationCount).ShouldBeTrue();
             replies.Values.Sum().Should().Be(iterationCount * connectionCount);
         }
 
@@ -141,13 +207,105 @@ namespace Akka.Tests.Routing
             var stopLatch = new TestLatch(routeeCount);
 
             var actor = Sys.ActorOf(new RandomPool(routeeCount)
-                .Props(Props.Create(() => new BroadcastActor(helloLatch, stopLatch))), "random-broadcast");
+                .Props(Props.Create(() => new RandomBroadcastActor(helloLatch, stopLatch))), "random-broadcast");
 
             actor.Tell(new Broadcast("hello"));
             helloLatch.Ready(5.Seconds());
 
             Sys.Stop(actor);
             stopLatch.Ready(5.Seconds());
+        }
+
+        [Fact]
+        public void Random_pool_must_be_controlled_with_management_messages()
+        {
+            IActorRef actor = Sys.ActorOf(new RandomPool(3)
+                .Props(Props.Create<EmptyBehaviorActor>()), "random-managed");
+
+            RouteeSize(actor).Should().Be(3);
+            actor.Tell(new AdjustPoolSize(4));
+            RouteeSize(actor).Should().Be(7);
+            actor.Tell(new AdjustPoolSize(-2));
+            RouteeSize(actor).Should().Be(5);
+
+            var other = new ActorSelectionRoutee(Sys.ActorSelection("/user/other"));
+            actor.Tell(new AddRoutee(other));
+            RouteeSize(actor).Should().Be(6);
+            actor.Tell(new RemoveRoutee(other));
+            RouteeSize(actor).Should().Be(5);
+        }
+
+        [Fact]
+        public async Task Random_group_must_deliver_messages_in_a_random_fashion()
+        {
+            const int connectionCount = 10;
+            const int iterationCount = 100;
+            var doneLatch = new TestLatch(connectionCount);
+
+            var replies = new Dictionary<string, int>();
+            for (int i = 1; i <= connectionCount; i++)
+            {
+                replies["target-" + i] = 0;
+            }
+
+            var paths = Enumerable.Range(1, connectionCount).Select(n =>
+            {
+                var routee = Sys.ActorOf(Props.Create(() => new RandomGroupActor(doneLatch)), "target-" + n);
+                return routee.Path.ToStringWithoutAddress();
+            });
+
+            var actor = Sys.ActorOf(new RandomGroup(paths).Props(), "random-group1");
+
+            for (int i = 0; i < iterationCount; i++)
+            {
+                for (int k = 0; k < connectionCount; k++)
+                {
+                    string id = await actor.Ask<string>("hit");
+                    replies[id] = replies[id] + 1;
+                }
+            }
+
+            actor.Tell(new Broadcast("end"));
+            doneLatch.Ready(5.Seconds());
+
+            replies.Values.ForEach(c => c.Should().BeGreaterThan(0));
+            replies.Values.Any(c => c != iterationCount).ShouldBeTrue();
+            replies.Values.Sum().Should().Be(iterationCount * connectionCount);
+        }
+
+        [Fact]
+        public async Task Random_logic_used_in_actor_must_deliver_messages_in_a_random_fashion()
+        {
+            const int connectionCount = 10;
+            const int iterationCount = 100;
+
+            var replies = new Dictionary<string, int>();
+            for (int i = 1; i <= connectionCount; i++)
+            {
+                replies["child-" + i] = 0;
+            }
+
+            var actor = Sys.ActorOf(Props.Create<RandomLogicActor>());
+            var childProps = Props.Create<RandomLogicPropsActor>();
+
+            Enumerable.Range(1, connectionCount).ForEach(_ => actor.Tell(childProps));
+
+            for (int i = 0; i < iterationCount; i++)
+            {
+                for (int k = 0; k < connectionCount; k++)
+                {
+                    string id = await actor.Ask<string>("hit");
+                    replies[id] = replies[id] + 1;
+                }
+            }
+
+            Watch(actor);
+            actor.Tell(new Broadcast("end"));
+            ExpectTerminated(actor);
+
+            replies.Values.ForEach(c => c.Should().BeGreaterThan(0));
+            replies.Values.Any(c => c != iterationCount).ShouldBeTrue();
+            replies.Values.Sum().Should().Be(iterationCount * connectionCount);
         }
     }
 }

--- a/src/core/Akka.Tests/Routing/RoundRobinSpec.cs
+++ b/src/core/Akka.Tests/Routing/RoundRobinSpec.cs
@@ -209,7 +209,7 @@ namespace Akka.Tests.Routing
             var helloLatch = new TestLatch(routeeCount);
             var stopLatch = new TestLatch(routeeCount);
 
-            var actor = Sys.ActorOf(new RandomPool(routeeCount)
+            var actor = Sys.ActorOf(new RoundRobinPool(routeeCount)
                 .Props(Props.Create(() => new RoundRobinPoolBroadcastActor(helloLatch, stopLatch))), "round-robin-broadcast");
 
             actor.Tell(new Broadcast("hello"));
@@ -222,7 +222,7 @@ namespace Akka.Tests.Routing
         [Fact]
         public void Round_robin_pool_must_be_controlled_with_management_messages()
         {
-            IActorRef actor = Sys.ActorOf(new RandomPool(3)
+            IActorRef actor = Sys.ActorOf(new RoundRobinPool(3)
                 .Props(Props.Create<EmptyBehaviorActor>()), "round-robin-managed");
 
             RouteeSize(actor).Should().Be(3);

--- a/src/core/Akka/Routing/Random.cs
+++ b/src/core/Akka/Routing/Random.cs
@@ -31,7 +31,7 @@ namespace Akka.Routing
                 return Routee.NoRoutee;
             }
 
-            return routees[ThreadLocalRandom.Current.Next(routees.Length - 1)%routees.Length];
+            return routees[ThreadLocalRandom.Current.Next(routees.Length)];
         }
     }
 
@@ -88,7 +88,7 @@ namespace Akka.Routing
         /// <returns>The newly created router tied to the given system.</returns>
         public override Router CreateRouter(ActorSystem system)
         {
-            return new Router(new RoundRobinRoutingLogic());
+            return new Router(new RandomLogic());
         }
 
         /// <summary>


### PR DESCRIPTION
I was playing around with `RandomPool` and it turned out it works as thought it is `round robin`.
I checked the code and found the root of the problem :)
Looks like a simple copy-paste typo.

Here is a list of fixes and additional improvements:

 - RandomLogic `Select Routee` upper bound fixed.
 - RandomPool `CreateRouter` fixed to use proper random logic.
 - RandomSpec improved to have additional check for stochasticity (some of all random values definitely should be different from `iterationCount`).
 - RandomSpec additional tests added for `RandomGroup` and `RandomLogic`.
 - RoundRobinSpec fixed to instantiate with proper round robin pools.