### PR TITLE
[WIP] Update Akka.Streams to 2.4.12

### DIFF
--- a/src/core/Akka.Streams.Tests/Dsl/FramingSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FramingSpec.cs
@@ -24,6 +24,7 @@ namespace Akka.Streams.Tests.Dsl
     public class FramingSpec : AkkaSpec
     {
         private readonly ITestOutputHelper _helper;
+
         private ActorMaterializer Materializer { get; }
 
         public FramingSpec(ITestOutputHelper helper) : base(helper)

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/GraphInterpreterSpecKit.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/GraphInterpreterSpecKit.cs
@@ -10,6 +10,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Akka.Actor;
+using Akka.Configuration;
 using Akka.Event;
 using Akka.Streams.Implementation;
 using Akka.Streams.Implementation.Fusing;
@@ -22,7 +23,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
 {
     public class GraphInterpreterSpecKit : AkkaSpec
     {
-        public GraphInterpreterSpecKit(ITestOutputHelper output = null) : base(output)
+        public GraphInterpreterSpecKit(ITestOutputHelper output = null, Config config = null) : base(output, config)
         {
         }
 

--- a/src/core/Akka.Streams.Tests/Implementation/GraphStageLogicSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/GraphStageLogicSpec.cs
@@ -8,12 +8,14 @@
 using System;
 using System.Linq;
 using Akka.Actor;
+using Akka.Configuration;
 using Akka.Pattern;
 using Akka.Streams.Dsl;
 using Akka.Streams.Stage;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
 using Akka.Streams.Tests.Implementation.Fusing;
+using Akka.Util;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -225,9 +227,46 @@ namespace Akka.Streams.Tests.Implementation
                 => new ReadNEmitRestOnCompleteLogic(this);
         }
 
+        private sealed class RandomLettersSource : GraphStage<SourceShape<string>>
+        {
+            #region internal classes
+
+            private sealed class Logic : GraphStageLogic
+            {
+                public Logic(RandomLettersSource stage) : base(stage.Shape)
+                {
+                    SetHandler(stage.Out, onPull: () =>
+                    {
+                        var c = NextChar(); // ASCII lower case letters
+
+                        Log.Debug($"Randomly generated: {c}");
+
+                        Push(stage.Out, c.ToString());
+                    });
+                }
+
+                private static char NextChar() => (char) ThreadLocalRandom.Current.Next('a', 'z' + 1);
+            }
+
+            #endregion
+
+            public RandomLettersSource()
+            {
+                Shape = new SourceShape<string>(Out);
+            }
+
+            private Outlet<string> Out { get; } = new Outlet<string>("RandomLettersSource.out");
+
+            public override SourceShape<string> Shape { get; }
+
+            protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes) => new Logic(this);
+        }
+
+        private static readonly Config Config = ConfigurationFactory.ParseString("akka.loglevel = DEBUG");
+
         private ActorMaterializer Materializer { get; }
 
-        public GraphStageLogicSpec(ITestOutputHelper output) : base(output)
+        public GraphStageLogicSpec(ITestOutputHelper output) : base(output, Config)
         {
             Materializer = ActorMaterializer.Create(Sys);
         }
@@ -355,7 +394,20 @@ namespace Akka.Streams.Tests.Implementation
         }
 
         [Fact]
