### PR TITLE
Incremental testing - fetch default branch in TeamCity

### DIFF
--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -45,6 +45,9 @@ module IncrementalTests =
 
     let getUpdatedFiles() = 
         let srcDir = __SOURCE_DIRECTORY__
+        let localBranches = getLocalBranches srcDir
+        if not (localBranches |> Seq.exists (fun b -> b = "v1.3")) then
+            checkoutTracked srcDir "v1.3" "origin/v1.3"
         let forkPoint = runSimpleGitCommand srcDir "merge-base --fork-point v1.3"
         let currentHash = getCurrentHash()
         getChangedFiles srcDir forkPoint currentHash

--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -47,7 +47,7 @@ module IncrementalTests =
         let srcDir = __SOURCE_DIRECTORY__
         let localBranches = getLocalBranches srcDir
         if not (localBranches |> Seq.exists (fun b -> b = "v1.3")) then
-            checkoutNewBranch srcDir "v1.3" "origin/v1.3"
+            directRunGitCommandAndFail srcDir "fetch origin v1.3:v1.3"
         let forkPoint = runSimpleGitCommand srcDir "merge-base --fork-point v1.3"
         let currentHash = getCurrentHash()
         getChangedFiles srcDir forkPoint currentHash

--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -47,7 +47,7 @@ module IncrementalTests =
         let srcDir = __SOURCE_DIRECTORY__
         let localBranches = getLocalBranches srcDir
         if not (localBranches |> Seq.exists (fun b -> b = "v1.3")) then
-            checkoutTracked srcDir "v1.3" "origin/v1.3"
+            checkoutNewBranch srcDir "v1.3" "origin/v1.3"
         let forkPoint = runSimpleGitCommand srcDir "merge-base --fork-point v1.3"
         let currentHash = getCurrentHash()
         getChangedFiles srcDir forkPoint currentHash


### PR DESCRIPTION
Since TeamCity only clones the feature branch of the PR, this leaves the incremental testing code with no way to compare changed files with `git merge-base --fork-point v1.3` on the TeamCity build agent.  Adding a check for the existence of `v1.3` branch locally and if it doesn't exist, run `git checkout -b v1.3 origin/v1.3` to get that branch onto the build agent