### PR TITLE
Increase timeout for NBench target in build.fsx

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -365,7 +365,7 @@ Target "NBench" <| fun _ ->
         let result = ExecProcess(fun info -> 
             info.FileName <- nbenchTestPath
             info.WorkingDirectory <- (Path.GetDirectoryName (FullName nbenchTestPath))
-            info.Arguments <- args) (System.TimeSpan.FromMinutes 25.0) (* Reasonably long-running task. *)
+            info.Arguments <- args) (System.TimeSpan.FromMinutes 45.0) (* Reasonably long-running task. *)
         if result <> 0 then failwithf "NBench.Runner failed. %s %s" nbenchTestPath args
     
     nbenchTestAssemblies |> Seq.iter (runNBench)


### PR DESCRIPTION
Increase timeout for NBench task used in Performance Tests by TeamCity CI from 25 minutes to 45 minutes in build.fsx