### PR TITLE
Handle GetShardHome after rebalance

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
@@ -1257,7 +1257,7 @@ namespace Akka.Cluster.Sharding
 
         public ILoggingAdapter Log { get; }
         public ImmutableDictionary<string, ICancelable> UnAckedHostShards { get; set; } = ImmutableDictionary<string, ICancelable>.Empty;
-        public ImmutableHashSet<string> RebalanceInProgress { get; set; } = ImmutableHashSet<string>.Empty;
+        public ImmutableDictionary<string, ImmutableHashSet<IActorRef>> RebalanceInProgress { get; set; } = ImmutableDictionary<string, ImmutableHashSet<IActorRef>>.Empty;
         // regions that have requested handoff, for graceful shutdown
         public ImmutableHashSet<IActorRef> GracefullShutdownInProgress { get; set; } = ImmutableHashSet<IActorRef>.Empty;
         public ImmutableHashSet<IActorRef> AliveRegions { get; set; } = ImmutableHashSet<IActorRef>.Empty;


### PR DESCRIPTION
Port of https://github.com/akka/akka/pull/24209

1. Previously if `GetShardHome` request was received while shard was rebalancing, request was ignored. It was not a problem, as retry was send later. Now, requests senders are collected, and once rebalance is done, they are being replied reactivelly (potentially before request retry).
2. Additionally while `DDataShardCoordinator` in the middle of the update, and `GetShardHome` is incoming for shard of known localization, we can reply right away instead of awaiting for update phase to complete. This is change done in one of the previous PRs on Akka JVM side.