### PR TITLE
[Sharding] - Align naming with akka

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingCustomShardAllocationSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingCustomShardAllocationSpec.cs
@@ -190,9 +190,9 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        internal IdExtractor extractEntityId = message => message is int ? Tuple.Create(message.ToString(), message) : null;
+        internal ExtractEntityId extractEntityId = message => message is int ? Tuple.Create(message.ToString(), message) : null;
 
-        internal ShardResolver extractShardId = message => message is int ? ((int)message).ToString() : null;
+        internal ExtractShardId extractShardId = message => message is int ? ((int)message).ToString() : null;
 
         private Lazy<IActorRef> _region;
         private Lazy<IActorRef> _allocator;
@@ -234,8 +234,8 @@ namespace Akka.Cluster.Sharding.Tests
                 typeName: "Entity",
                 entityProps: Props.Create<Entity>(),
                 settings: ClusterShardingSettings.Create(Sys),
-                idExtractor: extractEntityId,
-                shardResolver: extractShardId,
+                extractEntityId: extractEntityId,
+                extractShardId: extractShardId,
                 allocationStrategy: new TestAllocationStrategy(_allocator.Value),
                 handOffStopMessage: PoisonPill.Instance);
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingFailureSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingFailureSpec.cs
@@ -123,14 +123,14 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        internal IdExtractor extractEntityId = message =>
+        internal ExtractEntityId extractEntityId = message =>
         {
             if (message is Get) return Tuple.Create((message as Get).Id, message);
             if (message is Add) return Tuple.Create((message as Add).Id, message);
             return null;
         };
 
-        internal ShardResolver extractShardId = message =>
+        internal ExtractShardId extractShardId = message =>
         {
             if (message is Get) return (message as Get).Id[0].ToString();
             if (message is Add) return (message as Add).Id[0].ToString();
@@ -179,8 +179,8 @@ namespace Akka.Cluster.Sharding.Tests
                 typeName: "Entity",
                 entityProps: Props.Create<Entity>(),
                 settings: ClusterShardingSettings.Create(Sys),
-                idExtractor: extractEntityId,
-                shardResolver: extractShardId);
+                extractEntityId: extractEntityId,
+                extractShardId: extractShardId);
         }
 
         [MultiNodeFact]

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStateSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStateSpec.cs
@@ -133,9 +133,9 @@ namespace Akka.Cluster.Sharding.Tests
         readonly static int NumberOfShards = 2;
         readonly static string ShardTypeName = "Ping";
 
-        internal IdExtractor extractEntityId = message => message is Ping ? Tuple.Create(((Ping)message).Id.ToString(), message) : null;
+        internal ExtractEntityId extractEntityId = message => message is Ping ? Tuple.Create(((Ping)message).Id.ToString(), message) : null;
 
-        internal ShardResolver extractShardId = message => message is Ping ? (((Ping)message).Id % NumberOfShards).ToString() : null;
+        internal ExtractShardId extractShardId = message => message is Ping ? (((Ping)message).Id % NumberOfShards).ToString() : null;
 
         private Lazy<IActorRef> _region;
 
@@ -173,8 +173,8 @@ namespace Akka.Cluster.Sharding.Tests
                typeName: ShardTypeName,
                entityProps: Props.Create<ShardedActor>(),
                settings: ClusterShardingSettings.Create(Sys).WithRole("shard"),
-               idExtractor: extractEntityId,
-               shardResolver: extractShardId);
+               extractEntityId: extractEntityId,
+               extractShardId: extractShardId);
         }
 
         private void StartProxy()
@@ -182,8 +182,8 @@ namespace Akka.Cluster.Sharding.Tests
             ClusterSharding.Get(Sys).StartProxy(
                 typeName: ShardTypeName,
                 role: "shard",
-                idExtractor: extractEntityId,
-                shardResolver: extractShardId);
+                extractEntityId: extractEntityId,
+                extractShardId: extractShardId);
         }
 
         [MultiNodeFact]

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStatsSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStatsSpec.cs
@@ -136,9 +136,9 @@ namespace Akka.Cluster.Sharding.Tests
         readonly static int NumberOfShards = 3;
         readonly static string ShardTypeName = "Ping";
 
-        internal IdExtractor extractEntityId = message => message is Ping ? Tuple.Create(((Ping)message).Id.ToString(), message) : null;
+        internal ExtractEntityId extractEntityId = message => message is Ping ? Tuple.Create(((Ping)message).Id.ToString(), message) : null;
 
-        internal ShardResolver extractShardId = message => message is Ping ? (((Ping)message).Id % NumberOfShards).ToString() : null;
+        internal ExtractShardId extractShardId = message => message is Ping ? (((Ping)message).Id % NumberOfShards).ToString() : null;
 
         private Lazy<IActorRef> _region;
 
