### PR TITLE
added serve-docs.cmd and pages with default HOCON configurations for website

### DIFF
--- a/docs/articles/configuration/akka.cluster.md
+++ b/docs/articles/configuration/akka.cluster.md
@@ -1,0 +1,4 @@
+## Akka.Cluster Configuration
+Below is the default HOCON configuration for the base `Akka.Cluster` package.
+
+[!code[Akka.Cluster.dll HOCON Configuration](../../../src/core/Akka.Cluster/Configuration/Cluster.conf)]

--- a/docs/articles/configuration/akka.md
+++ b/docs/articles/configuration/akka.md
@@ -1,0 +1,4 @@
+## Akka Configuration
+Below is the default HOCON configuration for the base `Akka` package.
+
+[!code[Akka.dll HOCON Configuration](../../../src/core/Akka/Configuration/Pigeon.conf)]

--- a/docs/articles/configuration/akka.persistence.md
+++ b/docs/articles/configuration/akka.persistence.md
@@ -1,0 +1,4 @@
+## Akka.Persistence Configuration
+Below is the default HOCON configuration for the base `Akka.Persistence` package.
+
+[!code[Akka.Persistence.dll HOCON Configuration](../../../src/core/Akka.Persistence/persistence.conf)]

--- a/docs/articles/configuration/akka.remote.md
+++ b/docs/articles/configuration/akka.remote.md
@@ -1,0 +1,4 @@
+## Akka.Remote Configuration
+Below is the default HOCON configuration for the base `Akka.Remote` package.
+
+[!code[Akka.Remote.dll HOCON Configuration](../../../src/core/Akka.Remote/Configuration/Remote.conf)]

--- a/docs/articles/configuration/akka.streams.md
+++ b/docs/articles/configuration/akka.streams.md
@@ -1,0 +1,4 @@
+## Akka.Streams Configuration
+Below is the default HOCON configuration for the base `Akka.Steams` package.
+
+[!code[Akka.Streams.dll HOCON Configuration](../../../src/core/Akka.Streams/reference.conf)]

--- a/docs/articles/configuration/akka.testkit.md
+++ b/docs/articles/configuration/akka.testkit.md
@@ -1,0 +1,8 @@
+## Akka.TestKit Configuration
+Below is the default HOCON configuration for the base `Akka.TestKit` package.
+
+[!code[Akka.TestKit.dll HOCON Configuration](../../../src/core/Akka.TestKit/Internal/Reference.conf)]
+
+Additionally, it's also possible to change the default [`IScheduler` implementation](../../api/Akka.Actor.IScheduler.yml) in the `Akka.TestKit` to use [a virtualized `TestScheduler` implementation](../../api/Akka.TestKit.TestScheduler.yml) that Akka.NET developers can use to artifically advance time forward. To swap in the `TestScheduler`, developers will want to include the HOCON below:
+
+[!code[Akka.TestKit.dll TestScheduler HOCON Configuration](../../../src/core/Akka.TestKit/Configs/TestScheduler.conf)]

--- a/docs/articles/configuration/akka.testkit.md
+++ b/docs/articles/configuration/akka.testkit.md
@@ -3,6 +3,6 @@ Below is the default HOCON configuration for the base `Akka.TestKit` package.
 
 [!code[Akka.TestKit.dll HOCON Configuration](../../../src/core/Akka.TestKit/Internal/Reference.conf)]
 
-Additionally, it's also possible to change the default [`IScheduler` implementation](../../api/Akka.Actor.IScheduler.yml) in the `Akka.TestKit` to use [a virtualized `TestScheduler` implementation](../../api/Akka.TestKit.TestScheduler.yml) that Akka.NET developers can use to artifically advance time forward. To swap in the `TestScheduler`, developers will want to include the HOCON below:
+Additionally, it's also possible to change the default [`IScheduler` implementation](../../api/Akka.Actor.IScheduler.yml) in the `Akka.TestKit` to use [a virtualized `TestScheduler` implementation](../../api/Akka.TestKit.TestScheduler.yml) that Akka.NET developers can use to artificially advance time forward. To swap in the `TestScheduler`, developers will want to include the HOCON below:
 
 [!code[Akka.TestKit.dll TestScheduler HOCON Configuration](../../../src/core/Akka.TestKit/Configs/TestScheduler.conf)]

