### PR TITLE
[WIP] Akka.Persistence.Test OutOfMemoryExceptions

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -81,7 +81,6 @@ Target "RunTests" (fun _ ->
                   -- "./**/Akka.Streams.Tests.csproj"
                   -- "./**/Akka.Remote.TestKit.Tests.csproj"
                   -- "./**/Akka.MultiNodeTestRunner.Shared.Tests.csproj"      
-                  -- "./**/Akka.Persistence.Tests.csproj"
                   -- "./**/Akka.API.Tests.csproj"
                   -- "./**/Akka.Persistence.Sqlite.Tests.csproj"
 


### PR DESCRIPTION
Post-upgrade to xunit 2.3.0 beta, try un-ignoring Persistence.Tests and running CI to see if new runner resolves memory leak found when using `dotnet test`