### PR TITLE
Hide MatchHandler from the public API

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -287,8 +287,6 @@ namespace Akka.Actor
     public class ActorSelection : Akka.Actor.ICanTell
     {
         public ActorSelection() { }
-        [System.ObsoleteAttribute("The constructor is obsoleted, use ActorSelection(IActorRef anchor, IEnumerable<st" +
-            "ring> elements) [1.2.0]")]
         public ActorSelection(Akka.Actor.IActorRef anchor, Akka.Actor.SelectionPathElement[] path) { }
         public ActorSelection(Akka.Actor.IActorRef anchor, string path) { }
         public ActorSelection(Akka.Actor.IActorRef anchor, System.Collections.Generic.IEnumerable<string> elements) { }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -4,9 +4,11 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tests.MultiNode")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.MultiNodeTestRunner.Shared.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Persistence")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote.Tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote.Tests.MultiNode")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Streams")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.TestKit")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.TestKit.Tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Tests")]
@@ -128,6 +130,8 @@ namespace Akka.Actor
         public ActorIdentity(object messageId, Akka.Actor.IActorRef subject) { }
         public object MessageId { get; }
         public Akka.Actor.IActorRef Subject { get; }
+        public override bool Equals(object obj) { }
+        public override int GetHashCode() { }
         public override string ToString() { }
     }
     public class ActorInitializationException : Akka.Actor.AkkaException
