### PR TITLE
Add FinalTarget to kill running processes on TeamCity build agent

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -86,6 +86,7 @@ module internal ResultHandling =
 open BuildIncremental.IncrementalTests
 
 Target "RunTests" (fun _ ->    
+    ActivateFinalTarget "KillCreatedProcesses"
     let projects =
         match getBuildParamOrDefault "incremental" "" with
         | "true" -> getIncrementalUnitTests()

--- a/build.fsx
+++ b/build.fsx
@@ -110,6 +110,7 @@ Target "RunTests" (fun _ ->
 )
 
 Target "RunTestsNetCore" (fun _ ->
+    ActivateFinalTarget "KillCreatedProcesses"
     let projects =
         match getBuildParamOrDefault "incremental" "" with
         | "true" -> getIncrementalUnitTests()
@@ -132,6 +133,7 @@ Target "RunTestsNetCore" (fun _ ->
 )
 
 Target "MultiNodeTests" (fun _ ->
+    ActivateFinalTarget "KillCreatedProcesses"
     let multiNodeTestPath = findToolInSubPath "Akka.MultiNodeTestRunner.exe" (currentDirectory @@ "src" @@ "core" @@ "Akka.MultiNodeTestRunner" @@ "bin" @@ "Release" @@ "net452")
 
     let multiNodeTestAssemblies = 
@@ -166,6 +168,7 @@ Target "MultiNodeTests" (fun _ ->
 )
 
 Target "NBench" <| fun _ ->
+    ActivateFinalTarget "KillCreatedProcesses"
     CleanDir outputPerfTests
 
     let nbenchTestPath = findToolInSubPath "NBench.Runner.exe" (toolsDir @@ "NBench.Runner*")
@@ -324,10 +327,6 @@ FinalTarget "KillCreatedProcesses" (fun _ ->
     killAllCreatedProcesses()
 )
 
-Target "ActivateFinalTargets" (fun _ ->
-    ActivateFinalTarget "KillCreatedProcesses"
-)
-
 //--------------------------------------------------------------------------------
 // Help 
 //--------------------------------------------------------------------------------
@@ -386,11 +385,11 @@ Target "All" DoNothing
 Target "Nuget" DoNothing
 
 // build dependencies
-"Clean" ==> "ActivateFinalTargets" ==> "RestorePackages" ==> "Build" ==> "BuildRelease"
+"Clean" ==> "RestorePackages" ==> "Build" ==> "BuildRelease"
 
 // tests dependencies
 // "RunTests" step doesn't require Clean ==> "RestorePackages" step
-"Clean" ==> "ActivateFinalTargets" ==> "RestorePackages" ==> "RunTestsNetCore"
+"Clean" ==> "RestorePackages" ==> "RunTestsNetCore"
 
 // nuget dependencies
 "Clean" ==> "RestorePackages" ==> "Build" ==> "CreateNuget"

--- a/build.fsx
+++ b/build.fsx
@@ -323,7 +323,7 @@ Target "DocFx" (fun _ ->
 
 FinalTarget "KillCreatedProcesses" (fun _ ->
     log "The following processes were started during FAKE step..."
-    startedProcesses |> Seq.iter (fun (pid, _) -> logfn "%i: %s" pid (Process.GetProcessById(pid).ProcessName))
+    startedProcesses |> Seq.iter (fun (pid, _) -> logf "%i, " pid)
     log "Killing processes started by FAKE..."
     killAllCreatedProcesses()
 )

--- a/build.fsx
+++ b/build.fsx
@@ -5,6 +5,7 @@
 open System
 open System.IO
 open System.Text
+open System.Diagnostics
 
 open Fake
 open Fake.DotNetCli
@@ -322,7 +323,7 @@ Target "DocFx" (fun _ ->
 
 FinalTarget "KillCreatedProcesses" (fun _ ->
     log "The following processes were started during FAKE step..."
-    startedProcesses |> Seq.iter (fun (pid, _) -> logfn "%i" pid)
+    startedProcesses |> Seq.iter (fun (pid, _) -> logfn "%i: %s" pid (Process.GetProcessById(pid).ProcessName))
     log "Killing processes started by FAKE..."
     killAllCreatedProcesses()
 )

--- a/build.fsx
+++ b/build.fsx
@@ -316,6 +316,17 @@ Target "DocFx" (fun _ ->
                     DocFxJson = docsPath @@ "docfx.json" })
 )
 
+FinalTarget "KillCreatedProcesses" (fun _ ->
+    log "The following processes were started during FAKE step..."
+    startedProcesses |> Seq.iter (fun (pid, _) -> logfn "%i" pid)
+    log "Killing processes started by FAKE..."
+    killAllCreatedProcesses()
+)
+
+Target "ActivateFinalTargets" (fun _ ->
+    ActivateFinalTarget "KillCreatedProcesses"
+)
+
 //--------------------------------------------------------------------------------
 // Help 
 //--------------------------------------------------------------------------------
@@ -374,11 +385,11 @@ Target "All" DoNothing
 Target "Nuget" DoNothing
 
 // build dependencies
-"Clean" ==> "RestorePackages" ==> "Build" ==> "BuildRelease"
+"Clean" ==> "ActivateFinalTargets" ==> "RestorePackages" ==> "Build" ==> "BuildRelease"
 
 // tests dependencies
 // "RunTests" step doesn't require Clean ==> "RestorePackages" step
-"Clean" ==> "RestorePackages" ==> "RunTestsNetCore"
+"Clean" ==> "ActivateFinalTargets" ==> "RestorePackages" ==> "RunTestsNetCore"
 
 // nuget dependencies
 "Clean" ==> "RestorePackages" ==> "Build" ==> "CreateNuget"

--- a/build.fsx
+++ b/build.fsx
@@ -324,7 +324,7 @@ Target "DocFx" (fun _ ->
 FinalTarget "KillCreatedProcesses" (fun _ ->
     log "The following processes were started during FAKE step..."
     startedProcesses |> Seq.iter (fun (pid, _) -> logf "%i, " pid)
-    log "Killing processes started by FAKE..."
+    log (Environment.NewLine + "Killing processes started by FAKE...")
     killAllCreatedProcesses()
 )
 

--- a/src/core/Akka.Tests/Actor/Dispatch/Bug2751Spec.cs
+++ b/src/core/Akka.Tests/Actor/Dispatch/Bug2751Spec.cs
@@ -1,0 +1,54 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Bug2751Spec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Tests.Actor.Dispatch
+{
+    /// <summary>
+    /// Verifies that https://github.com/akkadotnet/akka.net/issues/2751 has been resolved
+    /// </summary>
+    public class Bug2751Spec : AkkaSpec
+    {
+        private class StopActor : ReceiveActor
+        {
+            private readonly IActorRef _testActor;
+
+            public StopActor(IActorRef testActor)
+            {
+                _testActor = testActor;
+                Receive<string>(s =>
+                {
+                    if (s == "stop")
+                    {
+                        Self.Tell("Hello");
+                        Context.Stop(Self);
+                    }
+                    else
+                    {
+                        _testActor.Tell(s);
+                    }
+                });
+            }
+        }
+
+        [Fact]
+        public void ShouldReceiveSysMsgBeforeUserMsg()
+        {
+            var stopper = Sys.ActorOf(Props.Create(() => new StopActor(TestActor)));
+            stopper.Tell("stop");
+            ExpectNoMsg(TimeSpan.FromMilliseconds(250));
+            Watch(stopper);
+            ExpectTerminated(stopper);
+            ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+        }
+    }
+
+}


### PR DESCRIPTION
Adds a FinalTarget called "KillCreatedProcesses" that should run regardless of failure or success of build script steps "RunTests" "RunTestsNetCore" "MultiNodeTests" and "NBench".

Attempt to resolve #2848