### PR TITLE
Fix deadlock when calling ActorSelection.ResolveOne from GUI context

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -364,7 +364,7 @@ Target "NBench" <| fun _ ->
         let result = ExecProcess(fun info -> 
             info.FileName <- nbenchTestPath
             info.WorkingDirectory <- (Path.GetDirectoryName (FullName nbenchTestPath))
-            info.Arguments <- args) (System.TimeSpan.FromMinutes 25.0) (* Reasonably long-running task. *)
+            info.Arguments <- args) (System.TimeSpan.FromMinutes 40.0) (* Reasonably long-running task. *)
         if result <> 0 then failwithf "NBench.Runner failed. %s %s" nbenchTestPath args
     
     nbenchTestAssemblies |> Seq.iter (runNBench)

--- a/src/contrib/transports/Akka.Remote.Transport.Helios/HeliosTcpTransport.cs
+++ b/src/contrib/transports/Akka.Remote.Transport.Helios/HeliosTcpTransport.cs
@@ -290,10 +290,10 @@ namespace Akka.Remote.Transport.Helios
                 var clientBootstrap = ClientFactory(remoteAddress);
                 var socketAddress = AddressToSocketAddress(remoteAddress);
 
-                var associate = await clientBootstrap.ConnectAsync(socketAddress);
+                var associate = await clientBootstrap.ConnectAsync(socketAddress).ConfigureAwait(false);
 
                 var handler = (TcpClientHandler)associate.Pipeline.Last();
-                return await handler.StatusFuture;
+                return await handler.StatusFuture.ConfigureAwait(false);
             }
             catch (AggregateException e) when (e.InnerException is ConnectException)
             {

--- a/src/contrib/transports/Akka.Remote.Transport.Helios/HeliosTransport.cs
+++ b/src/contrib/transports/Akka.Remote.Transport.Helios/HeliosTransport.cs
@@ -340,7 +340,7 @@ namespace Akka.Remote.Transport.Helios
 
             try
             {
-                var newServerChannel = await NewServer(listenAddress);
+                var newServerChannel = await NewServer(listenAddress).ConfigureAwait(false);
 
 
                 // Block reads until a handler actor is registered
@@ -369,7 +369,7 @@ namespace Akka.Remote.Transport.Helios
                 Log.Error(ex, "Failed to bind to {0}; shutting down Helios transport.", listenAddress);
                 try
                 {
-                    await Shutdown();
+                    await Shutdown().ConfigureAwait(false);
                 }
                 catch
                 {
@@ -384,12 +384,12 @@ namespace Akka.Remote.Transport.Helios
         /// </summary>
         /// <param name="remoteAddress">TBD</param>
         /// <returns>TBD</returns>
-        public override async Task<AssociationHandle> Associate(Address remoteAddress)
+        public override Task<AssociationHandle> Associate(Address remoteAddress)
         {
             if (!ServerChannel.IsOpen)
                 throw new HeliosConnectionException(ExceptionType.NotOpen, "Transport is not open");
 
-            return await AssociateInternal(remoteAddress);
+            return AssociateInternal(remoteAddress);
         }
 
         /// <summary>
@@ -406,10 +406,10 @@ namespace Akka.Remote.Transport.Helios
                     tasks.Add(channel.CloseAsync());
                 }
                 var all = Task.WhenAll(tasks);
-                await all;
+                await all.ConfigureAwait(false);
 
                 var server = ServerChannel?.CloseAsync() ?? TaskEx.Completed;
-                await server;
+                await server.ConfigureAwait(false);
 
                 return all.IsCompleted && server.IsCompleted;
             }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -3796,8 +3796,8 @@ namespace Akka.Pattern
         public Akka.Pattern.CircuitBreaker OnClose(System.Action callback) { }
         public Akka.Pattern.CircuitBreaker OnHalfOpen(System.Action callback) { }
         public Akka.Pattern.CircuitBreaker OnOpen(System.Action callback) { }
-        public async System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.Tasks.Task<T>> body) { }
-        public async System.Threading.Tasks.Task WithCircuitBreaker(System.Func<System.Threading.Tasks.Task> body) { }
+        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.Tasks.Task<T>> body) { }
+        public System.Threading.Tasks.Task WithCircuitBreaker(System.Func<System.Threading.Tasks.Task> body) { }
         public void WithSyncCircuitBreaker(System.Action body) { }
         public T WithSyncCircuitBreaker<T>(System.Func<T> body) { }
     }

--- a/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
+++ b/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
@@ -163,7 +163,6 @@
     <Compile Include="AsyncContext\SingleDisposable %28of T%29.cs" />
     <Compile Include="AsyncContext\SynchronizationContextSwitcher.cs" />
     <Compile Include="AsyncContext\SynchronousTaskExtensions.cs.cs" />
-    <Compile Include="SynchronizationContextHelper.cs" />
     <Compile Include="Transport\BackwardCompatibilitySpec.cs" />
     <Compile Include="DeadlineFailureDetectorSpec.cs" />
     <Compile Include="EndpointRegistrySpec.cs" />

--- a/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
+++ b/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
@@ -154,6 +154,16 @@
     <Compile Include="AckedDeliverySpec.cs" />
     <Compile Include="ActorsLeakSpec.cs" />
     <Compile Include="AddressUidExtensionSpecs.cs" />
+    <Compile Include="AsyncContext\AsyncContext.cs" />
+    <Compile Include="AsyncContext\AsyncContext.SynchronizationContext.cs" />
+    <Compile Include="AsyncContext\AsyncContext.TaskQueue.cs" />
+    <Compile Include="AsyncContext\AsyncContext.TaskScheduler.cs" />
+    <Compile Include="AsyncContext\BoundAction.cs" />
+    <Compile Include="AsyncContext\ExceptionHelpers.cs" />
+    <Compile Include="AsyncContext\SingleDisposable %28of T%29.cs" />
+    <Compile Include="AsyncContext\SynchronizationContextSwitcher.cs" />
+    <Compile Include="AsyncContext\SynchronousTaskExtensions.cs.cs" />
+    <Compile Include="SynchronizationContextHelper.cs" />
     <Compile Include="Transport\BackwardCompatibilitySpec.cs" />
     <Compile Include="DeadlineFailureDetectorSpec.cs" />
     <Compile Include="EndpointRegistrySpec.cs" />
@@ -217,7 +227,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Content Include="AsyncContext\about.txt" />
+  </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>

