### PR TITLE
Cluster updates to Akka JVM 2.4.16

### DIFF
--- a/src/core/Akka.Cluster.Tests.MultiNode/NodeChurnSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/NodeChurnSpec.cs
@@ -136,7 +136,7 @@ namespace Akka.Cluster.Tests.MultiNode
                     }
                 }
 
-                AwaitRemoved(systems);
+                AwaitRemoved(systems, n);
                 EnterBarrier("members-removed-" + n);
                 foreach (var node in systems)
                 {
@@ -167,16 +167,17 @@ namespace Akka.Cluster.Tests.MultiNode
             });
         }
 
-        private void AwaitRemoved(ImmutableList<ActorSystem> additionaSystems)
+        private void AwaitRemoved(ImmutableList<ActorSystem> additionaSystems, int round)
         {
             AwaitMembersUp(Roles.Count, timeout: 40.Seconds());
-            Within(20.Seconds(), () =>
+            EnterBarrier("removed-" + round);
+            Within(3.Seconds(), () =>
             {
                 AwaitAssert(() =>
                 {
                     additionaSystems.ForEach(s =>
                     {
-                        Cluster.Get(s).IsTerminated.Should().BeTrue();
+                        Cluster.Get(s).IsTerminated.Should().BeTrue($"{Cluster.Get(s).SelfAddress}");
                     });
                 });
             });

--- a/src/core/Akka.Cluster.Tests/GossipSpec.cs
+++ b/src/core/Akka.Cluster.Tests/GossipSpec.cs
@@ -158,6 +158,12 @@ namespace Akka.Cluster.Tests
         }
 
         [Fact]
+        public void A_gossip_must_not_have_Down_member_as_leader()
+        {
+            new Gossip(ImmutableSortedSet.Create(e3)).Leader(e3.UniqueAddress).Should().BeNull();
+        }
+
+        [Fact]
         public void A_gossip_must_merge_seen_table_correctly()
         {
             var vclockNode = VectorClock.Node.Create("something");

--- a/src/core/Akka.Cluster.Tests/ReachabilitySpec.cs
+++ b/src/core/Akka.Cluster.Tests/ReachabilitySpec.cs
@@ -293,5 +293,23 @@ namespace Akka.Cluster.Tests
             r.Status(nodeB, nodeC).Should().Be(Reachability.ReachabilityStatus.Reachable);
             r.Status(nodeB, nodeE).Should().Be(Reachability.ReachabilityStatus.Reachable);
         }
+
+        [Fact]
+        public void ReachabilityTable_must_remove_correctly_after_pruning()
+        {
+            var r = Reachability.Empty.
+                Unreachable(nodeB, nodeA).
+                Unreachable(nodeB, nodeC).
+                Unreachable(nodeD, nodeC).
+                Reachable(nodeB, nodeA).
+                Reachable(nodeB, nodeC);
+
+            r.Records.Should().BeEquivalentTo(ImmutableList.Create(
+                new Reachability.Record(nodeD, nodeC, Reachability.ReachabilityStatus.Unreachable, 1L)));
+
+            var r2 = r.Remove(ImmutableList.Create(nodeB));
+            r2.AllObservers.Should().BeEquivalentTo(ImmutableList.Create(nodeD));
+            r2.Versions.Keys.Should().BeEquivalentTo(ImmutableList.Create(nodeD));
+        }
     }
 }

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -266,7 +266,7 @@ namespace Akka.Cluster
         /// Command to initiate the process to join the specified
         /// seed nodes.
         /// </summary>
