### PR TITLE
Logging performance optimization + ease of use fix

### DIFF
--- a/src/core/Akka/Event/DefaultLogger.cs
+++ b/src/core/Akka/Event/DefaultLogger.cs
@@ -23,13 +23,13 @@ namespace Akka.Event
         /// <returns>TBD</returns>
         protected override bool Receive(object message)
         {
-            if(message is InitializeLogger)
+            if (message is InitializeLogger)
             {
                 Sender.Tell(new LoggerInitialized());
                 return true;
             }
             var logEvent = message as LogEvent;
-            if (logEvent == null) 
+            if (logEvent == null)
                 return false;
 
             Print(logEvent);
@@ -42,14 +42,7 @@ namespace Akka.Event
         /// <param name="logEvent">The log event that is to be output.</param>
         protected virtual void Print(LogEvent logEvent)
         {
-            try
-            {
-                StandardOutLogger.PrintLogEvent(logEvent);
-            }
-            catch (FormatException formatException)
-            {
-                
-            }
+            StandardOutLogger.PrintLogEvent(logEvent);
         }
     }
 }

--- a/src/core/Akka/Event/DefaultLogger.cs
+++ b/src/core/Akka/Event/DefaultLogger.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using Akka.Actor;
 using Akka.Dispatch;
 
@@ -41,7 +42,14 @@ namespace Akka.Event
         /// <param name="logEvent">The log event that is to be output.</param>
         protected virtual void Print(LogEvent logEvent)
         {
-            StandardOutLogger.PrintLogEvent(logEvent);
+            try
+            {
+                StandardOutLogger.PrintLogEvent(logEvent);
+            }
+            catch (FormatException formatException)
+            {
+                
+            }
         }
     }
 }

--- a/src/core/Akka/Event/LogEvent.cs
+++ b/src/core/Akka/Event/LogEvent.cs
@@ -6,11 +6,38 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using Akka.Actor;
 
 namespace Akka.Event
 {
+    /// <summary>
+    /// INTERNAL API.
+    /// 
+    /// Avoids redundant parsing of log levels and other frequently-used log items
+    /// </summary>
+    internal static class LogFormats
+    {
+        public static readonly IReadOnlyDictionary<LogLevel, string> PrettyPrintedLogLevel;
+
+        static LogFormats()
+        {
+            var dict = new Dictionary<LogLevel, string>();
+            foreach(LogLevel i in Enum.GetValues(typeof(LogLevel)))
+            {
+                dict.Add(i, Enum.GetName(typeof(LogLevel), i).Replace("Level", "").ToUpperInvariant());
+            }
+            PrettyPrintedLogLevel = dict;
+        }
+
+        public static string PrettyNameFor(this LogLevel level)
+        {
+            return PrettyPrintedLogLevel[level];
+        }
+    }
+
     /// <summary>
     /// This class represents a logging event in the system.
     /// </summary>
@@ -62,7 +89,7 @@ namespace Akka.Event
         /// <returns>A <see cref="System.String" /> that represents this LogEvent.</returns>
         public override string ToString()
         {
-            return string.Format("[{0}][{1}][Thread {2}][{3}] {4}", LogLevel().ToString().Replace("Level", "").ToUpperInvariant(), Timestamp, Thread.ManagedThreadId.ToString().PadLeft(4, '0'), LogSource, Message);
+            return string.Format("[{0}][{1}][Thread {2}][{3}] {4}", LogLevel().PrettyNameFor(), Timestamp, Thread.ManagedThreadId.ToString().PadLeft(4, '0'), LogSource, Message);
         }
     }
 }


### PR DESCRIPTION
The performance optimization is simple: don't dynamically create a new "ERROR", "INFO" string every time. Just cache one for each log level and re-use it.

The main thing here is a bug I've run into in my own code and in some end-user code I've reviewed: `FormatException`s thrown when the logging string itself isn't formatted correctly. When this error occurs here's the stack trace you get:

```
Cause: System.FormatException: Input string was not in a correct format.
   at System.Text.StringBuilder.FormatError()
   at System.Text.StringBuilder.AppendFormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.FormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.Format(String format, Object[] args)
   at System.Text.StringBuilder.AppendFormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.FormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.Format(String format, Object[] args)
   at Akka.Event.LogEvent.ToString()
   at Akka.TestKit.Xunit2.Internals.TestOutputLogger.<>c__DisplayClass0_0.<.ctor>b__0(Debug e)
   at lambda_method(Closure , Object , Action`1 , Action`1 , Action`1 , Action`1 , Action`1 )
   at Akka.Tools.MatchHandler.PartialHandlerArgumentsCapture`6.Handle(T value)
   at Akka.Actor.ReceiveActor.ExecutePartialMessageHandler(Object message, PartialAction`1 partialAction)
   at Akka.Actor.UntypedActor.Receive(Object message)
   at Akka.Actor.ActorBase.AroundReceive(Receive receive, Object message)
   at Akka.Actor.ActorCell.ReceiveMessage(Object message)
   at Akka.Actor.ActorCell.Invoke(Envelope envelope)
```

Not terribly helpful. Doesn't tell you anything about the log message that caused this error, thus you either have to download a bunch of debug symbols and set breakpoints inside Akka.NET or inside the `System.String` internals (I did the latter) and try to determine which log message actually caused this exception in the first place.

In this PR I introduce some code that isn't exactly beautiful, but it untangles the log message that threw the exception into an understandable error message and prints that instead of this same stack trace.