### PR TITLE
Minor fix to the Persistence Query sample code

### DIFF
--- a/docs/articles/persistence/persistence-query.md
+++ b/docs/articles/persistence/persistence-query.md
@@ -253,7 +253,7 @@ public class ExampleStore
 {
     public Task<object> Save(object evt)
     {
-        return Task.FromResult(default(object));
+        return Task.FromResult(evt);
     }
 }
 ```


### PR DESCRIPTION
Currently the code returns NULL which is not only not allowed but will silently fail if the faulted Task is not dealt with --and will probably confuse people, not just me :)

Let's instead return the actual event to keep the flow going.

