### PR TITLE
close #3150 - resolved issue with missing runtime assembly loaded dependencies

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -111,12 +111,12 @@ Target "RunTests" (fun _ ->
     let projects =
         match getBuildParamOrDefault "incremental" "" with
         | "true" -> log "The following test projects would be run under Incremental Test config..."
-                    getIncrementalUnitTests() |> Seq.map (fun x -> printfn "\t%s" x; x)
+                    getIncrementalUnitTests Net |> Seq.map (fun x -> printfn "\t%s" x; x)
         | "experimental" -> log "The following test projects would be run under Incremental Test config..."
-                            getIncrementalUnitTests() |> Seq.iter log
-                            getUnitTestProjects()
+                            (getIncrementalUnitTests Net) |> Seq.iter log
+                            getUnitTestProjects Net
         | _ -> log "All test projects will be run..."
-               getUnitTestProjects()
+               getUnitTestProjects Net
     
     let runSingleProject project =
         let result = ExecProcess(fun info ->
@@ -140,12 +140,12 @@ Target "RunTestsNetCore" (fun _ ->
     let projects =
         match getBuildParamOrDefault "incremental" "" with
         | "true" -> log "The following test projects would be run under Incremental Test config..."
-                    getIncrementalUnitTests() |> Seq.map (fun x -> printfn "\t%s" x; x)
+                    getIncrementalUnitTests NetCore |> Seq.map (fun x -> printfn "\t%s" x; x)
         | "experimental" -> log "The following test projects would be run under Incremental Test config..."
-                            getIncrementalUnitTests() |> Seq.iter log
-                            getUnitTestProjects()
+                            getIncrementalUnitTests NetCore |> Seq.iter log
+                            getUnitTestProjects NetCore
         | _ -> log "All test projects will be run..."
-               getUnitTestProjects()
+               getUnitTestProjects NetCore
      
     let runSingleProject project =
         let result = ExecProcess(fun info ->
@@ -171,9 +171,9 @@ Target "MultiNodeTests" (fun _ ->
     let multiNodeTestAssemblies = 
         match getBuildParamOrDefault "incremental" "" with
         | "true" -> log "The following test projects would be run under Incremental Test config..."
-                    getIncrementalMNTRTests() |> Seq.map (fun x -> printfn "\t%s" x; x)
+                    getIncrementalMNTRTests |> Seq.map (fun x -> printfn "\t%s" x; x)
         | "experimental" -> log "The following MNTR specs would be run under Incremental Test config..."
-                            getIncrementalMNTRTests() |> Seq.iter log
+                            getIncrementalMNTRTests |> Seq.iter log
                             getAllMntrTestAssemblies()
         | _ -> log "All test projects will be run"
                getAllMntrTestAssemblies()

--- a/build.fsx
+++ b/build.fsx
@@ -171,9 +171,9 @@ Target "MultiNodeTests" (fun _ ->
     let multiNodeTestAssemblies = 
         match getBuildParamOrDefault "incremental" "" with
         | "true" -> log "The following test projects would be run under Incremental Test config..."
-                    getIncrementalMNTRTests |> Seq.map (fun x -> printfn "\t%s" x; x)
+                    getIncrementalMNTRTests() |> Seq.map (fun x -> printfn "\t%s" x; x)
         | "experimental" -> log "The following MNTR specs would be run under Incremental Test config..."
-                            getIncrementalMNTRTests |> Seq.iter log
+                            getIncrementalMNTRTests() |> Seq.iter log
                             getAllMntrTestAssemblies()
         | _ -> log "All test projects will be run"
                getAllMntrTestAssemblies()

--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -258,7 +258,7 @@ module IncrementalTests =
     let getIncrementalUnitTests runtime =
         getIncrementalTestProjects2 Unit runtime
     
-    let getIncrementalMNTRTests =
+    let getIncrementalMNTRTests() =
         getIncrementalTestProjects2 MNTR Net
         |> Seq.map (fun p -> getAssemblyForProject p)
     

--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -16,6 +16,16 @@ module IncrementalTests =
     | Linux
     | All
 
+    type Runtime =
+    | NetCore
+    | Net
+
+    let SkippedTest name runtime =
+        match (name, runtime) with
+            | (EndsWith "Sqlite.Tests.csproj", NetCore) -> false
+            | _ -> true
+
+
     let (|IsRunnable|_|) name platform (csproj:string) =
         let isSupported =
             match platform with
@@ -30,12 +40,13 @@ module IncrementalTests =
         | IsRunnable "Akka.API.Tests.csproj" Linux proj -> false
         | _ -> true
 
-    let getUnitTestProjects() =
+    let getUnitTestProjects runtime =
         let allTestProjects = !! "./**/core/**/*.Tests.csproj"
                               ++ "./**/contrib/**/*.Tests.csproj"
                               -- "./**/serializers/**/*Wire*.csproj"
         allTestProjects 
         |> Seq.filter IsRunnable
+        |> Seq.filter (fun p -> SkippedTest p runtime) // filter out specs that should not be run based on .NET Core / .NET differences
 
     let isBuildScript (file:string) =
         match file with
@@ -43,6 +54,7 @@ module IncrementalTests =
         | EndsWith "ps1" -> true
         | EndsWith "cmd" -> true
         | EndsWith "sh" -> true
+        | EndsWith "props" -> true // use common.props to trigger full build
         | _ -> false
     
     let getHeadHashFor repositoryDir branch =
@@ -131,16 +143,18 @@ module IncrementalTests =
     // MultiNodeTestRunner incremental test selection
     //--------------------------------------------------------------------------------
 
-    let getMntrProjects() =
+    let getMntrProjects runtime =
         !! "./src/**/*Tests.MultiNode.csproj"
         |> Seq.map (fun x -> x.ToString())
+        |> Seq.filter (fun p -> SkippedTest p runtime) // filter out specs that should not be run based on .NET Core / .NET differences
     
     let getAllMntrTestAssemblies() = // if we're not running incremental tests
-        getMntrProjects()
+        getMntrProjects Net
         |> Seq.map (fun x -> getAssemblyForProject x)
+        |> Seq.filter (fun p -> SkippedTest p Net) // filter out specs that should not be run based on .NET Core / .NET differences
     
     let getAllMntrTestNetCoreAssemblies() = // if we're not running incremental tests
-        getMntrProjects()
+        getMntrProjects NetCore
         |> Seq.map (fun x -> getNetCoreAssemblyForProject x)
     
     //--------------------------------------------------------------------------------
@@ -215,7 +229,7 @@ module IncrementalTests =
                         //logfn "%s references %s but is not a test project..." proj.parentProject.projectName project
                         yield! findTestProjectsThatHaveDependencyOn proj.parentProject.projectName testMode }
     
-    let getIncrementalTestProjects2 testMode =
+    let getIncrementalTestProjects2 testMode runtime =
         logfn "Searching for incremental tests to run in %s test mode..." (testMode.ToString())
         let updatedFiles = getUpdatedFiles()
         log "The following files have been updated since forking from dev branch..."
@@ -223,10 +237,13 @@ module IncrementalTests =
         log "The following test projects will be run..."
         if (updatedFiles |> Seq.exists (fun p -> isBuildScript p)) then
             log "Full test suite"
-            match testMode with
-            | Unit -> getUnitTestProjects()
-            | MNTR -> getMntrProjects()
-            | Perf -> getPerfTestProjects()
+            let specs =
+                match testMode with
+                | Unit -> getUnitTestProjects runtime
+                | MNTR -> getMntrProjects runtime
+                | Perf -> getPerfTestProjects()
+            specs
+            |> Seq.filter (fun p -> SkippedTest p runtime) // filter out specs that should not be run based on .NET Core / .NET differences
         else
             updatedFiles
             |> generateContainingProjFileCollection
@@ -236,18 +253,19 @@ module IncrementalTests =
             |> Seq.map (fun p -> p.parentProject.projectPath)
             |> Seq.distinct
             |> Seq.filter IsRunnable
+            |> Seq.filter (fun p -> SkippedTest p runtime) // filter out specs that should not be run based on .NET Core / .NET differences
     
-    let getIncrementalUnitTests() =
-        getIncrementalTestProjects2 Unit
+    let getIncrementalUnitTests runtime =
+        getIncrementalTestProjects2 Unit runtime
     
-    let getIncrementalMNTRTests() =
-        getIncrementalTestProjects2 MNTR
+    let getIncrementalMNTRTests =
+        getIncrementalTestProjects2 MNTR Net
         |> Seq.map (fun p -> getAssemblyForProject p)
     
     let getIncrementalNetCoreMNTRTests() =
-        getIncrementalTestProjects2 MNTR
+        getIncrementalTestProjects2 MNTR NetCore
         |> Seq.map (fun p -> getNetCoreAssemblyForProject p)
     
     let getIncrementalPerfTests() =
-        getIncrementalTestProjects2 Perf
+        getIncrementalTestProjects2 Perf Net
         |> Seq.map (fun p -> getAssemblyForProject p)

--- a/src/common.props
+++ b/src/common.props
@@ -14,22 +14,9 @@
     <AkkaPackageTags>akka;actors;actor model;Akka;concurrency</AkkaPackageTags>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Maintenance Release for Akka.NET 1.3**
-Updates and bugfixes**:
-- Bugfix: Hyperion NuGet package restore creating duplicate assemblies for the same version inside Akka
-- Various documentation fixes and updates
-- Bugfix: issue where data sent via UDP when `ByteString` payload had buffers with length more than 1, `UdpSender` only wrote the first part of the buffers and dropped the rest.
-- Bugfix: Akka.IO.Tcp failed to write some outgoing messages.
-- Improved support for OSX &amp; Rider
-- Bugfix: Akka.Persistence support for `SerializerWithStringManifest` required by Akka.Cluster.Sharding and Akka.Cluster.Tools
-	- Akka.Persistence.Sqlite and Akka.Persistence.SqlServer were unable to support `SerializerWithStringManifest`, so using Akka.Cluster.Sharding with Sql plugins would not work.
-- Bugfix: Akka.Streams generic type parameters of the flow returned from current implementation of Bidiflow's JoinMat method were incorrect.
-- Bugfix: `PersistenceMessageSerializer` was failing with the wrong exceptoin when a non-supported type was provided.
-Akka.Persistence backwards compability warning**:
-- Akka.Persistence.Sql introduces an additional field to the schema used by Sql-based plugins to allow for the use of `SerializerWithStringManifest` called `serializer_id`.  It requires any previous Sql schema to be updated to have this field.  Details are included in the Akka.Persistence.Sqlite plugin README.md file.  Users of the Akka.Persistence.Sqlite plugin must alter their existing databases to add the field `serializer_id int (4)`:
-```
-ALTER TABLE {your_event_journal_table_name} ADD COLUMN `serializer_id` INTEGER ( 4 )
-ALTER TABLE {your_snapshot_table_name} ADD COLUMN `serializer_id` INTEGER ( 4 )
-```</PackageReleaseNotes>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PackageReleaseNotes>Placeholder</PackageReleaseNotes>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Resolves #3150 by simply copying 100% of nuget dependencies to the output directory for .NET Core. This is more of a work-around than a fix.

IMHO, we probably need to rewrite the multi-node testrunner to take advantage of the runtime.deps files and such for finding the locations of assemblies that are shared by multiple apps on a given .NET Core runtime.

Either way, this should allow specs to pass again.