### PR TITLE
Address & UniqueAddres -> IComparable interface

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCluster.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCluster.approved.txt
@@ -231,12 +231,12 @@ namespace Akka.Cluster
         public Akka.Actor.Props DowningActorProps { get; }
         public System.TimeSpan DownRemovalMargin { get; }
     }
-    public class UniqueAddress : System.IComparable<Akka.Cluster.UniqueAddress>, System.IEquatable<Akka.Cluster.UniqueAddress>
+    public class UniqueAddress : System.IComparable, System.IComparable<Akka.Cluster.UniqueAddress>, System.IEquatable<Akka.Cluster.UniqueAddress>
     {
         public UniqueAddress(Akka.Actor.Address address, int uid) { }
         public Akka.Actor.Address Address { get; }
         public int Uid { get; }
-        public int CompareTo(Akka.Cluster.UniqueAddress that) { }
+        public int CompareTo(Akka.Cluster.UniqueAddress uniqueAddress) { }
         public bool Equals(Akka.Cluster.UniqueAddress other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCluster.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCluster.approved.txt
@@ -196,7 +196,7 @@ namespace Akka.Cluster
         Akka.Actor.Props DowningActorProps { get; }
         System.TimeSpan DownRemovalMargin { get; }
     }
-    public class Member : System.IComparable<Akka.Cluster.Member>
+    public class Member : System.IComparable, System.IComparable<Akka.Cluster.Member>
     {
         public static readonly System.Collections.Generic.IComparer<Akka.Actor.Address> AddressOrdering;
         public Akka.Actor.Address Address { get; }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -364,9 +364,10 @@ namespace Akka.Actor
             where T :  class, Akka.Actor.IExtension
             where TI : Akka.Actor.IExtensionId { }
     }
-    public sealed class Address : Akka.Util.ISurrogated, System.ICloneable, System.IEquatable<Akka.Actor.Address>
+    public sealed class Address : Akka.Util.ISurrogated, System.ICloneable, System.IComparable, System.IComparable<Akka.Actor.Address>, System.IEquatable<Akka.Actor.Address>
     {
         public static readonly Akka.Actor.Address AllSystems;
+        public static readonly System.Collections.Generic.IComparer<Akka.Actor.Address> Comparer;
         public Address(string protocol, string system, string host = null, System.Nullable<int> port = null) { }
         public bool HasGlobalScope { get; }
         public bool HasLocalScope { get; }
@@ -375,6 +376,7 @@ namespace Akka.Actor
         public string Protocol { get; }
         public string System { get; }
         public object Clone() { }
+        public int CompareTo(Akka.Actor.Address other) { }
         public bool Equals(Akka.Actor.Address other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }

--- a/src/core/Akka.Cluster.Tests/MemberOrderingSpec.cs
+++ b/src/core/Akka.Cluster.Tests/MemberOrderingSpec.cs
@@ -20,7 +20,7 @@ namespace Akka.Cluster.Tests
         [Fact]
         public void MemberOrdering_must_order_members_by_host_and_port()
         {
-            var members = new SortedSet<Member>         
+            var members = new SortedSet<Member>       
             {
                 TestMember.Create(Address.Parse("akka://sys@darkstar:1112"), MemberStatus.Up),
                 TestMember.Create(Address.Parse("akka://sys@darkstar:1113"), MemberStatus.Joining),

--- a/src/core/Akka.Cluster/Member.cs
+++ b/src/core/Akka.Cluster/Member.cs
@@ -420,7 +420,7 @@ namespace Akka.Cluster
     /// The `uid` is needed to be able to distinguish different
     /// incarnations of a member with same hostname and port.
     /// </summary>
-    public class UniqueAddress : IComparable<UniqueAddress>, IEquatable<UniqueAddress>
+    public class UniqueAddress : IComparable<UniqueAddress>, IEquatable<UniqueAddress>, IComparable
     {
         /// <summary>
         /// The bound listening address for Akka.Remote.
@@ -468,16 +468,21 @@ namespace Akka.Cluster
         /// <summary>
         /// TBD
         /// </summary>
-        /// <param name="that">TBD</param>
+        /// <param name="uniqueAddress">TBD</param>
         /// <returns>TBD</returns>
-        public int CompareTo(UniqueAddress that)
+        public int CompareTo(UniqueAddress uniqueAddress)
         {
-            var result = Member.AddressOrdering.Compare(Address, that.Address);
-            if (result == 0)
-                if (Uid < that.Uid) return -1;
-                else if (Uid == that.Uid) return 0;
-                else return 1;
-            return result;
+            if (uniqueAddress == null) throw new ArgumentNullException(nameof(uniqueAddress));
+
+            var result = Address.Comparer.Compare(Address, uniqueAddress.Address);
+            return result == 0 ? Uid.CompareTo(uniqueAddress.Uid) : result;
+        }
+
+        int IComparable.CompareTo(object obj)
+        {
+            if (obj is UniqueAddress address) return CompareTo(address);
+
+            throw new ArgumentException($"Cannot compare {nameof(UniqueAddress)} with instance of type '{obj?.GetType().FullName ?? "null"}'.");
         }
 
         /// <inheritdoc cref="object.ToString"/>

--- a/src/core/Akka/Actor/Address.cs
+++ b/src/core/Akka/Actor/Address.cs
@@ -45,7 +45,7 @@ namespace Akka.Actor
                 if (result != 0) return result;
                 result = string.CompareOrdinal(x.Host ?? "", y.Host ?? "");
                 if (result != 0) return result;
-                result = Nullable.Compare(x.Port, x.Port);
+                result = (x.Port ?? 0).CompareTo(y.Port ?? 0);
                 return result;
             }
         }


### PR DESCRIPTION
This PR introduces an `IComparable<>`/`IComparable` interface implementations for both `Address`/`UniqueAddress`, which should help to fix #3010 and allow us to keep our implementations in line with Akka JVM code.

**WARNING: There is a difference in `UniqueAddress.CompareTo(UniqueAddress)` implementation!** Previously to compare address parts, a `Member.AddressOrdering` was used. This was different from JVM implementation, which by default uses `Address.addressOrdering`. The difference between the two is that the first one ignores the protocol and system name part of the address during comparison.