### PR TITLE
Customizable serializers

### DIFF
--- a/src/contrib/serializers/Akka.Serialization.Hyperion.Tests/Akka.Serialization.Hyperion.Tests.csproj
+++ b/src/contrib/serializers/Akka.Serialization.Hyperion.Tests/Akka.Serialization.Hyperion.Tests.csproj
@@ -55,6 +55,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="HyperionConfigTests.cs" />
     <Compile Include="HyperionTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -82,6 +83,9 @@
       <Project>{caa97041-cfc0-4081-9bd2-8b139e62a611}</Project>
       <Name>Akka.Serialization.TestKit</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/contrib/serializers/Akka.Serialization.Hyperion.Tests/HyperionConfigTests.cs
+++ b/src/contrib/serializers/Akka.Serialization.Hyperion.Tests/HyperionConfigTests.cs
@@ -1,0 +1,125 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="HyperionConfigTests.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Akka.Actor;
+using Akka.Configuration;
+using Xunit;
+
+namespace Akka.Serialization.Hyperion.Tests
+{
+    public class HyperionConfigTests
+    {
+        [Fact]
+        public void Hyperion_serializer_should_have_correct_defaults()
+        {
+            var config = ConfigurationFactory.ParseString(@"
+                akka.actor {
+                    serializers.hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                    serialization-bindings {
+                        ""System.Object"" = hyperion
+                    }
+                }
+            ");
+            using (var system = ActorSystem.Create(nameof(HyperionConfigTests), config))
+            {
+                var serializer = (HyperionSerializer)system.Serialization.FindSerializerForType(typeof(object));
+                Assert.Equal(true, serializer.Settings.VersionTolerance);
+                Assert.Equal(true, serializer.Settings.PreserveObjectReferences);
+                Assert.Equal("NoKnownTypes", serializer.Settings.KnownTypesProvider.Name);
+            }
+        }
+
+        [Fact]
+        public void Hyperion_serializer_should_allow_to_setup_custom_flags()
+        {
+            var config = ConfigurationFactory.ParseString(@"
+                akka.actor {
+                    serializers.hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                    serialization-bindings {
+                        ""System.Object"" = hyperion
+                    }
+                    serialization-settings.hyperion {
+                        preserve-object-references = false
+                        version-tolerance = false
+                    }
+                }
+            ");
+            using (var system = ActorSystem.Create(nameof(HyperionConfigTests), config))
+            {
+                var serializer = (HyperionSerializer)system.Serialization.FindSerializerForType(typeof(object));
+                Assert.Equal(false, serializer.Settings.VersionTolerance);
+                Assert.Equal(false, serializer.Settings.PreserveObjectReferences);
+                Assert.Equal("NoKnownTypes", serializer.Settings.KnownTypesProvider.Name);
+            }
+        }
+
+        [Fact]
+        public void Hyperion_serializer_should_allow_to_setup_custom_types_provider_with_default_constructor()
+        {
+            var config = ConfigurationFactory.ParseString(@"
+                akka.actor {
+                    serializers.hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                    serialization-bindings {
+                        ""System.Object"" = hyperion
+                    }
+                    serialization-settings.hyperion {
+                        known-types-provider = ""Akka.Serialization.Hyperion.Tests.DummyTypesProviderWithDefaultCtor, Akka.Serialization.Hyperion.Tests""
+                    }
+                }
+            ");
+            using (var system = ActorSystem.Create(nameof(HyperionConfigTests), config))
+            {
+                var serializer = (HyperionSerializer)system.Serialization.FindSerializerForType(typeof(object));
+                Assert.Equal(true, serializer.Settings.VersionTolerance);
+                Assert.Equal(true, serializer.Settings.PreserveObjectReferences);
+                Assert.Equal(typeof(DummyTypesProviderWithDefaultCtor), serializer.Settings.KnownTypesProvider);
+            }
+        }
+
+        [Fact]
+        public void Hyperion_serializer_should_allow_to_setup_custom_types_provider_with_non_default_constructor()
+        {
+            var config = ConfigurationFactory.ParseString(@"
+                akka.actor {
+                    serializers.hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                    serialization-bindings {
+                        ""System.Object"" = hyperion
+                    }
+                    serialization-settings.hyperion {
+                        known-types-provider = ""Akka.Serialization.Hyperion.Tests.DummyTypesProvider, Akka.Serialization.Hyperion.Tests""
+                    }
+                }
+            ");
+            using (var system = ActorSystem.Create(nameof(HyperionConfigTests), config))
+            {
+                var serializer = (HyperionSerializer)system.Serialization.FindSerializerForType(typeof(object));
+                Assert.Equal(true, serializer.Settings.VersionTolerance);
+                Assert.Equal(true, serializer.Settings.PreserveObjectReferences);
+                Assert.Equal(typeof(DummyTypesProvider), serializer.Settings.KnownTypesProvider);
+            }
+        }
+    }
+
+    class DummyTypesProvider : IKnownTypesProvider
+    {
+        public DummyTypesProvider(ExtendedActorSystem system)
+        {
+            if (system == null)
+                throw new ArgumentNullException(nameof(system));
+        }
+
+        public IEnumerable<Type> GetKnownTypes() => Enumerable.Empty<Type>();
+    }
+
+    class DummyTypesProviderWithDefaultCtor : IKnownTypesProvider
+    {
+        public IEnumerable<Type> GetKnownTypes() => Enumerable.Empty<Type>();
+    }
+}

--- a/src/contrib/serializers/Akka.Serialization.Hyperion/Akka.Serialization.Hyperion.csproj
+++ b/src/contrib/serializers/Akka.Serialization.Hyperion/Akka.Serialization.Hyperion.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <None Include="Akka.Serialization.Hyperion.nuspec" />
     <None Include="packages.config" />
+    <None Include="reference.conf" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Akka\Akka.csproj">

--- a/src/contrib/serializers/Akka.Serialization.Hyperion/Akka.Serialization.Hyperion.csproj
+++ b/src/contrib/serializers/Akka.Serialization.Hyperion/Akka.Serialization.Hyperion.csproj
@@ -41,6 +41,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="HyperionSerializer.cs" />
+    <Compile Include="IKnownTypesProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/contrib/serializers/Akka.Serialization.Hyperion/HyperionSerializer.cs
+++ b/src/contrib/serializers/Akka.Serialization.Hyperion/HyperionSerializer.cs
@@ -27,7 +27,18 @@ namespace Akka.Serialization
         /// Initializes a new instance of the <see cref="HyperionSerializer"/> class.
         /// </summary>
         /// <param name="system">The actor system to associate with this serializer.</param>
-        public HyperionSerializer(ExtendedActorSystem system) : this(system, HyperionSerializerSettings.Create(system))
+        public HyperionSerializer(ExtendedActorSystem system) 
+            : this(system, HyperionSerializerSettings.Default)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HyperionSerializer"/> class.
+        /// </summary>
+        /// <param name="system">The actor system to associate with this serializer.</param>
+        /// <param name="config">Configuration passed from related HOCON config path.</param>
+        public HyperionSerializer(ExtendedActorSystem system, Config config) 
+            : this(system, HyperionSerializerSettings.Create(config))
         {
         }
 
@@ -36,7 +47,8 @@ namespace Akka.Serialization
         /// </summary>
         /// <param name="system">The actor system to associate with this serializer.</param>
         /// <param name="settings">Serializer settings.</param>
-        public HyperionSerializer(ExtendedActorSystem system, HyperionSerializerSettings settings) : base(system)
+        public HyperionSerializer(ExtendedActorSystem system, HyperionSerializerSettings settings)
+            : base(system)
         {
             var akkaSurrogate =
                 Surrogate
@@ -121,12 +133,6 @@ namespace Akka.Serialization
             preserveObjectReferences: true,
             versionTolerance: true,
             knownTypesProvider: typeof(NoKnownTypes));
-
-        public static HyperionSerializerSettings Create(ExtendedActorSystem system)
-        {
-            var config = system.Settings.Config.GetConfig("akka.serializers.hyperion");
-            return config == null ? Default : Create(config);
-        }
 
         public static HyperionSerializerSettings Create(Config config)
         {

--- a/src/contrib/serializers/Akka.Serialization.Hyperion/IKnownTypesProvider.cs
+++ b/src/contrib/serializers/Akka.Serialization.Hyperion/IKnownTypesProvider.cs
@@ -1,0 +1,28 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="HyperionSerializer.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Akka.Serialization
+{
+    /// <summary>
+    /// Interface that can be implemented in order to determine some 
+    /// custom logic, that's going to provide a list of types that 
+    /// are known to be shared for all corresponding parties during 
+    /// remote communication.
+    /// </summary>
+    public interface IKnownTypesProvider
+    {
+        IEnumerable<Type> GetKnownTypes();
+    }
+
+    internal sealed class NoKnownTypes : IKnownTypesProvider
+    {
+        public IEnumerable<Type> GetKnownTypes() => new Type[0];
+    }
+}

--- a/src/contrib/serializers/Akka.Serialization.Hyperion/reference.conf
+++ b/src/contrib/serializers/Akka.Serialization.Hyperion/reference.conf
@@ -1,4 +1,4 @@
-﻿akka {
+﻿akka.actor {
 	serializers {
 		hyperion = "Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion"
 	}

--- a/src/contrib/serializers/Akka.Serialization.Hyperion/reference.conf
+++ b/src/contrib/serializers/Akka.Serialization.Hyperion/reference.conf
@@ -1,0 +1,27 @@
+﻿akka {
+	serializers {
+		hyperion = "Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion"
+	}
+	serialization-settings {
+		hyperion {
+			# If true, hyperion serializer will preserve references between objects. 
+			# This is necessary to support things such as cyclic dependencies between objects.
+			preserve-object-references = true
+
+			# If true, hyperion serializer will append an information about serialized fields 
+			# to a type manifest. This will increase the payload size of the serialized message, 
+			# but will also allow to provide a limited tolerance to message schema changes 
+			# between actor systems using different assembly versions, making incremental 
+			# cluster updates less restrictive.
+			version-tolerance = true
+
+			# A fully qualified type name with assembly to a type implementing 
+			# `Akka.Serialization.IKnownTypesProvider` interface, that can be used to supply 
+			# hyperion serializer with a list of types, that are expected to be well-known for 
+			# all communicating parties, effectivelly reducing a manifests size and serialization 
+			# time. No types are known by default. Implementing class must expose either a default 
+			# constructor or constructor accepting an `ExtendedActorSystem` as its only parameter.
+			known-types-provider = "Akka.Serialization.NoKnownTypes, Akka.Serialization.Hyperion"
+		}
+	}
+}

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -4427,6 +4427,7 @@ namespace Akka.Serialization
     {
         public NewtonSoftJsonSerializer(Akka.Actor.ExtendedActorSystem system) { }
         public NewtonSoftJsonSerializer(Akka.Actor.ExtendedActorSystem system, Akka.Configuration.Config config) { }
+        public NewtonSoftJsonSerializer(Akka.Actor.ExtendedActorSystem system, Akka.Serialization.NewtonSoftJsonSerializerSettings settings) { }
         public override int Identifier { get; }
         public override bool IncludeManifest { get; }
         public object Serializer { get; }
@@ -4445,6 +4446,15 @@ namespace Akka.Serialization
             public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) { }
             public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) { }
         }
+    }
+    public sealed class NewtonSoftJsonSerializerSettings
+    {
+        public static readonly Akka.Serialization.NewtonSoftJsonSerializerSettings Default;
+        public NewtonSoftJsonSerializerSettings(bool encodeTypeNames, bool preverveObjectReferences, System.Collections.Generic.IEnumerable<System.Type> converters) { }
+        public System.Collections.Generic.IEnumerable<System.Type> Converters { get; }
+        public bool EncodeTypeNames { get; }
+        public bool PreserveObjectReferences { get; }
+        public static Akka.Serialization.NewtonSoftJsonSerializerSettings Create(Akka.Configuration.Config config) { }
     }
     public class NullSerializer : Akka.Serialization.Serializer
     {

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -4426,6 +4426,7 @@ namespace Akka.Serialization
     public class NewtonSoftJsonSerializer : Akka.Serialization.Serializer
     {
         public NewtonSoftJsonSerializer(Akka.Actor.ExtendedActorSystem system) { }
+        public NewtonSoftJsonSerializer(Akka.Actor.ExtendedActorSystem system, Akka.Configuration.Config config) { }
         public override int Identifier { get; }
         public override bool IncludeManifest { get; }
         public object Serializer { get; }

--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -197,6 +197,7 @@
     <Compile Include="Routing\ScatterGatherFirstCompletedSpec.cs" />
     <Compile Include="Routing\SmallestMailboxSpec.cs" />
     <Compile Include="Routing\TailChoppingSpec.cs" />
+    <Compile Include="Serialization\NewtonsoftJsonConfigSpec.cs" />
     <Compile Include="Serialization\SerializationSpec.cs" />
     <Compile Include="TestUtils\Comparable.cs" />
     <Compile Include="TestUtils\PropsWithName.cs" />

--- a/src/core/Akka.Tests/Serialization/NewtonsoftJsonConfigSpec.cs
+++ b/src/core/Akka.Tests/Serialization/NewtonsoftJsonConfigSpec.cs
@@ -1,0 +1,125 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="NewtonsoftJsonConfigSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Xunit;
+
+namespace Akka.Tests.Serialization
+{
+    public class NewtonsoftJsonConfigSpec
+    {
+        [Fact]
+        public void Json_serializer_should_have_correct_defaults()
+        {
+            using (var system = ActorSystem.Create(nameof(NewtonsoftJsonConfigSpec)))
+            {
+                var serializer = (NewtonSoftJsonSerializer)system.Serialization.FindSerializerForType(typeof(object));
+                Assert.Equal(TypeNameHandling.All, serializer.Settings.TypeNameHandling);
+                Assert.Equal(PreserveReferencesHandling.Objects, serializer.Settings.PreserveReferencesHandling);
+                Assert.Equal(2, serializer.Settings.Converters.Count);
+                Assert.Equal(true, serializer.Settings.Converters.Any(x => x is DiscriminatedUnionConverter));
+                Assert.Equal(true, serializer.Settings.Converters.Any(x => x is NewtonSoftJsonSerializer.SurrogateConverter));
+            }
+        }
+
+        [Fact]
+        public void Json_serializer_should_allow_to_setup_custom_flags()
+        {
+            var config = ConfigurationFactory.ParseString(@"
+                akka.actor {
+                    serialization-settings.json {
+                        preserve-object-references = false
+                        encode-type-names = false
+                    }
+                }
+            ");
+            using (var system = ActorSystem.Create(nameof(NewtonsoftJsonConfigSpec), config))
+            {
+                var serializer = (NewtonSoftJsonSerializer)system.Serialization.FindSerializerForType(typeof(object));
+                Assert.Equal(TypeNameHandling.None, serializer.Settings.TypeNameHandling);
+                Assert.Equal(PreserveReferencesHandling.None, serializer.Settings.PreserveReferencesHandling);
+                Assert.Equal(2, serializer.Settings.Converters.Count);
+                Assert.Equal(true, serializer.Settings.Converters.Any(x => x is DiscriminatedUnionConverter));
+                Assert.Equal(true, serializer.Settings.Converters.Any(x => x is NewtonSoftJsonSerializer.SurrogateConverter));
+            }
+        }
+
+        [Fact]
+        public void Json_serializer_should_allow_to_setup_custom_converters()
+        {
+            var config = ConfigurationFactory.ParseString(@"
+                akka.actor {
+                    serialization-settings.json {
+                        converters = [   
+                            ""Akka.Tests.Serialization.DummyConverter, Akka.Tests""
+                            ""Akka.Tests.Serialization.DummyConverter2, Akka.Tests""
+                        ]
+                    }
+                }
+            ");
+            using (var system = ActorSystem.Create(nameof(NewtonsoftJsonConfigSpec), config))
+            {
+                var serializer = (NewtonSoftJsonSerializer)system.Serialization.FindSerializerForType(typeof(object));
+                Assert.Equal(TypeNameHandling.All, serializer.Settings.TypeNameHandling);
+                Assert.Equal(PreserveReferencesHandling.Objects, serializer.Settings.PreserveReferencesHandling);
+                Assert.Equal(4, serializer.Settings.Converters.Count);
+                Assert.Equal(true, serializer.Settings.Converters.Any(x => x is DiscriminatedUnionConverter));
+                Assert.Equal(true, serializer.Settings.Converters.Any(x => x is NewtonSoftJsonSerializer.SurrogateConverter));
+                Assert.Equal(true, serializer.Settings.Converters.Any(x => x is DummyConverter));
+                Assert.Equal(true, serializer.Settings.Converters.Any(x => x is DummyConverter2));
+            }
+        }
+    }
+
+    class DummyConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    class DummyConverter2 : JsonConverter
+    {
+        public DummyConverter2(ExtendedActorSystem system)
+        {
+            if (system == null) 
+                throw new ArgumentNullException(nameof(system));
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/core/Akka.Tests/Serialization/SerializationSpec.cs
+++ b/src/core/Akka.Tests/Serialization/SerializationSpec.cs
@@ -541,37 +541,87 @@ namespace Akka.Tests.Serialization
             Sys.Serialization.FindSerializerFor(123).GetType().ShouldBe(typeof(NewtonSoftJsonSerializer));
         }
 
+        [Fact]
+        public void Can_apply_a_config_based_serializer_by_the_binding()
+        {
+            var dummy = (DummySerializer)Sys.Serialization.FindSerializerFor("dummy");
+            dummy.Config.ShouldBe(null);
+
+            var dummy2 = (DummyConfigurableSerializer) Sys.Serialization.GetSerializerById(-7);
+            dummy2.Config.ShouldNotBe(null);
+            dummy2.Config.GetString("test-key").ShouldBe("test value");
+        }
 
         public SerializationSpec():base(GetConfig())
         {
         }
 
-        private static string GetConfig()
-        {
-            return @"
+        private static string GetConfig() => @"
+            akka.actor {
+                serializers {
+                    dummy = """ + typeof(DummySerializer).AssemblyQualifiedName + @"""
+                    dummy2 = """ + typeof(DummyConfigurableSerializer).AssemblyQualifiedName + @"""
+                }
 
-akka.actor {
-    serializers {
-        dummy = """ + typeof(DummySerializer).AssemblyQualifiedName + @"""
-    }
-
-    serialization-bindings {
-      ""System.String"" = dummy
-    }
-}
-";
-        }
+                serialization-bindings {
+                  ""System.String"" = dummy
+                }
+                serialization-settings {
+                    dummy2 {
+                        test-key = ""test value""
+                    }
+                }
+            }";
 
         public class DummySerializer : Serializer
         {
-            public DummySerializer(ExtendedActorSystem system) : base(system)
+            public readonly Config Config;
+
+            public DummySerializer(ExtendedActorSystem system) 
+                : base(system)
             {
             }
 
-            public override int Identifier
+            public DummySerializer(ExtendedActorSystem system, Config config) 
+                : base(system)
             {
-                get { return -5; }
+                Config = config;
             }
+
+            public override int Identifier => -6;
+
+            public override bool IncludeManifest
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public override byte[] ToBinary(object obj)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override object FromBinary(byte[] bytes, Type type)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public class DummyConfigurableSerializer : Serializer
+        {
+            public readonly Config Config;
+
+            public DummyConfigurableSerializer(ExtendedActorSystem system)
+                : base(system)
+            {
+            }
+
+            public DummyConfigurableSerializer(ExtendedActorSystem system, Config config)
+                : base(system)
+            {
+                Config = config;
+            }
+
+            public override int Identifier => -7;
 
             public override bool IncludeManifest
             {

--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -457,6 +457,11 @@ akka {
       "System.Byte[]" = bytes
       "System.Object" = json
     }
+	
+	# extra settings that can be custom to a serializer implementation
+	serialization-settings {
+	
+	}
   }
  
   # Used to set the behavior of the scheduler.

--- a/src/core/Akka/Serialization/NewtonSoftJsonSerializer.cs
+++ b/src/core/Akka/Serialization/NewtonSoftJsonSerializer.cs
@@ -21,37 +21,88 @@ using Newtonsoft.Json.Serialization;
 
 namespace Akka.Serialization
 {
-    internal sealed class NewtonSoftJsonSerializerSettings
+    /// <summary>
+    /// A typed settings for a <see cref="NewtonSoftJsonSerializer"/> class.
+    /// </summary>
+    public sealed class NewtonSoftJsonSerializerSettings
     {
-        public static NewtonSoftJsonSerializerSettings Create(Config config) => 
-            new NewtonSoftJsonSerializerSettings(converters: GetConverterTypes(config));
+        /// <summary>
+        /// A default instance of <see cref="NewtonSoftJsonSerializerSettings"/> used when no custom configuration has been provided.
+        /// </summary>
+        public static readonly NewtonSoftJsonSerializerSettings Default = new NewtonSoftJsonSerializerSettings(
+            encodeTypeNames: true,
+            preverveObjectReferences: true,
+            converters: Enumerable.Empty<Type>());
+        
+        /// <summary>
+        /// Creates a new instance of the <see cref="NewtonSoftJsonSerializerSettings"/> based on a provided <paramref name="config"/>.
+        /// Config may define several key-values:
+        /// 1. `encode-type-names` (boolean) mapped to <see cref="EncodeTypeNames"/>
+        /// 2. `preserve-object-references` (boolean) mapped to <see cref="PreserveObjectReferences"/>
+        /// 3. `converters` (type list) mapped to <see cref="Converters"/>. They must implement <see cref="JsonConverter"/> and define either default constructor or constructor taking <see cref="ExtendedActorSystem"/> as its only parameter.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">Raised when no <paramref name="config"/> was provided.</exception>
+        /// <exception cref="ArgumentException">Raised when types defined in `converters` list didn't inherit <see cref="JsonConverter"/>.</exception>
+        public static NewtonSoftJsonSerializerSettings Create(Config config)
+        {
+            if (config == null)
+                throw new ArgumentNullException(nameof(config), $"{nameof(NewtonSoftJsonSerializerSettings)} config was not provided");
+
+            return new NewtonSoftJsonSerializerSettings(
+                encodeTypeNames: config.GetBoolean("encode-type-names", true),
+                preverveObjectReferences: config.GetBoolean("preserve-object-references", true),
+                converters: GetConverterTypes(config));
+        }
 
         private static IEnumerable<Type> GetConverterTypes(Config config)
         {
             var converterNames = config.GetStringList("converters");
-            foreach (var converterName in converterNames)
-            {
-                var type = Type.GetType(converterName, true);
-                if (!typeof(JsonConverter).IsAssignableFrom(type))
-                    throw new ArgumentException($"Type {type} doesn't inherit from a {typeof(JsonConverter)}.");
 
-                yield return type;
-            }
+            if (converterNames != null)
+                foreach (var converterName in converterNames)
+                {
+                    var type = Type.GetType(converterName, true);
+                    if (!typeof(JsonConverter).IsAssignableFrom(type))
+                        throw new ArgumentException($"Type {type} doesn't inherit from a {typeof(JsonConverter)}.");
+
+                    yield return type;
+                }
         }
 
-        public NewtonSoftJsonSerializerSettings(IEnumerable<Type> converters)
-        {
-            if (converters == null)
-                throw new ArgumentNullException(nameof(converters), $"{nameof(NewtonSoftJsonSerializerSettings)} requires a sequence of converters.");
-            
-            Converters = converters;
-        }
+        /// <summary>
+        /// When true, serializer will encode a type names into serialized json $type field. This must be true 
+        /// if <see cref="NewtonSoftJsonSerializer"/> is a default serializer in order to support polymorphic 
+        /// deserialization.
+        /// </summary>
+        public bool EncodeTypeNames { get; }
+
+        /// <summary>
+        /// When true, serializer will track a reference dependencies in serialized object graph. This must be 
+        /// true if <see cref="NewtonSoftJsonSerializer"/>.
+        /// </summary>
+        public bool PreserveObjectReferences { get; }
 
         /// <summary>
         /// A collection of an aditional converter types to be applied to a <see cref="NewtonSoftJsonSerializer"/>.
         /// Converters must inherit from <see cref="JsonConverter"/> class and implement a default constructor.
         /// </summary>
         public IEnumerable<Type> Converters { get; }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="NewtonSoftJsonSerializerSettings"/>.
+        /// </summary>
+        /// <param name="encodeTypeNames">Determines if a special `$type` field should be emitted into serialized JSON. Must be true if corresponding serializer is used as default.</param>
+        /// <param name="preverveObjectReferences">Determines if object references should be tracked within serialized object graph. Must be true if corresponding serialize is used as default.</param>
+        /// <param name="converters">A list of types implementing a <see cref="JsonConverter"/> to support custom types serialization.</param>
+        public NewtonSoftJsonSerializerSettings(bool encodeTypeNames, bool preverveObjectReferences, IEnumerable<Type> converters)
+        {
+            if (converters == null)
+                throw new ArgumentNullException(nameof(converters), $"{nameof(NewtonSoftJsonSerializerSettings)} requires a sequence of converters.");
+
+            EncodeTypeNames = encodeTypeNames;
+            PreserveObjectReferences = preverveObjectReferences;
+            Converters = converters;
+        }
     }
 
     /// <summary>
@@ -67,6 +118,7 @@ namespace Akka.Serialization
         /// TBD
         /// </summary>
         public JsonSerializerSettings Settings { get { return _settings; } }
+
         /// <summary>
         /// TBD
         /// </summary>
@@ -77,30 +129,21 @@ namespace Akka.Serialization
         /// </summary>
         /// <param name="system">The actor system to associate with this serializer. </param>
         public NewtonSoftJsonSerializer(ExtendedActorSystem system)
-            : base(system)
+            : this(system, NewtonSoftJsonSerializerSettings.Default)
         {
-            _settings = new JsonSerializerSettings
-            {
-                PreserveReferencesHandling = PreserveReferencesHandling.Objects,
-                Converters = new List<JsonConverter> { new SurrogateConverter(this), new DiscriminatedUnionConverter() },
-                NullValueHandling = NullValueHandling.Ignore,
-                DefaultValueHandling = DefaultValueHandling.Ignore,
-                MissingMemberHandling = MissingMemberHandling.Ignore,
-                ObjectCreationHandling = ObjectCreationHandling.Replace, //important: if reuse, the serializer will overwrite properties in default references, e.g. Props.DefaultDeploy or Props.noArgs
-                ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-                TypeNameHandling = TypeNameHandling.All,
-                ContractResolver = new AkkaContractResolver()
-            };
-
-            _serializer = JsonSerializer.Create(_settings);
         }
 
         public NewtonSoftJsonSerializer(ExtendedActorSystem system, Config config)
+            : this(system, NewtonSoftJsonSerializerSettings.Create(config))
+        {
+        }
+
+
+        public NewtonSoftJsonSerializer(ExtendedActorSystem system, NewtonSoftJsonSerializerSettings settings)
             : base(system)
         {
-            var serializerSettings = NewtonSoftJsonSerializerSettings.Create(config);
-            var converters = serializerSettings.Converters
-                .Select(converterType => (JsonConverter) Activator.CreateInstance(converterType))
+            var converters = settings.Converters
+                .Select(type => CreateConverter(type, system))
                 .ToList();
 
             converters.Add(new SurrogateConverter(this));
@@ -108,19 +151,36 @@ namespace Akka.Serialization
 
             _settings = new JsonSerializerSettings
             {
-                PreserveReferencesHandling = PreserveReferencesHandling.Objects,
+                PreserveReferencesHandling = settings.PreserveObjectReferences 
+                    ? PreserveReferencesHandling.Objects 
+                    : PreserveReferencesHandling.None,
                 Converters = converters,
                 NullValueHandling = NullValueHandling.Ignore,
                 DefaultValueHandling = DefaultValueHandling.Ignore,
                 MissingMemberHandling = MissingMemberHandling.Ignore,
                 ObjectCreationHandling = ObjectCreationHandling.Replace, //important: if reuse, the serializer will overwrite properties in default references, e.g. Props.DefaultDeploy or Props.noArgs
                 ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-                TypeNameHandling = TypeNameHandling.All,
+                TypeNameHandling = settings.EncodeTypeNames
+                    ? TypeNameHandling.All 
+                    : TypeNameHandling.None,
                 ContractResolver = new AkkaContractResolver()
             };
 
             _serializer = JsonSerializer.Create(_settings);
+        }
 
+        private static JsonConverter CreateConverter(Type converterType, ExtendedActorSystem actorSystem)
+        {
+            var ctor = converterType.GetConstructors()
+                .FirstOrDefault(c =>
+                {
+                    var parameters = c.GetParameters();
+                    return parameters.Length == 1 && parameters[0].ParameterType == typeof(ExtendedActorSystem);
+                });
+
+            return ctor == null 
+                ? (JsonConverter)Activator.CreateInstance(converterType)
+                : (JsonConverter)Activator.CreateInstance(converterType, actorSystem);
         }
 
         /// <summary>


### PR DESCRIPTION
### Motivation

Some of the users lack an ability to customize used serializers i.e. adding custom converters to json.net serializer. Another time some of them may want to harden serializer constraints on themselves in order to achieve better performance. This is especially a case with new Hyperion serializer, which uses things like preserving object references and version tolerance, which both increase the serialization time and a payload size, causing our default hyperion settings to be actually always a worst case scenario for that library.

### Description

This PR introduces an ability to add custom options to serializers through HOCON config. It can be used as a general purpose mechanism. From now, users may define their own serializer configuration within `akka.actor.serialization-settings` i.e.:

```hocon
akka.actor {
  serializers {
    hyperion = "Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion"
  }
  serialization-bindings {
    "System.Object" = hyperion
  }
  serialization-settings {
    hyperion {
      version-tolerance = false
      preserve-object-references = false
    }
  }
}
```

This way a `Config` object holding an `akka.actor.serialization-settings.hyperion` section will be passed as a second parameter to constructor of a serializer aliased as "hyperion" in `akka.actor.serializers`. From there, a serializer class is free to interpret it. This behavior is done at `Serialization` class level, so it's applied automatically to any serializer, that wants to use it.

This PR introduces this behavior on 2 serializers:

1. `NewtonSoftJsonSerializer` may optionally take a config with a list of custom converter types to be added.
2. `HyperionSerializer` may optionally take a config with 3 settings:
    - `perserve-object-references` used to track references (not only values) in serialized object graph, including cyclic references.
    - `version-tolerance` which can be turned off to reduce a payload manifest size.
    - `known-types-provider` which takes a type name for a class implementing `IKnownTypesProvider` - an interface that will be used at start of an actor system to provide a list of types, that are assumed to be known by all communicating sides using Hyperion serializer. This also can be used to optimize Hyperion usage.

This new feature has its separate test to check if HOCON configs are bound to right serializers when serialization map is being created.