### PR TITLE
Add explicit reference to FSharp.Core

### DIFF
--- a/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
+++ b/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="4.2.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />

--- a/src/core/Akka.FSharp/Akka.FSharp.fsproj
+++ b/src/core/Akka.FSharp/Akka.FSharp.fsproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <PackageReference Include="FSharp.Quotations.Evaluator" Version="1.1.2" />
     <PackageReference Include="FsPickler" Version="5.2.0" />
+    <PackageReference Include="FSharp.Core" Version="4.2.3" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/core/Akka.Persistence.FSharp/Akka.Persistence.FSharp.fsproj
+++ b/src/core/Akka.Persistence.FSharp/Akka.Persistence.FSharp.fsproj
@@ -18,6 +18,9 @@
     <ProjectReference Include="..\Akka.Persistence\Akka.Persistence.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="4.2.3"/>
+  </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
Makes the reference to FSharp.Core explicit which should avoid problems with build tool version mismatches and matches the recommendations at

https://fsharp.github.io/2015/04/18/fsharp-core-notes.html

Have used version 4.2.3

> As of February 2018 new editions of F# libraries should generally do the following:
> Be netstandard1.6, or netstandard2.0 with an additional .NET Framework 4.5 (net45) build
> Use FSharp.Core nuget 4.2.3 (assembly version 4.4.1.0) or 4.3.3 (assembly version 4.4.3.0)  