### PR TITLE
CommandAsync for persistent actors

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
@@ -244,6 +244,7 @@ namespace Akka.Persistence
         public void PersistAsync<TEvent>(TEvent @event, System.Action<TEvent> handler) { }
         protected abstract bool ReceiveCommand(object message);
         protected abstract bool ReceiveRecover(object message);
+        protected void RunTask(System.Func<System.Threading.Tasks.Task> action) { }
         public void SaveSnapshot(object snapshot) { }
         protected override void Unhandled(object message) { }
     }
@@ -480,6 +481,11 @@ namespace Akka.Persistence
         protected void Command(System.Type messageType, System.Func<object, bool> handler) { }
         protected void Command(System.Action<object> handler) { }
         protected void CommandAny(System.Action<object> handler) { }
+        protected void CommandAnyAsync(System.Func<object, System.Threading.Tasks.Task> handler) { }
+        protected void CommandAsync<T>(System.Func<T, System.Threading.Tasks.Task> handler, System.Predicate<T> shouldHandle = null) { }
+        protected void CommandAsync<T>(System.Predicate<T> shouldHandle, System.Func<T, System.Threading.Tasks.Task> handler) { }
+        protected void CommandAsync(System.Type messageType, System.Func<object, System.Threading.Tasks.Task> handler, System.Predicate<object> shouldHandle = null) { }
+        protected void CommandAsync(System.Type messageType, System.Predicate<object> shouldHandle, System.Func<object, System.Threading.Tasks.Task> handler) { }
         protected virtual void OnCommand(object message) { }
         protected virtual void OnRecover(object message) { }
         protected void Recover<T>(System.Action<T> handler, System.Predicate<T> shouldHandle = null) { }

