### PR TITLE
Fix FSharp tests

### DIFF
--- a/buildIncremental.fsx
+++ b/buildIncremental.fsx
@@ -42,6 +42,7 @@ module IncrementalTests =
 
     let getUnitTestProjects runtime =
         let allTestProjects = !! "./**/core/**/*.Tests.csproj"
+                              ++ "./**/core/**/*.Tests.fsproj"
                               ++ "./**/contrib/**/*.Tests.csproj"
                               -- "./**/serializers/**/*Wire*.csproj"
         allTestProjects 

--- a/src/core/Akka.FSharp/FsApi.fs
+++ b/src/core/Akka.FSharp/FsApi.fs
@@ -380,7 +380,7 @@ module Linq =
             | _ -> failwith "Doesn't match"
  
     type Expression = 
-        static member ToExpression(f : System.Linq.Expressions.Expression<System.Func<FunActor<'Message, 'v>>>) = toExpression<FunActor<'Message, 'v>> f
+        static member ToExpression(f : System.Linq.Expressions.Expression<System.Func<FunActor<'Message, 'v>>>) = f
         static member ToExpression<'Actor>(f : Quotations.Expr<(unit -> 'Actor)>) = toExpression<'Actor> (QuotationEvaluator.ToLinqExpression f)  
         
 [<RequireQualifiedAccess>]


### PR DESCRIPTION
Possible fix for #3403 

This adds fsharp tests to the build and fixes two failing tests. I'm not entirely sure about the full context around changing the ToExpression overload however. 
