### PR TITLE
[WIP] Sql persistence update

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Query.Sql/AllEventsPublisher.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.Sql/AllEventsPublisher.cs
@@ -1,0 +1,215 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AllEventsPublisher.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Actor;
+using Akka.Event;
+using Akka.Persistence.Sql.Common.Journal;
+using Akka.Streams.Actors;
+using System;
+
+namespace Akka.Persistence.Query.Sql
+{
+    internal static class AllEventsPublisher
+    {
+        public sealed class Continue
+        {
+            public static readonly Continue Instance = new Continue();
+
+            private Continue()
+            {
+            }
+        }
+
+        public static Props Props(long fromOffset, long toOffset, TimeSpan? refreshDuration, int maxBufferSize, string writeJournalPluginId)
+        {
+            return refreshDuration.HasValue
+                ? Actor.Props.Create(() => new LiveAllEventsPublisher(fromOffset, toOffset, maxBufferSize, writeJournalPluginId, refreshDuration.Value))
+                : Actor.Props.Create(() => new CurrentAllEventsPublisher(fromOffset, toOffset, maxBufferSize, writeJournalPluginId));
+        }
+    }
+
+    internal abstract class AbstractAllEventsPublisher : ActorPublisher<EventEnvelope>
+    {
+        private ILoggingAdapter _log;
+
+        protected DeliveryBuffer<EventEnvelope> Buffer;
+        protected readonly IActorRef JournalRef;
+        protected long CurrentOffset;
+
+        protected AbstractAllEventsPublisher(long fromOffset, long toOffset, int maxBufferSize, string writeJournalPluginId)
+        {
+            FromOffset = CurrentOffset = fromOffset;
+            ToOffset = toOffset;
+            MaxBufferSize = maxBufferSize;
+            WriteJournalPluginId = writeJournalPluginId;
+            Buffer = new DeliveryBuffer<EventEnvelope>(OnNext);
+
+            JournalRef = Persistence.Instance.Apply(Context.System).JournalFor(writeJournalPluginId);
+        }
+
+        protected ILoggingAdapter Log => _log ?? (_log = Context.GetLogger());
+
+        protected long FromOffset { get; }
+        protected virtual long ToOffset { get; set; }
+        protected int MaxBufferSize { get; }
+        protected string WriteJournalPluginId { get; }
+
+        protected bool IsTimeForReplay => (Buffer.IsEmpty || Buffer.Length <= MaxBufferSize / 2) && (CurrentOffset <= ToOffset);
+
+        protected abstract void ReceiveInitialRequest();
+        protected abstract void ReceiveIdleRequest();
+        protected abstract void ReceiveRecoverySuccess(long highestSequenceNr);
+
+        protected override bool Receive(object message)
+        {
+            return Init(message);
+        }
+
+        protected bool Init(object message)
+        {
+            return message.Match()
+                .With<AllEventsPublisher.Continue>(() => { })
+                .With<Request>(_ => ReceiveInitialRequest())
+                .With<Cancel>(_ => Context.Stop(Self))
+                .WasHandled;
+        }
+
+        protected bool Idle(object message)
+        {
+            return message.Match()
+                .With<AllEventsPublisher.Continue>(() =>
+                {
+                    if (IsTimeForReplay) Replay();
+                })
+                .With<EventAppended>(() =>
+                {
+                    if (IsTimeForReplay) Replay();
+                })
+                .With<Request>(_ => ReceiveIdleRequest())
+                .With<Cancel>(_ => Context.Stop(Self))
+                .WasHandled;
+        }
+
+        protected void Replay()
+        {
+            var limit = MaxBufferSize - Buffer.Length;
+            Log.Debug("request replay for offset range from [{0}] to [{1}] limit [{2}]", CurrentOffset, ToOffset, limit);
+            JournalRef.Tell(new ReplayAllMessages(CurrentOffset, ToOffset, limit, Self));
+            Context.Become(Replaying(limit));
+        }
+
+        protected Receive Replaying(int limit)
+        {
+            return message => message.Match()
+                .With<ReplayedAllMessage>(replayed =>
+                {
+                    var seqNr = replayed.Persistent.SequenceNr;
+                    Buffer.Add(new EventEnvelope(
+                        offset: seqNr,
+                        persistenceId: replayed.Persistent.PersistenceId,
+                        sequenceNr: seqNr,
+                        @event: replayed.Persistent.Payload));
+                    CurrentOffset = replayed.Offset;
+                    Buffer.DeliverBuffer(TotalDemand);
+                })
+                .With<RecoverySuccess>(success =>
+                {
+                    Log.Debug("replay completed for current offset [{0}]", CurrentOffset);
+                    ReceiveRecoverySuccess(success.HighestSequenceNr);
+                })
+                .With<ReplayMessagesFailure>(failure =>
+                {
+                    Log.Debug("replay failed for offset [{0}], due to [{1}]", CurrentOffset, failure.Cause.Message);
+                    Buffer.DeliverBuffer(TotalDemand);
+                    OnErrorThenStop(failure.Cause);
+                })
+                .With<Request>(_ => Buffer.DeliverBuffer(TotalDemand))
+                .With<EventsByPersistenceIdPublisher.Continue>(() => { }) // skip during replay
+                .With<EventAppended>(() => { }) // skip during replay
+                .With<Cancel>(_ => Context.Stop(Self))
+                .WasHandled;
+        }
+    }
+
+    internal sealed class LiveAllEventsPublisher : AbstractAllEventsPublisher
+    {
+        private readonly ICancelable _tickCancelable;
+        public LiveAllEventsPublisher(long fromOffset, long toOffset, int maxBufferSize, string writeJournalPluginId, TimeSpan refreshInterval) 
+            : base(fromOffset, toOffset, maxBufferSize, writeJournalPluginId)
+        {
+            _tickCancelable = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(refreshInterval, refreshInterval, Self, AllEventsPublisher.Continue.Instance, Self);
+        }
+
+        protected override void PostStop()
+        {
+            _tickCancelable.Cancel();
+            base.PostStop();
+        }
+
+        protected override void ReceiveInitialRequest()
+        {
+            JournalRef.Tell(SubscribeAllEvents.Instance);
+            Replay();
+        }
+
+        protected override void ReceiveIdleRequest()
+        {
+            Buffer.DeliverBuffer(TotalDemand);
+            if (Buffer.IsEmpty && CurrentOffset > ToOffset)
+                OnCompleteThenStop();
+        }
+
+        protected override void ReceiveRecoverySuccess(long highestSequenceNr)
+        {
+            Buffer.DeliverBuffer(TotalDemand);
+            if (Buffer.IsEmpty && CurrentOffset > ToOffset)
+                OnCompleteThenStop();
+
+            Context.Become(Idle);
+        }
+    }
+
+    internal sealed class CurrentAllEventsPublisher : AbstractAllEventsPublisher
+    {
+        public CurrentAllEventsPublisher(long fromOffset, long toOffset, int maxBufferSize, string writeJournalPluginId) 
+            : base(fromOffset, toOffset, maxBufferSize, writeJournalPluginId)
+        {
+            _toOffset = toOffset;
+        }
+
+        private long _toOffset;
+        protected override long ToOffset => _toOffset;
+
+        protected override void ReceiveInitialRequest()
+        {
+            Replay();
+        }
+
+        protected override void ReceiveIdleRequest()
+        {
+            Buffer.DeliverBuffer(TotalDemand);
+            if (Buffer.IsEmpty && CurrentOffset > ToOffset)
+                OnCompleteThenStop();
+            else
+                Self.Tell(AllEventsPublisher.Continue.Instance);
+        }
+
+        protected override void ReceiveRecoverySuccess(long highestSequenceNr)
+        {
+            Buffer.DeliverBuffer(TotalDemand);
+            if (highestSequenceNr < ToOffset)
+                _toOffset = highestSequenceNr;
+
+            if (Buffer.IsEmpty && CurrentOffset > ToOffset)
+                OnCompleteThenStop();
+            else
+                Self.Tell(AllEventsPublisher.Continue.Instance);
+
+            Context.Become(Idle);
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Query.Sql/SqlReadJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.Sql/SqlReadJournal.cs
@@ -106,7 +106,7 @@ namespace Akka.Persistence.Query.Sql
         /// backend journal.
         /// </summary>
         public Source<EventEnvelope, NotUsed> EventsByPersistenceId(string persistenceId, long fromSequenceNr = 0, long toSequenceNr = long.MaxValue) =>
-                Source.ActorPublisher<EventEnvelope>(EventsByPersistenceIdPublisher.Props(persistenceId, fromSequenceNr, toSequenceNr, _refershInterval, _maxBufferSize, _writeJournalPluginId))
+                Source.ActorPublisher<EventEnvelope>(EventsByPersistenceIdPublisher.Props(persistenceId, fromSequenceNr, toSequenceNr, _refreshInterval, _maxBufferSize, _writeJournalPluginId))
                     .MapMaterializedValue(_ => NotUsed.Instance)
                     .Named("EventsByPersistenceId-" + persistenceId) as Source<EventEnvelope, NotUsed>;
 
@@ -156,7 +156,7 @@ namespace Akka.Persistence.Query.Sql
         /// backend journal.
         /// </summary>
         public Source<EventEnvelope, NotUsed> EventsByTag(string tag, long offset = 0) =>
-            Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, offset, long.MaxValue, _refershInterval, _maxBufferSize, _writeJournalPluginId))
+            Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, offset, long.MaxValue, _refreshInterval, _maxBufferSize, _writeJournalPluginId))
                 .MapMaterializedValue(_ => NotUsed.Instance)
                 .Named("EventsByTag-" + tag);
 
