### PR TITLE
Added support for SerializerWithStringManifest to Akka.Persistence.Sql.Common

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/BatchingSqlJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/BatchingSqlJournal.cs
@@ -1161,7 +1161,8 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// <param name="tags">Optional tags extracted from persistent event payload.</param>
         protected virtual void WriteEvent(TCommand command, IPersistentRepresentation persistent, string tags = "")
         {
-            var serializer = _serialization.FindSerializerFor(persistent.Payload);
+            var payloadType = persistent.Payload.GetType();
+            var serializer = _serialization.FindSerializerForType(payloadType, Setup.DefaultSerializer);
 
             string manifest = "";
             if (serializer is SerializerWithStringManifest)

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/BatchingSqlJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/BatchingSqlJournal.cs
@@ -19,6 +19,7 @@ using Akka.Configuration;
 using Akka.Event;
 using Akka.Pattern;
 using Akka.Persistence.Journal;
+using Akka.Serialization;
 using Akka.Util;
 
 namespace Akka.Persistence.Sql.Common.Journal
@@ -421,9 +422,14 @@ namespace Akka.Persistence.Sql.Common.Journal
         protected const int PayloadIndex = 5;
 
         /// <summary>
+        /// Default index of <see cref="Serializer.Identifier"/>
+        /// </summary>
+        protected const int SerializerIdIndex = 6;
+
+        /// <summary>
         /// Default index of tags column get from <see cref="ByTagSql"/> query.
         /// </summary>
-        protected const int OrderingIndex = 6;
+        protected const int OrderingIndex = 7;
 
         /// <summary>
         /// SQL query executed as result of <see cref="DeleteMessagesTo"/> request to journal.
@@ -549,7 +555,8 @@ namespace Akka.Persistence.Sql.Common.Journal
                 e.{conventions.TimestampColumnName} as Timestamp, 
                 e.{conventions.IsDeletedColumnName} as IsDeleted, 
                 e.{conventions.ManifestColumnName} as Manifest, 
-                e.{conventions.PayloadColumnName} as Payload";
+                e.{conventions.PayloadColumnName} as Payload,
+                e.{conventions.SerializerIdColumnName} as SerializerId";
 
             AllPersistenceIdsSql = $@"
                 SELECT DISTINCT e.{conventions.PersistenceIdColumnName} as PersistenceId 
@@ -593,7 +600,8 @@ namespace Akka.Persistence.Sql.Common.Journal
                     {conventions.IsDeletedColumnName},
                     {conventions.ManifestColumnName},
                     {conventions.PayloadColumnName},
-                    {conventions.TagsColumnName}
+                    {conventions.TagsColumnName},
+                    {conventions.SerializerIdColumnName}
                 ) VALUES (
                     @PersistenceId, 
                     @SequenceNr,
@@ -601,7 +609,8 @@ namespace Akka.Persistence.Sql.Common.Journal
                     @IsDeleted,
                     @Manifest,
                     @Payload,
-                    @Tag
+                    @Tag,
+                    @SerializerId
                 )";
         }
 
@@ -1152,11 +1161,21 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// <param name="tags">Optional tags extracted from persistent event payload.</param>
         protected virtual void WriteEvent(TCommand command, IPersistentRepresentation persistent, string tags = "")
         {
-            var payloadType = persistent.Payload.GetType();
-            var manifest = string.IsNullOrEmpty(persistent.Manifest)
-                ? payloadType.TypeQualifiedName()
-                : persistent.Manifest;
-            var serializer = _serialization.FindSerializerForType(payloadType, Setup.DefaultSerializer);
+            var serializer = _serialization.FindSerializerFor(persistent.Payload);
+
+            string manifest = "";
+            if (serializer is SerializerWithStringManifest)
+            {
+                manifest = ((SerializerWithStringManifest)serializer).Manifest(persistent.Payload);
+            }
+            else
+            {
+                if (serializer.IncludeManifest)
+                {
+                    manifest = persistent.Payload.GetType().TypeQualifiedName();
+                }
+            }
+
             var binary = serializer.ToBinary(persistent.Payload);
 
             AddParameter(command, "@PersistenceId", DbType.String, persistent.PersistenceId);
@@ -1166,6 +1185,7 @@ namespace Akka.Persistence.Sql.Common.Journal
             AddParameter(command, "@Manifest", DbType.String, manifest);
             AddParameter(command, "@Payload", DbType.Binary, binary);
             AddParameter(command, "@Tag", DbType.String, tags);
+            AddParameter(command, "@SerializerId", DbType.Int32, serializer.Identifier);
         }
 
         /// <summary>