--- a/src/core/Akka.Remote.Tests/AsyncContext/AsyncContext.SynchronizationContext.cs
+++ b/src/core/Akka.Remote.Tests/AsyncContext/AsyncContext.SynchronizationContext.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Threading;
+using Nito.AsyncEx.Synchronous;
+
+namespace Nito.AsyncEx
+{
+    public sealed partial class AsyncContext
+    {
+        /// <summary>
+        /// The <see cref="SynchronizationContext"/> implementation used by <see cref="AsyncContext"/>.
+        /// </summary>
+        private sealed class AsyncContextSynchronizationContext : SynchronizationContext
+        {
+            /// <summary>
+            /// The async context.
+            /// </summary>
+            private readonly AsyncContext _context;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="AsyncContextSynchronizationContext"/> class.
+            /// </summary>
+            /// <param name="context">The async context.</param>
+            public AsyncContextSynchronizationContext(AsyncContext context)
+            {
+                _context = context;
+            }
+
+            /// <summary>
+            /// Gets the async context.
+            /// </summary>
+            public AsyncContext Context
+            {
+                get
+                {
+                    return _context;
+                }
+            }
+
+            /// <summary>
+            /// Dispatches an asynchronous message to the async context. If all tasks have been completed and the outstanding asynchronous operation count is zero, then this method has undefined behavior.
+            /// </summary>
+            /// <param name="d">The <see cref="T:System.Threading.SendOrPostCallback"/> delegate to call. May not be <c>null</c>.</param>
+            /// <param name="state">The object passed to the delegate.</param>
+            public override void Post(SendOrPostCallback d, object state)
+            {
+                _context.Enqueue(_context._taskFactory.Run(() => d(state)), true);
+            }
+
+            /// <summary>
+            /// Dispatches an asynchronous message to the async context, and waits for it to complete.
+            /// </summary>
+            /// <param name="d">The <see cref="T:System.Threading.SendOrPostCallback"/> delegate to call. May not be <c>null</c>.</param>
+            /// <param name="state">The object passed to the delegate.</param>
+            public override void Send(SendOrPostCallback d, object state)
+            {
+                if (AsyncContext.Current == _context)
+                {
+                    d(state);
+                }
+                else
+                {
+                    var task = _context._taskFactory.Run(() => d(state));
+                    task.WaitAndUnwrapException();
+                }
+            }
+
+            /// <summary>
+            /// Responds to the notification that an operation has started by incrementing the outstanding asynchronous operation count.
+            /// </summary>
+            public override void OperationStarted()
+            {
+                _context.OperationStarted();
+            }
+
+            /// <summary>
+            /// Responds to the notification that an operation has completed by decrementing the outstanding asynchronous operation count.
+            /// </summary>
+            public override void OperationCompleted()
+            {
+                _context.OperationCompleted();
+            }
+
+            /// <summary>
+            /// Creates a copy of the synchronization context.
+            /// </summary>
+            /// <returns>A new <see cref="T:System.Threading.SynchronizationContext"/> object.</returns>
+            public override SynchronizationContext CreateCopy()
+            {
+                return new AsyncContextSynchronizationContext(_context);
+            }
+
+            /// <summary>
+            /// Returns a hash code for this instance.
+            /// </summary>
+            /// <returns>A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.</returns>
+            public override int GetHashCode()
+            {
+                return _context.GetHashCode();
+            }
+
+            /// <summary>
+            /// Determines whether the specified <see cref="System.Object"/> is equal to this instance. It is considered equal if it refers to the same underlying async context as this instance.
+            /// </summary>
+            /// <param name="obj">The <see cref="System.Object"/> to compare with this instance.</param>
+            /// <returns><c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; otherwise, <c>false</c>.</returns>
+            public override bool Equals(object obj)
+            {
+                var other = obj as AsyncContextSynchronizationContext;
+                if (other == null)
+                    return false;
+                return (_context == other._context);
+            }
+        }
+    }
+}

--- a/src/core/Akka.Remote.Tests/AsyncContext/AsyncContext.SynchronizationContext.cs
+++ b/src/core/Akka.Remote.Tests/AsyncContext/AsyncContext.SynchronizationContext.cs
@@ -43,7 +43,7 @@ namespace Nito.AsyncEx
             /// <param name="state">The object passed to the delegate.</param>
             public override void Post(SendOrPostCallback d, object state)
             {
-                _context.Enqueue(_context._taskFactory.Run(() => d(state)), true);
+                _context.Enqueue(_context._taskFactory.StartNew(() => d(state)), true);
             }
 
             /// <summary>
@@ -59,7 +59,7 @@ namespace Nito.AsyncEx
                 }
                 else
                 {
-                    var task = _context._taskFactory.Run(() => d(state));
+                    var task = _context._taskFactory.StartNew(() => d(state));
                     task.WaitAndUnwrapException();
                 }
             }

--- a/src/core/Akka.Remote.Tests/AsyncContext/AsyncContext.TaskQueue.cs
+++ b/src/core/Akka.Remote.Tests/AsyncContext/AsyncContext.TaskQueue.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Nito.AsyncEx
+{
+    public sealed partial class AsyncContext
+    {
+        /// <summary>
+        /// A blocking queue.
+        /// </summary>
+        private sealed class TaskQueue : IDisposable
+        {
+            /// <summary>
+            /// The underlying blocking collection.
+            /// </summary>
+            private readonly BlockingCollection<Tuple<Task, bool>> _queue;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="TaskQueue"/> class.
+            /// </summary>
+            public TaskQueue()
+            {
+                _queue = new BlockingCollection<Tuple<Task, bool>>();
+            }
+
+            /// <summary>
+            /// Gets a blocking enumerable that removes items from the queue. This enumerable only completes after <see cref="CompleteAdding"/> has been called.
+            /// </summary>
+            /// <returns>A blocking enumerable that removes items from the queue.</returns>
+            public IEnumerable<Tuple<Task, bool>> GetConsumingEnumerable()
+            {
+                return _queue.GetConsumingEnumerable();
+            }
+
+            /// <summary>
+            /// Generates an enumerable of <see cref="T:System.Threading.Tasks.Task"/> instances currently queued to the scheduler waiting to be executed.
+            /// </summary>
+            /// <returns>An enumerable that allows traversal of tasks currently queued to this scheduler.</returns>
+            [System.Diagnostics.DebuggerNonUserCode]
+            internal IEnumerable<Task> GetScheduledTasks()
+            {
+                foreach (var item in _queue)
+                    yield return item.Item1;
+            }
+
+            /// <summary>
+            /// Attempts to add the item to the queue. If the queue has been marked as complete for adding, this method returns <c>false</c>.
+            /// </summary>
+            /// <param name="item">The item to enqueue.</param>
+            /// <param name="propagateExceptions">A value indicating whether exceptions on this task should be propagated out of the main loop.</param>
+            public bool TryAdd(Task item, bool propagateExceptions)
+            {
+                try
+                {
+                    return _queue.TryAdd(Tuple.Create(item, propagateExceptions));
+                }
+                catch (InvalidOperationException)
+                {
+                    // vexing exception
+                    return false;
+                }
+            }
+
+            /// <summary>
+            /// Marks the queue as complete for adding, allowing the enumerator returned from <see cref="GetConsumingEnumerable"/> to eventually complete. This method may be called several times.
+            /// </summary>
+            public void CompleteAdding()
+            {
+                _queue.CompleteAdding();
+            }
+
+            /// <summary>
+            /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+            /// </summary>
+            public void Dispose()
+            {
+                _queue.Dispose();
+            }
+        }
+    }
+}

