### PR TITLE
Documentation titles clean-up.

### DIFF
--- a/docs/articles/actors/dependency-injection.md
+++ b/docs/articles/actors/dependency-injection.md
@@ -48,7 +48,7 @@ protected override void PreStart()
 > [!INFO]
 > There is currently still an extension method available for the actor Context. `Context.DI().ActorOf<>`. However this has been officially **deprecated** and will be removed in future versions.
 
-##Notes
+## Notes
 
 > [!WARNING]
 > You might be tempted at times to use an `IndirectActorProducer`

--- a/docs/articles/concepts/addressing.md
+++ b/docs/articles/concepts/addressing.md
@@ -11,7 +11,7 @@ This chapter describes how actors are identified and located within a possibly d
 
 The above image displays the relationship between the most important entities within an actor system, please read on for the details.
 
-##What is an Actor Reference?
+## What is an Actor Reference?
 An actor reference is a subtype of `ActorRef`, whose foremost purpose is to support sending messages to the actor it represents. Each actor has access to its canonical (local) reference through the `Self` property; this reference is also included as sender reference by default for all messages sent to other actors. Conversely, during message processing the actor has access to a reference representing the sender of the current message through the sender method.
 
 There are several different types of actor references that are supported depending on the configuration of the actor system:

--- a/docs/articles/concepts/message-delivery-reliability.md
+++ b/docs/articles/concepts/message-delivery-reliability.md
@@ -315,7 +315,7 @@ The dead letter service follows the same rules with respect to delivery
 guarantees as all other message sends, hence it cannot be used to implement
 guaranteed delivery.
 
-###How do I Receive Dead Letters?
+### How do I Receive Dead Letters?
 
 An actor can subscribe to class `Akka.Actor.DeadLetter` on the event
 stream, see [Event stream](xref:event-bus) for how to do that. The subscribed actor will then receive all dead

--- a/docs/articles/remoting/index.md
+++ b/docs/articles/remoting/index.md
@@ -17,10 +17,10 @@ Akka.Remote introduces the following capabilities to Akka.NET applications:
 1. **Remote deployment** - remotely deploy actors via the `ActorOf` method onto remote `ActorSystem` instances, anywhere on the network! The location of your actors on the network becomes a deployment detail in Akka.Remote.
 1. **Multiple network transports** - out of the box Akka.Remote ships with support for TCP, but has the ability to plugin third party transports and active multiple of them at the same time.
 
