### PR TITLE
Port JVM Akka's watchWith for custom termination messages

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -124,6 +124,7 @@ namespace Akka.Actor
         public void UseThreadContext(System.Action action) { }
         public Akka.Actor.IActorRef Watch(Akka.Actor.IActorRef subject) { }
         protected void WatchedActorTerminated(Akka.Actor.IActorRef actor, bool existenceConfirmed, bool addressTerminated) { }
+        public Akka.Actor.IActorRef WatchWith(Akka.Actor.IActorRef subject, object message) { }
     }
     public sealed class ActorIdentity
     {
@@ -981,6 +982,7 @@ namespace Akka.Actor
     {
         Akka.Actor.IActorRef Unwatch(Akka.Actor.IActorRef subject);
         Akka.Actor.IActorRef Watch(Akka.Actor.IActorRef subject);
+        Akka.Actor.IActorRef WatchWith(Akka.Actor.IActorRef subject, object message);
     }
     public interface ICell
     {
@@ -1103,6 +1105,7 @@ namespace Akka.Actor
         public void Send(Akka.Actor.IActorRef actorRef, object msg) { }
         public Akka.Actor.IActorRef Unwatch(Akka.Actor.IActorRef subject) { }
         public Akka.Actor.IActorRef Watch(Akka.Actor.IActorRef subject) { }
+        public Akka.Actor.IActorRef WatchWith(Akka.Actor.IActorRef subject, object message) { }
     }
     public interface INoSerializationVerificationNeeded { }
     public interface INotInfluenceReceiveTimeout { }

--- a/src/core/Akka/Actor/ActorCell.DeathWatch.cs
+++ b/src/core/Akka/Actor/ActorCell.DeathWatch.cs
@@ -31,7 +31,31 @@ namespace Akka.Actor
                 MaintainAddressTerminatedSubscription(() =>
                 {
                     a.SendSystemMessage(new Watch(a, _self)); // ➡➡➡ NEVER SEND THE SAME SYSTEM MESSAGE OBJECT TO TWO ACTORS
-                    _state = _state.AddWatching(a);
+                    _state = _state.AddWatching(a, null);
+                }, a);
+            }
+            return a;
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="subject">TBD</param>
+        /// <param name="message">TBD</param>
+        /// <returns>TBD</returns>
+        public IActorRef WatchWith(IActorRef subject, object message)
+        {
+            if (message == null)
+                throw new ArgumentNullException(nameof(message), "message must not be null");
+
+            var a = (IInternalActorRef)subject;
+
+            if (!a.Equals(Self) && !WatchingContains(a))
+            {
+                MaintainAddressTerminatedSubscription(() =>
+                {
+                    a.SendSystemMessage(new Watch(a, _self)); // ➡➡➡ NEVER SEND THE SAME SYSTEM MESSAGE OBJECT TO TWO ACTORS
+                    _state = _state.AddWatching(a, message);
                 }, a);
             }
             return a;
@@ -79,7 +103,8 @@ namespace Akka.Actor
         /// <param name="addressTerminated">TBD</param>
         protected void WatchedActorTerminated(IActorRef actor, bool existenceConfirmed, bool addressTerminated)
         {
-            if (WatchingContains(actor))
+            object message; // The custom termination message that was requested
+            if (TryGetWatching(actor, out message))
             {
                 MaintainAddressTerminatedSubscription(() =>
                 {
@@ -87,7 +112,7 @@ namespace Akka.Actor
                 }, actor);
                 if (!IsTerminating)
                 {
-                    Self.Tell(new Terminated(actor, existenceConfirmed, addressTerminated), actor);
+                    Self.Tell(message ?? new Terminated(actor, existenceConfirmed, addressTerminated), actor);
                     TerminatedQueuedFor(actor);
                 }
             }
@@ -109,6 +134,11 @@ namespace Akka.Actor
         private bool WatchingContains(IActorRef subject)
         {
             return _state.ContainsWatching(subject);
+        }
+
+        private bool TryGetWatching(IActorRef subject, out object message)
+        {
+            return _state.TryGetWatching(subject, out message);
         }
 
         /// <summary>

--- a/src/core/Akka/Actor/IActorContext.cs
+++ b/src/core/Akka/Actor/IActorContext.cs
@@ -29,6 +29,15 @@ namespace Akka.Actor
         IActorRef Watch(IActorRef subject);
 
         /// <summary>
+        /// Monitors the specified actor for termination. When the <paramref name="subject"/> terminates
+        /// the instance watching will receive the provided message.
+        /// </summary>
+        /// <param name="subject">The actor to monitor for termination.</param>
+        /// <param name="message">The custom termination message</param>
+        /// <returns>Returns the provided subject</returns>
+        IActorRef WatchWith(IActorRef subject, object message);
+
+        /// <summary>
         /// Stops monitoring the <paramref name="subject"/> for termination.
         /// </summary>
         /// <param name="subject">The actor to stop monitor for termination.</param>

--- a/src/core/Akka/Actor/Inbox.Actor.cs
+++ b/src/core/Akka/Actor/Inbox.Actor.cs
@@ -146,7 +146,13 @@ namespace Akka.Actor
                         _currentSelect = null;
                     }
                 })
-                .With<StartWatch>(sw => Context.Watch(sw.Target))
+                .With<StartWatch>(sw => 
+                {
+                    if (sw.Message == null)
+                        Context.Watch(sw.Target);
+                    else
+                        Context.WatchWith(sw.Target, sw.Message);
+                })
                 .With<StopWatch>(sw => Context.Unwatch(sw.Target))
                 .With<Kick>(() =>
                 {

--- a/src/core/Akka/Actor/Inbox.cs
+++ b/src/core/Akka/Actor/Inbox.cs
@@ -122,16 +122,23 @@ namespace Akka.Actor
         /// TBD
         /// </summary>
         /// <param name="target">TBD</param>
-        public StartWatch(IActorRef target)
+        /// <param name="message">TBD</param>
+        public StartWatch(IActorRef target, object message)
             : this()
         {
             Target = target;
+            Message = message;
         }
 
         /// <summary>
         /// TBD
         /// </summary>
         public IActorRef Target { get; private set; }
+
+        /// <summary>
+        /// The custom termination message or null
+        /// </summary>
+        public object Message { get; private set; }
     }
 
     /// <summary>
@@ -439,7 +446,13 @@ namespace Akka.Actor
         /// <returns>TBD</returns>
         public IActorRef Watch(IActorRef subject)
         {
-            Receiver.Tell(new StartWatch(subject));
+            Receiver.Tell(new StartWatch(subject, null));
+            return subject;
+        }
+
+        public IActorRef WatchWith(IActorRef subject, object message)
+        {
+            Receiver.Tell(new StartWatch(subject, message));
             return subject;
         }
 


### PR DESCRIPTION
I ported [PR #22794](https://github.com/akka/akka/pull/22794) from Akka that allows custom termination messages. The old deathwatch tests all pass and I added an additional one testing the custom message.
I think this is a really nice feature and worthwhile having, because this allows giving termination messages some more meaning and integrate them better in the message protocol of an actor.