### PR TITLE
Actorpath performance improvements

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -471,6 +471,7 @@ namespace Akka.Actor
     public class ChildActorPath : Akka.Actor.ActorPath
     {
         public ChildActorPath(Akka.Actor.ActorPath parentPath, string name, long uid) { }
+        public override System.Collections.Generic.IReadOnlyList<string> Elements { get; }
         public override Akka.Actor.ActorPath Parent { get; }
         public override Akka.Actor.ActorPath Root { get; }
         public override int CompareTo(Akka.Actor.ActorPath other) { }
@@ -1476,6 +1477,7 @@ namespace Akka.Actor
     public class RootActorPath : Akka.Actor.ActorPath
     {
         public RootActorPath(Akka.Actor.Address address, string name = "") { }
+        public override System.Collections.Generic.IReadOnlyList<string> Elements { get; }
         public override Akka.Actor.ActorPath Parent { get; }
         [Newtonsoft.Json.JsonIgnoreAttribute()]
         public override Akka.Actor.ActorPath Root { get; }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -165,7 +165,7 @@ namespace Akka.Actor
         protected ActorPath(Akka.Actor.Address address, string name) { }
         protected ActorPath(Akka.Actor.ActorPath parentPath, string name, long uid) { }
         public Akka.Actor.Address Address { get; }
-        public System.Collections.Generic.IReadOnlyList<string> Elements { get; }
+        public abstract System.Collections.Generic.IReadOnlyList<string> Elements { get; }
         public string Name { get; }
         public abstract Akka.Actor.ActorPath Parent { get; }
         public abstract Akka.Actor.ActorPath Root { get; }

--- a/src/core/Akka.Remote.Tests/Transport/AkkaProtocolSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaProtocolSpec.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
+using Akka.Remote.Serialization;
 using Akka.Remote.Transport;
 using Akka.TestKit;
 using Akka.Util.Internal;
@@ -30,7 +31,7 @@ namespace Akka.Remote.Tests.Transport
         Address remoteAddress = new Address("test", "testsystem2", "testhost2", 1234);
         Address remoteAkkaAddress = new Address("akka.test", "testsystem2", "testhost2", 1234);
 
-        AkkaPduCodec codec = new AkkaPduProtobuffCodec();
+        private AkkaPduCodec codec;
 
         SerializedMessage testMsg =
             new SerializedMessage { SerializerId = 0, Message = ByteString.CopyFromUtf8("foo") };
@@ -52,6 +53,7 @@ namespace Akka.Remote.Tests.Transport
 
             testHeartbeat = new InboundPayload(codec.ConstructHeartbeat());
             testPayload = new InboundPayload(testMsgPdu);
+            codec = new AkkaPduProtobuffCodec(Sys);
         }
 
         public class Collaborators

--- a/src/core/Akka.Remote.Tests/Transport/AkkaProtocolSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaProtocolSpec.cs
@@ -48,12 +48,12 @@ namespace Akka.Remote.Tests.Transport
         public AkkaProtocolSpec()
             : base(@"akka.test.default-timeout = 1.5 s")
         {
+            codec = new AkkaPduProtobuffCodec(Sys);
             testEnvelope = codec.ConstructMessage(localAkkaAddress, TestActor, testMsg);
             testMsgPdu = codec.ConstructPayload(testEnvelope);
 
             testHeartbeat = new InboundPayload(codec.ConstructHeartbeat());
             testPayload = new InboundPayload(testMsgPdu);
-            codec = new AkkaPduProtobuffCodec(Sys);
         }
 
         public class Collaborators

--- a/src/core/Akka.Remote.Tests/Transport/GenericTransportSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/GenericTransportSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Remote.Serialization;
 using Akka.Remote.Transport;
 using Akka.TestKit;
 using Google.Protobuf;
@@ -47,7 +48,7 @@ namespace Akka.Remote.Tests.Transport
             if (withAkkaProtocol) {
                 var provider = (RemoteActorRefProvider)((ExtendedActorSystem)Sys).Provider;
 
-                return new AkkaProtocolTransport(transport, Sys, new AkkaProtocolSettings(provider.RemoteSettings.Config), new AkkaPduProtobuffCodec());
+                return new AkkaProtocolTransport(transport, Sys, new AkkaProtocolSettings(provider.RemoteSettings.Config), new AkkaPduProtobuffCodec(Sys));
             }
 
             return transport;
@@ -153,7 +154,7 @@ namespace Akka.Remote.Tests.Transport
             handleB.ReadHandlerSource.SetResult(new ActorHandleEventListener(TestActor));
 
             var payload = ByteString.CopyFromUtf8("PDU");
-            var pdu = withAkkaProtocol ? new AkkaPduProtobuffCodec().ConstructPayload(payload) : payload;
+            var pdu = withAkkaProtocol ? new AkkaPduProtobuffCodec(Sys).ConstructPayload(payload) : payload;
             
             AwaitCondition(() => registry.ExistsAssociation(addressATest, addressBTest));
 

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -18,6 +18,7 @@ using Akka.Dispatch;
 using Akka.Dispatch.SysMsg;
 using Akka.Event;
 using Akka.Pattern;
+using Akka.Remote.Serialization;
 using Akka.Remote.Transport;
 using Akka.Serialization;
 using Akka.Util;
@@ -882,7 +883,7 @@ namespace Akka.Remote
                 Context.ActorOf(RARP.For(Context.System)
                     .ConfigureDispatcher(
                         EndpointWriter.EndpointWriterProps(_currentHandle, _localAddress, _remoteAddress, _refuseUid, _transport,
-                            _settings, new AkkaPduProtobuffCodec(), _receiveBuffers, Self)
+                            _settings, new AkkaPduProtobuffCodec(Context.System), _receiveBuffers, Self)
                             .WithDeploy(Deploy.Local)),
                     "endpointWriter");
             Context.Watch(writer);