-##Distributed by Default
+## Distributed by Default
 Everything in Akka is designed to work in a distributed setting: all interactions of actors use purely message passing and everything is asynchronous. This effort has been undertaken to ensure that all functions are available equally when running within a single machine or on a cluster of hundreds of machines. The key for enabling this is to go from remote to local by way of optimization instead of trying to go from local to remote by way of generalization. See [this classic paper](http://doc.akka.io/docs/misc/smli_tr-94-29.pdf) for a detailed discussion on why the second approach is bound to fail.
 
-##Ways in which Transparency is Broken
+## Ways in which Transparency is Broken
 What is true of Akka need not be true of the application which uses it, since designing for distributed execution poses some restrictions on what is possible. The most obvious one is that all messages sent over the wire must be serializable. While being a little less obvious this includes closures which are used as actor factories (i.e. within Props) if the actor is to be created on a remote node.
 
 Another consequence is that everything needs to be aware of all interactions being fully asynchronous, which in a computer network might mean that it may take several minutes for a message to reach its recipient (depending on configuration). It also means that the probability for a message to be lost is much higher than within one CLR, where it is close to zero (still: no hard guarantee!).
@@ -40,10 +40,10 @@ Messages exceeding the maximum size will be dropped.
 
 You also have to be aware that some protocols (e.g. UDP) might not support arbitrarily large messages.
 
-##How is Remoting Used?
+## How is Remoting Used?
 We took the idea of transparency to the limit in that there is nearly no API for the remoting layer of Akka: it is purely driven by configuration. Just write your application according to the principles outlined in the previous sections, then specify remote deployment of actor sub-trees in the configuration file. This way, your application can be scaled out without having to touch the code. The only piece of the API which allows programmatic influence on remote deployment is that Props contain a field which may be set to a specific Deploy instance; this has the same effect as putting an equivalent deployment into the configuration file (if both are given, configuration file wins).
 
-##Peer-to-Peer vs. Client-Server
+## Peer-to-Peer vs. Client-Server
 Akka Remoting is a communication module for connecting actor systems in a peer-to-peer fashion, and it is the foundation for Akka Clustering. The design of remoting is driven by two (related) design decisions:
 
 1. Communication between involved systems is symmetric: if a system A can connect to a system B then system B must also be able to connect to system A independently.
@@ -65,7 +65,7 @@ Akka.Remote is most commonly used in distributed applications that run across th
 
 That being said, it's a good idea to understand how Akka.Remote works if you intend to use clustering. So keep reading!
 
-##Marking Points for Scaling Up with Routers
+## Marking Points for Scaling Up with Routers
 In addition to being able to run different parts of an actor system on different nodes of a cluster, it is also possible to scale up onto more cores by multiplying actor sub-trees which support parallelization (think for example a search engine processing different queries in parallel). The clones can then be routed to in different fashions, e.g. round-robin. The only thing necessary to achieve this is that the developer needs to declare a certain actor as `WithRouter`, then—in its stead—a router actor will be created which will spawn up a configurable number of children of the desired type and route to them in the configured fashion. Once such a router has been declared, its configuration can be freely overridden from the configuration file, including mixing it with the remote deployment of (some of) the children. Read more about this in [Routers](xref:routers).
 
 ## Enabling Akka.Remote

--- a/docs/articles/streams/basics.md
+++ b/docs/articles/streams/basics.md
@@ -196,12 +196,12 @@ var otherSink = Flow.Create<int>().AlsoTo(sink).To(Sink.Ignore<int>());
 Source.From(Enumerable.Range(1, 6)).To(otherSink);
 ```  
    
-####Illegal stream elements
+#### Illegal stream elements
 In accordance to the Reactive Streams specification ([Rule 2.13] (https://github.com/reactive-streams/reactive-streams-jvm#2.13>))
 Akka Streams do not allow ``null`` to be passed through the stream as an element. In case you want to model the concept
 of absence of a value we recommend using ``Akka.Streams.Util.Option<T>`` or ``Akka.Util.Either<TA,TB>``.  
 
-#Back-pressure explained
+# Back-pressure explained
 
 Akka Streams implement an asynchronous non-blocking back-pressure protocol standardised by the [Reactive Streams](http://reactive-streams.org/)
 specification, which Akka is a founding member of.
@@ -230,7 +230,7 @@ with the upstream production rate or not.
 
 To illustrate this further let us consider both problem situations and how the back-pressure protocol handles them:
 
-####Slow Publisher, fast Subscriber
+#### Slow Publisher, fast Subscriber
 This is the happy case of course – we do not need to slow down the Publisher in this case. However signalling rates are
 rarely constant and could change at any point in time, suddenly ending up in a situation where the Subscriber is now
 slower than the Publisher. In order to safeguard from these situations, the back-pressure protocol must still be enabled
@@ -245,7 +245,7 @@ that the Publisher should not ever have to wait (be back-pressured) with publish
 As we can see, in this scenario we effectively operate in so called push-mode since the Publisher can continue producing
 elements as fast as it can, since the pending demand will be recovered just-in-time while it is emitting elements.
 
-####Fast Publisher, slow Subscriber
+#### Fast Publisher, slow Subscriber
 This is the case when back-pressuring the ``Publisher`` is required, because the ``Subscriber`` is not able to cope with
 the rate at which its upstream would like to emit data elements.
 
@@ -260,7 +260,7 @@ it will have to abide to this back-pressure by applying one of the below strateg
 As we can see, this scenario effectively means that the ``Subscriber`` will *pull* the elements from the Publisher –
 this mode of operation is referred to as pull-based back-pressure.
 
-#Stream Materialization
+# Stream Materialization
 
 When constructing flows and graphs in Akka Streams think of them as preparing a blueprint, an execution plan.
 Stream materialization is the process of taking a stream description (the graph) and allocating all the necessary resources
@@ -279,7 +279,7 @@ which will be running on the thread pools they have been configured to run on - 
 > [!NOTE]
 > Reusing *instances* of linear computation stages (Source, Sink, Flow) inside composite Graphs is legal, yet will materialize that stage multiple times.  
    
-####Operator Fusion
+#### Operator Fusion
 Akka Streams contains an initial version of stream operator fusion support. This means that
 the processing steps of a flow or stream graph can be executed within the same Actor and has three
 consequences:
@@ -327,7 +327,7 @@ The new fusing behavior can be disabled by setting the configuration parameter `
 In that case you can still manually fuse those graphs which shall run on less Actors. With the exception of the
 `SslTlsStage` and the ``GroupBy`` operator all built-in processing stages can be fused.
 
-####Combining materialized values
+#### Combining materialized values
 Since every processing stage in Akka Streams can provide a materialized value after being materialized, it is necessary
 to somehow express how these values should be composed to a final value when we plug these stages together. For this,
 many combinator methods have variants that take an additional argument, a function, that will be used to combine the
@@ -402,7 +402,7 @@ RunnableGraph<Tuple<TaskCompletionSource<int>, ICancelable, Task<int>>> r12 =
 > For details see [Accessing the materialized value inside the Graph](workingwithgraphs.md#accessing-the-materialized-value-inside-the-graph).
    
 
-#Stream ordering
+# Stream ordering
 In Akka Streams almost all computation stages *preserve input order* of elements. This means that if inputs ``{IA1,IA2,...,IAn}``
 "cause" outputs ``{OA1,OA2,...,OAk}`` and inputs ``{IB1,IB2,...,IBm}`` "cause" outputs ``{OB1,OB2,...,OBl}`` and all of
 ``IAi`` happened before all ``IBi`` then ``OAi`` happens before ``OBi``.

--- a/docs/articles/streams/buffersandworkingwithrate.md
+++ b/docs/articles/streams/buffersandworkingwithrate.md
@@ -3,10 +3,10 @@ layout: docs.hbs
 title: Buffers and working with rate
 ---
 
-#Buffers and working with rate
+# Buffers and working with rate
 When upstream and downstream rates differ, especially when the throughput has spikes, it can be useful to introduce buffers in a stream. In this chapter we cover how buffers are used in Akka Streams.
 
-##Buffers for asynchronous stages
+## Buffers for asynchronous stages
 In this section we will discuss internal buffers that are introduced as an optimization when using asynchronous stages.
 To run a stage asynchronously it has to be marked explicitly as such using the .async method. Being run asynchronously means that a stage, after handing out an element to its downstream consumer is able to immediately process the next message. To demonstrate what we mean by this, let's take a look at the following example:
 ```csharp
@@ -33,7 +33,7 @@ While pipelining in general increases throughput, in practice there is a cost of
 
 While this internal protocol is mostly invisible to the user (apart form its throughput increasing effects) there are situations when these details get exposed. In all of our previous examples we always assumed that the rate of the processing chain is strictly coordinated through the backpressure signal causing all stages to process no faster than the throughput of the connected chain. There are tools in Akka Streams however that enable the rates of different segments of a processing chain to be "detached" or to define the maximum throughput of the stream through external timing sources. These situations are exactly those where the internal batching buffering strategy suddenly becomes non-transparent.
 
-##Internal buffers and their effect
+## Internal buffers and their effect
 As we have explained, for performance reasons Akka Streams introduces a buffer for every asynchronous processing stage. The purpose of these buffers is solely optimization, in fact the size of 1 would be the most natural choice if there would be no need for throughput improvements. Therefore it is recommended to keep these buffer sizes small, and increase them only to a level suitable for the throughput requirements of the application. Default buffer sizes can be set through configuration:
 ```hocon
 akka.stream.materializer.max-input-buffer-size = 16
@@ -80,7 +80,7 @@ Running the above example one would expect the number 3 to be printed in every 3
 > [!NOTE]
 > In general, when time or rate driven processing stages exhibit strange behavior, one of the first solutions to try should be to decrease the input buffer of the affected elements to 1.
 
-##Buffers in Akka Streams
+## Buffers in Akka Streams
 In this section we will discuss explicit user defined buffers that are part of the domain logic of the stream processing pipeline of an application.
 
 The example below will ensure that 1000 jobs (but not more) are dequeued from an external (imaginary) system and stored locally in memory -- relieving the external system:
@@ -110,8 +110,8 @@ If our imaginary external job provider is a client using our API, we might want 
 ```csharp
 jobs.buffer(1000, OverflowStrategy.fail)
 ```
-##Rate transformation
-###Understanding conflate
+## Rate transformation
+### Understanding conflate
 When a fast producer can not be informed to slow down by backpressure or some other signal, conflate might be useful to combine elements from a producer until a demand signal comes from a consumer.
 
 Below is an example snippet that summarizes fast stream of elements to a standard deviation, mean and count of elements that have arrived while the stats have been calculated.
@@ -140,7 +140,7 @@ Another possible use of `conflate` is to not consider all elements for summary w
            return agg;
        }).Concat(identity);
 ```
-###Understanding expand
+### Understanding expand
 Expand helps to deal with slow producers which are unable to keep up with the demand coming from consumers. Expand allows to extrapolate a value to be sent as an element to a consumer.
 
 As a simple use of expand here is a flow that sends the same element to consumer when producer does not send any new elements.

--- a/docs/articles/streams/builtinstages.md
+++ b/docs/articles/streams/builtinstages.md
@@ -3,12 +3,12 @@ layout: docs.hbs
 title: Overview of built-in stages and their semantics
 ---
 
-#Source stages
+# Source stages
 These built-in sources are available from ``akka.stream.scaladsl.Source``:
 
 
 
-####FromEnumerator
+#### FromEnumerator
 
 Stream the values from an ``Enumerator``, requesting the next value when there is demand. The enumerator will be created anew
 for each materialization, which is the reason the method takes a function rather than an enumerator directly.
@@ -19,7 +19,7 @@ If the enumerator perform blocking operations, make sure to run it on a separate
 
 **completes** when the enumerator reaches its end
 
-####From
+#### From
 
 Stream the values of an ``IEnumerable<T>``.
 
@@ -28,7 +28,7 @@ Stream the values of an ``IEnumerable<T>``.
 **completes** when the last element of the enumerable has been emitted
 
 
-####Single
+#### Single
 
 Stream a single object
 
@@ -36,7 +36,7 @@ Stream a single object
 
 **completes** when the single value has been emitted
 
-####Repeat
+#### Repeat
 
 Stream a single object repeatedly
 
@@ -44,7 +44,7 @@ Stream a single object repeatedly
 
 **completes** never
 
-####Cycle
+#### Cycle
 
 Stream iterator in cycled manner. Internally new iterator is being created to cycle the one provided via argument meaning
 when original iterator runs out of elements process will start all over again from the beginning of the iterator
@@ -55,7 +55,7 @@ exception.
 
 **completes** never
 
-####Tick
+#### Tick
 
 A periodical repetition of an arbitrary object. Delay of first tick is specified
 separately from interval of the following ticks.
@@ -64,7 +64,7 @@ separately from interval of the following ticks.
 
 **completes** never
 
-####FromTask
+#### FromTask
 
 Send the single value of the ``Task`` when it completes and there is demand.
 If the task fails the stream is failed with that exception.
@@ -73,7 +73,7 @@ If the task fails the stream is failed with that exception.
 
 **completes** after the task has completed
 
-####Unfold
+#### Unfold
 
 Stream the result of a function as long as it returns not ``null``, the value inside the option
 consists of a tuple where the first value is a state passed back into the next call to the function allowing
@@ -85,7 +85,7 @@ Can be used to implement many stateful sources without having to touch the more 
 
 **completes** when the unfold function returns an null value
 
-####UnfoldAsync
+#### UnfoldAsync
 
 Just like ``Unfold`` but the fold function returns a ``Task`` which will cause the source to
 complete or emit when it completes.
@@ -96,7 +96,7 @@ Can be used to implement many stateful sources without having to touch the more 
 
 **completes** when the task returned by the unfold function completes with an null value
 
-####Empty
+#### Empty
 
 Complete right away without ever emitting any elements. Useful when you have to provide a source to
 an API but there are no elements to emit.
@@ -105,7 +105,7 @@ an API but there are no elements to emit.
 
 **completes** directly
 
-####Maybe
+#### Maybe
 
 Materialize a ``TaskCompletionSource<T>`` that if completed with a ``T`` will emit that `T` and then complete
 the stream, or if completed with ``null`` complete the stream right away.
@@ -114,7 +114,7 @@ the stream, or if completed with ``null`` complete the stream right away.
 
 **completes** after emitting not null value, or directly if the promise is completed with null value
 
-####Failed
+#### Failed
 
 Fail directly with a user specified exception.
 
@@ -122,7 +122,7 @@ Fail directly with a user specified exception.
 
 **completes** fails the stream directly with the given exception
 
-####ActorPublisher
+#### ActorPublisher
 
 Wrap an actor extending ``ActorPublisher`` as a source.
 
@@ -130,7 +130,7 @@ Wrap an actor extending ``ActorPublisher`` as a source.
 
 **completes** when the actor stops
 
-####ActorRef
+#### ActorRef
 
 Materialize an ``IActorRef``, sending messages to it will emit them on the stream. The actor contain
 a buffer but since communication is one way, there is no back pressure. Handling overflow is done by either dropping
@@ -140,7 +140,7 @@ elements or failing the stream, the strategy is chosen by the user.
 
 **completes** when the actorref is sent ``Akka.Actor.Status.Success`` or ``PoisonPill``
 
-####Combine
+#### Combine
 
 Combine several sources, using a given strategy such as merge or concat, into one source.
 
@@ -148,7 +148,7 @@ Combine several sources, using a given strategy such as merge or concat, into on
 
 **completes** when all sources has completed
 
-####UnfoldResource
+#### UnfoldResource
 
 Wrap any resource that can be opened, queried for next element (in a blocking way) and closed using three distinct functions into a source.
 
@@ -156,7 +156,7 @@ Wrap any resource that can be opened, queried for next element (in a blocking wa
 
 **completes**  when read function returns ``None``
 
-####UnfoldResourceAsync
+#### UnfoldResourceAsync
 
 Wrap any resource that can be opened, queried for next element (in a blocking way) and closed using three distinct functions into a source.
 Functions return ``Task`` to achieve asynchronous processing
@@ -165,7 +165,7 @@ Functions return ``Task`` to achieve asynchronous processing
 
 **completes** when ``Task`` from read function returns ``None``
 
-####Queue
+#### Queue
 
 Materialize a ``SourceQueue`` onto which elements can be pushed for emitting from the source. The queue contains
 a buffer, if elements are pushed onto the queue faster than the source is consumed the overflow will be handled with
@@ -176,17 +176,17 @@ a strategy specified by the user. Functionality for tracking when an element has
 
 **completes** when downstream completes
 
-####AsSubscriber
+#### AsSubscriber
 
 Integration with Reactive Streams, materializes into a ``Reactive.Streams.ISubscriber``.
 
 
-####FromPublisher
+#### FromPublisher
 
 Integration with Reactive Streams, subscribes to a ``Reactive.Streams.IPublisher``.
 
 
-####ZipN
+#### ZipN
 
 Combine the elements of multiple streams into a stream of sequences.
 
@@ -195,7 +195,7 @@ Combine the elements of multiple streams into a stream of sequences.
 **completes** when any upstream completes
 
 
-####ZipWithN
+#### ZipWithN
 
 Combine the elements of multiple streams into a stream of sequences using a combiner function.
 
@@ -204,12 +204,12 @@ Combine the elements of multiple streams into a stream of sequences using a comb
 **completes** when any upstream completes
 
 
-#Sink stages
+# Sink stages
 
 These built-in sinks are available from ``Akka.Stream.DSL.Sink``:
 
 
-####First
+#### First
 
 Materializes into a ``Task`` which completes with the first value arriving,
 after this the stream is canceled. If no element is emitted, the task is be failed.
@@ -218,7 +218,7 @@ after this the stream is canceled. If no element is emitted, the task is be fail
 
 **backpressures** never
 
-####FirstOrDefault
+#### FirstOrDefault
 Materializes into a ``Task<T>`` which completes with the first value arriving,
 or a ``default(T)`` if the stream completes without any elements emitted.
 
@@ -226,7 +226,7 @@ or a ``default(T)`` if the stream completes without any elements emitted.
 
 **backpressures** never
 
-####Last
+#### Last
 
 Materializes into a ``Task`` which will complete with the last value emitted when the stream
 completes. If the stream completes with no elements the task is failed.
@@ -235,7 +235,7 @@ completes. If the stream completes with no elements the task is failed.
 
 **backpressures** never
 
-####LasrOrDefault
+#### LasrOrDefault
 
 Materialize a ``Task<T>`` which completes with the last value
 emitted when the stream completes. if the stream completes with no elements the task is
@@ -245,7 +245,7 @@ completed with default(T).
 
 **backpressures** never
 
-####Ignore
+#### Ignore
 
 Consume all elements but discards them. Useful when a stream has to be consumed but there is no use to actually
 do anything with the elements.
@@ -254,13 +254,13 @@ do anything with the elements.
 
 **backpressures** never
 
-####Cancelled
+#### Cancelled
 
 Immediately cancel the stream
 
 **cancels** immediately
 
-####Seq
+#### Seq
 
 Collect values emitted from the stream into a collection, the collection is available through a ``Task`` or
 which completes when the stream completes. Note that the collection is bounded to ``int.MaxValue``,
@@ -268,7 +268,7 @@ if more element are emitted the sink will cancel the stream
 
 **cancels** If too many values are collected
 
-####Foreach
+#### Foreach
 
 Invoke a given procedure for each element received. Note that it is not safe to mutate shared state from the procedure.
 
@@ -282,7 +282,7 @@ Note that it is not safe to mutate state from the procedure.
 **backpressures** when the previous procedure invocation has not yet completed
 
 
-####ForeachParallel
+#### ForeachParallel
 
 Like ``Foreach`` but allows up to ``parallellism`` procedure calls to happen in parallel.
 
@@ -291,7 +291,7 @@ Like ``Foreach`` but allows up to ``parallellism`` procedure calls to happen in 
 **backpressures** when the previous parallel procedure invocations has not yet completed
 
 
-####OnComplete
+#### OnComplete
 
 Invoke a callback when the stream has completed or failed.
 
@@ -300,7 +300,7 @@ Invoke a callback when the stream has completed or failed.
 **backpressures** never
 
 
-####Aggregate
+#### Aggregate
 
 Fold over emitted element with a function, where each invocation will get the new element and the result from the
 previous fold invocation. The first invocation will be provided the ``zero`` value.
@@ -314,7 +314,7 @@ between invocations.
 
 **backpressures** when the previous fold function invocation has not yet completed
 
-####Sum
+#### Sum
 
 Apply a reduction function on the incoming elements and pass the result to the next invocation. The first invocation
 receives the two first elements of the flow.
@@ -326,7 +326,7 @@ Materializes into a task that will be completed by the last result of the reduct
 **backpressures** when the previous reduction function invocation has not yet completed
 
 
-####Combine
+#### Combine
 
 Combine several sinks into one using a user specified strategy
 
@@ -335,7 +335,7 @@ Combine several sinks into one using a user specified strategy
 **backpressures** depends on the strategy
 
 
-####ActorRef
+#### ActorRef
 
 Send the elements from the stream to an ``IActorRef``. No backpressure so care must be taken to not overflow the inbox.
 
@@ -344,7 +344,7 @@ Send the elements from the stream to an ``IActorRef``. No backpressure so care m
 **backpressures** never
 
 
-####ActorRefWithAck
+#### ActorRefWithAck
 
 Send the elements from the stream to an ``IActorRef`` which must then acknowledge reception after completing a message,
 to provide back pressure onto the sink.
@@ -354,7 +354,7 @@ to provide back pressure onto the sink.
 **backpressures** when the actor acknowledgement has not arrived
 
 
-####ActorSubscriber
+#### ActorSubscriber
 
 Create an actor from a ``Props`` upon materialization, where the actor implements ``ActorSubscriber``, which will
 receive the elements from the stream.
@@ -366,25 +366,25 @@ Materializes into an ``IActorRef`` to the created actor.
 **backpressures** depends on the actor implementation
 
 
-####AsPublisher
+#### AsPublisher
 
 Integration with Reactive Streams, materializes into a ``Reactive.Streams.IPublisher``.
 
 
-####FromSubscriber
+#### FromSubscriber
 
 Integration with Reactive Streams, wraps a ``Reactive.Streams.ISubscriber`` as a sink
 
 
 
 
-#Additional Sink and Source converters
+# Additional Sink and Source converters
 
 Sources and sinks for integrating with ``System.IO.Stream`` can be found on
 ``StreamConverters``. As they are blocking APIs the implementations of these stages are run on a separate
 dispatcher configured through the ``akka.stream.blocking-io-dispatcher``.
 
-####FromOutputStream
+#### FromOutputStream
 
 Create a sink that wraps an ``Stream``. Takes a function that produces an ``Stream``, when the sink is
 materialized the function will be called and bytes sent to the sink will be written to the returned ``Stream``.
@@ -398,7 +398,7 @@ to handle multiple invocations.
 The ``Stream`` will be closed when the stream that flows into the ``Sink`` is completed, and the ``Sink``
 will cancel its inflow when the ``Stream`` is no longer writable.
 
-####AsInputStream
+#### AsInputStream
 
 Create a sink which materializes into an ``Stream`` that can be read to trigger demand through the sink.
 Bytes emitted through the stream will be available for reading through the ``Stream``
@@ -406,7 +406,7 @@ Bytes emitted through the stream will be available for reading through the ``Str
 The ``Stream`` will be ended when the stream flowing into this ``Sink`` completes, and the closing the
 ``Stream`` will cancel the inflow of this ``Sink``.
 
-####FromInputStream
+#### FromInputStream
 
 Create a source that wraps an ``Stream``. Takes a function that produces an ``Stream``, when the source is
 materialized the function will be called and bytes from the ``Stream`` will be emitted into the stream.
@@ -420,7 +420,7 @@ to handle multiple invocations.
 The ``Stream`` will be closed when the ``Source`` is canceled from its downstream, and reaching the end of the
 ``Stream`` will complete the ``Source``.
 
-####AsOutputStream
+#### AsOutputStream
 
 Create a source that materializes into an ``Stream``. When bytes are written to the ``Stream`` they
 are emitted from the source
@@ -432,12 +432,12 @@ File IO Sinks and Sources
 -------------------------
 Sources and sinks for reading and writing files can be found on ``FileIO``.
 
-####FromFile
+#### FromFile
 
 Emit the contents of a file, as ``ByteString`` s, materializes into a ``Task`` which will be completed with
 a ``IOResult`` upon reaching the end of the file or if there is a failure.
 
-####ToFile
+#### ToFile
 
 Create a sink which will write incoming ``ByteString`` s to a given file.
 
@@ -467,7 +467,7 @@ However, these rate transformations are data-driven, i.e. it is the incoming ele
 rate is affected. This is in contrast with [Backpressure aware stages](#backpressure-aware-stages) which can change their processing behavior
 depending on being backpressured by downstream or not.
 
-####Select
+#### Select
 
 Transform each element in the stream by calling a mapping function with it and passing the returned value downstream.
 
@@ -477,7 +477,7 @@ Transform each element in the stream by calling a mapping function with it and p
 
 **completes** when upstream completes
 
-####SelectMany
+#### SelectMany
 
 Transform each element into zero or more elements that are individually passed downstream.
 
@@ -487,7 +487,7 @@ Transform each element into zero or more elements that are individually passed d
 
 **completes** when upstream completes and all remaining elements has been emitted
 
-####StatefulSelectMany
+#### StatefulSelectMany
 
 Transform each element into zero or more elements that are individually passed downstream. The difference to ``SelectMany`` is that
 the transformation function is created from a factory for every materialization of the flow.
@@ -498,7 +498,7 @@ the transformation function is created from a factory for every materialization 
 
 **completes** when upstream completes and all remaining elements has been emitted
 
-####Where
+#### Where
 
 Filter the incoming elements using a predicate. If the predicate returns true the element is passed downstream, if
 it returns false the element is discarded.
@@ -509,7 +509,7 @@ it returns false the element is discarded.
 
 **completes** when upstream completes
 
-####Collect
+#### Collect
 
 Apply a partial function to each incoming element, if the partial function is defined for a value the returned
 value is passed downstream. Can often replace ``Where`` followed by ``Select`` to achieve the same in one single stage.
@@ -520,7 +520,7 @@ value is passed downstream. Can often replace ``Where`` followed by ``Select`` t
 
 **completes** when upstream completes
 
-####Grouped
+#### Grouped
 
 Accumulate incoming events until the specified number of elements have been accumulated and then pass the collection of
 elements downstream.
@@ -531,7 +531,7 @@ elements downstream.
 
 **completes** when upstream completes
 
-####Sliding
+#### Sliding
 
 Provide a sliding window over the incoming stream and pass the windows as groups of elements downstream.
 
@@ -544,7 +544,7 @@ Note: the last window might be smaller than the requested size due to end of str
 **completes** when upstream completes
 
 
-####Scan
+#### Scan
 
 Emit its current value which starts at ``zero`` and then applies the current and next value to the given function
 emitting the next current value.
@@ -558,7 +558,7 @@ the second element is required from downstream.
 
 **completes** when upstream completes
 
-####Aggregate
+#### Aggregate
 
 Start with current value ``zero`` and then apply the current and next value to the given function, when upstream
 complete the current value is emitted downstream.
@@ -569,7 +569,7 @@ complete the current value is emitted downstream.
 
 **completes** when upstream completes
 
-####Skip
+#### Skip
 
 Skip ``n`` elements and then pass any subsequent element downstream.
 
@@ -579,7 +579,7 @@ Skip ``n`` elements and then pass any subsequent element downstream.
 
 **completes** when upstream completes
 
-####Take
+#### Take
 
 Pass ``n`` incoming elements downstream and then complete
 
@@ -590,7 +590,7 @@ Pass ``n`` incoming elements downstream and then complete
 **completes** when the defined number of elements has been taken or upstream completes
 
 
-####TakeWhile
+#### TakeWhile
 
 Pass elements downstream as long as a predicate function return true for the element include the element
 when the predicate first return false and then complete.
@@ -601,7 +601,7 @@ when the predicate first return false and then complete.
 
 **completes** when predicate returned false or upstream completes
 
-####SkipWhile
+#### SkipWhile
 
 Skip elements as long as a predicate function return true for the element
 
@@ -611,7 +611,7 @@ Skip elements as long as a predicate function return true for the element
 
 **completes** when upstream completes
 
-####Recover
+#### Recover
 
 Allow sending of one last element downstream when a failure has happened upstream.
 
@@ -621,7 +621,7 @@ Allow sending of one last element downstream when a failure has happened upstrea
 
 **completes** when upstream completes or upstream failed with exception pf can handle
 
-####RecoverWith
+#### RecoverWith
 
 Allow switching to alternative Source when a failure has happened upstream.
 
@@ -631,7 +631,7 @@ Allow switching to alternative Source when a failure has happened upstream.
 
 **completes** upstream completes or upstream failed with exception pf can handle
 
-####Detach
+#### Detach
 
 Detach upstream demand from downstream demand without detaching the stream rates.
 
@@ -642,7 +642,7 @@ Detach upstream demand from downstream demand without detaching the stream rates
 **completes** when upstream completes
 
 
-####Throttle
+#### Throttle
 
 Limit the throughput to a specific number of elements per time unit, or a specific total cost per time unit, where
 a function has to be provided to calculate the individual cost of each element.
@@ -654,13 +654,13 @@ a function has to be provided to calculate the individual cost of each element.
 **completes** when upstream completes
 
 
-#Asynchronous processing stages
+# Asynchronous processing stages
 
 These stages encapsulate an asynchronous computation, properly handling backpressure while taking care of the asynchronous
 operation at the same time (usually handling the completion of a Task).
 
 
-####SelectAsync
+#### SelectAsync
 
 Pass incoming elements to a function that return a ``Task`` result. When the task arrives the result is passed
 downstream. Up to ``n`` elements can be processed concurrently, but regardless of their completion time the incoming
@@ -674,7 +674,7 @@ If a Task fails, the stream also fails (unless a different supervision strategy 
 
 **completes** when upstream completes and all tasks has been completed and all elements has been emitted
 
-####SelectAsyncUnordered
+#### SelectAsyncUnordered
 
 Like ``SelectAsync`` but ``Task`` results are passed downstream as they arrive regardless of the order of the elements
 that triggered them.
@@ -688,11 +688,11 @@ If a Task fails, the stream also fails (unless a different supervision strategy 
 **completes** upstream completes and all tasks has been completed  and all elements has been emitted
 
 
-#Timer driven stages
+# Timer driven stages
 
 These stages process elements using timers, delaying, dropping or grouping elements for certain time durations.
 
-####TakeWithin
+#### TakeWithin
 
 Pass elements downstream within a timeout and then complete.
 
@@ -703,7 +703,7 @@ Pass elements downstream within a timeout and then complete.
 **completes** upstream completes or timer fires
 
 
-####SkipWithin
+#### SkipWithin
 
 Skip elements until a timeout has fired
 
@@ -713,7 +713,7 @@ Skip elements until a timeout has fired
 
 **completes** upstream completes
 
-####GroupedWithin
+#### GroupedWithin
 
 Chunk up the stream into groups of elements received within a time window, or limited by the given number of elements,
 whichever happens first.
@@ -725,7 +725,7 @@ whichever happens first.
 **completes** when upstream completes
 
 
-####InitialDelay
+#### InitialDelay
 
 Delay the initial element by a user specified duration from stream materialization.
 
@@ -736,7 +736,7 @@ Delay the initial element by a user specified duration from stream materializati
 **completes** when upstream completes
 
 
-####Delay
+#### Delay
 
 Delay every element passed through with a specific duration.
 
@@ -747,11 +747,11 @@ Delay every element passed through with a specific duration.
 **completes** when upstream completes and buffered elements has been drained
 
 
-#Backpressure aware stages
+# Backpressure aware stages
 
 These stages are aware of the backpressure provided by their downstreams and able to adapt their behavior to that signal.
 
-####Conflate
+#### Conflate
 
 Allow for a slower downstream by passing incoming elements and a summary into an aggregate function as long as
 there is backpressure. The summary value must be of the same type as the incoming elements, for example the sum or
@@ -763,7 +763,7 @@ average of incoming numbers, if aggregation should lead to a different type ``Co
 
 **completes** when upstream completes
 
-####ConflateWithSeed
+#### ConflateWithSeed
 
 Allow for a slower downstream by passing incoming elements and a summary into an aggregate function as long as there
 is backpressure. When backpressure starts or there is no backpressure element is passed into a ``seed`` function to
@@ -775,7 +775,7 @@ transform it to the summary type.
 
 **completes** when upstream completes
 
-####Batch
+#### Batch
 
 Allow for a slower downstream by passing incoming elements and a summary into an aggregate function as long as there
 is backpressure and a maximum number of batched elements is not yet reached. When the maximum number is reached and
@@ -794,7 +794,7 @@ aggregated to the batched value.
 **completes** when upstream completes and a "possibly pending" element was drained
 
 
-####BatchWeighted
+#### BatchWeighted
 
 Allow for a slower downstream by passing incoming elements and a summary into an aggregate function as long as there
 is backpressure and a maximum weight batched elements is not yet reached. The weight of each element is determined by
@@ -810,7 +810,7 @@ aggregated to the batched value.
 
 **completes** upstream completes and a "possibly pending" element was drained
 
-####Expand
+#### Expand
 
 Allow for a faster downstream by expanding the last incoming element to an ``Enumerator``
 
@@ -820,7 +820,7 @@ Allow for a faster downstream by expanding the last incoming element to an ``Enu
 
 **completes** when upstream completes
 
-####Buffer (Backpressure)
+#### Buffer (Backpressure)
 
 Allow for a temporarily faster upstream events by buffering ``size`` elements. When the buffer is full backpressure
 is applied.
@@ -831,7 +831,7 @@ is applied.
 
 **completes** when upstream completes and buffered elements has been drained
 
-####Buffer (Drop)
+#### Buffer (Drop)
 
 Allow for a temporarily faster upstream events by buffering ``size`` elements. When the buffer is full elements are
 dropped according to the specified ``OverflowStrategy``:
@@ -847,7 +847,7 @@ dropped according to the specified ``OverflowStrategy``:
 
 **completes** upstream completes and buffered elements has been drained
 
-####Buffer (Fail)
+#### Buffer (Fail)
 
 Allow for a temporarily faster upstream events by buffering ``size`` elements. When the buffer is full the stage fails
 the flow with a ``BufferOverflowException``.
@@ -859,12 +859,12 @@ the flow with a ``BufferOverflowException``.
 **completes** when upstream completes and buffered elements has been drained
 
 
-#Nesting and flattening stages
+# Nesting and flattening stages
 
 These stages either take a stream and turn it into a stream of streams (nesting) or they take a stream that contains
 nested streams and turn them into a stream of elements instead (flattening).
 
-#PrefixAndTail
+# PrefixAndTail
 
 Take up to `n` elements from the stream (less than `n` only if the upstream completes before emitting `n` elements)
 and returns a pair containing a strict sequence of the taken element and a stream representing the remaining elements.
@@ -876,7 +876,7 @@ and returns a pair containing a strict sequence of the taken element and a strea
 **completes** when prefix elements has been consumed and substream has been consumed
 
 
-####GroupBy
+#### GroupBy
 
 Demultiplex the incoming stream into separate output streams.
 
@@ -885,7 +885,7 @@ there is an element pending for a group whose substream backpressures
 
 **completes** when upstream completes (Until the end of stream it is not possible to know whether new substreams will be needed or not)
 
-####SplitWhen
+#### SplitWhen
 
 Split off elements into a new substream whenever a predicate function return ``true``.
 
@@ -895,7 +895,7 @@ Split off elements into a new substream whenever a predicate function return ``t
 
 **completes** when upstream completes (Until the end of stream it is not possible to know whether new substreams will be needed or not)
 
-####SplitAfter
+#### SplitAfter
 
 End the current substream whenever a predicate returns ``true``, starting a new substream for the next element.
 
@@ -905,7 +905,7 @@ End the current substream whenever a predicate returns ``true``, starting a new 
 
 **completes** when upstream completes (Until the end of stream it is not possible to know whether new substreams will be needed or not)
 
-####ConcatMany
+#### ConcatMany
 
 Transform each input element into a ``Source`` whose elements are then flattened into the output stream through
 concatenation. This means each source is fully consumed before consumption of the next source starts.
@@ -917,7 +917,7 @@ concatenation. This means each source is fully consumed before consumption of th
 **completes** when upstream completes and all consumed substreams complete
 
 
-####MergeMany
+#### MergeMany
 
 Transform each input element into a ``Source`` whose elements are then flattened into the output stream through
 merging. The maximum number of merged sources has to be specified.
@@ -929,11 +929,11 @@ merging. The maximum number of merged sources has to be specified.
 **completes** when upstream completes and all consumed substreams complete
 
 
-#Time aware stages
+# Time aware stages
 
 Those stages operate taking time into consideration.
 
-####InitialTimeout
+#### InitialTimeout
 
 If the first element has not passed through this stage before the provided timeout, the stream is failed
 with a ``TimeoutException``.
@@ -946,7 +946,7 @@ with a ``TimeoutException``.
 
 **cancels** when downstream cancels
 
-####CompletionTimeout
+#### CompletionTimeout
 
 If the completion of the stream does not happen until the provided timeout, the stream is failed
 with a ``TimeoutException``.
@@ -959,7 +959,7 @@ with a ``TimeoutException``.
 
 **cancels** when downstream cancels
 
-####IdleTimeout
+#### IdleTimeout
 
 If the time between two processed elements exceeds the provided timeout, the stream is failed
 with a ``TimeoutException``. The timeout is checked periodically, so the resolution of the
@@ -973,7 +973,7 @@ check is one period (equals to timeout value).
 
 **cancels** when downstream cancels
 
-####BackpressureTimeout
+#### BackpressureTimeout
 
 If the time between the emission of an element and the following downstream demand exceeds the provided timeout,
 the stream is failed with a ``TimeoutException``. The timeout is checked periodically, so the resolution of the
@@ -987,7 +987,7 @@ check is one period (equals to timeout value).
 
 **cancels** when downstream cancels
 
-####KeepAlive
+#### KeepAlive
 
 Injects additional (configured) elements if upstream does not emit for a configured amount of time.
 
@@ -999,7 +999,7 @@ Injects additional (configured) elements if upstream does not emit for a configu
 
 **cancels** when downstream cancels
 
-####InitialDelay
+#### InitialDelay
 
 Delays the initial element by the specified duration.
 
@@ -1012,12 +1012,12 @@ Delays the initial element by the specified duration.
 **cancels** when downstream cancels
 
 
-#Fan-in stages
+# Fan-in stages
 
 These stages take multiple streams as their input and provide a single output combining the elements from all of
 the inputs in different ways.
 
-####Merge
+#### Merge
 
 Merge multiple sources. Picks elements randomly if all sources has elements ready.
 
@@ -1027,7 +1027,7 @@ Merge multiple sources. Picks elements randomly if all sources has elements read
 
 **completes** when all upstreams complete (This behavior is changeable to completing when any upstream completes by setting ``eagerComplete=true``.)
 
-####MergeSorted
+#### MergeSorted
 
 Merge multiple sources. Waits for one element to be ready from each input stream and emits the
 smallest element.
@@ -1038,7 +1038,7 @@ smallest element.
 
 **completes** when all upstreams complete
 
-####Zip
+#### Zip
 
 Combines elements from each of multiple sources into tuples and passes the tuples downstream.
 
@@ -1048,7 +1048,7 @@ Combines elements from each of multiple sources into tuples and passes the tuple
 
 **completes** when any upstream completes
 
-####ZipWith
+#### ZipWith
 
 Combines elements from multiple sources through a ``combine`` function and passes the
 returned value downstream.
@@ -1059,7 +1059,7 @@ returned value downstream.
 
 **completes** when any upstream completes
 
-####Concat
+#### Concat
 
 After completion of the original upstream the elements of the given source will be emitted.
 
@@ -1069,7 +1069,7 @@ After completion of the original upstream the elements of the given source will 
 
 **completes** when all upstreams complete
 
-####Prepend
+#### Prepend
 
 Prepends the given source to the flow, consuming it until completion before the original source is consumed.
 
@@ -1081,7 +1081,7 @@ If materialized values needs to be collected ``prependMat`` is available.
 
 **completes** when all upstreams complete
 
-####OrElse
+#### OrElse
 
 If the primary source completes without emitting any elements, the elements from the secondary source
 are emitted. If the primary source emits any elements the secondary source is cancelled.
@@ -1099,7 +1099,7 @@ is available from the second stream
 **completes** the primary stream completes after emitting at least one element, when the primary stream completes
 without emitting and the secondary stream already has completed or when the secondary stream completes
 
-####Interleave
+#### Interleave
 
 Emits a specifiable number of elements from the original source, then from the provided source and repeats. If one
 source completes the rest of the other stream will be emitted.
@@ -1110,12 +1110,12 @@ source completes the rest of the other stream will be emitted.
 
 **completes** when both upstreams have completed
 
-#Fan-out stages
+# Fan-out stages
 
 These have one input and multiple outputs. They might route the elements between different outputs, or emit elements on
 multiple outputs at the same time.
 
-####Unzip
+#### Unzip
 
 Takes a stream of two element tuples and unzips the two elements into two different downstreams.
 
@@ -1125,7 +1125,7 @@ Takes a stream of two element tuples and unzips the two elements into two differ
 
 **completes** when upstream completes
 
-####UnzipWith
+#### UnzipWith
 
 Splits each element of input into multiple downstreams using a function
 
@@ -1135,7 +1135,7 @@ Splits each element of input into multiple downstreams using a function
 
 **completes** when upstream completes
 
-####broadcast
+#### broadcast
 
 Emit each incoming element each of ``n`` outputs.
 
@@ -1145,7 +1145,7 @@ Emit each incoming element each of ``n`` outputs.
 
 **completes** when upstream completes
 
-####Balance
+#### Balance
 
 Fan-out the stream to several streams. Each upstream element is emitted to the first available downstream consumer.
 
@@ -1156,9 +1156,9 @@ Fan-out the stream to several streams. Each upstream element is emitted to the f
 **completes** when upstream completes
 
 
-#Watching status stages
+# Watching status stages
 
-####WatchTermination
+#### WatchTermination
 
 Materializes to a ``Task`` that will be completed with Done or failed depending whether the upstream of the stage has been completed or failed.
 The stage otherwise passes through elements unchanged.
@@ -1170,7 +1170,7 @@ The stage otherwise passes through elements unchanged.
 **completes** when upstream completes
 
 
-####Monitor
+#### Monitor
 
 Materializes to a ``FlowMonitor`` that monitors messages flowing through or completion of the stage. The stage otherwise
 passes through elements unchanged. Note that the ``FlowMonitor`` inserts a memory barrier every time it processes an

--- a/docs/articles/streams/cookbook.md
+++ b/docs/articles/streams/cookbook.md
@@ -3,7 +3,7 @@ layout: docs.hbs
 title: Streams Cookbook
 ---
 
-#Introduction
+# Introduction
 
 This is a collection of patterns to demonstrate various usage of the Akka Streams API by solving small targeted
 problems in the format of "recipes". The purpose of this page is to give inspiration and ideas how to approach
@@ -17,12 +17,12 @@ as they appear in the main body of documentation.
 If you need a quick reference of the available processing stages used in the recipes see 
 [Overview of built-in stages and their semantics](builtinstages.md)
 
-#Working with Flows
+# Working with Flows
 
 In this collection we show simple recipes that involve linear flows. The recipes in this section are rather
 general, more targeted recipes are available as separate sections ( [Buffers and working with rate](buffersandworkingwithrate.md), [Working with streaming IO](workingwithstreamingio.md)).
 
-####Logging elements of a stream
+#### Logging elements of a stream
 
 **Situation:** During development it is sometimes helpful to see what happens in a particular section of a stream.
 
@@ -52,7 +52,7 @@ mySource.Log("before-select")
 mySource.Log("custom", null, Logging.GetLogger(sys, "customLogger"));
 ```
 
