### PR TITLE
InboxActor: EnqueueQuery and other methods should be private. Rewrite Receive #265

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,44 @@
-#### 1.3.6 February 26 2018 ####
-Placeholder for nightlies
+#### 1.3.6 April 17 2018 ####
+**Maintenance Release for Akka.NET 1.3**
+
+Akka.NET v1.3.6 is a minor patch consisting mostly of bug fixes.
+
+**Akka.FSharp on .NET Standard**
+The biggest change in this release is [the availability of Akka.FSharp on .NET Standard and .NET Core](https://github.com/akkadotnet/akka.net/issues/2826)!
+
+Akka.FSharp runs on .NET Standard 2.0 as of 1.3.6 (it doesn't support .NET Standard 1.6 like the rest of Akka.NET due to FSharp-specific, downstream dependencies.)
+
+**Updates and Additions**
+1. [Akka.Streams: Port 4 "streams contrib" stages - AccumulateWhileUnchanged, LastElement, PartitionWith, Sample](https://github.com/akkadotnet/akka.net/pull/3375)
+2. [Akka.Remote: Add `public-port` setting to allow for port aliasing inside environments like Docker, PCF](https://github.com/akkadotnet/akka.net/issues/3357)
+
+**Bugfixes**
+1. [Akka.Cluster.Sharding: Removing string.GetHashCode usage from distributed classes](https://github.com/akkadotnet/akka.net/pull/3363)
+2. [Akka.Cluster.Sharding: HashCodeMessageExtractor can create inconsistent ShardId's](https://github.com/akkadotnet/akka.net/issues/3361)
+3. [Akka.Remote: 
+Error while decoding incoming Akka PDU Exception when communicating between Remote Actors with a large number of messages on Linux](https://github.com/akkadotnet/akka.net/issues/3370)
+4. [Akka.Cluster.Sharding: DData: Cannot create a shard proxy on a cluster node that is not in the same role as the proxied shard entity](https://github.com/akkadotnet/akka.net/issues/3352)
+5. [Akka.Streams: Fix GroupedWithin allocation of new buffer after emit.](https://github.com/akkadotnet/akka.net/pull/3382)
+6. [Akka.Persistence: Add missing ReturnRecoveryPermit](https://github.com/akkadotnet/akka.net/pull/3372)
+
+You can see [the full set of changes for Akka.NET v1.3.6 here](hhttps://github.com/akkadotnet/akka.net/milestone/24).
+
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 7 | 261 | 38 | Aaron Stannard |
+| 6 | 28 | 28 | cimryan |
+| 5 | 53 | 20 | Tomasz Jaskula |
+| 2 | 7 | 4 | Ondrej Pialek |
+| 2 | 20 | 10 | Ismael Hamed |
+| 1 | 739 | 0 | Oleksandr Bogomaz |
+| 1 | 64 | 6 | Robert |
+| 1 | 23 | 29 | nathvi |
+| 1 | 2 | 1 | Sebastien Bacquet |
+| 1 | 1 | 2 | OndÅej PiÃ¡lek |
+| 1 | 1 | 1 | Steffen Skov |
+| 1 | 1 | 1 | Sean Gilliam |
+| 1 | 1 | 1 | Matthew Herman |
+| 1 | 1 | 1 | Jan Pluskal |
 
 #### 1.3.5 February 21 2018 ####
 **Maintenance Release for Akka.NET 1.3**

--- a/build.fsx
+++ b/build.fsx
@@ -300,10 +300,10 @@ let overrideVersionSuffix (project:string) =
     | _ -> versionSuffix
 
 Target "CreateNuget" (fun _ ->    
-    let projects = !! "src/**/*.csproj"
-                   -- "src/**/*.Tests*.csproj"
-                   -- "src/benchmark/**/*.csproj"
-                   -- "src/examples/**/*.csproj"
+    let projects = !! "src/**/*.*sproj"
+                   -- "src/**/*.Tests*.*sproj"
+                   -- "src/benchmark/**/*.*sproj"
+                   -- "src/examples/**/*.*sproj"
                    -- "src/**/*.MultiNodeTestRunner.csproj"
                    -- "src/**/*.MultiNodeTestRunner.Shared.csproj"
                    -- "src/**/*.NodeTestRunner.csproj"

--- a/src/common.props
+++ b/src/common.props
@@ -17,6 +17,38 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Placeholder for nightlies</PackageReleaseNotes>
+    <PackageReleaseNotes>Maintenance Release for Akka.NET 1.3**
+Akka.NET v1.3.6 is a minor patch consisting mostly of bug fixes.
+Akka.FSharp on .NET Standard**
+The biggest change in this release is [the availability of Akka.FSharp on .NET Standard and .NET Core](https://github.com/akkadotnet/akka.net/issues/2826)!
+Akka.FSharp runs on .NET Standard 2.0 as of 1.3.6 (it doesn't support .NET Standard 1.6 like the rest of Akka.NET due to FSharp-specific, downstream dependencies.)
+Updates and Additions**
+1. [Akka.Streams: Port 4 "streams contrib" stages - AccumulateWhileUnchanged, LastElement, PartitionWith, Sample](https://github.com/akkadotnet/akka.net/pull/3375)
+2. [Akka.Remote: Add `public-port` setting to allow for port aliasing inside environments like Docker, PCF](https://github.com/akkadotnet/akka.net/issues/3357)
+Bugfixes**
+1. [Akka.Cluster.Sharding: Removing string.GetHashCode usage from distributed classes](https://github.com/akkadotnet/akka.net/pull/3363)
+2. [Akka.Cluster.Sharding: HashCodeMessageExtractor can create inconsistent ShardId's](https://github.com/akkadotnet/akka.net/issues/3361)
+3. [Akka.Remote:
+Error while decoding incoming Akka PDU Exception when communicating between Remote Actors with a large number of messages on Linux](https://github.com/akkadotnet/akka.net/issues/3370)
+4. [Akka.Cluster.Sharding: DData: Cannot create a shard proxy on a cluster node that is not in the same role as the proxied shard entity](https://github.com/akkadotnet/akka.net/issues/3352)
+5. [Akka.Streams: Fix GroupedWithin allocation of new buffer after emit.](https://github.com/akkadotnet/akka.net/pull/3382)
+6. [Akka.Persistence: Add missing ReturnRecoveryPermit](https://github.com/akkadotnet/akka.net/pull/3372)
+You can see [the full set of changes for Akka.NET v1.3.6 here](hhttps://github.com/akkadotnet/akka.net/milestone/24).
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 7 | 261 | 38 | Aaron Stannard |
+| 6 | 28 | 28 | cimryan |
+| 5 | 53 | 20 | Tomasz Jaskula |
+| 2 | 7 | 4 | Ondrej Pialek |
+| 2 | 20 | 10 | Ismael Hamed |
+| 1 | 739 | 0 | Oleksandr Bogomaz |
+| 1 | 64 | 6 | Robert |
+| 1 | 23 | 29 | nathvi |
+| 1 | 2 | 1 | Sebastien Bacquet |
+| 1 | 1 | 2 | OndÅej PiÃ¡lek |
+| 1 | 1 | 1 | Steffen Skov |
+| 1 | 1 | 1 | Sean Gilliam |
+| 1 | 1 | 1 | Matthew Herman |
+| 1 | 1 | 1 | Jan Pluskal |</PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -883,7 +883,8 @@ namespace Akka.Actor
         public static System.Threading.Tasks.Task<object> Ask(this Akka.Actor.ICanTell self, object message, System.Nullable<System.TimeSpan> timeout, System.Threading.CancellationToken cancellationToken) { }
         public static System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, object message, System.Nullable<System.TimeSpan> timeout = null) { }
         public static System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, object message, System.Threading.CancellationToken cancellationToken) { }
-        public static async System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, object message, System.Nullable<System.TimeSpan> timeout, System.Threading.CancellationToken cancellationToken) { }
+        public static System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, object message, System.Nullable<System.TimeSpan> timeout, System.Threading.CancellationToken cancellationToken) { }
+        public static async System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, System.Func<Akka.Actor.IActorRef, object> messageFactory, System.Nullable<System.TimeSpan> timeout, System.Threading.CancellationToken cancellationToken) { }
     }
     public class static GracefulStopSupport
     {

--- a/src/core/Akka.Remote/Akka.Remote.csproj
+++ b/src/core/Akka.Remote/Akka.Remote.csproj
@@ -13,7 +13,7 @@
     <ProjectReference Include="..\Akka\Akka.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DotNetty.Handlers" Version="0.4.6" />
+    <PackageReference Include="DotNetty.Handlers" Version="[0.4.6]" />
     <PackageReference Include="Google.Protobuf" Version="3.3.0" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/src/core/Akka.Tests/Actor/AskSpec.cs
+++ b/src/core/Akka.Tests/Actor/AskSpec.cs
@@ -11,6 +11,7 @@ using Akka.Actor;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Akka.Util.Internal;
 using Nito.AsyncEx;
 
 namespace Akka.Tests.Actor
@@ -69,6 +70,23 @@ namespace Akka.Tests.Actor
                     Sender.Tell("bar");
                 }
             }
+        }
+
+        public class ReplyToActor : UntypedActor
+        {
+            protected override void OnReceive(object message)
+            {
+                var requester = message.AsInstanceOf<IActorRef>();
+                requester.Tell("i_hear_ya");
+            }
+        }
+
+        [Fact]
+        public async Task Can_Ask_Response_actor()
+        {
+            var actor = Sys.ActorOf<ReplyToActor>();
+            var res = await actor.Ask<string>( sender => sender, null, CancellationToken.None);
+            res.ShouldBe("i_hear_ya");
         }
 
         [Fact]

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -100,7 +100,24 @@ namespace Akka.Actor
         /// This exception is thrown if the system can't resolve the target provider.
         /// </exception>
         /// <returns>TBD</returns>
-        public static async Task<T> Ask<T>(this ICanTell self, object message, TimeSpan? timeout, CancellationToken cancellationToken)
+        public static Task<T> Ask<T>(this ICanTell self, object message, TimeSpan? timeout, CancellationToken cancellationToken)
+        {
+            return Ask<T>(self, _ => message, timeout, cancellationToken);
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <typeparam name="T">TBD</typeparam>
+        /// <param name="self">TBD</param>
+        /// <param name="messageFactory">Factory method that creates a message that can encapsulate the 'Sender' IActorRef</param>
+        /// <param name="timeout">TBD</param>
+        /// <param name="cancellationToken">TBD</param>
+        /// <exception cref="ArgumentException">
+        /// This exception is thrown if the system can't resolve the target provider.
+        /// </exception>
+        /// <returns>TBD</returns>
+        public static async Task<T> Ask<T>(this ICanTell self, Func<IActorRef,object> messageFactory, TimeSpan? timeout, CancellationToken cancellationToken)
         {
             await SynchronizationContextManager.RemoveContext;
 
@@ -108,7 +125,7 @@ namespace Akka.Actor
             if (provider == null)
                 throw new ArgumentException("Unable to resolve the target Provider", nameof(self));
 
-            return (T) await Ask(self, message, provider, timeout, cancellationToken);
+            return (T)await Ask(self, messageFactory, provider, timeout, cancellationToken);
         }
 
         /// <summary>
@@ -134,7 +151,7 @@ namespace Akka.Actor
         private static readonly bool isRunContinuationsAsynchronouslyAvailable = Enum.IsDefined(typeof(TaskCreationOptions), RunContinuationsAsynchronously);
 
 
-        private static async Task<object> Ask(ICanTell self, object message, IActorRefProvider provider,
+        private static async Task<object> Ask(ICanTell self, Func<IActorRef, object> messageFactory, IActorRefProvider provider,
             TimeSpan? timeout, CancellationToken cancellationToken)
         {
             TaskCompletionSource<object> result;
@@ -174,6 +191,7 @@ namespace Akka.Actor
             var future = new FutureActorRef(result, () => { }, path, isRunContinuationsAsynchronouslyAvailable);
             //The future actor needs to be registered in the temp container
             provider.RegisterTempActor(future, path);
+            var message = messageFactory(future);
             self.Tell(message, future);
 
             try


### PR DESCRIPTION
I updated the Inbox.Actor.cs to have all public methods be private and I rewrote the receive class so that it is using and if else statements with is instead of a switch statement.