### PR TITLE
Akka Fsm Update

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -720,6 +720,7 @@ namespace Akka.Actor
         public TState StateName { get; }
         public void CancelTimer(string name) { }
         public Akka.Actor.FSMBase.State<TState, TData> GoTo(TState nextStateName) { }
+        [System.ObsoleteAttribute("This method is obsoleted. Use GoTo(nextStateName).Using(newStateData) [1.2.0]")]
         public Akka.Actor.FSMBase.State<TState, TData> GoTo(TState nextStateName, TData stateData) { }
         public void Initialize() { }
         public bool IsTimerActive(string name) { }
@@ -750,52 +751,59 @@ namespace Akka.Actor
     public abstract class FSMBase : Akka.Actor.ActorBase
     {
         protected FSMBase() { }
-        public class CurrentState<TS>
+        public sealed class CurrentState<TS>
         {
             public CurrentState(Akka.Actor.IActorRef fsmRef, TS state) { }
             public Akka.Actor.IActorRef FsmRef { get; }
             public TS State { get; }
+            public override bool Equals(object obj) { }
+            public override int GetHashCode() { }
+            public override string ToString() { }
         }
-        public class Event<TD> : Akka.Actor.INoSerializationVerificationNeeded
+        public sealed class Event<TD> : Akka.Actor.INoSerializationVerificationNeeded
         {
             public Event(object fsmEvent, TD stateData) { }
             public object FsmEvent { get; }
             public TD StateData { get; }
             public override string ToString() { }
         }
-        public class Failure : Akka.Actor.FSMBase.Reason
+        public sealed class Failure : Akka.Actor.FSMBase.Reason
         {
             public Failure(object cause) { }
             public object Cause { get; }
         }
-        public class LogEntry<TS, TD>
+        public sealed class LogEntry<TS, TD>
         {
             public LogEntry(TS stateName, TD stateData, object fsmEvent) { }
             public object FsmEvent { get; }
             public TD StateData { get; }
             public TS StateName { get; }
+            public override string ToString() { }
         }
-        public class Normal : Akka.Actor.FSMBase.Reason
+        public sealed class Normal : Akka.Actor.FSMBase.Reason
         {
+            [System.ObsoleteAttribute("This constructor is obsoleted. Use Normal.Instance [1.2.0]")]
             public Normal() { }
+            public static Akka.Actor.FSMBase.Normal Instance { get; }
         }
         public abstract class Reason
         {
             protected Reason() { }
         }
-        public class Shutdown : Akka.Actor.FSMBase.Reason
+        public sealed class Shutdown : Akka.Actor.FSMBase.Reason
         {
+            [System.ObsoleteAttribute("This constructor is obsoleted. Use Shutdown.Instance [1.2.0]")]
             public Shutdown() { }
+            public static Akka.Actor.FSMBase.Shutdown Instance { get; }
         }
         public class State<TS, TD> : System.IEquatable<Akka.Actor.FSMBase.State<TS, TD>>
         {
-            public State(TS stateName, TD stateData, System.Nullable<System.TimeSpan> timeout = null, Akka.Actor.FSMBase.Reason stopReason = null, System.Collections.Generic.List<object> replies = null) { }
-            public System.Collections.Generic.List<object> Replies { get; set; }
+            public State(TS stateName, TD stateData, System.Nullable<System.TimeSpan> timeout = null, Akka.Actor.FSMBase.Reason stopReason = null, System.Collections.Generic.IReadOnlyCollection<object> replies = null, bool notifies = True) { }
+            public System.Collections.Generic.IReadOnlyCollection<object> Replies { get; set; }
             public TD StateData { get; }
             public TS StateName { get; }
             public Akka.Actor.FSMBase.Reason StopReason { get; }
             public System.Nullable<System.TimeSpan> Timeout { get; }
-            public Akka.Actor.FSMBase.State<TS, TD> Copy(System.Nullable<System.TimeSpan> timeout, Akka.Actor.FSMBase.Reason stopReason = null, System.Collections.Generic.List<object> replies = null) { }
             public bool Equals(Akka.Actor.FSMBase.State<TS, TD> other) { }
             public override bool Equals(object obj) { }
             public Akka.Actor.FSMBase.State<TS, TD> ForMax(System.TimeSpan timeout) { }
@@ -804,31 +812,36 @@ namespace Akka.Actor
             public override string ToString() { }
             public Akka.Actor.FSMBase.State<TS, TD> Using(TD nextStateData) { }
         }
-        public class StateTimeout
+        public sealed class StateTimeout
         {
+            [System.ObsoleteAttribute("This constructor is obsoleted. Use Shutdown.Instance [1.2.0]")]
             public StateTimeout() { }
+            public static Akka.Actor.FSMBase.StateTimeout Instance { get; }
         }
-        public class StopEvent<TS, TD> : Akka.Actor.INoSerializationVerificationNeeded
+        public sealed class StopEvent<TS, TD> : Akka.Actor.INoSerializationVerificationNeeded
         {
             public StopEvent(Akka.Actor.FSMBase.Reason reason, TS terminatedState, TD stateData) { }
             public Akka.Actor.FSMBase.Reason Reason { get; }
             public TD StateData { get; }
             public TS TerminatedState { get; }
+            public override string ToString() { }
         }
-        public class SubscribeTransitionCallBack
+        public sealed class SubscribeTransitionCallBack
         {
             public SubscribeTransitionCallBack(Akka.Actor.IActorRef actorRef) { }
             public Akka.Actor.IActorRef ActorRef { get; }
         }
-        public class Transition<TS>
+        public sealed class Transition<TS>
         {
             public Transition(Akka.Actor.IActorRef fsmRef, TS from, TS to) { }
             public TS From { get; }
             public Akka.Actor.IActorRef FsmRef { get; }
             public TS To { get; }
+            public override bool Equals(object obj) { }
+            public override int GetHashCode() { }
             public override string ToString() { }
         }
-        public class UnsubscribeTransitionCallBack
+        public sealed class UnsubscribeTransitionCallBack
         {
             public UnsubscribeTransitionCallBack(Akka.Actor.IActorRef actorRef) { }
             public Akka.Actor.IActorRef ActorRef { get; }
@@ -3952,7 +3965,7 @@ namespace Akka.Routing
         protected CustomRouterConfig() { }
         protected CustomRouterConfig(string routerDispatcher) { }
     }
-    public class Deafen : Akka.Routing.ListenerMessage
+    public sealed class Deafen : Akka.Routing.ListenerMessage
     {
         public Deafen(Akka.Actor.IActorRef listener) { }
         public Akka.Actor.IActorRef Listener { get; }
@@ -4020,7 +4033,7 @@ namespace Akka.Routing
     {
         Akka.Routing.ListenerSupport Listeners { get; }
     }
-    public class Listen : Akka.Routing.ListenerMessage
+    public sealed class Listen : Akka.Routing.ListenerMessage
     {
         public Listen(Akka.Actor.IActorRef listener) { }
         public Akka.Actor.IActorRef Listener { get; }
@@ -4386,7 +4399,7 @@ namespace Akka.Routing
             public Akka.Util.ISurrogated FromSurrogate(Akka.Actor.ActorSystem system) { }
         }
     }
-    public class WithListeners : Akka.Routing.ListenerMessage
+    public sealed class WithListeners : Akka.Routing.ListenerMessage
     {
         public WithListeners(System.Action<Akka.Actor.IActorRef> listenerFunction) { }
         public System.Action<Akka.Actor.IActorRef> ListenerFunction { get; }
@@ -5073,7 +5086,7 @@ namespace Akka.Util.Internal
         public static string BetweenDoubleQuotes(this string self) { }
         public static System.Collections.Generic.IEnumerable<T> Concat<T>(this System.Collections.Generic.IEnumerable<T> enumerable, T item) { }
         public static System.Collections.Generic.IEnumerable<T> Drop<T>(this System.Collections.Generic.IEnumerable<T> self, int count) { }
-        public static void ForEach<T>(this System.Collections.Generic.IEnumerable<T> enumerable, System.Action<T> action) { }
+        public static void ForEach<T>(this System.Collections.Generic.IEnumerable<T> source, System.Action<T> action) { }
         public static TValue GetOrElse<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> hash, TKey key, TValue elseValue) { }
         public static T GetOrElse<T>(this T obj, T elseValue) { }
         public static T Head<T>(this System.Collections.Generic.IEnumerable<T> self) { }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -798,8 +798,8 @@ namespace Akka.Actor
         }
         public class State<TS, TD> : System.IEquatable<Akka.Actor.FSMBase.State<TS, TD>>
         {
-            public State(TS stateName, TD stateData, System.Nullable<System.TimeSpan> timeout = null, Akka.Actor.FSMBase.Reason stopReason = null, System.Collections.Generic.IReadOnlyCollection<object> replies = null, bool notifies = True) { }
-            public System.Collections.Generic.IReadOnlyCollection<object> Replies { get; set; }
+            public State(TS stateName, TD stateData, System.Nullable<System.TimeSpan> timeout = null, Akka.Actor.FSMBase.Reason stopReason = null, System.Collections.Generic.IReadOnlyList<object> replies = null, bool notifies = True) { }
+            public System.Collections.Generic.IReadOnlyList<object> Replies { get; set; }
             public TD StateData { get; }
             public TS StateName { get; }
             public Akka.Actor.FSMBase.Reason StopReason { get; }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
@@ -854,7 +854,7 @@ namespace Akka.Persistence.Fsm
             public System.Action<TData> AfterTransitionHandler { get; }
             public Akka.Util.ILinearSeq<TEvent> DomainEvents { get; }
             public bool Notifies { get; set; }
-            public System.Collections.Generic.IReadOnlyCollection<object> Replies { get; }
+            public System.Collections.Generic.IReadOnlyList<object> Replies { get; }
             public TData StateData { get; }
             public TState StateName { get; }
             public Akka.Actor.FSMBase.Reason StopReason { get; }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
@@ -830,14 +830,14 @@ namespace Akka.Persistence.Fsm
         public void WhenUnhandled(Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.StateFunction stateFunction) { }
         public class State<TState, TData, TEvent> : Akka.Actor.FSMBase.State<TState, TData>
         {
-            public State(TState stateName, TData stateData, System.Nullable<System.TimeSpan> timeout = null, Akka.Actor.FSMBase.Reason stopReason = null, System.Collections.Generic.List<object> replies = null, Akka.Util.ILinearSeq<TEvent> domainEvents = null, System.Action<TData> afterTransitionDo = null) { }
+            public State(TState stateName, TData stateData, System.Nullable<System.TimeSpan> timeout = null, Akka.Actor.FSMBase.Reason stopReason = null, System.Collections.Generic.IReadOnlyCollection<object> replies = null, Akka.Util.ILinearSeq<TEvent> domainEvents = null, System.Action<TData> afterTransitionDo = null) { }
             public System.Action<TData> AfterTransitionHandler { get; }
             public Akka.Util.ILinearSeq<TEvent> DomainEvents { get; }
-            public bool Notifies { get; set; }
+            public new bool Notifies { get; set; }
             public Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.State AndThen(System.Action<TData> handler) { }
             public Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.State Applying(Akka.Util.ILinearSeq<TEvent> events) { }
             public Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.State Applying(TEvent e) { }
-            public Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.State Copy(System.Nullable<System.TimeSpan> timeout, Akka.Actor.FSMBase.Reason stopReason = null, System.Collections.Generic.List<object> replies = null, Akka.Util.ILinearSeq<TEvent> domainEvents = null, System.Action<TData> afterTransitionDo = null) { }
+            public Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.State Copy(System.Nullable<System.TimeSpan> timeout, Akka.Actor.FSMBase.Reason stopReason = null, System.Collections.Generic.IReadOnlyCollection<object> replies = null, Akka.Util.ILinearSeq<TEvent> domainEvents = null, System.Action<TData> afterTransitionDo = null) { }
             public Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.State ForMax(System.TimeSpan timeout) { }
             public Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.State Replying(object replyValue) { }
             public Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.State Using(TData nextStateData) { }
@@ -854,7 +854,7 @@ namespace Akka.Persistence.Fsm
             public System.Action<TData> AfterTransitionHandler { get; }
             public Akka.Util.ILinearSeq<TEvent> DomainEvents { get; }
             public bool Notifies { get; set; }
-            public System.Collections.Generic.List<object> Replies { get; }
+            public System.Collections.Generic.IReadOnlyCollection<object> Replies { get; }
             public TData StateData { get; }
             public TState StateName { get; }
             public Akka.Actor.FSMBase.Reason StopReason { get; }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
@@ -830,14 +830,14 @@ namespace Akka.Persistence.Fsm
         public void WhenUnhandled(Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.StateFunction stateFunction) { }
         public class State<TState, TData, TEvent> : Akka.Actor.FSMBase.State<TState, TData>
         {
-            public State(TState stateName, TData stateData, System.Nullable<System.TimeSpan> timeout = null, Akka.Actor.FSMBase.Reason stopReason = null, System.Collections.Generic.IReadOnlyCollection<object> replies = null, Akka.Util.ILinearSeq<TEvent> domainEvents = null, System.Action<TData> afterTransitionDo = null) { }
+            public State(TState stateName, TData stateData, System.Nullable<System.TimeSpan> timeout = null, Akka.Actor.FSMBase.Reason stopReason = null, System.Collections.Generic.IReadOnlyList<object> replies = null, Akka.Util.ILinearSeq<TEvent> domainEvents = null, System.Action<TData> afterTransitionDo = null) { }
             public System.Action<TData> AfterTransitionHandler { get; }
             public Akka.Util.ILinearSeq<TEvent> DomainEvents { get; }
             public new bool Notifies { get; set; }
             public Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.State AndThen(System.Action<TData> handler) { }
             public Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.State Applying(Akka.Util.ILinearSeq<TEvent> events) { }
             public Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.State Applying(TEvent e) { }
-            public Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.State Copy(System.Nullable<System.TimeSpan> timeout, Akka.Actor.FSMBase.Reason stopReason = null, System.Collections.Generic.IReadOnlyCollection<object> replies = null, Akka.Util.ILinearSeq<TEvent> domainEvents = null, System.Action<TData> afterTransitionDo = null) { }
+            public Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.State Copy(System.Nullable<System.TimeSpan> timeout, Akka.Actor.FSMBase.Reason stopReason = null, System.Collections.Generic.IReadOnlyList<object> replies = null, Akka.Util.ILinearSeq<TEvent> domainEvents = null, System.Action<TData> afterTransitionDo = null) { }
             public Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.State ForMax(System.TimeSpan timeout) { }
             public Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.State Replying(object replyValue) { }
             public Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.State Using(TData nextStateData) { }

--- a/src/core/Akka.Persistence/Fsm/PersistentFSMBase.cs
+++ b/src/core/Akka.Persistence/Fsm/PersistentFSMBase.cs
@@ -1059,7 +1059,7 @@ namespace Akka.Persistence.Fsm
             /// <summary>
             /// TBD
             /// </summary>
-            public IReadOnlyCollection<object> Replies
+            public IReadOnlyList<object> Replies
             {
                 get
                 {

--- a/src/core/Akka.Persistence/Fsm/PersistentFSMBase.cs
+++ b/src/core/Akka.Persistence/Fsm/PersistentFSMBase.cs
@@ -245,7 +245,7 @@ namespace Akka.Persistence.Fsm
         /// <returns>TBD</returns>
         public State Stop()
         {
-            return Stop(new FSMBase.Normal());
+            return Stop(FSMBase.Normal.Instance);
         }
 
         /// <summary>
@@ -659,7 +659,7 @@ namespace Akka.Persistence.Fsm
              * Setting this instance's state to Terminated does no harm during restart, since
              * the new instance will initialize fresh using StartWith.
              */
-            Terminate(Stay().WithStopReason(new FSMBase.Shutdown()));
+            Terminate(Stay().WithStopReason(FSMBase.Shutdown.Instance));
             base.PostStop();
         }
 
@@ -1059,7 +1059,7 @@ namespace Akka.Persistence.Fsm
             /// <summary>
             /// TBD
             /// </summary>
-            public List<object> Replies
+            public IReadOnlyCollection<object> Replies
             {
                 get
                 {
@@ -1137,7 +1137,7 @@ namespace Akka.Persistence.Fsm
             /// <param name="domainEvents">TBD</param>
             /// <param name="afterTransitionDo">TBD</param>
             public State(TState stateName, TData stateData, TimeSpan? timeout = null, FSMBase.Reason stopReason = null,
-                List<object> replies = null, ILinearSeq<TEvent> domainEvents = null, Action<TData> afterTransitionDo = null)
+                IReadOnlyList<object> replies = null, ILinearSeq<TEvent> domainEvents = null, Action<TData> afterTransitionDo = null)
                 : base(stateName, stateData, timeout, stopReason, replies)
             {
                 AfterTransitionHandler = afterTransitionDo;
@@ -1208,7 +1208,7 @@ namespace Akka.Persistence.Fsm
             /// <param name="afterTransitionDo">TBD</param>
             /// <returns>TBD</returns>
             public State Copy(TimeSpan? timeout, FSMBase.Reason stopReason = null,
-                List<object> replies = null, ILinearSeq<TEvent> domainEvents = null, Action<TData> afterTransitionDo = null)
+                IReadOnlyList<object> replies = null, ILinearSeq<TEvent> domainEvents = null, Action<TData> afterTransitionDo = null)
             {
                 return new State(StateName, StateData, timeout ?? Timeout, stopReason ?? StopReason,
                     replies ?? Replies,

--- a/src/core/Akka.Remote.TestKit/BarrierCoordinator.cs
+++ b/src/core/Akka.Remote.TestKit/BarrierCoordinator.cs
@@ -482,7 +482,7 @@ namespace Akka.Remote.TestKit
                         //we only allow the deadlines to get shorter
                         if (enterDeadline.TimeLeft < @event.StateData.Deadline.TimeLeft)
                         {
-                            SetTimer("Timeout", new StateTimeout(), enterDeadline.TimeLeft, false);
+                            SetTimer("Timeout", StateTimeout.Instance, enterDeadline.TimeLeft, false);
                             nextState = HandleBarrier(@event.StateData.Copy(arrived: together, deadline: enterDeadline));
                         }
                         else
@@ -516,7 +516,7 @@ namespace Akka.Remote.TestKit
 
             OnTransition((state, nextState) =>
             {
-                if (state == State.Idle && nextState == State.Waiting) SetTimer("Timeout", new StateTimeout(), NextStateData.Deadline.TimeLeft, false);
+                if (state == State.Idle && nextState == State.Waiting) SetTimer("Timeout", StateTimeout.Instance, NextStateData.Deadline.TimeLeft, false);
                 else if(state == State.Waiting && nextState == State.Idle) CancelTimer("Timeout");
             });
 

--- a/src/core/Akka.Tests/Actor/FSMActorSpec.cs
+++ b/src/core/Akka.Tests/Actor/FSMActorSpec.cs
@@ -1,0 +1,566 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="FSMActorSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Akka.Actor;
+using Akka.Actor.Internal;
+using Akka.Event;
+using Akka.TestKit;
+using FluentAssertions;
+using Xunit;
+using static Akka.Actor.FSMBase;
+
+namespace Akka.Tests.Actor
+{
+    public class FSMActorSpec : AkkaSpec
+    {
+        #region Actors
+        public class Latches
+        {
+            public Latches(ActorSystem system)
+            {
+                UnlockedLatch = new TestLatch();
+                LockedLatch = new TestLatch();
+                UnhandledLatch = new TestLatch();
+                TerminatedLatch = new TestLatch();
+                TransitionLatch = new TestLatch();
+                InitialStateLatch = new TestLatch();
+                TransitionCallBackLatch = new TestLatch();
+            }
+
+            public TestLatch UnlockedLatch { get; }
+
+            public TestLatch LockedLatch { get; }
+
+            public TestLatch UnhandledLatch { get; }
+
+            public TestLatch TerminatedLatch { get; }
+
+            public TestLatch TransitionLatch { get; }
+
+            public TestLatch InitialStateLatch { get; }
+
+            public TestLatch TransitionCallBackLatch { get; }
+        }
+        public enum LockState
+        {
+            Locked,
+            Open
+        }
+
+        public sealed class CodeState
+        {
+            public CodeState(string soFar, string code)
+            {
+                SoFar = soFar;
+                Code = code;
+            }
+
+            public string SoFar { get; }
+
+            public string Code { get; }
+        }
+
+        public class Hello
+        {
+            public static Hello Instance { get; } = new Hello();
+
+            private Hello() { }
+        }
+
+        public class Bye
+        {
+            public static Bye Instance { get; } = new Bye();
+
+            private Bye() { }
+        }
+
+        public class Lock : FSM<LockState, CodeState>
+        {
+            private readonly Latches _latches;
+            private readonly ILoggingAdapter Log = Context.GetLogger();
+
+            public Lock(string code, TimeSpan timeout, Latches latches)
+            {
+                var code1 = code;
+                _latches = latches;
+                StartWith(LockState.Locked, new CodeState("", code1));
+
+                When(LockState.Locked, evt =>
+                {
+                    if (evt.FsmEvent is char)
+                    {
+                        var codeState = evt.StateData;
+                        if (codeState.Code == code1)
+                        {
+                            DoUnlock();
+                            return GoTo(LockState.Open).Using(new CodeState("", codeState.Code)).ForMax(timeout);
+                        }
+                    }
+                    else if (evt.FsmEvent.Equals("hello"))
+                    {
+                        return Stay().Replying("world");
+                    }
+                    else if (evt.FsmEvent.Equals("bey"))
+                    {
+                        return Stop(Shutdown.Instance);
+                    }
+
+                    return null;
+                });
+
+                When(LockState.Open, evt =>
+                {
+                    if (evt.FsmEvent is StateTimeout)
+                    {
+                        DoLock();
+                        return GoTo(LockState.Locked);
+                    }
+
+                    return null;
+                });
+
+                WhenUnhandled(evt =>
+                {
+                    var msg = evt.FsmEvent;
+                    Log.Warning($"unhandled event {msg} in state {StateName} with data {StateData}");
+                    latches.UnhandledLatch.Open();
+                    return Stay();
+                });
+
+                OnTransition((state, nextState) =>
+                {
+                    if (state == LockState.Locked && nextState == LockState.Open)
+                    {
+                        _latches.TransitionLatch.Open();
+                    }
+                });
+
+                OnTermination(evt =>
+                {
+                    if (evt.Reason == Shutdown.Instance && evt.TerminatedState == LockState.Locked)
+                    {
+                        // stop is called from lockstate with shutdown as reason...
+                        latches.TerminatedLatch.Open();
+                    }
+                });
+
+                Initialize();
+            }
+
+            private void DoLock()
+            {
+                _latches.LockedLatch.Open();
+            }
+
+            private void DoUnlock()
+            {
+                _latches.UnlockedLatch.Open();
+            }
+        }
+
+        public class TransitionTester : UntypedActor
+        {
+            private readonly Latches _latches;
+
+            public TransitionTester(Latches latches)
+            {
+                _latches = latches;
+            }
+
+            protected override void OnReceive(object message)
+            {
+                if (message is Transition<object>)
+                {
+                    _latches.TransitionCallBackLatch.Open();
+                }
+                else if (message is CurrentState<LockState>)
+                {
+                    _latches.InitialStateLatch.Open();
+                }
+            }
+        }
+
+        public class AnswerTester : UntypedActor
+        {
+            private readonly TestLatch _answerLatch;
+            private readonly IActorRef _lockFsm;
+
+            public AnswerTester(TestLatch answerLatch, IActorRef lockFsm)
+            {
+                _answerLatch = answerLatch;
+                _lockFsm = lockFsm;
+            }
+
+            protected override void OnReceive(object message)
+            {
+                if (message is Hello)
+                {
+                    _lockFsm.Tell("hello");
+                }
+                else if (message.Equals("world"))
+                {
+                    _answerLatch.Open();
+                }
+                else if (message is Bye)
+                {
+                    _lockFsm.Tell("bye");
+                }
+            }
+        }
+
+        public class ActorLogTermination : FSM<int, object>
+        {
+            public ActorLogTermination()
+            {
+                StartWith(1, null);
+
+                When(1, evt =>
+                {
+                    if (evt.FsmEvent.Equals("go"))
+                    {
+                        return GoTo(2);
+                    }
+                    return null;
+                });
+            }
+        }
+
+        public class ActorStopTermination : FSM<int, object>
+        {
+            private readonly TestLatch _testLatch;
+
+            public ActorStopTermination(TestLatch testLatch, IActorRef testActor)
+            {
+                _testLatch = testLatch;
+
+                StartWith(1, null);
+
+                When(1, evt => null);
+
+                OnTermination(x =>
+                {
+                    testActor.Tell(x);
+                });
+            }
+
+            protected override void PreStart()
+            {
+                _testLatch.CountDown();
+            }
+        }
+
+        public class ActorStopReason : FSM<int, object>
+        {
+            public ActorStopReason(string expected, IActorRef testActor)
+            {
+                StartWith(1, null);
+
+                When(1, evt =>
+                {
+                    if (evt.FsmEvent.Equals(2))
+                    {
+                        return Stop(Normal.Instance, expected);
+                    }
+
+                    return null;
+                });
+
+                OnTermination(x =>
+                {
+                    if (x.Reason is Normal 
+                        && x.TerminatedState == 1 
+                        && x.StateData.Equals(expected))
+                    {
+                        testActor.Tell("green");
+                    }
+                });
+            }
+        }
+
+        public class StopTimersFSM : FSM<string, object>
+        {
+            public StopTimersFSM(IActorRef testActor, List<string> timerNames)
+            {
+                StartWith("not-started", null);
+
+                When("not-started", evt =>
+                {
+                    if (evt.FsmEvent.Equals("start"))
+                    {
+                        return GoTo("started").Replying("starting");
+                    }
+
+                    return null;
+                });
+
+                When("started", evt =>
+                {
+                    if (evt.FsmEvent.Equals("stop"))
+                    {
+                        return Stop();
+                    }
+
+                    return null;
+                }, 10.Seconds());
+
+                OnTransition((state1, state2) =>
+                {
+                    if (state1.Equals("not-started") && state2.Equals("started"))
+                    {
+                        foreach (var timerName in timerNames)
+                        {
+                            SetTimer(timerName, new object(), 10.Seconds(), false);
+                        }
+                    }
+                });
+
+                OnTermination(x =>
+                {
+                    foreach (var timerName in timerNames)
+                    {
+                        IsTimerActive(timerName).Should().BeFalse();
+                        var intern = (IInternalSupportsTestFSMRef<string, object>)this;
+                        intern.IsStateTimerActive.Should().BeFalse();
+                    }
+                    testActor.Tell("stopped");
+                });
+            }
+        }
+
+        public class RollingEventLogFsm : FSM<int, int>, ILoggingFSM
+        {
+            public RollingEventLogFsm()
+            {
+                StartWith(1, 0);
+
+                When(1, evt =>
+                {
+                    if (evt.FsmEvent.Equals("count"))
+                    {
+                        return Stay().Using(evt.StateData + 1);
+                    }
+                    else if (evt.FsmEvent.Equals("log"))
+                    {
+                        return Stay().Replying("getlog");
+                    }
+
+                    return null;
+                });
+            }
+        }
+
+        public class TransformingStateFsm : FSM<int, int>
+        {
+            public TransformingStateFsm()
+            {
+                StartWith(0, 0);
+
+                When(0, evt =>
+                {
+                    return Transform(evt2 =>
+                    {
+                        if (evt2.FsmEvent.Equals("go"))
+                            return Stay();
+
+                        return null;
+                    }).Using(state =>
+                    {
+                        return GoTo(1);
+                    })(evt);
+                });
+
+                When(1, evt =>
+                {
+                    return Stay();
+                });
+            }
+        }
+
+        public const string OverrideInitState = "init";
+        public const string OverrideTimeoutToInf = "override-timeout-to-inf";
+        public class CancelStateTimeoutFsm : FSM<string, string>
+        {
+            public CancelStateTimeoutFsm(TestProbe p)
+            {
+                StartWith(OverrideInitState, "");
+
+                When(OverrideInitState, evt =>
+                {
+                    if (evt.FsmEvent is StateTimeout)
+                    {
+                        p.Ref.Tell(StateTimeout.Instance);
+                        return Stay();
+                    }
+
+                    if (evt.FsmEvent.Equals(OverrideTimeoutToInf))
+                    {
+                        p.Ref.Tell(OverrideTimeoutToInf);
+                        return Stay().ForMax(TimeSpan.MaxValue);
+                    }
+
+                    return null;
+                }, 1.Seconds());
+
+                Initialize();
+            }
+        }
+
+        #endregion
+
+        [Fact(Skip = "Not implemented yet")]
+        public void FSMActor_must_unlock_the_lock()
+        {
+            var latches = new Latches(Sys);
+            var timeout = 2.Seconds();
+            var lockFsm = Sys.ActorOf(Props.Create(() => new Lock("33221", 1.Seconds(), latches)));
+            var transitionTester = Sys.ActorOf(Props.Create(() => new TransitionTester(latches)));
+            lockFsm.Tell(new SubscribeTransitionCallBack(transitionTester));
+            latches.InitialStateLatch.Ready(timeout);
+
+            lockFsm.Tell('3');
+            lockFsm.Tell('3');
+            lockFsm.Tell('2');
+            lockFsm.Tell('2');
+            lockFsm.Tell('1');
+
+            latches.UnlockedLatch.Ready(timeout);
+            latches.TransitionLatch.Ready(timeout);
+            latches.TransitionCallBackLatch.Ready(timeout);
+            latches.LockedLatch.Ready(timeout);
+
+            EventFilter.Warning("unhandled event").ExpectOne(() =>
+            {
+                lockFsm.Tell("not_handled");
+                latches.UnhandledLatch.Ready(timeout);
+            });
+
+            var answerLatch = new TestLatch();
+            var tester = Sys.ActorOf(Props.Create(() => new AnswerTester(answerLatch, lockFsm)));
+            tester.Tell(Hello.Instance);
+            answerLatch.Ready(timeout);
+
+            tester.Tell(Bye.Instance);
+            latches.TerminatedLatch.Ready(timeout);
+        }
+
+        [Fact]
+        public void FSMActor_must_log_termination()
+        {
+            var actorRef = Sys.ActorOf(Props.Create(() => new ActorLogTermination()));
+            var name = actorRef.Path.ToStringWithUid();
+            EventFilter.Error("Next state 2 does not exist").ExpectOne(() =>
+            {
+                Sys.EventStream.Subscribe(TestActor, typeof(Error));
+                actorRef.Tell("go");
+                var error = ExpectMsg<Error>(1.Seconds());
+                error.LogSource.Should().Contain(name);
+                error.Message.Should().Be("Next state 2 does not exist");
+                Sys.EventStream.Unsubscribe(TestActor);
+            });
+        }
+
+        [Fact]
+        public void FSMActor_must_run_onTermination_upon_ActorRef_Stop()
+        {
+            var started = new TestLatch(1);
+            var actorRef = Sys.ActorOf(Props.Create(() => new ActorStopTermination(started, TestActor)));
+            started.Ready();
+            Sys.Stop(actorRef);
+            var stopEvent = ExpectMsg<StopEvent<int, object>>(1.Seconds());
+            stopEvent.Reason.Should().BeOfType<Shutdown>();
+            stopEvent.TerminatedState.Should().Be(1);
+        }
+
+        [Fact]
+        public void FSMActor_must_run_onTermination_with_updated_state_upon_stop()
+        {
+            var expected = "pigdog";
+            var actorRef = Sys.ActorOf(Props.Create(() => new ActorStopReason(expected, TestActor)));
+            actorRef.Tell(2);
+            ExpectMsg("green");
+        }
+
+        [Fact]
+        public void FSMActor_must_cancel_all_timers_when_terminated()
+        {
+            var timerNames = new List<string> {"timer-1", "timer-2", "timer-3"};
+
+            var fsmRef = new TestFSMRef<StopTimersFSM, string, object>(Sys, Props.Create(
+                () => new StopTimersFSM(TestActor, timerNames)));
+
+            Action<bool> checkTimersActive = active =>
+            {
+                foreach (var timer in timerNames)
+                {
+                    fsmRef.IsTimerActive(timer).Should().Be(active);
+                    fsmRef.IsStateTimerActive().Should().Be(active);
+                }
+            };
+
+            checkTimersActive(false);
+
+            fsmRef.Tell("start");
+            ExpectMsg("starting", 1.Seconds());
+            checkTimersActive(true);
+
+            fsmRef.Tell("stop");
+            ExpectMsg("stopped", 1.Seconds());
+        }
+
+        [Fact(Skip = "Not implemented yet")]
+        public void FSMActor_must_log_events_and_transitions_if_asked_to_do_so()
+        {
+        }
+
+        [Fact(Skip = "Does not pass due to LoggingFsm limitations")]
+        public void FSMActor_must_fill_rolling_event_log_and_hand_it_out()
+        {
+            var fsmRef = new TestActorRef<RollingEventLogFsm>(Sys, Props.Create<RollingEventLogFsm>());
+            fsmRef.Tell("log");
+            ExpectMsg<object>(1.Seconds());
+            fsmRef.Tell("count");
+            fsmRef.Tell("log");
+            ExpectMsg<object>(1.Seconds());
+            fsmRef.Tell("count");
+            fsmRef.Tell("log");
+            ExpectMsg<object>(1.Seconds());
+        }
+
+        [Fact]
+        public void FSMActor_must_allow_transforming_of_state_results()
+        {
+            var fsmRef = Sys.ActorOf(Props.Create<TransformingStateFsm>());
+            fsmRef.Tell(new SubscribeTransitionCallBack(TestActor));
+            fsmRef.Tell("go");
+            ExpectMsg(new CurrentState<int>(fsmRef, 0));
+            ExpectMsg(new Transition<int>(fsmRef, 0, 1));
+        }
+
+        [Fact(Skip = "Not implemented yet")]
+        public void FSMActor_must_allow_cancelling_stateTimeout_by_issuing_forMax()
+        {
+            var sys = ActorSystem.Create("fsmEvent", Sys.Settings.Config);
+            var p = CreateTestProbe(sys);
+
+            var fsmRef = sys.ActorOf(Props.Create(() => new CancelStateTimeoutFsm(p)));
+
+            try
+            {
+                p.ExpectMsg<StateTimeout>();
+                fsmRef.Tell(OverrideTimeoutToInf);
+                p.ExpectMsg(OverrideTimeoutToInf);
+                p.ExpectNoMsg(3.Seconds());
+            }
+            finally
+            {
+                sys.WhenTerminated.Wait();
+            }
+        }
+    }
+}

--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Actor\CoordinatedShutdownSpec.cs" />
     <Compile Include="Actor\Dispatch\ActorModelSpec.cs" />
     <Compile Include="Actor\Dispatch\CurrentSynchronizationContextDispatcherSpecs.cs" />
+    <Compile Include="Actor\FSMActorSpec.cs" />
     <Compile Include="Actor\HotSwapSpec.cs" />
     <Compile Include="Actor\DeadLetterSupressionSpec.cs" />
     <Compile Include="Actor\InboxSpec.cs" />

--- a/src/core/Akka/Actor/FSM.cs
+++ b/src/core/Akka/Actor/FSM.cs
@@ -9,9 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
 using Akka.Actor.Internal;
-using Akka.Dispatch.SysMsg;
 using Akka.Event;
 using Akka.Pattern;
 using Akka.Routing;
@@ -31,10 +29,10 @@ namespace Akka.Actor
         /// before sending any <see cref="Transition{TS}"/> messages.
         /// </summary>
         /// <typeparam name="TS">The type of the state being used in this finite state machine.</typeparam>
-        public class CurrentState<TS>
+        public sealed class CurrentState<TS>
         {
             /// <summary>
-            /// TBD
+            /// Initializes a new instance of the CurrentState
             /// </summary>
             /// <param name="fsmRef">TBD</param>
             /// <param name="state">TBD</param>
@@ -47,12 +45,39 @@ namespace Akka.Actor
             /// <summary>
             /// TBD
             /// </summary>
-            public IActorRef FsmRef { get; private set; }
+            public IActorRef FsmRef { get; }
 
             /// <summary>
             /// TBD
             /// </summary>
-            public TS State { get; private set; }
+            public TS State { get; }
+
+            #region Equality
+            private bool Equals(CurrentState<TS> other)
+            {
+                return Equals(FsmRef, other.FsmRef) && EqualityComparer<TS>.Default.Equals(State, other.State);
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(null, obj)) return false;
+                if (ReferenceEquals(this, obj)) return true;
+                return obj is CurrentState<TS> && Equals((CurrentState<TS>)obj);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return ((FsmRef != null ? FsmRef.GetHashCode() : 0) * 397) ^ EqualityComparer<TS>.Default.GetHashCode(State);
+                }
+            }
+
+            public override string ToString()
+            {
+                return $"CurrentState <{State}>";
+            }
+            #endregion
         }
 
         /// <summary>
@@ -60,35 +85,59 @@ namespace Akka.Actor
         /// (use <see cref="SubscribeTransitionCallBack"/>)
         /// </summary>
         /// <typeparam name="TS">The type of state used</typeparam>
-        public class Transition<TS>
+        public sealed class Transition<TS>
         {
             /// <summary>
-            /// TBD
+            /// Initializes a new instance of the Transition
             /// </summary>
             /// <param name="fsmRef">TBD</param>
             /// <param name="from">TBD</param>
             /// <param name="to">TBD</param>
-            public Transition(IActorRef fsmRef, TS @from, TS to)
+            public Transition(IActorRef fsmRef, TS from, TS to)
             {
                 To = to;
-                From = @from;
+                From = from;
                 FsmRef = fsmRef;
             }
 
             /// <summary>
             /// TBD
             /// </summary>
-            public IActorRef FsmRef { get; private set; }
+            public IActorRef FsmRef { get; }
 
             /// <summary>
             /// TBD
             /// </summary>
-            public TS From { get; private set; }
+            public TS From { get; }
 
             /// <summary>
             /// TBD
             /// </summary>
-            public TS To { get; private set; }
+            public TS To { get; }
+
+            #region Equality
+            private bool Equals(Transition<TS> other)
+            {
+                return Equals(FsmRef, other.FsmRef) && EqualityComparer<TS>.Default.Equals(From, other.From) && EqualityComparer<TS>.Default.Equals(To, other.To);
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(null, obj)) return false;
+                if (ReferenceEquals(this, obj)) return true;
+                return obj is Transition<TS> && Equals((Transition<TS>)obj);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hashCode = (FsmRef != null ? FsmRef.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ EqualityComparer<TS>.Default.GetHashCode(From);
+                    hashCode = (hashCode * 397) ^ EqualityComparer<TS>.Default.GetHashCode(To);
+                    return hashCode;
+                }
+            }
 
             /// <summary>
             /// TBD
@@ -96,8 +145,10 @@ namespace Akka.Actor
             /// <returns>TBD</returns>
             public override string ToString()
             {
-                return String.Format("Transition({0}, {1})", From, To);
+                return $"Transition({From}, {To})";
             }
+
+            #endregion
         }
 
         /// <summary>
@@ -105,10 +156,10 @@ namespace Akka.Actor
         /// followed by a series of <see cref="Transition{TS}"/> updates. Cancel the subscription using
         /// <see cref="CurrentState{TS}"/>.
         /// </summary>
-        public class SubscribeTransitionCallBack
+        public sealed class SubscribeTransitionCallBack
         {
             /// <summary>
-            /// TBD
+            /// Initializes a new instance of the SubscribeTransitionCallBack
             /// </summary>
             /// <param name="actorRef">TBD</param>
             public SubscribeTransitionCallBack(IActorRef actorRef)
@@ -119,17 +170,17 @@ namespace Akka.Actor
             /// <summary>
             /// TBD
             /// </summary>
-            public IActorRef ActorRef { get; private set; }
+            public IActorRef ActorRef { get; }
         }
 
         /// <summary>
         /// Unsubscribe from <see cref="SubscribeTransitionCallBack"/> notifications which were
         /// initialized by sending the corresponding <see cref="Transition{TS}"/>.
         /// </summary>
-        public class UnsubscribeTransitionCallBack
+        public sealed class UnsubscribeTransitionCallBack
         {
             /// <summary>
-            /// TBD
+            /// Initializes a new instance of the UnsubscribeTransitionCallBack
             /// </summary>
             /// <param name="actorRef">TBD</param>
             public UnsubscribeTransitionCallBack(IActorRef actorRef)
@@ -140,7 +191,7 @@ namespace Akka.Actor
             /// <summary>
             /// TBD
             /// </summary>
-            public IActorRef ActorRef { get; private set; }
+            public IActorRef ActorRef { get; }
         }
 
         /// <summary>
@@ -151,23 +202,45 @@ namespace Akka.Actor
         /// <summary>
         /// Default <see cref="Reason"/> if calling Stop().
         /// </summary>
-        public class Normal : Reason { }
+        public sealed class Normal : Reason
+        {
+            [Obsolete("This constructor is obsoleted. Use Normal.Instance [1.2.0]")]
+            public Normal() { }
+
+            /// <summary>
+            /// Singleton instance of Normal
+            /// </summary>
+#pragma warning disable 618
+            public static Normal Instance { get; } = new Normal();
+#pragma warning restore 618
+        }
 
         /// <summary>
-        /// Reason given when someone as calling <see cref="Stop"/> from outside;
+        /// Reason given when someone as calling <see cref="FSM{TState,TData}.Stop()"/> from outside;
         /// also applies to <see cref="ActorSystem"/> supervision directive.
         /// </summary>
-        public class Shutdown : Reason { }
+        public sealed class Shutdown : Reason
+        {
+            [Obsolete("This constructor is obsoleted. Use Shutdown.Instance [1.2.0]")]
+            public Shutdown() { }
+
+            /// <summary>
+            /// Singleton instance of Shutdown
+            /// </summary>
+#pragma warning disable 618
+            public static Shutdown Instance { get; } = new Shutdown();
+#pragma warning restore 618
+        }
 
         /// <summary>
         /// Signifies that the <see cref="FSM{T,S}"/> is shutting itself down because of an error,
         /// e.g. if the state to transition into does not exist. You can use this to communicate a more
         /// precise cause to the <see cref="FSM{T,S}.OnTermination"/> block.
         /// </summary>
-        public class Failure : Reason
+        public sealed class Failure : Reason
         {
             /// <summary>
-            /// TBD
+            /// Initializes a new instance of the Failure
             /// </summary>
             /// <param name="cause">TBD</param>
             public Failure(object cause)
@@ -178,22 +251,29 @@ namespace Akka.Actor
             /// <summary>
             /// TBD
             /// </summary>
-            public object Cause { get; private set; }
+            public object Cause { get; }
         }
 
         /// <summary>
         /// Used in the event of a timeout between transitions
         /// </summary>
-        public class StateTimeout { }
+        public sealed class StateTimeout
+        {
+            [Obsolete("This constructor is obsoleted. Use Shutdown.Instance [1.2.0]")]
+            public StateTimeout() { }
 
-        /*
-         * INTERNAL API - used for ensuring that state changes occur on-time
-         */
+            /// <summary>
+            /// Singleton instance of StateTimeout
+            /// </summary>
+#pragma warning disable 618
+            public static StateTimeout Instance { get; } = new StateTimeout();
+#pragma warning restore 618
+        }
 
         /// <summary>
-        /// TBD
+        /// INTERNAL API
         /// </summary>
-        internal class TimeoutMarker
+        internal sealed class TimeoutMarker
         {
             /// <summary>
             /// TBD
@@ -207,17 +287,18 @@ namespace Akka.Actor
             /// <summary>
             /// TBD
             /// </summary>
-            public long Generation { get; private set; }
+            public long Generation { get; }
         }
 
         /// <summary>
-        /// TBD
+        /// INTERNAL API
         /// </summary>
-        [DebuggerDisplay("Timer {Name,nq}, message: {Message")]
+        [DebuggerDisplay("Timer {Name,nq}, message: {Message}")]
         internal class Timer : INoSerializationVerificationNeeded
         {
-            private readonly ILoggingAdapter _debugLog;
-
+            private ICancelable _ref;
+            private readonly IScheduler _scheduler;
+            
             /// <summary>
             /// TBD
             /// </summary>
@@ -226,47 +307,41 @@ namespace Akka.Actor
             /// <param name="repeat">TBD</param>
             /// <param name="generation">TBD</param>
             /// <param name="context">TBD</param>
-            /// <param name="debugLog">TBD</param>
-            public Timer(string name, object message, bool repeat, int generation, IActorContext context, ILoggingAdapter debugLog)
+            public Timer(string name, object message, bool repeat, int generation, IActorContext context)
             {
-                _debugLog = debugLog;
                 Context = context;
                 Generation = generation;
                 Repeat = repeat;
                 Message = message;
                 Name = name;
-                var scheduler = context.System.Scheduler;
-                _scheduler = scheduler;
-                _ref = new Cancelable(scheduler);
+
+                _scheduler = context.System.Scheduler;
             }
 
-            private readonly IScheduler _scheduler;
-            private readonly ICancelable _ref;
+            /// <summary>
+            /// TBD
+            /// </summary>
+            public string Name { get; }
 
             /// <summary>
             /// TBD
             /// </summary>
-            public string Name { get; private set; }
+            public object Message { get; }
 
             /// <summary>
             /// TBD
             /// </summary>
-            public object Message { get; private set; }
+            public bool Repeat { get; }
 
             /// <summary>
             /// TBD
             /// </summary>
-            public bool Repeat { get; private set; }
+            public int Generation { get; }
 
             /// <summary>
             /// TBD
             /// </summary>
-            public int Generation { get; private set; }
-
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public IActorContext Context { get; private set; }
+            public IActorContext Context { get; }
 
             /// <summary>
             /// TBD
@@ -275,21 +350,9 @@ namespace Akka.Actor
             /// <param name="timeout">TBD</param>
             public void Schedule(IActorRef actor, TimeSpan timeout)
             {
-                var name = Name;
-                var message = Message;
-
-                Action send;
-                if(_debugLog != null)
-                    send = () =>
-                    {
-                        _debugLog.Debug("{0}Timer '{1}' went off. Sending {2} -> {3}",_ref.IsCancellationRequested ? "Cancelled " : "", name, message, actor);
-                        actor.Tell(this, Context.Self);
-                    };
-                else
-                    send = () => actor.Tell(this, Context.Self);
-
-                if(Repeat) _scheduler.Advanced.ScheduleRepeatedly(timeout, timeout, send, _ref);
-                else _scheduler.Advanced.ScheduleOnce(timeout, send, _ref);
+                _ref = Repeat 
+                    ? _scheduler.ScheduleTellRepeatedlyCancelable(timeout, timeout, actor, this, Context.Self) 
+                    : _scheduler.ScheduleTellOnceCancelable(timeout, actor, this, Context.Self);
             }
 
             /// <summary>
@@ -297,9 +360,10 @@ namespace Akka.Actor
             /// </summary>
             public void Cancel()
             {
-                if (!_ref.IsCancellationRequested)
+                if (_ref != null)
                 {
                     _ref.Cancel(false);
+                    _ref = null;
                 }
             }
         }
@@ -309,10 +373,10 @@ namespace Akka.Actor
         /// </summary>
         /// <typeparam name="TS">The name of the state</typeparam>
         /// <typeparam name="TD">The data of the state</typeparam>
-        public class LogEntry<TS, TD>
+        public sealed class LogEntry<TS, TD>
         {
             /// <summary>
-            /// TBD
+            /// Initializes a new instance of the LogEntry
             /// </summary>
             /// <param name="stateName">TBD</param>
             /// <param name="stateData">TBD</param>
@@ -327,17 +391,26 @@ namespace Akka.Actor
             /// <summary>
             /// TBD
             /// </summary>
-            public TS StateName { get; private set; }
+            public TS StateName { get; }
 
             /// <summary>
             /// TBD
             /// </summary>
-            public TD StateData { get; private set; }
+            public TD StateData { get; }
 
             /// <summary>
             /// TBD
             /// </summary>
-            public object FsmEvent { get; private set; }
+            public object FsmEvent { get; }
+
+            /// <summary>
+            /// TBD
+            /// </summary>
+            /// <returns>TBD</returns>
+            public override string ToString()
+            {
+                return $"StateName: <{StateName}>, StateData: <{StateData}>, FsmEvent: <{FsmEvent}>";
+            }
         }
 
         /// <summary>
@@ -350,46 +423,52 @@ namespace Akka.Actor
         public class State<TS, TD> : IEquatable<State<TS, TD>>
         {
             /// <summary>
-            /// TBD
+            /// Initializes a new instance of the State
             /// </summary>
             /// <param name="stateName">TBD</param>
             /// <param name="stateData">TBD</param>
             /// <param name="timeout">TBD</param>
             /// <param name="stopReason">TBD</param>
             /// <param name="replies">TBD</param>
-            public State(TS stateName, TD stateData, TimeSpan? timeout = null, Reason stopReason = null, List<object> replies = null)
+            public State(TS stateName, TD stateData, TimeSpan? timeout = null, Reason stopReason = null, IReadOnlyList<object> replies = null, bool notifies = true)
             {
                 Replies = replies ?? new List<object>();
                 StopReason = stopReason;
                 Timeout = timeout;
                 StateData = stateData;
                 StateName = stateName;
+                Notifies = notifies;
             }
 
             /// <summary>
             /// TBD
             /// </summary>
-            public TS StateName { get; private set; }
+            public TS StateName { get; }
 
             /// <summary>
             /// TBD
             /// </summary>
-            public TD StateData { get; private set; }
+            public TD StateData { get; }
 
             /// <summary>
             /// TBD
             /// </summary>
-            public TimeSpan? Timeout { get; private set; }
+            public TimeSpan? Timeout { get; }
 
             /// <summary>
             /// TBD
             /// </summary>
-            public Reason StopReason { get; private set; }
+            public Reason StopReason { get; }
 
             /// <summary>
             /// TBD
             /// </summary>
-            public List<object> Replies { get; protected set; }
+            public IReadOnlyList<object> Replies { get; protected set; }
+
+            /// <summary>
+            /// TBD
+            /// </summary>
+            internal bool Notifies { get; }
 
             /// <summary>
             /// TBD
@@ -398,9 +477,9 @@ namespace Akka.Actor
             /// <param name="stopReason">TBD</param>
             /// <param name="replies">TBD</param>
             /// <returns>TBD</returns>
-            public State<TS, TD> Copy(TimeSpan? timeout, Reason stopReason = null, List<object> replies = null)
+            internal State<TS, TD> Copy(TimeSpan? timeout, Reason stopReason = null, IReadOnlyList<object> replies = null)
             {
-                return new State<TS, TD>(StateName, StateData, timeout, stopReason ?? StopReason, replies ?? Replies);
+                return new State<TS, TD>(StateName, StateData, timeout, stopReason ?? StopReason, replies ?? Replies, Notifies);
             }
 
             /// <summary>
@@ -412,7 +491,8 @@ namespace Akka.Actor
             /// <returns>TBD</returns>
             public State<TS, TD> ForMax(TimeSpan timeout)
             {
-                if (timeout <= TimeSpan.MaxValue) return Copy(timeout);
+                if (timeout <= TimeSpan.MaxValue)
+                    return Copy(timeout);
                 return Copy(timeout: null);
             }
 
@@ -423,9 +503,10 @@ namespace Akka.Actor
             /// <returns>TBD</returns>
             public State<TS, TD> Replying(object replyValue)
             {
-                if (Replies == null) Replies = new List<object>();
-                var newReplies = Replies.ToArray().ToList();
+                var newReplies = new List<object>(Replies.Count + 1);
                 newReplies.Add(replyValue);
+                newReplies.AddRange(Replies);
+
                 return Copy(Timeout, replies: newReplies);
             }
 
@@ -437,7 +518,7 @@ namespace Akka.Actor
             /// <returns>TBD</returns>
             public State<TS, TD> Using(TD nextStateData)
             {
-                return new State<TS, TD>(StateName, nextStateData, Timeout, StopReason, Replies);
+                return new State<TS, TD>(StateName, nextStateData, Timeout, StopReason, Replies, Notifies);
             }
 
             /// <summary>
@@ -451,12 +532,20 @@ namespace Akka.Actor
             }
 
             /// <summary>
+            /// INTERNAL API
+            /// </summary>
+            internal State<TS, TD> WithNotification(bool notifies)
+            {
+                return new State<TS, TD>(StateName, StateData, Timeout, StopReason, Replies, notifies);
+            }
+
+            /// <summary>
             /// TBD
             /// </summary>
             /// <returns>TBD</returns>
             public override string ToString()
             {
-                return StateName + ", " + StateData;
+                return $"{StateName}, {StateData}";
             }
 
             /// <summary>
@@ -466,8 +555,8 @@ namespace Akka.Actor
             /// <returns>TBD</returns>
             public bool Equals(State<TS, TD> other)
             {
-                if(ReferenceEquals(null, other)) return false;
-                if(ReferenceEquals(this, other)) return true;
+                if (ReferenceEquals(null, other)) return false;
+                if (ReferenceEquals(this, other)) return true;
                 return EqualityComparer<TS>.Default.Equals(StateName, other.StateName) && EqualityComparer<TD>.Default.Equals(StateData, other.StateData) && Timeout.Equals(other.Timeout) && Equals(StopReason, other.StopReason) && Equals(Replies, other.Replies);
             }
 
@@ -478,9 +567,9 @@ namespace Akka.Actor
             /// <returns>TBD</returns>
             public override bool Equals(object obj)
             {
-                if(ReferenceEquals(null, obj)) return false;
-                if(ReferenceEquals(this, obj)) return true;
-                if(obj.GetType() != GetType()) return false;
+                if (ReferenceEquals(null, obj)) return false;
+                if (ReferenceEquals(this, obj)) return true;
+                if (obj.GetType() != GetType()) return false;
                 return Equals((State<TS, TD>)obj);
             }
 
@@ -507,10 +596,10 @@ namespace Akka.Actor
         /// which allows pattern matching to extract both state and data.
         /// </summary>
         /// <typeparam name="TD">The state data for this event</typeparam>
-        public class Event<TD> : INoSerializationVerificationNeeded
+        public sealed class Event<TD> : INoSerializationVerificationNeeded
         {
             /// <summary>
-            /// TBD
+            /// Initializes a new instance of the Event
             /// </summary>
             /// <param name="fsmEvent">TBD</param>
             /// <param name="stateData">TBD</param>
@@ -523,12 +612,12 @@ namespace Akka.Actor
             /// <summary>
             /// TBD
             /// </summary>
-            public object FsmEvent { get; private set; }
+            public object FsmEvent { get; }
 
             /// <summary>
             /// TBD
             /// </summary>
-            public TD StateData { get; private set; }
+            public TD StateData { get; }
 
             /// <summary>
             /// TBD
@@ -536,7 +625,7 @@ namespace Akka.Actor
             /// <returns>TBD</returns>
             public override string ToString()
             {
-                return "Event: <" + FsmEvent + ">, StateData: <" + StateData + ">";
+                return $"Event: <{FsmEvent}>, StateData: <{StateData}>";
             }
         }
 
@@ -545,10 +634,10 @@ namespace Akka.Actor
         /// </summary>
         /// <typeparam name="TS">TBD</typeparam>
         /// <typeparam name="TD">TBD</typeparam>
-        public class StopEvent<TS, TD> : INoSerializationVerificationNeeded
+        public sealed class StopEvent<TS, TD> : INoSerializationVerificationNeeded
         {
             /// <summary>
-            /// TBD
+            /// Initializes a new instance of the StopEvent
             /// </summary>
             /// <param name="reason">TBD</param>
             /// <param name="terminatedState">TBD</param>
@@ -563,17 +652,26 @@ namespace Akka.Actor
             /// <summary>
             /// TBD
             /// </summary>
-            public Reason Reason { get; private set; }
+            public Reason Reason { get; }
 
             /// <summary>
             /// TBD
             /// </summary>
-            public TS TerminatedState { get; private set; }
+            public TS TerminatedState { get; }
 
             /// <summary>
             /// TBD
             /// </summary>
-            public TD StateData { get; private set; }
+            public TD StateData { get; }
+
+            /// <summary>
+            /// TBD
+            /// </summary>
+            /// <returns>TBD</returns>
+            public override string ToString()
+            {
+                return $"Reason: <{Reason}>, TerminatedState: <{TerminatedState}>, StateData: <{StateData}>";
+            }
         }
 
         #endregion
@@ -589,26 +687,26 @@ namespace Akka.Actor
         private readonly ILoggingAdapter _log = Context.GetLogger();
 
         /// <summary>
-        /// TBD
+        /// Initializes a new instance of the FSM class.
         /// </summary>
         protected FSM()
         {
-            if(this is ILoggingFSM)
+            if (this is ILoggingFSM)
                 DebugEvent = Context.System.Settings.FsmDebugEvent;
         }
 
         /// <summary>
-        /// TBD
+        /// Delegate describing this state's response to input
         /// </summary>
         /// <param name="fsmEvent">TBD</param>
         /// <returns>TBD</returns>
         public delegate State<TState, TData> StateFunction(Event<TData> fsmEvent);
 
         /// <summary>
-        /// TBD
+        /// Handler which is called upon each state transition
         /// </summary>
-        /// <param name="initialState">TBD</param>
-        /// <param name="nextState">TBD</param>
+        /// <param name="initialState">State designator for the initial state</param>
+        /// <param name="nextState">State designator for the next state</param>
         public delegate void TransitionHandler(TState initialState, TState nextState);
 
         #region Finite State Machine Domain Specific Language (FSM DSL if you like acronyms)
@@ -650,13 +748,7 @@ namespace Akka.Actor
             return new State<TState, TData>(nextStateName, _currentState.StateData);
         }
 
-        /// <summary>
-        /// Produce transition to other state. Return this from a state function
-        /// in order to effect the transition.
-        /// </summary>
-        /// <param name="nextStateName">State designator for the next state</param>
-        /// <param name="stateData">Data for next state</param>
-        /// <returns>State transition descriptor</returns>
+        [Obsolete("This method is obsoleted. Use GoTo(nextStateName).Using(newStateData) [1.2.0]")]
         public State<TState, TData> GoTo(TState nextStateName, TData stateData)
         {
             return new State<TState, TData>(nextStateName, stateData);
@@ -669,34 +761,34 @@ namespace Akka.Actor
         /// <returns>Descriptor for staying in the current state.</returns>
         public State<TState, TData> Stay()
         {
-            return GoTo(_currentState.StateName);
+            return GoTo(_currentState.StateName).WithNotification(false);
         }
 
         /// <summary>
         /// Produce change descriptor to stop this FSM actor with <see cref="FSMBase.Reason"/> <see cref="FSMBase.Normal"/>
         /// </summary>
-        /// <returns>TBD</returns>
+        /// <returns>Descriptor for stopping in the current state.</returns>
         public State<TState, TData> Stop()
         {
-            return Stop(new Normal());
+            return Stop(Normal.Instance);
         }
 
         /// <summary>
         /// Produce change descriptor to stop this FSM actor with the specified <see cref="FSMBase.Reason"/>.
         /// </summary>
-        /// <param name="reason">TBD</param>
-        /// <returns>TBD</returns>
+        /// <param name="reason">Reason why this <see cref="FSM{TState,TData}"/> is shutting down.</param>
+        /// <returns>Descriptor for stopping in the current state.</returns>
         public State<TState, TData> Stop(Reason reason)
         {
             return Stop(reason, _currentState.StateData);
         }
 
         /// <summary>
-        /// TBD
+        /// Produce change descriptor to stop this FSM actor with the specified <see cref="FSMBase.Reason"/>.
         /// </summary>
-        /// <param name="reason">TBD</param>
-        /// <param name="stateData">TBD</param>
-        /// <returns>TBD</returns>
+        /// <param name="reason">Reason why this <see cref="FSM{TState,TData}"/> is shutting down.</param>
+        /// <param name="stateData">State data.</param>
+        /// <returns>Descriptor for stopping in the current state.</returns>
         public State<TState, TData> Stop(Reason reason, TData stateData)
         {
             return Stay().Using(stateData).WithStopReason(reason);
@@ -719,7 +811,7 @@ namespace Akka.Actor
             /// <summary>
             /// TBD
             /// </summary>
-            public StateFunction Func { get; private set; }
+            public StateFunction Func { get; }
 
             /// <summary>
             /// TBD
@@ -734,6 +826,13 @@ namespace Akka.Actor
         }
 
         /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="func">TBD</param>
+        /// <returns>TBD</returns>
+        public TransformHelper Transform(StateFunction func) => new TransformHelper(func);
+
+        /// <summary>
         /// Schedule named timer to deliver message after given delay, possibly repeating.
         /// Any existing timer with the same name will automatically be canceled before adding
         /// the new timer.
@@ -744,28 +843,29 @@ namespace Akka.Actor
         /// <param name="repeat">send once if false, scheduleAtFixedRate if true</param>
         public void SetTimer(string name, object msg, TimeSpan timeout, bool repeat = false)
         {
-            if(DebugEvent)
-                _log.Debug("setting " + (repeat ? "repeating" : "") + "timer '{0}' / {1}: {2}", name, timeout, msg);
-            if(_timers.ContainsKey(name))
+            if (DebugEvent)
+            {
+                _log.Debug($"setting {(repeat ? "repeating" : "")} timer {name}/{timeout}: {msg}");
+            }
+            if (_timers.ContainsKey(name))
+            { 
                 _timers[name].Cancel();
-            var timer = new Timer(name, msg, repeat, _timerGen.Next(), Context, DebugEvent ? _log : null);
-            timer.Schedule(Self, timeout);
+            }
 
-            if (!_timers.ContainsKey(name))
-                _timers.Add(name, timer);
-            else
-                _timers[name] = timer;
+            var timer = new Timer(name, msg, repeat, _timerGen.Next(), Context);
+            timer.Schedule(Self, timeout);
+            _timers[name] = timer;
         }
 
         /// <summary>
-        /// Cancel a named <see cref="Timer"/>, ensuring that the message is not subsequently delivered (no race.)
+        /// Cancel a named <see cref="FSMBase.Timer"/>, ensuring that the message is not subsequently delivered (no race.)
         /// </summary>
         /// <param name="name">The name of the timer to cancel.</param>
         public void CancelTimer(string name)
         {
             if (DebugEvent)
             {
-                _log.Debug("Cancelling timer {0}", name);
+                _log.Debug($"Cancelling timer {name}");
             }
 
             if (_timers.ContainsKey(name))
@@ -795,24 +895,14 @@ namespace Akka.Actor
         /// <param name="timeout">TBD</param>
         public void SetStateTimeout(TState state, TimeSpan? timeout)
         {
-            if(!_stateTimeouts.ContainsKey(state))
-                _stateTimeouts.Add(state, timeout);
-            else
-                _stateTimeouts[state] = timeout;
+            _stateTimeouts[state] = timeout;
         }
 
-        //Internal API
-        bool IInternalSupportsTestFSMRef<TState, TData>.IsStateTimerActive
-        {
-            get
-            {
-                return _timeoutFuture != null;
-            }
-        }
+        // Internal API
+        bool IInternalSupportsTestFSMRef<TState, TData>.IsStateTimerActive => _timeoutFuture != null;
 
         /// <summary>
-        /// Set handler which is called upon each state transition, i.e. not when
-        /// staying in the same state. 
+        /// Set handler which is called upon each state transition
         /// </summary>
         /// <param name="transitionHandler">TBD</param>
         public void OnTransition(TransitionHandler transitionHandler)
@@ -856,6 +946,9 @@ namespace Akka.Actor
         /// <summary>
         /// Current state name
         /// </summary>
+        /// <exception cref="IllegalStateException">
+        /// This exception is thrown if this property is accessed before <see cref="StartWith"/> was called.
+        /// </exception>
         public TState StateName
         {
             get
@@ -869,6 +962,9 @@ namespace Akka.Actor
         /// <summary>
         /// Current state data
         /// </summary>
+        /// <exception cref="IllegalStateException">
+        /// This exception is thrown if this property is accessed before <see cref="StartWith"/> was called.
+        /// </exception>
         public TData StateData
         {
             get
@@ -889,27 +985,20 @@ namespace Akka.Actor
         {
             get
             {
-                if(_nextState == null) throw new InvalidOperationException("NextStateData is only available during OnTransition");
-                return _nextState.StateData;
+                if (_nextState != null)
+                    return _nextState.StateData;
+                throw new InvalidOperationException("NextStateData is only available during OnTransition");
             }
         }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="func">TBD</param>
-        /// <returns>TBD</returns>
-        public TransformHelper Transform(StateFunction func) { return new TransformHelper(func); }
 
         #endregion
 
         #region Internal implementation details
 
-        private readonly ListenerSupport _listener = new ListenerSupport();
         /// <summary>
-        /// TBD
+        /// Retrieves the support needed to interact with an actor's listeners.
         /// </summary>
-        public ListenerSupport Listeners { get { return _listener; } }
+        public ListenerSupport Listeners { get; } = new ListenerSupport();
 
         /// <summary>
         /// Can be set to enable debugging on certain actions taken by the FSM
@@ -1017,63 +1106,23 @@ namespace Akka.Actor
 
         #region Actor methods
 
-        /// <summary>
-        /// Main actor receive method
-        /// </summary>
-        /// <param name="message">TBD</param>
-        /// <returns>TBD</returns>
+        /// <inheritdoc/>
         protected override bool Receive(object message)
         {
-            var match = PatternMatch.Match(message)
-                .With<TimeoutMarker>(marker =>
+            var timeoutMarker = message as TimeoutMarker;
+            if (timeoutMarker != null)
+            {
+                if (_generation == timeoutMarker.Generation)
                 {
-                    if (_generation == marker.Generation)
-                    {
-                        ProcessMsg(new StateTimeout(), "state timeout");
-                    }
-                })
-                .With<Timer>(t =>
-                {
-                    if (_timers.ContainsKey(t.Name) && _timers[t.Name].Generation == t.Generation)
-                    {
-                        if (_timeoutFuture != null)
-                        {
-                            _timeoutFuture.Cancel(false);
-                            _timeoutFuture = null;
-                        }
-                        _generation++;
-                        if (!t.Repeat)
-                        {
-                            _timers.Remove(t.Name);
-                        }
-                        ProcessMsg(t.Message,t);
-                    }
-                })
-                .With<SubscribeTransitionCallBack>(cb =>
-                {
-                    Context.Watch(cb.ActorRef);
-                    Listeners.Add(cb.ActorRef);
-                    //send the current state back as a reference point
-                    cb.ActorRef.Tell(new CurrentState<TState>(Self, _currentState.StateName));
-                })
-                .With<Listen>(l =>
-                {
-                    Context.Watch(l.Listener);
-                    Listeners.Add(l.Listener);
-                    l.Listener.Tell(new CurrentState<TState>(Self, _currentState.StateName));
-                })
-                .With<UnsubscribeTransitionCallBack>(ucb =>
-                {
-                    Context.Unwatch(ucb.ActorRef);
-                    Listeners.Remove(ucb.ActorRef);
-                })
-                .With<Deafen>(d =>
-                {
-                    Context.Unwatch(d.Listener);
-                    Listeners.Remove(d.Listener);
-                })
-                .With<InternalActivateFsmLogging>(_=> { DebugEvent = true; })
-                .Default(msg =>
+                    ProcessMsg(StateTimeout.Instance, "state timeout");
+                }
+                return true;
+            }
+
+            var timer = message as Timer;
+            if (timer != null)
+            {
+                if (_timers.ContainsKey(timer.Name) && _timers[timer.Name].Generation == timer.Generation)
                 {
                     if (_timeoutFuture != null)
                     {
@@ -1081,9 +1130,58 @@ namespace Akka.Actor
                         _timeoutFuture = null;
                     }
                     _generation++;
-                    ProcessMsg(msg, Sender);
-                });
-            return match.WasHandled;
+                    if (!timer.Repeat)
+                    {
+                        _timers.Remove(timer.Name);
+                    }
+                    ProcessMsg(timer.Message, timer);
+                }
+                return true;
+            }
+
+            var subscribeTransitionCallBack = message as SubscribeTransitionCallBack;
+            if (subscribeTransitionCallBack != null)
+            {
+                Context.Watch(subscribeTransitionCallBack.ActorRef);
+                Listeners.Add(subscribeTransitionCallBack.ActorRef);
+                //send the current state back as a reference point
+                subscribeTransitionCallBack.ActorRef.Tell(new CurrentState<TState>(Self, _currentState.StateName));
+                return true;
+            }
+
+            var listen = message as Listen;
+            if (listen != null)
+            {
+                Context.Watch(listen.Listener);
+                Listeners.Add(listen.Listener);
+                listen.Listener.Tell(new CurrentState<TState>(Self, _currentState.StateName));
+                return true;
+            }
+
+            var unsubscribeTransitionCallBack = message as UnsubscribeTransitionCallBack;
+            if (unsubscribeTransitionCallBack != null)
+            {
+                Context.Unwatch(unsubscribeTransitionCallBack.ActorRef);
+                Listeners.Remove(unsubscribeTransitionCallBack.ActorRef);
+                return true;
+            }
+
+            var deafen = message as Deafen;
+            if (deafen != null)
+            {
+                Context.Unwatch(deafen.Listener);
+                Listeners.Remove(deafen.Listener);
+                return true;
+            }
+
+            if (_timeoutFuture != null)
+            {
+                _timeoutFuture.Cancel(false);
+                _timeoutFuture = null;
+            }
+            _generation++;
+            ProcessMsg(message, Sender);
+            return true;
         }
 
         private void ProcessMsg(object any, object source)
@@ -1094,40 +1192,49 @@ namespace Akka.Actor
 
         private void ProcessEvent(Event<TData> fsmEvent, object source)
         {
-            if(DebugEvent)
+            if (DebugEvent)
             {
                 var srcStr = GetSourceString(source);
-                _log.Debug("processing {0} from {1}", fsmEvent, srcStr);
+                _log.Debug("processing {0} from {1} in state {2}", fsmEvent, srcStr, StateName);
             }
+
             var stateFunc = _stateFunctions[_currentState.StateName];
             var oldState = _currentState;
-            State<TState, TData> upcomingState = null;
 
-            if(stateFunc != null)
+            State<TState, TData> nextState = null;
+
+            if (stateFunc != null)
             {
-                upcomingState = stateFunc(fsmEvent);
+                nextState = stateFunc(fsmEvent);
             }
 
-            if(upcomingState == null)
+            if (nextState == null)
             {
-                upcomingState = HandleEvent(fsmEvent);
+                nextState = HandleEvent(fsmEvent);
             }
 
-            ApplyState(upcomingState);
-            if(DebugEvent && !Equals(oldState, upcomingState))
+            ApplyState(nextState);
+
+            if (DebugEvent && !Equals(oldState, nextState))
             {
-                _log.Debug("transition {0} -> {1}", oldState, upcomingState);
+                _log.Debug("transition {0} -> {1}", oldState, nextState);
             }
         }
 
         private string GetSourceString(object source)
         {
             var s = source as string;
-            if(s != null) return s;
+            if (s != null)
+                return s;
+
             var timer = source as Timer;
-            if(timer != null) return "timer '" + timer.Name + "'";
+            if (timer != null)
+                return "timer '" + timer.Name + "'";
+
             var actorRef = source as IActorRef;
-            if(actorRef != null) return actorRef.ToString();
+            if (actorRef != null)
+                return actorRef.ToString();
+
             return "unknown";
         }
 
@@ -1137,43 +1244,44 @@ namespace Akka.Actor
             ApplyState(upcomingState);
         }
 
-        private void ApplyState(State<TState, TData> upcomingState)
+        private void ApplyState(State<TState, TData> nextState)
         {
-            if (upcomingState.StopReason == null){ MakeTransition(upcomingState);
-                return;
-            }
-            var replies = upcomingState.Replies;
-            replies.Reverse();
-            foreach (var reply in replies)
+            if (nextState.StopReason == null)
             {
-                Sender.Tell(reply);
-            }
-            Terminate(upcomingState);
-            Context.Stop(Self);
-        }
-
-        private void MakeTransition(State<TState, TData> upcomingState)
-        {
-            if (!_stateFunctions.ContainsKey(upcomingState.StateName))
-            {
-                Terminate(
-                    Stay()
-                        .WithStopReason(
-                            new Failure(String.Format("Next state {0} does not exist", upcomingState.StateName))));
+                MakeTransition(nextState);
             }
             else
             {
-                var replies = upcomingState.Replies;
-                replies.Reverse();
-                foreach (var r in replies) { Sender.Tell(r); }
-                if (!_currentState.StateName.Equals(upcomingState.StateName))
+                for (int i = nextState.Replies.Count - 1; i >= 0; i--)
                 {
-                    _nextState = upcomingState;
-                    HandleTransition(_currentState.StateName, _nextState.StateName);
-                    Listeners.Gossip(new Transition<TState>(Self, _currentState.StateName, _nextState.StateName));
+                    Sender.Tell(nextState.Replies[i]);
+                }
+                Terminate(nextState);
+                Context.Stop(Self);
+            }
+        }
+
+        private void MakeTransition(State<TState, TData> nextState)
+        {
+            if (!_stateFunctions.ContainsKey(nextState.StateName))
+            {
+                Terminate(Stay().WithStopReason(new Failure($"Next state {nextState.StateName} does not exist")));
+            }
+            else
+            {
+                for (int i = nextState.Replies.Count - 1; i >= 0; i--)
+                {
+                    Sender.Tell(nextState.Replies[i]);
+                }
+                if (!_currentState.StateName.Equals(nextState.StateName) || nextState.Notifies)
+                {
+                    _nextState = nextState;
+                    HandleTransition(_currentState.StateName, nextState.StateName);
+                    Listeners.Gossip(new Transition<TState>(Self, _currentState.StateName, nextState.StateName));
                     _nextState = null;
                 }
-                _currentState = upcomingState;
+                _currentState = nextState;
+
                 var timeout = _currentState.Timeout ?? _stateTimeouts[_currentState.StateName];
                 if (timeout.HasValue)
                 {
@@ -1192,8 +1300,12 @@ namespace Akka.Actor
             {
                 var reason = upcomingState.StopReason;
                 LogTermination(reason);
-                foreach (var t in _timers) { t.Value.Cancel(); }
+                foreach (var t in _timers)
+                {
+                    t.Value.Cancel();
+                }
                 _timers.Clear();
+                _timeoutFuture?.Cancel();
                 _currentState = upcomingState;
 
                 var stopEvent = new StopEvent<TState, TData>(reason, _currentState.StateName, _currentState.StateData);
@@ -1214,7 +1326,7 @@ namespace Akka.Actor
              * Setting this instance's state to Terminated does no harm during restart, since
              * the new instance will initialize fresh using StartWith.
              */
-            Terminate(Stay().WithStopReason(new Shutdown()));
+            Terminate(Stay().WithStopReason(Shutdown.Instance));
             base.PostStop();
         }
 
@@ -1227,18 +1339,18 @@ namespace Akka.Actor
         /// <param name="reason">TBD</param>
         protected virtual void LogTermination(Reason reason)
         {
-            PatternMatch.Match(reason)
-                .With<Failure>(f =>
+            var failure = reason as Failure;
+            if (failure != null)
+            {
+                if (failure.Cause is Exception)
                 {
-                    if (f.Cause is Exception)
-                    {
-                        _log.Error(f.Cause.AsInstanceOf<Exception>(), "terminating due to Failure");
-                    }
-                    else
-                    {
-                        _log.Error(f.Cause.ToString());
-                    }
-                });
+                    _log.Error(failure.Cause.AsInstanceOf<Exception>(), "terminating due to Failure");
+                }
+                else
+                {
+                    _log.Error(failure.Cause.ToString());
+                }
+            }
         }
     }
 

--- a/src/core/Akka/Routing/Listeners.cs
+++ b/src/core/Akka/Routing/Listeners.cs
@@ -40,7 +40,7 @@ namespace Akka.Routing
     /// The class represents a <see cref="ListenerMessage"/> sent by an <see cref="IActorRef"/> to another <see cref="IActorRef"/>
     /// instructing the second actor to start listening for messages sent by the first actor.
     /// </summary>
-    public class Listen : ListenerMessage
+    public sealed class Listen : ListenerMessage
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Listen"/> class.
@@ -54,14 +54,14 @@ namespace Akka.Routing
         /// <summary>
         /// The actor that receives the message.
         /// </summary>
-        public IActorRef Listener { get; private set; }
+        public IActorRef Listener { get; }
     }
 
     /// <summary>
     /// The class represents a <see cref="ListenerMessage"/> sent by an <see cref="IActorRef"/> to another <see cref="IActorRef"/>
     /// instructing the second actor to stop listening for messages sent by the first actor.
     /// </summary>
-    public class Deafen : ListenerMessage
+    public sealed class Deafen : ListenerMessage
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Deafen"/> class.
@@ -75,14 +75,14 @@ namespace Akka.Routing
         /// <summary>
         /// The actor that no longer receives the message.
         /// </summary>
-        public IActorRef Listener { get; private set; }
+        public IActorRef Listener { get; }
     }
 
     /// <summary>
     /// This class represents a <see cref="ListenerMessage"/> instructing an <see cref="IActorRef"/>
     /// to perform a supplied <see cref="Action{IActorRef}"/> for all of its listeners.
     /// </summary>
-    public class WithListeners : ListenerMessage
+    public sealed class WithListeners : ListenerMessage
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="WithListeners"/> class.
@@ -96,7 +96,7 @@ namespace Akka.Routing
         /// <summary>
         /// The action to perform for all of an actor's listeners.
         /// </summary>
-        public Action<IActorRef> ListenerFunction { get; private set; }
+        public Action<IActorRef> ListenerFunction { get; }
     }
 
     /// <summary>

--- a/src/core/Akka/Util/Internal/Extensions.cs
+++ b/src/core/Akka/Util/Internal/Extensions.cs
@@ -201,14 +201,14 @@ namespace Akka.Util.Internal
         }
 
         /// <summary>
-        /// TBD
+        /// Applies a delegate <paramref name="action" /> to all elements of this enumerable.
         /// </summary>
-        /// <typeparam name="T">TBD</typeparam>
-        /// <param name="enumerable">TBD</param>
-        /// <param name="action">TBD</param>
-        public static void ForEach<T>(this IEnumerable<T> enumerable, Action<T> action)
+        /// <typeparam name="T">The type of the elements of <paramref name="source" />.</typeparam>
+        /// <param name="source">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> to iterate.</param>
+        /// <param name="action">The function that is applied for its side-effect to every element. The result of function <paramref name="action" /> is discarded.</param>
+        public static void ForEach<T>(this IEnumerable<T> source, Action<T> action)
         {
-            foreach (var item in enumerable)
+            foreach (var item in source)
                 action(item);
         }
 


### PR DESCRIPTION
- [x] [additional debug logging for fsm](https://github.com/akka/akka/pull/20954) [2.4.9]
- [x] [per additional test for onTransition behaviour when initialize](https://github.com/akka/akka/pull/17960) [2.4.0]
- [x] [cancel StateTimeout when FSM actor is stopped](https://github.com/akka/akka/pull/16396) [2.4.0]
- [x] [Send transistion on goto(CurrentState) in FSM](https://github.com/akka/akka/pull/15561) [2.4.0]
- [x] Make all messages as sealed
- [ ] [forMax(Inf) can now override stateTimeout](https://github.com/akka/akka/pull/17152) [2.3.10]
- [ ] Implement `FSMActor_must_unlock_the_lock` test
- [ ] Implement `FSMActor_must_log_events_and_transitions_if_asked_to_do_so` test
- [ ] Implement `FSMActor_must_fill_rolling_event_log_and_hand_it_out` test