-####Flattening a stream of sequences
+#### Flattening a stream of sequences
 
 **Situation:** A stream is given as a stream of sequence of elements, but a stream of elements needed instead, streaming
 all the nested elements inside the sequences separately.
@@ -66,7 +66,7 @@ Source<List<Message>,NotUsed > myData = someDataSource;
 Source<Message, NotUsed> flattened = myData.SelectMany(x => x);
 ```
 
-####Draining a stream to a strict collection
+#### Draining a stream to a strict collection
 
 **Situation:** A possibly unbounded sequence of elements is given as a stream, which needs to be collected into a collection while ensuring boundedness
 
@@ -95,7 +95,7 @@ var limited = mySource.Limit(MAX_ALLOWED_SIZE).RunWith(Sink.Seq<string>(), mater
 var ignoreOverflow = mySource.Take(MAX_ALLOWED_SIZE).RunWith(Sink.Seq<string>(), materializer);
 ```
 
-####Calculating the digest of a ByteString stream
+#### Calculating the digest of a ByteString stream
 
 **Situation:** A stream of bytes is given as a stream of ``ByteStrings`` and we want to calculate the cryptographic digest
 of the stream.
@@ -157,7 +157,7 @@ var data = Source.Empty<ByteString>();
 var digest = data.Via(new DigestCalculator("SHA-256"));
 ```
 
-####Parsing lines from a stream of ByteStrings
+#### Parsing lines from a stream of ByteStrings
 
 **Situation:** A stream of bytes is given as a stream of ``ByteStrings`` containing lines terminated by line ending
 characters (or, alternatively, containing binary frames delimited by a special delimiter byte sequence) which
@@ -172,7 +172,7 @@ var linesStream = rawData
     .Select(b => b.DecodeString());
 ```
 