--- a/src/core/Akka.Persistence.Tests/PersistentActorSpecAsyncAwait.Actors.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorSpecAsyncAwait.Actors.cs
@@ -1,0 +1,1300 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="PersistentActorSpec.Actors.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using Akka.Actor;
+using Akka.TestKit;
+using Akka.Util.Internal;
+using Akka.Persistence.Internal;
+using System.Threading.Tasks;
+
+namespace Akka.Persistence.Tests
+{
+    public partial class PersistentActorSpecAsyncAwait
+    {
+        internal class BehaviorOneActor : ExamplePersistentActor
+        {
+            public BehaviorOneActor(string name) : base(name) { }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                return CommonBehavior(message) || Receiver(message);
+            }
+
+            protected bool Receiver(object message)
+            {
+                if (message is Cmd cmd)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+                        PersistAll(new[] { new Evt(cmd.Data + "-1"), new Evt(cmd.Data + "-2") }, UpdateStateHandler);
+                    });
+                }
+                else if (message is DeleteMessagesSuccess)
+                {
+                    if (AskedForDelete == null)
+                        throw new ArgumentNullException("Received DeleteMessagesSuccess without anyone asking for delete!");
+                    AskedForDelete.Tell(message);
+                }
+                else return false;
+                return true;
+            }
+
+            protected override void OnPersistRejected(Exception cause, object @event, long sequenceNr)
+            {
+                if (@event is Evt)
+                    Sender.Tell("Rejected: " + ((Evt)@event).Data);
+                else
+                    base.OnPersistRejected(cause, @event, sequenceNr);
+            }
+
+            protected override void OnPersistFailure(Exception cause, object @event, long sequenceNr)
+            {
+                if (@event is Evt)
+                    Sender.Tell("Failure: " + ((Evt)@event).Data);
+                else
+                    base.OnPersistFailure(cause, @event, sequenceNr);
+            }
+        }
+        internal class Cmd
+        {
+            public Cmd(object data)
+            {
+                Data = data;
+            }
+
+            public object Data { get; private set; }
+
+            public override string ToString()
+            {
+                return "Cmd(" + Data + ")";
+            }
+        }
+
+        internal class Evt
+        {
+            public Evt(object data)
+            {
+                Data = data;
+            }
+
+            public object Data { get; private set; }
+
+            public override string ToString()
+            {
+                return "Evt(" + Data + ")";
+            }
+        }
+
+
+
+
+
+        internal class LatchCmd : INoSerializationVerificationNeeded
+        {
+            public LatchCmd(TestLatch latch, object data)
+            {
+                Latch = latch;
+                Data = data;
+            }
+
+            public TestLatch Latch { get; private set; }
+            public object Data { get; private set; }
+        }
+
+        internal class Delete
+        {
+            public Delete(long toSequenceNr)
+            {
+                ToSequenceNr = toSequenceNr;
+            }
+
+            public long ToSequenceNr { get; private set; }
+
+            public override string ToString()
+            {
+                return "Delete(" + ToSequenceNr + ")";
+            }
+        }
+
+
+        internal abstract class ExamplePersistentActor : NamedPersistentActor
+        {
+            protected ImmutableArray<object> Events = ImmutableArray<object>.Empty;
+            protected IActorRef AskedForDelete;
+
+            protected readonly Action<object> UpdateStateHandler;
+
+            protected ExamplePersistentActor(string name)
+                : base(name)
+            {
+                UpdateStateHandler = o => UpdateState(o);
+            }
+
+            protected override bool ReceiveRecover(object message)
+            {
+                return UpdateState(message);
+            }
+
+            protected bool UpdateState(object message)
+            {
+                if (message is Evt)
+                    Events = Events.AddFirst((message as Evt).Data);
+                else if (message is IActorRef)
+                    AskedForDelete = (IActorRef)message;
+                else
+                    return false;
+                return true;
+            }
+
+            protected bool CommonBehavior(object message)
+            {
+                if (message is GetState) Sender.Tell(Events.Reverse().ToArray());
+                else if (message.ToString() == "boom") throw new TestException("boom");
+                else if (message is Delete)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+                        Persist(Sender, s => AskedForDelete = s);
+                        DeleteMessages(((Delete)message).ToSequenceNr);
+                    });
+                }
+                else return false;
+                return true;
+            }
+        }
+
+
+        internal class BehaviorTwoActor : ExamplePersistentActor
+        {
+            public BehaviorTwoActor(string name) : base(name) { }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                return CommonBehavior(message) || Receiver(message);
+            }
+
+            protected bool Receiver(object message)
+            {
+                if (message is Cmd cmd)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+                        PersistAll(new[] { new Evt(cmd.Data + "-1"), new Evt(cmd.Data + "-2") }, UpdateStateHandler);
+                        PersistAll(new[] { new Evt(cmd.Data + "-3"), new Evt(cmd.Data + "-4") }, UpdateStateHandler);
+                    });
+                    return true;
+                }
+                return false;
+            }
+        }
+        internal class BehaviorThreeActor : ExamplePersistentActor
+        {
+            public BehaviorThreeActor(string name) : base(name) { }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                return CommonBehavior(message) || Receiver(message);
+            }
+
+            protected bool Receiver(object message)
+            {
+                if (message is Cmd cmd)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+                        PersistAll(new[] { new Evt(cmd.Data + "-11"), new Evt(cmd.Data + "-12") }, UpdateStateHandler);
+                        UpdateState(new Evt(cmd.Data + "-10"));
+                    });
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        internal class ChangeBehaviorInLastEventHandlerActor : ExamplePersistentActor
+        {
+            public ChangeBehaviorInLastEventHandlerActor(string name) : base(name) { }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (CommonBehavior(message)) return true;
+
+                if (message is Cmd cmd)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+                        Persist(new Evt(cmd.Data + "-0"), evt =>
+                        {
+                            UpdateState(evt);
+                            Context.Become(NewBehavior);
+                        });
+                    });
+                    return true;
+                }
+                return false;
+            }
+
+            protected bool NewBehavior(object message)
+            {
+                if (message is Cmd cmd)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+                        Persist(new Evt(cmd.Data + "-21"), UpdateStateHandler);
+                        Persist(new Evt(cmd.Data + "-22"), evt =>
+                        {
+                            UpdateState(evt);
+                            Context.UnbecomeStacked();
+                        });
+                    });
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        internal class ChangeBehaviorInFirstEventHandlerActor : ExamplePersistentActor
+        {
+            public ChangeBehaviorInFirstEventHandlerActor(string name) : base(name) { }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (CommonBehavior(message)) return true;
+
+                if (message is Cmd cmd)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+                        Persist(new Evt(cmd.Data + "-0"), evt =>
+                        {
+                            UpdateState(evt);
+                            Context.Become(NewBehavior);
+                        });
+                    });
+                    return true;
+                }
+                return false;
+            }
+
+            protected bool NewBehavior(object message)
+            {
+                if (message is Cmd cmd)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+                        Persist(new Evt(cmd.Data + "-21"), evt =>
+                        {
+                            UpdateState(evt);
+                            Context.UnbecomeStacked();
+                        });
+                        Persist(new Evt(cmd.Data + "-22"), UpdateStateHandler);
+                    });
+                    return true;
+                }
+                return false;
+            }
+        }
+        internal class ChangeBehaviorInCommandHandlerFirstActor : ExamplePersistentActor
+        {
+            public ChangeBehaviorInCommandHandlerFirstActor(string name) : base(name) { }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (CommonBehavior(message)) return true;
+
+                if (message is Cmd cmd)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+                        Context.Become(NewBehavior);
+                        Persist(new Evt(cmd.Data + "-0"), UpdateStateHandler);
+                    });
+                    return true;
+                }
+                return false;
+            }
+
+            protected bool NewBehavior(object message)
+            {
+                if (message is Cmd cmd)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+                        Context.UnbecomeStacked();
+                        PersistAll(new[] { new Evt(cmd.Data + "-31"), new Evt(cmd.Data + "-32") }, UpdateStateHandler);
+                        UpdateState(new Evt(cmd.Data + "-30"));
+                    });
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        internal class ChangeBehaviorInCommandHandlerLastActor : ExamplePersistentActor
+        {
+            public ChangeBehaviorInCommandHandlerLastActor(string name) : base(name) { }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (CommonBehavior(message)) return true;
+
+                if (message is Cmd cmd)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+                        Persist(new Evt(cmd.Data + "-0"), UpdateStateHandler);
+                        Context.Become(NewBehavior);
+                    });
+                    return true;
+                }
+                return false;
+            }
+
+            protected bool NewBehavior(object message)
+            {
+                if (message is Cmd cmd)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+                        PersistAll(new[] { new Evt(cmd.Data + "-31"), new Evt(cmd.Data + "-32") }, UpdateStateHandler);
+                        UpdateState(new Evt(cmd.Data + "-30"));
+                        Context.UnbecomeStacked();
+                    });
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        internal class SnapshottingPersistentActor : ExamplePersistentActor
+        {
+            protected readonly IActorRef Probe;
+            public SnapshottingPersistentActor(string name, IActorRef probe)
+                : base(name)
+            {
+                Probe = probe;
+            }
+
+            protected override bool ReceiveRecover(object message)
+            {
+                if (!base.ReceiveRecover(message))
+                {
+                    if (message is SnapshotOffer)
+                    {
+                        Probe.Tell("offered");
+                        Events = (message as SnapshotOffer).Snapshot.AsInstanceOf<ImmutableArray<object>>();
+                    }
+                    else return false;
+                }
+                return true;
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (CommonBehavior(message)) return true;
+                if (message is Cmd) HandleCmd(message as Cmd);
+                else if (message is SaveSnapshotSuccess) Probe.Tell("saved");
+                else if (message.ToString() == "snap") SaveSnapshot(Events);
+                else return false;
+                return true;
+            }
+
+            private void HandleCmd(Cmd cmd)
+            {
+                RunTask(async () =>
+                {
+                    await Task.Yield();
+                    await Task.Delay(100);
+                    PersistAll(new[] { new Evt(cmd.Data + "-41"), new Evt(cmd.Data + "-42") }, UpdateStateHandler);
+                });
+            }
+        }
+
+        internal class SnapshottingBecomingPersistentActor : SnapshottingPersistentActor
+        {
+            public const string Message = "It's changing me";
+            public const string Response = "I'm becoming";
+            public SnapshottingBecomingPersistentActor(string name, IActorRef probe) : base(name, probe) { }
+
+            private bool BecomingRecover(object message)
+            {
+                if (message is SnapshotOffer)
+                {
+                    Context.Become(BecomingCommand);
+                    // sending ourself a normal message here also tests
+                    // that we stash them until recovery is complete
+                    Self.Tell(Message);
+                    return base.ReceiveRecover(message);
+                }
+                return false;
+            }
+
+            protected override bool ReceiveRecover(object message)
+            {
+                return BecomingRecover(message) || base.ReceiveRecover(message);
+            }
+
+            private bool BecomingCommand(object message)
+            {
+                if (ReceiveCommand(message)) return true;
+                if (message.ToString() == Message) Probe.Tell(Response);
+                else return false;
+                return true;
+            }
+        }
+
+        internal class ReplyInEventHandlerActor : ExamplePersistentActor
+        {
+            public ReplyInEventHandlerActor(string name) : base(name) { }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (message is Cmd)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+                        Persist(new Evt("a"), evt => Sender.Tell(evt.Data));
+                    });
+                }
+                else return false;
+                return true;
+            }
+        }
+
+        internal class AsyncPersistActor : ExamplePersistentActor
+        {
+            private int _counter = 0;
+            public AsyncPersistActor(string name)
+                : base(name)
+            {
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (!CommonBehavior(message))
+                {
+                    var cmd = message as Cmd;
+                    if (cmd != null)
+                    {
+                        RunTask(async () =>
+                        {
+                            await Task.Yield();
+                            await Task.Delay(100);
+
+                            Sender.Tell(cmd.Data);
+                            PersistAsync(new Evt(cmd.Data.ToString() + "-" + (++_counter)), evt =>
+                            {
+                                Sender.Tell(evt.Data);
+                            });
+                        });
+
+                        return true;
+                    }
+                }
+                else return true;
+                return false;
+            }
+
+            protected override void OnPersistFailure(Exception cause, object @event, long sequenceNr)
+            {
+                if (@event is Evt)
+                    Sender.Tell(string.Format("Failure: {0}", ((Evt)@event).Data));
+                else
+                    base.OnPersistFailure(cause, @event, sequenceNr);
+            }
+        }
+
+        internal class AsyncPersistThreeTimesActor : ExamplePersistentActor
+        {
+            private int _counter = 0;
+            public AsyncPersistThreeTimesActor(string name)
+                : base(name)
+            {
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (!CommonBehavior(message))
+                {
+                    var cmd = message as Cmd;
+                    if (cmd != null)
+                    {
+                        RunTask(async () =>
+                        {
+                            await Task.Yield();
+                            await Task.Delay(100);
+
+                            Sender.Tell(cmd.Data);
+                            for (int i = 1; i <= 3; i++)
+                            {
+                                PersistAsync(new Evt(cmd.Data.ToString() + "-" + (++_counter)), evt =>
+                                {
+                                    Sender.Tell("a" + evt.Data.ToString().Substring(1));
+                                });
+                            }
+                        });
+
+                        return true;
+                    }
+                }
+                else return true;
+                return false;
+            }
+        }
+
+        internal class AsyncPersistSameEventTwiceActor : ExamplePersistentActor
+        {
+            private AtomicCounter _sendMessageCounter = new AtomicCounter(0);
+            public AsyncPersistSameEventTwiceActor(string name)
+                : base(name)
+            {
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (!CommonBehavior(message))
+                {
+                    var cmd = message as Cmd;
+                    if (cmd != null)
+                    {
+                        RunTask(async () =>
+                        {
+                            await Task.Yield();
+                            await Task.Delay(100);
+
+                            Sender.Tell(cmd.Data);
+                            var @event = new Evt(cmd.Data);
+
+                            PersistAsync(@event, evt =>
+                            {
+                                Thread.Sleep(300);
+                                Sender.Tell(evt.Data.ToString() + "-a-" + _sendMessageCounter.IncrementAndGet());
+                            });
+
+                            PersistAsync(@event, evt => Sender.Tell(evt.Data.ToString() + "-b-" + _sendMessageCounter.IncrementAndGet()));
+                        });
+
+                        return true;
+                    }
+                }
+                else return true;
+                return false;
+            }
+        }
+
+        internal class PersistAllNullActor : ExamplePersistentActor
+        {
+            public PersistAllNullActor(string name)
+                : base(name)
+            {
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (!CommonBehavior(message))
+                {
+                    var cmd = message as Cmd;
+                    if (cmd != null)
+                    {
+                        RunTask(async () =>
+                        {
+                            await Task.Yield();
+                            await Task.Delay(100);
+
+                            var data = (string)cmd.Data;
+                            if (data.Contains("defer"))
+                            {
+                                DeferAsync("before-nil", evt => Sender.Tell(evt));
+                                PersistAll<object>(null, evt => Sender.Tell("Null"));
+                                DeferAsync("after-nil", evt => Sender.Tell(evt));
+                                Sender.Tell(data);
+                            }
+                            else if (data.Contains("persist"))
+                            {
+                                Persist("before-nil", evt => Sender.Tell(evt));
+                                PersistAll<object>(null, evt => Sender.Tell("Null"));
+                                DeferAsync("after-nil", evt => Sender.Tell(evt));
+                                Sender.Tell(data);
+                                //return true;
+                            }
+                        });
+
+                        return true;
+                    }
+                }
+                else return true;
+                return false;
+            }
+        }
+
+        internal class AsyncPersistAndPersistMixedSyncAsyncSyncActor : ExamplePersistentActor
+        {
+            private int _counter = 0;
+            public AsyncPersistAndPersistMixedSyncAsyncSyncActor(string name)
+                : base(name)
+            {
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (!CommonBehavior(message))
+                {
+                    var cmd = message as Cmd;
+                    if (cmd != null)
+                    {
+                        RunTask(async () =>
+                        {
+                            await Task.Yield();
+                            await Task.Delay(100);
+
+                            Sender.Tell(cmd.Data);
+
+                            Persist(new Evt(cmd.Data + "-e1"), evt => Sender.Tell(evt.Data + "-" + (++_counter)));
+                            PersistAsync(new Evt(cmd.Data + "-ea2"), evt => Sender.Tell(evt.Data + "-" + (++_counter)));
+                            Persist(new Evt(cmd.Data + "-e3"), evt => Sender.Tell(evt.Data + "-" + (++_counter)));
+                        });
+
+                        return true;
+                    }
+                }
+                else return true;
+                return false;
+            }
+        }
+
+        internal class AsyncPersistAndPersistMixedSyncAsyncActor : ExamplePersistentActor
+        {
+            private int _counter = 0;
+
+            public AsyncPersistAndPersistMixedSyncAsyncActor(string name)
+                : base(name)
+            {
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (!CommonBehavior(message))
+                {
+                    var cmd = message as Cmd;
+                    if (cmd != null)
+                    {
+                        RunTask(async () =>
+                        {
+                            await Task.Yield();
+                            await Task.Delay(100);
+                            Sender.Tell(cmd.Data);
+
+                            Persist(new Evt(cmd.Data + "-e1"), evt => Sender.Tell(evt.Data + "-" + (++_counter)));
+                            PersistAsync(new Evt(cmd.Data + "-ea2"), evt => Sender.Tell(evt.Data + "-" + (++_counter)));
+                        });
+
+                        return true;
+                    }
+                }
+                else return true;
+                return false;
+            }
+        }
+
+        internal class AsyncPersistHandlerCorrelationCheck : ExamplePersistentActor
+        {
+            private int _counter = 0;
+            public AsyncPersistHandlerCorrelationCheck(string name)
+                : base(name)
+            {
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (!CommonBehavior(message))
+                {
+                    var cmd = message as Cmd;
+                    if (cmd != null)
+                    {
+                        RunTask(async () =>
+                        {
+                            await Task.Yield();
+                            await Task.Delay(10);
+                            PersistAsync(new Evt(cmd.Data), evt =>
+                            {
+                                if (!cmd.Data.Equals(evt.Data)) Sender.Tell("Expected " + cmd.Data + " but got " + evt.Data);
+                                if ("done" != evt.Data.ToString()) Sender.Tell("done");
+                            });
+                        });
+
+                        return true;
+                    }
+                }
+                else return true;
+                return false;
+            }
+        }
+
+        internal class ValueTypeEventPersistentActor : ExamplePersistentActor
+        {
+            public ValueTypeEventPersistentActor(string name)
+                : base(name)
+            {
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                var cmd = message as Cmd;
+                if (cmd != null && cmd.Data.ToString() == "a")
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+                        Persist(5L, i =>
+                        {
+                            Sender.Tell(i);
+                        });
+                    });
+                    return true;
+                }
+                else return false;
+            }
+        }
+
+        internal class HandleRecoveryFinishedEventPersistentActor : SnapshottingPersistentActor
+        {
+            public HandleRecoveryFinishedEventPersistentActor(string name, IActorRef probe)
+                : base(name, probe)
+            {
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (!base.ReceiveCommand(message)) Probe.Tell(message.ToString());
+                return true;
+            }
+
+            protected override bool ReceiveRecover(object message)
+            {
+                return SendingRecover(message) || base.ReceiveRecover(message);
+            }
+
+            protected bool SendingRecover(object message)
+            {
+                if (message is SnapshotOffer)
+                {
+                    // sending ourself a normal message tests
+                    // that we stash them until recovery is complete
+                    Self.Tell("I am the stashed");
+                    base.ReceiveRecover(message);
+                }
+                else if (message is RecoveryCompleted)
+                {
+                    Probe.Tell(RecoveryCompleted.Instance);
+                    Self.Tell("I am the recovered");
+                    UpdateState(new Evt(RecoveryCompleted.Instance));
+                }
+                else return false;
+                return true;
+            }
+        }
+
+        internal class DeferringWithPersistActor : ExamplePersistentActor
+        {
+            public DeferringWithPersistActor(string name)
+                : base(name)
+            {
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                var cmd = message as Cmd;
+                if (cmd != null)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+                        DeferAsync("d-1", Sender.Tell);
+                        Persist(cmd.Data + "-2", Sender.Tell);
+                        DeferAsync("d-3", Sender.Tell);
+                        DeferAsync("d-4", Sender.Tell);
+                    });
+
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        internal class DeferringWithAsyncPersistActor : ExamplePersistentActor
+        {
+            public DeferringWithAsyncPersistActor(string name)
+                : base(name)
+            {
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                var cmd = message as Cmd;
+                if (cmd != null)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+                        DeferAsync("d-" + cmd.Data + "-1", Sender.Tell);
+                        PersistAsync("pa-" + cmd.Data + "-2", Sender.Tell);
+                        DeferAsync("d-" + cmd.Data + "-3", Sender.Tell);
+                        DeferAsync("d-" + cmd.Data + "-4", Sender.Tell);
+                    });
+
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        internal class DeferringMixedCallsPPADDPADPersistActor : ExamplePersistentActor
+        {
+            public DeferringMixedCallsPPADDPADPersistActor(string name)
+                : base(name)
+            {
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                var cmd = message as Cmd;
+                if (cmd != null)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+                        Persist("p-" + cmd.Data + "-1", Sender.Tell);
+                        PersistAsync("pa-" + cmd.Data + "-2", Sender.Tell);
+                        DeferAsync("d-" + cmd.Data + "-3", Sender.Tell);
+                        DeferAsync("d-" + cmd.Data + "-4", Sender.Tell);
+                        PersistAsync("pa-" + cmd.Data + "-5", Sender.Tell);
+                        DeferAsync("d-" + cmd.Data + "-6", Sender.Tell);
+                    });
+
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        internal class DeferringWithNoPersistCallsPersistActor : ExamplePersistentActor
+        {
+            public DeferringWithNoPersistCallsPersistActor(string name)
+                : base(name)
+            {
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                var cmd = message as Cmd;
+                if (cmd != null)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+
+                        DeferAsync("d-1", Sender.Tell);
+                        DeferAsync("d-2", Sender.Tell);
+                        DeferAsync("d-3", Sender.Tell);
+                    });
+
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        internal class StressOrdering : ExamplePersistentActor
+        {
+            public StressOrdering(string name)
+                : base(name)
+            {
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (message is LatchCmd)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+                        var latchCmd = message as LatchCmd;
+                        Sender.Tell(latchCmd.Data);
+                        latchCmd.Latch.Ready(TimeSpan.FromSeconds(5));
+                        PersistAsync(latchCmd.Data, _ => { });
+                    });
+                }
+                else if (message is Cmd)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+                        var cmd = message as Cmd;
+                        Sender.Tell(cmd.Data);
+                        PersistAsync(cmd.Data, _ => { });
+                    });
+                }
+                else if (message is string)
+                    Sender.Tell(message.ToString());
+                else return false;
+                return true;
+            }
+        }
+
+        internal class RecoverMessageCausedRestart : ExamplePersistentActor
+        {
+            private IActorRef _master;
+            public RecoverMessageCausedRestart(string name) : base(name)
+            {
+
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (message.Equals("boom"))
+                {
+                    _master = Sender;
+                    throw new TestException("boom");
+                }
+                return false;
+            }
+
+            protected override void PreRestart(Exception reason, object message)
+            {
+                _master?.Tell($"failed with {reason.GetType().Name} while processing {message}");
+                Context.Stop(Self);
+            }
+        }
+
+        internal class MultipleAndNestedPersists : ExamplePersistentActor
+        {
+            private readonly IActorRef _probe;
+
+            public MultipleAndNestedPersists(string name, IActorRef probe)
+                : base(name)
+            {
+                _probe = probe;
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (message is string s)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+
+                        _probe.Tell(s);
+                        Persist(s + "-outer-1", outer =>
+                        {
+                            _probe.Tell(outer);
+                            Persist(s + "-inner-1", inner => _probe.Tell(inner));
+                        });
+                        Persist(s + "-outer-2", outer =>
+                        {
+                            _probe.Tell(outer);
+                            Persist(s + "-inner-2", inner => _probe.Tell(inner));
+                        });
+                    });
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        internal class MultipleAndNestedPersistAsyncs : ExamplePersistentActor
+        {
+            private readonly IActorRef _probe;
+
+            public MultipleAndNestedPersistAsyncs(string name, IActorRef probe)
+                : base(name)
+            {
+                _probe = probe;
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (message is string s)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+
+                        _probe.Tell(s);
+                        PersistAsync(s + "-outer-1", outer =>
+                        {
+                            _probe.Tell(outer);
+                            PersistAsync(s + "-inner-1", inner => _probe.Tell(inner));
+                        });
+                        PersistAsync(s + "-outer-2", outer =>
+                        {
+                            _probe.Tell(outer);
+                            PersistAsync(s + "-inner-2", inner => _probe.Tell(inner));
+                        });
+                    });
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        internal class NestedPersistNormalAndAsyncs : ExamplePersistentActor
+        {
+            private readonly IActorRef _probe;
+
+            public NestedPersistNormalAndAsyncs(string name, IActorRef probe)
+                : base(name)
+            {
+                _probe = probe;
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (message is string s)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+
+                        _probe.Tell(s);
+                        Persist(s + "-outer-1", outer =>
+                        {
+                            _probe.Tell(outer);
+                            PersistAsync(s + "-inner-async-1", inner => _probe.Tell(inner));
+                        });
+                        Persist(s + "-outer-2", outer =>
+                        {
+                            _probe.Tell(outer);
+                            PersistAsync(s + "-inner-async-2", inner => _probe.Tell(inner));
+                        });
+                    });
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        internal class NestedPersistAsyncsAndNormal : ExamplePersistentActor
+        {
+            private readonly IActorRef _probe;
+
+            public NestedPersistAsyncsAndNormal(string name, IActorRef probe)
+                : base(name)
+            {
+                _probe = probe;
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (message is string s)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+
+                        _probe.Tell(s);
+                        PersistAsync(s + "-outer-async-1", outer =>
+                        {
+                            _probe.Tell(outer);
+                            Persist(s + "-inner-1", inner => _probe.Tell(inner));
+                        });
+                        PersistAsync(s + "-outer-async-2", outer =>
+                        {
+                            _probe.Tell(outer);
+                            Persist(s + "-inner-2", inner => _probe.Tell(inner));
+                        });
+                    });
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        internal class NestedPersistInAsyncEnforcesStashing : ExamplePersistentActor
+        {
+            private readonly IActorRef _probe;
+
+            public NestedPersistInAsyncEnforcesStashing(string name, IActorRef probe)
+                : base(name)
+            {
+                _probe = probe;
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (message is string s)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+
+                        _probe.Tell(s);
+                        PersistAsync(s + "-outer-async", outer =>
+                        {
+                            _probe.Tell(outer);
+                            Persist(s + "-inner", inner =>
+                            {
+                                _probe.Tell(inner);
+                                Thread.Sleep(1000); // really long wait here
+                                                    // the next incoming command must be handled by the following function
+                                Context.Become(_ =>
+                                {
+                                    Sender.Tell("done");
+                                    return true;
+                                });
+                            });
+                        });
+                    });
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        internal class DeeplyNestedPersists : ExamplePersistentActor
+        {
+            private readonly int _maxDepth;
+            private readonly IActorRef _probe;
+            private readonly Dictionary<string, int> _currentDepths = new Dictionary<string, int>();
+
+            public DeeplyNestedPersists(string name, int maxDepth, IActorRef probe)
+                : base(name)
+            {
+                _maxDepth = maxDepth;
+                _probe = probe;
+            }
+
+            private void WeMustGoDeeper(string dWithDepth)
+            {
+                var d = dWithDepth.Split('-')[0];
+                _probe.Tell(dWithDepth);
+                int currentDepth;
+                if (!_currentDepths.TryGetValue(d, out currentDepth)) currentDepth = 1;
+                if (currentDepth < _maxDepth)
+                {
+                    _currentDepths[d] = currentDepth + 1;
+                    Persist(d + "-" + _currentDepths[d], WeMustGoDeeper);
+                }
+                else
+                {
+                    // reset depth counter before next command
+                    _currentDepths[d] = 1;
+                }
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (message is string s)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+
+                        _probe.Tell(s);
+                        Persist(s + "-1", WeMustGoDeeper);
+                    });
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        internal class DeeplyNestedPersistAsyncs : ExamplePersistentActor
+        {
+            private readonly int _maxDepth;
+            private readonly IActorRef _probe;
+            private readonly Dictionary<string, int> _currentDepths = new Dictionary<string, int>();
+
+            public DeeplyNestedPersistAsyncs(string name, int maxDepth, IActorRef probe)
+                : base(name)
+            {
+                _maxDepth = maxDepth;
+                _probe = probe;
+            }
+
+            private void WeMustGoDeeper(string dWithDepth)
+            {
+                var d = dWithDepth.Split('-')[0];
+                _probe.Tell(dWithDepth);
+                int currentDepth;
+                if (!_currentDepths.TryGetValue(d, out currentDepth)) currentDepth = 1;
+                if (currentDepth < _maxDepth)
+                {
+                    _currentDepths[d] = currentDepth + 1;
+                    PersistAsync(d + "-" + _currentDepths[d], WeMustGoDeeper);
+                }
+                else
+                {
+                    // reset depth counter before next command
+                    _currentDepths[d] = 1;
+                }
+            }
+
+            protected override bool ReceiveCommand(object message)
+            {
+                if (message is string s)
+                {
+                    RunTask(async () =>
+                    {
+                        await Task.Yield();
+                        await Task.Delay(100);
+
+                        _probe.Tell(s);
+                        PersistAsync(s + "-1", WeMustGoDeeper);
+                    });
+                    return true;
+                }
+                return false;
+            }
+        }
+    }
+}
+

