### PR TITLE
MailboxesSpec.Can_use_unbounded_priority_mailbox fixed

### DIFF
--- a/src/core/Akka/Actor/Message.cs
+++ b/src/core/Akka/Actor/Message.cs
@@ -17,9 +17,9 @@ namespace Akka.Actor
         /// <summary>
         /// Initializes a new instance of the <see cref="Envelope"/> struct.
         /// </summary>
-        /// <param name="message">TBD</param>
-        /// <param name="sender">TBD</param>
-        /// <param name="system">TBD</param>
+        /// <param name="message">The message being sent.</param>
+        /// <param name="sender">The actor who sent the message.</param>
+        /// <param name="system">The current actor system.</param>
         /// <exception cref="ArgumentNullException">
         /// This exception is thrown if the given <paramref name="message"/> is undefined.
         /// </exception>
@@ -35,10 +35,10 @@ namespace Akka.Actor
         }
 
         /// <summary>
-        /// TBD
+        /// Initializes a new instance of the <see cref="Envelope"/> struct.
         /// </summary>
-        /// <param name="message">TBD</param>
-        /// <param name="sender">TBD</param>
+        /// <param name="message">The message being sent.</param>
+        /// <param name="sender">The actor who sent the message.</param>
         public Envelope(object message, IActorRef sender)
         {
             Message = message;
@@ -58,9 +58,9 @@ namespace Akka.Actor
         public object Message { get; private set; }
 
         /// <summary>
-        /// TBD
+        /// Converts the <see cref="Envelope"/> to a string representation.
         /// </summary>
-        /// <returns>TBD</returns>
+        /// <returns>A string.</returns>
         public override string ToString()
         {
             return "<" + (Message ?? "null") + "> from " + (Sender == ActorRefs.NoSender ? "NoSender" : Sender.ToString());

--- a/src/core/Akka/Dispatch/Mailbox.cs
+++ b/src/core/Akka/Dispatch/Mailbox.cs
@@ -210,25 +210,25 @@ namespace Akka.Dispatch
         internal bool ShouldProcessMessage() { return (CurrentStatus() & MailboxStatus.ShouldNotProcessMask) == 0; }
 
         /// <summary>
-        /// TBD
+        /// Returns the number of times this mailbox is currently suspended.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal int SuspendCount() { return CurrentStatus() / MailboxStatus.SuspendUnit; }
 
         /// <summary>
-        /// TBD
+        /// Returns <c>true</c> if the mailbox is currently suspended from processing. <c>false</c> otherwise.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool IsSuspended() { return (CurrentStatus() & MailboxStatus.SuspendMask) != 0; }
 
         /// <summary>
-        /// TBD
+        /// Returns <c>true</c> if the mailbox is closed. <c>false</c> otherwise.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool IsClosed() { return (CurrentStatus() == MailboxStatus.Closed); }
 
         /// <summary>
-        /// TBD
+        /// Returns <c>true</c> if the mailbox is scheduled for execution on a <see cref="Dispatcher"/>. <c>false</c> otherwise.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool IsScheduled()
@@ -237,7 +237,7 @@ namespace Akka.Dispatch
         }
 
         /// <summary>
-        /// TBD
+        /// Updates the status of the current mailbox.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool UpdateStatus(int oldStatus, int newStatus)
@@ -246,7 +246,7 @@ namespace Akka.Dispatch
         }
 
         /// <summary>
-        /// TBD
+        /// Forcefully sets the status of the current mailbox.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void SetStatus(int newStatus)
@@ -296,9 +296,9 @@ namespace Akka.Dispatch
         }
 
         /// <summary>
-        ///  Set the new primary status to 
+        ///  Set the new primary status to <see cref="MailboxStatus.Closed"/>.
         /// </summary>