@@ -1181,12 +1201,21 @@ namespace Akka.Persistence.Sql.Common.Journal
             var manifest = reader.GetString(ManifestIndex);
             var payload = reader[PayloadIndex];
 
-            var type = Type.GetType(manifest, true);
-            var deserializer = _serialization.FindSerializerForType(type, Setup.DefaultSerializer);
-            var deserialized = deserializer.FromBinary((byte[])payload, type);
+            object deserialized;
+            if (reader.IsDBNull(SerializerIdIndex))
+            {
+                // Support old writes that did not set the serializer id
+                var type = Type.GetType(manifest, true);
+                var deserializer = _serialization.FindSerializerForType(type, Setup.DefaultSerializer);
+                deserialized = deserializer.FromBinary((byte[])payload, type);
+            }
+            else
+            {
+                var serializerId = reader.GetInt32(SerializerIdIndex);
+                deserialized = _serialization.Deserialize((byte[])payload, serializerId, manifest);
+            }
 
-            var persistent = new Persistent(deserialized, sequenceNr, persistenceId, manifest, isDeleted, ActorRefs.NoSender, null);
-            return persistent;
+            return new Persistent(deserialized, sequenceNr, persistenceId, manifest, isDeleted, ActorRefs.NoSender, null);
         }
 
         /// <summary>

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryExecutor.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryExecutor.cs
@@ -6,7 +6,6 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Data;
 using System.Data.Common;
@@ -15,6 +14,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Serialization;
 using Akka.Util;
 
 namespace Akka.Persistence.Sql.Common.Journal
@@ -156,6 +156,10 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// TBD
         /// </summary>
         public readonly string OrderingColumnName;
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public readonly string SerializerIdColumnName;
 
         /// <summary>
         /// TBD
@@ -181,6 +185,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// <param name="isDeletedColumnName">TBD</param>
         /// <param name="tagsColumnName">TBD</param>
         /// <param name="orderingColumnName">TBD</param>
+        /// <param name="serializerIdColumnName">TBD</param>
         /// <param name="timeout">TBD</param>
         /// <param name="defaultSerializer">The default serializer used when not type override matching is found</param>
         public QueryConfiguration(
@@ -195,6 +200,7 @@ namespace Akka.Persistence.Sql.Common.Journal
             string isDeletedColumnName,
             string tagsColumnName,
             string orderingColumnName,
+            string serializerIdColumnName,
             TimeSpan timeout,
             string defaultSerializer)
         {
@@ -211,6 +217,7 @@ namespace Akka.Persistence.Sql.Common.Journal
             TagsColumnName = tagsColumnName;
             OrderingColumnName = orderingColumnName;
             DefaultSerializer = defaultSerializer;
+            SerializerIdColumnName = serializerIdColumnName;
         }
 
         /// <summary>
@@ -257,7 +264,11 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// <summary>
         /// TBD
         /// </summary>
-        protected const int OrderingIndex = 6;
+        protected const int SerializerIdIndex = 6;
+        /// <summary>
+        /// TBD
+        /// </summary>
+        protected const int OrderingIndex = 7;
 
         /// <summary>
         /// TBD
@@ -295,7 +306,8 @@ namespace Akka.Persistence.Sql.Common.Journal
                 e.{Configuration.TimestampColumnName} as Timestamp, 
                 e.{Configuration.IsDeletedColumnName} as IsDeleted, 
                 e.{Configuration.ManifestColumnName} as Manifest, 
-                e.{Configuration.PayloadColumnName} as Payload";
+                e.{Configuration.PayloadColumnName} as Payload,
+                e.{Configuration.SerializerIdColumnName} as SerializerId";
 
             AllPersistenceIdsSql = $@"
                 SELECT DISTINCT e.{Configuration.PersistenceIdColumnName} as PersistenceId 
@@ -339,7 +351,8 @@ namespace Akka.Persistence.Sql.Common.Journal
                     {Configuration.IsDeletedColumnName},
                     {Configuration.ManifestColumnName},
                     {Configuration.PayloadColumnName},
-                    {Configuration.TagsColumnName}
+                    {Configuration.TagsColumnName},
+                    {Configuration.SerializerIdColumnName}
                 ) VALUES (
                     @PersistenceId, 
                     @SequenceNr,
@@ -347,7 +360,8 @@ namespace Akka.Persistence.Sql.Common.Journal
                     @IsDeleted,
                     @Manifest,
                     @Payload,
-                    @Tag
+                    @Tag,
+                    @SerializerId
                 )";
 
             QueryEventsSql = $@"
