### PR TITLE
Add logging behavior to Akka.Persistence SqlJournal to fail loudly when backend store connection cannot be established

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/SqlJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/SqlJournal.cs
@@ -282,19 +282,26 @@ namespace Akka.Persistence.Sql.Common.Journal
                 .WasHandled;
         }
 
-        private async Task<AllPersistenceIds> Initialize()
+        private async Task<object> Initialize()
         {
-            using (var connection = CreateDbConnection())
+            try
             {
-                await connection.OpenAsync();
-
-                if (_settings.AutoInitialize)
+                using (var connection = CreateDbConnection())
                 {
-                    await QueryExecutor.CreateTablesAsync(connection, _pendingRequestsCancellation.Token);
-                }
+                    await connection.OpenAsync();
 
-                var ids = await QueryExecutor.SelectAllPersistenceIdsAsync(connection, _pendingRequestsCancellation.Token);
-                return new AllPersistenceIds(ids);
+                    if (_settings.AutoInitialize)
+                    {
+                        await QueryExecutor.CreateTablesAsync(connection, _pendingRequestsCancellation.Token);
+                    }
+
+                    var ids = await QueryExecutor.SelectAllPersistenceIdsAsync(connection, _pendingRequestsCancellation.Token);
+                    return new AllPersistenceIds(ids);
+                }
+            }
+            catch (Exception e)
+            {
+                return new Failure { Exception = e };
             }
         }
 
@@ -304,16 +311,8 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// <returns>TBD</returns>
         public DbConnection CreateDbConnection()
         {
-            try
-            {
-                var connectionString = GetConnectionString();
-                return CreateDbConnection(connectionString);
-            }
-            catch (Exception e)
-            {
-                Log.Error(e, "Failure creating DbConnection");
-                throw;
-            }
+            var connectionString = GetConnectionString();
+            return CreateDbConnection(connectionString);
         }
 
         /// <summary>

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/SqlJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/SqlJournal.cs
@@ -301,7 +301,7 @@ namespace Akka.Persistence.Sql.Common.Journal
             }
             catch (Exception e)
             {
-                return new Failure { Exception = e };
+                return new Failure {Exception = e};
             }
         }
 

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/SqlJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/SqlJournal.cs
@@ -304,8 +304,16 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// <returns>TBD</returns>
         public DbConnection CreateDbConnection()
         {
-            var connectionString = GetConnectionString();
-            return CreateDbConnection(connectionString);
+            try
+            {
+                var connectionString = GetConnectionString();
+                return CreateDbConnection(connectionString);
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "Failure creating DbConnection");
+                throw;
+            }
         }
 
         /// <summary>

--- a/src/contrib/persistence/Akka.Persistence.Sql.TestKit/Akka.Persistence.Sql.TestKit.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sql.TestKit/Akka.Persistence.Sql.TestKit.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SqlJournalConnectionFailureSpec.cs" />
     <Compile Include="SqlJournalQuerySpec.cs" />
+    <Compile Include="SqlSnapshotConnectionFailureSpec.cs" />
     <Compile Include="TestActor.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/contrib/persistence/Akka.Persistence.Sql.TestKit/Akka.Persistence.Sql.TestKit.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sql.TestKit/Akka.Persistence.Sql.TestKit.csproj
@@ -11,6 +11,8 @@
     <AssemblyName>Akka.Persistence.Sql.TestKit</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -57,8 +59,16 @@
       <HintPath>..\..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="xunit.runner.utility.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
@@ -72,6 +82,7 @@
     <Compile Include="EventsByPersistenceIdSpec.cs" />
     <Compile Include="EventsByTagSpec.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SqlJournalConnectionFailureSpec.cs" />
     <Compile Include="SqlJournalQuerySpec.cs" />
     <Compile Include="TestActor.cs" />
   </ItemGroup>