--- a/docs/articles/configuration/toc.yml
+++ b/docs/articles/configuration/toc.yml
@@ -1,0 +1,12 @@
+- name: Akka
+  href: akka.md
+- name: Akka.Remote
+  href: akka.remote.md
+- name: Akka.Cluster
+  href: akka.cluster.md
+- name: Akka.Persistence
+  href: akka.persistence.md
+- name: Akka.Streams
+  href: akka.streams.md
+- name: Akka.TestKit
+  href: akka.testkit.md

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -176,3 +176,5 @@
     href: utilities/scheduler.md
   - name: Circuit Breaker
     href: utilities/circuit-breaker.md
+- name: Configurations
+  href: configuration/toc.yml

--- a/serve-docs.cmd
+++ b/serve-docs.cmd
@@ -1,0 +1,1 @@
+PowerShell.exe -file "serve-docs.ps1" %*  .\docs\docfx.json --serve -p 8100

--- a/serve-docs.ps1
+++ b/serve-docs.ps1
@@ -1,0 +1,21 @@
+# docfx.ps1
+$VisualStudioVersion = "15.0";
+$DotnetSDKVersion = "2.0.0";
+
+# Get dotnet paths
+$MSBuildExtensionsPath = "C:\Program Files\dotnet\sdk\" + $DotnetSDKVersion;
+$MSBuildSDKsPath = $MSBuildExtensionsPath + "\SDKs";
+
+# Get Visual Studio install path
+$VSINSTALLDIR =  $(Get-ItemProperty "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\SxS\VS7").$VisualStudioVersion;
+
+# Add Visual Studio environment variables
+$env:VisualStudioVersion = $VisualStudioVersion;
+$env:VSINSTALLDIR = $VSINSTALLDIR;
+
+# Add dotnet environment variables
+$env:MSBuildExtensionsPath = $MSBuildExtensionsPath;
+$env:MSBuildSDKsPath = $MSBuildSDKsPath;
+
+# Build our docs
+& .\tools\docfx.console\tools\docfx @args

--- a/src/common.props
+++ b/src/common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2017 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.3.5</VersionPrefix>
+    <VersionPrefix>1.3.6</VersionPrefix>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>
@@ -17,14 +17,6 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Maintenance Release for Akka.NET 1.3**
-Akka.NET v1.3.5 is a minor patch containing only bugfixes.
-Updates and Bugfixes**
-1. [Akka.Cluster.Tools: DistributedPubSub Fix premature pruning of topics](https://github.com/akkadotnet/akka.net/pull/3322)
-You can see [the full set of changes for Akka.NET v1.3.4 here](https://github.com/akkadotnet/akka.net/milestone/23).
-| COMMITS | LOC+ | LOC- | AUTHOR |
-| --- | --- | --- | --- |
-| 4 | 4405 | 4284 | Aaron Stannard |
-| 1 | 4 | 4 | Joshua Garnett |</PackageReleaseNotes>
+    <PackageReleaseNotes>Placeholder for nightlies</PackageReleaseNotes>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
We should probably expand what I've started here and add support for `Cluster.Sharding` and the `/src/contrib` projects, but this is a good start. One of the most frequently requested areas where users ask for help is "how do I configure X/Y/Z?" I usually steer them to the right place in the source code, but I think putting this up on the website and exposing it that way is much more easily discoverable.

Also copied over some scripts I use to make it easier to preview DocFx websites locally for proofing: `serve-docs.ps1` and `serve-docs.cmd`.