### PR TITLE
WIP Add Akka.FSharp to v1.3 build

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -67,6 +67,16 @@ Target "RestorePackages" (fun _ ->
                 Project = solution
                 NoCache = false
                 AdditionalArgs = additionalArgs })
+
+    !! "./src/**/*.fsproj" 
+    -- "./src/**/Akka.Persistence.FSharp.fsproj" 
+    -- "./src/examples/**/*.fsproj" |> Seq.iter (fun project -> 
+        DotNetCli.Restore
+            (fun p -> 
+                { p with
+                    Project = project
+                    NoCache = false
+                    AdditionalArgs = additionalArgs }))
 )
 
 Target "Build" (fun _ ->   
@@ -78,6 +88,16 @@ Target "Build" (fun _ ->
                 Project = solution
                 Configuration = configuration
                 AdditionalArgs = additionalArgs })
+    
+    !! "./src/**/*.fsproj" 
+    -- "./src/**/Akka.Persistence.FSharp.fsproj" 
+    -- "./src/examples/**/*.fsproj" |> Seq.iter (fun project -> 
+        DotNetCli.Build
+            (fun p -> 
+                { p with
+                    Project = project
+                    Configuration = configuration
+                    AdditionalArgs = additionalArgs }))
 
     let sourceBasePath = __SOURCE_DIRECTORY__ @@ "src" @@ "core"
     let ntrBasePath = sourceBasePath @@ "Akka.NodeTestRunner" @@ "bin" @@ "Release"

--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -32,6 +32,7 @@ module IncrementalTests =
 
     let getUnitTestProjects() =
         let allTestProjects = !! "./**/core/**/*.Tests.csproj"
+                              ++ "./**/core/**/*.Tests.fsproj"
                               ++ "./**/contrib/**/*.Tests.csproj"
                               -- "./**/serializers/**/*Wire*.csproj"
         allTestProjects 
@@ -82,7 +83,7 @@ module IncrementalTests =
   
     // Gather all of the folder paths that contain .csproj files
     let getAllProjectFolders() =
-        !! "./src/**/*.csproj"
+        !! "./src/**/*.csproj" ++ "./src/**/*.fsproj"
         |> Seq.map (fun f -> DirectoryName (FullName f))
 
     // Check if the altered file is inside of any of the folder paths that contain .csproj files
@@ -102,7 +103,7 @@ module IncrementalTests =
         let findCsprojFileFor fileProjectContains =
             //let projectFolder, file, contains = fileProjectContains
             match fileProjectContains.contains with
-            | true -> Some(!! (fileProjectContains.projectFolder @@ "*.csproj") |> Seq.head)
+            | true -> Some(!! (fileProjectContains.projectFolder @@ "*.csproj") ++ (fileProjectContains.projectFolder @@ "*.fsproj") |> Seq.head)
             | false -> None
         fileProjectContainsSeq
         |> Seq.map (fun x -> findCsprojFileFor x) 
@@ -193,12 +194,12 @@ module IncrementalTests =
 
     let isTestProject csproj testMode =
         match testMode with
-        | Unit -> (filename csproj).Contains("Tests.csproj")
+        | Unit -> (filename csproj).Contains("Tests.csproj") || (filename csproj).Contains("Tests.fsproj")
         | MNTR -> (filename csproj).Contains("Tests.MultiNode.csproj")
         | Perf -> (filename csproj).Contains("Tests.Performance.csproj")
 
     let getAllProjectDependencies testMode =
-        !! "./src/**/*.csproj"
+        !! "./src/**/*.csproj" ++ "./src/**/*.fsproj"
         |> Seq.map (fun f -> { parentProject = { projectName = filename f; projectPath = f }; dependencies = getDependentProjects f; isTestProject = isTestProject f testMode })
     
     let rec findTestProjectsThatHaveDependencyOn project testMode =

--- a/src/Akka.sln
+++ b/src/Akka.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.16
+VisualStudioVersion = 15.0.26430.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Benchmark", "Benchmark", "{73108242-625A-4D7B-AA09-63375DBAE464}"
 EndProject
