### PR TITLE
[WIP] resolve issues with .NET Core dependency globbing

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -143,9 +143,9 @@ Target "RunTestsNetCore" (fun _ ->
                     getIncrementalUnitTests NetCore |> Seq.map (fun x -> printfn "\t%s" x; x)
         | "experimental" -> log "The following test projects would be run under Incremental Test config..."
                             getIncrementalUnitTests NetCore |> Seq.iter log
-                            getUnitTestProjects()
+                            getUnitTestProjects NetCore
         | _ -> log "All test projects will be run..."
-               getUnitTestProjects()
+               getUnitTestProjects NetCore
      
     let runSingleProject project =
         let result = ExecProcess(fun info ->
@@ -171,9 +171,9 @@ Target "MultiNodeTests" (fun _ ->
     let multiNodeTestAssemblies = 
         match getBuildParamOrDefault "incremental" "" with
         | "true" -> log "The following test projects would be run under Incremental Test config..."
-                    getIncrementalMNTRTests() |> Seq.map (fun x -> printfn "\t%s" x; x)
+                    getIncrementalMNTRTests |> Seq.map (fun x -> printfn "\t%s" x; x)
         | "experimental" -> log "The following MNTR specs would be run under Incremental Test config..."
-                            getIncrementalMNTRTests() |> Seq.iter log
+                            getIncrementalMNTRTests |> Seq.iter log
                             getAllMntrTestAssemblies()
         | _ -> log "All test projects will be run"
                getAllMntrTestAssemblies()

--- a/build.fsx
+++ b/build.fsx
@@ -111,12 +111,12 @@ Target "RunTests" (fun _ ->
     let projects =
         match getBuildParamOrDefault "incremental" "" with
         | "true" -> log "The following test projects would be run under Incremental Test config..."
-                    getIncrementalUnitTests() |> Seq.map (fun x -> printfn "\t%s" x; x)
+                    getIncrementalUnitTests Net |> Seq.map (fun x -> printfn "\t%s" x; x)
         | "experimental" -> log "The following test projects would be run under Incremental Test config..."
-                            getIncrementalUnitTests() |> Seq.iter log
-                            getUnitTestProjects()
+                            (getIncrementalUnitTests Net) |> Seq.iter log
+                            getUnitTestProjects Net
         | _ -> log "All test projects will be run..."
-               getUnitTestProjects()
+               getUnitTestProjects Net
     
     let runSingleProject project =
         let result = ExecProcess(fun info ->
@@ -140,9 +140,9 @@ Target "RunTestsNetCore" (fun _ ->
     let projects =
         match getBuildParamOrDefault "incremental" "" with
         | "true" -> log "The following test projects would be run under Incremental Test config..."
-                    getIncrementalUnitTests() |> Seq.map (fun x -> printfn "\t%s" x; x)
+                    getIncrementalUnitTests NetCore |> Seq.map (fun x -> printfn "\t%s" x; x)
         | "experimental" -> log "The following test projects would be run under Incremental Test config..."
-                            getIncrementalUnitTests() |> Seq.iter log
+                            getIncrementalUnitTests NetCore |> Seq.iter log
                             getUnitTestProjects()
         | _ -> log "All test projects will be run..."
                getUnitTestProjects()

--- a/build.ps1
+++ b/build.ps1
@@ -31,7 +31,7 @@ Param(
 
 $FakeVersion = "4.63.0"
 $NBenchVersion = "1.0.1"
-$DotNetChannel = "preview";
+$DotNetChannel = "LTS";
 $DotNetVersion = "2.0.0";
 $DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/v$DotNetVersion/scripts/obtain/dotnet-install.ps1";
 $NugetVersion = "4.3.0";

--- a/src/common.props
+++ b/src/common.props
@@ -14,22 +14,6 @@
     <AkkaPackageTags>akka;actors;actor model;Akka;concurrency</AkkaPackageTags>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Maintenance Release for Akka.NET 1.3**
-Updates and bugfixes**:
-- Bugfix: Hyperion NuGet package restore creating duplicate assemblies for the same version inside Akka
-- Various documentation fixes and updates
-- Bugfix: issue where data sent via UDP when `ByteString` payload had buffers with length more than 1, `UdpSender` only wrote the first part of the buffers and dropped the rest.
-- Bugfix: Akka.IO.Tcp failed to write some outgoing messages.
-- Improved support for OSX &amp; Rider
-- Bugfix: Akka.Persistence support for `SerializerWithStringManifest` required by Akka.Cluster.Sharding and Akka.Cluster.Tools
-	- Akka.Persistence.Sqlite and Akka.Persistence.SqlServer were unable to support `SerializerWithStringManifest`, so using Akka.Cluster.Sharding with Sql plugins would not work.
-- Bugfix: Akka.Streams generic type parameters of the flow returned from current implementation of Bidiflow's JoinMat method were incorrect.
-- Bugfix: `PersistenceMessageSerializer` was failing with the wrong exceptoin when a non-supported type was provided.
-Akka.Persistence backwards compability warning**:
-- Akka.Persistence.Sql introduces an additional field to the schema used by Sql-based plugins to allow for the use of `SerializerWithStringManifest` called `serializer_id`.  It requires any previous Sql schema to be updated to have this field.  Details are included in the Akka.Persistence.Sqlite plugin README.md file.  Users of the Akka.Persistence.Sqlite plugin must alter their existing databases to add the field `serializer_id int (4)`:
-```
-ALTER TABLE {your_event_journal_table_name} ADD COLUMN `serializer_id` INTEGER ( 4 )
-ALTER TABLE {your_snapshot_table_name} ADD COLUMN `serializer_id` INTEGER ( 4 )
-```</PackageReleaseNotes>
+    <PackageReleaseNotes>Placeholder</PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/src/common.props
+++ b/src/common.props
@@ -9,7 +9,7 @@
     <NoWarn>$(NoWarn);CS1591;NU1605</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
-    <XunitVersion>2.3.0</XunitVersion>
+    <XunitVersion>2.3.0-beta5-*</XunitVersion>
     <TestSdkVersion>15.3.0</TestSdkVersion>
     <AkkaPackageTags>akka;actors;actor model;Akka;concurrency</AkkaPackageTags>
   </PropertyGroup>

--- a/src/common.props
+++ b/src/common.props
@@ -6,7 +6,7 @@
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;NU1605</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <XunitVersion>2.3.0</XunitVersion>

--- a/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
+++ b/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <AssemblyName>Akka.Streams.Tests</AssemblyName>
-    <TargetFrameworks>net452;netcoreapp1.1.1</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
+++ b/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <AssemblyName>Akka.Streams.Tests</AssemblyName>
-    <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Attempt at resolving #3150 

Looks like something in the tooling we use changed suddenly, unrelated to our own changes, which has affected the way .NET Core projects copy their output to their respective bin folders from dependent DLLs.

switched to LTS .NET SDK channel to see if this helps.