### PR TITLE
Fix issue with not publishing release notes to NuGet

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -571,14 +571,14 @@ Target "All" DoNothing
 Target "Nuget" DoNothing
 
 // build dependencies
-"Clean" ==> "RestorePackages" ==> "Build" ==> "PublishMntr" ==> "BuildRelease"
+"Clean" ==> "RestorePackages" ==> "AssemblyInfo" ==> "Build" ==> "PublishMntr" ==> "BuildRelease"
 
 // tests dependencies
 // "RunTests" step doesn't require Clean ==> "RestorePackages" step
 "Clean" ==> "RestorePackages" ==> "RunTestsNetCore"
 
 // nuget dependencies
-"Clean" ==> "RestorePackages" ==> "Build" ==> "PublishMntr" ==> "CreateMntrNuget" ==> "CreateNuget"
+"BuildRelease" ==> "CreateMntrNuget" ==> "CreateNuget"
 "CreateNuget" ==> "PublishNuget" ==> "Nuget"
 
 // docs

--- a/src/common.props
+++ b/src/common.props
@@ -3,7 +3,6 @@
     <Copyright>Copyright © 2013-2017 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
     <VersionPrefix>1.3.0</VersionPrefix>
-    <PackageReleaseNotes>Placeholder</PackageReleaseNotes>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>
@@ -12,5 +11,45 @@
   <PropertyGroup>
     <XunitVersion>2.3.0-beta2-*</XunitVersion>
     <AkkaPackageTags>akka;actors;actor model;Akka;concurrency</AkkaPackageTags>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PackageReleaseNotes>Feature Release for Akka.NET**
