### PR TITLE
Enable Akka.Cluster.Sharding.Tests.MultiNode specs on .NET Core

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/Akka.Cluster.Sharding.Tests.MultiNode.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/Akka.Cluster.Sharding.Tests.MultiNode.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.Cluster.Sharding</AssemblyTitle>
-    <TargetFrameworks>net452;</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/core/Akka.NodeTestRunner/Akka.NodeTestRunner.csproj
+++ b/src/core/Akka.NodeTestRunner/Akka.NodeTestRunner.csproj
@@ -21,9 +21,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1'">
-    <PackageReference Include="System.Runtime.Loader">
-      <Version>4.3.0</Version>
-    </PackageReference>
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.2" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">


### PR DESCRIPTION
Enables Akka.Cluster.Sharding.Tests.MultiNode to be run under `MultiNodeTestsNetCore` step in CI.  Fixes bug in NodeTestRunner related to loading dependent assemblies into context on .NET Core.