### PR TITLE
[WIP] Bugfix SnapshotFailureRobustnessSpec on .NET Core

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -74,22 +74,26 @@ Target "RunTests" (fun _ ->
     let projects =
         match isWindows with
         // Windows
-        | true -> !! "./**/core/**/*.Tests.csproj"
-                  ++ "./**/contrib/**/*.Tests.csproj"
-                  -- "./**/Akka.Streams.Tests.csproj"
-                  -- "./**/Akka.Remote.TestKit.Tests.csproj"
-                  -- "./**/Akka.MultiNodeTestRunner.Shared.Tests.csproj"
-                  -- "./**/serializers/**/*Wire*.csproj"
-                  -- "./**/Akka.Persistence.Tests.csproj"                 
+        //| true -> !! "./**/core/**/*.Tests.csproj"
+        //          ++ "./**/contrib/**/*.Tests.csproj"
+        //          -- "./**/Akka.Streams.Tests.csproj"
+        //          -- "./**/Akka.Remote.TestKit.Tests.csproj"
+        //          -- "./**/Akka.MultiNodeTestRunner.Shared.Tests.csproj"
+        //          -- "./**/serializers/**/*Wire*.csproj"
+        //          -- "./**/Akka.Persistence.Tests.csproj"                 
+        | true -> !! "./**/Akka.Persistence.Tests.csproj"
+        //// Linux/Mono
+        //| _ -> !! "./**/core/**/*.Tests.csproj"
+        //          ++ "./**/contrib/**/*.Tests.csproj"
+        //          -- "./**/serializers/**/*Wire*.csproj"
+        //          -- "./**/Akka.Streams.Tests.csproj"
+        //          -- "./**/Akka.Remote.TestKit.Tests.csproj"
+        //          -- "./**/Akka.MultiNodeTestRunner.Shared.Tests.csproj"      
+        //          -- "./**/Akka.Persistence.Tests.csproj"
+        //          -- "./**/Akka.API.Tests.csproj"
+         
         // Linux/Mono
-        | _ -> !! "./**/core/**/*.Tests.csproj"
-                  ++ "./**/contrib/**/*.Tests.csproj"
-                  -- "./**/serializers/**/*Wire*.csproj"
-                  -- "./**/Akka.Streams.Tests.csproj"
-                  -- "./**/Akka.Remote.TestKit.Tests.csproj"
-                  -- "./**/Akka.MultiNodeTestRunner.Shared.Tests.csproj"      
-                  -- "./**/Akka.Persistence.Tests.csproj"
-                  -- "./**/Akka.API.Tests.csproj"
+        | _ -> !! "./**/Akka.Persistence.Tests.csproj"
 
     let runSingleProject project =
         DotNetCli.RunCommand
@@ -97,7 +101,7 @@ Target "RunTests" (fun _ ->
                 { p with 
                     WorkingDir = (Directory.GetParent project).FullName
                     TimeOut = TimeSpan.FromMinutes 30. })
-                (sprintf "xunit -parallel none -teamcity -xml %s_xunit.xml" (outputTests @@ fileNameWithoutExt project)) 
+                (sprintf "xunit -parallel none -class Akka.Persistence.Tests.SnapshotFailureRobustnessSpec -xml %s_xunit.xml" (outputTests @@ fileNameWithoutExt project)) 
 
     CreateDir outputTests
     projects |> Seq.iter (runSingleProject)

--- a/build.fsx
+++ b/build.fsx
@@ -101,7 +101,7 @@ Target "RunTests" (fun _ ->
                 { p with 
                     WorkingDir = (Directory.GetParent project).FullName
                     TimeOut = TimeSpan.FromMinutes 30. })
-                (sprintf "xunit -parallel none -class Akka.Persistence.Tests.SnapshotFailureRobustnessSpec -xml %s_xunit.xml" (outputTests @@ fileNameWithoutExt project)) 
+                (sprintf "xunit -parallel none -class Akka.Persistence.Tests.SnapshotFailureRobustnessSpec -teamcity -xml %s_xunit.xml" (outputTests @@ fileNameWithoutExt project)) 
 
     CreateDir outputTests
     projects |> Seq.iter (runSingleProject)

--- a/src/core/Akka.Tests.Performance/Akka.Tests.Performance.csproj
+++ b/src/core/Akka.Tests.Performance/Akka.Tests.Performance.csproj
@@ -14,7 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="NBench" Version="1.0.1" />
-    <PackageReference Include="NBench.Runner" Version="1.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/src/core/Akka.Tests.Performance/Akka.Tests.Performance.csproj
+++ b/src/core/Akka.Tests.Performance/Akka.Tests.Performance.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="NBench" Version="1.0.1" />
+    <PackageReference Include="NBench.Runner" Version="1.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">


### PR DESCRIPTION
2 tests fail when running the following tests on Linux/.NET Core:

```
Akka.Persistence.Tests.SnapshotFailureRobustnessSpec.PersistentActor_with_a_failing_snapshot_should_recover_state_starting_from_the_most_recent_complete_snapshot [FAIL]
      Failed: Expected a message of type System.Int64, but received {SaveSnapshotFailure<meta: SnapshotMetadata<pid: AkkaSpec-0, seqNr: 2, timestamp: 0001/01/01>, cause: System.IO.IOException: The file '/etc/akka.net/src/core/Akka.Persistence.Tests/bin/Debug/netcoreapp1.1/target/snapshots-SnapshotFailureRobustnessSpec/snapshot-AkkaSpec-0-2-636324624892276020.tmp' already exists.
         at System.IO.UnixFileSystem.MoveFile(String sourceFullPath, String destFullPath)
         at System.IO.FileInfo.MoveTo(String destFileName)
         at Akka.Persistence.Tests.SnapshotFailureRobustnessSpec.FailingLocalSnapshotStore.Save(SnapshotMetadata metadata, Object payload) in /etc/akka.net/src/core/Akka.Persistence.Tests/SnapshotFailureRobustnessSpec.cs:line 167
         at Akka.Persistence.Snapshot.LocalSnapshotStore.<>c__DisplayClass9_0.<SaveAsync>b__0() in /etc/akka.net/src/core/Akka.Persistence/Snapshot/LocalSnapshotStore.cs:line 82
         at Akka.Persistence.Snapshot.LocalSnapshotStore.<>c__DisplayClass27_0`1.<RunWithStreamDispatcher>b__0() in /etc/akka.net/src/core/Akka.Persistence/Snapshot/LocalSnapshotStore.cs:line 372
      --- End of stack trace from previous location where exception was thrown ---
         at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
         at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
         at System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter.GetResult()
         at Akka.Util.Internal.AtomicState.<CallThrough>d__8.MoveNext() in /etc/akka.net/src/core/Akka/Util/Internal/AtomicState.cs:line 131
      --- End of stack trace from previous location where exception was thrown ---
         at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
         at Akka.Util.Internal.AtomicState.<CallThrough>d__8.MoveNext() in /etc/akka.net/src/core/Akka/Util/Internal/AtomicState.cs:line 142>} (type Akka.Persistence.SaveSnapshotFailure) instead  from [akka://AkkaSpec/user/$a#2012751837]
      Expected: True
      Actual:   False
      Stack Trace:
        /etc/akka.net/src/contrib/testkits/Akka.TestKit.Xunit2/XunitAssertions.cs(26,0): at Akka.TestKit.Xunit2.XunitAssertions.Fail(String format, Object[] args)
        /etc/akka.net/src/core/Akka.TestKit/TestKitBase_Expect.cs(247,0): at Akka.TestKit.TestKitBase.InternalExpectMsgEnvelope[T](Nullable`1 timeout, Action`2 assert, String hint, Boolean shouldLog)
        /etc/akka.net/src/core/Akka.TestKit/TestKitBase_Expect.cs(224,0): at Akka.TestKit.TestKitBase.InternalExpectMsgEnvelope[T](Nullable`1 timeout, Action`1 msgAssert, Action`1 senderAssert, String hint)
        /etc/akka.net/src/core/Akka.TestKit/TestKitBase_Expect.cs(199,0): at Akka.TestKit.TestKitBase.InternalExpectMsg[T](Nullable`1 timeout, Action`1 msgAssert, String hint)
        /etc/akka.net/src/core/Akka.TestKit/TestKitBase_Expect.cs(54,0): at Akka.TestKit.TestKitBase.ExpectMsg[T](T message, Nullable`1 timeout, String hint)
        /etc/akka.net/src/core/Akka.Persistence.Tests/SnapshotFailureRobustnessSpec.cs(211,0): at Akka.Persistence.Tests.SnapshotFailureRobustnessSpec.PersistentActor_with_a_failing_snapshot_should_recover_state_starting_from_the_most_recent_complete_snapshot()
    Akka.Persistence.Tests.SnapshotFailureRobustnessSpec.PersistentActor_with_a_failing_snapshot_should_fail_recovery_and_stop_actor_when_no_snapshot_could_be_loaded [FAIL]
      Failed: Expected a message of type System.Int64, but received {SaveSnapshotFailure<meta: SnapshotMetadata<pid: AkkaSpec-0, seqNr: 2, timestamp: 0001/01/01>, cause: System.IO.IOException: The file '/etc/akka.net/src/core/Akka.Persistence.Tests/bin/Debug/netcoreapp1.1/target/snapshots-SnapshotFailureRobustnessSpec/snapshot-AkkaSpec-0-2-636324624897889060.tmp' already exists.
         at System.IO.UnixFileSystem.MoveFile(String sourceFullPath, String destFullPath)
         at System.IO.FileInfo.MoveTo(String destFileName)
         at Akka.Persistence.Tests.SnapshotFailureRobustnessSpec.FailingLocalSnapshotStore.Save(SnapshotMetadata metadata, Object payload) in /etc/akka.net/src/core/Akka.Persistence.Tests/SnapshotFailureRobustnessSpec.cs:line 167
         at Akka.Persistence.Snapshot.LocalSnapshotStore.<>c__DisplayClass9_0.<SaveAsync>b__0() in /etc/akka.net/src/core/Akka.Persistence/Snapshot/LocalSnapshotStore.cs:line 82
         at Akka.Persistence.Snapshot.LocalSnapshotStore.<>c__DisplayClass27_0`1.<RunWithStreamDispatcher>b__0() in /etc/akka.net/src/core/Akka.Persistence/Snapshot/LocalSnapshotStore.cs:line 372
      --- End of stack trace from previous location where exception was thrown ---
         at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
         at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
         at System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter.GetResult()
         at Akka.Util.Internal.AtomicState.<CallThrough>d__8.MoveNext() in /etc/akka.net/src/core/Akka/Util/Internal/AtomicState.cs:line 131
      --- End of stack trace from previous location where exception was thrown ---
         at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
         at Akka.Util.Internal.AtomicState.<CallThrough>d__8.MoveNext() in /etc/akka.net/src/core/Akka/Util/Internal/AtomicState.cs:line 142>} (type Akka.Persistence.SaveSnapshotFailure) instead  from [akka://AkkaSpec/user/$a#11829999]
      Expected: True
      Actual:   False
      Stack Trace:
        /etc/akka.net/src/contrib/testkits/Akka.TestKit.Xunit2/XunitAssertions.cs(26,0): at Akka.TestKit.Xunit2.XunitAssertions.Fail(String format, Object[] args)
        /etc/akka.net/src/core/Akka.TestKit/TestKitBase_Expect.cs(247,0): at Akka.TestKit.TestKitBase.InternalExpectMsgEnvelope[T](Nullable`1 timeout, Action`2 assert, String hint, Boolean shouldLog)
        /etc/akka.net/src/core/Akka.TestKit/TestKitBase_Expect.cs(224,0): at Akka.TestKit.TestKitBase.InternalExpectMsgEnvelope[T](Nullable`1 timeout, Action`1 msgAssert, Action`1 senderAssert, String hint)
        /etc/akka.net/src/core/Akka.TestKit/TestKitBase_Expect.cs(199,0): at Akka.TestKit.TestKitBase.InternalExpectMsg[T](Nullable`1 timeout, Action`1 msgAssert, String hint)
        /etc/akka.net/src/core/Akka.TestKit/TestKitBase_Expect.cs(54,0): at Akka.TestKit.TestKitBase.ExpectMsg[T](T message, Nullable`1 timeout, String hint)
        /etc/akka.net/src/core/Akka.Persistence.Tests/SnapshotFailureRobustnessSpec.cs(241,0): at Akka.Persistence.Tests.SnapshotFailureRobustnessSpec.PersistentActor_with_a_failing_snapshot_should_fail_recovery_and_stop_actor_when_no_snapshot_could_be_loa...
```

Putting up a [WIP] PR with this test isolated to get a better picture of the issue from CI's view