### PR TITLE
Obsoleted TypedActor

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -1686,6 +1686,7 @@ namespace Akka.Actor
         public TerminatedProps() { }
         public override Akka.Actor.ActorBase NewActor() { }
     }
+    [System.ObsoleteAttribute("TypedActor in its current shape will be removed in v1.5")]
     public abstract class TypedActor : Akka.Actor.ActorBase
     {
         protected TypedActor() { }

--- a/src/core/Akka.TestKit/Internal/Reference.conf
+++ b/src/core/Akka.TestKit/Internal/Reference.conf
@@ -10,7 +10,7 @@ akka {
 	# to use EventFiltering. If no filter is specified it logs to StdOut just like
 	# DefaultLogger.
   loggers = ["Akka.TestKit.TestEventListener, Akka.TestKit"]
-
+  suppress-json-serializer-warning = true
   test {
     # factor by which to scale timeouts during tests, e.g. to account for shared
     # build system load

--- a/src/core/Akka/Actor/TypedActor.cs
+++ b/src/core/Akka/Actor/TypedActor.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Reflection;
 
 namespace Akka.Actor
@@ -25,6 +26,7 @@ namespace Akka.Actor
     /// <summary>
     ///     Class TypedActor.
     /// </summary>
+    [Obsolete("TypedActor in its current shape will be removed in v1.5")]
     public abstract class TypedActor : ActorBase
     {
         /// <summary>


### PR DESCRIPTION
We already encouraged users away from using `TypedActor` and were talking about removing it from the API but no steps were made. This PR adds obsoletes a `TypedActor` class.

Additional feature - it sets up an `akka.suppress-json-serializer-warning = on` in all tests. I think that having JSON serializer warning is useless in case of tests and only adds an unnecessary noise for test output (as it will be printed at least once per each test).