### PR TITLE
Sharding updated to v2.5.2

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/Akka.Cluster.Sharding.Tests.MultiNode.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/Akka.Cluster.Sharding.Tests.MultiNode.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\serializers\Akka.Serialization.Hyperion\Akka.Serialization.Hyperion.csproj" />
     <ProjectReference Include="..\Akka.Cluster.Sharding\Akka.Cluster.Sharding.csproj" />
     <ProjectReference Include="..\..\..\core\Akka.Cluster.TestKit\Akka.Cluster.TestKit.csproj" />
     <ProjectReference Include="..\..\..\core\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj" />

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/AsyncWriteProxy.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/AsyncWriteProxy.cs
@@ -1,0 +1,462 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AsyncWriteProxy.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Akka.Actor;
+using System.Runtime.Serialization;
+using Akka.Event;
+using Akka.Persistence.Journal;
+using Akka.Persistence;
+using System.Threading;
+using Akka.Util.Internal;
+using Akka.Actor.Internal;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    /// <summary>
+    /// This exception is thrown when the replay inactivity exceeds a specified timeout.
+    /// </summary>
+    [Serializable]
+    public class AsyncReplayTimeoutException : AkkaException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncReplayTimeoutException"/> class.
+        /// </summary>
+        public AsyncReplayTimeoutException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncReplayTimeoutException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public AsyncReplayTimeoutException(string message)
+            : base(message)
+        {
+        }
+
+#if SERIALIZATION
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncReplayTimeoutException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        protected AsyncReplayTimeoutException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+#endif
+    }
+
+    /// <summary>
+    /// TBD
+    /// </summary>
+    [Serializable]
+    public sealed class SetStore
+    {
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="store">TBD</param>
+        /// <exception cref="ArgumentNullException">
+        /// This exception is thrown when the specified <paramref name="store"/> is undefined.
+        /// </exception>
+        public SetStore(IActorRef store)
+        {
+            if (store == null)
+                throw new ArgumentNullException(nameof(store), "SetStore requires non-null reference to store actor");
+
+            Store = store;
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public readonly IActorRef Store;
+    }
+
+    /// <summary>
+    /// A journal that delegates actual storage to a target actor. For testing only.
+    /// </summary>
+    public abstract class AsyncWriteProxy : AsyncWriteJournal, IWithUnboundedStash
+    {
+        private bool _isInitialized;
+        private bool _isInitTimedOut;
+        private IActorRef _store;
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        protected AsyncWriteProxy()
+        {
+            _isInitialized = false;
+            _isInitTimedOut = false;
+            _store = null;
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public abstract TimeSpan Timeout { get; }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public override void AroundPreStart()
+        {
+            Context.System.Scheduler.ScheduleTellOnce(Timeout, Self, InitTimeout.Instance, Self);
+            base.AroundPreStart();
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="receive">TBD</param>
+        /// <param name="message">TBD</param>
+        /// <returns>TBD</returns>
+        protected override bool AroundReceive(Receive receive, object message)
+        {
+            if (_isInitialized)
+            {
+                if (!(message is InitTimeout))
+                    return base.AroundReceive(receive, message);
+            }
+            else if (message is SetStore)
+            {
+                _store = ((SetStore)message).Store;
+                Stash.UnstashAll();
+                _isInitialized = true;
+            }
+            else if (message is InitTimeout)
+            {
+                _isInitTimedOut = true;
+                Stash.UnstashAll(); // will trigger appropriate failures
+            }
+            else if (_isInitTimedOut)
+            {
+                return base.AroundReceive(receive, message);
+            }
+            else Stash.Stash();
+            return true;
+        }
+
+
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="messages">TBD</param>
+        /// <exception cref="TimeoutException">
+        /// This exception is thrown when the store has not been initialized.
+        /// </exception>
+        /// <returns>TBD</returns>
+        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
+        {
+            if (_store == null)
+                return StoreNotInitialized<IImmutableList<Exception>>();
+
+            return _store.AskEx<object>(sender => new WriteMessages(messages, sender, 1), Timeout)
+                .ContinueWith(r =>
+                {
+                    if (r.IsCanceled)
+                        return (IImmutableList<Exception>)messages.Select(i => (Exception)new TimeoutException()).ToImmutableList();
+                    if (r.IsFaulted)
+                        return messages.Select(i => (Exception)r.Exception).ToImmutableList();
+
+                    if (r.Result is WriteMessageSuccess wms)
+                    {
+                        return messages.Select(i => (Exception)null).ToImmutableList();
+                    }
+                    if (r.Result is WriteMessageFailure wmf)
+                    {
+                        return messages.Select(i => wmf.Cause).ToImmutableList();
+                    }
+                    return null;
+                }, TaskContinuationOptions.ExecuteSynchronously);
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="persistenceId">TBD</param>
+        /// <param name="toSequenceNr">TBD</param>
+        /// <exception cref="TimeoutException">
+        /// This exception is thrown when the store has not been initialized.
+        /// </exception>
+        /// <returns>TBD</returns>
+        protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr)
+        {
+            if (_store == null)
+                return StoreNotInitialized<object>();
+
+            var result = new TaskCompletionSource<object>();
+
+            _store.AskEx(sender => new DeleteMessagesTo(persistenceId, toSequenceNr, sender), Timeout).ContinueWith(r =>
+            {
+                if (r.IsFaulted)
+                    result.TrySetException(r.Exception);
+                else if (r.IsCanceled)
+                    result.TrySetException(new TimeoutException());
+                else
+                    result.TrySetResult(true);
+            }, TaskContinuationOptions.ExecuteSynchronously);
+
+            return result.Task;
+
+
+            //return _store.AskEx(sender => new DeleteMessagesTo(persistenceId, toSequenceNr, sender), Timeout);
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="context">TBD</param>
+        /// <param name="persistenceId">TBD</param>
+        /// <param name="fromSequenceNr">TBD</param>
+        /// <param name="toSequenceNr">TBD</param>
+        /// <param name="max">TBD</param>
+        /// <param name="recoveryCallback">TBD</param>
+        /// <exception cref="TimeoutException">
+        /// This exception is thrown when the store has not been initialized.
+        /// </exception>
+        /// <returns>TBD</returns>
+        public override Task ReplayMessagesAsync(IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, Action<IPersistentRepresentation> recoveryCallback)
+        {
+            if (_store == null)
+                return StoreNotInitialized<object>();
+
+            var replayCompletionPromise = new TaskCompletionSource<object>();
+            var mediator = context.ActorOf(Props.Create(() => new ReplayMediator(recoveryCallback, replayCompletionPromise, Timeout)).WithDeploy(Deploy.Local));
+
+            _store.Tell(new ReplayMessages(fromSequenceNr, toSequenceNr, max, persistenceId, mediator), mediator);
+
+            return replayCompletionPromise.Task;
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="persistenceId">TBD</param>
+        /// <param name="fromSequenceNr">TBD</param>
+        /// <exception cref="TimeoutException">
+        /// This exception is thrown when the store has not been initialized.
+        /// </exception>
+        /// <returns>TBD</returns>
+        public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
+        {
+            if (_store == null)
+                return StoreNotInitialized<long>();
+
+            return _store.AskEx<object>(sender => new ReplayMessages(0, 0, 0, persistenceId, sender), Timeout)
+                .ContinueWith(t =>
+                {
+                    if (t.IsCanceled || t.IsFaulted)
+                        return 0L;
+
+                    if (t.Result is RecoverySuccess rs)
+                    {
+                        return rs.HighestSequenceNr;
+                    }
+                    return 0L;
+                }/*, TaskContinuationOptions.OnlyOnRanToCompletion*/, TaskContinuationOptions.ExecuteSynchronously);
+        }
+
+        private Task<T> StoreNotInitialized<T>()
+        {
+            var promise = new TaskCompletionSource<T>();
+            promise.SetException(new TimeoutException("Store not intialized."));
+            return promise.Task;
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public IStash Stash { get; set; }
+
+        // sent to self only
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public class InitTimeout
+        {
+            private InitTimeout() { }
+            private static readonly InitTimeout _instance = new InitTimeout();
+
+            /// <summary>
+            /// TBD
+            /// </summary>
+            public static InitTimeout Instance
+            {
+                get
+                {
+                    return _instance;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// TBD
+    /// </summary>
+    internal class ReplayMediator : ActorBase
+    {
+        private readonly Action<IPersistentRepresentation> _replayCallback;
+        private readonly TaskCompletionSource<object> _replayCompletionPromise;
+        private readonly TimeSpan _replayTimeout;
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="replayCallback">TBD</param>
+        /// <param name="replayCompletionPromise">TBD</param>
+        /// <param name="replayTimeout">TBD</param>
+        public ReplayMediator(Action<IPersistentRepresentation> replayCallback, TaskCompletionSource<object> replayCompletionPromise, TimeSpan replayTimeout)
+        {
+            _replayCallback = replayCallback;
+            _replayCompletionPromise = replayCompletionPromise;
+            _replayTimeout = replayTimeout;
+
+            Context.SetReceiveTimeout(replayTimeout);
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="message">TBD</param>
+        /// <exception cref="AsyncReplayTimeoutException">
+        /// This exception is thrown when the replay timed out due to inactivity.
+        /// </exception>
+        /// <returns>TBD</returns>
+        protected override bool Receive(object message)
+        {
+            if (message is ReplayedMessage rm)
+            {
+                //rm.Persistent
+                _replayCallback(rm.Persistent);
+            }
+            //else if (message is IPersistentRepresentation) _replayCallback(message as IPersistentRepresentation);
+            else if (message is RecoverySuccess)
+            {
+                _replayCompletionPromise.SetResult(new object());
+                Context.Stop(Self);
+            }
+            else if (message is ReplayMessagesFailure)
+            {
+                var failure = message as ReplayMessagesFailure;
+                _replayCompletionPromise.SetException(failure.Cause);
+                Context.Stop(Self);
+            }
+            else if (message is ReceiveTimeout)
+            {
+                var timeoutException = new AsyncReplayTimeoutException($"Replay timed out after {_replayTimeout.TotalSeconds}s of inactivity");
+                _replayCompletionPromise.SetException(timeoutException);
+                Context.Stop(Self);
+            }
+            else return false;
+            return true;
+        }
+    }
+
+    internal static class FuturesEx
+    {
+        public static Task<object> AskEx(this ICanTell self, Func<IActorRef, object> messageFactory, TimeSpan? timeout = null)
+        {
+            return self.AskEx<object>(messageFactory, timeout, CancellationToken.None);
+        }
+
+        public static Task<object> AskEx(this ICanTell self, Func<IActorRef, object> messageFactory, CancellationToken cancellationToken)
+        {
+            return self.AskEx<object>(messageFactory, null, cancellationToken);
+        }
+
+        public static Task<object> AskEx(this ICanTell self, Func<IActorRef, object> messageFactory, TimeSpan? timeout, CancellationToken cancellationToken)
+        {
+            return self.AskEx<object>(messageFactory, timeout, cancellationToken);
+        }
+
+        public static Task<T> AskEx<T>(this ICanTell self, Func<IActorRef, object> messageFactory, TimeSpan? timeout = null)
+        {
+            return self.AskEx<T>(messageFactory, timeout, CancellationToken.None);
+        }
+
+        public static Task<T> AskEx<T>(this ICanTell self, Func<IActorRef, object> messageFactory, CancellationToken cancellationToken)
+        {
+            return self.AskEx<T>(messageFactory, null, cancellationToken);
+        }
+
+        public static Task<T> AskEx<T>(this ICanTell self, Func<IActorRef, object> messageFactory, TimeSpan? timeout, CancellationToken cancellationToken)
+        {
+            IActorRefProvider provider = ResolveProvider(self);
+            if (provider == null)
+                throw new ArgumentException("Unable to resolve the target Provider", nameof(self));
+
+            return AskEx(self, messageFactory, provider, timeout, cancellationToken).CastTask<object, T>();
+        }
+        internal static IActorRefProvider ResolveProvider(ICanTell self)
+        {
+            if (InternalCurrentActorCellKeeper.Current != null)
+                return InternalCurrentActorCellKeeper.Current.SystemImpl.Provider;
+
+            if (self is IInternalActorRef)
+                return self.AsInstanceOf<IInternalActorRef>().Provider;
+
+            if (self is ActorSelection)
+                return ResolveProvider(self.AsInstanceOf<ActorSelection>().Anchor);
+
+            return null;
+        }
+
+        private static Task<object> AskEx(ICanTell self, Func<IActorRef, object> messageFactory, IActorRefProvider provider, TimeSpan? timeout, CancellationToken cancellationToken)
+        {
+            var result = new TaskCompletionSource<object>();
+
+            CancellationTokenSource timeoutCancellation = null;
+            timeout = timeout ?? provider.Settings.AskTimeout;
+            List<CancellationTokenRegistration> ctrList = new List<CancellationTokenRegistration>(2);
+
+            if (timeout != System.Threading.Timeout.InfiniteTimeSpan && timeout.Value > default(TimeSpan))
+            {
+                timeoutCancellation = new CancellationTokenSource();
+                ctrList.Add(timeoutCancellation.Token.Register(() => result.TrySetCanceled()));
+                timeoutCancellation.CancelAfter(timeout.Value);
+            }
+
+            if (cancellationToken.CanBeCanceled)
+                ctrList.Add(cancellationToken.Register(() => result.TrySetCanceled()));
+
+            //create a new tempcontainer path
+            ActorPath path = provider.TempPath();
+            //callback to unregister from tempcontainer
+            Action unregister =
+                () =>
+                {
+                    // cancelling timeout (if any) in order to prevent memory leaks
+                    // (a reference to 'result' variable in CancellationToken's callback)
+                    if (timeoutCancellation != null)
+                    {
+                        timeoutCancellation.Cancel();
+                        timeoutCancellation.Dispose();
+                    }
+                    for (var i = 0; i < ctrList.Count; i++)
+                    {
+                        ctrList[i].Dispose();
+                    }
+                    provider.UnregisterTempActor(path);
+                };
+
+            var future = new FutureActorRef(result, unregister, path);
+            //The future actor needs to be registered in the temp container
+            provider.RegisterTempActor(future, path);
+            self.Tell(messageFactory(future), future);
+            return result.Task;
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingCustomShardAllocationSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingCustomShardAllocationSpec.cs
@@ -304,13 +304,13 @@ namespace Akka.Cluster.Sharding.Tests
                 }, _config.First);
                 RunOn(() =>
                 {
-                    LastSender.Path.Should().Be(Node(_config.First) / "user" / "sharding" / "Entity" / "2" / "2");
+                    LastSender.Path.Should().Be(Node(_config.First) / "system" / "sharding" / "Entity" / "2" / "2");
                 }, _config.Second);
                 EnterBarrier("second-started");
 
                 RunOn(() =>
                 {
-                    Sys.ActorSelection(Node(_config.Second) / "user" / "sharding" / "Entity").Tell(new Identify(null));
+                    Sys.ActorSelection(Node(_config.Second) / "system" / "sharding" / "Entity").Tell(new Identify(null));
                     var secondRegion = ExpectMsg<ActorIdentity>().Subject;
                     _allocator.Value.Tell(new UseRegion(secondRegion));
                     ExpectMsg<UseRegionAck>();
@@ -326,7 +326,7 @@ namespace Akka.Cluster.Sharding.Tests
 
                 RunOn(() =>
                 {
-                    LastSender.Path.Should().Be(Node(_config.Second) / "user" / "sharding" / "Entity" / "3" / "3");
+                    LastSender.Path.Should().Be(Node(_config.Second) / "system" / "sharding" / "Entity" / "3" / "3");
                 }, _config.First);
 
                 EnterBarrier("after-2");
@@ -348,7 +348,7 @@ namespace Akka.Cluster.Sharding.Tests
                         _region.Value.Tell(2, p.Ref);
                         p.ExpectMsg(2, TimeSpan.FromSeconds(2));
 
-                        p.LastSender.Path.Should().Be(Node(_config.Second) / "user" / "sharding" / "Entity" / "2" / "2");
+                        p.LastSender.Path.Should().Be(Node(_config.Second) / "system" / "sharding" / "Entity" / "2" / "2");
                     });
 
                     _region.Value.Tell(1);

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingCustomShardAllocationSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingCustomShardAllocationSpec.cs
@@ -20,6 +20,7 @@ using Akka.Event;
 using Akka.TestKit.TestActors;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using FluentAssertions;
 
 namespace Akka.Cluster.Sharding.Tests
 {
@@ -259,7 +260,7 @@ namespace Akka.Cluster.Sharding.Tests
             {
                 Sys.ActorSelection(Node(_config.First) / "system" / "akka.persistence.journal.MemoryJournal").Tell(new Identify(null));
                 var sharedStore = ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
-                Assert.NotNull(sharedStore);
+                sharedStore.Should().NotBeNull();
 
                 MemoryJournalShared.SetStore(sharedStore, Sys);
             }, _config.First, _config.Second);
@@ -288,7 +289,7 @@ namespace Akka.Cluster.Sharding.Tests
                     ExpectMsg<UseRegionAck>();
                     _region.Value.Tell(1);
                     ExpectMsg(1);
-                    Assert.Equal(_region.Value.Path / "1" / "1", LastSender.Path);
+                    LastSender.Path.Should().Be(_region.Value.Path / "1" / "1");
                 }, _config.First);
                 EnterBarrier("first-started");
 
@@ -299,11 +300,11 @@ namespace Akka.Cluster.Sharding.Tests
 
                 RunOn(() =>
                 {
-                    Assert.Equal(_region.Value.Path / "2" / "2", LastSender.Path);
+                    LastSender.Path.Should().Be(_region.Value.Path / "2" / "2");
                 }, _config.First);
                 RunOn(() =>
                 {
-                    Assert.Equal(Node(_config.First) / "user" / "sharding" / "Entity" / "2" / "2", LastSender.Path);
+                    LastSender.Path.Should().Be(Node(_config.First) / "user" / "sharding" / "Entity" / "2" / "2");
                 }, _config.Second);
                 EnterBarrier("second-started");
 
@@ -320,12 +321,12 @@ namespace Akka.Cluster.Sharding.Tests
                 ExpectMsg(3);
                 RunOn(() =>
                 {
-                    Assert.Equal(_region.Value.Path / "3" / "3", LastSender.Path);
+                    LastSender.Path.Should().Be(_region.Value.Path / "3" / "3");
                 }, _config.Second);
 
                 RunOn(() =>
                 {
-                    Assert.Equal(Node(_config.Second) / "user" / "sharding" / "Entity" / "3" / "3", LastSender.Path);
+                    LastSender.Path.Should().Be(Node(_config.Second) / "user" / "sharding" / "Entity" / "3" / "3");
                 }, _config.First);
 
                 EnterBarrier("after-2");
@@ -347,12 +348,12 @@ namespace Akka.Cluster.Sharding.Tests
                         _region.Value.Tell(2, p.Ref);
                         p.ExpectMsg(2, TimeSpan.FromSeconds(2));
 
-                        Assert.Equal(Node(_config.Second) / "user" / "sharding" / "Entity" / "2" / "2", p.LastSender.Path);
+                        p.LastSender.Path.Should().Be(Node(_config.Second) / "user" / "sharding" / "Entity" / "2" / "2");
                     });
 
                     _region.Value.Tell(1);
                     ExpectMsg(1);
-                    Assert.Equal(_region.Value.Path / "1" / "1", LastSender.Path);
+                    LastSender.Path.Should().Be(_region.Value.Path / "1" / "1");
                 }, _config.First);
                 EnterBarrier("after-2");
             });

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingCustomShardAllocationSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingCustomShardAllocationSpec.cs
@@ -1,0 +1,361 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ClusterShardingCustomShardAllocationSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Linq;
+using Akka.Actor;
+using Akka.Cluster.TestKit;
+using Akka.Cluster.Tests.MultiNode;
+using Akka.Configuration;
+using Akka.Persistence.Journal;
+using Akka.Remote.TestKit;
+using Akka.Remote.Transport;
+using Xunit;
+using Akka.Event;
+using Akka.TestKit.TestActors;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    public class ClusterShardingCustomShardAllocationSpecConfig : MultiNodeConfig
+    {
+        public RoleName First { get; private set; }
+
+        public RoleName Second { get; private set; }
+
+        public ClusterShardingCustomShardAllocationSpecConfig()
+        {
+            First = Role("first");
+            Second = Role("second");
+
+            CommonConfig = DebugConfig(false)
+                .WithFallback(ConfigurationFactory.ParseString(@"
+                    akka.actor {
+                        serializers {
+                            hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                        }
+                        serialization-bindings {
+                            ""System.Object"" = hyperion
+                        }
+                    }
+
+                    akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.inmem""
+                    akka.persistence.journal.plugin = ""akka.persistence.journal.memory-journal-shared""
+
+                    akka.persistence.journal.MemoryJournal {
+                        class = ""Akka.Persistence.Journal.MemoryJournal, Akka.Persistence""
+                        plugin-dispatcher = ""akka.actor.default-dispatcher""
+                    }
+
+                    akka.persistence.journal.memory-journal-shared {
+                        class = ""Akka.Cluster.Sharding.Tests.MemoryJournalShared, Akka.Cluster.Sharding.Tests.MultiNode""
+                        plugin-dispatcher = ""akka.actor.default-dispatcher""
+                        timeout = 5s
+                    }
+                "))
+                .WithFallback(MultiNodeClusterSpec.ClusterConfig());
+        }
+    }
+
+    public class ClusterShardingCustomShardAllocationSpec : MultiNodeClusterSpec
+    {
+        #region setup
+
+        internal class Entity : ActorBase
+        {
+            protected override bool Receive(object message)
+            {
+                switch (message)
+                {
+                    case int id:
+                        Sender.Tell(id);
+                        return true;
+                }
+                return false;
+            }
+        }
+
+        internal class AllocateReq
+        {
+            public static readonly AllocateReq Instance = new AllocateReq();
+
+            private AllocateReq()
+            {
+            }
+        }
+
+        internal class UseRegion
+        {
+            public readonly IActorRef Region;
+
+            public UseRegion(IActorRef region)
+            {
+                Region = region;
+            }
+        }
+
+        internal class UseRegionAck
+        {
+            public static readonly UseRegionAck Instance = new UseRegionAck();
+
+            private UseRegionAck()
+            {
+            }
+        }
+
+        internal class RebalanceReq
+        {
+            public static readonly RebalanceReq Instance = new RebalanceReq();
+
+            private RebalanceReq()
+            {
+            }
+        }
+
+        internal class RebalanceShards
+        {
+            public readonly IImmutableSet<string> Shards;
+
+            public RebalanceShards(IImmutableSet<string> shards)
+            {
+                Shards = shards;
+            }
+        }
+
+        internal class RebalanceShardsAck
+        {
+            public static readonly RebalanceShardsAck Instance = new RebalanceShardsAck();
+
+            private RebalanceShardsAck()
+            {
+            }
+        }
+
+        internal class Allocator : ActorBase
+        {
+            IActorRef UseRegion;
+            IImmutableSet<string> Rebalance = ImmutableHashSet<string>.Empty;
+
+            protected override bool Receive(object message)
+            {
+                switch (message)
+                {
+                    case UseRegion r:
+                        UseRegion = r.Region;
+                        Sender.Tell(UseRegionAck.Instance);
+                        return true;
+                    case AllocateReq _:
+                        if (UseRegion != null)
+                            Sender.Tell(UseRegion);
+                        return true;
+                    case RebalanceShards rs:
+                        Rebalance = rs.Shards;
+                        Sender.Tell(RebalanceShardsAck.Instance);
+                        return true;
+                    case RebalanceReq _:
+                        Sender.Tell(Rebalance);
+                        Rebalance = ImmutableHashSet<string>.Empty;
+                        return true;
+                }
+                return false;
+            }
+        }
+
+        class TestAllocationStrategy : IShardAllocationStrategy
+        {
+            public readonly IActorRef Ref;
+
+            public TestAllocationStrategy(IActorRef @ref)
+            {
+                Ref = @ref;
+            }
+
+            public Task<IActorRef> AllocateShard(IActorRef requester, string shardId, IImmutableDictionary<IActorRef, IImmutableList<string>> currentShardAllocations)
+            {
+                return Ref.Ask<IActorRef>(AllocateReq.Instance);
+            }
+
+            public Task<IImmutableSet<string>> Rebalance(IImmutableDictionary<IActorRef, IImmutableList<string>> currentShardAllocations, IImmutableSet<string> rebalanceInProgress)
+            {
+                return Ref.Ask<IImmutableSet<string>>(RebalanceReq.Instance);
+            }
+        }
+
+        internal IdExtractor extractEntityId = message => message is int ? Tuple.Create(message.ToString(), message) : null;
+
+        internal ShardResolver extractShardId = message => message is int ? ((int)message).ToString() : null;
+
+        private Lazy<IActorRef> _region;
+        private Lazy<IActorRef> _allocator;
+
+        private readonly ClusterShardingCustomShardAllocationSpecConfig _config;
+
+        public ClusterShardingCustomShardAllocationSpec()
+            : this(new ClusterShardingCustomShardAllocationSpecConfig())
+        {
+        }
+
+        protected ClusterShardingCustomShardAllocationSpec(ClusterShardingCustomShardAllocationSpecConfig config)
+            : base(config)
+        {
+            _config = config;
+
+            _region = new Lazy<IActorRef>(() => ClusterSharding.Get(Sys).ShardRegion("Entity"));
+
+            _allocator = new Lazy<IActorRef>(() => Sys.ActorOf(Props.Create<Allocator>(), "allocator"));
+        }
+
+        protected override int InitialParticipantsValueFactory { get { return Roles.Count; } }
+
+        #endregion
+
+        private void Join(RoleName from, RoleName to)
+        {
+            RunOn(() =>
+            {
+                Cluster.Join(GetAddress(to));
+                StartSharding();
+            }, from);
+            EnterBarrier(from.Name + "-joined");
+        }
+
+        private void StartSharding()
+        {
+            ClusterSharding.Get(Sys).Start(
+                typeName: "Entity",
+                entityProps: Props.Create<Entity>(),
+                settings: ClusterShardingSettings.Create(Sys),
+                idExtractor: extractEntityId,
+                shardResolver: extractShardId,
+                allocationStrategy: new TestAllocationStrategy(_allocator.Value),
+                handOffStopMessage: PoisonPill.Instance);
+        }
+
+        [MultiNodeFact]
+        public void Cluster_sharding_with_custom_allocation_strategy_specs()
+        {
+            Cluster_sharding_with_custom_allocation_strategy_should_setup_shared_journal();
+            Cluster_sharding_with_custom_allocation_strategy_should_use_specified_region();
+            Cluster_sharding_with_custom_allocation_strategy_should_rebalance_specified_shards();
+        }
+
+        public void Cluster_sharding_with_custom_allocation_strategy_should_setup_shared_journal()
+        {
+            // start the Persistence extension
+            Persistence.Persistence.Instance.Apply(Sys);
+            RunOn(() =>
+            {
+                Persistence.Persistence.Instance.Apply(Sys).JournalFor("akka.persistence.journal.MemoryJournal");
+            }, _config.First);
+            EnterBarrier("persistence-started");
+
+            RunOn(() =>
+            {
+                Sys.ActorSelection(Node(_config.First) / "system" / "akka.persistence.journal.MemoryJournal").Tell(new Identify(null));
+                var sharedStore = ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
+                Assert.NotNull(sharedStore);
+
+                MemoryJournalShared.SetStore(sharedStore, Sys);
+            }, _config.First, _config.Second);
+            EnterBarrier("after-1");
+
+            RunOn(() =>
+            {
+                //check persistence running
+                var probe = CreateTestProbe();
+                var journal = Persistence.Persistence.Instance.Get(Sys).JournalFor(null);
+                journal.Tell(new Persistence.ReplayMessages(0, 0, long.MaxValue, Guid.NewGuid().ToString(), probe.Ref));
+                probe.ExpectMsg<Persistence.RecoverySuccess>(TimeSpan.FromSeconds(10));
+            }, _config.First, _config.Second);
+            EnterBarrier("after-1-test");
+        }
+
+        public void Cluster_sharding_with_custom_allocation_strategy_should_use_specified_region()
+        {
+            Within(TimeSpan.FromSeconds(10), () =>
+            {
+                Join(_config.First, _config.First);
+
+                RunOn(() =>
+                {
+                    _allocator.Value.Tell(new UseRegion(_region.Value));
+                    ExpectMsg<UseRegionAck>();
+                    _region.Value.Tell(1);
+                    ExpectMsg(1);
+                    Assert.Equal(_region.Value.Path / "1" / "1", LastSender.Path);
+                }, _config.First);
+                EnterBarrier("first-started");
+
+                Join(_config.Second, _config.First);
+
+                _region.Value.Tell(2);
+                ExpectMsg(2);
+
+                RunOn(() =>
+                {
+                    Assert.Equal(_region.Value.Path / "2" / "2", LastSender.Path);
+                }, _config.First);
+                RunOn(() =>
+                {
+                    Assert.Equal(Node(_config.First) / "user" / "sharding" / "Entity" / "2" / "2", LastSender.Path);
+                }, _config.Second);
+                EnterBarrier("second-started");
+
+                RunOn(() =>
+                {
+                    Sys.ActorSelection(Node(_config.Second) / "user" / "sharding" / "Entity").Tell(new Identify(null));
+                    var secondRegion = ExpectMsg<ActorIdentity>().Subject;
+                    _allocator.Value.Tell(new UseRegion(secondRegion));
+                    ExpectMsg<UseRegionAck>();
+                }, _config.First);
+                EnterBarrier("second-active");
+
+                _region.Value.Tell(3);
+                ExpectMsg(3);
+                RunOn(() =>
+                {
+                    Assert.Equal(_region.Value.Path / "3" / "3", LastSender.Path);
+                }, _config.Second);
+
+                RunOn(() =>
+                {
+                    Assert.Equal(Node(_config.Second) / "user" / "sharding" / "Entity" / "3" / "3", LastSender.Path);
+                }, _config.First);
+
+                EnterBarrier("after-2");
+            });
+        }
+
+        public void Cluster_sharding_with_custom_allocation_strategy_should_rebalance_specified_shards()
+        {
+            Within(TimeSpan.FromSeconds(15), () =>
+            {
+                RunOn(() =>
+                {
+                    _allocator.Value.Tell(new RebalanceShards(new string[] { "2" }.ToImmutableHashSet()));
+                    ExpectMsg<RebalanceShardsAck>();
+
+                    AwaitAssert(() =>
+                    {
+                        var p = CreateTestProbe();
+                        _region.Value.Tell(2, p.Ref);
+                        p.ExpectMsg(2, TimeSpan.FromSeconds(2));
+
+                        Assert.Equal(Node(_config.Second) / "user" / "sharding" / "Entity" / "2" / "2", p.LastSender.Path);
+                    });
+
+                    _region.Value.Tell(1);
+                    ExpectMsg(1);
+                    Assert.Equal(_region.Value.Path / "1" / "1", LastSender.Path);
+                }, _config.First);
+                EnterBarrier("after-2");
+            });
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingFailureSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingFailureSpec.cs
@@ -15,46 +15,63 @@ using Akka.Configuration;
 using Akka.Persistence.Journal;
 using Akka.Remote.TestKit;
 using Akka.Remote.Transport;
+using Xunit;
+using Akka.Event;
 
 namespace Akka.Cluster.Sharding.Tests
 {
     public class ClusterShardingFailureSpecConfig : MultiNodeConfig
     {
+        public RoleName Controller { get; private set; }
+
+        public RoleName First { get; private set; }
+
+        public RoleName Second { get; private set; }
+
         public ClusterShardingFailureSpecConfig()
         {
-            var controller = Role("controller");
-            var first = Role("first");
-            var second = Role("second");
+            Controller = Role("controller");
+            First = Role("first");
+            Second = Role("second");
 
-            CommonConfig = ConfigurationFactory.ParseString(@"
-                akka.loglevel = INFO
-                akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider""
-                akka.remote.log-remote-lifecycle-events = off
-                akka.cluster.auto-down-unreachable-after = 0s
-                akka.cluster.roles = [""backend""]
-                akka.persistence.journal.plugin = ""akka.persistence.journal.in-mem""
-                akka.persistence.journal.in-mem {
-                  timeout = 5s
-                  store {
-                    native = off
-                    dir = ""target/journal-ClusterShardingFailureSpec""
-                  }
-                }
-                akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.local""
-                akka.persistence.snapshot-store.local.dir = ""target/snapshots-ClusterShardingFailureSpec""
-                akka.cluster.sharding.coordinator-failure-backoff = 3s
-                akka.cluster.sharding.shard-failure-backoff = 3s
-            ");
+            CommonConfig = DebugConfig(false)
+                .WithFallback(ConfigurationFactory.ParseString(@"
+                    akka.actor {
+                        serializers {
+                            hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                        }
+                        serialization-bindings {
+                            ""System.Object"" = hyperion
+                        }
+                    }
+
+                    akka.cluster.auto-down-unreachable-after = 0s
+                    akka.cluster.roles = [""backend""]
+                    akka.cluster.sharding {
+                        coordinator-failure-backoff = 3s
+                        shard-failure-backoff = 3s
+                    }
+                    akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.inmem""
+                    akka.persistence.journal.plugin = ""akka.persistence.journal.memory-journal-shared""
+
+                    akka.persistence.journal.MemoryJournal {
+                        class = ""Akka.Persistence.Journal.MemoryJournal, Akka.Persistence""
+                        plugin-dispatcher = ""akka.actor.default-dispatcher""
+                    }
+
+                    akka.persistence.journal.memory-journal-shared {
+                        class = ""Akka.Cluster.Sharding.Tests.MemoryJournalShared, Akka.Cluster.Sharding.Tests.MultiNode""
+                        plugin-dispatcher = ""akka.actor.default-dispatcher""
+                        timeout = 5s
+                    }
+                "))
+                .WithFallback(MultiNodeClusterSpec.ClusterConfig());
 
             TestTransport = true;
         }
     }
 
-    public class ClusterShardingFailureNode1 : ClusterShardingFailureSpec { }
-    public class ClusterShardingFailureNode2 : ClusterShardingFailureSpec { }
-    public class ClusterShardingFailureNode3 : ClusterShardingFailureSpec { }
-
-    public abstract class ClusterShardingFailureSpec : MultiNodeClusterSpec
+    public class ClusterShardingFailureSpec : MultiNodeClusterSpec
     {
         #region setup
 
@@ -117,46 +134,23 @@ namespace Akka.Cluster.Sharding.Tests
             return null;
         };
 
-        private DirectoryInfo[] _storageLocations;
         private Lazy<IActorRef> _region;
-        private RoleName _first;
-        private RoleName _second;
-        private RoleName _controller;
 
-        protected ClusterShardingFailureSpec() : base(new ClusterShardingFailureSpecConfig())
+        private readonly ClusterShardingFailureSpecConfig _config;
+
+        public ClusterShardingFailureSpec()
+            : this(new ClusterShardingFailureSpecConfig())
         {
-            _storageLocations = new[]
-            {
-                "akka.persistence.journal.leveldb.dir",
-                "akka.persistence.journal.leveldb-shared.store.dir",
-                "akka.persistence.snapshot-store.local.dir"
-            }.Select(s => new DirectoryInfo(Sys.Settings.Config.GetString(s))).ToArray();
+        }
+
+        protected ClusterShardingFailureSpec(ClusterShardingFailureSpecConfig config)
+            : base(config)
+        {
+            _config = config;
 
             _region = new Lazy<IActorRef>(() => ClusterSharding.Get(Sys).ShardRegion("Entity"));
-
-            _controller = new RoleName("controller");
-            _first = new RoleName("first");
-            _second = new RoleName("second");
         }
 
-
-        protected override void AtStartup()
-        {
-            base.AtStartup();
-            RunOn(() =>
-            {
-                foreach (var location in _storageLocations) if (location.Exists) location.Delete();
-            }, _first);
-        }
-
-        protected override void AfterTermination()
-        {
-            base.AfterTermination();
-            RunOn(() =>
-            {
-                foreach (var location in _storageLocations) if (location.Exists) location.Delete();
-            }, _first);
-        }
 
         #endregion
 
@@ -164,8 +158,14 @@ namespace Akka.Cluster.Sharding.Tests
         {
             RunOn(() =>
             {
-                Cluster.Join(Node(to).Address);
+                Cluster.Join(GetAddress(to));
                 StartSharding();
+
+                AwaitAssert(() =>
+                {
+                    Assert.True(Cluster.State.Members.Select(i => i.UniqueAddress).Contains(Cluster.SelfUniqueAddress));
+                    Assert.True(Cluster.State.Members.Select(i => i.Status).All(i => i == MemberStatus.Up));
+                });
             }, from);
             EnterBarrier(from.Name + "-joined");
         }
@@ -180,35 +180,51 @@ namespace Akka.Cluster.Sharding.Tests
                 shardResolver: extractShardId);
         }
 
-        [MultiNodeFact(Skip = "TODO")]
-        public void ClusterSharding_with_flaky_journal_should_setup_shared_journal()
+        //[MultiNodeFact]
+        public void ClusterSharding_with_flaky_journal_network_specs()
+        {
+            ClusterSharding_with_flaky_journal_network_should_setup_shared_journal();
+            ClusterSharding_with_flaky_journal_network_should_join_cluster();
+            ClusterSharding_with_flaky_journal_network_should_recover_after_journal_network_failure();
+        }
+
+        public void ClusterSharding_with_flaky_journal_network_should_setup_shared_journal()
         {
             // start the Persistence extension
             Persistence.Persistence.Instance.Apply(Sys);
             RunOn(() =>
             {
-                Sys.ActorOf(Props.Create<MemoryJournal>(), "store");
-            }, _controller);
+                Persistence.Persistence.Instance.Apply(Sys).JournalFor("akka.persistence.journal.MemoryJournal");
+            }, _config.Controller);
             EnterBarrier("persistence-started");
 
             RunOn(() =>
             {
-                Sys.ActorSelection(Node(_first) / "user" / "store").Tell(new Identify(null));
-                var sharedStore = ExpectMsg<ActorIdentity>().Subject;
-                //TODO: SharedLeveldbJournal.setStore(sharedStore, system)
-            }, _first, _second);
+                Sys.ActorSelection(Node(_config.Controller) / "system" / "akka.persistence.journal.MemoryJournal").Tell(new Identify(null));
+                var sharedStore = ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
+                Assert.NotNull(sharedStore);
+
+                MemoryJournalShared.SetStore(sharedStore, Sys);
+            }, _config.First, _config.Second);
             EnterBarrier("after-1");
+
+            RunOn(() =>
+            {
+                //check persistence running
+                var probe = CreateTestProbe();
+                var journal = Persistence.Persistence.Instance.Get(Sys).JournalFor(null);
+                journal.Tell(new Persistence.ReplayMessages(0, 0, long.MaxValue, Guid.NewGuid().ToString(), probe.Ref));
+                probe.ExpectMsg<Persistence.RecoverySuccess>(TimeSpan.FromSeconds(10));
+            }, _config.First, _config.Second);
+            EnterBarrier("after-1-test");
         }
 
-        [MultiNodeFact(Skip = "TODO")]
-        public void ClusterSharding_with_flaky_journal_should_join_cluster()
+        public void ClusterSharding_with_flaky_journal_network_should_join_cluster()
         {
-            ClusterSharding_with_flaky_journal_should_setup_shared_journal();
-
-            Within(TimeSpan.FromSeconds(20), () =>
+            Within(TimeSpan.FromSeconds(30), () =>
             {
-                Join(_first, _first);
-                Join(_second, _first);
+                Join(_config.First, _config.First);
+                Join(_config.Second, _config.First);
 
                 RunOn(() =>
                 {
@@ -222,23 +238,20 @@ namespace Akka.Cluster.Sharding.Tests
                     ExpectMsg<Value>(v => v.Id == "20" && v.N == 2);
                     region.Tell(new Get("21"));
                     ExpectMsg<Value>(v => v.Id == "21" && v.N == 3);
-                }, _first);
+                }, _config.First);
                 EnterBarrier("after-2");
             });
         }
 
-        [MultiNodeFact(Skip = "TODO")]
-        public void ClusterSharding_with_flaky_journal_should_recover_after_journal_failure()
+        public void ClusterSharding_with_flaky_journal_network_should_recover_after_journal_network_failure()
         {
-            ClusterSharding_with_flaky_journal_should_join_cluster();
-
             Within(TimeSpan.FromSeconds(20), () =>
             {
                 RunOn(() =>
                 {
-                    TestConductor.Blackhole(_controller, _first, ThrottleTransportAdapter.Direction.Both).Wait();
-                    TestConductor.Blackhole(_controller, _second, ThrottleTransportAdapter.Direction.Both).Wait();
-                }, _controller);
+                    TestConductor.Blackhole(_config.Controller, _config.First, ThrottleTransportAdapter.Direction.Both).Wait();
+                    TestConductor.Blackhole(_config.Controller, _config.Second, ThrottleTransportAdapter.Direction.Both).Wait();
+                }, _config.Controller);
                 EnterBarrier("journal-backholded");
 
                 RunOn(() =>
@@ -249,14 +262,14 @@ namespace Akka.Cluster.Sharding.Tests
                     var probe = CreateTestProbe();
                     region.Tell(new Get("40"), probe.Ref);
                     probe.ExpectNoMsg(TimeSpan.FromSeconds(1));
-                }, _first);
+                }, _config.First);
                 EnterBarrier("first-delayed");
 
                 RunOn(() =>
                 {
-                    TestConductor.PassThrough(_controller, _first, ThrottleTransportAdapter.Direction.Both).Wait();
-                    TestConductor.PassThrough(_controller, _second, ThrottleTransportAdapter.Direction.Both).Wait();
-                }, _controller);
+                    TestConductor.PassThrough(_config.Controller, _config.First, ThrottleTransportAdapter.Direction.Both).Wait();
+                    TestConductor.PassThrough(_config.Controller, _config.Second, ThrottleTransportAdapter.Direction.Both).Wait();
+                }, _config.Controller);
                 EnterBarrier("journal-ok");
 
                 RunOn(() =>
@@ -289,7 +302,7 @@ namespace Akka.Cluster.Sharding.Tests
 
                     region.Tell(new Get("40"));
                     ExpectMsg<Value>(v => v.Id == "40" && v.N == 4);
-                }, _first);
+                }, _config.First);
                 EnterBarrier("verified-first");
 
                 RunOn(() =>
@@ -307,7 +320,7 @@ namespace Akka.Cluster.Sharding.Tests
                     ExpectMsg<Value>(v => v.Id == "20" && v.N == 4);
                     region.Tell(new Get("30"));
                     ExpectMsg<Value>(v => v.Id == "30" && v.N == 6);
-                }, _second);
+                }, _config.Second);
                 EnterBarrier("after-3");
             });
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingFailureSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingFailureSpec.cs
@@ -180,7 +180,7 @@ namespace Akka.Cluster.Sharding.Tests
                 shardResolver: extractShardId);
         }
 
