### PR TITLE
ActorPath.Elements optimization

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -166,7 +166,6 @@ namespace Akka.Actor
         protected ActorPath(Akka.Actor.ActorPath parentPath, string name, long uid) { }
         public Akka.Actor.Address Address { get; }
         public System.Collections.Generic.IReadOnlyList<string> Elements { get; }
-        public System.Collections.Generic.IReadOnlyList<string> ElementsWithUid { get; }
         public string Name { get; }
         public abstract Akka.Actor.ActorPath Parent { get; }
         public abstract Akka.Actor.ActorPath Root { get; }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -4902,6 +4902,12 @@ namespace Akka.Util
         public bool IsValueCreated { get; }
         public T Value { get; }
     }
+    public sealed class FastLazy<S, T>
+    {
+        public FastLazy(System.Func<S, T> producer, S state) { }
+        public bool IsValueCreated { get; }
+        public T Value { get; }
+    }
     public interface ILinearSeq<out T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
     {
         T Head { get; }

--- a/src/core/Akka/Actor/ActorCell.DeathWatch.cs
+++ b/src/core/Akka/Actor/ActorCell.DeathWatch.cs
@@ -120,7 +120,7 @@ namespace Akka.Actor
                 .GetWatchedBy()
                 .ToList();
 
-            if (!watchedBy.Any()) return;
+            if (watchedBy.Count == 0) return;
             try
             {
                 // Don't need to send to parent parent since it receives a DWN by default

--- a/src/core/Akka/Actor/Deployer.cs
+++ b/src/core/Akka/Actor/Deployer.cs
@@ -60,7 +60,7 @@ namespace Akka.Actor
                 return Deploy.None;
             }
 
-            var elements = rawElements.Skip(1);
+            var elements = rawElements.Drop(1);
             return Lookup(elements);
         }
 

--- a/src/core/Akka/Actor/Deployer.cs
+++ b/src/core/Akka/Actor/Deployer.cs
@@ -54,10 +54,13 @@ namespace Akka.Actor
         /// <returns>TBD</returns>
         public Deploy Lookup(ActorPath path)
         {
-            if (path.Elements.Head() != "user" || path.Elements.Count() < 2)
+            var rawElements = path.Elements;
+            if (rawElements[0] != "user" || rawElements.Count < 2)
+            {
                 return Deploy.None;
+            }
 
-            var elements = path.Elements.Drop(1);
+            var elements = rawElements.Skip(1);
             return Lookup(elements);
         }
 

--- a/src/core/Akka/Util/FastLazy.cs
+++ b/src/core/Akka/Util/FastLazy.cs
@@ -100,7 +100,7 @@ namespace Akka.Util
         private byte _created = 0;
         private byte _creating = 0;
         private T _createdValue;
-        private readonly S _state;
+        private S _state;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FastLazy{T}"/> class.
@@ -148,6 +148,7 @@ namespace Akka.Util
                     Volatile.Write(ref _creating, 1);
                     _createdValue = _producer(_state);
                     Volatile.Write(ref _created, 1);
+                    _state = default(S); // for reference types to make it suitable for gc
                 }
                 else
                 {

--- a/src/core/Akka/Util/FastLazy.cs
+++ b/src/core/Akka/Util/FastLazy.cs
@@ -81,5 +81,80 @@ namespace Akka.Util
             }
         }
     }
-}
 
+
+    /// <summary>
+    /// A fast, atomic lazy that only allows a single publish operation to happen,
+    /// but allows executions to occur concurrently.
+    /// 
+    /// Does not cache exceptions. Designed for use with <typeparamref name="T"/> types that are <see cref="IDisposable"/>
+    /// or are otherwise considered to be expensive to allocate. 
+    /// 
+    /// Read the full explanation here: https://github.com/Aaronontheweb/FastAtomicLazy#rationale
+    /// </summary>
+    /// <typeparam name="S">State type</typeparam>
+    /// <typeparam name="T">Value type</typeparam>
+    public sealed class FastLazy<S, T>
+    {
+        private readonly Func<S, T> _producer;
+        private byte _created = 0;
+        private byte _creating = 0;
+        private T _createdValue;
+        private readonly S _state;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FastLazy{T}"/> class.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// This exception is thrown if the given <paramref name="producer"/> or <paramref name="state"/> is undefined.
+        /// </exception>
+        public FastLazy(Func<S, T> producer, S state)
+        {
+            if(producer == null) throw new ArgumentNullException(nameof(producer), "Producer cannot be null");
+            if(state == null) throw new ArgumentNullException(nameof(state), "State cannot be null");
+            _producer = producer;
+            _state = state;
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <returns>TBD</returns>
+        public bool IsValueCreated => IsValueCreatedInternal();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool IsValueCreatedInternal()
+        {
+            return Volatile.Read(ref _created) == 1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool IsValueCreationInProgress()
+        {
+            return Volatile.Read(ref _creating) == 1;
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public T Value
+        {
+            get
+            {
+                if (IsValueCreatedInternal())
+                    return _createdValue;
+                if (!IsValueCreationInProgress())
+                {
+                    Volatile.Write(ref _creating, 1);
+                    _createdValue = _producer(_state);
+                    Volatile.Write(ref _created, 1);
+                }
+                else
+                {
+                    SpinWait.SpinUntil(IsValueCreatedInternal);
+                }
+                return _createdValue;
+            }
+        }
+    }
+}

--- a/src/core/Akka/Util/Internal/Extensions.cs
+++ b/src/core/Akka/Util/Internal/Extensions.cs
@@ -36,7 +36,7 @@ namespace Akka.Util.Internal
         /// <returns>TBD</returns>
         public static IEnumerable<T> Drop<T>(this IEnumerable<T> self, int count)
         {
-            return self.Skip(count).ToList();
+            return self.Skip(count);
         }
 
         /// <summary>


### PR DESCRIPTION
Fix for #2539
Based on @alexvaluyskiy idea.
The trick is reusing `Parent`'s cached elements.

Can't compare two snapshots in dotMemory, hence two different screenshots.

Baseline:
![default](https://cloud.githubusercontent.com/assets/6948307/23828498/70ba8710-06e4-11e7-9cca-756d6584a267.png)

Optimization:
![default](https://cloud.githubusercontent.com/assets/6948307/23828500/8eec1294-06e4-11e7-8e4f-afe5a64bf681.png)
