### PR TITLE
Changed Akka.IO configured buffer-size to 512B

### DIFF
--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -535,7 +535,7 @@ akka {
         class = "Akka.IO.Buffers.DirectBufferPool, Akka"
 
         # Size of a single byte buffer in bytes.
-        buffer-size = 256
+        buffer-size = 512
 
         # Number of byte buffers per segment. Every segement is a single continuous
         # byte array in memory. Once buffer pool will run out of byte buffers to 
@@ -557,35 +557,7 @@ akka {
       # on the pool again, to be reused later. This way we can reduce a GC pressure
       # by reusing the same components instead of recycling them.
       buffer-pool = "akka.io.tcp.direct-buffer-pool"
-
-      # The number of selectors to stripe the served channels over; each of
-      # these will use one select loop on the selector-dispatcher.
-	  direct-buffer-pool {
-	    
-        # Name of a class used as byte buffer.
-        class = "Akka.IO.Buffers.DirectBufferPool, Akka"
-
-        # The number of bytes per direct buffer in the pool used to read or write
-        # network data from the kernel.
-        buffer-size = 256 # 256B
-        
-        # The number of direct byte buffers used per segment. Segment is a default
-        # unit of allocation. When buffer pool needs to be resized, instead allocating
-        # a direct buffer, we allocate a whole segment of them.
-        buffers-per-segment = 250 #250 * 256B = 64 000
-
-        # The number of segments to start with.
-        initial-segments = 1
-        
-        # The maximal number of segments allowed to be allocated within that buffer.
-        buffer-pool-limit = 1000
-	    }
-
-	  # A config path to the section defining which byte buffer pool to use.
-	  # Buffer pools are used to mitigate GC-pressure made by potentiall allocation
-	  # and deallocation of byte buffers used for writing/receiving data from sockets.
-	  buffer-pool = "akka.io.tcp.direct-buffer-pool"
-
+      
       # The initial number of SocketAsyncEventArgs to be preallocated. This value
 	  # will grow infinitely if needed.
       nr-of-socket-async-event-args = 32
@@ -677,7 +649,7 @@ akka {
         class = "Akka.IO.Buffers.DirectBufferPool, Akka"
 
         # Size of a single byte buffer in bytes.
-        buffer-size = 256
+        buffer-size = 512
 
         # Number of byte buffers per segment. Every segement is a single continuous
         # byte array in memory. Once buffer pool will run out of byte buffers to 
@@ -703,34 +675,7 @@ akka {
       # The number of selectors to stripe the served channels over; each of
       # these will use one select loop on the selector-dispatcher.
       nr-of-socket-async-event-args = 32
-	
-	  direct-buffer-pool {
-	    
-		# Name of a class used as byte buffer.
-	    class = "Akka.IO.Buffers.DirectBufferPool, Akka"
-
-	    # The number of bytes per direct buffer in the pool used to read or write
-	    # network data from the kernel.
-	    buffer-size = 256 # 256B
-	    
-	    # The number of direct byte buffers used per segment. Segment is a default
-	    # unit of allocation. When buffer pool needs to be resized, instead allocating
-	    # a direct buffer, we allocate a whole segment of them.
-	    buffers-per-segment = 250
-	    
-	    # The maximal number of segments allowed to be allocated within that buffer.
-	    buffer-pool-limit = 1000
-	  }
-
-	  # A config path to the section defining which byte buffer pool to use.
-	  # Buffer pools are used to mitigate GC-pressure made by potentiall allocation
-	  # and deallocation of byte buffers used for writing/receiving data from sockets.
-	  buffer-pool = "akka.io.udp.direct-buffer-pool"
-
-      # The initial number of SocketAsyncEventArgs to be preallocated. This value
-	  # will grow infinitely if needed.
-      nr-of-socket-async-event-args = 32
-	  
+		  
       # Maximum number of open channels supported by this UDP module Generally
       # UDP does not require a large number of channels, therefore it is
       # recommended to keep this setting low.
@@ -787,29 +732,6 @@ akka {
     }
 
     udp-connected {
-	
-	  direct-buffer-pool {
-	    
-		# Name of a class used as byte buffer.
-	    class = "Akka.IO.Buffers.DirectBufferPool, Akka"
-
-	    # The number of bytes per direct buffer in the pool used to read or write
-	    # network data from the kernel.
-	    buffer-size = 256 # 256B
-	    
-	    # The number of direct byte buffers used per segment. Segment is a default
-	    # unit of allocation. When buffer pool needs to be resized, instead allocating
-	    # a direct buffer, we allocate a whole segment of them.
-	    buffers-per-segment = 250
-	    
-	    # The maximal number of segments allowed to be allocated within that buffer.
-	    buffer-pool-limit = 1000
-	  }
-
-	  # A config path to the section defining which byte buffer pool to use.
-	  # Buffer pools are used to mitigate GC-pressure made by potentiall allocation
-	  # and deallocation of byte buffers used for writing/receiving data from sockets.
-	  buffer-pool = "akka.io.udp-connected.direct-buffer-pool"
 
       # Default implementation of `Akka.IO.Buffers.IBufferPool` interface. It
       # allocates memory is so called segments. Each segment is then cut into 
@@ -822,7 +744,7 @@ akka {
         class = "Akka.IO.Buffers.DirectBufferPool, Akka"
 
         # Size of a single byte buffer in bytes.
-        buffer-size = 256
+        buffer-size = 512
 
         # Number of byte buffers per segment. Every segement is a single continuous
         # byte array in memory. Once buffer pool will run out of byte buffers to 


### PR DESCRIPTION
Increased direct-buffer-pool.buffer-size from 256B to 512B, for both UDP and TCP. Additionally removed redundant config sections. Related issue #3116 - reason is that 256 is often too small, and (specifically in case of UDP) it establishes an upper size limit of a payload. UDP-based protocols like TFTP and DNS have maximum frame size of 512B, so I think we should stick to it. DHCP has 548B, but this could slice up page caches in weird ways.