-        public void A_GraphStageLogic_must_invoke_lifecycle_hooks_in_the_right_order()
+        public void A_GraphStageLogic_must_support_logging_in_custom_graphstage()
+        {
+            const int n = 10;
+            EventFilter.Debug(start: "Randomly generated").Expect(n, () =>
+            {
+                Source.FromGraph(new RandomLettersSource())
+                    .Take(n)
+                    .RunWith(Sink.Ignore<string>(), Materializer)
+                    .Wait(TimeSpan.FromSeconds(3));
+            });
+        }
+
+        [Fact]
+        public void A_GraphStageLogic_must_invoke_livecycle_hooks_in_the_right_order()
         {
             this.AssertAllStagesStopped(() =>
             {

--- a/src/core/Akka.Streams/ActorMaterializer.cs
+++ b/src/core/Akka.Streams/ActorMaterializer.cs
@@ -29,7 +29,7 @@ namespace Akka.Streams
     /// steps are split up into asynchronous regions is implementation
     /// dependent.
     /// </summary>
-    public abstract class ActorMaterializer : IMaterializer, IDisposable
+    public abstract class ActorMaterializer : IMaterializer, IMaterializerLoggingProvider, IDisposable
     {
         /// <summary>
         /// TBD
@@ -180,6 +180,13 @@ namespace Akka.Streams
         /// <param name="props">TBD</param>
         /// <returns>TBD</returns>
         public abstract IActorRef ActorOf(MaterializationContext context, Props props);
+
+        /// <summary>
+        /// Creates a new logging adapter.
+        /// </summary>
+        /// <param name="logSource">The source that produces the log events.</param>
+        /// <returns>The newly created logging adapter.</returns>
+        public abstract ILoggingAdapter MakeLogger(object logSource);
 
         /// <inheritdoc/>
         public void Dispose() => Shutdown();

--- a/src/core/Akka.Streams/Akka.Streams.csproj
+++ b/src/core/Akka.Streams/Akka.Streams.csproj
@@ -99,6 +99,7 @@
     <Compile Include="FanOutShape.cs" />
     <Compile Include="FlowMonitor.cs" />
     <Compile Include="Fusing.cs" />
+    <Compile Include="IMaterializerLoggingProvider.cs" />
     <Compile Include="Implementation\ActorMaterializerImpl.cs" />
     <Compile Include="Implementation\ActorRefBackpressureSinkStage.cs" />
     <Compile Include="Implementation\ActorRefSinkActor.cs" />
@@ -166,6 +167,7 @@
     <Compile Include="Stage\AbstractStage.cs" />
     <Compile Include="Stage\Context.cs" />
     <Compile Include="Stage\GraphStage.cs" />
+    <Compile Include="Stage\IStageLogging .cs" />
     <Compile Include="Stage\Stage.cs" />
     <Compile Include="StreamLimitReachedException.cs" />
     <Compile Include="StreamTcpException.cs" />

--- a/src/core/Akka.Streams/Dsl/FlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/FlowOperations.cs
@@ -259,8 +259,8 @@ namespace Akka.Streams.Dsl
         /// <summary>
         /// Transform this stream by applying the given function <paramref name="asyncMapper"/> to each of the elements
         /// as they pass through this processing step. The function returns a <see cref="Task"/> and the
-        /// value of that task will be emitted downstream. As many tasks as requested elements by
-        /// downstream may run in parallel and each processed element will be emitted dowstream
+        /// value of that task will be emitted downstream. The number of tasks that shall run in parallel is given as
+        /// the first argument to <see cref="SelectAsyncUnordered{T,TIn,TOut,TMat}"/>. Each processed element will be emitted dowstream
         /// as soon as it is ready, i.e. it is possible that the elements are not emitted downstream
         /// in the same order as received from upstream.
         /// 

--- a/src/core/Akka.Streams/Dsl/Sink.cs
+++ b/src/core/Akka.Streams/Dsl/Sink.cs
@@ -270,8 +270,7 @@ namespace Akka.Streams.Dsl
         /// </summary>
         /// <typeparam name="TIn">TBD</typeparam>
         /// <returns>TBD</returns>
-        public static Sink<TIn, Task> Ignore<TIn>()
-            => new Sink<TIn, Task>(new SinkholeSink<TIn>(Shape<TIn>("BlackholeSink"), DefaultAttributes.IgnoreSink));
+        public static Sink<TIn, Task> Ignore<TIn>() => FromGraph(new IgnoreSink<TIn>());
 
         /// <summary>
         /// A <see cref="Sink{TIn,TMat}"/> that will invoke the given <paramref name="action"/> for each received element. 

--- a/src/core/Akka.Streams/Dsl/SourceOperations.cs
+++ b/src/core/Akka.Streams/Dsl/SourceOperations.cs
@@ -252,8 +252,9 @@ namespace Akka.Streams.Dsl
         /// <summary>
         /// Transform this stream by applying the given function <paramref name="asyncMapper"/> to each of the elements
         /// as they pass through this processing step. The function returns a <see cref="Task"/> and the
-        /// value of that task will be emitted downstream. As many tasks as requested elements by
-        /// downstream may run in parallel and each processed element will be emitted dowstream
+        /// value of that task will be emitted downstream. The number of tasks
+        /// that shall run in parallel is given as the first argument to <see cref="SelectAsyncUnordered{TIn,TOut,TMat}"/>. 
+        /// Each processed element will be emitted dowstream
         /// as soon as it is ready, i.e. it is possible that the elements are not emitted downstream
         /// in the same order as received from upstream.
         /// 

--- a/src/core/Akka.Streams/Dsl/SubFlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/SubFlowOperations.cs
@@ -259,8 +259,9 @@ namespace Akka.Streams.Dsl
         /// <summary>
         /// Transform this stream by applying the given function <paramref name="asyncMapper"/> to each of the elements
         /// as they pass through this processing step. The function returns a <see cref="Task"/> and the
-        /// value of that task will be emitted downstream. As many tasks as requested elements by
-        /// downstream may run in parallel and each processed element will be emitted downstream
+        /// value of that task will be emitted downstream.  The number of tasks
+        /// that shall run in parallel is given as the first argument to <see cref="SelectAsyncUnordered{TIn,TOut,TMat,TClosed}"/>.
+        /// Each processed element will be emitted dowstream
         /// as soon as it is ready, i.e. it is possible that the elements are not emitted downstream
         /// in the same order as received from upstream.
         /// 

--- a/src/core/Akka.Streams/IMaterializerLoggingProvider.cs
+++ b/src/core/Akka.Streams/IMaterializerLoggingProvider.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="IMaterializer.cs" company="Akka.NET Project">
+// <copyright file="IMaterializerLoggingProvider.cs" company="Akka.NET Project">
 //     Copyright (C) 2015-2017 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2017 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka.Streams/IMaterializerLoggingProvider.cs
+++ b/src/core/Akka.Streams/IMaterializerLoggingProvider.cs
@@ -1,0 +1,25 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="IMaterializer.cs" company="Akka.NET Project">
+//     Copyright (C) 2015-2017 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2017 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Event;
+
+namespace Akka.Streams
+{
+    /// <summary>
+    /// SPI intended only to be extended by custom <see cref="IMaterializer"/> implementations,
+    /// that also want to provide stages they materialize with specialized <see cref="ILoggingAdapter"/> instances.
+    /// </summary>
+    public interface IMaterializerLoggingProvider
+    {
+        /// <summary>
+        /// Creates a new logging adapter.
+        /// </summary>
+        /// <param name="logSource">The source that produces the log events.</param>
+        /// <returns>The newly created logging adapter.</returns>
+        ILoggingAdapter MakeLogger(object logSource);
+    }
+}

--- a/src/core/Akka.Streams/IO/IOResult.cs
+++ b/src/core/Akka.Streams/IO/IOResult.cs
@@ -43,7 +43,7 @@ namespace Akka.Streams.IO
         /// If the IO operation resulted in an error, returns the corresponding <see cref="Exception"/>
         /// or throws <see cref="NotSupportedException"/> otherwise.
         /// </summary>
-        /// <exception cref="NotSupportedException">TBD</exception>
+        /// <exception cref="NotSupportedException">Is thrown if the property is accessed for a successful <see cref="IOResult"/></exception>
         public Exception Error
         {
             get
@@ -55,5 +55,20 @@ namespace Akka.Streams.IO
             }
         }
 
+        /// <summary>
+        /// Creates successful IOResult
+        /// </summary>
+        /// <param name="count">Numeric value depending on context, for example IO operations performed or bytes processed.</param>
+        /// <returns>Successful IOResult</returns>
+        public static IOResult Success(long count) => new IOResult(count, Result.Success(NotUsed.Instance));
+
+        /// <summary>
+        /// Creates failed IOResult, <paramref name="count"/> should be the number of bytes (or other unit, please document in your APIs) processed before failing
+        /// </summary>
+        /// <param name="count">Numeric value depending on context, for example IO operations performed or bytes processed.</param>
+        /// <param name="reason">The corresponding <see cref="Exception"/></param>
+        /// <returns>Failed IOResult</returns>
+        public static IOResult Failed(long count, Exception reason)
+            => new IOResult(count, Result.Failure<NotUsed>(reason));
     }
 }

--- a/src/core/Akka.Streams/Implementation/IO/FilePublisher.cs
+++ b/src/core/Akka.Streams/Implementation/IO/FilePublisher.cs
@@ -15,7 +15,6 @@ using Akka.Event;
 using Akka.IO;
 using Akka.Streams.Actors;
 using Akka.Streams.IO;
-using Akka.Util;
 
 #pragma warning disable 1587
 
@@ -105,7 +104,7 @@ namespace Akka.Streams.Implementation.IO
             }
             catch (Exception ex)
             {
-                _completionPromise.TrySetResult(new IOResult(0, Result.Failure<NotUsed>(ex)));
+                _completionPromise.TrySetResult(IOResult.Failed(0, ex));
                 OnErrorThenStop(ex);
             }
 
