### PR TITLE
Revise TestActor used for EventsByPersistenceIdSpec to block until ack of Journal cleanup

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sql.TestKit/EventsByPersistenceIdSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.TestKit/EventsByPersistenceIdSpec.cs
@@ -91,7 +91,7 @@ namespace Akka.Persistence.Sql.TestKit
             var pref = Setup("g1");
 
             pref.Tell(new TestActor.DeleteCommand(3));
-            ExpectMsg("3-deleted");
+            AwaitAssert(() => ExpectMsg("3-deleted"));
 
             var src = queries.CurrentEventsByPersistenceId("g1", 0, long.MaxValue);
             src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), _materializer).Request(1).ExpectComplete();
@@ -104,7 +104,7 @@ namespace Akka.Persistence.Sql.TestKit
             var pref = Setup("g2");
 
             pref.Tell(new TestActor.DeleteCommand(3));
-            ExpectMsg("3-deleted");
+            AwaitAssert(() => ExpectMsg("3-deleted"));
 
             var src = queries.CurrentEventsByPersistenceId("g2", 0, 0);
             src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), _materializer).Request(1).ExpectComplete();
@@ -117,7 +117,7 @@ namespace Akka.Persistence.Sql.TestKit
             var pref = Setup("h");
 
             pref.Tell(new TestActor.DeleteCommand(2));
-            ExpectMsg("2-deleted");
+            AwaitAssert(() => ExpectMsg("2-deleted"));
 
             var src = queries.CurrentEventsByPersistenceId("h", 0, long.MaxValue);
             src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), _materializer).Request(1).ExpectNext("h-3").ExpectComplete();

--- a/src/contrib/persistence/Akka.Persistence.Sql.TestKit/TestActor.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.TestKit/TestActor.cs
@@ -32,12 +32,17 @@ namespace Akka.Persistence.Sql.TestKit
 
         public override string PersistenceId { get; }
         protected override bool ReceiveRecover(object message) => true;
+        private IActorRef _parentTestActor;
 
         protected override bool ReceiveCommand(object message) => message.Match()
             .With<DeleteCommand>(delete =>
             {
+                _parentTestActor = Sender;
                 DeleteMessages(delete.ToSequenceNr);
-                Sender.Tell(delete.ToSequenceNr.ToString() + "-deleted");
+            })
+            .With<DeleteMessagesSuccess>(deleteSuccess =>
+            {
+                _parentTestActor.Tell(deleteSuccess.ToSequenceNr.ToString() + "-deleted");
             })
             .With<string>(cmd =>
             {


### PR DESCRIPTION
PR in response to a set of tests deemed flaky by TeamCity CI.  Example here: http://petabridge-ci.cloudapp.net/viewLog.html?buildId=21833&tab=buildResultsDiv&buildTypeId=AkkaNet_AkkaPersistenceImplementations_AkkaPersistenceSqlServer_PrBuilds#testNameId-488764090331667693

Test failures were due to the `DeleteCommand` being sent to the `TestActor` not completing the Journal cleanup before the assertions were being made against the cleaned-up Journal.

```
Failed: Expected a message of type Akka.Streams.TestKit.TestSubscriber+OnComplete, 
but received {TestSubscriber.OnNext(g1-1)} 
(type Akka.Streams.TestKit.TestSubscriber+OnNext`1[System.Object]) instead  
from [akka://test/user/StreamSupervisor-16/Flow-0-0-select#2080382836]
```

Revised `TestActor` to send acknowledgement to TestKit actor only after it has received the `DeleteMessagesSuccess` message back from the Journal.  Also added `AwaitAssert` to wait for the `ExpectMsg("-deleted")` message or fail if not received within default timespan.