### PR TITLE
Increase DocFx build step timeout to 30 min

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -331,7 +331,7 @@ Target "DocFx" (fun _ ->
 
     DocFx (fun p -> 
                 { p with 
-                    Timeout = TimeSpan.FromMinutes 5.0; 
+                    Timeout = TimeSpan.FromMinutes 30.0; 
                     WorkingDirectory  = docsPath; 
                     DocFxJson = docsPath @@ "docfx.json" })
 )


### PR DESCRIPTION
Fixes timeout when building DocFx docs in TeamCity.