### PR TITLE
Akka.Streams.Util.IteratorAdapter destroys stack trace of captured errors.

### DIFF
--- a/src/core/Akka.Streams.Tests/Util/IteratorAdapterSpec.cs
+++ b/src/core/Akka.Streams.Tests/Util/IteratorAdapterSpec.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using Akka.Streams.Util;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Streams.Tests.Util
+{
+    public class IteratorAdapterSpec
+    {
+        [Fact]
+        public void IteratorAdapter_original_exception_should_be_preserved()
+        {
+            var iteratorAdapter = new IteratorAdapter<object>(new ThrowExceptioEnumerator<object>());
+            Action action = () => iteratorAdapter.Next();
+
+            action.ShouldThrow<AggregateException>();
+        }
+
+        class ThrowExceptioEnumerator<T> : IEnumerator<T>
+        {
+            public T Current => throw new NotImplementedException();
+
+            object IEnumerator.Current => throw new NotImplementedException();
+
+            public void Dispose()
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool MoveNext()
+            {
+                throw new NullReferenceException("ups");
+            }
+
+            public void Reset()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/core/Akka.Streams/Util/IteratorAdapter.cs
+++ b/src/core/Akka.Streams/Util/IteratorAdapter.cs
@@ -83,7 +83,7 @@ namespace Akka.Streams.Util
             if (!HasNext())
                 throw new InvalidOperationException();
             if (_exception != null)
-                throw _exception;
+                throw new AggregateException(_exception);
 
             _hasNext = null;
             _exception = null;


### PR DESCRIPTION
This PR addresses https://github.com/akkadotnet/akka.net/issues/3096.

Before changes
```
System.NullReferenceException : ups
   at Akka.Streams.Util.IteratorAdapter`1.Next()
   at Akka.Streams.Tests.Util.IteratorAdapterSpec.IteratorAdapter_original_exception_should_be_preserved() in C:\dev\projects\akka.net\src\core\Akka.Streams.Tests\Util\IteratorAdapterSpec.cs:line 17
```

after
```
System.AggregateException : One or more errors occurred.
---- System.NullReferenceException : ups
   at Akka.Streams.Util.IteratorAdapter`1.Next()
   at Akka.Streams.Tests.Util.IteratorAdapterSpec.IteratorAdapter_original_exception_should_be_preserved() in C:\dev\projects\akka.net\src\core\Akka.Streams.Tests\Util\IteratorAdapterSpec.cs:line 17
----- Inner Stack Trace -----
   at Akka.Streams.Tests.Util.IteratorAdapterSpec.ThrowExceptioEnumerator`1.MoveNext() in C:\dev\projects\akka.net\src\core\Akka.Streams.Tests\Util\IteratorAdapterSpec.cs:line 33
   at Akka.Streams.Util.IteratorAdapter`1.HasNext()
```

This is my first PR to akka.net - all feedback very much appreciated.