--- a/src/core/Akka.Remote/EndpointManager.cs
+++ b/src/core/Akka.Remote/EndpointManager.cs
@@ -1136,7 +1136,7 @@ namespace Akka.Remote
                         //Apply AkkaProtocolTransport wrapper to the end of the chain
                         //The chain at this point:
                         // AkkaProtocolTransport <-- Adapter <-- .. <-- Adapter <-- Driver
-                        transports.Add(new AkkaProtocolTransport(wrappedTransport, Context.System, new AkkaProtocolSettings(_conf), new AkkaPduProtobuffCodec()));
+                        transports.Add(new AkkaProtocolTransport(wrappedTransport, Context.System, new AkkaProtocolSettings(_conf), new AkkaPduProtobuffCodec(Context.System)));
                     }
 
                     // Collect all transports, listen addresses, and listener promises in one Task
@@ -1212,7 +1212,7 @@ namespace Akka.Remote
                     Context.ActorOf(RARP.For(Context.System)
                     .ConfigureDispatcher(
                         ReliableDeliverySupervisor.ReliableDeliverySupervisorProps(handleOption, localAddress,
-                            remoteAddress, refuseUid, transport, endpointSettings, new AkkaPduProtobuffCodec(),
+                            remoteAddress, refuseUid, transport, endpointSettings, new AkkaPduProtobuffCodec(Context.System),
                             _receiveBuffers, endpointSettings.Dispatcher)
                             .WithDeploy(Deploy.Local)),
                         string.Format("reliableEndpointWriter-{0}-{1}", AddressUrlEncoder.Encode(remoteAddress),
@@ -1224,7 +1224,7 @@ namespace Akka.Remote
                     Context.ActorOf(RARP.For(Context.System)
                     .ConfigureDispatcher(
                         EndpointWriter.EndpointWriterProps(handleOption, localAddress, remoteAddress, refuseUid,
-                            transport, endpointSettings, new AkkaPduProtobuffCodec(), _receiveBuffers,
+                            transport, endpointSettings, new AkkaPduProtobuffCodec(Context.System), _receiveBuffers,
                             reliableDeliverySupervisor: null)
                             .WithDeploy(Deploy.Local)),
                         string.Format("endpointWriter-{0}-{1}", AddressUrlEncoder.Encode(remoteAddress), _endpointId.Next()));

--- a/src/core/Akka.Remote/Serialization/ActorPathCache.cs
+++ b/src/core/Akka.Remote/Serialization/ActorPathCache.cs
@@ -1,0 +1,54 @@
+using System;
+using Akka.Actor;
+using System.Threading;
+
+namespace Akka.Remote.Serialization
+{
+    /// <summary>
+    /// INTERNAL API
+    /// </summary>
+    internal sealed class ActorPathThreadLocalCache : ExtensionIdProvider<ActorPathThreadLocalCache>, IExtension
+    {
+        private readonly ThreadLocal<ActorPathCache> _current = new ThreadLocal<ActorPathCache>(() => new ActorPathCache());
+
+        public ActorPathCache Cache => _current.Value;
+
+        public override ActorPathThreadLocalCache CreateExtension(ExtendedActorSystem system)
+        {
+            return new ActorPathThreadLocalCache();
+        }
+
+        public static ActorPathThreadLocalCache For(ActorSystem system)
+        {
+            return system.WithExtension<ActorPathThreadLocalCache, ActorPathThreadLocalCache>();
+        }
+    }
+
+    /// <summary>
+    /// INTERNAL API
+    /// </summary>
+    internal sealed class ActorPathCache : LruBoundedCache<string, ActorPath>
+    {
+        public ActorPathCache(int capacity = 1024, int evictAgeThreshold = 600) : base(capacity, evictAgeThreshold)
+        {
+        }
+
+        protected override int Hash(string k)
+        {
+            return FastHash.OfStringFast(k);
+        }
+
+        protected override ActorPath Compute(string k)
+        {
+            ActorPath actorPath;
+            if (ActorPath.TryParse(k, out actorPath))
+                return actorPath;
+            return null;
+        }
+
+        protected override bool IsCacheable(ActorPath v)
+        {
+            return v != null;
+        }
+    }
+}

--- a/src/core/Akka.Remote/Serialization/AddressCache.cs
+++ b/src/core/Akka.Remote/Serialization/AddressCache.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Threading;
+using Akka.Actor;
+
+namespace Akka.Remote.Serialization
+{
+    /// <summary>
+    /// INTERNAL API
+    /// </summary>
+    internal sealed class AddressThreadLocalCache : ExtensionIdProvider<AddressThreadLocalCache>, IExtension
+    {
+        public AddressThreadLocalCache()
+        {
+            _current = new ThreadLocal<AddressCache>(() => new AddressCache());
+        }
+
+        public override AddressThreadLocalCache CreateExtension(ExtendedActorSystem system)
+        {
+            return new AddressThreadLocalCache();
+        }
+
+        private readonly ThreadLocal<AddressCache> _current;
+
+        public AddressCache Cache => _current.Value;
+
+        public static AddressThreadLocalCache For(ActorSystem system)
+        {
+            return system.WithExtension<AddressThreadLocalCache, AddressThreadLocalCache>();
+        }
+    }
+
+    /// <summary>
+    /// INTERNAL API
+    /// </summary>
+    internal sealed class AddressCache : LruBoundedCache<string, Address>
+    {
+        public AddressCache(int capacity = 1024, int evictAgeThreshold = 600) : base(capacity, evictAgeThreshold)
+        {
+        }
+
+        protected override int Hash(string k)
+        {
+            return FastHash.OfStringFast(k);
+        }
+
+        protected override Address Compute(string k)
+        {
+            Address addr;
+            if (ActorPath.TryParseAddress(k, out addr))
+            {
+                return addr;
+            }
+            return Address.AllSystems;
+        }
+
+        protected override bool IsCacheable(Address v)
+        {
+            return v != Address.AllSystems;
+        }
+    }
+}

--- a/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
+++ b/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Internal;
 using Akka.Event;
+using Akka.Remote.Serialization;
 using Akka.Util.Internal;
 using Google.Protobuf;
 
@@ -241,7 +242,7 @@ namespace Akka.Remote.Transport
                         handle,
                         stateActorAssociationListener,
                         stateActorSettings,
-                        new AkkaPduProtobuffCodec(),
+                        new AkkaPduProtobuffCodec(Context.System),
                         failureDetector)), ActorNameFor(handle.RemoteAddress));
                 })
                 .With<AssociateUnderlying>(au => CreateOutboundStateActor(au.RemoteAddress, au.StatusPromise, null)) //need to create an Outbound ProtocolStateActor
