### PR TITLE
Bringing Remote transports docs up to date. #2670

### DIFF
--- a/docs/articles/remoting/transports.md
+++ b/docs/articles/remoting/transports.md
@@ -38,7 +38,7 @@ Out of the box Akka.NET uses a socket-based transport built on top of the [DotNe
 > [!NOTE]
 > DotNetty supports both TCP and UDP, but currently only TCP support is included within Akka.NET. TCP is what most Akka.Remote and Akka.Cluster users use.
 
-To enable the DotNetty TCP transport, we need to add a section for it inside our `remote` section in [HOCON configuration](/articles/concepts/configuration.md):
+To enable the DotNetty TCP transport, we need to add a section for it inside our `remote` section in [HOCON configuration](xref:configuration):
 
 ```xml
 akka {  


### PR DESCRIPTION
Updated the docs to illustrate the use of dot-netty instead of helios. I updated alot of links as well. Made them relative where i can, so the should point to the right document. But i can't be sure untill the site is updated.
Furthermore there is a section in there about how to configure multiple transports. That uses the TCP and UDP transport as an example. However how its written now suggest we actually have an UDP transport available for use. 
As far as i know, this isn't true. But i could be missing something. @Aaronontheweb  ?

Eitherway i'd like to change that part abit, to avoid confusion.
