### PR TITLE
fixed bug with DistributedPubSub automatic extension loading docs

### DIFF
--- a/docs/articles/clustering/distributed-publish-subscribe.md
+++ b/docs/articles/clustering/distributed-publish-subscribe.md
@@ -242,5 +242,5 @@ akka.cluster.pub-sub {
 It is recommended to load the extension when the actor system is started by defining it in akka.extensions configuration property. Otherwise it will be activated when first used and then it takes a while for it to be populated.
 
 ```hocon
-akka.extensions = ["akka.cluster.pubsub.DistributedPubSub"]
+akka.extensions = ["Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubExtensionProvider,Akka.Cluster.Tools"]
 ```

--- a/src/Akka.sln
+++ b/src/Akka.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.12
+VisualStudioVersion = 15.0.26730.15
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Benchmark", "Benchmark", "{73108242-625A-4D7B-AA09-63375DBAE464}"
 EndProject

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubConfigSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubConfigSpec.cs
@@ -23,7 +23,8 @@ namespace Akka.Cluster.Tools.Tests.PublishSubscribe
 
         public static Config GetConfig()
         {
-            return ConfigurationFactory.ParseString("akka.actor.provider = \"Akka.Cluster.ClusterActorRefProvider, Akka.Cluster\"");
+            return ConfigurationFactory.ParseString(@"akka.actor.provider = cluster
+                                                    akka.extensions = [""Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubExtensionProvider,Akka.Cluster.Tools""]");
         }
 
         [Fact]
@@ -41,6 +42,14 @@ namespace Akka.Cluster.Tools.Tests.PublishSubscribe
             var config = Sys.Settings.Config.GetConfig("akka.cluster.pub-sub");
             config.GetString("name").ShouldBe("distributedPubSubMediator");
             config.GetString("use-dispatcher").ShouldBe(string.Empty);
+        }
+
+        [Fact]
+        public void DistributedPubSub_must_load_via_HOCON()
+        {
+            // Validate that the syntax recommended at http://getakka.net/articles/clustering/distributed-publish-subscribe.html
+            // for automatically loading the DistributedPubSub plugin at startup is correct
+            Assert.True(Sys.HasExtension<DistributedPubSub>());
         }
     }
 }


### PR DESCRIPTION
The docs at http://getakka.net/articles/clustering/distributed-publish-subscribe.html currently contain an error in the section that explains how to configure `DistributedPubSub` to launch at startup. I've corrected this and added a spec to verify that my configuration is valid.