@@ -271,7 +272,7 @@ namespace Akka.Remote.Transport
                 statusPromise,
                 stateActorWrappedTransport,
                 stateActorSettings,
-                new AkkaPduProtobuffCodec(), failureDetector, refuseUid)),
+                new AkkaPduProtobuffCodec(Context.System), failureDetector, refuseUid)),
                 ActorNameFor(remoteAddress));
         }
 

--- a/src/core/Akka.Remote/Transport/ThrottleTransportAdapter.cs
+++ b/src/core/Akka.Remote/Transport/ThrottleTransportAdapter.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Dispatch.SysMsg;
+using Akka.Remote.Serialization;
 using Akka.Util;
 using Akka.Util.Internal;
 using Google.Protobuf;
@@ -1079,7 +1080,7 @@ namespace Akka.Remote.Transport
         /// <summary>
         /// Used for decoding certain types of throttled messages on-the-fly
         /// </summary>
-        private static readonly AkkaPduProtobuffCodec Codec = new AkkaPduProtobuffCodec();
+        private readonly AkkaPduProtobuffCodec _codec;
 
         /// <summary>
         /// TBD
@@ -1090,6 +1091,7 @@ namespace Akka.Remote.Transport
         /// <param name="inbound">TBD</param>
         public ThrottledAssociation(IActorRef manager, IAssociationEventListener associationHandler, AssociationHandle originalHandle, bool inbound)
         {
+            _codec = new AkkaPduProtobuffCodec(Context.System);
             Manager = manager;
             AssociationHandler = associationHandler;
             OriginalHandle = originalHandle;
@@ -1293,7 +1295,7 @@ namespace Akka.Remote.Transport
         {
             try
             {
-                var pdu = Codec.DecodePdu(b);
+                var pdu = _codec.DecodePdu(b);
                 if (pdu is Associate)
                 {
                     return pdu.AsInstanceOf<Associate>().Info.Origin;

--- a/src/core/Akka.Tests.Performance/Actor/ActorPathEqualitySpec.cs
+++ b/src/core/Akka.Tests.Performance/Actor/ActorPathEqualitySpec.cs
@@ -42,5 +42,19 @@ namespace Akka.Tests.Performance.Actor
             var b = TopLevelActorPath.Equals(TopLevelActorPath);
             _equalsThroughput.Increment();
         }
+
+        [PerfBenchmark(
+            Description =
+                "Tests how quickly ActorPath.Equals can perform against two equal paths (worst case performance)",
+            RunMode = RunMode.Throughput, NumberOfIterations = 13, RunTimeMilliseconds = 1000,
+            TestMode = TestMode.Measurement)]
+        [CounterThroughputAssertion(EqualsCounterName, MustBe.GreaterThan, MinimumAcceptableOperationsPerSecond
+        )]
+        [GcMeasurement(GcMetric.TotalCollections, GcGeneration.AllGc)]
+        public void ActorPath_GetHashCode_throughput(BenchmarkContext context)
+        {
+            var b = TopLevelActorPath.GetHashCode();
+            _equalsThroughput.Increment();
+        }
     }
 }

--- a/src/core/Akka.Tests.Performance/Actor/ActorPathEqualitySpec.cs
+++ b/src/core/Akka.Tests.Performance/Actor/ActorPathEqualitySpec.cs
@@ -1,0 +1,46 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ActorPathEqualitySpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Actor;
+using NBench;
+
+namespace Akka.Tests.Performance.Actor
+{
+    /// <summary>
+    /// Compares the performance of <see cref="ActorPath.Equals(object)"/> and <see cref="ActorPath.GetHashCode"/>
+    /// </summary>
+    public class ActorPathEqualitySpec
+    {
+        private const string EqualsCounterName = "EqualsOp";
+
+        private const double MinimumAcceptableOperationsPerSecond = 1000000.0d; //million op / second
+
+        private static readonly RootActorPath RootAddress = new RootActorPath(Address.AllSystems);
+        private static readonly ActorPath TopLevelActorPath = RootAddress / "user" / "foo1";
+        private Counter _equalsThroughput;
+
+        [PerfSetup]
+        public void Setup(BenchmarkContext context)
+        {
+            _equalsThroughput = context.GetCounter(EqualsCounterName);
+        }
+
+        [PerfBenchmark(
+            Description =
+                "Tests how quickly ActorPath.Equals can perform against two equal paths (worst case performance)",
+            RunMode = RunMode.Throughput, NumberOfIterations = 13, RunTimeMilliseconds = 1000,
+            TestMode = TestMode.Measurement)]
+        [CounterThroughputAssertion(EqualsCounterName, MustBe.GreaterThan, MinimumAcceptableOperationsPerSecond
+        )]
+        [GcMeasurement(GcMetric.TotalCollections, GcGeneration.AllGc)]
+        public void ActorPath_Equals_throughput(BenchmarkContext context)
+        {
+            var b = TopLevelActorPath.Equals(TopLevelActorPath);
+            _equalsThroughput.Increment();
+        }
+    }
+}

--- a/src/core/Akka.Tests.Performance/Actor/ActorPathSpec.cs
+++ b/src/core/Akka.Tests.Performance/Actor/ActorPathSpec.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using Akka.Actor;
 using NBench;
 

--- a/src/core/Akka.Tests/Actor/ActorPathSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorPathSpec.cs
@@ -164,7 +164,7 @@ namespace Akka.Tests.Actor
             var a = new Address("akka.tcp", "mysys");
             var rootA = new RootActorPath(a);
             var uid = rootA.ElementsWithUid;
-            Assert.True(uid.Count > 0); // always at least 1 element when UID is appended
+            Assert.True(uid.Count == 0); // RootActorPaths return no elements
         }
 
 

