### PR TITLE
Added integration source stage for .NET events

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
@@ -1517,6 +1517,8 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> Failed<T>(System.Exception cause) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> From<T>(System.Collections.Generic.IEnumerable<T> enumerable) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> FromEnumerator<T>(System.Func<System.Collections.Generic.IEnumerator<T>> enumeratorFactory) { }
+        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> FromEvent<TDelegate, T>(System.Func<System.Action<T>, TDelegate> conversion, System.Action<TDelegate> addHandler, System.Action<TDelegate> removeHandler, int maxBufferCapacity = 128, Akka.Streams.OverflowStrategy overflowStrategy = 2) { }
+        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> FromEvent<T>(System.Action<System.EventHandler<T>> addHandler, System.Action<System.EventHandler<T>> removeHandler, int maxBufferCapacity = 128, Akka.Streams.OverflowStrategy overflowStrategy = 2) { }
         public static Akka.Streams.Dsl.Source<T, TMat> FromGraph<T, TMat>(Akka.Streams.IGraph<Akka.Streams.SourceShape<T>, TMat> source) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> FromPublisher<T>(Reactive.Streams.IPublisher<T> publisher) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> FromTask<T>(System.Threading.Tasks.Task<T> task) { }
@@ -2324,6 +2326,13 @@ namespace Akka.Streams.Implementation
         public abstract Akka.Streams.Implementation.EnumerableActorName Copy(string newPrefix);
         public static Akka.Streams.Implementation.EnumerableActorName Create(string prefix) { }
         public abstract string Next();
