### PR TITLE
Removing string.GetHashCode usage from distributed classes

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/DDataShard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/DDataShard.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.DistributedData;
 using Akka.Event;
+using Akka.Util;
 
 namespace Akka.Cluster.Sharding
 {
@@ -110,7 +111,7 @@ namespace Akka.Cluster.Sharding
 
         private ORSetKey<EntryId> Key(EntryId entityId)
         {
-            var i = (Math.Abs(entityId.GetHashCode()) % NrOfKeys);
+            var i = Math.Abs(MurmurHash.StringHash(entityId)) % NrOfKeys;
             return _stateKeys[i];
         }
 

--- a/src/contrib/cluster/Akka.DistributedData/Replicator.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Replicator.cs
@@ -1017,7 +1017,7 @@ namespace Akka.DistributedData
                         _statusTotChunks = totChunks;
                     }
                     var chunk = (int)(_statusCount % totChunks);
-                    var entries = _dataEntries.Where(x => Math.Abs(x.Key.GetHashCode()) % totChunks == chunk)
+                    var entries = _dataEntries.Where(x => Math.Abs(MurmurHash.StringHash(x.Key)) % totChunks == chunk)
                         .Select(x => new KeyValuePair<string, Digest>(x.Key, GetDigest(x.Key)))
                         .ToImmutableDictionary();
                     var status = new Internal.Status(entries, chunk, totChunks);
@@ -1064,7 +1064,7 @@ namespace Akka.DistributedData
             var otherKeys = otherDigests.Keys.ToImmutableHashSet();
             var myKeys = (totChunks == 1
                     ? _dataEntries.Keys
-                    : _dataEntries.Keys.Where(x => Math.Abs(x.GetHashCode()) % totChunks == chunk))
+                    : _dataEntries.Keys.Where(x => Math.Abs(MurmurHash.StringHash(x)) % totChunks == chunk))
                 .ToImmutableHashSet();
 
             var otherMissingKeys = myKeys.Except(otherKeys);


### PR DESCRIPTION
Inspired by #3361

I have gone through the rest of the distributed / cluster codebase and replaced all `GetHashCode` calls on string instances that I could find.

I am raising this as a separate PR because these changes might not be needed. I do not know the codebase very well and in case these are private methods that do not rely on the same bucketing on remote nodes then it is fine to use `GetHashCode` and this PR might potentialy only slow Akka down (assuming `GetHashCode` is faster than the `MurmurHash`).

Submitting this for review and let me know if you want me to remove something but keep the rest.