### PR TITLE
fix 3021 - returned Akka.IO.Tcp semantics to use synchronous write

### DIFF
--- a/src/core/Akka.Tests/IO/TcpIntegrationSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpIntegrationSpec.cs
@@ -144,6 +144,27 @@ namespace Akka.Tests.IO
             });
         }
 
+        [Fact]
+        public void BugFix_3021_Tcp_Should_not_drop_large_messages()
+        {
+            new TestSetup(this).Run(x =>
+            {
+                var actors = x.EstablishNewClientConnection();
+
+                // create a 256 byte string
+                var str = Enumerable.Repeat("f", 128).Join("");
+                var testData = ByteString.FromString(str);
+
+                // queue 3 writes
+                actors.ClientHandler.Send(actors.ClientConnection, Tcp.Write.Create(testData));
+                actors.ClientHandler.Send(actors.ClientConnection, Tcp.Write.Create(testData));
+                actors.ClientHandler.Send(actors.ClientConnection, Tcp.Write.Create(testData));
+
+                var serverMsgs = actors.ServerHandler.ReceiveN(3, TimeSpan.FromMinutes(10));
+                
+            });
+        }
+
         class Aye : Tcp.Event { public static readonly Aye Instance = new Aye();}
         class Yes : Tcp.Event { public static readonly Yes Instance = new Yes();}
         [Fact]

--- a/src/core/Akka/IO/TcpConnection.cs
+++ b/src/core/Akka/IO/TcpConnection.cs
@@ -859,11 +859,6 @@ namespace Akka.IO
             }
 
             public override void Release() { }
-
-            public PendingWrite Copy(ByteString newData)
-            {
-                return new PendingBufferWrite(_connection, _sendArgs, _self, Commander, newData, Ack, _tail);
-            }
         }
     }
 }


### PR DESCRIPTION
TL;DR;, the design of this class as it currently stands is a port of the JVM and all of its semantics around queueing pending writes, backpressure, etc, all depend on synchronous socket sends. We still use async socket reads - those work fine. But all writes are performed synchronously as of this PR.

This resolves the issue I outlined in #3021 and makes it possible to queue writes with Akka.IO.Tcp again.