### PR TITLE
ClusterSingletonManager should ignore FSM events during shutdown

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
@@ -1,0 +1,210 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Cluster.Sharding.Serialization;
+using Akka.Cluster.Tools.Singleton;
+using Akka.Configuration;
+using Akka.TestKit;
+using Akka.TestKit.TestActors;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    public class CoordinatedShutdownShardingSpec : AkkaSpec
+    {
+        private ActorSystem sys1;
+        private ActorSystem sys2;
+        private ActorSystem sys3;
+
+        private IActorRef region1;
+        private IActorRef region2;
+        private IActorRef region3;
+
+        private TestProbe _probe1;
+        private TestProbe _probe2;
+        private TestProbe _probe3;
+
+        private static readonly Config SpecConfig;
+
+        private class EchoActor : ReceiveActor
+        {
+            public EchoActor()
+            {
+                ReceiveAny(_ => Sender.Tell(_));
+            }
+        }
+
+        private readonly ExtractEntityId _extractEntityId = message => Tuple.Create(message.ToString(), message);
+
+        private readonly ExtractShardId _extractShard = message => (message.GetHashCode() % 10).ToString();
+
+        static CoordinatedShutdownShardingSpec()
+        {
+            SpecConfig = ConfigurationFactory.ParseString(@"
+                akka.loglevel = DEBUG
+                akka.actor.provider = cluster
+                akka.remote.dot-netty.tcp.port = 0")
+                .WithFallback(ClusterSingletonManager.DefaultConfig()
+                .WithFallback(ClusterSharding.DefaultConfig()));
+        }
+
+        public CoordinatedShutdownShardingSpec(ITestOutputHelper helper) : base(SpecConfig, helper)
+        {
+            sys1 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
+            sys2 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
+            sys3 = Sys;
+
+            var props = Props.Create(() => new EchoActor());
+            region1 = ClusterSharding.Get(sys1).Start("type1", props, ClusterShardingSettings.Create(sys1),
+                _extractEntityId, _extractShard);
+            region2 = ClusterSharding.Get(sys2).Start("type1", props, ClusterShardingSettings.Create(sys2),
+                _extractEntityId, _extractShard);
+            region3 = ClusterSharding.Get(sys3).Start("type1", props, ClusterShardingSettings.Create(sys3),
+                _extractEntityId, _extractShard);
+
+
+            _probe1 = CreateTestProbe(sys1);
+            _probe2 = CreateTestProbe(sys2);
+            _probe3 = CreateTestProbe(sys3);
+
+            CoordinatedShutdown.Get(sys1).AddTask(CoordinatedShutdown.PhaseBeforeServiceUnbind, "unbind", () =>
+            {
+                _probe1.Ref.Tell("CS-unbind-1");
+                return Task.FromResult(Done.Instance);
+            });
+
+            CoordinatedShutdown.Get(sys2).AddTask(CoordinatedShutdown.PhaseBeforeServiceUnbind, "unbind", () =>
+            {
+                _probe2.Ref.Tell("CS-unbind-2");
+                return Task.FromResult(Done.Instance);
+            });
+
+            CoordinatedShutdown.Get(sys3).AddTask(CoordinatedShutdown.PhaseBeforeServiceUnbind, "unbind", () =>
+            {
+                _probe3.Ref.Tell("CS-unbind-3");
+                return Task.FromResult(Done.Instance);
+            });
+        }
+
+        protected override void BeforeTermination()
+        {
+            Shutdown(sys1);
+            Shutdown(sys2);
+        }
+
+        /// <summary>
+        /// Using region 2 as it is not shutdown in either test.
+        /// </summary>
+        private void PingEntities()
+        {
+            region2.Tell(1, _probe2.Ref);
+            _probe2.ExpectMsg<int>(10.Seconds()).Should().Be(1);
+            region2.Tell(2, _probe2.Ref);
+            _probe2.ExpectMsg<int>(10.Seconds()).Should().Be(2);
+            region2.Tell(3, _probe2.Ref);
+            _probe2.ExpectMsg<int>(10.Seconds()).Should().Be(3);
+        }
+
+        [Fact]
+        public void Sharding_and_CoordinatedShutdown_must_run_successfully()
+        {
+            InitCluster();
+            RunCoordinatedShutdownWhenLeaving();
+        }
+
+        private void InitCluster()
+        {
+            // FIXME this test should also work when coordinator is on the leaving sys1 node,
+            //       but currently there seems to be a race between the CS and the ClusterSingleton observing OldestChanged
+            //       and terminating coordinator singleton before the graceful sharding stop is done.
+
+            Cluster.Get(sys2).Join(Cluster.Get(sys2).SelfAddress); // coordinator will initially run on sys2
+            AwaitAssert(() => Cluster.Get(sys2).SelfMember.Status.Should().Be(MemberStatus.Up));
+
+            Cluster.Get(sys1).Join(Cluster.Get(sys2).SelfAddress);
+            Within(10.Seconds(), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    Cluster.Get(sys1).State.Members.Count.Should().Be(2);
+                    Cluster.Get(sys1).State.Members.All(x => x.Status == MemberStatus.Up).Should().BeTrue();
+                    Cluster.Get(sys2).State.Members.Count.Should().Be(2);
+                    Cluster.Get(sys2).State.Members.All(x => x.Status == MemberStatus.Up).Should().BeTrue();
+                });
+            });
+
+            Cluster.Get(sys3).Join(Cluster.Get(sys1).SelfAddress);
+            Within(10.Seconds(), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    Cluster.Get(sys1).State.Members.Count.Should().Be(3);
+                    Cluster.Get(sys1).State.Members.All(x => x.Status == MemberStatus.Up).Should().BeTrue();
+                    Cluster.Get(sys2).State.Members.Count.Should().Be(3);
+                    Cluster.Get(sys2).State.Members.All(x => x.Status == MemberStatus.Up).Should().BeTrue();
+                    Cluster.Get(sys3).State.Members.Count.Should().Be(3);
+                    Cluster.Get(sys3).State.Members.All(x => x.Status == MemberStatus.Up).Should().BeTrue();
+                });
+            });
+
+            PingEntities();
+        }
+
+        private void RunCoordinatedShutdownWhenLeaving()
+        {
+            Cluster.Get(sys3).Leave(Cluster.Get(sys1).SelfAddress);
+            _probe1.ExpectMsg("CS-unbind-1");
+
+            Within(10.Seconds(), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    Cluster.Get(sys2).State.Members.Count.Should().Be(2);
+                    Cluster.Get(sys3).State.Members.Count.Should().Be(2);
+                });
+            });
+
+            Within(10.Seconds(), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    Cluster.Get(sys1).IsTerminated.Should().BeTrue();
+                    sys1.WhenTerminated.IsCompleted.Should().BeTrue();
+                });
+            });
+
+            PingEntities();
+        }
+
+        private void RunCoordinatedShutdownWhenDowning()
+        {
+            // coordinator is on Sys2
+            Cluster.Get(sys2).Down(Cluster.Get(sys3).SelfAddress);
+            _probe3.ExpectMsg("CS-unbind-3");
+
+            Within(10.Seconds(), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    Cluster.Get(sys2).State.Members.Count.Should().Be(1);
+                });
+            });
+
+            Within(10.Seconds(), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    Cluster.Get(sys3).IsTerminated.Should().BeTrue();
+                    sys3.WhenTerminated.IsCompleted.Should().BeTrue();
+                });
+            });
+
+            PingEntities();
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
@@ -118,6 +118,7 @@ namespace Akka.Cluster.Sharding.Tests
         {
             InitCluster();
             RunCoordinatedShutdownWhenLeaving();
+            RunCoordinatedShutdownWhenDowning();
         }
 
         private void InitCluster()

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/OldestChangedBuffer.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/OldestChangedBuffer.cs
@@ -172,9 +172,13 @@ namespace Akka.Cluster.Tools.Singleton
 
         private void SendFirstChange()
         {
-            object change;
-            _changes = _changes.Dequeue(out change);
-            Context.Parent.Tell(change);
+            // don't send cluster change events if this node is shutting its self down, just wait for SelfExiting
+            if (!_cluster.IsTerminated)
+            {
+                object change;
+                _changes = _changes.Dequeue(out change);
+                Context.Parent.Tell(change);
+            }
         }
 
         /// <inheritdoc cref="ActorBase.PreStart"/>

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCluster.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCluster.approved.txt
@@ -25,6 +25,7 @@ namespace Akka.Cluster
         public Akka.Remote.DefaultFailureDetectorRegistry<Akka.Actor.Address> FailureDetector { get; }
         public bool IsTerminated { get; }
         public Akka.Actor.Address SelfAddress { get; }
+        public Akka.Cluster.Member SelfMember { get; }
         public System.Collections.Immutable.ImmutableHashSet<string> SelfRoles { get; }
         public Akka.Cluster.UniqueAddress SelfUniqueAddress { get; }
         public Akka.Cluster.ClusterSettings Settings { get; }

--- a/src/core/Akka.Cluster/Cluster.cs
+++ b/src/core/Akka.Cluster/Cluster.cs
@@ -406,6 +406,11 @@ namespace Akka.Cluster
         /// </summary>
         public ClusterEvent.CurrentClusterState State { get { return _readView._state; } }
 
+        /// <summary>
+        /// Access to the current member info for this node.
+        /// </summary>
+        public Member SelfMember => _readView.Self;
+
         private readonly AtomicBoolean _isTerminated = new AtomicBoolean(false);
 
         /// <summary>


### PR DESCRIPTION
Port of https://github.com/akka/akka/pull/24236 - solves the same issue in `ClusterSingletonManager`.

Note, we should also keep an eye on https://github.com/akka/akka/issues/24113, which addresses a related race condition inside the `ShardCoordinator`.