@@ -627,8 +641,21 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// <returns>TBD</returns>
         protected virtual void WriteEvent(DbCommand command, IPersistentRepresentation e, IImmutableSet<string> tags)
         {
-            var manifest = string.IsNullOrEmpty(e.Manifest) ? e.Payload.GetType().TypeQualifiedName() : e.Manifest;
             var serializer = Serialization.FindSerializerFor(e.Payload);
+
+            string manifest = "";
+            if (serializer is SerializerWithStringManifest)
+            {
+                manifest = ((SerializerWithStringManifest)serializer).Manifest(e.Payload);
+            }
+            else
+            {
+                if (serializer.IncludeManifest)
+                {
+                    manifest = e.Payload.GetType().TypeQualifiedName();
+                }
+            }
+
             var binary = serializer.ToBinary(e.Payload);
 
             AddParameter(command, "@PersistenceId", DbType.String, e.PersistenceId);
@@ -637,6 +664,7 @@ namespace Akka.Persistence.Sql.Common.Journal
             AddParameter(command, "@IsDeleted", DbType.Boolean, false);
             AddParameter(command, "@Manifest", DbType.String, manifest);
             AddParameter(command, "@Payload", DbType.Binary, binary);
+            AddParameter(command, "@SerializerId", DbType.Int32, serializer.Identifier);
 
             if (tags.Count != 0)
             {
@@ -665,9 +693,19 @@ namespace Akka.Persistence.Sql.Common.Journal
             var manifest = reader.GetString(ManifestIndex);
             var payload = reader[PayloadIndex];
 
-            var type = Type.GetType(manifest, true);
-            var deserializer = Serialization.FindSerializerForType(type, Configuration.DefaultSerializer);
-            var deserialized = deserializer.FromBinary((byte[])payload, type);
+            object deserialized;
+            if (reader.IsDBNull(SerializerIdIndex))
+            {
+                // Support old writes that did not set the serializer id
+                var type = Type.GetType(manifest, true);
+                var deserializer = Serialization.FindSerializerForType(type, Configuration.DefaultSerializer);
+                deserialized = deserializer.FromBinary((byte[])payload, type);
+            }
+            else
+            {
+                var serializerId = reader.GetInt32(SerializerIdIndex);
+                deserialized = Serialization.Deserialize((byte[])payload, serializerId, manifest);
+            }
 
             return new Persistent(deserialized, sequenceNr, persistenceId, manifest, isDeleted, ActorRefs.NoSender, null);
         }

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryExecutor.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryExecutor.cs
@@ -641,7 +641,8 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// <returns>TBD</returns>
         protected virtual void WriteEvent(DbCommand command, IPersistentRepresentation e, IImmutableSet<string> tags)
         {
-            var serializer = Serialization.FindSerializerFor(e.Payload);
+            var payloadType = e.Payload.GetType();
+            var serializer = Serialization.FindSerializerForType(payloadType, Configuration.DefaultSerializer);
 
             string manifest = "";
             if (serializer is SerializerWithStringManifest)

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Serialization/SqliteJournalSerializationSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Serialization/SqliteJournalSerializationSpec.cs
@@ -47,11 +47,6 @@ namespace Akka.Persistence.Sqlite.Tests.Serialization
                 }");
         }
 
-        [Fact(Skip = "Sql plugin does not support SerializerWithStringManifest")]
-        public override void Journal_should_serialize_Persistent_with_string_manifest()
-        {
-        }
-
         [Fact(Skip = "Sql plugin does not support EventAdapter.Manifest")]
         public override void Journal_should_serialize_Persistent_with_EventAdapter_manifest()
         {

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Serialization/SqliteSnapshotStoreSerializationSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Serialization/SqliteSnapshotStoreSerializationSpec.cs
@@ -39,10 +39,5 @@ namespace Akka.Persistence.Sqlite.Tests.Serialization
                     }
                 }");
         }
-
-        [Fact(Skip = "Sql plugin does not support SerializerWithStringManifest")]
-        public override void SnapshotStore_should_serialize_Payload_with_string_manifest()
-        {
-        }
     }
 }

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/BatchingSqliteJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/BatchingSqliteJournal.cs
@@ -38,6 +38,7 @@ namespace Akka.Persistence.Sqlite.Journal
                     isDeletedColumnName: "is_deleted",
                     tagsColumnName: "tags",
                     orderingColumnName: "ordering",
