### PR TITLE
Fixed NodeConfig usage in RemoteGatePiercingMultiNetSpec

### DIFF
--- a/src/core/Akka.Remote.Tests.MultiNode/RemoteGatePiercingSpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/RemoteGatePiercingSpec.cs
@@ -26,9 +26,12 @@ namespace Akka.Remote.Tests.MultiNode
       akka.remote.transport-failure-detector.acceptable-heartbeat-pause = 5 
             "));
 
-            NodeConfig(new[] {First, Second}, new[]
+            NodeConfig(new[] { First }, new[]
             {
-                ConfigurationFactory.ParseString("akka.remote.retry-gate-closed-for  = 1 d # Keep it long"),
+                ConfigurationFactory.ParseString("akka.remote.retry-gate-closed-for  = 1 d # Keep it long")
+            });
+            NodeConfig(new[] { Second }, new[]
+            {
                 ConfigurationFactory.ParseString("akka.remote.retry-gate-closed-for  = 1 s # Keep it short")
             });
 


### PR DESCRIPTION
Stumbled upon this during search for examples of `NodeConfig` usages for docs.
Seems there was intention to assign different gating durations to each role.
Considering implementation of [NodeConfig](https://github.com/akkadotnet/akka.net/blob/fe2f30a9b7ccd6a3d406d5b47cd0cfc26b2d5e6e/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs#L55) currently there is same config {gate-1d} with fallback {gate-1s} constructed for each node.
Spec is passing all this time but nevertheless it should be corrected.