### PR TITLE
increased FAKE nbench timeout from 15 to 25 minutes

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -364,7 +364,7 @@ Target "NBench" <| fun _ ->
         let result = ExecProcess(fun info -> 
             info.FileName <- nbenchTestPath
             info.WorkingDirectory <- (Path.GetDirectoryName (FullName nbenchTestPath))
-            info.Arguments <- args) (System.TimeSpan.FromMinutes 15.0) (* Reasonably long-running task. *)
+            info.Arguments <- args) (System.TimeSpan.FromMinutes 25.0) (* Reasonably long-running task. *)
         if result <> 0 then failwithf "NBench.Runner failed. %s %s" nbenchTestPath args
     
     nbenchTestAssemblies |> Seq.iter (runNBench)


### PR DESCRIPTION
Both https://github.com/akkadotnet/akka.net/pull/2509 and https://github.com/akkadotnet/akka.net/pull/2507 have run into issues where 15 minutes isn't long enough for them to complete their test suites for Akka.Tests.Performance. I've added 10 minutes to the timeout window to resolve this (and it will need to get longer the more specs we add to each assembly.)