### PR TITLE
Increment build number with TeamCity number for -beta releases

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -70,11 +70,11 @@ Target "Build" (fun _ ->
     if getBuildParam "nugetprerelease" = "dev" then
         XmlPokeInnerText "./src/common.props" "//Project/PropertyGroup/VersionPrefix" version        
 
-    //DotNetCli.Build
-    //    (fun p -> 
-    //        { p with
-    //            Project = solution
-    //            Configuration = configuration })
+    DotNetCli.Build
+        (fun p -> 
+            { p with
+                Project = solution
+                Configuration = configuration })
 )
 
 //--------------------------------------------------------------------------------


### PR DESCRIPTION
For nightlies, an environment variable is set by TeamCity `BUILD_NUMBER` that should then be passed into the Assembly Version in `common.props` so that the assembly version is `1.3.0.*`.  Nightly builds pass `nugetprerelease=dev` to enable this.