### PR TITLE
Parse VersionPrefix and PackageReleaseNotes from RELEASE_NOTES.md into common.props

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -50,6 +50,14 @@ Target "Clean" (fun _ ->
     CleanDirs !! "./**/obj"
 )
 
+Target "AssemblyInfo" (fun _ ->
+    let releaseNotes =
+        File.ReadLines "./RELEASE_NOTES.md"
+        |> ReleaseNotesHelper.parseReleaseNotes
+    XmlPokeInnerText "./src/common.props" "//Project/PropertyGroup/VersionPrefix" releaseNotes.AssemblyVersion    
+    XmlPokeInnerText "./src/common.props" "//Project/PropertyGroup/PackageReleaseNotes" (releaseNotes.Notes |> String.concat "\n")
+)
+
 Target "RestorePackages" (fun _ ->
     let additionalArgs = if versionSuffix.Length > 0 then [sprintf "/p:VersionSuffix=%s" versionSuffix] else []  
 

--- a/src/common.props
+++ b/src/common.props
@@ -3,15 +3,14 @@
     <Copyright>Copyright © 2013-2017 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
     <VersionPrefix>1.3.0</VersionPrefix>
+    <PackageReleaseNotes>Placeholder</PackageReleaseNotes>
     <PackageIconUrl>http://getakka.net/images/AkkaNetLogo.Normal.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>
-	  <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
-
   <PropertyGroup>
     <XunitVersion>2.3.0-beta2-*</XunitVersion>
     <AkkaPackageTags>akka;actors;actor model;Akka;concurrency</AkkaPackageTags>
   </PropertyGroup>
-  
 </Project>


### PR DESCRIPTION
On later releases, this PR ensures that we only need to update RELEASE_NOTES.md to change the VersionPrefix and include PackageReleaseNotes for the NuGet packages created on `dotnet pack` step.