-        /// <returns>TBD</returns>
+        /// <returns><c>true</c> if we were able to successfully close the mailbox. <c>false</c> otherwise.</returns>
         internal bool BecomeClosed()
         {
             var status = CurrentStatus();
@@ -313,7 +313,7 @@ namespace Akka.Dispatch
         /// <summary>
         /// Set scheduled status, keeping primary status as-is.
         /// </summary>
-        /// <returns>TBD</returns>
+        /// <returns>Returns <c>true</c> if the set operation succeeded. <c>false</c> otherwise.</returns>
         internal bool SetAsScheduled()
         {
             while (true)
@@ -332,7 +332,7 @@ namespace Akka.Dispatch
         /// <summary>
         /// Reset Scheduled status, keeping primary status as-is
         /// </summary>
-        /// <returns>TBD</returns>
+        /// <returns>Returns <c>true</c> if the set operation succeeded. <c>false</c> otherwise.</returns>
         internal bool SetAsIdle()
         {
             while (true)

--- a/src/core/Akka/Dispatch/Mailbox.cs
+++ b/src/core/Akka/Dispatch/Mailbox.cs
@@ -496,10 +496,10 @@ namespace Akka.Dispatch
 
         /* In JVM the following three methods are implemented as an internal trait. Added them directly onto the Mailbox itself instead. */
         /// <summary>
-        /// TBD
+        /// Enqueues a new <see cref="ISystemMessage"/> into the <see cref="Mailbox"/> for a given actor.
         /// </summary>
-        /// <param name="receiver">TBD</param>
-        /// <param name="message">TBD</param>
+        /// <param name="receiver">The actor who will receive the system message.</param>
+        /// <param name="message">The system message.</param>
         internal virtual void SystemEnqueue(IActorRef receiver, SystemMessage message)
         {
             Assert.Assert(message.Unlinked);
@@ -520,9 +520,9 @@ namespace Akka.Dispatch
         }
 
         /// <summary>
-        /// TBD
+        /// Drains <see cref="ISystemMessage"/> from this mailbox.
         /// </summary>
-        /// <param name="newContents">TBD</param>
+        /// <param name="newContents">The replacement queue for the system messages inside this mailbox.</param>
         internal virtual EarliestFirstSystemMessageList SystemDrain(LatestFirstSystemMessageList newContents)
         {
             var currentList = SystemQueue;
@@ -532,7 +532,8 @@ namespace Akka.Dispatch
         }
 
         /// <summary>
-        /// TBD
+        /// Returns <c>true</c> if there are <see cref="ISystemMessage"/> instances inside this mailbox.
+        /// <c>false</c> otherwise.
         /// </summary>
         internal virtual bool HasSystemMessages
         {
@@ -575,19 +576,20 @@ namespace Akka.Dispatch
     public abstract class MailboxType
     {
         /// <summary>
-        /// TBD
+        /// The settings for the given <see cref="ActorSystem"/>.
         /// </summary>
         protected readonly Settings Settings;
+
         /// <summary>
-        /// TBD
+        /// The configuration for this mailbox.
         /// </summary>
         protected readonly Config Config;
 
         /// <summary>
-        /// TBD
+        /// Constructor used for creating a <see cref="MailboxType"/>
         /// </summary>
-        /// <param name="settings">TBD</param>
-        /// <param name="config">TBD</param>
+        /// <param name="settings">The <see cref="ActorSystem.Settings"/> for this system.</param>
+        /// <param name="config">The <see cref="Config"/> for this mailbox.</param>
         protected MailboxType(Settings settings, Config config)
         {
             Settings = settings;
@@ -614,12 +616,7 @@ namespace Akka.Dispatch
     /// </summary>
     public sealed class UnboundedMailbox : MailboxType, IProducesMessageQueue<UnboundedMessageQueue>
     {
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="owner">TBD</param>
-        /// <param name="system">TBD</param>
-        /// <returns>TBD</returns>
+        /// <inheritdoc cref="MailboxType"/>
         public override IMessageQueue Create(IActorRef owner, ActorSystem system)
         {
             return new UnboundedMessageQueue();
@@ -627,17 +624,13 @@ namespace Akka.Dispatch
 
 
         /// <summary>
-        /// TBD
+        /// Default constructor for an unbounded mailbox.
         /// </summary>
         public UnboundedMailbox() : this(null, null)
         {
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="settings">TBD</param>
-        /// <param name="config">TBD</param>
+        /// <inheritdoc cref="MailboxType"/>
         public UnboundedMailbox(Settings settings, Config config) : base(settings, config)
         {
         }
@@ -649,19 +642,16 @@ namespace Akka.Dispatch
     public sealed class BoundedMailbox : MailboxType, IProducesMessageQueue<BoundedMessageQueue>
     {
         /// <summary>
-        /// TBD
+        /// The capacity of this mailbox.
         /// </summary>
         public int Capacity { get; }
+
         /// <summary>
-        /// TBD
+        /// The push timeout value. Will throw a timeout error after this period of time
         /// </summary>
         public TimeSpan PushTimeout { get; }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BoundedMailbox" /> class.
-        /// </summary>
-        /// <param name="settings">TBD</param>
-        /// <param name="config">TBD</param>
+        /// <inheritdoc cref="MailboxType"/>
         /// <exception cref="ArgumentException">
         /// This exception is thrown if the 'mailbox-capacity' in <paramref name="config"/>
         /// or the 'mailbox-push-timeout-time' in <paramref name="config"/> is negative.
@@ -675,12 +665,7 @@ namespace Akka.Dispatch
             if (PushTimeout.TotalSeconds < 0) throw new ArgumentException("The push time-out for BoundedMailbox cannot be be negative", nameof(config));
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="owner">TBD</param>
-        /// <param name="system">TBD</param>
-        /// <returns>TBD</returns>
+        /// <inheritdoc cref="MailboxType"/>
         public override IMessageQueue Create(IActorRef owner, ActorSystem system)
         {
             return new BoundedMessageQueue(Capacity, PushTimeout);
@@ -696,38 +681,29 @@ namespace Akka.Dispatch
     public abstract class UnboundedPriorityMailbox : MailboxType, IProducesMessageQueue<UnboundedPriorityMessageQueue>
     {
         /// <summary>
-        /// TBD
+        /// Function responsible for generating the priority value of a message based on its type and content.
         /// </summary>
-        /// <param name="message">TBD</param>
-        /// <returns>TBD</returns>
+        /// <param name="message">The message to inspect.</param>
+        /// <returns>An integer. The lower the value, the higher the priority.</returns>
         protected abstract int PriorityGenerator(object message);
 
         /// <summary>
-        /// TBD
+        /// The initial capacity of the unbounded mailbox.
         /// </summary>
         public int InitialCapacity { get; }
 
         /// <summary>
-        /// TBD
+        /// The default capacity of an unbounded priority mailbox.
         /// </summary>
         public const int DefaultCapacity = 11;
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="owner">TBD</param>
-        /// <param name="system">TBD</param>
-        /// <returns>TBD</returns>
+        /// <inheritdoc cref="MailboxType"/>
         public sealed override IMessageQueue Create(IActorRef owner, ActorSystem system)
         {
             return new UnboundedPriorityMessageQueue(PriorityGenerator, InitialCapacity);
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="settings">TBD</param>
-        /// <param name="config">TBD</param>
+        /// <inheritdoc cref="MailboxType"/>
         protected UnboundedPriorityMailbox(Settings settings, Config config) : base(settings, config)
         {
             InitialCapacity = DefaultCapacity;
@@ -741,21 +717,12 @@ namespace Akka.Dispatch
     /// </summary>
     public sealed class UnboundedDequeBasedMailbox : MailboxType, IProducesMessageQueue<UnboundedDequeMessageQueue>
     {
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="settings">TBD</param>
-        /// <param name="config">TBD</param>
+        /// <inheritdoc cref="MailboxType"/>
         public UnboundedDequeBasedMailbox(Settings settings, Config config) : base(settings, config)
         {
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="owner">TBD</param>
-        /// <param name="system">TBD</param>
-        /// <returns>TBD</returns>
+        /// <inheritdoc cref="MailboxType"/>
         public override IMessageQueue Create(IActorRef owner, ActorSystem system)
         {
             return new UnboundedDequeMessageQueue();
@@ -768,19 +735,17 @@ namespace Akka.Dispatch
     public sealed class BoundedDequeBasedMailbox : MailboxType, IProducesMessageQueue<BoundedDequeMessageQueue>
     {
         /// <summary>
-        /// TBD
+        /// The capacity of this mailbox.
         /// </summary>
         public int Capacity { get; }
+
         /// <summary>
-        /// TBD
+        /// The push timeout. Fires a <see cref="TimeoutException"/> if it takes longer than this to add a message to
+        /// a full bounded mailbox.
         /// </summary>
         public TimeSpan PushTimeout { get; }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BoundedDequeBasedMailbox" /> class.
-        /// </summary>
-        /// <param name="settings">TBD</param>
-        /// <param name="config">TBD</param>
+        /// <inheritdoc cref="MailboxType"/>
         /// <exception cref="ArgumentException">
         /// This exception is thrown if the 'mailbox-capacity' in <paramref name="config"/>
         /// or the 'mailbox-push-timeout-time' in <paramref name="config"/> is negative.
@@ -794,12 +759,7 @@ namespace Akka.Dispatch
             if (PushTimeout.TotalSeconds < 0) throw new ArgumentException("The push time-out for BoundedMailbox cannot be null", nameof(config));
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="owner">TBD</param>
-        /// <param name="system">TBD</param>
-        /// <returns>TBD</returns>
+        /// <inheritdoc cref="MailboxType"/>
         public override IMessageQueue Create(IActorRef owner, ActorSystem system)
         {
             return new BoundedDequeMessageQueue(Capacity, PushTimeout);

--- a/src/core/Akka/Dispatch/MessageQueues/BoundedMessageQueue.cs
+++ b/src/core/Akka/Dispatch/MessageQueues/BoundedMessageQueue.cs
@@ -20,9 +20,9 @@ namespace Akka.Dispatch.MessageQueues
         private readonly BlockingCollection<Envelope> _queue;
 
         /// <summary>
-        /// TBD
+        /// Creates a new bounded message queue.
         /// </summary>
-        /// <param name="config">TBD</param>
+        /// <param name="config">The configuration for this mailbox.</param>
         public BoundedMessageQueue(Config config)
             : this(config.GetInt("mailbox-capacity"), config.GetTimeSpan("mailbox-push-timeout-time"))
         {
@@ -53,21 +53,13 @@ namespace Akka.Dispatch.MessageQueues
             }
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
+        /// <inheritdoc cref="IMessageQueue"/>
         public bool HasMessages => _queue.Count > 0;
 
-        /// <summary>
-        /// TBD
-        /// </summary>
+        /// <inheritdoc cref="IMessageQueue"/>
         public int Count => _queue.Count;
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="receiver">TBD</param>
-        /// <param name="envelope">TBD</param>
+        /// <inheritdoc cref="IMessageQueue"/>
         public void Enqueue(IActorRef receiver, Envelope envelope)
         {
             if (!_queue.TryAdd(envelope, PushTimeOut)) // dump messages that can't be delivered in-time into DeadLetters
@@ -76,22 +68,13 @@ namespace Akka.Dispatch.MessageQueues
             }
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="envelope">TBD</param>
-        /// <returns>TBD</returns>
+        /// <inheritdoc cref="IMessageQueue"/>
         public bool TryDequeue(out Envelope envelope)
         {
             return _queue.TryTake(out envelope);
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="owner">TBD</param>
-        /// <param name="deadletters">TBD</param>
-        /// <returns>TBD</returns>
+        /// <inheritdoc cref="IMessageQueue"/>
         public void CleanUp(IActorRef owner, IMessageQueue deadletters)
         {
             Envelope msg;
@@ -102,7 +85,7 @@ namespace Akka.Dispatch.MessageQueues
         }
 
         /// <summary>
-        /// TBD
+        /// The push timeout for this bounded queue.
         /// </summary>
         public TimeSpan PushTimeOut { get; set; }
     }

--- a/src/core/Akka/Dispatch/MessageQueues/DequeWrapperMessageQueue.cs
+++ b/src/core/Akka/Dispatch/MessageQueues/DequeWrapperMessageQueue.cs
@@ -21,14 +21,15 @@ namespace Akka.Dispatch.MessageQueues
         private readonly Stack<Envelope> _prependBuffer = new Stack<Envelope>();
 
         /// <summary>
-        /// TBD
+        /// The underlying <see cref="IMessageQueue"/>.
         /// </summary>
         protected readonly IMessageQueue MessageQueue;
+
         /// <summary>
         /// Takes another <see cref="IMessageQueue"/> as an argument - wraps <paramref name="messageQueue"/>
         /// in order to provide it with prepend (<see cref="EnqueueFirst"/>) semantics.
         /// </summary>
-        /// <param name="messageQueue">TBD</param>
+        /// <param name="messageQueue">The underlying message queue wrapped by this one.</param>
         public DequeWrapperMessageQueue(IMessageQueue messageQueue)
         {
             MessageQueue = messageQueue;
@@ -51,11 +52,7 @@ namespace Akka.Dispatch.MessageQueues
             get { return MessageQueue.Count + _prependBuffer.Count; }
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="receiver">TBD</param>
-        /// <param name="envelope">TBD</param>
+        /// <inheritdoc cref="IMessageQueue"/>
         public void Enqueue(IActorRef receiver, Envelope envelope)
         {
             MessageQueue.Enqueue(receiver, envelope);
@@ -80,11 +77,7 @@ namespace Akka.Dispatch.MessageQueues
             return MessageQueue.TryDequeue(out envelope);
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="owner">TBD</param>
-        /// <param name="deadletters">TBD</param>
+        /// <inheritdoc cref="IMessageQueue"/>
         public void CleanUp(IActorRef owner, IMessageQueue deadletters)
         {
             Envelope msg;

--- a/src/core/Akka/Dispatch/MessageQueues/UnboundedMailboxQueue.cs
+++ b/src/core/Akka/Dispatch/MessageQueues/UnboundedMailboxQueue.cs
@@ -20,9 +20,7 @@ namespace Akka.Dispatch.MessageQueues
     {
         private readonly TQueue _queue = new TQueue();
 
-        /// <summary>
-        /// TBD
-        /// </summary>
+        /// <inheritdoc cref="IMessageQueue"/>
         public bool HasMessages
         {
 #if MONO
@@ -32,39 +30,25 @@ namespace Akka.Dispatch.MessageQueues
 #endif
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
+        /// <inheritdoc cref="IMessageQueue"/>
         public int Count
         {
             get { return _queue.Count; }
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="receiver">TBD</param>
-        /// <param name="envelope">TBD</param>
+        /// <inheritdoc cref="IMessageQueue"/>
         public void Enqueue(IActorRef receiver, Envelope envelope)
         {
             _queue.Enqueue(envelope);
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="envelope">TBD</param>
-        /// <returns>TBD</returns>
+        /// <inheritdoc cref="IMessageQueue"/>
         public bool TryDequeue(out Envelope envelope)
         {
             return _queue.TryDequeue(out envelope);
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="owner">TBD</param>
-        /// <param name="deadletters">TBD</param>
+        /// <inheritdoc cref="IMessageQueue"/>
         public void CleanUp(IActorRef owner, IMessageQueue deadletters)
         {
             Envelope msg;


### PR DESCRIPTION
Resolves #2308 - turns out it was an issue with the way that spec was written. Needed to wait for the mailbox to be suspended before we began queuing events.