### PR TITLE
Added GraphDSL.CreateMaterialized method

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
@@ -1241,6 +1241,8 @@ namespace Akka.Streams.Dsl
             where TShape2 : Akka.Streams.Shape
             where TShape3 : Akka.Streams.Shape
             where TShape4 : Akka.Streams.Shape { }
+        public static Akka.Streams.IGraph<TShape, TMat> CreateMaterialized<TShape, TMat>(System.Func<Akka.Streams.Dsl.GraphDsl.Builder<TMat>, TShape> buildBlock)
+            where TShape : Akka.Streams.Shape { }
         public sealed class Builder<T>
         {
             public Akka.Streams.Outlet<T> MaterializedValue { get; }
@@ -1292,7 +1294,7 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Inlet<TIn> In(int id) { }
         public override string ToString() { }
     }
-    public interface IRunnableGraph<TMat> : Akka.Streams.IGraph<Akka.Streams.ClosedShape>, Akka.Streams.IGraph<Akka.Streams.ClosedShape, TMat>
+    public interface IRunnableGraph<out TMat> : Akka.Streams.IGraph<Akka.Streams.ClosedShape>, Akka.Streams.IGraph<Akka.Streams.ClosedShape, TMat>
     {
         Akka.Streams.Dsl.IRunnableGraph<TMat> AddAttributes(Akka.Streams.Attributes attributes);
         Akka.Streams.Dsl.IRunnableGraph<TMat2> MapMaterializedValue<TMat2>(System.Func<TMat, TMat2> func);

--- a/src/core/Akka.Streams/CodeGen/Dsl/GraphApply.cs
+++ b/src/core/Akka.Streams/CodeGen/Dsl/GraphApply.cs
@@ -11,16 +11,18 @@ using Akka.Streams.Dsl.Internal;
 namespace Akka.Streams.Dsl
 {
     /// <summary>
-    /// TBD
+    /// A graph DSL, which defines an API for building complex graphs. Graph definitions 
+    /// are enclosed within a scope of functions defined by user, using a dedicated
+    /// <see cref="Builder{T}"/> helper to connect specific graph stages with each other.
     /// </summary>
     public partial class GraphDsl
     {
         /// <summary>
         /// Creates a new <see cref="IGraph{TShape, TMat}"/> by passing a <see cref="Builder{TMat}"/> to the given create function.
         /// </summary>
-        /// <typeparam name="TShape">TBD</typeparam>
-        /// <param name="buildBlock">TBD</param>
-        /// <returns>TBD</returns>
+        /// <typeparam name="TShape">Type describing shape of the returned graph.</typeparam>
+        /// <param name="buildBlock">A builder function used to construct the graph.</param>
+        /// <returns>A graph with no materialized value.</returns>
         public static IGraph<TShape, NotUsed> Create<TShape>(Func<Builder<NotUsed>, TShape> buildBlock)
             where TShape : Shape
             => CreateMaterialized<TShape, NotUsed>(buildBlock);
@@ -29,9 +31,9 @@ namespace Akka.Streams.Dsl
         /// Creates a new <see cref="IGraph{TShape, TMat}"/> by passing a <see cref="Builder{TMat}"/> to the given create function.
         /// </summary>
         /// <typeparam name="TShape">Shape of the produced graph.</typeparam>
-        /// <typeparam name="TMat">Value, that graph will materialize to after completion.</typeparam>
+        /// <typeparam name="TMat">A type of value, that graph will materialize to after completion.</typeparam>
         /// <param name="buildBlock">Graph construction function.</param>
-        /// <returns>TBD</returns>
+        /// <returns>A graph with materialized value.</returns>
         public static IGraph<TShape, TMat> CreateMaterialized<TShape, TMat>(Func<Builder<TMat>, TShape> buildBlock) where TShape : Shape
         {
             var builder = new Builder<TMat>();
@@ -45,12 +47,12 @@ namespace Akka.Streams.Dsl
         /// Creates a new <see cref="IGraph{TShape, TMat}"/> by importing the given graph <paramref name="g1"/> 
         /// and passing its <see cref="Shape"/> along with the <see cref="Builder{TMat}"/> to the given create function.
         /// </summary>
-        /// <typeparam name="TShapeOut">TBD</typeparam>
-        /// <typeparam name="TMat">TBD</typeparam>
-        /// <typeparam name="TShape1">TBD</typeparam>
-        /// <param name="g1">TBD</param>
-        /// <param name="buildBlock">TBD</param>
-        /// <returns>TBD</returns>
+        /// <typeparam name="TShapeOut">A type describing shape of the returned graph.</typeparam>
+        /// <typeparam name="TMat">A type of value, that graph will materialize to after completion.</typeparam>
+        /// <typeparam name="TShape1">A type of shape of the input graph.</typeparam>
+        /// <param name="g1">Graph used as input parameter.</param>
+        /// <param name="buildBlock">Graph construction function.</param>
+        /// <returns>A graph with materialized value.</returns>
         public static IGraph<TShapeOut, TMat> Create<TShapeOut, TMat, TShape1>(IGraph<TShape1, TMat> g1, Func<Builder<TMat>, TShape1, TShapeOut> buildBlock) 
             where TShapeOut: Shape
             where TShape1: Shape
@@ -62,22 +64,22 @@ namespace Akka.Streams.Dsl
 
             return new GraphImpl<TShapeOut, TMat>(shape, module);
         }
-        
+
         /// <summary>
         /// Creates a new <see cref="IGraph{TShape, TMat}"/> by importing the given graphs and passing their <see cref="Shape"/>s 
         /// along with the <see cref="Builder{TMat}"/> to the given create function.
         /// </summary>
-        /// <typeparam name="TShapeOut">TBD</typeparam>
-        /// <typeparam name="TMatOut">TBD</typeparam>
-        /// <typeparam name="TMat0">TBD</typeparam>
-        /// <typeparam name="TMat1">TBD</typeparam>
-        /// <typeparam name="TShape0">TBD</typeparam>
-        /// <typeparam name="TShape1">TBD</typeparam>
-        /// <param name="g0">TBD</param>
-        /// <param name="g1">TBD</param>
-        /// <param name="combineMaterializers">TBD</param>
-        /// <param name="buildBlock">TBD</param>
-        /// <returns>TBD</returns>
+        /// <typeparam name="TShapeOut">A type describing shape of the returned graph.</typeparam>
+        /// <typeparam name="TMatOut">A type of value, that graph will materialize to after completion.</typeparam>
+        /// <typeparam name="TMat0">A type of materialized value of the first input graph parameter.</typeparam>
+        /// <typeparam name="TMat1">A type of materialized value of the second input graph parameter.</typeparam>
+        /// <typeparam name="TShape0">A type describing the shape of a first input graph parameter.</typeparam>
+        /// <typeparam name="TShape1">A type describing the shape of a second input graph parameter.</typeparam>
+        /// <param name="g0">A first input graph.</param>
+        /// <param name="g1">A second input graph.</param>
+        /// <param name="combineMaterializers">Function used to determine output materialized value based on the materialized values of the passed graphs.</param>
+        /// <param name="buildBlock">A graph constructor function.</param>
+        /// <returns>A graph with materialized value.</returns>
         public static IGraph<TShapeOut, TMatOut> Create<TShapeOut, TMatOut, TMat0, TMat1, TShape0, TShape1>(
             IGraph<TShape0, TMat0> g0, IGraph<TShape1, TMat1> g1, 
             Func<TMat0, TMat1, TMatOut> combineMaterializers,
@@ -100,20 +102,20 @@ namespace Akka.Streams.Dsl
         /// Creates a new <see cref="IGraph{TShape, TMat}"/> by importing the given graphs and passing their <see cref="Shape"/>s 
         /// along with the <see cref="Builder{TMat}"/> to the given create function.
         /// </summary>
-        /// <typeparam name="TShapeOut">TBD</typeparam>
-        /// <typeparam name="TMatOut">TBD</typeparam>
-        /// <typeparam name="TMat0">TBD</typeparam>
-        /// <typeparam name="TMat1">TBD</typeparam>
-        /// <typeparam name="TMat2">TBD</typeparam>
-        /// <typeparam name="TShape0">TBD</typeparam>
-        /// <typeparam name="TShape1">TBD</typeparam>
-        /// <typeparam name="TShape2">TBD</typeparam>
-        /// <param name="g0">TBD</param>
-        /// <param name="g1">TBD</param>
-        /// <param name="g2">TBD</param>
-        /// <param name="combineMaterializers">TBD</param>
-        /// <param name="buildBlock">TBD</param>
-        /// <returns>TBD</returns>
+        /// <typeparam name="TShapeOut">A type describing shape of the returned graph.</typeparam>
+        /// <typeparam name="TMatOut">A type of value, that graph will materialize to after completion.</typeparam>
+        /// <typeparam name="TMat0">A type of materialized value of the first input graph parameter.</typeparam>
+        /// <typeparam name="TMat1">A type of materialized value of the second input graph parameter.</typeparam>
+        /// <typeparam name="TMat2">A type of materialized value of the third input graph parameter.</typeparam>
+        /// <typeparam name="TShape0">A type describing the shape of a first input graph parameter.</typeparam>
+        /// <typeparam name="TShape1">A type describing the shape of a second input graph parameter.</typeparam>
+        /// <typeparam name="TShape2">A type describing the shape of a third input graph parameter.</typeparam>
+        /// <param name="g0">A first input graph.</param>
+        /// <param name="g1">A second input graph.</param>
+        /// <param name="g2">A third input graph.</param>
+        /// <param name="combineMaterializers">Function used to determine output materialized value based on the materialized values of the passed graphs.</param>
+        /// <param name="buildBlock">A graph constructor function.</param>
+        /// <returns>A graph with materialized value.</returns>
         public static IGraph<TShapeOut, TMatOut> Create<TShapeOut, TMatOut, TMat0, TMat1, TMat2, TShape0, TShape1, TShape2>(
             IGraph<TShape0, TMat0> g0, IGraph<TShape1, TMat1> g1, IGraph<TShape2, TMat2> g2, 
             Func<TMat0, TMat1, TMat2, TMatOut> combineMaterializers,
@@ -138,23 +140,23 @@ namespace Akka.Streams.Dsl
         /// Creates a new <see cref="IGraph{TShape, TMat}"/> by importing the given graphs and passing their <see cref="Shape"/>s 
         /// along with the <see cref="Builder{TMat}"/> to the given create function.
         /// </summary>
-        /// <typeparam name="TShapeOut">TBD</typeparam>
-        /// <typeparam name="TMatOut">TBD</typeparam>
-        /// <typeparam name="TMat0">TBD</typeparam>
-        /// <typeparam name="TMat1">TBD</typeparam>
-        /// <typeparam name="TMat2">TBD</typeparam>
-        /// <typeparam name="TMat3">TBD</typeparam>
-        /// <typeparam name="TShape0">TBD</typeparam>
-        /// <typeparam name="TShape1">TBD</typeparam>
-        /// <typeparam name="TShape2">TBD</typeparam>
-        /// <typeparam name="TShape3">TBD</typeparam>
-        /// <param name="g0">TBD</param>
-        /// <param name="g1">TBD</param>
-        /// <param name="g2">TBD</param>
-        /// <param name="g3">TBD</param>
-        /// <param name="combineMaterializers">TBD</param>
-        /// <param name="buildBlock">TBD</param>
-        /// <returns>TBD</returns>
+        /// <typeparam name="TShapeOut">A type describing shape of the returned graph.</typeparam>
+        /// <typeparam name="TMatOut">A type of value, that graph will materialize to after completion.</typeparam>
+        /// <typeparam name="TMat0">A type of materialized value of the first input graph parameter.</typeparam>
+        /// <typeparam name="TMat1">A type of materialized value of the second input graph parameter.</typeparam>
+        /// <typeparam name="TMat2">A type of materialized value of the third input graph parameter.</typeparam>
+        /// <typeparam name="TMat3">A type of materialized value of the fourth input graph parameter.</typeparam>
+        /// <typeparam name="TShape0">A type describing the shape of a first input graph parameter.</typeparam>
+        /// <typeparam name="TShape1">A type describing the shape of a second input graph parameter.</typeparam>
+        /// <typeparam name="TShape2">A type describing the shape of a third input graph parameter.</typeparam>
+        /// <typeparam name="TShape3">A type describing the shape of a fourth input graph parameter.</typeparam>
+        /// <param name="g0">A first input graph.</param>
+        /// <param name="g1">A second input graph.</param>
+        /// <param name="g2">A third input graph.</param>
+        /// <param name="g3">A fourth input graph.</param>
+        /// <param name="combineMaterializers">Function used to determine output materialized value based on the materialized values of the passed graphs.</param>
+        /// <param name="buildBlock">A graph constructor function.</param>
+        /// <returns>A graph with materialized value.</returns>
         public static IGraph<TShapeOut, TMatOut> Create<TShapeOut, TMatOut, TMat0, TMat1, TMat2, TMat3, TShape0, TShape1, TShape2, TShape3>(
             IGraph<TShape0, TMat0> g0, IGraph<TShape1, TMat1> g1, IGraph<TShape2, TMat2> g2, IGraph<TShape3, TMat3> g3, 
             Func<TMat0, TMat1, TMat2, TMat3, TMatOut> combineMaterializers,
@@ -181,26 +183,26 @@ namespace Akka.Streams.Dsl
         /// Creates a new <see cref="IGraph{TShape, TMat}"/> by importing the given graphs and passing their <see cref="Shape"/>s 
         /// along with the <see cref="Builder{TMat}"/> to the given create function.
         /// </summary>
-        /// <typeparam name="TShapeOut">TBD</typeparam>
-        /// <typeparam name="TMatOut">TBD</typeparam>
-        /// <typeparam name="TMat0">TBD</typeparam>
-        /// <typeparam name="TMat1">TBD</typeparam>
-        /// <typeparam name="TMat2">TBD</typeparam>
-        /// <typeparam name="TMat3">TBD</typeparam>
-        /// <typeparam name="TMat4">TBD</typeparam>
-        /// <typeparam name="TShape0">TBD</typeparam>
-        /// <typeparam name="TShape1">TBD</typeparam>
-        /// <typeparam name="TShape2">TBD</typeparam>
-        /// <typeparam name="TShape3">TBD</typeparam>
-        /// <typeparam name="TShape4">TBD</typeparam>
-        /// <param name="g0">TBD</param>
-        /// <param name="g1">TBD</param>
-        /// <param name="g2">TBD</param>
-        /// <param name="g3">TBD</param>
-        /// <param name="g4">TBD</param>
-        /// <param name="combineMaterializers">TBD</param>
-        /// <param name="buildBlock">TBD</param>
-        /// <returns>TBD</returns>
+        /// <typeparam name="TShapeOut">A type describing shape of the returned graph.</typeparam>
+        /// <typeparam name="TMatOut">A type of value, that graph will materialize to after completion.</typeparam>
+        /// <typeparam name="TMat0">A type of materialized value of the first input graph parameter.</typeparam>
+        /// <typeparam name="TMat1">A type of materialized value of the second input graph parameter.</typeparam>
+        /// <typeparam name="TMat2">A type of materialized value of the third input graph parameter.</typeparam>
+        /// <typeparam name="TMat3">A type of materialized value of the fourth input graph parameter.</typeparam>
+        /// <typeparam name="TMat4">A type of materialized value of the fifth input graph parameter.</typeparam>
+        /// <typeparam name="TShape0">A type describing the shape of a first input graph parameter.</typeparam>
+        /// <typeparam name="TShape1">A type describing the shape of a second input graph parameter.</typeparam>
+        /// <typeparam name="TShape2">A type describing the shape of a third input graph parameter.</typeparam>
+        /// <typeparam name="TShape3">A type describing the shape of a fourth input graph parameter.</typeparam>
+        /// <typeparam name="TShape4">A type describing the shape of a fifth input graph parameter.</typeparam>
+        /// <param name="g0">A first input graph.</param>
+        /// <param name="g1">A second input graph.</param>
+        /// <param name="g2">A third input graph.</param>
+        /// <param name="g3">A fourth input graph.</param>
+        /// <param name="g4">A fifth input graph.</param>
+        /// <param name="combineMaterializers">Function used to determine output materialized value based on the materialized values of the passed graphs.</param>
+        /// <param name="buildBlock">A graph constructor function.</param>
+        /// <returns>A graph with materialized value.</returns>
         public static IGraph<TShapeOut, TMatOut> Create<TShapeOut, TMatOut, TMat0, TMat1, TMat2, TMat3, TMat4, TShape0, TShape1, TShape2, TShape3, TShape4>(
             IGraph<TShape0, TMat0> g0, IGraph<TShape1, TMat1> g1, IGraph<TShape2, TMat2> g2, IGraph<TShape3, TMat3> g3, IGraph<TShape4, TMat4> g4, 
             Func<TMat0, TMat1, TMat2, TMat3, TMat4, TMatOut> combineMaterializers,

--- a/src/core/Akka.Streams/CodeGen/Dsl/GraphApply.cs
+++ b/src/core/Akka.Streams/CodeGen/Dsl/GraphApply.cs
@@ -21,15 +21,26 @@ namespace Akka.Streams.Dsl
         /// <typeparam name="TShape">TBD</typeparam>
         /// <param name="buildBlock">TBD</param>
         /// <returns>TBD</returns>
-        public static IGraph<TShape, NotUsed> Create<TShape>(Func<Builder<NotUsed>, TShape> buildBlock) where TShape: Shape
+        public static IGraph<TShape, NotUsed> Create<TShape>(Func<Builder<NotUsed>, TShape> buildBlock)
+            where TShape : Shape
+            => CreateMaterialized<TShape, NotUsed>(buildBlock);
+
+        /// <summary>
+        /// Creates a new <see cref="IGraph{TShape, TMat}"/> by passing a <see cref="Builder{TMat}"/> to the given create function.
+        /// </summary>
+        /// <typeparam name="TShape">Shape of the produced graph.</typeparam>
+        /// <typeparam name="TMat">Value, that graph will materialize to after completion.</typeparam>
+        /// <param name="buildBlock">Graph construction function.</param>
+        /// <returns>TBD</returns>
+        public static IGraph<TShape, TMat> CreateMaterialized<TShape, TMat>(Func<Builder<TMat>, TShape> buildBlock) where TShape : Shape
         {
-            var builder = new Builder<NotUsed>();
+            var builder = new Builder<TMat>();
             var shape = buildBlock(builder);
             var module = builder.Module.ReplaceShape(shape);
 
-            return new GraphImpl<TShape, NotUsed>(shape, module);
+            return new GraphImpl<TShape, TMat>(shape, module);
         }
-        
+
         /// <summary>
         /// Creates a new <see cref="IGraph{TShape, TMat}"/> by importing the given graph <paramref name="g1"/> 
         /// and passing its <see cref="Shape"/> along with the <see cref="Builder{TMat}"/> to the given create function.

--- a/src/core/Akka.Streams/Dsl/RunnableGraph.cs
+++ b/src/core/Akka.Streams/Dsl/RunnableGraph.cs
@@ -14,7 +14,7 @@ namespace Akka.Streams.Dsl
     /// Flow with attached input and output, can be executed.
     /// </summary>
     /// <typeparam name="TMat">TBD</typeparam>
-    public interface IRunnableGraph<TMat> : IGraph<ClosedShape, TMat>
+    public interface IRunnableGraph<out TMat> : IGraph<ClosedShape, TMat>
     {
         /// <summary>
         /// Transform only the materialized value of this RunnableGraph, leaving all other properties as they were.


### PR DESCRIPTION
It's a small improvement: a `GraphDSL.CreateMaterialized<TShape, TMat>` method. It's more flexible than `GraphDSL.Create<TShape>` method as it allows to construct from scratch a graph, than may have materialized value different than `NotUsed`. 

It's necessary, as there is no other way to build a generic `IGraph<TMat>` version - builder dsl constructors are internal. Personally I need this for building F# API for constructing graphs.