### PR TITLE
Add an Ask 'overload' that allows message generation with `IActorRef` inside

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -883,7 +883,8 @@ namespace Akka.Actor
         public static System.Threading.Tasks.Task<object> Ask(this Akka.Actor.ICanTell self, object message, System.Nullable<System.TimeSpan> timeout, System.Threading.CancellationToken cancellationToken) { }
         public static System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, object message, System.Nullable<System.TimeSpan> timeout = null) { }
         public static System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, object message, System.Threading.CancellationToken cancellationToken) { }
-        public static async System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, object message, System.Nullable<System.TimeSpan> timeout, System.Threading.CancellationToken cancellationToken) { }
+        public static System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, object message, System.Nullable<System.TimeSpan> timeout, System.Threading.CancellationToken cancellationToken) { }
+        public static async System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, System.Func<Akka.Actor.IActorRef, object> messageFactory, System.Nullable<System.TimeSpan> timeout, System.Threading.CancellationToken cancellationToken) { }
     }
     public class static GracefulStopSupport
     {

--- a/src/core/Akka.Tests/Actor/AskSpec.cs
+++ b/src/core/Akka.Tests/Actor/AskSpec.cs
@@ -11,6 +11,7 @@ using Akka.Actor;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Akka.Util.Internal;
 using Nito.AsyncEx;
 
 namespace Akka.Tests.Actor
@@ -69,6 +70,23 @@ namespace Akka.Tests.Actor
                     Sender.Tell("bar");
                 }
             }
+        }
+
+        public class ReplyToActor : UntypedActor
+        {
+            protected override void OnReceive(object message)
+            {
+                var requester = message.AsInstanceOf<IActorRef>();
+                requester.Tell("i_hear_ya");
+            }
+        }
+
+        [Fact]
+        public async Task Can_Ask_Response_actor()
+        {
+            var actor = Sys.ActorOf<ReplyToActor>();
+            var res = await actor.Ask<string>( sender => sender, null, CancellationToken.None);
+            res.ShouldBe("i_hear_ya");
         }
 
         [Fact]

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -100,7 +100,24 @@ namespace Akka.Actor
         /// This exception is thrown if the system can't resolve the target provider.
         /// </exception>
         /// <returns>TBD</returns>
-        public static async Task<T> Ask<T>(this ICanTell self, object message, TimeSpan? timeout, CancellationToken cancellationToken)
+        public static Task<T> Ask<T>(this ICanTell self, object message, TimeSpan? timeout, CancellationToken cancellationToken)
+        {
+            return Ask<T>(self, _ => message, timeout, cancellationToken);
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <typeparam name="T">TBD</typeparam>
+        /// <param name="self">TBD</param>
+        /// <param name="messageFactory">Factory method that creates a message that can encapsulate the 'Sender' IActorRef</param>
+        /// <param name="timeout">TBD</param>
+        /// <param name="cancellationToken">TBD</param>
+        /// <exception cref="ArgumentException">
+        /// This exception is thrown if the system can't resolve the target provider.
+        /// </exception>
+        /// <returns>TBD</returns>
+        public static async Task<T> Ask<T>(this ICanTell self, Func<IActorRef,object> messageFactory, TimeSpan? timeout, CancellationToken cancellationToken)
         {
             await SynchronizationContextManager.RemoveContext;
 
@@ -108,7 +125,7 @@ namespace Akka.Actor
             if (provider == null)
                 throw new ArgumentException("Unable to resolve the target Provider", nameof(self));
 
-            return (T) await Ask(self, message, provider, timeout, cancellationToken);
+            return (T)await Ask(self, messageFactory, provider, timeout, cancellationToken);
         }
 
         /// <summary>
@@ -134,7 +151,7 @@ namespace Akka.Actor
         private static readonly bool isRunContinuationsAsynchronouslyAvailable = Enum.IsDefined(typeof(TaskCreationOptions), RunContinuationsAsynchronously);
 
 
-        private static async Task<object> Ask(ICanTell self, object message, IActorRefProvider provider,
+        private static async Task<object> Ask(ICanTell self, Func<IActorRef, object> messageFactory, IActorRefProvider provider,
             TimeSpan? timeout, CancellationToken cancellationToken)
         {
             TaskCompletionSource<object> result;
@@ -174,6 +191,7 @@ namespace Akka.Actor
             var future = new FutureActorRef(result, () => { }, path, isRunContinuationsAsynchronouslyAvailable);
             //The future actor needs to be registered in the temp container
             provider.RegisterTempActor(future, path);
+            var message = messageFactory(future);
             self.Tell(message, future);
 
             try


### PR DESCRIPTION
Change the inner `Ask` implementation to accept a message factory instead of a message, so the message can optionally encapsulate the sending `IActorRef` - the address of the light actor inside `Ask`. Only the most complex version of the public `Ask` extension (with Timeout and Cancellation params) also exposes this Factory option. Existing `Ask` extension methods proxy through this new one.

The reasoning behind this:
In the support framework of our application we sometimes need to encapsulate the 'requester' of a message explicitly into the payload, rather than rely on 'Sender'. Two cases stand out: Forwarding (where the generic-ness of the helper prevents us from using `ref.Forward` rather than `ref.Tell`, and the other case is merging/grouping requests -> multiple intended recipients of the answer.

When unit testing actors that expect such requests, we currently have to 'proxy' the message injected into Akka by `.Ask()` via a proxy actor that only inserts `Sender` into the correct field - a big hassle that makes tests harder to read and maintain.

We want to be able to just `sut.Ask<Response>( askRef => new Request( "question", respondTo = askRef) )`

The change is fairly trivial, and given the cost of `Ask` in general, the cost of the extra indirection to use the current `Ask` is negligible.