@@ -176,8 +176,8 @@ namespace Akka.Cluster.Sharding.Tests
                typeName: ShardTypeName,
                entityProps: Props.Create<ShardedActor>(),
                settings: ClusterShardingSettings.Create(Sys).WithRole("shard"),
-               idExtractor: extractEntityId,
-               shardResolver: extractShardId);
+               extractEntityId: extractEntityId,
+               extractShardId: extractShardId);
         }
 
         private void StartProxy()
@@ -185,8 +185,8 @@ namespace Akka.Cluster.Sharding.Tests
             ClusterSharding.Get(Sys).StartProxy(
                 typeName: ShardTypeName,
                 role: "shard",
-                idExtractor: extractEntityId,
-                shardResolver: extractShardId);
+                extractEntityId: extractEntityId,
+                extractShardId: extractShardId);
         }
 
         [MultiNodeFact]

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGracefulShutdownSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGracefulShutdownSpec.cs
@@ -85,9 +85,9 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        internal IdExtractor extractEntityId = message => message is int ? Tuple.Create(message.ToString(), message) : null;
+        internal ExtractEntityId extractEntityId = message => message is int ? Tuple.Create(message.ToString(), message) : null;
 
-        internal ShardResolver extractShardId = message => message is int ? message.ToString() : null;
+        internal ExtractShardId extractShardId = message => message is int ? message.ToString() : null;
 
         private readonly Lazy<IActorRef> _region;
 
@@ -125,8 +125,8 @@ namespace Akka.Cluster.Sharding.Tests
                 typeName: "Entity",
                 entityProps: Props.Create<Entity>(),
                 settings: ClusterShardingSettings.Create(Sys),
-                idExtractor: extractEntityId,
-                shardResolver: extractShardId,
+                extractEntityId: extractEntityId,
+                extractShardId: extractShardId,
                 allocationStrategy: allocationStrategy,
                 handOffStopMessage: StopEntity.Instance);
         }
@@ -241,8 +241,8 @@ namespace Akka.Cluster.Sharding.Tests
                         typeName: "EntityEmpty",
                         entityProps: Props.Create<Entity>(),
                         settings: ClusterShardingSettings.Create(Sys),
-                        idExtractor: extractEntityId,
-                        shardResolver: extractShardId,
+                        extractEntityId: extractEntityId,
+                        extractShardId: extractShardId,
                         allocationStrategy: allocationStrategy,
                         handOffStopMessage: StopEntity.Instance);
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingLeavingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingLeavingSpec.cs
@@ -124,8 +124,8 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        internal IdExtractor extractEntityId = message => message is Ping ? Tuple.Create((message as Ping).Id, message) : null;
-        internal ShardResolver extractShardId = message => message is Ping ? (message as Ping).Id[0].ToString() : null;
+        internal ExtractEntityId extractEntityId = message => message is Ping ? Tuple.Create((message as Ping).Id, message) : null;
+        internal ExtractShardId extractShardId = message => message is Ping ? (message as Ping).Id[0].ToString() : null;
 
         private readonly Lazy<IActorRef> _region;
 
@@ -171,8 +171,8 @@ namespace Akka.Cluster.Sharding.Tests
                 typeName: "Entity",
                 entityProps: Props.Create<Entity>(),
                 settings: ClusterShardingSettings.Create(Sys),
-                idExtractor: extractEntityId,
-                shardResolver: extractShardId);
+                extractEntityId: extractEntityId,
+                extractShardId: extractShardId);
         }
 
         [MultiNodeFact]

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingMinMembersSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingMinMembersSpec.cs
@@ -93,9 +93,9 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        internal IdExtractor extractEntityId = message => message is int ? Tuple.Create(message.ToString(), message) : null;
+        internal ExtractEntityId extractEntityId = message => message is int ? Tuple.Create(message.ToString(), message) : null;
 
-        internal ShardResolver extractShardId = message => message is int ? message.ToString() : null;
+        internal ExtractShardId extractShardId = message => message is int ? message.ToString() : null;
 
         private Lazy<IActorRef> _region;
 
@@ -133,8 +133,8 @@ namespace Akka.Cluster.Sharding.Tests
                 typeName: "Entity",
                 entityProps: Props.Create<EchoActor>(),
                 settings: ClusterShardingSettings.Create(Sys),
-                idExtractor: extractEntityId,
-                shardResolver: extractShardId,
+                extractEntityId: extractEntityId,
+                extractShardId: extractShardId,
                 allocationStrategy: allocationStrategy,
                 handOffStopMessage: StopEntity.Instance);
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesNewExtractorSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesNewExtractorSpec.cs
@@ -103,9 +103,9 @@ namespace Akka.Cluster.Sharding.Tests
 
         readonly static int ShardCount = 3;
 