+                    serializerIdColumnName: "serializer_id",
                     timeout: config.GetTimeSpan("connection-timeout"),
                     defaultSerializer: config.GetString("serializer")))
         {
@@ -104,6 +105,7 @@ namespace Akka.Persistence.Sqlite.Journal
                     {conventions.TimestampColumnName} INTEGER NOT NULL,
                     {conventions.PayloadColumnName} BLOB NOT NULL,
                     {conventions.TagsColumnName} VARCHAR(2000) NULL,
+                    {conventions.SerializerIdColumnName} INTEGER(4),
                     UNIQUE ({conventions.PersistenceIdColumnName}, {conventions.SequenceNrColumnName})
                 );"),
                 new KeyValuePair<string, string>("CreateMetadataSql", $@"

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/SqliteJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/SqliteJournal.cs
@@ -41,6 +41,7 @@ namespace Akka.Persistence.Sqlite.Journal
                 isDeletedColumnName: "is_deleted",
                 tagsColumnName: "tags",
                 orderingColumnName: "ordering",
+                serializerIdColumnName: "serializer_id",
                 timeout: config.GetTimeSpan("connection-timeout"),
                 defaultSerializer: config.GetString("serializer")), 
                     Context.System.Serialization, 

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/SqliteQueryExecutor.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/SqliteQueryExecutor.cs
@@ -37,6 +37,7 @@ namespace Akka.Persistence.Sqlite.Journal
                     {configuration.TimestampColumnName} INTEGER NOT NULL,
                     {configuration.PayloadColumnName} BLOB NOT NULL,
                     {configuration.TagsColumnName} VARCHAR(2000) NULL,
+                    {configuration.SerializerIdColumnName} INTEGER(4),
                     UNIQUE ({configuration.PersistenceIdColumnName}, {configuration.SequenceNrColumnName})
                 );";
 

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Snapshot/SqliteSnapshotStore.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Snapshot/SqliteSnapshotStore.cs
@@ -33,15 +33,19 @@ namespace Akka.Persistence.Sqlite.Snapshot
                     {configuration.TimestampColumnName} INTEGER(8) NOT NULL,
                     {configuration.ManifestColumnName} VARCHAR(255) NOT NULL,
                     {configuration.PayloadColumnName} BLOB NOT NULL,
+                    {configuration.SerializerIdColumnName} INTEGER(4),
                     PRIMARY KEY ({configuration.PersistenceIdColumnName}, {configuration.SequenceNrColumnName})
                 );";
 
             InsertSnapshotSql = $@"
                 UPDATE {configuration.FullSnapshotTableName}
-                SET {configuration.TimestampColumnName} = @Timestamp, {configuration.ManifestColumnName} = @Manifest, {configuration.PayloadColumnName} = @Payload
+                SET {configuration.TimestampColumnName} = @Timestamp, {configuration.ManifestColumnName} = @Manifest,
+                {configuration.PayloadColumnName} = @Payload, {configuration.SerializerIdColumnName} = @SerializerId
                 WHERE {configuration.PersistenceIdColumnName} = @PersistenceId AND {configuration.SequenceNrColumnName} = @SequenceNr;
-                INSERT OR IGNORE INTO {configuration.FullSnapshotTableName} ({configuration.PersistenceIdColumnName}, {configuration.SequenceNrColumnName}, {configuration.TimestampColumnName}, {configuration.ManifestColumnName}, {configuration.PayloadColumnName})
-                VALUES (@PersistenceId, @SequenceNr, @Timestamp, @Manifest, @Payload)";
+                INSERT OR IGNORE INTO {configuration.FullSnapshotTableName} ({configuration.PersistenceIdColumnName},
+                    {configuration.SequenceNrColumnName}, {configuration.TimestampColumnName},
+                    {configuration.ManifestColumnName}, {configuration.PayloadColumnName}, {configuration.SerializerIdColumnName})
+                VALUES (@PersistenceId, @SequenceNr, @Timestamp, @Manifest, @Payload, @SerializerId)";
         }
 
         /// <summary>
@@ -115,6 +119,7 @@ namespace Akka.Persistence.Sqlite.Snapshot
                 payloadColumnName: "payload",
                 manifestColumnName: "manifest",
                 timestampColumnName: "created_at",
+                serializerIdColumnName: "serializer_id",
                 timeout: config.GetTimeSpan("connection-timeout"),
                 defaultSerializer: config.GetString("serializer")), 
                 Context.System.Serialization);


### PR DESCRIPTION
This addresses #3019

* Added a serializer id to the sql columns
* Updated how the manifest is set to support SerializerWithStringManifest
* ReadEvent should be backwards compatible