### PR TITLE
Fix the materialised value of the Flow returned by Bidiflow JoinMat() #3055

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
@@ -1019,7 +1019,7 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Dsl.BidiFlow<TIn1, TOut12, TIn21, TOut2, TMat> Atop<TOut12, TIn21, TMat2>(Akka.Streams.Dsl.BidiFlow<TOut1, TOut12, TIn21, TIn2, TMat2> bidi) { }
         public Akka.Streams.Dsl.BidiFlow<TIn1, TOut12, TIn21, TOut2, TMat> AtopMat<TOut12, TIn21, TMat2, TMat3>(Akka.Streams.Dsl.BidiFlow<TOut1, TOut12, TIn21, TIn2, TMat2> bidi, System.Func<TMat, TMat2, TMat3> combine) { }
         public Akka.Streams.Dsl.Flow<TIn1, TOut2, TMat> Join<TMat2>(Akka.Streams.Dsl.Flow<TOut1, TIn2, TMat2> flow) { }
-        public Akka.Streams.Dsl.Flow<TIn1, TOut2, TMat> JoinMat<TMat2, TMat3>(Akka.Streams.Dsl.Flow<TOut1, TIn2, TMat2> flow, System.Func<TMat, TMat2, TMat3> combine) { }
+        public Akka.Streams.Dsl.Flow<TIn1, TOut2, TMat3> JoinMat<TMat2, TMat3>(Akka.Streams.Dsl.Flow<TOut1, TIn2, TMat2> flow, System.Func<TMat, TMat2, TMat3> combine) { }
         public Akka.Streams.IGraph<Akka.Streams.BidiShape<TIn1, TOut1, TIn2, TOut2>, TMat> Named(string name) { }
         public Akka.Streams.Dsl.BidiFlow<TIn2, TOut2, TIn1, TOut1, TMat> Reversed() { }
         public Akka.Streams.IGraph<Akka.Streams.BidiShape<TIn1, TOut1, TIn2, TOut2>, TMat> WithAttributes(Akka.Streams.Attributes attributes) { }

--- a/src/core/Akka.Streams/Dsl/BidiFlow.cs
+++ b/src/core/Akka.Streams/Dsl/BidiFlow.cs
@@ -345,12 +345,12 @@ namespace Akka.Streams.Dsl
         /// <param name="flow">TBD</param>
         /// <param name="combine">TBD</param>
         /// <returns>TBD</returns>
-        public Flow<TIn1, TOut2, TMat> JoinMat<TMat2, TMat3>(Flow<TOut1, TIn2, TMat2> flow, Func<TMat, TMat2, TMat3> combine)
+        public Flow<TIn1, TOut2, TMat3> JoinMat<TMat2, TMat3>(Flow<TOut1, TIn2, TMat2> flow, Func<TMat, TMat2, TMat3> combine)
         {
             var copy = flow.Module.CarbonCopy();
             var inlet = copy.Shape.Inlets.First();
             var outlet = copy.Shape.Outlets.First();
-            return new Flow<TIn1, TOut2, TMat>(Module
+            return new Flow<TIn1, TOut2, TMat3>(Module
                 .Compose(copy, combine)
                 .Wire(Shape.Outlets.First(), inlet)
                 .Wire(outlet, Shape.Inlets.ElementAt(1))


### PR DESCRIPTION
The generic type parameters of the flow returned from the current implementation of Bidiflow's JoinMat method are incorrect as discussed in issue #3055.
This patch corrects the type, an equivalent PR is also being raised with Lightbend for the Akka Scala project for consistency.