@@ -283,6 +287,8 @@ namespace Akka.Actor
     public class ActorSelection : Akka.Actor.ICanTell
     {
         public ActorSelection() { }
+        [System.ObsoleteAttribute("The constructor is obsoleted, use ActorSelection(IActorRef anchor, IEnumerable<st" +
+            "ring> elements) [1.2.0]")]
         public ActorSelection(Akka.Actor.IActorRef anchor, Akka.Actor.SelectionPathElement[] path) { }
         public ActorSelection(Akka.Actor.IActorRef anchor, string path) { }
         public ActorSelection(Akka.Actor.IActorRef anchor, System.Collections.Generic.IEnumerable<string> elements) { }
@@ -1011,6 +1017,8 @@ namespace Akka.Actor
     {
         public Identify(object messageId) { }
         public object MessageId { get; }
+        public override bool Equals(object obj) { }
+        public override int GetHashCode() { }
         public override string ToString() { }
     }
     public interface IExtension { }
@@ -4507,222 +4515,6 @@ namespace Akka.Serialization
         public virtual object FromBinary(byte[] bytes, System.Type type) { }
         public abstract object FromBinary(byte[] binary, string manifest);
         public abstract string Manifest(object o);
-    }
-}
-namespace Akka.Tools.MatchHandler
-{
-    public class Argument
-    {
-        public Argument(Akka.Tools.MatchHandler.PredicateAndHandler predicateAndHandler, object value, bool valueIsActionOrFunc) { }
-        public Akka.Tools.MatchHandler.PredicateAndHandler PredicateAndHandler { get; }
-        public object Value { get; }
-        public bool ValueIsActionOrFunc { get; }
-    }
-    public class CachedMatchCompiler<T> : Akka.Tools.MatchHandler.IMatchCompiler<T>
-    {
-        public static readonly Akka.Tools.MatchHandler.CachedMatchCompiler<T> Instance;
-        public CachedMatchCompiler(Akka.Tools.MatchHandler.IMatchExpressionBuilder expressionBuilder, Akka.Tools.MatchHandler.IPartialActionBuilder actionBuilder, Akka.Tools.MatchHandler.ILambdaExpressionCompiler expressionCompiler) { }
-        public Akka.Tools.MatchHandler.PartialAction<T> Compile(System.Collections.Generic.IReadOnlyList<Akka.Tools.MatchHandler.TypeHandler> handlers, System.Collections.Generic.IReadOnlyList<Akka.Tools.MatchHandler.Argument> capturedArguments, Akka.Tools.MatchHandler.MatchBuilderSignature signature) { }
-        public void CompileToMethod(System.Collections.Generic.IReadOnlyList<Akka.Tools.MatchHandler.TypeHandler> handlers, System.Collections.Generic.IReadOnlyList<Akka.Tools.MatchHandler.Argument> capturedArguments, Akka.Tools.MatchHandler.MatchBuilderSignature signature, System.Reflection.Emit.TypeBuilder typeBuilder, string methodName, System.Reflection.MethodAttributes methodAttributes = 22) { }
-    }
-    public class CompiledMatchHandlerWithArguments
-    {
-        public CompiledMatchHandlerWithArguments(System.Delegate compiledDelegate, object[] delegateArguments) { }
-        public System.Delegate CompiledDelegate { get; }
-        public object[] DelegateArguments { get; }
-    }
-    public enum HandlerKind
-    {
-        Action = 0,
-        ActionWithPredicate = 1,
-        Func = 2,
-    }
-    public interface ILambdaExpressionCompiler
-    {
-        System.Delegate Compile(System.Linq.Expressions.LambdaExpression expression);
-        void CompileToMethod(System.Linq.Expressions.LambdaExpression expression, System.Reflection.Emit.MethodBuilder method);
-    }
-    public interface IMatchCompiler<in T>
-    {
-        Akka.Tools.MatchHandler.PartialAction<T> Compile(System.Collections.Generic.IReadOnlyList<Akka.Tools.MatchHandler.TypeHandler> handlers, System.Collections.Generic.IReadOnlyList<Akka.Tools.MatchHandler.Argument> capturedArguments, Akka.Tools.MatchHandler.MatchBuilderSignature signature);
-        void CompileToMethod(System.Collections.Generic.IReadOnlyList<Akka.Tools.MatchHandler.TypeHandler> handlers, System.Collections.Generic.IReadOnlyList<Akka.Tools.MatchHandler.Argument> capturedArguments, Akka.Tools.MatchHandler.MatchBuilderSignature signature, System.Reflection.Emit.TypeBuilder typeBuilder, string methodName, System.Reflection.MethodAttributes methodAttributes = 22);
-    }
-    public interface IMatchExpressionBuilder
-    {
-        Akka.Tools.MatchHandler.MatchExpressionBuilderResult BuildLambdaExpression(System.Collections.Generic.IReadOnlyList<Akka.Tools.MatchHandler.TypeHandler> typeHandlers);
-        object[] CreateArgumentValuesArray(System.Collections.Generic.IReadOnlyList<Akka.Tools.MatchHandler.Argument> arguments);
-    }
-    public interface IPartialActionBuilder
-    {
-        Akka.Tools.MatchHandler.PartialAction<T> Build<T>(Akka.Tools.MatchHandler.CompiledMatchHandlerWithArguments handlerAndArgs);
-    }
-    public interface IPartialHandlerArgumentsCapture<T>
-    {
-        bool Handle(T message);
-        void Initialize(System.Delegate handler, System.Collections.Generic.IReadOnlyList<object> arguments);
-    }
-    public class LambdaExpressionCompiler : Akka.Tools.MatchHandler.ILambdaExpressionCompiler
-    {
-        public LambdaExpressionCompiler() { }
-        public System.Delegate Compile(System.Linq.Expressions.LambdaExpression expression) { }
-        public void CompileToMethod(System.Linq.Expressions.LambdaExpression expression, System.Reflection.Emit.MethodBuilder method) { }
-    }
-    public class MatchBuilder : Akka.Tools.MatchHandler.MatchBuilder<object>
-    {
-        public MatchBuilder(Akka.Tools.MatchHandler.IMatchCompiler<object> compiler) { }
-    }
-    public class MatchBuilder<TItem>
-    {
-        public MatchBuilder(Akka.Tools.MatchHandler.IMatchCompiler<TItem> compiler) { }
-        public Akka.Tools.MatchHandler.PartialAction<TItem> Build() { }
-        public void BuildToMethod(System.Reflection.Emit.TypeBuilder typeBuilder, string methodName, System.Reflection.MethodAttributes attributes = 22) { }
-        public void Match<T>(System.Action<T> handler, System.Predicate<T> shouldHandle = null)
-            where T : TItem { }
-        public void Match(System.Type handlesType, System.Action<TItem> handler, System.Predicate<TItem> shouldHandle = null) { }
-        public void Match<T>(System.Func<T, bool> handler)
-            where T : TItem { }
-        public void Match(System.Type handlesType, System.Func<TItem, bool> handler) { }
-        public void MatchAny(System.Action<TItem> handler) { }
-    }
-    public class MatchBuilderSignature : System.IEquatable<Akka.Tools.MatchHandler.MatchBuilderSignature>
-    {
-        public MatchBuilderSignature(System.Collections.Generic.IReadOnlyList<object> signature) { }
-        public bool Equals(Akka.Tools.MatchHandler.MatchBuilderSignature other) { }
-        public override bool Equals(object obj) { }
-        public override int GetHashCode() { }
-        public override string ToString() { }
-    }
-    public class MatchExpressionBuilder<T> : Akka.Tools.MatchHandler.IMatchExpressionBuilder
-    {
-        public MatchExpressionBuilder() { }
-        public Akka.Tools.MatchHandler.MatchExpressionBuilderResult BuildLambdaExpression(System.Collections.Generic.IReadOnlyList<Akka.Tools.MatchHandler.TypeHandler> typeHandlers) { }
-        public object[] CreateArgumentValuesArray(System.Collections.Generic.IReadOnlyList<Akka.Tools.MatchHandler.Argument> arguments) { }
-    }
-    public class MatchExpressionBuilderResult
-    {
-        public MatchExpressionBuilderResult(System.Linq.Expressions.LambdaExpression lambdaExpression, object[] arguments) { }
-        public object[] Arguments { get; }
-        public System.Linq.Expressions.LambdaExpression LambdaExpression { get; }
-    }
-    public delegate bool PartialAction<in T>(T item);
-    public class PartialActionBuilder : Akka.Tools.MatchHandler.IPartialActionBuilder
-    {
-        public const int MaxNumberOfArguments = 15;
-        public PartialActionBuilder() { }
-        public Akka.Tools.MatchHandler.PartialAction<T> Build<T>(Akka.Tools.MatchHandler.CompiledMatchHandlerWithArguments handlerAndArgs) { }
-    }
-    public sealed class PartialHandlerArgumentsCapture<T> : Akka.Tools.MatchHandler.IPartialHandlerArgumentsCapture<T>
-    {
-        public PartialHandlerArgumentsCapture() { }
-        public bool Handle(T value) { }
-        public void Initialize(System.Delegate handler, System.Collections.Generic.IReadOnlyList<object> arguments) { }
-    }
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7, T8, T9> : Akka.Tools.MatchHandler.IPartialHandlerArgumentsCapture<T>
-    {
-        public PartialHandlerArgumentsCapture() { }
-        public bool Handle(T value) { }
-        public void Initialize(System.Delegate handler, System.Collections.Generic.IReadOnlyList<object> arguments) { }
-    }
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : Akka.Tools.MatchHandler.IPartialHandlerArgumentsCapture<T>
-    {
-        public PartialHandlerArgumentsCapture() { }
-        public bool Handle(T value) { }
-        public void Initialize(System.Delegate handler, System.Collections.Generic.IReadOnlyList<object> arguments) { }
-    }
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : Akka.Tools.MatchHandler.IPartialHandlerArgumentsCapture<T>
-    {
-        public PartialHandlerArgumentsCapture() { }
-        public bool Handle(T value) { }
-        public void Initialize(System.Delegate handler, System.Collections.Generic.IReadOnlyList<object> arguments) { }
-    }
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : Akka.Tools.MatchHandler.IPartialHandlerArgumentsCapture<T>
-    {
-        public PartialHandlerArgumentsCapture() { }
-        public bool Handle(T value) { }
-        public void Initialize(System.Delegate handler, System.Collections.Generic.IReadOnlyList<object> arguments) { }
-    }
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : Akka.Tools.MatchHandler.IPartialHandlerArgumentsCapture<T>
-    {
-        public PartialHandlerArgumentsCapture() { }
-        public bool Handle(T value) { }
-        public void Initialize(System.Delegate handler, System.Collections.Generic.IReadOnlyList<object> arguments) { }
-    }
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : Akka.Tools.MatchHandler.IPartialHandlerArgumentsCapture<T>
-    {
-        public PartialHandlerArgumentsCapture() { }
-        public bool Handle(T value) { }
-        public void Initialize(System.Delegate handler, System.Collections.Generic.IReadOnlyList<object> arguments) { }
-    }
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> : Akka.Tools.MatchHandler.IPartialHandlerArgumentsCapture<T>
-    {
-        public PartialHandlerArgumentsCapture() { }
-        public bool Handle(T value) { }
-        public void Initialize(System.Delegate handler, System.Collections.Generic.IReadOnlyList<object> arguments) { }
-    }
-    public sealed class PartialHandlerArgumentsCapture<T, T1> : Akka.Tools.MatchHandler.IPartialHandlerArgumentsCapture<T>
-    {
-        public PartialHandlerArgumentsCapture() { }
-        public bool Handle(T value) { }
-        public void Initialize(System.Delegate handler, System.Collections.Generic.IReadOnlyList<object> arguments) { }
-    }
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2> : Akka.Tools.MatchHandler.IPartialHandlerArgumentsCapture<T>
-    {
-        public PartialHandlerArgumentsCapture() { }
-        public bool Handle(T value) { }
-        public void Initialize(System.Delegate handler, System.Collections.Generic.IReadOnlyList<object> arguments) { }
-    }
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3> : Akka.Tools.MatchHandler.IPartialHandlerArgumentsCapture<T>
-    {
-        public PartialHandlerArgumentsCapture() { }
-        public bool Handle(T value) { }
-        public void Initialize(System.Delegate handler, System.Collections.Generic.IReadOnlyList<object> arguments) { }
-    }
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4> : Akka.Tools.MatchHandler.IPartialHandlerArgumentsCapture<T>
-    {
-        public PartialHandlerArgumentsCapture() { }
-        public bool Handle(T value) { }
-        public void Initialize(System.Delegate handler, System.Collections.Generic.IReadOnlyList<object> arguments) { }
-    }
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5> : Akka.Tools.MatchHandler.IPartialHandlerArgumentsCapture<T>
-    {
-        public PartialHandlerArgumentsCapture() { }
-        public bool Handle(T value) { }
-        public void Initialize(System.Delegate handler, System.Collections.Generic.IReadOnlyList<object> arguments) { }
-    }
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6> : Akka.Tools.MatchHandler.IPartialHandlerArgumentsCapture<T>
-    {
-        public PartialHandlerArgumentsCapture() { }
-        public bool Handle(T value) { }
-        public void Initialize(System.Delegate handler, System.Collections.Generic.IReadOnlyList<object> arguments) { }
-    }
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7> : Akka.Tools.MatchHandler.IPartialHandlerArgumentsCapture<T>
-    {
-        public PartialHandlerArgumentsCapture() { }
-        public bool Handle(T value) { }
-        public void Initialize(System.Delegate handler, System.Collections.Generic.IReadOnlyList<object> arguments) { }
-    }
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7, T8> : Akka.Tools.MatchHandler.IPartialHandlerArgumentsCapture<T>
-    {
-        public PartialHandlerArgumentsCapture() { }
-        public bool Handle(T value) { }
-        public void Initialize(System.Delegate handler, System.Collections.Generic.IReadOnlyList<object> arguments) { }
-    }
-    public class PredicateAndHandler
-    {
-        public System.Linq.Expressions.Expression ActionOrFuncExpression { get; set; }
-        public System.Collections.Generic.IReadOnlyList<Akka.Tools.MatchHandler.Argument> Arguments { get; }
-        public bool HandlerFirstArgumentShouldBeBaseType { get; }
-        public Akka.Tools.MatchHandler.HandlerKind HandlerKind { get; }
-        public System.Linq.Expressions.Expression PredicateExpression { get; set; }
-        public static Akka.Tools.MatchHandler.PredicateAndHandler CreateAction(object action, object predicate = null, bool handlerFirstArgumentShouldBeBaseType = False) { }
-        public static Akka.Tools.MatchHandler.PredicateAndHandler CreateFunc(object func, bool handlerFirstArgumentShouldBeBaseType = False) { }
-    }
-    public class TypeHandler
-    {
-        public TypeHandler(System.Type handlesType) { }
-        public System.Collections.Generic.List<Akka.Tools.MatchHandler.PredicateAndHandler> Handlers { get; }
-        public System.Type HandlesType { get; }
-        public System.Collections.Generic.IEnumerable<Akka.Tools.MatchHandler.Argument> GetArguments() { }
     }
 }
 namespace Akka.Util

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
@@ -20,7 +20,7 @@ namespace Akka.Persistence
         public int WarnAfterNumberOfUnconfirmedAttempts { get; }
         public override void AroundPostStop() { }
         public override void AroundPreRestart(System.Exception cause, object message) { }
