### PR TITLE
Allow test failures to happen without failing build w/dotnet-xunit

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -70,13 +70,31 @@ Target "Build" (fun _ ->
 // Tests targets 
 //--------------------------------------------------------------------------------
 
+module internal ResultHandling =
+    let (|OK|Failure|) = function
+        | 0 -> OK
+        | x -> Failure x
+
+    let buildErrorMessage = function
+        | OK -> None
+        | Failure errorCode ->
+            Some (sprintf "xUnit2 reported an error (Error Code %d)" errorCode)
+
+    let failBuildWithMessage = function
+        | DontFailBuild -> traceError
+        | _ -> (fun m -> raise(FailedTestsException m))
+
+    let failBuildIfXUnitReportedError errorLevel =
+        buildErrorMessage
+        >> Option.iter (failBuildWithMessage errorLevel)
+
 Target "RunTests" (fun _ ->
     let projects =
         match isWindows with
         // Windows
         | true -> !! "./**/core/**/*.Tests.csproj"
                   ++ "./**/contrib/**/*.Tests.csproj"
-                  -- "./**/Akka.Remote.TestKit.Tests.csproj"
+                  -- "./**/Akka.Remote.TestKit.Tests.csproj" // TODO: remove once protobuf3 PR is merged
                   -- "./**/Akka.MultiNodeTestRunner.Shared.Tests.csproj"
                   -- "./**/serializers/**/*Wire*.csproj"
         // Linux/Mono
@@ -86,14 +104,14 @@ Target "RunTests" (fun _ ->
                   -- "./**/Akka.Remote.TestKit.Tests.csproj"
                   -- "./**/Akka.MultiNodeTestRunner.Shared.Tests.csproj"
                   -- "./**/Akka.API.Tests.csproj"
-
+     
     let runSingleProject project =
-        DotNetCli.RunCommand
-            (fun p -> 
-                { p with 
-                    WorkingDir = (Directory.GetParent project).FullName
-                    TimeOut = TimeSpan.FromMinutes 30. })
-                (sprintf "xunit -parallel none -teamcity -xml %s_xunit.xml" (outputTests @@ fileNameWithoutExt project)) 
+        let result = ExecProcess(fun info ->
+            info.FileName <- "dotnet"
+            info.WorkingDirectory <- (Directory.GetParent project).FullName
+            info.Arguments <- (sprintf "xunit -parallel none -teamcity -xml %s_xunit.xml" (outputTests @@ fileNameWithoutExt project))) (TimeSpan.FromMinutes 5.)
+        
+        ResultHandling.failBuildIfXUnitReportedError TestRunnerErrorLevel.Error result
 
     CreateDir outputTests
     projects |> Seq.iter (runSingleProject)

--- a/build.fsx
+++ b/build.fsx
@@ -111,7 +111,7 @@ Target "RunTests" (fun _ ->
             info.WorkingDirectory <- (Directory.GetParent project).FullName
             info.Arguments <- (sprintf "xunit -parallel none -teamcity -xml %s_xunit.xml" (outputTests @@ fileNameWithoutExt project))) (TimeSpan.FromMinutes 5.)
         
-        ResultHandling.failBuildIfXUnitReportedError TestRunnerErrorLevel.Error result
+        ResultHandling.failBuildIfXUnitReportedError TestRunnerErrorLevel.DontFailBuild result
 
     CreateDir outputTests
     projects |> Seq.iter (runSingleProject)

--- a/build.fsx
+++ b/build.fsx
@@ -102,7 +102,7 @@ Target "RunTests" (fun _ ->
         let result = ExecProcess(fun info ->
             info.FileName <- "dotnet"
             info.WorkingDirectory <- (Directory.GetParent project).FullName
-            info.Arguments <- (sprintf "xunit -parallel none -teamcity -xml %s_xunit.xml" (outputTests @@ fileNameWithoutExt project))) (TimeSpan.FromMinutes 5.)
+            info.Arguments <- (sprintf "xunit -parallel none -teamcity -xml %s_xunit.xml" (outputTests @@ fileNameWithoutExt project))) (TimeSpan.FromMinutes 30.)
         
         ResultHandling.failBuildIfXUnitReportedError TestRunnerErrorLevel.DontFailBuild result
 


### PR DESCRIPTION
Using the new `dotnet xunit` tooling seems to cause different exit codes upon test failures:

```
[12:43:57][Test collection for Akka.Persistence.Tests.PersistentActorStashingSpec (1)] Akka.Persistence.Tests.PersistentActorStashingSpec.PersistentActor_should_support_user_stash_operations_under_failures
[12:43:58][RunTests] [ERROR][6/20/2017 12:43:58 PM][Thread 0003][akka://AkkaSpec/user/$a] boom
[12:43:58][RunTests] Cause: Akka.Persistence.Tests.TestException: boom
[12:43:58][RunTests]    at Akka.Persistence.Tests.PersistentActorStashingSpec.UserStashFailureActor.ReceiveCommand(Object message) in D:\work\d26c9d7f36545acd\src\core\Akka.Persistence.Tests\PersistentActorStashingSpec.cs:line 208
[12:43:58][RunTests]    at Akka.Persistence.PersistentActor.Receive(Object message) in D:\work\d26c9d7f36545acd\src\core\Akka.Persistence\PersistentActor.cs:line 257
[12:43:58][RunTests]    at Akka.Actor.ActorBase.AroundReceive(Receive receive, Object message) in D:\work\d26c9d7f36545acd\src\core\Akka\Actor\ActorBase.cs:line 158
[12:43:58][RunTests]    at Akka.Persistence.Eventsourced.<ProcessingCommands>b__91_0(Receive receive, Object message) in D:\work\d26c9d7f36545acd\src\core\Akka.Persistence\Eventsourced.Recovery.cs:line 275
[12:43:58][RunTests]    at Akka.Persistence.Eventsourced.AroundReceive(Receive receive, Object message) in D:\work\d26c9d7f36545acd\src\core\Akka.Persistence\Eventsourced.Lifecycle.cs:line 38
[12:43:58][RunTests]    at Akka.Actor.ActorCell.ReceiveMessage(Object message) in D:\work\d26c9d7f36545acd\src\core\Akka\Actor\ActorCell.DefaultMessages.cs:line 179
[12:43:58][RunTests]    at Akka.Actor.ActorCell.Invoke(Envelope envelope) in D:\work\d26c9d7f36545acd\src\core\Akka\Actor\ActorCell.DefaultMessages.cs:line 81
[12:43:58][RunTests] Running build failed.
[12:43:58][RunTests] Error:
[12:43:58][RunTests] System.Exception: dotnet command failed on xunit -parallel none -teamcity -xml D:\work\d26c9d7f36545acd\TestResults\Akka.Persistence.Tests_xunit.xml
[12:43:58][RunTests]    at Fake.DotNetCli.RunCommand@78-3.Invoke(String message) in C:\code\fake\src\app\FakeLib\DotNetCLIHelper.fs:line 78
[12:43:58][RunTests]    at Fake.DotNetCli.RunCommand(FSharpFunc`2 setCommandParams, String args) in C:\code\fake\src\app\FakeLib\DotNetCLIHelper.fs:line 78
[12:43:58][RunTests]    at FSI_0005.Build.runSingleProject@91.Invoke(String project) in D:\work\d26c9d7f36545acd\build.fsx:line 91
[12:43:58][RunTests]    at Microsoft.FSharp.Collections.SeqModule.Iterate[T](FSharpFunc`2 action, IEnumerable`1 source)
[12:43:58][RunTests]    at FSI_0005.Build.clo@73-8.Invoke(Unit _arg4) in D:\work\d26c9d7f36545acd\build.fsx:line 99
[12:43:58][RunTests]    at Fake.TargetHelper.runSingleTarget(TargetTemplate`1 target) in C:\code\fake\src\app\FakeLib\TargetHelper.fs:line 626
```
It's difficult to know whether the test is simply failing, or there is a timeout, or there is an actual process failing.  This is resulting in test pass/fail numbers to be inconsistent, since the test suite doesn't continue running the tests if, in fact, this was just a test failure.  This PR uses the code from FAKE's FAKE.DotNet.Testing.Xunit2 namespace to run `dotnet xunit` as a process and has a custom `ResultHandler` that can be passed an ErrorLevel that can be altered as needed.