### PR TITLE
Disable test parallelization for Persistence.Tests

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -69,6 +69,7 @@ Target "RunTests" (fun _ ->
                    -- "./**/Akka.Streams.Tests.csproj"
                    -- "./**/Akka.Remote.TestKit.Tests.csproj"
                    -- "./**/serializers/**/*Wire*.csproj"
+                   -- "./**/Akka.Persistence.Tests.csproj"
 
     let runSingleProject project =
         DotNetCli.Test

--- a/src/core/Akka.Persistence.Tests/Properties/AssemblyInfo.cs
+++ b/src/core/Akka.Persistence.Tests/Properties/AssemblyInfo.cs
@@ -7,6 +7,7 @@
 
 using System.Reflection;
 using System.Runtime.InteropServices;
+using Xunit;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -30,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-//[assembly: CollectionBehavior(DisableTestParallelization = true)]
+// [assembly: CollectionBehavior(DisableTestParallelization = true)]
 


### PR DESCRIPTION
Disable test parallelization for Persistence.Tests to mitigate OutOfMemory exceptions in CI.  Should be applied to all test projects, but this is to see if there is an effect on the current CI test failures.