@@ -174,8 +174,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SpawnBenchmark", "benchmark\SpawnBenchmark\SpawnBenchmark.csproj", "{DA4BDE1E-1ACA-482A-9329-952C3E36F97D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RemotePingPong", "benchmark\RemotePingPong\RemotePingPong.csproj", "{5AA81B79-34DD-4DD7-9D40-A5CA389786DF}"
-EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Akka.FSharp", "core\Akka.FSharp\Akka.FSharp.fsproj", "{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -704,18 +702,6 @@ Global
 		{5AA81B79-34DD-4DD7-9D40-A5CA389786DF}.Release|x64.Build.0 = Release|Any CPU
 		{5AA81B79-34DD-4DD7-9D40-A5CA389786DF}.Release|x86.ActiveCfg = Release|Any CPU
 		{5AA81B79-34DD-4DD7-9D40-A5CA389786DF}.Release|x86.Build.0 = Release|Any CPU
-		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}.Debug|x64.Build.0 = Debug|Any CPU
-		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}.Debug|x86.Build.0 = Debug|Any CPU
-		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}.Release|x64.ActiveCfg = Release|Any CPU
-		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}.Release|x64.Build.0 = Release|Any CPU
-		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}.Release|x86.ActiveCfg = Release|Any CPU
-		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -788,6 +774,5 @@ Global
 		{99CCB7CA-E1EE-4497-BF52-2200A0EC5CB1} = {76F58DC4-19F1-43EF-A6E2-EC1CC8395AC5}
 		{DA4BDE1E-1ACA-482A-9329-952C3E36F97D} = {73108242-625A-4D7B-AA09-63375DBAE464}
 		{5AA81B79-34DD-4DD7-9D40-A5CA389786DF} = {73108242-625A-4D7B-AA09-63375DBAE464}
-		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81} = {01167D3C-49C4-4CDE-9787-C176D139ACDD}
 	EndGlobalSection
 EndGlobal

--- a/src/Akka.sln
+++ b/src/Akka.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.14
+VisualStudioVersion = 15.0.26430.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Benchmark", "Benchmark", "{73108242-625A-4D7B-AA09-63375DBAE464}"
 EndProject
@@ -174,6 +174,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SpawnBenchmark", "benchmark\SpawnBenchmark\SpawnBenchmark.csproj", "{DA4BDE1E-1ACA-482A-9329-952C3E36F97D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RemotePingPong", "benchmark\RemotePingPong\RemotePingPong.csproj", "{5AA81B79-34DD-4DD7-9D40-A5CA389786DF}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Akka.FSharp", "core\Akka.FSharp\Akka.FSharp.fsproj", "{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -702,6 +704,18 @@ Global
 		{5AA81B79-34DD-4DD7-9D40-A5CA389786DF}.Release|x64.Build.0 = Release|Any CPU
 		{5AA81B79-34DD-4DD7-9D40-A5CA389786DF}.Release|x86.ActiveCfg = Release|Any CPU
 		{5AA81B79-34DD-4DD7-9D40-A5CA389786DF}.Release|x86.Build.0 = Release|Any CPU
+		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}.Debug|x64.Build.0 = Debug|Any CPU
+		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}.Debug|x86.Build.0 = Debug|Any CPU
+		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}.Release|x64.ActiveCfg = Release|Any CPU
+		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}.Release|x64.Build.0 = Release|Any CPU
+		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}.Release|x86.ActiveCfg = Release|Any CPU
+		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -774,5 +788,6 @@ Global
 		{99CCB7CA-E1EE-4497-BF52-2200A0EC5CB1} = {76F58DC4-19F1-43EF-A6E2-EC1CC8395AC5}
 		{DA4BDE1E-1ACA-482A-9329-952C3E36F97D} = {73108242-625A-4D7B-AA09-63375DBAE464}
 		{5AA81B79-34DD-4DD7-9D40-A5CA389786DF} = {73108242-625A-4D7B-AA09-63375DBAE464}
+		{F8972185-CD9B-48D2-93A3-3EA5B3F47F81} = {01167D3C-49C4-4CDE-9787-C176D139ACDD}
 	EndGlobalSection
 EndGlobal