--- a/src/core/Akka.Persistence.Tests/PersistentActorSpecAsyncAwait.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorSpecAsyncAwait.cs
@@ -1,0 +1,615 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="PersistentActorSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Akka.Actor;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Persistence.Tests
+{
+    public partial class PersistentActorSpecAsyncAwait : PersistenceSpec
+    {
+        private readonly Random _random = new Random();
+        public PersistentActorSpecAsyncAwait()
+            : base(Configuration("PersistentActorSpecAsyncAwait"))
+        {
+            var pref = ActorOf(Props.Create(() => new BehaviorOneActor(Name)));
+            pref.Tell(new Cmd("a"));
+            pref.Tell(GetState.Instance);
+            ExpectMsgInOrder("a-1", "a-2");
+        }
+
+        [Fact]
+        public void PersistentActor_should_fail_fast_if_persistenceId_is_null()
+        {
+            EventFilter.Exception<ActorInitializationException>().And.Error(contains: "PersistenceId is [null] for PersistentActor").ExpectOne(() =>
+            {
+                var pref = ActorOf(Props.Create(() => new BehaviorOneActor(null)));
+                Watch(pref);
+                ExpectTerminated(pref);
+            });
+        }
+
+        [Fact]
+        public void PersistentActor_should_recover_from_persisted_events()
+        {
+            var pref = ActorOf(Props.Create(() => new BehaviorOneActor(Name)));
+            pref.Tell(GetState.Instance);
+            ExpectMsgInOrder("a-1", "a-2");
+        }
+
+        [Fact]
+        public void PersistentActor_should_handle_multiple_emitted_events_in_correct_order_for_single_persist_call()
+        {
+            var pref = ActorOf(Props.Create(() => new BehaviorOneActor(Name)));
+            pref.Tell(new Cmd("b"));
+            pref.Tell(GetState.Instance);
+            ExpectMsgInOrder("a-1", "a-2", "b-1", "b-2");
+        }
+
+        [Fact]
+        public void PersistentActor_should_handle_multiple_emitted_events_in_correct_order_for_multiple_persist_calls()
+        {
+            var pref = ActorOf(Props.Create(() => new BehaviorTwoActor(Name)));
+            pref.Tell(new Cmd("b"));
+            pref.Tell(GetState.Instance);
+            ExpectMsgInOrder("a-1", "a-2", "b-1", "b-2", "b-3", "b-4");
+        }
+
+        [Fact]
+        public void PersistentActor_should_receive_emitted_events_immediately_after_command()
+        {
+            var pref = ActorOf(Props.Create(() => new BehaviorThreeActor(Name)));
+            pref.Tell(new Cmd("b"));
+            pref.Tell(new Cmd("c"));
+            pref.Tell(GetState.Instance);
+            ExpectMsgInOrder("a-1", "a-2", "b-10", "b-11", "b-12", "c-10", "c-11", "c-12");
+        }
+
+        [Fact]
+        public void PersistentActor_should_recover_on_command_failure()
+        {
+            var pref = ActorOf(Props.Create(() => new BehaviorThreeActor(Name)));
+            pref.Tell(new Cmd("b"));
+            pref.Tell("boom");
+            pref.Tell(new Cmd("c"));
+            pref.Tell(GetState.Instance);
+            // cmd that was added to state before failure (b-10) is not replayed ...
+            ExpectMsgInOrder("a-1", "a-2", "b-11", "b-12", "c-10", "c-11", "c-12");
+        }
+
+        [Fact]
+        public void PersistentActor_should_allow_behavior_changes_in_event_handler_when_handling_first_event()
+        {
+            var pref = ActorOf(Props.Create(() => new ChangeBehaviorInFirstEventHandlerActor(Name)));
+            pref.Tell(new Cmd("b"));
+            pref.Tell(new Cmd("c"));
+            pref.Tell(new Cmd("d"));
+            pref.Tell(new Cmd("e"));
+            pref.Tell(GetState.Instance);
+            ExpectMsgInOrder("a-1", "a-2", "b-0", "c-21", "c-22", "d-0", "e-21", "e-22");
+        }
+
+        [Fact]
+        public void PersistentActor_should_allow_behavior_changes_in_event_handler_when_handling_the_last_event()
+        {
+            var pref = ActorOf(Props.Create(() => new ChangeBehaviorInLastEventHandlerActor(Name)));
+            pref.Tell(new Cmd("b"));
+            pref.Tell(new Cmd("c"));
+            pref.Tell(new Cmd("d"));
+            pref.Tell(new Cmd("e"));
+            pref.Tell(GetState.Instance);
+            ExpectMsgInOrder("a-1", "a-2", "b-0", "c-21", "c-22", "d-0", "e-21", "e-22");
+        }
+
+        [Fact]
+        public void PersistentActor_should_allow_behavior_changes_in_event_handler_as_first_action()
+        {
+            var pref = ActorOf(Props.Create(() => new ChangeBehaviorInCommandHandlerFirstActor(Name)));
+            pref.Tell(new Cmd("b"));
+            pref.Tell(new Cmd("c"));
+            pref.Tell(new Cmd("d"));
+            pref.Tell(new Cmd("e"));
+            pref.Tell(GetState.Instance);
+            ExpectMsgInOrder("a-1", "a-2", "b-0", "c-30", "c-31", "c-32", "d-0", "e-30", "e-31", "e-32");
+        }
+
+        [Fact]
+        public void PersistentActor_should_allow_behavior_changes_in_event_handler_as_last_action()
+        {
+            var pref = ActorOf(Props.Create(() => new ChangeBehaviorInCommandHandlerLastActor(Name)));
+            pref.Tell(new Cmd("b"));
+            pref.Tell(new Cmd("c"));
+            pref.Tell(new Cmd("d"));
+            pref.Tell(new Cmd("e"));
+            pref.Tell(GetState.Instance);
+            ExpectMsgInOrder("a-1", "a-2", "b-0", "c-30", "c-31", "c-32", "d-0", "e-30", "e-31", "e-32");
+        }
+
+        [Fact]
+        public void PersistentActor_should_support_snapshotting()
+        {
+            var pref = ActorOf(Props.Create(() => new SnapshottingPersistentActor(Name, TestActor)));
+            pref.Tell(new Cmd("b"));
+            pref.Tell("snap");
+            pref.Tell(new Cmd("c"));
+            ExpectMsg("saved");
+            pref.Tell(GetState.Instance);
+            ExpectMsgInOrder("a-1", "a-2", "b-41", "b-42", "c-41", "c-42");
+
+            var pref2 = ActorOf(Props.Create(() => new SnapshottingPersistentActor(Name, TestActor)));
+            ExpectMsg("offered");
+            pref2.Tell(GetState.Instance);
+            ExpectMsgInOrder("a-1", "a-2", "b-41", "b-42", "c-41", "c-42");
+        }
+
+        [Fact]
+        public void PersistentActor_should_support_Context_Become_during_recovery()
+        {
+            var pref = ActorOf(Props.Create(() => new SnapshottingPersistentActor(Name, TestActor)));
+            pref.Tell(new Cmd("b"));
+            pref.Tell("snap");
+            pref.Tell(new Cmd("c"));
+            ExpectMsg("saved");
+            pref.Tell(GetState.Instance);
+            ExpectMsgInOrder("a-1", "a-2", "b-41", "b-42", "c-41", "c-42");
+
+            var pref2 = ActorOf(Props.Create(() => new SnapshottingBecomingPersistentActor(Name, TestActor)));
+            ExpectMsg("offered");
+            ExpectMsg("I'm becoming");
+            pref2.Tell(GetState.Instance);
+            ExpectMsgInOrder("a-1", "a-2", "b-41", "b-42", "c-41", "c-42");
+        }
+
+        [Fact]
+        public void PersistentActor_should_be_able_to_reply_within_an_event_handler()
+        {
+            var pref = ActorOf(Props.Create(() => new ReplyInEventHandlerActor(Name)));
+            pref.Tell(new Cmd("a"));
+            ExpectMsg("a");
+        }
+
+        [Fact]
+        public void PersistentActor_should_be_able_to_persist_value_types_as_events()
+        {
+            var pref = ActorOf(Props.Create(() => new ValueTypeEventPersistentActor(Name)));
+            pref.Tell(new Cmd("a"));
+            ExpectMsg(5L);
+        }
+
+        [Fact]
+        public void PersistentActor_should_be_able_to_opt_out_from_stashing_messages_until_all_events_have_been_processed()
+        {
+            var pref = ActorOf(Props.Create(() => new AsyncPersistActor(Name)));
+            pref.Tell(new Cmd("x"));
+            pref.Tell(new Cmd("y"));
+            ExpectMsg("x");
+            ExpectMsg("y");
+            ExpectMsg("x-1");
+            ExpectMsg("y-2");
+        }
+
+        [Fact]
+        public void PersistentActor_should_support_multiple_PersistAsync_calls_for_one_command_and_execute_them_when_possible_not_hindering_command_processing()
+        {
+            var pref = ActorOf(Props.Create(() => new AsyncPersistThreeTimesActor(Name)));
+            var commands = Enumerable.Range(1, 10).Select(i => new Cmd("c-" + i)).ToArray();
+
+            foreach (var command in commands)
+            {
+                Thread.Sleep(_random.Next(10));
+                pref.Tell(command);
+            }
+
+            // each command = 1 reply + 3 event-replies
+            var all = ReceiveN(40).Select(x => x.ToString()).ToArray();
+            var replies = all.Where(r => r.Count(c => c == '-') == 1);
+            replies.ShouldOnlyContainInOrder(commands.Select(cmd => cmd.Data).ToArray());
+
+            // range(3, 30) is equivalent of Scala (3 to 32)
+            var expectedAcks = Enumerable.Range(3, 30).Select(i => "a-" + (i / 3) + "-" + (i - 2)).ToArray();
+            var acks = all.Where(r => r.Count(c => c == '-') == 2);
+            acks.ShouldOnlyContainInOrder(expectedAcks);
+        }
+
+        [Fact]
+        public void PersistentActor_should_reply_to_the_original_sender_of_a_command_even_on_PersistAsync()
+        {
+            // sanity check, the setting of Sender for PersistentRepresentation is handled by PersistentActor currently
+            // but as we want to remove it soon, keeping the explicit test here.
+            var pref = ActorOf(Props.Create(() => new AsyncPersistThreeTimesActor(Name)));
+            var commands = Enumerable.Range(1, 10).Select(i => new Cmd("c-" + i)).ToArray();
+            var probes = Enumerable.Range(1, 10).Select(_ => CreateTestProbe()).ToArray();
+
+            for (int i = 0; i < 10; i++)
+            {
+                pref.Tell(commands[i], probes[i].Ref);
+            }
+
+            Within(TimeSpan.FromSeconds(3), () =>
+            {
+                foreach (var probe in probes)
+                {
+                    probe.ExpectMsgAllOf<string>();
+                }
+            });
+        }
+
+        [Fact]
+        public void PersistentActor_should_support_the_same_event_being_PersistAsynced_multiple_times()
+        {
+            var pref = ActorOf(Props.Create(() => new AsyncPersistSameEventTwiceActor(Name)));
+            pref.Tell(new Cmd("x"));
+            ExpectMsg("x");
+
+            ExpectMsg("x-a-1");
+            ExpectMsg("x-b-2");
+            ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+        }
+
+        [Fact]
+        public void PersistentActor_should_support_calling_PersistAll_with_null()
+        {
+            var pref = ActorOf(Props.Create(() => new PersistAllNullActor(Name)));
+            pref.Tell(new Cmd("defer-x"));
+            ExpectMsg("before-nil");
+            ExpectMsg("after-nil");
+            ExpectMsg("defer-x");
+
+            pref.Tell(new Cmd("persist-x"));
+            ExpectMsg("persist-x");
+            ExpectMsg("before-nil");
+            ExpectMsg("after-nil");
+        }
+
+        [Fact]
+        public void PersistentActor_should_support_a_mix_of_persist_calls_sync_async_sync_and_persist_calls_in_expected_order()
+        {
+            var pref = ActorOf(Props.Create(() => new AsyncPersistAndPersistMixedSyncAsyncSyncActor(Name)));
+            pref.Tell(new Cmd("a"));
+            pref.Tell(new Cmd("b"));
+            pref.Tell(new Cmd("c"));
+
+            ExpectMsg("a");
+            ExpectMsg("a-e1-1");    // persist
+            ExpectMsg("a-ea2-2");   // persist async, but ordering enforced by sync persist below
+            ExpectMsg("a-e3-3");    // persist
+
+            ExpectMsg("b");
+            ExpectMsg("b-e1-4");
+            ExpectMsg("b-ea2-5");
+            ExpectMsg("b-e3-6");
+
+            ExpectMsg("c");
+            ExpectMsg("c-e1-7");
+            ExpectMsg("c-ea2-8");
+            ExpectMsg("c-e3-9");
+
+            ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+        }
+
+        [Fact]
+        public void PersistentActor_should_support_a_mix_of_persist_calls_sync_async_and_persist_calls()
+        {
+            var pref = ActorOf(Props.Create(() => new AsyncPersistAndPersistMixedSyncAsyncActor(Name)));
+            pref.Tell(new Cmd("a"));
+            pref.Tell(new Cmd("b"));
+            pref.Tell(new Cmd("c"));
+
+            ExpectMsg("a");
+            ExpectMsg("a-e1-1");    // persist, must be before next command
+
+            var expected = new HashSet<string> { "b", "a-ea2-2" };
+            var found = ExpectMsgAnyOf(expected.Cast<object>().ToArray());  // ea2 is PersistAsync, b can be processed before it
+            expected.Remove(found.ToString());
+            ExpectMsgAnyOf(expected.Cast<object>().ToArray());
+
+            ExpectMsg("b-e1-3");        // persist, must be before next command
+
+            var expected2 = new HashSet<string> { "c", "b-ea2-4" };
+            var found2 = ExpectMsgAnyOf(expected2.Cast<object>().ToArray());
+            expected.Remove(found2.ToString());
+            ExpectMsgAnyOf(expected2.Cast<object>().ToArray());
+
+            ExpectMsg("c-e1-5");
+            ExpectMsg("c-ea2-6");
+
+            ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+        }
+
+        [Fact]
+        public void PersistentActor_should_correlate_PersistAsync_handlers_after_restart()
+        {
+            var pref = ActorOf(Props.Create(() => new AsyncPersistHandlerCorrelationCheck(Name)));
+            for (int i = 1; i < 100; i++)
+            {
+                pref.Tell(new Cmd(i));
+            }
+            pref.Tell("boom");
+            for (int i = 1; i < 20; i++)
+            {
+                pref.Tell(new Cmd(i));
+            }
+            pref.Tell(new Cmd("done"));
+            ExpectMsg("done", TimeSpan.FromSeconds(5));
+        }
+
+        [Fact]
+        public void PersistentActor_should_allow_deferring_handlers_in_order_to_provide_ordered_processing_in_respect_to_Persist_handlers()
+        {
+            var pref = ActorOf(Props.Create(() => new DeferringWithPersistActor(Name)));
+            pref.Tell(new Cmd("a"));
+
+            ExpectMsg("d-1");
+            ExpectMsg("a-2");
+            ExpectMsg("d-3");
+            ExpectMsg("d-4");
+
+            ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+        }
+
+        [Fact]
+        public void PersistentActor_should_allow_deferring_handlers_in_order_to_provide_ordered_processing_in_respect_to_PersistAsync_handlers()
+        {
+            var pref = ActorOf(Props.Create(() => new DeferringWithAsyncPersistActor(Name)));
+            pref.Tell(new Cmd("a"));
+
+            ExpectMsg("d-a-1");
+            ExpectMsg("pa-a-2");
+            ExpectMsg("d-a-3");
+            ExpectMsg("d-a-4");
+
+            ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+        }
+
+        [Fact]
+        public void PersistentActor_should_invoke_deferred_handlers_in_presence_of_mixed_a_long_series_Persist_and_PersistAsync_calls()
+        {
+            var pref = ActorOf(Props.Create(() => new DeferringMixedCallsPPADDPADPersistActor(Name)));
+            var p1 = CreateTestProbe();
+            var p2 = CreateTestProbe();
+
+            pref.Tell(new Cmd("a"), p1.Ref);
+            pref.Tell(new Cmd("b"), p2.Ref);
+            p1.ExpectMsg("p-a-1");
+            p1.ExpectMsg("pa-a-2");
+            p1.ExpectMsg("d-a-3");
+            p1.ExpectMsg("d-a-4");
+            p1.ExpectMsg("pa-a-5");
+            p1.ExpectMsg("d-a-6");
+
+            p2.ExpectMsg("p-b-1");
+            p2.ExpectMsg("pa-b-2");
+            p2.ExpectMsg("d-b-3");
+            p2.ExpectMsg("d-b-4");
+            p2.ExpectMsg("pa-b-5");
+            p2.ExpectMsg("d-b-6");
+
+            ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+        }
+
+        [Fact]
+        public void PersistentActor_should_invoke_deferred_handlers_right_away_if_there_are_no_persist_handlers_registered()
+        {
+            var pref = ActorOf(Props.Create(() => new DeferringWithNoPersistCallsPersistActor(Name)));
+            pref.Tell(new Cmd("a"));
+
+            ExpectMsg("d-1");
+            ExpectMsg("d-2");
+            ExpectMsg("d-3");
+
+            ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+        }
+
+        [Fact]
+        public void PersistentActor_should_invoke_deferred_handlers_preserving_the_original_sender_reference()
+        {
+            var pref = ActorOf(Props.Create(() => new DeferringWithAsyncPersistActor(Name)));
+            var p1 = CreateTestProbe();
+            var p2 = CreateTestProbe();
+
+            pref.Tell(new Cmd("a"), p1.Ref);
+            pref.Tell(new Cmd("b"), p2.Ref);
+
+            p1.ExpectMsg("d-a-1");
+            p1.ExpectMsg("pa-a-2");
+            p1.ExpectMsg("d-a-3");
+            p1.ExpectMsg("d-a-4");
+
+            p2.ExpectMsg("d-b-1");
+            p2.ExpectMsg("pa-b-2");
+            p2.ExpectMsg("d-b-3");
+            p2.ExpectMsg("d-b-4");
+
+            ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+        }
+
+        [Fact]
+        public void PersistentActor_should_receive_RecoveryFinished_if_it_is_handled_after_all_events_have_been_replayed()
+        {
+            var pref = ActorOf(Props.Create(() => new SnapshottingPersistentActor(Name, TestActor)));
+            pref.Tell(new Cmd("b"));
+            pref.Tell("snap");
+            pref.Tell(new Cmd("c"));
+            ExpectMsg("saved");
+            pref.Tell(GetState.Instance);
+            ExpectMsgInOrder("a-1", "a-2", "b-41", "b-42", "c-41", "c-42");
+
+            var pref2 = ActorOf(Props.Create(() => new HandleRecoveryFinishedEventPersistentActor(Name, TestActor)));
+            ExpectMsg("offered");
+            ExpectMsg<RecoveryCompleted>();
+            ExpectMsg("I am the stashed");
+            ExpectMsg("I am the recovered");
+            pref2.Tell(GetState.Instance);
+            ExpectMsgInOrder("a-1", "a-2", "b-41", "b-42", "c-41", "c-42", RecoveryCompleted.Instance);
+        }
+
+        [Fact]
+        public void PersistentActor_should_preserve_order_of_incoming_messages()
+        {
+            var pref = ActorOf(Props.Create(() => new StressOrdering(Name)));
+            pref.Tell(new Cmd("a"));
+            var latch = new TestLatch(1);
+            pref.Tell(new LatchCmd(latch, "b"));
+            pref.Tell("c");
+            ExpectMsg("a");
+            ExpectMsg("b");
+            pref.Tell("d");
+            latch.CountDown();
+            ExpectMsg("c");
+            ExpectMsg("d");
+        }
+
+        [Fact]
+        public void PersistentActor_should_allow_multiple_Persists_with_nested_Persist_calls()
+        {
+            var pref = ActorOf(Props.Create(() => new MultipleAndNestedPersists(Name, TestActor)));
+            pref.Tell("a");
+            pref.Tell("b");
+
+            ExpectMsg("a");
+            ExpectMsg("a-outer-1");
+            ExpectMsg("a-outer-2");
+            ExpectMsg("a-inner-1");
+            ExpectMsg("a-inner-2");
+            // and only then process "b"
+            ExpectMsg("b");
+            ExpectMsg("b-outer-1");
+            ExpectMsg("b-outer-2");
+            ExpectMsg("b-inner-1");
+            ExpectMsg("b-inner-2");
+        }
+
+        [Fact]
+        public void PersistentActor_should_allow_multiple_PersistAsyncs_with_nested_PersistAsync_calls()
+        {
+            var pref = ActorOf(Props.Create(() => new MultipleAndNestedPersistAsyncs(Name, TestActor)));
+            pref.Tell("a");
+            pref.Tell("b");
+
+            var msgs = ReceiveN(10).Select(m => m.ToString()).ToArray();
+            var amsgs = msgs.Where(m => m.StartsWith("a")).ToArray();
+            var bmsgs = msgs.Where(m => m.StartsWith("b")).ToArray();
+            amsgs.ShouldOnlyContainInOrder("a", "a-outer-1", "a-outer-2", "a-inner-1", "a-inner-2");
+            bmsgs.ShouldOnlyContainInOrder("b", "b-outer-1", "b-outer-2", "b-inner-1", "b-inner-2");
+        }
+
+        [Fact]
+        public void PersistentActor_should_allow_deeply_nested_Persist_calls()
+        {
+            const int nestedPersists = 6;
+            var pref = ActorOf(Props.Create(() => new DeeplyNestedPersists(Name, nestedPersists, TestActor)));
+            pref.Tell("a");
+            pref.Tell("b");
+
+            ExpectMsg("a");
+            ReceiveN(nestedPersists).Select(m => m.ToString()).ShouldOnlyContainInOrder(Enumerable.Range(1, nestedPersists).Select(i => "a-" + i).ToArray());
+            // and only then process "b"
+            ExpectMsg("b");
+            ReceiveN(nestedPersists).Select(m => m.ToString()).ShouldOnlyContainInOrder(Enumerable.Range(1, nestedPersists).Select(i => "b-" + i).ToArray());
+        }
+
+        [Fact]
+        public void PersistentActor_should_allow_deeply_nested_PersistAsync_calls()
+        {
+            const int nestedPersistAsyncs = 6;
+            var pref = ActorOf(Props.Create(() => new DeeplyNestedPersistAsyncs(Name, nestedPersistAsyncs, TestActor)));
+            pref.Tell("a");
+            ExpectMsg("a");
+
+            var got = ReceiveN(nestedPersistAsyncs).Select(m => m.ToString()).OrderBy(m => m).ToArray();
+            got.ShouldOnlyContainInOrder(Enumerable.Range(1, nestedPersistAsyncs).Select(i => "a-" + i).ToArray());
+
+
+            pref.Tell("b");
+            pref.Tell("c");
+            got = ReceiveN(nestedPersistAsyncs*2 + 2).Select(m => m.ToString()).OrderBy(m => m).ToArray();
+            got.ShouldOnlyContainInOrder(
+                new [] {"b"}
+                .Union(Enumerable.Range(1, nestedPersistAsyncs).Select(i => "b-" + i))
+                .Union(new [] {"c"})
+                .Union(Enumerable.Range(1, nestedPersistAsyncs).Select(i => "c-" + i))
+                .ToArray());
+        }
+
+        [Fact]
+        public void PersistentActor_should_allow_mixed_nesting_of_PersistAsync_in_Persist_calls()
+        {
+            var pref = ActorOf(Props.Create(() => new NestedPersistNormalAndAsyncs(Name, TestActor)));
+            pref.Tell("a");
+
+            ExpectMsg("a");
+            ReceiveN(4).Select(m => m.ToString()).ToArray().ShouldOnlyContainInOrder("a-outer-1", "a-outer-2", "a-inner-async-1", "a-inner-async-2");
+        }
+
+        [Fact]
+        public void PersistentActor_should_allow_mixed_nesting_of_Persist_in_PersistAsync_calls()
+        {
+            var pref = ActorOf(Props.Create(() => new NestedPersistAsyncsAndNormal(Name, TestActor)));
+            pref.Tell("a");
+
+            ExpectMsg("a");
+            ReceiveN(4).Select(m => m.ToString()).ToArray().ShouldOnlyContainInOrder("a-outer-async-1", "a-outer-async-2", "a-inner-1", "a-inner-2");
+        }
+
+        [Fact]
+        public void PersistentActor_should_make_sure_Persist_retains_promised_semantics_when_nested_in_PersistAsync_callback()
+        {
+            var pref = ActorOf(Props.Create(() => new NestedPersistInAsyncEnforcesStashing(Name, TestActor)));
+            pref.Tell("a");
+
+            ExpectMsg("a");
+            ExpectMsg("a-outer-async");
+            ExpectMsg("a-inner");
+            pref.Tell("b");
+            ExpectMsg("done");
+            // which means that b only got applied after the inner Persist() handler finished
+            // so it keeps the Persist() semantics.
+            // Even though we should not recommend this style it can come in handy I guess
+        }
+
+        [Fact]
+        public void PersistentActor_should_be_able_to_delete_events()
+        {
+            var pref = ActorOf(Props.Create(() => new BehaviorOneActor(Name)));
+            pref.Tell(new Cmd("b"));
+            pref.Tell(GetState.Instance);
+            ExpectMsgInOrder("a-1", "a-2", "b-1", "b-2");
+            pref.Tell(new Delete(2)); // delete "a-1" and "a-2"
+            pref.Tell("boom"); // restart, recover
+            ExpectMsg<DeleteMessagesSuccess>();
+            pref.Tell(GetState.Instance);
+            ExpectMsgInOrder("b-1", "b-2");
+        }
+
+        [Fact]
+        public void PersistentActor_should_be_able_to_delete_all_events()
+        {
+            var pref = ActorOf(Props.Create(() => new BehaviorOneActor(Name)));
+            pref.Tell(new Cmd("b"));
+            pref.Tell(GetState.Instance);
+            ExpectMsgInOrder("a-1", "a-2", "b-1", "b-2");
+            pref.Tell(new Delete(long.MaxValue));
+            pref.Tell("boom"); // restart, recover
+            ExpectMsg<DeleteMessagesSuccess>();
+            pref.Tell(GetState.Instance);
+            ExpectMsg<object[]>(m => m.Length == 0);
+        }
+
+        [Fact]
+        public void PersistentActor_should_brecover_the_message_which_caused_the_restart()
+        {
+            var persistentActor = ActorOf(Props.Create(() => new RecoverMessageCausedRestart(Name)));
+            persistentActor.Tell("boom");
+            ExpectMsg("failed with TestException while processing boom");
+        }
+    }
+}

