### PR TITLE
Fix for ClusterSpec terminate ActorSystem via leave CoordinatedShutdown (#2728)

### DIFF
--- a/src/core/Akka.TestKit/Internal/BlockingCollectionTestActorQueue.cs
+++ b/src/core/Akka.TestKit/Internal/BlockingCollectionTestActorQueue.cs
@@ -38,6 +38,15 @@ namespace Akka.TestKit.Internal
         }
 
         /// <summary>
+        /// Return an <see cref="List{T}"/> for the items inside the collection.
+        /// </summary>
+        /// <returns>A <see cref="List{T}"/> for the <see cref="BlockingCollectionTestActorQueue{T}"/> items</returns>
+        public List<T> ToList()
+        {
+            return _queue.ToList();
+        }
+        
+        /// <summary>
         /// <para>
         /// Retrieves all items from the queue.
         /// </para>

--- a/src/core/Akka.TestKit/Internal/BlockingQueue.cs
+++ b/src/core/Akka.TestKit/Internal/BlockingQueue.cs
@@ -111,6 +111,22 @@ namespace Akka.TestKit.Internal
             return p.Value;
         }
 
+        /// <summary>
+        /// Copies the items from the <see cref="BlockingQueue{T}"/> instance into a new <see cref="List{T}"/>.
+        /// </summary>
+        /// <returns>A <see cref="List{T}"/> containing copies of the elements of the collection</returns>
+        public List<T> ToList()
+        {
+            var positionArray = _collection.ToArray();
+            var items = new List<T>();
+            foreach (var positioned in positionArray)
+            {
+                items.Add(positioned.Value);
+            }
+            return items;
+        }
+
+
         private class Positioned
         {
             private readonly T _value;

--- a/src/core/Akka.TestKit/Internal/ITestActorQueue.cs
+++ b/src/core/Akka.TestKit/Internal/ITestActorQueue.cs
@@ -27,6 +27,12 @@ namespace Akka.TestKit.Internal
     public interface ITestActorQueue<T> : ITestActorQueueProducer<T>
     {
         /// <summary>
+        /// Copies all the items from the <see cref="ITestActorQueue{T}"/> instance into a new <see cref="List{T}"/>
+        /// </summary>
+        /// <returns>TBD</returns>
+        List<T> ToList();
+
+        /// <summary>
         /// Get all messages.
         /// </summary>
         /// <returns>TBD</returns>

--- a/src/core/Akka.TestKit/Internal/InternalTestActor.cs
+++ b/src/core/Akka.TestKit/Internal/InternalTestActor.cs
@@ -81,7 +81,7 @@ namespace Akka.TestKit.Internal
         protected override void PostStop()
         {
             var self = Self;
-            foreach(var messageEnvelope in _queue.GetAll())
+            foreach(var messageEnvelope in _queue.ToList())
             {
                 var messageSender = messageEnvelope.Sender;
                 var message = messageEnvelope.Message;


### PR DESCRIPTION
Not actually a race condition. 
TestProbe empties its message queue at PostStop when it sends its queue to the dead letter mailbox. 
This behavior is different than the Java implementation, where messages are retained in the queue.
The bug happens when the test is delayed in such a way that the probe message is asserted after it is stopped and its message queue already emptied.