### PR TITLE
fixed race condition with creating priority queue

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -2614,6 +2614,8 @@ namespace Akka.Dispatch.MessageQueues
     }
     public class UnboundedPriorityMessageQueue : Akka.Dispatch.MessageQueues.BlockingMessageQueue
     {
+        [System.ObsoleteAttribute("Use UnboundedPriorityMessageQueue(Func<object, int> priorityGenerator, int initia" +
+            "lCapacity) instead.")]
         public UnboundedPriorityMessageQueue(int initialCapacity) { }
         public UnboundedPriorityMessageQueue(System.Func<object, int> priorityGenerator, int initialCapacity) { }
         protected override int LockedCount { get; }
@@ -4853,14 +4855,17 @@ namespace Akka.Util
         public override bool IsRight { get; }
         public TA Value { get; }
     }
-    public class ListPriorityQueue
+    public sealed class ListPriorityQueue
     {
+        [System.ObsoleteAttribute("Use ListPriorityQueue(initialCapacity, priorityCalculator) instead")]
         public ListPriorityQueue(int initialCapacity) { }
+        public ListPriorityQueue(int initialCapacity, System.Func<object, int> priorityCalculator) { }
         public int Count() { }
         public Akka.Actor.Envelope Dequeue() { }
         public void Enqueue(Akka.Actor.Envelope item) { }
         public bool IsConsistent() { }
         public Akka.Actor.Envelope Peek() { }
+        [System.ObsoleteAttribute("Use the constructor to set the priority calculator instead.")]
         public void SetPriorityCalculator(System.Func<object, int> priorityCalculator) { }
         public override string ToString() { }
     }

