### PR TITLE
Make FindSerializerForType faster

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Serialization/DistributedPubSubMessageSerializer.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Serialization/DistributedPubSubMessageSerializer.cs
@@ -15,6 +15,7 @@ using Akka.Actor;
 using Akka.Cluster.PubSub.Serializers.Proto;
 using Akka.Cluster.Tools.PublishSubscribe.Internal;
 using Akka.Serialization;
+using Akka.Util;
 using Google.ProtocolBuffers;
 using Address = Akka.Cluster.PubSub.Serializers.Proto.Address;
 using Delta = Akka.Cluster.Tools.PublishSubscribe.Internal.Delta;
@@ -308,7 +309,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
             else
             {
                 if (serializer.IncludeManifest)
-                    builder.SetMessageManifest(ByteString.CopyFromUtf8(TypeQualifiedNameForManifest(message.GetType())));
+                    builder.SetMessageManifest(ByteString.CopyFromUtf8(message.GetType().TypeQualifiedName()));
             }
 
             return builder.Build();

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -4474,6 +4474,8 @@ namespace Akka.Serialization
     {
         public Serialization(Akka.Actor.ExtendedActorSystem system) { }
         public Akka.Actor.ActorSystem System { get; }
+        public void AddSerializationMap(System.Type type, Akka.Serialization.Serializer serializer) { }
+        public void AddSerializer(Akka.Serialization.Serializer serializer) { }
         public object Deserialize(byte[] bytes, int serializerId, System.Type type) { }
         public object Deserialize(byte[] bytes, int serializerId, string manifest) { }
         public Akka.Serialization.Serializer FindSerializerFor(object obj) { }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -4486,7 +4486,6 @@ namespace Akka.Serialization
         public object Deserialize(byte[] bytes, int serializerId, string manifest) { }
         public Akka.Serialization.Serializer FindSerializerFor(object obj) { }
         public Akka.Serialization.Serializer FindSerializerForType(System.Type objectType) { }
-        public Akka.Serialization.Serializer GetSerializerById(int serializerId) { }
         public static string SerializedActorPath(Akka.Actor.IActorRef actorRef) { }
         public static T SerializeWithTransport<T>(Akka.Actor.ActorSystem system, Akka.Actor.Address address, System.Func<T> action) { }
     }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -4421,12 +4421,6 @@ namespace Akka.Serialization
         public override object FromBinary(byte[] bytes, System.Type type) { }
         public override byte[] ToBinary(object obj) { }
     }
