### PR TITLE
Added actor ref provider aliases

### DIFF
--- a/src/core/Akka.Cluster.Tests/ActorRefProvidersConfigSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ActorRefProvidersConfigSpec.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Remote;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Cluster.Tests
+{
+    /// <summary>
+    /// This class will be used to verify if akka.actor.provider aliases work as designed.
+    /// It's placed here instead of Akka.Tests to verify, that aliases are correctly resolved to actual classes.
+    /// </summary>
+    public class ActorRefProvidersConfigSpec
+    {
+        [Fact]
+        public void ActorProviderConfig_should_resolve_local_alias()
+        {
+            ConfigureAndVerify("local", typeof(LocalActorRefProvider));
+        }
+
+        [Fact]
+        public void ActorProviderConfig_should_resolve_remote_alias()
+        {
+            ConfigureAndVerify("remote", typeof(RemoteActorRefProvider));
+        }
+
+        [Fact]
+        public void ActorProviderConfig_should_resolve_cluster_alias()
+        {
+            ConfigureAndVerify("cluster", typeof(ClusterActorRefProvider));
+        }
+
+        private void ConfigureAndVerify(string alias, Type actorProviderType)
+        {
+            var config = ConfigurationFactory.ParseString(@"akka.actor.provider = " + alias);
+            using (var system = ActorSystem.Create(nameof(ActorRefProvidersConfigSpec), config))
+            {
+                var ext = (ExtendedActorSystem) system;
+                ext.Provider.GetType().ShouldBe(actorProviderType);
+            }
+        }
+    }
+}

--- a/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
+++ b/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
@@ -79,6 +79,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="ActorRefProvidersConfigSpec.cs" />
     <Compile Include="AutoDownSpec.cs" />
     <Compile Include="ClusterConfigSpec.cs" />
     <Compile Include="ClusterDeployerSpec.cs" />

--- a/src/core/Akka/Actor/Settings.cs
+++ b/src/core/Akka/Actor/Settings.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using Akka.Configuration;
 using Akka.Dispatch;
 using Akka.Routing;
+using Akka.Util;
 
 namespace Akka.Actor
 {
@@ -62,7 +63,7 @@ namespace Akka.Actor
             System = system;
             
             ConfigVersion = Config.GetString("akka.version");
-            ProviderClass = Config.GetString("akka.actor.provider");
+            ProviderClass = GetProviderClass(Config.GetString("akka.actor.provider"));
             var providerType = Type.GetType(ProviderClass);
             if (providerType == null)
                 throw new ConfigurationException($"'akka.actor.provider' is not a valid type name : '{ProviderClass}'");
@@ -120,6 +121,17 @@ namespace Akka.Actor
                 final val Daemonicity: Boolean = getBoolean("akka.daemonic")                
                 final val DefaultVirtualNodesFactor: Int = getInt("akka.actor.deployment.default.virtual-nodes-factor")
              */
+        }
+
+        private static string GetProviderClass(string provider)
+        {
+            switch (provider)
+            {
+                case "local": return typeof(LocalActorRefProvider).FullName;
+                case "remote": return "Akka.Remote.RemoteActorRefProvider, Akka.Remote";
+                case "cluster": return "Akka.Cluster.ClusterActorRefProvider, Akka.Cluster";
+                default: return provider;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This implements case mentioned in #2515 .

Instead of typing: 

- `akka.actor.provider = "Akka.Actor.LocalActorRefProvider"`
- `akka.actor.provider = "Akka.Remote.RemoteActorRefProvider, Akka.Remote"`
- `akka.actor.provider = "Akka.Cluster.ClusterActorRefProvider, Akka.Cluster"`

we'll be able to just write:

- `akka.actor.provider = local`
- `akka.actor.provider = remote`
- `akka.actor.provider = cluster` 

Tests to ensure, that this actually happens are attached in this PR.