-        //[MultiNodeFact]
+        [MultiNodeFact]
         public void ClusterSharding_with_flaky_journal_network_specs()
         {
             ClusterSharding_with_flaky_journal_network_should_setup_shared_journal();

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingFailureSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingFailureSpec.cs
@@ -17,6 +17,7 @@ using Akka.Remote.TestKit;
 using Akka.Remote.Transport;
 using Xunit;
 using Akka.Event;
+using FluentAssertions;
 
 namespace Akka.Cluster.Sharding.Tests
 {
@@ -163,8 +164,8 @@ namespace Akka.Cluster.Sharding.Tests
 
                 AwaitAssert(() =>
                 {
-                    Assert.True(Cluster.State.Members.Select(i => i.UniqueAddress).Contains(Cluster.SelfUniqueAddress));
-                    Assert.True(Cluster.State.Members.Select(i => i.Status).All(i => i == MemberStatus.Up));
+                    Cluster.State.Members.Select(i => i.UniqueAddress).Should().Contain(Cluster.SelfUniqueAddress);
+                    Cluster.State.Members.Select(i => i.Status).Should().OnlyContain(i => i == MemberStatus.Up);
                 });
             }, from);
             EnterBarrier(from.Name + "-joined");
@@ -202,7 +203,7 @@ namespace Akka.Cluster.Sharding.Tests
             {
                 Sys.ActorSelection(Node(_config.Controller) / "system" / "akka.persistence.journal.MemoryJournal").Tell(new Identify(null));
                 var sharedStore = ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
-                Assert.NotNull(sharedStore);
+                sharedStore.Should().NotBeNull();
 
                 MemoryJournalShared.SetStore(sharedStore, Sys);
             }, _config.First, _config.Second);

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingFailureSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingFailureSpec.cs
@@ -222,7 +222,7 @@ namespace Akka.Cluster.Sharding.Tests
 
         public void ClusterSharding_with_flaky_journal_network_should_join_cluster()
         {
-            Within(TimeSpan.FromSeconds(30), () =>
+            Within(TimeSpan.FromSeconds(20), () =>
             {
                 Join(_config.First, _config.First);
                 Join(_config.Second, _config.First);

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStateSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStateSpec.cs
@@ -298,7 +298,7 @@ namespace Akka.Cluster.Sharding.Tests
 
                     foreach (var region in regions)
                     {
-                        var path = new RootActorPath(region) / "user" / "sharding" / ShardTypeName;
+                        var path = new RootActorPath(region) / "system" / "sharding" / ShardTypeName;
                         Sys.ActorSelection(path).Tell(GetShardRegionState.Instance, probe.Ref);
                     }
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStateSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStateSpec.cs
@@ -1,0 +1,313 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ClusterShardingGetStateSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Linq;
+using Akka.Actor;
+using Akka.Cluster.TestKit;
+using Akka.Cluster.Tests.MultiNode;
+using Akka.Configuration;
+using Akka.Persistence.Journal;
+using Akka.Remote.TestKit;
+using Akka.Remote.Transport;
+using Xunit;
+using Akka.Event;
+using Akka.TestKit.TestActors;
+using System.Collections.Immutable;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    public class ClusterShardingGetStateSpecConfig : MultiNodeConfig
+    {
+        public RoleName Controller { get; private set; }
+
+        public RoleName First { get; private set; }
+
+        public RoleName Second { get; private set; }
+
+        public ClusterShardingGetStateSpecConfig()
+        {
+            Controller = Role("controller");
+            First = Role("first");
+            Second = Role("second");
+
+            CommonConfig = DebugConfig(false)
+                .WithFallback(ConfigurationFactory.ParseString(@"
+                    akka.actor {
+                        serializers {
+                            hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                        }
+                        serialization-bindings {
+                            ""System.Object"" = hyperion
+                        }
+                    }
+                    akka.cluster.auto-down-unreachable-after = 0s
+                    akka.cluster.sharding {
+                        coordinator-failure-backoff = 3s
+                        shard-failure-backoff = 3s
+                    }
+                    akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.inmem""
+                    akka.persistence.journal.plugin = ""akka.persistence.journal.memory-journal-shared""
+
+                    akka.persistence.journal.MemoryJournal {
+                        class = ""Akka.Persistence.Journal.MemoryJournal, Akka.Persistence""
+                        plugin-dispatcher = ""akka.actor.default-dispatcher""
+                    }
+
+                    akka.persistence.journal.memory-journal-shared {
+                        class = ""Akka.Cluster.Sharding.Tests.MemoryJournalShared, Akka.Cluster.Sharding.Tests.MultiNode""
+                        plugin-dispatcher = ""akka.actor.default-dispatcher""
+                        timeout = 5s
+                    }
+                "))
+                .WithFallback(MultiNodeClusterSpec.ClusterConfig());
+
+            NodeConfig(new RoleName[] { First, Second }, new Config[] {
+                ConfigurationFactory.ParseString(@"akka.cluster.roles=[""shard""]")
+            });
+        }
+    }
+
+    public class ClusterShardingGetStateSpec : MultiNodeClusterSpec
+    {
+        #region setup
+
+        [Serializable]
+        internal sealed class Stop
+        {
+            public static readonly Stop Instance = new Stop();
+            private Stop()
+            {
+            }
+        }
+
+        [Serializable]
+        internal sealed class Ping
+        {
+            public readonly int Id;
+
+            public Ping(int id)
+            {
+                Id = id;
+            }
+        }
+
+        [Serializable]
+        internal sealed class Pong
+        {
+            public static readonly Pong Instance = new Pong();
+            private Pong()
+            {
+            }
+        }
+
+        internal class ShardedActor : ActorBase
+        {
+            public ShardedActor()
+            {
+            }
+
+            protected override bool Receive(object message)
+            {
+                switch (message)
+                {
+                    case Stop _:
+                        Context.Stop(Self);
+                        return true;
+                    case Ping p:
+                        Sender.Tell(Pong.Instance);
+                        return true;
+                }
+                return false;
+            }
+        }
+
+        readonly static int NumberOfShards = 2;
+        readonly static string ShardTypeName = "Ping";
+
+        internal IdExtractor extractEntityId = message => message is Ping ? Tuple.Create(((Ping)message).Id.ToString(), message) : null;
+
+        internal ShardResolver extractShardId = message => message is Ping ? (((Ping)message).Id % NumberOfShards).ToString() : null;
+
+        private Lazy<IActorRef> _region;
+
+        private readonly ClusterShardingGetStateSpecConfig _config;
+
+        public ClusterShardingGetStateSpec()
+            : this(new ClusterShardingGetStateSpecConfig())
+        {
+        }
+
+        protected ClusterShardingGetStateSpec(ClusterShardingGetStateSpecConfig config)
+            : base(config)
+        {
+            _config = config;
+
+            _region = new Lazy<IActorRef>(() => ClusterSharding.Get(Sys).ShardRegion(ShardTypeName));
+        }
+
+        protected override int InitialParticipantsValueFactory { get { return Roles.Count; } }
+
+        #endregion
+
+        private void Join(RoleName from)
+        {
+            RunOn(() =>
+            {
+                Cluster.Join(GetAddress(_config.Controller));
+            }, from);
+            EnterBarrier(from.Name + "-joined");
+        }
+
+        private void StartShard()
+        {
+            ClusterSharding.Get(Sys).Start(
+               typeName: ShardTypeName,
+               entityProps: Props.Create<ShardedActor>(),
+               settings: ClusterShardingSettings.Create(Sys).WithRole("shard"),
+               idExtractor: extractEntityId,
+               shardResolver: extractShardId);
+        }
+
+        private void StartProxy()
+        {
+            ClusterSharding.Get(Sys).StartProxy(
+                typeName: ShardTypeName,
+                role: "shard",
+                idExtractor: extractEntityId,
+                shardResolver: extractShardId);
+        }
+
+        [MultiNodeFact]
+        public void Inspecting_cluster_sharding_state_specs()
+        {
+            Inspecting_cluster_sharding_state_should_setup_shared_journal();
+            Inspecting_cluster_sharding_state_should_join_cluster();
+            Inspecting_cluster_sharding_state_should_return_empty_state_when_no_sharded_actors_has_started();
+            Inspecting_cluster_sharding_state_should_trigger_sharded_actors();
+            Inspecting_cluster_sharding_state_should_get_shard_state();
+        }
+
+        public void Inspecting_cluster_sharding_state_should_setup_shared_journal()
+        {
+            // start the Persistence extension
+            Persistence.Persistence.Instance.Apply(Sys);
+            RunOn(() =>
+            {
+                Persistence.Persistence.Instance.Apply(Sys).JournalFor("akka.persistence.journal.MemoryJournal");
+            }, _config.Controller);
+            EnterBarrier("persistence-started");
+
+            RunOn(() =>
+            {
+                Sys.ActorSelection(Node(_config.Controller) / "system" / "akka.persistence.journal.MemoryJournal").Tell(new Identify(null));
+                var sharedStore = ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
+                Assert.NotNull(sharedStore);
+
+                MemoryJournalShared.SetStore(sharedStore, Sys);
+            }, _config.First, _config.Second);
+            EnterBarrier("after-1");
+
+            RunOn(() =>
+            {
+                //check persistence running
+                var probe = CreateTestProbe();
+                var journal = Persistence.Persistence.Instance.Get(Sys).JournalFor(null);
+                journal.Tell(new Persistence.ReplayMessages(0, 0, long.MaxValue, Guid.NewGuid().ToString(), probe.Ref));
+                probe.ExpectMsg<Persistence.RecoverySuccess>(TimeSpan.FromSeconds(10));
+            }, _config.First, _config.Second);
+            EnterBarrier("after-1-test");
+        }
+
+        public void Inspecting_cluster_sharding_state_should_join_cluster()
+        {
+            Join(_config.Controller);
+            Join(_config.First);
+            Join(_config.Second);
+
+            // make sure all nodes are up
+            AwaitAssert(() =>
+            {
+                Cluster.Get(Sys).SendCurrentClusterState(TestActor);
+                Assert.Equal(3, ExpectMsg<ClusterEvent.CurrentClusterState>().Members.Count);
+            });
+
+            RunOn(() =>
+            {
+                StartProxy();
+            }, _config.Controller);
+
+            RunOn(() =>
+            {
+                StartShard();
+            }, _config.First, _config.Second);
+
+            EnterBarrier("sharding started");
+        }
+
+        public void Inspecting_cluster_sharding_state_should_return_empty_state_when_no_sharded_actors_has_started()
+        {
+            AwaitAssert(() =>
+            {
+                var probe = CreateTestProbe();
+                _region.Value.Tell(GetCurrentRegions.Instance, probe.Ref);
+                Assert.Equal(0, probe.ExpectMsg<CurrentRegions>().Regions.Count);
+            });
+
+            EnterBarrier("empty sharding");
+        }
+
+        public void Inspecting_cluster_sharding_state_should_trigger_sharded_actors()
+        {
+            RunOn(() =>
+            {
+                Within(TimeSpan.FromSeconds(10), () =>
+                {
+                    AwaitAssert(() =>
+                    {
+                        var pingProbe = CreateTestProbe();
+                        // trigger starting of 4 entities
+                        foreach (var n in Enumerable.Range(1, 4))
+                        {
+                            _region.Value.Tell(new Ping(n), pingProbe.Ref);
+                        }
+                        pingProbe.ReceiveWhile(null, m => (Pong)m, 4);
+                    });
+                });
+            }, _config.Controller);
+
+            EnterBarrier("sharded actors started");
+        }
+
+        public void Inspecting_cluster_sharding_state_should_get_shard_state()
+        {
+            Within(TimeSpan.FromSeconds(10), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    var probe = CreateTestProbe();
+                    _region.Value.Tell(GetCurrentRegions.Instance, probe.Ref);
+                    var regions = probe.ExpectMsg<CurrentRegions>().Regions;
+                    Assert.Equal(2, regions.Count);
+
+                    foreach (var region in regions)
+                    {
+                        var path = new RootActorPath(region) / "user" / "sharding" / ShardTypeName;
+                        Sys.ActorSelection(path).Tell(GetShardRegionState.Instance, probe.Ref);
+                    }
+
+                    var states = probe.ReceiveWhile(null, m => (CurrentShardRegionState)m, regions.Count);
+                    var allEntityIds = states.SelectMany(i => i.Shards).SelectMany(j => j.EntityIds).ToImmutableHashSet();
+                    Assert.True(allEntityIds.SetEquals(new string[] { "1", "2", "3", "4" }));
+                });
+            });
+
+            EnterBarrier("done");
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStatsSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStatsSpec.cs
@@ -19,6 +19,7 @@ using Xunit;
 using Akka.Event;
 using Akka.TestKit.TestActors;
 using System.Collections.Immutable;
+using FluentAssertions;
 
 namespace Akka.Cluster.Sharding.Tests
 {
@@ -211,7 +212,7 @@ namespace Akka.Cluster.Sharding.Tests
             {
                 Sys.ActorSelection(Node(_config.Controller) / "system" / "akka.persistence.journal.MemoryJournal").Tell(new Identify(null));
                 var sharedStore = ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
-                Assert.NotNull(sharedStore);
+                sharedStore.Should().NotBeNull();
 
                 MemoryJournalShared.SetStore(sharedStore, Sys);
             }, _config.First, _config.Second, _config.Third);
@@ -240,7 +241,7 @@ namespace Akka.Cluster.Sharding.Tests
             {
                 AwaitAssert(() =>
                 {
-                    Assert.Equal(4, Cluster.Get(Sys).State.Members.Count(i => i.Status == MemberStatus.Up));
+                    Cluster.Get(Sys).State.Members.Count(i => i.Status == MemberStatus.Up).Should().Be(4);
                 });
             });
 
@@ -266,9 +267,9 @@ namespace Akka.Cluster.Sharding.Tests
                     var probe = CreateTestProbe();
                     _region.Value.Tell(new GetClusterShardingStats(Dilated(TimeSpan.FromSeconds(10))), probe.Ref);
                     var shardStats = probe.ExpectMsg<ClusterShardingStats>();
-                    Assert.Equal(3, shardStats.Regions.Count);
-                    Assert.Equal(0, shardStats.Regions.Values.Sum(i => i.Stats.Count));
-                    Assert.True(shardStats.Regions.Keys.All(i => i.HasGlobalScope));
+                    shardStats.Regions.Count.Should().Be(3);
+                    shardStats.Regions.Values.Sum(i => i.Stats.Count).Should().Be(0);
+                    shardStats.Regions.Keys.Should().OnlyContain(i => i.HasGlobalScope);
                 });
             });
 
@@ -309,9 +310,9 @@ namespace Akka.Cluster.Sharding.Tests
                     var probe = CreateTestProbe();
                     _region.Value.Tell(new GetClusterShardingStats(Dilated(TimeSpan.FromSeconds(10))), probe.Ref);
                     var regions = probe.ExpectMsg<ClusterShardingStats>().Regions;
-                    Assert.Equal(3, regions.Count);
-                    Assert.Equal(4, regions.Values.SelectMany(i => i.Stats.Values).Sum());
-                    Assert.True(regions.Keys.All(i => i.HasGlobalScope));
+                    regions.Count.Should().Be(3);
+                    regions.Values.SelectMany(i => i.Stats.Values).Sum().Should().Be(4);
+                    regions.Keys.Should().OnlyContain(i => i.HasGlobalScope);
                 });
             });
 
@@ -331,7 +332,7 @@ namespace Akka.Cluster.Sharding.Tests
                 {
                     AwaitAssert(() =>
                     {
-                        Assert.Equal(3, Cluster.Get(Sys).State.Members.Count);
+                        Cluster.Get(Sys).State.Members.Count.Should().Be(3);
                     });
                 });
             }, _config.First, _config.Second);
@@ -368,8 +369,8 @@ namespace Akka.Cluster.Sharding.Tests
                         var probe = CreateTestProbe();
                         _region.Value.Tell(new GetClusterShardingStats(Dilated(TimeSpan.FromSeconds(20))), probe.Ref);
                         var regions = probe.ExpectMsg<ClusterShardingStats>().Regions;
