### PR TITLE
Stop ClusterClient ResponseTunnel after first reply when ask is used

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/ClusterClient/ClusterClientSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/ClusterClient/ClusterClientSpec.cs
@@ -110,18 +110,18 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.Client
 
             public sealed class LatestContactPoints : INoSerializationVerificationNeeded
             {
-                public LatestContactPoints(ImmutableHashSet<ActorPath> contactPoints)
+                public LatestContactPoints(IImmutableSet<ActorPath> contactPoints)
                 {
                     ContactPoints = contactPoints;
                 }
 
-                public ImmutableHashSet<ActorPath> ContactPoints { get; }
+                public IImmutableSet<ActorPath> ContactPoints { get; }
             }
 
             #endregion
 
             private readonly IActorRef _targetClient;
-            private ImmutableHashSet<ActorPath> _contactPoints;
+            private IImmutableSet<ActorPath> _contactPoints;
 
             public TestClientListener(IActorRef targetClient)
             {
@@ -169,17 +169,17 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.Client
 
             public sealed class LatestClusterClients : INoSerializationVerificationNeeded
             {
-                public LatestClusterClients(ImmutableHashSet<IActorRef> clusterClients)
+                public LatestClusterClients(IImmutableSet<IActorRef> clusterClients)
                 {
                     ClusterClients = clusterClients;
                 }
 
-                public ImmutableHashSet<IActorRef> ClusterClients { get; }
+                public IImmutableSet<IActorRef> ClusterClients { get; }
             }
             #endregion
 
             private readonly IActorRef _targetReceptionist;
-            private ImmutableHashSet<IActorRef> _clusterClients;
+            private IImmutableSet<IActorRef> _clusterClients;
 
             public TestReceptionistListener(IActorRef targetReceptionist)
             {
@@ -602,7 +602,7 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.Client
                 RunOn(() =>
                 {
                     _remainingServerRoleNames.Count.Should().Be(1);
-                    var remainingContacts = _remainingServerRoleNames.Select(r => Node(r) / "system" / "receptionist").ToList();
+                    var remainingContacts = _remainingServerRoleNames.Select(r => Node(r) / "system" / "receptionist").ToImmutableHashSet();
                     var c = Sys.ActorOf(ClusterClient.Props(ClusterClientSettings.Create(Sys).WithInitialContacts(remainingContacts)), "client4");
 
                     c.Tell(new ClusterClient.Send("/user/service2", "bonjour4", localAffinity: true));

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/ClusterClient/ClusterClientSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/ClusterClient/ClusterClientSpec.cs
@@ -284,7 +284,7 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.Client
             ClusterClient_must_communicate_to_any_node_in_cluster();
             ClusterClient_must_work_with_ask();
             ClusterClient_must_demonstrate_usage();
-            ClusterClient_must_report_events();
+            //ClusterClient_must_report_events();
             //ClusterClient_must_reestablish_connection_to_another_receptionist_when_server_is_shutdown();
             //ClusterClient_must_reestablish_connection_to_receptionist_after_partition();
             //ClusterClient_must_reestablish_connection_to_receptionist_after_server_restart();

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/ClusterClient/ClusterClientConfigSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/ClusterClient/ClusterClientConfigSpec.cs
@@ -13,6 +13,7 @@ using Akka.Configuration;
 using Akka.TestKit;
 using Xunit;
 using FluentAssertions;
+using System.Collections.Immutable;
 
 namespace Akka.Cluster.Tools.Tests.ClusterClient
 {
@@ -55,7 +56,7 @@ namespace Akka.Cluster.Tools.Tests.ClusterClient
         public void ClusterClientSettings_must_throw_exception_on_empty_initial_contacts()
         {
             var clusterClientSettings = ClusterClientSettings.Create(Sys);
-            var exception = Assert.Throws<ArgumentException>(() => clusterClientSettings.WithInitialContacts(Enumerable.Empty<ActorPath>()));
+            var exception = Assert.Throws<ArgumentException>(() => clusterClientSettings.WithInitialContacts(ImmutableHashSet<ActorPath>.Empty));
             exception.Message.Should().Be("InitialContacts must be defined");
         }
 

--- a/src/contrib/cluster/Akka.Cluster.Tools/Client/ClusterClient.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Client/ClusterClient.cs
@@ -640,7 +640,7 @@ namespace Akka.Cluster.Tools.Client
         /// TBD
         /// </summary>
         /// <param name="contactPoints">TBD</param>
-        public ContactPoints(ImmutableHashSet<ActorPath> contactPoints)
+        public ContactPoints(IImmutableSet<ActorPath> contactPoints)
         {
             ContactPointsList = contactPoints;
         }
@@ -648,6 +648,6 @@ namespace Akka.Cluster.Tools.Client
         /// <summary>
         /// TBD
         /// </summary>
-        public ImmutableHashSet<ActorPath> ContactPointsList { get; }
+        public IImmutableSet<ActorPath> ContactPointsList { get; }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Tools/Client/ClusterClientSettings.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Client/ClusterClientSettings.cs
@@ -154,18 +154,6 @@ namespace Akka.Cluster.Tools.Client
         /// <summary>
         /// TBD
         /// </summary>
-        /// <param name="initialContacts">TBD</param>
-        /// <exception cref="ArgumentException">TBD</exception>
-        /// <returns>TBD</returns>
-        [Obsolete("Use WithInitialContacts(IImmutableSet<ActorPath> initialContacts) instead")]
-        public ClusterClientSettings WithInitialContacts(IEnumerable<ActorPath> initialContacts)
-        {
-            return WithInitialContacts(initialContacts.ToImmutableHashSet());
-        }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
         /// <param name="value">TBD</param>
         /// <returns>TBD</returns>
         public ClusterClientSettings WithEstablishingGetContactsInterval(TimeSpan value)

--- a/src/contrib/cluster/Akka.Cluster.Tools/Client/ClusterReceptionist.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Client/ClusterReceptionist.cs
@@ -130,7 +130,7 @@ namespace Akka.Cluster.Tools.Client
         /// The reply to <see cref="GetClusterClients"/>
         /// </summary>
         /// <param name="clusterClientsList">The presently known list of cluster clients.</param>
-        public ClusterClients(ImmutableHashSet<IActorRef> clusterClientsList)
+        public ClusterClients(IImmutableSet<IActorRef> clusterClientsList)
         {
             ClusterClientsList = clusterClientsList;
         }
@@ -138,7 +138,7 @@ namespace Akka.Cluster.Tools.Client
         /// <summary>
         /// TBD
         /// </summary>
-        public ImmutableHashSet<IActorRef> ClusterClientsList { get; }
+        public IImmutableSet<IActorRef> ClusterClientsList { get; }
     }
 
     /// <summary>

--- a/src/contrib/cluster/Akka.Cluster.Tools/Client/ClusterReceptionist.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Client/ClusterReceptionist.cs
@@ -625,9 +625,20 @@ namespace Akka.Cluster.Tools.Client
                 _log.Debug("ClientResponseTunnel for client [{0}] stopped due to inactivity", _client.Path);
                 Context.Stop(Self);
             }
-            else _client.Tell(message, ActorRefs.NoSender);
+            else
+            {
+                _client.Tell(message, ActorRefs.NoSender);
+                if (IsAsk())
+                    Context.Stop(Self);
+            }
 
             return true;
+        }
+
+        private bool IsAsk()
+        {
+            var pathElements = _client.Path.Elements;
+            return pathElements.Count == 2 && pathElements[0] == "temp" && pathElements.Last().StartsWith("$");
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedMessages.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedMessages.cs
@@ -8,6 +8,8 @@
 using System;
 using Akka.Actor;
 using Akka.Event;
+using System.Collections.Immutable;
+using System.Linq;
 
 namespace Akka.Cluster.Tools.PublishSubscribe
 {
@@ -693,15 +695,15 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         /// <summary>
         /// TBD
         /// </summary>
-        public string[] Topics { get; }
+        public IImmutableSet<string> Topics { get; }
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="topics">TBD</param>
-        public CurrentTopics(string[] topics)
+        public CurrentTopics(IImmutableSet<string> topics)
         {
-            Topics = topics ?? new string[0];
+            Topics = topics ?? ImmutableHashSet<string>.Empty;
         }
 
         /// <summary>
@@ -714,7 +716,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
             if (ReferenceEquals(other, null)) return false;
             if (ReferenceEquals(other, this)) return true;
 
-            return Equals(Topics, other.Topics);
+            return Topics.SequenceEqual(other.Topics);
         }
 
         /// <summary>

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubMediator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubMediator.cs
@@ -268,7 +268,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
             });
             Receive<GetTopics>(getTopics =>
             {
-                Sender.Tell(new CurrentTopics(GetCurrentTopics().ToArray()));
+                Sender.Tell(new CurrentTopics(GetCurrentTopics().ToImmutableHashSet()));
             });
             Receive<Subscribed>(subscribed =>
             {

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManager.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManager.cs
@@ -582,7 +582,7 @@ namespace Akka.Cluster.Tools.Singleton
         protected override void PreStart()
         {
             // subscribe to cluster changes, re-subscribe when restart
-            _cluster.Subscribe(Self, typeof(ClusterEvent.MemberExited), typeof(ClusterEvent.MemberRemoved));
+            _cluster.Subscribe(Self, ClusterEvent.InitialStateAsEvents, typeof(ClusterEvent.MemberExited), typeof(ClusterEvent.MemberRemoved));
 
             SetTimer(CleanupTimer, Cleanup.Instance, TimeSpan.FromMinutes(1.0), repeat: true);
 
@@ -1060,7 +1060,6 @@ namespace Akka.Cluster.Tools.Singleton
             WhenUnhandled(e =>
             {
                 var removed = e.FsmEvent as ClusterEvent.MemberRemoved;
-                if (e.FsmEvent is ClusterEvent.CurrentClusterState) return Stay();
                 if (e.FsmEvent is SelfExiting)
                 {
                     SelfMemberExited();

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/OldestChangedBuffer.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/OldestChangedBuffer.cs
@@ -155,8 +155,10 @@ namespace Akka.Cluster.Tools.Singleton
 
         private void Add(Member member)
         {
+            // replace, it's possible that the upNumber is changed
             if (MatchingRole(member))
                 TrackChanges(() => _membersByAge = _membersByAge.Add(member));
+
         }
 
         private void Remove(Member member)

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/OldestChangedBuffer.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/OldestChangedBuffer.cs
@@ -155,10 +155,8 @@ namespace Akka.Cluster.Tools.Singleton
 
         private void Add(Member member)
         {
-            // replace, it's possible that the upNumber is changed
             if (MatchingRole(member))
                 TrackChanges(() => _membersByAge = _membersByAge.Add(member));
-
         }
 
         private void Remove(Member member)

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveClusterTools.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveClusterTools.approved.txt
@@ -50,8 +50,8 @@ namespace Akka.Cluster.Tools.Client
     }
     public sealed class ClusterClients
     {
-        public ClusterClients(System.Collections.Immutable.ImmutableHashSet<Akka.Actor.IActorRef> clusterClientsList) { }
-        public System.Collections.Immutable.ImmutableHashSet<Akka.Actor.IActorRef> ClusterClientsList { get; }
+        public ClusterClients(System.Collections.Immutable.IImmutableSet<Akka.Actor.IActorRef> clusterClientsList) { }
+        public System.Collections.Immutable.IImmutableSet<Akka.Actor.IActorRef> ClusterClientsList { get; }
     }
     public sealed class ClusterClientSettings : Akka.Actor.INoSerializationVerificationNeeded
     {
@@ -69,8 +69,6 @@ namespace Akka.Cluster.Tools.Client
         public Akka.Cluster.Tools.Client.ClusterClientSettings WithEstablishingGetContactsInterval(System.TimeSpan value) { }
         public Akka.Cluster.Tools.Client.ClusterClientSettings WithHeartbeatInterval(System.TimeSpan value) { }
         public Akka.Cluster.Tools.Client.ClusterClientSettings WithInitialContacts(System.Collections.Immutable.IImmutableSet<Akka.Actor.ActorPath> initialContacts) { }
-        [System.ObsoleteAttribute("Use WithInitialContacts(IImmutableSet<ActorPath> initialContacts) instead")]
-        public Akka.Cluster.Tools.Client.ClusterClientSettings WithInitialContacts(System.Collections.Generic.IEnumerable<Akka.Actor.ActorPath> initialContacts) { }
         public Akka.Cluster.Tools.Client.ClusterClientSettings WithReconnectTimeout(System.Nullable<System.TimeSpan> reconnectTimeout) { }
         public Akka.Cluster.Tools.Client.ClusterClientSettings WithRefreshContactsInterval(System.TimeSpan value) { }
     }
@@ -121,8 +119,8 @@ namespace Akka.Cluster.Tools.Client
     }
     public sealed class ContactPoints
     {
-        public ContactPoints(System.Collections.Immutable.ImmutableHashSet<Akka.Actor.ActorPath> contactPoints) { }
-        public System.Collections.Immutable.ImmutableHashSet<Akka.Actor.ActorPath> ContactPointsList { get; }
+        public ContactPoints(System.Collections.Immutable.IImmutableSet<Akka.Actor.ActorPath> contactPoints) { }
+        public System.Collections.Immutable.IImmutableSet<Akka.Actor.ActorPath> ContactPointsList { get; }
     }
     public sealed class GetClusterClients
     {
@@ -165,8 +163,8 @@ namespace Akka.Cluster.Tools.PublishSubscribe
 {
     public sealed class CurrentTopics : System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.CurrentTopics>
     {
-        public CurrentTopics(string[] topics) { }
-        public string[] Topics { get; }
+        public CurrentTopics(System.Collections.Immutable.IImmutableSet<string> topics) { }
+        public System.Collections.Immutable.IImmutableSet<string> Topics { get; }
         public bool Equals(Akka.Cluster.Tools.PublishSubscribe.CurrentTopics other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }

--- a/src/core/Akka.Cluster.Tests.MultiNode/SurviveNetworkInstabilitySpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/SurviveNetworkInstabilitySpec.cs
@@ -101,20 +101,11 @@ namespace Akka.Cluster.Tests.MultiNode
         }
     }
 
-    public class SurviveNetworkInstabilityMultiNode1 : SurviveNetworkInstabilitySpec { }
-    public class SurviveNetworkInstabilityMultiNode2 : SurviveNetworkInstabilitySpec { }
-    public class SurviveNetworkInstabilityMultiNode3 : SurviveNetworkInstabilitySpec { }
-    public class SurviveNetworkInstabilityMultiNode4 : SurviveNetworkInstabilitySpec { }
-    public class SurviveNetworkInstabilityMultiNode5 : SurviveNetworkInstabilitySpec { }
-    public class SurviveNetworkInstabilityMultiNode6 : SurviveNetworkInstabilitySpec { }
-    public class SurviveNetworkInstabilityMultiNode7 : SurviveNetworkInstabilitySpec { }
-    public class SurviveNetworkInstabilityMultiNode8 : SurviveNetworkInstabilitySpec { }
-
-    public abstract class SurviveNetworkInstabilitySpec : MultiNodeClusterSpec
+    public class SurviveNetworkInstabilitySpec : MultiNodeClusterSpec
     {
         private readonly SurviveNetworkInstabilitySpecConfig _config;
 
-        protected SurviveNetworkInstabilitySpec()
+        public SurviveNetworkInstabilitySpec()
             : this(new SurviveNetworkInstabilitySpecConfig())
         {
         }


### PR DESCRIPTION
- [stop ClusterClient ResponseTunnel after first reply when ask is used](https://github.com/akka/akka/pull/22123) [2.4.17]
- [minor cleanup of cluster.subscribe usage](https://github.com/akka/akka/pull/21813) [2.4.14] 
- the last public API changes