### PR TITLE
Fix excessive rebalance in LeastShardAllocationStrategy

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/LeastShardAllocationStrategySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/LeastShardAllocationStrategySpec.cs
@@ -105,5 +105,22 @@ namespace Akka.Cluster.Sharding.Tests
             var r2 = _allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("shard2", "shard3")).Result;
             r2.Count.Should().Be(0);
         }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_dont_rebalance_excessive_shards_if_maxSimultaneousRebalance_gt_rebalanceThreshold()
+        {
+            var allocationStrategy = new LeastShardAllocationStrategy(2, 5);
+            var allocations = new Dictionary<IActorRef, IImmutableList<string>>
+            {
+                {_regionA, new []{"shard1", "shard2", "shard3", "shard4", "shard5", "shard6", "shard7", "shard8"}.ToImmutableList() },
+                {_regionB, new []{"shard9", "shard10", "shard11", "shard12" }.ToImmutableList() }
+            }.ToImmutableDictionary();
+
+            var r1 = allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("shard2")).Result;
+            r1.Should().BeEquivalentTo(new[] { "shard1", "shard3", "shard4" });
+
+            var r2 = _allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("shard5", "shard6", "shard7", "shard8")).Result;
+            r2.Count.Should().Be(0);
+        }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardAllocationStrategy.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardAllocationStrategy.cs
@@ -25,7 +25,7 @@ namespace Akka.Cluster.Sharding
         /// Invoked when the location of a new shard is to be decided.
         /// </summary>
         /// <param name="requester">
-        /// Actor reference to the <see cref="ShardRegion"/> that requested the location of the shard, can be returned 
+        /// Actor reference to the <see cref="ShardRegion"/> that requested the location of the shard, can be returned
         /// if preference should be given to the node where the shard was first accessed.
         /// </param>
         /// <param name="shardId">The id of the shard to allocate.</param>
@@ -52,8 +52,8 @@ namespace Akka.Cluster.Sharding
     }
 
     /// <summary>
-    /// The default implementation of <see cref="Akka.Cluster.Sharding.LeastShardAllocationStrategy"/> allocates new shards 
-    /// to the <see cref="ShardRegion"/> with least number of previously allocated shards. It picks shards 
+    /// The default implementation of <see cref="Akka.Cluster.Sharding.LeastShardAllocationStrategy"/> allocates new shards
+    /// to the <see cref="ShardRegion"/> with least number of previously allocated shards. It picks shards
     /// for rebalancing handoff from the <see cref="ShardRegion"/> with most number of previously allocated shards.
     /// They will then be allocated to the <see cref="ShardRegion"/> with least number of previously allocated shards,
     /// i.e. new members in the cluster. There is a configurable threshold of how large the difference
@@ -104,9 +104,10 @@ namespace Akka.Cluster.Sharding
                     currentShardAllocations.Select(kv => kv.Value.Where(s => !rebalanceInProgress.Contains(s)).ToArray());
                 var mostShards = GetMaxBy(shards, x => x.Length);
 
-                if (mostShards.Length - leastShardsRegion.Value.Count >= _rebalanceThreshold)
+                var difference = mostShards.Length - leastShardsRegion.Value.Count;
+                if (difference >= _rebalanceThreshold)
                 {
-                    return Task.FromResult<IImmutableSet<ShardId>>(mostShards.Take(_maxSimultaneousRebalance - rebalanceInProgress.Count).ToImmutableHashSet());
+                    return Task.FromResult<IImmutableSet<ShardId>>(mostShards.Take(Math.Min(difference, _maxSimultaneousRebalance - rebalanceInProgress.Count)).ToImmutableHashSet());
                 }
             }
 


### PR DESCRIPTION
Having maxSimultaneousRebalance > rebalanceThreshold in LeastShardAllocationStrategy caused shards "flapping" (deallocation of excessive shards followed by their immediate allocation on the same node)

Migrated from https://github.com/akka/akka/issues/23830