@@ -120,9 +131,7 @@
   <ItemGroup>
     <None Include="Akka.Persistence.Sql.TestKit.nuspec" />
     <None Include="app.config" />
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/contrib/persistence/Akka.Persistence.Sql.TestKit/SqlJournalConnectionFailureSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.TestKit/SqlJournalConnectionFailureSpec.cs
@@ -25,8 +25,8 @@ namespace Akka.Persistence.Sql.TestKit
         {
             EventFilter.Exception<Exception>().ExpectOne(() =>
             {
-                var perf = Sys.ActorOf(Props.Create(() => new ReceiveAnyPersistentActor("persistent-test-actor")));
-                perf.Tell("save");
+                var pref = Sys.ActorOf(Props.Create(() => new ReceiveAnyPersistentActor("persistent-test-actor")));
+                pref.Tell("save");
             });
 
             ExpectNoMsg();

--- a/src/contrib/persistence/Akka.Persistence.Sql.TestKit/SqlJournalConnectionFailureSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.TestKit/SqlJournalConnectionFailureSpec.cs
@@ -21,11 +21,11 @@ namespace Akka.Persistence.Sql.TestKit
         }
 
         [Fact]
-        public void SqlJournal_should_throw_visible_exception_upon_connection_failure()
+        public void Persistent_actor_should_throw_exception_upon_connection_failure()
         {
-            EventFilter.Error("Failure creating DbConnection").ExpectOne(() =>
+            EventFilter.Exception<Exception>().ExpectOne(() =>
             {
-                var perf = Sys.ActorOf(Props.Create(() => new ReceiveAnyPersistentActor("test-persistent-actor")));
+                var perf = Sys.ActorOf(Props.Create(() => new ReceiveAnyPersistentActor("persistent-test-actor")));
                 perf.Tell("save");
             });
 

--- a/src/contrib/persistence/Akka.Persistence.Sql.TestKit/SqlJournalConnectionFailureSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.TestKit/SqlJournalConnectionFailureSpec.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Sql.TestKit
+{
+    public abstract class SqlJournalConnectionFailureSpec : Akka.TestKit.Xunit2.TestKit
+    {
+        protected static readonly string DefaultInvalidConnectionString = "INVALID_CONNECTION_STRING";
+
+        public SqlJournalConnectionFailureSpec(Config config = null, ITestOutputHelper output = null)
+            : base(config)
+        {
+        }
+
+        [Fact]
+        public void SqlJournal_should_throw_visible_exception_upon_connection_failure()
+        {
+            EventFilter.Error("Failure creating DbConnection").ExpectOne(() =>
+            {
+                var perf = Sys.ActorOf(Props.Create(() => new ReceiveAnyPersistentActor("test-persistent-actor")));
+                perf.Tell("save");
+            });
+
+            ExpectNoMsg();
+        }
+
+        private class ReceiveAnyPersistentActor : TestReceivePersistentActor
+        {
+            public ReceiveAnyPersistentActor(string pid) : base(pid)
+            {
+                Command<string>(str => str.StartsWith("s"), e =>
+                {
+                    Persist(e, h =>
+                    {
+                        Sender.Tell("persisted:" + e);
+                    });
+                });
+                CommandAny(o => Sender.Tell("any:" + o, Self));
+            }
+        }
+
+        private abstract class TestReceivePersistentActor : ReceivePersistentActor
+        {
+            public readonly LinkedList<object> State = new LinkedList<object>();
+            private readonly string _persistenceId;
+
+            protected TestReceivePersistentActor(string persistenceId)
+            {
+                _persistenceId = persistenceId;
+            }
+
+            public override string PersistenceId
+            {
+                get { return _persistenceId; }
+            }
+        }
+    }
+}
+

--- a/src/contrib/persistence/Akka.Persistence.Sql.TestKit/SqlSnapshotConnectionFailureSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.TestKit/SqlSnapshotConnectionFailureSpec.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Sql.TestKit
+{
+    public abstract class SqlSnapshotConnectionFailureSpec : Akka.TestKit.Xunit2.TestKit
+    {
+        protected static readonly string DefaultInvalidConnectionString = "INVALID_CONNECTION_STRING";
+
+        public SqlSnapshotConnectionFailureSpec(Config config = null, ITestOutputHelper output = null) : base(config)
+        {
+        }
+
+        [Fact]
+        public void Persistent_actor_should_throw_exception_upon_connection_failure_when_saving_snapshot()
+        {
+            EventFilter.Exception<Exception>().ExpectOne(() =>
+            {
+                var pref = Sys.ActorOf(Props.Create(() => new SaveSnapshotTestActor("test-snapshot-actor", TestActor)));
+                pref.Tell(TakeSnapshot.Instance);
+            });
+
+            ExpectNoMsg();
+        }
+
+        // Borrowed from Akka.Persistence.Tests.SnapshotSpec
+        private class SaveSnapshotTestActor : NamedPersistentActor
+        {
+            private readonly IActorRef _probe;
+            protected LinkedList<string> _state = new LinkedList<string>();
+
+            public SaveSnapshotTestActor(string name, IActorRef probe)
+                : base(name)
+            {
+                _probe = probe;
+            }
+
+            protected override bool ReceiveRecover(object message)
+            {
+                return message.Match()
+                    .With<SnapshotOffer>(offer => _state = offer.Snapshot as LinkedList<string>)
+                    .With<string>(m => _state.AddFirst(m + "-" + LastSequenceNr))
+                    .WasHandled;
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                return message.Match()
+                    .With<string>(payload => Persist(payload, _ => _state.AddFirst(payload + "-" + LastSequenceNr)))
+                    .With<TakeSnapshot>(_ => SaveSnapshot(_state))
+                    .With<SaveSnapshotSuccess>(s => _probe.Tell(s.Metadata.SequenceNr))
+                    .With<GetState>(_ => _probe.Tell(_state.Reverse().ToArray()))
+                    .WasHandled;
+            }
+        }
+
+        internal class TakeSnapshot
+        {
+            public static readonly TakeSnapshot Instance = new TakeSnapshot();
+            private TakeSnapshot()
+            {
+            }
+        }
+
+        internal sealed class GetState
+        {
+            public static readonly GetState Instance = new GetState();
+            private GetState() { }
+        }
+
+        public abstract class NamedPersistentActor : PersistentActor
+        {
+            private readonly string _name;
+
+            protected NamedPersistentActor(string name)
+            {
+                _name = name;
+            }
+
+            public override string PersistenceId
+            {
+                get { return _name; }
+            }
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Sql.TestKit/packages.config
+++ b/src/contrib/persistence/Akka.Persistence.Sql.TestKit/packages.config
@@ -2,7 +2,10 @@
 <packages>
   <package id="Reactive.Streams" version="1.0.0-RC1" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
   <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.runner.utility" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Akka.Persistence.Sqlite.Tests.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Akka.Persistence.Sqlite.Tests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Query\SqliteAllPersistenceIdsSpec.cs" />
     <Compile Include="Query\SqliteEventsByPersistenceIdSpec.cs" />
     <Compile Include="SqliteConfigSpec.cs" />
+    <Compile Include="SqliteJournalConnectionFailureSpec.cs" />
     <Compile Include="SqliteJournalQuerySpec.cs" />
     <Compile Include="SqliteJournalSpec.cs" />
     <Compile Include="SqliteSnapshotStoreSpec.cs" />

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Akka.Persistence.Sqlite.Tests.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Akka.Persistence.Sqlite.Tests.csproj
@@ -72,6 +72,7 @@
     <Compile Include="SqliteJournalConnectionFailureSpec.cs" />
     <Compile Include="SqliteJournalQuerySpec.cs" />
     <Compile Include="SqliteJournalSpec.cs" />
+    <Compile Include="SqliteSnapshotStoreConnectionFailureSpec.cs" />
     <Compile Include="SqliteSnapshotStoreSpec.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteConfigSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteConfigSpec.cs
@@ -6,7 +6,11 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using Akka.Actor;
+using Akka.Configuration;
+using Akka.Persistence.Sql.TestKit;
+using Akka.Util.Internal;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteJournalConnectionFailureSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteJournalConnectionFailureSpec.cs
@@ -5,13 +5,13 @@ using System.Text;
 using System.Threading.Tasks;
 using Akka.Configuration;
 using Akka.Persistence.Sql.TestKit;
+using Akka.Util.Internal;
 using Xunit.Abstractions;
 
 namespace Akka.Persistence.Sqlite.Tests
 {
     public class SqliteJournalConnectionFailureSpec : SqlJournalConnectionFailureSpec
     {
-
         public SqliteJournalConnectionFailureSpec(ITestOutputHelper output) : base(CreateSpecConfig(DefaultInvalidConnectionString), output)
         {
         }

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteJournalConnectionFailureSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteJournalConnectionFailureSpec.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Configuration;
+using Akka.Persistence.Sql.TestKit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Sqlite.Tests
+{
+    public class SqliteJournalConnectionFailureSpec : SqlJournalConnectionFailureSpec
+    {
+
+        public SqliteJournalConnectionFailureSpec(ITestOutputHelper output) : base(CreateSpecConfig(DefaultInvalidConnectionString), output)
+        {
+        }
+
+        private static Config CreateSpecConfig(string connectionString)
+        {
+            return ConfigurationFactory.ParseString(@"
+                akka.persistence {
+                    publish-plugin-commands = on
+                    journal {
+                        plugin = ""akka.persistence.journal.sqlite""
+                        sqlite {
+                            class = ""Akka.Persistence.Sqlite.Journal.SqliteJournal, Akka.Persistence.Sqlite""
+                            plugin-dispatcher = ""akka.actor.default-dispatcher""
+                            table-name = event_journal
+                            metadata-table-name = journal_metadata
+                            auto-initialize = on
+                            connection-string = """ + connectionString + @"""
+                        }
+                    }
+                }");
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteSnapshotStoreConnectionFailureSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteSnapshotStoreConnectionFailureSpec.cs
@@ -10,11 +10,11 @@ using Xunit.Abstractions;
 
 namespace Akka.Persistence.Sqlite.Tests
 {
-    public class SqliteJournalConnectionFailureSpec : SqlJournalConnectionFailureSpec
+    public class SqliteSnapshotStoreConnectionFailureSpec : SqlSnapshotConnectionFailureSpec
     {
-        public SqliteJournalConnectionFailureSpec(ITestOutputHelper output)
+        public SqliteSnapshotStoreConnectionFailureSpec(ITestOutputHelper output)
             : base(CreateSpecConfig(DefaultInvalidConnectionString), output)
-        {
+        {            
         }
 
         private static Config CreateSpecConfig(string connectionString)
@@ -22,13 +22,12 @@ namespace Akka.Persistence.Sqlite.Tests
             return ConfigurationFactory.ParseString(@"
                 akka.persistence {
                     publish-plugin-commands = on
-                    journal {
-                        plugin = ""akka.persistence.journal.sqlite""
+                    snapshot-store {
+                        plugin = ""akka.persistence.snapshot-store.sqlite""
                         sqlite {
-                            class = ""Akka.Persistence.Sqlite.Journal.SqliteJournal, Akka.Persistence.Sqlite""
+                            class = ""Akka.Persistence.Sqlite.Snapshot.SqliteSnapshotStore, Akka.Persistence.Sqlite""
                             plugin-dispatcher = ""akka.actor.default-dispatcher""
-                            table-name = event_journal
-                            metadata-table-name = journal_metadata
+                            table-name = snapshot_store
                             auto-initialize = on
                             connection-string = """ + connectionString + @"""
                         }

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/SqliteJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/SqliteJournal.cs
@@ -69,16 +69,8 @@ namespace Akka.Persistence.Sqlite.Journal
         /// </summary>
         protected override void PreStart()
         {
-            try
-            {
-                ConnectionContext.Remember(GetConnectionString());
-                base.PreStart();
-            }
-            catch (Exception e)
-            {
-                Log.Error(e, "Failure creating DbConnection");
-                throw;
-            }
+            ConnectionContext.Remember(GetConnectionString());
+            base.PreStart();
         }
 
         /// <summary>

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/SqliteJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/SqliteJournal.cs
@@ -69,8 +69,16 @@ namespace Akka.Persistence.Sqlite.Journal
         /// </summary>
         protected override void PreStart()
         {
-            ConnectionContext.Remember(GetConnectionString());
-            base.PreStart();
+            try
+            {
+                ConnectionContext.Remember(GetConnectionString());
+                base.PreStart();
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "Failure creating DbConnection");
+                throw;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Per Issue #2320, added try/catch to `SqlJournal.CreateDbConnection()` to catch and log failures in overridden calls to `CreateDbConnection(string connectionString)` by Akka.Persistence plugins.  Added new spec called `SqlJournalConnectionFailureSpec` that should be implemented by plugins to ensure that they don't swallow exceptions during establishing connection to Journal store.  Implemented said spec in Akka.Persistence.Sqlite.Tests as an example.  Also added missing xunit dependencies to Akka.Persistence.Sql.Testkit (i.e. xunit, xunit.core, etc)