### PR TITLE
Added an issue template to the repos

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,6 @@
+When creating a new issue, please make sure the following information is part of your issue description. (if applicable). Thank You!
+
+- Which Akka.Net version you are using
+- On which platform you are using Akka.Net
+- A list of steps to reproduce the issue. Or an gist or github repo which can be easily used to reproduce your case.
+


### PR DESCRIPTION
Lately there are numerous issues being created where people don't
specify which Akka.Net version they are using, and other basic stuff.
This template uses the github issue template feature to make people
aware of these things. And will hopefully lead to a better quality of
issue reporting.