### PR TITLE
Update Remote.conf reference HOCON with valid TLS settings for DotNettySslSupport

### DIFF
--- a/src/core/Akka.Remote/Configuration/Remote.conf
+++ b/src/core/Akka.Remote/Configuration/Remote.conf
@@ -466,55 +466,17 @@ akka {
 
     dot-netty.ssl = ${akka.remote.dot-netty.tcp}
     dot-netty.ssl = {
-      # Enable SSL/TLS encryption.
-      # This must be enabled on both the client and server to work.
-      enable-ssl = true
-
-      security {
-        # This is the Java Key Store used by the server connection
-        key-store = "keystore"
-
-        # This password is used for decrypting the key store
-        key-store-password = "changeme"
-
-        # This password is used for decrypting the key
-        key-password = "changeme"
-
-        # This is the Java Key Store used by the client connection
-        trust-store = "truststore"
-
-        # This password is used for decrypting the trust store
-        trust-store-password = "changeme"
-
-        # Protocol to use for SSL encryption, choose from:
-        # Java 6 & 7:
-        #   'SSLv3', 'TLSv1'
-        # Java 7:
-        #   'TLSv1.1', 'TLSv1.2'
-        protocol = "TLSv1"
-
-        # Example: ["TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA"]
-        # You need to install the JCE Unlimited Strength Jurisdiction Policy
-        # Files to use AES 256.
-        # More info here:
-        # http://docs.oracle.com/javase/7/docs/technotes/guides/security/SunProviders.html#SunJCEProvider
-        enabled-algorithms = ["TLS_RSA_WITH_AES_128_CBC_SHA"]
-
-        # There are three options, in increasing order of security:
-        # "" or SecureRandom => (default)
-        # "SHA1PRNG" => Can be slow because of blocking issues on Linux
-        # "AES128CounterSecureRNG" => fastest startup and based on AES encryption
-        # algorithm
-        # "AES256CounterSecureRNG"
-        # The following use one of 3 possible seed sources, depending on
-        # availability: /dev/random, random.org and SecureRandom (provided by Java)
-        # "AES128CounterInetRNG"
-        # "AES256CounterInetRNG" (Install JCE Unlimited Strength Jurisdiction
-        # Policy Files first)
-        # Setting a value here may require you to supply the appropriate cipher
-        # suite (see enabled-algorithms section above)
-        random-number-generator = ""
-      }
+		certificate {
+			# Valid certificate path required
+			path = ""
+			# Valid certificate password required
+			password = ""
+			# Default key storage flag is "default-key-set"
+			# Available flags include: 
+			#     default-key-set | exportable | machine-key-set | persist-key-set | user-key-set | user-protected
+			# flags = [ "default-key-set" ]
+		}
+		suppress-validation = false
     }
 
     ### Default configuration for the failure injector transport adapter


### PR DESCRIPTION
Update Remote.conf to show valid reference for enabling TLS for Akka.Remote using same configuration used in `DotNettySslSupportSpec`