### PR TITLE
Akka v1.2.2 release notes [dev]

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+#### 1.2.2 June 28 2017 ####
+**Maintenance Release for Akka.NET 1.2**
+
+Finally, fully resolves issues related to Akka.Cluster nodes not being able to cleanly leave or join a cluster after a period of network instability. Also includes some minor fixes for clustered routers and Akka.Persistence.
+
+[See the full set of Akka.NET 1.2.2 fixes here](https://github.com/akkadotnet/akka.net/milestone/16).
+
 #### 1.2.1 June 22 2017 ####
 **Maintenance Release for Akka.NET 1.2**
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,10 @@ Finally, fully resolves issues related to Akka.Cluster nodes not being able to c
 
 [See the full set of Akka.NET 1.2.2 fixes here](https://github.com/akkadotnet/akka.net/milestone/16).
 
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 13 | 589 | 52 | Aaron Stannard |
+
 #### 1.2.1 June 22 2017 ####
 **Maintenance Release for Akka.NET 1.2**
 

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -4,5 +4,5 @@ using System.Reflection;
 [assembly: AssemblyCompanyAttribute("Akka.NET Team")]
 [assembly: AssemblyCopyrightAttribute("Copyright © 2013-2017 Akka.NET Team")]
 [assembly: AssemblyTrademarkAttribute("")]
-[assembly: AssemblyVersionAttribute("1.2.0.0")]
-[assembly: AssemblyFileVersionAttribute("1.2.0.0")]
+[assembly: AssemblyVersionAttribute("1.2.2.0")]
+[assembly: AssemblyFileVersionAttribute("1.2.2.0")]

--- a/src/core/Akka.FSharp/Properties/AssemblyInfo.fs
+++ b/src/core/Akka.FSharp/Properties/AssemblyInfo.fs
@@ -10,9 +10,9 @@ open System.Runtime.InteropServices
 [<assembly: AssemblyCompanyAttribute("Akka.NET Team")>]
 [<assembly: ComVisibleAttribute(false)>]
 [<assembly: CLSCompliantAttribute(true)>]
-[<assembly: AssemblyVersionAttribute("1.2.0.0")>]
-[<assembly: AssemblyFileVersionAttribute("1.2.0.0")>]
+[<assembly: AssemblyVersionAttribute("1.2.2.0")>]
+[<assembly: AssemblyFileVersionAttribute("1.2.2.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "1.2.0.0"
+    let [<Literal>] Version = "1.2.2.0"


### PR DESCRIPTION
#### 1.2.2 June 28 2017 ####
**Maintenance Release for Akka.NET 1.2**

Finally, fully resolves issues related to Akka.Cluster nodes not being able to cleanly leave or join a cluster after a period of network instability. Also includes some minor fixes for clustered routers and Akka.Persistence.

[See the full set of Akka.NET 1.2.2 fixes here](https://github.com/akkadotnet/akka.net/milestone/16).

| COMMITS | LOC+ | LOC- | AUTHOR |
| --- | --- | --- | --- |
| 13 | 589 | 52 | Aaron Stannard |