-                        Assert.Equal(2, regions.Count);
-                        Assert.Equal(4, regions.Values.SelectMany(i => i.Stats.Values).Sum());
+                        regions.Count.Should().Be(2);
+                        regions.Values.SelectMany(i => i.Stats.Values).Sum().Should().Be(4);
                     });
                 });
             }, _config.Controller);

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStatsSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStatsSpec.cs
@@ -1,0 +1,380 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ClusterShardingGetStatsSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Linq;
+using Akka.Actor;
+using Akka.Cluster.TestKit;
+using Akka.Cluster.Tests.MultiNode;
+using Akka.Configuration;
+using Akka.Persistence.Journal;
+using Akka.Remote.TestKit;
+using Akka.Remote.Transport;
+using Xunit;
+using Akka.Event;
+using Akka.TestKit.TestActors;
+using System.Collections.Immutable;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    public class ClusterShardingGetStatsSpecConfig : MultiNodeConfig
+    {
+        public RoleName Controller { get; private set; }
+
+        public RoleName First { get; private set; }
+
+        public RoleName Second { get; private set; }
+
+        public RoleName Third { get; private set; }
+
+        public ClusterShardingGetStatsSpecConfig()
+        {
+            Controller = Role("controller");
+            First = Role("first");
+            Second = Role("second");
+            Third = Role("third");
+
+            CommonConfig = DebugConfig(false)
+                .WithFallback(ConfigurationFactory.ParseString(@"
+                    akka.actor {
+                        serializers {
+                            hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                        }
+                        serialization-bindings {
+                            ""System.Object"" = hyperion
+                        }
+                    }
+                    akka.cluster.auto-down-unreachable-after = 0s
+                    akka.cluster.sharding {
+                        updating-state-timeout = 2s
+                        waiting-for-state-timeout = 2s
+                    }
+                    akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.inmem""
+                    akka.persistence.journal.plugin = ""akka.persistence.journal.memory-journal-shared""
+
+                    akka.persistence.journal.MemoryJournal {
+                        class = ""Akka.Persistence.Journal.MemoryJournal, Akka.Persistence""
+                        plugin-dispatcher = ""akka.actor.default-dispatcher""
+                    }
+
+                    akka.persistence.journal.memory-journal-shared {
+                        class = ""Akka.Cluster.Sharding.Tests.MemoryJournalShared, Akka.Cluster.Sharding.Tests.MultiNode""
+                        plugin-dispatcher = ""akka.actor.default-dispatcher""
+                        timeout = 5s
+                    }
+                "))
+                .WithFallback(MultiNodeClusterSpec.ClusterConfig());
+
+            NodeConfig(new RoleName[] { First, Second, Third }, new Config[] {
+                ConfigurationFactory.ParseString(@"akka.cluster.roles=[""shard""]")
+            });
+        }
+    }
+
+    public class ClusterShardingGetStatsSpec : MultiNodeClusterSpec
+    {
+        #region setup
+
+        [Serializable]
+        internal sealed class Stop
+        {
+            public static readonly Stop Instance = new Stop();
+            private Stop()
+            {
+            }
+        }
+
+        [Serializable]
+        internal sealed class Ping
+        {
+            public readonly int Id;
+
+            public Ping(int id)
+            {
+                Id = id;
+            }
+        }
+
+        [Serializable]
+        internal sealed class Pong
+        {
+            public static readonly Pong Instance = new Pong();
+            private Pong()
+            {
+            }
+        }
+
+        internal class ShardedActor : ActorBase
+        {
+            public ShardedActor()
+            {
+            }
+
+            protected override bool Receive(object message)
+            {
+                switch (message)
+                {
+                    case Stop _:
+                        Context.Stop(Self);
+                        return true;
+                    case Ping p:
+                        Sender.Tell(Pong.Instance);
+                        return true;
+                }
+                return false;
+            }
+        }
+
+        readonly static int NumberOfShards = 3;
+        readonly static string ShardTypeName = "Ping";
+
+        internal IdExtractor extractEntityId = message => message is Ping ? Tuple.Create(((Ping)message).Id.ToString(), message) : null;
+
+        internal ShardResolver extractShardId = message => message is Ping ? (((Ping)message).Id % NumberOfShards).ToString() : null;
+
+        private Lazy<IActorRef> _region;
+
+        private readonly ClusterShardingGetStatsSpecConfig _config;
+
+        public ClusterShardingGetStatsSpec()
+            : this(new ClusterShardingGetStatsSpecConfig())
+        {
+        }
+
+        protected ClusterShardingGetStatsSpec(ClusterShardingGetStatsSpecConfig config)
+            : base(config)
+        {
+            _config = config;
+
+            _region = new Lazy<IActorRef>(() => ClusterSharding.Get(Sys).ShardRegion(ShardTypeName));
+        }
+
+        protected override int InitialParticipantsValueFactory { get { return Roles.Count; } }
+
+        #endregion
+
+        private void Join(RoleName from)
+        {
+            RunOn(() =>
+            {
+                Cluster.Join(GetAddress(_config.Controller));
+            }, from);
+            EnterBarrier(from.Name + "-joined");
+        }
+
+        private void StartShard()
+        {
+            ClusterSharding.Get(Sys).Start(
+               typeName: ShardTypeName,
+               entityProps: Props.Create<ShardedActor>(),
+               settings: ClusterShardingSettings.Create(Sys).WithRole("shard"),
+               idExtractor: extractEntityId,
+               shardResolver: extractShardId);
+        }
+
+        private void StartProxy()
+        {
+            ClusterSharding.Get(Sys).StartProxy(
+                typeName: ShardTypeName,
+                role: "shard",
+                idExtractor: extractEntityId,
+                shardResolver: extractShardId);
+        }
+
+        [MultiNodeFact]
+        public void Inspecting_cluster_sharding_state_specs()
+        {
+            Inspecting_cluster_sharding_state_should_setup_shared_journal();
+            Inspecting_cluster_sharding_state_should_join_cluster();
+            Inspecting_cluster_sharding_state_should_return_empty_state_when_no_sharded_actors_has_started();
+            Inspecting_cluster_sharding_state_should_trigger_sharded_actors();
+            Inspecting_cluster_sharding_state_should_get_shard_state();
+            Inspecting_cluster_sharding_state_should_return_stats_after_a_node_leaves();
+        }
+
+        public void Inspecting_cluster_sharding_state_should_setup_shared_journal()
+        {
+            // start the Persistence extension
+            Persistence.Persistence.Instance.Apply(Sys);
+            RunOn(() =>
+            {
+                Persistence.Persistence.Instance.Apply(Sys).JournalFor("akka.persistence.journal.MemoryJournal");
+            }, _config.Controller);
+            EnterBarrier("persistence-started");
+
+            RunOn(() =>
+            {
+                Sys.ActorSelection(Node(_config.Controller) / "system" / "akka.persistence.journal.MemoryJournal").Tell(new Identify(null));
+                var sharedStore = ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
+                Assert.NotNull(sharedStore);
+
+                MemoryJournalShared.SetStore(sharedStore, Sys);
+            }, _config.First, _config.Second, _config.Third);
+            EnterBarrier("after-1");
+
+            RunOn(() =>
+            {
+                //check persistence running
+                var probe = CreateTestProbe();
+                var journal = Persistence.Persistence.Instance.Get(Sys).JournalFor(null);
+                journal.Tell(new Persistence.ReplayMessages(0, 0, long.MaxValue, Guid.NewGuid().ToString(), probe.Ref));
+                probe.ExpectMsg<Persistence.RecoverySuccess>(TimeSpan.FromSeconds(10));
+            }, _config.First, _config.Second, _config.Third);
+            EnterBarrier("after-1-test");
+        }
+
+        public void Inspecting_cluster_sharding_state_should_join_cluster()
+        {
+            Join(_config.Controller);
+            Join(_config.First);
+            Join(_config.Second);
+            Join(_config.Third);
+
+            // make sure all nodes are up
+            Within(TimeSpan.FromSeconds(10), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    Assert.Equal(4, Cluster.Get(Sys).State.Members.Count(i => i.Status == MemberStatus.Up));
+                });
+            });
+
+            RunOn(() =>
+            {
+                StartProxy();
+            }, _config.Controller);
+
+            RunOn(() =>
+            {
+                StartShard();
+            }, _config.First, _config.Second, _config.Third);
+
+            EnterBarrier("sharding started");
+        }
+
+        public void Inspecting_cluster_sharding_state_should_return_empty_state_when_no_sharded_actors_has_started()
+        {
+            Within(TimeSpan.FromSeconds(10), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    var probe = CreateTestProbe();
+                    _region.Value.Tell(new GetClusterShardingStats(Dilated(TimeSpan.FromSeconds(10))), probe.Ref);
+                    var shardStats = probe.ExpectMsg<ClusterShardingStats>();
+                    Assert.Equal(3, shardStats.Regions.Count);
+                    Assert.Equal(0, shardStats.Regions.Values.Sum(i => i.Stats.Count));
+                    Assert.True(shardStats.Regions.Keys.All(i => i.HasGlobalScope));
+                });
+            });
+
+            EnterBarrier("empty sharding");
+        }
+
+        public void Inspecting_cluster_sharding_state_should_trigger_sharded_actors()
+        {
+            RunOn(() =>
+            {
+                Within(TimeSpan.FromSeconds(10), () =>
+                {
+                    AwaitAssert(() =>
+                    {
+                        var pingProbe = CreateTestProbe();
+
+
+                        // trigger starting of 2 entities on first and second node
+                        // but leave third node without entities
+                        foreach (var n in new int[] { 1, 2, 4, 6 })
+                        {
+                            _region.Value.Tell(new Ping(n), pingProbe.Ref);
+                        }
+                        pingProbe.ReceiveWhile(null, m => (Pong)m, 4);
+                    });
+                });
+            }, _config.Controller);
+
+            EnterBarrier("sharded actors started");
+        }
+
+        public void Inspecting_cluster_sharding_state_should_get_shard_state()
+        {
+            Within(TimeSpan.FromSeconds(10), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    var probe = CreateTestProbe();
+                    _region.Value.Tell(new GetClusterShardingStats(Dilated(TimeSpan.FromSeconds(10))), probe.Ref);
+                    var regions = probe.ExpectMsg<ClusterShardingStats>().Regions;
+                    Assert.Equal(3, regions.Count);
+                    Assert.Equal(4, regions.Values.SelectMany(i => i.Stats.Values).Sum());
+                    Assert.True(regions.Keys.All(i => i.HasGlobalScope));
+                });
+            });
+
+            EnterBarrier("got shard state");
+        }
+
+        public void Inspecting_cluster_sharding_state_should_return_stats_after_a_node_leaves()
+        {
+            RunOn(() =>
+            {
+                Cluster.Get(Sys).Leave(Node(_config.Third).Address);
+            }, _config.Controller);
+
+            RunOn(() =>
+            {
+                Within(TimeSpan.FromSeconds(30), () =>
+                {
+                    AwaitAssert(() =>
+                    {
+                        Assert.Equal(3, Cluster.Get(Sys).State.Members.Count);
+                    });
+                });
+            }, _config.First, _config.Second);
+
+            EnterBarrier("third node removed");
+
+
+            RunOn(() =>
+            {
+                Within(TimeSpan.FromSeconds(10), () =>
+                {
+                    AwaitAssert(() =>
+                    {
+                        var pingProbe = CreateTestProbe();
+                        // make sure we have the 4 entities still alive across the fewer nodes
+                        foreach (var n in new int[] { 1, 2, 4, 6 })
+                        {
+                            _region.Value.Tell(new Ping(n), pingProbe.Ref);
+                        }
+                        pingProbe.ReceiveWhile(null, m => (Pong)m, 4);
+                    });
+                });
+            }, _config.Controller);
+
+            EnterBarrier("shards revived");
+
+
+            RunOn(() =>
+            {
+                Within(TimeSpan.FromSeconds(20), () =>
+                {
+                    AwaitAssert(() =>
+                    {
+                        var probe = CreateTestProbe();
+                        _region.Value.Tell(new GetClusterShardingStats(Dilated(TimeSpan.FromSeconds(20))), probe.Ref);
+                        var regions = probe.ExpectMsg<ClusterShardingStats>().Regions;
+                        Assert.Equal(2, regions.Count);
+                        Assert.Equal(4, regions.Values.SelectMany(i => i.Stats.Values).Sum());
+                    });
+                });
+            }, _config.Controller);
+
+            EnterBarrier("done");
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGracefulShutdownSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGracefulShutdownSpec.cs
@@ -246,7 +246,7 @@ namespace Akka.Cluster.Sharding.Tests
 
                     Watch(regionEmpty);
                     regionEmpty.Tell(GracefulShutdown.Instance);
-                    ExpectTerminated(regionEmpty);
+                    ExpectTerminated(regionEmpty, TimeSpan.FromSeconds(5));
                 }, _config.First);
             });
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGracefulShutdownSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGracefulShutdownSpec.cs
@@ -16,6 +16,7 @@ using Akka.Persistence.Journal;
 using Akka.Remote.TestKit;
 using Xunit;
 using System.Collections.Immutable;
+using FluentAssertions;
 
 namespace Akka.Cluster.Sharding.Tests
 {
@@ -151,7 +152,7 @@ namespace Akka.Cluster.Sharding.Tests
             {
                 Sys.ActorSelection(Node(_config.First) / "system" / "akka.persistence.journal.MemoryJournal").Tell(new Identify(null));
                 var sharedStore = ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
-                Assert.NotNull(sharedStore);
+                sharedStore.Should().NotBeNull();
 
                 MemoryJournalShared.SetStore(sharedStore, Sys);
             }, _config.First, _config.Second);
@@ -187,7 +188,7 @@ namespace Akka.Cluster.Sharding.Tests
                         })
                         .ToImmutableHashSet();
 
-                    Assert.Equal(2, regionAddresses.Count);
+                    regionAddresses.Count.Should().Be(2);
                 });
                 EnterBarrier("after-2");
             });
@@ -211,7 +212,7 @@ namespace Akka.Cluster.Sharding.Tests
                         {
                             _region.Value.Tell(i, probe.Ref);
                             probe.ExpectMsg(i, TimeSpan.FromSeconds(1));
-                            Assert.Equal(_region.Value.Path / i.ToString() / i.ToString(), probe.LastSender.Path);
+                            probe.LastSender.Path.Should().Be(_region.Value.Path / i.ToString() / i.ToString());
                         }
                     });
                 }, _config.First);

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingLeavingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingLeavingSpec.cs
@@ -172,12 +172,13 @@ namespace Akka.Cluster.Sharding.Tests
                 shardResolver: extractShardId);
         }
 
-        //[MultiNodeFact]
+        [MultiNodeFact]
         public void ClusterSharding_with_leaving_member_specs()
         {
             ClusterSharding_with_leaving_member_should_setup_shared_journal();
             ClusterSharding_with_leaving_member_should_join_cluster();
             ClusterSharding_with_leaving_member_should_initialize_shards();
+            ClusterSharding_with_leaving_member_should__recover_after_leaving_coordinator_node();
         }
 
         public void ClusterSharding_with_leaving_member_should_setup_shared_journal()

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingLeavingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingLeavingSpec.cs
@@ -17,6 +17,7 @@ using Akka.Persistence.Journal;
 using Akka.Remote.TestKit;
 using Xunit;
 using System.Collections.Immutable;
+using FluentAssertions;
 
 namespace Akka.Cluster.Sharding.Tests
 {
@@ -155,7 +156,7 @@ namespace Akka.Cluster.Sharding.Tests
                 {
                     AwaitAssert(() =>
                     {
-                        Assert.True(Cluster.State.Members.Any(i => i.UniqueAddress == Cluster.SelfUniqueAddress && i.Status == MemberStatus.Up));
+                        Cluster.State.Members.Should().Contain(i => i.UniqueAddress == Cluster.SelfUniqueAddress && i.Status == MemberStatus.Up);
                     });
                 });
             }, from);
@@ -193,7 +194,7 @@ namespace Akka.Cluster.Sharding.Tests
 
             Sys.ActorSelection(Node(_config.First) / "system" / "akka.persistence.journal.MemoryJournal").Tell(new Identify(null));
             var sharedStore = ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
-            Assert.NotNull(sharedStore);
+            sharedStore.Should().NotBeNull();
 
             MemoryJournalShared.SetStore(sharedStore, Sys);
 
@@ -274,7 +275,7 @@ namespace Akka.Cluster.Sharding.Tests
                             var r = kv.Value;
                             region.Tell(new Ping(id), probe.Ref);
                             if (r.Path.Address.Equals(firstAddress))
-                                Assert.NotEqual(r, probe.ExpectMsg<IActorRef>(TimeSpan.FromSeconds(1)));
+                                probe.ExpectMsg<IActorRef>(TimeSpan.FromSeconds(1)).Should().NotBe(r);
                             else
                                 probe.ExpectMsg(r, TimeSpan.FromSeconds(1)); // should not move
                         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingLeavingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingLeavingSpec.cs
@@ -16,43 +16,58 @@ using Akka.Configuration;
 using Akka.Persistence.Journal;
 using Akka.Remote.TestKit;
 using Xunit;
+using System.Collections.Immutable;
 
 namespace Akka.Cluster.Sharding.Tests
 {
     public class ClusterShardingLeavingSpecConfig : MultiNodeConfig
     {
+        public RoleName First { get; private set; }
+
+        public RoleName Second { get; private set; }
+
+        public RoleName Third { get; private set; }
+
+        public RoleName Fourth { get; private set; }
+
         public ClusterShardingLeavingSpecConfig()
         {
-            var first = Role("first");
-            var second = Role("second");
-            var third = Role("third");
-            var fourth = Role("fourth");
+            First = Role("first");
+            Second = Role("second");
+            Third = Role("third");
+            Fourth = Role("fourth");
 
-            CommonConfig = ConfigurationFactory.ParseString(@"
-                akka.loglevel = INFO
-                akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider""
-                akka.remote.log-remote-lifecycle-events = off
-                akka.cluster.auto-down-unreachable-after = 0s
-                akka.persistence.journal.plugin = ""Akka.Persistence.Journal.in-mem""
-                akka.persistence.journal.in-mem {
-                  timeout = 5s
-                  store {
-                    native = off
-                    dir = ""target/journal-ClusterShardingLeavingSpec""
-                  }
-                }
-                akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.local""
-                akka.persistence.snapshot-store.local.dir = ""target/snapshots-ClusterShardingLeavingSpec""
-            ");
+            CommonConfig = DebugConfig(false)
+                .WithFallback(ConfigurationFactory.ParseString(@"
+                    akka.actor {
+                        serializers {
+                            hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                        }
+                        serialization-bindings {
+                            ""System.Object"" = hyperion
+                        }
+                    }
+                    akka.cluster.auto-down-unreachable-after = 0s
+
+                    akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.inmem""
+                    akka.persistence.journal.plugin = ""akka.persistence.journal.memory-journal-shared""
+
+                    akka.persistence.journal.MemoryJournal {
+                        class = ""Akka.Persistence.Journal.MemoryJournal, Akka.Persistence""
+                        plugin-dispatcher = ""akka.actor.default-dispatcher""
+                    }
+
+                    akka.persistence.journal.memory-journal-shared {
+                        class = ""Akka.Cluster.Sharding.Tests.MemoryJournalShared, Akka.Cluster.Sharding.Tests.MultiNode""
+                        plugin-dispatcher = ""akka.actor.default-dispatcher""
+                        timeout = 5s
+                    }
+                "))
+                .WithFallback(MultiNodeClusterSpec.ClusterConfig());
         }
     }
 
-    public class ClusterShardingLeavingNode1 : ClusterShardinLeavingSpec { }
-    public class ClusterShardingLeavingNode2 : ClusterShardinLeavingSpec { }
-    public class ClusterShardingLeavingNode3 : ClusterShardinLeavingSpec { }
-    public class ClusterShardingLeavingNode4 : ClusterShardinLeavingSpec { }
-
-    public abstract class ClusterShardinLeavingSpec : MultiNodeClusterSpec
+    public class ClusterShardinLeavingSpec : MultiNodeClusterSpec
     {
         #region setup
 
@@ -80,8 +95,8 @@ namespace Akka.Cluster.Sharding.Tests
         [Serializable]
         internal sealed class Locations
         {
-            public readonly IDictionary<string, IActorRef> LocationMap;
-            public Locations(IDictionary<string, IActorRef> locationMap)
+            public readonly IImmutableDictionary<string, IActorRef> LocationMap;
+            public Locations(IImmutableDictionary<string, IActorRef> locationMap)
             {
                 LocationMap = locationMap;
             }
@@ -109,50 +124,24 @@ namespace Akka.Cluster.Sharding.Tests
         internal IdExtractor extractEntityId = message => message is Ping ? Tuple.Create((message as Ping).Id, message) : null;
         internal ShardResolver extractShardId = message => message is Ping ? (message as Ping).Id[0].ToString() : null;
 
-        private readonly DirectoryInfo[] _storageLocations;
         private readonly Lazy<IActorRef> _region;
 
-        private readonly RoleName _first;
-        private readonly RoleName _second;
-        private readonly RoleName _third;
-        private readonly RoleName _fourth;
+        private readonly ClusterShardingLeavingSpecConfig _config;
 
-        protected ClusterShardinLeavingSpec() : base(new ClusterShardingLeavingSpecConfig())
+        public ClusterShardinLeavingSpec()
+            : this(new ClusterShardingLeavingSpecConfig())
         {
-            _storageLocations = new[]
-            {
-                "akka.persistence.journal.leveldb.dir",
-                "akka.persistence.journal.leveldb-shared.store.dir",
-                "akka.persistence.snapshot-store.local.dir"
-            }.Select(s => new DirectoryInfo(Sys.Settings.Config.GetString(s))).ToArray();
+        }
 
-            _first = new RoleName("first");
-            _second = new RoleName("second");
-            _third = new RoleName("third");
-            _fourth = new RoleName("fourth");
+        protected ClusterShardinLeavingSpec(ClusterShardingLeavingSpecConfig config)
+            : base(config)
+        {
+            _config = config;
 
             _region = new Lazy<IActorRef>(() => ClusterSharding.Get(Sys).ShardRegion("Entity"));
         }
 
         protected override int InitialParticipantsValueFactory { get { return Roles.Count; } }
-
-        protected override void AtStartup()
-        {
-            base.AtStartup();
-            RunOn(() =>
-            {
-                foreach (var location in _storageLocations) if (location.Exists) location.Delete();
-            }, _first);
-        }
-
-        protected override void AfterTermination()
-        {
-            base.AfterTermination();
-            RunOn(() =>
-            {
-                foreach (var location in _storageLocations) if (location.Exists) location.Delete();
-            }, _first);
-        }
 
         #endregion
 
@@ -162,9 +151,12 @@ namespace Akka.Cluster.Sharding.Tests
             {
                 Cluster.Join(Node(to).Address);
                 StartSharding();
-                Within(TimeSpan.FromSeconds(5), () =>
+                Within(TimeSpan.FromSeconds(15), () =>
                 {
-                    AwaitAssert(() => Assert.True(Cluster.ReadView.State.Members.Any(m => m.UniqueAddress == Cluster.SelfUniqueAddress && m.Status == MemberStatus.Up)));
+                    AwaitAssert(() =>
+                    {
+                        Assert.True(Cluster.State.Members.Any(i => i.UniqueAddress == Cluster.SelfUniqueAddress && i.Status == MemberStatus.Up));
+                    });
                 });
             }, from);
             EnterBarrier(from.Name + "-joined");
@@ -180,45 +172,56 @@ namespace Akka.Cluster.Sharding.Tests
                 shardResolver: extractShardId);
         }
 
-        [MultiNodeFact(Skip = "TODO")]
+        //[MultiNodeFact]
+        public void ClusterSharding_with_leaving_member_specs()
+        {
+            ClusterSharding_with_leaving_member_should_setup_shared_journal();
+            ClusterSharding_with_leaving_member_should_join_cluster();
+            ClusterSharding_with_leaving_member_should_initialize_shards();
+        }
+
         public void ClusterSharding_with_leaving_member_should_setup_shared_journal()
         {
             // start the Persistence extension
             Persistence.Persistence.Instance.Apply(Sys);
             RunOn(() =>
             {
-                Sys.ActorOf(Props.Create<MemoryJournal>(), "store");
-            }, _first);
+                Persistence.Persistence.Instance.Apply(Sys).JournalFor("akka.persistence.journal.MemoryJournal");
+            }, _config.First);
             EnterBarrier("persistence-started");
 
-            Sys.ActorSelection(Node(_first) / "user" / "store").Tell(new Identify(null));
-            var sharedStore = ExpectMsg<ActorIdentity>().Subject;
+            Sys.ActorSelection(Node(_config.First) / "system" / "akka.persistence.journal.MemoryJournal").Tell(new Identify(null));
+            var sharedStore = ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
+            Assert.NotNull(sharedStore);
 
-            //SharedLeveldbJournal.setStore(sharedStore, system)
+            MemoryJournalShared.SetStore(sharedStore, Sys);
+
             EnterBarrier("after-1");
+
+            //check persistence running
+            var probe = CreateTestProbe();
+            var journal = Persistence.Persistence.Instance.Get(Sys).JournalFor(null);
+            journal.Tell(new Persistence.ReplayMessages(0, 0, long.MaxValue, Guid.NewGuid().ToString(), probe.Ref));
+            probe.ExpectMsg<Persistence.RecoverySuccess>(TimeSpan.FromSeconds(10));
+
+            EnterBarrier("after-1-test");
         }
 
-        [MultiNodeFact(Skip = "TODO")]
         public void ClusterSharding_with_leaving_member_should_join_cluster()
         {
-            ClusterSharding_with_leaving_member_should_setup_shared_journal();
-
             Within(TimeSpan.FromSeconds(20), () =>
             {
-                Join(_first, _first);
-                Join(_second, _first);
-                Join(_third, _first);
-                Join(_fourth, _first);
+                Join(_config.First, _config.First);
+                Join(_config.Second, _config.First);
+                Join(_config.Third, _config.First);
+                Join(_config.Fourth, _config.First);
 
                 EnterBarrier("after-2");
             });
         }
 
-        [MultiNodeFact(Skip = "TODO")]
         public void ClusterSharding_with_leaving_member_should_initialize_shards()
         {
-            ClusterSharding_with_leaving_member_should_join_cluster();
-
             RunOn(() =>
             {
                 var shardLocations = Sys.ActorOf(Props.Create<ShardLocations>(), "shardLocations");
@@ -229,60 +232,55 @@ namespace Akka.Cluster.Sharding.Tests
                         _region.Value.Tell(new Ping(id));
                         return new KeyValuePair<string, IActorRef>(id, ExpectMsg<IActorRef>());
                     })
-                    .ToDictionary(kv => kv.Key, kv => kv.Value);
+                    .ToImmutableDictionary(kv => kv.Key, kv => kv.Value);
 
                 shardLocations.Tell(new Locations(locations));
-            }, _first);
+            }, _config.First);
             EnterBarrier("after-3");
         }
 
-        [MultiNodeFact(Skip = "TODO")]
-        public void ClusterSharding_with_leaving_member_should_recover_after_leaving_coordinator_node()
+        public void ClusterSharding_with_leaving_member_should__recover_after_leaving_coordinator_node()
         {
-            ClusterSharding_with_leaving_member_should_initialize_shards();
 
-            Within(TimeSpan.FromSeconds(30), () =>
+            Sys.ActorSelection(Node(_config.First) / "user" / "shardLocations").Tell(GetLocations.Instance);
+            var originalLocations = ExpectMsg<Locations>();
+            var firstAddress = Node(_config.First).Address;
+
+            RunOn(() =>
             {
-                RunOn(() =>
-                {
-                    Cluster.Leave(Node(_first).Address);
-                }, _third);
+                Cluster.Leave(Node(_config.First).Address);
+            }, _config.Third);
 
-                RunOn(() =>
-                {
-                    var region = _region.Value;
-                    Watch(region);
-                    ExpectTerminated(region, TimeSpan.FromSeconds(15));
-                }, _first);
-                EnterBarrier("stopped");
+            RunOn(() =>
+            {
+                var region = _region.Value;
+                Watch(region);
+                ExpectTerminated(region, TimeSpan.FromSeconds(15));
+            }, _config.First);
+            EnterBarrier("stopped");
 
-                RunOn(() =>
+            RunOn(() =>
+            {
+                Within(TimeSpan.FromSeconds(15), () =>
                 {
-                    Sys.ActorSelection(Node(_first) / "user" / "sharedLocations").Tell(GetLocations.Instance);
-                    var locations = ExpectMsg<Locations>();
-                    var firstAddress = Node(_first).Address;
                     AwaitAssert(() =>
                     {
                         var region = _region.Value;
                         var probe = CreateTestProbe();
-                        foreach (var kv in locations.LocationMap)
+                        foreach (var kv in originalLocations.LocationMap)
                         {
                             var id = kv.Key;
                             var r = kv.Value;
                             region.Tell(new Ping(id), probe.Ref);
                             if (r.Path.Address.Equals(firstAddress))
-                            {
                                 Assert.NotEqual(r, probe.ExpectMsg<IActorRef>(TimeSpan.FromSeconds(1)));
-                            }
                             else
-                            {
                                 probe.ExpectMsg(r, TimeSpan.FromSeconds(1)); // should not move
-                            }
                         }
                     });
-                }, _second, _third, _fourth);
-                EnterBarrier("after-4");
-            });
+                });
+            }, _config.Second, _config.Third, _config.Fourth);
+            EnterBarrier("after-4");
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingMinMembersSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingMinMembersSpec.cs
@@ -19,6 +19,7 @@ using Xunit;
 using Akka.Event;
 using Akka.TestKit.TestActors;
 using System.Collections.Immutable;
+using FluentAssertions;
 
 namespace Akka.Cluster.Sharding.Tests
 {
@@ -157,7 +158,7 @@ namespace Akka.Cluster.Sharding.Tests
             {
                 Sys.ActorSelection(Node(_config.First) / "system" / "akka.persistence.journal.MemoryJournal").Tell(new Identify(null));
                 var sharedStore = ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
-                Assert.NotNull(sharedStore);
+                sharedStore.Should().NotBeNull();
 
                 MemoryJournalShared.SetStore(sharedStore, Sys);
             }, _config.First, _config.Second, _config.Third);
@@ -196,8 +197,8 @@ namespace Akka.Cluster.Sharding.Tests
                 {
                     AwaitAssert(() =>
                     {
-                        Assert.Equal(3, Cluster.State.Members.Count);
-                        Assert.True(Cluster.State.Members.All(i => i.Status == MemberStatus.Up));
+                        Cluster.State.Members.Count.Should().Be(3);
+                        Cluster.State.Members.Should().OnlyContain(i => i.Status == MemberStatus.Up);
                     });
                 });
                 EnterBarrier("all-up");
@@ -233,8 +234,8 @@ namespace Akka.Cluster.Sharding.Tests
                 var secondAddress = Node(_config.Second).Address;
                 var thirdAddress = Node(_config.Third).Address;
 
-                Assert.True(stats.Regions.Keys.ToImmutableHashSet().SetEquals(new Address[] { firstAddress, secondAddress, thirdAddress }));
-                Assert.Equal(1, stats.Regions[firstAddress].Stats.Values.Sum());
+                stats.Regions.Keys.Should().BeEquivalentTo(new Address[] { firstAddress, secondAddress, thirdAddress });
+                stats.Regions[firstAddress].Stats.Values.Sum().Should().Be(1);
                 EnterBarrier("after-2");
             });
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesNewExtractorSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesNewExtractorSpec.cs
@@ -19,6 +19,7 @@ using Xunit;
 using Akka.Event;
 using Akka.TestKit.TestActors;
 using System.Collections.Immutable;
+using FluentAssertions;
 
 namespace Akka.Cluster.Sharding.Tests
 {
@@ -197,7 +198,7 @@ namespace Akka.Cluster.Sharding.Tests
             {
                 Sys.ActorSelection(Node(_config.First) / "system" / "akka.persistence.journal.MemoryJournal").Tell(new Identify(null));
                 var sharedStore = ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
-                Assert.NotNull(sharedStore);
+                sharedStore.Should().NotBeNull();
 
                 MemoryJournalShared.SetStore(sharedStore, Sys);
             }, _config.Second, _config.Third);
@@ -228,8 +229,8 @@ namespace Akka.Cluster.Sharding.Tests
                     {
                         AwaitAssert(() =>
                         {
-                            Assert.Equal(3, Cluster.State.Members.Count);
-                            Assert.True(Cluster.State.Members.All(i => i.Status == MemberStatus.Up));
+                            Cluster.State.Members.Count.Should().Be(3);
+                            Cluster.State.Members.Should().OnlyContain(i => i.Status == MemberStatus.Up);
                         });
                     });
                 }, _config.First, _config.Second, _config.Third);
@@ -269,8 +270,8 @@ namespace Akka.Cluster.Sharding.Tests
                     {
                         AwaitAssert(() =>
                         {
-                            Assert.Equal(1, Cluster.State.Members.Count);
-                            Assert.True(Cluster.State.Members.All(i => i.Status == MemberStatus.Up));
+                            Cluster.State.Members.Count.Should().Be(1);
+                            Cluster.State.Members.Should().OnlyContain(i => i.Status == MemberStatus.Up);
                         });
                     });
                 }, _config.First);
@@ -293,7 +294,7 @@ namespace Akka.Cluster.Sharding.Tests
                     ExpectTerminated(Region(Sys));
                     AwaitAssert(() =>
                     {
-                        Assert.True(Cluster.Get(Sys).IsTerminated);
+                        Cluster.Get(Sys).IsTerminated.Should().BeTrue();
                     });
 
                 }, _config.Second, _config.Third);
@@ -310,7 +311,7 @@ namespace Akka.Cluster.Sharding.Tests
                         Persistence.Persistence.Instance.Apply(sys2);
                         sys2.ActorSelection(Node(_config.First) / "system" / "akka.persistence.journal.MemoryJournal").Tell(new Identify(null), probe2.Ref);
                         var sharedStore = probe2.ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
-                        Assert.NotNull(sharedStore);
+                        sharedStore.Should().NotBeNull();
 
                         MemoryJournalShared.SetStore(sharedStore, sys2);
                     }
@@ -326,7 +327,7 @@ namespace Akka.Cluster.Sharding.Tests
                         {
                             Region(sys2).Tell(GetShardRegionState.Instance);
                             var reply = ExpectMsg<CurrentShardRegionState>();
-                            Assert.NotEmpty(reply.Shards);
+                            reply.Shards.Should().NotBeEmpty();
                             stats = reply;
                         });
                     });
