### PR TITLE
[WIP] Exception from ReceiveRecover should stop the PersistentActor

### DIFF
--- a/src/core/Akka.Persistence.Tests/PersistentActorSpec.Actors.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorSpec.Actors.cs
@@ -1121,6 +1121,20 @@ namespace Akka.Persistence.Tests
                 return false;
             }
         }
+
+        internal class ExceptionActor : ExamplePersistentActor
+        {
+            public ExceptionActor(string name) 
+                : base(name)
+            { }
+
+            protected override bool ReceiveCommand(object message) => CommonBehavior(message);
+            protected override bool ReceiveRecover(object message)
+            {
+                if (message is RecoveryCompleted _) throw new TestException("boom");
+                return false;
+            }
+        }
     }
 }
 

--- a/src/core/Akka.Persistence.Tests/PersistentActorSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorSpec.cs
@@ -611,5 +611,13 @@ namespace Akka.Persistence.Tests
             persistentActor.Tell("boom");
             ExpectMsg("failed with TestException while processing boom");
         }
+
+        [Fact]
+        public void PersistentActor_should_stop_actor_when_direct_exception_from_receiveRecover()
+        {
+            var persistentActor = ActorOf(Props.Create(() => new ExceptionActor(Name)));
+            Watch(persistentActor);
+            ExpectTerminated(persistentActor);
+        }
     }
 }


### PR DESCRIPTION
In the current implementation, a persistent actor will enter a restart loop due to default supervision (i.e. restart) if an exception is thrown when handling a RecoveryCompleted. 

Original PR: [#24340](https://github.com/akka/akka/pull/24340)