### PR TITLE
Akka.NET v1.2.3 Production Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,14 @@
+#### 1.2.3 July 07 2017 ####
+**Maintenance Release for Akka.NET 1.2**
+
+Resolves a bug introduced in Akka.NET 1.2.2 that caused Akka.Remote to not terminate properly under some conditions during `ActorSystem.Terminate`.
+
+[See the full set of Akka.NET 1.2.3 fixes here](https://github.com/akkadotnet/akka.net/milestone/18).
+
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 3 | 46 | 63 | Aaron Stannard |
+
 #### 1.2.2 June 28 2017 ####
 **Maintenance Release for Akka.NET 1.2**
 

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -4,5 +4,5 @@ using System.Reflection;
 [assembly: AssemblyCompanyAttribute("Akka.NET Team")]
 [assembly: AssemblyCopyrightAttribute("Copyright © 2013-2017 Akka.NET Team")]
 [assembly: AssemblyTrademarkAttribute("")]
-[assembly: AssemblyVersionAttribute("1.2.2.0")]
-[assembly: AssemblyFileVersionAttribute("1.2.2.0")]
+[assembly: AssemblyVersionAttribute("1.2.3.0")]
+[assembly: AssemblyFileVersionAttribute("1.2.3.0")]

--- a/src/core/Akka.FSharp/Properties/AssemblyInfo.fs
+++ b/src/core/Akka.FSharp/Properties/AssemblyInfo.fs
@@ -10,9 +10,9 @@ open System.Runtime.InteropServices
 [<assembly: AssemblyCompanyAttribute("Akka.NET Team")>]
 [<assembly: ComVisibleAttribute(false)>]
 [<assembly: CLSCompliantAttribute(true)>]
-[<assembly: AssemblyVersionAttribute("1.2.2.0")>]
-[<assembly: AssemblyFileVersionAttribute("1.2.2.0")>]
+[<assembly: AssemblyVersionAttribute("1.2.3.0")>]
+[<assembly: AssemblyFileVersionAttribute("1.2.3.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "1.2.2.0"
+    let [<Literal>] Version = "1.2.3.0"

--- a/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
+++ b/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
@@ -191,6 +191,7 @@
     <Compile Include="Transport\AkkaProtocolStressTest.cs" />
     <Compile Include="Transport\DotNettySslSupportSpec.cs" />
     <Compile Include="Transport\DotNettyTransportDnsResolutionSpec.cs" />
+    <Compile Include="Transport\DotNettyTransportShutdownSpec.cs" />
     <Compile Include="Transport\GenericTransportSpec.cs" />
     <Compile Include="Transport\TestTransportSpec.cs" />
     <Compile Include="Transport\ThrottleModeSpec.cs" />

--- a/src/core/Akka.Remote.Tests/Transport/DotNettyTransportShutdownSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettyTransportShutdownSpec.cs
@@ -1,0 +1,283 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="DotNettyTransportShutdownSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Remote.Transport;
+using Akka.Remote.Transport.DotNetty;
+using Akka.TestKit;
+using Xunit;
+using FluentAssertions;
+
+namespace Akka.Remote.Tests.Transport
+{
+    /// <summary>
+    /// Verify that the <see cref="DotNettyTransport"/> can cleanly shut itself down.
+    /// </summary>
+    public class DotNettyTransportShutdownSpec : AkkaSpec
+    {
+        private static readonly Config Config = ConfigurationFactory.ParseString(@"
+            akka {
+                loglevel = DEBUG
+                actor.provider = ""Akka.Remote.RemoteActorRefProvider,Akka.Remote""
+                remote {
+                    dot-netty.tcp {
+                        port = 0
+                        hostname = ""127.0.0.1""
+                        log-transport = true
+                    }
+                }
+            }");
+
+        public DotNettyTransportShutdownSpec() : base(Config)
+        {
+            
+        }
+
+        [Fact]
+        public async Task DotNettyTcpTransport_should_cleanly_terminate_unused_inbound_endpoint()
+        {
+            var t1 = new TcpTransport(Sys, Sys.Settings.Config.GetConfig("akka.remote.dot-netty.tcp"));
+            try
+            {
+                // bind
+                await t1.Listen();
+
+                // verify that ServerChannel is active and open
+                var sc = t1.ServerChannel;
+                sc.Should().NotBeNull();
+                sc.Active.Should().BeTrue();
+                sc.Open.Should().BeTrue();
+
+                // shutdown
+                await t1.Shutdown();
+                sc.Open.Should().BeFalse();
+                sc.CloseCompletion.IsCompleted.Should().BeTrue();
+            }
+            finally
+            {
+                await t1.Shutdown();
+            }
+        }
+
+        [Fact]
+        public async Task DotNettyTcpTransport_should_cleanly_terminate_active_endpoints_upon_outbound_disassociate()
+        {
+            var t1 = new TcpTransport(Sys, Sys.Settings.Config.GetConfig("akka.remote.dot-netty.tcp"));
+            var t2 = new TcpTransport(Sys, Sys.Settings.Config.GetConfig("akka.remote.dot-netty.tcp"));
+            try
+            {
+                var p1 = CreateTestProbe();
+                var p2 = CreateTestProbe();
+
+                // bind
+                var c1 = await t1.Listen();
+                c1.Item2.SetResult(new ActorAssociationEventListener(p1));
+                var c2 = await t2.Listen();
+                c2.Item2.SetResult(new ActorAssociationEventListener(p2));
+
+                // t1 --> t2 association
+                var handle = await t1.Associate(c2.Item1);
+                handle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p1));
+                var inboundHandle = p2.ExpectMsg<InboundAssociation>().Association; // wait for the inbound association handle to show up
+                inboundHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p2));
+
+                t1.ConnectionGroup.Count.Should().Be(2);
+                t2.ConnectionGroup.Count.Should().Be(2);
+
+                var chan1 = t1.ConnectionGroup.Single(x => !x.Id.Equals(t1.ServerChannel.Id));
+                var chan2 = t2.ConnectionGroup.Single(x => !x.Id.Equals(t2.ServerChannel.Id));
+
+                // force a disassociation
+                handle.Disassociate();
+
+                // verify that the connections are terminated
+                p1.ExpectMsg<Disassociated>();
+                AwaitCondition(() => t1.ConnectionGroup.Count == 1);
+                AwaitCondition(() => t2.ConnectionGroup.Count == 1);
+
+                // verify that the connection channels were terminated on both ends
+                chan1.CloseCompletion.IsCompleted.Should().BeTrue();
+                chan2.CloseCompletion.IsCompleted.Should().BeTrue();
+            }
+            finally
+            {
+                await t1.Shutdown();
+                await t2.Shutdown();
+            }
+        }
+
+        [Fact]
+        public async Task DotNettyTcpTransport_should_cleanly_terminate_active_endpoints_upon_outbound_shutdown()
+        {
+            var t1 = new TcpTransport(Sys, Sys.Settings.Config.GetConfig("akka.remote.dot-netty.tcp"));
+            var t2 = new TcpTransport(Sys, Sys.Settings.Config.GetConfig("akka.remote.dot-netty.tcp"));
+            try
+            {
+                var p1 = CreateTestProbe();
+                var p2 = CreateTestProbe();
+
+                // bind
+                var c1 = await t1.Listen();
+                c1.Item2.SetResult(new ActorAssociationEventListener(p1));
+                var c2 = await t2.Listen();
+                c2.Item2.SetResult(new ActorAssociationEventListener(p2));
+
+                // t1 --> t2 association
+                var handle = await t1.Associate(c2.Item1);
+                handle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p1));
+                var inboundHandle = p2.ExpectMsg<InboundAssociation>().Association; // wait for the inbound association handle to show up
+                inboundHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p2));
+
+                t1.ConnectionGroup.Count.Should().Be(2);
+                t2.ConnectionGroup.Count.Should().Be(2);
+
+                var chan1 = t1.ConnectionGroup.Single(x => !x.Id.Equals(t1.ServerChannel.Id));
+                var chan2 = t2.ConnectionGroup.Single(x => !x.Id.Equals(t2.ServerChannel.Id));
+
+                //  shutdown remoting on t1
+                await t1.Shutdown();
+
+                p2.ExpectMsg<Disassociated>();
+                // verify that the connections are terminated
+                AwaitCondition(() => t1.ConnectionGroup.Count == 0, null, message: $"Expected 0 open connection but found {t1.ConnectionGroup.Count}");
+                AwaitCondition(() => t2.ConnectionGroup.Count == 1, null,message: $"Expected 1 open connection but found {t2.ConnectionGroup.Count}");
+
+                // verify that the connection channels were terminated on both ends
+                chan1.CloseCompletion.IsCompleted.Should().BeTrue();
+                chan2.CloseCompletion.IsCompleted.Should().BeTrue();
+            }
+            finally
+            {
+                await t1.Shutdown();
+                await t2.Shutdown();
+            }
+        }
+
+        [Fact]
+        public async Task DotNettyTcpTransport_should_cleanly_terminate_active_endpoints_upon_inbound_disassociate()
+        {
+            var t1 = new TcpTransport(Sys, Sys.Settings.Config.GetConfig("akka.remote.dot-netty.tcp"));
+            var t2 = new TcpTransport(Sys, Sys.Settings.Config.GetConfig("akka.remote.dot-netty.tcp"));
+            try
+            {
+                var p1 = CreateTestProbe();
+                var p2 = CreateTestProbe();
+
+                // bind
+                var c1 = await t1.Listen();
+                c1.Item2.SetResult(new ActorAssociationEventListener(p1));
+                var c2 = await t2.Listen();
+                c2.Item2.SetResult(new ActorAssociationEventListener(p2));
+
+                // t1 --> t2 association
+                var handle = await t1.Associate(c2.Item1);
+                handle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p1));
+                var inboundHandle = p2.ExpectMsg<InboundAssociation>().Association; // wait for the inbound association handle to show up
+                inboundHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p2));
+
+                t1.ConnectionGroup.Count.Should().Be(2);
+                t2.ConnectionGroup.Count.Should().Be(2);
+
+                var chan1 = t1.ConnectionGroup.Single(x => !x.Id.Equals(t1.ServerChannel.Id));
+                var chan2 = t2.ConnectionGroup.Single(x => !x.Id.Equals(t2.ServerChannel.Id));
+
+                // force a disassociation
+                inboundHandle.Disassociate();
+
+                // verify that the connections are terminated
+                AwaitCondition(() => t1.ConnectionGroup.Count == 1, null, message: $"Expected 1 open connection but found {t1.ConnectionGroup.Count}");
+                AwaitCondition(() => t2.ConnectionGroup.Count == 1, null, message: $"Expected 1 open connection but found {t2.ConnectionGroup.Count}");
+
+                // verify that the connection channels were terminated on both ends
+                chan1.CloseCompletion.IsCompleted.Should().BeTrue();
+                chan2.CloseCompletion.IsCompleted.Should().BeTrue();
+            }
+            finally
+            {
+                await t1.Shutdown();
+                await t2.Shutdown();
+            }
+        }
+
+        [Fact]
+        public async Task DotNettyTcpTransport_should_cleanly_terminate_active_endpoints_upon_inbound_shutdown()
+        {
+            var t1 = new TcpTransport(Sys, Sys.Settings.Config.GetConfig("akka.remote.dot-netty.tcp"));
+            var t2 = new TcpTransport(Sys, Sys.Settings.Config.GetConfig("akka.remote.dot-netty.tcp"));
+            try
+            {
+                var p1 = CreateTestProbe();
+                var p2 = CreateTestProbe();
+
+                // bind
+                var c1 = await t1.Listen();
+                c1.Item2.SetResult(new ActorAssociationEventListener(p1));
+                var c2 = await t2.Listen();
+                c2.Item2.SetResult(new ActorAssociationEventListener(p2));
+
+                // t1 --> t2 association
+                var handle = await t1.Associate(c2.Item1);
+                handle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p1));
+                var inboundHandle = p2.ExpectMsg<InboundAssociation>().Association; // wait for the inbound association handle to show up
+                inboundHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p2));
+
+                t1.ConnectionGroup.Count.Should().Be(2);
+                t2.ConnectionGroup.Count.Should().Be(2);
+
+                var chan1 = t1.ConnectionGroup.Single(x => !x.Id.Equals(t1.ServerChannel.Id));
+                var chan2 = t2.ConnectionGroup.Single(x => !x.Id.Equals(t2.ServerChannel.Id));
+
+                // shutdown inbound side
+                await t2.Shutdown();
+
+                // verify that the connections are terminated
+                AwaitCondition(() => t1.ConnectionGroup.Count == 1, null, message: $"Expected 1 open connection but found {t1.ConnectionGroup.Count}");
+                AwaitCondition(() => t2.ConnectionGroup.Count == 0, null, message: $"Expected 0 open connection but found {t2.ConnectionGroup.Count}");
+
+                // verify that the connection channels were terminated on both ends
+                chan1.CloseCompletion.IsCompleted.Should().BeTrue();
+                chan2.CloseCompletion.IsCompleted.Should().BeTrue();
+            }
+            finally
+            {
+                await t1.Shutdown();
+                await t2.Shutdown();
+            }
+        }
+
+        [Fact]
+        public async Task DotNettyTcpTransport_should_cleanly_terminate_endpoints_upon_failed_outbound_connection()
+        {
+            var t1 = new TcpTransport(Sys, Sys.Settings.Config.GetConfig("akka.remote.dot-netty.tcp"));
+            try
+            {
+                var p1 = CreateTestProbe();
+
+                // bind
+                var c1 = await t1.Listen();
+                c1.Item2.SetResult(new ActorAssociationEventListener(p1));
+
+                // t1 --> t2 association
+                await Assert.ThrowsAsync<InvalidAssociationException>(async () =>
+                {
+                    var a = await t1.Associate(c1.Item1.WithPort(c1.Item1.Port + 100));
+                });
+                
+
+                t1.ConnectionGroup.Count.Should().Be(1);
+            }
+            finally
+            {
+                await t1.Shutdown();
+            }
+        }
+    }
+}

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -64,91 +64,70 @@ namespace Akka.Remote
         }
 
         /// <summary>
