### PR TITLE
upgraded to DotNetty v0.4.3

### DIFF
--- a/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
+++ b/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
@@ -55,20 +55,20 @@
     <Optimize>false</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.4.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Buffers.0.4.0\lib\net451\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers.0.4.3\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.4.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs.0.4.0\lib\net451\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.0.4.3\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.4.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Common.0.4.0\lib\net451\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common.0.4.3\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.4.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Transport.0.4.0\lib\net451\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport.0.4.3\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FluentAssertions, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
@@ -104,21 +104,29 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.Logging.1.0.0\lib\netstandard1.1\Microsoft.Extensions.Logging.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.1.0.0\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />

--- a/src/core/Akka.Remote.Tests/app.config
+++ b/src/core/Akka.Remote.Tests/app.config
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.5.0.0" newVersion="4.5.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.5.0.0" newVersion="4.5.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup></configuration>

--- a/src/core/Akka.Remote.Tests/packages.config
+++ b/src/core/Akka.Remote.Tests/packages.config
@@ -1,31 +1,51 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers" version="0.4.0" targetFramework="net451" requireReinstallation="true" />
-  <package id="DotNetty.Codecs" version="0.4.0" targetFramework="net451" requireReinstallation="true" />
-  <package id="DotNetty.Common" version="0.4.0" targetFramework="net451" requireReinstallation="true" />
-  <package id="DotNetty.Transport" version="0.4.0" targetFramework="net451" requireReinstallation="true" />
+  <package id="DotNetty.Buffers" version="0.4.3" targetFramework="net45" />
+  <package id="DotNetty.Codecs" version="0.4.3" targetFramework="net45" />
+  <package id="DotNetty.Common" version="0.4.3" targetFramework="net45" />
+  <package id="DotNetty.Transport" version="0.4.3" targetFramework="net45" />
   <package id="FluentAssertions" version="4.2.1" targetFramework="net45" />
   <package id="FsCheck" version="2.5.0" targetFramework="net45" />
   <package id="FsCheck.Xunit" version="2.5.0" targetFramework="net45" />
   <package id="FSharp.Core" version="3.1.2.5" targetFramework="net45" />
   <package id="Google.ProtocolBuffers" version="2.4.1.555" targetFramework="net45" />
   <package id="Helios" version="2.1.3" targetFramework="net45" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net451" />
-  <package id="Microsoft.Extensions.Logging" version="1.0.0" targetFramework="net451" />
-  <package id="Microsoft.Extensions.Logging.Abstractions" version="1.0.0" targetFramework="net451" />
-  <package id="System.Collections" version="4.0.11" targetFramework="net451" />
-  <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net451" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.0" targetFramework="net45" />
+  <package id="Microsoft.Extensions.Logging" version="1.1.1" targetFramework="net45" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="1.1.1" targetFramework="net45" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net45" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net45" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net45" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
-  <package id="System.ComponentModel" version="4.0.1" targetFramework="net451" />
-  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net451" />
-  <package id="System.Globalization" version="4.0.11" targetFramework="net451" />
-  <package id="System.Linq" version="4.1.0" targetFramework="net451" />
-  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net451" />
-  <package id="System.Reflection" version="4.1.0" targetFramework="net451" />
-  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net451" />
-  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net451" />
-  <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net451" />
-  <package id="System.Threading" version="4.0.11" targetFramework="net451" />
+  <package id="System.ComponentModel" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net45" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net45" />
+  <package id="System.IO" version="4.3.0" targetFramework="net45" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net45" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net45" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net45" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net45" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net45" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net45" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net45" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net45" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net45" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/src/core/Akka.Remote/Akka.Remote.csproj
+++ b/src/core/Akka.Remote/Akka.Remote.csproj
@@ -51,24 +51,24 @@
     <Optimize>false</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetty.Buffers, Version=0.3.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Buffers.0.3.2\lib\net45\DotNetty.Buffers.dll</HintPath>
+    <Reference Include="DotNetty.Buffers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers.0.4.3\lib\net45\DotNetty.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Codecs, Version=0.3.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Codecs.0.3.2\lib\net45\DotNetty.Codecs.dll</HintPath>
+    <Reference Include="DotNetty.Codecs, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.0.4.3\lib\net45\DotNetty.Codecs.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Common, Version=0.3.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Common.0.3.2\lib\net45\DotNetty.Common.dll</HintPath>
+    <Reference Include="DotNetty.Common, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common.0.4.3\lib\net45\DotNetty.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Handlers, Version=0.3.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Handlers.0.3.2\lib\net45\DotNetty.Handlers.dll</HintPath>
+    <Reference Include="DotNetty.Handlers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Handlers.0.4.3\lib\net45\DotNetty.Handlers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DotNetty.Transport, Version=0.3.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetty.Transport.0.3.2\lib\net45\DotNetty.Transport.dll</HintPath>
+    <Reference Include="DotNetty.Transport, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport.0.4.3\lib\net45\DotNetty.Transport.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.ProtocolBuffers, Version=2.4.1.555, Culture=neutral, PublicKeyToken=55f7125234beb589, processorArchitecture=MSIL">
@@ -79,12 +79,34 @@
       <HintPath>..\..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.Serialization.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\SharedAssemblyInfo.cs">

--- a/src/core/Akka.Remote/packages.config
+++ b/src/core/Akka.Remote/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetty.Buffers" version="0.3.2" targetFramework="net45" />
-  <package id="DotNetty.Codecs" version="0.3.2" targetFramework="net45" />
-  <package id="DotNetty.Common" version="0.3.2" targetFramework="net45" />
-  <package id="DotNetty.Handlers" version="0.3.2" targetFramework="net45" />
-  <package id="DotNetty.Transport" version="0.3.2" targetFramework="net45" />
+  <package id="DotNetty.Buffers" version="0.4.3" targetFramework="net45" />
+  <package id="DotNetty.Codecs" version="0.4.3" targetFramework="net45" />
+  <package id="DotNetty.Common" version="0.4.3" targetFramework="net45" />
+  <package id="DotNetty.Handlers" version="0.4.3" targetFramework="net45" />
+  <package id="DotNetty.Transport" version="0.4.3" targetFramework="net45" />
   <package id="Google.ProtocolBuffers" version="2.4.1.555" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Resolves issues we've had with DotNetty not allowing the main thread to exit without shutting down the `ActorSystem` first.