### PR TITLE
Fixing Akka.Remote logging. We don't log the stack trace for known situations. (#2452)

### DIFF
--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -109,7 +109,7 @@ namespace Akka.Remote
                 }
                 if (payload is ActorSelectionMessage)
                 {
-                    var sel = (ActorSelectionMessage) payload;
+                    var sel = (ActorSelectionMessage)payload;
 
                     var actorPath = "/" + string.Join("/", sel.Elements.Select(x => x.ToString()));
                     if (settings.UntrustedMode
@@ -214,8 +214,8 @@ namespace Akka.Remote
         /// <param name="localAddress">TBD</param>
         /// <param name="remoteAddress">TBD</param>
         /// <param name="cause">TBD</param>
-        public ShutDownAssociation(Address localAddress, Address remoteAddress, Exception cause = null)
-            : base(string.Format("Shut down address: {0}", remoteAddress), cause)
+        public ShutDownAssociation(string message, Address localAddress, Address remoteAddress, Exception cause = null)
+            : base(message, cause)
         {
             RemoteAddress = remoteAddress;
             LocalAddress = localAddress;
@@ -240,12 +240,13 @@ namespace Akka.Remote
         /// <summary>
         /// TBD
         /// </summary>
+        /// <param name="message">TBD</param>
         /// <param name="localAddress">TBD</param>
         /// <param name="remoteAddress">TbD</param>
         /// <param name="cause">TBD</param>
         /// <param name="disassociateInfo">TBD</param>
-        public InvalidAssociation(Address localAddress, Address remoteAddress, Exception cause = null, DisassociateInfo? disassociateInfo = null)
-            : base(string.Format("Invalid address: {0}", remoteAddress), cause)
+        public InvalidAssociation(string message, Address localAddress, Address remoteAddress, Exception cause = null, DisassociateInfo? disassociateInfo = null)
+            : base(message, cause)
         {
             RemoteAddress = remoteAddress;
             LocalAddress = localAddress;
@@ -653,7 +654,7 @@ namespace Akka.Remote
                         Context.System.Scheduler.ScheduleTellOnce(_settings.RetryGateClosedFor, Self, new Ungate(), Self);
                     }
                 }
-                
+
                 Become(() => Gated(true, earlyUngateRequested));
             });
             Receive<IsIdle>(idle => Sender.Tell(Idle.Instance));
@@ -1085,18 +1086,7 @@ namespace Akka.Remote
         {
             if (_handle == null)
             {
-                Transport
-                    .Associate(RemoteAddress, _refuseUid)
-                    .ContinueWith(handle =>
-                    {
-                        if (handle.IsFaulted)
-                        {
-                            var inner = handle.Exception?.Flatten().InnerException;
-                            return (object)new Status.Failure(new InvalidAssociationException("Association failure", inner));
-                        }
-                        return new Handle(handle.Result);
-                    }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default)
-                    .PipeTo(Self);
+                AssociateAsync().PipeTo(Self);
             }
             else
             {
@@ -1105,6 +1095,18 @@ namespace Akka.Remote
 
             var ackIdleInterval = new TimeSpan(Settings.SysMsgAckTimeout.Ticks / 2);
             _ackIdleTimerCancelable = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(ackIdleInterval, ackIdleInterval, Self, AckIdleCheckTimer.Instance, Self);
+        }
+
+        private async Task<object> AssociateAsync()
+        {
+            try
+            {
+                return new Handle(await Transport.Associate(RemoteAddress, _refuseUid));
+            }
+            catch (Exception e)
+            {
+                return new Status.Failure(e.InnerException);
+            }
         }
 
         /// <summary>
@@ -1141,15 +1143,13 @@ namespace Akka.Remote
             {
                 if (failure.Cause is InvalidAssociationException)
                 {
-                    PublishAndThrow(new InvalidAssociation(LocalAddress, RemoteAddress, failure.Cause),
-                        LogLevel.WarningLevel);
+                    if (failure.Cause.InnerException == null)
+                    {
+                        PublishAndThrow(new InvalidAssociation(failure.Cause.Message, LocalAddress, RemoteAddress), LogLevel.WarningLevel);
+                    }
                 }
-                else
-                {
-                    PublishAndThrow(
-                        new EndpointAssociationException(string.Format("Association failed with {0}",
-                            RemoteAddress)), LogLevel.DebugLevel);
-                }
+
+                PublishAndThrow(new InvalidAssociation($"Association failed with {RemoteAddress}", LocalAddress, RemoteAddress, failure.Cause), LogLevel.WarningLevel);
             });
             Receive<Handle>(handle =>
             {
@@ -1282,7 +1282,7 @@ namespace Akka.Remote
         {
             reason.Match()
                 .With<EndpointDisassociatedException>(endpoint => PublishDisassociated())
-                .With<ShutDownAssociation>(shutdown => {}) // don't log an error for planned shutdowns
+                .With<ShutDownAssociation>(shutdown => { }) // don't log an error for planned shutdowns
                 .Default(msg => PublishError(reason, level));
 
             if (needToThrow)
@@ -1924,7 +1924,7 @@ namespace Akka.Remote
                 if (ackAndMessage.AckOption != null && _reliableDeliverySupervisor != null)
                     _reliableDeliverySupervisor.Tell(ackAndMessage.AckOption);
             });
-            ReceiveAny(o => {}); // ignore
+            ReceiveAny(o => { }); // ignore
         }
 
         #endregion