@@ -200,7 +200,7 @@ namespace Akka.Persistence.Query.Sql
         /// backend journal.
         /// </summary>
         public Source<EventEnvelope, NotUsed> AllEvents(long fromOffset = 0, long toOffset = long.MaxValue) =>
-            Source.ActorPublisher<EventEnvelope>(AllEventsPublisher.Props(fromOffset, toOffset, _refershInterval, _maxBufferSize, _writeJournalPluginId))
+            Source.ActorPublisher<EventEnvelope>(AllEventsPublisher.Props(fromOffset, toOffset, _refreshInterval, _maxBufferSize, _writeJournalPluginId))
                 .MapMaterializedValue(_ => NotUsed.Instance)
                 .Named("AllEvents");
 

--- a/src/contrib/persistence/Akka.Persistence.Query.Sql/SqlReadJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.Sql/SqlReadJournal.cs
@@ -171,7 +171,7 @@ namespace Akka.Persistence.Query.Sql
                 .Named("EventsByTag-" + tag);
 
         /// <summary>
-        /// <see cref="AllEvents"/> is used for retrieving all events (both current and upcoming) visible by current journal.
+        /// <see cref="Events"/> is used for retrieving all events (both current and upcoming) visible by current journal.
         /// <para></para>
         /// You can retrieve a subset of all events by specifying <paramref name="fromOffset"/> and <paramref name="toOffset"/> range. 
         /// Note that the corresponding offset of each event is provided in the <see cref="EventEnvelope"/>, which makes it possible to