@@ -195,10 +194,10 @@ namespace Akka.Streams.Implementation.IO
             }
             catch (Exception ex)
             {
-                _completionPromise.TrySetResult(new IOResult(_readBytesTotal, Result.Failure<NotUsed>(ex)));
+                _completionPromise.TrySetResult(IOResult.Failed(_readBytesTotal, ex));
             }
 
-            _completionPromise.TrySetResult(new IOResult(_readBytesTotal, Result.Success(NotUsed.Instance)));
+            _completionPromise.TrySetResult(IOResult.Success(_readBytesTotal));
         }
     }
 }

--- a/src/core/Akka.Streams/Implementation/IO/FileSubscriber.cs
+++ b/src/core/Akka.Streams/Implementation/IO/FileSubscriber.cs
@@ -80,7 +80,7 @@ namespace Akka.Streams.Implementation.IO
             }
             catch (Exception ex)
             {
-                _completionPromise.TrySetResult(new IOResult(_bytesWritten, Result.Failure<NotUsed>(ex)));
+                _completionPromise.TrySetResult(IOResult.Failed(_bytesWritten, ex));
                 Cancel();
             }
         }
@@ -104,14 +104,14 @@ namespace Akka.Streams.Implementation.IO
                     }
                     catch (Exception ex)
                     {
-                        _completionPromise.TrySetResult(new IOResult(_bytesWritten, Result.Failure<NotUsed>(ex)));
+                        _completionPromise.TrySetResult(IOResult.Failed(_bytesWritten, ex));
                         Cancel();
                     }
                 })
                 .With<OnError>(error =>
                 {
                     _log.Error(error.Cause, $"Tearing down FileSink({_f.FullName}) due to upstream error");
-                    _completionPromise.TrySetResult(new IOResult(_bytesWritten, Result.Failure<NotUsed>(error.Cause)));
+                    _completionPromise.TrySetResult(IOResult.Failed(_bytesWritten, error.Cause));
                     Context.Stop(Self);
                 })
                 .With<OnComplete>(() =>
@@ -122,7 +122,7 @@ namespace Akka.Streams.Implementation.IO
                     }
                     catch (Exception ex)
                     {
-                        _completionPromise.TrySetResult(new IOResult(_bytesWritten, Result.Failure<NotUsed>(ex)));
+                        _completionPromise.TrySetResult(IOResult.Failed(_bytesWritten, ex));
                     } 
                     Context.Stop(Self);
                 })
