### PR TITLE
tail-chopping routers could not be selected from config

### DIFF
--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -123,7 +123,6 @@ akka {
           round-robin-group = "Akka.Routing.RoundRobinGroup"
           random-pool = "Akka.Routing.RandomPool"
           random-group = "Akka.Routing.RandomGroup"
-          balancing-pool = "Akka.Routing.BalancingPool"
           smallest-mailbox-pool = "Akka.Routing.SmallestMailboxPool"
           broadcast-pool = "Akka.Routing.BroadcastPool"
           broadcast-group = "Akka.Routing.BroadcastGroup"
@@ -131,6 +130,8 @@ akka {
           scatter-gather-group = "Akka.Routing.ScatterGatherFirstCompletedGroup"
           consistent-hashing-pool = "Akka.Routing.ConsistentHashingPool"
           consistent-hashing-group = "Akka.Routing.ConsistentHashingGroup"
+          tail-chopping-pool = "Akka.Routing.TailChoppingPool"
+          tail-chopping-group = "Akka.Routing.TailChoppingGroup"
     }
  
     deployment {


### PR DESCRIPTION
It was not possible to use tail-chopping routers from config.
- added "tail-chopping-*" routers to Pigeon.conf
- removed non-existing "balancing-pool" router.