### PR TITLE
Update NuGet.config to use live nightlies

### DIFF
--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -6,6 +6,6 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="netcorenightly" value="https://www.myget.org/F/akka-netcore/api/v3/index.json" />
+    <add key="netcorenightly" value="https://www.myget.org/F/akkadotnet-netcore/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/contrib/cluster/Akka.DistributedData/Akka.DistributedData.csproj
+++ b/src/contrib/cluster/Akka.DistributedData/Akka.DistributedData.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hyperion" version="0.9.5" />
+    <PackageReference Include="Hyperion" version="0.9.5-beta" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">


### PR DESCRIPTION
Updates NuGet.config to point to nightlies that are live and pushed daily to MyGet feed.