@@ -140,10 +140,10 @@ namespace Akka.Streams.Implementation.IO
             }
             catch (Exception ex)
             {
-                _completionPromise.TrySetResult(new IOResult(_bytesWritten, Result.Failure<NotUsed>(ex)));
+                _completionPromise.TrySetResult(IOResult.Failed(_bytesWritten, ex));
             }
 
-            _completionPromise.TrySetResult(new IOResult(_bytesWritten, Result.Success(NotUsed.Instance)));
+            _completionPromise.TrySetResult(IOResult.Success(_bytesWritten));
             base.PostStop();
         }
     }

--- a/src/core/Akka.Streams/Implementation/IO/InputStreamPublisher.cs
+++ b/src/core/Akka.Streams/Implementation/IO/InputStreamPublisher.cs
@@ -91,9 +91,9 @@ namespace Akka.Streams.Implementation.IO
             }
             catch (Exception ex)
             {
-                _completionSource.SetResult(new IOResult(_readBytesTotal, Result.Failure<NotUsed>(ex)));
+                _completionSource.SetResult(IOResult.Failed(_readBytesTotal, ex));
             }
-            _completionSource.SetResult(new IOResult(_readBytesTotal, Result.Success(NotUsed.Instance)));
+            _completionSource.SetResult(IOResult.Success(_readBytesTotal));
         }
 
         private void ReadAndSignal()