@@ -336,7 +337,7 @@ namespace Akka.Cluster.Sharding.Tests
                         foreach (var entityId in shardState.EntityIds)
                         {
                             var calculatedShardId = extractShardId2(int.Parse(entityId));
-                            Assert.Equal(shardState.ShardId, calculatedShardId);
+                            calculatedShardId.ShouldAllBeEquivalentTo(shardState.ShardId);
                         }
                     }
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesNewExtractorSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesNewExtractorSpec.cs
@@ -1,0 +1,356 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ClusterShardingRememberEntitiesNewExtractorSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Linq;
+using Akka.Actor;
+using Akka.Cluster.TestKit;
+using Akka.Cluster.Tests.MultiNode;
+using Akka.Configuration;
+using Akka.Persistence.Journal;
+using Akka.Remote.TestKit;
+using Akka.Remote.Transport;
+using Xunit;
+using Akka.Event;
+using Akka.TestKit.TestActors;
+using System.Collections.Immutable;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    public class ClusterShardingRememberEntitiesNewExtractorSpecConfig : MultiNodeConfig
+    {
+        public RoleName First { get; private set; }
+
+        public RoleName Second { get; private set; }
+
+        public RoleName Third { get; private set; }
+
+        public ClusterShardingRememberEntitiesNewExtractorSpecConfig()
+        {
+            First = Role("first");
+            Second = Role("second");
+            Third = Role("third");
+
+            CommonConfig = DebugConfig(false)
+                .WithFallback(ConfigurationFactory.ParseString(@"
+                    akka.actor {
+                        serializers {
+                            hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                        }
+                        serialization-bindings {
+                            ""System.Object"" = hyperion
+                        }
+                    }
+                    akka.cluster.auto-down-unreachable-after = 0s
+
+                    akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.inmem""
+                    akka.persistence.journal.plugin = ""akka.persistence.journal.memory-journal-shared""
+
+                    akka.persistence.journal.MemoryJournal {
+                        class = ""Akka.Persistence.Journal.MemoryJournal, Akka.Persistence""
+                        plugin-dispatcher = ""akka.actor.default-dispatcher""
+                    }
+
+                    akka.persistence.journal.memory-journal-shared {
+                        class = ""Akka.Cluster.Sharding.Tests.MemoryJournalShared, Akka.Cluster.Sharding.Tests.MultiNode""
+                        plugin-dispatcher = ""akka.actor.default-dispatcher""
+                        timeout = 5s
+                    }
+                "))
+                .WithFallback(MultiNodeClusterSpec.ClusterConfig());
+
+            var roleConfig = ConfigurationFactory.ParseString(@"akka.cluster.roles = [sharding]");
+
+            NodeConfig(new RoleName[] { Second, Third }, new Config[] { roleConfig });
+        }
+    }
+
+    public class ClusterShardingRememberEntitiesNewExtractorSpec : MultiNodeClusterSpec
+    {
+        #region setup
+
+        [Serializable]
+        internal sealed class Started
+        {
+            public readonly IActorRef Ref;
+            public Started(IActorRef @ref)
+            {
+                Ref = @ref;
+            }
+        }
+
+        internal class TestEntity : ActorBase
+        {
+            public TestEntity(IActorRef probe)
+            {
+                probe?.Tell(new Started(Self));
+            }
+
+            protected override bool Receive(object message)
+            {
+                Sender.Tell(message);
+                return true;
+            }
+        }
+
+        readonly static int ShardCount = 3;
+
+        internal IdExtractor extractEntityId = message => message is int ? Tuple.Create(message.ToString(), message) : null;
+
+        internal static ShardResolver extractShardId1 = message =>
+        {
+            if (message is int)
+                return (((int)message) % ShardCount).ToString();
+            if (message is ShardRegion.StartEntity)
+                return extractShardId1(((ShardRegion.StartEntity)message).EntityId);
+            return null;
+        };
+
+        internal static ShardResolver extractShardId2 = message =>
+        {
+            if (message is int)
+                return (((int)message + 1) % ShardCount).ToString();
+            if (message is ShardRegion.StartEntity)
+                return extractShardId2(((ShardRegion.StartEntity)message).EntityId);
+            return null;
+        };
+
+        readonly static string TypeName = "Entity";
+
+        private readonly ClusterShardingRememberEntitiesNewExtractorSpecConfig _config;
+
+        public ClusterShardingRememberEntitiesNewExtractorSpec()
+            : this(new ClusterShardingRememberEntitiesNewExtractorSpecConfig())
+        {
+        }
+
+        protected ClusterShardingRememberEntitiesNewExtractorSpec(ClusterShardingRememberEntitiesNewExtractorSpecConfig config)
+            : base(config)
+        {
+            _config = config;
+
+        }
+
+        protected override int InitialParticipantsValueFactory { get { return Roles.Count; } }
+
+        #endregion
+
+        private void Join(RoleName from, RoleName to)
+        {
+            RunOn(() =>
+            {
+                Cluster.Join(GetAddress(to));
+            }, from);
+            EnterBarrier(from.Name + "-joined");
+        }
+
+        private void StartShardingWithExtractor1()
+        {
+            ClusterSharding.Get(Sys).Start(
+                typeName: TypeName,
+                entityProps: Props.Create(() => new TestEntity(null)),
+                settings: ClusterShardingSettings.Create(Sys).WithRememberEntities(true).WithRole("sharding"),
+                idExtractor: extractEntityId,
+                shardResolver: extractShardId1);
+        }
+
+        private void StartShardingWithExtractor2(ActorSystem sys, IActorRef probe)
+        {
+            ClusterSharding.Get(sys).Start(
+                typeName: TypeName,
+                entityProps: Props.Create(() => new TestEntity(probe)),
+                settings: ClusterShardingSettings.Create(Sys).WithRememberEntities(true).WithRole("sharding"),
+                idExtractor: extractEntityId,
+                shardResolver: extractShardId2);
+        }
+
+        private IActorRef Region(ActorSystem sys)
+        {
+            return ClusterSharding.Get(sys).ShardRegion(TypeName);
+        }
+
+        [MultiNodeFact]
+        public void Cluster_sharding_with_remember_entities_specs()
+        {
+            Cluster_sharding_with_remember_entities_should_setup_shared_journal();
+            Cluster_sharding_with_remember_entities_should_start_up_first_cluster_and_sharding();
+            Cluster_sharding_with_remember_entities_should_shutdown_sharding_nodes();
+            Cluster_sharding_with_remember_entities_should_start_new_nodes_with_different_extractor_and_have_the_entities_running_on_the_right_shards();
+        }
+
+        public void Cluster_sharding_with_remember_entities_should_setup_shared_journal()
+        {
+            // start the Persistence extension
+            Persistence.Persistence.Instance.Apply(Sys);
+            RunOn(() =>
+            {
+                Persistence.Persistence.Instance.Apply(Sys).JournalFor("akka.persistence.journal.MemoryJournal");
+            }, _config.First);
+            EnterBarrier("persistence-started");
+
+            RunOn(() =>
+            {
+                Sys.ActorSelection(Node(_config.First) / "system" / "akka.persistence.journal.MemoryJournal").Tell(new Identify(null));
+                var sharedStore = ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
+                Assert.NotNull(sharedStore);
+
+                MemoryJournalShared.SetStore(sharedStore, Sys);
+            }, _config.Second, _config.Third);
+            EnterBarrier("after-1");
+
+            RunOn(() =>
+            {
+                //check persistence running
+                var probe = CreateTestProbe();
+                var journal = Persistence.Persistence.Instance.Get(Sys).JournalFor(null);
+                journal.Tell(new Persistence.ReplayMessages(0, 0, long.MaxValue, Guid.NewGuid().ToString(), probe.Ref));
+                probe.ExpectMsg<Persistence.RecoverySuccess>(TimeSpan.FromSeconds(10));
+            }, _config.Second, _config.Third);
+            EnterBarrier("after-1-test");
+        }
+
+        public void Cluster_sharding_with_remember_entities_should_start_up_first_cluster_and_sharding()
+        {
+            Within(TimeSpan.FromSeconds(15), () =>
+            {
+                Join(_config.First, _config.First);
+                Join(_config.Second, _config.First);
+                Join(_config.Third, _config.First);
+
+                RunOn(() =>
+                {
+                    Within(Remaining, () =>
+                    {
+                        AwaitAssert(() =>
+                        {
+                            Assert.Equal(3, Cluster.State.Members.Count);
+                            Assert.True(Cluster.State.Members.All(i => i.Status == MemberStatus.Up));
+                        });
+                    });
+                }, _config.First, _config.Second, _config.Third);
+
+                RunOn(() =>
+                {
+                    StartShardingWithExtractor1();
+                }, _config.Second, _config.Third);
+                EnterBarrier("first-cluster-up");
+
+                RunOn(() =>
+                {
+                    // one entity for each shard id
+                    foreach (var n in Enumerable.Range(1, 10))
+                    {
+                        Region(Sys).Tell(n);
+                        ExpectMsg(n);
+                    }
+                }, _config.Second, _config.Third);
+                EnterBarrier("first-cluster-entities-up");
+            });
+        }
+
+        public void Cluster_sharding_with_remember_entities_should_shutdown_sharding_nodes()
+        {
+            Within(TimeSpan.FromSeconds(30), () =>
+            {
+                RunOn(() =>
+                {
+                    TestConductor.Exit(_config.Second, 0).Wait();
+                    TestConductor.Exit(_config.Third, 0).Wait();
+                }, _config.First);
+
+                RunOn(() =>
+                {
+                    Within(Remaining, () =>
+                    {
+                        AwaitAssert(() =>
+                        {
+                            Assert.Equal(1, Cluster.State.Members.Count);
+                            Assert.True(Cluster.State.Members.All(i => i.Status == MemberStatus.Up));
+                        });
+                    });
+                }, _config.First);
+
+            });
+            EnterBarrier("first-sharding-cluster-stopped");
+        }
+
+        public void Cluster_sharding_with_remember_entities_should_start_new_nodes_with_different_extractor_and_have_the_entities_running_on_the_right_shards()
+        {
+            Within(TimeSpan.FromSeconds(30), () =>
+            {
+                // start it with a new shard id extractor, which will put the entities
+                // on different shards
+
+                RunOn(() =>
+                {
+                    Watch(Region(Sys));
+                    Cluster.Get(Sys).Leave(Cluster.Get(Sys).SelfAddress);
+                    ExpectTerminated(Region(Sys));
+                    AwaitAssert(() =>
+                    {
+                        Assert.True(Cluster.Get(Sys).IsTerminated);
+                    });
+
+                }, _config.Second, _config.Third);
+                EnterBarrier("first-cluster-terminated");
+
+                // no sharding nodes left of the original cluster, start a new nodes
+                RunOn(() =>
+                {
+                    var sys2 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
+                    var probe2 = CreateTestProbe(sys2);
+
+                    {
+                        // setup Persistence
+                        Persistence.Persistence.Instance.Apply(sys2);
+                        sys2.ActorSelection(Node(_config.First) / "system" / "akka.persistence.journal.MemoryJournal").Tell(new Identify(null), probe2.Ref);
+                        var sharedStore = probe2.ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
+                        Assert.NotNull(sharedStore);
+
+                        MemoryJournalShared.SetStore(sharedStore, sys2);
+                    }
+
+                    Cluster.Get(sys2).Join(Node(_config.First).Address);
+                    StartShardingWithExtractor2(sys2, probe2.Ref);
+                    probe2.ExpectMsg<Started>(TimeSpan.FromSeconds(20));
+
+                    CurrentShardRegionState stats = null;
+                    Within(TimeSpan.FromSeconds(10), () =>
+                    {
+                        AwaitAssert(() =>
+                        {
+                            Region(sys2).Tell(GetShardRegionState.Instance);
+                            var reply = ExpectMsg<CurrentShardRegionState>();
+                            Assert.NotEmpty(reply.Shards);
+                            stats = reply;
+                        });
+                    });
+
+                    foreach (var shardState in stats.Shards)
+                    {
+                        foreach (var entityId in shardState.EntityIds)
+                        {
+                            var calculatedShardId = extractShardId2(int.Parse(entityId));
+                            Assert.Equal(shardState.ShardId, calculatedShardId);
+                        }
+                    }
+
+                    EnterBarrier("verified");
+                    Shutdown(sys2);
+                }, _config.Second, _config.Third);
+
+                RunOn(() =>
+                {
+                    EnterBarrier("verified");
+                }, _config.First);
+
+                EnterBarrier("done");
+            });
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesSpec.cs
@@ -19,6 +19,7 @@ using Xunit;
 using Akka.Event;
 using Akka.TestKit.TestActors;
 using System.Collections.Immutable;
+using FluentAssertions;
 
 namespace Akka.Cluster.Sharding.Tests
 {
@@ -169,7 +170,7 @@ namespace Akka.Cluster.Sharding.Tests
             {
                 Sys.ActorSelection(Node(_config.First) / "system" / "akka.persistence.journal.MemoryJournal").Tell(new Identify(null));
                 var sharedStore = ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
-                Assert.NotNull(sharedStore);
+                sharedStore.Should().NotBeNull();
 
                 MemoryJournalShared.SetStore(sharedStore, Sys);
             }, _config.First, _config.Second, _config.Third);
@@ -211,8 +212,8 @@ namespace Akka.Cluster.Sharding.Tests
                     {
                         AwaitAssert(() =>
                         {
-                            Assert.Equal(2, Cluster.State.Members.Count);
-                            Assert.True(Cluster.State.Members.All(i => i.Status == MemberStatus.Up));
+                            Cluster.State.Members.Count.Should().Be(2);
+                            Cluster.State.Members.Should().OnlyContain(i => i.Status == MemberStatus.Up);
                         });
                     });
                 }, _config.Second, _config.Third);
@@ -246,7 +247,7 @@ namespace Akka.Cluster.Sharding.Tests
                     ExpectTerminated(_region.Value);
                     AwaitAssert(() =>
                     {
-                        Assert.True(Cluster.Get(Sys).IsTerminated);
+                        Cluster.Get(Sys).IsTerminated.Should().BeTrue();
                     });
                     // no nodes left of the original cluster, start a new cluster
 
@@ -258,7 +259,7 @@ namespace Akka.Cluster.Sharding.Tests
                         Persistence.Persistence.Instance.Apply(sys2);
                         sys2.ActorSelection(Node(_config.First) / "system" / "akka.persistence.journal.MemoryJournal").Tell(new Identify(null), probe2.Ref);
                         var sharedStore = probe2.ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
-                        Assert.NotNull(sharedStore);
+                        sharedStore.Should().NotBeNull();
 
                         MemoryJournalShared.SetStore(sharedStore, sys2);
                     }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesSpec.cs
@@ -1,0 +1,276 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ClusterShardingRememberEntitiesSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Linq;
+using Akka.Actor;
+using Akka.Cluster.TestKit;
+using Akka.Cluster.Tests.MultiNode;
+using Akka.Configuration;
+using Akka.Persistence.Journal;
+using Akka.Remote.TestKit;
+using Akka.Remote.Transport;
+using Xunit;
+using Akka.Event;
+using Akka.TestKit.TestActors;
+using System.Collections.Immutable;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    public class ClusterShardingRememberEntitiesSpecConfig : MultiNodeConfig
+    {
+        public RoleName First { get; private set; }
+
+        public RoleName Second { get; private set; }
+
+        public RoleName Third { get; private set; }
+
+        public ClusterShardingRememberEntitiesSpecConfig()
+        {
+            First = Role("first");
+            Second = Role("second");
+            Third = Role("third");
+
+            CommonConfig = DebugConfig(false)
+                .WithFallback(ConfigurationFactory.ParseString(@"
+                    akka.actor {
+                        serializers {
+                            hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                        }
+                        serialization-bindings {
+                            ""System.Object"" = hyperion
+                        }
+                    }
+                    akka.cluster.auto-down-unreachable-after = 0s
+
+                    akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.inmem""
+                    akka.persistence.journal.plugin = ""akka.persistence.journal.memory-journal-shared""
+
+                    akka.persistence.journal.MemoryJournal {
+                        class = ""Akka.Persistence.Journal.MemoryJournal, Akka.Persistence""
+                        plugin-dispatcher = ""akka.actor.default-dispatcher""
+                    }
+
+                    akka.persistence.journal.memory-journal-shared {
+                        class = ""Akka.Cluster.Sharding.Tests.MemoryJournalShared, Akka.Cluster.Sharding.Tests.MultiNode""
+                        plugin-dispatcher = ""akka.actor.default-dispatcher""
+                        timeout = 5s
+                    }
+                "))
+                .WithFallback(MultiNodeClusterSpec.ClusterConfig());
+        }
+    }
+
+    public class ClusterShardingRememberEntitiesSpec : MultiNodeClusterSpec
+    {
+        #region setup
+
+        [Serializable]
+        internal sealed class Started
+        {
+            public readonly IActorRef Ref;
+
+            public Started(IActorRef @ref)
+            {
+                Ref = @ref;
+            }
+        }
+
+        internal class TestEntity : ActorBase
+        {
+            public TestEntity(IActorRef probe)
+            {
+                probe.Tell(new Started(Self));
+            }
+
+            protected override bool Receive(object message)
+            {
+                Sender.Tell(message);
+                return true;
+            }
+        }
+
+        internal IdExtractor extractEntityId = message => message is int ? Tuple.Create(message.ToString(), message) : null;
+
+        internal ShardResolver extractShardId = message =>
+        {
+            if (message is int)
+                return ((int)message).ToString();
+            if (message is ShardRegion.StartEntity)
+                return ((ShardRegion.StartEntity)message).EntityId.ToString();
+            return null;
+        };
+
+        private Lazy<IActorRef> _region;
+
+        private readonly ClusterShardingRememberEntitiesSpecConfig _config;
+
+        public ClusterShardingRememberEntitiesSpec()
+            : this(new ClusterShardingRememberEntitiesSpecConfig())
+        {
+        }
+
+        protected ClusterShardingRememberEntitiesSpec(ClusterShardingRememberEntitiesSpecConfig config)
+            : base(config)
+        {
+            _config = config;
+
+            _region = new Lazy<IActorRef>(() => ClusterSharding.Get(Sys).ShardRegion("Entity"));
+        }
+
+        protected override int InitialParticipantsValueFactory { get { return Roles.Count; } }
+
+        #endregion
+
+        private void Join(RoleName from, RoleName to)
+        {
+            RunOn(() =>
+            {
+                Cluster.Join(GetAddress(to));
+            }, from);
+            EnterBarrier(from.Name + "-joined");
+        }
+
+        private void StartSharding(ActorSystem sys, IActorRef probe)
+        {
+            var allocationStrategy = new LeastShardAllocationStrategy(2, 1);
+            ClusterSharding.Get(sys).Start(
+                typeName: "Entity",
+                entityProps: Props.Create(() => new TestEntity(probe)),
+                settings: ClusterShardingSettings.Create(Sys).WithRememberEntities(true),
+                idExtractor: extractEntityId,
+                shardResolver: extractShardId);
+        }
+
+        [MultiNodeFact]
+        public void Cluster_sharding_with_remember_entities_specs()
+        {
+            Cluster_sharding_with_remember_entities_should_setup_shared_journal();
+            Cluster_sharding_with_remember_entities_should_start_remembered_entities_when_coordinator_fail_over();
+            Cluster_sharding_with_remember_entities_should_start_remembered_entities_in_new_cluster();
+        }
+
+        public void Cluster_sharding_with_remember_entities_should_setup_shared_journal()
+        {
+            // start the Persistence extension
+            Persistence.Persistence.Instance.Apply(Sys);
+            RunOn(() =>
+            {
+                Persistence.Persistence.Instance.Apply(Sys).JournalFor("akka.persistence.journal.MemoryJournal");
+            }, _config.First);
+            EnterBarrier("persistence-started");
+
+            RunOn(() =>
+            {
+                Sys.ActorSelection(Node(_config.First) / "system" / "akka.persistence.journal.MemoryJournal").Tell(new Identify(null));
+                var sharedStore = ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
+                Assert.NotNull(sharedStore);
+
+                MemoryJournalShared.SetStore(sharedStore, Sys);
+            }, _config.First, _config.Second, _config.Third);
+            EnterBarrier("after-1");
+
+            RunOn(() =>
+            {
+                //check persistence running
+                var probe = CreateTestProbe();
+                var journal = Persistence.Persistence.Instance.Get(Sys).JournalFor(null);
+                journal.Tell(new Persistence.ReplayMessages(0, 0, long.MaxValue, Guid.NewGuid().ToString(), probe.Ref));
+                probe.ExpectMsg<Persistence.RecoverySuccess>(TimeSpan.FromSeconds(10));
+            }, _config.First, _config.Second, _config.Third);
+            EnterBarrier("after-1-test");
+        }
+
+        public void Cluster_sharding_with_remember_entities_should_start_remembered_entities_when_coordinator_fail_over()
+        {
+            Within(TimeSpan.FromSeconds(30), () =>
+            {
+                Join(_config.Second, _config.Second);
+                RunOn(() =>
+                {
+                    StartSharding(Sys, TestActor);
+                    _region.Value.Tell(1);
+                    ExpectMsg<Started>();
+                }, _config.Second);
+                EnterBarrier("second-started");
+
+                Join(_config.Third, _config.Second);
+                RunOn(() =>
+                {
+                    StartSharding(Sys, TestActor);
+                }, _config.Third);
+
+                RunOn(() =>
+                {
+                    Within(Remaining, () =>
+                    {
+                        AwaitAssert(() =>
+                        {
+                            Assert.Equal(2, Cluster.State.Members.Count);
+                            Assert.True(Cluster.State.Members.All(i => i.Status == MemberStatus.Up));
+                        });
+                    });
+                }, _config.Second, _config.Third);
+                EnterBarrier("all-up");
+
+                RunOn(() =>
+                {
+                    TestConductor.Exit(_config.Second, 0).Wait();
+                }, _config.First);
+
+                EnterBarrier("crash-second");
+
+                RunOn(() =>
+                {
+                    ExpectMsg<Started>(Remaining);
+                }, _config.Third);
+
+                EnterBarrier("after-2");
+            });
+        }
+
+        public void Cluster_sharding_with_remember_entities_should_start_remembered_entities_in_new_cluster()
+        {
+            Within(TimeSpan.FromSeconds(30), () =>
+            {
+                RunOn(() =>
+                {
+                    Watch(_region.Value);
+
+                    Cluster.Get(Sys).Leave(Cluster.Get(Sys).SelfAddress);
+                    ExpectTerminated(_region.Value);
+                    AwaitAssert(() =>
+                    {
+                        Assert.True(Cluster.Get(Sys).IsTerminated);
+                    });
+                    // no nodes left of the original cluster, start a new cluster
+
+                    var sys2 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
+                    var probe2 = CreateTestProbe(sys2);
+
+                    {
+                        // setup Persistence
+                        Persistence.Persistence.Instance.Apply(sys2);
+                        sys2.ActorSelection(Node(_config.First) / "system" / "akka.persistence.journal.MemoryJournal").Tell(new Identify(null), probe2.Ref);
+                        var sharedStore = probe2.ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
+                        Assert.NotNull(sharedStore);
+
+                        MemoryJournalShared.SetStore(sharedStore, sys2);
+                    }
+
+                    Cluster.Get(sys2).Join(Cluster.Get(sys2).SelfAddress);
+                    StartSharding(sys2, probe2.Ref);
+                    probe2.ExpectMsg<Started>(TimeSpan.FromSeconds(20));
+
+                    Shutdown(sys2);
+                }, _config.Third);
+                EnterBarrier("after-3");
+            });
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
@@ -549,11 +549,15 @@ namespace Akka.Cluster.Sharding.Tests
 
                     r.Tell(new Counter.Get(11));
                     ExpectMsg(1);
-                    // local on first
-                    LastSender.Path.Should().Be(r.Path / "11" / "11");
+                    var path11 = LastSender.Path;
+                    LastSender.Path.ToStringWithoutAddress().Should().Be((r.Path / "11" / "11").ToStringWithoutAddress());
                     r.Tell(new Counter.Get(12));
                     ExpectMsg(1);
-                    LastSender.Path.Should().Be(Node(_config.Second) / "user" / "counterRegion" / "0" / "12");
+                    var path12 = LastSender.Path;
+                    LastSender.Path.ToStringWithoutAddress().Should().Be((r.Path / "0" / "12").ToStringWithoutAddress());
+
+                    //one has to be local, the other one remote
+                    (path11.Address.HasLocalScope && path12.Address.HasGlobalScope || path11.Address.HasGlobalScope && path12.Address.HasLocalScope).Should().BeTrue();
                 }, _config.First);
                 EnterBarrier("first-update");
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
@@ -387,7 +387,7 @@ namespace Akka.Cluster.Sharding.Tests
 
                     ExpectMsg(2);
                     r.Tell(GetCurrentRegions.Instance);
-                    ExpectMsg<CurrentRegions>(m => m.Regions.Length == 1 && m.Regions[0].Equals(Cluster.SelfAddress));
+                    ExpectMsg<CurrentRegions>(m => m.Regions.Count == 1 && m.Regions.Contains(Cluster.SelfAddress));
                 }, _first);
 
                 EnterBarrier("after-2");
@@ -449,9 +449,9 @@ namespace Akka.Cluster.Sharding.Tests
                     Assert.Equal(r.Path / "2" / "2", LastSender.Path);
 
                     r.Tell(GetCurrentRegions.Instance);