-        internal IdExtractor extractEntityId = message => message is int ? Tuple.Create(message.ToString(), message) : null;
+        internal ExtractEntityId extractEntityId = message => message is int ? Tuple.Create(message.ToString(), message) : null;
 
-        internal static ShardResolver extractShardId1 = message =>
+        internal static ExtractShardId extractShardId1 = message =>
         {
             if (message is int)
                 return (((int)message) % ShardCount).ToString();
@@ -114,7 +114,7 @@ namespace Akka.Cluster.Sharding.Tests
             return null;
         };
 
-        internal static ShardResolver extractShardId2 = message =>
+        internal static ExtractShardId extractShardId2 = message =>
         {
             if (message is int)
                 return (((int)message + 1) % ShardCount).ToString();
@@ -158,8 +158,8 @@ namespace Akka.Cluster.Sharding.Tests
                 typeName: TypeName,
                 entityProps: Props.Create(() => new TestEntity(null)),
                 settings: ClusterShardingSettings.Create(Sys).WithRememberEntities(true).WithRole("sharding"),
-                idExtractor: extractEntityId,
-                shardResolver: extractShardId1);
+                extractEntityId: extractEntityId,
+                extractShardId: extractShardId1);
         }
 
         private void StartShardingWithExtractor2(ActorSystem sys, IActorRef probe)
@@ -168,8 +168,8 @@ namespace Akka.Cluster.Sharding.Tests
                 typeName: TypeName,
                 entityProps: Props.Create(() => new TestEntity(probe)),
                 settings: ClusterShardingSettings.Create(Sys).WithRememberEntities(true).WithRole("sharding"),
-                idExtractor: extractEntityId,
-                shardResolver: extractShardId2);
+                extractEntityId: extractEntityId,
+                extractShardId: extractShardId2);
         }
 
         private IActorRef Region(ActorSystem sys)

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesSpec.cs
@@ -98,9 +98,9 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        internal IdExtractor extractEntityId = message => message is int ? Tuple.Create(message.ToString(), message) : null;
+        internal ExtractEntityId extractEntityId = message => message is int ? Tuple.Create(message.ToString(), message) : null;
 
-        internal ShardResolver extractShardId = message =>
+        internal ExtractShardId extractShardId = message =>
         {
             if (message is int)
                 return ((int)message).ToString();
@@ -146,8 +146,8 @@ namespace Akka.Cluster.Sharding.Tests
                 typeName: "Entity",
                 entityProps: Props.Create(() => new TestEntity(probe)),
                 settings: ClusterShardingSettings.Create(Sys).WithRememberEntities(true),
-                idExtractor: extractEntityId,
-                shardResolver: extractShardId);
+                extractEntityId: extractEntityId,
+                extractShardId: extractShardId);
         }
 
         [MultiNodeFact]

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
@@ -175,7 +175,7 @@ namespace Akka.Cluster.Sharding.Tests
 
         #endregion
 
-        public static readonly IdExtractor ExtractEntityId = message =>
+        public static readonly ExtractEntityId ExtractEntityId = message =>
         {
             if (message is EntityEnvelope)
             {
@@ -189,7 +189,7 @@ namespace Akka.Cluster.Sharding.Tests
             return null;
         };
 
-        public static readonly ShardResolver ExtractShardId = message =>
+        public static readonly ExtractShardId ExtractShardId = message =>
         {
             if (message is EntityEnvelope)
                 return (((EntityEnvelope)message).Id % NumberOfShards).ToString();
@@ -812,24 +812,24 @@ namespace Akka.Cluster.Sharding.Tests
                         typeName: "Counter",
                         entityProps: Props.Create<Counter>(),
                         settings: ClusterShardingSettings.Create(Sys),
-                        idExtractor: Counter.ExtractEntityId,
-                        shardResolver: Counter.ExtractShardId);
+                        extractEntityId: Counter.ExtractEntityId,
+                        extractShardId: Counter.ExtractShardId);
 
                     //#counter-start
                     ClusterSharding.Get(Sys).Start(
                         typeName: "AnotherCounter",
                         entityProps: Props.Create<AnotherCounter>(),
                         settings: ClusterShardingSettings.Create(Sys),
-                        idExtractor: Counter.ExtractEntityId,
-                        shardResolver: Counter.ExtractShardId);
+                        extractEntityId: Counter.ExtractEntityId,
+                        extractShardId: Counter.ExtractShardId);
 
                     //#counter-supervisor-start
                     ClusterSharding.Get(Sys).Start(
                       typeName: "SupervisedCounter",
                       entityProps: Props.Create<CounterSupervisor>(),
                       settings: ClusterShardingSettings.Create(Sys),
-                      idExtractor: Counter.ExtractEntityId,
-                      shardResolver: Counter.ExtractShardId);
+                      extractEntityId: Counter.ExtractEntityId,
+                      extractShardId: Counter.ExtractShardId);
                 }, _config.Third, _config.Fourth, _config.Fifth, _config.Sixth);
                 EnterBarrier("extension-started");
 
