### PR TITLE
Akka.NET v1.2.2 Production Release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,8 +217,6 @@ FakesAssemblies/
 /src/.Akka.boltdata/TestResults.json
 resetdev.bat
 /src/packages/repositories.config
-/src/.nuget
-/src/.nuget/NuGet.exe
 
 # FAKE build folder
 .fake/

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,14 @@
+#### 1.2.2 June 28 2017 ####
+**Maintenance Release for Akka.NET 1.2**
+
+Finally, fully resolves issues related to Akka.Cluster nodes not being able to cleanly leave or join a cluster after a period of network instability. Also includes some minor fixes for clustered routers and Akka.Persistence.
+
+[See the full set of Akka.NET 1.2.2 fixes here](https://github.com/akkadotnet/akka.net/milestone/16).
+
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 13 | 589 | 52 | Aaron Stannard |
+
 #### 1.2.1 June 22 2017 ####
 **Maintenance Release for Akka.NET 1.2**
 

--- a/build.cmd
+++ b/build.cmd
@@ -8,7 +8,7 @@ SET CACHED_NUGET=%LocalAppData%\NuGet\NuGet.exe
 IF EXIST %CACHED_NUGET% goto copynuget
 echo Downloading latest version of NuGet.exe...
 IF NOT EXIST %LocalAppData%\NuGet md %LocalAppData%\NuGet
-@powershell -NoProfile -ExecutionPolicy unrestricted -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://www.nuget.org/nuget.exe' -OutFile '%CACHED_NUGET%'"
+@powershell -NoProfile -ExecutionPolicy unrestricted -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/v4.1.0/nuget.exe' -OutFile '%CACHED_NUGET%'"
 
 :copynuget
 IF EXIST src\.nuget\nuget.exe goto restore
@@ -17,12 +17,7 @@ copy %CACHED_NUGET% src\.nuget\nuget.exe > nul
 
 :restore
 
-src\.nuget\NuGet.exe update -self
-
-
 pushd %~dp0
-
-src\.nuget\NuGet.exe update -self
 
 src\.nuget\NuGet.exe install FAKE -ConfigFile src\.nuget\Nuget.Config -OutputDirectory src\packages -ExcludeVersion -Version 4.16.1
 

--- a/build.sh
+++ b/build.sh
@@ -10,11 +10,8 @@ popd  > /dev/null
 
 if ! [ -f $SCRIPT_PATH/src/.nuget/nuget.exe ] 
     then
-        wget "https://www.nuget.org/nuget.exe" -P $SCRIPT_PATH/src/.nuget/
+        wget "https://dist.nuget.org/win-x86-commandline/v4.1.0/nuget.exe" -P $SCRIPT_PATH/src/.nuget/
 fi
-
-mono $SCRIPT_PATH/src/.nuget/nuget.exe update -self
-
 
 SCRIPT_PATH="${BASH_SOURCE[0]}";
 if ([ -h "${SCRIPT_PATH}" ]) then
@@ -24,8 +21,6 @@ pushd . > /dev/null
 cd `dirname ${SCRIPT_PATH}` > /dev/null
 SCRIPT_PATH=`pwd`;
 popd  > /dev/null
-
-mono $SCRIPT_PATH/src/.nuget/nuget.exe update -self
 
 mono $SCRIPT_PATH/src/.nuget/nuget.exe install FAKE -OutputDirectory $SCRIPT_PATH/src/packages -ExcludeVersion -Version 4.61.3
 

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -4,5 +4,5 @@ using System.Reflection;
 [assembly: AssemblyCompanyAttribute("Akka.NET Team")]
 [assembly: AssemblyCopyrightAttribute("Copyright © 2013-2017 Akka.NET Team")]
 [assembly: AssemblyTrademarkAttribute("")]
-[assembly: AssemblyVersionAttribute("1.2.0.0")]
-[assembly: AssemblyFileVersionAttribute("1.2.0.0")]
+[assembly: AssemblyVersionAttribute("1.2.2.0")]
+[assembly: AssemblyFileVersionAttribute("1.2.2.0")]

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCluster.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCluster.approved.txt
@@ -210,6 +210,8 @@ namespace Akka.Cluster
         public static Akka.Cluster.Member HighestPriorityOf(Akka.Cluster.Member m1, Akka.Cluster.Member m2) { }
         public bool IsOlderThan(Akka.Cluster.Member other) { }
         public static System.Collections.Immutable.ImmutableHashSet<Akka.Cluster.Member> PickHighestPriority(System.Collections.Generic.IEnumerable<Akka.Cluster.Member> a, System.Collections.Generic.IEnumerable<Akka.Cluster.Member> b) { }
+        public static System.Collections.Immutable.ImmutableSortedSet<Akka.Cluster.Member> PickNextTransition(System.Collections.Generic.IEnumerable<Akka.Cluster.Member> a, System.Collections.Generic.IEnumerable<Akka.Cluster.Member> b) { }
+        public static Akka.Cluster.Member PickNextTransition(Akka.Cluster.Member a, Akka.Cluster.Member b) { }
         public override string ToString() { }
     }
     public enum MemberStatus

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCluster.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCluster.approved.txt
@@ -186,6 +186,7 @@ namespace Akka.Cluster
         public System.TimeSpan SeedNodeTimeout { get; }
         public System.TimeSpan UnreachableNodesReaperInterval { get; }
         public string UseDispatcher { get; }
+        public bool VerboseGossipReceivedLogging { get; }
         public bool VerboseHeartbeatLogging { get; }
     }
     public interface IClusterMessage { }