-                    ExpectMsg<CurrentRegions>(x => x.Regions.Length == 2
-                                                   && x.Regions[0].Equals(Cluster.SelfAddress)
-                                                   && x.Regions[1].Equals(Node(_first).Address));
+                    ExpectMsg<CurrentRegions>(x => x.Regions.Count == 2
+                                                   && x.Regions.Contains(Cluster.SelfAddress)
+                                                   && x.Regions.Contains(Node(_first).Address));
                 }, _second);
                 EnterBarrier("after-3");
             });

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
@@ -27,47 +27,82 @@ namespace Akka.Cluster.Sharding.Tests
 {
     public class ClusterShardingSpecConfig : MultiNodeConfig
     {
-        public ClusterShardingSpecConfig()
+        public RoleName Controller { get; private set; }
+
+        public RoleName First { get; private set; }
+
+        public RoleName Second { get; private set; }
+
+        public RoleName Third { get; private set; }
+
+        public RoleName Fourth { get; private set; }
+
+        public RoleName Fifth { get; private set; }
+
+        public RoleName Sixth { get; private set; }
+
+        public ClusterShardingSpecConfig(/*string entityRecoveryStrategy*/)
         {
-            var controller = Role("controller");
-            var first = Role("first");
-            var second = Role("second");
-            var third = Role("third");
-            var fourth = Role("fourth");
-            var fifth = Role("fifth");
-            var sixth = Role("sixth");
+            Controller = Role("controller");
+            First = Role("first");
+            Second = Role("second");
+            Third = Role("third");
+            Fourth = Role("fourth");
+            Fifth = Role("fifth");
+            Sixth = Role("sixth");
 
-            CommonConfig = ConfigurationFactory.ParseString(@"
-                akka.loglevel = INFO
-                akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider""
-                akka.remote.log-remote-lifecycle-events = off
-                akka.cluster.auto-down-unreachable-after = 0s
-                akka.cluster.roles = [""backend""]
-                akka.persistence.journal.plugin = ""akka.persistence.journal.leveldb-shared""
-                akka.persistence.journal.leveldb-shared.store {
-                  native = off
-                  dir = ""target/journal-ClusterShardingSpec""
-                }
-                akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.local""
-                akka.persistence.snapshot-store.local.dir = ""target/snapshots-ClusterShardingSpec""
-                akka.cluster.sharding {
-                  retry-interval = 1 s
-                  handoff-timeout = 10 s
-                  shard-start-timeout = 5s
-                  entity-restart-backoff = 1s
-                  rebalance-interval = 2 s
-                  entity-recovery-strategy = ""all""
-                  entity-recovery-constant-rate-strategy {
-                    frequency = 1 ms
-                    number-of-entities = 1
-                  }
-                  least-shard-allocation-strategy {
-                    rebalance-threshold = 2
-                    max-simultaneous-rebalance = 1
-                  }
-                }");
+            CommonConfig = DebugConfig(false)
+                .WithFallback(ConfigurationFactory.ParseString(@"
+                    akka.actor {
+                        serializers {
+                            hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                        }
+                        serialization-bindings {
+                            ""System.Object"" = hyperion
+                        }
+                    }
 
-            NodeConfig(new[] { sixth }, new[] { ConfigurationFactory.ParseString(@"akka.cluster.roles = [""frontend""]") });
+                    akka.cluster.auto-down-unreachable-after = 0s
+                    akka.cluster.roles = [""backend""]
+                    akka.cluster.sharding {
+                        retry-interval = 1 s
+                        handoff-timeout = 10 s
+                        shard-start-timeout = 5s
+                        entity-restart-backoff = 1s
+                        rebalance-interval = 2 s
+                        entity-recovery-strategy = ""all""
+                        entity-recovery-constant-rate-strategy {
+                            frequency = 1 ms
+                            number-of-entities = 1
+                        }
+                        least-shard-allocation-strategy {
+                            rebalance-threshold = 2
+                            max-simultaneous-rebalance = 1
+                        }
+                    }
+
+                    akka.testconductor.barrier-timeout = 70s
+
+
+                    akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.inmem""
+                    akka.persistence.journal.plugin = ""akka.persistence.journal.memory-journal-shared""
+
+                    akka.persistence.journal.MemoryJournal {
+                        class = ""Akka.Persistence.Journal.MemoryJournal, Akka.Persistence""
+                        plugin-dispatcher = ""akka.actor.default-dispatcher""
+                    }
+
+                    akka.persistence.journal.memory-journal-shared {
+                        class = ""Akka.Cluster.Sharding.Tests.MemoryJournalShared, Akka.Cluster.Sharding.Tests.MultiNode""
+                        plugin-dispatcher = ""akka.actor.default-dispatcher""
+                        timeout = 5s
+                    }
+                "))
+                .WithFallback(Sharding.ClusterSharding.DefaultConfig())
+                .WithFallback(ClusterSingletonManager.DefaultConfig())
+                .WithFallback(MultiNodeClusterSpec.ClusterConfig());
+
+            NodeConfig(new[] { Sixth }, new[] { ConfigurationFactory.ParseString(@"akka.cluster.roles = [""frontend""]") });
         }
     }
 
@@ -156,14 +191,15 @@ namespace Akka.Cluster.Sharding.Tests
         public static readonly ShardResolver ExtractShardId = message =>
         {
             if (message is EntityEnvelope)
-                return (((EntityEnvelope)message).Id % ShardsCount).ToString();
+                return (((EntityEnvelope)message).Id % NumberOfShards).ToString();
             if (message is Get)
-                return (((Get)message).CounterId % ShardsCount).ToString();
+                return (((Get)message).CounterId % NumberOfShards).ToString();
+            if (message is ShardRegion.StartEntity)
+                return (long.Parse(((ShardRegion.StartEntity)message).EntityId) % NumberOfShards).ToString();
             return null;
-
         };
 
-        public const int ShardsCount = 12;
+        public const int NumberOfShards = 12;
         private int _count = 0;
 
         public Counter()
@@ -178,7 +214,8 @@ namespace Akka.Cluster.Sharding.Tests
             Thread.Sleep(500);
         }
 
-        public override string PersistenceId { get { return Self.Path.Parent.Name + "-" + Self.Path.Name; } }
+        public override string PersistenceId { get { return "Counter-" + Self.Path.Name; } }
+
         protected override bool ReceiveRecover(object message)
         {
             return message.Match()
@@ -190,7 +227,7 @@ namespace Akka.Cluster.Sharding.Tests
         {
             return message.Match()
                 .With<Increment>(_ => Persist(new CounterChanged(1), UpdateState))
-                .With<Increment>(_ => Persist(new CounterChanged(-1), UpdateState))
+                .With<Decrement>(_ => Persist(new CounterChanged(-1), UpdateState))
                 .With<Get>(_ => Sender.Tell(_count))
                 .With<ReceiveTimeout>(_ => Context.Parent.Tell(new Passivate(Stop.Instance)))
                 .With<Stop>(_ => Context.Stop(Self))
@@ -202,22 +239,95 @@ namespace Akka.Cluster.Sharding.Tests
             _count += e.Delta;
         }
     }
-    public class ClusterShardingNode1 : ClusterShardingSpec { }
-    public class ClusterShardingNode2 : ClusterShardingSpec { }
-    public class ClusterShardingNode3 : ClusterShardingSpec { }
+
+    internal class QualifiedCounter : Counter
+    {
+        public static Props Props(string typeName)
+        {
+            return Actor.Props.Create(() => new QualifiedCounter(typeName));
+        }
+
+        public readonly string TypeName;
+
+        public override string PersistenceId { get { return TypeName + "-" + Self.Path.Name; } }
+
+        public QualifiedCounter(string typeName)
+        {
+            TypeName = typeName;
+        }
+    }
+
+    internal class AnotherCounter : QualifiedCounter
+    {
+        public AnotherCounter()
+            : base("AnotherCounter")
+        {
+        }
+    }
+
+    internal class CounterSupervisor : ActorBase
+    {
+        public readonly IActorRef Counter;
+
+        public CounterSupervisor()
+        {
+            Counter = Context.ActorOf(Props.Create<Counter>(), "theCounter");
+        }
+
+        protected override SupervisorStrategy SupervisorStrategy()
+        {
+            return new AllForOneStrategy(Decider.From(ex =>
+            {
+                switch (ex)
+                {
+                    //case _: IllegalArgumentException     ⇒ SupervisorStrategy.Resume
+                    //case _: ActorInitializationException ⇒ SupervisorStrategy.Stop
+                    //case _: DeathPactException           ⇒ SupervisorStrategy.Stop
+                    //case _: Exception                    ⇒ SupervisorStrategy.Restart
+
+                    default:
+                        return Directive.Restart;
+                }
+            }));
+        }
+
+        protected override bool Receive(object message)
+        {
+            Counter.Forward(message);
+            return true;
+        }
+    }
+
+
+    public class ClusterShardingSpecRecoveryAll : ClusterShardingSpec
+    {
+        public ClusterShardingSpecRecoveryAll()
+            : this(new ClusterShardingSpecConfig(/*"all"*/))
+        {
+        }
+
+        protected ClusterShardingSpecRecoveryAll(ClusterShardingSpecConfig config)
+            : base(config)
+        {
+        }
+    }
+
+    //public class ClusterShardingSpecRecoveryConstant : ClusterShardingSpec
+    //{
+    //    public ClusterShardingSpecRecoveryConstant()
+    //        : this(new ClusterShardingSpecConfig("constant"))
+    //    {
+    //    }
+
+    //    protected ClusterShardingSpecRecoveryConstant(ClusterShardingSpecConfig config)
+    //        : base(config)
+    //    {
+    //    }
+    //}
 
     public abstract class ClusterShardingSpec : MultiNodeClusterSpec
     {
         #region Setup
-
-        private readonly DirectoryInfo[] _storageLocations;
-        private readonly RoleName _controller;
-        private readonly RoleName _second;
-        private readonly RoleName _first;
-        private readonly RoleName _third;
-        private readonly RoleName _fourth;
-        private readonly RoleName _sixth;
-        private readonly RoleName _fifth;
 
         private readonly Lazy<IActorRef> _region;
         private readonly Lazy<IActorRef> _rebalancingRegion;
@@ -227,64 +337,31 @@ namespace Akka.Cluster.Sharding.Tests
         private readonly Lazy<IActorRef> _rebalancingPersistentRegion;
         private readonly Lazy<IActorRef> _autoMigrateRegion;
 
-        protected ClusterShardingSpec() : base(new ClusterShardingSpecConfig())
-        {
-            _storageLocations = new[]
-            {
-                "akka.persistence.journal.leveldb.dir",
-                "akka.persistence.journal.leveldb-shared.store.dir",
-                "akka.persistence.snapshot-store.local.dir"
-            }.Select(s => new DirectoryInfo(Sys.Settings.Config.GetString(s))).ToArray();
+        private readonly ClusterShardingSpecConfig _config;
 
-            _controller = new RoleName("controller");
-            _first = new RoleName("first");
-            _second = new RoleName("second");
-            _third = new RoleName("third");
-            _fourth = new RoleName("fourth");
-            _fifth = new RoleName("fifth");
-            _sixth = new RoleName("sixth");
+        protected ClusterShardingSpec(ClusterShardingSpecConfig config)
+            : base(config)
+        {
+            _config = config;
 
             _region = new Lazy<IActorRef>(() => CreateRegion("counter", false));
             _rebalancingRegion = new Lazy<IActorRef>(() => CreateRegion("rebalancingCounter", false));
 
-            _persistentEntitiesRegion = new Lazy<IActorRef>(() => CreateRegion("PersistentCounterEntities", true));
-            _anotherPersistentRegion = new Lazy<IActorRef>(() => CreateRegion("AnotherPersistentCounter", true));
-            _persistentRegion = new Lazy<IActorRef>(() => CreateRegion("PersistentCounter", true));
-            _rebalancingPersistentRegion = new Lazy<IActorRef>(() => CreateRegion("RebalancingPersistentCounter", true));
-            _autoMigrateRegion = new Lazy<IActorRef>(() => CreateRegion("AutoMigrateRegionTest", true));
+            _persistentEntitiesRegion = new Lazy<IActorRef>(() => CreateRegion("RememberCounterEntities", true));
+            _anotherPersistentRegion = new Lazy<IActorRef>(() => CreateRegion("AnotherRememberCounter", true));
+            _persistentRegion = new Lazy<IActorRef>(() => CreateRegion("RememberCounter", true));
+            _rebalancingPersistentRegion = new Lazy<IActorRef>(() => CreateRegion("RebalancingRememberCounter", true));
+            _autoMigrateRegion = new Lazy<IActorRef>(() => CreateRegion("AutoMigrateRememberRegionTest", true));
         }
 
         protected override int InitialParticipantsValueFactory { get { return Roles.Count; } }
-
-        protected override void AtStartup()
-        {
-            base.AtStartup();
-            RunOn(() =>
-            {
-                foreach (var dir in _storageLocations)
-                {
-                    if (dir.Exists) dir.Delete();
-                }
-            }, _controller);
-        }
-
-        protected override void AfterTermination()
-        {
-            base.AfterTermination();
-            RunOn(() =>
-            {
-                foreach (var dir in _storageLocations)
-                {
-                    if (dir.Exists) dir.Delete();
-                }
-            }, _controller);
-        }
 
         private void Join(RoleName from, RoleName to)
         {
             RunOn(() =>
             {
                 Cluster.Join(Node(to).Address);
+                CreateCoordinator();
             }, from);
 
             EnterBarrier(from.Name + "-joined");
@@ -294,15 +371,16 @@ namespace Akka.Cluster.Sharding.Tests
         {
             var typeNames = new[]
             {
-                "counter", "rebalancingCounter", "PersistentCounterEntities", "AnotherPersistentCounter",
-                "PersistentCounter", "RebalancingPersistentCounter", "AutoMigrateRegionTest"
+                "counter", "rebalancingCounter", "RememberCounterEntities", "AnotherRememberCounter",
+                "RememberCounter", "RebalancingRememberCounter", "AutoMigrateRememberRegionTest"
             };
 
             foreach (var typeName in typeNames)
             {
-                var rebalanceEnabled = string.Equals(typeName, "rebalancing", StringComparison.InvariantCultureIgnoreCase);
+                var rebalanceEnabled = typeName.ToLowerInvariant().StartsWith("rebalancing");
+                var rememberEnabled = typeName.ToLowerInvariant().Contains("remember");
                 var singletonProps = BackoffSupervisor.Props(
-                    CoordinatorProps(typeName, rebalanceEnabled),
+                    CoordinatorProps(typeName, rebalanceEnabled, rememberEnabled),
                     "coordinator",
                     TimeSpan.FromSeconds(5),
                     TimeSpan.FromSeconds(5),
@@ -316,27 +394,33 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        private Props CoordinatorProps(string typeName, bool rebalanceEntities)
+        private Props CoordinatorProps(string typeName, bool rebalanceEntities, bool rememberEntities)
         {
             var allocationStrategy = new LeastShardAllocationStrategy(2, 1);
-            var config = ConfigurationFactory.ParseString(string.Format(""));
-            var settings = ClusterShardingSettings.Create(config, Sys.Settings.Config.GetConfig("akka.cluster.singleton"));
-
+            var config = ConfigurationFactory.ParseString(string.Format(@"
+                handoff-timeout = 10s
+                shard-start-timeout = 10s
+                rebalance-interval = " + (rebalanceEntities ? "2s" : "3600s")))
+                .WithFallback(Sys.Settings.Config.GetConfig("akka.cluster.sharding"));
+            var settings = ClusterShardingSettings.Create(config, Sys.Settings.Config.GetConfig("akka.cluster.singleton"))
+                .WithRememberEntities(rememberEntities);
             return PersistentShardCoordinator.Props(typeName, settings, allocationStrategy);
         }
 
         private IActorRef CreateRegion(string typeName, bool rememberEntities)
         {
             var config = ConfigurationFactory.ParseString(@"
-              retry-interval = 1s
-              shard-failure-backoff = 1s
-              entity-restart-backoff = 1s
-              buffer-size = 1000").WithFallback(Sys.Settings.Config.GetConfig("akka.cluster.sharding"));
-            var settings = ClusterShardingSettings.Create(config, Sys.Settings.Config.GetConfig("akka.cluster.singleton")).WithRememberEntities(rememberEntities);
+                retry-interval = 1s
+                shard-failure-backoff = 1s
+                entity-restart-backoff = 1s
+                buffer-size = 1000")
+                .WithFallback(Sys.Settings.Config.GetConfig("akka.cluster.sharding"));
+            var settings = ClusterShardingSettings.Create(config, Sys.Settings.Config.GetConfig("akka.cluster.singleton"))
+                .WithRememberEntities(rememberEntities);
 
             return Sys.ActorOf(Props.Create(() => new ShardRegion(
                 typeName,
-                Props.Create<Counter>(),
+                QualifiedCounter.Props(typeName),
                 settings,
                 "/user/" + typeName + "Coordinator/singleton/coordinator",
                 Counter.ExtractEntityId,
@@ -349,32 +433,66 @@ namespace Akka.Cluster.Sharding.Tests
 
         #region Cluster shardings specs
 
-        [MultiNodeFact(Skip = "TODO")]
+        [MultiNodeFact]
+        public void ClusterSharding_specs()
+        {
+            ClusterSharding_should_setup_shared_journal();
+            ClusterSharding_should_work_in_single_node_cluster();
+            ClusterSharding_should_use_second_node();
+            ClusterSharding_should_support_passivation_and_activation_of_entities();
+            ClusterSharding_should_support_proxy_only_mode();
+            ClusterSharding_should_failover_shards_on_crashed_node();
+            ClusterSharding_should_use_third_and_fourth_node();
+            ClusterSharding_should_recover_coordinator_state_after_coordinator_crash();
+            ClusterSharding_should_rebalance_to_nodes_with_less_shards();
+
+            ClusterSharding_should_be_easy_to_use_with_extensions();
+
+            ClusterSharding_should_be_easy_API_for_starting();
+
+            PersistentClusterShards_should_recover_entities_upon_restart();
+            PersistentClusterShards_should_permanently_stop_entities_which_passivate();
+            PersistentClusterShards_should_restart_entities_which_stop_without_passivation();
+            PersistentClusterShards_should_be_migrated_to_new_regions_upon_region_failure();
+            PersistentClusterShards_should_ensure_rebalance_restarts_shards();
+        }
+
         public void ClusterSharding_should_setup_shared_journal()
         {
             // start the Persistence extension
             Persistence.Persistence.Instance.Apply(Sys);
-            RunOn(() => Sys.ActorOf<MemoryJournal>("store"), _controller);
+            RunOn(() =>
+            {
+                Persistence.Persistence.Instance.Apply(Sys).JournalFor("akka.persistence.journal.MemoryJournal");
+            }, _config.Controller);
             EnterBarrier("persistence-started");
 
             RunOn(() =>
             {
-                Sys.ActorSelection(Node(_controller) / "user" / "store").Tell(new Identify(null));
-                var sharedStore = ExpectMsg<ActorIdentity>().Subject;
-                //SharedLeveldbJournal.setStore(sharedStore, system)
-            }, _first, _second, _third, _fourth, _fifth, _sixth);
+                Sys.ActorSelection(Node(_config.Controller) / "system" / "akka.persistence.journal.MemoryJournal").Tell(new Identify(null));
+                var sharedStore = ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
+                Assert.NotNull(sharedStore);
 
+                MemoryJournalShared.SetStore(sharedStore, Sys);
+            }, _config.First, _config.Second, _config.Third, _config.Fourth, _config.Fifth, _config.Sixth);
             EnterBarrier("after-1");
+
+            RunOn(() =>
+            {
+                //check persistence running
+                var probe = CreateTestProbe();
+                var journal = Persistence.Persistence.Instance.Get(Sys).JournalFor(null);
+                journal.Tell(new Persistence.ReplayMessages(0, 0, long.MaxValue, Guid.NewGuid().ToString(), probe.Ref));
+                probe.ExpectMsg<Persistence.RecoverySuccess>(TimeSpan.FromSeconds(10));
+            }, _config.First, _config.Second);
+            EnterBarrier("after-1-test");
         }
 
-        [MultiNodeFact(Skip = "TODO")]
         public void ClusterSharding_should_work_in_single_node_cluster()
         {
-            ClusterSharding_should_setup_shared_journal();
-
             Within(TimeSpan.FromSeconds(20), () =>
             {
-                Join(_first, _first);
+                Join(_config.First, _config.First);
 
                 RunOn(() =>
                 {
@@ -388,20 +506,17 @@ namespace Akka.Cluster.Sharding.Tests
                     ExpectMsg(2);
                     r.Tell(GetCurrentRegions.Instance);
                     ExpectMsg<CurrentRegions>(m => m.Regions.Count == 1 && m.Regions.Contains(Cluster.SelfAddress));
-                }, _first);
+                }, _config.First);
 
                 EnterBarrier("after-2");
             });
         }
 
-        [MultiNodeFact(Skip = "TODO")]
         public void ClusterSharding_should_use_second_node()
         {
-            ClusterSharding_should_work_in_single_node_cluster();
-
-            Within(TimeSpan.FromSeconds(20), () =>
+            Within(TimeSpan.FromSeconds(30), () =>
             {
-                Join(_second, _first);
+                Join(_config.Second, _config.First);
 
                 RunOn(() =>
                 {
@@ -420,7 +535,7 @@ namespace Akka.Cluster.Sharding.Tests
                     ExpectMsg(1);
                     r.Tell(new Counter.Get(12));
                     ExpectMsg(1);
-                }, _second);
+                }, _config.Second);
                 EnterBarrier("second-update");
 
                 RunOn(() =>
@@ -429,7 +544,7 @@ namespace Akka.Cluster.Sharding.Tests
                     r.Tell(new Counter.EntityEnvelope(2, Counter.Increment.Instance));
                     r.Tell(new Counter.Get(2));
                     ExpectMsg(3);
-                    Assert.Equal(Node(_second) / "user" / "counterRegion" / "2" / "2", LastSender.Path);
+                    Assert.Equal(Node(_config.Second) / "user" / "counterRegion" / "2" / "2", LastSender.Path);
 
                     r.Tell(new Counter.Get(11));
                     ExpectMsg(1);
@@ -437,8 +552,8 @@ namespace Akka.Cluster.Sharding.Tests
                     Assert.Equal(r.Path / "11" / "11", LastSender.Path);
                     r.Tell(new Counter.Get(12));
                     ExpectMsg(1);
-                    Assert.Equal(Node(_second) / "user" / "counterRegion" / "0" / "12", LastSender.Path);
-                }, _first);
+                    Assert.Equal(Node(_config.Second) / "user" / "counterRegion" / "0" / "12", LastSender.Path);
+                }, _config.First);
                 EnterBarrier("first-update");
 
                 RunOn(() =>
@@ -449,39 +564,31 @@ namespace Akka.Cluster.Sharding.Tests
                     Assert.Equal(r.Path / "2" / "2", LastSender.Path);
 
                     r.Tell(GetCurrentRegions.Instance);
-                    ExpectMsg<CurrentRegions>(x => x.Regions.Count == 2
-                                                   && x.Regions.Contains(Cluster.SelfAddress)
-                                                   && x.Regions.Contains(Node(_first).Address));
-                }, _second);
+                    ExpectMsg<CurrentRegions>(x => x.Regions.SetEquals(new[] { Cluster.SelfAddress, Node(_config.First).Address }));
+                }, _config.Second);
                 EnterBarrier("after-3");
             });
         }
 
-        [MultiNodeFact(Skip = "TODO")]
         public void ClusterSharding_should_support_passivation_and_activation_of_entities()
         {
-            ClusterSharding_should_use_second_node();
-
             RunOn(() =>
             {
                 var r = _region.Value;
                 r.Tell(new Counter.Get(2));
-                ExpectMsg(3); //TODO: shouldn't we tell increment 3x first?
+                ExpectMsg(3);
                 r.Tell(new Counter.EntityEnvelope(2, ReceiveTimeout.Instance));
                 // let the Passivate-Stop roundtrip begin to trigger buffering of subsequent messages
                 Thread.Sleep(200);
                 r.Tell(new Counter.EntityEnvelope(2, Counter.Increment.Instance));
                 r.Tell(new Counter.Get(2));
                 ExpectMsg(4);
-            }, _second);
+            }, _config.Second);
             EnterBarrier("after-4");
         }
 
-        [MultiNodeFact(Skip = "TODO")]
         public void ClusterSharding_should_support_proxy_only_mode()
         {
-            ClusterSharding_should_support_passivation_and_activation_of_entities();
-
             Within(TimeSpan.FromSeconds(10), () =>
             {
                 RunOn(() =>
@@ -497,39 +604,31 @@ namespace Akka.Cluster.Sharding.Tests
                         settings: settings,
                         coordinatorPath: "/user/counterCoordinator/singleton/coordinator",
                         extractEntityId: Counter.ExtractEntityId,
-                        extractShardId: Counter.ExtractShardId));
-
-                    proxy.Tell(new Counter.EntityEnvelope(1, Counter.Increment.Instance));
-                    proxy.Tell(new Counter.EntityEnvelope(1, Counter.Increment.Instance));
-                    proxy.Tell(new Counter.EntityEnvelope(2, Counter.Increment.Instance));
-                    proxy.Tell(new Counter.EntityEnvelope(2, Counter.Increment.Instance));
-                    proxy.Tell(new Counter.EntityEnvelope(2, Counter.Increment.Instance));
-                    proxy.Tell(new Counter.EntityEnvelope(2, Counter.Increment.Instance));
+                        extractShardId: Counter.ExtractShardId
+                        ), "regionProxy");
 
                     proxy.Tell(new Counter.Get(1));
                     ExpectMsg(2);
                     proxy.Tell(new Counter.Get(2));
                     ExpectMsg(4);
-                }, _second);
+                }, _config.Second);
                 EnterBarrier("after-5");
             });
         }
 
-        [MultiNodeFact(Skip = "TODO")]
         public void ClusterSharding_should_failover_shards_on_crashed_node()
         {
-            ClusterSharding_should_support_proxy_only_mode();
-
             Within(TimeSpan.FromSeconds(30), () =>
             {
                 // mute logging of deadLetters during shutdown of systems
-                if (!Log.IsDebugEnabled) Sys.EventStream.Publish(new Mute(new DeadLettersFilter(new PredicateMatcher(x => true), new PredicateMatcher(x => true))));
+                if (!Log.IsDebugEnabled)
+                    Sys.EventStream.Publish(new Mute(new DeadLettersFilter(new PredicateMatcher(x => true), new PredicateMatcher(x => true))));
                 EnterBarrier("logs-muted");
 
                 RunOn(() =>
                 {
-                    TestConductor.Exit(_second, 0).Wait();
-                }, _controller);
+                    TestConductor.Exit(_config.Second, 0).Wait();
+                }, _config.Controller);
                 EnterBarrier("crash-second");
 
                 RunOn(() =>
@@ -557,20 +656,17 @@ namespace Akka.Cluster.Sharding.Tests
                             Assert.Equal(r.Path / "0" / "12", probe2.LastSender.Path);
                         });
                     });
-                }, _first);
+                }, _config.First);
                 EnterBarrier("after-6");
             });
         }
 
-        [MultiNodeFact(Skip = "TODO")]
         public void ClusterSharding_should_use_third_and_fourth_node()
         {
-            ClusterSharding_should_failover_shards_on_crashed_node();
-
             Within(TimeSpan.FromSeconds(15), () =>
             {
-                Join(_third, _first);
-                Join(_fourth, _first);
+                Join(_config.Third, _config.First);
+                Join(_config.Fourth, _config.First);
 
                 RunOn(() =>
                 {
@@ -581,7 +677,7 @@ namespace Akka.Cluster.Sharding.Tests
                     r.Tell(new Counter.Get(3));
                     ExpectMsg(10);
                     Assert.Equal(r.Path / "3" / "3", LastSender.Path);
-                }, _third);
+                }, _config.Third);
                 EnterBarrier("third-update");
 
                 RunOn(() =>
@@ -593,7 +689,7 @@ namespace Akka.Cluster.Sharding.Tests
                     r.Tell(new Counter.Get(4));
                     ExpectMsg(20);
                     Assert.Equal(r.Path / "4" / "4", LastSender.Path);
-                }, _fourth);
+                }, _config.Fourth);
                 EnterBarrier("fourth-update");
 
                 RunOn(() =>
@@ -602,13 +698,13 @@ namespace Akka.Cluster.Sharding.Tests
                     r.Tell(new Counter.EntityEnvelope(3, Counter.Increment.Instance));
                     r.Tell(new Counter.Get(3));
                     ExpectMsg(11);
-                    Assert.Equal(Node(_third) / "user" / "counterRegion" / "3" / "3", LastSender.Path);
+                    Assert.Equal(Node(_config.Third) / "user" / "counterRegion" / "3" / "3", LastSender.Path);
 
                     r.Tell(new Counter.EntityEnvelope(4, Counter.Increment.Instance));
                     r.Tell(new Counter.Get(4));
                     ExpectMsg(21);
-                    Assert.Equal(Node(_third) / "user" / "counterRegion" / "4" / "4", LastSender.Path);
-                }, _first);
+                    Assert.Equal(Node(_config.Fourth) / "user" / "counterRegion" / "4" / "4", LastSender.Path);
+                }, _config.First);
                 EnterBarrier("first-update");
 
                 RunOn(() =>
@@ -617,7 +713,7 @@ namespace Akka.Cluster.Sharding.Tests
                     r.Tell(new Counter.Get(3));
                     ExpectMsg(11);
                     Assert.Equal(r.Path / "3" / "3", LastSender.Path);
-                }, _third);
+                }, _config.Third);
 
                 RunOn(() =>
                 {
@@ -625,23 +721,20 @@ namespace Akka.Cluster.Sharding.Tests
                     r.Tell(new Counter.Get(4));
                     ExpectMsg(21);
                     Assert.Equal(r.Path / "4" / "4", LastSender.Path);
-                }, _fourth);
+                }, _config.Fourth);
                 EnterBarrier("after-7");
             });
         }
 
-        [MultiNodeFact(Skip = "TODO")]
         public void ClusterSharding_should_recover_coordinator_state_after_coordinator_crash()
         {
-            ClusterSharding_should_use_third_and_fourth_node();
-
             Within(TimeSpan.FromSeconds(60), () =>
             {
-                Join(_fifth, _fourth);
+                Join(_config.Fifth, _config.Fourth);
                 RunOn(() =>
                 {
-                    TestConductor.Exit(_first, 0).Wait();
-                }, _controller);
+                    TestConductor.Exit(_config.First, 0).Wait();
+                }, _config.Controller);
                 EnterBarrier("crash-first");
 
                 RunOn(() =>
@@ -653,7 +746,7 @@ namespace Akka.Cluster.Sharding.Tests
                         {
                             _region.Value.Tell(new Counter.Get(3), probe3.Ref);
                             probe3.ExpectMsg(11);
-                            Assert.Equal(Node(_third) / "user" / "counterRegion" / "3" / "3", probe3.LastSender.Path);
+                            Assert.Equal(Node(_config.Third) / "user" / "counterRegion" / "3" / "3", probe3.LastSender.Path);
                         });
                     });
 
@@ -664,19 +757,16 @@ namespace Akka.Cluster.Sharding.Tests
                         {
                             _region.Value.Tell(new Counter.Get(4), probe4.Ref);
                             probe4.ExpectMsg(21);
-                            Assert.Equal(Node(_fourth) / "user" / "counterRegion" / "4" / "4", probe4.LastSender.Path);
+                            Assert.Equal(Node(_config.Fourth) / "user" / "counterRegion" / "4" / "4", probe4.LastSender.Path);
                         });
                     });
-                }, _fifth);
+                }, _config.Fifth);
                 EnterBarrier("after-8");
             });
         }
 
-        [MultiNodeFact(Skip = "TODO")]
         public void ClusterSharding_should_rebalance_to_nodes_with_less_shards()
         {
-            ClusterSharding_should_recover_coordinator_state_after_coordinator_crash();
-
             Within(TimeSpan.FromSeconds(60), () =>
             {
                 RunOn(() =>
@@ -688,10 +778,10 @@ namespace Akka.Cluster.Sharding.Tests
                         rebalancingRegion.Tell(new Counter.Get(i));
                         ExpectMsg(1);
                     }
-                }, _fourth);
+                }, _config.Fourth);
                 EnterBarrier("rebalancing-shards-allocated");
 
-                Join(_sixth, _third);
+                Join(_config.Sixth, _config.Third);
 
                 RunOn(() =>
                 {
@@ -713,16 +803,13 @@ namespace Akka.Cluster.Sharding.Tests
                             Assert.True(count >= 2);
                         });
                     });
-                }, _sixth);
+                }, _config.Sixth);
                 EnterBarrier("after-9");
             });
         }
 
-        [MultiNodeFact(Skip = "TODO")]
         public void ClusterSharding_should_be_easy_to_use_with_extensions()
         {
-            ClusterSharding_should_rebalance_to_nodes_with_less_shards();
-
             Within(TimeSpan.FromSeconds(50), () =>
             {
                 RunOn(() =>
@@ -738,11 +825,20 @@ namespace Akka.Cluster.Sharding.Tests
                     //#counter-start
                     ClusterSharding.Get(Sys).Start(
                         typeName: "AnotherCounter",
-                        entityProps: Props.Create<Counter>(),
+                        entityProps: Props.Create<AnotherCounter>(),
                         settings: ClusterShardingSettings.Create(Sys),
                         idExtractor: Counter.ExtractEntityId,
                         shardResolver: Counter.ExtractShardId);
-                }, _third, _fourth, _fifth, _sixth);
+
+                    //#counter-supervisor-start
+                    ClusterSharding.Get(Sys).Start(
+                      typeName: "SupervisedCounter",
+                      entityProps: Props.Create<CounterSupervisor>(),
+                      settings: ClusterShardingSettings.Create(Sys),
+                      idExtractor: Counter.ExtractEntityId,
+                      shardResolver: Counter.ExtractShardId);
+                    //#counter-supervisor-start
+                }, _config.Third, _config.Fourth, _config.Fifth, _config.Sixth);
                 EnterBarrier("extension-started");
 
                 RunOn(() =>
@@ -755,13 +851,13 @@ namespace Akka.Cluster.Sharding.Tests
                     counterRegion.Tell(new Counter.EntityEnvelope(123, Counter.Increment.Instance));
                     counterRegion.Tell(new Counter.Get(123));
                     ExpectMsg(1);
-
                     //#counter-usage
+
                     var anotherCounterRegion = ClusterSharding.Get(Sys).ShardRegion("AnotherCounter");
                     anotherCounterRegion.Tell(new Counter.EntityEnvelope(123, Counter.Decrement.Instance));
                     anotherCounterRegion.Tell(new Counter.Get(123));
                     ExpectMsg(-1);
-                }, _fifth);
+                }, _config.Fifth);
                 EnterBarrier("extension-used");
 
                 // sixth is a frontend node, i.e. proxy only
@@ -774,16 +870,13 @@ namespace Akka.Cluster.Sharding.Tests
                         ExpectMsg(1);
                         Assert.NotEqual(Cluster.SelfAddress, LastSender.Path.Address);
                     }
-                }, _sixth);
+                }, _config.Sixth);
                 EnterBarrier("after-10");
             });
         }
 
-        [MultiNodeFact(Skip = "TODO")]
         public void ClusterSharding_should_be_easy_API_for_starting()
         {
-            ClusterSharding_should_be_easy_to_use_with_extensions();
-
             Within(TimeSpan.FromSeconds(50), () =>
             {
                 RunOn(() =>
@@ -798,7 +891,7 @@ namespace Akka.Cluster.Sharding.Tests
                     var counterRegionViaGet = ClusterSharding.Get(Sys).ShardRegion("ApiTest");
 
                     Assert.Equal(counterRegionViaGet, counterRegionViaStart);
-                }, _first);
+                }, _config.First);
                 EnterBarrier("after-11");
             });
         }
@@ -807,8 +900,7 @@ namespace Akka.Cluster.Sharding.Tests
 
         #region Persistent cluster shards specs
 
-        [MultiNodeFact(Skip = "TODO")]
-        public void Persistent_cluster_shards_should_recover_entities_upon_restart()
+        public void PersistentClusterShards_should_recover_entities_upon_restart()
         {
             Within(TimeSpan.FromSeconds(50), () =>
             {
@@ -816,7 +908,7 @@ namespace Akka.Cluster.Sharding.Tests
                 {
                     var x = _persistentEntitiesRegion.Value;
                     var y = _anotherPersistentRegion.Value;
-                }, _third, _fourth, _fifth);
+                }, _config.Third, _config.Fourth, _config.Fifth);
                 EnterBarrier("persistent-start");
 
                 RunOn(() =>
@@ -830,7 +922,7 @@ namespace Akka.Cluster.Sharding.Tests
                     var shard = Sys.ActorSelection(LastSender.Path.Parent);
                     var region = Sys.ActorSelection(LastSender.Path.Parent.Parent);
 
-                    // stop shard
+                    //Stop the shard cleanly
                     region.Tell(new PersistentShardCoordinator.HandOff("1"));
                     ExpectMsg<PersistentShardCoordinator.ShardStopped>(s => s.Shard == "1", TimeSpan.FromSeconds(10));
 
@@ -848,12 +940,19 @@ namespace Akka.Cluster.Sharding.Tests
                     //Check that counter 1 is now alive again, even though we have
                     // not sent a message to it via the ShardRegion
                     var counter1 = Sys.ActorSelection(LastSender.Path.Parent / "1");
-                    counter1.Tell(new Identify(2));
-                    Assert.NotNull(ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(3)).Subject);
+                    Within(TimeSpan.FromSeconds(5), () =>
+                    {
+                        AwaitAssert(() =>
+                        {
+                            var probe2 = CreateTestProbe();
+                            counter1.Tell(new Identify(2), probe2.Ref);
+                            probe2.ExpectMsg<ActorIdentity>(i => i.Subject != null, TimeSpan.FromSeconds(2));
+                        });
+                    });
 
                     counter1.Tell(new Counter.Get(1));
                     ExpectMsg(1);
-                }, _third);
+                }, _config.Third);
                 EnterBarrier("after-shard-restart");
 
                 RunOn(() =>
@@ -869,22 +968,19 @@ namespace Akka.Cluster.Sharding.Tests
                     var secondCounter1 = Sys.ActorSelection(LastSender.Path.Parent / "1");
                     secondCounter1.Tell(new Identify(3));
                     ExpectMsg<ActorIdentity>(i => i.MessageId.Equals(3) && i.Subject == null, TimeSpan.FromSeconds(3));
-                }, _fourth);
+                }, _config.Fourth);
                 EnterBarrier("after-12");
             });
         }
 
-        [MultiNodeFact(Skip = "TODO")]
-        public void Persistent_cluster_shards_should_permanently_stop_entities_which_passivate()
+        public void PersistentClusterShards_should_permanently_stop_entities_which_passivate()
         {
-            Persistent_cluster_shards_should_recover_entities_upon_restart();
-
-            Within(TimeSpan.FromSeconds(15), () =>
+            Within(TimeSpan.FromSeconds(20), () =>
             {
                 RunOn(() =>
                 {
                     var x = _persistentRegion.Value;
-                }, _third, _fourth, _fifth);
+                }, _config.Third, _config.Fourth, _config.Fifth);
                 EnterBarrier("cluster-started-12");
 
                 RunOn(() =>
@@ -930,10 +1026,10 @@ namespace Akka.Cluster.Sharding.Tests
                     AwaitAssert(() =>
                     {
                         shard.Tell(new Identify(2), probe2.Ref);
-                        probe1.ExpectMsg<ActorIdentity>(i => i.MessageId.Equals(1) && i.Subject == null, TimeSpan.FromSeconds(1));
+                        probe2.ExpectMsg<ActorIdentity>(i => i.MessageId.Equals(2) && i.Subject == null, TimeSpan.FromSeconds(1));
                     }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(500));
 
-                }, _third);
+                }, _config.Third);
                 EnterBarrier("shard-shutdonw-12");
 
                 RunOn(() =>
@@ -949,25 +1045,25 @@ namespace Akka.Cluster.Sharding.Tests
                     ExpectMsg<ActorIdentity>(i => i.MessageId.Equals(3) && i.Subject == null);
 
                     // check counter 13 is alive again
-                    Sys.ActorSelection(shard / "13").Tell(new Identify(4));
-                    ExpectMsg<ActorIdentity>(i => i.MessageId.Equals(4) && i.Subject != null);
-
-                }, _fourth);
+                    var probe3 = CreateTestProbe();
+                    AwaitAssert(() =>
+                    {
+                        Sys.ActorSelection(shard / "13").Tell(new Identify(4), probe3.Ref);
+                        probe3.ExpectMsg<ActorIdentity>(i => i.MessageId.Equals(4) && i.Subject != null);
+                    }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(500));
+                }, _config.Fourth);
                 EnterBarrier("after-13");
             });
         }
 
-        [MultiNodeFact(Skip = "TODO")]
-        public void Persistent_cluster_shards_should_restart_entities_which_stop_without_passivation()
+        public void PersistentClusterShards_should_restart_entities_which_stop_without_passivation()
         {
-            Persistent_cluster_shards_should_permanently_stop_entities_which_passivate();
-
             Within(TimeSpan.FromSeconds(50), () =>
             {
                 RunOn(() =>
                 {
                     var x = _persistentRegion.Value;
-                }, _third, _fourth);
+                }, _config.Third, _config.Fourth);
                 EnterBarrier("cluster-started-12");
 
                 RunOn(() =>
@@ -986,16 +1082,13 @@ namespace Akka.Cluster.Sharding.Tests
                         counter1.Tell(new Identify(1), probe.Ref);
                         Assert.NotNull(probe.ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(1)).Subject);
                     }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(500));
-                }, _third);
+                }, _config.Third);
                 EnterBarrier("after-14");
             });
         }
 
-        [MultiNodeFact(Skip = "TODO")]
-        public void Persistent_cluster_shards_should_be_migrated_to_new_regions_upon_region_failure()
+        public void PersistentClusterShards_should_be_migrated_to_new_regions_upon_region_failure()
         {
-            Persistent_cluster_shards_should_restart_entities_which_stop_without_passivation();
-
             Within(TimeSpan.FromSeconds(15), () =>
             {
                 //Start only one region, and force an entity onto that region
@@ -1004,7 +1097,7 @@ namespace Akka.Cluster.Sharding.Tests
                     _autoMigrateRegion.Value.Tell(new Counter.EntityEnvelope(1, Counter.Increment.Instance));
                     _autoMigrateRegion.Value.Tell(new Counter.Get(1));
                     ExpectMsg(1);
-                }, _third);
+                }, _config.Third);
                 EnterBarrier("shard1-region3");
 
                 //Start another region and test it talks to node 3
@@ -1014,18 +1107,18 @@ namespace Akka.Cluster.Sharding.Tests
                     _autoMigrateRegion.Value.Tell(new Counter.Get(1));
                     ExpectMsg(2);
 