@@ -1986,10 +1986,10 @@ namespace Akka.Remote
             switch (info)
             {
                 case DisassociateInfo.Quarantined:
-                    throw new InvalidAssociation(LocalAddress, RemoteAddress, new InvalidAssociationException("The remote system has quarantined this system. No further associations " +
-                                                                                                              "to the remote system are possible until this system is restarted."), DisassociateInfo.Quarantined);
+                    throw new InvalidAssociation("The remote system has quarantined this system. No further associations " +
+                                                   "to the remote system are possible until this system is restarted.", LocalAddress, RemoteAddress, disassociateInfo: DisassociateInfo.Quarantined);
                 case DisassociateInfo.Shutdown:
-                    throw new ShutDownAssociation(LocalAddress, RemoteAddress, new InvalidAssociationException("The remote system terminated the association because it is shutting down."));
+                    throw new ShutDownAssociation($"The remote system terminated the association because it is shutting down. Shut down address: {RemoteAddress}", LocalAddress, RemoteAddress);
                 case DisassociateInfo.Unknown:
                 default:
                     Context.Stop(Self);

--- a/src/core/Akka.Remote/EndpointManager.cs
+++ b/src/core/Akka.Remote/EndpointManager.cs
@@ -591,7 +591,7 @@ namespace Akka.Remote
                         {
                             var causedBy = ia.InnerException == null
                                 ? ""
-                                : string.Format("Caused by: [{0}]", ia.InnerException);
+                                : $"Caused by: [{ia.InnerException}]";
                             _log.Warning("Tried to associate with unreachable remote address [{0}]. Address is now gated for {1} ms, all messages to this address will be delivered to dead letters. Reason: [{2}] {3}",
                                 ia.RemoteAddress, _settings.RetryGateClosedFor.TotalMilliseconds, ia.Message, causedBy);
                             _endpoints.MarkAsFailed(Sender, Deadline.Now + _settings.RetryGateClosedFor);

--- a/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
+++ b/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
@@ -136,7 +136,8 @@ namespace Akka.Remote.Transport
         /// </summary>
         protected override Props ManagerProps
         {
-            get {
+            get
+            {
                 return _managerProps ??
                        (_managerProps =
                            Props.Create(() => new AkkaProtocolManager(WrappedTransport, Settings))
@@ -160,14 +161,14 @@ namespace Akka.Remote.Transport
         /// <param name="remoteAddress">TBD</param>
         /// <param name="refuseUid">TBD</param>
         /// <returns>TBD</returns>
-        public Task<AkkaProtocolHandle> Associate(Address remoteAddress, int? refuseUid)
+        public async Task<AkkaProtocolHandle> Associate(Address remoteAddress, int? refuseUid)
         {
             // Prepare a Task and pass its completion source to the manager
             var statusPromise = new TaskCompletionSource<AssociationHandle>();
 
             manager.Tell(new AssociateUnderlyingRefuseUid(SchemeAugmenter.RemoveScheme(remoteAddress), statusPromise, refuseUid));
 
-            return statusPromise.Task.CastTask<AssociationHandle, AkkaProtocolHandle>();
+            return (AkkaProtocolHandle)await statusPromise.Task;
         }
 
         #region Static properties
@@ -231,7 +232,7 @@ namespace Akka.Remote.Transport
                     var stateActorSettings = _settings;
                     var failureDetector = CreateTransportFailureDetector();
                     Context.ActorOf(RARP.For(Context.System).ConfigureDispatcher(ProtocolStateActor.InboundProps(
-                        new HandshakeInfo(stateActorLocalAddress, AddressUidExtension.Uid(Context.System)), 
+                        new HandshakeInfo(stateActorLocalAddress, AddressUidExtension.Uid(Context.System)),
                         handle,
                         stateActorAssociationListener,
                         stateActorSettings,
@@ -347,7 +348,7 @@ namespace Akka.Remote.Transport
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
-            return obj is HandshakeInfo && Equals((HandshakeInfo) obj);
+            return obj is HandshakeInfo && Equals((HandshakeInfo)obj);
         }
 
         private bool Equals(HandshakeInfo other)
@@ -446,7 +447,7 @@ namespace Akka.Remote.Transport
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
             if (obj.GetType() != this.GetType()) return false;
-            return Equals((AkkaProtocolHandle) obj);
+            return Equals((AkkaProtocolHandle)obj);
         }
 
         /// <summary>
@@ -838,7 +839,7 @@ namespace Akka.Remote.Transport
                             {
                                 //Otherwise, retry
                                 SetTimer("associate-retry", wrappedHandle,
-                                    ((RemoteActorRefProvider) ((ActorSystemImpl) Context.System).Provider) //TODO: rewrite using RARP ActorSystem Extension
+                                    ((RemoteActorRefProvider)((ActorSystemImpl)Context.System).Provider) //TODO: rewrite using RARP ActorSystem Extension
                                         .RemoteSettings.BackoffPeriod, repeat: false);
                                 nextState = Stay();
                             }


### PR DESCRIPTION
The old and new logs are in the issue #2452 