### PR TITLE
Update build.fsx to specify framework netstandard1.6 on Linux build

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -48,6 +48,9 @@ Target "Build" (fun _ ->
                    ++ "./**/contrib/**/*.csproj"
                    -- "./**/Akka.MultiNodeTestRunner.Shared.Tests.csproj"
                    -- "./**/serializers/**/*Wire*.csproj"
+    
+    if (isMono) then
+        setEnvironVar "FrameworkPathOverride" "/usr/lib/mono/4.5/"
 
     let runSingleProject project =
         DotNetCli.Build


### PR DESCRIPTION
Makes sure Linux dotnetcore cli is building for netstandard1.6 instead of net45.  Also using this branch to test triggers in TeamCity CI.