### PR TITLE
Fix TcpOutgoingConnection memory leak (#3211)

### DIFF
--- a/src/core/Akka/IO/SocketEventArgsPool.cs
+++ b/src/core/Akka/IO/SocketEventArgsPool.cs
@@ -70,7 +70,9 @@ namespace Akka.IO
             }
             catch (InvalidOperationException)
             {
-                // it can be that for some reason socket is in use and haven't closed yet
+                // it can be that for some reason socket is in use and haven't closed yet. Dispose anyway to avoid leaks.
+                e.Dispose();
+                active--;
             }
         }
 

--- a/src/core/Akka/IO/SocketEventArgsPool.cs
+++ b/src/core/Akka/IO/SocketEventArgsPool.cs
@@ -70,9 +70,7 @@ namespace Akka.IO
             }
             catch (InvalidOperationException)
             {
-                // it can be that for some reason socket is in use and haven't closed yet. Dispose anyway to avoid leaks.
-                e.Dispose();
-                active--;
+                // it can be that for some reason socket is in use and haven't closed yet
             }
         }
 

--- a/src/core/Akka/IO/TcpConnection.cs
+++ b/src/core/Akka/IO/TcpConnection.cs
@@ -622,8 +622,10 @@ namespace Akka.IO
             if (IsWritePending)
             {
                 pendingWrite.Release(); // we should release ConnectionInfo event args (if they're not released already)
-                ReleaseSocketAsyncEventArgs();
             }
+
+            // always try to release SocketAsyncEventArgs to avoid memory leaks
+            ReleaseSocketAsyncEventArgs();
 
             if (closedMessage != null)
             {

--- a/src/core/Akka/IO/TcpConnection.cs
+++ b/src/core/Akka/IO/TcpConnection.cs
@@ -85,7 +85,6 @@ namespace Akka.IO
         protected readonly Socket Socket;
         protected SocketAsyncEventArgs ReceiveArgs;
         protected SocketAsyncEventArgs SendArgs;
-        protected SocketAsyncEventArgs ConnectArgs;
 
         protected readonly ILoggingAdapter Log = Context.GetLogger();
         private readonly bool pullMode;
@@ -560,12 +559,6 @@ namespace Akka.IO
             {
                 Tcp.SocketEventArgsPool.Release(SendArgs);
                 SendArgs = null;
-            }
-
-            if (ConnectArgs != null)
-            {
-                Tcp.SocketEventArgsPool.Release(ConnectArgs);
-                ConnectArgs = null;
             }
         }
 

--- a/src/core/Akka/IO/TcpConnection.cs
+++ b/src/core/Akka/IO/TcpConnection.cs
@@ -85,6 +85,7 @@ namespace Akka.IO
         protected readonly Socket Socket;
         protected SocketAsyncEventArgs ReceiveArgs;
         protected SocketAsyncEventArgs SendArgs;
+        protected SocketAsyncEventArgs ConnectArgs;
 
         protected readonly ILoggingAdapter Log = Context.GetLogger();
         private readonly bool pullMode;
@@ -559,6 +560,12 @@ namespace Akka.IO
             {
                 Tcp.SocketEventArgsPool.Release(SendArgs);
                 SendArgs = null;
+            }
+
+            if (ConnectArgs != null)
+            {
+                Tcp.SocketEventArgsPool.Release(ConnectArgs);
+                ConnectArgs = null;
             }
         }
 

--- a/src/core/Akka/IO/TcpOutgoingConnection.cs
+++ b/src/core/Akka/IO/TcpOutgoingConnection.cs
@@ -124,13 +124,13 @@ namespace Akka.IO
             {
                 Log.Debug("Attempting connection to [{0}]", address);
 
-                ConnectArgs = Tcp.SocketEventArgsPool.Acquire(Self);
-                ConnectArgs.RemoteEndPoint = address;
+                var connectArgs = Tcp.SocketEventArgsPool.Acquire(Self);
+                connectArgs.RemoteEndPoint = address;
                 // we don't setup buffer here, it shouldn't be necessary just for connection
-                if (!Socket.ConnectAsync(ConnectArgs))
+                if (!Socket.ConnectAsync(connectArgs))
                     Self.Tell(IO.Tcp.SocketConnected.Instance);
 
-                Become(Connecting(Tcp.Settings.FinishConnectRetries, ConnectArgs, fallbackAddress));
+                Become(Connecting(Tcp.Settings.FinishConnectRetries, connectArgs, fallbackAddress));
             });
         }
 

--- a/src/core/Akka/IO/TcpOutgoingConnection.cs
+++ b/src/core/Akka/IO/TcpOutgoingConnection.cs
@@ -124,13 +124,13 @@ namespace Akka.IO
             {
                 Log.Debug("Attempting connection to [{0}]", address);
 
-                var connectArgs = Tcp.SocketEventArgsPool.Acquire(Self);
-                connectArgs.RemoteEndPoint = address;
+                ConnectArgs = Tcp.SocketEventArgsPool.Acquire(Self);
+                ConnectArgs.RemoteEndPoint = address;
                 // we don't setup buffer here, it shouldn't be necessary just for connection
-                if (!Socket.ConnectAsync(connectArgs))
+                if (!Socket.ConnectAsync(ConnectArgs))
                     Self.Tell(IO.Tcp.SocketConnected.Instance);
 
-                Become(Connecting(Tcp.Settings.FinishConnectRetries, connectArgs, fallbackAddress));
+                Become(Connecting(Tcp.Settings.FinishConnectRetries, ConnectArgs, fallbackAddress));
             });
         }
 


### PR DESCRIPTION
TcpOutgoingConnection saves reference to SocketAsyncEventArgs it acquires during connection in a protected field on base TcpConnection class. This field is then being disposed when closing connection.

Also PreallocatedSocketEventAgrsPool forces dispose of SocketAsyncEventArgs during release even if InvalidOperationException is caught. This also lead to some memory leak because this exception gets raised quite often when system is under load.