### PR TITLE
renaming the unbounded mailbox queue files

### DIFF
--- a/src/core/Akka/Dispatch/MessageQueues/UnboundedMessageQueue.cs
+++ b/src/core/Akka/Dispatch/MessageQueues/UnboundedMessageQueue.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="UnboundedMailboxQueue.cs" company="Akka.NET Project">
+// <copyright file="UnboundedMessageQueue.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/core/Akka/Dispatch/MessageQueues/UnboundedPriorityMessageQueue.cs
+++ b/src/core/Akka/Dispatch/MessageQueues/UnboundedPriorityMessageQueue.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="UnboundedPriorityMailboxQueue.cs" company="Akka.NET Project">
+// <copyright file="UnboundedPriorityMessageQueue.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>


### PR DESCRIPTION
_( This is for issue #2696. )_

Two of the MessageQueue classes had file names that did not match the classes they contained.

* UnboundedMailboxQueue.cs -> UnboundedMessageQueue.cs
* UnboundedPriorityMailboxQueue.cs -> UnboundedPriorityMessageQueue.cs