### PR TITLE
Akka.NET v1.3.5 Release Notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,17 @@
-#### 1.3.5 February 1 2018 ####
-Placeholder for nightlies
+#### 1.3.5 February 21 2018 ####
+**Maintenance Release for Akka.NET 1.3**
+
+Akka.NET v1.3.5 is a minor patch containing only bugfixes.
+
+**Updates and Bugfixes**
+1. [Akka.Cluster.Tools: DistributedPubSub Fix premature pruning of topics](https://github.com/akkadotnet/akka.net/pull/3322)
+
+You can see [the full set of changes for Akka.NET v1.3.4 here](https://github.com/akkadotnet/akka.net/milestone/23).
+
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 4 | 4405 | 4284 | Aaron Stannard |
+| 1 | 4 | 4 | Joshua Garnett |
 
 #### 1.3.4 February 1 2018 ####
 **Maintenance Release for Akka.NET 1.3**

--- a/src/common.props
+++ b/src/common.props
@@ -17,6 +17,14 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Placeholder for nightlies</PackageReleaseNotes>
+    <PackageReleaseNotes>Maintenance Release for Akka.NET 1.3**
+Akka.NET v1.3.5 is a minor patch containing only bugfixes.
+Updates and Bugfixes**
+1. [Akka.Cluster.Tools: DistributedPubSub Fix premature pruning of topics](https://github.com/akkadotnet/akka.net/pull/3322)
+You can see [the full set of changes for Akka.NET v1.3.4 here](https://github.com/akkadotnet/akka.net/milestone/23).
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 4 | 4405 | 4284 | Aaron Stannard |
+| 1 | 4 | 4 | Joshua Garnett |</PackageReleaseNotes>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
#### 1.3.5 February 21 2018 ####
**Maintenance Release for Akka.NET 1.3**

Akka.NET v1.3.5 is a minor patch containing only bugfixes.

**Updates and Bugfixes**
1. [Akka.Cluster.Tools: DistributedPubSub Fix premature pruning of topics](https://github.com/akkadotnet/akka.net/pull/3322)

You can see [the full set of changes for Akka.NET v1.3.4 here](https://github.com/akkadotnet/akka.net/milestone/23).

| COMMITS | LOC+ | LOC- | AUTHOR |
| --- | --- | --- | --- |
| 4 | 4405 | 4284 | Aaron Stannard |
| 1 | 4 | 4 | Joshua Garnett |
