### PR TITLE
A replicator is not needed for a Shard Proxy

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
@@ -222,7 +222,6 @@ namespace Akka.Cluster.Sharding
                     var coordinatorSingletonManagerName = CoordinatorSingletonManagerName(encName);
                     var coordinatorPath = CoordinatorPath(encName);
                     var shardRegion = Context.Child(encName);
-                    var replicator = Replicator(settings);
 
                     if (Equals(shardRegion, ActorRefs.Nobody))
                     {
@@ -233,7 +232,7 @@ namespace Akka.Cluster.Sharding
                             coordinatorPath: coordinatorPath,
                             extractEntityId: startProxy.ExtractEntityId,
                             extractShardId: startProxy.ExtractShardId,
-                            replicator: replicator,
+                            replicator: Context.System.DeadLetters,
                             majorityMinCap: _majorityMinCap).WithDispatcher(Context.Props.Dispatcher), encName);
                     }
 


### PR DESCRIPTION
Fixes #3352 

Looks like a copy-paste error from the real shard startup. The replicator is only used when a shard is created, and this does not happen on a Proxy.

The Akka source code also does not pass the replicator in. See https://github.com/manonthegithub/akka/blob/232b4d0d7a38cb84f8a87c43322f50314cd6650e/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala#L681