### PR TITLE
Added a local journal plugin backed by disk

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
@@ -1004,6 +1004,16 @@ namespace Akka.Persistence.Journal
         string Manifest(object evt);
         object ToJournal(object evt);
     }
+    public class LocalJournal : Akka.Persistence.Journal.AsyncWriteJournal
+    {
+        public LocalJournal(Akka.Configuration.Config journalConfig) { }
+        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr) { }
+        public Akka.Persistence.IPersistentRepresentation Load(System.IO.FileInfo file) { }
+        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr) { }
+        public override System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback) { }
+        protected System.IO.FileInfo WithOutputStream(Akka.Persistence.IPersistentRepresentation payload, System.Action<System.IO.Stream> p) { }
+        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages) { }
+    }
     public class MemoryJournal : Akka.Persistence.Journal.AsyncWriteJournal
     {
         public MemoryJournal() { }

--- a/src/core/Akka.Persistence.TCK.Tests/Akka.Persistence.TCK.Tests.csproj
+++ b/src/core/Akka.Persistence.TCK.Tests/Akka.Persistence.TCK.Tests.csproj
@@ -1,15 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\common.props" />
-
   <PropertyGroup>
     <AssemblyTitle>Akka.Persistence.TCK.Tests</AssemblyTitle>
     <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
- 
   <ItemGroup>
     <ProjectReference Include="..\Akka.Persistence.TCK\Akka.Persistence.TCK.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
@@ -17,19 +14,15 @@
     <DotNetCliToolReference Include="dotnet-xunit" Version="$(XunitVersion)" />
     <PackageReference Include="FluentAssertions" Version="4.14.0" />
   </ItemGroup>
-
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <DefineConstants>$(DefineConstants);SERIALIZABLE</DefineConstants>
   </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Persistence.TCK.Tests/LocalJournalSpec.cs
+++ b/src/core/Akka.Persistence.TCK.Tests/LocalJournalSpec.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Akka.Configuration;
+using Akka.Persistence.TCK.Journal;
+using Akka.Persistence.TestKit.Tests;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.TCK.Tests
+{
+    public class LocalJournalSpec: JournalSpec
+    {
+        private readonly string _path;
+
+        protected override bool SupportsRejectingNonSerializableObjects {
+            get { return false; }
+        }
+
+        public LocalJournalSpec(ITestOutputHelper output) : base(ConfigurationFactory.ParseString($@"
+            akka.test.timefactor = 3
+            akka.persistence.journal.plugin = ""akka.persistence.journal.local""
+            akka.persistence.journal.local.dir = ""target/journals-{Guid.NewGuid()}"""), "LocalJournalSpec", output)
+        {
+            _path = Sys.Settings.Config.GetString("akka.persistence.journal.local.dir");
+            Sys.CreateStorageLocations(_path);
+            Initialize();
+        }
+        
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            Sys.DeleteStorageLocations(_path);
+        }
+    }
+}

--- a/src/core/Akka.Persistence.Tests/Akka.Persistence.Tests.csproj
+++ b/src/core/Akka.Persistence.Tests/Akka.Persistence.Tests.csproj
@@ -1,18 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\common.props" />
-
   <PropertyGroup>
     <AssemblyTitle>Akka.Persistence.Tests</AssemblyTitle>
     <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\contrib\serializers\Akka.Serialization.Hyperion\Akka.Serialization.Hyperion.csproj" />
     <ProjectReference Include="..\Akka.Persistence\Akka.Persistence.csproj" />
     <ProjectReference Include="..\Akka.Remote\Akka.Remote.csproj" />
     <ProjectReference Include="..\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
@@ -20,19 +17,15 @@
     <DotNetCliToolReference Include="dotnet-xunit" Version="$(XunitVersion)" />
     <PackageReference Include="FluentAssertions" Version="4.14.0" />
   </ItemGroup>
-
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <DefineConstants>$(DefineConstants);SERIALIZABLE</DefineConstants>
   </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Persistence/Journal/LocalJournal.cs
+++ b/src/core/Akka.Persistence/Journal/LocalJournal.cs
@@ -1,0 +1,257 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Dispatch;
+using Akka.Event;
+
+namespace Akka.Persistence.Journal
+{
+    public class LocalJournal : AsyncWriteJournal
+    {
+        private const string TempFileExtension = ".tmp";
+        private const string BackupFileExtension = ".bak";
+
+        private readonly MessageDispatcher _streamDispatcher;
+        private readonly DirectoryInfo _dir;
+
+        private readonly Akka.Serialization.Serialization _serialization;
+        private readonly ILoggingAdapter _log;
+
+        public LocalJournal(Config journalConfig)
+        {
+            _streamDispatcher = Context.System.Dispatchers.Lookup(journalConfig.GetString("stream-dispatcher"));
+            _dir = new DirectoryInfo(journalConfig.GetString("dir"));
+            _serialization = Context.System.Serialization;
+            _log = Context.GetLogger();
+        }
+
+        public override Task ReplayMessagesAsync(IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, Action<IPersistentRepresentation> recoveryCallback)
+        {
+            return RunWithStreamDispatcher(() =>
+            {
+                var files = GetJournalFiles(persistenceId);
+                int count = 0;
+
+                foreach (var file in files)
+                {
+                    var parts = file.Name.Split('-');
+                    var sequence = Convert.ToInt64(parts[parts.Length - 1].TrimStart('0'));
+                    if (sequence >= fromSequenceNr && sequence <= toSequenceNr)
+                    {
+                        var journal = Load(file);
+                        if (!journal.IsDeleted)
+                        {
+                            recoveryCallback(journal);
+                        }
+
+                        count++;
+                    }
+
+                    if (count >= max) break;
+                }
+
+                return new object();
+            });
+        }
+
+        public IPersistentRepresentation Load(FileInfo file)
+        {
+            return WithInputStream(file, stream =>
+            {
+                var buffer = new byte[stream.Length];
+                stream.Read(buffer, 0, buffer.Length);
+
+                var serializer = _serialization.FindSerializerForType(typeof(IPersistentRepresentation));
+                return serializer.FromBinary<IPersistentRepresentation>(buffer);
+            });
+        }
+
+        public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
+        {
+            return RunWithStreamDispatcher(() =>
+            {
+                var files = GetJournalFiles(persistenceId);
+                if (files.Length == 0) return 0;
+
+                var lastFile = files[files.Length - 1];
+                return Load(lastFile).SequenceNr;
+            });
+        }
+
+        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
+        {
+            return RunWithStreamDispatcher(() =>
+            {
+                WriteMessages(messages);
+                return (IImmutableList<Exception>)null;
+            });
+        }
+
+        protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr)
+        {
+            return RunWithStreamDispatcher(() =>
+            {
+                var files = GetJournalFiles(persistenceId);
+
+                var toDelete = new List<FileInfo>();
+
+                foreach (var file in files)
+                {
+                    // skip tmp files
+                    if (file.Name.EndsWith(TempFileExtension)) continue;
+                    if (file.Name.EndsWith(BackupFileExtension)) continue;
+
+                    var parts = file.Name.Split('-');
+                    var trimmedSequence = parts[parts.Length - 1].TrimStart('0');
+                    var sequence = Convert.ToInt64(trimmedSequence);
+                    if (sequence <= toSequenceNr)
+                    {
+                        toDelete.Add(file);
+                    }
+                }
+
+                if (toDelete.Count > 0)
+                {
+                    // delete all files except the last one
+                    FileInfo last = toDelete[toDelete.Count - 1];
+                    toDelete.RemoveAt(toDelete.Count - 1);
+                    foreach (var file in toDelete)
+                    {
+                        try
+                        {
+                            file.Delete();
+                        }
+                        catch (Exception ex)
+                        {
+                            _log.Warning("Failed to delete file, ignoring: " + ex);
+                        }
+                    }
+
+                    // read the last file and set is deleted to to true
+                    var journal = Load(last);
+                    var updated = journal.Update(journal.SequenceNr, journal.PersistenceId, true, journal.Sender, journal.WriterGuid);
+
+                    // dotnet standard 1.6 doesn't have support for replace, so we must delete and then resave
+                    last.Delete();
+                    Save(updated);
+                }
+
+                return new object();
+            });
+        }
+
+        private FileInfo[] GetJournalFiles(string persistenceId)
+        {
+            var prefix = $"{Uri.EscapeDataString(persistenceId)}-*";
+            return GetJournalDir().GetFiles(prefix, SearchOption.TopDirectoryOnly);
+        }
+
+        private void WriteMessages(IEnumerable<AtomicWrite> messages)
+        {
+            foreach (var w in messages)
+            {
+                foreach (var p in (IEnumerable<IPersistentRepresentation>)w.Payload)
+                {
+                    Save(p);
+                }
+            }
+        }
+
+        private void Save(IPersistentRepresentation payload)
+        {
+            var serializer = _serialization.FindSerializerForType(typeof(IPersistentRepresentation));
+            var binary = serializer.ToBinary(payload);
+
+            var tempFile = WithOutputStream(payload, stream => { stream.Write(binary, 0, binary.Length); });
+            tempFile.MoveTo(GetJournalFileForWrite(payload.PersistenceId, payload.SequenceNr).FullName);
+        }
+
+        protected FileInfo WithOutputStream(IPersistentRepresentation payload, Action<Stream> p)
+        {
+            var tmpFile = GetJournalFileForWrite(payload.PersistenceId, payload.SequenceNr, TempFileExtension);
+            WithStream(new BufferedStream(new FileStream(tmpFile.FullName, FileMode.Create)), stream =>
+            {
+                p(stream);
+                stream.Flush();
+                return new object();
+            });
+            return tmpFile;
+        }
+
+        private T WithInputStream<T>(FileInfo file, Func<Stream, T> p)
+        {
+            return WithStream(new BufferedStream(new FileStream(file.FullName, FileMode.Open)), p);
+        }
+
+        private T WithStream<T>(Stream stream, Func<Stream, T> p)
+        {
+            try
+            {
+                var result = p(stream);
+                return result;
+            }
+            finally
+            {
+                stream.Dispose();
+            }
+        }
+
+        private DirectoryInfo GetJournalDir()
+        {
+            if (!_dir.Exists || (_dir.Attributes & FileAttributes.Directory) == 0)
+            {
+                // try to create the directory, on failure double check if someone else beat us to it
+                Exception exception;
+                try
+                {
+                    _dir.Create();
+                    exception = null;
+                }
+                catch (Exception e)
+                {
+                    exception = e;
+                }
+                finally
+                {
+                    _dir.Refresh();
+                }
+                if (exception != null || ((_dir.Attributes & FileAttributes.Directory) == 0))
+                {
+                    throw new IOException("Failed to create snapshot directory " + _dir.FullName, exception);
+                }
+            }
+            return _dir;
+        }
+
+        private FileInfo GetJournalFileForWrite(string persistenceId, long sequenceNumber, string extension = "")
+        {
+            var sequencePadded = sequenceNumber.ToString().PadLeft(6, '0');
+            var filename = $"{Uri.EscapeDataString(persistenceId)}-{sequencePadded}{extension}";
+            return new FileInfo(Path.Combine(GetJournalDir().FullName, filename));
+        }
+
+        private Task<T> RunWithStreamDispatcher<T>(Func<T> fn)
+        {
+            var promise = new TaskCompletionSource<T>();
+
+            _streamDispatcher.Schedule(() =>
+            {
+                try
+                {
+                    var result = fn();
+                    promise.SetResult(result);
+                }
+                catch (Exception e)
+                {
+                    promise.SetException(e);
+                }
+            });
+
+            return promise.Task;
+        }
+    }
+}

--- a/src/core/Akka.Persistence/persistence.conf
+++ b/src/core/Akka.Persistence/persistence.conf
@@ -214,6 +214,18 @@ akka.persistence.snapshot-store.inmem {
     plugin-dispatcher = "akka.actor.default-dispatcher"
 }
 
+# Local file system journal plugin.
+akka.persistence.journal.local {
+    # Class name of the plugin.
+    class = "Akka.Persistence.Journal.LocalJournal, Akka.Persistence"
+    # Dispatcher for the plugin actor.
+    plugin-dispatcher = "akka.persistence.dispatchers.default-plugin-dispatcher"
+    # Dispatcher for streaming snapshot IO.
+    stream-dispatcher = "akka.persistence.dispatchers.default-stream-dispatcher"
+    # Storage location of snapshot files.
+    dir = "journals"
+}
+
 # Local file system snapshot store plugin.
 akka.persistence.snapshot-store.local {
     # Class name of the plugin.


### PR DESCRIPTION
LocalJournal is an akka persistence plugin that is backed by disk.  This follows a similar pattern as the LocalSnapshotStore, but supports the journal api methods.