### PR TITLE
Add Serilog docs page to the table of contents

### DIFF
--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -168,6 +168,8 @@
     href: utilities/event-bus.md
   - name: Logging
     href: utilities/logging.md
+  - name: Serilog
+    href: utilities/serilog.md
   - name: Scheduler
     href: utilities/scheduler.md
   - name: Circuit Breaker


### PR DESCRIPTION
Serilog docs page is accessible (http://getakka.net/articles/utilities/serilog.html) but not visible in the table of contents.