--- a/src/core/Akka/Actor/ActorCell.Children.cs
+++ b/src/core/Akka/Actor/ActorCell.Children.cs
@@ -21,7 +21,7 @@ namespace Akka.Actor
         private long _nextRandomNameDoNotCallMeDirectly = -1; // Interlocked.Increment automatically adds 1 to this value. Allows us to start from 0.
 
         /// <summary>
-        /// TBD
+        /// The child container collection, used to house information about all child actors.
         /// </summary>
         public IChildrenContainer ChildrenContainer
         {
@@ -34,11 +34,14 @@ namespace Akka.Actor
         }
 
         /// <summary>
-        /// TBD
+        /// Attaches a child to the current <see cref="ActorCell"/>.
+        /// 
+        /// This method is used in the process of starting actors.
         /// </summary>
-        /// <param name="props">TBD</param>
-        /// <param name="isSystemService">TBD</param>
-        /// <param name="name">TBD</param>
+        /// <param name="props">The <see cref="Props"/> this child actor will use.</param>
+        /// <param name="isSystemService">If <c>true</c>, then this actor is a system actor and activates a special initialization path.</param>
+        /// <param name="name">The name of the actor being started. Can be <c>null</c>, and if it is we will automatically 
+        /// generate a random name for this actor.</param>
         /// <exception cref="InvalidActorNameException">
         /// This exception is thrown if the given <paramref name="name"/> is an invalid actor name.
         /// </exception>