@@ -877,8 +877,8 @@ namespace Akka.Cluster.Sharding.Tests
                         typeName: "ApiTest",
                         entityProps: Props.Create<Counter>(),
                         settings: ClusterShardingSettings.Create(Sys),
-                        idExtractor: Counter.ExtractEntityId,
-                        shardResolver: Counter.ExtractShardId);
+                        extractEntityId: Counter.ExtractEntityId,
+                        extractShardId: Counter.ExtractShardId);
 
                     var counterRegionViaGet = ClusterSharding.Get(Sys).ShardRegion("ApiTest");
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
@@ -283,12 +283,12 @@ namespace Akka.Cluster.Sharding
         /// The <see cref="Actor.Props"/> of the entity actors that will be created by the <see cref="Sharding.ShardRegion"/>
         /// </param>
         /// <param name="settings">Configuration settings, see <see cref="ClusterShardingSettings"/></param>
-        /// <param name="idExtractor">
+        /// <param name="extractEntityId">
         /// Partial function to extract the entity id and the message to send to the entity from the incoming message,
         /// if the partial function does not match the message will be `unhandled`,
         /// i.e.posted as `Unhandled` messages on the event stream
         /// </param>
-        /// <param name="shardResolver">
+        /// <param name="extractShardId">
         /// Function to determine the shard id for an incoming message, only messages that passed the `extractEntityId` will be used
         /// </param>
         /// <param name="allocationStrategy">Possibility to use a custom shard allocation and rebalancing logic</param>
