### PR TITLE
Possible fix for racy sql testkit specs

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sql.TestKit/AllPersistenceIdsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.TestKit/AllPersistenceIdsSpec.cs
@@ -34,14 +34,14 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_query_AllPersistenceIds_should_implement_standard_AllPersistenceIdsQuery()
         {
-            var _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
-            (_queries is IAllPersistenceIdsQuery).Should().BeTrue();
+            var queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            (queries is IAllPersistenceIdsQuery).Should().BeTrue();
         }
 
         [Fact]
         public void Sql_query_AllPersistenceIds_should_find_existing_persistence_ids()
         {
-            var _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            var queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             Sys.ActorOf(TestKit.TestActor.Props("a")).Tell("a1");
             ExpectMsg("a1-done");
             Sys.ActorOf(TestKit.TestActor.Props("b")).Tell("b1");
@@ -49,7 +49,7 @@ namespace Akka.Persistence.Sql.TestKit
             Sys.ActorOf(TestKit.TestActor.Props("c")).Tell("c1");
             ExpectMsg("c1-done");
 
-            var source = _queries.CurrentPersistenceIds();
+            var source = queries.CurrentPersistenceIds();
             var probe = source.RunWith(this.SinkProbe<string>(), _materializer);
             probe.Within(TimeSpan.FromSeconds(10), () =>
                 probe.Request(5)
@@ -60,7 +60,7 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_query_AllPersistenceIds_should_find_new_persistence_ids()
         {
-            var _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            var queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             Sys.ActorOf(TestKit.TestActor.Props("a")).Tell("a1");
             ExpectMsg("a1-done");
             Sys.ActorOf(TestKit.TestActor.Props("b")).Tell("b1");
@@ -68,7 +68,7 @@ namespace Akka.Persistence.Sql.TestKit
             Sys.ActorOf(TestKit.TestActor.Props("c")).Tell("c1");
             ExpectMsg("c1-done");
 
-            var source = _queries.CurrentPersistenceIds();
+            var source = queries.CurrentPersistenceIds();
             var probe = source.RunWith(this.SinkProbe<string>(), _materializer);
             probe.Within(TimeSpan.FromSeconds(10), () =>
                 probe.Request(5)
@@ -79,7 +79,7 @@ namespace Akka.Persistence.Sql.TestKit
             Sys.ActorOf(TestKit.TestActor.Props("d")).Tell("d1");
             ExpectMsg("d1-done");
 
-            source = _queries.AllPersistenceIds();
+            source = queries.AllPersistenceIds();
             var newprobe = source.RunWith(this.SinkProbe<string>(), _materializer);
             newprobe.Within(TimeSpan.FromSeconds(10), () =>
             {

--- a/src/contrib/persistence/Akka.Persistence.Sql.TestKit/EventsByPersistenceIdSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.TestKit/EventsByPersistenceIdSpec.cs
@@ -32,17 +32,17 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_query_EventsByPersistenceId_should_implement_standard_EventsByTagQuery()
         {
-            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
-            (_queries is IEventsByPersistenceIdQuery).Should().BeTrue();
+            SqlReadJournal queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            (queries is IEventsByPersistenceIdQuery).Should().BeTrue();
         }
 
         [Fact]
         public void Sql_query_EventsByPersistenceId_should_find_existing_events()
         {
-            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            SqlReadJournal queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = Setup("a");
 
-            var src = _queries.CurrentEventsByPersistenceId("a", 0, long.MaxValue);
+            var src = queries.CurrentEventsByPersistenceId("a", 0, long.MaxValue);
             var probe = src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), _materializer);
             probe.Request(2)
                 .ExpectNext("a-1", "a-2")
@@ -55,9 +55,9 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_query_EventsByPersistenceId_should_find_existing_events_up_to_a_sequence_number()
         {
-            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            SqlReadJournal queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = Setup("b");
-            var src = _queries.CurrentEventsByPersistenceId("b", 0L, 2L);
+            var src = queries.CurrentEventsByPersistenceId("b", 0L, 2L);
             var probe = src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), _materializer)
                 .Request(5)
                 .ExpectNext("b-1", "b-2")
@@ -67,9 +67,9 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_query_EventsByPersistenceId_should_not_see_new_events_after_demand_request()
         {
-            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            SqlReadJournal queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = Setup("f");
-            var src = _queries.CurrentEventsByPersistenceId("f", 0L, long.MaxValue);
+            var src = queries.CurrentEventsByPersistenceId("f", 0L, long.MaxValue);
             var probe = src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), _materializer)
                 .Request(2)
                 .ExpectNext("f-1", "f-2")
@@ -87,79 +87,79 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_query_EventsByPersistenceId_should_return_empty_stream_for_cleaned_journal_from_0_to_MaxLong()
         {
-            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            SqlReadJournal queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = Setup("g1");
 
             pref.Tell(new TestActor.DeleteCommand(3));
             ExpectMsg("3-deleted");
 
-            var src = _queries.CurrentEventsByPersistenceId("g1", 0, long.MaxValue);
+            var src = queries.CurrentEventsByPersistenceId("g1", 0, long.MaxValue);
             src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), _materializer).Request(1).ExpectComplete();
         }
 
         [Fact]
         public void Sql_query_EventsByPersistenceId_should_return_empty_stream_for_cleaned_journal_from_0_to_0()
         {
-            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            SqlReadJournal queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = Setup("g2");
 
             pref.Tell(new TestActor.DeleteCommand(3));
             ExpectMsg("3-deleted");
 
-            var src = _queries.CurrentEventsByPersistenceId("g2", 0, 0);
+            var src = queries.CurrentEventsByPersistenceId("g2", 0, 0);
             src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), _materializer).Request(1).ExpectComplete();
         }
 
         [Fact]
         public void Sql_query_EventsByPersistenceId_should_return_remaining_values_after_partial_journal_cleanup()
         {
-            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            SqlReadJournal queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = Setup("h");
 
             pref.Tell(new TestActor.DeleteCommand(2));
             ExpectMsg("2-deleted");
 
-            var src = _queries.CurrentEventsByPersistenceId("h", 0, long.MaxValue);
+            var src = queries.CurrentEventsByPersistenceId("h", 0, long.MaxValue);
             src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), _materializer).Request(1).ExpectNext("h-3").ExpectComplete();
         }
 
         [Fact]
         public void Sql_query_EventsByPersistenceId_should_return_empty_stream_for_empty_journal()
         {
-            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            SqlReadJournal queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = SetupEmpty("i");
 
-            var src = _queries.CurrentEventsByPersistenceId("i", 0L, long.MaxValue);
+            var src = queries.CurrentEventsByPersistenceId("i", 0L, long.MaxValue);
             src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), _materializer).Request(1).ExpectComplete();
         }
 
         [Fact]
         public void Sql_query_EventsByPersistenceId_should_return_empty_stream_for_journal_from_0_to_0()
         {
-            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            SqlReadJournal queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = Setup("k1");
 
-            var src = _queries.CurrentEventsByPersistenceId("k1", 0, 0);
+            var src = queries.CurrentEventsByPersistenceId("k1", 0, 0);
             src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), _materializer).Request(1).ExpectComplete();
         }
 
         [Fact]
         public void Sql_query_EventsByPersistenceId_should_return_empty_stream_for_empty_journal_from_0_to_0()
         {
-            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            SqlReadJournal queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = SetupEmpty("k2");
 
-            var src = _queries.CurrentEventsByPersistenceId("k2", 0, 0);
+            var src = queries.CurrentEventsByPersistenceId("k2", 0, 0);
             src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), _materializer).Request(1).ExpectComplete();
         }
 
         [Fact]
         public void Sql_query_EventsByPersistenceId_should_return_empty_stream_for_journal_from_SequenceNr_greater_than_HighestSequenceNr()
         {
-            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            SqlReadJournal queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = Setup("l");
 
-            var src = _queries.CurrentEventsByPersistenceId("l", 4, 3);
+            var src = queries.CurrentEventsByPersistenceId("l", 4, 3);
             src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), _materializer).Request(1).ExpectComplete();
 
         }
