### PR TITLE
Fix an inconstant ToString on ConsistentRoutee when the node is remot…

### DIFF
--- a/src/core/Akka.Remote.Tests/RemoteConsistentHashingRouterSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteConsistentHashingRouterSpec.cs
@@ -45,6 +45,44 @@ namespace Akka.Remote.Tests
             var result2 = keys.Select(k => consistentHash2.NodeFor(k).Routee);
             Assert.Equal(result2,result1);
         }
+
+        /// <summary>
+        /// This test creates two nodes each with a local routee to themselves and a remote routee to the other node.
+        /// When using ToString on ConsistentRoutee the local and remote routees are treated differently.
+        /// This test ensures the two are hashed the same.
+        /// </summary>
+        [Fact]
+        public void ConsistentHashingGroup_must_use_same_hash_ring_independent_of_local_and_remote_nodes()
+        {
+            var a1 = new Address("akka.tcp", "RemoteConsistentHashingRouterSpec-1", "client1", 2552);
+            var a2 = new Address("akka.tcp", "RemoteConsistentHashingRouterSpec-1", "client2", 2552);
+            var localActor = Sys.ActorOf(Props.Empty, "a");
+
+            var s1 = new ActorRefRoutee(localActor);
+            var s2 = new ActorSelectionRoutee(Sys.ActorSelection("akka.tcp://RemoteConsistentHashingRouterSpec-1@client2:2552/user/a"));
+            var nodes1 = new List<ConsistentRoutee>(new[] { new ConsistentRoutee(s1, a1), new ConsistentRoutee(s2, a1) });
+
+            var s4 = new ActorSelectionRoutee(Sys.ActorSelection("akka.tcp://RemoteConsistentHashingRouterSpec-1@client1:2552/user/a"));
+            var s5 = new ActorRefRoutee(localActor);
+
+            var nodes2 = new List<ConsistentRoutee>(new[] { new ConsistentRoutee(s5, a2), new ConsistentRoutee(s4, a2) });
+
+            var consistentHash1 = ConsistentHash.Create(nodes1, 10);
+            var consistentHash2 = ConsistentHash.Create(nodes2, 10);
+            var keys = new List<string>(new[] { "A", "B", "C", "D", "E", "F", "G" });
+
+            var result1 = keys
+                .Select(k => consistentHash1.NodeFor(k))
+                .Select(routee => routee.ToString())
+                .ToArray();
+
+            var result2 = keys
+                .Select(k => consistentHash2.NodeFor(k))
+                .Select(routee => routee.ToString())
+                .ToArray();
+
+            result1
+                .ShouldOnlyContainInOrder(result2);
+        }
     }
 }
-

--- a/src/core/Akka/Routing/ConsistentHashRouter.cs
+++ b/src/core/Akka/Routing/ConsistentHashRouter.cs
@@ -292,7 +292,7 @@ namespace Akka.Routing
                 case ActorRefRoutee actorRef:
                     return ToStringWithFullAddress(actorRef.Actor.Path);
                 case ActorSelectionRoutee selection:
-                    return ToStringWithFullAddress(selection.Selection.Anchor.Path) +
+                    return ToStringWithFullAddress(selection.Selection.Anchor.Path).TrimEnd('/') +
                             selection.Selection.PathString;
                 default:
                     return Routee.ToString();


### PR DESCRIPTION
…e vs local

Signed-off-by: Joshua Benjamin <benjamin@syncromatics.com>