### PR TITLE
ValueTuple for all projects except for streams 

### DIFF
--- a/src/benchmark/PingPong/Program.cs
+++ b/src/benchmark/PingPong/Program.cs
@@ -164,7 +164,7 @@ namespace PingPong
             }
         }
 
-        private static async Task<Tuple<bool, long, int>> Benchmark<TActor>(int factor, int numberOfClients, long numberOfRepeats, PrintStats printStats, long bestThroughput, int redCount) where TActor : ActorBase
+        private static async Task<(bool, long, int)> Benchmark<TActor>(int factor, int numberOfClients, long numberOfRepeats, PrintStats printStats, long bestThroughput, int redCount) where TActor : ActorBase
         {
             var totalMessagesReceived = GetTotalMessagesReceived(numberOfRepeats);
             //times 2 since the client and the destination both send messages
@@ -197,7 +197,7 @@ namespace PingPong
             if (!countdown.Wait(TimeSpan.FromSeconds(10)))
             {
                 Console.WriteLine("The system did not start in 10 seconds. Aborting.");
-                return Tuple.Create(false, bestThroughput, redCount);
+                return (false, bestThroughput, redCount);
             }
             var setupTime = totalWatch.Elapsed;
             var sw = Stopwatch.StartNew();
@@ -237,7 +237,7 @@ namespace PingPong
             }
             Console.ForegroundColor = foregroundColor;
 
-            return Tuple.Create(redCount <= 3, bestThroughput, redCount);
+            return (redCount <= 3, bestThroughput, redCount);
         }
 
         private static long GetTotalMessagesReceived(long numberOfRepeats)

--- a/src/benchmark/RemotePingPong/Program.cs
+++ b/src/benchmark/RemotePingPong/Program.cs
@@ -141,7 +141,7 @@ namespace RemotePingPong
             return numberOfClients * numberOfRepeats * 2;
         }
 
-        private static async Task<Tuple<bool, long, int>> Benchmark(int numberOfClients, long numberOfRepeats, long bestThroughput, int redCount)
+        private static async Task<(bool, long, int)> Benchmark(int numberOfClients, long numberOfRepeats, long bestThroughput, int redCount)
         {
             var totalMessagesReceived = GetTotalMessagesReceived(numberOfClients, numberOfRepeats);
             var system1 = ActorSystem.Create("SystemA", CreateActorSystemConfig("SystemA", "127.0.0.1", 0));
@@ -211,7 +211,7 @@ namespace RemotePingPong
 
             Console.ForegroundColor = foregroundColor;
             Console.WriteLine("{0,10},{1,8},{2,10},{3,11}", numberOfClients, totalMessagesReceived, throughput, sw.Elapsed.TotalMilliseconds.ToString("F2", CultureInfo.InvariantCulture));
-            return Tuple.Create(redCount <= 3, bestThroughput, redCount);
+            return (redCount <= 3, bestThroughput, redCount);
         }
 
         private class AllStartedActor : UntypedActor

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingCustomShardAllocationSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingCustomShardAllocationSpec.cs
@@ -181,9 +181,9 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        internal ExtractEntityId extractEntityId = message => message is int ? (message.ToString(), message) : (default(string), default(object));
+        internal ExtractEntityId extractEntityId = message => message is int ? (message.ToString(), message) : ((string, object)?)null;
 
-        internal ExtractShardId extractShardId = message => message is int ? message.ToString() : default(string);
+        internal ExtractShardId extractShardId = message => message is int ? message.ToString() : null;
 
         private Lazy<IActorRef> _region;
         private Lazy<IActorRef> _allocator;

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingCustomShardAllocationSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingCustomShardAllocationSpec.cs
@@ -181,9 +181,9 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        internal ExtractEntityId extractEntityId = message => message is int ? Tuple.Create(message.ToString(), message) : null;
+        internal ExtractEntityId extractEntityId = message => message is int ? (message.ToString(), message) : (default(string), default(object));
 
-        internal ExtractShardId extractShardId = message => message is int ? message.ToString() : null;
+        internal ExtractShardId extractShardId = message => message is int ? message.ToString() : default(string);
 
         private Lazy<IActorRef> _region;
         private Lazy<IActorRef> _allocator;

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingFailureSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingFailureSpec.cs
@@ -156,7 +156,7 @@ namespace Akka.Cluster.Sharding.Tests
                 case Add msg:
                     return (msg.Id, message);
             }
-            return (default(string), default(object));
+            return null;
         };
 
         internal ExtractShardId extractShardId = message =>
@@ -168,7 +168,7 @@ namespace Akka.Cluster.Sharding.Tests
                 case Add msg:
                     return msg.Id[0].ToString();
             }
-            return default(string);
+            return null;
         };
 
         private Lazy<IActorRef> _region;

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingFailureSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingFailureSpec.cs
@@ -152,11 +152,11 @@ namespace Akka.Cluster.Sharding.Tests
             switch (message)
             {
                 case Get msg:
-                    return Tuple.Create(msg.Id, message);
+                    return (msg.Id, message);
                 case Add msg:
-                    return Tuple.Create(msg.Id, message);
+                    return (msg.Id, message);
             }
-            return null;
+            return (default(string), default(object));
         };
 
         internal ExtractShardId extractShardId = message =>
@@ -168,7 +168,7 @@ namespace Akka.Cluster.Sharding.Tests
                 case Add msg:
                     return msg.Id[0].ToString();
             }
-            return null;
+            return default(string);
         };
 
         private Lazy<IActorRef> _region;

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStateSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStateSpec.cs
@@ -127,9 +127,9 @@ namespace Akka.Cluster.Sharding.Tests
         readonly static int NumberOfShards = 2;
         readonly static string ShardTypeName = "Ping";
 
-        internal ExtractEntityId extractEntityId = message => message is Ping p ? (p.Id.ToString(), message) : (default(string), default(object));
+        internal ExtractEntityId extractEntityId = message => message is Ping p ? (p.Id.ToString(), message) : ((string, object)?)null;
 
-        internal ExtractShardId extractShardId = message => message is Ping p ? (p.Id % NumberOfShards).ToString() : default(string);
+        internal ExtractShardId extractShardId = message => message is Ping p ? (p.Id % NumberOfShards).ToString() : null;
 
         private Lazy<IActorRef> _region;
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStateSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStateSpec.cs
@@ -127,9 +127,9 @@ namespace Akka.Cluster.Sharding.Tests
         readonly static int NumberOfShards = 2;
         readonly static string ShardTypeName = "Ping";
 
-        internal ExtractEntityId extractEntityId = message => message is Ping p ? Tuple.Create(p.Id.ToString(), message) : null;
+        internal ExtractEntityId extractEntityId = message => message is Ping p ? (p.Id.ToString(), message) : (default(string), default(object));
 
-        internal ExtractShardId extractShardId = message => message is Ping p ? (p.Id % NumberOfShards).ToString() : null;
+        internal ExtractShardId extractShardId = message => message is Ping p ? (p.Id % NumberOfShards).ToString() : default(string);
 
         private Lazy<IActorRef> _region;
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStatsSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStatsSpec.cs
@@ -127,9 +127,9 @@ namespace Akka.Cluster.Sharding.Tests
         readonly static int NumberOfShards = 3;
         readonly static string ShardTypeName = "Ping";
 
-        internal ExtractEntityId extractEntityId = message => message is Ping p ? Tuple.Create(p.Id.ToString(), message) : null;
+        internal ExtractEntityId extractEntityId = message => message is Ping p ? (p.Id.ToString(), message) : (default(string), default(object));
 
-        internal ExtractShardId extractShardId = message => message is Ping p ? (p.Id % NumberOfShards).ToString() : null;
+        internal ExtractShardId extractShardId = message => message is Ping p ? (p.Id % NumberOfShards).ToString() : default(string);
 
         private Lazy<IActorRef> _region;
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStatsSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStatsSpec.cs
@@ -127,9 +127,9 @@ namespace Akka.Cluster.Sharding.Tests
         readonly static int NumberOfShards = 3;
         readonly static string ShardTypeName = "Ping";
 
-        internal ExtractEntityId extractEntityId = message => message is Ping p ? (p.Id.ToString(), message) : (default(string), default(object));
+        internal ExtractEntityId extractEntityId = message => message is Ping p ? (p.Id.ToString(), message) : ((string, object)?)null;
 
-        internal ExtractShardId extractShardId = message => message is Ping p ? (p.Id % NumberOfShards).ToString() : default(string);
+        internal ExtractShardId extractShardId = message => message is Ping p ? (p.Id % NumberOfShards).ToString() : null;
 
         private Lazy<IActorRef> _region;
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGracefulShutdownSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGracefulShutdownSpec.cs
@@ -106,9 +106,9 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        internal ExtractEntityId extractEntityId = message => message is int ? (message.ToString(), message) : (default(string), default(object));
+        internal ExtractEntityId extractEntityId = message => message is int ? (message.ToString(), message) : ((string, object)?)null;
 
-        internal ExtractShardId extractShardId = message => message is int ? message.ToString() : default(string);
+        internal ExtractShardId extractShardId = message => message is int ? message.ToString() : null;
 
         private readonly Lazy<IActorRef> _region;
 
@@ -131,7 +131,7 @@ namespace Akka.Cluster.Sharding.Tests
             EnterBarrier("startup");
         }
         protected bool IsDDataMode { get; }
-        
+
         protected override void AfterTermination()
         {
             base.AfterTermination();

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGracefulShutdownSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGracefulShutdownSpec.cs
@@ -106,9 +106,9 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        internal ExtractEntityId extractEntityId = message => message is int ? Tuple.Create(message.ToString(), message) : null;
+        internal ExtractEntityId extractEntityId = message => message is int ? (message.ToString(), message) : (default(string), default(object));
 
-        internal ExtractShardId extractShardId = message => message is int ? message.ToString() : null;
+        internal ExtractShardId extractShardId = message => message is int ? message.ToString() : default(string);
 
         private readonly Lazy<IActorRef> _region;
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingLeavingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingLeavingSpec.cs
@@ -143,8 +143,8 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        internal ExtractEntityId extractEntityId = message => message is Ping p ? Tuple.Create(p.Id, message) : null;
-        internal ExtractShardId extractShardId = message => message is Ping p ? p.Id[0].ToString() : null;
+        internal ExtractEntityId extractEntityId = message => message is Ping p ? (p.Id, message) : (default(string), default(object));
+        internal ExtractShardId extractShardId = message => message is Ping p ? p.Id[0].ToString() : default(string);
 
         private readonly Lazy<IActorRef> _region;
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingLeavingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingLeavingSpec.cs
@@ -143,8 +143,8 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        internal ExtractEntityId extractEntityId = message => message is Ping p ? (p.Id, message) : (default(string), default(object));
-        internal ExtractShardId extractShardId = message => message is Ping p ? p.Id[0].ToString() : default(string);
+        internal ExtractEntityId extractEntityId = message => message is Ping p ? (p.Id, message) : ((string, object)?)null;
+        internal ExtractShardId extractShardId = message => message is Ping p ? p.Id[0].ToString() : null;
 
         private readonly Lazy<IActorRef> _region;
 
@@ -168,7 +168,7 @@ namespace Akka.Cluster.Sharding.Tests
 
         protected override int InitialParticipantsValueFactory => Roles.Count;
         protected bool IsDDataMode { get; }
-        
+
         protected override void AfterTermination()
         {
             base.AfterTermination();

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingMinMembersSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingMinMembersSpec.cs
@@ -81,7 +81,7 @@ namespace Akka.Cluster.Sharding.Tests
 
     public class PersistentClusterShardingMinMembersSpec : ClusterShardingMinMembersSpec
     {
-        public PersistentClusterShardingMinMembersSpec() :this(new PersistentClusterShardingMinMembersSpecConfig()) { }
+        public PersistentClusterShardingMinMembersSpec() : this(new PersistentClusterShardingMinMembersSpecConfig()) { }
         protected PersistentClusterShardingMinMembersSpec(PersistentClusterShardingMinMembersSpecConfig config) : base(config, typeof(PersistentClusterShardingMinMembersSpec)) { }
     }
     public class DDataClusterShardingMinMembersSpec : ClusterShardingMinMembersSpec
@@ -111,14 +111,14 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        internal ExtractEntityId extractEntityId = message => message is int ? (message.ToString(), message) : (default(string), default(object));
+        internal ExtractEntityId extractEntityId = message => message is int ? (message.ToString(), message) : ((string, object)?)null;
 
-        internal ExtractShardId extractShardId = message => message is int ? message.ToString() : default(string);
+        internal ExtractShardId extractShardId = message => message is int ? message.ToString() : null;
 
         private Lazy<IActorRef> _region;
 
         private readonly ClusterShardingMinMembersSpecConfig _config;
-        
+
         private readonly List<FileInfo> _storageLocations;
 
         protected ClusterShardingMinMembersSpec(ClusterShardingMinMembersSpecConfig config, Type type)
@@ -137,7 +137,7 @@ namespace Akka.Cluster.Sharding.Tests
             EnterBarrier("startup");
         }
         protected bool IsDDataMode { get; }
-        
+
         protected override void AfterTermination()
         {
             base.AfterTermination();

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingMinMembersSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingMinMembersSpec.cs
@@ -111,9 +111,9 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        internal ExtractEntityId extractEntityId = message => message is int ? Tuple.Create(message.ToString(), message) : null;
+        internal ExtractEntityId extractEntityId = message => message is int ? (message.ToString(), message) : (default(string), default(object));
 
-        internal ExtractShardId extractShardId = message => message is int ? message.ToString() : null;
+        internal ExtractShardId extractShardId = message => message is int ? message.ToString() : default(string);
 
         private Lazy<IActorRef> _region;
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesNewExtractorSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesNewExtractorSpec.cs
@@ -133,7 +133,7 @@ namespace Akka.Cluster.Sharding.Tests
 
         static readonly int ShardCount = 3;
 
-        internal ExtractEntityId extractEntityId = message => message is int ? Tuple.Create(message.ToString(), message) : null;
+        internal ExtractEntityId extractEntityId = message => message is int ? (message.ToString(), message) : (default(string), default(object));
 
         internal static ExtractShardId extractShardId1 = message =>
         {
@@ -144,7 +144,7 @@ namespace Akka.Cluster.Sharding.Tests
                 case ShardRegion.StartEntity msg:
                     return extractShardId1(msg.EntityId);
             }
-            return null;
+            return default(string);
         };
 
         internal static ExtractShardId extractShardId2 = message =>
@@ -156,7 +156,7 @@ namespace Akka.Cluster.Sharding.Tests
                 case ShardRegion.StartEntity msg:
                     return extractShardId2(msg.EntityId);
             }
-            return null;
+            return default(string);
         };
 
         static readonly string TypeName = "Entity";

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesNewExtractorSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesNewExtractorSpec.cs
@@ -133,7 +133,7 @@ namespace Akka.Cluster.Sharding.Tests
 
         static readonly int ShardCount = 3;
 
-        internal ExtractEntityId extractEntityId = message => message is int ? (message.ToString(), message) : (default(string), default(object));
+        internal ExtractEntityId extractEntityId = message => message is int ? (message.ToString(), message) : ((string, object)?)null;
 
         internal static ExtractShardId extractShardId1 = message =>
         {
@@ -144,7 +144,7 @@ namespace Akka.Cluster.Sharding.Tests
                 case ShardRegion.StartEntity msg:
                     return extractShardId1(msg.EntityId);
             }
-            return default(string);
+            return null;
         };
 
         internal static ExtractShardId extractShardId2 = message =>
@@ -156,7 +156,7 @@ namespace Akka.Cluster.Sharding.Tests
                 case ShardRegion.StartEntity msg:
                     return extractShardId2(msg.EntityId);
             }
-            return default(string);
+            return null;
         };
 
         static readonly string TypeName = "Entity";

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesSpec.cs
@@ -125,7 +125,7 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        internal ExtractEntityId extractEntityId = message => message is int ? (message.ToString(), message) : (default(string), default(object));
+        internal ExtractEntityId extractEntityId = message => message is int ? (message.ToString(), message) : ((string, object)?)null;
 
         internal ExtractShardId extractShardId = message =>
         {
@@ -136,7 +136,7 @@ namespace Akka.Cluster.Sharding.Tests
                 case ShardRegion.StartEntity msg:
                     return msg.EntityId.ToString();
             }
-            return default(string);
+            return null;
         };
 
         private Lazy<IActorRef> _region;

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesSpec.cs
@@ -125,7 +125,7 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        internal ExtractEntityId extractEntityId = message => message is int ? Tuple.Create(message.ToString(), message) : null;
+        internal ExtractEntityId extractEntityId = message => message is int ? (message.ToString(), message) : (default(string), default(object));
 
         internal ExtractShardId extractShardId = message =>
         {
@@ -136,7 +136,7 @@ namespace Akka.Cluster.Sharding.Tests
                 case ShardRegion.StartEntity msg:
                     return msg.EntityId.ToString();
             }
-            return null;
+            return default(string);
         };
 
         private Lazy<IActorRef> _region;

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
@@ -197,11 +197,11 @@ namespace Akka.Cluster.Sharding.Tests
             switch (message)
             {
                 case EntityEnvelope env:
-                    return Tuple.Create(env.Id.ToString(), env.Payload);
+                    return (env.Id.ToString(), env.Payload);
                 case Get msg:
-                    return Tuple.Create(msg.CounterId.ToString(), message);
+                    return (msg.CounterId.ToString(), message);
             }
-            return null;
+            return (default(string), default(object));
         };
 
         public static readonly ExtractShardId ExtractShardId = message =>
@@ -215,7 +215,7 @@ namespace Akka.Cluster.Sharding.Tests
                 case ShardRegion.StartEntity msg:
                     return (long.Parse(msg.EntityId) % NumberOfShards).ToString();
             }
-            return null;
+            return default(string);
         };
 
         public const int NumberOfShards = 12;

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
@@ -201,7 +201,7 @@ namespace Akka.Cluster.Sharding.Tests
                 case Get msg:
                     return (msg.CounterId.ToString(), message);
             }
-            return (default(string), default(object));
+            return ((string, object)?)null;
         };
 
         public static readonly ExtractShardId ExtractShardId = message =>
@@ -215,7 +215,7 @@ namespace Akka.Cluster.Sharding.Tests
                 case ShardRegion.StartEntity msg:
                     return (long.Parse(msg.EntityId) % NumberOfShards).ToString();
             }
-            return default(string);
+            return null;
         };
 
         public const int NumberOfShards = 12;

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingInternalsSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingInternalsSpec.cs
@@ -24,13 +24,14 @@ namespace Akka.Cluster.Sharding.Tests
             clusterSharding = ClusterSharding.Get(Sys);
         }
 
-        private Tuple<string, object> ExtractEntityId(object message)
+        private (string, object)? ExtractEntityId(object message)
         {
             switch (message)
             {
                 case int i:
-                    return new Tuple<string, object>(i.ToString(), message);
+                    return (i.ToString(), message);
             }
+
             throw new NotSupportedException();
         }
 
@@ -88,7 +89,7 @@ namespace Akka.Cluster.Sharding.Tests
             var shardName = "test";
             var emptyHandlerActor = Sys.ActorOf(Props.Create(() => new EmptyHandlerActor()));
             var handOffStopper = Sys.ActorOf(
-                Props.Create(() => new ShardRegion.HandOffStopper(shardName, probe.Ref, new IActorRef[] { emptyHandlerActor }, HandOffStopMessage.Instsnce, TimeSpan.FromMilliseconds(10)))
+                Props.Create(() => new ShardRegion.HandOffStopper(shardName, probe.Ref, new IActorRef[] { emptyHandlerActor }, HandOffStopMessage.Instance, TimeSpan.FromMilliseconds(10)))
               );
 
             Watch(emptyHandlerActor);