@@ -167,10 +167,10 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_live_query_EventsByPersistenceId_should_find_new_events()
         {
-            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            SqlReadJournal queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = Setup("c");
 
-            var src = _queries.EventsByPersistenceId("c", 0, long.MaxValue);
+            var src = queries.EventsByPersistenceId("c", 0, long.MaxValue);
             var probe = src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), _materializer)
                 .Request(5)
                 .ExpectNext("c-1", "c-2", "c-3");
@@ -184,10 +184,10 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_live_query_EventsByPersistenceId_should_find_new_events_up_to_SequenceNr()
         {
-            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            SqlReadJournal queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = Setup("d");
 
-            var src = _queries.EventsByPersistenceId("d", 0, 4);
+            var src = queries.EventsByPersistenceId("d", 0, 4);
             var probe = src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), _materializer)
                 .Request(5)
                 .ExpectNext("d-1", "d-2", "d-3");
@@ -201,10 +201,10 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_live_query_EventsByPersistenceId_should_find_new_events_after_demand_request()
         {
-            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            SqlReadJournal queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = Setup("e");
 
-            var src = _queries.EventsByPersistenceId("e", 0, long.MaxValue);
+            var src = queries.EventsByPersistenceId("e", 0, long.MaxValue);
             var probe = src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), _materializer)
                 .Request(2)
                 .ExpectNext("e-1", "e-2")

