### PR TITLE
Fixed Akka.Cluster.TestKit nuget package (Fixes #3131)

### DIFF
--- a/src/core/Akka.Cluster.TestKit/Akka.Cluster.TestKit.csproj
+++ b/src/core/Akka.Cluster.TestKit/Akka.Cluster.TestKit.csproj
@@ -12,7 +12,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Akka.Remote.TestKit\Akka.Remote.TestKit.csproj" />
     <ProjectReference Include="..\Akka.Cluster\Akka.Cluster.csproj" />
-    <ProjectReference Include="..\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/src/core/Akka.Cluster.TestKit/MultiNodeClusterSpec.cs
+++ b/src/core/Akka.Cluster.TestKit/MultiNodeClusterSpec.cs
@@ -362,14 +362,14 @@ namespace Akka.Cluster.TestKit
                     AwaitAssert(() =>
                     {
                         foreach (var a in canNotBePartOfMemberRing)
-                            ClusterView.Members.Select(m => m.Address).Contains(a).ShouldBeFalse();
+                            _assertions.AssertFalse(ClusterView.Members.Select(m => m.Address).Contains(a));
                     });
-                AwaitAssert(() => ClusterView.Members.Count.ShouldBe(numbersOfMembers));
-                AwaitAssert(() => ClusterView.Members.All(m => m.Status == MemberStatus.Up).ShouldBeTrue("All members should be up"));
+                AwaitAssert(() => _assertions.AssertEqual(numbersOfMembers, ClusterView.Members.Count));
+                AwaitAssert(() => _assertions.AssertTrue(ClusterView.Members.All(m => m.Status == MemberStatus.Up), "All members should be up"));
                 // clusterView.leader is updated by LeaderChanged, await that to be updated also
                 var firstMember = ClusterView.Members.FirstOrDefault();
                 var expectedLeader = firstMember == null ? null : firstMember.Address;
-                AwaitAssert(() => ClusterView.Leader.ShouldBe(expectedLeader));
+                AwaitAssert(() => _assertions.AssertEqual(expectedLeader, ClusterView.Leader));
             });
         }
 


### PR DESCRIPTION
Removed Akka.Cluster.TestKit's dependency on Akka.Test.Shared.Internals which is not on nuget (and according to it's readme not intended to be public).

Replaced the usages of "Should" extension assertions with ITestKitAssertions as they were used elsewhere in the file, and the Shared.Internals extensions weren't really providing that much value.