### PR TITLE
[WIP] debug Linux incremental test failures

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -15,10 +15,6 @@ open Fake.Git
 // Variables
 let configuration = "Release"
 let solution = "./src/Akka.sln"
-let versionSuffix = 
-    match (getBuildParam "nugetprerelease") with
-    | "dev" -> "beta"
-    | _ -> ""
 
 // Directories
 let toolsDir = __SOURCE_DIRECTORY__ @@ "tools"
@@ -31,12 +27,11 @@ let outputMultiNode = outputTests @@ "multinode"
 let outputBinariesNet45 = outputBinaries @@ "net45"
 let outputBinariesNetStandard = outputBinaries @@ "netstandard1.6"
 
-let assemblyVersion = XMLRead true "./src/common.props" "" "" "//Project/PropertyGroup/VersionPrefix" |> Seq.head
 let buildNumber = environVarOrDefault "BUILD_NUMBER" "0"
-let version = 
+let versionSuffix = 
     match (getBuildParam "nugetprerelease") with
-    | "dev" -> assemblyVersion + "." + buildNumber
-    | _ -> assemblyVersion
+    | "dev" -> "beta" + (if (not (buildNumber = "0")) then ("-" + buildNumber) else "")
+    | _ -> ""
 
 Target "Clean" (fun _ ->
     ActivateFinalTarget "KillCreatedProcesses"
@@ -67,14 +62,14 @@ Target "RestorePackages" (fun _ ->
 )
 
 Target "Build" (fun _ ->   
-    if getBuildParam "nugetprerelease" = "dev" then
-        XmlPokeInnerText "./src/common.props" "//Project/PropertyGroup/VersionPrefix" version        
+    let additionalArgs = if versionSuffix.Length > 0 then [sprintf "/p:VersionSuffix=%s" versionSuffix] else []  
 
     DotNetCli.Build
         (fun p -> 
             { p with
                 Project = solution
-                Configuration = configuration })
+                Configuration = configuration
+                AdditionalArgs = additionalArgs })
 )
 
 //--------------------------------------------------------------------------------

--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -66,11 +66,11 @@ module IncrementalTests =
     let getUpdatedFiles() = 
         let srcDir = __SOURCE_DIRECTORY__
         let localBranches = getLocalBranches srcDir
+        !! (srcDir @@ ".git/*") |> Seq.iter log
         log "Local branches..."
         localBranches |> Seq.iter log
         if (not (localBranches |> Seq.exists (fun b -> b = akkaDefaultBranch)) || isMono) then
-            log "default branch information not available... fetching"
-            !! (srcDir @@ ".git/*") |> Seq.iter log
+            log "Default branch information not available... fetching"
             directRunGitCommandAndFail srcDir ("pull")
             directRunGitCommandAndFail srcDir ("fsck")
             directRunGitCommandAndFail srcDir (sprintf "fetch origin %s:%s" akkaDefaultBranch akkaDefaultBranch)

--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -68,7 +68,7 @@ module IncrementalTests =
         let localBranches = getLocalBranches srcDir
         log "Local branches..."
         localBranches |> Seq.iter log
-        if not (localBranches |> Seq.exists (fun b -> b = akkaDefaultBranch)) then
+        if (not (localBranches |> Seq.exists (fun b -> b = akkaDefaultBranch)) || isMono) then
             log "default branch information not available... fetching"
             directRunGitCommandAndFail srcDir ("fsck")
             directRunGitCommandAndFail srcDir (sprintf "fetch origin %s:%s" akkaDefaultBranch akkaDefaultBranch)

--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -70,6 +70,7 @@ module IncrementalTests =
         localBranches |> Seq.iter log
         if not (localBranches |> Seq.exists (fun b -> b = akkaDefaultBranch)) then
             log "default branch information not available... fetching"
+            directRunGitCommandAndFail srcDir ("fsck")
             directRunGitCommandAndFail srcDir (sprintf "fetch origin %s:%s" akkaDefaultBranch akkaDefaultBranch)
         getBranchesFileDiff srcDir akkaDefaultBranch
         |> Seq.map (fun (_, fi) -> FullName fi)