--- a/src/core/Akka.Cluster.Tests.MultiNode/LeaderLeavingSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/LeaderLeavingSpec.cs
@@ -99,7 +99,7 @@ akka.cluster.publish-stats-interval = 25 s")
                         EnterBarrier("leader-left");
 
                         // verify that the LEADER is EXITING
-                        exitingLatch.Ready(TestLatch.DefaultTimeout);
+                        exitingLatch.Ready(TestKitSettings.DefaultTimeout);
 
                         EnterBarrier("leader-shutdown");
                         MarkNodeAsUnavailable(oldLeaderAddress);

--- a/src/core/Akka.Cluster.Tests.MultiNode/Routing/UseRoleIgnoredSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/Routing/UseRoleIgnoredSpec.cs
@@ -131,7 +131,7 @@ namespace Akka.Cluster.Tests.MultiNode.Routing
             A_cluster_must_start_cluster();
             A_cluster_must_pool_local_off_roles_off();
             A_cluster_must_group_local_off_roles_off();
-            //A_cluster_must_pool_local_on_role_b();
+            A_cluster_must_pool_local_on_role_b();
             A_cluster_must_group_local_on_role_b();
             A_cluster_must_pool_local_on_role_a();
             A_cluster_must_group_local_on_role_a();

--- a/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
+++ b/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
@@ -43,6 +43,10 @@
       <HintPath>..\..\packages\FsCheck.2.5.0\lib\net45\FsCheck.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="FsCheck.Xunit, Version=2.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FsCheck.Xunit.2.5.0\lib\net45\FsCheck.Xunit.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="FSharp.Core, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\FSharp.Core.3.1.2.5\lib\net40\FSharp.Core.dll</HintPath>
       <Private>True</Private>

--- a/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
+++ b/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
@@ -39,6 +39,14 @@
       <HintPath>..\..\packages\FluentAssertions.3.3.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="FsCheck, Version=2.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FsCheck.2.5.0\lib\net45\FsCheck.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FSharp.Core, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FSharp.Core.3.1.2.5\lib\net40\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Google.ProtocolBuffers, Version=2.4.1.555, Culture=neutral, PublicKeyToken=55f7125234beb589, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.dll</HintPath>
       <Private>True</Private>
@@ -94,12 +102,14 @@
     <Compile Include="ClusterDeployerSpec.cs" />
     <Compile Include="ClusterDomainEventPublisherSpec.cs" />
     <Compile Include="ClusterDomainEventSpec.cs" />
+    <Compile Include="ClusterGenerators.cs" />
     <Compile Include="ClusterHeartBeatSenderStateSpec.cs" />
     <Compile Include="ClusterSpec.cs" />
     <Compile Include="ClusterSpecBase.cs" />
     <Compile Include="DowningProviderSpec.cs" />
     <Compile Include="GossipSpec.cs" />
     <Compile Include="HeartbeatNodeRingSpec.cs" />
+    <Compile Include="MemberOrderingModelBasedTests.cs" />
     <Compile Include="MemberOrderingSpec.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Proto\ClusterMessageSerializerSpec.cs" />

--- a/src/core/Akka.Cluster.Tests/ClusterConfigSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterConfigSpec.cs
@@ -61,6 +61,7 @@ namespace Akka.Cluster.Tests
             settings.SchedulerTicksPerWheel.Should().Be(512);
 
             settings.VerboseHeartbeatLogging.Should().BeFalse();
+            settings.VerboseGossipReceivedLogging.Should().BeFalse();
             settings.RunCoordinatedShutdownWhenDown.Should().BeTrue();
         }
     }

--- a/src/core/Akka.Cluster.Tests/ClusterGenerators.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterGenerators.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using Akka.Actor;
+using Akka.Tests.Shared.Internals.Helpers;
+using FsCheck;
+
+namespace Akka.Cluster.Tests
+{
+    /// <summary>
+    /// INTERNAL API.
+    /// 
+    /// FsCheck data generators for Akka.Cluster types.
+    /// </summary>
+    public class ClusterGenerators
+    {
+        public static Arbitrary<Address> AddressGenerator()
+        {
+            /*
+             * In order to help guarantee collisions and duplicates in random tests, we hold all parts
+             * of the address other than the port number constant.
+             */
+            Func<IPAddress, int, Address> combiner = (address, i) => new Address("akka.tcp", "cluster", address.ToString(), i);
+            var producer = FsharpDelegateHelper.Create(combiner);
+
+            return Arb.From(Gen.Map2(producer, Arb.Default.IPAddress().Generator, Gen.Choose(1, 65535)));
+        }
+
+        public static Arbitrary<UniqueAddress> UniqueAddressGenerator()
+        {
+            var gen1 = Arb.Default.Int32().Generator;
+            var gen2 = AddressGenerator();
+
+            // randomize both addresses and ports
+            Func<int, Address, UniqueAddress> combiner = (uid, addr) => new UniqueAddress(addr, uid);
+            var producer = FsharpDelegateHelper.Create(combiner);
+
+            return Arb.From(Gen.Map2(producer, gen1, gen2.Generator));
+        }
+
+        public static Arbitrary<MemberStatus> MemberStatusGenerator()
+        {
+            return Arb.From(Gen.Elements(Enum.GetValues(typeof(MemberStatus)).Cast<MemberStatus>()));
+        }
+    }
+}

--- a/src/core/Akka.Cluster.Tests/ClusterGenerators.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterGenerators.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿//-----------------------------------------------------------------------
+// <copyright file="ClusterGenerators.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
 using System.Linq;
 using System.Net;
 using Akka.Actor;