--- a/src/core/Akka.Remote.Tests/AsyncContext/AsyncContext.TaskScheduler.cs
+++ b/src/core/Akka.Remote.Tests/AsyncContext/AsyncContext.TaskScheduler.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Nito.AsyncEx
+{
+    public sealed partial class AsyncContext
+    {
+        /// <summary>
+        /// A task scheduler which schedules tasks to an async context.
+        /// </summary>
+        private sealed class AsyncContextTaskScheduler : TaskScheduler
+        {
+            /// <summary>
+            /// The async context for this task scheduler.
+            /// </summary>
+            private readonly AsyncContext _context;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="AsyncContextTaskScheduler"/> class.
+            /// </summary>
+            /// <param name="context">The async context for this task scheduler. May not be <c>null</c>.</param>
+            public AsyncContextTaskScheduler(AsyncContext context)
+            {
+                _context = context;
+            }
+
+            /// <summary>
+            /// Generates an enumerable of <see cref="T:System.Threading.Tasks.Task"/> instances currently queued to the scheduler waiting to be executed.
+            /// </summary>
+            /// <returns>An enumerable that allows traversal of tasks currently queued to this scheduler.</returns>
+            [System.Diagnostics.DebuggerNonUserCode]
+            protected override IEnumerable<Task> GetScheduledTasks()
+            {
+                return _context._queue.GetScheduledTasks();
+            }
+
+            /// <summary>
+            /// Queues a <see cref="T:System.Threading.Tasks.Task"/> to the scheduler. If all tasks have been completed and the outstanding asynchronous operation count is zero, then this method has undefined behavior.
+            /// </summary>
+            /// <param name="task">The <see cref="T:System.Threading.Tasks.Task"/> to be queued.</param>
+            protected override void QueueTask(Task task)
+            {
+                _context.Enqueue(task, false);
+            }
+
+            /// <summary>
+            /// Determines whether the provided <see cref="T:System.Threading.Tasks.Task"/> can be executed synchronously in this call, and if it can, executes it.
+            /// </summary>
+            /// <param name="task">The <see cref="T:System.Threading.Tasks.Task"/> to be executed.</param>
+            /// <param name="taskWasPreviouslyQueued">A Boolean denoting whether or not task has previously been queued. If this parameter is True, then the task may have been previously queued (scheduled); if False, then the task is known not to have been queued, and this call is being made in order to execute the task inline without queuing it.</param>
+            /// <returns>A Boolean value indicating whether the task was executed inline.</returns>
+            /// <exception cref="T:System.InvalidOperationException">The <paramref name="task"/> was already executed.</exception>
+            protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
+            {
+                return (AsyncContext.Current == _context) && TryExecuteTask(task);
+            }
+
+            /// <summary>
+            /// Indicates the maximum concurrency level this <see cref="T:System.Threading.Tasks.TaskScheduler"/> is able to support.
+            /// </summary>
+            public override int MaximumConcurrencyLevel
+            {
+                get { return 1; }
+            }
+
+            /// <summary>
+            /// Exposes the base <see cref="TaskScheduler.TryExecuteTask"/> method.
+            /// </summary>
+            /// <param name="task">The task to attempt to execute.</param>
+            public void DoTryExecuteTask(Task task)
+            {
+                TryExecuteTask(task);
+            }
+        }
+    }
+}