@@ -48,7 +51,7 @@ namespace Akka.Actor
         /// <exception cref="InvalidOperationException">
         /// This exception is thrown if the actor tries to create a child while it is terminating or is terminated.
         /// </exception>
-        /// <returns>TBD</returns>
+        /// <returns>A reference to the initialized child actor.</returns>
         public virtual IActorRef AttachChild(Props props, bool isSystemService, string name = null)
         {
             return MakeChild(props, name == null ? GetRandomActorName() : CheckName(name), true, isSystemService);

--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -618,64 +618,60 @@ namespace Akka.Actor
                 var acc = new Stack<string>();
                 while (true)
                 {
-                    switch (p)
-                    {
-                        case RootActorPath r:
-                            return acc.ToList();
-                        default:
-                            acc.Push(p.Name);
-                            p = p.Parent;
-                            continue;
-                    }
+                    if (p is RootActorPath)
+                        return acc.ToList();
+                    acc.Push(p.Name);
+                    p = p.Parent;
                 }
             }
-        }
-
-        /// <inheritdoc/>
-        public override ActorPath Root
-        {
-            get
-            {
-                var current = _parent;
-                while (current is ChildActorPath)
-                {
-                    current = ((ChildActorPath)current)._parent;
-                }
-                return current.Root;
-            }
-        }
-
-        /// <summary>
-        /// Creates a copy of the given ActorPath and applies a new Uid
-        /// </summary>
-        /// <param name="uid"> The uid. </param>
-        /// <returns> ActorPath. </returns>
-        public override ActorPath WithUid(long uid)
-        {
-            if (uid == Uid)
-                return this;
-            return new ChildActorPath(_parent, _name, uid);
-        }
-
-        /// <inheritdoc/>
-        public override int CompareTo(ActorPath other)
-        {
-            return InternalCompareTo(this, other);
-        }
-
-        private int InternalCompareTo(ActorPath left, ActorPath right)
-        {
-            if (ReferenceEquals(left, right)) return 0;
-            var leftRoot = left as RootActorPath;
-            if (leftRoot != null)
-                return leftRoot.CompareTo(right);
-            var rightRoot = right as RootActorPath;
-            if (rightRoot != null)
-                return -rightRoot.CompareTo(left);
-            var nameCompareResult = Compare(left.Name, right.Name, StringComparison.Ordinal);
-            if (nameCompareResult != 0)
-                return nameCompareResult;
-            return InternalCompareTo(left.Parent, right.Parent);
         }
     }
+
+    /// <inheritdoc/>
+    public override ActorPath Root
+    {
+        get
+        {
+            var current = _parent;
+            while (current is ChildActorPath)
+            {
+                current = ((ChildActorPath)current)._parent;
+            }
+            return current.Root;
+        }
+    }
+
+    /// <summary>
+    /// Creates a copy of the given ActorPath and applies a new Uid
+    /// </summary>
+    /// <param name="uid"> The uid. </param>
+    /// <returns> ActorPath. </returns>
+    public override ActorPath WithUid(long uid)
+    {
+        if (uid == Uid)
+            return this;
+        return new ChildActorPath(_parent, _name, uid);
+    }
+
+    /// <inheritdoc/>
+    public override int CompareTo(ActorPath other)
+    {
+        return InternalCompareTo(this, other);
+    }
+
+    private int InternalCompareTo(ActorPath left, ActorPath right)
+    {
+        if (ReferenceEquals(left, right)) return 0;
+        var leftRoot = left as RootActorPath;
+        if (leftRoot != null)
+            return leftRoot.CompareTo(right);
+        var rightRoot = right as RootActorPath;
+        if (rightRoot != null)
+            return -rightRoot.CompareTo(left);
+        var nameCompareResult = Compare(left.Name, right.Name, StringComparison.Ordinal);
+        if (nameCompareResult != 0)
+            return nameCompareResult;
+        return InternalCompareTo(left.Parent, right.Parent);
+    }
+}
 }

--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -499,7 +499,14 @@ namespace Akka.Actor
         /// <inheritdoc/>
         public override int GetHashCode()
         {
-            return ToString().GetHashCode();
+            unchecked
+            {
+                var hash = 17;
+                hash = (hash * 23) ^ Address.GetHashCode();
+                foreach (var e in Elements)
+                    hash = (hash * 23) ^ e.GetHashCode();
+                return hash;
+            }
         }
 
         /// <inheritdoc/>

