### PR TITLE
Improved Config performance

### DIFF
--- a/src/core/Akka/Configuration/Hocon/HoconObject.cs
+++ b/src/core/Akka/Configuration/Hocon/HoconObject.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Newtonsoft.Json;
+using System.Text.RegularExpressions;
 
 namespace Akka.Configuration.Hocon
 {
@@ -32,6 +33,8 @@ namespace Akka.Configuration.Hocon
     /// </summary>
     public class HoconObject : IHoconElement
     {
+        private static readonly Regex EscapeRegex = new Regex("[ \t:]{1}", RegexOptions.Compiled);
+
         /// <summary>
         /// Initializes a new instance of the <see cref="HoconObject"/> class.
         /// </summary>
@@ -165,10 +168,13 @@ namespace Akka.Configuration.Hocon
 
         private string QuoteIfNeeded(string text)
         {
-            if (text.ToCharArray().Intersect(" \t".ToCharArray()).Any())
+            if (text == null) return "";
+
+            if (EscapeRegex.IsMatch(text))
             {
                 return "\"" + text + "\"";
             }
+
             return text;
         }
 


### PR DESCRIPTION
## before
 |                               Method |           Mean |  Gen 0 | Allocated |
 |------------------------------------- |---------------:|-------:|----------:|
 |                    Config_GetBoolean |    534.1718 ns | 0.0100 |     344 B |
 |                        Config_GetInt |    612.6211 ns | 0.0100 |     344 B |
 |                       Config_GetLong |    632.0545 ns | 0.0097 |     344 B |
 |                     Config_GetString |    519.4849 ns | 0.0102 |     352 B |
 |                      Config_GetFloat |    684.5236 ns | 0.0101 |     352 B |
 |                     Config_GetDouble |    657.3743 ns | 0.0099 |     352 B |
 |                    Config_GetDecimal |    764.9903 ns | 0.0108 |     352 B |
 |                   Config_GetTimeSpan |  2,962.0917 ns | 0.0542 |    1976 B |
 |                 Config_GetStringList |  1,316.7996 ns | 0.0331 |    1120 B |
 |                      Config_ToString | 22,784.6902 ns | 0.6571 |   22049 B |
 |       Config_ToStringIncludeFallback | 22,382.5304 ns | 0.6449 |   22049 B |
 |        Config_Substitution_GetString |    870.9426 ns | 0.0179 |     640 B |
 | Config_Substitution_Concat_GetString |  1,023.8611 ns | 0.0220 |     768 B |
 
## after
 |                               Method |           Mean |  Gen 0 | Allocated |
 |------------------------------------- |---------------:|-------:|----------:|
 |                    Config_GetBoolean |    464.0734 ns | 0.0087 |     304 B |
 |                        Config_GetInt |    543.0760 ns | 0.0085 |     304 B |
 |                       Config_GetLong |    624.9176 ns | 0.0081 |     304 B |
 |                     Config_GetString |    456.2888 ns | 0.0089 |     312 B |
 |                      Config_GetFloat |    605.1826 ns | 0.0084 |     312 B |
 |                     Config_GetDouble |    575.6793 ns | 0.0089 |     312 B |
 |                    Config_GetDecimal |    628.3461 ns | 0.0085 |     312 B |
 |                   Config_GetTimeSpan |  1,852.3602 ns | 0.0336 |    1184 B |
 |                 Config_GetStringList |  1,226.7296 ns | 0.0304 |    1040 B |
 |                      Config_ToString | 17,009.3570 ns | 0.4130 |   14697 B |
 |       Config_ToStringIncludeFallback | 17,237.8764 ns | 0.4089 |   14697 B |
 |        Config_Substitution_GetString |    786.1535 ns | 0.0141 |     520 B |
 | Config_Substitution_Concat_GetString |    957.7990 ns | 0.0177 |     648 B |