@@ -199,18 +199,18 @@ namespace Akka.Persistence.Query.Sql
         /// The stream is completed with failure if there is a failure in executing the query in the
         /// backend journal.
         /// </summary>
-        public Source<EventEnvelope, NotUsed> AllEvents(long fromOffset = 0, long toOffset = long.MaxValue) =>
-            Source.ActorPublisher<EventEnvelope>(AllEventsPublisher.Props(fromOffset, toOffset, _refreshInterval, _maxBufferSize, _writeJournalPluginId))
+        public Source<EventEnvelope, NotUsed> Events(long fromOffset = 0, long toOffset = long.MaxValue) =>
+            Source.ActorPublisher<EventEnvelope>(EventsPublisher.Props(fromOffset, toOffset, _refreshInterval, _maxBufferSize, _writeJournalPluginId))
                 .MapMaterializedValue(_ => NotUsed.Instance)
-                .Named("AllEvents");
+                .Named("Events");
 
         /// <summary>
-        /// Same type of query as <see cref="AllEvents"/> but the event stream
+        /// Same type of query as <see cref="Events"/> but the event stream
         /// is completed immediately when it reaches the end of the "result set". Events that are
         /// stored after the query is completed are not included in the event stream.
         /// </summary>
         public Source<EventEnvelope, NotUsed> CurrentEvents(long fromOffset = 0, long toOffset = long.MaxValue) =>
-            Source.ActorPublisher<EventEnvelope>(AllEventsPublisher.Props(fromOffset, toOffset, null, _maxBufferSize, _writeJournalPluginId))
+            Source.ActorPublisher<EventEnvelope>(EventsPublisher.Props(fromOffset, toOffset, null, _maxBufferSize, _writeJournalPluginId))
                 .MapMaterializedValue(_ => NotUsed.Instance)
                 .Named("CurrentEvents");
     }

--- a/src/contrib/persistence/Akka.Persistence.Query.Sql/SqlReadJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.Sql/SqlReadJournal.cs
@@ -105,8 +105,8 @@ namespace Akka.Persistence.Query.Sql
         /// The stream is completed with failure if there is a failure in executing the query in the
         /// backend journal.
         /// </summary>
-        public Source<EventEnvelope, NotUsed> EventsByPersistenceId(string persistenceId, long fromSequenceNr, long toSequenceNr) =>
-                Source.ActorPublisher<EventEnvelope>(EventsByPersistenceIdPublisher.Props(persistenceId, fromSequenceNr, toSequenceNr, _refreshInterval, _maxBufferSize, _writeJournalPluginId))
+        public Source<EventEnvelope, NotUsed> EventsByPersistenceId(string persistenceId, long fromSequenceNr = 0, long toSequenceNr = long.MaxValue) =>
+                Source.ActorPublisher<EventEnvelope>(EventsByPersistenceIdPublisher.Props(persistenceId, fromSequenceNr, toSequenceNr, _refershInterval, _maxBufferSize, _writeJournalPluginId))
                     .MapMaterializedValue(_ => NotUsed.Instance)
                     .Named("EventsByPersistenceId-" + persistenceId) as Source<EventEnvelope, NotUsed>;
 
@@ -115,7 +115,7 @@ namespace Akka.Persistence.Query.Sql
         /// is completed immediately when it reaches the end of the "result set". Events that are
         /// stored after the query is completed are not included in the event stream.
         /// </summary>
-        public Source<EventEnvelope, NotUsed> CurrentEventsByPersistenceId(string persistenceId, long fromSequenceNr, long toSequenceNr) =>
+        public Source<EventEnvelope, NotUsed> CurrentEventsByPersistenceId(string persistenceId, long fromSequenceNr = 0, long toSequenceNr = long.MaxValue) =>
                 Source.ActorPublisher<EventEnvelope>(EventsByPersistenceIdPublisher.Props(persistenceId, fromSequenceNr, toSequenceNr, null, _maxBufferSize, _writeJournalPluginId))
                     .MapMaterializedValue(_ => NotUsed.Instance)
                     .Named("CurrentEventsByPersistenceId-" + persistenceId) as Source<EventEnvelope, NotUsed>;
@@ -155,8 +155,8 @@ namespace Akka.Persistence.Query.Sql
         /// The stream is completed with failure if there is a failure in executing the query in the
         /// backend journal.
         /// </summary>
-        public Source<EventEnvelope, NotUsed> EventsByTag(string tag, long offset) =>
-            Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, offset, long.MaxValue, _refreshInterval, _maxBufferSize, _writeJournalPluginId))
+        public Source<EventEnvelope, NotUsed> EventsByTag(string tag, long offset = 0) =>
+            Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, offset, long.MaxValue, _refershInterval, _maxBufferSize, _writeJournalPluginId))
                 .MapMaterializedValue(_ => NotUsed.Instance)
                 .Named("EventsByTag-" + tag);
 
@@ -165,9 +165,53 @@ namespace Akka.Persistence.Query.Sql
         /// is completed immediately when it reaches the end of the "result set". Events that are
         /// stored after the query is completed are not included in the event stream.
         /// </summary>
-        public Source<EventEnvelope, NotUsed> CurrentEventsByTag(string tag, long offset) =>
+        public Source<EventEnvelope, NotUsed> CurrentEventsByTag(string tag, long offset = 0) =>
             Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, offset, long.MaxValue, null, _maxBufferSize, _writeJournalPluginId))
                 .MapMaterializedValue(_ => NotUsed.Instance)
                 .Named("EventsByTag-" + tag);