-                    Assert.Equal(Node(_third) / "user" / "AutoMigrateRegionTestRegion" / "1" / "1", LastSender.Path);
+                    Assert.Equal(Node(_config.Third) / "user" / "AutoMigrateRememberRegionTestRegion" / "1" / "1", LastSender.Path);
 
                     // kill region 3
                     Sys.ActorSelection(LastSender.Path.Parent.Parent).Tell(PoisonPill.Instance);
-                }, _fourth);
+                }, _config.Fourth);
                 EnterBarrier("region4-up");
 
                 // Wait for migration to happen
                 //Test the shard, thus counter was moved onto node 4 and started.
                 RunOn(() =>
                 {
-                    var counter1 = Sys.ActorSelection(ActorPath.Parse("user") / "AutoMigrateRegionTestRegion" / "1" / "1");
+                    var counter1 = Sys.ActorSelection("user/AutoMigrateRememberRegionTestRegion/1/1");
                     var probe = CreateTestProbe();
                     AwaitAssert(() =>
                     {
@@ -1035,35 +1128,32 @@ namespace Akka.Cluster.Sharding.Tests
 
                     counter1.Tell(new Counter.Get(1));
                     ExpectMsg(2);
-                }, _fourth);
+                }, _config.Fourth);
                 EnterBarrier("after-15");
             });
         }
 
-        [MultiNodeFact(Skip = "TODO")]
-        public void Persistent_cluster_shards_should_ensure_rebalance_restarts_shards()
+        public void PersistentClusterShards_should_ensure_rebalance_restarts_shards()
         {
-            Persistent_cluster_shards_should_be_migrated_to_new_regions_upon_region_failure();
-
             Within(TimeSpan.FromSeconds(50), () =>
             {
                 RunOn(() =>
                 {
-                    for (int i = 1; i <= 12; i++)
+                    for (int i = 2; i <= 12; i++)
                         _rebalancingPersistentRegion.Value.Tell(new Counter.EntityEnvelope(i, Counter.Increment.Instance));
 
-                    for (int i = 1; i <= 12; i++)
+                    for (int i = 2; i <= 12; i++)
                     {
                         _rebalancingPersistentRegion.Value.Tell(new Counter.Get(i));
                         ExpectMsg(1);
                     }
-                }, _fourth);
+                }, _config.Fourth);
                 EnterBarrier("entities-started");
 
                 RunOn(() =>
                 {
                     var r = _rebalancingPersistentRegion.Value;
-                }, _fifth);
+                }, _config.Fifth);
                 EnterBarrier("fifth-joined-shard");
 
                 RunOn(() =>
@@ -1077,13 +1167,13 @@ namespace Akka.Cluster.Sharding.Tests
                             entity.Tell(new Identify(i));
 
                             var msg = ReceiveOne(TimeSpan.FromSeconds(3)) as ActorIdentity;
-                            if (msg != null && msg.Subject != null)
+                            if (msg != null && msg.Subject != null && msg.MessageId.Equals(i))
                                 count++;
                         }
 
                         Assert.True(count >= 2);
                     });
-                }, _fifth);
+                }, _config.Fifth);
                 EnterBarrier("after-16");
             });
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/MemoryJournalShared.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/MemoryJournalShared.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Akka.Cluster.Sharding.Tests
 {
-    public class MemoryJournalShared : AsyncWriteProxy
+    public class MemoryJournalShared : AsyncWriteProxyEx
     {
         public override TimeSpan Timeout { get; }
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/MemoryJournalShared.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/MemoryJournalShared.cs
@@ -1,0 +1,25 @@
+﻿using Akka.Actor;
+using Akka.Persistence.Journal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    public class MemoryJournalShared : AsyncWriteProxy
+    {
+        public override TimeSpan Timeout { get; }
+
+        public MemoryJournalShared()
+        {
+            Timeout = Context.System.Settings.Config.GetTimeSpan("akka.persistence.journal.memory-journal-shared.timeout");
+        }
+
+        public static void SetStore(IActorRef store, ActorSystem system)
+        {
+            Persistence.Persistence.Instance.Get(system).JournalFor(null).Tell(new SetStore(store));
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingConfigSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingConfigSpec.cs
@@ -31,7 +31,7 @@ namespace Akka.Cluster.Sharding.Tests
             Assert.NotNull(config);
             Assert.Equal("sharding", config.GetString("guardian-name"));
             Assert.Equal(string.Empty, config.GetString("role"));
-            Assert.Equal(false, config.GetBoolean("remember-entities"));
+            Assert.False(config.GetBoolean("remember-entities"));
             Assert.Equal(TimeSpan.FromSeconds(5), config.GetTimeSpan("coordinator-failure-backoff"));
             Assert.Equal(TimeSpan.FromSeconds(2), config.GetTimeSpan("retry-interval"));
             Assert.Equal(100000, config.GetInt("buffer-size"));

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingMessageSerializerSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingMessageSerializerSpec.cs
@@ -58,7 +58,7 @@ namespace Akka.Cluster.Sharding.Tests
                 .CreateBuilder<string, IActorRef>()
                 .AddAndReturn("a", region1)
                 .AddAndReturn("b", region2)
-                .AddAndReturn("c", region3)
+                .AddAndReturn("c", region2)
                 .ToImmutableDictionary();
 
             var regions = ImmutableDictionary
@@ -69,10 +69,10 @@ namespace Akka.Cluster.Sharding.Tests
                 .ToImmutableDictionary();
 
             var state = new PersistentShardCoordinator.State(
-                shards,
-                regions,
-                ImmutableHashSet.Create(regionProxy1, regionProxy2),
-                ImmutableHashSet.Create("d"));
+                shards: shards,
+                regions: regions,
+                regionProxies: ImmutableHashSet.Create(regionProxy1, regionProxy2),
+                unallocatedShards: ImmutableHashSet.Create("d"));
 
             CheckSerialization(state);
         }
@@ -128,6 +128,13 @@ namespace Akka.Cluster.Sharding.Tests
         public void ClusterShardingMessageSerializer_must_be_able_to_serializable_ShardStats()
         {
             CheckSerialization(new Shard.ShardStats("a", 23));
+        }
+
+        [Fact]
+        public void ClusterShardingMessageSerializer_must_be_able_to_serialize_StartEntity()
+        {
+            CheckSerialization(new ShardRegion.StartEntity("42"));
+            CheckSerialization(new ShardRegion.StartEntityAck("13", "37"));
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ConstantRateEntityRecoveryStrategySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ConstantRateEntityRecoveryStrategySpec.cs
@@ -28,7 +28,7 @@ namespace Akka.Cluster.Sharding.Tests
         }
 
         [Fact]
-        public void ConstantRateEntityRecoveryStrategySpec_must_recover_entities()
+        public void ConstantRateEntityRecoveryStrategy_must_recover_entities()
         {
             var entities = ImmutableHashSet.Create<EntityId>("1", "2", "3", "4", "5");
             var startTime = DateTime.UtcNow;
@@ -54,7 +54,7 @@ namespace Akka.Cluster.Sharding.Tests
         }
 
         [Fact]
-        public void ConstantRateEntityRecoveryStrategySpec_must_no_recover_when_no_entities_to_recover()
+        public void ConstantRateEntityRecoveryStrategy_must_no_recover_when_no_entities_to_recover()
         {
             var result = strategy.RecoverEntities(ImmutableHashSet<EntityId>.Empty);
             result.Should().BeEmpty();

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/LeastShardAllocationStrategySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/LeastShardAllocationStrategySpec.cs
@@ -64,11 +64,11 @@ namespace Akka.Cluster.Sharding.Tests
             var r2 = _allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result;
             r2.Should().BeEquivalentTo(new[] { "shard2", "shard3" });
 
-            var r3 = _allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("shard4")).Result;
+            var r3 = _allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("shard4")).Result;
             r3.Count.Should().Be(0);
 
             allocations = allocations.SetItem(_regionA, new[] { "shard1", "shard5", "shard6" }.ToImmutableList());
-            var r4 = _allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("shard1")).Result;
+            var r4 = _allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("shard1")).Result;
             r4.Should().BeEquivalentTo(new[] { "shard2" });
         }
 
@@ -85,7 +85,7 @@ namespace Akka.Cluster.Sharding.Tests
             var r1 = _allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result;
             r1.Should().BeEquivalentTo(new[] { "shard2", "shard3" });
 
-            var r2 = _allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("shard2").Add("shard3")).Result;
+            var r2 = _allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("shard2", "shard3")).Result;
             r2.Count.Should().Be(0);
         }
 
@@ -99,10 +99,10 @@ namespace Akka.Cluster.Sharding.Tests
                 {_regionC, ImmutableList<string>.Empty}
             }.ToImmutableDictionary();
 
-            var r1 = _allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("shard2")).Result;
+            var r1 = _allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("shard2")).Result;
             r1.Should().BeEquivalentTo(new[] { "shard3" });
 
-            var r2 = _allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("shard2").Add("shard3")).Result;
+            var r2 = _allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("shard2", "shard3")).Result;
             r2.Count.Should().Be(0);
         }
     }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/LeastShardAllocationStrategySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/LeastShardAllocationStrategySpec.cs
@@ -12,6 +12,7 @@ using Akka.Actor;
 using Akka.TestKit;
 using Akka.TestKit.Xunit2;
 using Xunit;
+using FluentAssertions;
 
 namespace Akka.Cluster.Sharding.Tests
 {
@@ -42,7 +43,7 @@ namespace Akka.Cluster.Sharding.Tests
             }.ToImmutableDictionary();
 
             var result = _allocationStrategy.AllocateShard(_regionA, "shard3", allocations).Result;
-            Assert.Equal(result, _regionC);
+            result.Should().Be(_regionC);
         }
 
         [Fact]
@@ -57,18 +58,18 @@ namespace Akka.Cluster.Sharding.Tests
 
             // so far regionB has 2 shards and regionC has 0 shards, but the diff is less than rebalanceThreshold
             var r1 = _allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result;
-            Assert.Equal(0, r1.Count);
+            r1.Count.Should().Be(0);
 
             allocations = allocations.SetItem(_regionB, new[] { "shard2", "shard3", "shard4" }.ToImmutableList());
             var r2 = _allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result;
-            Assert.True(r2.SetEquals(new[] { "shard2", "shard3" }));
+            r2.Should().BeEquivalentTo(new[] { "shard2", "shard3" });
 
             var r3 = _allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("shard4")).Result;
-            Assert.Equal(0, r3.Count);
+            r3.Count.Should().Be(0);
 
             allocations = allocations.SetItem(_regionA, new[] { "shard1", "shard5", "shard6" }.ToImmutableList());
             var r4 = _allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("shard1")).Result;
-            Assert.True(r4.SetEquals(new[] { "shard2" }));
+            r4.Should().BeEquivalentTo(new[] { "shard2" });
         }
 
         [Fact]
@@ -82,10 +83,10 @@ namespace Akka.Cluster.Sharding.Tests
             }.ToImmutableDictionary();
 
             var r1 = _allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result;
-            Assert.True(r1.SetEquals(new[] { "shard2", "shard3" }));
+            r1.Should().BeEquivalentTo(new[] { "shard2", "shard3" });
 
             var r2 = _allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("shard2").Add("shard3")).Result;
-            Assert.Equal(0, r2.Count);
+            r2.Count.Should().Be(0);
         }
 
         [Fact]
@@ -99,10 +100,10 @@ namespace Akka.Cluster.Sharding.Tests
             }.ToImmutableDictionary();
 
             var r1 = _allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("shard2")).Result;
-            Assert.True(r1.SetEquals(new[] { "shard3" }));
+            r1.Should().BeEquivalentTo(new[] { "shard3" });
 
             var r2 = _allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("shard2").Add("shard3")).Result;
-            Assert.Equal(0, r2.Count);
+            r2.Count.Should().Be(0);
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
@@ -44,8 +44,8 @@ namespace Akka.Cluster.Sharding
     }
 
     /// <summary>
-    /// Convenience implementation of <see cref="IMessageExtractor"/> that 
-    /// construct ShardId based on the <see cref="object.GetHashCode"/> of the EntityId. 
+    /// Convenience implementation of <see cref="IMessageExtractor"/> that
+    /// construct ShardId based on the <see cref="object.GetHashCode"/> of the EntityId.
     /// The number of unique shards is limited by the given MaxNumberOfShards.
     /// </summary>
     public abstract class HashCodeMessageExtractor : IMessageExtractor
@@ -99,7 +99,7 @@ namespace Akka.Cluster.Sharding
 
     /// <summary>
     /// <para>
-    /// This extension provides sharding functionality of actors in a cluster. 
+    /// This extension provides sharding functionality of actors in a cluster.
     /// The typical use case is when you have many stateful actors that together consume
     /// more resources (e.g. memory) than fit on one machine. You need to distribute them across
     /// several nodes in the cluster and you want to be able to interact with them using their
@@ -255,7 +255,7 @@ namespace Akka.Cluster.Sharding
                 var guardianName = system.Settings.Config.GetString("akka.cluster.sharding.guardian-name");
                 var dispatcher = system.Settings.Config.GetString("akka.cluster.sharding.use-dispatcher");
                 if (string.IsNullOrEmpty(dispatcher)) dispatcher = Dispatchers.DefaultDispatcherId;
-                return system.ActorOf(Props.Create(() => new ClusterShardingGuardian()).WithDispatcher(dispatcher), guardianName);
+                return system.SystemActorOf(Props.Create(() => new ClusterShardingGuardian()).WithDispatcher(dispatcher), guardianName);
             });
         }
 
@@ -274,18 +274,18 @@ namespace Akka.Cluster.Sharding
         }
 
         /// <summary>
-        /// Register a named entity type by defining the <see cref="Actor.Props"/> of the entity actor and 
-        /// functions to extract entity and shard identifier from messages. The <see cref="Sharding.ShardRegion"/> 
+        /// Register a named entity type by defining the <see cref="Actor.Props"/> of the entity actor and
+        /// functions to extract entity and shard identifier from messages. The <see cref="Sharding.ShardRegion"/>
         /// actor for this type can later be retrieved with the <see cref="ShardRegion"/> method.
         /// </summary>
         /// <param name="typeName">The name of the entity type</param>
         /// <param name="entityProps">
-        /// The <see cref="Actor.Props"/> of the entity actors that will be created by the <see cref="Sharding.ShardRegion"/> 
+        /// The <see cref="Actor.Props"/> of the entity actors that will be created by the <see cref="Sharding.ShardRegion"/>
         /// </param>
         /// <param name="settings">Configuration settings, see <see cref="ClusterShardingSettings"/></param>
         /// <param name="idExtractor">
-        /// Partial function to extract the entity id and the message to send to the entity from the incoming message, 
-        /// if the partial function does not match the message will be `unhandled`, 
+        /// Partial function to extract the entity id and the message to send to the entity from the incoming message,
+        /// if the partial function does not match the message will be `unhandled`,
         /// i.e.posted as `Unhandled` messages on the event stream
         /// </param>
         /// <param name="shardResolver">
@@ -293,7 +293,7 @@ namespace Akka.Cluster.Sharding
         /// </param>
         /// <param name="allocationStrategy">Possibility to use a custom shard allocation and rebalancing logic</param>
         /// <param name="handOffStopMessage">
-        /// The message that will be sent to entities when they are to be stopped for a rebalance or 
+        /// The message that will be sent to entities when they are to be stopped for a rebalance or
         /// graceful shutdown of a <see cref="Sharding.ShardRegion"/>, e.g. <see cref="PoisonPill"/>.
         /// </param>
         /// <exception cref="IllegalStateException">
@@ -321,18 +321,18 @@ namespace Akka.Cluster.Sharding
         }
 
         /// <summary>
-        /// Register a named entity type by defining the <see cref="Actor.Props"/> of the entity actor and 
-        /// functions to extract entity and shard identifier from messages. The <see cref="Sharding.ShardRegion"/> 
+        /// Register a named entity type by defining the <see cref="Actor.Props"/> of the entity actor and
+        /// functions to extract entity and shard identifier from messages. The <see cref="Sharding.ShardRegion"/>
         /// actor for this type can later be retrieved with the <see cref="ShardRegion"/> method.
         /// </summary>
         /// <param name="typeName">The name of the entity type</param>
         /// <param name="entityProps">
-        /// The <see cref="Actor.Props"/> of the entity actors that will be created by the <see cref="Sharding.ShardRegion"/> 
+        /// The <see cref="Actor.Props"/> of the entity actors that will be created by the <see cref="Sharding.ShardRegion"/>
         /// </param>
         /// <param name="settings">Configuration settings, see <see cref="ClusterShardingSettings"/></param>
         /// <param name="idExtractor">
-        /// Partial function to extract the entity id and the message to send to the entity from the incoming message, 
-        /// if the partial function does not match the message will be `unhandled`, 
+        /// Partial function to extract the entity id and the message to send to the entity from the incoming message,
+        /// if the partial function does not match the message will be `unhandled`,
         /// i.e.posted as `Unhandled` messages on the event stream
         /// </param>
         /// <param name="shardResolver">
@@ -340,7 +340,7 @@ namespace Akka.Cluster.Sharding
         /// </param>
         /// <param name="allocationStrategy">Possibility to use a custom shard allocation and rebalancing logic</param>
         /// <param name="handOffStopMessage">
-        /// The message that will be sent to entities when they are to be stopped for a rebalance or 
+        /// The message that will be sent to entities when they are to be stopped for a rebalance or
         /// graceful shutdown of a <see cref="Sharding.ShardRegion"/>, e.g. <see cref="PoisonPill"/>.
         /// </param>
         /// <exception cref="IllegalStateException">
@@ -368,18 +368,18 @@ namespace Akka.Cluster.Sharding
         }
 
         /// <summary>
-        /// Register a named entity type by defining the <see cref="Actor.Props"/> of the entity actor and 
-        /// functions to extract entity and shard identifier from messages. The <see cref="Sharding.ShardRegion"/> 
+        /// Register a named entity type by defining the <see cref="Actor.Props"/> of the entity actor and
+        /// functions to extract entity and shard identifier from messages. The <see cref="Sharding.ShardRegion"/>
         /// actor for this type can later be retrieved with the <see cref="ShardRegion"/> method.
         /// </summary>
         /// <param name="typeName">The name of the entity type</param>
         /// <param name="entityProps">
-        /// The <see cref="Actor.Props"/> of the entity actors that will be created by the <see cref="Sharding.ShardRegion"/> 
+        /// The <see cref="Actor.Props"/> of the entity actors that will be created by the <see cref="Sharding.ShardRegion"/>
         /// </param>
         /// <param name="settings">Configuration settings, see <see cref="ClusterShardingSettings"/></param>
         /// <param name="idExtractor">
-        /// Partial function to extract the entity id and the message to send to the entity from the incoming message, 
-        /// if the partial function does not match the message will be `unhandled`, 
+        /// Partial function to extract the entity id and the message to send to the entity from the incoming message,
+        /// if the partial function does not match the message will be `unhandled`,
         /// i.e.posted as `Unhandled` messages on the event stream
         /// </param>
         /// <param name="shardResolver">
@@ -400,18 +400,18 @@ namespace Akka.Cluster.Sharding
         }
 
         /// <summary>
-        /// Register a named entity type by defining the <see cref="Actor.Props"/> of the entity actor and 
-        /// functions to extract entity and shard identifier from messages. The <see cref="Sharding.ShardRegion"/> 
+        /// Register a named entity type by defining the <see cref="Actor.Props"/> of the entity actor and
+        /// functions to extract entity and shard identifier from messages. The <see cref="Sharding.ShardRegion"/>
         /// actor for this type can later be retrieved with the <see cref="ShardRegion"/> method.
         /// </summary>
         /// <param name="typeName">The name of the entity type</param>
         /// <param name="entityProps">
-        /// The <see cref="Actor.Props"/> of the entity actors that will be created by the <see cref="Sharding.ShardRegion"/> 
+        /// The <see cref="Actor.Props"/> of the entity actors that will be created by the <see cref="Sharding.ShardRegion"/>
         /// </param>
         /// <param name="settings">Configuration settings, see <see cref="ClusterShardingSettings"/></param>
         /// <param name="idExtractor">
-        /// Partial function to extract the entity id and the message to send to the entity from the incoming message, 
-        /// if the partial function does not match the message will be `unhandled`, 
+        /// Partial function to extract the entity id and the message to send to the entity from the incoming message,
+        /// if the partial function does not match the message will be `unhandled`,
         /// i.e.posted as `Unhandled` messages on the event stream
         /// </param>
         /// <param name="shardResolver">
@@ -432,13 +432,13 @@ namespace Akka.Cluster.Sharding
         }
 
         /// <summary>
-        /// Register a named entity type by defining the <see cref="Actor.Props"/> of the entity actor and 
-        /// functions to extract entity and shard identifier from messages. The <see cref="Sharding.ShardRegion"/> 
+        /// Register a named entity type by defining the <see cref="Actor.Props"/> of the entity actor and
+        /// functions to extract entity and shard identifier from messages. The <see cref="Sharding.ShardRegion"/>
         /// actor for this type can later be retrieved with the <see cref="ShardRegion"/> method.
         /// </summary>
         /// <param name="typeName">The name of the entity type</param>
         /// <param name="entityProps">
-        /// The <see cref="Actor.Props"/> of the entity actors that will be created by the <see cref="Sharding.ShardRegion"/> 
+        /// The <see cref="Actor.Props"/> of the entity actors that will be created by the <see cref="Sharding.ShardRegion"/>
         /// </param>
         /// <param name="settings">Configuration settings, see <see cref="ClusterShardingSettings"/></param>
         /// <param name="messageExtractor">
@@ -446,7 +446,7 @@ namespace Akka.Cluster.Sharding
         /// </param>
         /// <param name="allocationStrategy">Possibility to use a custom shard allocation and rebalancing logic</param>
         /// <param name="handOffMessage">
-        /// The message that will be sent to entities when they are to be stopped for a rebalance or 
+        /// The message that will be sent to entities when they are to be stopped for a rebalance or
         /// graceful shutdown of a <see cref="Sharding.ShardRegion"/>, e.g. <see cref="PoisonPill"/>.
         /// </param>
         /// <returns>The actor ref of the <see cref="Sharding.ShardRegion"/> that is to be responsible for the shard.</returns>
@@ -460,13 +460,13 @@ namespace Akka.Cluster.Sharding
         }
 
         /// <summary>
-        /// Register a named entity type by defining the <see cref="Actor.Props"/> of the entity actor and 
-        /// functions to extract entity and shard identifier from messages. The <see cref="Sharding.ShardRegion"/> 
+        /// Register a named entity type by defining the <see cref="Actor.Props"/> of the entity actor and
+        /// functions to extract entity and shard identifier from messages. The <see cref="Sharding.ShardRegion"/>
         /// actor for this type can later be retrieved with the <see cref="ShardRegion"/> method.
         /// </summary>
         /// <param name="typeName">The name of the entity type</param>
         /// <param name="entityProps">
-        /// The <see cref="Actor.Props"/> of the entity actors that will be created by the <see cref="Sharding.ShardRegion"/> 
+        /// The <see cref="Actor.Props"/> of the entity actors that will be created by the <see cref="Sharding.ShardRegion"/>
         /// </param>
         /// <param name="settings">Configuration settings, see <see cref="ClusterShardingSettings"/></param>
         /// <param name="messageExtractor">
@@ -474,7 +474,7 @@ namespace Akka.Cluster.Sharding
         /// </param>
         /// <param name="allocationStrategy">Possibility to use a custom shard allocation and rebalancing logic</param>
         /// <param name="handOffMessage">
-        /// The message that will be sent to entities when they are to be stopped for a rebalance or 
+        /// The message that will be sent to entities when they are to be stopped for a rebalance or
         /// graceful shutdown of a <see cref="Sharding.ShardRegion"/>, e.g. <see cref="PoisonPill"/>.
         /// </param>
         /// <returns>The actor ref of the <see cref="Sharding.ShardRegion"/> that is to be responsible for the shard.</returns>
@@ -488,13 +488,13 @@ namespace Akka.Cluster.Sharding
         }
 
         /// <summary>
-        /// Register a named entity type by defining the <see cref="Actor.Props"/> of the entity actor and 
-        /// functions to extract entity and shard identifier from messages. The <see cref="Sharding.ShardRegion"/> 
+        /// Register a named entity type by defining the <see cref="Actor.Props"/> of the entity actor and
+        /// functions to extract entity and shard identifier from messages. The <see cref="Sharding.ShardRegion"/>
         /// actor for this type can later be retrieved with the <see cref="ShardRegion"/> method.
         /// </summary>
         /// <param name="typeName">The name of the entity type</param>
         /// <param name="entityProps">
-        /// The <see cref="Actor.Props"/> of the entity actors that will be created by the <see cref="Sharding.ShardRegion"/> 
+        /// The <see cref="Actor.Props"/> of the entity actors that will be created by the <see cref="Sharding.ShardRegion"/>
         /// </param>
         /// <param name="settings">Configuration settings, see <see cref="ClusterShardingSettings"/></param>
         /// <param name="messageExtractor">
@@ -515,13 +515,13 @@ namespace Akka.Cluster.Sharding
         }
 
         /// <summary>
-        /// Register a named entity type by defining the <see cref="Actor.Props"/> of the entity actor and 
-        /// functions to extract entity and shard identifier from messages. The <see cref="Sharding.ShardRegion"/> 
+        /// Register a named entity type by defining the <see cref="Actor.Props"/> of the entity actor and
+        /// functions to extract entity and shard identifier from messages. The <see cref="Sharding.ShardRegion"/>
         /// actor for this type can later be retrieved with the <see cref="ShardRegion"/> method.
         /// </summary>
         /// <param name="typeName">The name of the entity type</param>
         /// <param name="entityProps">
-        /// The <see cref="Actor.Props"/> of the entity actors that will be created by the <see cref="Sharding.ShardRegion"/> 
+        /// The <see cref="Actor.Props"/> of the entity actors that will be created by the <see cref="Sharding.ShardRegion"/>
         /// </param>
         /// <param name="settings">Configuration settings, see <see cref="ClusterShardingSettings"/></param>
         /// <param name="messageExtractor">
@@ -542,19 +542,19 @@ namespace Akka.Cluster.Sharding
         }
 
         /// <summary>
-        /// Register a named entity type `ShardRegion` on this node that will run in proxy only mode, i.e.it will 
+        /// Register a named entity type `ShardRegion` on this node that will run in proxy only mode, i.e.it will
         /// delegate messages to other `ShardRegion` actors on other nodes, but not host any entity actors itself.
-        /// The <see cref="Sharding.ShardRegion"/>  actor for this type can later be retrieved with the 
+        /// The <see cref="Sharding.ShardRegion"/>  actor for this type can later be retrieved with the
         /// <see cref="ShardRegion"/>  method.
         /// </summary>
         /// <param name="typeName">The name of the entity type.</param>
         /// <param name="role">
-        /// Specifies that this entity type is located on cluster nodes with a specific role. 
+        /// Specifies that this entity type is located on cluster nodes with a specific role.
         /// If the role is not specified all nodes in the cluster are used.
         /// </param>
         /// <param name="idExtractor">
-        /// Partial function to extract the entity id and the message to send to the  entity from the incoming message, 
-        /// if the partial function does not match the message will  be `unhandled`, i.e.posted as `Unhandled` messages 
+        /// Partial function to extract the entity id and the message to send to the  entity from the incoming message,
+        /// if the partial function does not match the message will  be `unhandled`, i.e.posted as `Unhandled` messages
         /// on the event stream
         /// </param>
         /// <param name="shardResolver">
@@ -572,19 +572,19 @@ namespace Akka.Cluster.Sharding
         }
 
         /// <summary>
-        /// Register a named entity type `ShardRegion` on this node that will run in proxy only mode, i.e.it will 
+        /// Register a named entity type `ShardRegion` on this node that will run in proxy only mode, i.e.it will
         /// delegate messages to other `ShardRegion` actors on other nodes, but not host any entity actors itself.
-        /// The <see cref="Sharding.ShardRegion"/>  actor for this type can later be retrieved with the 
+        /// The <see cref="Sharding.ShardRegion"/>  actor for this type can later be retrieved with the
         /// <see cref="ShardRegion"/>  method.
         /// </summary>
         /// <param name="typeName">The name of the entity type.</param>
         /// <param name="role">
-        /// Specifies that this entity type is located on cluster nodes with a specific role. 
+        /// Specifies that this entity type is located on cluster nodes with a specific role.
         /// If the role is not specified all nodes in the cluster are used.
         /// </param>
         /// <param name="idExtractor">
-        /// Partial function to extract the entity id and the message to send to the  entity from the incoming message, 
-        /// if the partial function does not match the message will  be `unhandled`, i.e.posted as `Unhandled` messages 
+        /// Partial function to extract the entity id and the message to send to the  entity from the incoming message,
+        /// if the partial function does not match the message will  be `unhandled`, i.e.posted as `Unhandled` messages
         /// on the event stream
         /// </param>
         /// <param name="shardResolver">
@@ -602,14 +602,14 @@ namespace Akka.Cluster.Sharding
         }
 
         /// <summary>
-        /// Register a named entity type `ShardRegion` on this node that will run in proxy only mode, i.e.it will 
+        /// Register a named entity type `ShardRegion` on this node that will run in proxy only mode, i.e.it will
         /// delegate messages to other `ShardRegion` actors on other nodes, but not host any entity actors itself.
-        /// The <see cref="Sharding.ShardRegion"/>  actor for this type can later be retrieved with the 
+        /// The <see cref="Sharding.ShardRegion"/>  actor for this type can later be retrieved with the
         /// <see cref="ShardRegion"/>  method.
         /// </summary>
         /// <param name="typeName">The name of the entity type.</param>
         /// <param name="role">
-        /// Specifies that this entity type is located on cluster nodes with a specific role. 
+        /// Specifies that this entity type is located on cluster nodes with a specific role.
         /// If the role is not specified all nodes in the cluster are used.
         /// </param>
         /// <param name="messageExtractor">
@@ -629,14 +629,14 @@ namespace Akka.Cluster.Sharding
         }
 
         /// <summary>
-        /// Register a named entity type `ShardRegion` on this node that will run in proxy only mode, i.e.it will 
+        /// Register a named entity type `ShardRegion` on this node that will run in proxy only mode, i.e.it will
         /// delegate messages to other `ShardRegion` actors on other nodes, but not host any entity actors itself.
-        /// The <see cref="Sharding.ShardRegion"/>  actor for this type can later be retrieved with the 
+        /// The <see cref="Sharding.ShardRegion"/>  actor for this type can later be retrieved with the
         /// <see cref="ShardRegion"/>  method.
         /// </summary>
         /// <param name="typeName">The name of the entity type.</param>
         /// <param name="role">
-        /// Specifies that this entity type is located on cluster nodes with a specific role. 
+        /// Specifies that this entity type is located on cluster nodes with a specific role.
         /// If the role is not specified all nodes in the cluster are used.
         /// </param>
         /// <param name="messageExtractor">
@@ -704,13 +704,13 @@ namespace Akka.Cluster.Sharding
     public delegate Tuple<EntityId, Msg> IdExtractor(Msg message);
 
     /// <summary>
-    /// Interface of functions to extract entity id,  shard id, and the message to send 
+    /// Interface of functions to extract entity id,  shard id, and the message to send
     /// to the entity from an incoming message.
     /// </summary>
     public interface IMessageExtractor
     {
         /// <summary>
-        /// Extract the entity id from an incoming <paramref name="message"/>. 
+        /// Extract the entity id from an incoming <paramref name="message"/>.
         /// If <see langword="null"/> is returned the message will be `unhandled`, i.e. posted as `Unhandled`
         ///  messages on the event stream
         /// </summary>
@@ -729,7 +729,7 @@ namespace Akka.Cluster.Sharding
         object EntityMessage(object message);
 
         /// <summary>
-        /// Extract the entity id from an incoming <paramref name="message"/>. Only messages that 
+        /// Extract the entity id from an incoming <paramref name="message"/>. Only messages that
         /// passed the <see cref="EntityId"/> method will be used as input to this method.
         /// </summary>
         /// <param name="message">TBD</param>
@@ -801,11 +801,11 @@ namespace Akka.Cluster.Sharding
     }
 
     /// <summary>