-        /// TBD
+        /// Remoting system daemon responsible for powering remote deployment capabilities.
         /// </summary>
         public IInternalActorRef RemoteDaemon { get { return RemoteInternals.RemoteDaemon; } }
         /// <summary>
-        /// TBD
+        /// The remote transport. Wraps all of the underlying physical network transports.
         /// </summary>
         public RemoteTransport Transport { get { return RemoteInternals.Transport; } }
 
         /// <summary>
-        /// TBD
+        /// The remoting settings
         /// </summary>
         internal RemoteSettings RemoteSettings { get; private set; }
 
         /* these are only available after Init() is called */
 
-        /// <summary>
-        /// TBD
-        /// </summary>
+        /// <inheritdoc/>
         public ActorPath RootPath
         {
             get { return _local.RootPath; }
         }
 
 
-        /// <summary>
-        /// TBD
-        /// </summary>
+        /// <inheritdoc/>
         public IInternalActorRef RootGuardian { get { return _local.RootGuardian; } }
-        /// <summary>
-        /// TBD
-        /// </summary>
+
+        /// <inheritdoc/>
         public LocalActorRef Guardian { get { return _local.Guardian; } }
-        /// <summary>
-        /// TBD
-        /// </summary>
+
+        /// <inheritdoc/>
         public LocalActorRef SystemGuardian { get { return _local.SystemGuardian; } }
