### PR TITLE
[WIP] Optimizations for actor creation

### DIFF
--- a/src/Akka.sln
+++ b/src/Akka.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27004.2010
+VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Benchmark", "Benchmark", "{73108242-625A-4D7B-AA09-63375DBAE464}"
 EndProject

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -1881,9 +1881,9 @@ namespace Akka.Actor.Internal
     }
     public abstract class ChildrenContainerBase : Akka.Actor.Internal.IChildrenContainer
     {
-        protected ChildrenContainerBase(System.Collections.Immutable.IImmutableDictionary<string, Akka.Actor.Internal.IChildStats> children) { }
+        protected ChildrenContainerBase(System.Collections.Immutable.ImmutableDictionary<string, Akka.Actor.Internal.IChildStats> children) { }
         public System.Collections.Generic.IReadOnlyCollection<Akka.Actor.IInternalActorRef> Children { get; }
-        protected System.Collections.Immutable.IImmutableDictionary<string, Akka.Actor.Internal.IChildStats> InternalChildren { get; }
+        protected System.Collections.Immutable.ImmutableDictionary<string, Akka.Actor.Internal.IChildStats> InternalChildren { get; }
         public virtual bool IsNormal { get; }
         public virtual bool IsTerminating { get; }
         public System.Collections.Generic.IReadOnlyCollection<Akka.Actor.Internal.ChildRestartStats> Stats { get; }
@@ -1959,39 +1959,31 @@ namespace Akka.Actor.Internal
     {
         public static Akka.Actor.ActorCell Current { get; set; }
     }
-    public class NormalChildrenContainer : Akka.Actor.Internal.ChildrenContainerBase
+    public sealed class NormalChildrenContainer : Akka.Actor.Internal.ChildrenContainerBase
     {
         public override Akka.Actor.Internal.IChildrenContainer Add(string name, Akka.Actor.Internal.ChildRestartStats stats) { }
-        public static Akka.Actor.Internal.IChildrenContainer Create(System.Collections.Immutable.IImmutableDictionary<string, Akka.Actor.Internal.IChildStats> children) { }
+        public static Akka.Actor.Internal.IChildrenContainer Create(System.Collections.Immutable.ImmutableDictionary<string, Akka.Actor.Internal.IChildStats> children) { }
         public override Akka.Actor.Internal.IChildrenContainer Remove(Akka.Actor.IActorRef child) { }
         public override Akka.Actor.Internal.IChildrenContainer Reserve(string name) { }
         public override Akka.Actor.Internal.IChildrenContainer ShallDie(Akka.Actor.IActorRef actor) { }
         public override string ToString() { }
         public override Akka.Actor.Internal.IChildrenContainer Unreserve(string name) { }
     }
-    public abstract class SuspendReason
+    public struct SuspendReason
     {
-        protected SuspendReason() { }
-        public class Creation : Akka.Actor.Internal.SuspendReason, Akka.Actor.Internal.SuspendReason.IWaitingForChildren
-        {
-            public Creation() { }
-        }
-        public interface IWaitingForChildren { }
-        public class Recreation : Akka.Actor.Internal.SuspendReason, Akka.Actor.Internal.SuspendReason.IWaitingForChildren
-        {
-            public Recreation(System.Exception cause) { }
-            public System.Exception Cause { get; }
-        }
-        public class Termination : Akka.Actor.Internal.SuspendReason
-        {
-            public static Akka.Actor.Internal.SuspendReason.Termination Instance { get; }
-        }
-        public class UserRequest : Akka.Actor.Internal.SuspendReason
-        {
-            public static Akka.Actor.Internal.SuspendReason.UserRequest Instance { get; }
-        }
+        public static readonly Akka.Actor.Internal.SuspendReason Creation;
+        public static readonly Akka.Actor.Internal.SuspendReason Termination;
+        public static readonly Akka.Actor.Internal.SuspendReason UserRequest;
+        public SuspendReason(System.Exception cause) { }
+        public System.Exception Cause { get; }
+        public bool IsCreation { get; }
+        public bool IsRecreation { get; }
+        public bool IsTermination { get; }
+        public bool IsUserRequest { get; }
+        public bool IsWaitingForChildren { get; }
+        public int Status { get; }
     }
-    public class TerminatedChildrenContainer : Akka.Actor.Internal.EmptyChildrenContainer
+    public sealed class TerminatedChildrenContainer : Akka.Actor.Internal.EmptyChildrenContainer
     {
         public new static Akka.Actor.Internal.IChildrenContainer Instance { get; }
         public override bool IsNormal { get; }
@@ -2000,10 +1992,10 @@ namespace Akka.Actor.Internal
         public override Akka.Actor.Internal.IChildrenContainer Reserve(string name) { }
         public override string ToString() { }
     }
-    public class TerminatingChildrenContainer : Akka.Actor.Internal.ChildrenContainerBase
+    public sealed class TerminatingChildrenContainer : Akka.Actor.Internal.ChildrenContainerBase
     {
-        public TerminatingChildrenContainer(System.Collections.Immutable.IImmutableDictionary<string, Akka.Actor.Internal.IChildStats> children, Akka.Actor.IActorRef toDie, Akka.Actor.Internal.SuspendReason reason) { }
-        public TerminatingChildrenContainer(System.Collections.Immutable.IImmutableDictionary<string, Akka.Actor.Internal.IChildStats> children, System.Collections.Immutable.ImmutableHashSet<Akka.Actor.IActorRef> toDie, Akka.Actor.Internal.SuspendReason reason) { }
+        public TerminatingChildrenContainer(System.Collections.Immutable.ImmutableDictionary<string, Akka.Actor.Internal.IChildStats> children, Akka.Actor.IActorRef toDie, Akka.Actor.Internal.SuspendReason reason) { }
+        public TerminatingChildrenContainer(System.Collections.Immutable.ImmutableDictionary<string, Akka.Actor.Internal.IChildStats> children, System.Collections.Immutable.ImmutableHashSet<Akka.Actor.IActorRef> toDie, Akka.Actor.Internal.SuspendReason reason) { }
         public override bool IsNormal { get; }
         public override bool IsTerminating { get; }
         public Akka.Actor.Internal.SuspendReason Reason { get; }

--- a/src/core/Akka/Actor/ActorCell.Children.cs
+++ b/src/core/Akka/Actor/ActorCell.Children.cs
@@ -238,8 +238,7 @@ namespace Akka.Actor
         {
             get
             {
-                var terminating = ChildrenContainer as TerminatingChildrenContainer;
-                return terminating != null && terminating.Reason is SuspendReason.IWaitingForChildren;
+                return ChildrenContainer is TerminatingChildrenContainer terminating && terminating.Reason.IsWaitingForChildren;
             }
         }
 
@@ -378,15 +377,14 @@ namespace Akka.Actor
         /// <returns>TBD</returns>
         protected SuspendReason RemoveChildAndGetStateChange(IActorRef child)
         {
-            var terminating = ChildrenContainer as TerminatingChildrenContainer;
-            if (terminating != null)
+            if (ChildrenContainer is TerminatingChildrenContainer terminating)
             {
                 var newContainer = UpdateChildrenRefs(c => c.Remove(child));
-                if (newContainer is TerminatingChildrenContainer) return null;
+                if (newContainer is TerminatingChildrenContainer) return default(SuspendReason);
                 return terminating.Reason;
             }
             UpdateChildrenRefs(c => c.Remove(child));
-            return null;
+            return default(SuspendReason);
         }
 
         private static string CheckName(string name)

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/ChildStats.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/ChildStats.cs
@@ -22,18 +22,15 @@ namespace Akka.Actor.Internal
     /// </summary>
     public class ChildNameReserved : IChildStats
     {
-        private static readonly ChildNameReserved _instance = new ChildNameReserved();
         private ChildNameReserved() {/* Intentionally left blank */}
 
         /// <summary>
         /// TBD
         /// </summary>
-        public static ChildNameReserved Instance { get { return _instance; } }
+        public static ChildNameReserved Instance { get; } = new ChildNameReserved();
+
         /// <inheritdoc/>
-        public override string ToString()
-        {
-            return "Name Reserved";
-        }
+        public override string ToString() => "Name Reserved";
     }
 
     /// <summary>
@@ -42,7 +39,6 @@ namespace Akka.Actor.Internal
     /// </summary>
     public class ChildRestartStats : IChildStats
     {
-        private readonly IInternalActorRef _child;
         private uint _maxNrOfRetriesCount;
         private long _restartTimeWindowStartTicks;
 
@@ -54,7 +50,7 @@ namespace Akka.Actor.Internal
         /// <param name="restartTimeWindowStartTicks">TBD</param>
         public ChildRestartStats(IInternalActorRef child, uint maxNrOfRetriesCount = 0, long restartTimeWindowStartTicks = 0)
         {
-            _child = child;
+            Child = child;
             _maxNrOfRetriesCount = maxNrOfRetriesCount;
             _restartTimeWindowStartTicks = restartTimeWindowStartTicks;
         }
@@ -62,22 +58,22 @@ namespace Akka.Actor.Internal
         /// <summary>
         /// TBD
         /// </summary>
-        public long Uid { get { return Child.Path.Uid; } }
+        public long Uid => Child.Path.Uid;
 
         /// <summary>
         /// TBD
         /// </summary>
-        public IInternalActorRef Child { get { return _child; } }
+        public IInternalActorRef Child { get; }
 
         /// <summary>
         /// TBD
         /// </summary>
-        public uint MaxNrOfRetriesCount { get { return _maxNrOfRetriesCount; } }
+        public uint MaxNrOfRetriesCount => _maxNrOfRetriesCount;
 
         /// <summary>
         /// TBD
         /// </summary>
-        public long RestartTimeWindowStartTicks { get { return _restartTimeWindowStartTicks; } }
+        public long RestartTimeWindowStartTicks => _restartTimeWindowStartTicks;
 
         /// <summary>
         /// TBD

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainerBase.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainerBase.cs
@@ -55,25 +55,25 @@ namespace Akka.Actor.Internal
             }
         }
 
-        private readonly IImmutableDictionary<string, IChildStats> _children;
-
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="children">TBD</param>
-        protected ChildrenContainerBase(IImmutableDictionary<string, IChildStats> children)
+        protected ChildrenContainerBase(ImmutableDictionary<string, IChildStats> children)
         {
-            _children = children;
+            InternalChildren = children;
         }
 
         /// <summary>
         /// TBD
         /// </summary>
-        public virtual bool IsTerminating { get { return false; } }
+        public virtual bool IsTerminating => false;
+
         /// <summary>
         /// TBD
         /// </summary>
-        public virtual bool IsNormal { get { return true; } }
+        public virtual bool IsNormal => true;
+
         /// <summary>
         /// TBD
         /// </summary>
@@ -138,7 +138,7 @@ namespace Akka.Actor.Internal
         /// <summary>
         /// TBD
         /// </summary>
-        protected IImmutableDictionary<string, IChildStats> InternalChildren { get { return _children; } }
+        protected ImmutableDictionary<string, IChildStats> InternalChildren { get; }
 
         /// <summary>
         /// TBD
@@ -165,8 +165,7 @@ namespace Akka.Actor.Internal
             if (InternalChildren.TryGetValue(actor.Path.Name, out var stats))
             {
                 //Since the actor exists, ChildRestartStats is the only valid ChildStats.
-                var crStats = stats as ChildRestartStats;
-                if (crStats != null && actor.Equals(crStats.Child))
+                if (stats is ChildRestartStats crStats && actor.Equals(crStats.Child))
                 {
                     childRestartStats = crStats;
                     return true;
@@ -181,11 +180,7 @@ namespace Akka.Actor.Internal
         /// </summary>
         /// <param name="actor">TBD</param>
         /// <returns>TBD</returns>
-        public bool Contains(IActorRef actor)
-        {
-            ChildRestartStats stats;
-            return TryGetByRef(actor, out stats);
-        }
+        public bool Contains(IActorRef actor) => TryGetByRef(actor, out _);
 
         /// <summary>
         /// TBD
@@ -197,8 +192,7 @@ namespace Akka.Actor.Internal
         {
             sb.Append('<');
             var childStats = kvp.Value;
-            var childRestartStats = childStats as ChildRestartStats;
-            if (childRestartStats != null)
+            if (childStats is ChildRestartStats childRestartStats)
             {
                 sb.Append(childRestartStats.Child.Path.ToStringWithUid()).Append(':');
                 sb.Append(childRestartStats.MaxNrOfRetriesCount).Append(" retries>");

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/EmptyChildrenContainer.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/EmptyChildrenContainer.cs
@@ -17,7 +17,6 @@ namespace Akka.Actor.Internal
     public class EmptyChildrenContainer : IChildrenContainer
     {
         private static readonly ImmutableDictionary<string, IChildStats> _emptyStats = ImmutableDictionary<string, IChildStats>.Empty;
-        private static readonly IChildrenContainer _instance = new EmptyChildrenContainer();
 
         /// <summary>
         /// TBD
@@ -30,7 +29,7 @@ namespace Akka.Actor.Internal
         /// <summary>
         /// TBD
         /// </summary>
-        public static IChildrenContainer Instance { get { return _instance; } }
+        public static IChildrenContainer Instance { get; } = new EmptyChildrenContainer();
 
         /// <summary>
         /// TBD
@@ -49,10 +48,7 @@ namespace Akka.Actor.Internal
         /// </summary>
         /// <param name="child">TBD</param>
         /// <returns>TBD</returns>
-        public IChildrenContainer Remove(IActorRef child)
-        {
-            return this;
-        }
+        public IChildrenContainer Remove(IActorRef child) => this;
 
         /// <summary>
         /// TBD
@@ -83,68 +79,55 @@ namespace Akka.Actor.Internal
         /// </summary>
         /// <param name="actor">TBD</param>
         /// <returns>TBD</returns>
-        public bool Contains(IActorRef actor)
-        {
-            return false;
-        }
+        public bool Contains(IActorRef actor) => false;
 
         /// <summary>
         /// TBD
         /// </summary>
-        public IReadOnlyCollection<IInternalActorRef> Children { get { return ImmutableList<IInternalActorRef>.Empty; } }
+        public IReadOnlyCollection<IInternalActorRef> Children => ImmutableList<IInternalActorRef>.Empty;
 
         /// <summary>
         /// TBD
         /// </summary>
-        public IReadOnlyCollection<ChildRestartStats> Stats { get { return ImmutableList<ChildRestartStats>.Empty; } }
+        public IReadOnlyCollection<ChildRestartStats> Stats => ImmutableList<ChildRestartStats>.Empty;
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="actor">TBD</param>
         /// <returns>TBD</returns>
-        public IChildrenContainer ShallDie(IActorRef actor)
-        {
-            return this;
-        }
+        public IChildrenContainer ShallDie(IActorRef actor) => this;
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="name">TBD</param>
         /// <returns>TBD</returns>
-        public virtual IChildrenContainer Reserve(string name)
-        {
-            return NormalChildrenContainer.Create(_emptyStats.Add(name, ChildNameReserved.Instance));
-        }
+        public virtual IChildrenContainer Reserve(string name) => 
+            NormalChildrenContainer.Create(_emptyStats.Add(name, ChildNameReserved.Instance));
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="name">TBD</param>
         /// <returns>TBD</returns>
-        public IChildrenContainer Unreserve(string name)
-        {
-            return this;
-        }
+        public IChildrenContainer Unreserve(string name) => this;
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <returns>TBD</returns>
-        public override string ToString()
-        {
-            return "No children";
-        }
+        public override string ToString() => "No children";
 
         /// <summary>
         /// TBD
         /// </summary>
-        public virtual bool IsTerminating { get { return false; } }
+        public virtual bool IsTerminating => false;
+
         /// <summary>
         /// TBD
         /// </summary>
-        public virtual bool IsNormal { get { return true; } }
+        public virtual bool IsNormal => true;
     }
 }
 

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/NormalChildrenContainer.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/NormalChildrenContainer.cs
@@ -8,7 +8,6 @@
 using System.Collections.Immutable;
 using System.Text;
 using Akka.Util.Internal;
-using Akka.Util.Internal.Collections;
 
 namespace Akka.Actor.Internal
 {
@@ -17,9 +16,9 @@ namespace Akka.Actor.Internal
     /// children are currently terminating (which is the time period between calling
     /// context.stop(child) and processing the ChildTerminated() system message).
     /// </summary>
-    public class NormalChildrenContainer : ChildrenContainerBase
+    public sealed class NormalChildrenContainer : ChildrenContainerBase
     {
-        private NormalChildrenContainer(IImmutableDictionary<string, IChildStats> children)
+        private NormalChildrenContainer(ImmutableDictionary<string, IChildStats> children)
             : base(children)
         {
         }
@@ -29,11 +28,8 @@ namespace Akka.Actor.Internal
         /// </summary>
         /// <param name="children">TBD</param>
         /// <returns>TBD</returns>
-        public static IChildrenContainer Create(IImmutableDictionary<string, IChildStats> children)
-        {
-            if (children.Count == 0) return EmptyChildrenContainer.Instance;
-            return new NormalChildrenContainer(children);
-        }
+        public static IChildrenContainer Create(ImmutableDictionary<string, IChildStats> children) => 
+            children.Count == 0 ? EmptyChildrenContainer.Instance : new NormalChildrenContainer(children);
 
         /// <summary>
         /// TBD
@@ -41,30 +37,24 @@ namespace Akka.Actor.Internal
         /// <param name="name">TBD</param>
         /// <param name="stats">TBD</param>
         /// <returns>TBD</returns>
-        public override IChildrenContainer Add(string name, ChildRestartStats stats)
-        {
-            return Create(InternalChildren.SetItem(name, stats));
-        }
+        public override IChildrenContainer Add(string name, ChildRestartStats stats) => 
+            new NormalChildrenContainer(InternalChildren.SetItem(name, stats));
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="child">TBD</param>
         /// <returns>TBD</returns>
-        public override IChildrenContainer Remove(IActorRef child)
-        {
-            return Create(InternalChildren.Remove(child.Path.Name));
-        }
+        public override IChildrenContainer Remove(IActorRef child) => 
+            Create(InternalChildren.Remove(child.Path.Name));
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="actor">TBD</param>
         /// <returns>TBD</returns>
-        public override IChildrenContainer ShallDie(IActorRef actor)
-        {
-            return new TerminatingChildrenContainer(InternalChildren, actor, SuspendReason.UserRequest.Instance);
-        }
+        public override IChildrenContainer ShallDie(IActorRef actor) => 
+            new TerminatingChildrenContainer(InternalChildren, actor, SuspendReason.UserRequest);
 
         /// <summary>
         /// TBD

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/SuspendReason.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/SuspendReason.cs
@@ -6,83 +6,69 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Akka.Actor.Internal
 {
-    /// <summary>
-    /// TBD
-    /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
-    /// </summary>
-    public abstract class SuspendReason
+    internal static class SuspendReasonStatus
     {
-        /// <summary>
-        /// TBD
-        /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
-        /// </summary>
-        // ReSharper disable once InconsistentNaming
-        public interface IWaitingForChildren
+        public const int Creation = 1;
+        public const int Recreation = 2;
+        public const int Termination = 4;
+        public const int UserRequest = 8;
+
+        public const int WaitingForChildren = Creation | Recreation;
+    }
+
+    public struct SuspendReason
+    {
+        public static readonly SuspendReason Creation = new SuspendReason(SuspendReasonStatus.Creation);
+        public static readonly SuspendReason Termination = new SuspendReason(SuspendReasonStatus.Termination);
+        public static readonly SuspendReason UserRequest = new SuspendReason(SuspendReasonStatus.UserRequest);
+
+        public int Status { get; }
+        public Exception Cause { get; }
+
+        private SuspendReason(int status)
         {
-            //Intentionally left blank
+            Status = status;
+            Cause = null;
         }
 
-        /// <summary>
-        /// TBD
-        /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
-        /// </summary>
-        public class Creation : SuspendReason, IWaitingForChildren
+        public SuspendReason(Exception cause)
         {
-            //Intentionally left blank
+            Status = SuspendReasonStatus.Recreation;
+            Cause = cause;
         }
 
-        /// <summary>
-        /// TBD
-        /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
-        /// </summary>
-        public class Recreation : SuspendReason, IWaitingForChildren
+        public bool IsCreation
         {
-            private readonly Exception _cause;
-
-            /// <summary>
-            /// TBD
-            /// </summary>
-            /// <param name="cause">TBD</param>
-            public Recreation(Exception cause)
-            {
-                _cause = cause;
-            }
-
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public Exception Cause { get { return _cause; } }
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return (Status & SuspendReasonStatus.Creation) != 0; }
         }
 
-        /// <summary>
-        /// TBD
-        /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
-        /// </summary>
-        public class Termination : SuspendReason
+        public bool IsRecreation
         {
-            private static readonly Termination _instance = new Termination();
-            private Termination() { }
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public static Termination Instance { get { return _instance; } }
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return (Status & SuspendReasonStatus.Recreation) != 0; }
         }
 
-        /// <summary>
-        /// TBD
-        /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
-        /// </summary>
-        public class UserRequest : SuspendReason
+        public bool IsTermination
         {
-            private static readonly UserRequest _instance = new UserRequest();
-            private UserRequest() { }
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public static UserRequest Instance { get { return _instance; } }
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return (Status & SuspendReasonStatus.Termination) != 0; }
+        }
+
+        public bool IsUserRequest
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return (Status & SuspendReasonStatus.UserRequest) != 0; }
+        }
+
+        public bool IsWaitingForChildren
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return (Status & SuspendReasonStatus.WaitingForChildren) != 0; }
         }
     }
 }

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/TerminatedChildrenContainer.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/TerminatedChildrenContainer.cs
@@ -14,10 +14,8 @@ namespace Akka.Actor.Internal
     /// terminated while stopping; it is necessary to distinguish from the normal
     /// empty state while calling handleChildTerminated() for the last time.
     /// </summary>