--- a/src/core/Akka.Remote.Tests/AsyncContext/AsyncContext.cs
+++ b/src/core/Akka.Remote.Tests/AsyncContext/AsyncContext.cs
@@ -1,0 +1,253 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Nito.AsyncEx.Synchronous;
+
+namespace Nito.AsyncEx
+{
+    /// <summary>
+    /// Provides a context for asynchronous operations. This class is threadsafe.
+    /// </summary>
+    /// <remarks>
+    /// <para><see cref="Execute()"/> may only be called once. After <see cref="Execute()"/> returns, the async context should be disposed.</para>
+    /// </remarks>
+    [DebuggerDisplay("Id = {Id}, OperationCount = {_outstandingOperations}")]
+    [DebuggerTypeProxy(typeof(DebugView))]
+    public sealed partial class AsyncContext : IDisposable
+    {
+        /// <summary>
+        /// The queue holding the actions to run.
+        /// </summary>
+        private readonly TaskQueue _queue;
+
+        /// <summary>
+        /// The <see cref="SynchronizationContext"/> for this <see cref="AsyncContext"/>.
+        /// </summary>
+        private readonly AsyncContextSynchronizationContext _synchronizationContext;
+
+        /// <summary>
+        /// The <see cref="TaskScheduler"/> for this <see cref="AsyncContext"/>.
+        /// </summary>
+        private readonly AsyncContextTaskScheduler _taskScheduler;
+
+        /// <summary>
+        /// The <see cref="TaskFactory"/> for this <see cref="AsyncContext"/>.
+        /// </summary>
+        private readonly TaskFactory _taskFactory;
+
+        /// <summary>
+        /// The number of outstanding operations, including actions in the queue.
+        /// </summary>
+        private int _outstandingOperations;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncContext"/> class. This is an advanced operation; most people should use one of the static <c>Run</c> methods instead.
+        /// </summary>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public AsyncContext()
+        {
+            _queue = new TaskQueue();
+            _synchronizationContext = new AsyncContextSynchronizationContext(this);
+            _taskScheduler = new AsyncContextTaskScheduler(this);
+            _taskFactory = new TaskFactory(CancellationToken.None, TaskCreationOptions.HideScheduler, TaskContinuationOptions.HideScheduler, _taskScheduler);
+        }
+
+        /// <summary>
+        /// Gets a semi-unique identifier for this asynchronous context. This is the same identifier as the context's <see cref="TaskScheduler"/>.
+        /// </summary>
+        public int Id => _taskScheduler.Id;
+
+        /// <summary>
+        /// Increments the outstanding asynchronous operation count.
+        /// </summary>
+        private void OperationStarted()
+        {
+            var newCount = Interlocked.Increment(ref _outstandingOperations);
+        }
+
+        /// <summary>
+        /// Decrements the outstanding asynchronous operation count.
+        /// </summary>
+        private void OperationCompleted()
+        {
+            var newCount = Interlocked.Decrement(ref _outstandingOperations);
+            if (newCount == 0)
+                _queue.CompleteAdding();
+        }
+
+        /// <summary>
+        /// Queues a task for execution by <see cref="Execute"/>. If all tasks have been completed and the outstanding asynchronous operation count is zero, then this method has undefined behavior.
+        /// </summary>
+        /// <param name="task">The task to queue. May not be <c>null</c>.</param>
+        /// <param name="propagateExceptions">A value indicating whether exceptions on this task should be propagated out of the main loop.</param>
+        private void Enqueue(Task task, bool propagateExceptions)
+        {
+            OperationStarted();
+            task.ContinueWith(_ => OperationCompleted(), CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, _taskScheduler);
+            _queue.TryAdd(task, propagateExceptions);
+
+            // If we fail to add to the queue, just drop the Task. This is the same behavior as the TaskScheduler.FromCurrentSynchronizationContext(WinFormsSynchronizationContext).
+        }
+
+        /// <summary>
+        /// Disposes all resources used by this class. This method should NOT be called while <see cref="Execute"/> is executing.
+        /// </summary>
+        public void Dispose()
+        {
+            _queue.Dispose();
+        }
+
+        /// <summary>
+        /// Executes all queued actions. This method returns when all tasks have been completed and the outstanding asynchronous operation count is zero. This method will unwrap and propagate errors from tasks that are supposed to propagate errors.
+        /// </summary>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public void Execute()
+        {
+            using (new SynchronizationContextSwitcher(_synchronizationContext))
+            {
+                var tasks = _queue.GetConsumingEnumerable();
+                foreach (var task in tasks)
+                {
+                    _taskScheduler.DoTryExecuteTask(task.Item1);
+
+                    // Propagate exception if necessary.
+                    if (task.Item2)
+                        task.Item1.WaitAndUnwrapException();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Queues a task for execution, and begins executing all tasks in the queue. This method returns when all tasks have been completed and the outstanding asynchronous operation count is zero. This method will unwrap and propagate errors from the task.
+        /// </summary>
+        /// <param name="action">The action to execute. May not be <c>null</c>.</param>
+        public static void Run(Action action)
+        {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            using (var context = new AsyncContext())
+            {
+                var task = context._taskFactory.Run(action);
+                context.Execute();
+                task.WaitAndUnwrapException();
+            }
+        }
+
+        /// <summary>
+        /// Queues a task for execution, and begins executing all tasks in the queue. This method returns when all tasks have been completed and the outstanding asynchronous operation count is zero. Returns the result of the task. This method will unwrap and propagate errors from the task.
+        /// </summary>
+        /// <typeparam name="TResult">The result type of the task.</typeparam>
+        /// <param name="action">The action to execute. May not be <c>null</c>.</param>
+        public static TResult Run<TResult>(Func<TResult> action)
+        {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            using (var context = new AsyncContext())
+            {
+                var task = context._taskFactory.Run(action);
+                context.Execute();
+                return task.WaitAndUnwrapException();
+            }
+        }
+
+        /// <summary>
+        /// Queues a task for execution, and begins executing all tasks in the queue. This method returns when all tasks have been completed and the outstanding asynchronous operation count is zero. This method will unwrap and propagate errors from the task proxy.
+        /// </summary>
+        /// <param name="action">The action to execute. May not be <c>null</c>.</param>
+        public static void Run(Func<Task> action)
+        {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            // ReSharper disable AccessToDisposedClosure
+            using (var context = new AsyncContext())
+            {
+                context.OperationStarted();
+                var task = context._taskFactory.Run(action).ContinueWith(t =>
+                {
+                    context.OperationCompleted();
+                    t.WaitAndUnwrapException();
+                }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, context._taskScheduler);
+                context.Execute();
+                task.WaitAndUnwrapException();
+            }
+            // ReSharper restore AccessToDisposedClosure
+        }
+
+        /// <summary>
+        /// Queues a task for execution, and begins executing all tasks in the queue. This method returns when all tasks have been completed and the outstanding asynchronous operation count is zero. Returns the result of the task proxy. This method will unwrap and propagate errors from the task proxy.
+        /// </summary>
+        /// <typeparam name="TResult">The result type of the task.</typeparam>
+        /// <param name="action">The action to execute. May not be <c>null</c>.</param>
+        public static TResult Run<TResult>(Func<Task<TResult>> action)
+        {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            // ReSharper disable AccessToDisposedClosure
+            using (var context = new AsyncContext())
+            {
+                context.OperationStarted();
+                var task = context._taskFactory.Run(action).ContinueWith(t =>
+                {
+                    context.OperationCompleted();
+                    return t.WaitAndUnwrapException();
+                }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, context._taskScheduler);
+                context.Execute();
+                return task.WaitAndUnwrapException();
+            }
+            // ReSharper restore AccessToDisposedClosure
+        }
+
+        /// <summary>
+        /// Gets the current <see cref="AsyncContext"/> for this thread, or <c>null</c> if this thread is not currently running in an <see cref="AsyncContext"/>.
+        /// </summary>
+        public static AsyncContext Current
+        {
+            get
+            {
+                var syncContext = SynchronizationContext.Current as AsyncContextSynchronizationContext;
+                if (syncContext == null)
+                {
+                    return null;
+                }
+
+                return syncContext.Context;
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="SynchronizationContext"/> for this <see cref="AsyncContext"/>. From inside <see cref="Execute"/>, this value is always equal to <see cref="System.Threading.SynchronizationContext.Current"/>.
+        /// </summary>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public SynchronizationContext SynchronizationContext => _synchronizationContext;
+
+        /// <summary>
+        /// Gets the <see cref="TaskScheduler"/> for this <see cref="AsyncContext"/>. From inside <see cref="Execute"/>, this value is always equal to <see cref="TaskScheduler.Current"/>.
+        /// </summary>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public TaskScheduler Scheduler => _taskScheduler;
+
+        /// <summary>
+        /// Gets the <see cref="TaskFactory"/> for this <see cref="AsyncContext"/>. Note that this factory has the <see cref="TaskCreationOptions.HideScheduler"/> option set. Be careful with async delegates; you may need to call <see cref="M:System.Threading.SynchronizationContext.OperationStarted"/> and <see cref="M:System.Threading.SynchronizationContext.OperationCompleted"/> to prevent early termination of this <see cref="AsyncContext"/>.
+        /// </summary>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public TaskFactory Factory => _taskFactory;
+
+        [DebuggerNonUserCode]
+        internal sealed class DebugView
+        {
+            private readonly AsyncContext _context;
+
+            public DebugView(AsyncContext context)
+            {
+                _context = context;
+            }
+
+            public TaskScheduler TaskScheduler => _context._taskScheduler;
+        }
+    }
+}

--- a/src/core/Akka.Remote.Tests/AsyncContext/AsyncContext.cs
+++ b/src/core/Akka.Remote.Tests/AsyncContext/AsyncContext.cs
@@ -129,7 +129,7 @@ namespace Nito.AsyncEx
 
             using (var context = new AsyncContext())
             {
-                var task = context._taskFactory.Run(action);
+                var task = context._taskFactory.StartNew(action);
                 context.Execute();
                 task.WaitAndUnwrapException();
             }
@@ -147,7 +147,7 @@ namespace Nito.AsyncEx
 
             using (var context = new AsyncContext())
             {
-                var task = context._taskFactory.Run(action);
+                var task = context._taskFactory.StartNew(action);
                 context.Execute();
                 return task.WaitAndUnwrapException();
             }
@@ -166,7 +166,7 @@ namespace Nito.AsyncEx
             using (var context = new AsyncContext())
             {
                 context.OperationStarted();
-                var task = context._taskFactory.Run(action).ContinueWith(t =>
+                var task = context._taskFactory.StartNew(action).ContinueWith(t =>
                 {
                     context.OperationCompleted();
                     t.WaitAndUnwrapException();
@@ -191,13 +191,13 @@ namespace Nito.AsyncEx
             using (var context = new AsyncContext())
             {
                 context.OperationStarted();
-                var task = context._taskFactory.Run(action).ContinueWith(t =>
+                var task = context._taskFactory.StartNew(action).ContinueWith(t =>
                 {
                     context.OperationCompleted();
                     return t.WaitAndUnwrapException();
                 }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, context._taskScheduler);
                 context.Execute();
-                return task.WaitAndUnwrapException();
+                return task.WaitAndUnwrapException().Result;
             }
             // ReSharper restore AccessToDisposedClosure
         }

--- a/src/core/Akka.Remote.Tests/AsyncContext/AsyncEx.LICENSE
+++ b/src/core/Akka.Remote.Tests/AsyncContext/AsyncEx.LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 StephenCleary
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/core/Akka.Remote.Tests/AsyncContext/BoundAction.cs
+++ b/src/core/Akka.Remote.Tests/AsyncContext/BoundAction.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace Nito.Disposables.Internals
+{
+    /// <summary>
+    /// A field containing a bound action.
+    /// </summary>
+    /// <typeparam name="T">The type of context for the action.</typeparam>
+    public sealed class BoundActionField<T>
+    {
+        private BoundAction field;
+
+        /// <summary>
+        /// Initializes the field with the specified action and context.
+        /// </summary>
+        /// <param name="action">The action delegate.</param>
+        /// <param name="context">The context.</param>
+        public BoundActionField(Action<T> action, T context)
+        {
+            field = new BoundAction(action, context);
+        }
+
+        /// <summary>
+        /// Whether the field is empty.
+        /// </summary>
+        public bool IsEmpty => Interlocked.CompareExchange(ref field, null, null) == null;
+
+        /// <summary>
+        /// Atomically retrieves the bound action from the field and sets the field to <c>null</c>. May return <c>null</c>.
+        /// </summary>
+        public IBoundAction TryGetAndUnset()
+        {
+            return Interlocked.Exchange(ref field, null);
+        }
+
+        /// <summary>
+        /// Attempts to update the context of the bound action stored in the field. Returns <c>false</c> if the field is <c>null</c>.
+        /// </summary>
+        /// <param name="contextUpdater">The function used to update an existing context. This may be called more than once if more than one thread attempts to simultanously update the context.</param>
+        public bool TryUpdateContext(Func<T, T> contextUpdater)
+        {
+            while (true)
+            {
+                var original = Interlocked.CompareExchange(ref field, field, field);
+                if (original == null)
+                    return false;
+                var updatedContext = new BoundAction(original, contextUpdater);
+                var result = Interlocked.CompareExchange(ref field, updatedContext, original);
+                if (ReferenceEquals(original, result))
+                    return true;
+            }
+        }
+
+        /// <summary>
+        /// An action delegate bound with its context.
+        /// </summary>
+        public interface IBoundAction
+        {
+            /// <summary>
+            /// Executes the action. This should only be done after the bound action is retrieved from a field by <see cref="TryGetAndUnset"/>.
+            /// </summary>
+            void Invoke();
+        }
+
+        private sealed class BoundAction : IBoundAction
+        {
+            private readonly Action<T> _action;
+            private readonly T _context;
+
+            public BoundAction(Action<T> action, T context)
+            {
+                _action = action;
+                _context = context;
+            }
+
+            public BoundAction(BoundAction originalBoundAction, Func<T, T> contextUpdater)
+            {
+                _action = originalBoundAction._action;
+                _context = contextUpdater(originalBoundAction._context);
+            }
+
+            public void Invoke() => _action?.Invoke(_context);
+        }
+    }
+}

--- a/src/core/Akka.Remote.Tests/AsyncContext/Disposables.LICENSE
+++ b/src/core/Akka.Remote.Tests/AsyncContext/Disposables.LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Stephen Cleary
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/core/Akka.Remote.Tests/AsyncContext/ExceptionHelpers.cs
+++ b/src/core/Akka.Remote.Tests/AsyncContext/ExceptionHelpers.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Runtime.ExceptionServices;
+
+internal static class ExceptionHelpers
+{
+    /// <summary>
+    /// Attempts to prepare the exception for re-throwing by preserving the stack trace. The returned exception should be immediately thrown.
+    /// </summary>
+    /// <param name="exception">The exception. May not be <c>null</c>.</param>
+    /// <returns>The <see cref="Exception"/> that was passed into this method.</returns>
+    public static Exception PrepareForRethrow(Exception exception)
+    {
+        ExceptionDispatchInfo.Capture(exception).Throw();
+
+        // The code cannot ever get here. We just return a value to work around a badly-designed API (ExceptionDispatchInfo.Throw):
+        //  https://connect.microsoft.com/VisualStudio/feedback/details/689516/exceptiondispatchinfo-api-modifications (http://www.webcitation.org/6XQ7RoJmO)
+        return exception;
+    }
+}

--- a/src/core/Akka.Remote.Tests/AsyncContext/SingleDisposable (of T).cs
+++ b/src/core/Akka.Remote.Tests/AsyncContext/SingleDisposable (of T).cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Threading;
+using Nito.Disposables.Internals;
+
+namespace Nito.Disposables
+{
+    /// <summary>
+    /// A base class for disposables that need exactly-once semantics in a threadsafe way. All disposals of this instance block until the disposal is complete.
+    /// </summary>
+    /// <typeparam name="T">The type of "context" for the derived disposable. Since the context should not be modified, strongly consider making this an immutable type.</typeparam>
+    /// <remarks>
+    /// <para>If <see cref="Dispose()"/> is called multiple times, only the first call will execute the disposal code. Other calls to <see cref="Dispose()"/> will wait for the disposal to complete.</para>
+    /// </remarks>
+    public abstract class SingleDisposable<T> : IDisposable
+    {
+        /// <summary>
+        /// The context. This is never <c>null</c>. This is empty if this instance has already been disposed (or is being disposed).
+        /// </summary>
+        private readonly BoundActionField<T> _context;
+
+        private readonly ManualResetEventSlim _mre = new ManualResetEventSlim();
+
+        /// <summary>
+        /// Creates a disposable for the specified context.
+        /// </summary>
+        /// <param name="context">The context passed to <see cref="Dispose(T)"/>.</param>
+        protected SingleDisposable(T context)
+        {
+            _context = new BoundActionField<T>(Dispose, context);
+        }
+
+        /// <summary>
+        /// Whether this instance is currently disposing or has been disposed.
+        /// </summary>
+        public bool IsDisposeStarted => _context.IsEmpty;
+
+        /// <summary>
+        /// Whether this instance is disposed (finished disposing).
+        /// </summary>
+        public bool IsDispoed => _mre.IsSet;
+
+        /// <summary>
+        /// Whether this instance is currently disposing, but not finished yet.
+        /// </summary>
+        public bool IsDisposing => IsDisposeStarted && !IsDispoed;
+
+        /// <summary>
+        /// The actul disposal method, called only once from <see cref="Dispose()"/>.
+        /// </summary>
+        /// <param name="context">The context for the disposal operation.</param>
+        protected abstract void Dispose(T context);
+
+        /// <summary>
+        /// Disposes this instance.
+        /// </summary>
+        /// <remarks>
+        /// <para>If <see cref="Dispose()"/> is called multiple times, only the first call will execute the disposal code. Other calls to <see cref="Dispose()"/> will wait for the disposal to complete.</para>
+        /// </remarks>
+        public void Dispose()
+        {
+            var context = _context.TryGetAndUnset();
+            if (context == null)
+            {
+                _mre.Wait();
+                return;
+            }
+            try
+            {
+                context.Invoke();
+            }
+            finally
+            {
+                _mre.Set();
+            }
+        }
+
+        /// <summary>
+        /// Attempts to update the stored context. This method returns <c>false</c> if this instance has already been disposed (or is being disposed).
+        /// </summary>
+        /// <param name="contextUpdater">The function used to update an existing context. This may be called more than once if more than one thread attempts to simultanously update the context.</param>
+        protected bool TryUpdateContext(Func<T, T> contextUpdater) => _context.TryUpdateContext(contextUpdater);
+    }
+}

--- a/src/core/Akka.Remote.Tests/AsyncContext/SynchronizationContextSwitcher.cs
+++ b/src/core/Akka.Remote.Tests/AsyncContext/SynchronizationContextSwitcher.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nito.AsyncEx
+{
+    /// <summary>
+    /// Utility class for temporarily switching <see cref="SynchronizationContext"/> implementations.
+    /// </summary>
+    public sealed class SynchronizationContextSwitcher : Disposables.SingleDisposable<object>
+    {
+        /// <summary>
+        /// The previous <see cref="SynchronizationContext"/>.
+        /// </summary>
+        private readonly SynchronizationContext _oldContext;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SynchronizationContextSwitcher"/> class, installing the new <see cref="SynchronizationContext"/>.
+        /// </summary>
+        /// <param name="newContext">The new <see cref="SynchronizationContext"/>. This can be <c>null</c> to remove an existing <see cref="SynchronizationContext"/>.</param>
+        public SynchronizationContextSwitcher(SynchronizationContext newContext)
+            : base(new object())
+        {
+            _oldContext = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(newContext);
+        }
+
+        /// <summary>
+        /// Restores the old <see cref="SynchronizationContext"/>.
+        /// </summary>
+        protected override void Dispose(object context)
+        {
+            SynchronizationContext.SetSynchronizationContext(_oldContext);
+        }
+
+        /// <summary>
+        /// Executes a synchronous delegate without the current <see cref="SynchronizationContext"/>. The current context is restored when this function returns.
+        /// </summary>
+        /// <param name="action">The delegate to execute.</param>
+        public static void NoContext(Action action)
+        {
+            using (new SynchronizationContextSwitcher(null))
+                action();
+        }
+
+        /// <summary>
+        /// Executes an asynchronous delegate without the current <see cref="SynchronizationContext"/>. The current context is restored when this function returns its task.
+        /// </summary>
+        /// <param name="action">The delegate to execute.</param>
+        public static Task NoContextAsync(Func<Task> action)
+        {
+            using (new SynchronizationContextSwitcher(null))
+                return action();
+        }
+    }
+}

--- a/src/core/Akka.Remote.Tests/AsyncContext/SynchronousTaskExtensions.cs.cs
+++ b/src/core/Akka.Remote.Tests/AsyncContext/SynchronousTaskExtensions.cs.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nito.AsyncEx.Synchronous
+{
+    /// <summary>
+    /// Provides synchronous extension methods for tasks.
+    /// </summary>
+    public static class TaskExtensions
+    {
+        /// <summary>
+        /// Waits for the task to complete, unwrapping any exceptions.
+        /// </summary>
+        /// <param name="task">The task. May not be <c>null</c>.</param>
+        public static void WaitAndUnwrapException(this Task task)
+        {
+            if (task == null)
+                throw new ArgumentNullException(nameof(task));
+            task.GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Waits for the task to complete, unwrapping any exceptions.
+        /// </summary>
+        /// <param name="task">The task. May not be <c>null</c>.</param>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was cancelled before the <paramref name="task"/> completed, or the <paramref name="task"/> raised an <see cref="OperationCanceledException"/>.</exception>
+        public static void WaitAndUnwrapException(this Task task, CancellationToken cancellationToken)
+        {
+            if (task == null)
+                throw new ArgumentNullException(nameof(task));
+            try
+            {
+                task.Wait(cancellationToken);
+            }
+            catch (AggregateException ex)
+            {
+                throw ExceptionHelpers.PrepareForRethrow(ex.InnerException);
+            }
+        }
+
+        /// <summary>
+        /// Waits for the task to complete, unwrapping any exceptions.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result of the task.</typeparam>
+        /// <param name="task">The task. May not be <c>null</c>.</param>
+        /// <returns>The result of the task.</returns>
+        public static TResult WaitAndUnwrapException<TResult>(this Task<TResult> task)
+        {
+            if (task == null)
+                throw new ArgumentNullException(nameof(task));
+            return task.GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Waits for the task to complete, unwrapping any exceptions.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result of the task.</typeparam>
+        /// <param name="task">The task. May not be <c>null</c>.</param>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <returns>The result of the task.</returns>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was cancelled before the <paramref name="task"/> completed, or the <paramref name="task"/> raised an <see cref="OperationCanceledException"/>.</exception>
+        public static TResult WaitAndUnwrapException<TResult>(this Task<TResult> task, CancellationToken cancellationToken)
+        {
+            if (task == null)
+                throw new ArgumentNullException(nameof(task));
+            try
+            {
+                task.Wait(cancellationToken);
+                return task.Result;
+            }
+            catch (AggregateException ex)
+            {
+                throw ExceptionHelpers.PrepareForRethrow(ex.InnerException);
+            }
+        }
+
+        /// <summary>
+        /// Waits for the task to complete, but does not raise task exceptions. The task exception (if any) is unobserved.
+        /// </summary>
+        /// <param name="task">The task. May not be <c>null</c>.</param>
+        public static void WaitWithoutException(this Task task)
+        {
+            if (task == null)
+                throw new ArgumentNullException(nameof(task));
+            try
+            {
+                task.Wait();
+            }
+            catch (AggregateException)
+            {
+            }
+        }
+
+        /// <summary>
+        /// Waits for the task to complete, but does not raise task exceptions. The task exception (if any) is unobserved.
+        /// </summary>
+        /// <param name="task">The task. May not be <c>null</c>.</param>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was cancelled before the <paramref name="task"/> completed.</exception>
+        public static void WaitWithoutException(this Task task, CancellationToken cancellationToken)
+        {
+            if (task == null)
+                throw new ArgumentNullException(nameof(task));
+            try
+            {
+                task.Wait(cancellationToken);
+            }
+            catch (AggregateException)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+        }
+    }
+}

--- a/src/core/Akka.Remote.Tests/AsyncContext/about.txt
+++ b/src/core/Akka.Remote.Tests/AsyncContext/about.txt
@@ -1,0 +1,4 @@
+﻿this was copied because the nuget only supports .net 4.6+
+
+https://github.com/StephenCleary/AsyncEx
+https://github.com/StephenCleary/Disposables

--- a/src/core/Akka.Remote.Tests/RemotingSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemotingSpec.cs
@@ -19,6 +19,7 @@ using Akka.Util.Internal;
 using Google.ProtocolBuffers;
 using Xunit;
 using Xunit.Abstractions;
+using Nito.AsyncEx;
 
 namespace Akka.Remote.Tests
 {
@@ -162,6 +163,28 @@ namespace Akka.Remote.Tests
             var msg = await here.Ask<Tuple<string, IActorRef>>("ping", TimeSpan.FromSeconds(1.5));
             Assert.Equal("pong", msg.Item1);
             Assert.IsType<FutureActorRef>(msg.Item2);
+        }
+
+        [Fact]
+        public void Resolve_does_not_deadlock()
+        {
+            // here is really an ActorSelection
+            var actorSelection = (ActorSelection)here;
+            var actorRef = actorSelection.ResolveOne(TimeSpan.FromSeconds(10)).Result;
+            // the only test is that the ResolveOne works, so if we got here, the test passes
+        }
+
+        [Fact]
+        public void Resolve_does_not_deadlock_GuiApplication()
+        {
+            AsyncContext.Run(() =>
+            {
+                // here is really an ActorSelection
+                var actorSelection = (ActorSelection)here;
+                var actorRef = actorSelection.ResolveOne(TimeSpan.FromSeconds(10)).Result;
+                // the only test is that the ResolveOne works, so if we got here, the test passes
+                return Task.Delay(0);
+            });
         }
 
         [Fact]

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -1103,7 +1103,7 @@ namespace Akka.Remote
         {
             try
             {
-                return new Handle(await Transport.Associate(RemoteAddress, _refuseUid));
+                return new Handle(await Transport.Associate(RemoteAddress, _refuseUid).ConfigureAwait(false));
             }
             catch (Exception e)
             {

--- a/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
+++ b/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
@@ -171,7 +171,7 @@ namespace Akka.Remote.Transport
 
             manager.Tell(new AssociateUnderlyingRefuseUid(SchemeAugmenter.RemoveScheme(remoteAddress), statusPromise, refuseUid));
 
-            return (AkkaProtocolHandle)await statusPromise.Task;
+            return (AkkaProtocolHandle)await statusPromise.Task.ConfigureAwait(false);
         }
 
         #region Static properties

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
@@ -154,7 +154,7 @@ namespace Akka.Remote.Transport.DotNetty
             var dns = listenAddress as DnsEndPoint;
             if (dns != null)
             {
-                listenAddress = await DnsToIPEndpoint(dns);
+                listenAddress = await DnsToIPEndpoint(dns).ConfigureAwait(false);
             }
             
             return await ServerFactory().BindAsync(listenAddress).ConfigureAwait(false);
@@ -171,7 +171,7 @@ namespace Akka.Remote.Transport.DotNetty
 
             try
             {
-                var newServerChannel = await NewServer(listenAddress);
+                var newServerChannel = await NewServer(listenAddress).ConfigureAwait(false);
                 
                 // Block reads until a handler actor is registered
                 // no incoming connections will be accepted until this value is reset
@@ -203,7 +203,7 @@ namespace Akka.Remote.Transport.DotNetty
                 Log.Error(ex, "Failed to bind to {0}; shutting down DotNetty transport.", listenAddress);
                 try
                 {
-                    await Shutdown();
+                    await Shutdown().ConfigureAwait(false);
                 }
                 catch
                 {
@@ -218,7 +218,7 @@ namespace Akka.Remote.Transport.DotNetty
             if (!ServerChannel.Open)
                 throw new ChannelException("Transport is not open");
 
-            return await AssociateInternal(remoteAddress);
+            return await AssociateInternal(remoteAddress).ConfigureAwait(false);
         }
 
         protected abstract Task<AssociationHandle> AssociateInternal(Address remoteAddress);
@@ -233,10 +233,10 @@ namespace Akka.Remote.Transport.DotNetty
                     tasks.Add(channel.CloseAsync());
                 }
                 var all = Task.WhenAll(tasks);
-                await all;
+                await all.ConfigureAwait(false);
 
                 var server = ServerChannel?.CloseAsync() ?? TaskEx.Completed;
-                await server;
+                await server.ConfigureAwait(false);
 
                 return all.IsCompleted && server.IsCompleted;
             }
@@ -283,12 +283,12 @@ namespace Akka.Remote.Transport.DotNetty
             IPEndPoint endpoint;
             //if (!Settings.EnforceIpFamily)
             //{
-            //    endpoint = await ResolveNameAsync(dns);
+            //    endpoint = await ResolveNameAsync(dns).ConfigureAwait(false);
             //}
             //else
             //{
                 var addressFamily = Settings.DnsUseIpv6 ? AddressFamily.InterNetworkV6 : AddressFamily.InterNetwork;
-                endpoint = await ResolveNameAsync(dns, addressFamily);
+                endpoint = await ResolveNameAsync(dns, addressFamily).ConfigureAwait(false);
             //}
             return endpoint;
         }
@@ -388,7 +388,7 @@ namespace Akka.Remote.Transport.DotNetty
 
         private async Task<IPEndPoint> ResolveNameAsync(DnsEndPoint address)
         {
-            var resolved = await Dns.GetHostEntryAsync(address.Host);
+            var resolved = await Dns.GetHostEntryAsync(address.Host).ConfigureAwait(false);
             //NOTE: for some reason while Helios takes first element from resolved address list
             // on the DotNetty side we need to take the last one in order to be compatible
             return new IPEndPoint(resolved.AddressList[resolved.AddressList.Length - 1], address.Port);
@@ -396,7 +396,7 @@ namespace Akka.Remote.Transport.DotNetty
 
         private async Task<IPEndPoint> ResolveNameAsync(DnsEndPoint address, AddressFamily addressFamily)
         {
-            var resolved = await Dns.GetHostEntryAsync(address.Host);
+            var resolved = await Dns.GetHostEntryAsync(address.Host).ConfigureAwait(false);
             var found = resolved.AddressList.LastOrDefault(a => a.AddressFamily == addressFamily);
             if (found == null)
             {

--- a/src/core/Akka.Remote/Transport/DotNetty/TcpTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/TcpTransport.cs
@@ -186,10 +186,10 @@ namespace Akka.Remote.Transport.DotNetty
             {
                 var clientBootstrap = ClientFactory(remoteAddress);
                 var socketAddress = AddressToSocketAddress(remoteAddress);
-                socketAddress = await MapEndpointAsync(socketAddress);
-                var associate = await clientBootstrap.ConnectAsync(socketAddress);
+                socketAddress = await MapEndpointAsync(socketAddress).ConfigureAwait(false);
+                var associate = await clientBootstrap.ConnectAsync(socketAddress).ConfigureAwait(false);
                 var handler = (TcpClientHandler)associate.Pipeline.Last();
-                return await handler.StatusFuture;
+                return await handler.StatusFuture.ConfigureAwait(false);
             }
             catch (AggregateException e) when (e.InnerException is ConnectException)
             {
@@ -217,7 +217,7 @@ namespace Akka.Remote.Transport.DotNetty
 
             var dns = socketAddress as DnsEndPoint;
             if (dns != null)
-                ipEndPoint = await DnsToIPEndpoint(dns);
+                ipEndPoint = await DnsToIPEndpoint(dns).ConfigureAwait(false);
             else
                 ipEndPoint = (IPEndPoint) socketAddress;
 

--- a/src/core/Akka.Remote/Transport/TransportAdapters.cs
+++ b/src/core/Akka.Remote/Transport/TransportAdapters.cs
@@ -275,7 +275,7 @@ namespace Akka.Remote.Transport
             {
                 var listenAddress = listenerTask.Result.Item1;
                 var listenerPromise = listenerTask.Result.Item2;
-                listenerPromise.TrySetResult(await InterceptListen(listenAddress, upstreamListenerPromise.Task));
+                listenerPromise.TrySetResult(await InterceptListen(listenAddress, upstreamListenerPromise.Task).ConfigureAwait(false));
                 return
                     new Tuple<Address, TaskCompletionSource<IAssociationEventListener>>(
                         SchemeAugmenter.AugmentScheme(listenAddress), upstreamListenerPromise);

--- a/src/core/Akka/Actor/ActorSelection.cs
+++ b/src/core/Akka/Actor/ActorSelection.cs
@@ -123,7 +123,7 @@ namespace Akka.Actor
         {
             try
             {
-                var identity = await this.Ask<ActorIdentity>(new Identify(null), timeout);
+                var identity = await this.Ask<ActorIdentity>(new Identify(null), timeout).ConfigureAwait(false);
                 if(identity.Subject == null)
                     throw new ActorNotFoundException("subject was null");
 

--- a/src/core/Akka/Pattern/CircuitBreaker.cs
+++ b/src/core/Akka/Pattern/CircuitBreaker.cs
@@ -138,9 +138,9 @@ namespace Akka.Pattern
         /// <typeparam name="T">TBD</typeparam>
         /// <param name="body">Call needing protected</param>
         /// <returns><see cref="Task"/> containing the call result</returns>
-        public async Task<T> WithCircuitBreaker<T>(Func<Task<T>> body)
+        public Task<T> WithCircuitBreaker<T>(Func<Task<T>> body)
         {
-            return await CurrentState.Invoke<T>(body);
+            return CurrentState.Invoke<T>(body);
         }
 
         /// <summary>
@@ -148,9 +148,9 @@ namespace Akka.Pattern
         /// </summary>
         /// <param name="body">Call needing protected</param>
         /// <returns><see cref="Task"/></returns>
-        public async Task WithCircuitBreaker(Func<Task> body)
+        public Task WithCircuitBreaker(Func<Task> body)
         {
-            await CurrentState.Invoke(body);
+            return CurrentState.Invoke(body);
         }
 
         /// <summary>

--- a/src/core/Akka/Pattern/CircuitBreakerState.cs
+++ b/src/core/Akka/Pattern/CircuitBreakerState.cs
@@ -106,13 +106,13 @@ namespace Akka.Pattern
         /// <param name="body">Implementation of the call that needs protected</param>
         /// <exception cref="OpenCircuitException">TBD</exception>
         /// <returns><see cref="Task"/> containing result of protected call</returns>
-        public override async Task<T> Invoke<T>(Func<Task<T>> body)
+        public override Task<T> Invoke<T>(Func<Task<T>> body)
         {
             if (!_lock.CompareAndSet(true, false))
             {
                 throw new OpenCircuitException();
             }
-            return await CallThrough(body);
+            return CallThrough(body);
         }
 
         /// <summary>
@@ -122,13 +122,13 @@ namespace Akka.Pattern
         /// <param name="body">Implementation of the call that needs protected</param>
         /// <exception cref="OpenCircuitException">TBD</exception>
         /// <returns><see cref="Task"/> containing result of protected call</returns>
-        public override async Task Invoke(Func<Task> body)
+        public override Task Invoke(Func<Task> body)
         {
             if (!_lock.CompareAndSet(true, false))
             {
                 throw new OpenCircuitException();
             }
-            await CallThrough(body);
+            return CallThrough(body);
         }
 
         /// <summary>
@@ -188,9 +188,9 @@ namespace Akka.Pattern
         /// <typeparam name="T">TBD</typeparam>
         /// <param name="body">Implementation of the call that needs protected</param>
         /// <returns><see cref="Task"/> containing result of protected call</returns>
-        public override async Task<T> Invoke<T>(Func<Task<T>> body)
+        public override Task<T> Invoke<T>(Func<Task<T>> body)
         {
-            return await CallThrough(body);
+            return CallThrough(body);
         }
 
         /// <summary>
@@ -198,9 +198,9 @@ namespace Akka.Pattern
         /// </summary>
         /// <param name="body">Implementation of the call that needs protected</param>
         /// <returns><see cref="Task"/> containing result of protected call</returns>
-        public override async Task Invoke(Func<Task> body)
+        public override Task Invoke(Func<Task> body)
         {
-            await CallThrough(body);
+            return CallThrough(body);
         }
 
         /// <summary>

--- a/src/core/Akka/Routing/TailChopping.cs
+++ b/src/core/Akka/Routing/TailChopping.cs
@@ -123,7 +123,7 @@ namespace Akka.Routing
                     try
                     {
 
-                        completion.TrySetResult(await ((Task<object>)_routees[currentIndex].Ask(message, _within)));
+                        completion.TrySetResult(await ((Task<object>)_routees[currentIndex].Ask(message, _within)).ConfigureAwait(false));
                     }
                     catch (TaskCanceledException)
                     {

--- a/src/core/Akka/Util/Internal/AtomicState.cs
+++ b/src/core/Akka/Util/Internal/AtomicState.cs
@@ -67,7 +67,7 @@ namespace Akka.Util.Internal
                             listener.Invoke();
                         }
                     }
-                );
+                ).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace Akka.Util.Internal
             T result = default(T);
             try
             {
-                result = await task();
+                result = await task().ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -128,7 +128,7 @@ namespace Akka.Util.Internal
 
             try
             {
-                await task();
+                await task().ConfigureAwait(false);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
The first test passes, the second test blocks indefinitely (even though I passed a timeout!).

This is probably an issue with a missing ``.ConfigureAwait(false)``.

``SynchronizationContextHelper`` was copied from here: http://stackoverflow.com/questions/14087257/how-to-add-synchronization-context-to-async-test-method

