### PR TITLE
Switch Akka.Cluster.Sharding NuGet dependency for Akka.Cluster.Tools to NuGet release version

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -389,7 +389,7 @@ module Nuget =
         | "Akka" -> []
         | "Akka.Cluster" -> ["Akka.Remote", release.NugetVersion]
         | "Akka.Cluster.TestKit" -> ["Akka.Remote.TestKit", release.NugetVersion; "Akka.Cluster", release.NugetVersion]
-        | "Akka.Cluster.Sharding" -> ["Akka.Cluster.Tools", preReleaseVersion; "Akka.Persistence", preReleaseVersion]
+        | "Akka.Cluster.Sharding" -> ["Akka.Cluster.Tools", release.NugetVersion; "Akka.Persistence", preReleaseVersion]
         | "Akka.Cluster.Tools" -> ["Akka.Cluster", release.NugetVersion]
         | "Akka.MultiNodeTestRunner" -> [] // all binaries for the multinodetest runner have to be included locally
         | "Akka.Persistence.TestKit" -> ["Akka.Persistence", preReleaseVersion; "Akka.TestKit.Xunit2", release.NugetVersion]


### PR DESCRIPTION
Update dependency on Akka.Cluster.Tools for NuGet pack step in build.fsx to use release.NugetVersion instead of preReleaseVersion.