-    public class TerminatedChildrenContainer : EmptyChildrenContainer
+    public sealed class TerminatedChildrenContainer : EmptyChildrenContainer
     {
-        private static readonly IChildrenContainer _instance = new TerminatedChildrenContainer();
-
         private TerminatedChildrenContainer()
         {
             //Intentionally left blank
@@ -25,7 +23,7 @@ namespace Akka.Actor.Internal
         /// <summary>
         /// TBD
         /// </summary>
-        public new static IChildrenContainer Instance { get { return _instance; } }
+        public new static IChildrenContainer Instance { get; } = new TerminatedChildrenContainer();
 
         /// <summary>
         /// TBD
@@ -33,10 +31,7 @@ namespace Akka.Actor.Internal
         /// <param name="name">TBD</param>
         /// <param name="stats">TBD</param>
         /// <returns>TBD</returns>
-        public override IChildrenContainer Add(string name, ChildRestartStats stats)
-        {
-            return this;
-        }
+        public override IChildrenContainer Add(string name, ChildRestartStats stats) => this;
 
         /// <summary>
         /// N/A
@@ -44,29 +39,23 @@ namespace Akka.Actor.Internal
         /// <param name="name">N/A</param>
         /// <returns>N/A</returns>
         /// <exception cref="InvalidOperationException">This exception is automatically thrown since the name belongs to an actor that is already terminated.</exception>
-        public override IChildrenContainer Reserve(string name)
-        {
-            throw new InvalidOperationException($"Cannot reserve actor name '{name}': already terminated");
-        }
+        public override IChildrenContainer Reserve(string name) => throw new InvalidOperationException($"Cannot reserve actor name '{name}': already terminated");
 
         /// <summary>
         /// TBD
         /// </summary>
-        public override bool IsTerminating { get { return true; } }
+        public override bool IsTerminating => true;
 
         /// <summary>
         /// TBD
         /// </summary>
-        public override bool IsNormal { get { return false; } }
+        public override bool IsNormal => false;
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <returns>TBD</returns>
-        public override string ToString()
-        {
-            return "Terminated";
-        }
+        public override string ToString() => "Terminated";
     }
 }
 


