### PR TITLE
Incremental tests - account for sole change to test project

### DIFF
--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -145,7 +145,7 @@ module IncrementalTests =
         seq { for proj in allProjects do
                 for dep in proj.dependencies do
                     if (proj.parentProject.projectName = project && proj.isTestProject) then
-                        // logfn "%s is a test project..." proj.parentProject.projectName
+                        // if the altered project is a test project (e.g. Akka.Tests)
                         yield proj;
                     if (dep.projectName = project && proj.isTestProject) then
                         // logfn "%s references %s and is a test project..." proj.parentProject.projectName project

--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -144,6 +144,9 @@ module IncrementalTests =
         let allProjects = getAllProjectDependencies testMode
         seq { for proj in allProjects do
                 for dep in proj.dependencies do
+                    if (proj.parentProject.projectName = project && proj.isTestProject) then
+                        // logfn "%s is a test project..." proj.parentProject.projectName
+                        yield proj;
                     if (dep.projectName = project && proj.isTestProject) then
                         // logfn "%s references %s and is a test project..." proj.parentProject.projectName project
                         yield proj


### PR DESCRIPTION
As it stands, incremental testing will search for test projects that have a dependency or indirect dependency on a changed project.  It didn't account for if the only project that was changed was a test project, e.g. if the PR was only a change to `Akka.Tests.csproj`.  This will force incremental testing to run test projects if they were the only project changed.