### PR TITLE
Fix locked files issue: kill dotnet and xunit.console processes left behind

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -328,10 +328,14 @@ Target "DocFx" (fun _ ->
 )
 
 FinalTarget "KillCreatedProcesses" (fun _ ->
-    log "The following processes were started during FAKE step..."
-    startedProcesses |> Seq.iter (fun (pid, _) -> logf "%i, " pid)
-    log (Environment.NewLine + "Killing processes started by FAKE...")
+    log "Killing processes started by FAKE:"
+    startedProcesses |> Seq.iter (fun (pid, _) -> logfn "%i" pid)
     killAllCreatedProcesses()
+    log "Killing any remaining dotnet and xunit.console.exe processes:"
+    getProcessesByName "dotnet" |> Seq.iter (fun p -> logfn "pid: %i; name: %s" p.Id p.ProcessName)
+    killProcess "dotnet"
+    getProcessesByName "xunit.console" |> Seq.iter (fun p -> logfn "pid: %i; name: %s" p.Id p.ProcessName)
+    killProcess "xunit.console"
 )
 
 //--------------------------------------------------------------------------------


### PR DESCRIPTION
The `dotnet xunit` process has a timeout set to 30 minutes.  If the test run were to reach that 30 minute timeout, the build would fail but due to a bug in dotnet-xunit detailed in #2848 - the xunit.console.exe process would not be shut down.  This causes subsequent builds on the agent to be unable to clean files and start a new build, as they were locked.

This adds to the `KillCreatedProcesses` build target to always run a cleanup of both `dotnet` and `xunit.console` processes regardless of failure/success.