--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -126,8 +126,11 @@ namespace Akka.Actor
             return !s.StartsWith("$") && Validate(s.ToCharArray(), s.Length);
         }
 
-        private static bool IsValidChar(char c) => (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || ValidSymbols.Contains(c);
-        private static bool IsHexChar(char c) => (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F') || (c >= '0' && c <= '9');
+        private static bool IsValidChar(char c) => (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+                                                   (c >= '0' && c <= '9') || ValidSymbols.Contains(c);
+
+        private static bool IsHexChar(char c) => (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F') ||
+                                                 (c >= '0' && c <= '9');
 
         private static bool Validate(IReadOnlyList<char> chars, int len)
         {
@@ -510,6 +513,7 @@ namespace Akka.Actor
 
             return String.Concat(withAddress, "#", Uid.ToString());
         }
+
         /// <summary>
         /// Generate String representation, replacing the Address in the RootActorPath
         /// with the given one unless this path’s address includes host and port
@@ -625,52 +629,52 @@ namespace Akka.Actor
                 }
             }
         }
-    }
 
-    /// <inheritdoc/>
-    public override ActorPath Root
-    {
-        get
+        /// <inheritdoc/>
+        public override ActorPath Root
         {
-            var current = _parent;
-            while (current is ChildActorPath)
+            get
             {
-                current = ((ChildActorPath)current)._parent;
+                var current = _parent;
+                while (current is ChildActorPath)
+                {
+                    current = ((ChildActorPath)current)._parent;
+                }
+                return current.Root;
             }
-            return current.Root;
         }
-    }
 
-    /// <summary>
-    /// Creates a copy of the given ActorPath and applies a new Uid
-    /// </summary>
-    /// <param name="uid"> The uid. </param>
-    /// <returns> ActorPath. </returns>
-    public override ActorPath WithUid(long uid)
-    {
-        if (uid == Uid)
-            return this;
-        return new ChildActorPath(_parent, _name, uid);
-    }
+        /// <summary>
+        /// Creates a copy of the given ActorPath and applies a new Uid
+        /// </summary>
+        /// <param name="uid"> The uid. </param>
+        /// <returns> ActorPath. </returns>
+        public override ActorPath WithUid(long uid)
+        {
+            if (uid == Uid)
+                return this;
+            return new ChildActorPath(_parent, _name, uid);
+        }
 
-    /// <inheritdoc/>
-    public override int CompareTo(ActorPath other)
-    {
-        return InternalCompareTo(this, other);
-    }
+        /// <inheritdoc/>
+        public override int CompareTo(ActorPath other)
+        {
+            return InternalCompareTo(this, other);
+        }
 
-    private int InternalCompareTo(ActorPath left, ActorPath right)
-    {
-        if (ReferenceEquals(left, right)) return 0;
-        var leftRoot = left as RootActorPath;
-        if (leftRoot != null)
-            return leftRoot.CompareTo(right);
-        var rightRoot = right as RootActorPath;
-        if (rightRoot != null)
-            return -rightRoot.CompareTo(left);
-        var nameCompareResult = Compare(left.Name, right.Name, StringComparison.Ordinal);
-        if (nameCompareResult != 0)
-            return nameCompareResult;
-        return InternalCompareTo(left.Parent, right.Parent);
+        private int InternalCompareTo(ActorPath left, ActorPath right)
+        {
+            if (ReferenceEquals(left, right)) return 0;
+            var leftRoot = left as RootActorPath;
+            if (leftRoot != null)
+                return leftRoot.CompareTo(right);
+            var rightRoot = right as RootActorPath;
+            if (rightRoot != null)
+                return -rightRoot.CompareTo(left);
+            var nameCompareResult = Compare(left.Name, right.Name, StringComparison.Ordinal);
+            if (nameCompareResult != 0)
+                return nameCompareResult;
+            return InternalCompareTo(left.Parent, right.Parent);
+        }
     }
 }

--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -614,23 +614,20 @@ namespace Akka.Actor
         {
             get
             {
-                IEnumerable<string> Rec(ActorPath p, Stack<string> acc)
+                ActorPath p = this;
+                var acc = new Stack<string>();
+                while (true)
                 {
-                    while (true)
+                    switch (p)
                     {
-                        switch (p)
-                        {
-                            case RootActorPath r:
-                                return acc;
-                            default:
-                                acc.Push(p.Name);
-                                p = p.Parent;
-                                continue;
-                        }
+                        case RootActorPath r:
+                            return acc.ToList();
+                        default:
+                            acc.Push(p.Name);
+                            p = p.Parent;
+                            continue;
                     }
                 }
-
-                return Rec(this, new Stack<string>()).ToList();
             }
         }
 

--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -674,4 +674,3 @@ namespace Akka.Actor
         return InternalCompareTo(left.Parent, right.Parent);
     }
 }
