### PR TITLE
removed copyright from Nito.AsyncEx files

### DIFF
--- a/src/core/Akka.Tests.Shared.Internals/AsyncContext/AsyncContext.SynchronizationContext.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AsyncContext/AsyncContext.SynchronizationContext.cs
@@ -1,11 +1,4 @@
-﻿//-----------------------------------------------------------------------
-// <copyright file="AsyncContext.SynchronizationContext.cs" company="Akka.NET Project">
-//     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
-//     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/akka.net>
-// </copyright>
-//-----------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading;
 using Nito.AsyncEx.Synchronous;
 

--- a/src/core/Akka.Tests.Shared.Internals/AsyncContext/AsyncContext.TaskQueue.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AsyncContext/AsyncContext.TaskQueue.cs
@@ -1,11 +1,4 @@
-﻿//-----------------------------------------------------------------------
-// <copyright file="AsyncContext.TaskQueue.cs" company="Akka.NET Project">
-//     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
-//     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/akka.net>
-// </copyright>
-//-----------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/core/Akka.Tests.Shared.Internals/AsyncContext/AsyncContext.TaskScheduler.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AsyncContext/AsyncContext.TaskScheduler.cs
@@ -1,11 +1,4 @@
-﻿//-----------------------------------------------------------------------
-// <copyright file="AsyncContext.TaskScheduler.cs" company="Akka.NET Project">
-//     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
-//     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/akka.net>
-// </copyright>
-//-----------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Nito.AsyncEx

--- a/src/core/Akka.Tests.Shared.Internals/AsyncContext/AsyncContext.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AsyncContext/AsyncContext.cs
@@ -1,11 +1,4 @@
-﻿//-----------------------------------------------------------------------
-// <copyright file="AsyncContext.cs" company="Akka.NET Project">
-//     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
-//     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/akka.net>
-// </copyright>
-//-----------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/core/Akka.Tests.Shared.Internals/AsyncContext/BoundAction.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AsyncContext/BoundAction.cs
@@ -1,11 +1,4 @@
-﻿//-----------------------------------------------------------------------
-// <copyright file="BoundAction.cs" company="Akka.NET Project">
-//     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
-//     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/akka.net>
-// </copyright>
-//-----------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/src/core/Akka.Tests.Shared.Internals/AsyncContext/ExceptionHelpers.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AsyncContext/ExceptionHelpers.cs
@@ -1,11 +1,4 @@
-﻿//-----------------------------------------------------------------------
-// <copyright file="ExceptionHelpers.cs" company="Akka.NET Project">
-//     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
-//     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/akka.net>
-// </copyright>
-//-----------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Runtime.ExceptionServices;
 
 internal static class ExceptionHelpers

--- a/src/core/Akka.Tests.Shared.Internals/AsyncContext/SingleDisposable (of T).cs
+++ b/src/core/Akka.Tests.Shared.Internals/AsyncContext/SingleDisposable (of T).cs
@@ -1,11 +1,4 @@
-﻿//-----------------------------------------------------------------------
-// <copyright file="SingleDisposable (of T).cs" company="Akka.NET Project">
-//     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
-//     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/akka.net>
-// </copyright>
-//-----------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading;
 using Nito.Disposables.Internals;
 

--- a/src/core/Akka.Tests.Shared.Internals/AsyncContext/SynchronizationContextSwitcher.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AsyncContext/SynchronizationContextSwitcher.cs
@@ -1,11 +1,4 @@
-﻿//-----------------------------------------------------------------------
-// <copyright file="SynchronizationContextSwitcher.cs" company="Akka.NET Project">
-//     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
-//     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/akka.net>
-// </copyright>
-//-----------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/core/Akka.Tests.Shared.Internals/AsyncContext/SynchronousTaskExtensions.cs.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AsyncContext/SynchronousTaskExtensions.cs.cs
@@ -1,11 +1,4 @@
-﻿//-----------------------------------------------------------------------
-// <copyright file="SynchronousTaskExtensions.cs.cs" company="Akka.NET Project">
-//     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
-//     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/akka.net>
-// </copyright>
-//-----------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;


### PR DESCRIPTION
Tagged these when we did the mass copyright update yesterday. That was unintentional. Removed the headers from these files.