### PR TITLE
[WIP] Limits the number of concurrent Persistent actors during recovery

### DIFF
--- a/docs/articles/persistence/event-sourcing.md
+++ b/docs/articles/persistence/event-sourcing.md
@@ -35,7 +35,11 @@ public override string PersistenceId { get; } = "my-stable-persistence-id";
 > `PersistenceId` must be unique to a given entity in the journal (database table/keyspace). When replaying messages persisted to the journal, you query messages with a `PersistenceId`. So, if two different entities share the same `PersistenceId`, message-replaying behavior is corrupted.
 
 ## Recovery
-By default, a persistent actor is automatically recovered on start and on restart by replaying journaled messages. New messages sent to a persistent actor during recovery do not interfere with replayed messages. They are cached and received by a persistent actor after recovery phase completes.
+By default, a persistent actor is automatically recovered on start and on restart by replaying journaled messages. New messages sent to a persistent actor during recovery do not interfere with replayed messages. They are stashed and received by a persistent actor after recovery phase completes.
+
+The number of concurrent recoveries of recoveries that can be in progress at the same time is limited to not overload the system and the backend data store. When exceeding the limit the actors will wait until other recoveries have been completed. This is configured by:
+
+    akka.persistence.max-concurrent-recoveries = 50
 
 > [!NOTE]
 > Accessing the `Sender` for replayed messages will always result in a `DeadLetters` reference, as the original sender is presumed to be long gone. If you indeed have to notify an actor during recovery in the future, store its `ActorPath` explicitly in your persisted events.

--- a/src/core/Akka.Persistence/Akka.Persistence.csproj
+++ b/src/core/Akka.Persistence/Akka.Persistence.csproj
@@ -77,6 +77,7 @@
     <Compile Include="PersistentView.Recovery.cs" />
     <Compile Include="PersistentView.Lifecycle.cs" />
     <Compile Include="Protocol.cs" />
+    <Compile Include="RecoveryPermitter.cs" />
     <Compile Include="Serialization\Proto\PersistenceMessages.cs" />
     <Compile Include="Snapshotter.cs" />
     <Compile Include="JournalProtocol.cs" />

--- a/src/core/Akka.Persistence/RecoveryPermitter.cs
+++ b/src/core/Akka.Persistence/RecoveryPermitter.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Pattern;
+using Akka.Persistence.Internal;
+
+namespace Akka.Persistence
+{
+    public class RequestRecoveryPermit
+    { }
+
+    public class RecoveryPermitGranted
+    { }
+
+    public class ReturnRecoveryPermit
+    { }
+
+    /// <summary>
+    /// When starting many persistent actors at the same time the journal its data store is protected 
+    /// from being overloaded by limiting number of recoveries that can be in progress at the same time.
+    /// </summary>
+    public class RecoveryPermitter : UntypedActor
+    {
+        private readonly int maxPermits;
+        private readonly LinkedList<IActorRef> pending = new LinkedList<IActorRef>();
+        private readonly ILoggingAdapter Log = Context.GetLogger();
+        private int usedPermits;
+        private int maxPendingStats;
+
+        public static Props Props(int maxPermits) =>
+            Actor.Props.Create(() => new RecoveryPermitter(maxPermits));
+
+        public RecoveryPermitter(int maxPermits)
+        {
+            this.maxPermits = maxPermits;
+        }
+
+        protected override void OnReceive(object message)
+        {
+            message.Match()
+                .With<RequestRecoveryPermit>(_ =>
+                {
+                    Context.Watch(Sender);
+                    if (usedPermits > maxPermits)
+                    {
+                        if (pending.Count == 0)
+                            Log.Debug("Exceeded max-concurrent-recoveries [{0}]. First pending {1}", maxPermits, Sender);
+                        pending.AddLast(Sender);
+                        maxPendingStats = Math.Max(maxPendingStats, pending.Count);
+                    }
+                    else
+                    {
+                        RecoveryPermitGranted(Sender);
+                    }
+                })
+                .With<ReturnRecoveryPermit>(_ => ReturnRecoveryPermit(Sender))
+                .With<Terminated>(terminated =>
+                {
+                    if (!pending.Remove(terminated.ActorRef))
+                        ReturnRecoveryPermit(terminated.ActorRef);
+                });
+        }
+
+        private void ReturnRecoveryPermit(IActorRef actorRef)
+        {
+            usedPermits--;
+            Context.Unwatch(actorRef);
+
+            if (usedPermits < 0)
+                throw new IllegalStateException("Permits must not be negative");
+
+            if (pending.Count > 0)
+            {
+                var popRef = pending.Pop();
+                RecoveryPermitGranted(popRef);
+            }
+
+            if (pending.Count != 0 || maxPendingStats <= 0)
+                return;
+
+            Log.Debug("Drained pending recovery permit requests, max in progress was [{0}], still [{1}] in progress", usedPermits + maxPendingStats, usedPermits);
+            maxPendingStats = 0;
+        }
+
+        private void RecoveryPermitGranted(IActorRef actorRef)
+        {
+            usedPermits++;
+            actorRef.Tell(new RecoveryPermitGranted());
+        }
+    }
+}

--- a/src/core/Akka.Persistence/persistence.conf
+++ b/src/core/Akka.Persistence/persistence.conf
@@ -10,6 +10,13 @@
 
 # Default persistence extension settings.
 akka.persistence {
+    # When starting many persistent actors at the same time the journal
+    # and its data store is protected from being overloaded by limiting number
+    # of recoveries that can be in progress at the same time. When
+    # exceeding the limit the actors will wait until other recoveries have
+    # been completed.   
+    max-concurrent-recoveries = 50
+
     # Fully qualified class name providing a default internal stash overflow strategy.
     # It needs to be a subclass of Akka.Persistence.StashOverflowStrategyConfigurator
     # The default strategy throws StashOverflowException


### PR DESCRIPTION
This is a port of the original [#22783](https://github.com/akka/akka/issues/22638). The main idea is to limit the number of concurrent persistent actors to avoid overwhelming both the persistent journal and the backend store.

- [x] ~~core implementation~~
- [ ] unit tests