### PR TITLE
Fix in resolving serializer id

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -4489,6 +4489,8 @@ namespace Akka.Serialization
         public Serialization(Akka.Actor.ExtendedActorSystem system) { }
         public Akka.Actor.ActorSystem System { get; }
         public void AddSerializationMap(System.Type type, Akka.Serialization.Serializer serializer) { }
+        [System.ObsoleteAttribute("No longer supported. Use the AddSerializer(name, serializer) overload instead.", true)]
+        public void AddSerializer(Akka.Serialization.Serializer serializer) { }
         public void AddSerializer(string name, Akka.Serialization.Serializer serializer) { }
         public object Deserialize(byte[] bytes, int serializerId, System.Type type) { }
         public object Deserialize(byte[] bytes, int serializerId, string manifest) { }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -4489,7 +4489,7 @@ namespace Akka.Serialization
         public Serialization(Akka.Actor.ExtendedActorSystem system) { }
         public Akka.Actor.ActorSystem System { get; }
         public void AddSerializationMap(System.Type type, Akka.Serialization.Serializer serializer) { }
-        public void AddSerializer(Akka.Serialization.Serializer serializer) { }
+        public void AddSerializer(string name, Akka.Serialization.Serializer serializer) { }
         public object Deserialize(byte[] bytes, int serializerId, System.Type type) { }
         public object Deserialize(byte[] bytes, int serializerId, string manifest) { }
         public Akka.Serialization.Serializer FindSerializerFor(object obj, string defaultSerializerName = null) { }

--- a/src/core/Akka.Tests/Serialization/CustomSerializerSpec.cs
+++ b/src/core/Akka.Tests/Serialization/CustomSerializerSpec.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Linq;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Xunit;
+
+namespace Akka.Tests.Serialization
+{
+    public class CustomSerializerSpec
+    {
+        /// <summary>
+        /// Here we basically verify that a serializer decides where its Serializer Identifier is coming
+        /// from. When using the default Serializer base class, it read from hocon config. But this should not be 
+        /// a neccesity
+        /// </summary>
+        [Fact]
+        public void Custom_serializer_must_be_owner_of_its_serializerId()
+        {
+            var config = ConfigurationFactory.ParseString(@"
+                akka.actor {
+                    serializers {
+                        custom = tnw = ""Akka.Tests.Serialization.CustomSerializer, Akka.Tests""
+                    }
+                    serialization-bindings {
+                        ""System.Object"" = custom
+                    }
+                }
+            ");
+            //The above config explictly does not configures the serialization-identifiers section
+            using (var system = ActorSystem.Create(nameof(CustomSerializerSpec), config))
+            {
+                var serializer = (CustomSerializer)system.Serialization.FindSerializerForType(typeof(object));
+                Assert.Equal(666, serializer.Identifier);
+            }
+        }
+    }
+
+    public class CustomSerializer : Serializer
+    {
+        public CustomSerializer(ExtendedActorSystem system) : base(system)
+        {
+        }
+
+        /// <summary>
+        /// This custom serializer overrides the Identifier implementation and returns a hard coded value
+        /// </summary>
+        public override int Identifier => 666;
+
+        public override bool IncludeManifest => false;
+
+        public override byte[] ToBinary(object obj)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override object FromBinary(byte[] bytes, Type type)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/core/Akka.Tests/Serialization/CustomSerializerSpec.cs
+++ b/src/core/Akka.Tests/Serialization/CustomSerializerSpec.cs
@@ -22,7 +22,7 @@ namespace Akka.Tests.Serialization
             var config = ConfigurationFactory.ParseString(@"
                 akka.actor {
                     serializers {
-                        custom = tnw = ""Akka.Tests.Serialization.CustomSerializer, Akka.Tests""
+                        custom = ""Akka.Tests.Serialization.CustomSerializer, Akka.Tests""
                     }
                     serialization-bindings {
                         ""System.Object"" = custom

--- a/src/core/Akka/Serialization/Serialization.cs
+++ b/src/core/Akka/Serialization/Serialization.cs
@@ -124,10 +124,8 @@ namespace Akka.Serialization
         {
             if (name == null)
                 return null;
-
-            if (!_serializersByName.TryGetValue(name, out Serializer serializer))
-                throw new ArgumentException($"Couldn't find serializer for [{name}] make sure you correctly defined.");
-
+           
+            _serializersByName.TryGetValue(name, out Serializer serializer);
             return serializer;
         }
 
@@ -271,7 +269,7 @@ namespace Akka.Serialization
                 }
             }
 
-            if (serializer == null)
+            if (serializer == null)  
                 serializer = GetSerializerByName(defaultSerializerName);
 
             // do a final check for the "object" serializer

--- a/src/core/Akka/Serialization/Serialization.cs
+++ b/src/core/Akka/Serialization/Serialization.cs
@@ -71,7 +71,7 @@ namespace Akka.Serialization
             System = system;
 
             _nullSerializer = new NullSerializer(system);
-            AddSerializer(_nullSerializer);
+            AddSerializer("null",_nullSerializer);
 
             var serializersConfig = system.Settings.Config.GetConfig("akka.actor.serializers").AsEnumerable().ToList();
             var serializerBindingConfig = system.Settings.Config.GetConfig("akka.actor.serialization-bindings").AsEnumerable().ToList();


### PR DESCRIPTION
Serializer id is now only determined once, upon initialisation. And its
the serializer implementation which dictates where that id comes from.
We no longer assume it always comes from the hocon config.