### PR TITLE
Fix potential exception in KeepOldest split brain strategy

### DIFF
--- a/src/core/Akka.Cluster/SplitBrainResolver.cs
+++ b/src/core/Akka.Cluster/SplitBrainResolver.cs
@@ -171,6 +171,11 @@ namespace Akka.Cluster
             var remaining = MembersWithRole(context.Remaining);
             var unreachable = MembersWithRole(context.Unreachable);
 
+            if (remaining.IsEmpty && unreachable.IsEmpty) // prevent exception due to both lists being empty
+            {
+                return new Member[0];
+            }
+
             var oldest = remaining.Union(unreachable).ToImmutableSortedSet(Member.AgeOrdering).First();
             if (remaining.Contains(oldest))
             {
@@ -178,11 +183,11 @@ namespace Akka.Cluster
                     ? context.Remaining 
                     : context.Unreachable;
             }
-            else if (DownIfAlone && context.Unreachable.Count == 1) // oldest is unreachable, but it's alone
+            if (DownIfAlone && context.Unreachable.Count == 1) // oldest is unreachable, but it's alone
             {
                 return context.Unreachable;
             }
-            else return context.Remaining;
+            return context.Remaining;
         }
 
         private ImmutableSortedSet<Member> MembersWithRole(ImmutableSortedSet<Member> members) => string.IsNullOrEmpty(Role)


### PR DESCRIPTION
I have found another issue when attempting to use KeepOldest strategy when sometimes the remaining and unreachable lists can be empty with an exception being generated due to the use of .First().

I have also removed some else statements Resharper pointed out were unnecessary.