+Akka.NET 1.3.0 is a major feature release that introduces the significant changes to Akka.NET and its runtime.
+.NET Core and .NET Standard 1.6 Support**
+This release introduces support for .NET Standard 1.6 for our core libraries and .NET Core 1.1 for the MultiNode Test Runner standalone executable. All packages for Akka.NET are dual-released under both .NET 4.5 and .NET Standard 1.6.
+As a side note: Akka.NET on .NET 4.5 is not wire compatible with Akka.NET on .NET Core; this is due to fundamental changes made to the base types in the CLR on .NET Core. It's a common problem facing many different serializers and networking libraries in .NET at the moment. You can use a X-plat serializer we've developed here: https://github.com/akkadotnet/akka.net/pull/2947 - please comment on that thread if you're considering building hybrid .NET and .NET Core clusters.
+Akka.Persistence Released to Market**
+Akka.Persistence has graduated from beta status to stable modules and its interfaces are now considered to be stable. We'll begin updating all of the Akka.Persistence plugins to stable and to add .NET Standard / .NET 4.5 support to each of them as well following this patch.
+DocFx-based Documentation Site**
+Documentation is now generated using DocFx and compiled from within the Akka.NET project rather than a separate documentation repository.
+API Changes**
+This release does **not** maintain wire format compatibility with the previous release (v1.2.3) inside Akka.Remote; primarily this is due to having to upgrade from Google Protobuf2 to Protobuf3 in order to add .NET Standard support, but we've also taken the liberty of making other serialization improvements while we're at it. So be advised that during an upgrade from 1.2.* to 1.3.* there will be periods of network disruption between nodes using different versions of the service.
+Akka.Remote Performance Improvements**
+Akka.Remote's throughput has been significantly increased.
+[See the full set of Akka.NET 1.3.0 fixes here](https://github.com/akkadotnet/akka.net/milestone/14).
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 64 | 7109 | 2670 | Marc Piechura |
+| 61 | 2420 | 6703 | Nick Chamberlain |
+| 46 | 2316 | 10066 | Aaron Stannard |
+| 42 | 56428 | 85473 | Alex Valuyskiy |
+| 32 | 7924 | 9483 | ravengerUA |
+| 31 | 17284 | 13592 | Bartosz Sypytkowski |
+| 25 | 2527 | 1124 | Gregorius Soedharmo |
+| 21 | 7810 | 1688 | zbynek001 |
+| 11 | 1932 | 2167 | Sean Gilliam |
+| 9 | 946 | 219 | Arjen Smits |
+| 4 | 679 | 105 | alexvaluyskiy |
+| 4 | 344 | 6 | Lealand Vettleson |
+| 4 | 1644 | 2210 | Arkatufus |
+| 3 | 32 | 6 | Lukas Rieger |
+| 3 | 153 | 17 | Quartus Dev |
+| 2 | 8 | 11 | Paweł Bańka |
+| 2 | 4866 | 12678 | olegz |
+| 2 | 1148 | 176 | Ismael Hamed |
+| 1 | 62 | 5 | Mikhail Kantarovskiy |
+| 1 | 4 | 2 | tstojecki |
+| 1 | 22 | 2 | Maxim Cherednik |
+| 1 | 1 | 1 | Sean Killeen |</PackageReleaseNotes>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes issue where our NuGet packages were published with the releaseNotes being "Placeholder" instead of  the actual release notes.

Verified in the .nuspec file:

```
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
  <metadata>
    <id>Akka</id>
    <version>1.3.0</version>
    <authors>Akka.NET Team</authors>
    <owners>Akka.NET Team</owners>
    <requireLicenseAcceptance>false</requireLicenseAcceptance>
    <licenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</licenseUrl>
    <projectUrl>https://github.com/akkadotnet/akka.net</projectUrl>
    <iconUrl>http://getakka.net/images/akkalogo.png</iconUrl>
    <description>Akka.NET is a port of the popular Java/Scala framework Akka to .NET</description>
    <releaseNotes>Feature Release for Akka.NET**
Akka.NET 1.3.0 is a major feature release that introduces the significant changes to Akka.NET and its runtime.
.NET Core and .NET Standard 1.6 Support**
This release introduces support for .NET Standard 1.6 for our core libraries and .NET Core 1.1 for the MultiNode Test Runner standalone executable. All packages for Akka.NET are dual-released under both .NET 4.5 and .NET Standard 1.6.
As a side note: Akka.NET on .NET 4.5 is not wire compatible with Akka.NET on .NET Core; this is due to fundamental changes made to the base types in the CLR on .NET Core. It's a common problem facing many different serializers and networking libraries in .NET at the moment. You can use a X-plat serializer we've developed here: https://github.com/akkadotnet/akka.net/pull/2947 - please comment on that thread if you're considering building hybrid .NET and .NET Core clusters.
Akka.Persistence Released to Market**
Akka.Persistence has graduated from beta status to stable modules and its interfaces are now considered to be stable. We'll begin updating all of the Akka.Persistence plugins to stable and to add .NET Standard / .NET 4.5 support to each of them as well following this patch.
DocFx-based Documentation Site**
Documentation is now generated using DocFx and compiled from within the Akka.NET project rather than a separate documentation repository.
API Changes**
This release does **not** maintain wire format compatibility with the previous release (v1.2.3) inside Akka.Remote; primarily this is due to having to upgrade from Google Protobuf2 to Protobuf3 in order to add .NET Standard support, but we've also taken the liberty of making other serialization improvements while we're at it. So be advised that during an upgrade from 1.2.* to 1.3.* there will be periods of network disruption between nodes using different versions of the service.
Akka.Remote Performance Improvements**
Akka.Remote's throughput has been significantly increased.
[See the full set of Akka.NET 1.3.0 fixes here](https://github.com/akkadotnet/akka.net/milestone/14).
| COMMITS | LOC+ | LOC- | AUTHOR |
| --- | --- | --- | --- |
| 64 | 7109 | 2670 | Marc Piechura |
| 61 | 2420 | 6703 | Nick Chamberlain |
| 46 | 2316 | 10066 | Aaron Stannard |
| 42 | 56428 | 85473 | Alex Valuyskiy |
| 32 | 7924 | 9483 | ravengerUA |
| 31 | 17284 | 13592 | Bartosz Sypytkowski |
| 25 | 2527 | 1124 | Gregorius Soedharmo |
| 21 | 7810 | 1688 | zbynek001 |
| 11 | 1932 | 2167 | Sean Gilliam |
| 9 | 946 | 219 | Arjen Smits |
| 4 | 679 | 105 | alexvaluyskiy |
| 4 | 344 | 6 | Lealand Vettleson |
| 4 | 1644 | 2210 | Arkatufus |
| 3 | 32 | 6 | Lukas Rieger |
| 3 | 153 | 17 | Quartus Dev |
| 2 | 8 | 11 | Paweł Bańka |
| 2 | 4866 | 12678 | olegz |
| 2 | 1148 | 176 | Ismael Hamed |
| 1 | 62 | 5 | Mikhail Kantarovskiy |
| 1 | 4 | 2 | tstojecki |
| 1 | 22 | 2 | Maxim Cherednik |
| 1 | 1 | 1 | Sean Killeen |</releaseNotes>
    <copyright>Copyright © 2013-2017 Akka.NET Team</copyright>
    <tags>akka actors actor model Akka concurrency</tags>
    <dependencies>
      <group targetFramework=".NETFramework4.5">
        <dependency id="Newtonsoft.Json" version="9.0.1" exclude="Build,Analyzers" />
        <dependency id="System.Collections.Immutable" version="1.3.1" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.6">
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
        <dependency id="Newtonsoft.Json" version="9.0.1" exclude="Build,Analyzers" />
        <dependency id="System.Collections.Immutable" version="1.3.1" exclude="Build,Analyzers" />
        <dependency id="System.Diagnostics.TraceSource" version="4.3.0" exclude="Build,Analyzers" />
        <dependency id="System.Net.NameResolution" version="4.3.0" exclude="Build,Analyzers" />
        <dependency id="System.Reflection.Emit" version="4.3.0" exclude="Build,Analyzers" />
        <dependency id="System.Reflection.TypeExtensions" version="4.3.0" exclude="Build,Analyzers" />
        <dependency id="System.Threading.Thread" version="4.3.0" exclude="Build,Analyzers" />
        <dependency id="System.Threading.ThreadPool" version="4.3.0" exclude="Build,Analyzers" />
      </group>
    </dependencies>
  </metadata>
</package>
```