--- a/src/core/Akka.Cluster.Tests/MemberOrderingModelBasedTests.cs
+++ b/src/core/Akka.Cluster.Tests/MemberOrderingModelBasedTests.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿//-----------------------------------------------------------------------
+// <copyright file="MemberOrderingModelBasedTests.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/src/core/Akka.Cluster.Tests/MemberOrderingModelBasedTests.cs
+++ b/src/core/Akka.Cluster.Tests/MemberOrderingModelBasedTests.cs
@@ -1,12 +1,236 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Tests.Shared.Internals.Helpers;
+using Akka.Util.Internal;
+using FsCheck;
+using FsCheck.Experimental;
+using FsCheck.Xunit;
 
 namespace Akka.Cluster.Tests
 {
-    class MemberOrderingModelBasedTests
+    public class MemberOrderingModelBasedTests
     {
+        public MemberOrderingModelBasedTests()
+        {
+            // register the custom generators to make testing easier
+            Arb.Register<ClusterGenerators>();
+        }
+
+        [Property]
+        public Property MemberOrderingMustObeyModel()
+        {
+            return new MembershipMachine().ToProperty();
+        }
+
+        [Property(MaxTest = 1000)]
+        public Property DistinctMemberAddressesMustCompareDifferently(Address[] addresses)
+        {
+            if (addresses.Length == 0)
+                return true.Classify(true, "empty set");
+            var addressCount = addresses.Length;
+            var distinctCount = addresses.Distinct().Count(); // uses `Address.Equals` under the hood
+            if (addressCount != distinctCount)
+                return true.Classify(false, "all distinct").Classify(false, "empty set");
+
+            // use the sort to help us short-circuit a comparison problem
+            var sortedAddresses = addresses.OrderBy(x => x, Member.AddressOrdering).ToList();
+
+            var a1 = sortedAddresses.First();
+            foreach (var a2 in sortedAddresses.Skip(1))
+            {
+                if (Member.AddressOrdering.Compare(a1, a2) == 0)
+                    return false.Classify(true, "all distinct").Classify(false, "empty set")
+                        .Label($"Expected {a1} and {a2} to compare as different, but did not. Compared as same");
+                a1 = a2; // next member
+            }
+
+            return true.Classify(true, "all distinct").Classify(false, "empty set"); ;
+        }
+    }
+
+    public class MembershipMachine : Machine<MembershipState, MembershipModel>
+    {
+        public MembershipMachine()
+        {
+            // register the custom generators to make testing easier
+            Arb.Register<ClusterGenerators>();
+        }
+
+        public override Gen<Operation<MembershipState, MembershipModel>> Next(MembershipModel model)
+        {
+            if (model.AllMembers.Count == 0)
+                return AddNewMember.Generator();
+            return Gen.OneOf(ChangeMemberStatus.Generator(model.AllMembers.Keys), AddNewMember.Generator());
+        }
+
+        public override Arbitrary<Setup<MembershipState, MembershipModel>> Setup => Arb.From(Arb.Generate<MembershipSetup>()
+            .Select(x => (Setup<MembershipState, MembershipModel>)x)); // compiler ceremony :(
+
+        #region Setup
+
+        public class MembershipSetup : Setup<MembershipState, MembershipModel>
+        {
+            private readonly Member[] _members;
+
+            public MembershipSetup(UniqueAddress[] addresses)
+            {
+                // filter out any duplicates
+                _members =
+                    addresses.Distinct()
+                        .Select(x => new Member(x, int.MaxValue, MemberStatus.Up, ImmutableHashSet<string>.Empty))
+                        .ToArray();
+            }
+
+            public override MembershipState Actual()
+            {
+                return new MembershipState() { Members = ImmutableSortedSet<Member>.Empty.Union(_members) };
+            }
+
+            public override MembershipModel Model()
+            {
+                return new MembershipModel(_members.ToImmutableDictionary(x => x.Address, x => x));
+            }
+
+            public override string ToString()
+            {
+                return $"{GetType()}(Members = [{string.Join(",", _members.Select(x => x.ToString()))}]";
+            }
+        }
+
+        #endregion
+
+        #region Operations
+
+        public class ChangeMemberStatus : Operation<MembershipState, MembershipModel>
+        {
+            public static Gen<Operation<MembershipState, MembershipModel>> Generator(IEnumerable<Address> addresses)
+            {
+                var statusGen = ClusterGenerators.MemberStatusGenerator().Generator;
+                Func<Address, MemberStatus, Operation<MembershipState, MembershipModel>> generator =
+                    (address, status) => new ChangeMemberStatus(address, status);
+
+                var producer = FsharpDelegateHelper.Create(generator);
+
+                return Gen.Map2(producer, Gen.Elements(addresses), statusGen);
+            }
+
+            public readonly Address TargetedMember;
+            public readonly MemberStatus NewStatus;
+
+            public ChangeMemberStatus(Address targetedMember, MemberStatus newStatus)
+            {
+                TargetedMember = targetedMember;
+                NewStatus = newStatus;
+            }
+
+            public override bool Pre(MembershipModel model)
+            {
+                var containsMember = model.AllMembers.ContainsKey(TargetedMember);
+                if (!containsMember) return false; // short-circuit
+
+                var m = model.AllMembers[TargetedMember];
+                return Member.AllowedTransitions[m.Status].Contains(NewStatus);
+            }
+
+            public override Property Check(MembershipState actual, MembershipModel model)
+            {
+                var members = actual.Members;
+
+                var mergedMembers = Member.PickHighestPriority(members, model.AllMembers.Values).ToImmutableSortedSet();
+
+                actual.Members = mergedMembers;
+                return
+                    mergedMembers.SetEquals(model.AllMembers.Values)
+                        .Label("Merged members should equal predicted members.");
+            }
+
+            public override MembershipModel Run(MembershipModel model)
+            {
+                var m = model.AllMembers[TargetedMember];
+                return model.UpdateMember(m.Copy(NewStatus));
+            }
+        }
+
+        public class AddNewMember : Operation<MembershipState, MembershipModel>
+        {
+            public static Gen<Operation<MembershipState, MembershipModel>> Generator()
+            {
+                return Arb.Generate<AddNewMember>().Select(x => (Operation<MembershipState, MembershipModel>)x);
+            }
+
+            private readonly UniqueAddress _address;
+
+            public AddNewMember(UniqueAddress address)
+            {
+                _address = address;
+            }
+
+            public override bool Pre(MembershipModel model)
+            {
+                var containsMember = model.AllMembers.ContainsKey(_address.Address);
+                if (!containsMember) return true; // short-circuit
+
+                // check to see if UniqueAddress already exists (simulates a restart)
+                var member = model.AllMembers[_address.Address];
+                return !member.UniqueAddress.Equals(_address);
+            }
+
+            public override Property Check(MembershipState actual, MembershipModel model)
+            {
+                var members = actual.Members;
+                actual.Members = members.Add(new Member(_address, int.MaxValue, MemberStatus.Up,
+                    ImmutableHashSet<string>.Empty));
+
+                var except = actual.Members.SymmetricExcept(model.AllMembers.Values);
+
+                return
+                    actual.Members.SetEquals(model.AllMembers.Values)
+                        .Label($"Both sets should contain same set of members. Instead found members not included in both sequences: [{string.Join(",", except)}]");
+            }
+
+            public override MembershipModel Run(MembershipModel model)
+            {
+                return
+                    model.UpdateMember(new Member(_address, int.MaxValue, MemberStatus.Up,
+                        ImmutableHashSet<string>.Empty));
+            }
+
+            public override string ToString()
+            {
+                return $"{GetType()}(Address = {_address})";
+            }
+        }
+
+        #endregion
+    }
+
+    public class MembershipState
+    {
+        public ImmutableSortedSet<Member> Members { get; set; }
+    }
+
+    public class MembershipModel
+    {
+        public MembershipModel(ImmutableDictionary<Address, Member> allMembers)
+        {
+            AllMembers = allMembers;
+        }
+
+        public ImmutableDictionary<Address, Member> AllMembers { get; }
+
+        public ImmutableSortedSet<Member> MembersByAge
+            => ImmutableSortedSet<Member>.Empty.Union(AllMembers.Values).WithComparer(Member.AgeOrdering);
+
+        public MembershipModel UpdateMember(Member m)
+        {
+            if (AllMembers.ContainsKey(m.Address))
+                return new MembershipModel(AllMembers.SetItem(m.Address, m));
+            return new MembershipModel(AllMembers.Add(m.Address, m));
+        }
     }
 }

