### PR TITLE
Fixed performance degradation if recovering with big numbers of snaps…

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Snapshot/QueryExecutor.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Snapshot/QueryExecutor.cs
@@ -273,7 +273,8 @@ namespace Akka.Persistence.Sql.Common.Snapshot
                 WHERE {Configuration.PersistenceIdColumnName} = @PersistenceId 
                     AND {Configuration.SequenceNrColumnName} <= @SequenceNr
                     AND {Configuration.TimestampColumnName} <= @Timestamp
-                ORDER BY {Configuration.SequenceNrColumnName} DESC";
+                ORDER BY {Configuration.SequenceNrColumnName} DESC
+                LIMIT 1";
 
             DeleteSnapshotSql = $@"
                 DELETE FROM {Configuration.FullSnapshotTableName}

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Snapshot/SqlSnapshotStore.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Snapshot/SqlSnapshotStore.cs
@@ -110,9 +110,10 @@ namespace Akka.Persistence.Sql.Common.Snapshot
             try
             {
                 using (var connection = CreateDbConnection())
+                using (var nestedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(_pendingRequestsCancellation.Token))
                 {
-                    await connection.OpenAsync(_pendingRequestsCancellation.Token);
-                    await QueryExecutor.CreateTableAsync(connection, _pendingRequestsCancellation.Token);
+                    await connection.OpenAsync(nestedCancellationTokenSource.Token);
+                    await QueryExecutor.CreateTableAsync(connection, nestedCancellationTokenSource.Token);
                     return Initialized.Instance;
                 }
             }
@@ -163,9 +164,10 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         protected override async Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
         {
             using (var connection = CreateDbConnection())
+            using (var nestedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(_pendingRequestsCancellation.Token))
             {
-                await connection.OpenAsync(_pendingRequestsCancellation.Token);
-                return await QueryExecutor.SelectSnapshotAsync(connection, _pendingRequestsCancellation.Token, persistenceId, criteria.MaxSequenceNr, criteria.MaxTimeStamp);
+                await connection.OpenAsync(nestedCancellationTokenSource.Token);
+                return await QueryExecutor.SelectSnapshotAsync(connection, nestedCancellationTokenSource.Token, persistenceId, criteria.MaxSequenceNr, criteria.MaxTimeStamp);
             }
         }
 
@@ -178,9 +180,10 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         protected override async Task SaveAsync(SnapshotMetadata metadata, object snapshot)
         {
             using (var connection = CreateDbConnection())
+            using (var nestedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(_pendingRequestsCancellation.Token))
             {
-                await connection.OpenAsync();
-                await QueryExecutor.InsertAsync(connection, _pendingRequestsCancellation.Token, snapshot, metadata);
+                await connection.OpenAsync(nestedCancellationTokenSource.Token);
+                await QueryExecutor.InsertAsync(connection, nestedCancellationTokenSource.Token, snapshot, metadata);
             }
         }
 
@@ -192,10 +195,11 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         protected override async Task DeleteAsync(SnapshotMetadata metadata)
         {
             using (var connection = CreateDbConnection())
+            using (var nestedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(_pendingRequestsCancellation.Token))    
             {
-                await connection.OpenAsync();
+                await connection.OpenAsync(nestedCancellationTokenSource.Token);
                 DateTime? timestamp = metadata.Timestamp != DateTime.MinValue ? metadata.Timestamp : default(DateTime?);
-                await QueryExecutor.DeleteAsync(connection, _pendingRequestsCancellation.Token, metadata.PersistenceId, metadata.SequenceNr, timestamp);
+                await QueryExecutor.DeleteAsync(connection, nestedCancellationTokenSource.Token, metadata.PersistenceId, metadata.SequenceNr, timestamp);
             }
         }
 
@@ -208,9 +212,10 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         protected override async Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
         {
             using (var connection = CreateDbConnection())
+            using (var nestedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(_pendingRequestsCancellation.Token))
             {
-                await connection.OpenAsync();
-                await QueryExecutor.DeleteBatchAsync(connection, _pendingRequestsCancellation.Token, persistenceId, criteria.MaxSequenceNr, criteria.MaxTimeStamp);
+                await connection.OpenAsync(nestedCancellationTokenSource.Token);
+                await QueryExecutor.DeleteBatchAsync(connection, nestedCancellationTokenSource.Token, persistenceId, criteria.MaxSequenceNr, criteria.MaxTimeStamp);
             }
         }
         


### PR DESCRIPTION
1) If your actor has a big number of snapshots then system experiences performance degradation. 

The reason for this degradation is SQL-driver rows pre-fetch. Furthermore, the current implementation of SelectSnapshotAsync reads only one row, so there is no reason to query more than one snapshot row.

2) DbCommand has memory leaks in ExecuteNonQueryAsync and ExecuteDbDataReaderAsync methods. So you should provide new cancellation token for each SQL command and dispose it (more here: https://github.com/dotnet/corefx/issues/16439).