### PR TITLE
no longer deploy local routees when clustered pool router is on wrong role type

### DIFF
--- a/src/core/Akka.Cluster.Tests.MultiNode/Routing/UseRoleIgnoredSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/Routing/UseRoleIgnoredSpec.cs
@@ -131,7 +131,7 @@ namespace Akka.Cluster.Tests.MultiNode.Routing
             A_cluster_must_start_cluster();
             A_cluster_must_pool_local_off_roles_off();
             A_cluster_must_group_local_off_roles_off();
-            //A_cluster_must_pool_local_on_role_b();
+            A_cluster_must_pool_local_on_role_b();
             A_cluster_must_group_local_on_role_b();
             A_cluster_must_pool_local_on_role_a();
             A_cluster_must_group_local_on_role_a();

--- a/src/core/Akka/Routing/RoutedActorCell.cs
+++ b/src/core/Akka/Routing/RoutedActorCell.cs
@@ -160,14 +160,7 @@ namespace Akka.Routing
             if (RouterConfig is Pool)
             {
                 var pool = (Pool)RouterConfig;
-                // must not use pool.GetNrOfInstances(system) for old (not re-compiled) custom routers
-                // for binary backwards compatibility reasons
-                var deprecatedNrOfInstances = pool.NrOfInstances;
-
-                var nrOfRoutees = deprecatedNrOfInstances < 0
-                    ? pool.GetNrOfInstances(System)
-                    : deprecatedNrOfInstances;
-
+                var nrOfRoutees = pool.GetNrOfInstances(System);
                 if (nrOfRoutees > 0)
                     AddRoutees(Vector.Fill<Routee>(nrOfRoutees)(() => pool.NewRoutee(RouteeProps, this)));
             }


### PR DESCRIPTION
close #2783 