--- a/src/core/Akka.Cluster.Tests/MemberOrderingModelBasedTests.cs
+++ b/src/core/Akka.Cluster.Tests/MemberOrderingModelBasedTests.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Akka.Cluster.Tests
+{
+    class MemberOrderingModelBasedTests
+    {
+    }
+}

--- a/src/core/Akka.Cluster.Tests/MemberOrderingSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MemberOrderingSpec.cs
@@ -94,16 +94,23 @@ namespace Akka.Cluster.Tests
         }
 
         [Fact]
+        public void MemberOrdering_must_work_pick_member_with_legal_transition()
         {
             var address1 = new Address("akka.tcp", "sys1", "host1", 9001);
             var address2 = address1.WithPort(9002);
             var address3 = address1.WithPort(9003);
 
             var s1 = ImmutableSortedSet
+                .Create(TestMember.Create(address1, MemberStatus.Joining))
+                .Add(TestMember.Create(address2, MemberStatus.Up, ImmutableHashSet<string>.Empty, upNumber: 1));
 
+            var s2 = ImmutableSortedSet.Create(TestMember.Create(address1, MemberStatus.Up, ImmutableHashSet<string>.Empty, upNumber:2));
 
             var s3 = ImmutableSortedSet
+                .Create(TestMember.Create(address1, MemberStatus.Up))
+                .Add(TestMember.Create(address2, MemberStatus.Up));
 
+            var u1 = Member.PickNextTransition(s2, s1);
             u1.Should().BeEquivalentTo(s3);
             u1.Single(x => x.Address.Equals(address1)).Status.Should().Be(MemberStatus.Up);
 
@@ -117,6 +124,8 @@ namespace Akka.Cluster.Tests
                 .Add(TestMember.Create(address2, MemberStatus.Up))
                 .Add(TestMember.Create(address3, MemberStatus.Up));
 
+            var u2 = Member.PickNextTransition(s4, s1);
+            u2.Should().BeEquivalentTo(s5);
             u2.Single(x => x.Address.Equals(address1)).Status.Should().Be(MemberStatus.Up);
         }
 

--- a/src/core/Akka.Cluster.Tests/MemberOrderingSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MemberOrderingSpec.cs
@@ -94,6 +94,33 @@ namespace Akka.Cluster.Tests
         }
 
         [Fact]