-    /// INTERNAL API. Rebalancing process is performed by this actor. It sends 
-    /// <see cref="PersistentShardCoordinator.BeginHandOff"/> to all <see cref="ShardRegion"/> actors followed 
-    /// by <see cref="PersistentShardCoordinator.HandOff"/> to the <see cref="ShardRegion"/> responsible for 
-    /// the shard. When the handoff is completed it sends <see cref="RebalanceDone"/> to its parent 
-    /// <see cref="PersistentShardCoordinator"/>. If the process takes longer than the `handOffTimeout` it 
+    /// INTERNAL API. Rebalancing process is performed by this actor. It sends
+    /// <see cref="PersistentShardCoordinator.BeginHandOff"/> to all <see cref="ShardRegion"/> actors followed
+    /// by <see cref="PersistentShardCoordinator.HandOff"/> to the <see cref="ShardRegion"/> responsible for
+    /// the shard. When the handoff is completed it sends <see cref="RebalanceDone"/> to its parent
+    /// <see cref="PersistentShardCoordinator"/>. If the process takes longer than the `handOffTimeout` it
     /// also sends <see cref="RebalanceDone"/>.
     /// </summary>
     internal class RebalanceWorker : ActorBase

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
@@ -219,7 +219,7 @@ namespace Akka.Cluster.Sharding
                             settings: settings,
                             coordinatorPath: coordinatorPath,
                             extractEntityId: startProxy.ExtractEntityId,
-                            extractShardId: startProxy.ExtractShardId), encName);
+                            extractShardId: startProxy.ExtractShardId).WithDispatcher(Context.Props.Dispatcher), encName);
                     }
 
                     Sender.Tell(new Started(shardRegion));

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
@@ -160,49 +160,77 @@ namespace Akka.Cluster.Sharding
         {
             Receive<Start>(start =>
             {
-                var settings = start.Settings;
-                var encName = Uri.EscapeDataString(start.TypeName);
-                var coordinatorSingletonManagerName = CoordinatorSingletonManagerName(encName);
-                var coordinatorPath = CoordinatorPath(encName);
-                var shardRegion = Context.Child(encName);
-
-                if (Equals(shardRegion, ActorRefs.Nobody))
+                try
                 {
-                    var minBackoff = settings.TunningParameters.CoordinatorFailureBackoff;
-                    var maxBackoff = new TimeSpan(minBackoff.Ticks * 5);
-                    var coordinatorProps = PersistentShardCoordinator.Props(start.TypeName, settings, start.AllocationStrategy);
-                    var singletonProps = BackoffSupervisor.Props(coordinatorProps, "coordinator", minBackoff, maxBackoff, 0.2).WithDeploy(Deploy.Local);
-                    var singletonSettings = settings.CoordinatorSingletonSettings.WithSingletonName("singleton").WithRole(settings.Role);
-                    var shardCoordinatorSingleton = Context.ActorOf(ClusterSingletonManager.Props(singletonProps, PoisonPill.Instance, singletonSettings), coordinatorSingletonManagerName);
+                    var settings = start.Settings;
+                    var encName = Uri.EscapeDataString(start.TypeName);
+                    var coordinatorSingletonManagerName = CoordinatorSingletonManagerName(encName);
+                    var coordinatorPath = CoordinatorPath(encName);
+                    var shardRegion = Context.Child(encName);
+
+                    if (Equals(shardRegion, ActorRefs.Nobody))
+                    {
+                        if (Equals(Context.Child(coordinatorSingletonManagerName), ActorRefs.Nobody))
+                        {
+                            var minBackoff = settings.TunningParameters.CoordinatorFailureBackoff;
+                            var maxBackoff = new TimeSpan(minBackoff.Ticks * 5);
+                            var coordinatorProps = PersistentShardCoordinator.Props(start.TypeName, settings, start.AllocationStrategy);
+                            var singletonProps = BackoffSupervisor.Props(coordinatorProps, "coordinator", minBackoff, maxBackoff, 0.2).WithDeploy(Deploy.Local);
+                            var singletonSettings = settings.CoordinatorSingletonSettings.WithSingletonName("singleton").WithRole(settings.Role);
+                            Context.ActorOf(ClusterSingletonManager.Props(singletonProps, PoisonPill.Instance, singletonSettings).WithDispatcher(Context.Props.Dispatcher), coordinatorSingletonManagerName);
+                        }
+                        shardRegion = Context.ActorOf(ShardRegion.Props(
+                            typeName: start.TypeName,
+                            entityProps: start.EntityProps,
+                            settings: settings,
+                            coordinatorPath: coordinatorPath,
+                            extractEntityId: start.IdExtractor,
+                            extractShardId: start.ShardResolver,
+                            handOffStopMessage: start.HandOffStopMessage).WithDispatcher(Context.Props.Dispatcher), encName);
+                    }
+
+                    Sender.Tell(new Started(shardRegion));
                 }
-
-                shardRegion = Context.ActorOf(ShardRegion.Props(
-                    typeName: start.TypeName,
-                    entityProps: start.EntityProps,
-                    settings: settings,
-                    coordinatorPath: coordinatorPath,
-                    extractEntityId: start.IdExtractor,
-                    extractShardId: start.ShardResolver,
-                    handOffStopMessage: start.HandOffStopMessage), encName);
-
-                Sender.Tell(new Started(shardRegion));
+                catch (Exception ex)
+                {
+                    //TODO: JVM version matches NonFatal. Can / should we do something similar?
+                    // don't restart
+                    // could be invalid ReplicatorSettings, or InvalidActorNameException
+                    // if it has already been started
+                    Sender.Tell(new Status.Failure(ex));
+                }
             });
 
             Receive<StartProxy>(startProxy =>
             {
-                var settings = startProxy.Settings;
-                var encName = Uri.EscapeDataString(startProxy.TypeName);
-                var coordinatorSingletonManagerName = CoordinatorSingletonManagerName(encName);
-                var coordinatorPath = CoordinatorPath(encName);
+                try
+                {
+                    var settings = startProxy.Settings;
+                    var encName = Uri.EscapeDataString(startProxy.TypeName);
+                    var coordinatorSingletonManagerName = CoordinatorSingletonManagerName(encName);
+                    var coordinatorPath = CoordinatorPath(encName);
+                    var shardRegion = Context.Child(encName);
 
-                var shardRegion = Context.ActorOf(ShardRegion.ProxyProps(
-                    typeName: startProxy.TypeName,
-                    settings: settings,
-                    coordinatorPath: coordinatorPath,
-                    extractEntityId: startProxy.ExtractEntityId,
-                    extractShardId: startProxy.ExtractShardId), encName);
+                    if (Equals(shardRegion, ActorRefs.Nobody))
+                    {
 
-                Sender.Tell(new Started(shardRegion));
+                        shardRegion = Context.ActorOf(ShardRegion.ProxyProps(
+                            typeName: startProxy.TypeName,
+                            settings: settings,
+                            coordinatorPath: coordinatorPath,
+                            extractEntityId: startProxy.ExtractEntityId,
+                            extractShardId: startProxy.ExtractShardId), encName);
+                    }
+
+                    Sender.Tell(new Started(shardRegion));
+                }
+                catch (Exception ex)
+                {
+                    //TODO: JVM version matches NonFatal. Can / should we do something similar?
+                    // don't restart
+                    // could be InvalidActorNameException if it has already been started
+                    Sender.Tell(new Status.Failure(ex));
+                }
             });
         }
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShard.cs
@@ -209,14 +209,14 @@ namespace Akka.Cluster.Sharding
         /// <param name="handler">TBD</param>
         protected override void ProcessChange<T>(T evt, Action<T> handler)
         {
-            SaveSnapshotIfNeeded();
+            SaveSnapshotWhenNeeded();
             _persistent.Persist(evt, handler);
         }
 
         /// <summary>
         /// TBD
         /// </summary>
-        protected void SaveSnapshotIfNeeded()
+        protected void SaveSnapshotWhenNeeded()
         {
             if (_persistent.LastSequenceNr % Settings.TunningParameters.SnapshotAfter == 0 && _persistent.LastSequenceNr != 0)
             {

--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShard.cs
@@ -10,6 +10,7 @@ using System.Collections.Immutable;
 using Akka.Actor;
 using Akka.Persistence;
 using Akka.Util.Internal;
+using System.Threading.Tasks;
 
 namespace Akka.Cluster.Sharding
 {
@@ -282,7 +283,7 @@ namespace Akka.Cluster.Sharding
         private void RestartRememberedEntities()
         {
             RememberedEntitiesRecoveryStrategy.RecoverEntities(State.Entries).ForEach(scheduledRecovery =>
-                scheduledRecovery.ContinueWith(t => new RestartEntities(t.Result)).PipeTo(_context.Self));
+                scheduledRecovery.ContinueWith(t => new RestartEntities(t.Result), TaskContinuationOptions.ExecuteSynchronously).PipeTo(_context.Self));
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShard.cs
@@ -17,22 +17,69 @@ namespace Akka.Cluster.Sharding
     using EntryId = String;
     using Msg = Object;
 
+    public class PersistentShardActor : PersistentActor, IPersistentActorContext
+    {
+        private readonly PersistentShard _shardSemantic;
+
+        public PersistentShardActor(
+            string typeName,
+            string shardId,
+            Props entityProps,
+            ClusterShardingSettings settings,
+            IdExtractor extractEntityId,
+            ShardResolver extractShardId,
+            object handOffStopMessage)
+        {
+            _shardSemantic = new PersistentShard(
+                context: Context,
+                persistentContext: this,
+                unhandled: Unhandled,
+                typeName: typeName,
+                shardId: shardId,
+                entityProps: entityProps,
+                settings: settings,
+                extractEntityId: extractEntityId,
+                extractShardId: extractShardId,
+                handOffStopMessage: handOffStopMessage);
+
+            JournalPluginId = _shardSemantic.JournalPluginId;
+            SnapshotPluginId = _shardSemantic.SnapshotPluginId;
+        }
+
+        public override string PersistenceId => _shardSemantic.PersistenceId;
+
+        protected override bool ReceiveCommand(object message)
+        {
+            return _shardSemantic.ReceiveCommand(message);
+        }
+
+        protected override bool ReceiveRecover(object message)
+        {
+            return _shardSemantic.ReceiveRecover(message);
+        }
+    }
+
+    public interface IPersistentActorContext
+    {
+        long LastSequenceNr { get; }
+        long SnapshotSequenceNr { get; }
+
+        void Persist<TEvent>(TEvent @event, Action<TEvent> handler);
+        void DeleteMessages(long toSequenceNr);
+        void SaveSnapshot(object snapshot);
+        void DeleteSnapshot(long sequenceNr);
+        void DeleteSnapshots(SnapshotSelectionCriteria criteria);
+    }
+
     /// <summary>
     /// This actor creates children entity actors on demand that it is told to be
     /// responsible for. It is used when `rememberEntities` is enabled.
     /// </summary>
     public class PersistentShard : Shard
     {
-        /// <summary>
-        /// TBD
-        /// </summary>
-        protected int PersistCount = 0;
+        private readonly IPersistentActorContext _persistent;
 
         private readonly string _persistenceId;
-        /// <summary>
-        /// TBD
-        /// </summary>
-        public override string PersistenceId { get { return _persistenceId; } }
 
         /// <summary>
         /// TBD
@@ -45,6 +92,9 @@ namespace Akka.Cluster.Sharding
         /// <param name="extractShardId">TBD</param>
         /// <param name="handOffStopMessage">TBD</param>
         public PersistentShard(
+            IActorContext context,
+            IPersistentActorContext persistentContext,
+            Action<object> unhandled,
             string typeName,
             string shardId,
             Props entityProps,
@@ -52,22 +102,29 @@ namespace Akka.Cluster.Sharding
             IdExtractor extractEntityId,
             ShardResolver extractShardId,
             object handOffStopMessage)
-            : base(typeName, shardId, entityProps, settings, extractEntityId, extractShardId, handOffStopMessage)
+            : base(context, unhandled, typeName, shardId, entityProps, settings, extractEntityId, extractShardId, handOffStopMessage)
         {
+            _persistent = persistentContext;
             _persistenceId = "/sharding/" + TypeName + "Shard/" + ShardId;
-            JournalPluginId = Settings.JournalPluginId;
-            SnapshotPluginId = Settings.SnapshotPluginId;
-
         }
+
+        public string PersistenceId => _persistenceId;
+        public string JournalPluginId => Settings.JournalPluginId;
+        public string SnapshotPluginId => Settings.SnapshotPluginId;
 
         private EntityRecoveryStrategy RememberedEntitiesRecoveryStrategy => Settings.TunningParameters.EntityRecoveryStrategy == "constant"
             ? EntityRecoveryStrategy.ConstantStrategy(
-                Context.System,
+                _context.System,
                 Settings.TunningParameters.EntityRecoveryConstantRateStrategyFrequency,
                 Settings.TunningParameters.EntityRecoveryConstantRateStrategyNumberOfEntities)
             : EntityRecoveryStrategy.AllStrategy;
 
-        protected override bool ReceiveCommand(object message)
+        public override void Initialized()
+        {
+            // would be initialized after recovery completed
+        }
+
+        public bool ReceiveCommand(object message)
         {
             switch (message)
             {
@@ -85,7 +142,7 @@ namespace Akka.Cluster.Sharding
                     var deleteToSequenceNr = m.Metadata.SequenceNr - Settings.TunningParameters.KeepNrOfBatches * Settings.TunningParameters.SnapshotAfter;
                     if (deleteToSequenceNr > 0)
                     {
-                        DeleteMessages(deleteToSequenceNr);
+                        _persistent.DeleteMessages(deleteToSequenceNr);
                     }
                     break;
                 case SaveSnapshotFailure m:
@@ -93,7 +150,7 @@ namespace Akka.Cluster.Sharding
                     break;
                 case DeleteMessagesSuccess m:
                     Log.Debug("PersistentShard messages to {0} deleted successfully", m.ToSequenceNr);
-                    DeleteSnapshots(new SnapshotSelectionCriteria(m.ToSequenceNr - 1));
+                    _persistent.DeleteSnapshots(new SnapshotSelectionCriteria(m.ToSequenceNr - 1));
                     break;
 
                 case DeleteMessagesFailure m:
@@ -116,7 +173,7 @@ namespace Akka.Cluster.Sharding
         /// </summary>
         /// <param name="message">TBD</param>
         /// <returns>TBD</returns>
-        protected override bool ReceiveRecover(object message)
+        public bool ReceiveRecover(object message)
         {
             SnapshotOffer offer;
             if (message is EntityStarted)
@@ -152,7 +209,7 @@ namespace Akka.Cluster.Sharding
         protected override void ProcessChange<T>(T evt, Action<T> handler)
         {
             SaveSnapshotIfNeeded();
-            Persist(evt, handler);
+            _persistent.Persist(evt, handler);
         }
 
         /// <summary>
@@ -160,11 +217,10 @@ namespace Akka.Cluster.Sharding
         /// </summary>
         protected void SaveSnapshotIfNeeded()
         {
-            PersistCount++;
-            if ((PersistCount % Settings.TunningParameters.SnapshotAfter) == 0)
+            if (_persistent.LastSequenceNr % Settings.TunningParameters.SnapshotAfter == 0 && _persistent.LastSequenceNr != 0)
             {
-                Log.Debug("Saving snapshot, sequence number [{0}]", SnapshotSequenceNr);
-                SaveSnapshot(State);
+                Log.Debug("Saving snapshot, sequence number [{0}]", _persistent.SnapshotSequenceNr);
+                _persistent.SaveSnapshot(State);
             }
         }
 
@@ -174,12 +230,14 @@ namespace Akka.Cluster.Sharding
         /// <param name="tref">TBD</param>
         protected override void EntityTerminated(IActorRef tref)
         {
-
             if (IdByRef.TryGetValue(tref, out var id))
             {
+                IdByRef = IdByRef.Remove(tref);
+                RefById = RefById.Remove(id);
+
                 if (MessageBuffers.TryGetValue(id, out var buffer) && buffer.Count != 0)
                 {
-                    // Note; because we're not persisting the EntityStopped, we don't need
+                    //Note; because we're not persisting the EntityStopped, we don't need
                     // to persist the EntityStarted either.
                     Log.Debug("Starting entity [{0}] again, there are buffered messages for it", id);
                     SendMessageBuffer(new EntityStarted(id));
@@ -189,14 +247,14 @@ namespace Akka.Cluster.Sharding
                     if (!Passivating.Contains(tref))
                     {
                         Log.Debug("Entity [{0}] stopped without passivating, will restart after backoff", id);
-                        Context.System.Scheduler.ScheduleTellOnce(Settings.TunningParameters.EntityRestartBackoff, Sender, new RestartEntity(id), Self);
+                        _context.System.Scheduler.ScheduleTellOnce(Settings.TunningParameters.EntityRestartBackoff, _context.Self, new RestartEntity(id), ActorRefs.NoSender);
                     }
                     else
                         ProcessChange(new EntityStopped(id), PassivateCompleted);
                 }
-            }
 
-            Passivating = Passivating.Remove(tref);
+                Passivating = Passivating.Remove(tref);
+            }
         }
 
         /// <summary>
@@ -210,13 +268,12 @@ namespace Akka.Cluster.Sharding
         protected override void DeliverTo(string id, object message, object payload, IActorRef sender)
         {
             var name = Uri.EscapeDataString(id);
-            var child = Context.Child(name);
+            var child = _context.Child(name);
             if (Equals(child, ActorRefs.Nobody))
             {
                 // Note; we only do this if remembering, otherwise the buffer is an overhead
                 MessageBuffers = MessageBuffers.SetItem(id, ImmutableList<Tuple<object, IActorRef>>.Empty.Add(Tuple.Create(message, sender)));
-                SaveSnapshotIfNeeded();
-                Persist(new EntityStarted(id), SendMessageBuffer);
+                ProcessChange(new EntityStarted(id), SendMessageBuffer);
             }
             else
                 child.Tell(payload, sender);
@@ -225,24 +282,7 @@ namespace Akka.Cluster.Sharding
         private void RestartRememberedEntities()
         {
             RememberedEntitiesRecoveryStrategy.RecoverEntities(State.Entries).ForEach(scheduledRecovery =>
-                scheduledRecovery.ContinueWith(t => new RestartEntities(t.Result)).PipeTo(Self));
-        }
-
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="typeName">TBD</param>
-        /// <param name="shardId">TBD</param>
-        /// <param name="entryProps">TBD</param>
-        /// <param name="settings">TBD</param>
-        /// <param name="idExtractor">TBD</param>
-        /// <param name="shardResolver">TBD</param>
-        /// <param name="handOffStopMessage">TBD</param>
-        /// <returns>TBD</returns>
-        public static Actor.Props Props(string typeName, ShardId shardId, Props entryProps, ClusterShardingSettings settings, IdExtractor idExtractor, ShardResolver shardResolver, object handOffStopMessage)
-        {
-            return Actor.Props.Create(() => new PersistentShard(typeName, shardId, entryProps, settings, idExtractor, shardResolver, handOffStopMessage)).WithDeploy(Deploy.Local);
+                scheduledRecovery.ContinueWith(t => new RestartEntities(t.Result)).PipeTo(_context.Self));
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.Messages.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.Messages.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using Akka.Actor;
 using Akka.Event;
+using System.Collections.Immutable;
 
 namespace Akka.Cluster.Sharding
 {
@@ -547,7 +548,7 @@ namespace Akka.Cluster.Sharding
         /// Result of <see cref="PersistentShardCoordinator.AllocateShard"/> is piped to self with this message.
         /// </summary>
         [Serializable]
-        public sealed class AllocateShardResult : ICoordinatorCommand
+        public sealed class AllocateShardResult
         {
             /// <summary>
             /// TBD
@@ -580,18 +581,18 @@ namespace Akka.Cluster.Sharding
         /// Result of `rebalance` is piped to self with this message.
         /// </summary>
         [Serializable]
-        public sealed class RebalanceResult : ICoordinatorCommand
+        public sealed class RebalanceResult
         {
             /// <summary>
             /// TBD
             /// </summary>
-            public readonly IEnumerable<ShardId> Shards;
+            public readonly IImmutableSet<ShardId> Shards;
 
             /// <summary>
             /// TBD
             /// </summary>
             /// <param name="shards">TBD</param>
-            public RebalanceResult(IEnumerable<string> shards)
+            public RebalanceResult(IImmutableSet<string> shards)
             {
                 Shards = shards;
             }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
@@ -541,7 +541,7 @@ namespace Akka.Cluster.Sharding
                 else
                     shardsTask.ContinueWith(t => !(t.IsFaulted || t.IsCanceled)
                         ? new RebalanceResult(t.Result)
-                        : new RebalanceResult(ImmutableHashSet<ShardId>.Empty))
+                        : new RebalanceResult(ImmutableHashSet<ShardId>.Empty), TaskContinuationOptions.ExecuteSynchronously)
                     .PipeTo(Self);
             }
         }
@@ -604,7 +604,7 @@ namespace Akka.Cluster.Sharding
                         else
                             regionTask.ContinueWith(t => !(t.IsFaulted || t.IsCanceled)
                                 ? new AllocateShardResult(shard, t.Result, getShardHomeSender)
-                                : new AllocateShardResult(shard, null, getShardHomeSender))
+                                : new AllocateShardResult(shard, null, getShardHomeSender), TaskContinuationOptions.ExecuteSynchronously)
                             .PipeTo(Self);
                     }
                 }
@@ -706,10 +706,10 @@ namespace Akka.Cluster.Sharding
         {
             var sender = Sender;
             Task.WhenAll(
-                _aliveRegions.Select(regionActor => regionActor.Ask<ShardRegionStats>(GetShardRegionStats.Instance, message.Timeout).ContinueWith(r => Tuple.Create(regionActor, r.Result)))
+                _aliveRegions.Select(regionActor => regionActor.Ask<ShardRegionStats>(GetShardRegionStats.Instance, message.Timeout).ContinueWith(r => Tuple.Create(regionActor, r.Result), TaskContinuationOptions.ExecuteSynchronously))
                 ).ContinueWith(allRegionStats =>
                 {
-                    if(allRegionStats.IsFaulted || allRegionStats.IsCanceled)
+                    if (allRegionStats.IsFaulted || allRegionStats.IsCanceled)
                     {
                         return new ClusterShardingStats(ImmutableDictionary<Address, ShardRegionStats>.Empty);
                     }
@@ -723,7 +723,7 @@ namespace Akka.Cluster.Sharding
 
                         return new ClusterShardingStats(regions);
                     }
-                }).PipeTo(sender);
+                }, TaskContinuationOptions.ExecuteSynchronously).PipeTo(sender);
         }
 
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
@@ -727,7 +727,7 @@ namespace Akka.Cluster.Sharding
         }
 
 
-        private void SaveSnapshotIfNeeded()
+        private void SaveSnapshotWhenNeeded()
         {
             if (LastSequenceNr % Settings.TunningParameters.SnapshotAfter == 0 && LastSequenceNr != 0)
             {
@@ -930,7 +930,7 @@ namespace Akka.Cluster.Sharding
         /// <returns>TBD</returns>
         protected void Update<TEvent>(TEvent e, Action<TEvent> handler) where TEvent : IDomainEvent
         {
-            SaveSnapshotIfNeeded();
+            SaveSnapshotWhenNeeded();
             Persist(e, handler);
         }
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Serialization/Proto/ClusterShardingMessages.g.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Serialization/Proto/ClusterShardingMessages.g.cs
@@ -10,7 +10,7 @@ using scg = global::System.Collections.Generic;
 namespace Akka.Cluster.Sharding.Serialization.Proto.Msg {
 
   /// <summary>Holder for reflection information generated from ClusterShardingMessages.proto</summary>
-  internal static partial class ClusterShardingMessagesReflection {
+  public static partial class ClusterShardingMessagesReflection {
 
     #region Descriptor
     /// <summary>File descriptor for ClusterShardingMessages.proto</summary>
@@ -28,32 +28,37 @@ namespace Akka.Cluster.Sharding.Serialization.Proto.Msg {
             "ZGluZy5TZXJpYWxpemF0aW9uLlByb3RvLk1zZy5Db29yZGluYXRvclN0YXRl",
             "LlNoYXJkRW50cnkSDwoHcmVnaW9ucxgCIAMoCRIVCg1yZWdpb25Qcm94aWVz",
             "GAMgAygJEhkKEXVuYWxsb2NhdGVkU2hhcmRzGAQgAygJGjAKClNoYXJkRW50",
-            "cnkSDwoHc2hhcmRJZBgBIAEoCRIRCglyZWdpb25SZWYYAiABKAkiHwoOU2hh",
-            "cmRJZE1lc3NhZ2USDQoFc2hhcmQYASABKAkiMwoSU2hhcmRIb21lQWxsb2Nh",
-            "dGVkEg0KBXNoYXJkGAEgASgJEg4KBnJlZ2lvbhgCIAEoCSIqCglTaGFyZEhv",
-            "bWUSDQoFc2hhcmQYASABKAkSDgoGcmVnaW9uGAIgASgJIh8KC0VudGl0eVN0",
-            "YXRlEhAKCGVudGl0aWVzGAEgAygJIiEKDUVudGl0eVN0YXJ0ZWQSEAoIZW50",
-            "aXR5SWQYASABKAkiIQoNRW50aXR5U3RvcHBlZBIQCghlbnRpdHlJZBgBIAEo",
-            "CSIwCgpTaGFyZFN0YXRzEg0KBXNoYXJkGAEgASgJEhMKC2VudGl0eUNvdW50",
-            "GAIgASgFYgZwcm90bzM="));
+            "cnkSDwoHc2hhcmRJZBgBIAEoCRIRCglyZWdpb25SZWYYAiABKAkiHgoPQWN0",
+            "b3JSZWZNZXNzYWdlEgsKA3JlZhgBIAEoCSIfCg5TaGFyZElkTWVzc2FnZRIN",
+            "CgVzaGFyZBgBIAEoCSIzChJTaGFyZEhvbWVBbGxvY2F0ZWQSDQoFc2hhcmQY",
+            "ASABKAkSDgoGcmVnaW9uGAIgASgJIioKCVNoYXJkSG9tZRINCgVzaGFyZBgB",
+            "IAEoCRIOCgZyZWdpb24YAiABKAkiHwoLRW50aXR5U3RhdGUSEAoIZW50aXRp",
+            "ZXMYASADKAkiIQoNRW50aXR5U3RhcnRlZBIQCghlbnRpdHlJZBgBIAEoCSIh",
+            "Cg1FbnRpdHlTdG9wcGVkEhAKCGVudGl0eUlkGAEgASgJIjAKClNoYXJkU3Rh",
+            "dHMSDQoFc2hhcmQYASABKAkSEwoLZW50aXR5Q291bnQYAiABKAUiHwoLU3Rh",
+            "cnRFbnRpdHkSEAoIZW50aXR5SWQYASABKAkiMwoOU3RhcnRFbnRpdHlBY2sS",
+            "EAoIZW50aXR5SWQYASABKAkSDwoHc2hhcmRJZBgCIAEoCWIGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.CoordinatorState), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.CoordinatorState.Parser, new[]{ "Shards", "Regions", "RegionProxies", "UnallocatedShards" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.CoordinatorState.Types.ShardEntry), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.CoordinatorState.Types.ShardEntry.Parser, new[]{ "ShardId", "RegionRef" }, null, null, null)}),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ActorRefMessage), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ActorRefMessage.Parser, new[]{ "Ref" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ShardIdMessage), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ShardIdMessage.Parser, new[]{ "Shard" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ShardHomeAllocated), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ShardHomeAllocated.Parser, new[]{ "Shard", "Region" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ShardHome), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ShardHome.Parser, new[]{ "Shard", "Region" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.EntityState), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.EntityState.Parser, new[]{ "Entities" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.EntityStarted), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.EntityStarted.Parser, new[]{ "EntityId" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.EntityStopped), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.EntityStopped.Parser, new[]{ "EntityId" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ShardStats), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ShardStats.Parser, new[]{ "Shard", "EntityCount" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ShardStats), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ShardStats.Parser, new[]{ "Shard", "EntityCount" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.StartEntity), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.StartEntity.Parser, new[]{ "EntityId" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.StartEntityAck), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.StartEntityAck.Parser, new[]{ "EntityId", "ShardId" }, null, null, null)
           }));
     }
     #endregion
 
   }
   #region Messages