--- a/src/core/Akka.Persistence.Tests/ReceivePersistentActorAsyncAwaitSpec.cs
+++ b/src/core/Akka.Persistence.Tests/ReceivePersistentActorAsyncAwaitSpec.cs
@@ -1,0 +1,649 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AsyncAwaitSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.TestKit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Tests
+{
+    class ReceiveTimeoutAsyncActor : ReceivePersistentActor
+    {
+        private IActorRef _replyTo;
+
+        public override string PersistenceId { get; }
+
+        public ReceiveTimeoutAsyncActor(string persistenceId)
+        {
+            PersistenceId = persistenceId;
+
+            RecoverAny(o => { });
+
+            Command<ReceiveTimeout>(t =>
+            {
+                _replyTo.Tell("GotIt");
+            });
+            CommandAsync<string>(async s =>
+            {
+                _replyTo = Sender;
+
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+                SetReceiveTimeout(TimeSpan.FromMilliseconds(100));
+            });
+        }
+    }
+    class AsyncActor : ReceivePersistentActor
+    {
+        public override string PersistenceId { get; }
+
+        public AsyncActor(string persistenceId)
+        {
+            PersistenceId = persistenceId;
+
+            RecoverAny(o => { });
+
+            CommandAsync<string>(async s =>
+            {
+                await Task.Yield();
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+                if (s == "stop")
+                {
+                    Sender.Tell("done");
+                }
+            });
+        }
+    }
+
+    public class SuspendActor : ReceivePersistentActor
+    {
+        public override string PersistenceId { get; }
+
+        public SuspendActor(string persistenceId)
+        {
+            PersistenceId = persistenceId;
+
+            RecoverAny(o => { });
+
+            var state = 0;
+            Command<string>(s => s == "change", _ =>
+            {
+                state = 1;
+            });
+            CommandAsync<string>(async m_ =>
+            {
+                Self.Tell("change");
+                await Task.Delay(TimeSpan.FromSeconds(1));
+                var cell = (ActorCell)Context;
+                var current = cell.CurrentMessage;
+                //ensure we have the correct current message here
+                Assert.Same(m_, current);
+                //we expect that state should not have changed due to an incoming message
+                Sender.Tell(state);
+            });
+        }
+    }
+
+    public class AsyncAwaitActor : ReceivePersistentActor
+    {
+        public override string PersistenceId { get; }
+
+        public AsyncAwaitActor(string persistenceId)
+        {
+            PersistenceId = persistenceId;
+
+            RecoverAny(o => { });
+
+            CommandAsync<string>(async _ =>
+            {
+                var sender = Sender;
+                var self = Self;
+                await Task.Yield();
+                await Task.Delay(TimeSpan.FromSeconds(1));
+                Assert.Same(sender, Sender);
+                Assert.Same(self, Self);
+                Sender.Tell("done");
+            });
+
+            CommandAsync<int>(async msg =>
+            {
+                await Task.Yield();
+                Sender.Tell("handled");
+            }, i => i > 10);
+
+            CommandAsync(typeof(double), async msg =>
+            {
+                await Task.Yield();
+                Sender.Tell("handled");
+            });
+
+            CommandAnyAsync(async msg =>
+            {
+                await Task.Yield();
+                Sender.Tell("receiveany");
+            });
+        }
+    }
+
+    public class PersistentAsyncAwaitActor : PersistentActor
+    {
+        public override string PersistenceId { get; }
+
+        public PersistentAsyncAwaitActor(string persistenceId)
+        {
+            PersistenceId = persistenceId;
+        }
+
+        protected override bool ReceiveRecover(object message)
+        {
+            return false;
+        }
+
+        protected override bool ReceiveCommand(object message)
+        {
+            if (message is string)
+            {
+                RunTask(async () =>
+                {
+                    var sender = Sender;
+                    var self = Self;
+                    await Task.Yield();
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+                    Assert.Same(sender, Sender);
+                    Assert.Same(self, Self);
+                    Sender.Tell("done");
+                });
+                return true;
+            }
+            return false;
+        }
+    }
+
+    public class Asker : ReceivePersistentActor
+    {
+        public override string PersistenceId { get; }
+
+        public Asker(string persistenceId, IActorRef other)
+        {
+            PersistenceId = persistenceId;
+
+            RecoverAny(o => { });
+
+            CommandAsync<string>(async _ =>
+            {
+                var sender = Sender;
+                var self = Self;
+                var res = await other.Ask("start");
+                Assert.Same(sender, Sender);
+                Assert.Same(self, Self);
+                Sender.Tell(res);
+            });
+        }
+    }
+
+    public class PersistentAsker : PersistentActor
+    {
+        private readonly IActorRef _other;
+
+        public override string PersistenceId { get; }
+
+        public PersistentAsker(string persistenceId, IActorRef other)
+        {
+            PersistenceId = persistenceId;
+            _other = other;
+        }
+
+        protected override bool ReceiveRecover(object message)
+        {
+            return false;
+        }
+
+        protected override bool ReceiveCommand(object message)
+        {
+            if (message is string)
+            {
+                RunTask(async () =>
+                {
+                    var sender = Sender;
+                    var self = Self;
+                    var res = await _other.Ask("start");
+                    Assert.Same(sender, Sender);
+                    Assert.Same(self, Self);
+                    Sender.Tell(res);
+                });
+                return true;
+            }
+            return false;
+        }
+    }
+
+    public class BlockingAsker : ReceivePersistentActor
+    {
+        public override string PersistenceId { get; }
+
+        public BlockingAsker(string persistenceId, IActorRef other)
+        {
+            PersistenceId = persistenceId;
+
+            RecoverAny(o => { });
+
+            Command<string>(_ =>
+            {
+                //not async, blocking wait
+                var res = other.Ask("start").Result;
+                Sender.Tell(res);
+            });
+        }
+    }
+
+    public class BlockingAskSelf : ReceivePersistentActor
+    {
+        public override string PersistenceId { get; }
+
+        public BlockingAskSelf(string persistenceId)
+        {
+            PersistenceId = persistenceId;
+
+            RecoverAny(o => { });
+
+            Command<int>(_ =>
+            {
+                //since this actor is blocking in the handler below, it will never
+                //be able to execute this section
+                Sender.Tell("done");
+            });
+            Command<string>(_ =>
+            {
+                //ask and block
+                var res = Self.Ask(123).Result;
+                Sender.Tell(res);
+            });
+        }
+    }
+
+    public class AsyncExceptionActor : ReceivePersistentActor
+    {
+        private readonly IActorRef _callback;
+        public override string PersistenceId { get; }
+
+        public AsyncExceptionActor(string persistenceId, IActorRef callback)
+        {
+            PersistenceId = persistenceId;
+
+            RecoverAny(o => { });
+
+            _callback = callback;
+            CommandAsync<string>(async _ =>
+            {
+                await Task.Yield();
+                ThrowException();
+            });
+        }
+
+        protected override void PostRestart(Exception reason)
+        {
+            _callback.Tell("done");
+            base.PostRestart(reason);
+        }
+
+        private static void ThrowException()
+        {
+            throw new Exception("should be handled by supervisor");
+        }
+    }
+
+    public class AsyncTplActor : ReceivePersistentActor
+    {
+        public override string PersistenceId { get; }
+
+        public AsyncTplActor(string persistenceId)
+        {
+            PersistenceId = persistenceId;
+
+            RecoverAny(o => { });
+
+            Command<string>(m =>
+            {
+                //this is also safe, all tasks complete in the actor context
+                RunTask(async () =>
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(1))
+                        .ContinueWith(t => { Sender.Tell("done"); });
+                });
+            });
+        }
+    }
+
+    public class AsyncTplExceptionActor : ReceivePersistentActor
+    {
+        private readonly IActorRef _callback;
+
+        public override string PersistenceId { get; }
+
+        public AsyncTplExceptionActor(string persistenceId, IActorRef callback)
+        {
+            PersistenceId = persistenceId;
+
+            RecoverAny(o => { });
+
+            _callback = callback;
+            Command<string>(m =>
+            {
+                RunTask(async () =>
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(1))
+                   .ContinueWith(t => { throw new Exception("foo"); });
+                });
+            });
+        }
+
+        protected override void PostRestart(Exception reason)
+        {
+            _callback.Tell("done");
+            base.PostRestart(reason);
+        }
+    }
+
+    public class RestartMessage
+    {
+        public object Message { get; private set; }
+
+        public RestartMessage(object message)
+        {
+            Message = message;
+        }
+    }
+
+    public class ReceivePersistentActorAsyncAwaitSpec : AkkaSpec
+    {
+        public ReceivePersistentActorAsyncAwaitSpec(ITestOutputHelper output = null)
+            : base("akka.persistence.journal.plugin = \"akka.persistence.journal.inmem\"", output)
+        {
+        }
+
+        [Fact]
+        public async Task PersistentActors_should_be_able_to_async_await_ask_message_loop()
+        {
+            var actor = Sys.ActorOf(Props.Create(() => new PersistentAsyncAwaitActor("pid")), "Worker");
+            var asker = Sys.ActorOf(Props.Create(() => new PersistentAsker("pid", actor)), "Asker");
+            var task = asker.Ask("start", TimeSpan.FromSeconds(5));
+            actor.Tell(123, ActorRefs.NoSender);
+            var res = await task;
+            Assert.Equal("done", res);
+        }
+
+        [Fact]
+        public async Task Actors_should_be_able_to_async_await_in_message_loop()
+        {
+            var actor = Sys.ActorOf(Props.Create(() => new AsyncAwaitActor("pid")));
+            var task = actor.Ask<string>("start", TimeSpan.FromSeconds(50));
+            actor.Tell(123, ActorRefs.NoSender);
+            var res = await task;
+            Assert.Equal("done", res);
+        }
+
+        [Fact]
+        public async Task Actors_should_be_able_to_async_await_ask_message_loop()
+        {
+            var actor = Sys.ActorOf(Props.Create(() => new AsyncAwaitActor("pid")), "Worker");
+            var asker = Sys.ActorOf(Props.Create(() => new Asker("pid", actor)), "Asker");
+            var task = asker.Ask("start", TimeSpan.FromSeconds(5));
+            actor.Tell(123, ActorRefs.NoSender);
+            var res = await task;
+            Assert.Equal("done", res);
+        }
+
+        [Fact]
+        public async Task Actors_should_be_able_to_block_ask_message_loop()
+        {
+            var actor = Sys.ActorOf(Props.Create(() => new AsyncAwaitActor("pid")).WithDispatcher("akka.actor.task-dispatcher"), "Worker");
+            var asker = Sys.ActorOf(Props.Create(() => new BlockingAsker("pid", actor)).WithDispatcher("akka.actor.task-dispatcher"), "Asker");
+            var task = asker.Ask("start", TimeSpan.FromSeconds(5));
+            actor.Tell(123, ActorRefs.NoSender);
+            var res = await task;
+            Assert.Equal("done", res);
+        }
+
+        [Fact(Skip = "Maybe not possible to solve")]
+        public async Task Actors_should_be_able_to_block_ask_self_message_loop()
+        {
+            var asker = Sys.ActorOf(Props.Create(() => new BlockingAskSelf("pid")), "Asker");
+            var task = asker.Ask("start", TimeSpan.FromSeconds(5));
+            var res = await task;
+            Assert.Equal("done", res);
+        }
+
+        [Fact]
+        public void Actors_should_be_able_to_supervise_async_exceptions()
+        {
+            var asker = Sys.ActorOf(Props.Create(() => new AsyncExceptionActor("pid", TestActor)));
+            asker.Tell("start");
+            ExpectMsg("done", TimeSpan.FromSeconds(5));
+        }
+
+        [Fact]
+        public async Task Actors_should_be_able_to_use_ContinueWith()
+        {
+            var asker = Sys.ActorOf(Props.Create(() => new AsyncTplActor("pid")));
+            var res = await asker.Ask("start", TimeSpan.FromSeconds(5));
+            Assert.Equal("done", res);
+        }
+
+        [Fact]
+        public void Actors_should_be_able_to_supervise_exception_ContinueWith()
+        {
+            var asker = Sys.ActorOf(Props.Create(() => new AsyncTplExceptionActor("pid", TestActor)));
+            asker.Tell("start");
+            ExpectMsg("done", TimeSpan.FromSeconds(5));
+        }
+
+
+        [Fact]
+        public async Task Actors_should_be_able_to_suspend_reentrancy()
+        {
+            var asker = Sys.ActorOf(Props.Create(() => new SuspendActor("pid")));
+            var res = await asker.Ask<int>("start", TimeSpan.FromSeconds(5));
+            res.ShouldBe(0);
+        }
+
+        [Fact]
+        public async Task Actor_should_be_able_to_resume_suspend()
+        {
+            var asker = Sys.ActorOf(Props.Create(() => new AsyncActor("pid")));
+
+            for (var i = 0; i < 10; i++)
+            {
+                asker.Tell("msg #" + i);
+            }
+
+            var res = await asker.Ask<string>("stop", TimeSpan.FromSeconds(5));
+            res.ShouldBe("done");
+        }
+
+        [Fact]
+        public void Actor_should_be_able_to_ReceiveTimeout_after_async_operation()
+        {
+            //Given
+            var pid = "pa-1";
+
+            var actor = Sys.ActorOf(Props.Create(() => new ReceiveTimeoutAsyncActor(pid)));
+
+            actor.Tell("hello");
+            ExpectMsg<string>(m => m == "GotIt");
+        }
+
+        public class AsyncExceptionCatcherActor : ReceivePersistentActor
+        {
+            private string _lastMessage;
+
+            public override string PersistenceId { get; }
+
+            public AsyncExceptionCatcherActor(string persistenceId)
+            {
+                PersistenceId = persistenceId;
+
+                RecoverAny(o => { });
+
+                CommandAsync<string>(async m =>
+                {
+                    _lastMessage = m;
+                    try
+                    {
+                        // Throw an exception in the ActorTaskScheduler
+                        await Task.Factory.StartNew(() =>
+                        {
+                            throw new Exception("should not restart");
+                        });
+                    }
+                    catch (Exception)
+                    {
+                    }
+                });
+
+                Command<int>(_ => Sender.Tell(_lastMessage, Self));
+            }
+        }
+
+        [Fact]
+        public async Task Actor_should_not_restart_if_exception_is_catched()
+        {
+            var actor = Sys.ActorOf(Props.Create(() => new AsyncExceptionCatcherActor("pid")));
+
+            actor.Tell("hello");
+
+            var lastMessage = await actor.Ask(123);
+
+            lastMessage.ShouldBe("hello");
+        }
+
+        public class AsyncFailingActor : ReceivePersistentActor
+        {
+            public override string PersistenceId { get; }
+
+            public AsyncFailingActor(string persistenceId)
+            {
+                PersistenceId = persistenceId;
+
+                RecoverAny(o => { });
+
+                CommandAsync<string>(async m =>
+                {
+                    ThrowException();
+                });
+            }
+
+            protected override void PreRestart(Exception reason, object message)
+            {
+                Sender.Tell(new RestartMessage(message), Self);
+
+                base.PreRestart(reason, message);
+            }
+
+            private static void ThrowException()
+            {
+                throw new Exception("foo");
+            }
+        }
+
+        [Fact]
+        public void Actor_PreRestart_should_give_the_failing_message()
+        {
+            var actor = Sys.ActorOf(Props.Create(() => new AsyncFailingActor("pid")));
+
+            actor.Tell("hello");
+
+            ExpectMsg<RestartMessage>(m => "hello".Equals(m.Message));
+        }
+
+        public class AsyncPipeToDelayActor : ReceivePersistentActor
+        {
+            public override string PersistenceId { get; }
+
+            public AsyncPipeToDelayActor(string persistenceId)
+            {
+                PersistenceId = persistenceId;
+
+                RecoverAny(o => { });
+
+                CommandAsync<string>(async msg =>
+                {
+                    Task.Run(() =>
+                    {
+                        Thread.Sleep(10);
+                        return msg;
+                    }).PipeTo(Sender, Self); //LogicalContext is lost?!?
+
+                    Thread.Sleep(3000);
+                });
+            }
+        }
+
+        public class AsyncReentrantActor : ReceivePersistentActor
+        {
+            public override string PersistenceId { get; }
+
+            public AsyncReentrantActor(string persistenceId)
+            {
+                PersistenceId = persistenceId;
+
+                RecoverAny(o => { });
+
+                CommandAsync<string>(async msg =>
+                {
+                    var sender = Sender;
+                    Task.Run(() =>
+                    {
+                        //Sleep to make sure the task is not completed when ContinueWith is called
+                        Thread.Sleep(100);
+                        return msg;
+                    }).ContinueWith(_ => sender.Tell(msg)); // ContinueWith will schedule with the implicit ActorTaskScheduler
+
+                    Thread.Sleep(3000);
+                });
+            }
+        }
+
+        [Fact]
+        public void ActorTaskScheduler_reentrancy_should_not_be_possible()
+        {
+            var actor = Sys.ActorOf(Props.Create(() => new AsyncReentrantActor("pid")));
+            actor.Tell("hello");
+
+            ExpectNoMsg(1000);
+        }
+
+        [Fact]
+        public void Actor_PipeTo_should_not_be_delayed_by_async_receive()
+        {
+            var actor = Sys.ActorOf(Props.Create(() => new AsyncPipeToDelayActor("pid")));
+
+            actor.Tell("hello");
+            ExpectMsg<string>(m => "hello".Equals(m), TimeSpan.FromMilliseconds(1000));
+        }
+
+        [Fact]
+        public async Task Actor_receiveasync_overloads_should_work()
+        {
+            var actor = Sys.ActorOf(Props.Create(() => new AsyncAwaitActor("pid")));
+
+            actor.Tell(11);
+            ExpectMsg<string>(m => "handled".Equals(m), TimeSpan.FromMilliseconds(1000));
+
+            actor.Tell(9);
+            ExpectMsg<string>(m => "receiveany".Equals(m), TimeSpan.FromMilliseconds(1000));
+
+            actor.Tell(1.0);
+            ExpectMsg<string>(m => "handled".Equals(m), TimeSpan.FromMilliseconds(1000));
+
+
+        }
+    }
+}
+

