### PR TITLE
Ask/PipeTo improvements

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -1653,7 +1653,6 @@ namespace Akka.Actor
         {
             public readonly System.Exception Cause;
             public Failure(System.Exception cause) { }
-            public bool IsCancelled { get; }
             public override string ToString() { }
         }
         public class Success : Akka.Actor.Status

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -1653,6 +1653,7 @@ namespace Akka.Actor
         {
             public readonly System.Exception Cause;
             public Failure(System.Exception cause) { }
+            public bool IsCancelled { get; }
             public override string ToString() { }
         }
         public class Success : Akka.Actor.Status

--- a/src/core/Akka.Tests/Actor/AskSpec.cs
+++ b/src/core/Akka.Tests/Actor/AskSpec.cs
@@ -265,7 +265,7 @@ namespace Akka.Tests.Actor
         {
             var actor = Sys.ActorOf<SomeActor>();
             var result = await actor.Ask<Status.Failure>("return-cancelled", timeout: TimeSpan.FromSeconds(3));
-            result.IsCancelled.ShouldBe(true);
+            result.Cause.ShouldBe(null);
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/AskSpec.cs
+++ b/src/core/Akka.Tests/Actor/AskSpec.cs
@@ -21,19 +21,39 @@ namespace Akka.Tests.Actor
             : base(@"akka.actor.ask-timeout = 3000ms")
         { }
 
+        public class ExpectedTestException : Exception
+        {
+            public ExpectedTestException(string message) : base(message)
+            {
+            }
+        }
+        
         public class SomeActor : UntypedActor
         {
             protected override void OnReceive(object message)
             {
-                if (message.Equals("timeout"))
+                switch (message)
                 {
-                    Thread.Sleep(5000);
+                    case "timeout":
+                        Thread.Sleep(5000);
+                        break;
+                    case "answer":
+                        Sender.Tell("answer");
+                        break;
+                    case "throw":
+                        Task.Run(ThrowNested).PipeTo(Sender); 
+                        break;
+                    case "return-cancelled":
+                        var token = new CancellationToken(canceled: true);
+                        new Task(() => { }, token).PipeTo(Sender);
+                        break;
                 }
-
-                if (message.Equals("answer"))
-                {
-                    Sender.Tell("answer");
-                }
+            }
+            
+            internal async Task ThrowNested()
+            {
+                await Task.Delay(1);
+                throw new ExpectedTestException("BOOM!");
             }
         }
 
@@ -202,6 +222,50 @@ namespace Akka.Tests.Actor
             var waitActor = Sys.ActorOf(Props.Create(() => new WaitActor(replyActor, TestActor)));
             waitActor.Tell("ask");
             ExpectMsg("bar");
+        }
+        
+        [Fact]
+        public void Generic_Ask_when_Failure_is_returned_should_throw_error_payload_and_preserve_stack_trace()
+        {
+            var actor = Sys.ActorOf<SomeActor>();
+            var aggregateException = Assert.Throws<AggregateException>(() =>
+            {
+                var result = actor.Ask<string>("throw", timeout: TimeSpan.FromSeconds(3)).Result;
+            });
+            var exception = aggregateException.Flatten().InnerException;
+            exception.GetType().ShouldBe(typeof(ExpectedTestException));
+            exception.Message.ShouldBe("BOOM!");
+            exception.StackTrace.Contains(nameof(SomeActor.ThrowNested)).ShouldBeTrue("stack trace should be preserved");
+        }
+        
+        [Fact]
+        public async Task Generic_Ask_when_Failure_is_and_Failure_was_expected_should_not_throw()
+        {
+            var actor = Sys.ActorOf<SomeActor>();
+            var result = await actor.Ask<Status.Failure>("throw", timeout: TimeSpan.FromSeconds(3));
+            var exception = ((AggregateException)result.Cause).Flatten().InnerException;
+            exception.GetType().ShouldBe(typeof(ExpectedTestException));
+            exception.Message.ShouldBe("BOOM!");
+        }
+        
+        [Fact]
+        public async Task Generic_Ask_when_asker_task_was_cancelled_and_should_fail()
+        {
+            var actor = Sys.ActorOf<SomeActor>();
+            var aggregateException = Assert.Throws<AggregateException>(() =>
+            {
+                var result = actor.Ask<string>("return-cancelled", timeout: TimeSpan.FromSeconds(3)).Result;
+            });
+            var exception = aggregateException.Flatten().InnerException;
+            exception.GetType().ShouldBe(typeof(TaskCanceledException));
+        }
+        
+        [Fact]
+        public async Task Generic_Ask_when_asker_task_was_cancelled_and_Failure_was_expected_should_return_a_Failure()
+        {
+            var actor = Sys.ActorOf<SomeActor>();
+            var result = await actor.Ask<Status.Failure>("return-cancelled", timeout: TimeSpan.FromSeconds(3));
+            result.IsCancelled.ShouldBe(true);
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/PipeToSupportSpec.cs
+++ b/src/core/Akka.Tests/Actor/PipeToSupportSpec.cs
@@ -81,7 +81,7 @@ namespace Akka.Tests.Actor
             _task.PipeTo(TestActor);
             _taskWithoutResult.PipeTo(TestActor, failure: e => $"Exception found: [{e}]" );
             _taskCompletionSource.SetCanceled();
-            ExpectMsg<Status.Failure>(x => x.IsCancelled && x.Cause == null);
+            ExpectMsg<Status.Failure>(x => x.Cause == null);
             ExpectMsg("Exception found: []");
         }
     }