-}

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -597,25 +597,27 @@ namespace Akka.Actor
     }
 
     /// <summary>
-    /// TBD
+    /// INTERNAL API
+    /// 
+    /// Used to power actors that use an <see cref="ActorCell"/>, which is the majority of them.
     /// </summary>
     public abstract class ActorRefWithCell : InternalActorRefBase
     {
         /// <summary>
-        /// TBD
+        /// The <see cref="ActorCell"/>.
         /// </summary>
         public abstract ICell Underlying { get; }
 
         /// <summary>
-        /// TBD
+        /// An iterable collection of the actor's children. Empty if there are none.
         /// </summary>
         public abstract IEnumerable<IActorRef> Children { get; }
 
         /// <summary>
-        /// TBD
+        /// Fetches a reference to a single child actor.
         /// </summary>
-        /// <param name="name">TBD</param>
-        /// <returns>TBD</returns>
+        /// <param name="name">The name of the child we're trying to fetch.</param>
+        /// <returns>If the child exists, it returns the child actor. Otherwise, we return <see cref="ActorRefs.Nobody"/>.</returns>
         public abstract IInternalActorRef GetSingleChild(string name);
 
     }

--- a/src/core/Akka/Actor/Address.cs
+++ b/src/core/Akka/Actor/Address.cs
@@ -119,7 +119,7 @@ namespace Akka.Actor
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return string.Equals(Host, other.Host) && Port == other.Port && string.Equals(System, other.System) && string.Equals(Protocol, other.Protocol);
+            return Port == other.Port && string.Equals(Host, other.Host) && string.Equals(System, other.System) && string.Equals(Protocol, other.Protocol);
         }
 
         /// <inheritdoc/>