-        protected override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
+        protected internal override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
         public bool ConfirmDelivery(long deliveryId) { }
         public void Deliver(Akka.Actor.ActorPath destination, System.Func<long, object> deliveryMessageMapper) { }
         public void Deliver(Akka.Actor.ActorSelection destination, System.Func<long, object> deliveryMessageMapper) { }
@@ -39,7 +39,7 @@ namespace Akka.Persistence
         public int WarnAfterNumberOfUnconfirmedAttempts { get; }
         public override void AroundPostStop() { }
         public override void AroundPreRestart(System.Exception cause, object message) { }
-        protected override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
+        protected internal override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
         public bool ConfirmDelivery(long deliveryId) { }
         public void Deliver(Akka.Actor.ActorPath destination, System.Func<long, object> deliveryMessageMapper) { }
         public void Deliver(Akka.Actor.ActorSelection destination, System.Func<long, object> deliveryMessageMapper) { }
@@ -225,7 +225,7 @@ namespace Akka.Persistence
         public override void AroundPostStop() { }
         public override void AroundPreRestart(System.Exception cause, object message) { }
         public override void AroundPreStart() { }
-        protected override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
+        protected internal override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
         public void DeferAsync<TEvent>(TEvent evt, System.Action<TEvent> handler) { }
         public void DeleteMessages(long toSequenceNr) { }
         public void DeleteSnapshot(long sequenceNr) { }
@@ -443,7 +443,7 @@ namespace Akka.Persistence
         public Akka.Actor.IStash Stash { get; set; }
         public abstract string ViewId { get; }
         public override void AroundPreStart() { }
-        protected override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
+        protected internal override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
         public void DeleteSnapshot(long sequenceNr) { }
         public void DeleteSnapshots(Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         public void LoadSnapshot(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, long toSequenceNr) { }
@@ -926,7 +926,7 @@ namespace Akka.Persistence.Journal
         public Akka.Actor.IStash Stash { get; set; }
         public abstract System.TimeSpan Timeout { get; }
         public override void AroundPreStart() { }
-        protected override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
+        protected internal override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
         protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr) { }
         public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr) { }
         public override System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback) { }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
@@ -846,7 +846,7 @@ namespace Akka.Streams.Actors
         public override void AroundPostStop() { }
         public override void AroundPreRestart(System.Exception cause, object message) { }
         public override void AroundPreStart() { }
-        protected override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
+        protected internal override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
         public void OnComplete() { }
         public void OnCompleteThenStop() { }
         public void OnError(System.Exception cause) { }
@@ -874,7 +874,7 @@ namespace Akka.Streams.Actors
         public override void AroundPostStop() { }
         public override void AroundPreRestart(System.Exception cause, object message) { }
         public override void AroundPreStart() { }
-        protected override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
+        protected internal override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
         protected void Cancel() { }
         public static Reactive.Streams.ISubscriber<T> Create<T>(Akka.Actor.IActorRef @ref) { }
         protected void Request(long n) { }