--- a/src/core/Akka/Actor/ActorBase.cs
+++ b/src/core/Akka/Actor/ActorBase.cs
@@ -38,8 +38,9 @@ namespace Akka.Actor
         }
         
         /// <summary>
-        /// Indicates the failure of some operation that was requested and includes an
-        /// <see cref="Exception"/> describing the underlying cause of the problem.
+        /// Indicates the failure of some operation that was requested and includes an <see cref="Exception"/>
+        /// describing the underlying cause of the problem. It is possible for a <see cref="Cause"/> to return null -
+        /// this case indicates, that operation which produced a failure message, has been prematurely cancelled. 
         /// </summary>
         public class Failure : Status
         {
@@ -56,11 +57,6 @@ namespace Akka.Actor
             {
                 Cause = cause;
             }
-
-            /// <summary>
-            /// Checks if a provided failure message was a result of cancelled operation.
-            /// </summary>
-            public bool IsCancelled => Cause == null;
 
             /// <inheritdoc/>
             public override string ToString() => $"Failure: {Cause}";

--- a/src/core/Akka/Actor/ActorBase.cs
+++ b/src/core/Akka/Actor/ActorBase.cs
@@ -57,11 +57,13 @@ namespace Akka.Actor
                 Cause = cause;
             }
 
+            /// <summary>
+            /// Checks if a provided failure message was a result of cancelled operation.
+            /// </summary>
+            public bool IsCancelled => Cause == null;
+
             /// <inheritdoc/>
-            public override string ToString()
-            {
-                return $"Failure: {Cause}";
-            }
+            public override string ToString() => $"Failure: {Cause}";
         }
     }
 

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -117,7 +117,7 @@ namespace Akka.Actor
             if (result is Status.Failure f && typeof(T) != FailureType)
             {
                 // if failure was result of cancelled task, exception will be null
-                var cause = f.Cause ?? new TaskCanceledException();
+                var cause = f.Cause?.InnerException ?? new TaskCanceledException();
                 ExceptionDispatchInfo.Capture(cause).Throw();
                 return default(T);
             }

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor.Internal;
@@ -24,6 +25,8 @@ namespace Akka.Actor
     /// </summary>
     public static class Futures
     {
+        private static readonly Type FailureType = typeof(Status.Failure);
+        
         //when asking from outside of an actor, we need to pass a system, so the FutureActor can register itself there and be resolvable for local and remote calls
         /// <summary>
         /// TBD
@@ -108,7 +111,17 @@ namespace Akka.Actor
             if (provider == null)
                 throw new ArgumentException("Unable to resolve the target Provider", nameof(self));
 
-            return (T) await Ask(self, message, provider, timeout, cancellationToken);
+            var result = await Ask(self, message, provider, timeout, cancellationToken);
+            
+            // if failure was delivered and not expected, rethrow it
+            if (result is Status.Failure f && typeof(T) != FailureType)
+            {
+                // if failure was result of cancelled task, exception will be null
+                var cause = f.Cause ?? new TaskCanceledException();
+                ExceptionDispatchInfo.Capture(cause).Throw();
+                return default(T);
+            }
+            else return (T) result;
         }
 
         /// <summary>


### PR DESCRIPTION
This PR introduces:

1. Several tests in `PipeTo` over cancelled tasks to verify correct behavior: see #3320
2. Similar tests for `Ask`.
2. `IsCancelled` property in `Status.Failure` message - by default failures for cancelled task never have exceptions.
3.  The biggest improvement is `Status.Failure` propagation inside `Ask<>` - previously if i.e. Ask was expecting a string but `Status.Failure` was returned, ask was failing with InvalidCastException. Original failure reason was lost. Now the exception wrapped by `Status.Failure` will be re-thrown with a stack trace from origin.