### PR TITLE
Fixed broken delta propagation merge

### DIFF
--- a/src/contrib/cluster/Akka.DistributedData/Internal/Internal.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Internal/Internal.cs
@@ -498,12 +498,11 @@ namespace Akka.DistributedData.Internal
 
             var cleanedData = Cleaned(otherData, Pruning);
             IReplicatedData mergedData;
-            if (cleanedData is IReplicatedDelta)
+            if (cleanedData is IReplicatedDelta d)
             {
-                var delta = Data as IReplicatedDelta;
-                if (delta == null) throw new ArgumentException("Expected IReplicatedDelta");
+                var delta = Data as IDeltaReplicatedData ?? throw new ArgumentException($"Expected {nameof(IDeltaReplicatedData)} but got '{Data}' instead.");
 
-                mergedData = delta.Merge(cleanedData);
+                mergedData = delta.MergeDelta(d);
             }
             else mergedData = Data.Merge(cleanedData);
 


### PR DESCRIPTION
This PR changes 2 things:

1. It fixes critical error related to delta state merges during deltas propagation in DistributedData plugin. **Without it DData will be unusable**.
2. It changes behavior of `DistributedData.GetAsync` - previously it was throwing a `KeyNotFoundException` if a CRDT with provided key was not found. I think this was wrong, as it's not an exceptional scenario. Actually it's pretty common when we deal with masterless distributed data. Instead I've changed generic constraint to class (all current CRDTs are classes) and return null on key not found.