### PR TITLE
[WIP] Upgrade DocFx to v2.21.1 and set maxParallelism to 1

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -416,7 +416,7 @@ Target "Nuget" DoNothing
 "CreateNuget" ==> "PublishNuget" ==> "Nuget"
 
 // docs
-"Clean" ==> "Docfx"
+"BuildRelease" ==> "Docfx"
 
 // all
 "BuildRelease" ==> "All"

--- a/build.ps1
+++ b/build.ps1
@@ -37,7 +37,7 @@ $DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/sc
 $NugetVersion = "4.1.0";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/v$NugetVersion/nuget.exe"
 $ProtobufVersion = "3.2.0"
-$DocfxVersion = "2.17.3"
+$DocfxVersion = "2.21.1"
 
 # Make sure tools folder exists
 $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -71,6 +71,7 @@
       "template"
     ],
     "postProcessors": [],
-    "noLangKeyword": false
+    "noLangKeyword": false,
+    "maxParallelism": 1
   }
 }


### PR DESCRIPTION
Per #2891.  Test setting maxParallelism to 1 on the build agent to mitigate the early success and completion of `docfx.exe build`.  Also upgrade DocFx to latest version.  WIP for testing on build server since docs build locally fine.