--- a/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
+++ b/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
@@ -8,11 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="ApiTests.fs" />
+    <Compile Include="Tests.fs" />
     <Compile Include="ApiTests.fs" />
     <Compile Include="ComputationExpression.fs" />
     <Compile Include="InfrastructureTests.fs" />
-    <Compile Include="Tests.fs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -23,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.1.0" />
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.1" PrivateAssets="All" />
+    <PackageReference Include="FSharp.Core" Version="4.2.2" />
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.5" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />

--- a/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
+++ b/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.2.2" />
+    <PackageReference Include="FSharp.Core" Version="4.1.17" />
     <PackageReference Include="FSharp.NET.Sdk" Version="1.0.5" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />

--- a/src/core/Akka.FSharp/Akka.FSharp.fsproj
+++ b/src/core/Akka.FSharp/Akka.FSharp.fsproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
   <Import Project="..\..\common.props" />
-
   <PropertyGroup>
     <AssemblyTitle>Akka.FSharp</AssemblyTitle>
     <Description>F# API support for Akka.NET</Description>
@@ -9,46 +8,25 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="FsApi.fs" />
     <Compile Include="Schedulers.fs" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Akka\Akka.csproj" />
   </ItemGroup>
-
   <ItemGroup>
-    <Reference Include="FSharp.Core">
-      <HintPath>..\..\packages\FSharp.Core.4.1.17\lib\net45\FSharp.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="FSharp.PowerPack">
-      <HintPath>..\..\packages\FSPowerPack.Core.Community.3.0.0.0\Lib\Net40\FSharp.PowerPack.dll</HintPath>
-    </Reference>
-    <Reference Include="FSharp.PowerPack.Linq">
-      <HintPath>..\..\packages\FSPowerPack.Linq.Community.3.0.0.0\Lib\Net40\FSharp.PowerPack.Linq.dll</HintPath>
-    </Reference>
-    <Reference Include="FsPickler">
-      <HintPath>..\..\packages\FsPickler.3.2.0\lib\net45\FsPickler.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="mscorlib" />
-    <PackageReference Include="FSharp.Core" Version="4.1.0" />
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="FsPickler" Version="1.2.21" />
+    <PackageReference Include="FSharp.Core" Version="4.2.2" />
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.5" PrivateAssets="All" />
+    <PackageReference Include="FsPickler" Version="3.3.0" />
     <PackageReference Include="FSPowerPack.Core.Community" Version="3.0.0.0" />
     <PackageReference Include="FSPowerPack.Linq.Community" Version="3.0.0.0" />
   </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
     <Reference Include="System.Numerics" />
   </ItemGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>
-
 </Project>

--- a/src/core/Akka.FSharp/Akka.FSharp.fsproj
+++ b/src/core/Akka.FSharp/Akka.FSharp.fsproj
@@ -16,9 +16,9 @@
     <ProjectReference Include="..\Akka\Akka.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.2.2" />
+    <PackageReference Include="FSharp.Core" Version="4.1.17" />
     <PackageReference Include="FSharp.NET.Sdk" Version="1.0.5" PrivateAssets="All" />
-    <PackageReference Include="FsPickler" Version="3.3.0" />
+    <PackageReference Include="FsPickler" Version="3.2.0" />
     <PackageReference Include="FSPowerPack.Core.Community" Version="3.0.0.0" />
     <PackageReference Include="FSPowerPack.Linq.Community" Version="3.0.0.0" />
   </ItemGroup>

--- a/src/core/Akka.FSharp/Akka.FSharp.fsproj
+++ b/src/core/Akka.FSharp/Akka.FSharp.fsproj
@@ -21,6 +21,7 @@
     <PackageReference Include="FsPickler" Version="3.2.0" />
     <PackageReference Include="FSPowerPack.Core.Community" Version="3.0.0.0" />
     <PackageReference Include="FSPowerPack.Linq.Community" Version="3.0.0.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />

--- a/src/core/Akka.FSharp/FsApi.fs
+++ b/src/core/Akka.FSharp/FsApi.fs
@@ -278,6 +278,7 @@ module Actors =
                         member __.ActorSelection(path : ActorPath) = context.ActorSelection(path)
                         member __.Watch(aref:IActorRef) = context.Watch aref
                         member __.Unwatch(aref:IActorRef) = context.Unwatch aref