+
+        /// <summary>
+        /// <see cref="AllEvents"/> is used for retrieving all events (both current and upcoming) visible by current journal.
+        /// <para></para>
+        /// You can retrieve a subset of all events by specifying <paramref name="fromOffset"/> and <paramref name="toOffset"/> range. 
+        /// Note that the corresponding offset of each event is provided in the <see cref="EventEnvelope"/>, which makes it possible to
+        /// resume the stream at a later point from a given offset.
+        /// <para></para>
+        /// In addition to the <paramref name="EventEnvelope.Offset"/> the <see cref="EventEnvelope"/> also provides `persistenceId` 
+        /// and `sequenceNr` for each event. The `sequenceNr` is the sequence number for the persistent actor with the
+        /// `persistenceId` that persisted the event. The `persistenceId` + `sequenceNr` is an unique
+        /// identifier for the event.
+        /// <para></para>
+        /// The returned event stream is ordered by the offset (tag sequence number), which corresponds
+        /// to the same order as the write journal stored the events. The same stream elements (in same order)
+        /// are returned for multiple executions of the query. Deleted events are not deleted from the
+        /// tagged event stream.
+        /// <para></para>
+        /// The stream is not completed when it reaches the end of the currently stored events,
+        /// but it continues to push new events when new events are persisted.
+        /// Corresponding query that is completed when it reaches the end of the currently
+        /// stored events is provided by <see cref="CurrentEvents"/>.
+        /// <para></para>
+        /// The SQL write journal is notifying the query side as soon as events are persisted, but for
+        /// efficiency reasons the query side retrieves the events in batches that sometimes can
+        /// be delayed up to the configured `refresh-interval`.
+        /// <para></para>
+        /// The stream is completed with failure if there is a failure in executing the query in the
+        /// backend journal.
+        /// </summary>
+        public Source<EventEnvelope, NotUsed> AllEvents(long fromOffset = 0, long toOffset = long.MaxValue) =>
+            Source.ActorPublisher<EventEnvelope>(AllEventsPublisher.Props(fromOffset, toOffset, _refershInterval, _maxBufferSize, _writeJournalPluginId))
+                .MapMaterializedValue(_ => NotUsed.Instance)
+                .Named("AllEvents");
+
+        /// <summary>
+        /// Same type of query as <see cref="AllEvents"/> but the event stream
+        /// is completed immediately when it reaches the end of the "result set". Events that are
+        /// stored after the query is completed are not included in the event stream.
+        /// </summary>
+        public Source<EventEnvelope, NotUsed> CurrentEvents(long fromOffset = 0, long toOffset = long.MaxValue) =>
+            Source.ActorPublisher<EventEnvelope>(AllEventsPublisher.Props(fromOffset, toOffset, null, _maxBufferSize, _writeJournalPluginId))
+                .MapMaterializedValue(_ => NotUsed.Instance)
+                .Named("CurrentEvents");
     }
 }

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryApi.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryApi.cs
@@ -148,6 +148,18 @@ namespace Akka.Persistence.Sql.Common.Journal
     }
 
     /// <summary>
+    /// Subscribe the `sender` to changes (appended events) for all incomming events.
+    /// Used by query-side. The journal will send <see cref="EventAppended"/> messages to
+    /// the subscriber when `asyncWriteMessages` has been called.
+    /// </summary>
+    [Serializable]
+    public sealed class SubscribeAllEvents : ISubscriptionCommand
+    {
+        public static readonly SubscribeAllEvents Instance = new SubscribeAllEvents();
+        private SubscribeAllEvents() { }
+    }
+
+    /// <summary>
     /// TBD
     /// </summary>
     [Serializable]
@@ -258,6 +270,88 @@ namespace Akka.Persistence.Sql.Common.Journal
         {
             Persistent = persistent;
             Tag = tag;
+            Offset = offset;
+        }
+    }
+
+
+    /// <summary>
+    /// TBD
+    /// </summary>
+    [Serializable]
+    public sealed class ReplayAllMessages : IJournalRequest
+    {
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public readonly long FromOffset;
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public readonly long ToOffset;
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public readonly long Max;
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public readonly IActorRef ReplyTo;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReplayTaggedMessages"/> class.
+        /// </summary>
+        /// <param name="fromOffset">TBD</param>
+        /// <param name="toOffset">TBD</param>
+        /// <param name="max">TBD</param>
+        /// <param name="replyTo">TBD</param>
+        /// <exception cref="ArgumentException">
+        /// This exception is thrown for a number of reasons. These include the following:
+        /// <ul>
+        /// <li>The specified <paramref name="fromOffset"/> is less than zero.</li>
+        /// <li>The specified <paramref name="toOffset"/> is less than or equal to zero.</li>
+        /// <li>The specified <paramref name="max"/> is less than or equal to zero.</li>
+        /// </ul>
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        /// This exception is thrown when the specified <paramref name="tag"/> is null or empty.
+        /// </exception>
+        public ReplayAllMessages(long fromOffset, long toOffset, long max, IActorRef replyTo)
+        {
+            if (fromOffset < 0) throw new ArgumentException("From offset may not be a negative number", nameof(fromOffset));
+            if (toOffset <= 0) throw new ArgumentException("To offset must be a positive number", nameof(toOffset));
+            if (max <= 0) throw new ArgumentException("Maximum number of replayed messages must be a positive number", nameof(max));
+
+            FromOffset = fromOffset;
+            ToOffset = toOffset;
+            Max = max;
+            ReplyTo = replyTo;
+        }
+    }
+
+    /// <summary>
+    /// TBD
+    /// </summary>
+    [Serializable]
+    public sealed class ReplayedAllMessage : INoSerializationVerificationNeeded, IDeadLetterSuppression
+    {
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public readonly IPersistentRepresentation Persistent;
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public readonly long Offset;
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="persistent">TBD</param>
+        /// <param name="offset">TBD</param>
+        public ReplayedAllMessage(IPersistentRepresentation persistent, long offset)
+        {
+            Persistent = persistent;
             Offset = offset;
         }
     }