@@ -301,18 +301,18 @@ namespace Akka.Cluster.Sharding
         /// </exception>
         /// <returns>The actor ref of the <see cref="Sharding.ShardRegion"/> that is to be responsible for the shard.</returns>
         public IActorRef Start(
-            string typeName, //TODO: change type name to type instance?
+            string typeName,
             Props entityProps,
             ClusterShardingSettings settings,
-            IdExtractor idExtractor,
-            ShardResolver shardResolver,
+            ExtractEntityId extractEntityId,
+            ExtractShardId extractShardId,
             IShardAllocationStrategy allocationStrategy,
             object handOffStopMessage)
         {
             RequireClusterRole(settings.Role);
 
             var timeout = _system.Settings.CreationTimeout;
-            var startMsg = new ClusterShardingGuardian.Start(typeName, entityProps, settings, idExtractor, shardResolver, allocationStrategy, handOffStopMessage);
+            var startMsg = new ClusterShardingGuardian.Start(typeName, entityProps, settings, extractEntityId, extractShardId, allocationStrategy, handOffStopMessage);
 
             var started = _guardian.Value.Ask<ClusterShardingGuardian.Started>(startMsg, timeout).Result;
             var shardRegion = started.ShardRegion;
@@ -330,12 +330,12 @@ namespace Akka.Cluster.Sharding
         /// The <see cref="Actor.Props"/> of the entity actors that will be created by the <see cref="Sharding.ShardRegion"/>
         /// </param>
         /// <param name="settings">Configuration settings, see <see cref="ClusterShardingSettings"/></param>
-        /// <param name="idExtractor">
+        /// <param name="extractEntityId">
         /// Partial function to extract the entity id and the message to send to the entity from the incoming message,
         /// if the partial function does not match the message will be `unhandled`,
         /// i.e.posted as `Unhandled` messages on the event stream
         /// </param>
-        /// <param name="shardResolver">
+        /// <param name="extractShardId">
         /// Function to determine the shard id for an incoming message, only messages that passed the `extractEntityId` will be used
         /// </param>
         /// <param name="allocationStrategy">Possibility to use a custom shard allocation and rebalancing logic</param>
@@ -348,18 +348,18 @@ namespace Akka.Cluster.Sharding
         /// </exception>
         /// <returns>The actor ref of the <see cref="Sharding.ShardRegion"/> that is to be responsible for the shard.</returns>
         public async Task<IActorRef> StartAsync(
-            string typeName, //TODO: change type name to type instance?
+            string typeName,
             Props entityProps,
             ClusterShardingSettings settings,
-            IdExtractor idExtractor,
-            ShardResolver shardResolver,
+            ExtractEntityId extractEntityId,
+            ExtractShardId extractShardId,
             IShardAllocationStrategy allocationStrategy,
             object handOffStopMessage)
         {
             RequireClusterRole(settings.Role);
 
             var timeout = _system.Settings.CreationTimeout;
-            var startMsg = new ClusterShardingGuardian.Start(typeName, entityProps, settings, idExtractor, shardResolver, allocationStrategy, handOffStopMessage);
+            var startMsg = new ClusterShardingGuardian.Start(typeName, entityProps, settings, extractEntityId, extractShardId, allocationStrategy, handOffStopMessage);
 
             var started = await _guardian.Value.Ask<ClusterShardingGuardian.Started>(startMsg, timeout);
             var shardRegion = started.ShardRegion;
@@ -377,26 +377,26 @@ namespace Akka.Cluster.Sharding
         /// The <see cref="Actor.Props"/> of the entity actors that will be created by the <see cref="Sharding.ShardRegion"/>
         /// </param>
         /// <param name="settings">Configuration settings, see <see cref="ClusterShardingSettings"/></param>
-        /// <param name="idExtractor">
+        /// <param name="extractEntityId">
         /// Partial function to extract the entity id and the message to send to the entity from the incoming message,
         /// if the partial function does not match the message will be `unhandled`,
         /// i.e.posted as `Unhandled` messages on the event stream
         /// </param>
-        /// <param name="shardResolver">
+        /// <param name="extractShardId">
         /// Function to determine the shard id for an incoming message, only messages that passed the `extractEntityId` will be used
         /// </param>
         /// <returns>The actor ref of the <see cref="Sharding.ShardRegion"/> that is to be responsible for the shard.</returns>
         public IActorRef Start(
-            string typeName, //TODO: change type name to type instance?
+            string typeName,
             Props entityProps,
             ClusterShardingSettings settings,
-            IdExtractor idExtractor,
-            ShardResolver shardResolver)
+            ExtractEntityId extractEntityId,
+            ExtractShardId extractShardId)
         {
             var allocationStrategy = new LeastShardAllocationStrategy(
                 Settings.TunningParameters.LeastShardAllocationRebalanceThreshold,
                 Settings.TunningParameters.LeastShardAllocationMaxSimultaneousRebalance);
-            return Start(typeName, entityProps, settings, idExtractor, shardResolver, allocationStrategy, PoisonPill.Instance);
+            return Start(typeName, entityProps, settings, extractEntityId, extractShardId, allocationStrategy, PoisonPill.Instance);
         }
 
         /// <summary>
@@ -409,26 +409,26 @@ namespace Akka.Cluster.Sharding
         /// The <see cref="Actor.Props"/> of the entity actors that will be created by the <see cref="Sharding.ShardRegion"/>
         /// </param>
         /// <param name="settings">Configuration settings, see <see cref="ClusterShardingSettings"/></param>
-        /// <param name="idExtractor">
+        /// <param name="extractEntityId">
         /// Partial function to extract the entity id and the message to send to the entity from the incoming message,
         /// if the partial function does not match the message will be `unhandled`,
         /// i.e.posted as `Unhandled` messages on the event stream
         /// </param>
-        /// <param name="shardResolver">
+        /// <param name="extractShardId">
         /// Function to determine the shard id for an incoming message, only messages that passed the `extractEntityId` will be used
         /// </param>
         /// <returns>The actor ref of the <see cref="Sharding.ShardRegion"/> that is to be responsible for the shard.</returns>
         public Task<IActorRef> StartAsync(
-            string typeName, //TODO: change type name to type instance?
+            string typeName,
             Props entityProps,
             ClusterShardingSettings settings,
-            IdExtractor idExtractor,
-            ShardResolver shardResolver)
+            ExtractEntityId extractEntityId,
+            ExtractShardId extractShardId)
         {
             var allocationStrategy = new LeastShardAllocationStrategy(
                 Settings.TunningParameters.LeastShardAllocationRebalanceThreshold,
                 Settings.TunningParameters.LeastShardAllocationMaxSimultaneousRebalance);
-            return StartAsync(typeName, entityProps, settings, idExtractor, shardResolver, allocationStrategy, PoisonPill.Instance);
+            return StartAsync(typeName, entityProps, settings, extractEntityId, extractShardId, allocationStrategy, PoisonPill.Instance);
         }
 
         /// <summary>
@@ -453,10 +453,10 @@ namespace Akka.Cluster.Sharding
         public IActorRef Start(string typeName, Props entityProps, ClusterShardingSettings settings,
             IMessageExtractor messageExtractor, IShardAllocationStrategy allocationStrategy, object handOffMessage)
         {
-            IdExtractor idExtractor = messageExtractor.ToIdExtractor();
-            ShardResolver shardResolver = messageExtractor.ShardId;
+            ExtractEntityId extractEntityId = messageExtractor.ToExtractEntityId();
+            ExtractShardId extractShardId = messageExtractor.ShardId;
 
-            return Start(typeName, entityProps, settings, idExtractor, shardResolver, allocationStrategy, handOffMessage);
+            return Start(typeName, entityProps, settings, extractEntityId, extractShardId, allocationStrategy, handOffMessage);
         }
 
         /// <summary>
