### PR TITLE
Lock NuGet version to v4.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,8 +217,6 @@ FakesAssemblies/
 /src/.Akka.boltdata/TestResults.json
 resetdev.bat
 /src/packages/repositories.config
-/src/.nuget
-/src/.nuget/NuGet.exe
 
 # FAKE build folder
 .fake/

--- a/build.cmd
+++ b/build.cmd
@@ -8,7 +8,7 @@ SET CACHED_NUGET=%LocalAppData%\NuGet\NuGet.exe
 IF EXIST %CACHED_NUGET% goto copynuget
 echo Downloading latest version of NuGet.exe...
 IF NOT EXIST %LocalAppData%\NuGet md %LocalAppData%\NuGet
-@powershell -NoProfile -ExecutionPolicy unrestricted -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://www.nuget.org/nuget.exe' -OutFile '%CACHED_NUGET%'"
+@powershell -NoProfile -ExecutionPolicy unrestricted -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/v4.1.0/nuget.exe' -OutFile '%CACHED_NUGET%'"
 
 :copynuget
 IF EXIST src\.nuget\nuget.exe goto restore
@@ -18,8 +18,6 @@ copy %CACHED_NUGET% src\.nuget\nuget.exe > nul
 :restore
 
 pushd %~dp0
-
-src\.nuget\NuGet.exe update -self
 
 src\.nuget\NuGet.exe install FAKE -ConfigFile src\.nuget\Nuget.Config -OutputDirectory src\packages -ExcludeVersion -Version 4.16.1
 

--- a/build.cmd
+++ b/build.cmd
@@ -8,7 +8,7 @@ SET CACHED_NUGET=%LocalAppData%\NuGet\NuGet.exe
 IF EXIST %CACHED_NUGET% goto copynuget
 echo Downloading latest version of NuGet.exe...
 IF NOT EXIST %LocalAppData%\NuGet md %LocalAppData%\NuGet
-@powershell -NoProfile -ExecutionPolicy unrestricted -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://www.nuget.org/nuget.exe' -OutFile '%CACHED_NUGET%'"
+@powershell -NoProfile -ExecutionPolicy unrestricted -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/v4.1.0/nuget.exe' -OutFile '%CACHED_NUGET%'"
 
 :copynuget
 IF EXIST src\.nuget\nuget.exe goto restore
@@ -17,12 +17,7 @@ copy %CACHED_NUGET% src\.nuget\nuget.exe > nul
 
 :restore
 
-src\.nuget\NuGet.exe update -self
-
-
 pushd %~dp0
-
-src\.nuget\NuGet.exe update -self
 
 src\.nuget\NuGet.exe install FAKE -ConfigFile src\.nuget\Nuget.Config -OutputDirectory src\packages -ExcludeVersion -Version 4.16.1
 

--- a/build.cmd
+++ b/build.cmd
@@ -8,7 +8,7 @@ SET CACHED_NUGET=%LocalAppData%\NuGet\NuGet.exe
 IF EXIST %CACHED_NUGET% goto copynuget
 echo Downloading latest version of NuGet.exe...
 IF NOT EXIST %LocalAppData%\NuGet md %LocalAppData%\NuGet
-@powershell -NoProfile -ExecutionPolicy unrestricted -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/v4.1.0/nuget.exe' -OutFile '%CACHED_NUGET%'"
+@powershell -NoProfile -ExecutionPolicy unrestricted -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://www.nuget.org/nuget.exe' -OutFile '%CACHED_NUGET%'"
 
 :copynuget
 IF EXIST src\.nuget\nuget.exe goto restore
@@ -18,6 +18,8 @@ copy %CACHED_NUGET% src\.nuget\nuget.exe > nul
 :restore
 
 pushd %~dp0
+
+src\.nuget\NuGet.exe update -self
 
 src\.nuget\NuGet.exe install FAKE -ConfigFile src\.nuget\Nuget.Config -OutputDirectory src\packages -ExcludeVersion -Version 4.16.1
 

--- a/build.sh
+++ b/build.sh
@@ -10,11 +10,8 @@ popd  > /dev/null
 
 if ! [ -f $SCRIPT_PATH/src/.nuget/nuget.exe ] 
     then
-        wget "https://www.nuget.org/nuget.exe" -P $SCRIPT_PATH/src/.nuget/
+        wget "https://dist.nuget.org/win-x86-commandline/v4.1.0/nuget.exe" -P $SCRIPT_PATH/src/.nuget/
 fi
-
-mono $SCRIPT_PATH/src/.nuget/nuget.exe update -self
-
 
 SCRIPT_PATH="${BASH_SOURCE[0]}";
 if ([ -h "${SCRIPT_PATH}" ]) then
@@ -24,8 +21,6 @@ pushd . > /dev/null
 cd `dirname ${SCRIPT_PATH}` > /dev/null
 SCRIPT_PATH=`pwd`;
 popd  > /dev/null
-
-mono $SCRIPT_PATH/src/.nuget/nuget.exe update -self
 
 mono $SCRIPT_PATH/src/.nuget/nuget.exe install FAKE -OutputDirectory $SCRIPT_PATH/src/packages -ExcludeVersion -Version 4.61.3
 


### PR DESCRIPTION
Change NuGet download URL to specific v4.1.0 distribution and remove `update -self` from build scripts.