--- a/src/contrib/persistence/Akka.Persistence.Sql.TestKit/EventsByPersistenceIdSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.TestKit/EventsByPersistenceIdSpec.cs
@@ -22,23 +22,24 @@ namespace Akka.Persistence.Sql.TestKit
     public abstract class EventsByPersistenceIdSpec : Akka.TestKit.Xunit2.TestKit
     {
         private readonly ActorMaterializer _materializer;
-        private readonly SqlReadJournal _queries;
+        //private SqlReadJournal _queries;
 
         protected EventsByPersistenceIdSpec(Config config, ITestOutputHelper output) : base(config, output: output)
         {
             _materializer = Sys.Materializer();
-            _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
         }
 
         [Fact]
         public void Sql_query_EventsByPersistenceId_should_implement_standard_EventsByTagQuery()
         {
+            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             (_queries is IEventsByPersistenceIdQuery).Should().BeTrue();
         }
 
         [Fact]
         public void Sql_query_EventsByPersistenceId_should_find_existing_events()
         {
+            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = Setup("a");
 
             var src = _queries.CurrentEventsByPersistenceId("a", 0, long.MaxValue);
@@ -54,6 +55,7 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_query_EventsByPersistenceId_should_find_existing_events_up_to_a_sequence_number()
         {
+            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = Setup("b");
             var src = _queries.CurrentEventsByPersistenceId("b", 0L, 2L);
             var probe = src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), _materializer)
@@ -65,6 +67,7 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_query_EventsByPersistenceId_should_not_see_new_events_after_demand_request()
         {
+            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = Setup("f");
             var src = _queries.CurrentEventsByPersistenceId("f", 0L, long.MaxValue);
             var probe = src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), _materializer)
