### PR TITLE
InternalApi and ApiMayChange annotations

### DIFF
--- a/src/contrib/cluster/Akka.DistributedData/FastMerge.cs
+++ b/src/contrib/cluster/Akka.DistributedData/FastMerge.cs
@@ -5,6 +5,8 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using Akka.Annotations;
+
 namespace Akka.DistributedData
 {
     /// <summary>
@@ -24,6 +26,7 @@ namespace Akka.DistributedData
     /// a full merge is performed instead of the fast forward merge.
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public abstract class FastMerge<T> : IReplicatedData<T> where T : FastMerge<T>
     {
         /// <summary>
@@ -36,6 +39,7 @@ namespace Akka.DistributedData
         /// </summary>
         /// <param name="newData">TBD</param>
         /// <returns>TBD</returns>
+        [InternalApi]
         protected T AssignAncestor(T newData)
         {
             newData.Ancestor = Ancestor ?? this;
@@ -48,12 +52,14 @@ namespace Akka.DistributedData
         /// </summary>
         /// <param name="newData">TBD</param>
         /// <returns>TBD</returns>
+        [InternalApi]
         protected bool IsAncestorOf(T newData) => ReferenceEquals(newData.Ancestor, this);
 
         /// <summary>
         /// INTERNAL API: should be called from merge 
         /// </summary>
         /// <returns>TBD</returns>
+        [InternalApi]
         protected T ClearAncestor()
         {
             Ancestor = null;

--- a/src/contrib/transports/Akka.Remote.Transport.Helios/HeliosTcpTransport.cs
+++ b/src/contrib/transports/Akka.Remote.Transport.Helios/HeliosTcpTransport.cs
@@ -12,6 +12,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.Configuration;
 using Akka.Event;
 using Google.Protobuf;
@@ -25,6 +26,7 @@ namespace Akka.Remote.Transport.Helios
     /// <summary>
     /// INTERNAL API
     /// </summary>
+    [InternalApi]
     abstract class TcpHandlers : CommonHandlers
     {
         private IHandleEventListener _listener;
@@ -214,6 +216,7 @@ namespace Akka.Remote.Transport.Helios
     /// <summary>
     /// INTERNAL API
     /// </summary>
+    [InternalApi]
     class TcpAssociationHandle : AssociationHandle
     {
         private readonly IChannel _channel;

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -2016,7 +2016,12 @@ namespace Akka.Actor.Internal
 namespace Akka.Annotations
 {
     [System.AttributeUsageAttribute(System.AttributeTargets.Module | System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.All, AllowMultiple=false, Inherited=true)]
-    public class InternalApiAttribute : System.Attribute
+    public sealed class ApiMayChangeAttribute : System.Attribute
+    {
+        public ApiMayChangeAttribute() { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Module | System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.All, AllowMultiple=false, Inherited=true)]
+    public sealed class InternalApiAttribute : System.Attribute
     {
         public InternalApiAttribute() { }
     }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -280,6 +280,7 @@ namespace Akka.Actor
         public static readonly Akka.Actor.Nobody Nobody;
         public static readonly Akka.Actor.IActorRef NoSender;
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public abstract class ActorRefWithCell : Akka.Actor.InternalActorRefBase
     {
         protected ActorRefWithCell() { }
@@ -520,6 +521,7 @@ namespace Akka.Actor
         protected override bool SpecialHandle(object message, Akka.Actor.IActorRef sender) { }
         protected override void TellInternal(object message, Akka.Actor.IActorRef sender) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class DeadLetterMailbox : Akka.Dispatch.Mailbox
     {
         public DeadLetterMailbox(Akka.Actor.IActorRef deadLetters) { }
@@ -961,6 +963,7 @@ namespace Akka.Actor
         Akka.Actor.ActorPath TempPath();
         void UnregisterTempActor(Akka.Actor.ActorPath path);
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public interface IActorRefScope
     {
         bool IsLocal { get; }
@@ -990,6 +993,7 @@ namespace Akka.Actor
         Akka.Actor.IActorRef Watch(Akka.Actor.IActorRef subject);
         Akka.Actor.IActorRef WatchWith(Akka.Actor.IActorRef subject, object message);
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public interface ICell
     {
         Akka.Actor.Internal.IChildrenContainer ChildrenContainer { get; }
@@ -1068,6 +1072,7 @@ namespace Akka.Actor
     {
         Akka.Actor.IActorContext ActorContext { get; }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public interface IInternalActorRef : Akka.Actor.IActorRef, Akka.Actor.IActorRefScope, Akka.Actor.ICanTell, Akka.Util.ISurrogated, System.IComparable, System.IComparable<Akka.Actor.IActorRef>, System.IEquatable<Akka.Actor.IActorRef>
     {
         [System.ObsoleteAttribute("Use Context.Watch and Receive<Terminated> [1.1.0]")]
@@ -1115,6 +1120,7 @@ namespace Akka.Actor
     }
     public interface INoSerializationVerificationNeeded { }
     public interface INotInfluenceReceiveTimeout { }
+    [Akka.Annotations.InternalApiAttribute()]
     public abstract class InternalActorRefBase : Akka.Actor.ActorRefBase, Akka.Actor.IActorRef, Akka.Actor.IActorRefScope, Akka.Actor.ICanTell, Akka.Actor.IInternalActorRef, Akka.Util.ISurrogated, System.IComparable, System.IComparable<Akka.Actor.IActorRef>, System.IEquatable<Akka.Actor.IActorRef>
     {
         protected InternalActorRefBase() { }
@@ -1267,6 +1273,7 @@ namespace Akka.Actor
         public LoggerInitializationException(string message, System.Exception cause = null) { }
         protected LoggerInitializationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public abstract class MinimalActorRef : Akka.Actor.InternalActorRefBase, Akka.Actor.IActorRefScope, Akka.Actor.ILocalRef
     {
         protected MinimalActorRef() { }
@@ -1488,6 +1495,7 @@ namespace Akka.Actor
         public override int CompareTo(Akka.Actor.ActorPath other) { }
         public override Akka.Actor.ActorPath WithUid(long uid) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public class RootGuardianActorRef : Akka.Actor.LocalActorRef
     {
         public RootGuardianActorRef(Akka.Actor.Internal.ActorSystemImpl system, Akka.Actor.Props props, Akka.Dispatch.MessageDispatcher dispatcher, Akka.Dispatch.MailboxType mailboxType, Akka.Actor.IInternalActorRef supervisor, Akka.Actor.ActorPath path, Akka.Actor.IInternalActorRef deadLetters, System.Collections.Generic.IReadOnlyDictionary<string, Akka.Actor.IInternalActorRef> extraNames) { }
@@ -1702,6 +1710,7 @@ namespace Akka.Actor
         protected TypedActor() { }
         protected virtual bool Receive(object message) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public class UnstartedCell : Akka.Actor.ICell
     {
         public UnstartedCell(Akka.Actor.Internal.ActorSystemImpl system, Akka.Actor.RepointableActorRef self, Akka.Actor.Props props, Akka.Actor.IInternalActorRef supervisor) { }
@@ -1928,11 +1937,13 @@ namespace Akka.Actor.Internal
     {
         void Init();
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public interface IInternalSupportsTestFSMRef<TState, TData>
     {
         bool IsStateTimerActive { get; }
         void ApplyState(Akka.Actor.FSMBase.State<TState, TData> upcomingState);
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public class InternalActivateFsmLogging
     {
         public static Akka.Actor.Internal.InternalActivateFsmLogging Instance { get; }
@@ -2000,6 +2011,14 @@ namespace Akka.Actor.Internal
     public class UnboundedStashImpl : Akka.Actor.Internal.AbstractStash
     {
         public UnboundedStashImpl(Akka.Actor.IActorContext context) { }
+    }
+}
+namespace Akka.Annotations
+{
+    [System.AttributeUsageAttribute(System.AttributeTargets.Module | System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.All, AllowMultiple=false, Inherited=true)]
+    public class InternalApiAttribute : System.Attribute
+    {
+        public InternalApiAttribute() { }
     }
 }
 namespace Akka
@@ -2374,6 +2393,7 @@ namespace Akka.Dispatch
     {
         public Dispatcher(Akka.Dispatch.MessageDispatcherConfigurator configurator, string id, int throughput, System.Nullable<long> throughputDeadlineTime, Akka.Dispatch.ExecutorServiceFactory executorServiceFactory, System.TimeSpan shutdownTimeout) { }
         protected override void ExecuteTask(Akka.Dispatch.IRunnable run) { }
+        [Akka.Annotations.InternalApiAttribute()]
         protected override void Shutdown() { }
     }
     public sealed class DispatcherConfigurator : Akka.Dispatch.MessageDispatcherConfigurator
@@ -2400,12 +2420,14 @@ namespace Akka.Dispatch
         public abstract void Execute(Akka.Dispatch.IRunnable run);
         public abstract void Shutdown();
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public abstract class ExecutorServiceConfigurator : Akka.Dispatch.ExecutorServiceFactory
     {
         protected ExecutorServiceConfigurator(Akka.Configuration.Config config, Akka.Dispatch.IDispatcherPrerequisites prerequisites) { }
         public Akka.Configuration.Config Config { get; }
         public Akka.Dispatch.IDispatcherPrerequisites Prerequisites { get; }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public abstract class ExecutorServiceFactory
     {
         protected ExecutorServiceFactory() { }
@@ -2490,6 +2512,7 @@ namespace Akka.Dispatch
         public string Id { get; set; }
         protected long Inhabitants { get; }
         public Akka.Dispatch.Mailboxes Mailboxes { get; }
+        [Akka.Annotations.InternalApiAttribute()]
         public System.TimeSpan ShutdownTimeout { get; set; }
         public int Throughput { get; set; }
         public System.Nullable<long> ThroughputDeadlineTime { get; set; }
@@ -2500,6 +2523,7 @@ namespace Akka.Dispatch
         protected void ReportFailure(System.Exception ex) { }
         public void Schedule(System.Action run) { }
         public void Schedule(Akka.Dispatch.IRunnable run) { }
+        [Akka.Annotations.InternalApiAttribute()]
         protected abstract void Shutdown();
         public virtual void SystemDispatch(Akka.Actor.ActorCell cell, Akka.Dispatch.SysMsg.SystemMessage message) { }
     }
@@ -2651,6 +2675,7 @@ namespace Akka.Dispatch.SysMsg
         public System.Exception Reason { get; }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class Failed : Akka.Dispatch.SysMsg.SystemMessage, Akka.Dispatch.SysMsg.IStashWhenFailed
     {
         public Failed(Akka.Actor.IActorRef child, System.Exception cause, long uid) { }
@@ -2705,6 +2730,7 @@ namespace Akka.Dispatch.SysMsg
         public Suspend() { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public abstract class SystemMessage : Akka.Actor.INoSerializationVerificationNeeded, Akka.Dispatch.SysMsg.ISystemMessage
     {
         protected SystemMessage() { }
@@ -4470,6 +4496,7 @@ namespace Akka.Serialization
         public abstract byte[] ToBinary(object obj);
         public byte[] ToBinaryWithAddress(Akka.Actor.Address address, object obj) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public class static SerializerIdentifierHelper
     {
         public static int GetSerializerIdentifierFromConfig(System.Type type, Akka.Actor.ExtendedActorSystem system) { }
@@ -4721,6 +4748,7 @@ namespace Akka.Util
         public TickTimeTokenBucket(long capacity, long period) { }
         public override long CurrentTime { get; }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public abstract class TokenBucket
     {
         protected TokenBucket(long capacity, long ticksBetweenTokens) { }
@@ -4732,6 +4760,7 @@ namespace Akka.Util
     {
         public static bool Implements<T>(this System.Type type) { }
         public static bool Implements(this System.Type type, System.Type moreGeneralType) { }
+        [Akka.Annotations.InternalApiAttribute()]
         public static string TypeQualifiedName(this System.Type type) { }
     }
     public class static Vector
@@ -4843,6 +4872,7 @@ namespace Akka.Util.Internal
         public static System.Text.StringBuilder AppendJoin<T>(this System.Text.StringBuilder sb, string separator, System.Collections.Generic.IEnumerable<T> values) { }
         public static System.Text.StringBuilder AppendJoin<T>(this System.Text.StringBuilder sb, string separator, System.Collections.Generic.IEnumerable<T> values, System.Action<System.Text.StringBuilder, T, int> valueAppender) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public class static TaskExtensions
     {
         public static System.Threading.Tasks.Task<TResult> CastTask<TTask, TResult>(this System.Threading.Tasks.Task<TTask> task) { }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
@@ -408,6 +408,7 @@ namespace Akka.Persistence
             public long AutoUpdateReplayMax { get; }
         }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public class Persistent : Akka.Persistence.IPersistentRepresentation, Akka.Persistence.Serialization.IMessage, System.IEquatable<Akka.Persistence.IPersistentRepresentation>
     {
         public Persistent(object payload, long sequenceNr = 0, string persistenceId = null, string manifest = null, bool isDeleted = False, Akka.Actor.IActorRef sender = null, string writerGuid = null) { }
@@ -1082,6 +1083,7 @@ namespace Akka.Persistence.Journal
     public abstract class WriteJournalBase : Akka.Actor.ActorBase
     {
         protected WriteJournalBase() { }
+        [Akka.Annotations.InternalApiAttribute()]
         protected System.Collections.Generic.IEnumerable<Akka.Persistence.IPersistentRepresentation> AdaptFromJournal(Akka.Persistence.IPersistentRepresentation representation) { }
         protected Akka.Persistence.IPersistentRepresentation AdaptToJournal(Akka.Persistence.IPersistentRepresentation representation) { }
         protected System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> PreparePersistentBatch(System.Collections.Generic.IEnumerable<Akka.Persistence.IPersistentEnvelope> resequenceables) { }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveRemote.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveRemote.approved.txt
@@ -107,6 +107,7 @@ namespace Akka.Remote
         public abstract bool IsMonitoring { get; }
         public abstract void HeartBeat();
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public class static FailureDetectorLoader
     {
         public static Akka.Remote.FailureDetector Load(string fqcn, Akka.Configuration.Config config, Akka.Actor.ActorSystem system) { }
@@ -156,6 +157,7 @@ namespace Akka.Remote
         public override void Suspend() { }
         protected override void TellInternal(object message, Akka.Actor.IActorRef sender) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public class RemoteActorRefProvider : Akka.Actor.IActorRefProvider
     {
         public RemoteActorRefProvider(string systemName, Akka.Actor.Settings settings, Akka.Event.EventStream eventStream) { }
@@ -229,6 +231,7 @@ namespace Akka.Remote
             public string TransportClass { get; set; }
         }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public abstract class RemoteTransport
     {
         protected RemoteTransport(Akka.Actor.ExtendedActorSystem system, Akka.Remote.RemoteActorRefProvider provider) { }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
@@ -553,6 +553,7 @@ namespace Akka.Streams
     public interface IGraph<out TShape>
         where out TShape : Akka.Streams.Shape
     {
+        [Akka.Annotations.InternalApiAttribute()]
         Akka.Streams.Implementation.IModule Module { get; }
         TShape Shape { get; }
     }
@@ -2068,6 +2069,7 @@ namespace Akka.Streams.Dsl
 }
 namespace Akka.Streams.Dsl.Internal
 {
+    [Akka.Annotations.InternalApiAttribute()]
     public class GraphImpl<TShape, TMat> : Akka.Streams.IGraph<TShape>, Akka.Streams.IGraph<TShape, TMat>
         where TShape : Akka.Streams.Shape
     {
@@ -2080,6 +2082,7 @@ namespace Akka.Streams.Dsl.Internal
         public override string ToString() { }
         public Akka.Streams.IGraph<TShape, TMat> WithAttributes(Akka.Streams.Attributes attributes) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public class static ModuleExtractor
     {
         public static Akka.Streams.Util.Option<Akka.Streams.Implementation.IModule> Unapply<TShape, TMat>(Akka.Streams.IGraph<TShape, TMat> graph)
@@ -2106,8 +2109,10 @@ namespace Akka.Streams.Implementation
         public ActorMaterializerImpl(Akka.Actor.ActorSystem system, Akka.Streams.ActorMaterializerSettings settings, Akka.Dispatch.Dispatchers dispatchers, Akka.Actor.IActorRef supervisor, Akka.Util.AtomicBoolean haveShutDown, Akka.Streams.Implementation.EnumerableActorName flowNames) { }
         public override Akka.Dispatch.MessageDispatcher ExecutionContext { get; }
         public override bool IsShutdown { get; }
+        [Akka.Annotations.InternalApiAttribute()]
         public override Akka.Event.ILoggingAdapter Logger { get; }
         public override Akka.Streams.ActorMaterializerSettings Settings { get; }
+        [Akka.Annotations.InternalApiAttribute()]
         public override Akka.Actor.IActorRef Supervisor { get; }
         public override Akka.Actor.ActorSystem System { get; }
         public override Akka.Streams.ActorMaterializerSettings EffectiveSettings(Akka.Streams.Attributes attributes) { }
@@ -2126,6 +2131,7 @@ namespace Akka.Streams.Implementation
         public static readonly Akka.Streams.Implementation.NormalShutdownException NormalShutdownReason;
         public const string NormalShutdownReasonMessage = "Cannot subscribe to shut-down Publisher";
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public class ActorPublisher<TOut> : Akka.Streams.Implementation.IActorPublisher, Akka.Streams.IUntypedPublisher, Reactive.Streams.IPublisher<TOut>
     {
         protected readonly Akka.Actor.IActorRef Impl;
@@ -2135,6 +2141,7 @@ namespace Akka.Streams.Implementation
         public void Subscribe(Reactive.Streams.ISubscriber<TOut> subscriber) { }
         public System.Collections.Generic.IEnumerable<Reactive.Streams.ISubscriber<TOut>> TakePendingSubscribers() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class ActorPublisherSource<TOut> : Akka.Streams.Implementation.SourceModule<TOut, Akka.Actor.IActorRef>
     {
         public ActorPublisherSource(Akka.Actor.Props props, Akka.Streams.Attributes attributes, Akka.Streams.SourceShape<TOut> shape) { }
@@ -2143,6 +2150,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Implementation.SourceModule<TOut, Akka.Actor.IActorRef> NewInstance(Akka.Streams.SourceShape<TOut> shape) { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class ActorRefSink<TIn> : Akka.Streams.Implementation.SinkModule<TIn, Akka.NotUsed>
     {
         public ActorRefSink(Akka.Actor.IActorRef @ref, object onCompleteMessage, Akka.Streams.Attributes attributes, Akka.Streams.SinkShape<TIn> shape) { }
@@ -2162,6 +2170,7 @@ namespace Akka.Streams.Implementation
         public static Akka.Actor.Props Props(Akka.Actor.IActorRef @ref, int highWatermark, object onCompleteMessage) { }
         protected override bool Receive(object message) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class ActorRefSource<TOut> : Akka.Streams.Implementation.SourceModule<TOut, Akka.Actor.IActorRef>
     {
         public ActorRefSource(int bufferSize, Akka.Streams.OverflowStrategy overflowStrategy, Akka.Streams.Attributes attributes, Akka.Streams.SourceShape<TOut> shape) { }
@@ -2171,6 +2180,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Implementation.SourceModule<TOut, Akka.Actor.IActorRef> NewInstance(Akka.Streams.SourceShape<TOut> shape) { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class ActorSubscriberSink<TIn> : Akka.Streams.Implementation.SinkModule<TIn, Akka.Actor.IActorRef>
     {
         public ActorSubscriberSink(Akka.Actor.Props props, Akka.Streams.Attributes attributes, Akka.Streams.SinkShape<TIn> shape) { }
@@ -2207,6 +2217,7 @@ namespace Akka.Streams.Implementation
         public virtual System.Collections.Immutable.ImmutableArray<Akka.Streams.Implementation.IModule> SubModules { get; }
         public virtual System.Collections.Immutable.IImmutableDictionary<Akka.Streams.InPort, Akka.Streams.OutPort> Upstreams { get; }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class BackpressureTimeout<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public readonly System.TimeSpan Timeout;
@@ -2247,6 +2258,7 @@ namespace Akka.Streams.Implementation
         public void OnNext(T element) { }
         public void OnSubscribe(Reactive.Streams.ISubscription subscription) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class CancelSink<T> : Akka.Streams.Implementation.SinkModule<T, Akka.NotUsed>
     {
         public CancelSink(Akka.Streams.Attributes attributes, Akka.Streams.SinkShape<T> shape) { }
@@ -2255,6 +2267,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Implementation.SinkModule<T, Akka.NotUsed> NewInstance(Akka.Streams.SinkShape<T> shape) { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class Completion<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public readonly System.TimeSpan Timeout;
@@ -2292,6 +2305,7 @@ namespace Akka.Streams.Implementation
         public override string ToString() { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class DelayInitial<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public readonly System.TimeSpan Delay;
@@ -2329,6 +2343,7 @@ namespace Akka.Streams.Implementation
         public static Akka.Streams.Implementation.EnumerableActorName Create(string prefix) { }
         public abstract string Next();
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class EventSourceStage<TDelegate, TEventArgs> : Akka.Streams.Stage.GraphStage<Akka.Streams.SourceShape<TEventArgs>>
     {
         public EventSourceStage(System.Action<TDelegate> addHandler, System.Action<TDelegate> removeHandler, System.Func<System.Action<TEventArgs>, TDelegate> conversion, int maxBuffer, Akka.Streams.OverflowStrategy overflowStrategy) { }
@@ -2346,9 +2361,13 @@ namespace Akka.Streams.Implementation
     public abstract class ExtendedActorMaterializer : Akka.Streams.ActorMaterializer
     {
         protected ExtendedActorMaterializer() { }
+        [Akka.Annotations.InternalApiAttribute()]
         public override Akka.Actor.IActorRef ActorOf(Akka.Streams.MaterializationContext context, Akka.Actor.Props props) { }
+        [Akka.Annotations.InternalApiAttribute()]
         protected Akka.Actor.IActorRef ActorOf(Akka.Actor.Props props, string name, string dispatcher) { }
+        [Akka.Annotations.InternalApiAttribute()]
         public abstract TMat Materialize<TMat>(Akka.Streams.IGraph<Akka.Streams.ClosedShape, TMat> runnable, System.Func<Akka.Streams.Implementation.Fusing.GraphInterpreterShell, Akka.Actor.IActorRef> subFlowFuser);
+        [Akka.Annotations.InternalApiAttribute()]
         public abstract TMat Materialize<TMat>(Akka.Streams.IGraph<Akka.Streams.ClosedShape, TMat> runnable, System.Func<Akka.Streams.Implementation.Fusing.GraphInterpreterShell, Akka.Actor.IActorRef> subFlowFuser, Akka.Streams.Attributes initialAttributes);
     }
     public class static FanIn
@@ -2413,6 +2432,7 @@ namespace Akka.Streams.Implementation
             public void OnSubscribe(Reactive.Streams.ISubscription subscription) { }
         }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public class static FanOut
     {
         public struct ExposedPublishers<T> : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
@@ -2444,6 +2464,7 @@ namespace Akka.Streams.Implementation
             public override string ToString() { }
         }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public abstract class FanOut<T> : Akka.Actor.ActorBase, Akka.Streams.Implementation.IPump
     {
         protected readonly Akka.Streams.Implementation.OutputBunch<T> OutputBunch;
@@ -2465,6 +2486,7 @@ namespace Akka.Streams.Implementation
         protected override bool Receive(object message) { }
         public void WaitForUpstream(int waitForUpstream) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class FirstOrDefaultStage<T> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SinkShape<T>, System.Threading.Tasks.Task<T>>
     {
         public readonly Akka.Streams.Inlet<T> In;
@@ -2509,6 +2531,7 @@ namespace Akka.Streams.Implementation
     {
         System.Collections.Generic.IEnumerable<Akka.Streams.Implementation.ICursor> Cursors { get; }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class Idle<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public readonly System.TimeSpan Timeout;
@@ -2517,6 +2540,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class IdleInject<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
         where TIn : TOut
     {
@@ -2526,6 +2550,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class IdleTimeoutBidi<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.BidiShape<TIn, TIn, TOut, TOut>>
     {
         public readonly Akka.Streams.Inlet<TIn> In1;
@@ -2578,6 +2603,7 @@ namespace Akka.Streams.Implementation
         Akka.Streams.Implementation.IModule Wire(Akka.Streams.OutPort from, Akka.Streams.InPort to);
         Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes);
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class Initial<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public readonly System.TimeSpan Timeout;
@@ -2629,6 +2655,7 @@ namespace Akka.Streams.Implementation
         void WaitForUpstream(int waitForUpstream);
     }
     public interface ISpecViolation { }
+    [Akka.Annotations.InternalApiAttribute()]
     public class JsonObjectParser
     {
         public JsonObjectParser(int maximumObjectLength = 2147483647) { }
@@ -2636,6 +2663,7 @@ namespace Akka.Streams.Implementation
         public void Offer(Akka.IO.ByteString input) { }
         public Akka.Streams.Util.Option<Akka.IO.ByteString> Poll() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class LastOrDefaultStage<T> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SinkShape<T>, System.Threading.Tasks.Task<T>>
     {
         public readonly Akka.Streams.Inlet<T> In;
@@ -2647,6 +2675,7 @@ namespace Akka.Streams.Implementation
     {
         public static Akka.Streams.Implementation.LazySource<TOut, TMat> Create<TOut, TMat>(System.Func<Akka.Streams.Dsl.Source<TOut, TMat>> create) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class LazySource<TOut, TMat> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SourceShape<TOut>, System.Threading.Tasks.Task<TMat>>
     {
         public LazySource(System.Func<Akka.Streams.Dsl.Source<TOut, TMat>> sourceFactory) { }
@@ -2656,6 +2685,7 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<System.Threading.Tasks.Task<TMat>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public abstract class MaterializerSession
     {
         protected readonly Akka.Streams.Attributes InitialAttributes;
@@ -2678,6 +2708,7 @@ namespace Akka.Streams.Implementation
             protected MaterializationPanicException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class MaybeSource<TOut> : Akka.Streams.Implementation.SourceModule<TOut, System.Threading.Tasks.TaskCompletionSource<TOut>>
     {
         public MaybeSource(Akka.Streams.Attributes attributes, Akka.Streams.SourceShape<TOut> shape) { }
@@ -2719,6 +2750,7 @@ namespace Akka.Streams.Implementation
         public virtual Akka.Streams.Implementation.IModule Wire(Akka.Streams.OutPort from, Akka.Streams.InPort to) { }
         public abstract Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes);
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class NoopSubscriptionTimeout : Akka.Actor.ICancelable
     {
         public static readonly Akka.Streams.Implementation.NoopSubscriptionTimeout Instance;
@@ -2768,6 +2800,7 @@ namespace Akka.Streams.Implementation
         public void UnmarkCancelledOutputs(bool enabled) { }
         public void UnmarkOutput(int output) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class ProcessorModule<TIn, TOut, TMat> : Akka.Streams.Implementation.AtomicModule, Akka.Streams.Implementation.IProcessorModule
     {
         public ProcessorModule(System.Func<System.Tuple<Reactive.Streams.IProcessor<TIn, TOut>, TMat>> createProcessor, Akka.Streams.Attributes attributes = null) { }
@@ -2780,6 +2813,7 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.Implementation.IModule ReplaceShape(Akka.Streams.Shape shape) { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class PublisherSource<TOut> : Akka.Streams.Implementation.SourceModule<TOut, Akka.NotUsed>
     {
         public PublisherSource(Reactive.Streams.IPublisher<TOut> publisher, Akka.Streams.Attributes attributes, Akka.Streams.SourceShape<TOut> shape) { }
@@ -2789,6 +2823,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Implementation.SourceModule<TOut, Akka.NotUsed> NewInstance(Akka.Streams.SourceShape<TOut> shape) { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class QueueSink<T> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SinkShape<T>, Akka.Streams.ISinkQueue<T>>
     {
         public readonly Akka.Streams.Inlet<T> In;
@@ -2798,6 +2833,7 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<Akka.Streams.ISinkQueue<T>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class QueueSource<TOut> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SourceShape<TOut>, Akka.Streams.ISourceQueueWithComplete<TOut>>
     {
         public QueueSource(int maxBuffer, Akka.Streams.OverflowStrategy overflowStrategy) { }
@@ -2846,6 +2882,7 @@ namespace Akka.Streams.Implementation
         public static void TryOnSubscribe<T>(Reactive.Streams.ISubscriber<T> subscriber, Reactive.Streams.ISubscription subscription) { }
         public static void TryRequest(Reactive.Streams.ISubscription subscription, long demand) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public class ResizableMultiReaderRingBuffer<T>
     {
         protected readonly Akka.Streams.Implementation.ICursors Cursors;
@@ -2863,6 +2900,7 @@ namespace Akka.Streams.Implementation
         public override string ToString() { }
         public bool Write(T value) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class SeqStage<T> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SinkShape<T>, System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<T>>>
     {
         public readonly Akka.Streams.Inlet<T> In;
@@ -2902,6 +2940,7 @@ namespace Akka.Streams.Implementation
         public virtual void Error(System.Exception e) { }
         protected bool WaitingExposedPublisher(object message) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class SinkholeSubscriber<TIn> : Reactive.Streams.ISubscriber<TIn>
     {
         public SinkholeSubscriber(System.Threading.Tasks.TaskCompletionSource<Akka.NotUsed> whenCompleted) { }
@@ -2910,6 +2949,7 @@ namespace Akka.Streams.Implementation
         public void OnNext(TIn element) { }
         public void OnSubscribe(Reactive.Streams.ISubscription subscription) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public abstract class SinkModule<TIn, TMat> : Akka.Streams.Implementation.AtomicModule, Akka.Streams.Implementation.ISinkModule
     {
         protected SinkModule(Akka.Streams.SinkShape<TIn> shape) { }
@@ -2922,6 +2962,7 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.Implementation.IModule ReplaceShape(Akka.Streams.Shape shape) { }
         public virtual string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public abstract class SourceModule<TOut, TMat> : Akka.Streams.Implementation.AtomicModule, Akka.Streams.Implementation.ISourceModule
     {
         protected SourceModule(Akka.Streams.SourceShape<TOut> shape) { }
@@ -3049,6 +3090,7 @@ namespace Akka.Streams.Implementation
         public Akka.Actor.Receive CurrentReceive { get; }
         public void Become(Akka.Actor.Receive receive) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class SubscriberSink<TIn> : Akka.Streams.Implementation.SinkModule<TIn, Akka.NotUsed>
     {
         public SubscriberSink(Reactive.Streams.ISubscriber<TIn> subscriber, Akka.Streams.Attributes attributes, Akka.Streams.SinkShape<TIn> shape) { }
@@ -3057,6 +3099,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Implementation.SinkModule<TIn, Akka.NotUsed> NewInstance(Akka.Streams.SinkShape<TIn> shape) { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class SubscriberSource<TOut> : Akka.Streams.Implementation.SourceModule<TOut, Reactive.Streams.ISubscriber<TOut>>
     {
         public SubscriberSource(Akka.Streams.Attributes attributes, Akka.Streams.SourceShape<TOut> shape) { }
@@ -3071,12 +3114,14 @@ namespace Akka.Streams.Implementation
         public SubscriptionTimeoutException(string message, System.Exception innerException) { }
         protected SubscriptionTimeoutException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public class Throttle<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Throttle(int cost, System.TimeSpan per, int maximumBurst, System.Func<T, int> costCalculation, Akka.Streams.ThrottleMode mode) { }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public class static Timers
     {
         public const string GraphStageLogicTimer = "GraphStageLogicTimer";
@@ -3097,6 +3142,7 @@ namespace Akka.Streams.Implementation
         public Akka.Streams.Implementation.TransferState And(Akka.Streams.Implementation.TransferState other) { }
         public Akka.Streams.Implementation.TransferState Or(Akka.Streams.Implementation.TransferState other) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public class Unfold<TState, TElement> : Akka.Streams.Stage.GraphStage<Akka.Streams.SourceShape<TElement>>
     {
         public readonly Akka.Streams.Outlet<TElement> Out;
@@ -3106,6 +3152,7 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.SourceShape<TElement> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public class UnfoldAsync<TState, TElement> : Akka.Streams.Stage.GraphStage<Akka.Streams.SourceShape<TElement>>
     {
         public readonly Akka.Streams.Outlet<TElement> Out;
@@ -3115,6 +3162,7 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.SourceShape<TElement> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class UnfoldResourceSource<TOut, TSource> : Akka.Streams.Stage.GraphStage<Akka.Streams.SourceShape<TOut>>
     {
         public UnfoldResourceSource(System.Func<TSource> create, System.Func<TSource, Akka.Streams.Util.Option<TOut>> readData, System.Action<TSource> close) { }
@@ -3124,6 +3172,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class UnfoldResourceSourceAsync<TOut, TSource> : Akka.Streams.Stage.GraphStage<Akka.Streams.SourceShape<TOut>>
     {
         public UnfoldResourceSourceAsync(System.Func<System.Threading.Tasks.Task<TSource>> create, System.Func<TSource, System.Threading.Tasks.Task<Akka.Streams.Util.Option<TOut>>> readData, System.Func<TSource, System.Threading.Tasks.Task> close) { }
@@ -3133,6 +3182,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class VirtualProcessor<T> : Akka.Util.AtomicReference<object>, Reactive.Streams.IProcessor<T, T>, Reactive.Streams.IPublisher<T>, Reactive.Streams.ISubscriber<T>
     {
         public VirtualProcessor() { }
@@ -3145,6 +3195,7 @@ namespace Akka.Streams.Implementation
 }
 namespace Akka.Streams.Implementation.Fusing
 {
+    [Akka.Annotations.InternalApiAttribute()]
     public class ActorGraphInterpreter : Akka.Actor.ActorBase
     {
         public ActorGraphInterpreter(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell) { }
@@ -3262,6 +3313,7 @@ namespace Akka.Streams.Implementation.Fusing
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class Aggregate<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public Aggregate(TOut zero, System.Func<TOut, TIn, TOut> aggregate) { }
@@ -3272,6 +3324,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class AggregateAsync<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public AggregateAsync(TOut zero, System.Func<TOut, TIn, System.Threading.Tasks.Task<TOut>> aggregate) { }
@@ -3282,17 +3335,20 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class Batch<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public Batch(long max, System.Func<TIn, long> costFunc, System.Func<TIn, TOut> seed, System.Func<TOut, TIn, TOut> aggregate) { }
         public override Akka.Streams.FlowShape<TIn, TOut> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class Buffer<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Buffer(int count, Akka.Streams.OverflowStrategy overflowStrategy) { }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class Collect<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public Collect(System.Func<TIn, TOut> func) { }
@@ -3303,6 +3359,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class Delay<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Delay(System.TimeSpan delay, Akka.Streams.DelayOverflowStrategy strategy) { }
@@ -3310,6 +3367,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class Detacher<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Detacher() { }
@@ -3317,6 +3375,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class Expand<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public Expand(System.Func<TIn, System.Collections.Generic.IEnumerator<TOut>> extrapolate) { }
@@ -3327,6 +3386,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class GraphAssembly
     {
         public readonly int[] InletOwners;
@@ -3341,6 +3401,7 @@ namespace Akka.Streams.Implementation.Fusing
         public System.Tuple<Connection[], Akka.Streams.Stage.GraphStageLogic[]> Materialize(Akka.Streams.Attributes inheritedAttributes, Akka.Streams.Implementation.IModule[] copiedModules, System.Collections.Generic.IDictionary<Akka.Streams.Implementation.IModule, object> materializedValues, System.Action<Akka.Streams.Implementation.Fusing.IMaterializedValueSource> register) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class GraphInterpreter
     {
         public readonly Akka.Streams.Implementation.Fusing.GraphAssembly Assembly;
@@ -3387,6 +3448,7 @@ namespace Akka.Streams.Implementation.Fusing
         public void SetHandler(Akka.Streams.Implementation.Fusing.GraphInterpreter.Connection connection, Akka.Streams.Stage.IInHandler handler) { }
         public void SetHandler(Akka.Streams.Implementation.Fusing.GraphInterpreter.Connection connection, Akka.Streams.Stage.IOutHandler handler) { }
         public override string ToString() { }
+        [Akka.Annotations.InternalApiAttribute()]
         public sealed class Connection
         {
             public Connection(int id, int inOwnerId, Akka.Streams.Stage.GraphStageLogic inOwner, int outOwnerId, Akka.Streams.Stage.GraphStageLogic outOwner, Akka.Streams.Stage.IInHandler inHandler, Akka.Streams.Stage.IOutHandler outHandler) { }
@@ -3423,6 +3485,7 @@ namespace Akka.Streams.Implementation.Fusing
             public abstract Akka.Streams.Outlet Out { get; }
         }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class GraphInterpreterShell
     {
         public GraphInterpreterShell(Akka.Streams.Implementation.Fusing.GraphAssembly assembly, Connection[] connections, Akka.Streams.Stage.GraphStageLogic[] logics, Akka.Streams.Shape shape, Akka.Streams.ActorMaterializerSettings settings, Akka.Streams.Implementation.ExtendedActorMaterializer materializer) { }
@@ -3437,6 +3500,7 @@ namespace Akka.Streams.Implementation.Fusing
         public override string ToString() { }
         public void TryAbort(System.Exception reason) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class GraphModule : Akka.Streams.Implementation.AtomicModule
     {
         public readonly Akka.Streams.Implementation.Fusing.GraphAssembly Assembly;
@@ -3449,6 +3513,7 @@ namespace Akka.Streams.Implementation.Fusing
         public override string ToString() { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public class GraphStageModule : Akka.Streams.Implementation.AtomicModule
     {
         public readonly Akka.Streams.Stage.IGraphStageWithMaterializedValue<Akka.Streams.Shape, object> Stage;
@@ -3464,6 +3529,7 @@ namespace Akka.Streams.Implementation.Fusing
     {
         public static Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T> Identity<T>() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class Grouped<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, System.Collections.Generic.IEnumerable<T>>>
     {
         public Grouped(int count) { }
@@ -3474,6 +3540,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class GroupedWithin<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, System.Collections.Generic.IEnumerable<T>>>
     {
         public GroupedWithin(int count, System.TimeSpan timeout) { }
@@ -3487,6 +3554,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Attributes InitialAttributes { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class IgnoreSink<T> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SinkShape<T>, System.Threading.Tasks.Task>
     {
         public IgnoreSink() { }
@@ -3504,6 +3572,7 @@ namespace Akka.Streams.Implementation.Fusing
         Akka.Streams.Implementation.Fusing.IMaterializedValueSource CopySource();
         void SetValue(object result);
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class Intersperse<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Intersperse(T inject) { }
@@ -3511,6 +3580,7 @@ namespace Akka.Streams.Implementation.Fusing
         public bool InjectStartEnd { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class LimitWeighted<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public LimitWeighted(long max, System.Func<T, long> costFunc) { }
@@ -3518,12 +3588,14 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class Log<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Log(string name, System.Func<T, object> extract, Akka.Event.ILoggingAdapter adapter) { }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class MaterializedValueSource<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.SourceShape<T>>, Akka.Streams.Implementation.Fusing.IMaterializedValueSource
     {
         public readonly Akka.Streams.Outlet<T> Outlet;
@@ -3537,6 +3609,7 @@ namespace Akka.Streams.Implementation.Fusing
         public void SetValue(T value) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class OnCompleted<TIn, TOut> : Akka.Streams.Stage.PushStage<TIn, TOut>
     {
         public OnCompleted(System.Action success, System.Action<System.Exception> failure) { }
@@ -3544,6 +3617,7 @@ namespace Akka.Streams.Implementation.Fusing
         public override Akka.Streams.Stage.ITerminationDirective OnUpstreamFailure(System.Exception cause, Akka.Streams.Stage.IContext<TOut> context) { }
         public override Akka.Streams.Stage.ITerminationDirective OnUpstreamFinish(Akka.Streams.Stage.IContext<TOut> context) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class Recover<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Recover(System.Func<System.Exception, Akka.Streams.Util.Option<T>> recovery) { }
@@ -3551,6 +3625,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class RecoverWith<TOut, TMat> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<TOut>
     {
         public RecoverWith(System.Func<System.Exception, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat>> partialFunction, int maximumRetries) { }
@@ -3558,6 +3633,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class Scan<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public Scan(TOut zero, System.Func<TOut, TIn, TOut> aggregate) { }
@@ -3568,6 +3644,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class ScanAsync<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public ScanAsync(TOut zero, System.Func<TOut, TIn, System.Threading.Tasks.Task<TOut>> aggregate) { }
@@ -3578,6 +3655,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class Select<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public Select(System.Func<TIn, TOut> func) { }
@@ -3588,6 +3666,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class SelectAsync<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public readonly Akka.Streams.Inlet<TIn> In;
@@ -3597,6 +3676,7 @@ namespace Akka.Streams.Implementation.Fusing
         public override Akka.Streams.FlowShape<TIn, TOut> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class SelectAsyncUnordered<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public readonly Akka.Streams.Inlet<TIn> In;
@@ -3606,11 +3686,13 @@ namespace Akka.Streams.Implementation.Fusing
         public override Akka.Streams.FlowShape<TIn, TOut> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class SelectError<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public SelectError(System.Func<System.Exception, System.Exception> selector) { }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public abstract class SimpleLinearGraphStage<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, T>>
     {
         public readonly Akka.Streams.Inlet<T> Inlet;
@@ -3625,6 +3707,7 @@ namespace Akka.Streams.Implementation.Fusing
         public override Akka.Streams.SourceShape<T> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class Skip<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Skip(long count) { }
@@ -3632,6 +3715,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class SkipWhile<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public SkipWhile(System.Predicate<T> predicate) { }
@@ -3639,11 +3723,13 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class SkipWithin<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public SkipWithin(System.TimeSpan timeout) { }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class Sliding<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, System.Collections.Generic.IEnumerable<T>>>
     {
         public Sliding(int count, int step) { }
@@ -3654,6 +3740,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class StatefulSelectMany<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public StatefulSelectMany(System.Func<System.Func<TIn, System.Collections.Generic.IEnumerable<TOut>>> concatFactory) { }
@@ -3662,6 +3749,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class Sum<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Sum(System.Func<T, T, T> reduce) { }
@@ -3669,6 +3757,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public abstract class SupervisedGraphStageLogic : Akka.Streams.Stage.GraphStageLogic
     {
         protected SupervisedGraphStageLogic(Akka.Streams.Attributes inheritedAttributes, Akka.Streams.Shape shape) { }
@@ -3677,6 +3766,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected virtual void OnStop(System.Exception ex) { }
         protected Akka.Streams.Util.Option<T> WithSupervision<T>(System.Func<T> function) { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class Take<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Take(long count) { }
@@ -3684,6 +3774,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class TakeWhile<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public TakeWhile(System.Predicate<T> predicate, bool inclusive) { }
@@ -3691,6 +3782,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class TakeWithin<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public TakeWithin(System.TimeSpan timeout) { }
@@ -3713,6 +3805,7 @@ namespace Akka.Streams.Implementation.Fusing
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<Akka.Actor.ICancelable> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class Where<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Where(System.Predicate<T> predicate) { }
@@ -3722,6 +3815,7 @@ namespace Akka.Streams.Implementation.Fusing
 }
 namespace Akka.Streams.Implementation.IO
 {
+    [Akka.Annotations.InternalApiAttribute()]
     public class IncomingConnectionStage : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<Akka.IO.ByteString, Akka.IO.ByteString>>
     {
         public IncomingConnectionStage(Akka.Actor.IActorRef connection, System.Net.EndPoint remoteAddress, bool halfClose) { }
@@ -4035,6 +4129,7 @@ namespace Akka.Streams.Stage
             public override void OnDownstreamFinish() { }
             public override void OnPull() { }
         }
+        [Akka.Annotations.InternalApiAttribute()]
         protected class SubSinkInlet<T>
         {
             public SubSinkInlet(Akka.Streams.Stage.GraphStageLogic logic, string name) { }
@@ -4048,6 +4143,7 @@ namespace Akka.Streams.Stage
             public void SetHandler(Akka.Streams.Stage.InHandler handler) { }
             public override string ToString() { }
         }
+        [Akka.Annotations.InternalApiAttribute()]
         protected class SubSourceOutlet<T>
         {
             public SubSourceOutlet(Akka.Streams.Stage.GraphStageLogic logic, string name) { }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
@@ -4092,6 +4092,7 @@ namespace Akka.Streams.Stage
         protected System.Action GetAsyncCallback(System.Action handler) { }
         protected Akka.Streams.Stage.IInHandler GetHandler(Akka.Streams.Inlet inlet) { }
         protected Akka.Streams.Stage.IOutHandler GetHandler(Akka.Streams.Outlet outlet) { }
+        [Akka.Annotations.ApiMayChangeAttribute()]
         protected Akka.Streams.Stage.StageActorRef GetStageActorRef(Akka.Streams.Stage.StageActorRef.Receive receive) { }
         protected internal T Grab<T>(Akka.Streams.Inlet inlet) { }
         protected internal T Grab<T>(Akka.Streams.Inlet<T> inlet) { }

--- a/src/core/Akka.Cluster.Tests/ClusterGenerators.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterGenerators.cs
@@ -10,6 +10,7 @@ using System;
 using System.Linq;
 using System.Net;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.Tests.Shared.Internals.Helpers;
 using FsCheck;
 
@@ -20,6 +21,7 @@ namespace Akka.Cluster.Tests
     /// 
     /// FsCheck data generators for Akka.Cluster types.
     /// </summary>
+    [InternalApi]
     public class ClusterGenerators
     {
         public static Arbitrary<Address> AddressGenerator()

--- a/src/core/Akka.Persistence/Journal/WriteJournal.cs
+++ b/src/core/Akka.Persistence/Journal/WriteJournal.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Akka.Actor;
+using Akka.Annotations;
 
 namespace Akka.Persistence.Journal
 {
@@ -44,6 +45,7 @@ namespace Akka.Persistence.Journal
         /// <summary>
         /// INTERNAL API
         /// </summary>
+        [InternalApi]
         protected IEnumerable<IPersistentRepresentation> AdaptFromJournal(IPersistentRepresentation representation)
         {
             return _eventAdapters.Get(representation.Payload.GetType())

--- a/src/core/Akka.Persistence/Persistent.cs
+++ b/src/core/Akka.Persistence/Persistent.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.Persistence.Journal;
 using Akka.Persistence.Serialization;
 
@@ -275,6 +276,7 @@ namespace Akka.Persistence
     /// <summary>
     /// INTERNAL API.
     /// </summary>
+    [InternalApi]
     [Serializable]
     public class Persistent : IPersistentRepresentation, IEquatable<IPersistentRepresentation>
     {

--- a/src/core/Akka.Remote.TestKit/Player.cs
+++ b/src/core/Akka.Remote.TestKit/Player.cs
@@ -14,6 +14,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Internal;
+using Akka.Annotations;
 using Akka.Configuration;
 using Akka.Event;
 using Akka.Pattern;
@@ -171,6 +172,7 @@ namespace Akka.Remote.TestKit
     /// 
     /// INTERNAL API.
     /// </summary>
+    [InternalApi]
     class ClientFSM : FSM<ClientFSM.State, ClientFSM.Data>, ILoggingFSM
         //TODO: RequireMessageQueue
     {

--- a/src/core/Akka.Remote/FailureDetectorRegistry.cs
+++ b/src/core/Akka.Remote/FailureDetectorRegistry.cs
@@ -7,6 +7,7 @@
 
 using System;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.Configuration;
 using Akka.Event;
 
@@ -59,6 +60,7 @@ namespace Akka.Remote
     /// 
     /// Utility class to create <see cref="FailureDetector"/> instances via reflection.
     /// </summary>
+    [InternalApi]
     public static class FailureDetectorLoader
     {
         /// <summary>

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -12,6 +12,7 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Internal;
+using Akka.Annotations;
 using Akka.Configuration;
 using Akka.Dispatch;
 using Akka.Dispatch.SysMsg;
@@ -25,6 +26,7 @@ namespace Akka.Remote
     /// <summary>
     /// INTERNAL API
     /// </summary>
+    [InternalApi]
     public class RemoteActorRefProvider : IActorRefProvider
     {
         private readonly ILoggingAdapter _log;

--- a/src/core/Akka.Remote/RemoteTransport.cs
+++ b/src/core/Akka.Remote/RemoteTransport.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.Event;
 
 namespace Akka.Remote
@@ -23,6 +24,7 @@ namespace Akka.Remote
     /// be available (i.e. fully initialized) by the time the first message is received or when the Start() method
     /// returns, whichever happens first.
     /// </summary>
+    [InternalApi]
     public abstract class RemoteTransport
     {
         /// <summary>

--- a/src/core/Akka.Streams.TestKit.Tests/StreamTestDefaultMailbox.cs
+++ b/src/core/Akka.Streams.TestKit.Tests/StreamTestDefaultMailbox.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Reflection;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.Configuration;
 using Akka.Dispatch;
 using Akka.Dispatch.MessageQueues;
@@ -20,6 +21,7 @@ namespace Akka.Streams.TestKit.Tests
     /// This mailbox is only used in tests to verify that stream actors are using
     /// the dispatcher defined in <see cref="ActorMaterializerSettings"/>
     /// </summary>
+    [InternalApi]
     public sealed class StreamTestDefaultMailbox : MailboxType, IProducesMessageQueue<UnboundedMessageQueue>
     {
 

--- a/src/core/Akka.Streams/Dsl/Internal/GraphImpl.cs
+++ b/src/core/Akka.Streams/Dsl/Internal/GraphImpl.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using Akka.Annotations;
 using Akka.Streams.Implementation;
 using Akka.Streams.Util;
 
@@ -15,6 +16,7 @@ namespace Akka.Streams.Dsl.Internal
     /// </summary>
     /// <typeparam name="TShape">TBD</typeparam>
     /// <typeparam name="TMat">TBD</typeparam>
+    [InternalApi]
     public class GraphImpl<TShape, TMat> : IGraph<TShape, TMat> where TShape : Shape
     {
         /// <summary>
@@ -75,6 +77,7 @@ namespace Akka.Streams.Dsl.Internal
     /// <summary>
     /// INTERNAL API
     /// </summary>
+    [InternalApi]
     public static class ModuleExtractor
     {
         /// <summary>

--- a/src/core/Akka.Streams/Extra/Timed.cs
+++ b/src/core/Akka.Streams/Extra/Timed.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Diagnostics;
+using Akka.Annotations;
 using Akka.Streams.Dsl;
 using Akka.Streams.Implementation.Fusing;
 using Akka.Streams.Stage;
@@ -34,6 +35,7 @@ namespace Akka.Streams.Extra
         /// <param name="measuredOps">TBD</param>
         /// <param name="onComplete">TBD</param>
         /// <returns>TBD</returns>
+        [InternalApi]
         public static Source<TOut, TMat2> Timed<TIn, TOut, TMat, TMat2>(Source<TIn, TMat> source, Func<Source<TIn, TMat>, Source<TOut, TMat2>> measuredOps, Action<TimeSpan> onComplete)
         {
             var ctx = new TimedFlowContext();
@@ -89,6 +91,7 @@ namespace Akka.Streams.Extra
         /// <param name="matching">TBD</param>
         /// <param name="onInterval">TBD</param>
         /// <returns>TBD</returns>
+        [InternalApi]
         public static IFlow<TIn, TMat> TimedIntervalBetween<TIn, TMat>(IFlow<TIn, TMat> flow, Func<TIn, bool> matching, Action<TimeSpan> onInterval)
         {
             var timedInterval =

--- a/src/core/Akka.Streams/Graph.cs
+++ b/src/core/Akka.Streams/Graph.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using Akka.Annotations;
 using Akka.Streams.Implementation;
 
 namespace Akka.Streams
@@ -22,6 +23,7 @@ namespace Akka.Streams
         /// <summary>
         /// INTERNAL API: Every materializable element must be backed by a stream layout module
         /// </summary>
+        [InternalApi]
         IModule Module { get; }
     }
 

--- a/src/core/Akka.Streams/Implementation/ActorMaterializerImpl.cs
+++ b/src/core/Akka.Streams/Implementation/ActorMaterializerImpl.cs
@@ -11,6 +11,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.Dispatch;
 using Akka.Event;
 using Akka.Pattern;
@@ -26,30 +27,33 @@ namespace Akka.Streams.Implementation
     public abstract class ExtendedActorMaterializer : ActorMaterializer
     {
         /// <summary>
-        /// TBD
+        /// INTERNAL API
         /// </summary>
         /// <typeparam name="TMat">TBD</typeparam>
         /// <param name="runnable">TBD</param>
         /// <param name="subFlowFuser">TBD</param>
         /// <returns>TBD</returns>
+        [InternalApi]
         public abstract TMat Materialize<TMat>(IGraph<ClosedShape, TMat> runnable, Func<GraphInterpreterShell, IActorRef> subFlowFuser);
 
         /// <summary>
-        /// TBD
+        /// INTERNAL API
         /// </summary>
         /// <typeparam name="TMat">TBD</typeparam>
         /// <param name="runnable">TBD</param>
         /// <param name="subFlowFuser">TBD</param>
         /// <param name="initialAttributes">TBD</param>
         /// <returns>TBD</returns>
+        [InternalApi]
         public abstract TMat Materialize<TMat>(IGraph<ClosedShape, TMat> runnable, Func<GraphInterpreterShell, IActorRef> subFlowFuser, Attributes initialAttributes);
 
         /// <summary>
-        /// TBD
+        /// INTERNAL API
         /// </summary>
         /// <param name="context">TBD</param>
         /// <param name="props">TBD</param>
         /// <returns>TBD</returns>
+        [InternalApi]
         public override IActorRef ActorOf(MaterializationContext context, Props props)
         {
             var dispatcher = props.Deploy.Dispatcher == Deploy.NoDispatcherGiven
@@ -60,13 +64,14 @@ namespace Akka.Streams.Implementation
         }
 
         /// <summary>
-        /// TBD
+        /// INTERNAL API
         /// </summary>
         /// <param name="props">TBD</param>
         /// <param name="name">TBD</param>
         /// <param name="dispatcher">TBD</param>
         /// <exception cref="IllegalStateException">TBD</exception>
         /// <returns>TBD</returns>
+        [InternalApi]
         protected IActorRef ActorOf(Props props, string name, string dispatcher)
         {
             var localActorRef = Supervisor as LocalActorRef;
@@ -253,21 +258,27 @@ namespace Akka.Streams.Implementation
         /// TBD
         /// </summary>
         public override bool IsShutdown => _haveShutDown.Value;
+
         /// <summary>
         /// TBD
         /// </summary>
         public override ActorMaterializerSettings Settings => _settings;
+
         /// <summary>
         /// TBD
         /// </summary>
         public override ActorSystem System => _system;
+
         /// <summary>
-        /// TBD
+        /// INTERNAL API
         /// </summary>
+        [InternalApi]
         public override IActorRef Supervisor => _supervisor;
+
         /// <summary>
-        /// TBD
+        /// INTERNAL API
         /// </summary>
+        [InternalApi]
         public override ILoggingAdapter Logger => _logger ?? (_logger = GetLogger());
 
         /// <summary>

--- a/src/core/Akka.Streams/Implementation/ActorPublisher.cs
+++ b/src/core/Akka.Streams/Implementation/ActorPublisher.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.Event;
 using Akka.Pattern;
 using Akka.Util;
@@ -154,7 +155,7 @@ namespace Akka.Streams.Implementation
         /// </summary>
         public static readonly NormalShutdownException NormalShutdownReason = new NormalShutdownException(NormalShutdownReasonMessage);
     }
-    
+
     /// <summary>
     /// INTERNAL API
     /// 
@@ -162,6 +163,7 @@ namespace Akka.Streams.Implementation
     /// ActorRef! If you don't need to subclass, prefer the apply() method on the companion object which takes care of this.
     /// </summary>
     /// <typeparam name="TOut">TBD</typeparam>
+    [InternalApi]
     public class ActorPublisher<TOut> : IActorPublisher, IPublisher<TOut>
     {
         /// <summary>

--- a/src/core/Akka.Streams/Implementation/Buffers.cs
+++ b/src/core/Akka.Streams/Implementation/Buffers.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using Akka.Annotations;
 
 namespace Akka.Streams.Implementation
 {
@@ -134,6 +135,7 @@ namespace Akka.Streams.Implementation
         /// This exception is thrown when the specified <paramref name="size"/> is less than 1.
         /// </exception>
         /// <returns>TBD</returns>
+        [InternalApi]
         public static FixedSizeBuffer<T> Create<T>(int size)
         {
             if (size < 1)

--- a/src/core/Akka.Streams/Implementation/FanOut.cs
+++ b/src/core/Akka.Streams/Implementation/FanOut.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.Event;
 using Akka.Pattern;
 using Reactive.Streams;
@@ -395,6 +396,7 @@ namespace Akka.Streams.Implementation
     /// <summary>
     /// INTERNAL API
     /// </summary>
+    [InternalApi]
     public static class FanOut
     {
         /// <summary>
@@ -527,6 +529,7 @@ namespace Akka.Streams.Implementation
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public abstract class FanOut<T> : ActorBase, IPump
     {
 

--- a/src/core/Akka.Streams/Implementation/Fusing/ActorGraphInterpreter.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/ActorGraphInterpreter.cs
@@ -11,10 +11,10 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.Event;
 using Akka.Pattern;
 using Akka.Streams.Stage;
-using Akka.Util.Internal;
 using Reactive.Streams;
 using static Akka.Streams.Implementation.Fusing.GraphInterpreter;
 
@@ -24,6 +24,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// <summary>
     /// INTERNAL API
     /// </summary>
+    [InternalApi]
     public sealed class GraphModule : AtomicModule
     {
         /// <summary>
@@ -104,6 +105,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// <summary>
     /// INTERNAL API
     /// </summary>
+    [InternalApi]
     public sealed class GraphInterpreterShell
     {
         private readonly GraphAssembly _assembly;
@@ -441,6 +443,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// <summary>
     /// INTERNAL API
     /// </summary>
+    [InternalApi]
     public class ActorGraphInterpreter : ActorBase
     {
         #region messages

--- a/src/core/Akka.Streams/Implementation/Fusing/GraphAssembly.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/GraphAssembly.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Akka.Annotations;
 using Akka.Pattern;
 using Akka.Streams.Stage;
 using static Akka.Streams.Implementation.Fusing.GraphInterpreter;
@@ -49,6 +50,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// In addition, it is also assumed by the infrastructure that the order of exposed inputs and outputs in the
     /// corresponding segments of these arrays matches the exact same order of the ports in the <see cref="Shape"/>.
     /// </summary>
+    [InternalApi]
     public sealed class GraphAssembly
     {
         /// <summary>

--- a/src/core/Akka.Streams/Implementation/Fusing/GraphInterpreter.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/GraphInterpreter.cs
@@ -11,6 +11,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.Event;
 using Akka.Streams.Stage;
 using Akka.Streams.Util;
@@ -95,6 +96,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// edge of a balance is pulled, dissolving the original cycle).
     ///
     /// </summary>
+    [InternalApi]
     public sealed class GraphInterpreter
     {
         #region internal classes
@@ -190,6 +192,7 @@ namespace Akka.Streams.Implementation.Fusing
         /// Contains all the necessary information for the GraphInterpreter to be able to implement a connection
         /// between an output and input ports.
         /// </summary>
+        [InternalApi]
         public sealed class Connection
         {
             /// <summary>

--- a/src/core/Akka.Streams/Implementation/Fusing/GraphStages.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/GraphStages.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.Streams.Dsl;
 using Akka.Streams.Implementation.Stages;
 using Akka.Streams.Stage;
@@ -68,6 +69,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// <summary>
     /// INTERNAL API
     /// </summary>
+    [InternalApi]
     public class GraphStageModule : AtomicModule
     {
         /// <summary>
@@ -129,6 +131,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public abstract class SimpleLinearGraphStage<T> : GraphStage<FlowShape<T, T>>
     {
         /// <summary>
@@ -207,6 +210,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class Detacher<T> : SimpleLinearGraphStage<T>
     {
         #region internal classes
@@ -647,6 +651,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// This source is not reusable, it is only created internally.
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class MaterializedValueSource<T> : GraphStage<SourceShape<T>>, IMaterializedValueSource
     {
         #region internal classes
@@ -881,6 +886,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// 
     /// Discards all received elements.
     /// </summary>
+    [InternalApi]
     public sealed class IgnoreSink<T> : GraphStageWithMaterializedValue<SinkShape<T>, Task>
     {
         #region Internal classes

--- a/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
@@ -11,6 +11,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.Event;
 using Akka.Pattern;
 using Akka.Streams.Dsl;
@@ -30,6 +31,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
     /// <typeparam name="TOut">TBD</typeparam>
+    [InternalApi]
     public sealed class Select<TIn, TOut> : GraphStage<FlowShape<TIn, TOut>>
     {
         #region Logic
@@ -123,6 +125,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class Where<T> : SimpleLinearGraphStage<T>
     {
         #region Logic
@@ -199,6 +202,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class TakeWhile<T> : SimpleLinearGraphStage<T>
     {
         #region Logic
@@ -289,6 +293,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class SkipWhile<T> : SimpleLinearGraphStage<T>
     {
         #region Logic
@@ -374,6 +379,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// <summary>
     /// INTERNAL API
     /// </summary>
+    [InternalApi]
     public abstract class SupervisedGraphStageLogic : GraphStageLogic
     {
         private readonly Lazy<Decider> _decider;
@@ -451,6 +457,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
     /// <typeparam name="TOut">TBD</typeparam>
+    [InternalApi]
     public sealed class Collect<TIn, TOut> : GraphStage<FlowShape<TIn, TOut>>
     {
         #region Logic
@@ -550,6 +557,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class Recover<T> : SimpleLinearGraphStage<T>
     {
         #region Logic 
@@ -645,6 +653,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// would log the e2 error.
     /// </summary>
     /// <typeparam name="T"></typeparam>
+    [InternalApi]
     public sealed class SelectError<T> : SimpleLinearGraphStage<T>
     {
         #region Logic
@@ -689,6 +698,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class Take<T> : SimpleLinearGraphStage<T>
     {
         #region Logic
@@ -767,6 +777,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class Skip<T> : SimpleLinearGraphStage<T>
     {
         #region Logic
@@ -838,6 +849,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
     /// <typeparam name="TOut">TBD</typeparam>
+    [InternalApi]
     public sealed class Scan<TIn, TOut> : GraphStage<FlowShape<TIn, TOut>>
     {
         #region Logic 
@@ -970,6 +982,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
     /// <typeparam name="TOut">TBD</typeparam>
+    [InternalApi]
     public sealed class ScanAsync<TIn, TOut> : GraphStage<FlowShape<TIn, TOut>>
     {
         #region Logic
@@ -1153,6 +1166,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
     /// <typeparam name="TOut">TBD</typeparam>
+    [InternalApi]
     public sealed class Aggregate<TIn, TOut> : GraphStage<FlowShape<TIn, TOut>>
     {
         #region Logic
@@ -1277,6 +1291,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
     /// <typeparam name="TOut">TBD</typeparam>
+    [InternalApi]
     public sealed class AggregateAsync<TIn, TOut> : GraphStage<FlowShape<TIn, TOut>>
     {
         #region Logic
@@ -1449,6 +1464,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class Intersperse<T> : SimpleLinearGraphStage<T>
     {
         #region internal class
@@ -1564,6 +1580,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class Grouped<T> : GraphStage<FlowShape<T, IEnumerable<T>>>
     {
         #region Logic
@@ -1677,6 +1694,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class LimitWeighted<T> : SimpleLinearGraphStage<T>
     {
         #region Logic
@@ -1774,6 +1792,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class Sliding<T> : GraphStage<FlowShape<T, IEnumerable<T>>>
     {
         #region Logic
@@ -1898,6 +1917,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class Buffer<T> : SimpleLinearGraphStage<T>
     {
         #region Logic
@@ -2051,6 +2071,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
     /// <typeparam name="TOut">TBD</typeparam>
+    [InternalApi]
     public sealed class OnCompleted<TIn, TOut> : PushStage<TIn, TOut>
     {
         private readonly Action _success;
@@ -2104,6 +2125,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
     /// <typeparam name="TOut">TBD</typeparam>
+    [InternalApi]
     public sealed class Batch<TIn, TOut> : GraphStage<FlowShape<TIn, TOut>>
     {
         #region internal classes
@@ -2329,6 +2351,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
     /// <typeparam name="TOut">TBD</typeparam>
+    [InternalApi]
     public sealed class Expand<TIn, TOut> : GraphStage<FlowShape<TIn, TOut>>
     {
         #region internal classes
@@ -2459,6 +2482,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
     /// <typeparam name="TOut">TBD</typeparam>
+    [InternalApi]
     public sealed class SelectAsync<TIn, TOut> : GraphStage<FlowShape<TIn, TOut>>
     {
         #region internal classes
@@ -2644,6 +2668,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
     /// <typeparam name="TOut">TBD</typeparam>
+    [InternalApi]
     public sealed class SelectAsyncUnordered<TIn, TOut> : GraphStage<FlowShape<TIn, TOut>>
     {
         #region internal classes
@@ -2792,6 +2817,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class Log<T> : SimpleLinearGraphStage<T>
     {
         private static readonly Attributes.LogLevels DefaultLogLevels = new Attributes.LogLevels(
@@ -2956,6 +2982,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class GroupedWithin<T> : GraphStage<FlowShape<T, IEnumerable<T>>>
     {
         #region internal classes
@@ -3106,6 +3133,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class Delay<T> : SimpleLinearGraphStage<T>
     {
         #region internal classes
@@ -3285,6 +3313,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class TakeWithin<T> : SimpleLinearGraphStage<T>
     {
         #region internal class
@@ -3341,6 +3370,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class SkipWithin<T> : SimpleLinearGraphStage<T>
     {
         private readonly TimeSpan _timeout;
@@ -3404,6 +3434,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class Sum<T> : SimpleLinearGraphStage<T>
     {
         #region internal classes
@@ -3509,6 +3540,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// </summary>
     /// <typeparam name="TOut">TBD</typeparam>
     /// <typeparam name="TMat">TBD</typeparam>
+    [InternalApi]
     public sealed class RecoverWith<TOut, TMat> : SimpleLinearGraphStage<TOut>
     {
         #region internal classes
@@ -3631,6 +3663,7 @@ namespace Akka.Streams.Implementation.Fusing
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
     /// <typeparam name="TOut">TBD</typeparam>
+    [InternalApi]
     public sealed class StatefulSelectMany<TIn, TOut> : GraphStage<FlowShape<TIn, TOut>>
     {
         #region internal classes

--- a/src/core/Akka.Streams/Implementation/Fusing/StreamOfStreams.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/StreamOfStreams.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using Akka.Annotations;
 using Akka.Pattern;
 using Akka.Streams.Actors;
 using Akka.Streams.Dsl;
@@ -1148,6 +1149,7 @@ namespace Akka.Streams.Implementation.Fusing
         /// <typeparam name="TMat">TBD</typeparam>
         /// <param name="s">TBD</param>
         /// <exception cref="NotSupportedException">TBD</exception>
+        [InternalApi]
         public static void Kill<T, TMat>(Source<T, TMat> s)
         {
             var module = s.Module as GraphStageModule;

--- a/src/core/Akka.Streams/Implementation/IO/TcpStages.cs
+++ b/src/core/Akka.Streams/Implementation/IO/TcpStages.cs
@@ -10,6 +10,7 @@ using System.Collections.Immutable;
 using System.Net;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.IO;
 using Akka.Pattern;
 using Akka.Streams.Dsl;
@@ -228,6 +229,7 @@ namespace Akka.Streams.Implementation.IO
     /// <summary>
     /// INTERNAL API
     /// </summary>
+    [InternalApi]
     public class IncomingConnectionStage : GraphStage<FlowShape<ByteString, ByteString>>
     {
         private readonly IActorRef _connection;

--- a/src/core/Akka.Streams/Implementation/JsonObjectParser.cs
+++ b/src/core/Akka.Streams/Implementation/JsonObjectParser.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using Akka.Annotations;
 using Akka.IO;
 using Akka.Streams.Dsl;
 using Akka.Streams.Util;
@@ -22,6 +23,7 @@ namespace Akka.Streams.Implementation
     /// 
     /// Leading whitespace between elements will be trimmed.
     /// </summary>
+    [InternalApi]
     public class JsonObjectParser
     {
         private static readonly byte SquareBraceStart = Convert.ToByte('[');

--- a/src/core/Akka.Streams/Implementation/Modules.cs
+++ b/src/core/Akka.Streams/Implementation/Modules.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.Streams.Actors;
 using Reactive.Streams;
 
@@ -36,6 +37,7 @@ namespace Akka.Streams.Implementation
     /// </summary>
     /// <typeparam name="TOut">TBD</typeparam>
     /// <typeparam name="TMat">TBD</typeparam>
+    [InternalApi]
     public abstract class SourceModule<TOut, TMat> : AtomicModule, ISourceModule
     {
         private readonly SourceShape<TOut> _shape;
@@ -132,6 +134,7 @@ namespace Akka.Streams.Implementation
     /// Holds a `Subscriber` representing the input side of the flow. The `Subscriber` can later be connected to an upstream `Publisher`.
     /// </summary>
     /// <typeparam name="TOut">TBD</typeparam>
+    [InternalApi]
     public sealed class SubscriberSource<TOut> : SourceModule<TOut, ISubscriber<TOut>>
     {
         /// <summary>
@@ -186,6 +189,7 @@ namespace Akka.Streams.Implementation
     /// downstream and the propagation of back-pressure upstream.
     /// </summary>
     /// <typeparam name="TOut">TBD</typeparam>
+    [InternalApi]
     public sealed class PublisherSource<TOut> : SourceModule<TOut, NotUsed>
     {
         private readonly IPublisher<TOut> _publisher;
@@ -247,6 +251,7 @@ namespace Akka.Streams.Implementation
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="TOut">TBD</typeparam>
+    [InternalApi]
     public sealed class MaybeSource<TOut> : SourceModule<TOut, TaskCompletionSource<TOut>>
     {
         /// <summary>
@@ -298,6 +303,7 @@ namespace Akka.Streams.Implementation
     /// Creates and wraps an actor into <see cref="IPublisher{T}"/> from the given <see cref="Props"/>, which should be props for an <see cref="ActorPublisher{T}"/>.
     /// </summary>
     /// <typeparam name="TOut">TBD</typeparam>
+    [InternalApi]
     public sealed class ActorPublisherSource<TOut> : SourceModule<TOut, IActorRef>
     {
         private readonly Props _props;
@@ -353,6 +359,7 @@ namespace Akka.Streams.Implementation
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="TOut">TBD</typeparam>
+    [InternalApi]
     public sealed class ActorRefSource<TOut> : SourceModule<TOut, IActorRef>
     {
         private readonly int _bufferSize;

--- a/src/core/Akka.Streams/Implementation/ResizableMultiReaderRingBuffer.cs
+++ b/src/core/Akka.Streams/Implementation/ResizableMultiReaderRingBuffer.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
+using Akka.Annotations;
 using Akka.Streams.Util;
 
 namespace Akka.Streams.Implementation
@@ -70,6 +71,7 @@ namespace Akka.Streams.Implementation
     /// elements, rather, if full, the buffer tries to grow and rejects further writes if max capacity is reached.
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public class ResizableMultiReaderRingBuffer<T>
     {
         private readonly int _maxSizeBit;

--- a/src/core/Akka.Streams/Implementation/SinkholeSubscriber.cs
+++ b/src/core/Akka.Streams/Implementation/SinkholeSubscriber.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Akka.Annotations;
 using Reactive.Streams;
 
 namespace Akka.Streams.Implementation
@@ -15,6 +16,7 @@ namespace Akka.Streams.Implementation
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
+    [InternalApi]
     public sealed class SinkholeSubscriber<TIn> : ISubscriber<TIn>
     {
         private readonly TaskCompletionSource<NotUsed> _whenCompleted;

--- a/src/core/Akka.Streams/Implementation/Sinks.cs
+++ b/src/core/Akka.Streams/Implementation/Sinks.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.Pattern;
 using Akka.Streams.Actors;
 using Akka.Streams.Dsl;
@@ -43,6 +44,7 @@ namespace Akka.Streams.Implementation
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
     /// <typeparam name="TMat">TBD</typeparam>
+    [InternalApi]
     public abstract class SinkModule<TIn, TMat> : AtomicModule, ISinkModule
     {
         private readonly SinkShape<TIn> _shape;
@@ -146,6 +148,7 @@ namespace Akka.Streams.Implementation
     /// a subscriber connects and creates demand for elements to be emitted.
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
+    [InternalApi]
     internal class PublisherSink<TIn> : SinkModule<TIn, IPublisher<TIn>>
     {
         /// <summary>
@@ -258,6 +261,7 @@ namespace Akka.Streams.Implementation
     /// Attaches a subscriber to this stream.
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
+    [InternalApi]
     public sealed class SubscriberSink<TIn> : SinkModule<TIn, NotUsed>
     {
         private readonly ISubscriber<TIn> _subscriber;
@@ -314,6 +318,7 @@ namespace Akka.Streams.Implementation
     /// A sink that immediately cancels its upstream upon materialization.
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class CancelSink<T> : SinkModule<T, NotUsed>
     {
         /// <summary>
@@ -368,6 +373,7 @@ namespace Akka.Streams.Implementation
     /// which should be <see cref="Props"/> for an <see cref="ActorSubscriber"/>.
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
+    [InternalApi]
     public sealed class ActorSubscriberSink<TIn> : SinkModule<TIn, IActorRef>
     {
         private readonly Props _props;
@@ -425,6 +431,7 @@ namespace Akka.Streams.Implementation
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
+    [InternalApi]
     public sealed class ActorRefSink<TIn> : SinkModule<TIn, NotUsed>
     {
         private readonly IActorRef _ref;
@@ -489,6 +496,7 @@ namespace Akka.Streams.Implementation
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class LastOrDefaultStage<T> : GraphStageWithMaterializedValue<SinkShape<T>, Task<T>>
     {
         #region stage logic
@@ -568,6 +576,7 @@ namespace Akka.Streams.Implementation
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class FirstOrDefaultStage<T> : GraphStageWithMaterializedValue<SinkShape<T>, Task<T>>
     {
         #region stage logic
@@ -643,6 +652,7 @@ namespace Akka.Streams.Implementation
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class SeqStage<T> : GraphStageWithMaterializedValue<SinkShape<T>, Task<IImmutableList<T>>>
     {
         #region stage logic
@@ -730,6 +740,7 @@ namespace Akka.Streams.Implementation
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class QueueSink<T> : GraphStageWithMaterializedValue<SinkShape<T>, ISinkQueue<T>>
     {
         #region stage logic

--- a/src/core/Akka.Streams/Implementation/Sources.cs
+++ b/src/core/Akka.Streams/Implementation/Sources.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Akka.Annotations;
 using Akka.Pattern;
 using Akka.Streams.Dsl;
 using Akka.Streams.Implementation.Stages;
@@ -22,6 +23,7 @@ namespace Akka.Streams.Implementation
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="TOut">TBD</typeparam>
+    [InternalApi]
     public sealed class QueueSource<TOut> : GraphStageWithMaterializedValue<SourceShape<TOut>, ISourceQueueWithComplete<TOut>>
     {
         #region internal classes
@@ -394,6 +396,7 @@ namespace Akka.Streams.Implementation
     /// </summary>
     /// <typeparam name="TOut">TBD</typeparam>
     /// <typeparam name="TSource">TBD</typeparam>
+    [InternalApi]
     public sealed class UnfoldResourceSource<TOut, TSource> : GraphStage<SourceShape<TOut>>
     {
         #region Logic
@@ -533,6 +536,7 @@ namespace Akka.Streams.Implementation
     /// </summary>
     /// <typeparam name="TOut">TBD</typeparam>
     /// <typeparam name="TSource">TBD</typeparam>
+    [InternalApi]
     public sealed class UnfoldResourceSourceAsync<TOut, TSource> : GraphStage<SourceShape<TOut>>
     {
         #region Logic
@@ -751,6 +755,7 @@ namespace Akka.Streams.Implementation
     /// <summary>
     /// INTERNAL API
     /// </summary>
+    [InternalApi]
     public sealed class LazySource<TOut, TMat> : GraphStageWithMaterializedValue<SourceShape<TOut>, Task<TMat>>
     {
         #region Logic
@@ -874,6 +879,7 @@ namespace Akka.Streams.Implementation
     /// </summary>
     /// <typeparam name="TEventArgs"></typeparam>
     /// <typeparam name="TDelegate">Delegate</typeparam>
+    [InternalApi]
     public sealed class EventSourceStage<TDelegate, TEventArgs> : GraphStage<SourceShape<TEventArgs>>
     {
         #region logic

--- a/src/core/Akka.Streams/Implementation/StreamSubscriptionTimeout.cs
+++ b/src/core/Akka.Streams/Implementation/StreamSubscriptionTimeout.cs
@@ -9,6 +9,7 @@ using System;
 using System.Runtime.Serialization;
 using System.Threading;
 using Akka.Actor;
+using Akka.Annotations;
 using Reactive.Streams;
 
 namespace Akka.Streams.Implementation
@@ -93,6 +94,7 @@ namespace Akka.Streams.Implementation
     /// Subscription timeout which does not start any scheduled events and always returns `true`.
     /// This specialized implementation is to be used for "noop" timeout mode.
     /// </summary>
+    [InternalApi]
     public sealed class NoopSubscriptionTimeout : ICancelable
     {
         /// <summary>

--- a/src/core/Akka.Streams/Implementation/Throttle.cs
+++ b/src/core/Akka.Streams/Implementation/Throttle.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using Akka.Annotations;
 using Akka.Streams.Implementation.Fusing;
 using Akka.Streams.Stage;
 using Akka.Streams.Util;
@@ -17,6 +18,7 @@ namespace Akka.Streams.Implementation
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public class Throttle<T> : SimpleLinearGraphStage<T>
     {
         #region stage logic

--- a/src/core/Akka.Streams/Implementation/Timers.cs
+++ b/src/core/Akka.Streams/Implementation/Timers.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using Akka.Annotations;
 using Akka.Streams.Implementation.Fusing;
 using Akka.Streams.Implementation.Stages;
 using Akka.Streams.Stage;
@@ -23,6 +24,7 @@ namespace Akka.Streams.Implementation
     ///  - if the timer fires before the event happens, these stages all fail the stream
     ///  - otherwise, these streams do not interfere with the element flow, ordinary completion or failure
     /// </summary>
+    [InternalApi]
     public static class Timers
     {
         /// <summary>
@@ -43,6 +45,7 @@ namespace Akka.Streams.Implementation
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class Initial<T> : SimpleLinearGraphStage<T>
     {
         #region Logic
@@ -122,6 +125,7 @@ namespace Akka.Streams.Implementation
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class Completion<T> : SimpleLinearGraphStage<T>
     {
         #region stage logic
@@ -192,6 +196,7 @@ namespace Akka.Streams.Implementation
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class Idle<T> : SimpleLinearGraphStage<T>
     {
         #region stage logic
@@ -273,6 +278,7 @@ namespace Akka.Streams.Implementation
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class BackpressureTimeout<T> : SimpleLinearGraphStage<T>
     {
         #region stage logic
@@ -361,6 +367,7 @@ namespace Akka.Streams.Implementation
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
     /// <typeparam name="TOut">TBD</typeparam>
+    [InternalApi]
     public sealed class IdleTimeoutBidi<TIn, TOut> : GraphStage<BidiShape<TIn, TIn, TOut, TOut>>
     {
         #region Logic
@@ -478,6 +485,7 @@ namespace Akka.Streams.Implementation
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
+    [InternalApi]
     public sealed class DelayInitial<T> : SimpleLinearGraphStage<T>
     {
         #region stage logic
@@ -565,6 +573,7 @@ namespace Akka.Streams.Implementation
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
     /// <typeparam name="TOut">TBD</typeparam>
+    [InternalApi]
     public sealed class IdleInject<TIn, TOut> : GraphStage<FlowShape<TIn, TOut>> where TIn : TOut
     {
         #region Logic

--- a/src/core/Akka.Streams/Implementation/Unfold.cs
+++ b/src/core/Akka.Streams/Implementation/Unfold.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Akka.Annotations;
 using Akka.Streams.Stage;
 using Akka.Util;
 
@@ -17,6 +18,7 @@ namespace Akka.Streams.Implementation
     /// </summary>
     /// <typeparam name="TState">TBD</typeparam>
     /// <typeparam name="TElement">TBD</typeparam>
+    [InternalApi]
     public class Unfold<TState, TElement> : GraphStage<SourceShape<TElement>>
     {
         #region internal classes
@@ -90,6 +92,7 @@ namespace Akka.Streams.Implementation
     /// </summary>
     /// <typeparam name="TState">TBD</typeparam>
     /// <typeparam name="TElement">TBD</typeparam>
+    [InternalApi]
     public class UnfoldAsync<TState, TElement> : GraphStage<SourceShape<TElement>>
     {
         #region stage logic

--- a/src/core/Akka.Streams/Stage/GraphStage.cs
+++ b/src/core/Akka.Streams/Stage/GraphStage.cs
@@ -1556,6 +1556,7 @@ namespace Akka.Streams.Stage
         /// </summary>
         /// <param name="receive">Callback that will be called upon receiving of a message by this special Actor</param>
         /// <returns>Minimal actor with watch method</returns>
+        [ApiMayChange]
         protected StageActorRef GetStageActorRef(StageActorRef.Receive receive)
         {
             if (_stageActorRef == null)

--- a/src/core/Akka.Streams/Stage/GraphStage.cs
+++ b/src/core/Akka.Streams/Stage/GraphStage.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.Dispatch.SysMsg;
 using Akka.Event;
 using Akka.Pattern;
@@ -1606,6 +1607,7 @@ namespace Akka.Streams.Stage
         /// when the stage shuts down lest the corresponding Sink be left hanging.
         /// </summary>
         /// <typeparam name="T">TBD</typeparam>
+        [InternalApi]
         protected class SubSinkInlet<T>
         {
             private readonly string _name;
@@ -1741,6 +1743,7 @@ namespace Akka.Streams.Stage
         /// given time limit, see e.g. ActorMaterializerSettings.
         /// </summary>
         /// <typeparam name="T">TBD</typeparam>
+        [InternalApi]
         protected class SubSourceOutlet<T>
         {
             private readonly string _name;

--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -103,10 +103,9 @@ namespace Akka.Actor
 
             #endregion
         }
-
-        /** INTERNAL API */
+        
         /// <summary>
-        /// TBD
+        /// INTERNAL API
         /// </summary>
         internal static char[] ValidSymbols = @"""-_.*$+:@&=,!~';""()".ToCharArray();
 

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor.Internal;
+using Akka.Annotations;
 using Akka.Dispatch.SysMsg;
 using Akka.Event;
 using Akka.Util;
@@ -28,6 +29,7 @@ namespace Akka.Actor
     /// necessary to distinguish between local and non-local references, this is the only
     /// method provided on the scope. 
     /// </summary>
+    [InternalApi]
     public interface IActorRefScope
     {
         /// <summary>
@@ -358,6 +360,7 @@ namespace Akka.Actor
     /// Used by built-in <see cref="IActorRef"/> implementations for handling
     /// internal operations that are not exposed directly to end-users.
     /// </summary>
+    [InternalApi]
     public interface IInternalActorRef : IActorRef, IActorRefScope
     {
         /// <summary>
@@ -433,6 +436,7 @@ namespace Akka.Actor
     /// 
     /// Abstract implementation of <see cref="IInternalActorRef"/>.
     /// </summary>
+    [InternalApi]
     public abstract class InternalActorRefBase : ActorRefBase, IInternalActorRef
     {
         /// <inheritdoc cref="IInternalActorRef"/>
@@ -481,6 +485,7 @@ namespace Akka.Actor
     /// 
     /// Barebones <see cref="IActorRef"/> with no backing actor or <see cref="ActorCell"/>.
     /// </summary>
+    [InternalApi]
     public abstract class MinimalActorRef : InternalActorRefBase, ILocalRef
     {
         /// <inheritdoc cref="InternalActorRefBase"/>
@@ -601,6 +606,7 @@ namespace Akka.Actor
     /// 
     /// Used to power actors that use an <see cref="ActorCell"/>, which is the majority of them.
     /// </summary>
+    [InternalApi]
     public abstract class ActorRefWithCell : InternalActorRefBase
     {
         /// <summary>

--- a/src/core/Akka/Actor/Cell.cs
+++ b/src/core/Akka/Actor/Cell.cs
@@ -8,13 +8,15 @@
 using System;
 using System.Collections.Generic;
 using Akka.Actor.Internal;
+using Akka.Annotations;
 using Akka.Dispatch.SysMsg;
 
 namespace Akka.Actor
 {
     /// <summary>
-    /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
+    /// INTERNAL API
     /// </summary>
+    [InternalApi]
     public interface ICell
     {
         /// <summary>Gets the "self" reference which this Cell is attached to.</summary>

--- a/src/core/Akka/Actor/DeadLetterMailbox.cs
+++ b/src/core/Akka/Actor/DeadLetterMailbox.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using Akka.Annotations;
 using Akka.Dispatch;
 using Akka.Dispatch.MessageQueues;
 using Akka.Dispatch.SysMsg;
@@ -81,6 +82,7 @@ namespace Akka.Actor
     /// 
     /// Mailbox for dead letters.
     /// </summary>
+    [InternalApi]
     public sealed class DeadLetterMailbox : Mailbox
     {
         private readonly IActorRef _deadLetters;

--- a/src/core/Akka/Actor/Internal/InternalSupportsTestFSMRef.cs
+++ b/src/core/Akka/Actor/Internal/InternalSupportsTestFSMRef.cs
@@ -5,6 +5,8 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using Akka.Annotations;
+
 namespace Akka.Actor.Internal
 {
     /// <summary>
@@ -14,6 +16,7 @@ namespace Akka.Actor.Internal
     /// </summary>
     /// <typeparam name="TState">TBD</typeparam>
     /// <typeparam name="TData">TBD</typeparam>
+    [InternalApi]
     public interface IInternalSupportsTestFSMRef<TState, TData>
     {
         /// <summary>
@@ -34,6 +37,7 @@ namespace Akka.Actor.Internal
     /// INTERNAL API. Used for testing.
     /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
     /// </summary>
+    [InternalApi]
     public class InternalActivateFsmLogging
     {
         private static readonly InternalActivateFsmLogging _instance = new InternalActivateFsmLogging();

--- a/src/core/Akka/Actor/RepointableActorRef.cs
+++ b/src/core/Akka/Actor/RepointableActorRef.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Akka.Actor.Internal;
+using Akka.Annotations;
 using Akka.Dispatch;
 using Akka.Dispatch.SysMsg;
 using Akka.Event;
@@ -332,6 +333,7 @@ namespace Akka.Actor
     /// <summary>
     /// INTERNAL API
     /// </summary>
+    [InternalApi]
     public class UnstartedCell : ICell
     {
         private readonly ActorSystemImpl _system;

--- a/src/core/Akka/Actor/RootGuardianActorRef.cs
+++ b/src/core/Akka/Actor/RootGuardianActorRef.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using Akka.Actor.Internal;
+using Akka.Annotations;
 using Akka.Dispatch;
 
 namespace Akka.Actor
@@ -17,6 +18,7 @@ namespace Akka.Actor
     /// 
     /// Used by <see cref="GuardianActor"/>
     /// </summary>
+    [InternalApi]
     public class RootGuardianActorRef : LocalActorRef
     {
         private IInternalActorRef _tempContainer;

--- a/src/core/Akka/Annotations/Attributes.cs
+++ b/src/core/Akka/Annotations/Attributes.cs
@@ -20,7 +20,29 @@ namespace Akka.Annotations
     /// may be put on the same line as the INTERNAL API comment in order to clarify further.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Constructor | AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Module, Inherited = true, AllowMultiple = false)]
-    public class InternalApiAttribute : Attribute
+    public sealed class InternalApiAttribute : Attribute
     {
+    }
+
+    /// <summary>
+    /// Marks APIs that are meant to evolve towards becoming stable APIs, but are not stable APIs yet.
+    /// 
+    /// Evolving interfaces MAY change from one patch release to another (i.e. 1.3.0 to 1.3.1) without up-front notice.
+    /// A best-effort approach is taken to not cause more breakage than really neccessary, and usual deprecation techniques 
+    /// are utilised while evolving these APIs, however there is NO strong guarantee regarding the source or binary 
+    /// compatibility of APIs marked using this annotation. 
+    /// 
+    /// It MAY also change when promoting the API to stable, for example such changes may include removal of deprecated 
+    /// methods that were introduced during the evolution and final refactoring that were deferred because they would 
+    /// have introduced to much breaking changes during the evolution phase. 
+    /// 
+    /// Promoting the API to stable MAY happen in a patch release.
+    /// 
+    /// It is encouraged to document in xmldoc how exactly this API is expected to evolve.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Constructor | AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Module, Inherited = true, AllowMultiple = false)]
+    public sealed class ApiMayChangeAttribute : Attribute
+    {
+        
     }
 }

--- a/src/core/Akka/Annotations/Attributes.cs
+++ b/src/core/Akka/Annotations/Attributes.cs
@@ -1,0 +1,26 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Attributes.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+
+namespace Akka.Annotations
+{
+    /// <summary>
+    /// Marks APIs that are considered internal to Akka and may change at any point in time without any warning.
+    /// 
+    /// For example, this annotation should be used for code that should be inherently internal, but it cannot be
+    /// due to limitations of .NET encapsulation in areas such as inheritance or serialization.
+    /// 
+    /// If a method/class annotated with this method has a xdoc comment, the first line MUST include 
+    /// in order to be easily identifiable from generated documentation. Additional information
+    /// may be put on the same line as the INTERNAL API comment in order to clarify further.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Constructor | AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Module, Inherited = true, AllowMultiple = false)]
+    public class InternalApiAttribute : Attribute
+    {
+    }
+}

--- a/src/core/Akka/Dispatch/AbstractDispatcher.cs
+++ b/src/core/Akka/Dispatch/AbstractDispatcher.cs
@@ -10,6 +10,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.Configuration;
 using Akka.Dispatch.SysMsg;
 using Akka.Event;
@@ -86,6 +87,7 @@ namespace Akka.Dispatch
     /// <summary>
     /// INTERNAL API - used to configure the executor used by the <see cref="Dispatcher"/>
     /// </summary>
+    [InternalApi]
     public abstract class ExecutorServiceConfigurator : ExecutorServiceFactory
     {
         /// <summary>
@@ -410,6 +412,7 @@ namespace Akka.Dispatch
         /// how long it will wait until it shuts itself down, defaulting to your Akka.NET config's 'akka.actor.default-dispatcher.shutdown-timeout'
         /// or the system default specified.
         /// </summary>
+        [InternalApi]
         public TimeSpan ShutdownTimeout { get; protected set; }
 
         /// <summary>
@@ -515,6 +518,7 @@ namespace Akka.Dispatch
         /// <remarks>
         /// MUST BE IDEMPOTENT
         /// </remarks>
+        [InternalApi]
         protected abstract void Shutdown();
 
         private readonly ShutdownAction _shutdownAction;

--- a/src/core/Akka/Dispatch/CachingConfig.cs
+++ b/src/core/Akka/Dispatch/CachingConfig.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using Akka.Annotations;
 using Akka.Configuration;
 using Akka.Configuration.Hocon;
 
@@ -22,6 +23,7 @@ namespace Akka.Dispatch
     /// 
     /// All other <see cref="Config"/> operations are delegated to the wrapped <see cref="Config"/>.
     /// </summary>
+    [InternalApi]
     class CachingConfig : Config
     {
         private static readonly Config EmptyConfig = ConfigurationFactory.Empty;

--- a/src/core/Akka/Dispatch/Dispatcher.cs
+++ b/src/core/Akka/Dispatch/Dispatcher.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Threading;
+using Akka.Annotations;
 using Akka.Event;
 using Akka.Util;
 
@@ -96,6 +97,7 @@ namespace Akka.Dispatch
         /// <remarks>
         /// MUST BE IDEMPOTENT
         /// </remarks>
+        [InternalApi]
         protected override void Shutdown()
         {
             var newDelegate = _executorService.Clone();

--- a/src/core/Akka/Dispatch/ExecutorService.cs
+++ b/src/core/Akka/Dispatch/ExecutorService.cs
@@ -7,6 +7,7 @@
 
 using System;
 using Akka.Actor;
+using Akka.Annotations;
 
 namespace Akka.Dispatch
 {
@@ -47,6 +48,7 @@ namespace Akka.Dispatch
     /// 
     /// Used to produce <see cref="ExecutorServiceFactory"/> instances for use inside <see cref="Dispatcher"/>s
     /// </summary>
+    [InternalApi]
     public abstract class ExecutorServiceFactory
     {
         /// <summary>

--- a/src/core/Akka/Dispatch/SysMsg/ISystemMessage.cs
+++ b/src/core/Akka/Dispatch/SysMsg/ISystemMessage.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.Event;
 using Assert = System.Diagnostics.Debug;
 
@@ -276,6 +277,7 @@ namespace Akka.Dispatch.SysMsg
     /// <see cref="ISystemMessage"/> is an interface and too basic to express
     /// all of the capabilities needed to express a full-fledged system message.
     /// </summary>
+    [InternalApi]
     public abstract class SystemMessage : ISystemMessage
     {
         /// <summary>
@@ -356,6 +358,7 @@ namespace Akka.Dispatch.SysMsg
     /// <summary>
     /// INTERNAL API
     /// </summary>
+    [InternalApi]
     public sealed class Failed : SystemMessage, IStashWhenFailed
     {
         private readonly long _uid;

--- a/src/core/Akka/Event/EventBusUnsubscriber.cs
+++ b/src/core/Akka/Event/EventBusUnsubscriber.cs
@@ -5,12 +5,9 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
 using Akka.Actor;
 using Akka.Actor.Internal;
+using Akka.Annotations;
 using Akka.Util.Internal;
 
 namespace Akka.Event
@@ -27,6 +24,7 @@ namespace Akka.Event
     /// subscribe calls * because of the need of linearizing the history message sequence and the possibility of sometimes
     /// watching a few actors too much - we opt for the 2nd choice here.
     /// </summary>
+    [InternalApi]
     class EventStreamUnsubscriber : ActorBase
     {
         private readonly EventStream _eventStream;

--- a/src/core/Akka/IO/UdpConnectedManager.cs
+++ b/src/core/Akka/IO/UdpConnectedManager.cs
@@ -7,13 +7,17 @@
 
 using System;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.Event;
 
 namespace Akka.IO
 {
     using ByteBuffer = ArraySegment<byte>;
 
-    // INTERNAL API
+    /// <summary>
+    /// INTERNAL API
+    /// </summary>
+    [InternalApi]
     class UdpConnectedManager : ActorBase
     {
         private readonly UdpConnectedExt _udpConn;

--- a/src/core/Akka/IO/UdpListener.cs
+++ b/src/core/Akka/IO/UdpListener.cs
@@ -9,6 +9,7 @@ using System;
 using System.Linq;
 using System.Net.Sockets;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.Dispatch;
 using Akka.Event;
 using Akka.Util.Internal;
@@ -18,7 +19,10 @@ namespace Akka.IO
     using static Udp;
     using ByteBuffer = ArraySegment<byte>;
 
-    // INTERNAL API
+    /// <summary>
+    /// INTERNAL API
+    /// </summary>
+    [InternalApi]
     class UdpListener : WithUdpSend, IRequiresMessageQueue<IUnboundedMessageQueueSemantics>
     {
         private readonly IActorRef _bindCommander;

--- a/src/core/Akka/Serialization/Serializer.cs
+++ b/src/core/Akka/Serialization/Serializer.cs
@@ -9,6 +9,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.Util;
 
 namespace Akka.Serialization
@@ -149,6 +150,7 @@ namespace Akka.Serialization
     /// <summary>
     /// INTERNAL API.
     /// </summary>
+    [InternalApi]
     public static class SerializerIdentifierHelper
     {
         internal const string SerializationIdentifiers = "akka.actor.serialization-identifiers";

--- a/src/core/Akka/Util/Internal/TaskExtensions.cs
+++ b/src/core/Akka/Util/Internal/TaskExtensions.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Akka.Annotations;
 
 namespace Akka.Util.Internal
 {
@@ -16,6 +17,7 @@ namespace Akka.Util.Internal
     ///
     /// Extensions for working with <see cref="Task"/> types
     /// </summary>
+    [InternalApi]
     public static class TaskExtensions
     {
         /// <summary>

--- a/src/core/Akka/Util/TokenBucket.cs
+++ b/src/core/Akka/Util/TokenBucket.cs
@@ -7,12 +7,14 @@
 
 
 using System;
+using Akka.Annotations;
 
 namespace Akka.Util
 {
     /// <summary>
     /// INTERNAL API
     /// </summary>
+    [InternalApi]
     public abstract class TokenBucket
     {
         private readonly long _capacity;

--- a/src/core/Akka/Util/TypeExtensions.cs
+++ b/src/core/Akka/Util/TypeExtensions.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Reflection;
+using Akka.Annotations;
 
 namespace Akka.Util
 {
@@ -50,6 +51,7 @@ namespace Akka.Util
         /// </summary>
         /// <param name="type">TBD</param>
         /// <returns>Returns the type qualified name including namespace and assembly, but not assembly version.</returns>
+        [InternalApi]
         public static string TypeQualifiedName(this Type type)
         {
             string shortened;


### PR DESCRIPTION
Just like in case of Akka, I've added attribute annotations for parts of the API which are not stable (`ApiMayChange`) or shouldn't be treated as public even thou they are (because of .NET limitations). Regarding latter, I've annotated only those members/types which have either public/protected/not-set encapsulation. I didn't bother to add `InternalApi` to internal types, as this would be redundant.

Those attributes could be possibly used and leveraged in future by static analysis tools to make sure users are not unintentionally using private parts of Akka.NET API.