-####Implementing reduce-by-key
+#### Implementing reduce-by-key
 
 
 **Situation:** Given a stream of elements, we want to calculate some aggregated value on different subgroups of the
@@ -245,7 +245,7 @@ var counts = words.Via(ReduceByKey(MaximumDistinctWords,
 > Please note that the reduce-by-key version we discussed above is sequential in reading the overall input stream, 
 in other words it is **NOT** a parallelization pattern like MapReduce and similar frameworks.
 
-####Sorting elements to multiple groups with groupBy
+#### Sorting elements to multiple groups with groupBy
 
 **Situation:** The ``GroupBy`` operation strictly partitions incoming elements, each element belongs to exactly one group.
 Sometimes we want to map elements into multiple groups simultaneously.
@@ -278,11 +278,11 @@ var multiGroups = messageAndTopic.GroupBy(2, tuple => tuple.Item2).Select(tuple 
 });
 ```
 
-#Working with Graphs
+# Working with Graphs
 
 In this collection we show recipes that use stream graph elements to achieve various goals.
 
-####Triggering the flow of elements programmatically
+#### Triggering the flow of elements programmatically
 
 **Situation:** Given a stream of elements we want to control the emission of those elements according to a trigger signal.
 In other words, even if the stream would be able to flow (not being backpressured) we want to hold back elements until a
@@ -326,7 +326,7 @@ var graph = RunnableGraph.FromGraph(GraphDsl.Create(b =>
 }));
 ```
 
-####Balancing jobs to a fixed pool of workers
+#### Balancing jobs to a fixed pool of workers
 
 **Situation:** Given a stream of jobs and a worker process expressed as a `Flow` create a pool of workers
 that automatically balances incoming jobs to available workers, then merges the results.
@@ -361,12 +361,12 @@ var worker = Flow.Create<Job>().Select(j => new Done(j));
 var processedJobs = myJobs.Via(Balancer(worker, 3));
 ```
 
-#Working with rate
+# Working with rate
 
 This collection of recipes demonstrate various patterns where rate differences between upstream and downstream
 needs to be handled by other strategies than simple backpressure.
 
-####Dropping elements
+#### Dropping elements
 
 **Situation:** Given a fast producer and a slow consumer, we want to drop elements if necessary to not slow down
 the producer too much.
@@ -385,7 +385,7 @@ var droppyStream = Flow.Create<Message>().Conflate((lastMessage, newMessage) => 
 There is a more general version of ``Conflate`` named ``ConflateWithSeed`` that allows to express more complex aggregations, more
 similar to a ``Aggregate``.
 
-####Dropping broadcast
+#### Dropping broadcast
 
 **Situation:** The default ``Broadcast`` graph element is properly backpressured, but that means that a slow downstream
 consumer can hold back the other downstream consumers resulting in lowered throughput. In other words the rate of
@@ -415,7 +415,7 @@ var graph = RunnableGraph.FromGraph(GraphDsl.Create(mysink1, mysink2, mysink3, T
     }));
 ```
 
-####Collecting missed ticks
+#### Collecting missed ticks
 
 **Situation:** Given a regular (stream) source of ticks, instead of trying to backpressure the producer of the ticks
 we want to keep a counter of the missed ticks instead and pass it down when possible.
@@ -437,7 +437,7 @@ var missed = Flow.Create<Tick>()
   .ConflateWithSeed(seed: _ => 0, aggregate: (missedTicks, tick) => missedTicks + 1);
 ```
 
-####Create a stream processor that repeats the last element seen
+#### Create a stream processor that repeats the last element seen
 
 **Situation:** Given a producer and consumer, where the rate of neither is known in advance, we want to ensure that none
 of them is slowing down the other by dropping earlier unconsumed elements from the upstream if necessary, and repeating
@@ -553,7 +553,7 @@ public sealed class HoldWithWait<T> : GraphStage<FlowShape<T, T>>
 }
 ```
 
-####Globally limiting the rate of a set of streams
+#### Globally limiting the rate of a set of streams
 
 **Situation:** Given a set of independent streams that we cannot merge, we want to globally limit the aggregate
 throughput of the set of streams.
@@ -682,9 +682,9 @@ public Flow<T, T, NotUsed> LimitGlobal<T>(IActorRef limiter, TimeSpan maxAllowed
 > [!NOTE]
 > The global actor used for limiting introduces a global bottleneck. You might want to assign a dedicated dispatcher for this actor.
 
-#Working with IO
+# Working with IO
 
-####Chunking up a stream of ByteStrings into limited size ByteStrings
+#### Chunking up a stream of ByteStrings into limited size ByteStrings
 
 **Situation:** Given a stream of ByteStrings we want to produce a stream of ByteStrings containing the same bytes in
 the same sequence, but capping the size of ByteStrings. In other words we want to slice up ByteStrings into smaller
@@ -775,7 +775,7 @@ var rawBytes = Source.Empty<ByteString>();
 var chunkStream = rawBytes.Via(new Chunker(ChunkLimit));
 ```
 
-####Limit the number of bytes passing through a stream of ByteStrings
+#### Limit the number of bytes passing through a stream of ByteStrings
 
 **Situation:** Given a stream of ByteStrings we want to fail the stream if more than a given maximum of bytes has been
 consumed.
@@ -827,7 +827,7 @@ public class ByteLimiter : GraphStage<FlowShape<ByteString, ByteString>>
 var limiter = Flow.Create<ByteString>().Via(new ByteLimiter(SizeLimit));
 ```
 
-####Compact ByteStrings in a stream of ByteStrings
+#### Compact ByteStrings in a stream of ByteStrings
 
 **Situation:** After a long stream of transformations, due to their immutable, structural sharing nature ByteStrings may
 refer to multiple original ByteString instances unnecessarily retaining memory. As the final step of a transformation
@@ -841,7 +841,7 @@ var data = Source.Empty<ByteString>();
 var compacted = data.Select(b => b.Compact());
 ```
 
-####Injecting keep-alive messages into a stream of ByteStrings
+#### Injecting keep-alive messages into a stream of ByteStrings
 
 **Situation:** Given a communication channel expressed as a stream of ByteStrings we want to inject keep-alive messages
 but only if this does not interfere with normal traffic.

--- a/docs/articles/streams/designprinciples.md
+++ b/docs/articles/streams/designprinciples.md
@@ -3,13 +3,13 @@ layout: docs.hbs
 title: Design Principles behind Akka Streams
 ---
 
-#Design Principles behind Akka Streams
+# Design Principles behind Akka Streams
 It took quite a while until we were reasonably happy with the look and feel of the API and the architecture of the implementation, and while being guided by intuition the design phase was very much exploratory research. This section details the findings and codifies them into a set of principles that have emerged during the process.
 
 > [!NOTE]
 > As detailed in the introduction keep in mind that the Akka Streams API is completely decoupled from the Reactive Streams interfaces which are just an implementation detail for how to pass stream data between individual processing stages.
 
-##What shall users of Akka Streams expect?
+## What shall users of Akka Streams expect?
 Akka is built upon a conscious decision to offer APIs that are minimal and consistent --as opposed to easy or intuitive. The credo is that we favour explicitness over magic, and if we provide a feature then it must work always, no exceptions. Another way to say this is that we minimize the number of rules a user has to learn instead of trying to keep the rules close to what we think users might expect.
 
 From this follows that the principles implemented by Akka Streams are:
@@ -20,7 +20,7 @@ From this follows that the principles implemented by Akka Streams are:
 
 This means that we provide all the tools necessary to express any stream processing topology, that we model all the essential aspects of this domain (back-pressure, buffering, transformations, failure recovery, etc.) and that whatever the user builds is reusable in a larger context.
 
-###Akka Streams does not send dropped stream elements to the dead letter office
+### Akka Streams does not send dropped stream elements to the dead letter office
 One important consequence of offering only features that can be relied upon is the restriction that Akka Streams cannot ensure that all objects sent through a processing topology will be processed. Elements can be dropped for a number of reason:
 
 - plan user code can consume on element in a Select(...) stage and produce an entirely different one as its result
@@ -30,12 +30,12 @@ One important consequence of offering only features that can be relied upon is t
 
 This means that sending CLR objects into a stream that needs to be cleaned up will require the user to ensure that this happens outside of the Akka Streams facilities (e.g. by cleaning them up after a time-out or when their results are observed on the stream output, or by other means like finalizers etc.)
 
-###Resulting implementation Constraints
+### Resulting implementation Constraints
 Compositionality entails re-usability of partial stream topologies, which led us to the lifted approach of describing data flows as (partial) graphs that can act as composite sources, flows (a.k.a. pipes) and sinks of data. These building blocks shall then be freely shareable, with the ability to combine them freely to form larger graphs. The representation of these pieces must therefore be an immutable blueprint that is materialized in an explicit step in order to start the stream processing. The resulting stream processing engine is then also immutable in the sense of having a fixed topology that is prescribed by the blueprint. Dynamic networks need to be modelled by explicitly using the Reactive Streams interfaces for plugging different engines together.
 
 The process of materialization will often create specific objects that are useful to interact with the processing engine once it is running, for example for shutting it down or for extracting metrics. This means that the materialization function produces a result termed the *materialized value of a graph*.
 
-##What shall users of streaming libraries expect?
+## What shall users of streaming libraries expect?
 We expect libraries to be built on top of Akka Streams, in fact on the JVM" Akka HTTP is one such example that lives within the Akka project itself. In order to allow users to profit from the principles that are described for Akka Streams above, the following rules are established:
 
 - libraries shall provide their users with reusable pieces, i.e expose factories that return graphs, allowing full compositionality
@@ -47,7 +47,7 @@ The second rule allows a library to additionally provide nice sugar for the comm
 > [!NOTE]
 > One important consequence of this is that a reusable flow description cannot be bound to "live" resources, any connection to or allocation of such resources must be deferred until materialization time. Examples of "live" resources are already existing TCP connections, a multicast Publisher, etc.; a TickSource does not fall into this category if its timer is created only upon materialization (as is the case for our implementation). <br>Exceptions from this need to be well-justified and carefully documented.
 
-###Resulting Implementation Constraints
+### Resulting Implementation Constraints
 Akka Streams must enable a library to express any stream processing utility in terms of immutable blueprints. The most common building blocks are
 
 - Source: something with exactly one output stream
@@ -59,7 +59,7 @@ Akka Streams must enable a library to express any stream processing utility in t
 > [!NOTE]
 > A source that emits a stream of streams is still just a normal Source, the kind of elements that are produced does not play a role in the static stream topology that is being expressed.
 
-##The difference between Error and Failure
+## The difference between Error and Failure
 The starting point for this discussion is the definition given by the [Reactive Manifesto](http://www.reactivemanifesto.org/glossary#Failure). Translated to streams this means that an error is accessible within the stream as a normal data element, while a failure means that the stream itself has failed and is collapsing. In concrete terms, on the Reactive Streams interface level data elements (including errors) are signalled via `onNext` while failures raise the `onError` signal.
 
 > [!NOTE]
@@ -69,7 +69,7 @@ There is only limited support for treating `onError` in Akka Streams compared to
 
 The ability for failures to propagate faster than data elements is essential for tearing down streams that are back-pressured --especially since back-pressure can be the failure mode (e.g. by tripping upstream buffers which then abort because they cannot do anything else; or if a dead-lock occurred).
 
-##The semantics of stream recovery
+## The semantics of stream recovery
 A recovery element (i.e. any transformation that absorbs an `onError` signal and turns that into possibly more data elements followed normal stream completion) acts as a bulkhead that confines a stream collapse to a given region of the stream topology. Within the collapsed region buffered elements may be lost, but the outside is not affected by the failure.
 
 This works in the same fashion as a `try-catch` expression: it marks a region in which exceptions are caught, but the exact amount of code that was skipped within this region in case of a failure might not be known precisely-the placement of statements matters.

--- a/docs/articles/streams/error-handling.md
+++ b/docs/articles/streams/error-handling.md
@@ -11,7 +11,7 @@ strategies, but the semantics have been adapted to the domain of stream processi
 > *ZipWith*, *GraphStage* junction, *ActorPublisher* source and *ActorSubscriber* sink 
 components do not honour the supervision strategy attribute yet.
 
-#Supervision Strategies
+# Supervision Strategies
 
 There are three ways to handle exceptions from application code:
 
@@ -92,7 +92,7 @@ var result = source.Limit(1000).RunWith(Sink.Seq<int>(), materializer);
 // result here will be a Task completed with Success(List(0, 1, 4, 0, 5, 12))
 ```
 
-#Errors from SelectAsync
+# Errors from SelectAsync
 Stream supervision can also be applied to the tasks of ``SelectAsync``.
 
 Let's say that we use an external service to lookup email addresses and we would like to

--- a/docs/articles/streams/introduction.md
+++ b/docs/articles/streams/introduction.md
@@ -3,9 +3,9 @@ layout: docs.hbs
 title: Streams Introduction
 ---
 
-#Introduction
+# Introduction
 
-##Motivation
+## Motivation
 The way we consume services from the internet today includes many instances of streaming data, both downloading from a service as well as uploading to it or peer-to-peer data transfers. Regarding data as a stream of elements instead of in its entirety is very useful because it matches the way computers send and receive them (for example via TCP), but it is often also a necessity because data sets frequently become to large to be handled as a whole. We spread computations or analyses over large clusters and call it "big data", where the whole principle of processing them is by feeding those data sequentially --as a stream-- through some CPUs.
 
 Actors can be seen as dealing with streams as well: they send and receive series of messages in order to transfer knowledge (or data) from one place to another. We have found it tedious and error-prone to implement all the proper measures in order to achieve stable streaming between actors, since in addition to sending and receiving we also need to take care to not overflow any buffers or mailboxes in the process. Another pitfall is that Actor messages can be lost and must be retransmitted in that case lest the stream have holes on the receiving side. When dealing with streams of elements of a fixed given type, Actors also do not currently offer good static guarantees that no wiring errors are made: type-safety could be improved in this case.
@@ -13,12 +13,12 @@ Actors can be seen as dealing with streams as well: they send and receive series
 For these reasons it was decided to bundle up a solution to these problems as an Akka Streams API. The purpose is to offer an intuitive and safe way to formulate stream processing setups such that we can then execute them efficiently and with bounded resource usage -- no more OutOfMemoryErrors. In order to achieve this our streams need to be able to limit the buffering that they employ, they need to be able to slow down producers if the consumers cannot keep up. This feature is called back-pressure and is at the core of the [Reactive Streams](http://www.reactive-streams.org/) initiative of which Akka is a founding member. For you this means that the hard problem of propagating and reacting to back-pressure has been incorporated in the design of Akka Streams already, so you have one less thing to worry about; it also means that Akka Streams interoperate seamlessly with all other Reactive Streams implementations (where Reactive Streams interfaces define the interoperability SPI while implementations like Akka Streams offer a nice user API).
 Note that work is currently underway to provide an official reactive-streams implementation for the CLR.
 
-##Relationship with Reactive Streams
+## Relationship with Reactive Streams
 The Akka Streams API is completely decoupled from the Reactive Streams interfaces. While Akka Streams focus on the formulation of transformations on data streams the scope of Reactive Streams is just to define a common mechanism of how to move data across an asynchronous boundary without losses, buffering or resource exhaustion.
 
 The relationship between these two is that the Akka Streams API is geared towards end-users while the Akka Streams implementation uses the Reactive Streams interfaces internally to pass data between the different processing stages. For this reason you will not find any resemblance between the Reactive Streams interfaces and the Akka Streams API. This is in line with the expectations of the Reactive Streams project, whose primary purpose is to define interfaces such that different streaming implementation can interoperate; it is not the purpose of Reactive Streams to describe an end-user API.
 
-##How to read these docs
+## How to read these docs
 Stream processing is a different paradigm to the Actor Model or to Task composition, therefore it may take some careful study of this subject until you feel familiair with the tools and techniques. The documentation is here to help and for best results we recommend the following approach:
 
 * Read the [Quick Start Guide](quickstart.md) to get a feel for how streams look like and what they can do.

--- a/docs/articles/streams/modularitycomposition.md
+++ b/docs/articles/streams/modularitycomposition.md
@@ -5,7 +5,7 @@ title: Modularity, Composition and Hierarchy
 
 Akka Streams provide a uniform model of stream processing graphs, which allows flexible composition of reusable components. In this chapter we show how these look like from the conceptual and API perspective, demonstrating the modularity aspects of the library.
 
-#Basics of composition and modularity
+# Basics of composition and modularity
 
 Every processing stage used in Akka Streams can be imagined as a "box" with input and output ports where elements to be processed arrive and leave the stage. In this view, a `Source` is nothing else than a "box" with a single output port, or, a `BidiFlow` is a "box" with exactly two input and two output ports. In the figure below we illustrate the most common used stages viewed as "boxes".
 
@@ -105,7 +105,7 @@ var runnableGraph = nestedSource.To(nestedSink);
 var runnableGraph2 = Source.Single(0).To(Sink.Aggregate<int, int>(0, (sum, x) => sum + x));
 ```
 
-#Composing complex systems
+# Composing complex systems
 In the previous section we explored the possibility of composition, and hierarchy, but we stayed away from non-linear,
 generalized graph components. There is nothing in Akka Streams though that enforces that stream processing layouts
 can only be linear. The DSL for `Source` and friends is optimized for creating such linear chains, as they are
@@ -277,7 +277,7 @@ We have also seen, that every module has a `Shape` (for example a `Sink` has a `
 independently which DSL was used to create it. This uniform representation enables the rich composability of various
 stream processing entities in a convenient way.
 
-#Materialized values
+# Materialized values
 After realizing that `RunnableGraph` is nothing more than a module with no unused ports (it is an island), it becomes clear that
 after materialization the only way to communicate with the running stream processing logic is via some side-channel.
 This side channel is represented as a *materialized value*. The situation is similar to `Actor`'s, where the
@@ -375,7 +375,7 @@ var runnableGraph = nestedSource.ToMaterialized(nestedSink, (completion, rest) =
 > [!NOTE]
 > The nested structure in the above example is not necessary for combining the materialized values, it just demonstrates how the two features work together. See [Combining materialized values](basics.md#combining-materialized-values) for further examples of combining materialized values without nesting and hierarchy involved.
 
-#Attributes
+# Attributes
 We have seen that we can use ``Named()`` to introduce a nesting level in the fluid DSL (and also explicit nesting by using
 ``Create()`` from :class:`GraphDSL`). Apart from having the effect of adding a nesting level, ``Named()`` is actually
 a shorthand for calling ``WithAttributes(Attributes.CreateName("someName"))``. Attributes provide a way to fine-tune certain

--- a/docs/articles/streams/pipeliningandparallelism.md
+++ b/docs/articles/streams/pipeliningandparallelism.md
@@ -17,7 +17,7 @@ like to make pancakes, but they need to produce sufficient amount in a cooking s
 happy. To increase their pancake production throughput they use two frying pans. How they organize their pancake
 processing is markedly different.
 
-#Pipelining
+# Pipelining
 
 Bartosz uses the two frying pans in an asymmetric fashion. The first pan is only used to fry one side of the
 pancake then the half-finished pancake is flipped into the second pan for the finishing fry on the other side.
@@ -57,7 +57,7 @@ not be able to operate at full capacity [*1](_).
 For more details about the behavior of these and how to add additional buffers refer to 
 [Buffers and working with rate](buffersandworkingwithrate.md).
 
-#Parallel processing
+# Parallel processing
 Chris uses the two frying pans symmetrically. He uses both pans to fully fry a pancake on both sides, then puts
 the results on a shared plate. Whenever a pan becomes empty, he takes the next scoop from the shared bowl of batter.
 In essence he parallelizes the same process over multiple pans. This is how this setup will look like if implemented
@@ -93,7 +93,7 @@ by strict round-robin balancing and merging stages that put in and take out panc
 A more detailed example of creating a worker pool can be found in the cookbook: 
 [Balancing jobs to a fixed pool of workers](cookbook.md#balancing-jobs-to-a-fixed-pool-of-workers)
 
-#Combining pipelining and parallel processing
+# Combining pipelining and parallel processing
 
 The two concurrency patterns that we demonstrated as means to increase throughput are not exclusive.
 In fact, it is rather simple to combine the two approaches and streams provide

--- a/docs/articles/streams/quickstart.md
+++ b/docs/articles/streams/quickstart.md
@@ -57,7 +57,7 @@ We can use the new and shiny Sink we just created by attaching it to our factori
 factorials.Select(_ => _.ToString()).RunWith(LineSink("factorial2.txt"), materializer);
 ```
 
-##Time-Based Processing
+## Time-Based Processing
 Before we start looking at a more involved example we explore the streaming nature of what Akka Streams can do. Starting from the `factorials` source we transform the stream by zipping it together with another stream, represented by a `Source` that emits the number 0 to 100: the first number emitted by the `factorials` source is the factorial of zero, the second is the factorial of one, and so on. We combine these two by forming strings like "3! = 6".
 
 ```csharp

--- a/docs/articles/streams/reactivetweets.md
+++ b/docs/articles/streams/reactivetweets.md
@@ -154,7 +154,7 @@ expresses a graph that is a *partial graph*. Concepts around composing and nesti
 explained in detail in [Modularity, Composition and Hierarchy](modularitycomposition.md#basics-of-composition-and-modularity). It is also possible to wrap complex computation graphs as Flows, Sinks or Sources, which will be explained in detail in
 [Constructing Sources, Sinks and Flows from Partial Graphs](workingwithgraphs.md#constructing-sources-sinks-and-flows-from-partial-graphs).
 
-#Back-pressure in action
+# Back-pressure in action
 
 One of the main advantages of Akka Streams is that they *always* propagate back-pressure information from stream Sinks
 (Subscribers) to their Sources (Publishers). It is not an optional feature, and is enabled at all times. To learn more
@@ -178,7 +178,7 @@ The ``Buffer`` element takes an explicit and required ``OverflowStrategy``, whic
 when it receives another element while it is full. Strategies provided include dropping the oldest element (``DropHead``),
 dropping the entire buffer, signalling errors etc. Be sure to pick and choose the strategy that fits your use case best.
 
-#Materialized value
+# Materialized value
 
 So far we've been only processing data using Flows and consuming it into some kind of external Sink - be it by printing
 values or storing them in some external system. However sometimes we may be interested in some value that can be

--- a/docs/articles/streams/stream-dynamic.md
+++ b/docs/articles/streams/stream-dynamic.md
@@ -3,7 +3,7 @@ layout: docs.hbs
 title: Dynamic stream handling
 ---
 
-#Controlling graph completion with KillSwitch
+# Controlling graph completion with KillSwitch
 
 A ``KillSwitch`` allows the completion of graphs of ``FlowShape`` from the outside. It consists of a flow element that
 can be linked to a graph of ``FlowShape`` needing completion control.
@@ -32,7 +32,7 @@ Graph completion is performed by both
 
 A ``KillSwitch`` can control the completion of one or multiple streams, and therefore comes in two different flavours.
 
-####UniqueKillSwitch
+#### UniqueKillSwitch
 
 ``UniqueKillSwitch`` allows to control the completion of **one** materialized ``Graph`` of ``FlowShape``. Refer to the
 below for usage examples.
@@ -81,7 +81,7 @@ last.Wait();
 last.Exception.Should().Be(error);
 ```
 
-####SharedKillSwitch
+#### SharedKillSwitch
 
 A ``SharedKillSwitch`` allows to control the completion of an arbitrary number graphs of ``FlowShape``. It can be
 materialized multiple times via its ``Flow`` method, and all materialized graphs linked to it are controlled by the switch.

--- a/docs/articles/streams/testingstreams.md
+++ b/docs/articles/streams/testingstreams.md
@@ -16,7 +16,7 @@ flows and sinks. This makes them easily testable by wiring them up to other
 sources or sinks, or some test harnesses that `Akka.Testkit` or
 `Akka.Streams.Testkit` provide.
 
-#Built in sources, sinks and combinators
+# Built in sources, sinks and combinators
 
 Testing a custom sink can be as simple as attaching a source that emits
 elements from a predefined collection, running a constructed test flow and
@@ -65,7 +65,7 @@ task.Wait(TimeSpan.FromMilliseconds(500)).Should().BeTrue();
 task.Result.ShouldAllBeEquivalentTo(Enumerable.Range(1, 4));
 ```
 
-#TestKit
+# TestKit
 
 Akka Stream offers integration with Actors out of the box. This support can be
 used for writing stream tests that use familiar `TestProbe` from the
@@ -132,7 +132,7 @@ task.Wait(TimeSpan.FromMilliseconds(500)).Should().BeTrue();
 task.Result.Should().Be("123");
 ```
 
-#Streams TestKit
+# Streams TestKit
 
 You may have noticed various code patterns that emerge when testing stream
 pipelines. Akka Stream has a separate `Akka.Streams.Testkit` module that
@@ -213,7 +213,7 @@ var ex = sub.ExpectError();
 ex.Message.Should().Contain("C-47");
 ```
 
-#Fuzzing Mode
+# Fuzzing Mode
 
 For testing, it is possible to enable a special stream execution mode that exercises concurrent execution paths
 more aggressively (at the cost of reduced performance) and therefore helps exposing race conditions in tests. To

--- a/docs/articles/streams/workingwithgraphs.md
+++ b/docs/articles/streams/workingwithgraphs.md
@@ -14,7 +14,7 @@ Some graph operations which are common enough and fit the linear style of Flows,
 streams, such that the second one is consumed after the first one has completed), may have shorthand methods defined on
 `Flow` or `Source` themselves, however you should keep in mind that those are also implemented as graph junctions.
 
-#Constructing Graphs
+# Constructing Graphs
 
 Graphs are built from simple Flows which serve as the linear connections within the graphs as well as junctions
 which serve as fan-in and fan-out points for Flows. Thanks to the junctions having meaningful types based on their behaviour
@@ -108,7 +108,7 @@ RunnableGraph.FromGraph(GraphDsl.Create(topHeadSink, bottomHeadSink, Keep.Both,
 	}));
 ```
 
-#Constructing and combining Partial Graphs
+# Constructing and combining Partial Graphs
 
 Sometimes it is not possible (or needed) to construct the entire computation graph in one place, but instead construct all of its different phases in different places and in the end connect them all into a complete graph and run it.
 
@@ -166,7 +166,7 @@ Then we import it (all of its nodes and connections) explicitly into the closed 
 > Please note that `GraphDSL` is not able to provide compile time type-safety about whether or not all elements have been properly connected—this validation is performed as a runtime check during the graph's instantiation. A partial graph also verifies that all ports are either connected or part of the returned `Shape`.
 
 
-#Constructing Sources, Sinks and Flows from Partial Graphs
+# Constructing Sources, Sinks and Flows from Partial Graphs
 
 Instead of treating a partial graph as simply a collection of flows and junctions which may not yet all be
 connected it is sometimes useful to expose such a complex graph as a simpler structure,
@@ -229,7 +229,7 @@ var pairUpWithToString = Flow.FromGraph(
 pairUpWithToString.RunWith(Source.From(new[] {1}), Sink.First<Tuple<int, string>>(), materializer);
 ```
 
-#Combining Sources and Sinks with simplified API
+# Combining Sources and Sinks with simplified API
 There is a simplified API you can use to combine sources and sinks with junctions like: ``Broadcast<T>``, ``Balance<T>``,  ``Merge<In>`` and ``Concat<A>`` without the need for using the Graph DSL. The combine method takes care of constructing the necessary graph underneath. In following example we combine two sources into one (fan-in):
 
 ```csharp
@@ -252,7 +252,7 @@ var sink = Sink.Combine(i => new Broadcast<int>(i), sendRemotely, localProcessin
 Source.From(new[] {0, 1, 2}).RunWith(sink, materializer);
 ```
 
-#Building reusable Graph components
+# Building reusable Graph components
 It is possible to build reusable, encapsulated components of arbitrary input and output ports using the graph DSL.
 
 As an example, we will build a graph junction that represents a pool of workers, where a worker is expressed
@@ -307,7 +307,7 @@ public class PriorityWorkerPoolShape<TIn, TOut> : Shape
 }
 ```
 
-#Predefined shapes
+# Predefined shapes
 In general a custom `Shape` needs to be able to provide all its input and output ports, be able to copy itself, and also be
 able to create a new instance from given ports. There are some predefined shapes provided to avoid unnecessary
 boilerplate:
@@ -398,7 +398,7 @@ RunnableGraph.FromGraph(GraphDsl.Create(b =>
 })).Run(materializer);
 ```
 
-#Bidirectional Flows
+# Bidirectional Flows
 A graph topology that is often useful is that of two flows going in opposite directions. Take for example a codec stage that serializes outgoing messages and deserializes incoming octet streams. Another such stage could add a framing protocol that attaches a length header to outgoing data and parses incoming frames back into the original octet stream chunks. These two stages are meant to be composed, applying one atop the other as part of a protocol stack. For this purpose exists the special type `BidiFlow` which is a graph that has exactly two open inlets and two open outlets. The corresponding shape is called `BidiShape` and is defined like this:
 
 ```csharp
@@ -660,7 +660,7 @@ result.Result.ShouldAllBeEquivalentTo(Enumerable.Range(0, 10));
 
 This example demonstrates how `BidiFlow` subgraphs can be hooked together and also turned around with the ``.Reversed`` method. The test simulates both parties of a network communication protocol without actually having to open a network connection—the flows can just be connected directly.
 
-#Accessing the materialized value inside the Graph
+# Accessing the materialized value inside the Graph
 In certain cases it might be necessary to feed back the materialized value of a Graph (partial, closed or backing a
 Source, Sink, Flow or BidiFlow). This is possible by using ``builder.MaterializedValue`` which gives an ``Outlet`` that
 can be used in the graph as an ordinary source or outlet, and which will eventually emit the materialized value.
@@ -695,7 +695,7 @@ var cyclicAggregate = Source.FromGraph(GraphDsl.Create(Sink.Aggregate<int, int>(
     }));
 ```
 
-#Graph cycles, liveness and deadlocks
+# Graph cycles, liveness and deadlocks
 Cycles in bounded stream topologies need special considerations to avoid potential deadlocks and other liveness issues. This section shows several examples of problems that can arise from the presence of feedback arcs in stream processing graphs.
 
 The first example demonstrates a graph that contains a naïve cycle. The graph takes elements from the source, prints them, then broadcasts those elements to a consumer (we just used ``Sink.Ignore`` for now) and to a feedback arc that is merged back into the main stream via a ``Merge`` junction.

--- a/docs/articles/streams/workingwithstreamingio.md
+++ b/docs/articles/streams/workingwithstreamingio.md
@@ -3,7 +3,7 @@ layout: docs.hbs
 title: Working with streaming IO
 ---
 
-#Streaming File IO
+# Streaming File IO
 
 Akka Streams provide simple Sources and Sinks that can work with `ByteString` instances to perform IO operations on files.
 


### PR DESCRIPTION
Add a space after # in all doc files.