@@ -84,6 +87,7 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_query_EventsByPersistenceId_should_return_empty_stream_for_cleaned_journal_from_0_to_MaxLong()
         {
+            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = Setup("g1");
 
             pref.Tell(new TestActor.DeleteCommand(3));
@@ -96,6 +100,7 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_query_EventsByPersistenceId_should_return_empty_stream_for_cleaned_journal_from_0_to_0()
         {
+            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = Setup("g2");
 
             pref.Tell(new TestActor.DeleteCommand(3));
@@ -108,6 +113,7 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_query_EventsByPersistenceId_should_return_remaining_values_after_partial_journal_cleanup()
         {
+            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = Setup("h");
 
             pref.Tell(new TestActor.DeleteCommand(2));
@@ -120,6 +126,7 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_query_EventsByPersistenceId_should_return_empty_stream_for_empty_journal()
         {
+            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = SetupEmpty("i");
 
             var src = _queries.CurrentEventsByPersistenceId("i", 0L, long.MaxValue);
@@ -129,6 +136,7 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_query_EventsByPersistenceId_should_return_empty_stream_for_journal_from_0_to_0()
         {
+            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = Setup("k1");
 
             var src = _queries.CurrentEventsByPersistenceId("k1", 0, 0);
@@ -138,6 +146,7 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_query_EventsByPersistenceId_should_return_empty_stream_for_empty_journal_from_0_to_0()
         {
+            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = SetupEmpty("k2");
 
             var src = _queries.CurrentEventsByPersistenceId("k2", 0, 0);
@@ -147,6 +156,7 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_query_EventsByPersistenceId_should_return_empty_stream_for_journal_from_SequenceNr_greater_than_HighestSequenceNr()
         {
+            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = Setup("l");
 
             var src = _queries.CurrentEventsByPersistenceId("l", 4, 3);
@@ -157,6 +167,7 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_live_query_EventsByPersistenceId_should_find_new_events()
         {
+            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = Setup("c");
 
             var src = _queries.EventsByPersistenceId("c", 0, long.MaxValue);
@@ -173,6 +184,7 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_live_query_EventsByPersistenceId_should_find_new_events_up_to_SequenceNr()
         {
+            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = Setup("d");
 
             var src = _queries.EventsByPersistenceId("d", 0, 4);
@@ -189,6 +201,7 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_live_query_EventsByPersistenceId_should_find_new_events_after_demand_request()
         {
+            SqlReadJournal _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var pref = Setup("e");
 
             var src = _queries.EventsByPersistenceId("e", 0, long.MaxValue);

--- a/src/contrib/persistence/Akka.Persistence.Sql.TestKit/EventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.TestKit/EventsByTagSpec.cs
@@ -24,23 +24,24 @@ namespace Akka.Persistence.Sql.TestKit
     public abstract class EventsByTagSpec : Akka.TestKit.Xunit2.TestKit
     {
         private readonly ActorMaterializer _materializer;
-        private readonly SqlReadJournal _queries;
+        //private readonly SqlReadJournal _queries;
 
         protected EventsByTagSpec(Config config, ITestOutputHelper output) : base(config, output: output)
         {
             _materializer = Sys.Materializer();
-            _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
         }
 
         [Fact]
         public void Sql_query_EventsByTag_should_implement_standard_EventsByTagQuery()
         {
+            var _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             (_queries is IEventsByTagQuery).Should().BeTrue();
         }
 
         [Fact]
         public void Sql_query_EventsByTag_should_find_existing_events()
         {
+            var _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var a = SetupEmpty("a");
             var b = SetupEmpty("b");
 
@@ -75,6 +76,7 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_query_EventsByTag_should_not_see_new_events_after_demand_request()
         {
+            var _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             Sql_query_EventsByTag_should_find_existing_events();
 
             var c = SetupEmpty("c");
@@ -97,6 +99,7 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_query_EventsByTag_should_find_events_from_offset()
         {
+            var _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             Sql_query_EventsByTag_should_not_see_new_events_after_demand_request();
 
             var greenSrc = _queries.CurrentEventsByTag("green", offset: 2);
@@ -111,6 +114,7 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_live_query_EventsByTag_should_find_new_events()
         {
+            var _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             Sql_query_EventsByTag_should_find_events_from_offset();
 
             var d = SetupEmpty("d");
@@ -135,6 +139,7 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_live_query_EventsByTag_should_find_events_from_offset()
         {
+            var _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             Sql_live_query_EventsByTag_should_find_new_events();
 
             var greenSrc = _queries.EventsByTag("green", offset: 2);

--- a/src/contrib/persistence/Akka.Persistence.Sql.TestKit/EventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.TestKit/EventsByTagSpec.cs
@@ -34,14 +34,14 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_query_EventsByTag_should_implement_standard_EventsByTagQuery()
         {
-            var _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
-            (_queries is IEventsByTagQuery).Should().BeTrue();
+            var queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            (queries is IEventsByTagQuery).Should().BeTrue();
         }
 
         [Fact]
         public void Sql_query_EventsByTag_should_find_existing_events()
         {
-            var _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            var queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             var a = SetupEmpty("a");
             var b = SetupEmpty("b");
 
@@ -56,7 +56,7 @@ namespace Akka.Persistence.Sql.TestKit
             b.Tell("a green leaf");
             ExpectMsg("a green leaf-done");
 
-            var greenSrc = _queries.CurrentEventsByTag("green", offset: 0);
+            var greenSrc = queries.CurrentEventsByTag("green", offset: 0);
             var probe = greenSrc.RunWith(this.SinkProbe<EventEnvelope>(), _materializer);
             probe.Request(2)
                 .ExpectNext(new EventEnvelope(2, "a", 2, "a green apple"))
@@ -66,7 +66,7 @@ namespace Akka.Persistence.Sql.TestKit
                 .ExpectNext(new EventEnvelope(5, "b", 2, "a green leaf"))
                 .ExpectComplete();
 
-            var blackSrc = _queries.CurrentEventsByTag("black", offset: 0);
+            var blackSrc = queries.CurrentEventsByTag("black", offset: 0);
             probe = blackSrc.RunWith(this.SinkProbe<EventEnvelope>(), _materializer);
             probe.Request(5)
                 .ExpectNext(new EventEnvelope(3, "b", 1, "a black car"))
@@ -76,11 +76,11 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_query_EventsByTag_should_not_see_new_events_after_demand_request()
         {
-            var _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            var queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             Sql_query_EventsByTag_should_find_existing_events();
 
             var c = SetupEmpty("c");
-            var greenSrc = _queries.CurrentEventsByTag("green", offset: 0);
+            var greenSrc = queries.CurrentEventsByTag("green", offset: 0);
             var probe = greenSrc.RunWith(this.SinkProbe<EventEnvelope>(), _materializer);
             probe.Request(2)
                 .ExpectNext(new EventEnvelope(2, "a", 2, "a green apple"))
@@ -99,10 +99,10 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_query_EventsByTag_should_find_events_from_offset()
         {
-            var _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            var queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             Sql_query_EventsByTag_should_not_see_new_events_after_demand_request();
 
-            var greenSrc = _queries.CurrentEventsByTag("green", offset: 2);
+            var greenSrc = queries.CurrentEventsByTag("green", offset: 2);
             var probe = greenSrc.RunWith(this.SinkProbe<EventEnvelope>(), _materializer);
             probe.Request(10)
                 .ExpectNext(new EventEnvelope(4, "a", 3, "a green banana"))
@@ -114,12 +114,12 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_live_query_EventsByTag_should_find_new_events()
         {
-            var _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            var queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             Sql_query_EventsByTag_should_find_events_from_offset();
 
             var d = SetupEmpty("d");
 
-            var blackSrc = _queries.EventsByTag("black", offset: 0);
+            var blackSrc = queries.EventsByTag("black", offset: 0);
             var probe = blackSrc.RunWith(this.SinkProbe<EventEnvelope>(), _materializer);
             probe.Request(2)
                 .ExpectNext(new EventEnvelope(3, "b", 1, "a black car"))
@@ -139,10 +139,10 @@ namespace Akka.Persistence.Sql.TestKit
         [Fact]
         public void Sql_live_query_EventsByTag_should_find_events_from_offset()
         {
-            var _queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            var queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
             Sql_live_query_EventsByTag_should_find_new_events();
 
-            var greenSrc = _queries.EventsByTag("green", offset: 2);
+            var greenSrc = queries.EventsByTag("green", offset: 2);
             var probe = greenSrc.RunWith(this.SinkProbe<EventEnvelope>(), _materializer);
             probe.Request(10)
                 .ExpectNext(new EventEnvelope(4, "a", 3L, "a green banana"))


### PR DESCRIPTION
As i have discovered before. XUnit in combination with the akka TestKit causes some wierd stuff sometimes.
One thing that happens is that state you expect to be reinitialized for each test is sometimes reused between tests.

Reference to where i encountered a similar case: http://stackoverflow.com/questions/40767924/testing-behavior-not-consistent-when-watching-actor-for-termination/40929659#40929659

What this PR does, is move the SqlReadJournal reference to the local scope. Thereby eliminating any chance there is concurrent access to that resource where its not expected.

The EventsByTagSpec might need more refactoring. But worked consistently locally on the SqlLite tests implementation whereas before are very racy.