-        /// <summary>
-        /// TBD
-        /// </summary>
+
+        /// <inheritdoc/>
         public IInternalActorRef TempContainer { get { return _local.TempContainer; } }
-        /// <summary>
-        /// TBD
-        /// </summary>
+
+        /// <inheritdoc/>
         public IActorRef DeadLetters { get { return _local.DeadLetters; } }
-        /// <summary>
-        /// TBD
-        /// </summary>
+
+        /// <inheritdoc/>
         public Deployer Deployer { get; protected set; }
-        /// <summary>
-        /// TBD
-        /// </summary>
+
+        /// <inheritdoc/>
         public Address DefaultAddress { get { return Transport.DefaultAddress; } }
-        /// <summary>
-        /// TBD
-        /// </summary>
+
+        /// <inheritdoc/>
         public Settings Settings { get { return _local.Settings; } }
-        /// <summary>
-        /// TBD
-        /// </summary>
+
+        /// <inheritdoc/>
         public Task TerminationTask { get { return _local.TerminationTask; } }
+
         private IInternalActorRef InternalDeadLetters { get { return (IInternalActorRef)_local.DeadLetters; } }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <returns>TBD</returns>
+        /// <inheritdoc/>
         public ActorPath TempPath()
         {
             return _local.TempPath();
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="actorRef">TBD</param>
-        /// <param name="path">TBD</param>
+        /// <inheritdoc/>
         public void RegisterTempActor(IInternalActorRef actorRef, ActorPath path)
         {
             _local.RegisterTempActor(actorRef, path);
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="path">TBD</param>
+        /// <inheritdoc/>
         public void UnregisterTempActor(ActorPath path)
         {
             _local.UnregisterTempActor(path);
@@ -156,16 +135,14 @@ namespace Akka.Remote
 
         private volatile IActorRef _remotingTerminator;
         private volatile IActorRef _remoteWatcher;
+
         /// <summary>
-        /// TBD
+        /// The remote death watcher.
         /// </summary>
         internal IActorRef RemoteWatcher => _remoteWatcher;
         private volatile IActorRef _remoteDeploymentWatcher;
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="system">TBD</param>
+        /// <inheritdoc/>
         public virtual void Init(ActorSystemImpl system)
         {
             _system = system;

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -28,11 +28,11 @@ namespace Akka.Remote
         private readonly ILoggingAdapter _log;
 
         /// <summary>
-        /// TBD
+        /// Creates a new remote actor ref provider instance.
         /// </summary>
-        /// <param name="systemName">TBD</param>
-        /// <param name="settings">TBD</param>
-        /// <param name="eventStream">TBD</param>
+        /// <param name="systemName">Name of the actor system.</param>
+        /// <param name="settings">The actor system settings.</param>
+        /// <param name="eventStream">The <see cref="EventStream"/> instance used by this system.</param>
         public RemoteActorRefProvider(string systemName, Settings settings, EventStream eventStream)
         {
             settings.InjectTopLevelFallback(RemoteConfigFactory.Default());
@@ -67,6 +67,7 @@ namespace Akka.Remote
         /// Remoting system daemon responsible for powering remote deployment capabilities.
         /// </summary>
         public IInternalActorRef RemoteDaemon { get { return RemoteInternals.RemoteDaemon; } }
+
         /// <summary>
         /// The remote transport. Wraps all of the underlying physical network transports.
         /// </summary>
@@ -84,7 +85,6 @@ namespace Akka.Remote
         {
             get { return _local.RootPath; }
         }
-
 
         /// <inheritdoc/>
         public IInternalActorRef RootGuardian { get { return _local.RootGuardian; } }

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -51,7 +51,7 @@ namespace Akka.Remote
 
         private Internals RemoteInternals
         {
-            get { return _internals ?? (_internals = CreateInternals()); }
+            get { return _internals; }
         }
 
         private Internals CreateInternals()
@@ -153,6 +153,8 @@ namespace Akka.Remote
                 _system.SystemActorOf(
                     RemoteSettings.ConfigureDispatcher(Props.Create(() => new RemotingTerminator(_local.SystemGuardian))),
                     "remoting-terminator");
+
+            _internals = CreateInternals();
 
             _remotingTerminator.Tell(RemoteInternals);
 

--- a/src/core/Akka.Remote/Transport/DotNetty/AkkaLoggingHandler.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/AkkaLoggingHandler.cs
@@ -18,102 +18,107 @@ using ILoggingAdapter = Akka.Event.ILoggingAdapter;
 
 namespace Akka.Remote.Transport.DotNetty
 {
+    /// <summary>
+    /// INTERNAL API
+    /// 
+    /// Used for adding additional debug logging to the DotNetty transport
+    /// </summary>
     internal class AkkaLoggingHandler : ChannelHandlerAdapter
     {
-        private readonly ILoggingAdapter log;
+        private readonly ILoggingAdapter _log;
         
         public AkkaLoggingHandler(ILoggingAdapter log)
         {
-            this.log = log;
+            this._log = log;
         }
 
         public override void ChannelRegistered(IChannelHandlerContext ctx)
         {
-            log.Debug("Channel {0} registered", ctx.Channel);
+            _log.Debug("Channel {0} registered", ctx.Channel);
             ctx.FireChannelRegistered();
         }
 
         public override void ChannelUnregistered(IChannelHandlerContext ctx)
         {
-            log.Debug("Channel {0} unregistered", ctx.Channel);
+            _log.Debug("Channel {0} unregistered", ctx.Channel);
             ctx.FireChannelUnregistered();
         }
 
         public override void ChannelActive(IChannelHandlerContext ctx)
         {
-            log.Debug("Channel {0} active", ctx.Channel);
+            _log.Debug("Channel {0} active", ctx.Channel);
             ctx.FireChannelActive();
         }
 
         public override void ChannelInactive(IChannelHandlerContext ctx)
         {
-            log.Debug("Channel {0} inactive", ctx.Channel);
+            _log.Debug("Channel {0} inactive", ctx.Channel);
             ctx.FireChannelInactive();
         }
 
         public override void ExceptionCaught(IChannelHandlerContext ctx, Exception cause)
         {
-            log.Error(cause, "Channel {0} caught exception", ctx.Channel);
+            _log.Error(cause, "Channel {0} caught exception", ctx.Channel);
             ctx.FireExceptionCaught(cause);
         }
 
         public override void UserEventTriggered(IChannelHandlerContext ctx, object evt)
         {
-            log.Debug("Channel {0} triggered user event [{1}]", ctx.Channel, evt);
+            _log.Debug("Channel {0} triggered user event [{1}]", ctx.Channel, evt);
             ctx.FireUserEventTriggered(evt);
         }
 
         public override Task BindAsync(IChannelHandlerContext ctx, EndPoint localAddress)
         {
-            log.Info("Channel {0} bind to address {1}", ctx.Channel, localAddress);
+            _log.Info("Channel {0} bind to address {1}", ctx.Channel, localAddress);
             return ctx.BindAsync(localAddress);
         }
 
         public override Task ConnectAsync(IChannelHandlerContext ctx, EndPoint remoteAddress, EndPoint localAddress)
         {
-            log.Info("Channel {0} connect (remote: {1}, local: {2})", ctx.Channel, remoteAddress, localAddress);
+            _log.Info("Channel {0} connect (remote: {1}, local: {2})", ctx.Channel, remoteAddress, localAddress);
             return ctx.ConnectAsync(remoteAddress, localAddress);
         }
 
         public override Task DisconnectAsync(IChannelHandlerContext ctx)
         {
-            log.Info("Channel {0} disconnect", ctx.Channel);
+            _log.Info("Channel {0} disconnect", ctx.Channel);
             return ctx.DisconnectAsync();
         }
 
         public override Task CloseAsync(IChannelHandlerContext ctx)
         {
-            log.Info("Channel {0} close", ctx.Channel);
+            _log.Info("Channel {0} close", ctx.Channel);
             return ctx.CloseAsync();
         }
 
         public override Task DeregisterAsync(IChannelHandlerContext ctx)
         {
-            log.Debug("Channel {0} deregister", ctx.Channel);
+            _log.Debug("Channel {0} deregister", ctx.Channel);
             return ctx.DeregisterAsync();
         }
 
         public override void ChannelRead(IChannelHandlerContext ctx, object message)
         {
-            if (log.IsDebugEnabled)
+            if (_log.IsDebugEnabled)
             {
-                log.Debug("Channel {0} received a message ({1}) of type [{2}]", ctx.Channel, message, message == null ? "NULL" : message.GetType().TypeQualifiedName());
+                _log.Debug("Channel {0} received a message ({1}) of type [{2}]", ctx.Channel, message, message == null ? "NULL" : message.GetType().TypeQualifiedName());
             }
             ctx.FireChannelRead(message);
         }
 
         public override Task WriteAsync(IChannelHandlerContext ctx, object message)
         {
-            if (log.IsDebugEnabled)
+            if (_log.IsDebugEnabled)
             {
-                log.Debug("Channel {0} writing a message ({1}) of type [{2}]", ctx.Channel, message, message == null ? "NULL" : message.GetType().TypeQualifiedName());
+                _log.Debug("Channel {0} writing a message ({1}) of type [{2}]", ctx.Channel, message, message == null ? "NULL" : message.GetType().TypeQualifiedName());
             }
             return ctx.WriteAsync(message);
         }
 
         public override void Flush(IChannelHandlerContext ctx)
         {
-            log.Debug("Channel {0} flushing", ctx.Channel);
+            _log.Debug("Channel {0} flushing", ctx.Channel);
             ctx.Flush();
         }
         

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
@@ -123,7 +123,7 @@ namespace Akka.Remote.Transport.DotNetty
         protected readonly TaskCompletionSource<IAssociationEventListener> AssociationListenerPromise;
         protected readonly ILoggingAdapter Log;
         protected volatile Address LocalAddress;
-        protected volatile IChannel ServerChannel;
+        protected internal volatile IChannel ServerChannel;
 
         private readonly IEventLoopGroup serverEventLoopGroup;
         private readonly IEventLoopGroup clientEventLoopGroup;

--- a/src/core/Akka.Remote/Transport/DotNetty/TcpTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/TcpTransport.cs
@@ -23,11 +23,11 @@ namespace Akka.Remote.Transport.DotNetty
 {
     internal abstract class TcpHandlers : CommonHandlers
     {
-        private IHandleEventListener listener;
+        private IHandleEventListener _listener;
         
         protected void NotifyListener(IHandleEvent msg)
         {
-            listener?.Notify(msg);
+            _listener?.Notify(msg);
         }
         
         protected TcpHandlers(DotNettyTransport transport, ILoggingAdapter log) : base(transport, log)
@@ -36,7 +36,7 @@ namespace Akka.Remote.Transport.DotNetty
         
         protected override void RegisterListener(IChannel channel, IHandleEventListener listener, object msg, IPEndPoint remoteAddress)
         {
-            this.listener = listener;
+            this._listener = listener;
         }
         
         protected override AssociationHandle CreateHandle(IChannel channel, Address localAddress, Address remoteAddress)
@@ -79,12 +79,12 @@ namespace Akka.Remote.Transport.DotNetty
 
     internal sealed class TcpServerHandler : TcpHandlers
     {
-        private readonly Task<IAssociationEventListener> associationEventListener;
+        private readonly Task<IAssociationEventListener> _associationEventListener;
         
         public TcpServerHandler(DotNettyTransport transport, ILoggingAdapter log, Task<IAssociationEventListener> associationEventListener) 
             : base(transport, log)
         {
-            this.associationEventListener = associationEventListener;
+            this._associationEventListener = associationEventListener;
         }
         
         public override void ChannelActive(IChannelHandlerContext context)
@@ -98,7 +98,7 @@ namespace Akka.Remote.Transport.DotNetty
             // disable automatic reads
             channel.Configuration.AutoRead = false;
 
-            associationEventListener.ContinueWith(r =>
+            _associationEventListener.ContinueWith(r =>
             {
                 var listener = r.Result;
                 var remoteAddress = DotNettyTransport.MapSocketToAddress(
@@ -114,15 +114,15 @@ namespace Akka.Remote.Transport.DotNetty
 
     internal sealed class TcpClientHandler : TcpHandlers
     {
-        private readonly TaskCompletionSource<AssociationHandle> statusPromise = new TaskCompletionSource<AssociationHandle>();
-        private readonly Address remoteAddress;
+        private readonly TaskCompletionSource<AssociationHandle> _statusPromise = new TaskCompletionSource<AssociationHandle>();
+        private readonly Address _remoteAddress;
 
-        public Task<AssociationHandle> StatusFuture => statusPromise.Task;
+        public Task<AssociationHandle> StatusFuture => _statusPromise.Task;
         
         public TcpClientHandler(DotNettyTransport transport, ILoggingAdapter log, Address remoteAddress) 
             : base(transport, log)
         {
-            this.remoteAddress = remoteAddress;
+            _remoteAddress = remoteAddress;
         }
         
         public override void ChannelActive(IChannelHandlerContext context)
@@ -134,8 +134,8 @@ namespace Akka.Remote.Transport.DotNetty
         private void InitOutbound(IChannel channel, IPEndPoint socketAddress, object msg)
         {
             AssociationHandle handle;
-            Init(channel, socketAddress, remoteAddress, msg, out handle);
-            statusPromise.TrySetResult(handle);
+            Init(channel, socketAddress, _remoteAddress, msg, out handle);
+            _statusPromise.TrySetResult(handle);
         }
     }
 

--- a/src/core/Akka/Event/Logging.cs
+++ b/src/core/Akka/Event/Logging.cs
@@ -91,7 +91,8 @@ namespace Akka.Event
         {
             // if we're runing Akka.Remote or Akka.Cluster, this will grab the default inbound listening address
             // otherwise, it'll default to just using the local absolute path
-            var addr = ((ExtendedActorSystem) context.System).Provider.DefaultAddress ?? Address.AllSystems;
+            var provider = ((ExtendedActorSystem) context.System).Provider;
+                ?? Address.AllSystems;
             var logSource = addr.Equals(Address.AllSystems) ? context.Self.ToString() : context.Self.Path.ToSerializationFormatWithAddress(addr);
             var logClass = context.Props.Type;
 

--- a/src/core/Akka/Event/Logging.cs
+++ b/src/core/Akka/Event/Logging.cs
@@ -89,11 +89,7 @@ namespace Akka.Event
         /// <returns>The newly created logging adapter.</returns>
         public static ILoggingAdapter GetLogger(this IActorContext context, ILogMessageFormatter logMessageFormatter = null)
         {
-            // if we're runing Akka.Remote or Akka.Cluster, this will grab the default inbound listening address
-            // otherwise, it'll default to just using the local absolute path
-            var provider = ((ExtendedActorSystem) context.System).Provider;
-                ?? Address.AllSystems;
-            var logSource = addr.Equals(Address.AllSystems) ? context.Self.ToString() : context.Self.Path.ToSerializationFormatWithAddress(addr);
+            var logSource = context.Self.ToString();
             var logClass = context.Props.Type;
 
             return new BusLogging(context.System.EventStream, logSource, logClass, logMessageFormatter ?? new DefaultLogMessageFormatter());

--- a/src/core/Akka/Util/ConcurrentSet.cs
+++ b/src/core/Akka/Util/ConcurrentSet.cs
@@ -18,14 +18,14 @@ namespace Akka.Util
     /// <typeparam name="T">TBD</typeparam>
     public class ConcurrentSet<T> : ICollection<T>, IEnumerable<T>, IEnumerable
     {
-        private readonly ConcurrentDictionary<T, byte> storage;
+        private readonly ConcurrentDictionary<T, byte> _storage;
 
         /// <summary>
         /// TBD
         /// </summary>
         public ConcurrentSet()
         {
-            storage = new ConcurrentDictionary<T, byte>();
+            _storage = new ConcurrentDictionary<T, byte>();
         }
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace Akka.Util
         /// <param name="collection">TBD</param>
         public ConcurrentSet(IEnumerable<T> collection)
         {
-            storage = new ConcurrentDictionary<T, byte>(collection.Select(_ => new KeyValuePair<T, byte>(_, 0)));
+            _storage = new ConcurrentDictionary<T, byte>(collection.Select(_ => new KeyValuePair<T, byte>(_, 0)));
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace Akka.Util
         /// <param name="comparer">TBD</param>
         public ConcurrentSet(IEqualityComparer<T> comparer)
         {
-            storage = new ConcurrentDictionary<T, byte>(comparer);
+            _storage = new ConcurrentDictionary<T, byte>(comparer);
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace Akka.Util
         /// <param name="comparer">TBD</param>
         public ConcurrentSet(IEnumerable<T> collection, IEqualityComparer<T> comparer)
         {
-            storage = new ConcurrentDictionary<T, byte>(collection.Select(_ => new KeyValuePair<T, byte>(_, 0)),
+            _storage = new ConcurrentDictionary<T, byte>(collection.Select(_ => new KeyValuePair<T, byte>(_, 0)),
                 comparer);
         }
 
@@ -64,7 +64,7 @@ namespace Akka.Util
         /// <param name="capacity">TBD</param>
         public ConcurrentSet(int concurrencyLevel, int capacity)
         {
-            storage = new ConcurrentDictionary<T, byte>(concurrencyLevel, capacity);
+            _storage = new ConcurrentDictionary<T, byte>(concurrencyLevel, capacity);
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace Akka.Util
         /// <param name="comparer">TBD</param>
         public ConcurrentSet(int concurrencyLevel, IEnumerable<T> collection, IEqualityComparer<T> comparer)
         {
-            storage = new ConcurrentDictionary<T, byte>(concurrencyLevel,
+            _storage = new ConcurrentDictionary<T, byte>(concurrencyLevel,
                 collection.Select(_ => new KeyValuePair<T, byte>(_, 0)), comparer);
         }
 
@@ -87,7 +87,7 @@ namespace Akka.Util
         /// <param name="comparer">TBD</param>
         public ConcurrentSet(int concurrencyLevel, int capacity, IEqualityComparer<T> comparer)
         {
-            storage = new ConcurrentDictionary<T, byte>(concurrencyLevel, capacity, comparer);
+            _storage = new ConcurrentDictionary<T, byte>(concurrencyLevel, capacity, comparer);
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace Akka.Util
         /// </summary>
         public bool IsEmpty
         {
-            get { return storage.IsEmpty; }
+            get { return _storage.IsEmpty; }
         }
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace Akka.Util
         /// </summary>
         public int Count
         {
-            get { return storage.Count; }
+            get { return _storage.Count; }
         }
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace Akka.Util
         /// </summary>
         public void Clear()
         {
-            storage.Clear();
+            _storage.Clear();
         }
 
         /// <summary>
@@ -121,17 +121,17 @@ namespace Akka.Util
         /// <returns>TBD</returns>
         public bool Contains(T item)
         {
-            return storage.ContainsKey(item);
+            return _storage.ContainsKey(item);
         }
 
         void ICollection<T>.Add(T item)
         {
-            ((ICollection<KeyValuePair<T, byte>>) storage).Add(new KeyValuePair<T, byte>(item, 0));
+            ((ICollection<KeyValuePair<T, byte>>) _storage).Add(new KeyValuePair<T, byte>(item, 0));
         }
 
         void ICollection<T>.CopyTo(T[] array, int arrayIndex)
         {
-            foreach (var pair in storage)
+            foreach (var pair in _storage)
                 array[arrayIndex++] = pair.Key;
         }
 
@@ -147,12 +147,12 @@ namespace Akka.Util
 
         IEnumerator<T> IEnumerable<T>.GetEnumerator()
         {
-            return storage.Keys.GetEnumerator();
+            return _storage.Keys.GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return storage.Keys.GetEnumerator();
+            return _storage.Keys.GetEnumerator();
         }
 
         /// <summary>
@@ -162,7 +162,7 @@ namespace Akka.Util
         /// <returns>TBD</returns>
         public bool TryAdd(T item)
         {
-            return storage.TryAdd(item, 0);
+            return _storage.TryAdd(item, 0);
         }
 
         /// <summary>
@@ -173,7 +173,7 @@ namespace Akka.Util
         public bool TryRemove(T item)
         {
             byte dontCare;
-            return storage.TryRemove(item, out dontCare);
+            return _storage.TryRemove(item, out dontCare);
         }
     }
 }

--- a/src/examples/Chat/ChatClient/Program.cs
+++ b/src/examples/Chat/ChatClient/Program.cs
@@ -54,7 +54,12 @@ akka {
                             {
                                 NewUsername = rest
                             });
-                        }                        
+                        }
+                        if (cmd == "/exit")
+                        {
+                            Console.WriteLine("exiting");
+                            break;
+                        }
                     }
                     else
                     {
@@ -64,6 +69,8 @@ akka {
                         });
                     }
                 }
+
+                system.Terminate().Wait();
             }
         }
     }


### PR DESCRIPTION
#### 1.2.3 July 07 2017 ####
**Maintenance Release for Akka.NET 1.2**

Resolves a bug introduced in Akka.NET 1.2.2 that caused Akka.Remote to not terminate properly under some conditions during `ActorSystem.Terminate`.

[See the full set of Akka.NET 1.2.3 fixes here](https://github.com/akkadotnet/akka.net/milestone/18).

| COMMITS | LOC+ | LOC- | AUTHOR |
| --- | --- | --- | --- |
| 3 | 46 | 63 | Aaron Stannard |