### PR TITLE
changed ActorCell.ReceiveMessage method to be protected and virtual

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -93,6 +93,7 @@ namespace Akka.Actor
         protected void PrepareForNewActor() { }
         protected virtual void PreStart() { }
         protected void ReceivedTerminated(Akka.Actor.Terminated t) { }
+        protected virtual void ReceiveMessage(object message) { }
         public void ReceiveMessageForTest(Akka.Actor.Envelope envelope) { }
         protected Akka.Actor.Internal.SuspendReason RemoveChildAndGetStateChange(Akka.Actor.IActorRef child) { }
         protected void RemWatcher(Akka.Actor.IActorRef watchee, Akka.Actor.IActorRef watcher) { }

--- a/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
+++ b/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
@@ -171,10 +171,10 @@ namespace Akka.Actor
         }
 
         /// <summary>
-        /// TBD
+        /// Receives the next message from the mailbox and feeds it to the underlying actor instance.
         /// </summary>
-        /// <param name="message">TBD</param>
-        internal void ReceiveMessage(object message)
+        /// <param name="message">The message that will be sent to the actor.</param>
+        protected virtual void ReceiveMessage(object message)
         {
             var wasHandled = _actor.AroundReceive(_state.GetCurrentBehavior(), message);
 


### PR DESCRIPTION
API change and that may also have some performance impact (`virtual` methods can't be inlined by the compiler). 

Rationale for this change is that it allows developers who are working on aspect-oriented add-ons for Akka.NET, such as yours truly, to be able to decorate 100% of actors with instrumentation and other goodies without having to have the user consume a custom actor base class or anything else that makes "infrastructure" a foreground concern. Also makes it possible to instrument built-in `/system` actors, which is part of my goal.

Using a custom `ActorCell` allows me to keep most of this stuff out of end-user code. However, at the moment there isn't a way for me to inject instrumentation at the time of processing a message, aside from doing it inside a custom `IMessageQueue` implementation used inside the `Mailbox` of the actor. I don't like the `IMessageQueue` approach namely because things like accessing a distributing tracing engine or a monitoring system seems like concerns of the actor, rather than its message-ordering infrastructure. Edit: there's also relevant pieces of information I can't access from within the `IMessageQueue`, such as the implementation type of the actor processing the message

Anyway, if there aren't any major objections or horrible performance implications (I could try to get cute with IL injection or something else) I think this would be a good way to provide some extensibility for this case.