### PR TITLE
AkkaPduCodec performance fixes [remoting]

### DIFF
--- a/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
+++ b/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
@@ -381,24 +381,20 @@ namespace Akka.Remote.Transport
             }
         }
 
-        private static ByteString _heartbeatPdu;
+        /*
+         * Since there's never any ActorSystem-specific information coded directly
+         * into the heartbeat messages themselves (i.e. no handshake info,) there's no harm in caching in the
+         * same heartbeat byte buffer and re-using it.
+         */
+        private static readonly ByteString HeartbeatPdu = ConstructControlMessagePdu(CommandType.Heartbeat);
 
         /// <summary>
-        /// TBD
+        /// Creates a new Heartbeat message instance.
         /// </summary>
-        /// <returns>TBD</returns>
+        /// <returns>The Heartbeat message.</returns>
         public override ByteString ConstructHeartbeat()
         {
-            /*
-             * Since there's never any ActorSystem-specific information coded directly
-             * into the heartbeat messages themselves (i.e. no handshake info,) there's no harm in caching in the
-             * same heartbeat byte buffer and re-using it.
-             */
-            if (_heartbeatPdu == null)
-            {
-                _heartbeatPdu = ConstructControlMessagePdu(CommandType.Heartbeat);
-            }
-            return _heartbeatPdu;
+            return HeartbeatPdu;
         }
 
         /// <summary>
@@ -549,7 +545,7 @@ namespace Akka.Remote.Transport
             get { return ConstructControlMessagePdu(CommandType.DisassociateQuarantined); }
         }
 
-        private ByteString ConstructControlMessagePdu(CommandType code, AkkaHandshakeInfo handshakeInfo = null)
+        private static ByteString ConstructControlMessagePdu(CommandType code, AkkaHandshakeInfo handshakeInfo = null)
         {
             var controlMessage = new AkkaControlMessage() { CommandType = code };
             if (handshakeInfo != null)

--- a/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
+++ b/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
@@ -556,12 +556,12 @@ namespace Akka.Remote.Transport
             return new AkkaProtocolMessage() { Instruction = controlMessage }.ToByteString();
         }
 
-        private Address DecodeAddress(AddressData origin)
+        private static Address DecodeAddress(AddressData origin)
         {
             return new Address(origin.Protocol, origin.System, origin.Hostname, (int)origin.Port);
         }
 
-        private ActorRefData SerializeActorRef(Address defaultAddress, IActorRef actorRef)
+        private static ActorRefData SerializeActorRef(Address defaultAddress, IActorRef actorRef)
         {
             return new ActorRefData()
             {
@@ -571,7 +571,7 @@ namespace Akka.Remote.Transport
             };
         }
 
-        private AddressData SerializeAddress(Address address)
+        private static AddressData SerializeAddress(Address address)
         {
             if (string.IsNullOrEmpty(address.Host) || !address.Port.HasValue)
                 throw new ArgumentException($"Address {address} could not be serialized: host or port missing");


### PR DESCRIPTION
Noticed some low-hanging fruit for performance in the `AkkaPduCodec` fixes while I was working on implementing a custom serializer for Akka.Remote today.

This is the class responsible for serializing 100% of message traffic that passes over each Akka.Remote connection.