-    public class Information
-    {
-        public Information() { }
-        public Akka.Actor.Address Address { get; set; }
-        public Akka.Actor.ActorSystem System { get; set; }
-    }
     public class JavaSerializer : Akka.Serialization.Serializer
     {
         public JavaSerializer(Akka.Actor.ExtendedActorSystem system) { }
@@ -4480,8 +4474,6 @@ namespace Akka.Serialization
     {
         public Serialization(Akka.Actor.ExtendedActorSystem system) { }
         public Akka.Actor.ActorSystem System { get; }
-        public void AddSerializationMap(System.Type type, Akka.Serialization.Serializer serializer) { }
-        public void AddSerializer(Akka.Serialization.Serializer serializer) { }
         public object Deserialize(byte[] bytes, int serializerId, System.Type type) { }
         public object Deserialize(byte[] bytes, int serializerId, string manifest) { }
         public Akka.Serialization.Serializer FindSerializerFor(object obj) { }
@@ -4496,9 +4488,9 @@ namespace Akka.Serialization
         public virtual int Identifier { get; }
         public abstract bool IncludeManifest { get; }
         public abstract object FromBinary(byte[] bytes, System.Type type);
+        public T FromBinary<T>(byte[] bytes) { }
         public abstract byte[] ToBinary(object obj);
         public byte[] ToBinaryWithAddress(Akka.Actor.Address address, object obj) { }
-        protected static string TypeQualifiedNameForManifest(System.Type type) { }
     }
     public class static SerializerIdentifierHelper
     {

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
@@ -1132,7 +1132,6 @@ namespace Akka.Persistence.Serialization
     {
         public MessageSerializer(Akka.Actor.ExtendedActorSystem system) { }
         public override bool IncludeManifest { get; }
-        public Akka.Serialization.Information TransportInformation { get; }
         public override object FromBinary(byte[] bytes, System.Type type) { }
         public override byte[] ToBinary(object obj) { }
     }
@@ -1153,7 +1152,6 @@ namespace Akka.Persistence.Serialization
     {
         public SnapshotSerializer(Akka.Actor.ExtendedActorSystem system) { }
         public override bool IncludeManifest { get; }
-        public Akka.Serialization.Information TransportInformation { get; }
         public override object FromBinary(byte[] bytes, System.Type type) { }
         public override byte[] ToBinary(object obj) { }
     }

--- a/src/core/Akka.Persistence.Tests/Serialization/TestSerializers.cs
+++ b/src/core/Akka.Persistence.Tests/Serialization/TestSerializers.cs
@@ -9,6 +9,7 @@ using System;
 using System.Text;
 using Akka.Actor;
 using Akka.Serialization;
+using Akka.Util;
 
 namespace Akka.Persistence.Tests.Serialization
 {
@@ -47,7 +48,7 @@ namespace Akka.Persistence.Tests.Serialization
 
     public class MyPayload2Serializer : SerializerWithStringManifest
     {
-        private readonly string _manifestV1 = TypeQualifiedNameForManifest(typeof (MyPayload));
+        private readonly string _manifestV1 = typeof(MyPayload).TypeQualifiedName();
         private readonly string _manifestV2 = "MyPayload-V2";
 
         public MyPayload2Serializer(ExtendedActorSystem system) : base(system)
@@ -119,7 +120,7 @@ namespace Akka.Persistence.Tests.Serialization
 
     public class MySnapshotSerializer2 : SerializerWithStringManifest
     {
-        private readonly string _oldManifest = TypeQualifiedNameForManifest(typeof (MySnapshot));
+        private readonly string _oldManifest = typeof(MySnapshot).TypeQualifiedName();
         private readonly string _currentManifest = "MySnapshot-V2";
 
         public MySnapshotSerializer2(ExtendedActorSystem system) : base(system)
@@ -154,7 +155,7 @@ namespace Akka.Persistence.Tests.Serialization
     public class OldPayloadSerializer : SerializerWithStringManifest
     {
         private readonly string _oldPayloadTypeName = "Akka.Persistence.Tests.Serialization.OldPayload,Akka.Persistence.Tests";
-        private readonly string _myPayloadTypeName = TypeQualifiedNameForManifest(typeof(MyPayload));
+        private readonly string _myPayloadTypeName = typeof(MyPayload).TypeQualifiedName();
 
         public OldPayloadSerializer(ExtendedActorSystem system) : base(system)
         {
@@ -167,14 +168,14 @@ namespace Akka.Persistence.Tests.Serialization
 
         public override string Manifest(object o)
         {
-            return TypeQualifiedNameForManifest(o.GetType());
+            return o.GetType().TypeQualifiedName();
         }
 
         public override byte[] ToBinary(object obj)
         {
             if (obj is MyPayload)
                 return Encoding.UTF8.GetBytes(string.Format(".{0}", ((MyPayload) obj).Data));
-            if (TypeQualifiedNameForManifest(obj.GetType()).Equals(_oldPayloadTypeName))
+            if (obj.GetType().TypeQualifiedName().Equals(_oldPayloadTypeName))
                 return Encoding.UTF8.GetBytes(obj.ToString());
             return null;
         }

--- a/src/core/Akka.Persistence/Serialization/MessageSerializer.cs
+++ b/src/core/Akka.Persistence/Serialization/MessageSerializer.cs
@@ -11,6 +11,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Akka.Actor;
 using Akka.Serialization;
+using Akka.Util;
 using Google.ProtocolBuffers;
 
 namespace Akka.Persistence.Serialization
@@ -39,7 +40,7 @@ namespace Akka.Persistence.Serialization
         /// <summary>
         /// TBD
         /// </summary>
-        public Information TransportInformation
+        internal Information TransportInformation
         {
             get
             {
@@ -198,7 +199,7 @@ namespace Akka.Persistence.Serialization
                     builder.SetPayloadManifest(ByteString.CopyFromUtf8(manifest));
             }
             else if (serializer.IncludeManifest)
-                builder.SetPayloadManifest(ByteString.CopyFromUtf8(TypeQualifiedNameForManifest(payload.GetType())));
+                builder.SetPayloadManifest(ByteString.CopyFromUtf8(payload.GetType().TypeQualifiedName()));
 
             var bytes = serializer.ToBinary(payload);
 

--- a/src/core/Akka.Persistence/Serialization/SnapshotSerializer.cs
+++ b/src/core/Akka.Persistence/Serialization/SnapshotSerializer.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Text;
 using Akka.Actor;
 using Akka.Serialization;
+using Akka.Util;
 
 namespace Akka.Persistence.Serialization
 {
@@ -105,10 +106,11 @@ namespace Akka.Persistence.Serialization
             : base(system)
         {
         }
+
         /// <summary>
         /// TBD
         /// </summary>
-        public Information TransportInformation
+        internal Information TransportInformation
         {
             get
             {
@@ -178,7 +180,7 @@ namespace Akka.Persistence.Serialization
                 }
                 else if (serializer.IncludeManifest)
                 {
-                    var snapshotTypeBinary = Encoding.UTF8.GetBytes(TypeQualifiedNameForManifest(snapshot.GetType()));
+                    var snapshotTypeBinary = Encoding.UTF8.GetBytes(snapshot.GetType().TypeQualifiedName());
                     headerOut.Write(snapshotTypeBinary, 0, snapshotTypeBinary.Length);
                 }
 

--- a/src/core/Akka.Tests.Performance/Akka.Tests.Performance.csproj
+++ b/src/core/Akka.Tests.Performance/Akka.Tests.Performance.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Dispatch\MessageDispatchAndReceiveBenchmark.cs" />
     <Compile Include="Dispatch\ReceiveOnlyBenchmark.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Util\SerializationBenchmarks.cs" />
     <Compile Include="Util\StandardOutWriterMemoryBenchmark.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/core/Akka.Tests.Performance/Util/SerializationBenchmarks.cs
+++ b/src/core/Akka.Tests.Performance/Util/SerializationBenchmarks.cs
@@ -1,0 +1,55 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SerializationBenchmarks.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Akka.Actor;
+using Akka.Routing;
+using Akka.Util.Internal;
+using NBench;
+
+namespace Akka.Tests.Performance.Util
+{
+    public class SerializationBenchmarks
+    {
+        protected ActorSystem System;
+        private Serialization.Serialization _serialization;
+        private Counter _findSerializerForTypeThroughput;
+        private const string CreateThroughputCounter = "FindSerializerForTypeThroughput";
+
+        [PerfSetup]
+        public void Setup(BenchmarkContext context)
+        {
+            System = ActorSystem.Create("SerializationBenchmarks");
+            _serialization = new Serialization.Serialization(System.AsInstanceOf<ExtendedActorSystem>());
+            _findSerializerForTypeThroughput = context.GetCounter(CreateThroughputCounter);
+        }
+
+        [PerfBenchmark(RunMode = RunMode.Iterations, NumberOfIterations = 13, TestMode = TestMode.Measurement)]
+        [CounterMeasurement(CreateThroughputCounter)]
+        public void FindSerializerForTypePerf(BenchmarkContext context)
+        {
+            for (int i = 0; i < 1000000; i++)
+            {
+                _serialization.FindSerializerForType(typeof(Dictionary<string, int>));
+                _serialization.FindSerializerForType(typeof(List<string>));
+                _serialization.FindSerializerForType(typeof(RoundRobinPool));
+                _serialization.FindSerializerForType(typeof(string));
+                _serialization.FindSerializerForType(typeof(RoundRobinGroup));
+                _serialization.FindSerializerForType(typeof(byte[]));
+                _findSerializerForTypeThroughput.Increment();
+            }
+        }
+
+        [PerfCleanup]
+        public void TearDown()
+        {
+            System.Terminate().Wait();
+        }
+    }
+}
+

--- a/src/core/Akka/Serialization/Serialization.cs
+++ b/src/core/Akka/Serialization/Serialization.cs
@@ -123,14 +123,25 @@ namespace Akka.Serialization
         /// </summary>
         public ActorSystem System { get; }
 
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="serializer">TBD</param>
+        /// <returns>TBD</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void AddSerializer(Serializer serializer)
+        public void AddSerializer(Serializer serializer)
         {
             _serializers.Add(serializer.Identifier, serializer);
         }
 
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="type">TBD</param>
+        /// <param name="serializer">TBD</param>
+        /// <returns>TBD</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void AddSerializationMap(Type type, Serializer serializer)
+        public void AddSerializationMap(Type type, Serializer serializer)
         {
             _serializerMap[type] = serializer;
         }

--- a/src/core/Akka/Serialization/Serialization.cs
+++ b/src/core/Akka/Serialization/Serialization.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -60,7 +61,7 @@ namespace Akka.Serialization
 
         private readonly Serializer _nullSerializer;
 
-        private readonly Dictionary<Type, Serializer> _serializerMap = new Dictionary<Type, Serializer>();
+        private readonly ConcurrentDictionary<Type, Serializer> _serializerMap = new ConcurrentDictionary<Type, Serializer>();
         private readonly Dictionary<int, Serializer> _serializers = new Dictionary<int, Serializer>();
 
         /// <summary>
@@ -118,7 +119,7 @@ namespace Akka.Serialization
                     continue;
                 }
 
-                _serializerMap.Add(messageType, serializer);
+                _serializerMap.TryAdd(messageType, serializer);
             }
         }
 
@@ -143,7 +144,7 @@ namespace Akka.Serialization
         /// <param name="serializer">TBD</param>
         public void AddSerializationMap(Type type, Serializer serializer)
         {
-            _serializerMap.Add(type, serializer);
+            _serializerMap.TryAdd(type, serializer);
         }
 
         /// <summary>
@@ -257,7 +258,7 @@ namespace Akka.Serialization
                 if (serializer == null)
                     throw new SerializationException($"Serializer not found for type {objectType.Name}");
 
-                _serializerMap.Add(type, serializer);
+                _serializerMap.TryAdd(type, serializer);
                 return serializer;
             }
         }

--- a/src/core/Akka/Serialization/Serialization.cs
+++ b/src/core/Akka/Serialization/Serialization.cs
@@ -244,11 +244,14 @@ namespace Akka.Serialization
                 {
                     // force deferral of the base "object" serializer until all other higher-level types have been evaluated
                     if (serializerType.Key.IsAssignableFrom(type) && serializerType.Key != _objectType)
+                    {
                         serializer = serializerType.Value;
+                        break;
+                    }
                 }
 
                 //do a final check for the "object" serializer
-                if (_serializerMap.ContainsKey(_objectType) && _objectType.IsAssignableFrom(type))
+                if (serializer == null && _serializerMap.ContainsKey(_objectType) && _objectType.IsAssignableFrom(type))
                     serializer = _serializerMap[_objectType];
 
                 if (serializer == null)

--- a/src/core/Akka/Serialization/Serializer.cs
+++ b/src/core/Akka/Serialization/Serializer.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Linq;
 using Akka.Actor;
+using Akka.Util;
 
 namespace Akka.Serialization
 {
@@ -87,22 +88,11 @@ namespace Akka.Serialization
         public abstract object FromBinary(byte[] bytes, Type type);
 
         /// <summary>
-        /// Utility to be used by implementors to create a manifest from the type.
-        /// The manifest is used to look up the type on deserialization.
-        /// Returns the type qualified name including namespace and assembly, but not assembly version.
+        /// Deserializes a byte array into an object.
         /// </summary>
-        /// <remarks>
-        /// See <see cref="Type.GetType(string)"/> for details on how a type is looked up
-        /// from a name. In particular, if the (partial) assembly name is not included
-        /// only the assembly calling <see cref="Type.GetType(string)"/> is searched.
-        /// If the (partial) assembly name is included, it searches in the specified assembly.
-        /// </remarks>
-        /// <param name="type">TBD</param>
-        /// <returns>TBD</returns>
-        protected static string TypeQualifiedNameForManifest(Type type)
-        {
-            return type == null ? string.Empty : string.Format("{0},{1}", type.FullName, type.Assembly.GetName().Name);
-        }
+        /// <param name="bytes">The array containing the serialized object</param>
+        /// <returns>The object contained in the array</returns>
+        public T FromBinary<T>(byte[] bytes) => (T)FromBinary(bytes, typeof(T));
     }
 
     /// <summary>
@@ -131,7 +121,7 @@ namespace Akka.Serialization
         /// <returns>TBD</returns>
         public sealed override object FromBinary(byte[] bytes, Type type)
         {
-            var manifest = TypeQualifiedNameForManifest(type);
+            var manifest = type.TypeQualifiedName();
             return FromBinary(bytes, manifest);
         }
 


### PR DESCRIPTION
Related https://github.com/akkadotnet/akka.net/issues/2566

I've reused some parts of Scala implementation
**Before**: 1 400 243 ops/s
**After**: 4 551 167 ops/s