### PR TITLE
Add a filter for only a single mntr spec to be run under multi-plat

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -185,7 +185,6 @@ Target "MultiNodeTestsNetCore" (fun _ ->
         | null -> ()
         | _ ->
             let spec = getBuildParam "spec"
-
             let args = StringBuilder()
                     |> append multiNodeTestPath
                     |> append assembly
@@ -221,12 +220,15 @@ Target "MultiNodeTestsMultiPlatform" (fun _ ->
 
     printfn "Using MultiNodeTestRunner: %s" multiNodeTestPath
 
+    let defaultSpec = "Akka.Remote.Tests.MultiNode.RemoteDeliverySpec"
+    let sampleMntrSpecAssemblyFilter (assemblies:seq<string>) =
+        assemblies |> Seq.filter (fun x -> x.Contains("Akka.Remote.Tests.MultiNode.dll"))
+
     let runMultiNodeSpec assembly =
         match assembly with
         | null -> ()
         | _ ->
-            let spec = getBuildParam "spec"
-
+            let spec = getBuildParamOrDefault "spec" defaultSpec
             let args = StringBuilder()
                     |> append multiNodeTestPath
                     |> append assembly
@@ -243,7 +245,9 @@ Target "MultiNodeTestsMultiPlatform" (fun _ ->
                 info.Arguments <- args) (System.TimeSpan.FromMinutes 60.0) (* This is a VERY long running task. *)
             if result <> 0 then failwithf "MultiNodeTestRunner failed. %s %s" multiNodeTestPath args
     
-    multiNodeTestAssemblies |> Seq.iter (runMultiNodeSpec)
+    multiNodeTestAssemblies 
+    |> sampleMntrSpecAssemblyFilter 
+    |> Seq.iter (runMultiNodeSpec)
 )
 
 Target "MultiNodeTests" (fun _ ->
@@ -264,7 +268,6 @@ Target "MultiNodeTests" (fun _ ->
 
     let runMultiNodeSpec assembly =
         let spec = getBuildParam "spec"
-
         let args = StringBuilder()
                 |> append assembly
                 |> append "-Dmultinode.teamcity=true"

--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -118,6 +118,13 @@ module IncrementalTests =
             logf "Could not find built assembly for %s.  Make sure project is built in Release config." (fileNameWithoutExt project);
             reraise()
     
+    // Utility function to check if a .csproj file targets netstandard1.6 or netcoreapp1.1
+    let projectTargetsNetCore project =
+        let targetFrameworks = (XMLRead true project "" "" "//Project/PropertyGroup/TargetFrameworks") |> Seq.head
+        match targetFrameworks with
+        | p when p.Contains("netstandard1.6") || p.Contains("netcoreapp1.1") -> true
+        | _ -> false
+
     let getNetCoreAssemblyForProject project =
         try
             !! ("src" @@ "**" @@ "bin" @@ "Release" @@ "netcoreapp1.1" @@ fileNameWithoutExt project + ".dll")
@@ -246,6 +253,7 @@ module IncrementalTests =
     
     let getIncrementalNetCoreMNTRTests() =
         getIncrementalTestProjects2 MNTR
+        |> Seq.filter (fun p -> projectTargetsNetCore p)
         |> Seq.map (fun p -> getNetCoreAssemblyForProject p)
     
     let getIncrementalPerfTests() =

--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -140,6 +140,7 @@ module IncrementalTests =
 
     let getMntrProjects() =
         !! "./src/**/*Tests.MultiNode.csproj"
+        |> Seq.filter (fun p -> projectTargetsNetCore p)
         |> Seq.map (fun x -> x.ToString())
     
     let getAllMntrTestAssemblies() = // if we're not running incremental tests

--- a/src/Akka.sln
+++ b/src/Akka.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.14
+VisualStudioVersion = 15.0.26430.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Benchmark", "Benchmark", "{73108242-625A-4D7B-AA09-63375DBAE464}"
 EndProject


### PR DESCRIPTION
Putting this PR in to set up TeamCity to run MultiNode specs across runners kicked off as both .NET Core and .NET 4.5.2, limiting it to a single spec: `Akka.Remote.Tests.MultiNode.RemoteDeliverySpec`

This spec fails, indicating that we haven't achieved compatibility between target platforms as far as the 2 mntr runners are showing.  Submitting the PR simply to be able to set up the infrastructure in TeamCity so it's ready to run in the future.