--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -70,6 +70,7 @@ module IncrementalTests =
         localBranches |> Seq.iter log
         if (not (localBranches |> Seq.exists (fun b -> b = akkaDefaultBranch)) || isMono) then
             log "default branch information not available... fetching"
+            directRunGitCommandAndFail srcDir ("pull")
             directRunGitCommandAndFail srcDir ("fsck")
             directRunGitCommandAndFail srcDir (sprintf "fetch origin %s:%s" akkaDefaultBranch akkaDefaultBranch)
         getBranchesFileDiff srcDir akkaDefaultBranch

--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -65,16 +65,12 @@ module IncrementalTests =
 
     let getUpdatedFiles() = 
         let srcDir = __SOURCE_DIRECTORY__
-        log srcDir
-        log gitPath
         let localBranches = getLocalBranches srcDir
         !! (srcDir @@ ".git/*") |> Seq.iter log
         log "Local branches..."
         localBranches |> Seq.iter log
         if (not (localBranches |> Seq.exists (fun b -> b = akkaDefaultBranch)) || isMono) then
             log "Default branch information not available... fetching"
-            directRunGitCommandAndFail srcDir ("pull")
-            directRunGitCommandAndFail srcDir ("fsck")
             directRunGitCommandAndFail srcDir (sprintf "fetch origin %s:%s" akkaDefaultBranch akkaDefaultBranch)
         getBranchesFileDiff srcDir akkaDefaultBranch
         |> Seq.map (fun (_, fi) -> FullName fi)

--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -66,6 +66,7 @@ module IncrementalTests =
     let getUpdatedFiles() = 
         let srcDir = __SOURCE_DIRECTORY__
         log srcDir
+        log gitPath
         let localBranches = getLocalBranches srcDir
         !! (srcDir @@ ".git/*") |> Seq.iter log
         log "Local branches..."

--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -65,6 +65,7 @@ module IncrementalTests =
 
     let getUpdatedFiles() = 
         let srcDir = __SOURCE_DIRECTORY__
+        log srcDir
         let localBranches = getLocalBranches srcDir
         !! (srcDir @@ ".git/*") |> Seq.iter log
         log "Local branches..."

--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -70,6 +70,7 @@ module IncrementalTests =
         localBranches |> Seq.iter log
         if (not (localBranches |> Seq.exists (fun b -> b = akkaDefaultBranch)) || isMono) then
             log "default branch information not available... fetching"
+            !! (srcDir @@ ".git/*") |> Seq.iter log
             directRunGitCommandAndFail srcDir ("pull")
             directRunGitCommandAndFail srcDir ("fsck")
             directRunGitCommandAndFail srcDir (sprintf "fetch origin %s:%s" akkaDefaultBranch akkaDefaultBranch)


### PR DESCRIPTION
When running any Git commands related to incremental testing on Linux, the TeamCity build agent throws the following errors:

```
[20:56:47][docker] Searching for incremental tests to run in Unit test mode...
[20:56:47][docker] git branch
[20:56:48][docker] ﻿Local branches...
[20:56:48][docker] default branch information not available... fetching
[20:56:48][docker] ﻿﻿﻿﻿error: object directory /etc/buildAgent/system/git/git-63A8AB84.git/objects does not exist; check .git/objects/info/alternates.
[20:56:48][docker] error: refs/pull/2683/head does not point to a valid object!
[20:56:48][docker] error: refs/pull/2836/head does not point to a valid object!
[20:56:48][docker] error: refs/pull/2875/head does not point to a valid object!
[20:56:48][docker] error: refs/pull/2877/head does not point to a valid object!
[20:56:48][docker] error: refs/pull/2880/head does not point to a valid object!
[20:56:48][docker] error: refs/pull/2883/head does not point to a valid object!
[20:56:48][docker] error: refs/pull/2884/head does not point to a valid object!
[20:56:48][docker] error: refs/tags/v0.1.1 does not point to a valid object!
[20:56:48][docker] error: refs/tags/v0.1.1.1 does not point to a valid object!
```

Cannot reproduce locally using an Ubuntu machine running Docker that runs the build inside a container (closest mirror to live TeamCity environment).

This PR is WIP to add diagnostics like `git fsck` to find the root cause