### PR TITLE
Improving Support for OSX & Rider

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -447,7 +447,11 @@ Target "PublishNuget" (fun _ ->
 // Serialization
 //--------------------------------------------------------------------------------
 Target "Protobuf" <| fun _ ->
-    let protocPath = findToolInSubPath "protoc.exe" "src/packages/Google.Protobuf.Tools/tools/windows_x64"
+
+    let protocPath =
+        if isWindows then findToolInSubPath "protoc.exe" "src/packages/Google.Protobuf.Tools/tools/windows_x64"
+        elif isMacOS then findToolInSubPath "protoc" "src/packages/Google.Protobuf.Tools/tools/macosx_x64"
+        else findToolInSubPath "protoc" "src/packages/Google.Protobuf.Tools/tools/linux_x64"
 
     let protoFiles = [
         ("WireFormats.proto", "/src/core/Akka.Remote/Serialization/Proto/");
@@ -465,7 +469,8 @@ Target "Protobuf" <| fun _ ->
     let runProtobuf assembly =
         let protoName, destinationPath = assembly
         let args = StringBuilder()
-                |> append (sprintf "-I=%s;%s" (__SOURCE_DIRECTORY__ @@ "/src/protobuf/") (__SOURCE_DIRECTORY__ @@ "/src/protobuf/common") )
+                |> append (sprintf "-I=%s" (__SOURCE_DIRECTORY__ @@ "/src/protobuf/") )
+                |> append (sprintf "-I=%s" (__SOURCE_DIRECTORY__ @@ "/src/protobuf/common") )
                 |> append (sprintf "--csharp_out=internal_access:%s" (__SOURCE_DIRECTORY__ @@ destinationPath))
                 |> append "--csharp_opt=file_extension=.g.cs"
                 |> append (__SOURCE_DIRECTORY__ @@ "/src/protobuf" @@ protoName)

--- a/build.sh
+++ b/build.sh
@@ -51,12 +51,13 @@ if [ ! -f "$DOTNET_EXE" ]; then
     fi
     curl -Lsfo "$SCRIPT_DIR/.dotnet/dotnet-install.sh" $DOTNET_INSTALLER_URL
     bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version $DOTNET_VERSION --install-dir .dotnet --no-path
-    export PATH="$SCRIPT_DIR/.dotnet":$PATH
-    export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-    export DOTNET_CLI_TELEMETRY_OPTOUT=1
-    chmod -R 0755 ".dotnet"
-    "$SCRIPT_DIR/.dotnet/dotnet" --info
 fi
+
+export PATH="$SCRIPT_DIR/.dotnet":$PATH
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+chmod -R 0755 ".dotnet"
+"$SCRIPT_DIR/.dotnet/dotnet" --info
 
 ###########################################################################
 # INSTALL NUGET
@@ -94,7 +95,6 @@ fi
 # INSTALL PROTOC
 ###########################################################################
 
-unameOut="$(uname -s)"
 if [[ $(uname -s) == Darwin* ]]; then
     PROTOC_EXE="src/packages/Google.Protobuf.Tools/tools/macosx_x64/protoc"
 else

--- a/src/contrib/cluster/Akka.DistributedData.LightningDB/Akka.DistributedData.LightningDB.csproj
+++ b/src/contrib/cluster/Akka.DistributedData.LightningDB/Akka.DistributedData.LightningDB.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LightningDB" version="0.9.8" />
+    <PackageReference Include="LightningDB" Version="0.9.8" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/contrib/cluster/Akka.DistributedData/Akka.DistributedData.csproj
+++ b/src/contrib/cluster/Akka.DistributedData/Akka.DistributedData.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hyperion" version="0.9.6" />
+    <PackageReference Include="Hyperion" Version="0.9.6" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/src/contrib/dependencyinjection/Akka.DI.Core/Akka.DI.Core.csproj
+++ b/src/contrib/dependencyinjection/Akka.DI.Core/Akka.DI.Core.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.2" />
   </ItemGroup>
 
 

--- a/src/core/Akka.Remote/Akka.Remote.csproj
+++ b/src/core/Akka.Remote/Akka.Remote.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\common.props" />
-
   <PropertyGroup>
     <AssemblyTitle>Akka.Remote</AssemblyTitle>
     <Description>Remote actor support for Akka.NET</Description>
@@ -9,35 +8,27 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <EmbeddedResource Include="Configuration\Remote.conf" />
     <ProjectReference Include="..\Akka\Akka.csproj" />
   </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="DotNetty.Handlers" version="0.4.6" />
+    <PackageReference Include="DotNetty.Handlers" Version="0.4.6" />
     <PackageReference Include="Google.Protobuf" Version="3.3.0" />
   </ItemGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <DefineConstants>$(DefineConstants);SERIALIZATION</DefineConstants>
   </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard1.6|AnyCPU'">
     <Optimize>False</Optimize>
   </PropertyGroup>
-
   <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
-
 </Project>

--- a/src/core/Akka.Streams/Akka.Streams.csproj
+++ b/src/core/Akka.Streams/Akka.Streams.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\common.props" />
-
   <PropertyGroup>
     <AssemblyTitle>Akka.Streams</AssemblyTitle>
     <Description>Reactive stream support for Akka.NET</Description>
@@ -9,21 +8,16 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <EmbeddedResource Include="reference.conf" />
     <ProjectReference Include="..\Akka\Akka.csproj" />
-    <PackageReference Include="Reactive.Streams" version="1.0.2" />
   </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
     <PackageReference Include="System.Reflection.TypeExtensions" version="4.3.0" />
   </ItemGroup>
-
   <ItemGroup>
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
   </ItemGroup>
-
   <ItemGroup>
     <None Update="CodeGen\Dsl\GraphApply.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
@@ -71,21 +65,19 @@
       <DependentUpon>FanOutShape.tt</DependentUpon>
     </Compile>
   </ItemGroup>
-
+  <ItemGroup>
+    <PackageReference Include="Reactive.Streams" Version="1.0.2" />
+  </ItemGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <DefineConstants>$(DefineConstants);SERIALIZATION;CLONEABLE;AKKAIO</DefineConstants>
   </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard1.6|AnyCPU'">
     <Optimize>False</Optimize>
   </PropertyGroup>
-
 </Project>


### PR DESCRIPTION
* Rider/OSX appears to be less forgiving around the csproj format and requires that the nuget dependencies use Version and not version.
* Updated the build.sh script to only install dotnet once and also to pull down protoc from nuget.
* The FAKE build has been updated to support building the Protobuf target on OSX & Linux