### PR TITLE
Unit test Akka.FSharp.System.create with extensions

### DIFF
--- a/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
+++ b/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <Content Include="App.config" />
+    <ProjectReference Include="..\..\contrib\cluster\Akka.Cluster.Tools\Akka.Cluster.Tools.csproj" />
     <ProjectReference Include="..\Akka.FSharp\Akka.FSharp.fsproj" />
     <ProjectReference Include="..\Akka.TestKit\Akka.TestKit.csproj" />
     <ProjectReference Include="..\Akka.Remote\Akka.Remote.csproj" />

--- a/src/core/Akka.FSharp.Tests/InfrastructureTests.fs
+++ b/src/core/Akka.FSharp.Tests/InfrastructureTests.fs
@@ -34,3 +34,14 @@ let ``IActorRef should be possible to use as a Key`` () =
         let aref = spawn system "UnitActor" (actorOf2 getWhateverHandler)
         Set.empty.Add(aref).Count 
         |> equals 1
+
+[<Fact>]
+let ``System.create should support extensions`` () =
+    let extensionConfig = 
+        """
+            akka.actor.provider = cluster
+            akka.extensions = ["Akka.Cluster.Tools.Client.ClusterClientReceptionistExtensionProvider, Akka.Cluster.Tools"]
+        """
+        |> Configuration.parse
+    let system = System.create "my-system" extensionConfig
+    system |> (isNull >> not)


### PR DESCRIPTION
Add a unit test to demonstrate a bug with Akka.FSharp.System.create when creating with a configuration that has akka.extensions specified.