+                        member __.WatchWith(aref:IActorRef, msg) = context.WatchWith (aref, msg)
                         member __.Log = lazy (Akka.Event.Logging.GetLogger(context))
                         member __.Defer fn = deferables <- fn::deferables 
                         member __.Stash() = (this :> IWithUnboundedStash).Stash.Stash()

--- a/src/core/Akka.FSharp/app.config
+++ b/src/core/Akka.FSharp/app.config
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <configSections>
+    <section name="akka" type="Akka.Configuration.Hocon.AkkaConfigurationSection, Akka" />
+  </configSections>
+  <akka>
+    <hocon><![CDATA[
+      akka {
+        test {
+          value = 10
+        }
+      }
+      ]]></hocon>
+  </akka>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="2.0.0.0-4.4.1.0" newVersion="4.4.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+  </startup>
+</configuration>


### PR DESCRIPTION
Builds Akka.FSharp and Akka.FSharp.Tests using the build script, but does not add it to the .sln because VS 2017 15.2 doesn't support the new format of MSBuild 15 projects for .fsproj per this issue: https://github.com/Microsoft/visualfsharp/issues/2316

**Note**: 2 specs fail and I'm having difficulty grokking why

```
    Akka.FSharp.Tests.InfrastructureTests.IActorRef should be possible to use as a Key [FAIL]
      System.ArgumentException : Expression of type 'Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,Akka.FSharp.Actors+FunActor`2[System.Object,System.Object]]' cannot be used for return type 'Akka.
FSharp.Actors+FunActor`2[System.Object,System.Object]'
      Stack Trace:
           at System.Linq.Expressions.Expression.ValidateLambdaArgs(Type delegateType, Expression& body, ReadOnlyCollection`1 parameters)
           at System.Linq.Expressions.Expression.Lambda(Type delegateType, Expression body, String name, Boolean tailCall, IEnumerable`1 parameters)
           at System.Linq.Expressions.Expression.Lambda(Type delegateType, Expression body, IEnumerable`1 parameters)
           at Microsoft.FSharp.Linq.RuntimeHelpers.LeafExpressionConverter.ConvExprToLinqInContext(ConvEnv env, FSharpExpr inp)
           at Microsoft.FSharp.Linq.RuntimeHelpers.LeafExpressionConverter.QuotationToLambdaExpression[T](FSharpExpr`1 e)
           at Akka.FSharp.Spawn.spawnOpt[Message,Returned](IActorRefFactory actorFactory, String name, FSharpFunc`2 f, FSharpList`1 options)
           at Akka.FSharp.Tests.InfrastructureTests.IActorRef should be possible to use as a Key()
    Akka.FSharp.Tests.ApiTests.actor that accepts _ will receive string message [FAIL]
      System.ArgumentException : Expression of type 'Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,Akka.FSharp.Actors+FunActor`2[System.Object,System.Object]]' cannot be used for return type 'Akka.
FSharp.Actors+FunActor`2[System.Object,System.Object]'
      Stack Trace:
           at System.Linq.Expressions.Expression.ValidateLambdaArgs(Type delegateType, Expression& body, ReadOnlyCollection`1 parameters)
           at System.Linq.Expressions.Expression.Lambda(Type delegateType, Expression body, String name, Boolean tailCall, IEnumerable`1 parameters)
           at System.Linq.Expressions.Expression.Lambda(Type delegateType, Expression body, IEnumerable`1 parameters)
           at Microsoft.FSharp.Linq.RuntimeHelpers.LeafExpressionConverter.ConvExprToLinqInContext(ConvEnv env, FSharpExpr inp)
           at Microsoft.FSharp.Linq.RuntimeHelpers.LeafExpressionConverter.QuotationToLambdaExpression[T](FSharpExpr`1 e)
           at Akka.FSharp.Spawn.spawnOpt[Message,Returned](IActorRefFactory actorFactory, String name, FSharpFunc`2 f, FSharpList`1 options)
           at Akka.FSharp.Tests.ApiTests.actor that accepts _ will receive string message()
```

I was unable to resolve these so WIP until I can get a little help.