--- a/src/contrib/persistence/Akka.Persistence.Sql.TestKit/AllEventsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.TestKit/AllEventsSpec.cs
@@ -90,7 +90,7 @@ namespace Akka.Persistence.Sql.TestKit
             b.Tell("B1");
             ExpectMsg("B1-done");
 
-            var src = queries.AllEvents();
+            var src = queries.Events();
             var probe = src.RunWith(this.SinkProbe<EventEnvelope>(), _materializer);
             probe.Request(4)
                 .ExpectNext(new EventEnvelope(1, "a", 1, "A1"))
@@ -117,7 +117,7 @@ namespace Akka.Persistence.Sql.TestKit
 
             Sql_live_query_AllEvents_should_find_new_events();
 
-            var src = queries.AllEvents(fromOffset: 2, toOffset: 6);
+            var src = queries.Events(fromOffset: 2, toOffset: 6);
             var probe = src.RunWith(this.SinkProbe<EventEnvelope>(), _materializer);
             probe.Request(10)
                 .ExpectNext(new EventEnvelope(2, "a", 2, "A2"))

--- a/src/contrib/persistence/Akka.Persistence.Sql.TestKit/AllEventsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.TestKit/AllEventsSpec.cs
@@ -1,4 +1,11 @@
-﻿using Akka.Actor;
+﻿//-----------------------------------------------------------------------
+// <copyright file="AllEventsSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Actor;
 using Akka.Configuration;
 using Akka.Persistence.Query;
 using Akka.Persistence.Query.Sql;