--- a/src/core/Akka.Streams/Implementation/IO/OutputStreamSubscriber.cs
+++ b/src/core/Akka.Streams/Implementation/IO/OutputStreamSubscriber.cs
@@ -89,7 +89,7 @@ namespace Akka.Streams.Implementation.IO
                     }
                     catch (Exception ex)
                     {
-                        _completionPromise.TrySetResult(new IOResult(_bytesWritten, Result.Failure<NotUsed>(ex)));
+                        _completionPromise.TrySetResult(IOResult.Failed(_bytesWritten, ex));
                         Cancel();
                     }
                 })
@@ -97,7 +97,7 @@ namespace Akka.Streams.Implementation.IO
                 {
                     _log.Error(error.Cause,
                         $"Tearing down OutputStreamSink due to upstream error, wrote bytes: {_bytesWritten}");
-                    _completionPromise.TrySetResult(new IOResult(_bytesWritten, Result.Failure<NotUsed>(error.Cause)));
+                    _completionPromise.TrySetResult(IOResult.Failed(_bytesWritten, error.Cause));
                     Context.Stop(Self);
                 })
                 .With<OnComplete>(() =>
@@ -119,10 +119,10 @@ namespace Akka.Streams.Implementation.IO
             }
             catch (Exception ex)
             {
-                _completionPromise.TrySetResult(new IOResult(_bytesWritten, Result.Failure<NotUsed>(ex)));
+                _completionPromise.TrySetResult(IOResult.Failed(_bytesWritten, ex));
             }
 
-            _completionPromise.TrySetResult(new IOResult(_bytesWritten, Result.Success(NotUsed.Instance)));
+            _completionPromise.TrySetResult(IOResult.Success(_bytesWritten));
             base.PostStop();
         }
     }

--- a/src/core/Akka.Streams/Implementation/Sinks.cs
+++ b/src/core/Akka.Streams/Implementation/Sinks.cs
@@ -255,59 +255,6 @@ namespace Akka.Streams.Implementation
     /// <summary>
     /// INTERNAL API
     /// 
-    /// Attaches a subscriber to this stream which will just discard all received elements.
-    /// </summary>
-    /// <typeparam name="TIn">TBD</typeparam>
-    public sealed class SinkholeSink<TIn> : SinkModule<TIn, Task>
-    {
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="shape">TBD</param>
-        /// <param name="attributes">TBD</param>
-        public SinkholeSink(SinkShape<TIn> shape, Attributes attributes) : base(shape)
-        {
-            Attributes = attributes;
-        }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        public override Attributes Attributes { get; }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="attributes">TBD</param>
-        /// <returns>TBD</returns>
-        public override IModule WithAttributes(Attributes attributes)
-            => new SinkholeSink<TIn>(AmendShape(attributes), attributes);
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="shape">TBD</param>
-        /// <returns>TBD</returns>
-        protected override SinkModule<TIn, Task> NewInstance(SinkShape<TIn> shape)
-            => new SinkholeSink<TIn>(shape, Attributes);
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="context">TBD</param>
-        /// <param name="materializer">TBD</param>
-        /// <returns>TBD</returns>
-        public override object Create(MaterializationContext context, out Task materializer)
-        {
-            var p = new TaskCompletionSource<NotUsed>();
-            materializer = p.Task;
-            return new SinkholeSubscriber<TIn>(p);
-        }
-    }
-
-    /// <summary>
-    /// INTERNAL API
-    /// 
     /// Attaches a subscriber to this stream.
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>

--- a/src/core/Akka.Streams/Stage/GraphStage.cs
+++ b/src/core/Akka.Streams/Stage/GraphStage.cs
@@ -420,7 +420,7 @@ namespace Akka.Streams.Stage
     ///  The stage logic is always stopped once all its input and output ports have been closed, i.e. it is not possible to
     ///  keep the stage alive for further processing once it does not have any open ports.
     /// </summary>