-  internal sealed partial class CoordinatorState : pb::IMessage<CoordinatorState> {
+  public sealed partial class CoordinatorState : pb::IMessage<CoordinatorState> {
     private static readonly pb::MessageParser<CoordinatorState> _parser = new pb::MessageParser<CoordinatorState>(() => new CoordinatorState());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<CoordinatorState> Parser { get { return _parser; } }
@@ -374,14 +379,131 @@ namespace Akka.Cluster.Sharding.Serialization.Proto.Msg {
 
   }
 
-  internal sealed partial class ShardIdMessage : pb::IMessage<ShardIdMessage> {
+  public sealed partial class ActorRefMessage : pb::IMessage<ActorRefMessage> {
+    private static readonly pb::MessageParser<ActorRefMessage> _parser = new pb::MessageParser<ActorRefMessage>(() => new ActorRefMessage());
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pb::MessageParser<ActorRefMessage> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ClusterShardingMessagesReflection.Descriptor.MessageTypes[1]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public ActorRefMessage() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public ActorRefMessage(ActorRefMessage other) : this() {
+      ref_ = other.ref_;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public ActorRefMessage Clone() {
+      return new ActorRefMessage(this);
+    }
+
+    /// <summary>Field number for the "ref" field.</summary>
+    public const int RefFieldNumber = 1;
+    private string ref_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string Ref {
+      get { return ref_; }
+      set {
+        ref_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override bool Equals(object other) {
+      return Equals(other as ActorRefMessage);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool Equals(ActorRefMessage other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (Ref != other.Ref) return false;
+      return true;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (Ref.Length != 0) hash ^= Ref.GetHashCode();
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void WriteTo(pb::CodedOutputStream output) {
+      if (Ref.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(Ref);
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int CalculateSize() {
+      int size = 0;
+      if (Ref.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Ref);
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(ActorRefMessage other) {
+      if (other == null) {
+        return;
+      }
+      if (other.Ref.Length != 0) {
+        Ref = other.Ref;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(pb::CodedInputStream input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            input.SkipLastField();
+            break;
+          case 10: {
+            Ref = input.ReadString();
+            break;
+          }
+        }
+      }
+    }
+
+  }
+
+  public sealed partial class ShardIdMessage : pb::IMessage<ShardIdMessage> {
     private static readonly pb::MessageParser<ShardIdMessage> _parser = new pb::MessageParser<ShardIdMessage>(() => new ShardIdMessage());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<ShardIdMessage> Parser { get { return _parser; } }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ClusterShardingMessagesReflection.Descriptor.MessageTypes[1]; }
+      get { return global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ClusterShardingMessagesReflection.Descriptor.MessageTypes[2]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -491,14 +613,14 @@ namespace Akka.Cluster.Sharding.Serialization.Proto.Msg {
 
   }
 
-  internal sealed partial class ShardHomeAllocated : pb::IMessage<ShardHomeAllocated> {
+  public sealed partial class ShardHomeAllocated : pb::IMessage<ShardHomeAllocated> {
     private static readonly pb::MessageParser<ShardHomeAllocated> _parser = new pb::MessageParser<ShardHomeAllocated>(() => new ShardHomeAllocated());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<ShardHomeAllocated> Parser { get { return _parser; } }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ClusterShardingMessagesReflection.Descriptor.MessageTypes[2]; }
+      get { return global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ClusterShardingMessagesReflection.Descriptor.MessageTypes[3]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -636,14 +758,14 @@ namespace Akka.Cluster.Sharding.Serialization.Proto.Msg {
 
   }
 
-  internal sealed partial class ShardHome : pb::IMessage<ShardHome> {
+  public sealed partial class ShardHome : pb::IMessage<ShardHome> {
     private static readonly pb::MessageParser<ShardHome> _parser = new pb::MessageParser<ShardHome>(() => new ShardHome());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<ShardHome> Parser { get { return _parser; } }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ClusterShardingMessagesReflection.Descriptor.MessageTypes[3]; }
+      get { return global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ClusterShardingMessagesReflection.Descriptor.MessageTypes[4]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -781,14 +903,14 @@ namespace Akka.Cluster.Sharding.Serialization.Proto.Msg {
 
   }
 
-  internal sealed partial class EntityState : pb::IMessage<EntityState> {
+  public sealed partial class EntityState : pb::IMessage<EntityState> {
     private static readonly pb::MessageParser<EntityState> _parser = new pb::MessageParser<EntityState>(() => new EntityState());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<EntityState> Parser { get { return _parser; } }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ClusterShardingMessagesReflection.Descriptor.MessageTypes[4]; }
+      get { return global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ClusterShardingMessagesReflection.Descriptor.MessageTypes[5]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -890,14 +1012,14 @@ namespace Akka.Cluster.Sharding.Serialization.Proto.Msg {
 
   }
 
-  internal sealed partial class EntityStarted : pb::IMessage<EntityStarted> {
+  public sealed partial class EntityStarted : pb::IMessage<EntityStarted> {
     private static readonly pb::MessageParser<EntityStarted> _parser = new pb::MessageParser<EntityStarted>(() => new EntityStarted());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<EntityStarted> Parser { get { return _parser; } }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ClusterShardingMessagesReflection.Descriptor.MessageTypes[5]; }
+      get { return global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ClusterShardingMessagesReflection.Descriptor.MessageTypes[6]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1007,14 +1129,14 @@ namespace Akka.Cluster.Sharding.Serialization.Proto.Msg {
 
   }
 
-  internal sealed partial class EntityStopped : pb::IMessage<EntityStopped> {
+  public sealed partial class EntityStopped : pb::IMessage<EntityStopped> {
     private static readonly pb::MessageParser<EntityStopped> _parser = new pb::MessageParser<EntityStopped>(() => new EntityStopped());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<EntityStopped> Parser { get { return _parser; } }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ClusterShardingMessagesReflection.Descriptor.MessageTypes[6]; }
+      get { return global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ClusterShardingMessagesReflection.Descriptor.MessageTypes[7]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1124,14 +1246,14 @@ namespace Akka.Cluster.Sharding.Serialization.Proto.Msg {
 
   }
 
-  internal sealed partial class ShardStats : pb::IMessage<ShardStats> {
+  public sealed partial class ShardStats : pb::IMessage<ShardStats> {
     private static readonly pb::MessageParser<ShardStats> _parser = new pb::MessageParser<ShardStats>(() => new ShardStats());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<ShardStats> Parser { get { return _parser; } }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ClusterShardingMessagesReflection.Descriptor.MessageTypes[7]; }
+      get { return global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ClusterShardingMessagesReflection.Descriptor.MessageTypes[8]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1261,6 +1383,268 @@ namespace Akka.Cluster.Sharding.Serialization.Proto.Msg {
           }
           case 16: {
             EntityCount = input.ReadInt32();
+            break;
+          }
+        }
+      }
+    }
+
+  }
+
+  public sealed partial class StartEntity : pb::IMessage<StartEntity> {
+    private static readonly pb::MessageParser<StartEntity> _parser = new pb::MessageParser<StartEntity>(() => new StartEntity());
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pb::MessageParser<StartEntity> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ClusterShardingMessagesReflection.Descriptor.MessageTypes[9]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public StartEntity() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public StartEntity(StartEntity other) : this() {
+      entityId_ = other.entityId_;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public StartEntity Clone() {
+      return new StartEntity(this);
+    }
+
+    /// <summary>Field number for the "entityId" field.</summary>
+    public const int EntityIdFieldNumber = 1;
+    private string entityId_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string EntityId {
+      get { return entityId_; }
+      set {
+        entityId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override bool Equals(object other) {
+      return Equals(other as StartEntity);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool Equals(StartEntity other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (EntityId != other.EntityId) return false;
+      return true;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (EntityId.Length != 0) hash ^= EntityId.GetHashCode();
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void WriteTo(pb::CodedOutputStream output) {
+      if (EntityId.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(EntityId);
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int CalculateSize() {
+      int size = 0;
+      if (EntityId.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(EntityId);
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(StartEntity other) {
+      if (other == null) {
+        return;
+      }
+      if (other.EntityId.Length != 0) {
+        EntityId = other.EntityId;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(pb::CodedInputStream input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            input.SkipLastField();
+            break;
+          case 10: {
+            EntityId = input.ReadString();
+            break;
+          }
+        }
+      }
+    }
+
+  }
+
+  public sealed partial class StartEntityAck : pb::IMessage<StartEntityAck> {
+    private static readonly pb::MessageParser<StartEntityAck> _parser = new pb::MessageParser<StartEntityAck>(() => new StartEntityAck());
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pb::MessageParser<StartEntityAck> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ClusterShardingMessagesReflection.Descriptor.MessageTypes[10]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public StartEntityAck() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public StartEntityAck(StartEntityAck other) : this() {
+      entityId_ = other.entityId_;
+      shardId_ = other.shardId_;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public StartEntityAck Clone() {
+      return new StartEntityAck(this);
+    }
+
+    /// <summary>Field number for the "entityId" field.</summary>
+    public const int EntityIdFieldNumber = 1;
+    private string entityId_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string EntityId {
+      get { return entityId_; }
+      set {
+        entityId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "shardId" field.</summary>
+    public const int ShardIdFieldNumber = 2;
+    private string shardId_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string ShardId {
+      get { return shardId_; }
+      set {
+        shardId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override bool Equals(object other) {
+      return Equals(other as StartEntityAck);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool Equals(StartEntityAck other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (EntityId != other.EntityId) return false;
+      if (ShardId != other.ShardId) return false;
+      return true;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (EntityId.Length != 0) hash ^= EntityId.GetHashCode();
+      if (ShardId.Length != 0) hash ^= ShardId.GetHashCode();
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void WriteTo(pb::CodedOutputStream output) {
+      if (EntityId.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(EntityId);
+      }
+      if (ShardId.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(ShardId);
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int CalculateSize() {
+      int size = 0;
+      if (EntityId.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(EntityId);
+      }
+      if (ShardId.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(ShardId);
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(StartEntityAck other) {
+      if (other == null) {
+        return;
+      }
+      if (other.EntityId.Length != 0) {
+        EntityId = other.EntityId;
+      }
+      if (other.ShardId.Length != 0) {
+        ShardId = other.ShardId;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(pb::CodedInputStream input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            input.SkipLastField();
+            break;
+          case 10: {
+            EntityId = input.ReadString();
+            break;
+          }
+          case 18: {
+            ShardId = input.ReadString();
             break;
           }
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
@@ -19,11 +19,44 @@ namespace Akka.Cluster.Sharding
     using EntityId = String;
     using Msg = Object;
 
+    public class ShardActor : ActorBase
+    {
+        private readonly Shard _shardSemantic;
+
+        public ShardActor(
+            string typeName,
+            string shardId,
+            Props entityProps,
+            ClusterShardingSettings settings,
+            IdExtractor extractEntityId,
+            ShardResolver extractShardId,
+            object handOffStopMessage)
+        {
+            _shardSemantic = new Shard(
+                context: Context,
+                unhandled: Unhandled,
+                typeName: typeName,
+                shardId: shardId,
+                entityProps: entityProps,
+                settings: settings,
+                extractEntityId: extractEntityId,
+                extractShardId: extractShardId,
+                handOffStopMessage: handOffStopMessage);
+        }
+
+
+        protected override bool Receive(object message)
+        {
+            return _shardSemantic.HandleCommand(message);
+        }
+    }
+
+
     //TODO: figure out how not to derive from persistent actor for the sake of alternative ddata based impl
     /// <summary>
     /// TBD
     /// </summary>
-    public abstract class Shard : PersistentActor
+    public class Shard
     {
         #region messages
 
@@ -36,42 +69,6 @@ namespace Akka.Cluster.Sharding
         /// </summary>
         public interface IShardQuery { }
 
-        /// <summary>
-        /// When a <see cref="StateChange"/> fails to write to the journal, we will retry it after a back off.
-        /// </summary>
-        [Serializable]
-        protected internal class RetryPersistence : IShardCommand
-        {
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public readonly StateChange Payload;
-
-            /// <summary>
-            /// TBD
-            /// </summary>
-            /// <param name="payload">TBD</param>
-            public RetryPersistence(StateChange payload)
-            {
-                Payload = payload;
-            }
-        }
-
-        /// <summary>
-        /// The Snapshot tick for the shards.
-        /// </summary>
-        [Serializable]
-        protected internal sealed class SnapshotTick : IShardCommand
-        {
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public static readonly SnapshotTick Instance = new SnapshotTick();
-
-            private SnapshotTick()
-            {
-            }
-        }
 
         /// <summary>
         /// When an remembering entries and the entity stops without issuing a <see cref="Shard.Passivate"/>,
@@ -220,14 +217,14 @@ namespace Akka.Cluster.Sharding
             /// <summary>
             /// TBD
             /// </summary>
-            public readonly string[] EntityIds;
+            public readonly IImmutableSet< string> EntityIds;
 
             /// <summary>
             /// TBD
             /// </summary>
             /// <param name="shardId">TBD</param>
             /// <param name="entityIds">TBD</param>
-            public CurrentShardState(string shardId, string[] entityIds)
+            public CurrentShardState(string shardId, IImmutableSet<string> entityIds)
             {
                 ShardId = shardId;
                 EntityIds = entityIds;
@@ -306,6 +303,24 @@ namespace Akka.Cluster.Sharding
 
         #endregion
 
+        public static Props Props(
+            string typeName,
+            ShardId shardId,
+            Props entityProps,
+            ClusterShardingSettings settings,
+            IdExtractor extractEntityId,
+            ShardResolver extractShardId,
+            object handOffStopMessage)
+        {
+            if (settings.RememberEntities)
+                return Actor.Props.Create(() => new PersistentShardActor(typeName, shardId, entityProps, settings, extractEntityId, extractShardId, handOffStopMessage))
+                .WithDeploy(Deploy.Local);
+            else
+                return Actor.Props.Create(() => new ShardActor(typeName, shardId, entityProps, settings, extractEntityId, extractShardId, handOffStopMessage))
+                  .WithDeploy(Deploy.Local);
+        }
+
+
         /// <summary>
         /// Persistent state of the Shard.
         /// </summary>
@@ -363,6 +378,9 @@ namespace Akka.Cluster.Sharding
             #endregion
         }
 
+        protected readonly IActorContext _context;
+        protected readonly Action<object> _unhandled;
+
         /// <summary>
         /// TBD
         /// </summary>
@@ -391,7 +409,6 @@ namespace Akka.Cluster.Sharding
         /// TBD
         /// </summary>
         public readonly object HandOffStopMessage;
-
         /// <summary>
         /// TBD
         /// </summary>
@@ -433,7 +450,9 @@ namespace Akka.Cluster.Sharding
         /// <param name="extractEntityId">TBD</param>
         /// <param name="extractShardId">TBD</param>
         /// <param name="handOffStopMessage">TBD</param>
-        protected Shard(
+        public Shard(
+            IActorContext context,
+            Action <object> unhandled,
             string typeName,
             string shardId,
             Props entityProps,
@@ -442,6 +461,8 @@ namespace Akka.Cluster.Sharding
             ShardResolver extractShardId,
             object handOffStopMessage)
         {
+            _context = context;
+            _unhandled = unhandled;
             TypeName = typeName;
             ShardId = shardId;
             EntityProps = entityProps;
@@ -449,6 +470,8 @@ namespace Akka.Cluster.Sharding
             ExtractEntityId = extractEntityId;
             ExtractShardId = extractShardId;
             HandOffStopMessage = handOffStopMessage;
+
+            Initialized();
         }
 
         /// <summary>
@@ -456,7 +479,7 @@ namespace Akka.Cluster.Sharding
         /// </summary>
         protected ILoggingAdapter Log
         {
-            get { return _log ?? (_log = Context.GetLogger()); }
+            get { return _log ?? (_log = _context.GetLogger()); }
         }
 
         /// <summary>
@@ -472,9 +495,9 @@ namespace Akka.Cluster.Sharding
         /// <summary>
         /// TBD
         /// </summary>
-        protected virtual void Initialized()
+        public virtual void Initialized()
         {
-            Context.Parent.Tell(new ShardInitialized(ShardId));
+            _context.Parent.Tell(new ShardInitialized(ShardId));
         }
 
         /// <summary>
@@ -493,22 +516,24 @@ namespace Akka.Cluster.Sharding
         /// </summary>
         /// <param name="message">TBD</param>
         /// <returns>TBD</returns>
-        protected bool HandleCommand(object message)
+        public bool HandleCommand(object message)
         {
             if (message is Terminated) HandleTerminated(((Terminated) message).ActorRef);
             else if (message is PersistentShardCoordinator.ICoordinatorMessage) HandleCoordinatorMessage(message as PersistentShardCoordinator.ICoordinatorMessage);
             else if (message is IShardCommand) HandleShardCommand(message as IShardCommand);
+            else if (message is ShardRegion.StartEntity) HandleStartEntity(message as ShardRegion.StartEntity);
+            else if (message is ShardRegion.StartEntityAck) HandleStartEntityAck(message as ShardRegion.StartEntityAck);
             else if (message is IShardRegionCommand) HandleShardRegionCommand(message as IShardRegionCommand);
             else if (message is IShardQuery) HandleShardRegionQuery(message as IShardQuery);
-            else if (ExtractEntityId(message) != null) DeliverMessage(message, Sender);
+            else if (ExtractEntityId(message) != null) DeliverMessage(message, _context.Sender);
             else return false;
             return true;
         }
 
         private void HandleShardRegionQuery(IShardQuery query)
         {
-            if(query is GetCurrentShardState) Sender.Tell(new CurrentShardState(ShardId, RefById.Keys.ToArray()));
-            else if (query is GetShardStats) Sender.Tell(new ShardStats(ShardId, State.Entries.Count));
+            if(query is GetCurrentShardState) _context.Sender.Tell(new CurrentShardState(ShardId, RefById.Keys.ToImmutableHashSet()));
+            else if (query is GetShardStats) _context.Sender.Tell(new ShardStats(ShardId, State.Entries.Count));
         }
 
         /// <summary>
@@ -517,31 +542,63 @@ namespace Akka.Cluster.Sharding
         /// <param name="tref">TBD</param>
         protected virtual void EntityTerminated(IActorRef tref)
         {
-            if (IdByRef.TryGetValue(tref, out var id) && MessageBuffers.TryGetValue(id, out var buffer) && buffer.Count != 0)
+            if (IdByRef.TryGetValue(tref, out var id))
             {
-                Log.Debug("Starting entity [{0}] again, there are buffered messages for it", id);
-                SendMessageBuffer(new EntityStarted(id));
-            }
-            else
-                ProcessChange(new EntityStopped(id), PassivateCompleted);
+                IdByRef = IdByRef.Remove(tref);
+                RefById = RefById.Remove(id);
 
-            Passivating = Passivating.Remove(tref);
+                if (MessageBuffers.TryGetValue(id, out var buffer) && buffer.Count != 0)
+                {
+                    Log.Debug("Starting entity [{0}] again, there are buffered messages for it", id);
+                    SendMessageBuffer(new EntityStarted(id));
+                }
+                else
+                    ProcessChange(new EntityStopped(id), PassivateCompleted);
+
+                Passivating = Passivating.Remove(tref);
+            }
         }
 
         private void HandleShardCommand(IShardCommand message)
         {
             message.Match()
                 .With<RestartEntity>(restartEntity => GetEntity(restartEntity.EntityId))
-                .With<RestartEntities>(restartEntities => restartEntities.Entries.ForEach(entityId => GetEntity(entityId)));
+                .With<RestartEntities>(restartEntities => HandleRestartEntities(restartEntities.Entries));
         }
+
+        private void HandleStartEntity(ShardRegion.StartEntity start)
+        {
+            Log.Debug("Got a request from [{0}] to start entity [{1}] in shard [{2}]", _context.Sender, start.EntityId, ShardId);
+            GetEntity(start.EntityId);
+            _context.Sender.Tell(new ShardRegion.StartEntityAck(start.EntityId, ShardId));
+        }
+
+        private void HandleStartEntityAck(ShardRegion.StartEntityAck ack)
+        {
+            if (ack.ShardId != ShardId && State.Entries.Contains(ack.EntityId))
+            {
+                Log.Debug("Entity [{0}] previously owned by shard [{1}] started in shard [{2}]", ack.EntityId, ShardId, ack.ShardId);
+                ProcessChange(new EntityStopped(ack.EntityId), _ =>
+                {
+                    State = new ShardState(State.Entries.Remove(ack.EntityId));
+                    MessageBuffers = MessageBuffers.Remove(ack.EntityId);
+                });
+            }
+        }
+
+        private void HandleRestartEntities(IImmutableSet<EntityId> ids)
+        {
+            _context.ActorOf(RememberEntityStarter.Props(_context.Parent, TypeName, ShardId, ids, Settings, _context.Sender));
+        }
+
 
         private void HandleShardRegionCommand(IShardRegionCommand message)
         {
             var passivate = message as Passivate;
             if (passivate != null)
-                Passivate(Sender, passivate.StopMessage);
+                Passivate(_context.Sender, passivate.StopMessage);
             else
-                Unhandled(message);
+                _unhandled(message);
         }
 
         private void HandleCoordinatorMessage(PersistentShardCoordinator.ICoordinatorMessage message)
@@ -549,10 +606,10 @@ namespace Akka.Cluster.Sharding
             var handOff = message as PersistentShardCoordinator.HandOff;
             if (handOff != null)
             {
-                if (handOff.Shard == ShardId) HandOff(Sender);
+                if (handOff.Shard == ShardId) HandOff(_context.Sender);
                 else Log.Warning("Shard [{0}] can not hand off for another Shard [{1}]", ShardId, handOff.Shard);
             }
-            else Unhandled(message);
+            else _unhandled(message);
         }
 
         private void HandOff(IActorRef replyTo)
@@ -564,13 +621,11 @@ namespace Akka.Cluster.Sharding
 
                 if (State.Entries.Count != 0)
                 {
-                    //  handOffStopper = Some(context.watch(context.actorOf(
-                    //      handOffStopperProps(shardId, replyTo, idByRef.keySet, handOffStopMessage))))
-                    HandOffStopper = Context.Watch(Context.ActorOf(
+                    HandOffStopper = _context.Watch(_context.ActorOf(
                         ShardRegion.HandOffStopper.Props(ShardId, replyTo, IdByRef.Keys, HandOffStopMessage)));
 
                     //During hand off we only care about watching for termination of the hand off stopper
-                    Context.Become(message =>
+                    _context.Become(message =>
                     {
                         var terminated = message as Terminated;
                         if (terminated != null)
@@ -584,7 +639,7 @@ namespace Akka.Cluster.Sharding
                 else
                 {
                     replyTo.Tell(new PersistentShardCoordinator.ShardStopped(ShardId));
-                    Context.Stop(Self);
+                    _context.Stop(_context.Self);
                 }
             }
         }
@@ -592,21 +647,32 @@ namespace Akka.Cluster.Sharding
         private void HandleTerminated(IActorRef terminatedRef)
         {
             if (Equals(HandOffStopper, terminatedRef))
-                Context.Stop(Self);
+                _context.Stop(_context.Self);
             else if (IdByRef.ContainsKey(terminatedRef) && HandOffStopper == null)
                 EntityTerminated(terminatedRef);
         }
 
         private void Passivate(IActorRef entity, object stopMessage)
         {
-            if (IdByRef.TryGetValue(entity, out var id) && !MessageBuffers.ContainsKey(id))
+            if (IdByRef.TryGetValue(entity, out var id))
             {
-                Log.Debug("Passivating started on entity {0}", id);
+                if (!MessageBuffers.ContainsKey(id))
+                {
+                    Log.Debug("Passivating started on entity {0}", id);
 
-                Passivating = Passivating.Add(entity);
-                MessageBuffers = MessageBuffers.Add(id, ImmutableList<Tuple<object, IActorRef>>.Empty);
+                    Passivating = Passivating.Add(entity);
+                    MessageBuffers = MessageBuffers.Add(id, ImmutableList<Tuple<object, IActorRef>>.Empty);
 
-                entity.Tell(stopMessage);
+                    entity.Tell(stopMessage);
+                }
+                else
+                {
+                    Log.Debug("Passivation already in progress for {0}. Not sending stopMessage back to entity.", entity);
+                }
+            }
+            else
+            {
+                Log.Debug("Unknown entity {0}. Not sending stopMessage back to entity.", entity);
             }
         }
 
@@ -616,15 +682,9 @@ namespace Akka.Cluster.Sharding
         /// <param name="evt">TBD</param>
         protected void PassivateCompleted(EntityStopped evt)
         {
-            var id = evt.EntityId;
-            Log.Debug("Entity stopped [{0}]", id);
-
-            var entity = RefById[id];
-            IdByRef = IdByRef.Remove(entity);
-            RefById = RefById.Remove(id);
-
-            State = new ShardState(State.Entries.Remove(id));
-            MessageBuffers = MessageBuffers.Remove(id);
+            Log.Debug("Entity stopped after passivation [{0}]", evt.EntityId);
+            State = new ShardState(State.Entries.Remove(evt.EntityId));
+            MessageBuffers = MessageBuffers.Remove(evt.EntityId);
         }
 
         /// <summary>
@@ -637,18 +697,20 @@ namespace Akka.Cluster.Sharding
 
             // Get the buffered messages and remove the buffer
             if (MessageBuffers.TryGetValue(id, out var buffer))
+            {
                 MessageBuffers = MessageBuffers.Remove(id);
 
-            if (buffer.Count != 0)
-            {
-                Log.Debug("Sending message buffer for entity [{0}] ([{1}] messages)", id, buffer.Count);
+                if (buffer.Count != 0)
+                {
+                    Log.Debug("Sending message buffer for entity [{0}] ([{1}] messages)", id, buffer.Count);
 
-                GetEntity(id);
+                    GetEntity(id);
 
-                // Now there is no deliveryBuffer we can try to redeliver
-                // and as the child exists, the message will be directly forwarded
-                foreach (var pair in buffer)
-                    DeliverMessage(pair.Item1, pair.Item2);
+                    // Now there is no deliveryBuffer we can try to redeliver
+                    // and as the child exists, the message will be directly forwarded
+                    foreach (var pair in buffer)
+                        DeliverMessage(pair.Item1, pair.Item2);
+                }
             }
         }
 
@@ -661,7 +723,7 @@ namespace Akka.Cluster.Sharding
             if (string.IsNullOrEmpty(id))
             {
                 Log.Warning("Id must not be empty, dropping message [{0}]", message.GetType());
-                Context.System.DeadLetters.Tell(message);
+                _context.System.DeadLetters.Tell(message);
             }
             else
             {
@@ -669,8 +731,8 @@ namespace Akka.Cluster.Sharding
                 {
                     if (TotalBufferSize >= Settings.TunningParameters.BufferSize)
                     {
-                        Log.Warning("Buffer is full, dropping message for entity [{0}]", message.GetType());
-                        Context.System.DeadLetters.Tell(message);
+                        Log.Warning("Buffer is full, dropping message for entity [{0}]", id);
+                        _context.System.DeadLetters.Tell(message);
                     }
                     else
                     {
@@ -693,7 +755,7 @@ namespace Akka.Cluster.Sharding
         protected virtual void DeliverTo(string id, object message, object payload, IActorRef sender)
         {
             var name = Uri.EscapeDataString(id);
-            var child = Context.Child(name);
+            var child = _context.Child(name);
 
             if (Equals(child, ActorRefs.Nobody))
                 GetEntity(id).Tell(payload, sender);
@@ -709,12 +771,12 @@ namespace Akka.Cluster.Sharding
         protected IActorRef GetEntity(string id)
         {
             var name = Uri.EscapeDataString(id);
-            var child = Context.Child(name);
+            var child = _context.Child(name);
             if (Equals(child, ActorRefs.Nobody))
             {
                 Log.Debug("Starting entity [{0}] in shard [{1}]", id, ShardId);
 
-                child = Context.Watch(Context.ActorOf(EntityProps, name));
+                child = _context.Watch(_context.ActorOf(EntityProps, name));
                 IdByRef = IdByRef.SetItem(child, id);
                 RefById = RefById.SetItem(id, child);
                 State = new ShardState(State.Entries.Add(id));
@@ -724,5 +786,97 @@ namespace Akka.Cluster.Sharding
         }
 
         #endregion
+    }
+
+
+    class RememberEntityStarter : ActorBase
+    {
+        private class Tick : INoSerializationVerificationNeeded
+        {
+            public static readonly Tick Instance = new Tick();
+            private Tick()
+            {
+            }
+        }
+
+
+        public static Props Props(
+          IActorRef region,
+          string typeName,
+          ShardId shardId,
+          IImmutableSet<EntityId> ids,
+          ClusterShardingSettings settings,
+          IActorRef requestor)
+        {
+            return Actor.Props.Create(() => new RememberEntityStarter(region, typeName, shardId, ids, settings, requestor));
+        }
+
+
+        private readonly IActorRef _region;
+        private readonly string _typeName;
+        private readonly ShardId _shardId;
+        private readonly IImmutableSet<EntityId> _ids;
+        private readonly ClusterShardingSettings _settings;
+        private readonly IActorRef _requestor;
+
+        private IImmutableSet<EntityId> _waitingForAck;
+        private readonly ICancelable _tickTask;
+
+
+        public RememberEntityStarter(
+            IActorRef region,
+            string typeName,
+            ShardId shardId,
+            IImmutableSet<EntityId> ids,
+            ClusterShardingSettings settings,
+            IActorRef requestor
+            )
+        {
+            _region = region;
+            _typeName = typeName;
+            _shardId = shardId;
+            _ids = ids;
+            _settings = settings;
+            _requestor = requestor;
+
+            _waitingForAck = ids;
+
+            SendStart(ids);
+
+            var resendInterval = settings.TunningParameters.RetryInterval;
+            _tickTask = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(resendInterval, resendInterval, Self, Tick.Instance, ActorRefs.NoSender);
+        }
+
+
+
+        private void SendStart(IImmutableSet<EntityId> ids)
+        {
+            foreach(var id in ids)
+            {
+                _region.Tell(new ShardRegion.StartEntity(id));
+            }
+        }
+
+        protected override bool Receive(object message)
+        {
+            switch (message)
+            {
+                case ShardRegion.StartEntityAck ack:
+                    _waitingForAck = _waitingForAck.Remove(ack.EntityId);
+                    // inform whoever requested the start that it happened
+                    _requestor.Tell(ack);
+                    if (_waitingForAck.Count == 0) Context.Stop(Self);
+                    return true;
+                case Tick _:
+                    SendStart(_waitingForAck);
+                    return true;
+            }
+            return false;
+        }
+
+        protected override void PostStop()
+        {
+            _tickTask.Cancel();
+        }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
@@ -737,7 +737,7 @@ namespace Akka.Cluster.Sharding
                     else
                     {
                         Log.Debug("Message for entity [{0}] buffered", id);
-                        MessageBuffers.SetItem(id, buffer.Add(Tuple.Create(message, sender)));
+                        MessageBuffers = MessageBuffers.SetItem(id, buffer.Add(Tuple.Create(message, sender)));
                     }
                 }
                 else

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardAllocationStrategy.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardAllocationStrategy.cs
@@ -106,7 +106,7 @@ namespace Akka.Cluster.Sharding
 
                 if (mostShards.Length - leastShardsRegion.Value.Count >= _rebalanceThreshold)
                 {
-                    return Task.FromResult<IImmutableSet<ShardId>>(ImmutableHashSet.Create(mostShards.First()));
+                    return Task.FromResult<IImmutableSet<ShardId>>(mostShards.Take(_maxSimultaneousRebalance - rebalanceInProgress.Count).ToImmutableHashSet());
                 }
             }
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
@@ -83,6 +83,30 @@ namespace Akka.Cluster.Sharding
             {
                 EntityId = entityId;
             }
+
+            #region Equals
+
+            /// <inheritdoc/>
+            public override bool Equals(object obj)
+            {
+                var other = obj as StartEntity;
+
+                if (ReferenceEquals(other, null)) return false;
+                if (ReferenceEquals(other, this)) return true;
+
+                return EntityId.Equals(other.EntityId);
+            }
+
+            /// <inheritdoc/>
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return EntityId?.GetHashCode() ?? 0;
+                }
+            }
+
+            #endregion
         }
 
         /// <summary>
@@ -111,6 +135,33 @@ namespace Akka.Cluster.Sharding
                 EntityId = entityId;
                 ShardId = shardId;
             }
+
+            #region Equals
+
+            /// <inheritdoc/>
+            public override bool Equals(object obj)
+            {
+                var other = obj as StartEntityAck;
+
+                if (ReferenceEquals(other, null)) return false;
+                if (ReferenceEquals(other, this)) return true;
+
+                return EntityId.Equals(other.EntityId)
+                    && ShardId.Equals(other.ShardId);
+            }
+
+            /// <inheritdoc/>
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    int hashCode = EntityId?.GetHashCode() ?? 0;
+                    hashCode = (hashCode * 397) ^ (ShardId?.GetHashCode() ?? 0);
+                    return hashCode;
+                }
+            }
+
+            #endregion
         }
 
         #endregion

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardingMessages.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardingMessages.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using Akka.Actor;
+using System.Collections.Immutable;
 
 namespace Akka.Cluster.Sharding
 {
@@ -119,12 +120,12 @@ namespace Akka.Cluster.Sharding
         /// <summary>
         /// TBD
         /// </summary>
-        public readonly Address[] Regions;
+        public readonly IImmutableSet<Address> Regions;
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="regions">TBD</param>
-        public CurrentRegions(Address[] regions)
+        public CurrentRegions(IImmutableSet<Address> regions)
         {
             Regions = regions;
         }
@@ -166,13 +167,13 @@ namespace Akka.Cluster.Sharding
         /// <summary>
         /// TBD
         /// </summary>
-        public readonly IDictionary<Address, ShardRegionStats> Regions;
+        public readonly IImmutableDictionary<Address, ShardRegionStats> Regions;
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="regions">TBD</param>
-        public ClusterShardingStats(IDictionary<Address, ShardRegionStats> regions)
+        public ClusterShardingStats(IImmutableDictionary<Address, ShardRegionStats> regions)
         {
             Regions = regions;
         }
@@ -228,13 +229,13 @@ namespace Akka.Cluster.Sharding
         /// <summary>
         /// TBD
         /// </summary>
-        public readonly ISet<ShardState> Shards;
+        public readonly IImmutableSet<ShardState> Shards;
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="shards">TBD</param>
-        public CurrentShardRegionState(ISet<ShardState> shards)
+        public CurrentShardRegionState(IImmutableSet<ShardState> shards)
         {
             Shards = shards;
         }
@@ -249,13 +250,13 @@ namespace Akka.Cluster.Sharding
         /// <summary>
         /// TBD
         /// </summary>
-        public readonly IDictionary<string, int> Stats;
+        public readonly IImmutableDictionary<string, int> Stats;
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="stats">TBD</param>
-        public ShardRegionStats(IDictionary<string, int> stats)
+        public ShardRegionStats(IImmutableDictionary<string, int> stats)
         {
             Stats = stats;
         }
@@ -274,14 +275,14 @@ namespace Akka.Cluster.Sharding
         /// <summary>
         /// TBD
         /// </summary>
-        public readonly string[] EntityIds;
+        public readonly IImmutableSet<string> EntityIds;
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="shardId">TBD</param>
         /// <param name="entityIds">TBD</param>
-        public ShardState(string shardId, string[] entityIds)
+        public ShardState(string shardId, IImmutableSet<string> entityIds)
         {
             ShardId = shardId;
             EntityIds = entityIds;

--- a/src/protobuf/ClusterShardingMessages.proto
+++ b/src/protobuf/ClusterShardingMessages.proto
@@ -17,6 +17,10 @@ message CoordinatorState {
   repeated string unallocatedShards = 4; 
 }
 
+message ActorRefMessage {
+  string ref = 1;
+}
+
 message ShardIdMessage {
   string shard = 1;
 }
@@ -46,4 +50,13 @@ message EntityStopped {
 message ShardStats {
   string shard = 1;
   int32 entityCount = 2;
+}
+
+message StartEntity {
+    string entityId = 1;
+}
+
+message StartEntityAck {
+    string entityId = 1;
+    string shardId = 2;
 }


### PR DESCRIPTION
This PR updates sharding to version 2.5.2, including tests and multi-node tests.
All tests are passing on my end.

This also brings support for sharding entities without remembering feature, in the future DData support could be done in a similar way.

FYI:
**This update includes one breaking change**, which was introduced in akka 2.5.2:
If you are using Cluster Sharding with “remembering entities” there is one important change that requires that you make a change to your code when updating to 2.5.2. To solve a critical issue https://github.com/akka/akka/issues/22289 that could result in duplicate entities when the extractShardId function is changed (e.g. between deployments) there is now a new message Shard.StartEntity(entityId) that the extractShardId must understand.

close #1578
close #1579
close #1580
close #1581