--- a/src/core/Akka/Dispatch/MessageQueues/UnboundedPriorityMailboxQueue.cs
+++ b/src/core/Akka/Dispatch/MessageQueues/UnboundedPriorityMailboxQueue.cs
@@ -12,63 +12,63 @@ using Akka.Util;
 namespace Akka.Dispatch.MessageQueues
 {
     /// <summary> 
-    /// Base class message queue that uses a priority generator for messages 
+    /// Base class for a message queue that uses a priority generator for messages 
     /// </summary>
     public class UnboundedPriorityMessageQueue : BlockingMessageQueue
     {
         private readonly ListPriorityQueue _prioQueue;
 
         /// <summary>
-        /// TBD
+        /// DEPRECATED. Use UnboundedPriorityMessageQueue(Func{object, int} priorityGenerator, int initialCapacity) instead.        
         /// </summary>
-        /// <param name="initialCapacity">TBD</param>
-        public UnboundedPriorityMessageQueue(int initialCapacity)
+        /// <param name="initialCapacity">The initial capacity of the priority queue.</param>
+        [Obsolete("Use UnboundedPriorityMessageQueue(Func<object, int> priorityGenerator, int initialCapacity) instead.")]
+        public UnboundedPriorityMessageQueue(int initialCapacity) : this(ListPriorityQueue.DefaultPriorityCalculator, initialCapacity)
         {
-            _prioQueue = new ListPriorityQueue(initialCapacity);
+
         }
 
         /// <summary>
-        /// TBD
+        /// Creates a new unbounded priority message queue.
         /// </summary>
-        /// <param name="priorityGenerator">TBD</param>
-        /// <param name="initialCapacity">TBD</param>
-        public UnboundedPriorityMessageQueue(Func<object, int> priorityGenerator, int initialCapacity) : this(initialCapacity)
+        /// <param name="priorityGenerator">The calculator function for determining the priority of inbound messages.</param>
+        /// <param name="initialCapacity">The initial capacity of the queue.</param>
+        public UnboundedPriorityMessageQueue(Func<object, int> priorityGenerator, int initialCapacity)
         {
-            _prioQueue.SetPriorityCalculator(priorityGenerator);
+            _prioQueue = new ListPriorityQueue(initialCapacity, priorityGenerator);
         }
 
         /// <summary>
-        /// TBD
+        /// Unsafe method for computing the underlying message count. 
         /// </summary>
-        /// <param name="priorityGenerator">TBD</param>
-        /// <returns>TBD</returns>
-        internal void SetPriorityGenerator(Func<object, int> priorityGenerator)
-        {
-            _prioQueue.SetPriorityCalculator(priorityGenerator);
-        }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
+        /// <remarks>
+        /// Called from within a synchronization mechanism.
+        /// </remarks>
         protected override int LockedCount
         {
             get { return _prioQueue.Count(); }
         }
 
         /// <summary>
-        /// TBD
+        /// Unsafe method for enquing a new message to the queue.
         /// </summary>
-        /// <param name="envelope">TBD</param>
+        /// <param name="envelope">The message to enqueue.</param>
+        /// <remarks>
+        /// Called from within a synchronization mechanism.
+        /// </remarks>
         protected override void LockedEnqueue(Envelope envelope)
         {
             _prioQueue.Enqueue(envelope);
         }
 
         /// <summary>
-        /// TBD
+        /// Unsafe method for attempting to dequeue a message.
         /// </summary>
-        /// <param name="envelope">TBD</param>
-        /// <returns>TBD</returns>
+        /// <param name="envelope">The message that might be dequed.</param>
+        /// <returns><c>true</c> if a message was available to be dequeued, <c>false</c> otherwise.</returns>
+        /// <remarks>
+        /// Called from within a synchronization mechanism.
+        /// </remarks>
         protected override bool LockedTryDequeue(out Envelope envelope)
         {
             if (_prioQueue.Count() > 0)

--- a/src/core/Akka/Util/ListPriorityQueue.cs
+++ b/src/core/Akka/Util/ListPriorityQueue.cs
@@ -17,33 +17,53 @@ namespace Akka.Util
     /// See http://visualstudiomagazine.com/articles/2012/11/01/priority-queues-with-c.aspx for original implementation
     /// This specific version is adapted for Envelopes only and calculates a priority of envelope.Message
     /// </summary>
-    public class ListPriorityQueue
+    public sealed class ListPriorityQueue
     {
         private readonly List<Envelope> _data;
-        private Func<object, int> _priorityCalculator = message => 1;
+        /// <summary>
+        /// The default priority generator.
+        /// </summary>
+        internal static readonly Func<object, int> DefaultPriorityCalculator = message => 1;
+        private Func<object, int> _priorityCalculator;
 
         /// <summary>
-        /// TBD
+        /// DEPRECATED. Should always specify priority calculator instead.
         /// </summary>
-        /// <param name="initialCapacity">TBD</param>
-        public ListPriorityQueue(int initialCapacity)
+        /// <param name="initialCapacity">The current capacity of the priority queue.</param>
+        [Obsolete("Use ListPriorityQueue(initialCapacity, priorityCalculator) instead")]
+        public ListPriorityQueue(int initialCapacity) : this (initialCapacity, DefaultPriorityCalculator)
         {
-            _data = new List<Envelope>(initialCapacity);
+            
         }
 
         /// <summary>
-        /// TBD
+        /// Creates a new priority queue.
         /// </summary>
-        /// <param name="priorityCalculator">TBD</param>
+        /// <param name="initialCapacity">The initial capacity of the queue.</param>
+        /// <param name="priorityCalculator">The calculator function for assinging message priorities.</param>
+        public ListPriorityQueue(int initialCapacity, Func<object, int> priorityCalculator)
+        {
+            _data = new List<Envelope>(initialCapacity);
+            _priorityCalculator = priorityCalculator;
+        }
+
+        /// <summary>
+        /// DEPRECATED. Sets a new priority calculator.
+        /// </summary>
+        /// <param name="priorityCalculator">The calculator function for assinging message priorities.</param>
+        /// <remarks>
+        /// WARNING: SHOULD NOT BE USED. Use the constructor to set priority instead.
+        /// </remarks>
+        [Obsolete("Use the constructor to set the priority calculator instead.")]
         public void SetPriorityCalculator(Func<object, int> priorityCalculator)
         {
             _priorityCalculator = priorityCalculator;
         }
 
         /// <summary>
-        /// TBD
+        /// Enqueues a message into the priority queue.
         /// </summary>
-        /// <param name="item">TBD</param>
+        /// <param name="item">The item to enqueue.</param>
         public void Enqueue(Envelope item)
         {
 
@@ -59,9 +79,9 @@ namespace Akka.Util
         }
 
         /// <summary>
-        /// TBD
+        /// Dequeues the highest priority message at the front of the priority queue.
         /// </summary>
-        /// <returns>TBD</returns>
+        /// <returns>The highest priority message <see cref="Envelope"/>.</returns>
         public Envelope Dequeue()
         {
             // assumes pq is not empty; up to calling code
@@ -87,9 +107,9 @@ namespace Akka.Util
         }
 
         /// <summary>
-        /// TBD
+        /// Peek at the message at the front of the priority queue.
         /// </summary>
-        /// <returns>TBD</returns>
+        /// <returns>The highest priority message <see cref="Envelope"/>.</returns>
         public Envelope Peek()
         {
             var frontItem = _data[0];
@@ -97,18 +117,18 @@ namespace Akka.Util
         }
 
         /// <summary>
-        /// TBD
+        /// Counts the number of items in the priority queue.
         /// </summary>
-        /// <returns>TBD</returns>
+        /// <returns>The total number of items in the queue.</returns>
         public int Count()
         {
             return _data.Count;
         }
 
         /// <summary>
-        /// TBD
+        /// Converts the queue to a string representation.
         /// </summary>
-        /// <returns>TBD</returns>
+        /// <returns>A string representation of the queue.</returns>
         public override string ToString()
         {
             var s = "";


### PR DESCRIPTION
close #2308 - realized that this was the result of a weird design choice on my part back when we were working on releasing 1.1. Should never change the priority generator function at runtime. Now it's set via a constructor and is immutable, which should eliminate the issue.

CC @ronnieoverby