### PR TITLE
Serialization reload on settings change

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -1811,7 +1811,7 @@ namespace Akka.Actor.Internal
         public void UnstashAll() { }
         public void UnstashAll(System.Func<Akka.Actor.Envelope, bool> predicate) { }
     }
-    public class ActorSystemImpl : Akka.Actor.ExtendedActorSystem
+    public class ActorSystemImpl : Akka.Actor.ExtendedActorSystem, Akka.Actor.Internal.ISupportSerializationConfigReload
     {
         public ActorSystemImpl(string name) { }
         public ActorSystemImpl(string name, Akka.Configuration.Config config) { }

--- a/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
@@ -22,11 +22,16 @@ using Akka.Util;
 
 namespace Akka.Actor.Internal
 {
+    internal interface ISupportSerializationConfigReload
+    {
+        void ReloadSerialization();
+    }
+
     /// <summary>
     /// TBD
     /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
     /// </summary>
-    public class ActorSystemImpl : ExtendedActorSystem
+    public class ActorSystemImpl : ExtendedActorSystem, ISupportSerializationConfigReload
     {
         private IActorRef _logDeadLetterListener;
         private readonly ConcurrentDictionary<Type, Lazy<object>> _extensions = new ConcurrentDictionary<Type, Lazy<object>>();
@@ -398,6 +403,11 @@ namespace Akka.Actor.Internal
         private void ConfigureSerialization()
         {
             _serialization = new Serialization.Serialization(this);
+        }
+
+        void ISupportSerializationConfigReload.ReloadSerialization() {
+            if(_serialization != null)
+                ConfigureSerialization();
         }
 
         private void ConfigureMailboxes()

--- a/src/core/Akka/Actor/Settings.cs
+++ b/src/core/Akka/Actor/Settings.cs
@@ -32,6 +32,8 @@ namespace Akka.Actor
             //if we get a new config definition loaded after all ActorRefProviders have been started, such as Akka.Persistence...
             if(System != null && System.Dispatchers != null)
                 System.Dispatchers.ReloadPrerequisites(new DefaultDispatcherPrerequisites(System.EventStream, System.Scheduler, this, System.Mailboxes));
+            if (System is Internal.ISupportSerializationConfigReload rs)
+                rs.ReloadSerialization();
         }
 
         /// <summary>


### PR DESCRIPTION
Serializers configurations from extension default config are not correctly loaded.
At the time extension tries to inject it's default config with InjectTopLevelFallback, serializer configuration was already loaded and it's not reloaded afterwards. Currently only workaround I know about is providing all fallback configurations when creating ActorSystem itself. This pr tries to improve this.