### PR TITLE
Added human-friendly error message for malformed HOCON

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -2330,6 +2330,7 @@ namespace Akka.Configuration.Hocon
         public bool Matches(string pattern) { }
         public bool Matches(params string[] patterns) { }
         public char Peek() { }
+        protected string PickErrorLine(out int index) { }
         public void Pop() { }
         public void PullWhitespace() { }
         public void Push() { }

--- a/src/core/Akka.Tests/Configuration/HoconTests.cs
+++ b/src/core/Akka.Tests/Configuration/HoconTests.cs
@@ -930,7 +930,7 @@ ip = ""::1""
 }";
             var ex = Assert.Throws<FormatException>(() => { ConfigurationFactory.ParseString(hocon); });
 
-            var expectedMessage = @"Unknown token at position 26: 
+            var expectedMessage = $@"Unknown token at position {hocon.IndexOf('$')}: 
     ask-timeout = $10ms
                   ^    
 ".Replace("\r\n", "\n");

--- a/src/core/Akka.Tests/Configuration/HoconTests.cs
+++ b/src/core/Akka.Tests/Configuration/HoconTests.cs
@@ -16,6 +16,10 @@ namespace Akka.Tests.Configuration
 {
     public class HoconTests
     {
+        public HoconTests()
+        {
+        }
+
         //Added tests to conform to the HOCON spec https://github.com/Lightbendhub/config/blob/master/HOCON.md
         [Fact]
         public void Can_use_paths_as_keys_3_14()
@@ -915,6 +919,22 @@ ip = ""::1""
         {
             var hocon = @"akka.cluster.seed-nodes = [akka.tcp://Cluster@127.0.0.1:4053]";
             Assert.Throws<ConfigurationException>(() => { ConfigurationFactory.ParseString(hocon); });
+        }
+
+        [Fact]
+        public void Should_throw_human_readable_exception_message_when_parsing_invalid_string()
+        {
+            var hocon = 
+@"akka {
+    ask-timeout = $10ms
+}";
+            var ex = Assert.Throws<FormatException>(() => { ConfigurationFactory.ParseString(hocon); });
+
+            var expectedMessage = @"Unknown token at position 26: 
+    ask-timeout = $10ms
+                  ^    
+".Replace("\r\n", "\n");
+            ex.Message.Replace("\r\n", "\n").ShouldBe(expectedMessage);
         }
     }
 }


### PR DESCRIPTION
The problem with current HOCON parser is that it doesn't give any meaningful support, when a user has specified a malformed HOCON string. No position of issued token or anything else.

This PR introduces a human-friendly error messages. Example:

```hocon
akka {
  ask-timeout = $10s
}
```

will produce following error message:

```
Unknown token at position 26:
  ask-timeout = $10s
                ^
```