--- a/src/contrib/persistence/Akka.Persistence.Sql.TestKit/AllEventsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.TestKit/AllEventsSpec.cs
@@ -1,0 +1,141 @@
+﻿using Akka.Actor;
+using Akka.Configuration;
+using Akka.Persistence.Query;
+using Akka.Persistence.Query.Sql;
+using Akka.Streams;
+using Akka.Streams.TestKit;
+using System;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Sql.TestKit
+{
+    public abstract class AllEventsSpec : Akka.TestKit.Xunit2.TestKit
+    {
+        private readonly ActorMaterializer _materializer;
+
+        protected AllEventsSpec(Config config, ITestOutputHelper output) : base(config, output: output)
+        {
+            _materializer = Sys.Materializer();
+        }
+
+        [Fact]
+        public void Sql_query_CurrentEvents_should_find_existing_events()
+        {
+            var queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            var a = SetupEmpty("a");
+            var b = SetupEmpty("b");
+
+            a.Tell("A1");
+            ExpectMsg("A1-done");
+            a.Tell("A2");
+            ExpectMsg("A2-done");
+            b.Tell("B1");
+            ExpectMsg("B1-done");
+            a.Tell("A3");
+            ExpectMsg("A3-done");
+            b.Tell("B2");
+            ExpectMsg("B2-done");
+
+            var src = queries.CurrentEvents();
+            var probe = src.RunWith(this.SinkProbe<EventEnvelope>(), _materializer);
+            probe.Request(2)
+                .ExpectNext(new EventEnvelope(1, "a", 1, "A1"))
+                .ExpectNext(new EventEnvelope(2, "a", 2, "A2"));
+            probe.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
+            probe.Request(1)
+                .ExpectNext(new EventEnvelope(3, "b", 1, "B1"))
+                .ExpectComplete();
+            probe.Request(5)
+                .ExpectNext(new EventEnvelope(4, "a", 3, "A3"))
+                .ExpectNext(new EventEnvelope(5, "b", 2, "B2"))
+                .ExpectComplete();
+        }
+
+
+        [Fact]
+        public void Sql_query_CurrentEvents_should_find_existing_events_by_offset_range()
+        {
+            var queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+
+            Sql_query_CurrentEvents_should_find_existing_events();
+
+            var src = queries.CurrentEvents(fromOffset: 2, toOffset: 4);
+            var probe = src.RunWith(this.SinkProbe<EventEnvelope>(), _materializer);
+            probe.Request(10)
+                .ExpectNext(new EventEnvelope(2, "a", 2, "A2"))
+                .ExpectNext(new EventEnvelope(3, "b", 1, "B1"))
+                .ExpectNext(new EventEnvelope(4, "a", 3, "A3"))
+                .ExpectComplete();
+        }
+
+        [Fact]
+        public void Sql_live_query_AllEvents_should_find_new_events()
+        {
+            var queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            var a = SetupEmpty("a");
+            var b = SetupEmpty("b");
+
+            a.Tell("A1");
+            ExpectMsg("A1-done");
+            a.Tell("A2");
+            ExpectMsg("A2-done");
+            b.Tell("B1");
+            ExpectMsg("B1-done");
+
+            var src = queries.AllEvents();
+            var probe = src.RunWith(this.SinkProbe<EventEnvelope>(), _materializer);
+            probe.Request(4)
+                .ExpectNext(new EventEnvelope(1, "a", 1, "A1"))
+                .ExpectNext(new EventEnvelope(2, "a", 2, "A2"))
+                .ExpectNext(new EventEnvelope(3, "b", 1, "B1"));
+            probe.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
+
+            b.Tell("B2");
+            ExpectMsg("B2-done");
+            a.Tell("A3");
+            ExpectMsg("A3-done");
+
+            probe.ExpectNext(new EventEnvelope(4, "b", 2, "B2"));
+
+            probe.Request(2)
+                .ExpectNext(new EventEnvelope(5, "a", 3, "A3"));
+        }
+
+        [Fact]
+        public void Sql_live_query_AllEvents_should_find_new_events_by_offset_range()
+        {
+            var queries = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+            var c = SetupEmpty("c");
+
+            Sql_live_query_AllEvents_should_find_new_events();
+
+            var src = queries.AllEvents(fromOffset: 2, toOffset: 6);
+            var probe = src.RunWith(this.SinkProbe<EventEnvelope>(), _materializer);
+            probe.Request(10)
+                .ExpectNext(new EventEnvelope(2, "a", 2, "A2"))
+                .ExpectNext(new EventEnvelope(3, "b", 1, "B1"))
+                .ExpectNext(new EventEnvelope(4, "b", 2, "B2"))
+                .ExpectNext(new EventEnvelope(5, "a", 3, "A3"));
+
+            probe.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
+
+            c.Tell("C1");
+            ExpectMsg("C1-done");
+            c.Tell("C2");
+            ExpectMsg("C1-done");
+
+            probe
+                .ExpectNext(new EventEnvelope(5, "c", 1, "C1"))
+                .ExpectComplete(); // upperbound passed - we can complete now
+        }
+
+        private IActorRef SetupEmpty(string persistenceId) => Sys.ActorOf(TestKit.TestActor.Props(persistenceId));
+
+        protected override void Dispose(bool disposing)
+        {
+            _materializer.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/BatchingSqliteAllEventsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/BatchingSqliteAllEventsSpec.cs
@@ -1,0 +1,39 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="BatchingSqliteAllEventsSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Configuration;
+using Akka.Persistence.Query.Sql;
+using Akka.Persistence.Sql.TestKit;
+using Akka.Util.Internal;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Sqlite.Tests.Batching
+{
+    public class BatchingSqliteAllEventsSpec : AllEventsSpec
+    {
+        public static readonly AtomicCounter Counter = new AtomicCounter(0);
+        public static Config Config(int id) => ConfigurationFactory.ParseString($@"
+            akka.loglevel = INFO
+            akka.persistence.journal.plugin = ""akka.persistence.journal.sqlite""
+            akka.persistence.journal.sqlite {{
+                class = ""Akka.Persistence.Sqlite.Journal.BatchingSqliteJournal, Akka.Persistence.Sqlite""
+                plugin-dispatcher = ""akka.actor.default-dispatcher""
+                table-name = event_journal
+                metadata-table-name = journal_metadata
+                auto-initialize = on
+                store-as = binary
+                connection-string = ""Datasource=memdb-journal-batch-all-{id}.db;Mode=Memory;Cache=Shared""
+                refresh-interval = 1s
+            }}
+            akka.test.single-expect-default = 10s")
+            .WithFallback(SqlReadJournal.DefaultConfiguration());
+
+        public BatchingSqliteAllEventsSpec(ITestOutputHelper output) : base(Config(Counter.GetAndIncrement()), output)
+        {
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/Json/JsonBatchingSqliteAllEventsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/Json/JsonBatchingSqliteAllEventsSpec.cs
@@ -1,0 +1,39 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="JsonBatchingSqliteAllEventsSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Configuration;
+using Akka.Persistence.Query.Sql;
+using Akka.Persistence.Sql.TestKit;
+using Akka.Util.Internal;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Sqlite.Tests.Batching.Json
+{
+    public class JsonBatchingSqliteAllEventsSpec : AllEventsSpec
+    {
+        public static readonly AtomicCounter Counter = new AtomicCounter(0);
+        public static Config Config(int id) => ConfigurationFactory.ParseString($@"
+            akka.loglevel = INFO
+            akka.persistence.journal.plugin = ""akka.persistence.journal.sqlite""
+            akka.persistence.journal.sqlite {{
+                class = ""Akka.Persistence.Sqlite.Journal.BatchingSqliteJournal, Akka.Persistence.Sqlite""
+                plugin-dispatcher = ""akka.actor.default-dispatcher""
+                table-name = event_journal
+                metadata-table-name = journal_metadata
+                auto-initialize = on
+                store-as = json
+                connection-string = ""Datasource=memdb-journal-batch-all-{id}.db;Mode=Memory;Cache=Shared""
+                refresh-interval = 1s
+            }}
+            akka.test.single-expect-default = 10s")
+            .WithFallback(SqlReadJournal.DefaultConfiguration());
+
+        public JsonBatchingSqliteAllEventsSpec(ITestOutputHelper output) : base(Config(Counter.GetAndIncrement()), output)
+        {
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/Json/JsonBatchingSqliteEventsByPersistenceIdSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/Json/JsonBatchingSqliteEventsByPersistenceIdSpec.cs
@@ -7,7 +7,7 @@
 
 using Akka.Configuration;
 using Akka.Persistence.Query.Sql;
-using Akka.Persistence.Sql.TestKit;
+using Akka.Persistence.TCK.Query;
 using Akka.Util.Internal;
 using Xunit.Abstractions;
 
@@ -32,7 +32,7 @@ namespace Akka.Persistence.Sqlite.Tests.Batching.Json
             akka.test.single-expect-default = 10s")
             .WithFallback(SqlReadJournal.DefaultConfiguration());
 
-        public JsonBatchingSqliteEventsByPersistenceIdSpec(ITestOutputHelper output) : base(Config(Counter.GetAndIncrement()), output)
+        public JsonBatchingSqliteEventsByPersistenceIdSpec(ITestOutputHelper output) : base(Config(Counter.GetAndIncrement()), output: output)
         {
         }
     }

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/Json/JsonBatchingSqliteEventsByPersistenceIdSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/Json/JsonBatchingSqliteEventsByPersistenceIdSpec.cs
@@ -1,0 +1,39 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="JsonBatchingSqliteEventsByPersistenceIdSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Configuration;
+using Akka.Persistence.Query.Sql;
+using Akka.Persistence.Sql.TestKit;
+using Akka.Util.Internal;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Sqlite.Tests.Batching.Json
+{
+    public class JsonBatchingSqliteEventsByPersistenceIdSpec : EventsByPersistenceIdSpec
+    {
+        public static readonly AtomicCounter Counter = new AtomicCounter(100);
+        public static Config Config(int id) => ConfigurationFactory.ParseString($@"
+            akka.loglevel = INFO
+            akka.persistence.journal.plugin = ""akka.persistence.journal.sqlite""
+            akka.persistence.journal.sqlite {{
+                class = ""Akka.Persistence.Sqlite.Journal.BatchingSqliteJournal, Akka.Persistence.Sqlite""
+                plugin-dispatcher = ""akka.actor.default-dispatcher""
+                table-name = event_journal
+                metadata-table-name = journal_metadata
+                auto-initialize = on
+                store-as = json
+                connection-string = ""Datasource=memdb-journal-batch-{id}.db;Mode=Memory;Cache=Shared""
+                refresh-interval = 1s
+            }}
+            akka.test.single-expect-default = 10s")
+            .WithFallback(SqlReadJournal.DefaultConfiguration());
+
+        public JsonBatchingSqliteEventsByPersistenceIdSpec(ITestOutputHelper output) : base(Config(Counter.GetAndIncrement()), output)
+        {
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/Json/JsonBatchingSqliteEventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/Json/JsonBatchingSqliteEventsByTagSpec.cs
@@ -1,0 +1,45 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="JsonBatchingSqliteEventsByTagSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Configuration;
+using Akka.Persistence.Query.Sql;
+using Akka.Persistence.Sql.TestKit;
+using Akka.Util.Internal;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Sqlite.Tests.Batching.Json
+{
+    public class JsonBatchingSqliteEventsByTagSpec : EventsByTagSpec
+    {
+        public static readonly AtomicCounter Counter = new AtomicCounter(200);
+        public static Config Config(int id) => ConfigurationFactory.ParseString($@"
+            akka.loglevel = INFO
+            akka.persistence.journal.plugin = ""akka.persistence.journal.sqlite""
+            akka.persistence.journal.sqlite {{
+                event-adapters {{
+                  color-tagger  = ""Akka.Persistence.Sql.TestKit.ColorTagger, Akka.Persistence.Sql.TestKit""
+                }}
+                event-adapter-bindings = {{
+                  ""System.String"" = color-tagger
+                }}
+                class = ""Akka.Persistence.Sqlite.Journal.BatchingSqliteJournal, Akka.Persistence.Sqlite""
+                plugin-dispatcher = ""akka.actor.default-dispatcher""
+                table-name = event_journal
+                metadata-table-name = journal_metadata
+                auto-initialize = on
+                store-as = json
+                connection-string = ""Datasource=memdb-journal-batch-json-{id}.db;Mode=Memory;Cache=Shared""
+                refresh-interval = 1s
+            }}
+            akka.test.single-expect-default = 10s")
+            .WithFallback(SqlReadJournal.DefaultConfiguration());
+
+        public JsonBatchingSqliteEventsByTagSpec(ITestOutputHelper output) : base(Config(Counter.GetAndIncrement()), output)
+        {
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/Json/JsonBatchingSqliteEventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/Json/JsonBatchingSqliteEventsByTagSpec.cs
@@ -7,7 +7,7 @@
 
 using Akka.Configuration;
 using Akka.Persistence.Query.Sql;
-using Akka.Persistence.Sql.TestKit;
+using Akka.Persistence.TCK.Query;
 using Akka.Util.Internal;
 using Xunit.Abstractions;
 
@@ -38,7 +38,7 @@ namespace Akka.Persistence.Sqlite.Tests.Batching.Json
             akka.test.single-expect-default = 10s")
             .WithFallback(SqlReadJournal.DefaultConfiguration());
 
-        public JsonBatchingSqliteEventsByTagSpec(ITestOutputHelper output) : base(Config(Counter.GetAndIncrement()), output)
+        public JsonBatchingSqliteEventsByTagSpec(ITestOutputHelper output) : base(Config(Counter.GetAndIncrement()), output: output)
         {
         }
     }

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/Json/JsonBatchingSqliteJournalSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/Json/JsonBatchingSqliteJournalSpec.cs
@@ -6,7 +6,7 @@
 //-----------------------------------------------------------------------
 
 using Akka.Configuration;
-using Akka.Persistence.TestKit.Journal;
+using Akka.Persistence.TCK.Journal;
 using Akka.Util.Internal;
 using Xunit.Abstractions;
 

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/Json/JsonBatchingSqliteJournalSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/Json/JsonBatchingSqliteJournalSpec.cs
@@ -1,23 +1,23 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="BatchingSqliteJournalSpec.cs" company="Akka.NET Project">
-//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+// <copyright file="JsonBatchingSqliteJournalSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>
 //-----------------------------------------------------------------------
 
 using Akka.Configuration;
-using Akka.Persistence.TCK.Journal;
+using Akka.Persistence.TestKit.Journal;
 using Akka.Util.Internal;
 using Xunit.Abstractions;
 
-namespace Akka.Persistence.Sqlite.Tests.Batching
+namespace Akka.Persistence.Sqlite.Tests.Batching.Json
 {
-    public class BatchingSqliteJournalSpec : JournalSpec
+    public class JsonBatchingSqliteJournalSpec : JournalSpec
     {
-        private static AtomicCounter counter = new AtomicCounter(0);
+        private static AtomicCounter counter = new AtomicCounter(300);
 
-        public BatchingSqliteJournalSpec(ITestOutputHelper output)
-            : base(CreateSpecConfig($"Datasource=memdb-journal-batch-{counter.IncrementAndGet()}.db;Mode=Memory;Cache=Shared"), "BatchingSqliteJournalSpec", output)
+        public JsonBatchingSqliteJournalSpec(ITestOutputHelper output)
+            : base(CreateSpecConfig($"Datasource=memdb-journal-batch-json-{counter.IncrementAndGet()}.db;Mode=Memory;Cache=Shared"), "JsonBatchingSqliteJournalSpec", output)
         {
             SqlitePersistence.Get(Sys);
 
@@ -37,7 +37,7 @@ namespace Akka.Persistence.Sqlite.Tests.Batching
                             table-name = event_journal
                             metadata-table-name = journal_metadata
                             auto-initialize = on
-                            store-as = binary
+                            stored-as = json
                             connection-string = """ + connectionString + @"""
                         }
                     }

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/BatchingSqliteJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/BatchingSqliteJournal.cs
@@ -51,12 +51,13 @@ namespace Akka.Persistence.Sqlite.Journal
         /// <param name="autoInitialize">TBD</param>
         /// <param name="connectionTimeout">TBD</param>
         /// <param name="isolationLevel">TBD</param>
+        /// <param name="storedAs"></param>
         /// <param name="circuitBreakerSettings">TBD</param>
         /// <param name="replayFilterSettings">TBD</param>
         /// <param name="namingConventions">TBD</param>
         public BatchingSqliteJournalSetup(string connectionString, int maxConcurrentOperations, int maxBatchSize, int maxBufferSize, bool autoInitialize, 
-            TimeSpan connectionTimeout, IsolationLevel isolationLevel, CircuitBreakerSettings circuitBreakerSettings, ReplayFilterSettings replayFilterSettings, QueryConfiguration namingConventions) 
-            : base(connectionString, maxConcurrentOperations, maxBatchSize, maxBufferSize, autoInitialize, connectionTimeout, isolationLevel, circuitBreakerSettings, replayFilterSettings, namingConventions)
+            TimeSpan connectionTimeout, IsolationLevel isolationLevel, StoredAs storedAs, CircuitBreakerSettings circuitBreakerSettings, ReplayFilterSettings replayFilterSettings, QueryConfiguration namingConventions) 
+            : base(connectionString, maxConcurrentOperations, maxBatchSize, maxBufferSize, autoInitialize, connectionTimeout, isolationLevel, storedAs, circuitBreakerSettings, replayFilterSettings, namingConventions)
         {
         }
     }
@@ -83,6 +84,7 @@ namespace Akka.Persistence.Sqlite.Journal
         public BatchingSqliteJournal(BatchingSqliteJournalSetup setup) : base(setup)
         {
             var conventions = Setup.NamingConventions;
+            var payloadDataType = setup.StoredAs == StoredAs.Binary ? "BLOB" : "NVARCHAR(2000)";
             Initializers = ImmutableDictionary.CreateRange(new[]
             {
                 new KeyValuePair<string, string>("CreateJournalSql", $@"
@@ -93,7 +95,7 @@ namespace Akka.Persistence.Sqlite.Journal
                     {conventions.IsDeletedColumnName} INTEGER(1) NOT NULL,
                     {conventions.ManifestColumnName} VARCHAR(255) NULL,
                     {conventions.TimestampColumnName} INTEGER NOT NULL,
-                    {conventions.PayloadColumnName} BLOB NOT NULL,
+                    {conventions.PayloadColumnName} {payloadDataType} NOT NULL,
                     {conventions.TagsColumnName} VARCHAR(2000) NULL,
                     UNIQUE ({conventions.PersistenceIdColumnName}, {conventions.SequenceNrColumnName})
                 );"),

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -5,6 +5,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.MultiNodeTestRunner.Shared.Tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Persistence")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Persistence.Sql.Common")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote.Tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote.Tests.MultiNode")]

--- a/src/core/Akka/Properties/AssemblyInfo.cs
+++ b/src/core/Akka/Properties/AssemblyInfo.cs
@@ -36,4 +36,5 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("Akka.Cluster.TestKit")]
 [assembly: InternalsVisibleTo("Akka.Cluster.Tools")]
 [assembly: InternalsVisibleTo("Akka.Persistence")]
+[assembly: InternalsVisibleTo("Akka.Persistence.Sql.Common")]
 [assembly: InternalsVisibleTo("Akka.Streams")]


### PR DESCRIPTION
**DO NOT MERGE: work in progress**

This PR aims to bring two major features:

1. A common approach to support JSON data type columns for SQL-based journals.
2. Ability for SQL read journals to query current / live events - not only some of them (like in case of tags), but actually all of them.