### PR TITLE
Reduced allocations for serializers with IncludeManifest

### DIFF
--- a/src/core/Akka.Remote/MessageSerializer.cs
+++ b/src/core/Akka.Remote/MessageSerializer.cs
@@ -8,6 +8,7 @@
 using System;
 using Akka.Actor;
 using Akka.Serialization;
+using Akka.Util;
 using Google.Protobuf;
 using SerializedMessage = Akka.Remote.Serialization.Proto.Msg.Payload;
 
@@ -41,7 +42,8 @@ namespace Akka.Remote
         /// <returns>SerializedMessage.</returns>
         public static SerializedMessage Serialize(ActorSystem system, Address address, object message)
         {
-            Serializer serializer = system.Serialization.FindSerializerFor(message);
+            var objectType = message.GetType();
+            Serializer serializer = system.Serialization.FindSerializerForType(objectType);
 
             var serializedMsg = new SerializedMessage
             {
@@ -49,8 +51,7 @@ namespace Akka.Remote
                 SerializerId = serializer.Identifier
             };
 
-            var serializer2 = serializer as SerializerWithStringManifest;
-            if (serializer2 != null)
+            if (serializer is SerializerWithStringManifest serializer2)
             {
                 var manifest = serializer2.Manifest(message);
                 if (!string.IsNullOrEmpty(manifest))
@@ -61,7 +62,7 @@ namespace Akka.Remote
             else
             {
                 if (serializer.IncludeManifest)
-                    serializedMsg.MessageManifest = ByteString.CopyFromUtf8(message.GetType().AssemblyQualifiedName);
+                    serializedMsg.MessageManifest = ByteString.CopyFromUtf8(objectType.TypeQualifiedName());
             }
 
             return serializedMsg;


### PR DESCRIPTION
Slightly reduced allocations for serializers with Includemanifest=true

|                                         Method |      Mean |     Error |    StdDev |  Gen 0 | Allocated |
|----------------------------------------------- |----------:|----------:|----------:|-------:|----------:|
|          MessageSerializer_Serialize_Primitive | 47.544 us | 0.3309 us | 0.2583 us | 0.1261 |    6577 B |
| MessageSerializer_SerializeOptimized_Primitive | 48.715 us | 0.3919 us | 0.3474 us | 0.1221 |    6289 B |
|            MessageSerializer_Serialize_Complex | 63.856 us | 1.2648 us | 1.3533 us | 0.2360 |   10601 B |
|   MessageSerializer_SerializeOptimized_Complex | 64.427 us | 1.2760 us | 1.2532 us | 0.2360 |   10601 B |