+        {
+            var address1 = new Address("akka.tcp", "sys1", "host1", 9001);
+            var address2 = address1.WithPort(9002);
+            var address3 = address1.WithPort(9003);
+
+            var s1 = ImmutableSortedSet
+
+
+            var s3 = ImmutableSortedSet
+
+            u1.Should().BeEquivalentTo(s3);
+            u1.Single(x => x.Address.Equals(address1)).Status.Should().Be(MemberStatus.Up);
+
+            var s4 = ImmutableSortedSet
+                .Create(TestMember.Create(address1, MemberStatus.Up))
+                .Add(TestMember.Create(address2, MemberStatus.Up))
+                .Add(TestMember.Create(address3, MemberStatus.Joining));
+
+            var s5 = ImmutableSortedSet
+                .Create(TestMember.Create(address1, MemberStatus.Up))
+                .Add(TestMember.Create(address2, MemberStatus.Up))
+                .Add(TestMember.Create(address3, MemberStatus.Up));
+
+            u2.Single(x => x.Address.Equals(address1)).Status.Should().Be(MemberStatus.Up);
+        }
+
+        [Fact]
         public void MemberOrdering_must_work_with_sorted_set()
         {
             var address1 = new Address("akka.tcp", "sys1", "host1", 9001);

--- a/src/core/Akka.Cluster.Tests/TestMember.cs
+++ b/src/core/Akka.Cluster.Tests/TestMember.cs
@@ -12,14 +12,14 @@ namespace Akka.Cluster.Tests
 {
     static class TestMember
     {
-        public static Member Create(Address address, MemberStatus status)
+        public static Member Create(Address address, MemberStatus status, int uid = 0)
         {
-            return Create(address, status, ImmutableHashSet.Create<string>());
+            return Create(address, status, ImmutableHashSet.Create<string>(), uid);
         }
 
-        public static Member Create(Address address, MemberStatus status, ImmutableHashSet<string> roles)
+        public static Member Create(Address address, MemberStatus status, ImmutableHashSet<string> roles, int uid = 0, int upNumber = 0)
         {
-            return Member.Create(new UniqueAddress(address, 0), 0, status, roles);
+            return Member.Create(new UniqueAddress(address, uid), upNumber, status, roles);
         }
     }
 }

--- a/src/core/Akka.Cluster.Tests/app.config
+++ b/src/core/Akka.Cluster.Tests/app.config
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.3545" newVersion="2.2.0.3545"/>
+        <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.3545" newVersion="2.2.0.3545" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="xunit.execution.desktop" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.3545" newVersion="2.2.0.3545" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup></configuration>

--- a/src/core/Akka.Cluster.Tests/packages.config
+++ b/src/core/Akka.Cluster.Tests/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FluentAssertions" version="3.3.0" targetFramework="net452" />
+  <package id="FsCheck" version="2.5.0" targetFramework="net452" />
+  <package id="FSharp.Core" version="3.1.2.5" targetFramework="net452" />
   <package id="Google.ProtocolBuffers" version="2.4.1.555" targetFramework="net452" />
   <package id="Microsoft.NETCore.Platforms" version="1.0.1" targetFramework="net452" />
   <package id="NETStandard.Library" version="1.6.0" targetFramework="net452" />

--- a/src/core/Akka.Cluster.Tests/packages.config
+++ b/src/core/Akka.Cluster.Tests/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="FluentAssertions" version="3.3.0" targetFramework="net452" />
   <package id="FsCheck" version="2.5.0" targetFramework="net452" />
+  <package id="FsCheck.Xunit" version="2.5.0" targetFramework="net452" />
   <package id="FSharp.Core" version="3.1.2.5" targetFramework="net452" />
   <package id="Google.ProtocolBuffers" version="2.4.1.555" targetFramework="net452" />
   <package id="Microsoft.NETCore.Platforms" version="1.0.1" targetFramework="net452" />

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -2204,10 +2204,9 @@ namespace Akka.Cluster
                 _exitingConfirmed.Where(x => localGossip.GetMember(x).Status == MemberStatus.Exiting)
                 .ToImmutableHashSet();
 
+            var upNumber = 0;
             var changedMembers = localMembers.Select(m =>
             {
-                var upNumber = 0;
-
                 if (isJoiningUp(m))
                 {
                     // Move JOINING => UP (once all nodes have seen that this node is JOINING, i.e. we have a convergence)

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -2240,8 +2240,7 @@ namespace Akka.Cluster
                 // handle changes
 
                 // replace changed members
-                var newMembers = changedMembers
-                    .Union(localMembers)
+                var newMembers = Member.PickNextTransition(changedMembers, localMembers)
                     .Except(removedUnreachable)
                     .Where(x => !removedExitingConfirmed.Contains(x.UniqueAddress))
                     .ToImmutableSortedSet();

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -1311,7 +1311,9 @@ namespace Akka.Cluster
             if (message is GossipEnvelope)
             {
                 var ge = message as GossipEnvelope;
-                ReceiveGossip(ge);
+                var receivedType = ReceiveGossip(ge);
+                if(_cluster.Settings.VerboseGossipReceivedLogging)
+                    _log.Debug("Cluster Node [{0}] - Received gossip from [{1}] which was {2}.", _cluster.SelfAddress, ge.From, receivedType);
             }
             else if (message is GossipStatus)
             {
@@ -1787,23 +1789,23 @@ namespace Akka.Cluster
         public enum ReceiveGossipType
         {
             /// <summary>
-            /// TBD
+            /// Gossip is ignored because node was not part of cluster, unreachable, etc..
             /// </summary>
             Ignored,
             /// <summary>
-            /// TBD
+            /// Gossip received is older than what we currently have
             /// </summary>
             Older,
             /// <summary>
-            /// TBD
+            /// Gossip received is newer than what we currently have
             /// </summary>
             Newer,
             /// <summary>
-            /// TBD
+            /// Gossip received is same as what we currently have
             /// </summary>
             Same,
             /// <summary>
-            /// TBD
+            /// Gossip received is concurrent with what we haved, and then merged.
             /// </summary>
             Merge
         }

--- a/src/core/Akka.Cluster/ClusterSettings.cs
+++ b/src/core/Akka.Cluster/ClusterSettings.cs
@@ -70,6 +70,7 @@ namespace Akka.Cluster
                 .ToImmutableDictionary(kv => kv.Key, kv => kv.Value.GetObject().GetKey("min-nr-of-members").GetInt());
 
             VerboseHeartbeatLogging = cc.GetBoolean("debug.verbose-heartbeat-logging");
+            VerboseGossipReceivedLogging = cc.GetBoolean("debug.verbose-receive-gossip-logging");
 
             var downingProviderClassName = cc.GetString("downing-provider-class");
             if (!string.IsNullOrEmpty(downingProviderClassName))
@@ -212,6 +213,11 @@ namespace Akka.Cluster
         /// Determine whether or not to log heartbeat message in verbose mode.
         /// </summary>
         public bool VerboseHeartbeatLogging { get; }
+
+        /// <summary>
+        /// Determines whether or not to log gossip consumption logging in verbose mode
+        /// </summary>
+        public bool VerboseGossipReceivedLogging { get; }
 
         /// <summary>
         /// TBD

--- a/src/core/Akka.Cluster/Configuration/Cluster.conf
+++ b/src/core/Akka.Cluster/Configuration/Cluster.conf
@@ -178,6 +178,9 @@ akka {
     debug {
       # log heartbeat events (very verbose, useful mostly when debugging heartbeating issues)
       verbose-heartbeat-logging = off
+
+	  # log gossip merge events (very verbose, useful when debugging convergence issues)
+	  verbose-receive-gossip-logging = off
     }
   }
 

--- a/src/core/Akka.Cluster/Member.cs
+++ b/src/core/Akka.Cluster/Member.cs
@@ -263,11 +263,62 @@ namespace Akka.Cluster
         }
 
         /// <summary>
+        /// Combines and sorts two lists of <see cref="Member"/> into a single list ordered by Member's valid transitions
+        /// </summary>
+        /// <param name="a">The first collection of members.</param>
+        /// <param name="b">The second collection of members.</param>
+        /// <returns>An immutable hash set containing the members with the next logical transition.</returns>
+        public static ImmutableSortedSet<Member> PickNextTransition(IEnumerable<Member> a, IEnumerable<Member> b)
+        {
+            // group all members by Address => Seq[Member]
+            var groupedByAddress = (a.Concat(b)).GroupBy(x => x.UniqueAddress);
+
+            var acc = new HashSet<Member>();
+
+            foreach (var g in groupedByAddress)
+            {
+                if (g.Count() == 2) acc.Add(PickNextTransition(g.First(), g.Skip(1).First()));
+                else
+                {
+                    var m = g.First();
+                    acc.Add(m);
+                }
+            }
+
+            return acc.ToImmutableSortedSet();
+        }
+
+        /// <summary>
+        /// Compares two copies OF THE SAME MEMBER and returns whichever one is a valid transition of the other.
+        /// </summary>
+        /// <param name="a">First member instance.</param>
+        /// <param name="b">Second member instance.</param>
+        /// <returns>If a and b are different members, this method will return <c>null</c>. 
+        /// Otherwise, will return a or b depending on which one is a valid transition of the other.
+        /// If neither are a valid transition, we return <c>null</c></returns>
+        public static Member PickNextTransition(Member a, Member b)
+        {
+            if (a == null || b == null || !a.Equals(b))
+                return null;
+
+            // if the member statuses are equal, then it doesn't matter which one we return
+            if (a.Status.Equals(b.Status))
+                return a;
+
+            if (Member.AllowedTransitions[a.Status].Contains(b.Status))
+                return b;
+            if(Member.AllowedTransitions[b.Status].Contains(a.Status))
+                return a;
+
+            return null; // illegal transition
+        }
+
+        /// <summary>
         /// Combines and sorts two lists of <see cref="Member"/> into a single list ordered by highest prioirity
         /// </summary>
-        /// <param name="a">TBD</param>
-        /// <param name="b">TBD</param>
-        /// <returns>TBD</returns>
+        /// <param name="a">The first collection of members.</param>
+        /// <param name="b">The second collection of members.</param>
+        /// <returns>An immutable hash set containing the members with the highest priority.</returns>
         public static ImmutableHashSet<Member> PickHighestPriority(IEnumerable<Member> a, IEnumerable<Member> b)
         {
             // group all members by Address => Seq[Member]
@@ -290,9 +341,9 @@ namespace Akka.Cluster
         /// <summary>
         /// Picks the Member with the highest "priority" MemberStatus.
         /// </summary>
-        /// <param name="m1">TBD</param>
-        /// <param name="m2">TBD</param>
-        /// <returns>TBD</returns>
+        /// <param name="m1">The first member to compare.</param>
+        /// <param name="m2">The second member to compare.</param>
+        /// <returns>The higher priority of the two members.</returns>
         public static Member HighestPriorityOf(Member m1, Member m2)
         {
             if (m1.Status.Equals(m2.Status))

--- a/src/core/Akka.Cluster/Member.cs
+++ b/src/core/Akka.Cluster/Member.cs
@@ -14,7 +14,6 @@ using Akka.Util.Internal;
 
 namespace Akka.Cluster
 {
-    //TODO: Keep an eye on concurrency / immutability
     /// <summary>
     /// Represents the address, current status, and roles of a cluster member node.
     /// </summary>

--- a/src/core/Akka.FSharp/Properties/AssemblyInfo.fs
+++ b/src/core/Akka.FSharp/Properties/AssemblyInfo.fs
@@ -10,9 +10,9 @@ open System.Runtime.InteropServices
 [<assembly: AssemblyCompanyAttribute("Akka.NET Team")>]
 [<assembly: ComVisibleAttribute(false)>]
 [<assembly: CLSCompliantAttribute(true)>]
-[<assembly: AssemblyVersionAttribute("1.2.0.0")>]
-[<assembly: AssemblyFileVersionAttribute("1.2.0.0")>]
+[<assembly: AssemblyVersionAttribute("1.2.2.0")>]
+[<assembly: AssemblyFileVersionAttribute("1.2.2.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "1.2.0.0"
+    let [<Literal>] Version = "1.2.2.0"

--- a/src/core/Akka.Persistence.Tests/Akka.Persistence.Tests.csproj
+++ b/src/core/Akka.Persistence.Tests/Akka.Persistence.Tests.csproj
@@ -100,6 +100,7 @@
     <Compile Include="LoadPluginSpec.cs" />
     <Compile Include="MemoryEventAdapterSpec.cs" />
     <Compile Include="PerformanceSpec.cs" />
+    <Compile Include="PersistenceConfigAutoStartSpec.cs" />
     <Compile Include="PersistenceConfigSpec.cs" />
     <Compile Include="PersistenceSpec.cs" />
     <Compile Include="PersistentActorBoundedStashingSpec.cs" />

--- a/src/core/Akka.Persistence.Tests/PersistenceConfigAutoStartSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistenceConfigAutoStartSpec.cs
@@ -1,0 +1,107 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="PersistenceConfigAutoStartSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Persistence.Journal;
+using Akka.Persistence.Snapshot;
+using Akka.TestKit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Tests
+{
+    public class PersistenceConfigAutoStartSpec : AkkaSpec
+    {
+        #region internal classes
+
+        private sealed class TestRequest
+        {
+            public static readonly TestRequest Instance = new TestRequest();
+
+            private TestRequest()
+            {
+            }
+        }
+
+        public class TestJournal : MemoryJournal
+        {
+            private readonly string _testValue;
+
+            public TestJournal(Config config)
+            {
+                _testValue = config.GetString("test-value");
+            }
+
+            protected override bool AroundReceive(Receive receive, object message)
+            {
+                if (message is TestRequest)
+                {
+                    Sender.Tell(_testValue);
+                    return true;
+                }
+                else return base.AroundReceive(receive, message);
+            }
+        }
+
+        public class TestSnapshotStore : LocalSnapshotStore
+        {
+            private readonly string _testValue;
+
+            public TestSnapshotStore(Config config)
+            {
+                _testValue = config.GetString("test-value");
+            }
+
+            protected override bool AroundReceive(Receive receive, object message)
+            {
+                if (message is TestRequest)
+                {
+                    Sender.Tell(_testValue);
+                    return true;
+                }
+                else return base.AroundReceive(receive, message);
+            }
+        }
+
+        #endregion
+
+        private static readonly Config AutoStartConfig = ConfigurationFactory.ParseString(@"
+            akka.loglevel = INFO
+            akka.persistence.journal {
+                test {
+                    class = ""Akka.Persistence.Tests.PersistenceConfigAutoStartSpec+TestJournal, Akka.Persistence.Tests""
+                    plugin-dispatcher = ""akka.actor.default-dispatcher""
+                    test-value = ""A""
+                }
+                auto-start-journals = [akka.persistence.journal.test]
+            }
+            akka.persistence.snapshot-store {
+                test {
+                    class = ""Akka.Persistence.Tests.PersistenceConfigAutoStartSpec+TestSnapshotStore, Akka.Persistence.Tests""
+                    plugin-dispatcher = ""akka.actor.default-dispatcher""
+                    test-value = ""C""
+                }
+                auto-start-snapshot-stores = [akka.persistence.snapshot-store.test]
+            }
+        ");
+
+        public PersistenceConfigAutoStartSpec(ITestOutputHelper output = null) : base(AutoStartConfig, output)
+        {
+        }
+
+        [Fact]
+        public void Persistence_should_auto_start_journal_and_snapshotstore_when_specified()
+        {
+            EventFilter.Info(message: "Auto-starting journal plugin `akka.persistence.journal.test`")
+                .And.Info(message: "Auto-starting snapshot store `akka.persistence.snapshot-store.test`").Expect(2, () =>
+            {
+                var persistence = Persistence.Instance.Apply(Sys);
+            });
+        }
+    }
+}

--- a/src/core/Akka.Persistence/Persistence.cs
+++ b/src/core/Akka.Persistence/Persistence.cs
@@ -34,7 +34,7 @@ namespace Akka.Persistence
     }
 
     /// <summary>
-    /// TBD
+    /// Launches the Akka.Persistence runtime
     /// </summary>
     public class PersistenceExtension : IExtension
     {
@@ -55,12 +55,15 @@ namespace Akka.Persistence
         private const string SnapshotStoreFallbackConfigPath = "akka.persistence.snapshot-store-plugin-fallback";
 
         /// <summary>
-        /// TBD
+        /// Creates a new Akka.Persistence extension.
         /// </summary>
-        /// <param name="system">TBD</param>
-        /// <exception cref="NullReferenceException">TBD
+        /// <param name="system">The ActorSystem that will be using Akka.Persistence</param>
+        /// <exception cref="NullReferenceException">
         /// This exception is thrown when the default journal plugin, <c>journal.plugin</c> is not configured.
         /// </exception>
+        /// <remarks>
+        /// DO NOT CALL DIRECTLY. Will be instantiated automatically be Akka.Persistence actors.
+        /// </remarks>
         public PersistenceExtension(ExtendedActorSystem system)
         {
             _system = system;
@@ -106,7 +109,7 @@ namespace Akka.Persistence
                 JournalFor(id);
             });
 
-            _config.GetStringList("journal.auto-start-snapshot-stores").ForEach(id =>
+            _config.GetStringList("snapshot-store.auto-start-snapshot-stores").ForEach(id =>
             {
                 if (_log.IsInfoEnabled)
                     _log.Info("Auto-starting snapshot store `{0}`", id);
@@ -120,7 +123,7 @@ namespace Akka.Persistence
         public IStashOverflowStrategy DefaultInternalStashOverflowStrategy => _defaultInternalStashOverflowStrategy.Value;
 
         /// <summary>
-        /// TBD
+        /// The Akka.Persistence settings for the journal and snapshot store
         /// </summary>
         public PersistenceSettings Settings { get; }
 

--- a/src/core/Akka.TestKit/TestKitBase.cs
+++ b/src/core/Akka.TestKit/TestKitBase.cs
@@ -409,12 +409,12 @@ namespace Akka.TestKit
         /// <param name="system">The system to shutdown.</param>
         /// <param name="duration">The duration to wait for shutdown. Default is 5 seconds multiplied with the config value "akka.test.timefactor"</param>
         /// <param name="verifySystemShutdown">if set to <c>true</c> an exception will be thrown on failure.</param>
-        /// <exception cref="TimeoutException">TBD</exception>
+        /// <exception cref="TimeoutException">Thrown if we can't verify that the <see cref="ActorSystem"/> was shutdown within the given length of time.</exception>
         protected virtual void Shutdown(ActorSystem system, TimeSpan? duration = null, bool verifySystemShutdown = false)
         {
             if (system == null) system = _testState.System;
 
-            var durationValue = duration.GetValueOrDefault(Dilated(TimeSpan.FromSeconds(5)).Min(TimeSpan.FromSeconds(10)));
+            var durationValue = (duration ?? Dilated(TimeSpan.FromSeconds(5))).Min(TimeSpan.FromSeconds(10));
 
             var wasShutdownDuringWait = system.Terminate().Wait(durationValue);
             if(!wasShutdownDuringWait)

--- a/src/core/Akka.TestKit/TestKitBase.cs
+++ b/src/core/Akka.TestKit/TestKitBase.cs
@@ -409,12 +409,12 @@ namespace Akka.TestKit
         /// <param name="system">The system to shutdown.</param>
         /// <param name="duration">The duration to wait for shutdown. Default is 5 seconds multiplied with the config value "akka.test.timefactor"</param>
         /// <param name="verifySystemShutdown">if set to <c>true</c> an exception will be thrown on failure.</param>
-        /// <exception cref="TimeoutException">Thrown if we can't verify that the <see cref="ActorSystem"/> was shutdown within the given length of time.</exception>
+        /// <exception cref="TimeoutException">TBD</exception>
         protected virtual void Shutdown(ActorSystem system, TimeSpan? duration = null, bool verifySystemShutdown = false)
         {
             if (system == null) system = _testState.System;
 
-            var durationValue = (duration ?? Dilated(TimeSpan.FromSeconds(5))).Min(TimeSpan.FromSeconds(10));
+            var durationValue = duration.GetValueOrDefault(Dilated(TimeSpan.FromSeconds(5)).Min(TimeSpan.FromSeconds(10)));
 
             var wasShutdownDuringWait = system.Terminate().Wait(durationValue);
             if(!wasShutdownDuringWait)

--- a/src/core/Akka/Event/Logging.cs
+++ b/src/core/Akka/Event/Logging.cs
@@ -89,7 +89,10 @@ namespace Akka.Event
         /// <returns>The newly created logging adapter.</returns>
         public static ILoggingAdapter GetLogger(this IActorContext context, ILogMessageFormatter logMessageFormatter = null)
         {
-            var logSource = context.Self.ToString();
+            // if we're runing Akka.Remote or Akka.Cluster, this will grab the default inbound listening address
+            // otherwise, it'll default to just using the local absolute path
+            var addr = ((ExtendedActorSystem) context.System).Provider.DefaultAddress ?? Address.AllSystems;
+            var logSource = addr.Equals(Address.AllSystems) ? context.Self.ToString() : context.Self.Path.ToSerializationFormatWithAddress(addr);
             var logClass = context.Props.Type;
 
             return new BusLogging(context.System.EventStream, logSource, logClass, logMessageFormatter ?? new DefaultLogMessageFormatter());

--- a/src/core/Akka/Routing/RoutedActorCell.cs
+++ b/src/core/Akka/Routing/RoutedActorCell.cs
@@ -160,14 +160,7 @@ namespace Akka.Routing
             if (RouterConfig is Pool)
             {
                 var pool = (Pool)RouterConfig;
-                // must not use pool.GetNrOfInstances(system) for old (not re-compiled) custom routers
-                // for binary backwards compatibility reasons
-                var deprecatedNrOfInstances = pool.NrOfInstances;
-
-                var nrOfRoutees = deprecatedNrOfInstances < 0
-                    ? pool.GetNrOfInstances(System)
-                    : deprecatedNrOfInstances;
-
+                var nrOfRoutees = pool.GetNrOfInstances(System);
                 if (nrOfRoutees > 0)
                     AddRoutees(Vector.Fill<Routee>(nrOfRoutees)(() => pool.NewRoutee(RouteeProps, this)));
             }


### PR DESCRIPTION
#### 1.2.2 June 28 2017 ####
**Maintenance Release for Akka.NET 1.2**

Finally, fully resolves issues related to Akka.Cluster nodes not being able to cleanly leave or join a cluster after a period of network instability. Also includes some minor fixes for clustered routers and Akka.Persistence.

[See the full set of Akka.NET 1.2.2 fixes here](https://github.com/akkadotnet/akka.net/milestone/16).

| COMMITS | LOC+ | LOC- | AUTHOR |
| --- | --- | --- | --- |
| 13 | 589 | 52 | Aaron Stannard |