@@ -481,10 +481,10 @@ namespace Akka.Cluster.Sharding
         public Task<IActorRef> StartAsync(string typeName, Props entityProps, ClusterShardingSettings settings,
             IMessageExtractor messageExtractor, IShardAllocationStrategy allocationStrategy, object handOffMessage)
         {
-            IdExtractor idExtractor = messageExtractor.ToIdExtractor();
-            ShardResolver shardResolver = messageExtractor.ShardId;
+            ExtractEntityId extractEntityId = messageExtractor.ToExtractEntityId();
+            ExtractShardId extractShardId = messageExtractor.ShardId;
 
-            return StartAsync(typeName, entityProps, settings, idExtractor, shardResolver, allocationStrategy, handOffMessage);
+            return StartAsync(typeName, entityProps, settings, extractEntityId, extractShardId, allocationStrategy, handOffMessage);
         }
 
         /// <summary>
@@ -552,20 +552,20 @@ namespace Akka.Cluster.Sharding
         /// Specifies that this entity type is located on cluster nodes with a specific role.
         /// If the role is not specified all nodes in the cluster are used.
         /// </param>
-        /// <param name="idExtractor">
+        /// <param name="extractEntityId">
         /// Partial function to extract the entity id and the message to send to the  entity from the incoming message,
         /// if the partial function does not match the message will  be `unhandled`, i.e.posted as `Unhandled` messages
         /// on the event stream
         /// </param>
-        /// <param name="shardResolver">
+        /// <param name="extractShardId">
         /// Function to determine the shard id for an incoming message, only messages that passed the `extractEntityId` will be used
         /// </param>
         /// <returns>The actor ref of the <see cref="Sharding.ShardRegion"/> that is to be responsible for the shard.</returns>