-        internal sealed class JoinSeedNodes
+        internal sealed class JoinSeedNodes : IDeadLetterSuppression
         {
             readonly ImmutableList<Address> _seedNodes;
 
@@ -303,7 +303,7 @@ namespace Akka.Cluster
         /// <summary>
         /// See JoinSeedNode
         /// </summary>
-        internal class InitJoin : IClusterMessage
+        internal class InitJoin : IClusterMessage, IDeadLetterSuppression
         {
             /// <summary>
             /// TBD
@@ -319,7 +319,7 @@ namespace Akka.Cluster
         /// <summary>
         /// See JoinSeeNode
         /// </summary>
-        internal sealed class InitJoinAck : IClusterMessage
+        internal sealed class InitJoinAck : IClusterMessage, IDeadLetterSuppression
         {
             readonly Address _address;
 
@@ -371,7 +371,7 @@ namespace Akka.Cluster
         /// <summary>
         /// See JoinSeeNode
         /// </summary>
-        internal sealed class InitJoinNack : IClusterMessage
+        internal sealed class InitJoinNack : IClusterMessage, IDeadLetterSuppression
         {
             readonly Address _address;
 

--- a/src/core/Akka.Cluster/Gossip.cs
+++ b/src/core/Akka.Cluster/Gossip.cs
@@ -332,9 +332,9 @@ namespace Akka.Cluster
         private UniqueAddress LeaderOf(ImmutableSortedSet<Member> mbrs, UniqueAddress selfUniqueAddress)
         {
             var reachableMembers = _overview.Reachability.IsAllReachable
-                ? mbrs
+                ? mbrs.Where(m => m.Status != MemberStatus.Down)
                 : mbrs
-                    .Where(m => _overview.Reachability.IsReachable(m.UniqueAddress) || m.UniqueAddress == selfUniqueAddress)
+                    .Where(m => m.Status != MemberStatus.Down && _overview.Reachability.IsReachable(m.UniqueAddress) || m.UniqueAddress == selfUniqueAddress)
                     .ToImmutableSortedSet();
 
             if (!reachableMembers.Any()) return null;

--- a/src/core/Akka.Cluster/Reachability.cs
+++ b/src/core/Akka.Cluster/Reachability.cs
@@ -375,15 +375,8 @@ namespace Akka.Cluster
         {
             var nodesSet = nodes.ToImmutableHashSet();
             var newRecords = _records.FindAll(r => !nodesSet.Contains(r.Observer) && !nodesSet.Contains(r.Subject));
-            if (newRecords.Count == _records.Count)
-            {
-                return this;
-            }
-            else
-            {
-                var newVersions = _versions.RemoveRange(nodes);
-                return new Reachability(newRecords, newVersions);
-            }
+            var newVersions = _versions.RemoveRange(nodes);
+            return new Reachability(newRecords, newVersions);
         }
 
         /// <summary>
@@ -400,15 +393,8 @@ namespace Akka.Cluster
             else
             {
                 var newRecords = _records.FindAll(r => !nodes.Contains(r.Observer));
-                if (newRecords.Count == _records.Count)
-                {
-                    return this;
-                }
-                else
-                {
-                    var newVersions = _versions.RemoveRange(nodes);
-                    return new Reachability(newRecords, newVersions);
-                }
+                var newVersions = _versions.RemoveRange(nodes);
+                return new Reachability(newRecords, newVersions);
             }
         }
 

--- a/src/core/Akka.Remote.Tests/ActorsLeakSpec.cs
+++ b/src/core/Akka.Remote.Tests/ActorsLeakSpec.cs
@@ -17,6 +17,7 @@ using Akka.TestKit;
 using Akka.TestKit.TestActors;
 using Akka.Util.Internal;
 using Xunit;
+using FluentAssertions;
 
 namespace Akka.Remote.Tests
 {
@@ -222,9 +223,10 @@ namespace Akka.Remote.Tests
              */
             EventFilter.Exception<TimeoutException>().ExpectOne(() => { });
 
-            var finalActors = targets.SelectMany(CollectLiveActors).ToImmutableHashSet();
-
-            AssertActors(initialActors, finalActors);
+            AwaitAssert(() =>
+            {
+                AssertActors(initialActors, targets.SelectMany(CollectLiveActors).ToImmutableHashSet());
+            }, 5.Seconds());
         }
     }
 }


### PR DESCRIPTION
- [suppress deadletter for the cluster joining messages](https://github.com/akka/akka/pull/21156) [2.4.9]
- [harden NodeChurnSpec](https://github.com/akka/akka/pull/21141) [2.4.9]
- [Add a retry for a check for stopped actors](https://github.com/akka/akka/pull/21697) [2.4.12]
- [Reachability.remove didn't always remove all](https://github.com/akka/akka/pull/22016) [2.4.16]
- [don't use Down member as leader](https://github.com/akka/akka/pull/21990) [2.4.16]