### PR TITLE
Cleaning up racy specs part1

### DIFF
--- a/src/core/Akka.Cluster.Tests/ActorRefProvidersConfigSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ActorRefProvidersConfigSpec.cs
@@ -40,11 +40,13 @@ namespace Akka.Cluster.Tests
 
         private void ConfigureAndVerify(string alias, Type actorProviderType)
         {
-            var config = ConfigurationFactory.ParseString(@"akka.actor.provider = " + alias);
+            var config = ConfigurationFactory.ParseString(@"akka.actor.provider = " + alias)
+                .WithFallback(ConfigurationFactory.ParseString("akka.remote.dot-netty.tcp.port = 0")); // use a random port to avoid issues with async and parallelization
             using (var system = ActorSystem.Create(nameof(ActorRefProvidersConfigSpec), config))
             {
                 var ext = (ExtendedActorSystem) system;
                 ext.Provider.GetType().ShouldBe(actorProviderType);
+                system.Terminate().Wait(TimeSpan.FromSeconds(3)); // force the system to cleanup and shutdown
             }
         }
     }

--- a/src/core/Akka.Cluster.Tests/ClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterSpec.cs
@@ -20,6 +20,12 @@ namespace Akka.Cluster.Tests
 {
     public class ClusterSpec : AkkaSpec
     {
+
+        /*
+         * Portability note: all of the _cluster.Join(selfAddress) calls are necessary here, whereas they are not in the JVM
+         * because the JVM test suite relies on side-effects from one test to another, whereas all of our tests are fully isolated.
+         */
+
         const string Config = @"    
             akka.cluster {
               auto-down-unreachable-after = 0s
@@ -46,7 +52,7 @@ namespace Akka.Cluster.Tests
             _cluster = Cluster.Get(Sys);
         }
 
-        public void LeaderActions()
+        internal void LeaderActions()
         {
             _cluster.ClusterCore.Tell(InternalClusterAction.LeaderActionsTick.Instance);
         }
@@ -89,7 +95,6 @@ namespace Akka.Cluster.Tests
         {
             try
             {
-                // TODO: this should be removed
                 _cluster.Join(_selfAddress);
                 LeaderActions(); // Joining -> Up
 
@@ -113,7 +118,6 @@ namespace Akka.Cluster.Tests
         [Fact]
         public void A_cluster_must_publish_member_removed_when_shutdown()
         {
-            // TODO: this should be removed
             _cluster.Join(_selfAddress);
             LeaderActions(); // Joining -> Up
 
@@ -139,7 +143,6 @@ namespace Akka.Cluster.Tests
         [Fact]
         public void BugFix_2442_RegisterOnMemberUp_should_fire_if_node_already_up()
         {
-            // TODO: this should be removed
             _cluster.Join(_selfAddress);
             LeaderActions(); // Joining -> Up
 
@@ -182,15 +185,16 @@ namespace Akka.Cluster.Tests
 
             AwaitCondition(() => leaveTask.IsCompleted);
 
-            // A second call for LeaveAsync should complete immediately
+            // A second call for LeaveAsync should complete immediately (should be the same task as before)
             Cluster.Get(sys2).LeaveAsync().IsCompleted.Should().BeTrue();
         }
 
-#if CORECLR
-        [Fact(Skip = "Fails on .NET Core")]
-#else
-        [Fact(Skip = "Fails flakily on .NET 4.5")]
-#endif
+//#if CORECLR
+//        [Fact(Skip = "Fails on .NET Core")]
+//#else
+//        [Fact(Skip = "Fails flakily on .NET 4.5")]
+//#endif
+        [Fact]
         public void A_cluster_must_return_completed_LeaveAsync_task_if_member_already_removed()
         {
             // Join cluster
@@ -214,7 +218,7 @@ namespace Akka.Cluster.Tests
             });
 
             // LeaveAsync() task expected to complete immediately
-            _cluster.LeaveAsync().IsCompleted.Should().BeTrue();
+            AwaitCondition(() => _cluster.LeaveAsync().IsCompleted);
         }
 
         [Fact]
@@ -237,7 +241,7 @@ namespace Akka.Cluster.Tests
 
             // Cancelling the first task
             cts.Cancel();
-            task1.Should(t => t.IsCanceled, "Task should be cancelled.");
+            AwaitCondition(() => task1.IsCanceled, null, "Task should be cancelled");
 
             Within(TimeSpan.FromSeconds(10), () =>
             {
@@ -257,7 +261,7 @@ namespace Akka.Cluster.Tests
 
             // Subsequent LeaveAsync() tasks expected to complete immediately (not cancelled)
             var task3 = _cluster.LeaveAsync();
-            task3.Should(t => t.IsCompleted && !t.IsCanceled, "Task should be completed, but not cancelled.");
+            AwaitCondition(() => task3.IsCompleted && !task3.IsCanceled, null, "Task should be completed, but not cancelled.");
         }
 
         [Fact]

--- a/src/core/Akka.Cluster.Tests/ClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterSpec.cs
@@ -256,7 +256,7 @@ namespace Akka.Cluster.Tests
                 ExpectMsg<ClusterEvent.MemberRemoved>().Member.Address.Should().Be(_selfAddress);
 
                 // Second task should complete (not cancelled)
-                task2.Should(t => t.IsCompleted && !t.IsCanceled, "Task should be completed, but not cancelled.");
+                AwaitCondition(() => task2.IsCompleted && !task2.IsCanceled, null, "Task should be completed, but not cancelled.");
             });
 
             // Subsequent LeaveAsync() tasks expected to complete immediately (not cancelled)

--- a/src/core/Akka.Cluster.Tests/DowningProviderSpec.cs
+++ b/src/core/Akka.Cluster.Tests/DowningProviderSpec.cs
@@ -59,7 +59,7 @@ namespace Akka.Cluster.Tests
             loglevel = WARNING
             actor.provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""
             remote {
-              netty.tcp {
+              dot-netty.tcp {
                 hostname = ""127.0.0.1""
                 port = 0
               }
@@ -95,7 +95,7 @@ namespace Akka.Cluster.Tests
             {
                 var downingProvider = Cluster.Get(system).DowningProvider;
                 downingProvider.Should().BeOfType<DummyDowningProvider>();
-                AwaitCondition(() => 
+                AwaitCondition(() =>
                     (downingProvider as DummyDowningProvider).ActorPropsAccessed.Value,
                     TimeSpan.FromSeconds(3));
             }
@@ -106,13 +106,15 @@ namespace Akka.Cluster.Tests
         {
             var config = ConfigurationFactory.ParseString(
                 @"akka.cluster.downing-provider-class = ""Akka.Cluster.Tests.FailingDowningProvider, Akka.Cluster.Tests""");
-            using (var system = ActorSystem.Create("auto-downing", config.WithFallback(BaseConfig)))
-            {
-                var cluster = Cluster.Get(system);
-                cluster.Join(cluster.SelfAddress);
 
-                AwaitCondition(() => cluster.IsTerminated, TimeSpan.FromSeconds(3));
-            }
+            var system = ActorSystem.Create("auto-downing", config.WithFallback(BaseConfig));
+
+            var cluster = Cluster.Get(system);
+            cluster.Join(cluster.SelfAddress);
+
+            AwaitCondition(() => cluster.IsTerminated, TimeSpan.FromSeconds(3));
+
+            Shutdown(system);
         }
     }
 }

--- a/src/core/Akka.Tests/Routing/TailChoppingSpec.cs
+++ b/src/core/Akka.Tests/Routing/TailChoppingSpec.cs
@@ -127,8 +127,8 @@ namespace Akka.Tests.Routing
         [Fact]
         public void Tail_chopping_group_router_must_throw_exception_if_no_result_will_arrive_within_the_given_time()
         {
-            var actor1 = Sys.ActorOf(Props.Create(() => new TailChopTestActor(500.Milliseconds())), "Actor3");
-            var actor2 = Sys.ActorOf(Props.Create(() => new TailChopTestActor(500.Milliseconds())), "Actor4");
+            var actor1 = Sys.ActorOf(Props.Create(() => new TailChopTestActor(1500.Milliseconds())), "Actor3");
+            var actor2 = Sys.ActorOf(Props.Create(() => new TailChopTestActor(1500.Milliseconds())), "Actor4");
 
             var probe = CreateTestProbe();
             var paths = new List<string> { actor1.Path.ToString(), actor2.Path.ToString() };

--- a/src/core/Akka/Actor/ActorSystem.cs
+++ b/src/core/Akka/Actor/ActorSystem.cs
@@ -258,7 +258,7 @@ namespace Akka.Actor
             }
             finally
             {
-                // base.dispose(disposing);
+                
             }
         }
 


### PR DESCRIPTION
I've looked through some of these and the reasons for the raciness in most of these specs are due to issues where sockets aren't being cleaned up quickly enough or the timeouts are too narrowly defined. There might be some legitimate bugs with the specs here too, so I'm going to go through each one and submit some patches for each in the name of making our build process run more smoothly.

Current list:

* [x] Akka.Cluster.Tests.ActorProviderConfig_should_resolve_remote_alias
* [x] Akka.Cluster.Tests.ActorProviderConfig_should_resolve_cluster_alias
* [x] Akka.Cluster.Tests.ClusterSpec.A_cluster_must_cancel_LeaveAsync_task_if_CancellationToken_fired_before_node_left
* [x] Akka.Cluster.Tests.DowningProviderSpec.Downing_provider_should_stop_the_cluster_if_the_downing_provider_throws_exception_in_props
* [x] Akka.Cluster.Tests.ClusterSpec.A_cluster_must_return_completed_LeaveAsync_task_if_member_already_removed
* [x] Akka.Tests.Routing.TailChoppingSpec.Tail_chopping_group_router_must_throw_exception_if_no_result_will_arrive_within_the_given_time

The common thread with most of these issues is that they use the real socket system underneath Akka.Remote, so I suspect it's a problem with how that's being used / not giving it enough time.

I'm also going to see if these failures might be related to https://github.com/akkadotnet/akka.net/issues/2575 - which I was planning on fixing anyway. Stay tuned.