### PR TITLE
Remove building of sample project in DocFx step

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -319,10 +319,6 @@ Target "Protobuf" <| fun _ ->
 // Documentation 
 //--------------------------------------------------------------------------------  
 Target "DocFx" (fun _ ->
-    let docsExamplesSolution = "./docs/examples/DocsExamples.sln"
-    DotNetCli.Restore (fun p -> { p with Project = docsExamplesSolution })
-    DotNetCli.Build (fun p -> { p with Project = docsExamplesSolution; Configuration = configuration })
-
     let docsPath = "./docs"
 
     DocFx (fun p -> 


### PR DESCRIPTION
Remove the building of the example project from the `DocFx` build step.  It was intermingling with the DocFx generation making the build log confusing and possibly stopping the step too early.