### PR TITLE
Obsoleted actor producer pipeline extensions

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -202,6 +202,7 @@ namespace Akka.Actor
             public override int GetHashCode() { }
         }
     }
+    [System.ObsoleteAttribute("Actor producer pipeline API will be removed in v1.5.")]
     public class ActorProducerPipeline : System.Collections.Generic.IEnumerable<Akka.Actor.IActorProducerPlugin>, System.Collections.IEnumerable
     {
         public ActorProducerPipeline(System.Lazy<Akka.Event.ILoggingAdapter> log, System.Collections.Generic.IEnumerable<Akka.Actor.IActorProducerPlugin> plugins) { }
@@ -210,6 +211,7 @@ namespace Akka.Actor
         public void BeforeActorIncarnated(Akka.Actor.ActorBase actor, Akka.Actor.IActorContext context) { }
         public System.Collections.Generic.IEnumerator<Akka.Actor.IActorProducerPlugin> GetEnumerator() { }
     }
+    [System.ObsoleteAttribute("Actor producer pipeline API will be removed in v1.5.")]
     public class ActorProducerPipelineResolver
     {
         public ActorProducerPipelineResolver(System.Func<Akka.Event.ILoggingAdapter> logBuilder) { }
@@ -219,6 +221,7 @@ namespace Akka.Actor
         public bool Register(Akka.Actor.IActorProducerPlugin plugin) { }
         public bool Unregister(Akka.Actor.IActorProducerPlugin plugin) { }
     }
+    [System.ObsoleteAttribute("Actor producer pipeline API will be removed in v1.5.")]
     public abstract class ActorProducerPluginBase : Akka.Actor.IActorProducerPlugin
     {
         protected ActorProducerPluginBase() { }
@@ -226,6 +229,7 @@ namespace Akka.Actor
         public virtual void BeforeIncarnated(Akka.Actor.ActorBase actor, Akka.Actor.IActorContext context) { }
         public virtual bool CanBeAppliedTo(System.Type actorType) { }
     }
+    [System.ObsoleteAttribute("Actor producer pipeline API will be removed in v1.5.")]
     public abstract class ActorProducerPluginBase<TActor> : Akka.Actor.IActorProducerPlugin
         where TActor : Akka.Actor.ActorBase
     {
@@ -691,6 +695,7 @@ namespace Akka.Actor
     public abstract class ExtendedActorSystem : Akka.Actor.ActorSystem
     {
         protected ExtendedActorSystem() { }
+        [System.ObsoleteAttribute("Actor producer pipeline API will be removed in v1.5.")]
         public abstract Akka.Actor.ActorProducerPipelineResolver ActorPipelineResolver { get; }
         public abstract Akka.Actor.IInternalActorRef Guardian { get; }
         public abstract Akka.Actor.IInternalActorRef LookupRoot { get; }
@@ -925,6 +930,7 @@ namespace Akka.Actor
         void Stop(Akka.Actor.IActorRef child);
         void UnbecomeStacked();
     }
+    [System.ObsoleteAttribute("Actor producer pipeline API will be removed in v1.5.")]
     public interface IActorProducerPlugin
     {
         void AfterIncarnated(Akka.Actor.ActorBase actor, Akka.Actor.IActorContext context);

--- a/src/core/Akka/Actor/ActorProducerPipeline.cs
+++ b/src/core/Akka/Actor/ActorProducerPipeline.cs
@@ -18,6 +18,7 @@ namespace Akka.Actor
     /// <summary>
     /// Plugin interface used to define
     /// </summary>
+    [Obsolete("Actor producer pipeline API will be removed in v1.5.")]
     public interface IActorProducerPlugin
     {
         /// <summary>
@@ -45,6 +46,7 @@ namespace Akka.Actor
     /// <summary>
     /// Base actor producer pipeline plugin class.
     /// </summary>
+    [Obsolete("Actor producer pipeline API will be removed in v1.5.")]
     public abstract class ActorProducerPluginBase : IActorProducerPlugin
     {
         /// <summary>
@@ -75,6 +77,7 @@ namespace Akka.Actor
     /// <summary>
     /// Base generic actor producer pipeline plugin class.
     /// </summary>
+    [Obsolete("Actor producer pipeline API will be removed in v1.5.")]
     public abstract class ActorProducerPluginBase<TActor> : IActorProducerPlugin where TActor : ActorBase
     {
         /// <summary>
@@ -115,6 +118,7 @@ namespace Akka.Actor
     /// <summary>
     /// Class used to resolving actor producer pipelines depending on actor type.
     /// </summary>
+    [Obsolete("Actor producer pipeline API will be removed in v1.5.")]
     public class ActorProducerPipelineResolver
     {
         private readonly Lazy<ILoggingAdapter> _log;
@@ -230,6 +234,7 @@ namespace Akka.Actor
     /// <summary>
     /// TBD
     /// </summary>
+    [Obsolete("Actor producer pipeline API will be removed in v1.5.")]
     public class ActorProducerPipeline : IEnumerable<IActorProducerPlugin>
     {
         private Lazy<ILoggingAdapter> _log;

--- a/src/core/Akka/Actor/ExtendedActorSystem.cs
+++ b/src/core/Akka/Actor/ExtendedActorSystem.cs
@@ -5,6 +5,8 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
+
 namespace Akka.Actor
 {
     /// <summary>
@@ -41,6 +43,7 @@ namespace Akka.Actor
         /// Gets the actor producer pipeline resolver for current actor system. It may be used by
         /// Akka plugins to inject custom behavior directly into actor creation chain.
         /// </summary>
+        [Obsolete("Actor producer pipeline API will be removed in v1.5.")]
         public abstract ActorProducerPipelineResolver ActorPipelineResolver { get; }
 
         /// <summary>


### PR DESCRIPTION
As proposed in #3050 and #3057 , if we're going to modernize the way how we do create actors (including native support for dependency injection) an existing actor producer pipeline API will need to be removed - this isn't actually a great pain, as AFAIK it's not a very popular or well-known part of the API.

This PR obsoletes relevant types and fields with *Actor producer pipeline API will be removed in v1.5.* message, so that eventual users will be informed about this beforehand.