### PR TITLE
Enable performance tests on Windows/.NET Framework

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -30,7 +30,7 @@ Param(
 )
 
 $FakeVersion = "4.50.0"
-$NBenchVersion = "0.3.4"
+$NBenchVersion = "1.0.1"
 $DotNetChannel = "preview";
 $DotNetVersion = "1.0.3";
 $DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1";

--- a/src/core/Akka.Cluster.Tests.Performance/Akka.Cluster.Tests.Performance.csproj
+++ b/src/core/Akka.Cluster.Tests.Performance/Akka.Cluster.Tests.Performance.csproj
@@ -12,8 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NBench" Version="0.3.4" />
-    <PackageReference Include="NBench.PerformanceCounters" Version="0.3.4" />
+    <PackageReference Include="NBench" Version="1.0.1" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/core/Akka.Remote.Tests.Performance/Akka.Remote.Tests.Performance.csproj
+++ b/src/core/Akka.Remote.Tests.Performance/Akka.Remote.Tests.Performance.csproj
@@ -12,8 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NBench" Version="0.3.4" />
-    <PackageReference Include="NBench.PerformanceCounters" Version="0.3.4" />
+    <PackageReference Include="NBench" Version="1.0.1" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/core/Akka.Streams.Tests.Performance/Akka.Streams.Tests.Performance.csproj
+++ b/src/core/Akka.Streams.Tests.Performance/Akka.Streams.Tests.Performance.csproj
@@ -15,8 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NBench" Version="0.3.4" />
-    <PackageReference Include="NBench.PerformanceCounters" Version="0.3.4" />
+    <PackageReference Include="NBench" Version="1.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/src/core/Akka.Tests.Performance/Akka.Tests.Performance.csproj
+++ b/src/core/Akka.Tests.Performance/Akka.Tests.Performance.csproj
@@ -13,11 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NBench" Version="0.3.4" />
-    <PackageReference Include="NBench.PerformanceCounters" Version="0.3.4" />
+    <PackageReference Include="NBench" Version="1.0.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System.Configuration" />
     <Reference Include="System.Xml" />
   </ItemGroup>


### PR DESCRIPTION
Adds build step NBench and upgrades NBench to v1.0.1 to enable performance testing on v1.3 branch.