### PR TITLE
Update KeepMajority SplitBrainResolver strategy to avoid exception

### DIFF
--- a/src/core/Akka.Cluster/SplitBrainResolver.cs
+++ b/src/core/Akka.Cluster/SplitBrainResolver.cs
@@ -133,15 +133,14 @@ namespace Akka.Cluster
             var unreachable = MembersWithRole(context.Unreachable);
 
             if (remaining.Count < unreachable.Count) return context.Remaining;
-            else if (remaining.Count > unreachable.Count) return context.Unreachable;
-            else
-            {
-                // if the parts are of equal size the part containing the node with the lowest address is kept.
-                var oldest = remaining.Union(unreachable).First();
-                return remaining.Contains(oldest) 
-                    ? context.Unreachable 
-                    : context.Remaining;
-            }
+            if (remaining.Count > unreachable.Count) return context.Unreachable;
+            if (remaining.IsEmpty && unreachable.IsEmpty) return new Member[0];
+
+            // if the parts are of equal size the part containing the node with the lowest address is kept.
+            var oldest = remaining.Union(unreachable).First();
+            return remaining.Contains(oldest)
+                ? context.Unreachable
+                : context.Remaining;
         }
 
         private ImmutableSortedSet<Member> MembersWithRole(ImmutableSortedSet<Member> members) => string.IsNullOrEmpty(Role)


### PR DESCRIPTION
* Fix exception that can occur when remaining and unreachable variables both have zero elements
* tidy up if else logic as per Refactor recommendations

This fixes a bug which has been experienced in production where remaining and unreachable have zero elements which causes an exception when trying to call .First() to get the oldest in the else (which obviously does not exist).

Unfortunately I do not have the time right now to write a test for this due to work constraints, do with this as you will.