### PR TITLE
Use production Hyperion v0.9.5 instead of nightly

### DIFF
--- a/src/contrib/cluster/Akka.DistributedData/Akka.DistributedData.csproj
+++ b/src/contrib/cluster/Akka.DistributedData/Akka.DistributedData.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hyperion" version="0.9.5-beta" />
+    <PackageReference Include="Hyperion" version="0.9.5" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/src/contrib/serializers/Akka.Serialization.Hyperion/Akka.Serialization.Hyperion.csproj
+++ b/src/contrib/serializers/Akka.Serialization.Hyperion/Akka.Serialization.Hyperion.csproj
@@ -21,7 +21,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Hyperion" Version="0.9.5-beta" />
+    <PackageReference Include="Hyperion" Version="0.9.5" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <DefineConstants>$(DefineConstants);SERIALIZATION</DefineConstants>


### PR DESCRIPTION
Use production Hyperion v0.9.5 instead of nightly for Akka.Serialization.Hyperion and Akka.DistributedData