### PR TITLE
Akka.Remote - ShutDownAssociation exception logged during graceful stop

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -1283,7 +1283,7 @@ namespace Akka.Actor
         public OneForOneStrategy(System.Nullable<int> maxNrOfRetries, System.Nullable<System.TimeSpan> withinTimeRange, Akka.Actor.IDecider decider) { }
         public OneForOneStrategy(int maxNrOfRetries, int withinTimeMilliseconds, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = True) { }
         public OneForOneStrategy(int maxNrOfRetries, int withinTimeMilliseconds, Akka.Actor.IDecider decider, bool loggingEnabled = True) { }
-        public OneForOneStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
+        public OneForOneStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = True) { }
         public OneForOneStrategy(Akka.Actor.IDecider decider) { }
         protected OneForOneStrategy() { }
         public override Akka.Actor.IDecider Decider { get; }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -1283,6 +1283,7 @@ namespace Akka.Actor
         public OneForOneStrategy(System.Nullable<int> maxNrOfRetries, System.Nullable<System.TimeSpan> withinTimeRange, Akka.Actor.IDecider decider) { }
         public OneForOneStrategy(int maxNrOfRetries, int withinTimeMilliseconds, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = True) { }
         public OneForOneStrategy(int maxNrOfRetries, int withinTimeMilliseconds, Akka.Actor.IDecider decider, bool loggingEnabled = True) { }
+        public OneForOneStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
         public OneForOneStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = True) { }
         public OneForOneStrategy(Akka.Actor.IDecider decider) { }
         protected OneForOneStrategy() { }

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -1063,8 +1063,7 @@ namespace Akka.Remote
         {
             return new OneForOneStrategy(ex =>
             {
-                //we're going to throw an exception anyway
-                PublishAndThrow(ex, LogLevel.ErrorLevel);
+                PublishAndThrow(ex, LogLevel.ErrorLevel, false);
                 return Directive.Escalate;
             });
         }
@@ -1279,14 +1278,17 @@ namespace Akka.Remote
             return Deadline.Now + Settings.SysMsgAckTimeout;
         }
 
-        private void PublishAndThrow(Exception reason, LogLevel level)
+        private void PublishAndThrow(Exception reason, LogLevel level, bool needToThrow = true)
         {
             reason.Match()
                 .With<EndpointDisassociatedException>(endpoint => PublishDisassociated())
                 .With<ShutDownAssociation>(shutdown => {}) // don't log an error for planned shutdowns
                 .Default(msg => PublishError(reason, level));
 
-            throw reason;
+            if (needToThrow)
+            {
+                throw reason;
+            }
         }
 
         private IActorRef StartReadEndpoint(AkkaProtocolHandle handle)

--- a/src/core/Akka.Remote/EndpointManager.cs
+++ b/src/core/Akka.Remote/EndpointManager.cs
@@ -643,7 +643,7 @@ namespace Akka.Remote
                     });
 
                 return directive;
-            });
+            }, false);
         }
 
         /// <summary>

--- a/src/core/Akka/Actor/SupervisorStrategy.cs
+++ b/src/core/Akka/Actor/SupervisorStrategy.cs
@@ -349,8 +349,8 @@ namespace Akka.Actor
         /// <summary>
         /// Constructor that accepts only a decider and uses reasonable defaults for the other settings
         /// </summary>
-        /// <param name="localOnlyDecider">TBD</param>
-        /// <param name="loggingEnabled">TBD</param>
+        /// <param name="localOnlyDecider">mapping from Exception to <see cref="Directive" /></param>
+        /// <param name="loggingEnabled">If <c>true</c> failures will be logged</param>
         public OneForOneStrategy(Func<Exception, Directive> localOnlyDecider, bool loggingEnabled = true) : this(-1, -1, localOnlyDecider, loggingEnabled)
         {
             //Intentionally left blank

--- a/src/core/Akka/Actor/SupervisorStrategy.cs
+++ b/src/core/Akka/Actor/SupervisorStrategy.cs
@@ -350,6 +350,15 @@ namespace Akka.Actor
         /// Constructor that accepts only a decider and uses reasonable defaults for the other settings
         /// </summary>
         /// <param name="localOnlyDecider">mapping from Exception to <see cref="Directive" /></param>
+        public OneForOneStrategy(Func<Exception, Directive> localOnlyDecider) : this(-1, -1, localOnlyDecider, true)
+        {
+            //Intentionally left blank
+        }
+
+        /// <summary>
+        /// Constructor that accepts only a decider and uses reasonable defaults for the other settings
+        /// </summary>
+        /// <param name="localOnlyDecider">mapping from Exception to <see cref="Directive" /></param>
         /// <param name="loggingEnabled">If <c>true</c> failures will be logged</param>
         public OneForOneStrategy(Func<Exception, Directive> localOnlyDecider, bool loggingEnabled = true) : this(-1, -1, localOnlyDecider, loggingEnabled)
         {

--- a/src/core/Akka/Actor/SupervisorStrategy.cs
+++ b/src/core/Akka/Actor/SupervisorStrategy.cs
@@ -350,7 +350,8 @@ namespace Akka.Actor
         /// Constructor that accepts only a decider and uses reasonable defaults for the other settings
         /// </summary>
         /// <param name="localOnlyDecider">TBD</param>
-        public OneForOneStrategy(Func<Exception, Directive> localOnlyDecider) : this(-1, -1, localOnlyDecider, true)
+        /// <param name="loggingEnabled">TBD</param>
+        public OneForOneStrategy(Func<Exception, Directive> localOnlyDecider, bool loggingEnabled = true) : this(-1, -1, localOnlyDecider, loggingEnabled)
         {
             //Intentionally left blank
         }


### PR DESCRIPTION
1. Original ShutDownAssociation exception is not re-thrown, but rather escalated
2. EndpointManager's SupervisionStrategy default logging is turned off. Error logging will be done in the Decider itself in case of unexpected exceptions only