@@ -102,7 +103,7 @@ namespace Akka.Cluster.Sharding.Tests
 
         internal class HandOffStopMessage : INoSerializationVerificationNeeded
         {
-            public static readonly HandOffStopMessage Instsnce = new HandOffStopMessage();
+            public static readonly HandOffStopMessage Instance = new HandOffStopMessage();
             private HandOffStopMessage()
             {
             }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
@@ -42,7 +42,7 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        private readonly ExtractEntityId _extractEntityId = message => Tuple.Create(message.ToString(), message);
+        private readonly ExtractEntityId _extractEntityId = message => (message.ToString(), message);
 
         private readonly ExtractShardId _extractShard = message => (message.GetHashCode() % 10).ToString();
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/GetShardTypeNamesSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/GetShardTypeNamesSpec.cs
@@ -47,13 +47,14 @@ namespace Akka.Cluster.Sharding.Tests
             ClusterSharding.Get(Sys).ShardTypeNames.ShouldBeEquivalentTo(new string[] { "type1", "type2" });
         }
 
-        private Tuple<string, object> ExtractEntityId(object message)
+        private (string, object)? ExtractEntityId(object message)
         {
             switch (message)
             {
                 case int i:
-                    return new Tuple<string, object>(i.ToString(), message);
+                    return (i.ToString(), message);
             }
+
             throw new NotSupportedException();
         }
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/PersistentShardSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/PersistentShardSpec.cs
@@ -55,13 +55,14 @@ namespace Akka.Cluster.Sharding.Tests
         public void Persistent_Shard_must_remember_entities_started_with_StartEntity()
         {
             Func<string, Props> ep = id => Props.Create(() => new EntityActor(id));
+            ExtractEntityId extractEntityId = _ => ("entity-1", (object)"msg");
 
             var props = Props.Create(() => new PersistentShard(
               "cats",
               "shard-1",
               ep,
               ClusterShardingSettings.Create(Sys),
-              _ => Tuple.Create("entity-1", (object)"msg"),
+              extractEntityId,
               _ => "shard-1",
               PoisonPill.Instance
             ));

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ProxyShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ProxyShardingSpec.cs
@@ -41,12 +41,12 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        private Tuple<string, object> IdExtractor(object message)
+        private (string, object)? IdExtractor(object message)
         {
             switch (message)
             {
                 case int i:
-                    return new Tuple<string, object>(i.ToString(), message);
+                    return (i.ToString(), message);
             }
             throw new NotSupportedException();
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/SupervisionSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/SupervisionSpec.cs
@@ -88,7 +88,7 @@ namespace Akka.Cluster.Sharding.Tests
         #endregion
 
         private readonly ExtractEntityId _extractEntityId = message =>
-            message is Msg msg ? new Tuple<string, object>(msg.Id.ToString(), msg.Message) : null;
+            message is Msg msg ? (ValueTuple<string,object>?)(msg.Id.ToString(), msg.Message) : null;
 
         private readonly ExtractShardId _extractShard = message =>
             message is Msg msg ? (msg.Id % 2).ToString(CultureInfo.InvariantCulture) : null;

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
@@ -1031,7 +1031,7 @@ namespace Akka.Cluster.Sharding
         /// <returns>The actor ref of the <see cref="Sharding.ShardRegion"/> that is to be responsible for the shard.</returns>
         public IActorRef StartProxy(string typeName, string role, IMessageExtractor messageExtractor)
         {
-            (EntityId, Msg) extractEntityId(Msg msg)
+            (EntityId, Msg)? extractEntityId(Msg msg)
             {
                 var entityId = messageExtractor.EntityId(msg);
                 var entityMessage = messageExtractor.EntityMessage(msg);
@@ -1058,7 +1058,7 @@ namespace Akka.Cluster.Sharding
         /// <returns>The actor ref of the <see cref="Sharding.ShardRegion"/> that is to be responsible for the shard.</returns>
         public Task<IActorRef> StartProxyAsync(string typeName, string role, IMessageExtractor messageExtractor)
         {
-            (EntityId, Msg) extractEntityId(Msg msg)
+            (EntityId, Msg)? extractEntityId(Msg msg)
             {
                 var entityId = messageExtractor.EntityId(msg);
                 var entityMessage = messageExtractor.EntityMessage(msg);
@@ -1136,7 +1136,7 @@ namespace Akka.Cluster.Sharding
     /// message to support wrapping in message envelope that is unwrapped before
     /// sending to the entity actor.
     /// </summary>
-    public delegate (EntityId, Msg) ExtractEntityId(Msg message);
+    public delegate (EntityId, Msg)? ExtractEntityId(Msg message);
 
     /// <summary>
     /// Interface of functions to extract entity id,  shard id, and the message to send
@@ -1190,7 +1190,7 @@ namespace Akka.Cluster.Sharding
                     return (self.EntityId(msg), self.EntityMessage(msg));
                 //TODO: should we really use tuples?
 
-                return (default(string), default(object));
+                return null;
             };
 
             return extractEntityId;

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
@@ -1031,11 +1031,11 @@ namespace Akka.Cluster.Sharding
         /// <returns>The actor ref of the <see cref="Sharding.ShardRegion"/> that is to be responsible for the shard.</returns>
         public IActorRef StartProxy(string typeName, string role, IMessageExtractor messageExtractor)
         {
-            Tuple<EntityId, Msg> extractEntityId(Msg msg)
+            (EntityId, Msg) extractEntityId(Msg msg)
             {
                 var entityId = messageExtractor.EntityId(msg);
                 var entityMessage = messageExtractor.EntityMessage(msg);
-                return Tuple.Create(entityId, entityMessage);
+                return (entityId, entityMessage);
             };
 
             return StartProxy(typeName, role, extractEntityId, messageExtractor.ShardId);
@@ -1058,11 +1058,11 @@ namespace Akka.Cluster.Sharding
         /// <returns>The actor ref of the <see cref="Sharding.ShardRegion"/> that is to be responsible for the shard.</returns>
         public Task<IActorRef> StartProxyAsync(string typeName, string role, IMessageExtractor messageExtractor)
         {
-            Tuple<EntityId, Msg> extractEntityId(Msg msg)
+            (EntityId, Msg) extractEntityId(Msg msg)
             {
                 var entityId = messageExtractor.EntityId(msg);
                 var entityMessage = messageExtractor.EntityMessage(msg);
-                return Tuple.Create(entityId, entityMessage);
+                return (entityId, entityMessage);
             };
 
             return StartProxyAsync(typeName, role, extractEntityId, messageExtractor.ShardId);
@@ -1136,7 +1136,7 @@ namespace Akka.Cluster.Sharding
     /// message to support wrapping in message envelope that is unwrapped before
     /// sending to the entity actor.
     /// </summary>
-    public delegate Tuple<EntityId, Msg> ExtractEntityId(Msg message);
+    public delegate (EntityId, Msg) ExtractEntityId(Msg message);
 
     /// <summary>
     /// Interface of functions to extract entity id,  shard id, and the message to send
@@ -1187,10 +1187,10 @@ namespace Akka.Cluster.Sharding
             ExtractEntityId extractEntityId = msg =>
             {
                 if (self.EntityId(msg) != null)
-                    return Tuple.Create(self.EntityId(msg), self.EntityMessage(msg));
+                    return (self.EntityId(msg), self.EntityMessage(msg));
                 //TODO: should we really use tuples?
 
-                return null;
+                return (default(string), default(object));
             };
 
             return extractEntityId;

--- a/src/contrib/cluster/Akka.Cluster.Sharding/DDataShard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/DDataShard.cs
@@ -47,7 +47,7 @@ namespace Akka.Cluster.Sharding
         public ImmutableDictionary<IActorRef, string> IdByRef { get; set; } = ImmutableDictionary<IActorRef, string>.Empty;
         public ImmutableDictionary<string, long> LastMessageTimestamp { get; set; } = ImmutableDictionary<string, long>.Empty;
         public ImmutableHashSet<IActorRef> Passivating { get; set; } = ImmutableHashSet<IActorRef>.Empty;
-        public ImmutableDictionary<string, ImmutableList<Tuple<object, IActorRef>>> MessageBuffers { get; set; } = ImmutableDictionary<string, ImmutableList<Tuple<object, IActorRef>>>.Empty;
+        public ImmutableDictionary<string, ImmutableList<(object, IActorRef)>> MessageBuffers { get; set; } = ImmutableDictionary<string, ImmutableList<(object, IActorRef)>>.Empty;
         public ICancelable PassivateIdleTask { get; }
 
         private EntityRecoveryStrategy RememberedEntitiesRecoveryStrategy { get; }
@@ -184,7 +184,7 @@ namespace Akka.Cluster.Sharding
 
         private void SendUpdate(Shard.StateChange e, int retryCount)
         {
-            Replicator.Tell(Dsl.Update(Key(e.EntityId), ORSet<EntryId>.Empty, _writeConsistency, Tuple.Create(e, retryCount),
+            Replicator.Tell(Dsl.Update(Key(e.EntityId), ORSet<EntryId>.Empty, _writeConsistency, (e, retryCount),
                 existing =>
                 {
                     switch (e)
@@ -200,14 +200,14 @@ namespace Akka.Cluster.Sharding
         {
             switch (message)
             {
-                case UpdateSuccess success when Equals(((Tuple<Shard.StateChange, int>)success.Request).Item1, e):
+                case UpdateSuccess success when Equals((((Shard.StateChange, int))success.Request).Item1, e):
                     Log.Debug("The DDataShard state was successfully updated with {0}", e);
                     Context.UnbecomeStacked();
                     afterUpdateCallback(e);
                     Stash.UnstashAll();
                     break;
-                case UpdateTimeout timeout when Equals(((Tuple<Shard.StateChange, int>)timeout.Request).Item1, e):
-                    var t = (Tuple<Shard.StateChange, int>)timeout.Request;
+                case UpdateTimeout timeout when Equals((((Shard.StateChange, int))timeout.Request).Item1, e):
+                    var t = ((Shard.StateChange, int))timeout.Request;
                     var retryCount = t.Item2;
                     if (retryCount == MaxUpdateAttempts)
                     {
@@ -223,7 +223,7 @@ namespace Akka.Cluster.Sharding
                         SendUpdate(e, retryCount + 1);
                     }
                     break;
-                case ModifyFailure failure when Equals(((Tuple<Shard.StateChange, int>)failure.Request).Item1, e):
+                case ModifyFailure failure when Equals((((Shard.StateChange, int))failure.Request).Item1, e):
                     Log.Error("The DDataShard was unable to update state with error {0} and event {1}. Shard will be restarted", failure.Cause, e);
                     ExceptionDispatchInfo.Capture(failure.Cause).Throw();
                     break;

--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShard.cs
@@ -213,7 +213,7 @@ namespace Akka.Cluster.Sharding
                 else
                 {
                     // Note; we only do this if remembering, otherwise the buffer is an overhead
-                    MessageBuffers = MessageBuffers.SetItem(id, ImmutableList<(object, IActorRef)>.Empty.Add((message, sender));
+                    MessageBuffers = MessageBuffers.SetItem(id, ImmutableList<(object, IActorRef)>.Empty.Add((message, sender)));
                     ProcessChange(new Shard.EntityStarted(id), this.SendMessageBuffer);
                 }
             }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShard.cs
@@ -44,7 +44,7 @@ namespace Akka.Cluster.Sharding
         public ImmutableDictionary<IActorRef, string> IdByRef { get; set; } = ImmutableDictionary<IActorRef, string>.Empty;
         public ImmutableDictionary<string, long> LastMessageTimestamp { get; set; } = ImmutableDictionary<string, long>.Empty;
         public ImmutableHashSet<IActorRef> Passivating { get; set; } = ImmutableHashSet<IActorRef>.Empty;
-        public ImmutableDictionary<string, ImmutableList<Tuple<object, IActorRef>>> MessageBuffers { get; set; } = ImmutableDictionary<string, ImmutableList<Tuple<object, IActorRef>>>.Empty;
+        public ImmutableDictionary<string, ImmutableList<(object, IActorRef)>> MessageBuffers { get; set; } = ImmutableDictionary<string, ImmutableList<(object, IActorRef)>>.Empty;
         public ICancelable PassivateIdleTask { get; }
 
         private EntityRecoveryStrategy RememberedEntitiesRecoveryStrategy { get; }
@@ -213,7 +213,7 @@ namespace Akka.Cluster.Sharding
                 else
                 {
                     // Note; we only do this if remembering, otherwise the buffer is an overhead
-                    MessageBuffers = MessageBuffers.SetItem(id, ImmutableList<Tuple<object, IActorRef>>.Empty.Add(Tuple.Create(message, sender)));
+                    MessageBuffers = MessageBuffers.SetItem(id, ImmutableList<(object, IActorRef)>.Empty.Add((message, sender));
                     ProcessChange(new Shard.EntityStarted(id), this.SendMessageBuffer);
                 }
             }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
@@ -36,7 +36,7 @@ namespace Akka.Cluster.Sharding
         ImmutableDictionary<IActorRef, EntityId> IdByRef { get; set; }
         ImmutableDictionary<string, long> LastMessageTimestamp { get; set; }
         ImmutableHashSet<IActorRef> Passivating { get; set; }
-        ImmutableDictionary<EntityId, ImmutableList<Tuple<Msg, IActorRef>>> MessageBuffers { get; set; }
+        ImmutableDictionary<EntityId, ImmutableList<(Msg, IActorRef)>> MessageBuffers { get; set; }
         void Unhandled(object message);
         void ProcessChange<T>(T evt, Action<T> handler) where T : Shard.StateChange;
         void EntityTerminated(IActorRef tref);
@@ -378,7 +378,7 @@ namespace Akka.Cluster.Sharding
         public ImmutableDictionary<IActorRef, string> IdByRef { get; set; } = ImmutableDictionary<IActorRef, string>.Empty;
         public ImmutableDictionary<string, long> LastMessageTimestamp { get; set; } = ImmutableDictionary<string, long>.Empty;
         public ImmutableHashSet<IActorRef> Passivating { get; set; } = ImmutableHashSet<IActorRef>.Empty;
-        public ImmutableDictionary<string, ImmutableList<Tuple<object, IActorRef>>> MessageBuffers { get; set; } = ImmutableDictionary<string, ImmutableList<Tuple<object, IActorRef>>>.Empty;
+        public ImmutableDictionary<string, ImmutableList<(object, IActorRef)>> MessageBuffers { get; set; } = ImmutableDictionary<string, ImmutableList<(object, IActorRef)>>.Empty;
         public ICancelable PassivateIdleTask { get; }
 
         private EntityRecoveryStrategy RememberedEntitiesRecoveryStrategy { get; }
@@ -470,12 +470,11 @@ namespace Akka.Cluster.Sharding
                 case Shard.IShardQuery sq:
                     shard.HandleShardRegionQuery(sq);
                     return true;
-                case ShardRegion.RestartShard _:
+                case var _ when !shard.ExtractEntityId(message).Equals((default(string), default(object))):
                     return true;
                 case Shard.PassivateIdleTick _:
                     shard.PassivateIdleEntities();
                     return true;
-                case var _ when shard.ExtractEntityId(message) != null:
                     shard.DeliverMessage(message, shard.Context.Sender);
                     return true;
             }
@@ -623,7 +622,7 @@ namespace Akka.Cluster.Sharding
                     shard.Log.Debug("Passivating started on entity {0}", id);
 
                     shard.Passivating = shard.Passivating.Add(entity);
-                    shard.MessageBuffers = shard.MessageBuffers.Add(id, ImmutableList<Tuple<object, IActorRef>>.Empty);
+                    shard.MessageBuffers = shard.MessageBuffers.Add(id, ImmutableList<(object, IActorRef)>.Empty);
 
                     entity.Tell(stopMessage);
                 }
@@ -717,7 +716,7 @@ namespace Akka.Cluster.Sharding
                         else
                         {
                             shard.Log.Debug("Message for entity [{0}] buffered", id);
-                            shard.MessageBuffers = shard.MessageBuffers.SetItem(id, buffer.Add(Tuple.Create(message, sender)));
+                            shard.MessageBuffers = shard.MessageBuffers.SetItem(id, buffer.Add((message, sender)));
                         }
                     }
                     else

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
@@ -470,6 +470,8 @@ namespace Akka.Cluster.Sharding
                 case Shard.IShardQuery sq:
                     shard.HandleShardRegionQuery(sq);
                     return true;
+                case ShardRegion.RestartShard _:
+                    return true;
                 case var _ when shard.ExtractEntityId(message) != null:
                     return true;
                 case Shard.PassivateIdleTick _:

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
@@ -470,7 +470,7 @@ namespace Akka.Cluster.Sharding
                 case Shard.IShardQuery sq:
                     shard.HandleShardRegionQuery(sq);
                     return true;
-                case var _ when !shard.ExtractEntityId(message).Equals((default(string), default(object))):
+                case var _ when shard.ExtractEntityId(message) != null:
                     return true;
                 case Shard.PassivateIdleTick _:
                     shard.PassivateIdleEntities();
@@ -692,8 +692,8 @@ namespace Akka.Cluster.Sharding
         private static void DeliverMessage<TShard>(this TShard shard, object message, IActorRef sender) where TShard : IShard
         {
             var t = shard.ExtractEntityId(message);
-            var id = t.Item1;
-            var payload = t.Item2;
+            var id = t?.Item1;
+            var payload = t?.Item2;
 
             if (string.IsNullOrEmpty(id))
             {

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardCoordinator.cs
@@ -426,7 +426,7 @@ namespace Akka.Cluster.Sharding
         {
             var sender = coordinator.Sender;
             Task.WhenAll(
-                coordinator.AliveRegions.Select(regionActor => regionActor.Ask<ShardRegionStats>(GetShardRegionStats.Instance, message.Timeout).ContinueWith(r => Tuple.Create(regionActor, r.Result), TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnRanToCompletion))
+                coordinator.AliveRegions.Select(regionActor => regionActor.Ask<ShardRegionStats>(GetShardRegionStats.Instance, message.Timeout).ContinueWith(r => (regionActor, r.Result), TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnRanToCompletion))
                 ).ContinueWith(allRegionStats =>
                 {
                     if (allRegionStats.IsCanceled)

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
@@ -529,7 +529,7 @@ namespace Akka.Cluster.Sharding
                 case StartEntity _:
                     DeliverStartEntity(message, Sender);
                     return true;
-                case var _ when ExtractEntityId(message) != null:
+                case var _ when !ExtractEntityId(message).Equals((default(string), default(object))):
                     DeliverMessage(message, Sender);
                     return true;
                 default:
@@ -774,10 +774,10 @@ namespace Akka.Cluster.Sharding
                 }, TaskContinuationOptions.ExecuteSynchronously).PipeTo(sender);
         }
 
-        private Task<Tuple<ShardId, T>[]> AskAllShardsAsync<T>(object message)
+        private Task<(ShardId, T)[]> AskAllShardsAsync<T>(object message)
         {
             var timeout = TimeSpan.FromSeconds(3);
-            var tasks = Shards.Select(entity => entity.Value.Ask<T>(message, timeout).ContinueWith(t => Tuple.Create(entity.Key, t.Result), TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnRanToCompletion));
+            var tasks = Shards.Select(entity => entity.Value.Ask<T>(message, timeout).ContinueWith(t => (entity.Key, t.Result), TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnRanToCompletion));
             return Task.WhenAll(tasks);
         }
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
@@ -529,7 +529,7 @@ namespace Akka.Cluster.Sharding
                 case StartEntity _:
                     DeliverStartEntity(message, Sender);
                     return true;
-                case var _ when !ExtractEntityId(message).Equals((default(string), default(object))):
+                case var _ when ExtractEntityId(message) != null:
                     DeliverMessage(message, Sender);
                     return true;
                 default:

--- a/src/contrib/cluster/Akka.Cluster.Tools/Client/ClusterClient.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Client/ClusterClient.cs
@@ -190,7 +190,7 @@ namespace Akka.Cluster.Tools.Client
         private ImmutableList<IActorRef> _subscribers;
         private readonly ICancelable _heartbeatTask;
         private ICancelable _refreshContactsCancelable;
-        private readonly Queue<Tuple<object, IActorRef>> _buffer;
+        private readonly Queue<(object, IActorRef)> _buffer;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ClusterClient" /> class.
@@ -229,7 +229,7 @@ namespace Akka.Cluster.Tools.Client
             ScheduleRefreshContactsTick(settings.EstablishingGetContactsInterval);
             Self.Tell(RefreshContactsTick.Instance);
 
-            _buffer = new Queue<Tuple<object, IActorRef>>();
+            _buffer = new Queue<(object, IActorRef)>();
         }
 
         private void ScheduleRefreshContactsTick(TimeSpan interval)
@@ -474,13 +474,13 @@ namespace Akka.Cluster.Tools.Client
             {
                 var m = _buffer.Dequeue();
                 _log.Warning("Receptionist not available, buffer is full, dropping first message [{0}]", m.Item1.GetType().Name);
-                _buffer.Enqueue(Tuple.Create(message, Sender));
+                _buffer.Enqueue((message, Sender));
             }
             else
             {
                 if(_log.IsDebugEnabled) // don't invoke reflection call on message type if we don't have to
                     _log.Debug("Receptionist not available, buffering message type [{0}]", message.GetType().Name);
-                _buffer.Enqueue(Tuple.Create(message, Sender));
+                _buffer.Enqueue((message, Sender));
             }
         }
 

--- a/src/contrib/cluster/Akka.DistributedData.Tests/DeltaPropagationSelectorSpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/DeltaPropagationSelectorSpec.cs
@@ -35,7 +35,7 @@ namespace Akka.DistributedData.Tests
             protected override ImmutableArray<Address> AllNodes { get; }
             protected override int MaxDeltaSize => 10;
 
-            protected override DeltaPropagation CreateDeltaPropagation(ImmutableDictionary<string, Tuple<IReplicatedData, long, long>> deltas) =>
+            protected override DeltaPropagation CreateDeltaPropagation(ImmutableDictionary<string, (IReplicatedData, long, long)> deltas) =>
                 new DeltaPropagation(selfUniqueAddress, false, deltas
                     .Select(kv => new KeyValuePair<string, Delta>(kv.Key, new Delta(new DataEnvelope(kv.Value.Item1), kv.Value.Item2, kv.Value.Item3)))
                     .ToImmutableDictionary());

--- a/src/contrib/cluster/Akka.DistributedData.Tests/LWWDictionarySpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/LWWDictionarySpec.cs
@@ -32,8 +32,8 @@ namespace Akka.DistributedData.Tests
         public void LWWDictionary_must_be_able_to_set_entries()
         {
             var m = LWWDictionary.Create(
-                Tuple.Create(_node1, "a", 1),
-                Tuple.Create(_node2, "b", 2));
+                (_node1, "a", 1),
+                (_node2, "b", 2));
 
             Assert.Equal(m.Entries, ImmutableDictionary.CreateRange(new[]
             {
@@ -46,8 +46,8 @@ namespace Akka.DistributedData.Tests
         public void LWWDictionary_must_be_able_to_have_its_entries_correctly_merged_with_another_LWWMap_with_other_entries()
         {
             var m1 = LWWDictionary.Create(
-                Tuple.Create(_node1, "a", 1),
-                Tuple.Create(_node1, "b", 2));
+               (_node1, "a", 1),
+               (_node1, "b", 2));
             var m2 = LWWDictionary.Create(_node2, "c", 3);
 
             var expected = ImmutableDictionary.CreateRange(new[]
@@ -66,8 +66,8 @@ namespace Akka.DistributedData.Tests
         public void LWWDictionary_must_be_able_to_remove_entry()
         {
             var m1 = LWWDictionary.Create(
-                Tuple.Create(_node1, "a", 1),
-                Tuple.Create(_node2, "b", 2));
+               (_node1, "a", 1),
+               (_node2, "b", 2));
             var m2 = LWWDictionary.Create(_node2, "c", 3);
 
             var merged1 = m1.Merge(m2);

--- a/src/contrib/cluster/Akka.DistributedData.Tests/ORDictionarySpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/ORDictionarySpec.cs
@@ -33,8 +33,8 @@ namespace Akka.DistributedData.Tests
         public void ORDictionary_must_be_able_to_add_entries()
         {
             var m = ORDictionary.Create(
-                Tuple.Create(_node1, "a", GSet.Create("A")),
-                Tuple.Create(_node1, "b", GSet.Create("B")));
+                (_node1, "a", GSet.Create("A")),
+                (_node1, "b", GSet.Create("B")));
 
             m["a"].Elements.Should().BeEquivalentTo("A");
             m["b"].Elements.Should().BeEquivalentTo("B");
@@ -47,8 +47,8 @@ namespace Akka.DistributedData.Tests
         public void ORDictionary_must_be_able_to_add_entries_with_delta()
         {
             var m = ORDictionary.Create(
-                Tuple.Create(_node1, "a", GSet.Create("A")),
-                Tuple.Create(_node1, "b", GSet.Create("B")));
+                (_node1, "a", GSet.Create("A")),
+                (_node1, "b", GSet.Create("B")));
             var md = m.Delta;
 
             var m1 = ORDictionary<string, GSet<string>>.Empty.MergeDelta(md);

--- a/src/contrib/cluster/Akka.DistributedData.Tests/WriteAggregatorSpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/WriteAggregatorSpec.cs
@@ -347,12 +347,12 @@ namespace Akka.DistributedData.Tests
                     Sys.ActorOf(Props.Create(() => new WriteAckAdapter(probe)))))
                 .ToImmutableDictionary();
 
-        private IImmutableDictionary<Address, Tuple<TestProbe, IActorRef>> Probes() =>
+        private IImmutableDictionary<Address, (TestProbe, IActorRef)> Probes() =>
             _nodes.Select(address =>
                 {
                     var probe = CreateTestProbe("probe-" + address.Host);
-                    return new KeyValuePair<Address, Tuple<TestProbe, IActorRef>>(address,
-                        Tuple.Create(probe, Sys.ActorOf(Props.Create(() => new WriteAckAdapter(probe.Ref)))));
+                    return new KeyValuePair<Address, (TestProbe, IActorRef)>(address,
+                        (probe, Sys.ActorOf(Props.Create(() => new WriteAckAdapter(probe.Ref)))));
                 })
                 .ToImmutableDictionary();
     }

--- a/src/contrib/cluster/Akka.DistributedData/DeltaPropagationSelector.cs
+++ b/src/contrib/cluster/Akka.DistributedData/DeltaPropagationSelector.cs
@@ -26,7 +26,7 @@ namespace Akka.DistributedData
         public abstract int GossipInternalDivisor { get; }
         protected abstract ImmutableArray<Address> AllNodes { get; }
         protected abstract int MaxDeltaSize { get; }
-        protected abstract DeltaPropagation CreateDeltaPropagation(ImmutableDictionary<string, Tuple<IReplicatedData, long, long>> deltas);
+        protected abstract DeltaPropagation CreateDeltaPropagation(ImmutableDictionary<string, (IReplicatedData, long, long)> deltas);
 
         public long CurrentVersion(string key) => _deltaCounter.GetValueOrDefault(key, 0L);
 
@@ -79,12 +79,12 @@ namespace Akka.DistributedData
                 _deltaNodeRoundRobinCounter += sliceSize;
 
                 var result = ImmutableDictionary<Address, DeltaPropagation>.Empty.ToBuilder();
-                var cache = new Dictionary<Tuple<string, long, long>, IReplicatedData>();
+                var cache = new Dictionary<(string, long, long), IReplicatedData>();
                 foreach (var node in slice)
                 {
                     // collect the deltas that have not already been sent to the node and merge
                     // them into a delta group
-                    var deltas = ImmutableDictionary<string, Tuple<IReplicatedData, long, long>>.Empty.ToBuilder();
+                    var deltas = ImmutableDictionary<string, (IReplicatedData, long, long)>.Empty.ToBuilder();
                     foreach (var entry in _deltaEntries)
                     {
                         var key = entry.Key;
@@ -100,7 +100,7 @@ namespace Akka.DistributedData
 
                             // in most cases the delta group merging will be the same for each node,
                             // so we cache the merged results
-                            var cacheKey = Tuple.Create(key, fromSeqNr, toSeqNr);
+                            var cacheKey = (key, fromSeqNr, toSeqNr);
                             IReplicatedData deltaGroup;
                             if (!cache.TryGetValue(cacheKey, out deltaGroup))
                             {
@@ -121,7 +121,7 @@ namespace Akka.DistributedData
                                 cache[cacheKey] = deltaGroup;
                             }
 
-                            deltas[key] = Tuple.Create(deltaGroup, fromSeqNr, toSeqNr);
+                            deltas[key] = (deltaGroup, fromSeqNr, toSeqNr);
                             _deltaSentToNode = _deltaSentToNode.SetItem(key, deltaSentToNodeForKey.SetItem(node, toSeqNr));
                         }
                     }

--- a/src/contrib/cluster/Akka.DistributedData/LWWDictionary.cs
+++ b/src/contrib/cluster/Akka.DistributedData/LWWDictionary.cs
@@ -57,7 +57,7 @@ namespace Akka.DistributedData
         /// <typeparam name="TValue">TBD</typeparam>
         /// <param name="elements">TBD</param>
         /// <returns>TBD</returns>
-        public static LWWDictionary<TKey, TValue> Create<TKey, TValue>(params Tuple<UniqueAddress, TKey, TValue>[] elements) =>
+        public static LWWDictionary<TKey, TValue> Create<TKey, TValue>(params (UniqueAddress, TKey, TValue)[] elements) =>
             elements.Aggregate(LWWDictionary<TKey, TValue>.Empty, (dictionary, t) => dictionary.SetItem(t.Item1, t.Item2, t.Item3));
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace Akka.DistributedData
         /// <param name="elements">TBD</param>
         /// <param name="clock">TBD</param>
         /// <returns>TBD</returns>
-        public static LWWDictionary<TKey, TValue> Create<TKey, TValue>(IEnumerable<Tuple<UniqueAddress, TKey, TValue>> elements, Clock<TValue> clock = null) =>
+        public static LWWDictionary<TKey, TValue> Create<TKey, TValue>(IEnumerable<(UniqueAddress, TKey, TValue)> elements, Clock<TValue> clock = null) =>
             elements.Aggregate(LWWDictionary<TKey, TValue>.Empty, (dictionary, t) => dictionary.SetItem(t.Item1, t.Item2, t.Item3, clock));
     }
 

--- a/src/contrib/cluster/Akka.DistributedData/ORDictionary.cs
+++ b/src/contrib/cluster/Akka.DistributedData/ORDictionary.cs
@@ -27,10 +27,10 @@ namespace Akka.DistributedData
         public static ORDictionary<TKey, TValue> Create<TKey, TValue>(UniqueAddress node, TKey key, TValue value) where TValue : IReplicatedData<TValue> =>
             ORDictionary<TKey, TValue>.Empty.SetItem(node, key, value);
 
-        public static ORDictionary<TKey, TValue> Create<TKey, TValue>(params Tuple<UniqueAddress, TKey, TValue>[] elements) where TValue : IReplicatedData<TValue> =>
+        public static ORDictionary<TKey, TValue> Create<TKey, TValue>(params (UniqueAddress, TKey, TValue)[] elements) where TValue : IReplicatedData<TValue> =>
             elements.Aggregate(ORDictionary<TKey, TValue>.Empty, (acc, t) => acc.SetItem(t.Item1, t.Item2, t.Item3));
 
-        public static ORDictionary<TKey, TValue> Create<TKey, TValue>(IEnumerable<Tuple<UniqueAddress, TKey, TValue>> elements) where TValue : IReplicatedData<TValue> =>
+        public static ORDictionary<TKey, TValue> Create<TKey, TValue>(IEnumerable<(UniqueAddress, TKey, TValue)> elements) where TValue : IReplicatedData<TValue> =>
             elements.Aggregate(ORDictionary<TKey, TValue>.Empty, (acc, t) => acc.SetItem(t.Item1, t.Item2, t.Item3));
     }
 

--- a/src/contrib/cluster/Akka.DistributedData/Replicator.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Replicator.cs
@@ -312,7 +312,7 @@ namespace Akka.DistributedData
         /// <summary>
         /// The actual data.
         /// </summary>
-        private ImmutableDictionary<string, Tuple<DataEnvelope, Digest>> _dataEntries = ImmutableDictionary<string, Tuple<DataEnvelope, Digest>>.Empty;
+        private ImmutableDictionary<string, (DataEnvelope, Digest)> _dataEntries = ImmutableDictionary<string, (DataEnvelope, Digest)>.Empty;
 
         /// <summary>
         /// Keys that have changed, Changed event published to subscribers on FlushChanges
@@ -801,7 +801,7 @@ namespace Akka.DistributedData
             else if (newEnvelope.Data is DeletedData) digest = DeletedDigest;
             else digest = LazyDigest;
 
-            _dataEntries = _dataEntries.SetItem(key, Tuple.Create(newEnvelope, digest));
+            _dataEntries = _dataEntries.SetItem(key, (newEnvelope, digest));
             if (newEnvelope.Data is DeletedData)
             {
                 _deltaPropagationSelector.Delete(key);
@@ -812,14 +812,14 @@ namespace Akka.DistributedData
 
         private Digest GetDigest(string key)
         {
-            Tuple<DataEnvelope, Digest> value;
+            (DataEnvelope, Digest) value;
             var contained = _dataEntries.TryGetValue(key, out value);
             if (contained)
             {
                 if (Equals(value.Item2, LazyDigest))
                 {
                     var digest = Digest(value.Item1);
-                    _dataEntries = _dataEntries.SetItem(key, Tuple.Create(value.Item1, digest));
+                    _dataEntries = _dataEntries.SetItem(key, (value.Item1, digest));
                     return digest;
                 }
                 else return value.Item2;
@@ -838,13 +838,13 @@ namespace Akka.DistributedData
 
         private DataEnvelope GetData(string key)
         {
-            Tuple<DataEnvelope, Digest> value;
+            (DataEnvelope, Digest) value;
             return !_dataEntries.TryGetValue(key, out value) ? null : value.Item1;
         }
 
         private long GetDeltaSequenceNr(string key, UniqueAddress from)
         {
-            Tuple<DataEnvelope, Digest> tuple;
+            (DataEnvelope, Digest) tuple;
             return _dataEntries.TryGetValue(key, out tuple) ? tuple.Item1.DeltaVersions.VersionAt(@from) : 0L;
         }
 
@@ -854,7 +854,7 @@ namespace Akka.DistributedData
 
             return keys.Any(key =>
             {
-                Tuple<DataEnvelope, Digest> tuple;
+                (DataEnvelope, Digest) tuple;
                 return _dataEntries.TryGetValue(key, out tuple)
                     ? tuple.Item1.Pruning.ContainsKey(node)
                     : false;
@@ -1418,7 +1418,7 @@ namespace Akka.DistributedData
             protected override ImmutableArray<Address> AllNodes =>
                 _replicator._nodes.Union(_replicator._weaklyUpNodes).Except(_replicator._unreachable).OrderBy(x => x).ToImmutableArray();
 
-            protected override DeltaPropagation CreateDeltaPropagation(ImmutableDictionary<string, Tuple<IReplicatedData, long, long>> deltas)
+            protected override DeltaPropagation CreateDeltaPropagation(ImmutableDictionary<string, (IReplicatedData, long, long)> deltas)
             {
                 // Important to include the pruning state in the deltas. For example if the delta is based
                 // on an entry that has been pruned but that has not yet been performed on the target node.

--- a/src/contrib/cluster/Akka.DistributedData/Replicator.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Replicator.cs
@@ -296,8 +296,6 @@ namespace Akka.DistributedData
         private ImmutableHashSet<Address> _weaklyUpNodes = ImmutableHashSet<Address>.Empty;
 
         private ImmutableDictionary<UniqueAddress, long> _removedNodes = ImmutableDictionary<UniqueAddress, long>.Empty;
-        private ImmutableDictionary<UniqueAddress, long> _pruningPerformed = ImmutableDictionary<UniqueAddress, long>.Empty;
-        private ImmutableHashSet<UniqueAddress> _tombstonedNodes = ImmutableHashSet<UniqueAddress>.Empty;
 
         private Address _leader = null;
         private bool IsLeader => _leader != null && _leader == _selfAddress;
@@ -855,9 +853,7 @@ namespace Akka.DistributedData
             return keys.Any(key =>
             {
                 (DataEnvelope, Digest) tuple;
-                return _dataEntries.TryGetValue(key, out tuple)
-                    ? tuple.Item1.Pruning.ContainsKey(node)
-                    : false;
+                return _dataEntries.TryGetValue(key, out tuple) && tuple.Item1.Pruning.ContainsKey(node);
             });
         }
 

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/BatchingSqlJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/BatchingSqlJournal.cs
@@ -1086,7 +1086,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         private async Task HandleWriteMessages(WriteMessages req, TCommand command)
         {
             IJournalResponse summary = null;
-            var responses = new List<Tuple<IJournalResponse, IActorRef>>();
+            var responses = new List<(IJournalResponse, IActorRef)>();
             var tags = new HashSet<string>();
             var persistenceIds = new HashSet<string>();
             var actorInstanceId = req.ActorInstanceId;
@@ -1130,7 +1130,7 @@ namespace Akka.Persistence.Sql.Common.Journal
 
                                 await command.ExecuteNonQueryAsync();
 
-                                var response = Tuple.Create<IJournalResponse, IActorRef>(new WriteMessageSuccess(unadapted, actorInstanceId), unadapted.Sender);
+                                var response = (new WriteMessageSuccess(unadapted, actorInstanceId), unadapted.Sender);
                                 responses.Add(response);
                                 persistenceIds.Add(persistent.PersistenceId);
 
@@ -1140,7 +1140,7 @@ namespace Akka.Persistence.Sql.Common.Journal
                             {
                                 // database-related exceptions should result in failure
                                 summary = new WriteMessagesFailed(cause);
-                                var response = Tuple.Create<IJournalResponse, IActorRef>(new WriteMessageFailure(unadapted, cause, actorInstanceId), unadapted.Sender);
+                                var response = (new WriteMessageFailure(unadapted, cause, actorInstanceId), unadapted.Sender);
                                 responses.Add(response);
                             }
                             catch (Exception cause)
@@ -1148,7 +1148,7 @@ namespace Akka.Persistence.Sql.Common.Journal
                                 //TODO: this scope wraps atomic write. Atomic writes have all-or-nothing commits.
                                 // so we should revert transaction here. But we need to check how this affect performance.
 
-                                var response = Tuple.Create<IJournalResponse, IActorRef>(new WriteMessageRejected(unadapted, cause, actorInstanceId), unadapted.Sender);
+                                var response = (new WriteMessageRejected(unadapted, cause, actorInstanceId), unadapted.Sender);
                                 responses.Add(response);
                             }
                         }
@@ -1156,7 +1156,7 @@ namespace Akka.Persistence.Sql.Common.Journal
                     else
                     {
                         //TODO: other cases?
-                        var response = Tuple.Create<IJournalResponse, IActorRef>(new LoopMessageSuccess(envelope.Payload, actorInstanceId), envelope.Sender);
+                        var response = (new LoopMessageSuccess(envelope.Payload, actorInstanceId), envelope.Sender);
                         responses.Add(response);
                     }
                 }

--- a/src/contrib/serializers/Akka.Serialization.TestKit/AkkaSerializationSpec.cs
+++ b/src/contrib/serializers/Akka.Serialization.TestKit/AkkaSerializationSpec.cs
@@ -169,14 +169,14 @@ akka.actor {
         [Fact]
         public void CanSerializeImmutableMessages()
         {
-            var message = new ImmutableMessage(Tuple.Create("aaa", "bbb"));
+            var message = new ImmutableMessage(("aaa", "bbb"));
             AssertEqual(message);
         }
 
         [Fact]
         public void CanSerializeImmutableMessagesWithPrivateCtor()
         {
-            var message = new ImmutableMessageWithPrivateCtor(Tuple.Create("aaa", "bbb"));
+            var message = new ImmutableMessageWithPrivateCtor(("aaa", "bbb"));
             AssertEqual(message);
         }
 

--- a/src/contrib/serializers/Akka.Serialization.TestKit/ImmutableMessage.cs
+++ b/src/contrib/serializers/Akka.Serialization.TestKit/ImmutableMessage.cs
@@ -40,7 +40,7 @@ namespace Akka.Tests.Serialization
             }
         }
 
-        public ImmutableMessage(Tuple<string, string> nonConventionalArg)
+        public ImmutableMessage((string, string) nonConventionalArg)
         {
             Foo = nonConventionalArg.Item1;
             Bar = nonConventionalArg.Item2;

--- a/src/contrib/serializers/Akka.Serialization.TestKit/ImmutableMessageWithPrivateCtor.cs
+++ b/src/contrib/serializers/Akka.Serialization.TestKit/ImmutableMessageWithPrivateCtor.cs
@@ -39,7 +39,7 @@ namespace Akka.Tests.Serialization
             }
         }
 
-        public ImmutableMessageWithPrivateCtor(Tuple<string, string> nonConventionalArg)
+        public ImmutableMessageWithPrivateCtor((string, string) nonConventionalArg)
         {
             Foo = nonConventionalArg.Item1;
             Bar = nonConventionalArg.Item2;

--- a/src/contrib/transports/Akka.Remote.Transport.Helios/HeliosTransport.cs
+++ b/src/contrib/transports/Akka.Remote.Transport.Helios/HeliosTransport.cs
@@ -324,7 +324,7 @@ namespace Akka.Remote.Transport.Helios
         /// <exception cref="ConfigurationException">TBD</exception>
         /// <exception cref="Exception">TBD</exception>
         /// <returns>TBD</returns>
-        public override async Task<Tuple<Address, TaskCompletionSource<IAssociationEventListener>>> Listen()
+        public override async Task<(Address, TaskCompletionSource<IAssociationEventListener>)> Listen()
         {
             EndPoint listenAddress;
             IPAddress ip;
@@ -361,7 +361,7 @@ namespace Akka.Remote.Transport.Helios
 #pragma warning restore 4014
 
 
-                return Tuple.Create(addr, AssociationListenerPromise);
+                return (addr, AssociationListenerPromise);
             }
             catch (Exception ex)
             {

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -4973,7 +4973,7 @@ namespace Akka.Util.Internal
     }
     public class static InterlockedSpin
     {
-        public static TReturn ConditionallySwap<T, TReturn>(ref T reference, System.Func<T, System.Tuple<bool, T, TReturn>> updateIfTrue)
+        public static TReturn ConditionallySwap<T, TReturn>(ref T reference, System.Func<T, System.ValueTuple<bool, T, TReturn>> updateIfTrue)
             where T :  class { }
         public static T Swap<T>(ref T reference, System.Func<T, T> updater)
             where T :  class { }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -711,7 +711,11 @@ namespace Akka.Actor
     {
         public Envelope(object message, Akka.Actor.IActorRef sender, Akka.Actor.ActorSystem system) { }
         public Envelope(object message, Akka.Actor.IActorRef sender) { }
+        [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
+        [set: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public object Message { get; }
+        [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
+        [set: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public Akka.Actor.IActorRef Sender { get; }
         public override string ToString() { }
     }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
@@ -1078,7 +1078,9 @@ namespace Akka.Persistence.Journal
     {
         public Tagged(object payload, System.Collections.Generic.IEnumerable<string> tags) { }
         public Tagged(object payload, System.Collections.Immutable.IImmutableSet<string> tags) { }
+        [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public object Payload { get; }
+        [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public System.Collections.Immutable.IImmutableSet<string> Tags { get; }
     }
     public abstract class WriteJournalBase : Akka.Actor.ActorBase

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveRemote.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveRemote.approved.txt
@@ -524,7 +524,7 @@ namespace Akka.Remote.Transport
         public AssociationRegistry() { }
         public static void Clear() { }
         public void ClearLog() { }
-        public System.ValueTuple<Akka.Remote.Transport.IHandleEventListener, Akka.Remote.Transport.IHandleEventListener> DeregisterAssociation(System.ValueTuple<Akka.Actor.Address, Akka.Actor.Address> key) { }
+        public System.Nullable<System.ValueTuple<Akka.Remote.Transport.IHandleEventListener, Akka.Remote.Transport.IHandleEventListener>> DeregisterAssociation(System.ValueTuple<Akka.Actor.Address, Akka.Actor.Address> key) { }
         public bool ExistsAssociation(Akka.Actor.Address initiatorAddress, Akka.Actor.Address remoteAddress) { }
         public static Akka.Remote.Transport.AssociationRegistry Get(string key) { }
         public Akka.Remote.Transport.IHandleEventListener GetRemoteReadHandlerFor(Akka.Remote.Transport.TestAssociationHandle localHandle) { }
@@ -534,7 +534,7 @@ namespace Akka.Remote.Transport
         public void RegisterTransport(Akka.Remote.Transport.TestTransport transport, System.Threading.Tasks.Task<Akka.Remote.Transport.IAssociationEventListener> associationEventListenerTask) { }
         public Akka.Remote.Transport.IHandleEventListener RemoteListenerRelativeTo(Akka.Remote.Transport.TestAssociationHandle handle, System.ValueTuple<Akka.Remote.Transport.IHandleEventListener, Akka.Remote.Transport.IHandleEventListener> listenerPair) { }
         public void Reset() { }
-        public System.ValueTuple<Akka.Remote.Transport.TestTransport, System.Threading.Tasks.Task<Akka.Remote.Transport.IAssociationEventListener>> TransportFor(Akka.Actor.Address address) { }
+        public System.Nullable<System.ValueTuple<Akka.Remote.Transport.TestTransport, System.Threading.Tasks.Task<Akka.Remote.Transport.IAssociationEventListener>>> TransportFor(Akka.Actor.Address address) { }
         public bool TransportsReady(params Akka.Actor.Address[] addresses) { }
     }
     public class Blackhole : Akka.Remote.Transport.ThrottleMode

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveRemote.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveRemote.approved.txt
@@ -323,12 +323,12 @@ namespace Akka.Remote
         {
             public static Akka.Remote.RemoteWatcher.Stats Empty;
             public Stats(int watching, int watchingNodes) { }
-            public Stats(int watching, int watchingNodes, System.Collections.Immutable.ImmutableHashSet<System.Tuple<Akka.Actor.IActorRef, Akka.Actor.IActorRef>> watchingRefs, System.Collections.Immutable.ImmutableHashSet<Akka.Actor.Address> watchingAddresses) { }
+            public Stats(int watching, int watchingNodes, System.Collections.Immutable.ImmutableHashSet<System.ValueTuple<Akka.Actor.IActorRef, Akka.Actor.IActorRef>> watchingRefs, System.Collections.Immutable.ImmutableHashSet<Akka.Actor.Address> watchingAddresses) { }
             public int Watching { get; }
             public System.Collections.Immutable.ImmutableHashSet<Akka.Actor.Address> WatchingAddresses { get; }
             public int WatchingNodes { get; }
-            public System.Collections.Immutable.ImmutableHashSet<System.Tuple<Akka.Actor.IActorRef, Akka.Actor.IActorRef>> WatchingRefs { get; }
-            public Akka.Remote.RemoteWatcher.Stats Copy(int watching, int watchingNodes, System.Collections.Immutable.ImmutableHashSet<System.Tuple<Akka.Actor.IActorRef, Akka.Actor.IActorRef>> watchingRefs = null, System.Collections.Immutable.ImmutableHashSet<Akka.Actor.Address> watchingAddresses = null) { }
+            public System.Collections.Immutable.ImmutableHashSet<System.ValueTuple<Akka.Actor.IActorRef, Akka.Actor.IActorRef>> WatchingRefs { get; }
+            public Akka.Remote.RemoteWatcher.Stats Copy(int watching, int watchingNodes, System.Collections.Immutable.ImmutableHashSet<System.ValueTuple<Akka.Actor.IActorRef, Akka.Actor.IActorRef>> watchingRefs = null, System.Collections.Immutable.ImmutableHashSet<Akka.Actor.Address> watchingAddresses = null) { }
             public static Akka.Remote.RemoteWatcher.Stats Counts(int watching, int watchingNodes) { }
             public override bool Equals(object obj) { }
             public override int GetHashCode() { }
@@ -463,7 +463,7 @@ namespace Akka.Remote.Transport
         protected abstract void InterceptAssociate(Akka.Actor.Address remoteAddress, System.Threading.Tasks.TaskCompletionSource<Akka.Remote.Transport.AssociationHandle> statusPromise);
         protected abstract System.Threading.Tasks.Task<Akka.Remote.Transport.IAssociationEventListener> InterceptListen(Akka.Actor.Address listenAddress, System.Threading.Tasks.Task<Akka.Remote.Transport.IAssociationEventListener> listenerTask);
         public override bool IsResponsibleFor(Akka.Actor.Address remote) { }
-        public override System.Threading.Tasks.Task<System.Tuple<Akka.Actor.Address, System.Threading.Tasks.TaskCompletionSource<Akka.Remote.Transport.IAssociationEventListener>>> Listen() { }
+        public override System.Threading.Tasks.Task<System.ValueTuple<Akka.Actor.Address, System.Threading.Tasks.TaskCompletionSource<Akka.Remote.Transport.IAssociationEventListener>>> Listen() { }
         public override System.Threading.Tasks.Task<bool> Shutdown() { }
     }
     public abstract class Activity
@@ -524,24 +524,24 @@ namespace Akka.Remote.Transport
         public AssociationRegistry() { }
         public static void Clear() { }
         public void ClearLog() { }
-        public System.Tuple<Akka.Remote.Transport.IHandleEventListener, Akka.Remote.Transport.IHandleEventListener> DeregisterAssociation(System.Tuple<Akka.Actor.Address, Akka.Actor.Address> key) { }
+        public System.ValueTuple<Akka.Remote.Transport.IHandleEventListener, Akka.Remote.Transport.IHandleEventListener> DeregisterAssociation(System.ValueTuple<Akka.Actor.Address, Akka.Actor.Address> key) { }
         public bool ExistsAssociation(Akka.Actor.Address initiatorAddress, Akka.Actor.Address remoteAddress) { }
         public static Akka.Remote.Transport.AssociationRegistry Get(string key) { }
         public Akka.Remote.Transport.IHandleEventListener GetRemoteReadHandlerFor(Akka.Remote.Transport.TestAssociationHandle localHandle) { }
         public void LogActivity(Akka.Remote.Transport.Activity activity) { }
         public System.Collections.Generic.IList<Akka.Remote.Transport.Activity> LogSnapshot() { }
-        public void RegisterListenerPair(System.Tuple<Akka.Actor.Address, Akka.Actor.Address> key, System.Tuple<Akka.Remote.Transport.IHandleEventListener, Akka.Remote.Transport.IHandleEventListener> listeners) { }
+        public void RegisterListenerPair(System.ValueTuple<Akka.Actor.Address, Akka.Actor.Address> key, System.ValueTuple<Akka.Remote.Transport.IHandleEventListener, Akka.Remote.Transport.IHandleEventListener> listeners) { }
         public void RegisterTransport(Akka.Remote.Transport.TestTransport transport, System.Threading.Tasks.Task<Akka.Remote.Transport.IAssociationEventListener> associationEventListenerTask) { }
-        public Akka.Remote.Transport.IHandleEventListener RemoteListenerRelativeTo(Akka.Remote.Transport.TestAssociationHandle handle, System.Tuple<Akka.Remote.Transport.IHandleEventListener, Akka.Remote.Transport.IHandleEventListener> listenerPair) { }
+        public Akka.Remote.Transport.IHandleEventListener RemoteListenerRelativeTo(Akka.Remote.Transport.TestAssociationHandle handle, System.ValueTuple<Akka.Remote.Transport.IHandleEventListener, Akka.Remote.Transport.IHandleEventListener> listenerPair) { }
         public void Reset() { }
-        public System.Tuple<Akka.Remote.Transport.TestTransport, System.Threading.Tasks.Task<Akka.Remote.Transport.IAssociationEventListener>> TransportFor(Akka.Actor.Address address) { }
+        public System.ValueTuple<Akka.Remote.Transport.TestTransport, System.Threading.Tasks.Task<Akka.Remote.Transport.IAssociationEventListener>> TransportFor(Akka.Actor.Address address) { }
         public bool TransportsReady(params Akka.Actor.Address[] addresses) { }
     }
     public class Blackhole : Akka.Remote.Transport.ThrottleMode
     {
         public static Akka.Remote.Transport.Blackhole Instance { get; }
         public override System.TimeSpan TimeToAvailable(long currentNanoTime, int tokens) { }
-        public override System.Tuple<Akka.Remote.Transport.ThrottleMode, bool> TryConsumeTokens(long nanoTimeOfSend, int tokens) { }
+        public override System.ValueTuple<Akka.Remote.Transport.ThrottleMode, bool> TryConsumeTokens(long nanoTimeOfSend, int tokens) { }
     }
     public sealed class DisassociateAttempt : Akka.Remote.Transport.Activity
     {
@@ -648,7 +648,7 @@ namespace Akka.Remote.Transport
     {
         public readonly bool Inbound;
         public TestAssociationHandle(Akka.Actor.Address localAddress, Akka.Actor.Address remoteAddress, Akka.Remote.Transport.TestTransport transport, bool inbound) { }
-        public System.Tuple<Akka.Actor.Address, Akka.Actor.Address> Key { get; }
+        public System.ValueTuple<Akka.Actor.Address, Akka.Actor.Address> Key { get; }
         public override void Disassociate() { }
         public override bool Write(Google.Protobuf.ByteString payload) { }
     }
@@ -656,18 +656,18 @@ namespace Akka.Remote.Transport
     {
         public readonly Akka.Remote.Transport.SwitchableLoggedBehavior<Akka.Actor.Address, Akka.Remote.Transport.AssociationHandle> AssociateBehavior;
         public readonly Akka.Remote.Transport.SwitchableLoggedBehavior<Akka.Remote.Transport.TestAssociationHandle, bool> DisassociateBehavior;
-        public readonly Akka.Remote.Transport.SwitchableLoggedBehavior<bool, System.Tuple<Akka.Actor.Address, System.Threading.Tasks.TaskCompletionSource<Akka.Remote.Transport.IAssociationEventListener>>> ListenBehavior;
+        public readonly Akka.Remote.Transport.SwitchableLoggedBehavior<bool, System.ValueTuple<Akka.Actor.Address, System.Threading.Tasks.TaskCompletionSource<Akka.Remote.Transport.IAssociationEventListener>>> ListenBehavior;
         public readonly Akka.Actor.Address LocalAddress;
         public readonly Akka.Remote.Transport.SwitchableLoggedBehavior<bool, bool> ShutdownBehavior;
-        public readonly Akka.Remote.Transport.SwitchableLoggedBehavior<System.Tuple<Akka.Remote.Transport.TestAssociationHandle, Google.Protobuf.ByteString>, bool> WriteBehavior;
+        public readonly Akka.Remote.Transport.SwitchableLoggedBehavior<System.ValueTuple<Akka.Remote.Transport.TestAssociationHandle, Google.Protobuf.ByteString>, bool> WriteBehavior;
         public TestTransport(Akka.Actor.ActorSystem system, Akka.Configuration.Config conf) { }
         public TestTransport(Akka.Actor.Address localAddress, Akka.Remote.Transport.AssociationRegistry registry, long maximumPayloadBytes = 32000, string schemeIdentifier = "test") { }
         public override System.Threading.Tasks.Task<Akka.Remote.Transport.AssociationHandle> Associate(Akka.Actor.Address remoteAddress) { }
         public System.Threading.Tasks.Task<bool> DefaultDisassociate(Akka.Remote.Transport.TestAssociationHandle handle) { }
-        public System.Threading.Tasks.Task<System.Tuple<Akka.Actor.Address, System.Threading.Tasks.TaskCompletionSource<Akka.Remote.Transport.IAssociationEventListener>>> DefaultListen() { }
+        public System.Threading.Tasks.Task<System.ValueTuple<Akka.Actor.Address, System.Threading.Tasks.TaskCompletionSource<Akka.Remote.Transport.IAssociationEventListener>>> DefaultListen() { }
         public System.Threading.Tasks.Task Disassociate(Akka.Remote.Transport.TestAssociationHandle handle) { }
         public override bool IsResponsibleFor(Akka.Actor.Address remote) { }
-        public override System.Threading.Tasks.Task<System.Tuple<Akka.Actor.Address, System.Threading.Tasks.TaskCompletionSource<Akka.Remote.Transport.IAssociationEventListener>>> Listen() { }
+        public override System.Threading.Tasks.Task<System.ValueTuple<Akka.Actor.Address, System.Threading.Tasks.TaskCompletionSource<Akka.Remote.Transport.IAssociationEventListener>>> Listen() { }
         public override System.Threading.Tasks.Task<bool> Shutdown() { }
         public System.Threading.Tasks.Task<bool> Write(Akka.Remote.Transport.TestAssociationHandle handle, Google.Protobuf.ByteString payload) { }
     }
@@ -675,7 +675,7 @@ namespace Akka.Remote.Transport
     {
         protected ThrottleMode() { }
         public abstract System.TimeSpan TimeToAvailable(long currentNanoTime, int tokens);
-        public abstract System.Tuple<Akka.Remote.Transport.ThrottleMode, bool> TryConsumeTokens(long nanoTimeOfSend, int tokens);
+        public abstract System.ValueTuple<Akka.Remote.Transport.ThrottleMode, bool> TryConsumeTokens(long nanoTimeOfSend, int tokens);
     }
     public class ThrottlerProvider : Akka.Remote.Transport.ITransportAdapterProvider
     {
@@ -707,7 +707,7 @@ namespace Akka.Remote.Transport
         public Akka.Actor.ActorSystem System { get; set; }
         public abstract System.Threading.Tasks.Task<Akka.Remote.Transport.AssociationHandle> Associate(Akka.Actor.Address remoteAddress);
         public abstract bool IsResponsibleFor(Akka.Actor.Address remote);
-        public abstract System.Threading.Tasks.Task<System.Tuple<Akka.Actor.Address, System.Threading.Tasks.TaskCompletionSource<Akka.Remote.Transport.IAssociationEventListener>>> Listen();
+        public abstract System.Threading.Tasks.Task<System.ValueTuple<Akka.Actor.Address, System.Threading.Tasks.TaskCompletionSource<Akka.Remote.Transport.IAssociationEventListener>>> Listen();
         public virtual System.Threading.Tasks.Task<bool> ManagementCommand(object message) { }
         public abstract System.Threading.Tasks.Task<bool> Shutdown();
     }
@@ -719,7 +719,7 @@ namespace Akka.Remote.Transport
     {
         public static Akka.Remote.Transport.Unthrottled Instance { get; }
         public override System.TimeSpan TimeToAvailable(long currentNanoTime, int tokens) { }
-        public override System.Tuple<Akka.Remote.Transport.ThrottleMode, bool> TryConsumeTokens(long nanoTimeOfSend, int tokens) { }
+        public override System.ValueTuple<Akka.Remote.Transport.ThrottleMode, bool> TryConsumeTokens(long nanoTimeOfSend, int tokens) { }
     }
     public sealed class WriteAttempt : Akka.Remote.Transport.Activity
     {

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
@@ -3456,6 +3456,7 @@ namespace Akka.Streams.Implementation.Fusing
         public struct Abort : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public Abort(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell) { }
+            [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
         public struct AsyncInput : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
@@ -3464,6 +3465,7 @@ namespace Akka.Streams.Implementation.Fusing
             public readonly System.Action<object> Handler;
             public readonly Akka.Streams.Stage.GraphStageLogic Logic;
             public AsyncInput(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, Akka.Streams.Stage.GraphStageLogic logic, object @event, System.Action<object> handler) { }
+            [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
         public class BatchingActorInputBoundary : Akka.Streams.Implementation.Fusing.GraphInterpreter.UpstreamBoundaryStageLogic
@@ -3502,6 +3504,7 @@ namespace Akka.Streams.Implementation.Fusing
         {
             public readonly int Id;
             public Cancel(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id) { }
+            [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
         public struct ExposedPublisher : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
@@ -3509,6 +3512,7 @@ namespace Akka.Streams.Implementation.Fusing
             public readonly int Id;
             public readonly Akka.Streams.Implementation.IActorPublisher Publisher;
             public ExposedPublisher(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id, Akka.Streams.Implementation.IActorPublisher publisher) { }
+            [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
         public interface IBoundaryEvent : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
@@ -3519,6 +3523,7 @@ namespace Akka.Streams.Implementation.Fusing
         {
             public readonly int Id;
             public OnComplete(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id) { }
+            [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
         public struct OnError : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
@@ -3526,6 +3531,7 @@ namespace Akka.Streams.Implementation.Fusing
             public readonly System.Exception Cause;
             public readonly int Id;
             public OnError(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id, System.Exception cause) { }
+            [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
         public struct OnNext : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
@@ -3533,6 +3539,7 @@ namespace Akka.Streams.Implementation.Fusing
             public readonly object Event;
             public readonly int Id;
             public OnNext(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id, object @event) { }
+            [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
         public struct OnSubscribe : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
@@ -3540,6 +3547,7 @@ namespace Akka.Streams.Implementation.Fusing
             public readonly int Id;
             public readonly Reactive.Streams.ISubscription Subscription;
             public OnSubscribe(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id, Reactive.Streams.ISubscription subscription) { }
+            [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
         public struct RequestMore : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
@@ -3547,17 +3555,20 @@ namespace Akka.Streams.Implementation.Fusing
             public readonly long Demand;
             public readonly int Id;
             public RequestMore(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id, long demand) { }
+            [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
         public struct Resume : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public Resume(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell) { }
+            [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
         public struct SubscribePending : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly int Id;
             public SubscribePending(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id) { }
+            [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
     }
@@ -4563,7 +4574,9 @@ namespace Akka.Streams.Stage
     public struct LogicAndMaterializedValue<TMaterialized> : Akka.Streams.Stage.ILogicAndMaterializedValue<TMaterialized>
     {
         public LogicAndMaterializedValue(Akka.Streams.Stage.GraphStageLogic logic, TMaterialized materializedValue) { }
+        [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public Akka.Streams.Stage.GraphStageLogic Logic { get; }
+        [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public TMaterialized MaterializedValue { get; }
     }
     public abstract class OutGraphStageLogic : Akka.Streams.Stage.GraphStageLogic, Akka.Streams.Stage.IOutHandler
@@ -4707,7 +4720,9 @@ namespace Akka.Streams.Util
     {
         public static readonly Akka.Streams.Util.Option<T> None;
         public Option(T value) { }
+        [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public bool HasValue { get; }
+        [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public T Value { get; }
         public bool Equals(Akka.Streams.Util.Option<T> other) { }
         public override bool Equals(object obj) { }

--- a/src/core/Akka.Cluster.Tests.MultiNode/ClusterDeathWatchSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/ClusterDeathWatchSpec.cs
@@ -197,7 +197,7 @@ namespace Akka.Cluster.Tests.MultiNode
                     {
                         RemoteWatcher.Tell(Remote.RemoteWatcher.Stats.Empty);
                         var stats = ExpectMsg<Remote.RemoteWatcher.Stats>();
-                        stats.WatchingRefs.Contains(new Tuple<IActorRef, IActorRef>(subject5, TestActor)).ShouldBeTrue();
+                        stats.WatchingRefs.Contains((subject5, TestActor)).ShouldBeTrue();
                         stats.WatchingAddresses.Contains(GetAddress(_config.Fifth)).ShouldBeTrue();
                     });
                 }, _config.First);

--- a/src/core/Akka.Cluster.Tests.MultiNode/TransitionSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/TransitionSpec.cs
@@ -54,7 +54,7 @@ namespace Akka.Cluster.Tests.MultiNode
         {
             // sorts the addresses and provides the address of the node with the lowest port number
             // as that node will be the leader
-            return roles.Select(x => Tuple.Create(x, GetAddress(x).Port)).OrderBy(x => x.Item2).First().Item1;
+            return roles.Select(x => (x, GetAddress(x).Port)).OrderBy(x => x.Item2).First().Item1;
         }
 
         private RoleName[] NonLeader(params RoleName[] roles)

--- a/src/core/Akka.Cluster.Tests/ClusterDomainEventSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterDomainEventSpec.cs
@@ -37,12 +37,12 @@ namespace Akka.Cluster.Tests
 
         static readonly UniqueAddress selfDummyAddress = new UniqueAddress(new Address("akka.tcp", "sys", "selfDummy", 2552), 17);
 
-        private static Tuple<Gossip, ImmutableHashSet<UniqueAddress>> Converge(Gossip gossip)
+        private static (Gossip, ImmutableHashSet<UniqueAddress>) Converge(Gossip gossip)
         {
-            var seed = Tuple.Create(gossip, ImmutableHashSet.Create<UniqueAddress>());
+            var seed = (gossip, ImmutableHashSet.Create<UniqueAddress>());
 
             return gossip.Members.Aggregate(seed,
-                (t, m) => Tuple.Create(t.Item1.Seen(m.UniqueAddress), t.Item2.Add(m.UniqueAddress)));
+                (t, m) => (t.Item1.Seen(m.UniqueAddress), t.Item2.Add(m.UniqueAddress)));
         }
 
         [Fact]

--- a/src/core/Akka.Cluster/ClusterHeartbeat.cs
+++ b/src/core/Akka.Cluster/ClusterHeartbeat.cs
@@ -575,12 +575,12 @@ namespace Akka.Cluster
                 // The reason for not limiting it to strictly monitoredByNrOfMembers is that the leader must
                 // be able to continue its duties (e.g. removal of downed nodes) when many nodes are shutdown
                 // at the same time and nobody in the remaining cluster is monitoring some of the shutdown nodes.
-                Func<int, IEnumerator<UniqueAddress>, ImmutableSortedSet<UniqueAddress>, Tuple<int, ImmutableSortedSet<UniqueAddress>>> take = null;
+                Func<int, IEnumerator<UniqueAddress>, ImmutableSortedSet<UniqueAddress>, (int, ImmutableSortedSet<UniqueAddress>)> take = null;
                 take = (n, iter, acc) =>
                 {
                     if (iter.MoveNext() == false || n == 0)
                     {
-                        return Tuple.Create(n, acc);
+                        return (n, acc);
                     }
                     else
                     {

--- a/src/core/Akka.Cluster/Routing/ClusterRoutingConfig.cs
+++ b/src/core/Akka.Cluster/Routing/ClusterRoutingConfig.cs
@@ -890,10 +890,10 @@ namespace Akka.Cluster.Routing
             doAddRoutees = () =>
             {
                 var deploymentTarget = SelectDeploymentTarget();
-                if (deploymentTarget.Item1 != null && !string.IsNullOrEmpty(deploymentTarget.Item2))
+                if (deploymentTarget.HasValue)
                 {
-                    var address = deploymentTarget.Item1;
-                    var path = deploymentTarget.Item2;
+                    var address = deploymentTarget.Value.Item1;
+                    var path = deploymentTarget.Value.Item2;
                     var routee = _group.RouteeFor(address + path, Context);
                     UsedRouteePaths = UsedRouteePaths.SetItem(
                         address,
@@ -913,11 +913,11 @@ namespace Akka.Cluster.Routing
         /// TBD
         /// </summary>
         /// <returns>TBD</returns>
-        public (Address, string) SelectDeploymentTarget()
+        public (Address, string)? SelectDeploymentTarget()
         {
             var currentRoutees = Cell.Router.Routees.ToList();
             var currentNodes = AvailableNodes;
-            if (currentNodes.IsEmpty || currentRoutees.Count >= Settings.TotalInstances) return (default(Address), default(string));
+            if (currentNodes.IsEmpty || currentRoutees.Count >= Settings.TotalInstances) return null;
 
             //find the node with the least routees
             var unusedNodes = currentNodes.Except(UsedRouteePaths.Keys);
@@ -935,7 +935,7 @@ namespace Akka.Cluster.Routing
 
                 // pick next of unused paths
                 var minPath = Settings.RouteesPaths.FirstOrDefault(p => !minNode.Used.Contains(p));
-                return minPath == null ? (default(Address), default(string)) : (minNode.Address, minPath);
+                return minPath == null ? null : ((Address, string)?)(minNode.Address, minPath);
             }
         }
 

--- a/src/core/Akka.Cluster/Routing/ClusterRoutingConfig.cs
+++ b/src/core/Akka.Cluster/Routing/ClusterRoutingConfig.cs
@@ -890,7 +890,7 @@ namespace Akka.Cluster.Routing
             doAddRoutees = () =>
             {
                 var deploymentTarget = SelectDeploymentTarget();
-                if (deploymentTarget != null)
+                if (deploymentTarget.Item1 != null && !string.IsNullOrEmpty(deploymentTarget.Item2))
                 {
                     var address = deploymentTarget.Item1;
                     var path = deploymentTarget.Item2;
@@ -913,17 +913,17 @@ namespace Akka.Cluster.Routing
         /// TBD
         /// </summary>
         /// <returns>TBD</returns>
-        public Tuple<Address, string> SelectDeploymentTarget()
+        public (Address, string) SelectDeploymentTarget()
         {
             var currentRoutees = Cell.Router.Routees.ToList();
             var currentNodes = AvailableNodes;
-            if (currentNodes.IsEmpty || currentRoutees.Count >= Settings.TotalInstances) return null;
+            if (currentNodes.IsEmpty || currentRoutees.Count >= Settings.TotalInstances) return (default(Address), default(string));
 
             //find the node with the least routees
             var unusedNodes = currentNodes.Except(UsedRouteePaths.Keys);
             if (!unusedNodes.IsEmpty) //we found at least 1 totally unused node
             {
-                return new Tuple<Address, string>(unusedNodes.First(), Settings.RouteesPaths.First());
+                return (unusedNodes.First(), Settings.RouteesPaths.First());
             }
             else
             {
@@ -935,7 +935,7 @@ namespace Akka.Cluster.Routing
 
                 // pick next of unused paths
                 var minPath = Settings.RouteesPaths.FirstOrDefault(p => !minNode.Used.Contains(p));
-                return minPath == null ? null : new Tuple<Address, string>(minNode.Address, minPath);
+                return minPath == null ? (default(Address), default(string)) : (minNode.Address, minPath);
             }
         }
 

--- a/src/core/Akka.Cluster/Util.cs
+++ b/src/core/Akka.Cluster/Util.cs
@@ -120,7 +120,7 @@ namespace Akka.Cluster
         /// <param name="this">TBD</param>
         /// <param name="partitioner">TBD</param>
         /// <returns>TBD</returns>
-        public static Tuple<ImmutableSortedSet<T>, ImmutableSortedSet<T>> Partition<T>(this ImmutableSortedSet<T> @this,
+        public static (ImmutableSortedSet<T>, ImmutableSortedSet<T>) Partition<T>(this ImmutableSortedSet<T> @this,
             Func<T, bool> partitioner)
         {
             var @true = new List<T>();
@@ -131,7 +131,7 @@ namespace Akka.Cluster
                 (partitioner(item) ? @true : @false).Add(item);
             }
 
-            return Tuple.Create(@true.ToImmutableSortedSet(), @false.ToImmutableSortedSet());
+            return (@true.ToImmutableSortedSet(), @false.ToImmutableSortedSet());
         }
     }
 }

--- a/src/core/Akka.Remote.Tests.MultiNode/RemoteQuarantinePiercingSpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/RemoteQuarantinePiercingSpec.cs
@@ -38,7 +38,7 @@ namespace Akka.Remote.Tests.MultiNode
                 Receive<string>(str => str == "shutdown", c => Context.System.Terminate());
                 Receive<string>(str => str == "identify", c =>
                 {
-                    Sender.Tell(Tuple.Create(AddressUidExtension.Uid(Context.System), Self));
+                    Sender.Tell((AddressUidExtension.Uid(Context.System), Self));
                 });
             }
         }
@@ -59,10 +59,10 @@ namespace Akka.Remote.Tests.MultiNode
             _specConfig = specConfig;
         }
 
-        private Tuple<int, IActorRef> Identify(RoleName role, string actorName)
+        private (int, IActorRef) Identify(RoleName role, string actorName)
         {
             Sys.ActorSelection(Node(role) / "user" / actorName).Tell("identify");
-            return ExpectMsg<Tuple<int, IActorRef>>();
+            return ExpectMsg<(int, IActorRef)>();
         }
 
         [MultiNodeFact]
@@ -101,7 +101,7 @@ namespace Akka.Remote.Tests.MultiNode
                     AwaitAssert(() =>
                     {
                         Sys.ActorSelection(new RootActorPath(secondAddress) / "user" / "subject").Tell("identify");
-                        var tuple2 = ExpectMsg<Tuple<int, IActorRef>>(TimeSpan.FromSeconds(1));
+                        var tuple2 = ExpectMsg<(int, IActorRef)>(TimeSpan.FromSeconds(1));
                         tuple2.Item1.Should().NotBe(uidFirst);
                         tuple2.Item2.Should().NotBe(subjectFirst);
                     });

--- a/src/core/Akka.Remote.Tests.MultiNode/RemoteRestartedQuarantinedSpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/RemoteRestartedQuarantinedSpec.cs
@@ -49,7 +49,7 @@ namespace Akka.Remote.Tests.MultiNode
             {
                 Receive<string>(_ => Context.System.Terminate(), s => "shutdown".Equals(s));
                 Receive<string>(
-                    _ => Sender.Tell(new Tuple<int, IActorRef>(AddressUidExtension.Uid(Context.System), Self)),
+                    _ => Sender.Tell((AddressUidExtension.Uid(Context.System), Self)),
                     s => "identify".Equals(s));
             }
         }
@@ -58,7 +58,7 @@ namespace Akka.Remote.Tests.MultiNode
     public class RemoteRestartedQuarantinedSpec : MultiNodeSpec
     {
         private readonly RemoteRestartedQuarantinedMultiNetSpec _config;
-        private readonly Func<RoleName, string, Tuple<int, IActorRef>> _identifyWithUid;
+        private readonly Func<RoleName, string, (int, IActorRef)> _identifyWithUid;
 
         public RemoteRestartedQuarantinedSpec()
             : this(new RemoteRestartedQuarantinedMultiNetSpec())
@@ -73,7 +73,7 @@ namespace Akka.Remote.Tests.MultiNode
             _identifyWithUid = (role, actorName) =>
             {
                 Sys.ActorSelection(Node(role) / "user" / actorName).Tell("identify");
-                return ExpectMsg<Tuple<int, IActorRef>>();
+                return ExpectMsg<(int, IActorRef)>();
             };
         }
 

--- a/src/core/Akka.Remote.Tests.MultiNode/TestConductor/TestConductorSpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/TestConductor/TestConductorSpec.cs
@@ -137,8 +137,8 @@ namespace Akka.Remote.Tests.MultiNode.TestConductor
             }, _config.Slave);
 
             var minMax = IsNode(_config.Master)
-                ? new Tuple<TimeSpan, TimeSpan>(TimeSpan.Zero, TimeSpan.FromMilliseconds(500))
-                : new Tuple<TimeSpan, TimeSpan>(TimeSpan.FromSeconds(0.3), TimeSpan.FromSeconds(3));
+                ? (TimeSpan.Zero, TimeSpan.FromMilliseconds(500))
+                : (TimeSpan.FromSeconds(0.3), TimeSpan.FromSeconds(3));
 
             Within(minMax.Item1, minMax.Item2, () =>
             {

--- a/src/core/Akka.Remote.Tests/AccrualFailureDetectorSpec.cs
+++ b/src/core/Akka.Remote.Tests/AccrualFailureDetectorSpec.cs
@@ -17,7 +17,7 @@ namespace Akka.Remote.Tests
 
     public class AccrualFailureDetectorSpec : AkkaSpec
     {
-        public static IEnumerable<Tuple<T, T>> Slide<T>(IEnumerable<T> values)
+        public static IEnumerable<(T, T)> Slide<T>(IEnumerable<T> values)
         {
             using (var iterator = values.GetEnumerator())
             {
@@ -25,7 +25,7 @@ namespace Akka.Remote.Tests
                 {
                     var first = iterator.Current;
                     var second = iterator.MoveNext() ? iterator.Current : default(T);
-                    yield return Tuple.Create(first, second);
+                    yield return (first, second);
                 }
             }
         }

--- a/src/core/Akka.Remote.Tests/EndpointRegistrySpec.cs
+++ b/src/core/Akka.Remote.Tests/EndpointRegistrySpec.cs
@@ -54,7 +54,7 @@ namespace Akka.Remote.Tests
             Assert.Null(reg.ReadOnlyEndpointFor(address1));
 
             Assert.Equal(actorA, reg.RegisterReadOnlyEndpoint(address1, actorA, 0));
-            Assert.Equal(Tuple.Create(actorA, 0), reg.ReadOnlyEndpointFor(address1));
+            Assert.Equal((actorA, 0), reg.ReadOnlyEndpointFor(address1));
             Assert.Null(reg.WritableEndpointWithPolicyFor(address1));
             Assert.False(reg.IsWritable(actorA));
             Assert.True(reg.IsReadOnly(actorA));
@@ -71,7 +71,7 @@ namespace Akka.Remote.Tests
             Assert.Equal(actorA, reg.RegisterReadOnlyEndpoint(address1, actorA, 1));
             Assert.Equal(actorB, reg.RegisterWritableEndpoint(address1, actorB, null));
 
-            Assert.Equal(Tuple.Create(actorA,1), reg.ReadOnlyEndpointFor(address1));
+            Assert.Equal((actorA, 1), reg.ReadOnlyEndpointFor(address1));
             Assert.Equal(actorB, reg.WritableEndpointWithPolicyFor(address1).AsInstanceOf<EndpointManager.Pass>().Endpoint);
 
             Assert.False(reg.IsWritable(actorA));

--- a/src/core/Akka.Remote.Tests/EndpointRegistrySpec.cs
+++ b/src/core/Akka.Remote.Tests/EndpointRegistrySpec.cs
@@ -158,8 +158,9 @@ namespace Akka.Remote.Tests
             reg.RegisterReadOnlyEndpoint(address1, endpoint, 2);
 
             var ep = reg.ReadOnlyEndpointFor(address1);
-            ep.Item1.ShouldBe(endpoint);
-            ep.Item2.ShouldBe(2);
+            ep.Should(notNull => notNull.HasValue, $"{nameof(ep)} is null");
+            ep.Value.Item1.ShouldBe(endpoint);
+            ep.Value.Item2.ShouldBe(2);
         }
 
         [Fact]

--- a/src/core/Akka.Remote.Tests/RemoteRouterSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteRouterSpec.cs
@@ -40,9 +40,8 @@ namespace Akka.Remote.Tests
         {
             protected override void OnReceive(object message)
             {
-                if (message is ValueTuple<Props, string>)
+                if (message is ValueTuple<Props, string> tuple)
                 {
-                    var tuple = ((Props, string))message;
                     Sender.Tell(Context.ActorOf(tuple.Item1, tuple.Item2));
                 }
             }

--- a/src/core/Akka.Remote.Tests/RemoteRouterSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteRouterSpec.cs
@@ -40,9 +40,9 @@ namespace Akka.Remote.Tests
         {
             protected override void OnReceive(object message)
             {
-                var tuple = message as Tuple<Props, string>;
-                if (tuple != null)
+                if (message is ValueTuple<Props, string>)
                 {
+                    var tuple = ((Props, string))message;
                     Sender.Tell(Context.ActorOf(tuple.Item1, tuple.Item2));
                 }
             }
@@ -343,7 +343,7 @@ namespace Akka.Remote.Tests
             // it's used for the pool of the SimpleDnsManager "/IO-DNS/inet-address"
             var probe = CreateTestProbe(masterSystem);
             var parent = ((ExtendedActorSystem)masterSystem).SystemActorOf(FromConfig.Instance.Props(Props.Create<Parent>()), "sys-parent");
-            parent.Tell(Tuple.Create(FromConfig.Instance.Props(EchoActorProps), "round"), probe);
+            parent.Tell((FromConfig.Instance.Props(EchoActorProps), "round"), probe);
             var router = probe.ExpectMsg<IActorRef>();
             var replies = CollectRouteePaths(probe, router, 10);
             var children = new HashSet<ActorPath>(replies);

--- a/src/core/Akka.Remote.Tests/RemoteRouterSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteRouterSpec.cs
@@ -40,7 +40,7 @@ namespace Akka.Remote.Tests
         {
             protected override void OnReceive(object message)
             {
-                if (message is ValueTuple<Props, string> tuple)
+                if (message != null && message is ValueTuple<Props, string> tuple)
                 {
                     Sender.Tell(Context.ActorOf(tuple.Item1, tuple.Item2));
                 }

--- a/src/core/Akka.Remote.Tests/RemotingSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemotingSpec.cs
@@ -166,7 +166,7 @@ namespace Akka.Remote.Tests
             //TODO: using smaller numbers for the cancellation here causes a bug.
             //the remoting layer uses some "initialdelay task.delay" for 4 seconds.
             //so the token is cancelled before the delay completed.. 
-            var msg = await here.Ask<(string, IActorRef)>("ping", TimeSpan.FromSeconds(1.5));
+            var msg = await _here.Ask<(string, IActorRef)>("ping", TimeSpan.FromSeconds(1.5));
             Assert.Equal("pong", msg.Item1);
             Assert.IsType<FutureActorRef>(msg.Item2);
         }
@@ -177,11 +177,11 @@ namespace Akka.Remote.Tests
             // see https://github.com/akkadotnet/akka.net/issues/2546
 
             // the configure await causes the continuation (== the second ask) to be scheduled on the HELIOS worker thread
-            var msg = await here.Ask<(string, IActorRef)>("ping", TimeSpan.FromSeconds(1.5)).ConfigureAwait(false);
+            var msg = await _here.Ask<(string, IActorRef)>("ping", TimeSpan.FromSeconds(1.5)).ConfigureAwait(false);
             Assert.Equal("pong", msg.Item1);
 
             // the .Result here blocks the helios worker thread, deadlocking the whole system.
-            var msg2 = here.Ask<(string, IActorRef)>("ping", TimeSpan.FromSeconds(1.5)).Result;
+            var msg2 = _here.Ask<(string, IActorRef)>("ping", TimeSpan.FromSeconds(1.5)).Result;
             Assert.Equal("pong", msg2.Item1);
         }
         

--- a/src/core/Akka.Remote.Tests/RemotingSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemotingSpec.cs
@@ -496,7 +496,7 @@ namespace Akka.Remote.Tests
 
                 // Hijack associations through the test transport
                 AwaitCondition(() => registry.TransportsReady(rawLocalAddress, rawRemoteAddress));
-                var testTransport = registry.TransportFor(rawLocalAddress).Item1;
+                var testTransport = registry.TransportFor(rawLocalAddress).GetValueOrDefault().Item1;
                 testTransport.WriteBehavior.PushConstant(true);
 
                 // Force an outbound associate on the real system (which we will hijack)
@@ -578,7 +578,7 @@ namespace Akka.Remote.Tests
 
                 // Hijack associations through the test transport
                 AwaitCondition(() => registry.TransportsReady(rawLocalAddress, rawRemoteAddress));
-                var testTransport = registry.TransportFor(rawLocalAddress).Item1;
+                var testTransport = registry.TransportFor(rawLocalAddress).GetValueOrDefault().Item1;
                 testTransport.WriteBehavior.PushConstant(true);
 
                 // Force an outbound associate on the real system (which we will hijack)

--- a/src/core/Akka.Remote.Tests/RemotingSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemotingSpec.cs
@@ -157,7 +157,7 @@ namespace Akka.Remote.Tests
         public void Remoting_must_support_remote_lookups()
         {
             _here.Tell("ping", TestActor);
-            ExpectMsg(Tuple.Create("pong", TestActor), TimeSpan.FromSeconds(1.5));
+            ExpectMsg(("pong", TestActor), TimeSpan.FromSeconds(1.5));
         }
 
         [Fact]
@@ -166,7 +166,7 @@ namespace Akka.Remote.Tests
             //TODO: using smaller numbers for the cancellation here causes a bug.
             //the remoting layer uses some "initialdelay task.delay" for 4 seconds.
             //so the token is cancelled before the delay completed.. 
-            var msg = await _here.Ask<Tuple<string, IActorRef>>("ping", TimeSpan.FromSeconds(1.5));
+            var msg = await here.Ask<(string, IActorRef)>("ping", TimeSpan.FromSeconds(1.5));
             Assert.Equal("pong", msg.Item1);
             Assert.IsType<FutureActorRef>(msg.Item2);
         }
@@ -177,11 +177,11 @@ namespace Akka.Remote.Tests
             // see https://github.com/akkadotnet/akka.net/issues/2546
 
             // the configure await causes the continuation (== the second ask) to be scheduled on the HELIOS worker thread
-            var msg = await _here.Ask<Tuple<string, IActorRef>>("ping", TimeSpan.FromSeconds(1.5)).ConfigureAwait(false);
+            var msg = await here.Ask<(string, IActorRef)>("ping", TimeSpan.FromSeconds(1.5)).ConfigureAwait(false);
             Assert.Equal("pong", msg.Item1);
 
             // the .Result here blocks the helios worker thread, deadlocking the whole system.
-            var msg2 = _here.Ask<Tuple<string, IActorRef>>("ping", TimeSpan.FromSeconds(1.5)).Result;
+            var msg2 = here.Ask<(string, IActorRef)>("ping", TimeSpan.FromSeconds(1.5)).Result;
             Assert.Equal("pong", msg2.Item1);
         }
         
@@ -239,7 +239,7 @@ namespace Akka.Remote.Tests
         {
             Action<IActorDsl> act = dsl =>
             {
-                dsl.Receive<Tuple<Props, string>>((t, ctx) => ctx.Sender.Tell(ctx.ActorOf(t.Item1, t.Item2)));
+                dsl.Receive<(Props, string)>((t, ctx) => ctx.Sender.Tell(ctx.ActorOf(t.Item1, t.Item2)));
                 dsl.Receive<string>((s, ctx) =>
                 {
                     var sender = ctx.Sender;
@@ -250,11 +250,11 @@ namespace Akka.Remote.Tests
             var l = Sys.ActorOf(Props.Create(() => new Act(act)), "looker");
 
             // child is configured to be deployed on remote-sys (remoteSystem)
-            l.Tell(Tuple.Create(Props.Create<Echo1>(), "child"));
+            l.Tell((Props.Create<Echo1>(), "child"));
             var child = ExpectMsg<IActorRef>();
 
             // grandchild is configured to be deployed on RemotingSpec (Sys)
-            child.Tell(Tuple.Create(Props.Create<Echo1>(), "grandchild"));
+            child.Tell((Props.Create<Echo1>(), "grandchild"));
             var grandchild = ExpectMsg<IActorRef>();
             grandchild.AsInstanceOf<IActorRefScope>().IsLocal.ShouldBeTrue();
             grandchild.Tell(43);
@@ -277,7 +277,7 @@ namespace Akka.Remote.Tests
             child.Tell(PoisonPill.Instance);
             ExpectMsg("postStop");
             ExpectTerminated(child);
-            l.Tell(Tuple.Create(Props.Create<Echo1>(), "child"));
+            l.Tell((Props.Create<Echo1>(), "child"));
             var child2 = ExpectMsg<IActorRef>();
             child2.Tell(45);
             ExpectMsg(45);
@@ -294,16 +294,16 @@ namespace Akka.Remote.Tests
         {
             Action<IActorDsl> act = dsl =>
             {
-                dsl.Receive<Tuple<Props, string>>((t, ctx) => ctx.Sender.Tell(ctx.ActorOf(t.Item1, t.Item2)));
+                dsl.Receive<(Props, string)>((t, ctx) => ctx.Sender.Tell(ctx.ActorOf(t.Item1, t.Item2)));
                 dsl.Receive<ActorSelReq>((req, ctx) => ctx.Sender.Tell(ctx.ActorSelection(req.S)));
             };
 
             var l = Sys.ActorOf(Props.Create(() => new Act(act)), "looker");
             // child is configured to be deployed on remoteSystem
-            l.Tell(Tuple.Create(Props.Create<Echo1>(), "child"));
+            l.Tell((Props.Create<Echo1>(), "child"));
             var child = ExpectMsg<IActorRef>();
             // grandchild is configured to be deployed on RemotingSpec (system)
-            child.Tell(Tuple.Create(Props.Create<Echo1>(), "grandchild"));
+            child.Tell((Props.Create<Echo1>(), "grandchild"));
             var grandchild = ExpectMsg<IActorRef>();
             (grandchild as IActorRefScope).IsLocal.ShouldBeTrue();
             grandchild.Tell(53);
@@ -325,7 +325,7 @@ namespace Akka.Remote.Tests
             ExpectMsg<ActorSelection>().Tell(new Identify(null));
             ExpectMsg<ActorIdentity>().Subject.ShouldBeSame(l);
 
-            grandchild.Tell(Tuple.Create(Props.Create<Echo1>(), "grandgrandchild"));
+            grandchild.Tell((Props.Create<Echo1>(), "grandgrandchild"));
             var grandgrandchild = ExpectMsg<IActorRef>();
 
             Sys.ActorSelection("/user/looker/child").Tell(new Identify("idReq1"));
@@ -373,7 +373,7 @@ namespace Akka.Remote.Tests
             child.Tell(PoisonPill.Instance);
             ExpectMsg("postStop");
             ExpectMsg<Terminated>().ActorRef.ShouldBe(child);
-            l.Tell(Tuple.Create(Props.Create<Echo1>(), "child"));
+            l.Tell((Props.Create<Echo1>(), "child"));
             var child2 = ExpectMsg<IActorRef>();
             child2.Tell(new Identify("idReq15"));
             ExpectMsg<ActorIdentity>(i => i.MessageId.Equals("idReq15")).Subject.ShouldBe(child2);
@@ -424,7 +424,7 @@ namespace Akka.Remote.Tests
                 var r = Sys.ActorOf(Props.CreateBy<Resolve<Echo2>>(), "echo");
                 Assert.Equal("akka.test://remote-sys@localhost:12346/remote/akka.test/RemotingSpec@localhost:12345/user/echo", r.Path.ToString());
                 r.Tell("ping", TestActor);
-                ExpectMsg(Tuple.Create("pong", TestActor), TimeSpan.FromSeconds(1.5));
+                ExpectMsg(("pong", TestActor), TimeSpan.FromSeconds(1.5));
             }
             finally
             {
@@ -441,7 +441,7 @@ namespace Akka.Remote.Tests
             //have one of the routees send the message
             var targetRoutee = routees.Members.Cast<ActorRefRoutee>().Select(x => x.Actor).First();
             _here.Tell("ping", targetRoutee);
-            var msg = ExpectMsg<Tuple<string, IActorRef>>(TimeSpan.FromSeconds(1.5));
+            var msg = ExpectMsg<(string, IActorRef)>(TimeSpan.FromSeconds(1.5));
             Assert.Equal("pong", msg.Item1);
             Assert.Equal(targetRoutee, msg.Item2);
         }
@@ -457,7 +457,7 @@ namespace Akka.Remote.Tests
             var targetRoutee = routees.Members.Cast<ActorRefRoutee>().Select(x => x.Actor).First();
             var reporter = await targetRoutee.Ask<IActorRef>(new NestedDeployer.GetNestedReporter());
             _here.Tell("ping", reporter);
-            var msg = ExpectMsg<Tuple<string, IActorRef>>(TimeSpan.FromSeconds(1.5));
+            var msg = ExpectMsg<(string, IActorRef)>(TimeSpan.FromSeconds(1.5));
             Assert.Equal("pong", msg.Item1);
             Assert.Equal(reporter, msg.Item2);
         }
@@ -830,7 +830,7 @@ namespace Akka.Remote.Tests
             protected override void OnReceive(object message)
             {
                 message.Match()
-                    .With<Tuple<Props, string>>(props => Sender.Tell(Context.ActorOf<Echo1>(props.Item2)))
+                    .With<(Props, string)>(props => Sender.Tell(Context.ActorOf<Echo1>(props.Item2)))
                     .With<Exception>(ex => { throw ex; })
                     .With<ActorSelReq>(sel => Sender.Tell(Context.ActorSelection(sel.S)))
                     .Default(x =>
@@ -861,17 +861,17 @@ namespace Akka.Remote.Tests
                 message.Match()
                     .With<string>(str =>
                     {
-                        if (str.Equals("ping")) Sender.Tell(Tuple.Create("pong", Sender));
+                        if (str.Equals("ping")) Sender.Tell(("pong", Sender));
                     })
-                    .With<Tuple<string, IActorRef>>(actorTuple =>
+                    .With<(string, IActorRef)>(actorTuple =>
                     {
                         if (actorTuple.Item1.Equals("ping"))
                         {
-                            Sender.Tell(Tuple.Create("pong", actorTuple.Item2));
+                            Sender.Tell(("pong", actorTuple.Item2));
                         }
                         if (actorTuple.Item1.Equals("pong"))
                         {
-                            actorTuple.Item2.Tell(Tuple.Create("pong", Sender.Path.ToSerializationFormat()));
+                            actorTuple.Item2.Tell(("pong", Sender.Path.ToSerializationFormat()));
                         }
                     })
                     .Default(msg => Sender.Tell(msg));

--- a/src/core/Akka.Remote.Tests/Transport/AkkaProtocolStressTest.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaProtocolStressTest.cs
@@ -110,7 +110,7 @@ namespace Akka.Remote.Tests.Transport
 
                         if (seq > Limit*0.5)
                         {
-                            _controller.Tell(Tuple.Create(MaxSeq, Losses));
+                            _controller.Tell((MaxSeq, Losses));
                             Context.System.Scheduler.ScheduleTellRepeatedly(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), Self,
                                 ResendFinal.Instance, Self);
                             Context.Become(Done);
@@ -128,7 +128,7 @@ namespace Akka.Remote.Tests.Transport
             {
                 if (message is ResendFinal)
                 {
-                    _controller.Tell(Tuple.Create(MaxSeq, Losses));
+                    _controller.Tell((MaxSeq, Losses));
                 }
             }
         }
@@ -195,7 +195,7 @@ namespace Akka.Remote.Tests.Transport
             var tester = Sys.ActorOf(Props.Create(() => new SequenceVerifier(here, TestActor)));
             tester.Tell("start");
 
-            ExpectMsg<Tuple<int,int>>(TimeSpan.FromSeconds(60));
+            ExpectMsg<(int, int)>(TimeSpan.FromSeconds(60));
         }
 
         #endregion

--- a/src/core/Akka.Remote.Tests/Transport/ThrottleModeSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/ThrottleModeSpec.cs
@@ -22,18 +22,18 @@ namespace Akka.Remote.Tests.Transport
         public void ThrottleMode_must_allow_consumption_of_infinite_amount_of_tokens_when_unthrottled()
         {
             var bucket = Unthrottled.Instance;
-            bucket.TryConsumeTokens(0, 100).ShouldBe(Tuple.Create<ThrottleMode,bool>(Unthrottled.Instance, true));
-            bucket.TryConsumeTokens(100000, 1000).ShouldBe(Tuple.Create<ThrottleMode, bool>(Unthrottled.Instance, true));
-            bucket.TryConsumeTokens(1000000, 10000).ShouldBe(Tuple.Create<ThrottleMode, bool>(Unthrottled.Instance, true));
+            bucket.TryConsumeTokens(0, 100).ShouldBe((Unthrottled.Instance, true));
+            bucket.TryConsumeTokens(100000, 1000).ShouldBe((Unthrottled.Instance, true));
+            bucket.TryConsumeTokens(1000000, 10000).ShouldBe((Unthrottled.Instance, true));
         }
 
         [Fact]
         public void ThrottleMode_must_deny_consumption_of_any_amount_of_tokens_when_blackhole()
         {
             var bucket = Blackhole.Instance;
-            bucket.TryConsumeTokens(0, 100).ShouldBe(Tuple.Create<ThrottleMode, bool>(Blackhole.Instance, false));
-            bucket.TryConsumeTokens(100000, 1000).ShouldBe(Tuple.Create<ThrottleMode, bool>(Blackhole.Instance, false));
-            bucket.TryConsumeTokens(1000000, 10000).ShouldBe(Tuple.Create<ThrottleMode, bool>(Blackhole.Instance, false));
+            bucket.TryConsumeTokens(0, 100).ShouldBe((Blackhole.Instance, false));
+            bucket.TryConsumeTokens(100000, 1000).ShouldBe((Blackhole.Instance, false));
+            bucket.TryConsumeTokens(1000000, 10000).ShouldBe((Blackhole.Instance, false));
         }
 
         [Fact]

--- a/src/core/Akka.Remote/EndpointManager.cs
+++ b/src/core/Akka.Remote/EndpointManager.cs
@@ -745,9 +745,12 @@ namespace Akka.Remote
 
                 // Stop inbound read-only associations
                 var readPolicy = (_endpoints.ReadOnlyEndpointFor(quarantine.RemoteAddress), quarantine.Uid);
-                if (readPolicy.Item1.Item1 != null && quarantine.Uid == null)
-                    Context.Stop(readPolicy.Item1.Item1);
-                else if (readPolicy.Item1.Item1 != null && quarantine.Uid != null && readPolicy.Item1.Item2 == quarantine.Uid) { Context.Stop(readPolicy.Item1.Item1); }
+
+                var readOnlyEndpointExists = readPolicy.Item1?.Item1 != null;
+
+                if (readOnlyEndpointExists && quarantine.Uid == null)
+                    Context.Stop(readPolicy.Item1.Value.Item1);
+                else if (readOnlyEndpointExists && quarantine.Uid != null && readPolicy.Item1.Value.Item2 == quarantine.Uid) { Context.Stop(readPolicy.Item1.Value.Item1); }
                 else { } // nothing to stop
 
                 bool MatchesQuarantine(AkkaProtocolHandle handle)
@@ -915,9 +918,9 @@ namespace Akka.Remote
         {
             var readonlyEndpoint = _endpoints.ReadOnlyEndpointFor(ia.Association.RemoteAddress);
             var handle = ((AkkaProtocolHandle)ia.Association);
-            if (readonlyEndpoint.Item1 != null)
+            if (readonlyEndpoint?.Item1 != null)
             {
-                var endpoint = readonlyEndpoint.Item1;
+                var endpoint = readonlyEndpoint.Value.Item1;
                 if (_pendingReadHandoffs.TryGetValue(endpoint, out var protocolHandle))
                     protocolHandle.Disassociate("the existing readOnly association was replaced by a new incoming one", _log);
 

--- a/src/core/Akka.Remote/EndpointRegistry.cs
+++ b/src/core/Akka.Remote/EndpointRegistry.cs
@@ -138,7 +138,7 @@ namespace Akka.Remote
         /// </summary>
         /// <param name="address">The remote address to check.</param>
         /// <returns>A tuple containing the actor reference and the remote system UID, if they exist. Otherwise <c>null</c>.</returns>
-        public (IActorRef, int) ReadOnlyEndpointFor(Address address)
+        public (IActorRef, int)? ReadOnlyEndpointFor(Address address)
         {
             _addressToReadonly.TryGetValue(address, out var tmp);
             return tmp;

--- a/src/core/Akka.Remote/EndpointRegistry.cs
+++ b/src/core/Akka.Remote/EndpointRegistry.cs
@@ -18,8 +18,7 @@ namespace Akka.Remote
     /// </summary>
     internal class EndpointRegistry
     {
-        private Dictionary<Address, Tuple<int, Deadline>> _addressToRefuseUid = new Dictionary<Address, Tuple<int, Deadline>>();
-        private readonly Dictionary<Address, Tuple<IActorRef, int>> _addressToReadonly = new Dictionary<Address, Tuple<IActorRef, int>>();
+        private Dictionary<Address, (int, Deadline)> _addressToRefuseUid = new Dictionary<Address, (int, Deadline)>();
 
         private Dictionary<Address, EndpointManager.EndpointPolicy> _addressToWritable =
             new Dictionary<Address, EndpointManager.EndpointPolicy>();
@@ -91,7 +90,7 @@ namespace Akka.Remote
         /// <returns>The <see cref="endpoint"/> actor reference.</returns>
         public IActorRef RegisterReadOnlyEndpoint(Address address, IActorRef endpoint, int uid)
         {
-            _addressToReadonly[address] = Tuple.Create(endpoint, uid);
+            _addressToReadonly[address] = (endpoint, uid);
             _readonlyToAddress[endpoint] = address;
             return endpoint;
         }
@@ -139,7 +138,7 @@ namespace Akka.Remote
         /// </summary>
         /// <param name="address">The remote address to check.</param>
         /// <returns>A tuple containing the actor reference and the remote system UID, if they exist. Otherwise <c>null</c>.</returns>
-        public Tuple<IActorRef, int> ReadOnlyEndpointFor(Address address)
+        public (IActorRef, int) ReadOnlyEndpointFor(Address address)
         {
             _addressToReadonly.TryGetValue(address, out var tmp);
             return tmp;

--- a/src/core/Akka.Remote/EndpointRegistry.cs
+++ b/src/core/Akka.Remote/EndpointRegistry.cs
@@ -9,16 +9,16 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Akka.Actor;
-using Akka.Util.Internal;
 
 namespace Akka.Remote
 {
     /// <summary>
-    /// Not threadsafe - only to be used in HeadActor
+    /// Not thread safe - only to be used in HeadActor
     /// </summary>
     internal class EndpointRegistry
     {
         private Dictionary<Address, (int, Deadline)> _addressToRefuseUid = new Dictionary<Address, (int, Deadline)>();
+        private readonly Dictionary<Address, (IActorRef, int)> _addressToReadonly = new Dictionary<Address, (IActorRef, int)>();
 
         private Dictionary<Address, EndpointManager.EndpointPolicy> _addressToWritable =
             new Dictionary<Address, EndpointManager.EndpointPolicy>();
@@ -78,7 +78,7 @@ namespace Akka.Remote
         /// <param name="timeOfRelease">The timeframe for releasing quarantine.</param>
         public void RegisterWritableEndpointRefuseUid(Address remoteAddress, int refuseUid, Deadline timeOfRelease)
         {
-            _addressToRefuseUid[remoteAddress] = Tuple.Create(refuseUid, timeOfRelease);
+            _addressToRefuseUid[remoteAddress] = (refuseUid, timeOfRelease);
         }
 
         /// <summary>
@@ -281,7 +281,7 @@ namespace Akka.Remote
         public void MarkAsQuarantined(Address address, int uid, Deadline timeOfRelease)
         {
             _addressToWritable[address] = new EndpointManager.Quarantined(uid, timeOfRelease);
-            _addressToRefuseUid[address] = Tuple.Create(uid, timeOfRelease);
+            _addressToRefuseUid[address] = (uid, timeOfRelease);
         }
 
         /// <summary>

--- a/src/core/Akka.Remote/RemoteWatcher.cs
+++ b/src/core/Akka.Remote/RemoteWatcher.cs
@@ -278,7 +278,7 @@ namespace Akka.Remote
 
             readonly int _watching;
             readonly int _watchingNodes;
-            readonly ImmutableHashSet<Tuple<IActorRef, IActorRef>> _watchingRefs;
+            readonly ImmutableHashSet<(IActorRef, IActorRef)> _watchingRefs;
             readonly ImmutableHashSet<Address> _watchingAddresses;
 
             /// <summary>
@@ -286,8 +286,9 @@ namespace Akka.Remote
             /// </summary>
             /// <param name="watching">TBD</param>
             /// <param name="watchingNodes">TBD</param>
-            public Stats(int watching, int watchingNodes) : this(watching, watchingNodes, 
-                ImmutableHashSet<Tuple<IActorRef, IActorRef>>.Empty, ImmutableHashSet<Address>.Empty) { }
+            public Stats(int watching, int watchingNodes) : this(watching, watchingNodes,
+                ImmutableHashSet<(IActorRef, IActorRef)>.Empty, ImmutableHashSet<Address>.Empty)
+            { }
 
             /// <summary>
             /// TBD
@@ -296,7 +297,7 @@ namespace Akka.Remote
             /// <param name="watchingNodes">TBD</param>
             /// <param name="watchingRefs">TBD</param>
             /// <param name="watchingAddresses">TBD</param>
-            public Stats(int watching, int watchingNodes, ImmutableHashSet<Tuple<IActorRef, IActorRef>> watchingRefs, ImmutableHashSet<Address> watchingAddresses)
+            public Stats(int watching, int watchingNodes, ImmutableHashSet<(IActorRef, IActorRef)> watchingRefs, ImmutableHashSet<Address> watchingAddresses)
             {
                 _watching = watching;
                 _watchingNodes = watchingNodes;
@@ -317,7 +318,7 @@ namespace Akka.Remote
             /// <summary>
             /// TBD
             /// </summary>
-            public ImmutableHashSet<Tuple<IActorRef, IActorRef>> WatchingRefs => _watchingRefs;
+            public ImmutableHashSet<(IActorRef, IActorRef)> WatchingRefs => _watchingRefs;
 
             /// <summary>
             /// TBD
@@ -350,7 +351,7 @@ namespace Akka.Remote
             /// <param name="watchingRefs">TBD</param>
             /// <param name="watchingAddresses">TBD</param>
             /// <returns>TBD</returns>
-            public Stats Copy(int watching, int watchingNodes, ImmutableHashSet<Tuple<IActorRef, IActorRef>> watchingRefs = null, ImmutableHashSet<Address> watchingAddresses = null)
+            public Stats Copy(int watching, int watchingNodes, ImmutableHashSet<(IActorRef, IActorRef)> watchingRefs = null, ImmutableHashSet<Address> watchingAddresses = null)
             {
                 return new Stats(watching, watchingNodes, watchingRefs ?? WatchingRefs, watchingAddresses ?? WatchingAddresses);
             }
@@ -455,12 +456,12 @@ namespace Akka.Remote
             {
                 var watchSet = ImmutableHashSet.Create(Watching.SelectMany(pair =>
                 {
-                    var list = new List<Tuple<IActorRef, IActorRef>>(pair.Value.Count);
+                    var list = new List<(IActorRef, IActorRef)>(pair.Value.Count);
                     var wee = pair.Key;
-                    list.AddRange(pair.Value.Select(wer => Tuple.Create<IActorRef, IActorRef>(wee, wer)));
+                    list.AddRange(pair.Value.Select(wer => ((IActorRef)wee, (IActorRef)wer)));
                     return list;
                 }).ToArray());
-                Sender.Tell(new Stats(watchSet.Count(), WatchingNodes.Count, watchSet,
+                Sender.Tell(new Stats(watchSet.Count, WatchingNodes.Count, watchSet,
                     ImmutableHashSet.Create(WatchingNodes.ToArray())));
             }
             else

--- a/src/core/Akka.Remote/Serialization/DaemonMsgCreateSerializer.cs
+++ b/src/core/Akka.Remote/Serialization/DaemonMsgCreateSerializer.cs
@@ -203,7 +203,7 @@ namespace Akka.Remote.Serialization
             return system.Provider.ResolveActorRef(actorRefData.Path);
         }
 
-        private Tuple<int, bool, string, byte[]> Serialize(object obj)
+        private (int, bool, string, byte[]) Serialize(object obj)
         {
             var serializer = system.Serialization.FindSerializerFor(obj);
 
@@ -223,7 +223,7 @@ namespace Akka.Remote.Serialization
                 manifest = obj == null ? "null" : obj.GetType().TypeQualifiedName();
             }
 
-            return Tuple.Create(serializer.Identifier, hasManifest, manifest, serializer.ToBinary(obj));
+            return (serializer.Identifier, hasManifest, manifest, serializer.ToBinary(obj));
         }
     }
 }

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
@@ -169,7 +169,7 @@ namespace Akka.Remote.Transport.DotNetty
             return await ServerFactory().BindAsync(listenAddress).ConfigureAwait(false);
         }
 
-        public override async Task<Tuple<Address, TaskCompletionSource<IAssociationEventListener>>> Listen()
+        public override async Task<(Address, TaskCompletionSource<IAssociationEventListener>)> Listen()
         {
             EndPoint listenAddress;
             IPAddress ip;
@@ -206,7 +206,7 @@ namespace Akka.Remote.Transport.DotNetty
 #pragma warning restore 4014
 
 
-                return Tuple.Create(addr, AssociationListenerPromise);
+                return (addr, AssociationListenerPromise);
             }
             catch (Exception ex)
             {

--- a/src/core/Akka.Remote/Transport/Transport.cs
+++ b/src/core/Akka.Remote/Transport/Transport.cs
@@ -42,7 +42,7 @@ namespace Akka.Remote.Transport
         /// TBD
         /// </summary>
         /// <returns>TBD</returns>
-        public abstract Task<Tuple<Address, TaskCompletionSource<IAssociationEventListener>>> Listen();
+        public abstract Task<(Address, TaskCompletionSource<IAssociationEventListener>)> Listen();
 
         /// <summary>
         /// TBD

--- a/src/core/Akka.Remote/Transport/TransportAdapters.cs
+++ b/src/core/Akka.Remote/Transport/TransportAdapters.cs
@@ -266,7 +266,7 @@ namespace Akka.Remote.Transport
         /// TBD
         /// </summary>
         /// <returns>TBD</returns>
-        public override Task<Tuple<Address, TaskCompletionSource<IAssociationEventListener>>> Listen()
+        public override Task<(Address, TaskCompletionSource<IAssociationEventListener>)> Listen()
         {
             var upstreamListenerPromise = new TaskCompletionSource<IAssociationEventListener>();
             return WrappedTransport.Listen().ContinueWith(async listenerTask =>
@@ -274,9 +274,8 @@ namespace Akka.Remote.Transport
                 var listenAddress = listenerTask.Result.Item1;
                 var listenerPromise = listenerTask.Result.Item2;
                 listenerPromise.TrySetResult(await InterceptListen(listenAddress, upstreamListenerPromise.Task).ConfigureAwait(false));
-                return
-                    new Tuple<Address, TaskCompletionSource<IAssociationEventListener>>(
-                        SchemeAugmenter.AugmentScheme(listenAddress), upstreamListenerPromise);
+
+                return (SchemeAugmenter.AugmentScheme(listenAddress), upstreamListenerPromise);
             }, TaskContinuationOptions.ExecuteSynchronously).Unwrap();
         }
 

--- a/src/core/Akka.Tests.Shared.Internals/AsyncContext/AsyncContext.TaskQueue.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AsyncContext/AsyncContext.TaskQueue.cs
@@ -15,21 +15,21 @@ namespace Nito.AsyncEx
             /// <summary>
             /// The underlying blocking collection.
             /// </summary>
-            private readonly BlockingCollection<Tuple<Task, bool>> _queue;
+            private readonly BlockingCollection<(Task, bool)> _queue;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="TaskQueue"/> class.
             /// </summary>
             public TaskQueue()
             {
-                _queue = new BlockingCollection<Tuple<Task, bool>>();
+                _queue = new BlockingCollection<(Task, bool)>();
             }
 
             /// <summary>
             /// Gets a blocking enumerable that removes items from the queue. This enumerable only completes after <see cref="CompleteAdding"/> has been called.
             /// </summary>
             /// <returns>A blocking enumerable that removes items from the queue.</returns>
-            public IEnumerable<Tuple<Task, bool>> GetConsumingEnumerable()
+            public IEnumerable<(Task, bool)> GetConsumingEnumerable()
             {
                 return _queue.GetConsumingEnumerable();
             }
@@ -54,7 +54,7 @@ namespace Nito.AsyncEx
             {
                 try
                 {
-                    return _queue.TryAdd(Tuple.Create(item, propagateExceptions));
+                    return _queue.TryAdd((item, propagateExceptions));
                 }
                 catch (InvalidOperationException)
                 {

--- a/src/core/Akka.Tests/Actor/ActorLifeCycleSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorLifeCycleSpec.cs
@@ -36,14 +36,14 @@ namespace Akka.Tests
 
             private void Report(object message)
             {
-                testActor.Tell(Tuple.Create((string)message,id,CurrentGeneration));
+                testActor.Tell(((string)message,id,CurrentGeneration));
             }
 
             protected override void OnReceive(object message)
             {
                 if (message is string && (string)message == "status")
                 {
-                    testActor.Tell(Tuple.Create("OK",id,CurrentGeneration));
+                    testActor.Tell(("OK",id,CurrentGeneration));
                 }
             }
 
@@ -84,14 +84,14 @@ namespace Akka.Tests
 
             private void Report(object message)
             {
-                testActor.Tell(Tuple.Create((string)message, id, CurrentGeneration));
+                testActor.Tell(((string)message, id, CurrentGeneration));
             }
 
             protected override void OnReceive(object message)
             {
                 if (message is string && (string)message == "status")
                 {
-                    testActor.Tell(Tuple.Create("OK", id, CurrentGeneration));
+                    testActor.Tell(("OK", id, CurrentGeneration));
                 }
             }
 
@@ -115,24 +115,24 @@ namespace Akka.Tests
             var restarterProps = Props.Create(() => new LifeCycleTestActor(TestActor, id, generationProvider));
             var restarter = supervisor.Ask<IActorRef>(restarterProps).Result;
 
-            ExpectMsg(Tuple.Create( "preStart", id, 0));
+            ExpectMsg(( "preStart", id, 0));
             restarter.Tell(Kill.Instance);
-            ExpectMsg(Tuple.Create("preRestart", id, 0));
-            ExpectMsg(Tuple.Create("postRestart", id, 1));
+            ExpectMsg(("preRestart", id, 0));
+            ExpectMsg(("postRestart", id, 1));
             restarter.Tell("status");
-            ExpectMsg(Tuple.Create("OK", id, 1));
+            ExpectMsg(("OK", id, 1));
             restarter.Tell(Kill.Instance);
-            ExpectMsg(Tuple.Create("preRestart", id, 1));
-            ExpectMsg(Tuple.Create("postRestart", id, 2));
+            ExpectMsg(("preRestart", id, 1));
+            ExpectMsg(("postRestart", id, 2));
             restarter.Tell("status");
-            ExpectMsg(Tuple.Create("OK", id, 2));
+            ExpectMsg(("OK", id, 2));
             restarter.Tell(Kill.Instance);
-            ExpectMsg(Tuple.Create("preRestart", id, 2));
-            ExpectMsg(Tuple.Create("postRestart", id, 3));
+            ExpectMsg(("preRestart", id, 2));
+            ExpectMsg(("postRestart", id, 3));
             restarter.Tell("status");
-            ExpectMsg(Tuple.Create("OK", id, 3));
+            ExpectMsg(("OK", id, 3));
             restarter.Tell(Kill.Instance);
-            ExpectMsg(Tuple.Create("postStop", id, 3));
+            ExpectMsg(("postStop", id, 3));
             ExpectNoMsg(TimeSpan.FromSeconds(1));
             Sys.Stop(supervisor);
         }
@@ -146,24 +146,24 @@ namespace Akka.Tests
             var restarterProps = Props.Create(() => new LifeCycleTest2Actor(TestActor, id, generationProvider));
             var restarter = supervisor.Ask<IActorRef>(restarterProps).Result;
 
-            ExpectMsg(Tuple.Create("preStart", id, 0));
+            ExpectMsg(("preStart", id, 0));
             restarter.Tell(Kill.Instance);
-            ExpectMsg(Tuple.Create("postStop", id, 0));
-            ExpectMsg(Tuple.Create("preStart", id, 1));
+            ExpectMsg(("postStop", id, 0));
+            ExpectMsg(("preStart", id, 1));
             restarter.Tell("status");
-            ExpectMsg(Tuple.Create("OK", id, 1));
+            ExpectMsg(("OK", id, 1));
             restarter.Tell(Kill.Instance);
-            ExpectMsg(Tuple.Create("postStop", id, 1));
-            ExpectMsg(Tuple.Create("preStart", id, 2));
+            ExpectMsg(("postStop", id, 1));
+            ExpectMsg(("preStart", id, 2));
             restarter.Tell("status");
-            ExpectMsg(Tuple.Create("OK", id, 2));
+            ExpectMsg(("OK", id, 2));
             restarter.Tell(Kill.Instance);
-            ExpectMsg(Tuple.Create("postStop", id, 2));
-            ExpectMsg(Tuple.Create("preStart", id, 3));
+            ExpectMsg(("postStop", id, 2));
+            ExpectMsg(("preStart", id, 3));
             restarter.Tell("status");
-            ExpectMsg(Tuple.Create("OK", id, 3));
+            ExpectMsg(("OK", id, 3));
             restarter.Tell(Kill.Instance);
-            ExpectMsg(Tuple.Create("postStop", id, 3));
+            ExpectMsg(("postStop", id, 3));
             ExpectNoMsg(TimeSpan.FromSeconds(1));
             Sys.Stop(supervisor);
         } 
@@ -177,11 +177,11 @@ namespace Akka.Tests
             var restarterProps = Props.Create(() => new LifeCycleTest2Actor(TestActor, id, generationProvider));
             var restarter = supervisor.Ask<IInternalActorRef>(restarterProps).Result;
 
-            ExpectMsg(Tuple.Create("preStart", id, 0));
+            ExpectMsg(("preStart", id, 0));
             restarter.Tell("status");
-            ExpectMsg(Tuple.Create("OK", id, 0));
+            ExpectMsg(("OK", id, 0));
             restarter.Stop();
-            ExpectMsg(Tuple.Create("postStop", id, 0));
+            ExpectMsg(("postStop", id, 0));
             ExpectNoMsg(TimeSpan.FromSeconds(1));
         }
 
@@ -285,7 +285,7 @@ namespace Akka.Tests
                     .With<Spawn>(m =>
                     {
                         Context.ActorOf(Props.Create(() => new KillableActor(testActor)), m.Name);
-                        testActor.Tell(Tuple.Create("Created", m.Name));
+                        testActor.Tell(("Created", m.Name));
                     })
                     .With<ContextStop>(m =>
                     {
@@ -330,7 +330,7 @@ namespace Akka.Tests
             protected override void PostStop()
             {
                 Debug.WriteLine("inside poststop");
-                testActor.Tell(Tuple.Create("Terminated", Self.Path.Name));
+                testActor.Tell(("Terminated", Self.Path.Name));
             }
 
             protected override void OnReceive(object message)
@@ -344,15 +344,15 @@ namespace Akka.Tests
             var names = new[] {"Bob", "Jameson", "Natasha"};
             var supervisor = Sys.ActorOf(Props.Create(() => new SupervisorTestActor(TestActor)));
             supervisor.Tell(new SupervisorTestActor.Spawn(){ Name = names[0] });
-            ExpectMsg(Tuple.Create("Created",names[0]));
+            ExpectMsg(("Created",names[0]));
             supervisor.Tell(new SupervisorTestActor.Count());
             ExpectMsg(1);
             supervisor.Tell(new SupervisorTestActor.Spawn() { Name = names[1] });
-            ExpectMsg(Tuple.Create("Created", names[1]));
+            ExpectMsg(("Created", names[1]));
             supervisor.Tell(new SupervisorTestActor.Count());
             ExpectMsg(2);
             supervisor.Tell(new SupervisorTestActor.ContextStop() { Name = names[1] });
-            ExpectMsg(Tuple.Create("Terminated", names[1]));
+            ExpectMsg(("Terminated", names[1]));
        
             //we need to wait for the child actor to unregister itself from the parent.
             //this is done after PostStop so we have no way to wait for it
@@ -361,14 +361,14 @@ namespace Akka.Tests
             supervisor.Tell(new SupervisorTestActor.Count());
             ExpectMsg(1);
             supervisor.Tell(new SupervisorTestActor.Spawn() { Name = names[2] });
-            ExpectMsg(Tuple.Create("Created", names[2]));
+            ExpectMsg(("Created", names[2]));
             Task.Delay(100).Wait();
             supervisor.Tell(new SupervisorTestActor.Count());
             ExpectMsg(2);
             supervisor.Tell(new SupervisorTestActor.Stop() { Name = names[0] });
-            ExpectMsg(Tuple.Create("Terminated", names[0]));
+            ExpectMsg(("Terminated", names[0]));
             supervisor.Tell(new SupervisorTestActor.Stop() { Name = names[2] });
-            ExpectMsg(Tuple.Create("Terminated", names[2]));
+            ExpectMsg(("Terminated", names[2]));
 
             Task.Delay(100).Wait();
             supervisor.Tell(new SupervisorTestActor.Count());

--- a/src/core/Akka.Tests/Actor/FSMTransitionSpec.cs
+++ b/src/core/Akka.Tests/Actor/FSMTransitionSpec.cs
@@ -20,11 +20,11 @@ namespace Akka.Tests.Actor
         public void FSMTransitionNotifier_must_not_trigger_onTransition_for_stay()
         {
             var fsm = Sys.ActorOf(Props.Create(() => new SendAnyTransitionFSM(TestActor)));
-            ExpectMsg(new Tuple<int, int>(0, 0)); // caused by initialize(), OK.
+            ExpectMsg((0, 0)); // caused by initialize(), OK.
             fsm.Tell("stay"); // no transition event
             ExpectNoMsg(500.Milliseconds());
             fsm.Tell("goto"); // goto(current state)
-            ExpectMsg(new Tuple<int, int>(0, 0));
+            ExpectMsg((0, 0));
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace Akka.Tests.Actor
             Within(1.Seconds(), () =>
             {
                 fsm.Tell("tick");
-                ExpectMsg(new Tuple<int, int>(0, 1));
+                ExpectMsg((0, 1));
             });
         }
 
@@ -82,10 +82,10 @@ namespace Akka.Tests.Actor
                 fsm.Tell(new SubscribeTransitionCallBack(forward));
                 ExpectMsg(new CurrentState<int>(fsm, 0));
                 fsm.Tell("tick");
-                ExpectMsg(new Tuple<int, int>(0, 1));
+                ExpectMsg((0, 1));
                 ExpectMsg(new Transition<int>(fsm, 0, 1));
                 fsm.Tell("tick");
-                ExpectMsg(new Tuple<int, int>(1, 1));
+                ExpectMsg((1, 1));
                 ExpectMsg(new Transition<int>(fsm, 1, 1));
             });
         }
@@ -111,7 +111,7 @@ namespace Akka.Tests.Actor
             var fsmref = Sys.ActorOf<LeakyFSM>();
 
             fsmref.Tell("switch");
-            ExpectMsg(Tuple.Create(0, 1));
+            ExpectMsg((0, 1));
             fsmref.Tell("test");
             ExpectMsg("ok");
         }
@@ -136,7 +136,7 @@ namespace Akka.Tests.Actor
 
                 OnTransition((state1, state2) =>
                 {
-                    Target.Tell(Tuple.Create(state1, state2));
+                    Target.Tell((state1, state2));
                 });
 
                 Initialize();
@@ -211,10 +211,10 @@ namespace Akka.Tests.Actor
                 OnTransition((state1, state2) =>
                 {
                     if (state1 == 0 && state2 == 1)
-                        target.Tell(Tuple.Create(StateData, NextStateData));
+                        target.Tell((StateData, NextStateData));
 
                     if (state1 == 1 && state2 == 1)
-                        target.Tell(Tuple.Create(StateData, NextStateData));
+                        target.Tell((StateData, NextStateData));
                 });
             }
 
@@ -239,7 +239,7 @@ namespace Akka.Tests.Actor
 
                 OnTransition((state1, state2) =>
                 {
-                    NextStateData.Tell(Tuple.Create(state1, state2));
+                    NextStateData.Tell((state1, state2));
                 });
 
                 When(1, @event =>

--- a/src/core/Akka.Tests/Actor/PatternSpec.cs
+++ b/src/core/Akka.Tests/Actor/PatternSpec.cs
@@ -53,7 +53,7 @@ namespace Akka.Tests.Actor
             var latch = new TestLatch();
 
             //act
-            target.Tell(Tuple.Create(latch, TimeSpan.FromSeconds(2)));
+            target.Tell((latch, TimeSpan.FromSeconds(2)));
 
             //assert
             XAssert.Throws<TaskCanceledException>(() =>
@@ -98,7 +98,7 @@ namespace Akka.Tests.Actor
             protected override void OnReceive(object message)
             {
                 PatternMatch.Match(message)
-                    .With<Tuple<TestLatch, TimeSpan>>(t => t.Item1.Ready(t.Item2));
+                    .With<(TestLatch, TimeSpan)>(t => t.Item1.Ready(t.Item2));
             }
         }
 

--- a/src/core/Akka.Tests/Pattern/BackoffOnRestartSupervisorSpec.cs
+++ b/src/core/Akka.Tests/Pattern/BackoffOnRestartSupervisorSpec.cs
@@ -63,7 +63,7 @@ namespace Akka.Tests.Pattern
                     return;
                 });
 
-                Receive<Tuple<string, string>>(str => str.Item1.Equals("TO_PARENT"), msg =>
+                Receive<(string, string)>(str => str.Item1.Equals("TO_PARENT"), msg =>
                 {
                     Context.Parent.Tell(msg.Item2);
                 });
@@ -210,7 +210,7 @@ namespace Akka.Tests.Pattern
             probe.ExpectMsg("STARTED");
             var child = probe.LastSender;
 
-            child.Tell(Tuple.Create("TO_PARENT", "TEST_MESSAGE"));
+            child.Tell(("TO_PARENT", "TEST_MESSAGE"));
             probe.ExpectMsg("TEST_MESSAGE");
         }
 

--- a/src/core/Akka.Tests/Routing/SmallestMailboxSpec.cs
+++ b/src/core/Akka.Tests/Routing/SmallestMailboxSpec.cs
@@ -29,7 +29,7 @@ namespace Akka.Tests.Routing
             protected override void OnReceive(object message)
             {
                 message.Match()
-                    .With<Tuple<TestLatch, TestLatch>>(t =>
+                    .With<(TestLatch, TestLatch)>(t =>
                     {
                         TestLatch busy = t.Item1, receivedLatch = t.Item2;
                         usedActors.TryAdd(0, Self.Path.ToString());
@@ -37,7 +37,7 @@ namespace Akka.Tests.Routing
                         receivedLatch.CountDown();
                         busy.Ready(TestLatch.DefaultTimeout);
                     })
-                    .With<Tuple<int, TestLatch>>(t =>
+                    .With<(int, TestLatch)>(t =>
                     {
                         var msg = t.Item1; var receivedLatch = t.Item2;
                         usedActors.TryAdd(msg, Self.Path.ToString());
@@ -55,19 +55,19 @@ namespace Akka.Tests.Routing
 
             var busy = new TestLatch(1);
             var received0 = new TestLatch(1);
-            router.Tell(Tuple.Create(busy, received0));
+            router.Tell((busy, received0));
             received0.Ready(TestKitSettings.DefaultTimeout);
 
             var received1 = new TestLatch(1);
-            router.Tell(Tuple.Create(1, received1));
+            router.Tell((1, received1));
             received1.Ready(TestKitSettings.DefaultTimeout);
 
             var received2 = new TestLatch(1);
-            router.Tell(Tuple.Create(2, received2));
+            router.Tell((2, received2));
             received2.Ready(TestKitSettings.DefaultTimeout);
 
             var received3 = new TestLatch(1);
-            router.Tell(Tuple.Create(3, received3));
+            router.Tell((3, received3));
             received3.Ready(TestKitSettings.DefaultTimeout);
 
             busy.CountDown();

--- a/src/core/Akka.Tests/Serialization/SerializationSpec.cs
+++ b/src/core/Akka.Tests/Serialization/SerializationSpec.cs
@@ -97,7 +97,7 @@ namespace Akka.Tests.Serialization
                 }
             }
 
-            public ImmutableMessageWithPrivateCtor(Tuple<string, string> nonConventionalArg)
+            public ImmutableMessageWithPrivateCtor((string, string) nonConventionalArg)
             {
                 Foo = nonConventionalArg.Item1;
                 Bar = nonConventionalArg.Item2;
@@ -135,7 +135,7 @@ namespace Akka.Tests.Serialization
                 }
             }
 
-            public ImmutableMessage(Tuple<string,string> nonConventionalArg)
+            public ImmutableMessage((string, string) nonConventionalArg)
             {
                 Foo = nonConventionalArg.Item1;
                 Bar = nonConventionalArg.Item2;
@@ -241,14 +241,14 @@ namespace Akka.Tests.Serialization
         [Fact]
         public void Can_serialize_immutable_messages()
         {
-            var message = new ImmutableMessage(Tuple.Create("aaa", "bbb"));
-            AssertEqual(message);        
+            var message = new ImmutableMessage(("aaa", "bbb"));
+            AssertEqual(message);
         }
 
         [Fact]
         public void Can_serialize_immutable_messages_with_private_ctor()
         {
-            var message = new ImmutableMessageWithPrivateCtor(Tuple.Create("aaa", "bbb"));
+            var message = new ImmutableMessageWithPrivateCtor(("aaa", "bbb"));
             AssertEqual(message);
         }
 

--- a/src/core/Akka.Tests/Util/Internal/InterlockedSpinTests.cs
+++ b/src/core/Akka.Tests/Util/Internal/InterlockedSpinTests.cs
@@ -88,12 +88,12 @@ namespace Akka.Tests.Util.Internal
             //  Test that sharedVariable="updated"												 
             //  Test that updateWhenSignaled was called twice
 
-            Func<string, Tuple<bool, string, string>> updateWhenSignaled = i =>
+            Func<string, (bool, string, string)> updateWhenSignaled = i =>
             {
                 numberOfCallsToUpdateWhenSignaled++;
                 hasEnteredUpdateMethod.Set();	//Signal THREAD 1 to update sharedVariable
                 okToContinue.WaitOne(TimeSpan.FromSeconds(2));	//Wait for THREAD 1
-                return Tuple.Create(true, "updated", "returnValue");
+                return (true, "updated", "returnValue");
             };
             string result;
             var task = Task.Run(() => { result= InterlockedSpin.ConditionallySwap(ref sharedVariable, updateWhenSignaled); });
@@ -136,13 +136,13 @@ namespace Akka.Tests.Util.Internal
             //  Test that updateWhenSignaled was called twice
             //  Test that return from updateWhenSignaled is "break"
 
-            Func<string, Tuple<bool, string, string>> updateWhenSignaled = s =>
+            Func<string, (bool, string, string)> updateWhenSignaled = s =>
             {
                 numberOfCallsToUpdateWhenSignaled++;
                 hasEnteredUpdateMethod.Set();	//Signal to start-thread that we have entered the update method (it will chang
                 okToContinue.WaitOne(TimeSpan.FromSeconds(2));	//Wait to be signalled
                 var shouldUpdate = s == "";
-                return Tuple.Create(shouldUpdate, "updated", shouldUpdate ? "update" : "break");
+                return (shouldUpdate, "updated", shouldUpdate ? "update" : "break");
             };
             string result = "";
             var task = Task.Run(() => { result = InterlockedSpin.ConditionallySwap(ref sharedVariable, updateWhenSignaled); });

--- a/src/core/Akka/Actor/CoordinatedShutdown.cs
+++ b/src/core/Akka/Actor/CoordinatedShutdown.cs
@@ -245,7 +245,7 @@ namespace Akka.Actor
         internal readonly List<string> OrderedPhases;
 
         private readonly ConcurrentBag<Func<Task<Done>>> _clrShutdownTasks = new ConcurrentBag<Func<Task<Done>>>();
-        private readonly ConcurrentDictionary<string, ImmutableList<Tuple<string, Func<Task<Done>>>>> _tasks = new ConcurrentDictionary<string, ImmutableList<Tuple<string, Func<Task<Done>>>>>();
+        private readonly ConcurrentDictionary<string, ImmutableList<(string, Func<Task<Done>>)>> _tasks = new ConcurrentDictionary<string, ImmutableList<(string, Func<Task<Done>>)>>();
         private readonly AtomicReference<Reason> _runStarted = new AtomicReference<Reason>(null);
         private readonly AtomicBoolean _clrHooksStarted = new AtomicBoolean(false);
         private readonly TaskCompletionSource<Done> _runPromise = new TaskCompletionSource<Done>();
@@ -287,12 +287,12 @@ namespace Akka.Actor
 
             if (!_tasks.TryGetValue(phase, out var current))
             {
-                if (!_tasks.TryAdd(phase, ImmutableList<Tuple<string, Func<Task<Done>>>>.Empty.Add(Tuple.Create(taskName, task))))
+                if (!_tasks.TryAdd(phase, ImmutableList<(string, Func<Task<Done>>)>.Empty.Add((taskName, task))))
                     AddTask(phase, taskName, task); // CAS failed, retry
             }
             else
             {
-                if (!_tasks.TryUpdate(phase, current.Add(Tuple.Create(taskName, task)), current))
+                if (!_tasks.TryUpdate(phase, current.Add((taskName, task)), current))
                     AddTask(phase, taskName, task); // CAS failed, retry
             }
         }

--- a/src/core/Akka/Actor/Inbox.Actor.cs
+++ b/src/core/Akka/Actor/Inbox.Actor.cs
@@ -185,14 +185,16 @@ namespace Akka.Actor
 
             if (_clients.Count == 0)
             {
-                _currentDeadline.Item2.Cancel();
+                _currentDeadline.Item2?.Cancel();
+                _currentDeadline.Item2 = null;
             }
             else
             {
                 var next = _clientsByTimeout.FirstOrDefault();
                 if (next != null)
                 {
-                    _currentDeadline.Item2.Cancel();
+                    _currentDeadline.Item2?.Cancel();
+                    _currentDeadline.Item2 = null;
 
                     var delay = next.Deadline - Context.System.Scheduler.MonotonicClock;
 

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -16,6 +16,9 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkLibVersion)' ">

--- a/src/core/Akka/Routing/ConsistentHash.cs
+++ b/src/core/Akka/Routing/ConsistentHash.cs
@@ -47,10 +47,10 @@ namespace Akka.Routing
             _virtualNodesFactor = virtualNodesFactor;
         }
 
-        private Tuple<int[], T[]> _ring = null;
-        private Tuple<int[], T[]> RingTuple
+        private (int[], T[])? _ring = null;
+        private (int[], T[]) RingTuple
         {
-            get { return _ring ?? (_ring = Tuple.Create(_nodes.Keys.ToArray(), _nodes.Values.ToArray())); }
+            get { return ((int[], T[]))(_ring ?? (_ring = (_nodes.Keys.ToArray(), _nodes.Values.ToArray()))); }
         }
 
         private int[] NodeHashRing

--- a/src/core/Akka/Util/Internal/InterlockedSpin.cs
+++ b/src/core/Akka/Util/Internal/InterlockedSpin.cs
@@ -51,7 +51,7 @@ namespace Akka.Util.Internal
         /// <param name="reference">TBD</param>
         /// <param name="updateIfTrue">TBD</param>
         /// <returns>The third value from the tuple return by <paramref name="updateIfTrue"/>.</returns>
-        public static TReturn ConditionallySwap<T, TReturn>(ref T reference, Func<T, Tuple<bool, T, TReturn>> updateIfTrue) where T : class
+        public static TReturn ConditionallySwap<T, TReturn>(ref T reference, Func<T, (bool, T, TReturn)> updateIfTrue) where T : class
         {
             var spinWait = new SpinWait();
             while (true)

--- a/src/core/Akka/Util/MatchHandler/MatchExpressionBuilder.cs
+++ b/src/core/Akka/Util/MatchHandler/MatchExpressionBuilder.cs
@@ -144,7 +144,7 @@ namespace Akka.Tools.MatchHandler
             return new MatchExpressionBuilderResult(lambdaExpression, argumentValues);
         }
 
-        private static Tuple<ParameterExpression[], object[]> DecorateHandlerAndPredicateExpressions(IReadOnlyList<Argument> arguments, ParameterExpression inputParameter)
+        private static (ParameterExpression[], object[]) DecorateHandlerAndPredicateExpressions(IReadOnlyList<Argument> arguments, ParameterExpression inputParameter)
         {
             //Warning: This is using the same algorithm as CreateArgumentValuesArray.
             //         Any updates in this should be made in CreateArgumentValuesArray as well.
@@ -204,7 +204,7 @@ namespace Akka.Tools.MatchHandler
                         argument.PredicateAndHandler.PredicateExpression = expression;
                 }
             }
-            return Tuple.Create(parameters, argumentValues);
+            return (parameters, argumentValues);
         }
 
         /// <summary>


### PR DESCRIPTION
This pull request serves to close the issue: #3276 

I tried to find as many Tuples as i could find. Using the visual studio search capabilities.
Although i did not change every occurrence of `System.Tuple` and that's because i thought that on those rare occurrences the cost of boxing the `ValueTuple` to an object reference was not worth the conversion and the extra code. 
If you think that this is not the case let me know and i will change the remaining occurrences.

Thanks for your time.