### PR TITLE
Add KillCreatedProcesses activation to Clean step to cover BuildRelease runs

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -32,6 +32,8 @@ let outputBinariesNet45 = outputBinaries @@ "net45"
 let outputBinariesNetStandard = outputBinaries @@ "netstandard1.6"
 
 Target "Clean" (fun _ ->
+    ActivateFinalTarget "KillCreatedProcesses"
+
     CleanDir output
     CleanDir outputTests
     CleanDir outputPerfTests
@@ -172,7 +174,7 @@ Target "MultiNodeTests" (fun _ ->
 )
 
 Target "NBench" <| fun _ ->
-    ActivateFinalTarget "KillCreatedProcesses"
+    ActivateFinalTarget "KillCreatedProcesses"   
     CleanDir outputPerfTests
 
     let nbenchTestPath = findToolInSubPath "NBench.Runner.exe" (toolsDir @@ "NBench.Runner*")


### PR DESCRIPTION
Initially had applied the FAKE FinalTarget "KillCreatedProcesses" to test runs, but had a failed build and saw the symptom occur at a similar time so adding the activation of this target to the "Clean" step to cover BuildRelease and others that use a Clean step