### PR DESCRIPTION
**WORK IN PROGRESS**

I'm working on some optimizations around creating a child actors. Those will include:

- Adding `sealed` modifier where possible (current .NET Core compiler can inline virtcall for sealed classes).
- Replacing interfaces with actual classes where possible (again, avoid virtcalls, and add possibility to inline).
- Replacing scala-like interface-sealed class with tagged structs where this has any sense. Reasons:
    - Maybe JVM is able to specialize case class switch to more optimal version, but I guess struct + int-based switches and comparison is faster in .NET.
    - Also structs &rarr; no heap allocations.

Additionally I'm thinking about replacing internal sets used by `IChildrenContainer` implementations from immutable to mutable versions. **Is there any reason to actually use immutable collections?**

Some benchmarks comparing immutable/mutable set operations:

```
BenchmarkDotNet=v0.10.11, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.125)
Processor=Intel Core i5-6300HQ CPU 2.30GHz (Skylake), ProcessorCount=4
Frequency=2250000 Hz, Resolution=444.4444 ns, Timer=TSC
.NET Core SDK=2.1.2
  [Host]     : .NET Core 2.0.3 (Framework 4.6.25815.02), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.3 (Framework 4.6.25815.02), 64bit RyuJIT


                       Method |         Mean |      Error |     StdDev |          Min |          Max |         Op/s |  Gen 0 | Allocated |
----------------------------- |-------------:|-----------:|-----------:|-------------:|-------------:|-------------:|-------:|----------:|
          ImmutableSetAddItem |  1,887.23 ns | 25.5842 ns | 23.9314 ns |  1,859.94 ns |  1,935.84 ns |    529,877.2 | 0.1545 |     488 B |
            MutableSetAddItem |     34.31 ns |  0.1323 ns |  0.1033 ns |     33.98 ns |     34.35 ns | 29,146,988.5 |      - |       0 B |
    SortedImmutableSetAddItem |    753.85 ns |  0.6408 ns |  0.4634 ns |    753.26 ns |    754.67 ns |  1,326,527.6 | 0.1469 |     464 B |
      SortedMutableSetAddItem |    113.08 ns |  0.5415 ns |  0.4800 ns |    112.26 ns |    113.73 ns |  8,843,004.9 |      - |       0 B |
       ImmutableSetRemoveItem |  1,179.49 ns | 22.7134 ns | 25.2459 ns |  1,149.36 ns |  1,234.43 ns |    847,821.2 | 0.1183 |     376 B |
         MutableSetRemoveItem |     26.66 ns |  0.3931 ns |  0.3677 ns |     26.30 ns |     27.19 ns | 37,503,546.6 |      - |       0 B |
 SortedImmutableSetRemoveItem |    643.20 ns | 12.5951 ns | 11.7815 ns |    627.83 ns |    672.95 ns |  1,554,729.5 | 0.1163 |     368 B |
   SortedMutableSetRemoveItem |    198.63 ns |  0.3239 ns |  0.2529 ns |    198.17 ns |    199.02 ns |  5,034,478.1 |      - |       0 B |
        ImmutableSetEnumerate | 76,902.77 ns | 64.8008 ns | 57.4442 ns | 76,796.23 ns | 76,986.83 ns |     13,003.4 |      - |       0 B |
          MutableSetEnumerate |  1,728.08 ns |  1.1556 ns |  1.0809 ns |  1,726.34 ns |  1,729.49 ns |    578,677.4 |      - |       0 B |
  SortedImmutableSetEnumerate | 34,667.19 ns | 14.5656 ns | 13.6247 ns | 34,644.73 ns | 34,692.45 ns |     28,845.7 |      - |       0 B |
    SortedMutableSetEnumerate | 12,944.08 ns | 24.1978 ns | 22.6347 ns | 12,919.03 ns | 13,000.30 ns |     77,255.4 | 0.0458 |     192 B |

                              Method |          Mean |         Error |        StdDev |           Min |           Max |         Op/s |  Gen 0 | Allocated |
------------------------------------ |--------------:|--------------:|--------------:|--------------:|--------------:|-------------:|-------:|----------:|
          ImmutableDictionaryAddItem |   3,248.60 ns |    61.8991 ns |    57.9005 ns |   3,185.30 ns |   3,407.38 ns |    307,824.7 | 0.1945 |     616 B |
            MutableDictionaryAddItem |      48.03 ns |     0.2393 ns |     0.1998 ns |      47.74 ns |      48.50 ns | 20,821,790.1 |      - |       0 B |
    SortedImmutableDictionaryAddItem |   4,019.00 ns |    31.5921 ns |    28.0056 ns |   3,999.38 ns |   4,085.58 ns |    248,818.1 | 0.1602 |     528 B |
      SortedMutableDictionaryAddItem |   3,048.74 ns |    13.6629 ns |    12.7803 ns |   3,033.29 ns |   3,078.06 ns |    328,004.3 |      - |       0 B |
       ImmutableDictionaryRemoveItem |   2,711.59 ns |    21.5189 ns |    19.0759 ns |   2,682.92 ns |   2,751.26 ns |    368,787.8 | 0.1488 |     472 B |
         MutableDictionaryRemoveItem |     210.24 ns |     0.6072 ns |     0.5680 ns |     209.56 ns |     211.27 ns |  4,756,369.0 | 0.0150 |      48 B |
 SortedImmutableDictionaryRemoveItem |   4,395.44 ns |     7.3320 ns |     6.8583 ns |   4,385.01 ns |   4,409.59 ns |    227,508.3 | 0.1297 |     432 B |
   SortedMutableDictionaryRemoveItem |   3,518.90 ns |    10.2988 ns |     9.6335 ns |   3,504.25 ns |   3,530.31 ns |    284,180.1 | 0.0114 |      48 B |
        ImmutableDictionaryEnumerate | 120,396.39 ns | 1,384.9060 ns | 1,295.4419 ns | 119,174.50 ns | 123,571.48 ns |      8,305.9 |      - |       0 B |
          MutableDictionaryEnumerate |   2,437.69 ns |    11.2547 ns |     9.9770 ns |   2,419.62 ns |   2,453.23 ns |    410,224.6 |      - |       0 B |
  SortedImmutableDictionaryEnumerate |  64,721.63 ns |   577.1861 ns |   511.6604 ns |  64,041.74 ns |  65,494.60 ns |     15,450.8 |      - |       0 B |
    SortedMutableDictionaryEnumerate |  13,735.89 ns |    96.4481 ns |    80.5385 ns |  13,638.55 ns |  13,870.67 ns |     72,802.0 | 0.0458 |     192 B |
````
The operations are:

- Add 1 element to set filled with 201 elements.
- Remove 1 element from set filled with 201 elements.
- Enumerate (using foreach) over set of 201 elements.

I didn't checked dictionaries yet, but I guess the improvement is very similar. Therefore, if there's no actual reason to use immutables, we probably shouldn't use them.