--- a/src/core/Akka.Persistence/Eventsourced.Recovery.cs
+++ b/src/core/Akka.Persistence/Eventsourced.Recovery.cs
@@ -282,7 +282,11 @@ namespace Akka.Persistence
         {
             if (_eventBatch.Count > 0) FlushBatch();
 
-            if (_pendingStashingPersistInvocations > 0)
+            if (_asyncTaskRunning)
+            {
+                //do nothing, wait for the task to finish
+            }
+            else if (_pendingStashingPersistInvocations > 0)
                 ChangeState(PersistingEvents());
             else
                 UnstashInternally(err);

--- a/src/core/Akka.Persistence/PersistentActor.cs
+++ b/src/core/Akka.Persistence/PersistentActor.cs
@@ -12,6 +12,7 @@ using Akka.Actor;
 using Akka.Actor.Internal;
 using Akka.Configuration;
 using Akka.Tools.MatchHandler;
+using System.Threading.Tasks;
 
 namespace Akka.Persistence
 {
@@ -410,6 +411,15 @@ namespace Akka.Persistence
                 Unhandled(message);
         }
 
+        private Action<T> WrapAsyncHandler<T>(Func<T, Task> asyncHandler)
+        {
+            return m =>
+            {
+                Func<Task> wrap = () => asyncHandler(m);
+                RunTask(wrap);
+            };
+        }
+
         #region Recover helper methods
 
         private void EnsureMayConfigureRecoverHandlers()
@@ -504,6 +514,89 @@ namespace Akka.Persistence
         {
             if (_matchCommandBuilders.Count <= 0)
                 throw new InvalidOperationException("You may only call Command-methods when constructing the actor and inside Become().");
+        }
+
+        /// <summary>
+        /// Registers an asynchronous handler for incoming command of the specified type <typeparamref name="T"/>.
+        /// If <paramref name="shouldHandle"/>!=<c>null</c> then it must return true before a message is passed to <paramref name="handler"/>.
+        /// <remarks>The actor will be suspended until the task returned by <paramref name="handler"/> completes, including the <see cref="Eventsourced.Persist{TEvent}(TEvent, Action{TEvent})" /> and
+        /// <see cref="Eventsourced.PersistAll{TEvent}(IEnumerable{TEvent}, Action{TEvent})" /> calls.</remarks>
+        /// <remarks>This method may only be called when constructing the actor or from <see cref="Become(System.Action)"/> or <see cref="BecomeStacked"/>.</remarks>
+        /// <remarks>Note that handlers registered prior to this may have handled the message already.
+        /// In that case, this handler will not be invoked.</remarks>
+        /// </summary>
+        /// <typeparam name="T">The type of the message</typeparam>
+        /// <param name="handler">The message handler that is invoked for incoming messages of the specified type <typeparamref name="T"/></param>
+        /// <param name="shouldHandle">When not <c>null</c> it is used to determine if the message matches.</param>
+        protected void CommandAsync<T>(Func<T, Task> handler, Predicate<T> shouldHandle = null)
+        {
+            Command(WrapAsyncHandler(handler), shouldHandle);
+        }
+
+        /// <summary>
+        /// Registers an asynchronous handler for incoming command of the specified type <typeparamref name="T"/>.
+        /// If <paramref name="shouldHandle"/>!=<c>null</c> then it must return true before a message is passed to <paramref name="handler"/>.
+        /// <remarks>The actor will be suspended until the task returned by <paramref name="handler"/> completes, including the <see cref="Eventsourced.Persist{TEvent}(TEvent, Action{TEvent})" /> and
+        /// <see cref="Eventsourced.PersistAll{TEvent}(IEnumerable{TEvent}, Action{TEvent})" /> calls.</remarks>
+        /// <remarks>This method may only be called when constructing the actor or from <see cref="Become(System.Action)"/> or <see cref="BecomeStacked"/>.</remarks>
+        /// <remarks>Note that handlers registered prior to this may have handled the message already.
+        /// In that case, this handler will not be invoked.</remarks>
+        /// </summary>
+        /// <typeparam name="T">The type of the message</typeparam>
+        /// <param name="shouldHandle">When not <c>null</c> it is used to determine if the message matches.</param>
+        /// <param name="handler">The message handler that is invoked for incoming messages of the specified type <typeparamref name="T"/></param>
+        protected void CommandAsync<T>(Predicate<T> shouldHandle, Func<T, Task> handler)
+        {
+            Command(shouldHandle, WrapAsyncHandler(handler));
+        }
+
+        /// <summary>
+        /// Registers an asynchronous handler for incoming command of the specified type <typeparamref name="T"/>.
+        /// If <paramref name="shouldHandle"/>!=<c>null</c> then it must return true before a message is passed to <paramref name="handler"/>.
+        /// <remarks>The actor will be suspended until the task returned by <paramref name="handler"/> completes, including the <see cref="Eventsourced.Persist{TEvent}(TEvent, Action{TEvent})" /> and
+        /// <see cref="Eventsourced.PersistAll{TEvent}(IEnumerable{TEvent}, Action{TEvent})" /> calls.</remarks>
+        /// <remarks>This method may only be called when constructing the actor or from <see cref="Become(System.Action)"/> or <see cref="BecomeStacked"/>.</remarks>
+        /// <remarks>Note that handlers registered prior to this may have handled the message already.
+        /// In that case, this handler will not be invoked.</remarks>
+        /// </summary>
+        /// <param name="messageType">The type of the message</param>
+        /// <param name="handler">The message handler that is invoked for incoming messages of the specified type <typeparamref name="T"/></param>
+        /// <param name="shouldHandle">When not <c>null</c> it is used to determine if the message matches.</param>
+        protected void CommandAsync(Type messageType, Func<object, Task> handler, Predicate<object> shouldHandle = null)
+        {
+            Command(messageType, WrapAsyncHandler(handler), shouldHandle);
+        }
+
+        /// <summary>
+        /// Registers an asynchronous handler for incoming command of the specified type <typeparamref name="T"/>.
+        /// If <paramref name="shouldHandle"/>!=<c>null</c> then it must return true before a message is passed to <paramref name="handler"/>.
+        /// <remarks>The actor will be suspended until the task returned by <paramref name="handler"/> completes, including the <see cref="Eventsourced.Persist{TEvent}(TEvent, Action{TEvent})" /> and
+        /// <see cref="Eventsourced.PersistAll{TEvent}(IEnumerable{TEvent}, Action{TEvent})" /> calls.</remarks>
+        /// <remarks>This method may only be called when constructing the actor or from <see cref="Become(System.Action)"/> or <see cref="BecomeStacked"/>.</remarks>
+        /// <remarks>Note that handlers registered prior to this may have handled the message already.
+        /// In that case, this handler will not be invoked.</remarks>
+        /// </summary>
+        /// <param name="messageType">The type of the message</param>
+        /// <param name="shouldHandle">When not <c>null</c> it is used to determine if the message matches.</param>
+        /// <param name="handler">The message handler that is invoked for incoming messages of the specified type <typeparamref name="T"/></param>
+        protected void CommandAsync(Type messageType, Predicate<object> shouldHandle, Func<object, Task> handler)
+        {
+            Command(messageType, shouldHandle, WrapAsyncHandler(handler));
+        }
+
+        /// <summary>
+        /// Registers an asynchronous handler for incoming command of any type.
+        /// If <paramref name="shouldHandle"/>!=<c>null</c> then it must return true before a message is passed to <paramref name="handler"/>.
+        /// <remarks>The actor will be suspended until the task returned by <paramref name="handler"/> completes, including the <see cref="Eventsourced.Persist{TEvent}(TEvent, Action{TEvent})" /> and
+        /// <see cref="Eventsourced.PersistAll{TEvent}(IEnumerable{TEvent}, Action{TEvent})" /> calls.</remarks>
+        /// <remarks>This method may only be called when constructing the actor or from <see cref="Become(System.Action)"/> or <see cref="BecomeStacked"/>.</remarks>
+        /// <remarks>Note that handlers registered prior to this may have handled the message already.
+        /// In that case, this handler will not be invoked.</remarks>
+        /// </summary>
+        /// <param name="handler">The message handler that is invoked for incoming messages of the specified type <typeparamref name="T"/></param>
+        protected void CommandAnyAsync(Func<object, Task> handler)
+        {
+            CommandAny(WrapAsyncHandler(handler));
         }
 
         /// <summary>


### PR DESCRIPTION
Here is another try on CommandAsync topic.
I's introducing similar support for async/await as in ReceiveAsync.

Remarks:
- As with ReceiveAsync, all other commands to actor are blocked until the command handler task finishes processing the current command, including the Persist and PersistAll callbacks.
- It does NOT introduce async support for Persist callbacks, they work the same way as before
