### PR TITLE
added descriptive hocon for the akka.remote.dot-netty.tcp.public-port option

### DIFF
--- a/src/core/Akka.Remote.Tests/RemoteConfigSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteConfigSpec.cs
@@ -104,6 +104,7 @@ namespace Akka.Remote.Tests
             Assert.True(s.TcpKeepAlive);
             Assert.True(s.TcpReuseAddr);
             Assert.True(string.IsNullOrEmpty(c.GetString("hostname")));
+            Assert.Null(s.PublicPort);
             Assert.Equal(2, s.ServerSocketWorkerPoolSize);
             Assert.Equal(2, s.ClientSocketWorkerPoolSize);
             Assert.False(s.BackwardsCompatibilityModeEnabled);

--- a/src/core/Akka.Remote/Configuration/Remote.conf
+++ b/src/core/Akka.Remote/Configuration/Remote.conf
@@ -379,6 +379,15 @@ akka {
       # This port needs to be unique for each actor system on the same machine.
       port = 2552
 
+      # Similar in spirit to "public-hostname" setting, this allows Akka.Remote users
+      # to alias the port they're listening on. The socket will actually listen on the
+      # "port" setting, but when connecting to other ActorSystems this node will advertise
+      # itself as being connected to the "public-port". This is helpful when working with 
+      # hosting environments that rely on address translation and port-forwarding, such as Docker.
+      #
+      # Leave this setting to "0" if you don't intend to use it.
+      public-port = 0
+
       # The hostname or ip to bind the remoting to,
       # InetAddress.getLocalHost.getHostAddress is used if empty
       hostname = ""


### PR DESCRIPTION
Added this to make sure this data shows up on the website when #3388 is merged, so people don't have to go "guessing" for this option.