--- a/src/core/Akka.Persistence/AtLeastOnceDelivery.cs
+++ b/src/core/Akka.Persistence/AtLeastOnceDelivery.cs
@@ -159,7 +159,7 @@ namespace Akka.Persistence
         /// <param name="receive">TBD</param>
         /// <param name="message">TBD</param>
         /// <returns>TBD</returns>
-        protected override bool AroundReceive(Receive receive, object message)
+        protected internal override bool AroundReceive(Receive receive, object message)
         {
             return _atLeastOnceDeliverySemantic.AroundReceive(receive, message) || base.AroundReceive(receive, message);
         }

--- a/src/core/Akka.Persistence/AtLeastOnceDeliveryReceiveActor.cs
+++ b/src/core/Akka.Persistence/AtLeastOnceDeliveryReceiveActor.cs
@@ -133,7 +133,7 @@ namespace Akka.Persistence
         /// <param name="receive">TBD</param>
         /// <param name="message">TBD</param>
         /// <returns>TBD</returns>
-        protected override bool AroundReceive(Receive receive, object message)
+        protected internal override bool AroundReceive(Receive receive, object message)
         {
             return _atLeastOnceDeliverySemantic.AroundReceive(receive, message) || base.AroundReceive(receive, message);
         }

--- a/src/core/Akka.Persistence/Eventsourced.Lifecycle.cs
+++ b/src/core/Akka.Persistence/Eventsourced.Lifecycle.cs
@@ -33,7 +33,7 @@ namespace Akka.Persistence
         /// <param name="receive">TBD</param>
         /// <param name="message">TBD</param>
         /// <returns>TBD</returns>