-    public abstract class GraphStageLogic
+    public abstract class GraphStageLogic : IStageLogging
     {
         #region internal classes
 
@@ -843,6 +843,7 @@ namespace Akka.Streams.Stage
         public virtual bool KeepGoingAfterAllPortsClosed => false;
 
         private StageActorRef _stageActorRef;
+
         /// <summary>
         /// TBD
         /// </summary>
@@ -853,6 +854,31 @@ namespace Akka.Streams.Stage
                 if (_stageActorRef == null)
                     throw StageActorRefNotInitializedException.Instance;
                 return _stageActorRef;
+            }
+        }
+
+        private ILoggingAdapter _log;
+
+        /// <summary>
+        /// Override to customise reported log source 
+        /// </summary>
+        protected object LogSource => this;
+
+        public ILoggingAdapter Log
+        {
+            get
+            {
+                // only used in StageLogic, i.e. thread safe
+                if (_log == null)
+                {
+                    var provider = Materializer as IMaterializerLoggingProvider;
+                    if (provider != null)
+                        _log = provider.MakeLogger(LogSource);
+                    else
+                        _log = NoLogger.Instance;
+                }
+
+                return _log;
             }
         }
 

--- a/src/core/Akka.Streams/Stage/IStageLogging .cs
+++ b/src/core/Akka.Streams/Stage/IStageLogging .cs
@@ -1,0 +1,26 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Attributes.cs" company="Akka.NET Project">
+//     Copyright (C) 2015-2017 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2017 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+using Akka.Event;
+
+namespace Akka.Streams.Stage
+{
+    /// <summary>
+    /// Simple way to obtain a <see cref="ILoggingAdapter"/> when used together with an <see cref="ActorMaterializer"/>.
+    /// If used with a different materializer <see cref="NoLogger"/> will be returned.
+    ///
+    /// Make sure to only access `Log` from GraphStage callbacks (such as `Pull`, `Push` or the async-callback).
+    ///
+    /// Note, abiding to <see cref="Attributes.LogLevels"/> has to be done manually,
+    /// the logger itself is configured based on the logSource provided to it. Also, the `Log`
+    /// itself would not know if you're calling it from a "on element" context or not, which is why
+    /// these decisions have to be handled by the stage itself.
+    /// </summary>
+    public interface IStageLogging 
+    {
+        ILoggingAdapter Log { get; }
+    }
+}

--- a/src/core/Akka.Streams/Stage/IStageLogging .cs
+++ b/src/core/Akka.Streams/Stage/IStageLogging .cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="Attributes.cs" company="Akka.NET Project">
+// <copyright file="IStageLogging.cs" company="Akka.NET Project">
 //     Copyright (C) 2015-2017 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2017 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>


### PR DESCRIPTION
## 2.4.12 (01.10.2016 -  28.10.2016)
- [x]  [Convert Rechunker to GraphStage](https://github.com/akka/akka/pull/21083)
- [x]  [StageLogging that allows logger access in stages](https://github.com/akka/akka/pull/21696)
- [x]  [Rewrite Sink.ignore as a GraphStage](https://github.com/akka/akka/pull/21728)
- [ ]  [improve streams actor integration docs](https://github.com/akka/akka/pull/21700)
- [x]  [IOResult construction exposed, in bincompat way](https://github.com/akka/akka/pull/21070)
- [x]  [Increased timeout in long running test FramingSpec](https://github.com/akka/akka/pull/21686)
- [x]  [Optimized indexOf to speed up framing stage](https://github.com/akka/akka/pull/21539)
- [ ]  [Added a flag on takeWhile to allow it to include the final element](https://github.com/akka/akka/pull/21687)
- [ ]  [Add expectNextChainingPF method to streams testkit](https://github.com/akka/akka/pull/21617)
- [ ]  [Add scanAsync to Akka Streams, similar to scan but taking a Future](https://github.com/akka/akka/pull/21553)
- [ ]  [Run fold async does not resolve with zero](https://github.com/akka/akka/pull/21659)
- [ ]  [add zipWithIndex to FlowOps](https://github.com/akka/akka/pull/21435)
- [x]  [amending mapAsyncUnordered docs to include parallelism](https://github.com/akka/akka/pull/21609)