+    }
+    public sealed class EventSourceStage<TDelegate, TEventArgs> : Akka.Streams.Stage.GraphStage<Akka.Streams.SourceShape<TEventArgs>>
+    {
+        public EventSourceStage(System.Action<TDelegate> addHandler, System.Action<TDelegate> removeHandler, System.Func<System.Action<TEventArgs>, TDelegate> conversion, int maxBuffer, Akka.Streams.OverflowStrategy overflowStrategy) { }
+        public Akka.Streams.Outlet<TEventArgs> Out { get; }
+        public override Akka.Streams.SourceShape<TEventArgs> Shape { get; }
+        protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public abstract class ExposedPublisherReceive
     {

--- a/src/core/Akka.Streams.Tests/Dsl/EventSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/EventSourceSpec.cs
@@ -92,7 +92,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void EventSource_must_should_fail_downstream_in_Fail_overflow_mode()
+        public void EventSource_must_fail_downstream_in_Fail_overflow_mode()
         {
             var s = this.CreateManualSubscriberProbe<int>();
             Source.FromEvent<int>(h => _event += h, h => _event -= h, 1, OverflowStrategy.Fail)

--- a/src/core/Akka.Streams.Tests/Dsl/EventSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/EventSourceSpec.cs
@@ -1,0 +1,129 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="EventSourceSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Streams.Dsl;
+using Akka.Streams.TestKit;
+using Akka.TestKit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Streams.Tests.Dsl
+{
+    public class EventSourceSpec : AkkaSpec
+    {
+        private event EventHandler<int> _event;
+
+        private readonly ActorMaterializer _materializer;
+        public EventSourceSpec(ITestOutputHelper helper) : base(helper)
+        {
+            _materializer = ActorMaterializer.Create(Sys);
+        }
+
+        [Fact]
+        public void EventSource_must_emit_received_event_to_the_stream()
+        {
+            var s = this.CreateManualSubscriberProbe<int>();
+            Source.FromEvent<EventHandler<int>, int>(
+                conversion: onNext => (sender, e) => onNext(e),
+                addHandler: h => _event += h,
+                removeHandler: h => _event -= h)
+                .To(Sink.FromSubscriber(s))
+                .Run(_materializer);
+            var sub = s.ExpectSubscription();
+
+            sub.Request(2);
+            _event(this, 1);
+            s.ExpectNext(1);
+            _event(this, 2);
+            s.ExpectNext(2);
+            _event(this, 3);
+            sub.Request(1);
+            s.ExpectNext(3);
+            sub.Cancel();
+        }
+
+        [Fact]
+        public void EventSource_must_work_with_event_handlers()
+        {
+            var s = this.CreateManualSubscriberProbe<int>();
+            Source.FromEvent<int>(h => _event += h, h => _event -= h)
+                .To(Sink.FromSubscriber(s))
+                .Run(_materializer);
+            var sub = s.ExpectSubscription();
+
+            sub.Request(2);
+            _event(this, 1);
+            s.ExpectNext(1);
+            _event(this, 2);
+            s.ExpectNext(2);
+            _event(this, 3);
+            sub.Request(1);
+            s.ExpectNext(3);
+
+            sub.Cancel();
+        }
+
+        [Fact]
+        public void EventSource_must_be_reusable()
+        {
+            var source = Source.FromEvent<int>(h => _event += h, h => _event -= h);
+            var s1 = this.CreateManualSubscriberProbe<int>();
+            var s2 = this.CreateManualSubscriberProbe<int>();
+
+            source.To(Sink.FromSubscriber(s1)).Run(_materializer);
+            source.To(Sink.FromSubscriber(s2)).Run(_materializer);
+
+            var sub1 = s1.ExpectSubscription();
+            sub1.Request(2);
+            var sub2 = s2.ExpectSubscription();
+            sub2.Request(2);
+
+            _event(this, 123);
+
+            s1.ExpectNext(123);
+            s2.ExpectNext(123);
+            sub1.Cancel();
+            sub2.Cancel();
+        }
+
+        [Fact]
+        public void EventSource_must_should_fail_downstream_in_Fail_overflow_mode()
+        {
+            var s = this.CreateManualSubscriberProbe<int>();
+            Source.FromEvent<int>(h => _event += h, h => _event -= h, 1, OverflowStrategy.Fail)
+                .To(Sink.FromSubscriber(s))
+                .Run(_materializer);
+
+            s.ExpectSubscription();
+
+            _event(this, 1);
+            _event(this, 2);
+
+            s.ExpectError();
+        }
+
+        [Fact]
+        public void EventSource_must_detach_from_event()
+        {
+            var s = this.CreateManualSubscriberProbe<int>();
+            Source.FromEvent<int>(h => _event += h, h => _event -= h)
+                .To(Sink.FromSubscriber(s))
+                .Run(_materializer);
+            var sub = s.ExpectSubscription();
+            sub.Request(2);
+            
+            _event(this, 1);
+            s.ExpectNext(1);
+
+            sub.Cancel();
+
+            _event(this, 2);
+            s.ExpectNoMsg();
+        }
+    }
+}

--- a/src/core/Akka.Streams.Tests/Dsl/EventSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/EventSourceSpec.cs
@@ -37,11 +37,11 @@ namespace Akka.Streams.Tests.Dsl
             var sub = s.ExpectSubscription();
 
             sub.Request(2);
-            _event(this, 1);
+            _event?.Invoke(this, 1);
             s.ExpectNext(1);
-            _event(this, 2);
+            _event?.Invoke(this, 2);
             s.ExpectNext(2);
-            _event(this, 3);
+            _event?.Invoke(this, 3);
             sub.Request(1);
             s.ExpectNext(3);
             sub.Cancel();
@@ -57,11 +57,11 @@ namespace Akka.Streams.Tests.Dsl
             var sub = s.ExpectSubscription();
 
             sub.Request(2);
-            _event(this, 1);
+            _event?.Invoke(this, 1);
             s.ExpectNext(1);
-            _event(this, 2);
+            _event?.Invoke(this, 2);
             s.ExpectNext(2);
-            _event(this, 3);
+            _event?.Invoke(this, 3);
             sub.Request(1);
             s.ExpectNext(3);
 
@@ -83,7 +83,7 @@ namespace Akka.Streams.Tests.Dsl
             var sub2 = s2.ExpectSubscription();
             sub2.Request(2);
 
-            _event(this, 123);
+            _event?.Invoke(this, 123);
 
             s1.ExpectNext(123);
             s2.ExpectNext(123);
@@ -101,8 +101,8 @@ namespace Akka.Streams.Tests.Dsl
 
             s.ExpectSubscription();
 
-            _event(this, 1);
-            _event(this, 2);
+            _event?.Invoke(this, 1);
+            _event?.Invoke(this, 2);
 
             s.ExpectError();
         }
@@ -117,12 +117,12 @@ namespace Akka.Streams.Tests.Dsl
             var sub = s.ExpectSubscription();
             sub.Request(2);
             
-            _event(this, 1);
+            _event?.Invoke(this, 1);
             s.ExpectNext(1);
 
             sub.Cancel();
 
-            _event(this, 2);
+            _event?.Invoke(this, 2);
             s.ExpectNoMsg();
         }
     }


### PR DESCRIPTION
This PR brings 2 extra methods (versions of `FromEvent`, similar to another approach that can be seen in Rx.NET Observables). 

It's not ported from the JVM, however I think we should add it nonetheless: events are pretty essential part of the .NET ecosystem. They exist in many libraries, therefore to make it easier to integrate, we should add native support for them in Akka.Streams.