-        protected override bool AroundReceive(Receive receive, object message)
+        protected internal override bool AroundReceive(Receive receive, object message)
         {
             _currentState.StateReceive(receive, message);
             return true;

--- a/src/core/Akka.Persistence/Journal/AsyncWriteProxy.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteProxy.cs
@@ -296,7 +296,7 @@ namespace Akka.Persistence.Journal
         /// <param name="receive">TBD</param>
         /// <param name="message">TBD</param>
         /// <returns>TBD</returns>
-        protected override bool AroundReceive(Receive receive, object message)
+        protected internal override bool AroundReceive(Receive receive, object message)
         {
             if (_isInitialized)
             {

--- a/src/core/Akka.Persistence/PersistentView.Lifecycle.cs
+++ b/src/core/Akka.Persistence/PersistentView.Lifecycle.cs
@@ -42,7 +42,7 @@ namespace Akka.Persistence
         /// <param name="receive">TBD</param>
         /// <param name="message">TBD</param>
         /// <returns>TBD</returns>
-        protected override bool AroundReceive(Receive receive, object message)
+        protected internal override bool AroundReceive(Receive receive, object message)
         {
             _currentState.StateReceive(receive, message);
             return true;

--- a/src/core/Akka.Streams/Actors/ActorPublisher.cs
+++ b/src/core/Akka.Streams/Actors/ActorPublisher.cs
@@ -458,7 +458,7 @@ namespace Akka.Streams.Actors
         /// <param name="receive">TBD</param>
         /// <param name="message">TBD</param>
         /// <returns>TBD</returns>
-        protected override bool AroundReceive(Receive receive, object message)
+        protected internal override bool AroundReceive(Receive receive, object message)
         {
             if (message is Request)
             {

--- a/src/core/Akka.Streams/Actors/ActorSubscriber.cs
+++ b/src/core/Akka.Streams/Actors/ActorSubscriber.cs
@@ -150,7 +150,7 @@ namespace Akka.Streams.Actors
         /// <param name="receive">TBD</param>
         /// <param name="message">TBD</param>
         /// <returns>TBD</returns>
-        protected override bool AroundReceive(Receive receive, object message)
+        protected internal override bool AroundReceive(Receive receive, object message)
         {
             if (message is OnNext)
             {

--- a/src/core/Akka/Actor/ActorSelection.cs
+++ b/src/core/Akka/Actor/ActorSelection.cs
@@ -405,4 +405,3 @@ namespace Akka.Actor
         public override string ToString() => "..";
     }
 }
-

--- a/src/core/Akka/Actor/IAutoReceivedMessage.cs
+++ b/src/core/Akka/Actor/IAutoReceivedMessage.cs
@@ -10,23 +10,25 @@ using Akka.Event;
 namespace Akka.Actor
 {
     /// <summary>
-    /// TBD
+    /// Marker trait to show which Messages are automatically handled by Akka.NET
     /// </summary>
     public interface IAutoReceivedMessage : INoSerializationVerificationNeeded
     {
     }
 
     /// <summary>
-    /// TBD
+    /// When Death Watch is used, the watcher will receive a Terminated(watched) message when watched is terminated.
+    /// Terminated message can't be forwarded to another actor, since that actor might not be watching the subject.
+    /// Instead, if you need to forward Terminated to another actor you should send the information in your own message.
     /// </summary>
     public sealed class Terminated : IAutoReceivedMessage, IPossiblyHarmful, IDeadLetterSuppression
     {
         /// <summary>
-        /// TBD
+        /// Initializes a new instance of the <see cref="Terminated" /> class.
         /// </summary>
-        /// <param name="actorRef">TBD</param>
-        /// <param name="existenceConfirmed">TBD</param>
-        /// <param name="addressTerminated">TBD</param>
+        /// <param name="actorRef">the watched actor that terminated</param>
+        /// <param name="existenceConfirmed">is false when the Terminated message was not sent directly from the watched actor, but derived from another source, such as when watching a non-local ActorRef, which might not have been resolved</param>
+        /// <param name="addressTerminated">the Terminated message was derived from that the remote node hosting the watched actor was detected as unreachable</param>
         public Terminated(IActorRef actorRef, bool existenceConfirmed, bool addressTerminated)
         {
             ActorRef = actorRef;
@@ -35,27 +37,29 @@ namespace Akka.Actor
         }
 
         /// <summary>
-        /// TBD
+        /// The watched actor that terminated
         /// </summary>
-        public IActorRef ActorRef { get; private set; }
+        public IActorRef ActorRef { get; }
 
         /// <summary>
-        /// TBD
+        /// Is false when the Terminated message was not sent
+        /// directly from the watched actor, but derived from another source, such as 
+        /// when watching a non-local ActorRef, which might not have been resolved
         /// </summary>
-        public bool AddressTerminated { get; private set; }
+        public bool AddressTerminated { get; }
 
         /// <summary>
-        /// TBD
+        /// The Terminated message was derived from that the remote node hosting the watched actor was detected as unreachable
         /// </summary>
-        public bool ExistenceConfirmed { get; private set; }
+        public bool ExistenceConfirmed { get; }
 
         /// <summary>
-        /// TBD
+        /// Returns a <see cref="string" /> that represents this instance.
         /// </summary>
-        /// <returns>TBD</returns>
+        /// <returns>A <see cref="string" /> that represents this instance.</returns>
         public override string ToString()
         {
-            return "<Terminated>: " + ActorRef + " - ExistenceConfirmed=" + ExistenceConfirmed;
+            return $"<Terminated>: {ActorRef} - ExistenceConfirmed={ExistenceConfirmed}";
         }
     }
 
@@ -65,9 +69,9 @@ namespace Akka.Actor
     public sealed class Identify : IAutoReceivedMessage, INotInfluenceReceiveTimeout
     {
         /// <summary>
-        /// TBD
+        /// Initializes a new instance of the <see cref="Identify" /> class.
         /// </summary>
-        /// <param name="messageId">TBD</param>
+        /// <param name="messageId">A correlating ID used to distinguish multiple <see cref="Identify"/> requests to the same receiver.</param>
         public Identify(object messageId)
         {
             MessageId = messageId;
@@ -78,14 +82,33 @@ namespace Akka.Actor
         /// </summary>
         public object MessageId { get; }
 
+        #region Equals
+        private bool Equals(Identify other)
+        {
+            return Equals(MessageId, other.MessageId);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            return obj is Identify && Equals((Identify)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return (MessageId != null ? MessageId.GetHashCode() : 0);
+        }
+
         /// <summary>
-        /// TBD
+        /// Returns a <see cref="string" /> that represents this instance.
         /// </summary>
-        /// <returns>TBD</returns>
+        /// <returns>A <see cref="string" /> that represents this instance.</returns>
         public override string ToString()
         {
-            return "<Identify>: " + MessageId;
+            return $"<Identify>: {MessageId}";
         }
+        #endregion
     }
 
     /// <summary>
@@ -94,10 +117,10 @@ namespace Akka.Actor
     public sealed class ActorIdentity
     {
         /// <summary>
-        /// TBD
+        /// Initializes a new instance of the <see cref="ActorIdentity" /> class.
         /// </summary>
-        /// <param name="messageId">TBD</param>
-        /// <param name="subject">TBD</param>
+        /// <param name="messageId">The same correlating ID used in the original <see cref="Identify"/> message.</param>
+        /// <param name="subject">A reference to the underyling actor.</param>
         public ActorIdentity(object messageId, IActorRef subject)
         {
             MessageId = messageId;
@@ -107,22 +130,44 @@ namespace Akka.Actor
         /// <summary>
         /// The same correlating ID used in the original <see cref="Identify"/> message.
         /// </summary>
-        public object MessageId { get; private set; }
+        public object MessageId { get; }
 
         /// <summary>
         /// A reference to the underyling actor.
         /// </summary>
         /// <remarks>Will be <c>null</c> if sent an <see cref="ActorSelection"/> that could not be resolved.</remarks>
-        public IActorRef Subject { get; private set; }
+        public IActorRef Subject { get; }
+
+        #region Equals
+        private bool Equals(ActorIdentity other)
+        {
+            return Equals(MessageId, other.MessageId) && Equals(Subject, other.Subject);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            return obj is ActorIdentity && Equals((ActorIdentity)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((MessageId != null ? MessageId.GetHashCode() : 0) * 397) ^ (Subject != null ? Subject.GetHashCode() : 0);
+            }
+        }
 
         /// <summary>
-        /// TBD
+        /// Returns a <see cref="string" /> that represents this instance.
         /// </summary>
-        /// <returns>TBD</returns>
+        /// <returns>A <see cref="string" /> that represents this instance.</returns>
         public override string ToString()
         {
-            return "<ActorIdentity>: " + Subject + " - MessageId=" + MessageId;
+            return $"<ActorIdentity>: {Subject} - MessageId={MessageId}";
         }
+        #endregion
     }
 
     /// <summary>
@@ -136,28 +181,21 @@ namespace Akka.Actor
     public sealed class PoisonPill : IAutoReceivedMessage, IPossiblyHarmful, IDeadLetterSuppression
     {
         private PoisonPill() { }
-        private static readonly PoisonPill _instance = new PoisonPill();
-        /// <summary>
-        /// TBD
-        /// </summary>
-        public static PoisonPill Instance
-        {
-            get
-            {
-                return _instance;
-            }
-        }
 
         /// <summary>
-        /// TBD
+        /// The singleton instance of PoisonPill.
         /// </summary>
-        /// <returns>TBD</returns>
+        public static PoisonPill Instance { get; } = new PoisonPill();
+
+        /// <summary>
+        /// Returns a <see cref="string" /> that represents this instance.
+        /// </summary>
+        /// <returns>A <see cref="string" /> that represents this instance.</returns>
         public override string ToString()
         {
             return "<PoisonPill>";
         }
     }
-
 
     /// <summary>
     /// Sending an <see cref="Kill"/> message to an actor causes the actor to throw an 
@@ -170,29 +208,20 @@ namespace Akka.Actor
     {
         private Kill() { }
 
-        private static readonly Kill _instance = new Kill();
         /// <summary>
-        /// TBD
+        /// The singleton instance of Kill.
         /// </summary>
-        public static Kill Instance
-        {
-            get
-            {
-                return _instance;
-            }
-        }
+        public static Kill Instance { get; } = new Kill();
 
         /// <summary>
-        /// TBD
+        /// Returns a <see cref="string" /> that represents this instance.
         /// </summary>
-        /// <returns>TBD</returns>
+        /// <returns>A <see cref="string" /> that represents this instance.</returns>
         public override string ToString()
         {
             return "<Kill>";
         }
     }
-
-
 
     /// <summary>
     /// INTERNAL API
@@ -207,7 +236,7 @@ namespace Akka.Actor
     internal class AddressTerminated : IAutoReceivedMessage, IPossiblyHarmful, IDeadLetterSuppression
     {
         /// <summary>
-        /// TBD
+        /// Initializes a new instance of the <see cref="AddressTerminated" /> class.
         /// </summary>
         /// <param name="address">TBD</param>
         public AddressTerminated(Address address)
@@ -218,16 +247,15 @@ namespace Akka.Actor
         /// <summary>
         /// TBD
         /// </summary>
-        public Address Address { get; private set; }
+        public Address Address { get; }
 
         /// <summary>
-        /// TBD
+        /// Returns a <see cref="string" /> that represents this instance.
         /// </summary>
-        /// <returns>TBD</returns>
+        /// <returns>A <see cref="string" /> that represents this instance.</returns>
         public override string ToString()
         {
-            return "<AddressTerminated>: " + Address;
+            return $"<AddressTerminated>: {Address}";
         }
     }
 }
-

--- a/src/core/Akka/Properties/AssemblyInfo.cs
+++ b/src/core/Akka/Properties/AssemblyInfo.cs
@@ -40,3 +40,5 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("Akka.Cluster.Tests.MultiNode")]
 [assembly: InternalsVisibleTo("Akka.Cluster.TestKit")]
 [assembly: InternalsVisibleTo("Akka.Cluster.Tools")]
+[assembly: InternalsVisibleTo("Akka.Persistence")]
+[assembly: InternalsVisibleTo("Akka.Streams")]

--- a/src/core/Akka/Util/MatchHandler/Argument.cs
+++ b/src/core/Akka/Util/MatchHandler/Argument.cs
@@ -10,7 +10,7 @@ namespace Akka.Tools.MatchHandler
     /// <summary>
     /// TBD
     /// </summary>
-    public class Argument
+    internal class Argument
     {
         private readonly PredicateAndHandler _predicateAndHandler;
         private readonly object _value;

--- a/src/core/Akka/Util/MatchHandler/CachedMatchCompiler.cs
+++ b/src/core/Akka/Util/MatchHandler/CachedMatchCompiler.cs
@@ -18,7 +18,7 @@ namespace Akka.Tools.MatchHandler
     /// TBD
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
-    public class CachedMatchCompiler<T> : IMatchCompiler<T>
+    internal class CachedMatchCompiler<T> : IMatchCompiler<T>
     {
         private readonly IMatchExpressionBuilder _expressionBuilder;
         private readonly IPartialActionBuilder _actionBuilder;

--- a/src/core/Akka/Util/MatchHandler/CompiledMatchHandlerWithArguments.cs
+++ b/src/core/Akka/Util/MatchHandler/CompiledMatchHandlerWithArguments.cs
@@ -12,7 +12,7 @@ namespace Akka.Tools.MatchHandler
     /// <summary>
     /// TBD
     /// </summary>
-    public class CompiledMatchHandlerWithArguments
+    internal class CompiledMatchHandlerWithArguments
     {
         private readonly Delegate _compiledDelegate;
         private readonly object[] _delegateArguments;

--- a/src/core/Akka/Util/MatchHandler/HandlerKind.cs
+++ b/src/core/Akka/Util/MatchHandler/HandlerKind.cs
@@ -10,7 +10,7 @@ namespace Akka.Tools.MatchHandler
     /// <summary>
     /// TBD
     /// </summary>
-    public enum HandlerKind
+    internal enum HandlerKind
     {
         /// <summary>The handler is a Action&lt;T&gt;</summary>
         Action,

--- a/src/core/Akka/Util/MatchHandler/ILambdaExpressionCompiler.cs
+++ b/src/core/Akka/Util/MatchHandler/ILambdaExpressionCompiler.cs
@@ -14,7 +14,7 @@ namespace Akka.Tools.MatchHandler
     /// <summary>
     /// TBD
     /// </summary>
-    public interface ILambdaExpressionCompiler
+    internal interface ILambdaExpressionCompiler
     {
         /// <summary>
         /// Produces a delegate that represents the lambda expression.

--- a/src/core/Akka/Util/MatchHandler/IMatchCompiler.cs
+++ b/src/core/Akka/Util/MatchHandler/IMatchCompiler.cs
@@ -15,7 +15,7 @@ namespace Akka.Tools.MatchHandler
     /// TBD
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
-    public interface IMatchCompiler<in T>
+    internal interface IMatchCompiler<in T>
     {
         /// <summary>
         /// TBD
@@ -25,6 +25,7 @@ namespace Akka.Tools.MatchHandler
         /// <param name="signature">TBD</param>
         /// <returns>TBD</returns>
         PartialAction<T> Compile(IReadOnlyList<TypeHandler> handlers, IReadOnlyList<Argument> capturedArguments, MatchBuilderSignature signature);
+
         /// <summary>
         /// TBD
         /// </summary>

--- a/src/core/Akka/Util/MatchHandler/IMatchExpressionBuilder.cs
+++ b/src/core/Akka/Util/MatchHandler/IMatchExpressionBuilder.cs
@@ -12,7 +12,7 @@ namespace Akka.Tools.MatchHandler
     /// <summary>
     /// TBD
     /// </summary>
-    public interface IMatchExpressionBuilder
+    internal interface IMatchExpressionBuilder
     {
         /// <summary>
         /// TBD
@@ -20,6 +20,7 @@ namespace Akka.Tools.MatchHandler
         /// <param name="typeHandlers">TBD</param>
         /// <returns>TBD</returns>
         MatchExpressionBuilderResult BuildLambdaExpression(IReadOnlyList<TypeHandler> typeHandlers);
+
         /// <summary>
         /// TBD
         /// </summary>

--- a/src/core/Akka/Util/MatchHandler/IPartialActionBuilder.cs
+++ b/src/core/Akka/Util/MatchHandler/IPartialActionBuilder.cs
@@ -12,7 +12,7 @@ namespace Akka.Tools.MatchHandler
     /// <summary>
     /// TBD
     /// </summary>
-    public interface IPartialActionBuilder
+    internal interface IPartialActionBuilder
     {
         /// <summary>
         /// Builds the specified delegate and arguments to a <see cref="PartialAction{T}"/>

--- a/src/core/Akka/Util/MatchHandler/LambdaExpressionCompiler.cs
+++ b/src/core/Akka/Util/MatchHandler/LambdaExpressionCompiler.cs
@@ -14,7 +14,7 @@ namespace Akka.Tools.MatchHandler
     /// <summary>
     /// TBD
     /// </summary>
-    public class LambdaExpressionCompiler : ILambdaExpressionCompiler
+    internal class LambdaExpressionCompiler : ILambdaExpressionCompiler
     {
         /// <summary>
         /// TBD

--- a/src/core/Akka/Util/MatchHandler/MatchBuilder.cs
+++ b/src/core/Akka/Util/MatchHandler/MatchBuilder.cs
@@ -16,7 +16,7 @@ namespace Akka.Tools.MatchHandler
     /// TBD
     /// </summary>
     /// <typeparam name="TItem">TBD</typeparam>
-    public class MatchBuilder<TItem>
+    internal class MatchBuilder<TItem>
     {
         //This class works by collecting all handlers.
         //By creating a signature, made up of all types [Type], and types-of-handlers [HandlerKind], we can use the same code
@@ -261,7 +261,7 @@ namespace Akka.Tools.MatchHandler
     /// <summary>
     /// TBD
     /// </summary>
-    public class MatchBuilder : MatchBuilder<object>
+    internal class MatchBuilder : MatchBuilder<object>
     {
         /// <summary>
         /// TBD

--- a/src/core/Akka/Util/MatchHandler/MatchBuilderSignature.cs
+++ b/src/core/Akka/Util/MatchHandler/MatchBuilderSignature.cs
@@ -17,7 +17,7 @@ namespace Akka.Tools.MatchHandler
     /// Two signatures are equal if they contain the same <see cref="Type">Types</see> and <see cref="HandlerKind">HandlerKinds</see>
     /// in the same order.
     /// </summary>
-    public class MatchBuilderSignature : IEquatable<MatchBuilderSignature>
+    internal class MatchBuilderSignature : IEquatable<MatchBuilderSignature>
     {
         private readonly IReadOnlyList<object> _list;
 

--- a/src/core/Akka/Util/MatchHandler/MatchExpressionBuilder.cs
+++ b/src/core/Akka/Util/MatchHandler/MatchExpressionBuilder.cs
@@ -16,7 +16,7 @@ namespace Akka.Tools.MatchHandler
     /// TBD
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
-    public class MatchExpressionBuilder<T> : IMatchExpressionBuilder
+    internal class MatchExpressionBuilder<T> : IMatchExpressionBuilder
     {
         //See the end of file a description of what this class does
 

--- a/src/core/Akka/Util/MatchHandler/MatchExpressionBuilderResult.cs
+++ b/src/core/Akka/Util/MatchHandler/MatchExpressionBuilderResult.cs
@@ -12,7 +12,7 @@ namespace Akka.Tools.MatchHandler
     /// <summary>
     /// TBD
     /// </summary>
-    public class MatchExpressionBuilderResult
+    internal class MatchExpressionBuilderResult
     {
         private readonly LambdaExpression _lambdaExpression;
         private readonly object[] _arguments;

--- a/src/core/Akka/Util/MatchHandler/PartialAction.cs
+++ b/src/core/Akka/Util/MatchHandler/PartialAction.cs
@@ -13,6 +13,6 @@ namespace Akka.Tools.MatchHandler
     /// <typeparam name="T">The type of the argument</typeparam>
     /// <param name="item">The argument.</param>
     /// <returns>Returns <c>true</c> if the <paramref name="item"/> was handled</returns>
-    public delegate bool PartialAction<in T>(T item);
+    internal delegate bool PartialAction<in T>(T item);
 }
 

--- a/src/core/Akka/Util/MatchHandler/PartialActionBuilder.cs
+++ b/src/core/Akka/Util/MatchHandler/PartialActionBuilder.cs
@@ -12,7 +12,7 @@ namespace Akka.Tools.MatchHandler
     /// <summary>
     /// TBD
     /// </summary>
-    public class PartialActionBuilder : IPartialActionBuilder
+    internal class PartialActionBuilder : IPartialActionBuilder
     {
         /// <summary>
         /// The maximum number of arguments=15 not including the obligatory first value argument in a partial action. 

--- a/src/core/Akka/Util/MatchHandler/PartialHandlerArgumentsCapture.cs
+++ b/src/core/Akka/Util/MatchHandler/PartialHandlerArgumentsCapture.cs
@@ -1,4 +1,4 @@
-﻿// --- auto generated: 1/27/2017 10:09:00 PM --- //
+﻿// --- auto generated: 25.03.2017 11:38:45 --- //
 //-----------------------------------------------------------------------
 // <copyright file="PartialHandlerArgumentsCapture.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
@@ -15,7 +15,7 @@ namespace Akka.Tools.MatchHandler
     /// TBD
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
-    public interface IPartialHandlerArgumentsCapture<T>
+    internal interface IPartialHandlerArgumentsCapture<T>
     {
         /// <summary>
         /// TBD
@@ -35,7 +35,7 @@ namespace Akka.Tools.MatchHandler
     /// TBD
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
-    public sealed class PartialHandlerArgumentsCapture<T> : IPartialHandlerArgumentsCapture<T>
+    internal sealed class PartialHandlerArgumentsCapture<T> : IPartialHandlerArgumentsCapture<T>
     {
         /// <summary>
         /// TBD
@@ -60,7 +60,7 @@ namespace Akka.Tools.MatchHandler
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
     /// <typeparam name="T1">TBD</typeparam>
-    public sealed class PartialHandlerArgumentsCapture<T, T1> : IPartialHandlerArgumentsCapture<T>
+    internal sealed class PartialHandlerArgumentsCapture<T, T1> : IPartialHandlerArgumentsCapture<T>
     {
         /// <summary>
         /// TBD
@@ -87,7 +87,7 @@ namespace Akka.Tools.MatchHandler
     /// <typeparam name="T">TBD</typeparam>
     /// <typeparam name="T1">TBD</typeparam>
     /// <typeparam name="T2">TBD</typeparam>
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2> : IPartialHandlerArgumentsCapture<T>
+    internal sealed class PartialHandlerArgumentsCapture<T, T1, T2> : IPartialHandlerArgumentsCapture<T>
     {
         /// <summary>
         /// TBD
@@ -117,7 +117,7 @@ namespace Akka.Tools.MatchHandler
     /// <typeparam name="T1">TBD</typeparam>
     /// <typeparam name="T2">TBD</typeparam>
     /// <typeparam name="T3">TBD</typeparam>
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3> : IPartialHandlerArgumentsCapture<T>
+    internal sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3> : IPartialHandlerArgumentsCapture<T>
     {
         /// <summary>
         /// TBD
@@ -150,7 +150,7 @@ namespace Akka.Tools.MatchHandler
     /// <typeparam name="T2">TBD</typeparam>
     /// <typeparam name="T3">TBD</typeparam>
     /// <typeparam name="T4">TBD</typeparam>
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4> : IPartialHandlerArgumentsCapture<T>
+    internal sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4> : IPartialHandlerArgumentsCapture<T>
     {
         /// <summary>
         /// TBD
@@ -186,7 +186,7 @@ namespace Akka.Tools.MatchHandler
     /// <typeparam name="T3">TBD</typeparam>
     /// <typeparam name="T4">TBD</typeparam>
     /// <typeparam name="T5">TBD</typeparam>
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5> : IPartialHandlerArgumentsCapture<T>
+    internal sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5> : IPartialHandlerArgumentsCapture<T>
     {
         /// <summary>
         /// TBD
@@ -225,7 +225,7 @@ namespace Akka.Tools.MatchHandler
     /// <typeparam name="T4">TBD</typeparam>
     /// <typeparam name="T5">TBD</typeparam>
     /// <typeparam name="T6">TBD</typeparam>
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6> : IPartialHandlerArgumentsCapture<T>
+    internal sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6> : IPartialHandlerArgumentsCapture<T>
     {
         /// <summary>
         /// TBD
@@ -267,7 +267,7 @@ namespace Akka.Tools.MatchHandler
     /// <typeparam name="T5">TBD</typeparam>
     /// <typeparam name="T6">TBD</typeparam>
     /// <typeparam name="T7">TBD</typeparam>
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7> : IPartialHandlerArgumentsCapture<T>
+    internal sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7> : IPartialHandlerArgumentsCapture<T>
     {
         /// <summary>
         /// TBD
@@ -312,7 +312,7 @@ namespace Akka.Tools.MatchHandler
     /// <typeparam name="T6">TBD</typeparam>
     /// <typeparam name="T7">TBD</typeparam>
     /// <typeparam name="T8">TBD</typeparam>
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7, T8> : IPartialHandlerArgumentsCapture<T>
+    internal sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7, T8> : IPartialHandlerArgumentsCapture<T>
     {
         /// <summary>
         /// TBD
@@ -360,7 +360,7 @@ namespace Akka.Tools.MatchHandler
     /// <typeparam name="T7">TBD</typeparam>
     /// <typeparam name="T8">TBD</typeparam>
     /// <typeparam name="T9">TBD</typeparam>
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7, T8, T9> : IPartialHandlerArgumentsCapture<T>
+    internal sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7, T8, T9> : IPartialHandlerArgumentsCapture<T>
     {
         /// <summary>
         /// TBD
@@ -411,7 +411,7 @@ namespace Akka.Tools.MatchHandler
     /// <typeparam name="T8">TBD</typeparam>
     /// <typeparam name="T9">TBD</typeparam>
     /// <typeparam name="T10">TBD</typeparam>
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : IPartialHandlerArgumentsCapture<T>
+    internal sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : IPartialHandlerArgumentsCapture<T>
     {
         /// <summary>
         /// TBD
@@ -465,7 +465,7 @@ namespace Akka.Tools.MatchHandler
     /// <typeparam name="T9">TBD</typeparam>
     /// <typeparam name="T10">TBD</typeparam>
     /// <typeparam name="T11">TBD</typeparam>
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : IPartialHandlerArgumentsCapture<T>
+    internal sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : IPartialHandlerArgumentsCapture<T>
     {
         /// <summary>
         /// TBD
@@ -522,7 +522,7 @@ namespace Akka.Tools.MatchHandler
     /// <typeparam name="T10">TBD</typeparam>
     /// <typeparam name="T11">TBD</typeparam>
     /// <typeparam name="T12">TBD</typeparam>
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : IPartialHandlerArgumentsCapture<T>
+    internal sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : IPartialHandlerArgumentsCapture<T>
     {
         /// <summary>
         /// TBD
@@ -582,7 +582,7 @@ namespace Akka.Tools.MatchHandler
     /// <typeparam name="T11">TBD</typeparam>
     /// <typeparam name="T12">TBD</typeparam>
     /// <typeparam name="T13">TBD</typeparam>
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : IPartialHandlerArgumentsCapture<T>
+    internal sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : IPartialHandlerArgumentsCapture<T>
     {
         /// <summary>
         /// TBD
@@ -645,7 +645,7 @@ namespace Akka.Tools.MatchHandler
     /// <typeparam name="T12">TBD</typeparam>
     /// <typeparam name="T13">TBD</typeparam>
     /// <typeparam name="T14">TBD</typeparam>
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : IPartialHandlerArgumentsCapture<T>
+    internal sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : IPartialHandlerArgumentsCapture<T>
     {
         /// <summary>
         /// TBD
@@ -711,7 +711,7 @@ namespace Akka.Tools.MatchHandler
     /// <typeparam name="T13">TBD</typeparam>
     /// <typeparam name="T14">TBD</typeparam>
     /// <typeparam name="T15">TBD</typeparam>
-    public sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> : IPartialHandlerArgumentsCapture<T>
+    internal sealed class PartialHandlerArgumentsCapture<T, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> : IPartialHandlerArgumentsCapture<T>
     {
         /// <summary>
         /// TBD

--- a/src/core/Akka/Util/MatchHandler/PartialHandlerArgumentsCapture.tt
+++ b/src/core/Akka/Util/MatchHandler/PartialHandlerArgumentsCapture.tt
@@ -22,7 +22,7 @@ namespace Akka.Tools.MatchHandler
     /// TBD
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
-    public interface IPartialHandlerArgumentsCapture<T>
+    internal interface IPartialHandlerArgumentsCapture<T>
     {
         /// <summary>
         /// TBD
@@ -42,7 +42,7 @@ namespace Akka.Tools.MatchHandler
     /// TBD
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
-    public sealed class PartialHandlerArgumentsCapture<T> : IPartialHandlerArgumentsCapture<T>
+    internal sealed class PartialHandlerArgumentsCapture<T> : IPartialHandlerArgumentsCapture<T>
     {
         /// <summary>
         /// TBD
@@ -73,7 +73,7 @@ namespace Akka.Tools.MatchHandler
 <# for (var t = 1; t <= i; t++) { #>
     /// <typeparam name="T<#= t #>">TBD</typeparam>
 <# } #>
-    public sealed class PartialHandlerArgumentsCapture<T, <#= types #>> : IPartialHandlerArgumentsCapture<T>
+    internal sealed class PartialHandlerArgumentsCapture<T, <#= types #>> : IPartialHandlerArgumentsCapture<T>
     {
         /// <summary>
         /// TBD

--- a/src/core/Akka/Util/MatchHandler/PredicateAndHandler.cs
+++ b/src/core/Akka/Util/MatchHandler/PredicateAndHandler.cs
@@ -13,7 +13,7 @@ namespace Akka.Tools.MatchHandler
     /// <summary>
     /// TBD
     /// </summary>
-    public class PredicateAndHandler
+    internal class PredicateAndHandler
     {
         private readonly HandlerKind _handlerKind;
         private readonly bool _handlerFirstArgumentShouldBeBaseType;

--- a/src/core/Akka/Util/MatchHandler/TypeHandler.cs
+++ b/src/core/Akka/Util/MatchHandler/TypeHandler.cs
@@ -14,7 +14,7 @@ namespace Akka.Tools.MatchHandler
     /// <summary>
     /// TBD
     /// </summary>
-    public class TypeHandler
+    internal class TypeHandler
     {
         private readonly Type _handlesType;
         private readonly List<PredicateAndHandler> _handlers = new List<PredicateAndHandler>();


### PR DESCRIPTION
- Hide MatchHandler from the public API
- Added Xml comments to AutoReceive messages
- Enabled InternalVisibleTo for Persistence and for Streams