### PR TITLE
disabled Hyperion warning

### DIFF
--- a/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
+++ b/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
@@ -50,7 +50,6 @@ namespace Akka.Tests.Configuration
             settings.SerializeAllMessages.ShouldBeFalse();
             settings.SerializeAllCreators.ShouldBeFalse();
             settings.UnstartedPushTimeout.Seconds.ShouldBe(10);
-
             settings.DefaultVirtualNodesFactor.ShouldBe(10);
 
             settings.AddLoggingReceive.ShouldBeFalse();

--- a/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
@@ -231,7 +231,7 @@ namespace Akka.Actor.Internal
             {
                 Log.Warning($"NewtonSoftJsonSerializer has been detected as a default serializer. " +
                             $"It will be obsoleted in Akka.NET starting from version 1.5 in the favor of Hyperion " +
-                            $"(for more info visit: http://getakka.net/docs/Serialization#how-to-setup-hyperion-as-default-serializer ). " +
+                            $"(for more info visit: http://getakka.net/articles/networking/serialization.html#how-to-setup-hyperion-as-default-serializer ). " +
                             $"If you want to suppress this message set HOCON `{configPath}` config flag to on.");
             }
         }

--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -32,7 +32,7 @@ akka {
 
   # Suppresses warning about usage of the default (JSON.NET) serializer
   # which is going to be obsoleted at v1.5
-  suppress-json-serializer-warning = off
+  suppress-json-serializer-warning = on #disabled as of 1.3.2, given that the 1.5 timeframe is far out
  
   # Log level for the very basic logger activated during AkkaApplication startup
   # Options: OFF, ERROR, WARNING, INFO, DEBUG


### PR DESCRIPTION
We've had this warning in the codebase for a year and we've not set a timeframe for the Hyperion switch.

Urging users to switch from something stable (JSON.NET) to something that is still in beta (Hyperion) isn't the right call at the moment considering that we're not directing a lot of resources into Hyperion right now due to other priorities (i.e. such as integrating with all of the new standard APIs for configuration, dependency injection, Unity3D, Xamarin support, etc... - stuff that wasn't on anyone's radar a year ago.)

Beyond that the most urgent issues solved by Hyperion, related to Cluster.Sharding, were solved via dedicated Protobuf serializers in 1.3. The ultimate plan is still the same: to switch from JSON.NET to Hyperion in the 1.5 release. But the timeframe for that is indeterminate and realistically we're not focused on that right now. So let's get rid of the code smell and keep people on something that works.