--- a/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
@@ -231,32 +231,19 @@ namespace Akka.Actor.Internal
             }
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="props">TBD</param>
-        /// <param name="name">TBD</param>
-        /// <returns>TBD</returns>
+        /// <inheritdoc/>
         public override IActorRef ActorOf(Props props, string name = null)
         {
             return _provider.Guardian.Cell.AttachChild(props, false, name);
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="actorPath">TBD</param>
-        /// <returns>TBD</returns>
+        /// <inheritdoc/>
         public override ActorSelection ActorSelection(ActorPath actorPath)
         {
             return ActorRefFactoryShared.ActorSelection(actorPath, this);
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="actorPath">TBD</param>
-        /// <returns>TBD</returns>
+        /// <inheritdoc/>
         public override ActorSelection ActorSelection(string actorPath)
         {
             return ActorRefFactoryShared.ActorSelection(actorPath, this, _provider.RootGuardian);

--- a/src/core/Akka/Actor/LocalActorRef.cs
+++ b/src/core/Akka/Actor/LocalActorRef.cs
@@ -16,7 +16,7 @@ using Akka.Util.Internal;
 namespace Akka.Actor
 {
     /// <summary>
-    /// TBD
+    /// A local actor reference that exists inside the same process as the current <see cref="ActorSystem"/>.
     /// </summary>
     public class LocalActorRef : ActorRefWithCell, ILocalRef
     {
@@ -77,184 +77,140 @@ namespace Akka.Actor
         }
 
         /// <summary>
-        /// TBD
+        /// Creates a new <see cref="ActorCell"/> instance.
         /// </summary>
-        /// <param name="system">TBD</param>
-        /// <param name="self">TBD</param>
-        /// <param name="props">TBD</param>
-        /// <param name="dispatcher">TBD</param>
-        /// <param name="supervisor">TBD</param>
-        /// <returns>TBD</returns>
+        /// <param name="system">The actor system to which this actor belongs.</param>
+        /// <param name="self">The reference to this actor.</param>
+        /// <param name="props">The <see cref="Props"/> used to create this actor.</param>
+        /// <param name="dispatcher">The dispatcher this actor will run on.</param>
+        /// <param name="supervisor">A reference to this actor's supervising actor, typically its parent.</param>
+        /// <returns>A reference to an uninitialized actor cell.</returns>
         protected virtual ActorCell NewActorCell(ActorSystemImpl system, IInternalActorRef self, Props props,
             MessageDispatcher dispatcher, IInternalActorRef supervisor)
         {
             return new ActorCell(system, self, props, dispatcher, supervisor);
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
+        /// <inheritdoc/>
         public override ICell Underlying
         {
             get { return _cell; }
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
+        /// <inheritdoc/>
         public ActorCell Cell
         {
             get { return _cell; }
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
+        /// <inheritdoc/>
         public override IActorRefProvider Provider
         {
             get { return _cell.SystemImpl.Provider; }
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
+        /// <inheritdoc/>
         public override IInternalActorRef Parent
         {
             get { return _cell.Parent; }
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
+        /// <inheritdoc/>
         public override IEnumerable<IActorRef> Children
         {
             get { return _cell.GetChildren(); }
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
+        /// <inheritdoc/>
         public override void Start()
         {
             _cell.Start();
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
+        /// <inheritdoc/>
         public override void Stop()
         {
             _cell.Stop();
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
+        /// <inheritdoc/>
         public override void Suspend()
         {
             _cell.Suspend();
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
+        /// <inheritdoc/>
         public override bool IsLocal
         {
             get { return true; }
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="message">TBD</param>
+        /// <inheritdoc/>
         public override void SendSystemMessage(ISystemMessage message)
         {
             _cell.SendSystemMessage(message);
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
+        /// <inheritdoc/>
         public override ActorPath Path
         {
             get { return _path; }
         }
 
         /// <summary>
-        /// TBD
+        /// The <see cref="ActorSystem"/> to which this actor ref belongs.
         /// </summary>
         protected ActorSystem System => _system;
 
         /// <summary>
-        /// TBD
+        /// The <see cref="Props"/> used to create this actor.
         /// </summary>
         protected Props Props => _props;
 
         /// <summary>
-        /// TBD
+        /// The <see cref="MessageDispatcher"/> this actor will use to execute its message-processing.
         /// </summary>
         protected MessageDispatcher Dispatcher => _dispatcher;
 
         /// <summary>
-        /// TBD
+        /// The actor's supervisor, typically its parent.
         /// </summary>
         protected IInternalActorRef Supervisor => _supervisor;
 
-        /// <summary>
-        /// TBD
-        /// </summary>
+        /// <inheritdoc/>
         public override bool IsTerminated => _cell.IsTerminated;
 
         /// <summary>
-        /// TBD
+        /// The type of mailbox used by this actor
         /// </summary>
         protected MailboxType MailboxType { get; }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="causedByFailure">TBD</param>
+        /// <inheritdoc/>
         public override void Resume(Exception causedByFailure = null)
         {
             _cell.Resume(causedByFailure);
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="cause">TBD</param>
+        /// <inheritdoc/>
         public override void Restart(Exception cause)
         {
             _cell.Restart(cause);
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="message">TBD</param>
-        /// <param name="sender">TBD</param>
+        /// <inheritdoc/>
         protected override void TellInternal(object message, IActorRef sender)
         {
             _cell.SendMessage(sender, message);
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="name">TBD</param>
-        /// <returns>TBD</returns>
+        /// <inheritdoc/>
         public override IInternalActorRef GetSingleChild(string name)
         {
             IInternalActorRef child;
             return _cell.TryGetSingleChild(name, out child) ? child : ActorRefs.Nobody;
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="name">TBD</param>
-        /// <exception cref="NotSupportedException">TBD</exception>
-        /// <returns>TBD</returns>
+        /// <inheritdoc/>
         public override IActorRef GetChild(IEnumerable<string> name)
         {
             var current = (IActorRef)this;


### PR DESCRIPTION
Also going to try to address this race condition that keeps coming up on Linux....

```
[22:14:14]	[docker] [ERROR][07/17/2017 22:14:15][Thread 0150][LocalActorRefProvider(akka://AkkaSpec)] guardian [akka://AkkaSpec/] failed, shutting down!
[22:14:14]	[docker] Cause: System.NullReferenceException: Object reference not set to an instance of an object.
[22:14:14]	[docker]    at Akka.Actor.ActorPath.FillElements(ActorPath actorPath) in /checkout/src/core/Akka/Actor/ActorPath.cs:line 207
[22:14:14]	[docker]    at Akka.Actor.ActorPath.<>c.<.cctor>b__56_0(ActorPath actorPath) in /checkout/src/core/Akka/Actor/ActorPath.cs:line 156
[22:14:14]	[docker]    at Akka.Util.FastLazy`2.get_Value() in /checkout/src/core/Akka/Util/FastLazy.cs:line 149
[22:14:14]	[docker]    at Akka.Actor.ActorPath.get_Elements() in /checkout/src/core/Akka/Actor/ActorPath.cs:line 255
[22:14:14]	[docker]    at Akka.Actor.ActorPath.Equals(ActorPath other) in /checkout/src/core/Akka/Actor/ActorPath.cs:line 306
[22:14:14]	[docker]    at Akka.Actor.ActorRefBase.Equals(IActorRef other) in /checkout/src/core/Akka/Actor/ActorRef.cs:line 331
[22:14:14]	[docker]    at Akka.Actor.ActorCell.AddWatcher(IActorRef watchee, IActorRef watcher) in /checkout/src/core/Akka/Actor/ActorCell.DeathWatch.cs:line 223
[22:14:14]	[docker]    at Akka.Actor.ActorCell.SysMsgInvokeAll(EarliestFirstSystemMessageList messages, Int32 currentState) in /checkout/src/core/Akka/Actor/ActorCell.DefaultMessages.cs:line 262
```