### PR TITLE
Incremental-tests: fix bug with not being able to find --fork-point for fast-forwards

### DIFF
--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -51,10 +51,12 @@ module IncrementalTests =
         let currentBranch = runSimpleGitCommand srcDir "rev-parse --abbrev-ref HEAD"
         let forkPoint = runSimpleGitCommand srcDir (sprintf "merge-base %s v1.3" currentBranch)
         let currentHash = getCurrentHash()
-        getChangedFiles srcDir forkPoint currentHash
-        |> Seq.map (fun (_, fi) -> FullName fi)
-        // only consider files in ./src/ and build scripts
-        |> Seq.filter (fun fi -> (isInFolder (new DirectoryInfo("./src")) (new FileInfo(fi))) || (isBuildScript fi))
+        if (not (forkPoint = "") && not (currentHash = "")) then
+            getChangedFiles srcDir forkPoint currentHash
+            |> Seq.map (fun (_, fi) -> FullName fi)
+            |> Seq.filter (fun fi -> (isInFolder (new DirectoryInfo("./src")) (new FileInfo(fi))) || (isBuildScript fi))
+        else
+            failwith "Couldn't find commits to compare for incremental tests"
   
     // Gather all of the folder paths that contain .csproj files
     let getAllProjectFolders() =

--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -144,6 +144,9 @@ module IncrementalTests =
         let allProjects = getAllProjectDependencies testMode
         seq { for proj in allProjects do
                 for dep in proj.dependencies do
+                    if (proj.parentProject.projectName = project && proj.isTestProject) then
+                        // if the altered project is a test project (e.g. Akka.Tests)
+                        yield proj;
                     if (dep.projectName = project && proj.isTestProject) then
                         // logfn "%s references %s and is a test project..." proj.parentProject.projectName project
                         yield proj

--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -55,7 +55,13 @@ module IncrementalTests =
 
     let getUpdatedFiles() = 
         let srcDir = __SOURCE_DIRECTORY__
-        let lastCommitToDefaultBranch = getHeadHashFor srcDir "origin/v1.3"
+        let localBranches = getLocalBranches srcDir
+        log "Local branches..."
+        localBranches |> Seq.iter log
+        if not (localBranches |> Seq.exists (fun b -> b = "v1.3")) then
+            log "v1.3 branch information not available... fetching"
+            directRunGitCommandAndFail srcDir "fetch origin v1.3:v1.3"
+        let lastCommitToDefaultBranch = getHeadHashFor srcDir "v1.3"
         logfn "HEAD commit hash of origin/v1.3 branch: %s" lastCommitToDefaultBranch
         let currentHash = getCurrentHash()
         logfn "HEAD commit hash of current branch: %s" currentHash

--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -9,6 +9,8 @@ open Fake.Git
 
 module IncrementalTests =   
 
+    let akkaDefaultBranch = "v1.3"
+
     type Supports =
     | Windows
     | Linux
@@ -58,15 +60,15 @@ module IncrementalTests =
         let localBranches = getLocalBranches srcDir
         log "Local branches..."
         localBranches |> Seq.iter log
-        if not (localBranches |> Seq.exists (fun b -> b = "v1.3")) then
-            log "v1.3 branch information not available... fetching"
-            directRunGitCommandAndFail srcDir "fetch origin v1.3:v1.3"
-        let lastCommitToDefaultBranch = getHeadHashFor srcDir "v1.3"
-        logfn "HEAD commit hash of origin/v1.3 branch: %s" lastCommitToDefaultBranch
+        if not (localBranches |> Seq.exists (fun b -> b = akkaDefaultBranch)) then
+            log "default branch information not available... fetching"
+            directRunGitCommandAndFail srcDir (sprintf "fetch origin %s:%s" akkaDefaultBranch akkaDefaultBranch)
+        let lastCommitToDefaultBranch = getHeadHashFor srcDir akkaDefaultBranch
+        logfn "HEAD commit hash of default branch: %s" lastCommitToDefaultBranch
         let currentHash = getCurrentHash()
         logfn "HEAD commit hash of current branch: %s" currentHash
         let forkPoint = findMergeBase srcDir currentHash lastCommitToDefaultBranch
-        logfn "merge-base of v1.3 and current branch HEAD: %s" forkPoint
+        logfn "merge-base of default branch and current branch HEAD: %s" forkPoint
         if (not (forkPoint = "") && not (currentHash = "")) then
             getChangedFiles srcDir forkPoint currentHash
             |> Seq.map (fun (_, fi) -> FullName fi)

--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -47,8 +47,9 @@ module IncrementalTests =
         let srcDir = __SOURCE_DIRECTORY__
         let localBranches = getLocalBranches srcDir
         if not (localBranches |> Seq.exists (fun b -> b = "v1.3")) then
-            directRunGitCommandAndFail srcDir "fetch origin v1.3:v1.3"
-        let forkPoint = runSimpleGitCommand srcDir "merge-base --fork-point v1.3"
+            directRunGitCommandAndFail srcDir "fetch origin v1.3"
+        let currentBranch = runSimpleGitCommand srcDir "rev-parse --abbrev-ref HEAD"
+        let forkPoint = runSimpleGitCommand srcDir (sprintf "merge-base %s v1.3" currentBranch)
         let currentHash = getCurrentHash()
         getChangedFiles srcDir forkPoint currentHash
         |> Seq.map (fun (_, fi) -> FullName fi)

--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -45,6 +45,9 @@ module IncrementalTests =
 
     let getUpdatedFiles() = 
         let srcDir = __SOURCE_DIRECTORY__
+        let localBranches = getLocalBranches srcDir
+        if not (localBranches |> Seq.exists (fun b -> b = "v1.3")) then
+            directRunGitCommandAndFail srcDir "fetch origin v1.3:v1.3"
         let forkPoint = runSimpleGitCommand srcDir "merge-base --fork-point v1.3"
         let currentHash = getCurrentHash()
         getChangedFiles srcDir forkPoint currentHash


### PR DESCRIPTION
`git merge-base --fork-point` proved unreliable when commits could be fast forwarded.  Replacing with `git merge-base <branch> v1.3` and added failure detection.