-        public IActorRef StartProxy(string typeName, string role, IdExtractor idExtractor, ShardResolver shardResolver)
+        public IActorRef StartProxy(string typeName, string role, ExtractEntityId extractEntityId, ExtractShardId extractShardId)
         {
             var timeout = _system.Settings.CreationTimeout;
             var settings = ClusterShardingSettings.Create(_system).WithRole(role);
-            var startMsg = new ClusterShardingGuardian.StartProxy(typeName, settings, idExtractor, shardResolver);
+            var startMsg = new ClusterShardingGuardian.StartProxy(typeName, settings, extractEntityId, extractShardId);
             var started = _guardian.Value.Ask<ClusterShardingGuardian.Started>(startMsg, timeout).Result;
             _regions.TryAdd(typeName, started.ShardRegion);
             return started.ShardRegion;
@@ -582,20 +582,20 @@ namespace Akka.Cluster.Sharding
         /// Specifies that this entity type is located on cluster nodes with a specific role.
         /// If the role is not specified all nodes in the cluster are used.
         /// </param>
-        /// <param name="idExtractor">
+        /// <param name="extractEntityId">
         /// Partial function to extract the entity id and the message to send to the  entity from the incoming message,
         /// if the partial function does not match the message will  be `unhandled`, i.e.posted as `Unhandled` messages
         /// on the event stream
         /// </param>
-        /// <param name="shardResolver">
+        /// <param name="extractShardId">
         /// Function to determine the shard id for an incoming message, only messages that passed the `extractEntityId` will be used
         /// </param>
         /// <returns>The actor ref of the <see cref="Sharding.ShardRegion"/> that is to be responsible for the shard.</returns>
-        public async Task<IActorRef> StartProxyAsync(string typeName, string role, IdExtractor idExtractor, ShardResolver shardResolver)
+        public async Task<IActorRef> StartProxyAsync(string typeName, string role, ExtractEntityId extractEntityId, ExtractShardId extractShardId)
         {
             var timeout = _system.Settings.CreationTimeout;
             var settings = ClusterShardingSettings.Create(_system).WithRole(role);
-            var startMsg = new ClusterShardingGuardian.StartProxy(typeName, settings, idExtractor, shardResolver);
+            var startMsg = new ClusterShardingGuardian.StartProxy(typeName, settings, extractEntityId, extractShardId);
             var started = await _guardian.Value.Ask<ClusterShardingGuardian.Started>(startMsg, timeout);
             _regions.TryAdd(typeName, started.ShardRegion);
             return started.ShardRegion;
@@ -618,7 +618,7 @@ namespace Akka.Cluster.Sharding
         /// <returns>The actor ref of the <see cref="Sharding.ShardRegion"/> that is to be responsible for the shard.</returns>
         public IActorRef StartProxy(string typeName, string role, IMessageExtractor messageExtractor)
         {
-            IdExtractor extractEntityId = msg =>
+            ExtractEntityId extractEntityId = msg =>
             {
                 var entityId = messageExtractor.EntityId(msg);
                 var entityMessage = messageExtractor.EntityMessage(msg);
@@ -645,7 +645,7 @@ namespace Akka.Cluster.Sharding
         /// <returns>The actor ref of the <see cref="Sharding.ShardRegion"/> that is to be responsible for the shard.</returns>
         public Task<IActorRef> StartProxyAsync(string typeName, string role, IMessageExtractor messageExtractor)
         {
-            IdExtractor extractEntityId = msg =>
+            ExtractEntityId extractEntityId = msg =>
             {
                 var entityId = messageExtractor.EntityId(msg);
                 var entityMessage = messageExtractor.EntityMessage(msg);
@@ -686,10 +686,10 @@ namespace Akka.Cluster.Sharding
     /// <summary>
     /// Interface of the function used by the <see cref="ShardRegion"/> to
     /// extract the shard id from an incoming message.
-    /// Only messages that passed the <see cref="IdExtractor"/> will be used
+    /// Only messages that passed the <see cref="ExtractEntityId"/> will be used
     /// as input to this function.
     /// </summary>
-    public delegate ShardId ShardResolver(Msg message);
+    public delegate ShardId ExtractShardId(Msg message);
 
     /// <summary>
     /// Interface of the partial function used by the <see cref="ShardRegion"/> to
@@ -701,7 +701,7 @@ namespace Akka.Cluster.Sharding
     /// message to support wrapping in message envelope that is unwrapped before
     /// sending to the entity actor.
     /// </summary>
-    public delegate Tuple<EntityId, Msg> IdExtractor(Msg message);
+    public delegate Tuple<EntityId, Msg> ExtractEntityId(Msg message);
 
     /// <summary>
     /// Interface of functions to extract entity id,  shard id, and the message to send
@@ -747,9 +747,9 @@ namespace Akka.Cluster.Sharding
         /// </summary>
         /// <param name="self">TBD</param>
         /// <returns>TBD</returns>
-        public static IdExtractor ToIdExtractor(this IMessageExtractor self)
+        public static ExtractEntityId ToExtractEntityId(this IMessageExtractor self)
         {
-            IdExtractor idExtractor = msg =>
+            ExtractEntityId extractEntityId = msg =>
             {
                 if (self.EntityId(msg) != null)
                     return Tuple.Create(self.EntityId(msg), self.EntityMessage(msg));
@@ -758,7 +758,7 @@ namespace Akka.Cluster.Sharding
                 return null;
             };
 
-            return idExtractor;
+            return extractEntityId;
         }
     }
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
@@ -61,11 +61,11 @@ namespace Akka.Cluster.Sharding
             /// <summary>
             /// TBD
             /// </summary>
-            public readonly IdExtractor IdExtractor;
+            public readonly ExtractEntityId ExtractEntityId;
             /// <summary>
             /// TBD
             /// </summary>
-            public readonly ShardResolver ShardResolver;
+            public readonly ExtractShardId ExtractShardId;
             /// <summary>
             /// TBD
             /// </summary>
@@ -81,15 +81,15 @@ namespace Akka.Cluster.Sharding
             /// <param name="typeName">TBD</param>
             /// <param name="entityProps">TBD</param>
             /// <param name="settings">TBD</param>
-            /// <param name="idIdExtractor">TBD</param>
-            /// <param name="shardResolver">TBD</param>
+            /// <param name="extractEntityId">TBD</param>
+            /// <param name="extractShardId">TBD</param>
             /// <param name="allocationStrategy">TBD</param>
             /// <param name="handOffStopMessage">TBD</param>
             /// <exception cref="ArgumentNullException">
             /// This exception is thrown when the specified <paramref name="typeName"/> or <paramref name="entityProps"/> is undefined.
             /// </exception>
             public Start(string typeName, Props entityProps, ClusterShardingSettings settings,
-                IdExtractor idIdExtractor, ShardResolver shardResolver, IShardAllocationStrategy allocationStrategy, object handOffStopMessage)
+                ExtractEntityId extractEntityId, ExtractShardId extractShardId, IShardAllocationStrategy allocationStrategy, object handOffStopMessage)
             {
                 if (string.IsNullOrEmpty(typeName)) throw new ArgumentNullException(nameof(typeName), "ClusterSharding start requires type name to be provided");
                 if (entityProps == null) throw new ArgumentNullException(nameof(entityProps), $"ClusterSharding start requires Props for [{typeName}] to be provided");
@@ -97,8 +97,8 @@ namespace Akka.Cluster.Sharding
                 TypeName = typeName;
                 EntityProps = entityProps;
                 Settings = settings;
-                IdExtractor = idIdExtractor;
-                ShardResolver = shardResolver;
+                ExtractEntityId = extractEntityId;
+                ExtractShardId = extractShardId;
                 AllocationStrategy = allocationStrategy;
                 HandOffStopMessage = handOffStopMessage;
             }
@@ -121,11 +121,11 @@ namespace Akka.Cluster.Sharding
             /// <summary>
             /// TBD
             /// </summary>
-            public readonly IdExtractor ExtractEntityId;
+            public readonly ExtractEntityId ExtractEntityId;
             /// <summary>
             /// TBD
             /// </summary>
-            public readonly ShardResolver ExtractShardId;
+            public readonly ExtractShardId ExtractShardId;
 
             /// <summary>
             /// TBD
@@ -137,7 +137,7 @@ namespace Akka.Cluster.Sharding
             /// <exception cref="ArgumentException">
             /// This exception is thrown when the specified <paramref name="typeName"/> is undefined.
             /// </exception>
-            public StartProxy(string typeName, ClusterShardingSettings settings, IdExtractor extractEntityId, ShardResolver extractShardId)
+            public StartProxy(string typeName, ClusterShardingSettings settings, ExtractEntityId extractEntityId, ExtractShardId extractShardId)
             {
                 if (string.IsNullOrEmpty(typeName)) throw new ArgumentNullException(nameof(typeName), "ClusterSharding start proxy requires type name to be provided");
 
@@ -184,8 +184,8 @@ namespace Akka.Cluster.Sharding
                             entityProps: start.EntityProps,
                             settings: settings,
                             coordinatorPath: coordinatorPath,
-                            extractEntityId: start.IdExtractor,
-                            extractShardId: start.ShardResolver,
+                            extractEntityId: start.ExtractEntityId,
+                            extractShardId: start.ExtractShardId,
                             handOffStopMessage: start.HandOffStopMessage).WithDispatcher(Context.Props.Dispatcher), encName);
                     }
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShard.cs
@@ -27,8 +27,8 @@ namespace Akka.Cluster.Sharding
             string shardId,
             Props entityProps,
             ClusterShardingSettings settings,
-            IdExtractor extractEntityId,
-            ShardResolver extractShardId,
+            ExtractEntityId extractEntityId,
+            ExtractShardId extractShardId,
             object handOffStopMessage)
         {
             _shardSemantic = new PersistentShard(
@@ -100,8 +100,8 @@ namespace Akka.Cluster.Sharding
             string shardId,
             Props entityProps,
             ClusterShardingSettings settings,
-            IdExtractor extractEntityId,
-            ShardResolver extractShardId,
+            ExtractEntityId extractEntityId,
+            ExtractShardId extractShardId,
             object handOffStopMessage)
             : base(context, unhandled, typeName, shardId, entityProps, settings, extractEntityId, extractShardId, handOffStopMessage)
         {

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
@@ -28,8 +28,8 @@ namespace Akka.Cluster.Sharding
             string shardId,
             Props entityProps,
             ClusterShardingSettings settings,
-            IdExtractor extractEntityId,
-            ShardResolver extractShardId,
+            ExtractEntityId extractEntityId,
+            ExtractShardId extractShardId,
             object handOffStopMessage)
         {
             _shardSemantic = new Shard(
@@ -308,8 +308,8 @@ namespace Akka.Cluster.Sharding
             ShardId shardId,
             Props entityProps,
             ClusterShardingSettings settings,
-            IdExtractor extractEntityId,
-            ShardResolver extractShardId,
+            ExtractEntityId extractEntityId,
+            ExtractShardId extractShardId,
             object handOffStopMessage)
         {
             if (settings.RememberEntities)
@@ -400,11 +400,11 @@ namespace Akka.Cluster.Sharding
         /// <summary>
         /// TBD
         /// </summary>
-        public readonly IdExtractor ExtractEntityId;
+        public readonly ExtractEntityId ExtractEntityId;
         /// <summary>
         /// TBD
         /// </summary>
-        public readonly ShardResolver ExtractShardId;
+        public readonly ExtractShardId ExtractShardId;
         /// <summary>
         /// TBD
         /// </summary>
@@ -457,8 +457,8 @@ namespace Akka.Cluster.Sharding
             string shardId,
             Props entityProps,
             ClusterShardingSettings settings,
-            IdExtractor extractEntityId,
-            ShardResolver extractShardId,
+            ExtractEntityId extractEntityId,
+            ExtractShardId extractShardId,
             object handOffStopMessage)
         {
             _context = context;


### PR DESCRIPTION
This PR renames some items to align with akka naming. This is a continuation of #2767

`idExtractor` rename to `extractEntityId`
`shardResolver` renamed to `extractShardId`