### PR TITLE
Implement ReplyWhileStopped support for the BackoffSupervisor

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -3736,15 +3736,16 @@ namespace Akka.Pattern
         public abstract Akka.Pattern.BackoffOptions WithAutoReset(System.TimeSpan resetBackoff);
         public abstract Akka.Pattern.BackoffOptions WithDefaultStoppingStrategy();
         public abstract Akka.Pattern.BackoffOptions WithManualReset();
+        public abstract Akka.Pattern.BackoffOptions WithReplyWhileStopped(object replyWhileStopped);
         public abstract Akka.Pattern.BackoffOptions WithSupervisorStrategy(Akka.Actor.OneForOneStrategy supervisorStrategy);
     }
     public sealed class BackoffSupervisor : Akka.Pattern.BackoffSupervisorBase
     {
         public BackoffSupervisor(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
-        public BackoffSupervisor(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, Akka.Pattern.IBackoffReset reset, double randomFactor, Akka.Actor.SupervisorStrategy strategy) { }
+        public BackoffSupervisor(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, Akka.Pattern.IBackoffReset reset, double randomFactor, Akka.Actor.SupervisorStrategy strategy, object replyWhileStopped) { }
         public static Akka.Actor.Props Props(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
         public static Akka.Actor.Props Props(Akka.Pattern.BackoffOptions options) { }
-        public static Akka.Actor.Props PropsWithSupervisorStrategy(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, Akka.Actor.SupervisorStrategy strategy) { }
+        public static Akka.Actor.Props PropsWithSupervisorStrategy(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, Akka.Actor.SupervisorStrategy strategy, object replyWhileStopped) { }
         protected override bool Receive(object message) { }
         protected override Akka.Actor.SupervisorStrategy SupervisorStrategy() { }
         public sealed class CurrentChild
@@ -3784,6 +3785,7 @@ namespace Akka.Pattern
         protected Akka.Actor.IActorRef Child { get; set; }
         protected string ChildName { get; }
         protected Akka.Actor.Props ChildProps { get; }
+        protected object ReplyWhileStopped { get; set; }
         protected Akka.Pattern.IBackoffReset Reset { get; }
         protected int RestartCountN { get; set; }
         protected bool HandleBackoff(object message) { }

--- a/src/core/Akka/Pattern/BackoffOnRestartSupervisor.cs
+++ b/src/core/Akka/Pattern/BackoffOnRestartSupervisor.cs
@@ -26,7 +26,8 @@ namespace Akka.Pattern
             TimeSpan maxBackoff,
             IBackoffReset reset,
             double randomFactor,
-            OneForOneStrategy strategy) : base(childProps, childName, reset)
+            OneForOneStrategy strategy,
+            object replyWhileStopped) : base(childProps, childName, reset, replyWhileStopped)
         {
             _minBackoff = minBackoff;
             _maxBackoff = maxBackoff;

--- a/src/core/Akka/Pattern/BackoffSupervisor.cs
+++ b/src/core/Akka/Pattern/BackoffSupervisor.cs
@@ -113,7 +113,7 @@ namespace Akka.Pattern
             string childName,
             TimeSpan minBackoff,
             TimeSpan maxBackoff,
-            double randomFactor) : this(childProps, childName, minBackoff, maxBackoff, new AutoReset(minBackoff), randomFactor, Actor.SupervisorStrategy.DefaultStrategy)
+            double randomFactor) : this(childProps, childName, minBackoff, maxBackoff, new AutoReset(minBackoff), randomFactor, Actor.SupervisorStrategy.DefaultStrategy, null)
         {
         }
 
@@ -124,7 +124,8 @@ namespace Akka.Pattern
             TimeSpan maxBackoff,
             IBackoffReset reset,
             double randomFactor,
-            SupervisorStrategy strategy) : base(childProps, childName, reset)
+            SupervisorStrategy strategy,
+            object replyWhileStopped) : base(childProps, childName, reset, replyWhileStopped)
         {
             _minBackoff = minBackoff;
             _maxBackoff = maxBackoff;
@@ -173,7 +174,7 @@ namespace Akka.Pattern
             double randomFactor)
         {
             return PropsWithSupervisorStrategy(childProps, childName, minBackoff, maxBackoff, randomFactor,
-                Actor.SupervisorStrategy.DefaultStrategy);
+                Actor.SupervisorStrategy.DefaultStrategy, null);
         }
 
         /// <summary>
@@ -195,16 +196,19 @@ namespace Akka.Pattern
         /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
         /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
         /// <param name="strategy">The supervision strategy to use for handling exceptions in the child</param>
+        /// <param name="replyWhileStopped">The message that the supervisor will send in response to all messages while its child is stopped.</param>
         public static Props PropsWithSupervisorStrategy(
             Props childProps,
             string childName,
             TimeSpan minBackoff,
             TimeSpan maxBackoff,
             double randomFactor,
-            SupervisorStrategy strategy)
+            SupervisorStrategy strategy,
+            object replyWhileStopped
+            )
         {
              return Actor.Props.Create(
-                () => new BackoffSupervisor(childProps, childName, minBackoff, maxBackoff, new AutoReset(minBackoff), randomFactor, strategy));
+                () => new BackoffSupervisor(childProps, childName, minBackoff, maxBackoff, new AutoReset(minBackoff), randomFactor, strategy, replyWhileStopped));
         }
 
         internal static TimeSpan CalculateDelay(


### PR DESCRIPTION
As discussed in issue #3316 

Here's an implementation to port over support for ReplyWhileStopped to the BackoffSupervisor. It's important to note the minor, but breaking change to the API surface of the BackoffSupervisor constructor, this change was made in the Scala code base as well

It would be possible to reduce the breaking change by introducing an additional overload - at the expense of increasing the surface area, what your thoughts on this?