### PR TITLE
Throw on generic Ask if response was Status.Failure

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -1648,13 +1648,13 @@ namespace Akka.Actor
     public abstract class Status
     {
         protected Status() { }
-        public class Failure : Akka.Actor.Status
+        public sealed class Failure : Akka.Actor.Status
         {
             public readonly System.Exception Cause;
             public Failure(System.Exception cause) { }
             public override string ToString() { }
         }
-        public class Success : Akka.Actor.Status
+        public sealed class Success : Akka.Actor.Status
         {
             public readonly object Status;
             public Success(object status) { }
@@ -4890,7 +4890,7 @@ namespace Akka.Util.Internal
     [Akka.Annotations.InternalApiAttribute()]
     public class static TaskExtensions
     {
-        public static System.Threading.Tasks.Task<TResult> CastTask<TTask, TResult>(this System.Threading.Tasks.Task<TTask> task) { }
+        public static async System.Threading.Tasks.Task<TResult> CastTask<TSource, TResult>(this System.Threading.Tasks.Task<TSource> task) { }
         public static System.Threading.Tasks.Task WithCancellation(this System.Threading.Tasks.Task task, System.Threading.CancellationToken cancellationToken) { }
     }
 }

--- a/src/core/Akka.Tests/Actor/AskSpec.cs
+++ b/src/core/Akka.Tests/Actor/AskSpec.cs
@@ -156,10 +156,10 @@ namespace Akka.Tests.Actor
         public void Generic_Ask_when_Failure_is_returned_should_throw_error_payload_and_preserve_stack_trace()
         {
             var actor = Sys.ActorOf<SomeActor>();
-            var aggregateException = Assert.ThrowsAsync<AggregateException>(async () =>
+            var aggregateException = Assert.Throws<AggregateException>(() =>
             {
-                var result = await actor.Ask<string>("throw");
-            }).Result;
+                var result = actor.Ask<string>("throw", timeout: TimeSpan.FromSeconds(3)).Result;
+            });
             var exception = aggregateException.Flatten().InnerException;
             exception.GetType().ShouldBe(typeof(ExpectedTestException));
             exception.Message.ShouldBe("BOOM!");
@@ -170,7 +170,7 @@ namespace Akka.Tests.Actor
         public void Generic_Ask_when_Failure_is_and_Failure_was_expected_should_not_throw()
         {
             var actor = Sys.ActorOf<SomeActor>();
-            var result = actor.Ask<Status.Failure>("throw").Result;
+            var result = actor.Ask<Status.Failure>("throw", timeout: TimeSpan.FromSeconds(3)).Result;
             var exception = ((AggregateException)result.Cause).Flatten().InnerException;
             exception.GetType().ShouldBe(typeof(ExpectedTestException));
             exception.Message.ShouldBe("BOOM!");

--- a/src/core/Akka.Tests/Actor/AskSpec.cs
+++ b/src/core/Akka.Tests/Actor/AskSpec.cs
@@ -10,9 +10,16 @@ using Xunit;
 using Akka.Actor;
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Akka.Tests.Actor
 {
+    public class ExpectedTestException : Exception
+    {
+        public ExpectedTestException(string message) : base(message)
+        {
+        }
+    }
     
     public class AskSpec : AkkaSpec
     {
@@ -20,14 +27,17 @@ namespace Akka.Tests.Actor
         {
             protected override void OnReceive(object message)
             {
-                if (message.Equals("timeout"))
+                switch (message)
                 {
-                    Thread.Sleep(5000);
+                    case "timeout": Thread.Sleep(5000); break;
+                    case "answer": Sender.Tell("answer"); break;
+                    case "throw": Task.Run(ThrowNested).PipeTo(Sender); break;
                 }
-                if (message.Equals("answer"))
-                {
-                    Sender.Tell("answer");
-                }
+            }
+
+            internal async Task ThrowNested()
+            {
+                throw new ExpectedTestException("BOOM!");
             }
         }
 
@@ -140,6 +150,30 @@ namespace Akka.Tests.Actor
             var waitActor = Sys.ActorOf(Props.Create(() => new WaitActor(replyActor, TestActor)));
             waitActor.Tell("ask");
             ExpectMsg("bar");
+        }
+
+        [Fact]
+        public void Generic_Ask_when_Failure_is_returned_should_throw_error_payload_and_preserve_stack_trace()
+        {
+            var actor = Sys.ActorOf<SomeActor>();
+            var aggregateException = Assert.ThrowsAsync<AggregateException>(async () =>
+            {
+                var result = await actor.Ask<string>("throw");
+            }).Result;
+            var exception = aggregateException.Flatten().InnerException;
+            exception.GetType().ShouldBe(typeof(ExpectedTestException));
+            exception.Message.ShouldBe("BOOM!");
+            exception.StackTrace.Contains(nameof(SomeActor.ThrowNested)).ShouldBeTrue("stack trace should be preserved");
+        }
+
+        [Fact]
+        public void Generic_Ask_when_Failure_is_and_Failure_was_expected_should_not_throw()
+        {
+            var actor = Sys.ActorOf<SomeActor>();
+            var result = actor.Ask<Status.Failure>("throw").Result;
+            var exception = ((AggregateException)result.Cause).Flatten().InnerException;
+            exception.GetType().ShouldBe(typeof(ExpectedTestException));
+            exception.Message.ShouldBe("BOOM!");
         }
     }
 }

--- a/src/core/Akka/Actor/ActorBase.cs
+++ b/src/core/Akka/Actor/ActorBase.cs
@@ -20,7 +20,7 @@ namespace Akka.Actor
         /// <summary>
         /// Indicates the success of some operation which has been performed
         /// </summary>
-        public class Success : Status
+        public sealed class Success : Status
         {
             /// <summary>
             /// TBD
@@ -41,7 +41,7 @@ namespace Akka.Actor
         /// Indicates the failure of some operation that was requested and includes an
         /// <see cref="Exception"/> describing the underlying cause of the problem.
         /// </summary>
-        public class Failure : Status
+        public sealed class Failure : Status
         {
             /// <summary>
             /// The cause of the failure


### PR DESCRIPTION
Right now, when we're using a generic variant of `Ask<>` method, we are solving it by simply casting between Task results (from `object` to our expected `TResult` type). 

The problem here is that, by default Akka.NET solves failure cases to be returned to sender using `Status.Failure` message. In this case, if we'll try to cast `Failure` to generic type `TResult`, we'll end with `InvalidCastException`, swallowing the actual error (carried as a payload of `Failure` message) that happened underneath.

What this PR does, is simplifying casting method (I'm using `async` instead of manual cross task casting), and it checks for `Status.Failure` message - if it was returned and the `TResult` itself is not `Failure`, then we are simply rethrowing that error (while still preserving the stack trace). Additionally I've added 2 tests to verify that behavior. For non-generic variant of `Ask` method everything works as previously - since we cannot guarantee, that user didn't expected `Failure` message to be returned.

This should help an error readability a lot.