### PR TITLE
verified that wildcard ActorSelections actually do get delivered to deadletters when there's no matching recipient

### DIFF
--- a/src/core/Akka.Tests/Actor/ActorSelectionSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorSelectionSpec.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Akka.Actor;
 using Akka.Actor.Internal;
+using Akka.Actor.Dsl;
 using Akka.Event;
 using Akka.TestKit;
 using Akka.Util.Internal;
@@ -36,9 +37,9 @@ namespace Akka.Tests.Actor
             _c2 = Sys.ActorOf(Props, "c2");
             _c21 = _c2.Ask<IActorRef>(new Create("c21")).Result;
 
-            _all = new[] {_c1, _c2, _c21};
+            _all = new[] { _c1, _c2, _c21 };
         }
-        
+
         private ActorSystemImpl SystemImpl => Sys as ActorSystemImpl;
         private IInternalActorRef User => SystemImpl.Guardian;
         private IInternalActorRef System => SystemImpl.SystemGuardian;
@@ -76,7 +77,7 @@ namespace Akka.Tests.Actor
             var actorRef = result as IActorRef;
             if (actorRef != null)
                 return actorRef;
-            
+
             var selection = result as ActorSelection;
             return selection != null ? Identify(selection) : null;
         }
@@ -228,12 +229,12 @@ namespace Akka.Tests.Actor
                 AskNode(looker, new SelectString(elements.Join("/") + "/")).ShouldBe(result);
             };
 
-            check(_c1, User, new[] {".."});
+            check(_c1, User, new[] { ".." });
 
-            foreach (var l in new [] {_c1, _c2})
+            foreach (var l in new[] { _c1, _c2 })
                 foreach (var r in _all)
                 {
-                    var elements = new List<string> {".."};
+                    var elements = new List<string> { ".." };
                     elements.AddRange(r.Path.Elements.Drop(1));
                     check(l, r, elements.ToArray());
                 }
@@ -254,7 +255,7 @@ namespace Akka.Tests.Actor
                     AskNode(looker, new SelectString(target.Path.ToString())).ShouldBe(target);
                     AskNode(looker, new SelectString(target.Path.ToString() + "/")).ShouldBe(target);
                 }
-                if(!Equals(target, Root))
+                if (!Equals(target, Root))
                     AskNode(_c1, new SelectString("../../" + target.Path.Elements.Join("/") + "/")).ShouldBe(target);
             };
 
@@ -315,8 +316,8 @@ namespace Akka.Tests.Actor
         {
             new ActorSelection(_c21, "../../*").Tell(new GetSender(TestActor), _c1);
             //Three messages because the selection includes the TestActor, GetSender -> TestActor + response from c1 and c2 to TestActor
-            var actors = ReceiveWhile(_ => LastSender, msgs:3).Distinct();
-            actors.ShouldAllBeEquivalentTo(new[] {_c1, _c2});
+            var actors = ReceiveWhile(_ => LastSender, msgs: 3).Distinct();
+            actors.ShouldAllBeEquivalentTo(new[] { _c1, _c2 });
             ExpectNoMsg(TimeSpan.FromSeconds(1));
         }
 
@@ -324,8 +325,8 @@ namespace Akka.Tests.Actor
         public void An_ActorSelection_must_drop_messages_which_cannot_be_delivered()
         {
             new ActorSelection(_c21, "../../*/c21").Tell(new GetSender(TestActor), _c2);
-            
-            var actors = ReceiveWhile(_ => LastSender, msgs : 2).Distinct();
+
+            var actors = ReceiveWhile(_ => LastSender, msgs: 2).Distinct();
             actors.Should().HaveCount(1).And.Subject.First().ShouldBe(_c21);
             ExpectNoMsg(TimeSpan.FromSeconds(1));
 
@@ -344,11 +345,11 @@ namespace Akka.Tests.Actor
             var task = Sys.ActorSelection("user/none").ResolveOne(Dilated(TimeSpan.FromSeconds(1)));
             task.Invoking(t => t.Wait()).ShouldThrow<ActorNotFoundException>();
         }
-        
+
         [Fact]
         public void An_ActorSelection_must_compare_equally()
         {
-            new ActorSelection(_c21,"../*/hello").ShouldBe(new ActorSelection(_c21, "../*/hello"));
+            new ActorSelection(_c21, "../*/hello").ShouldBe(new ActorSelection(_c21, "../*/hello"));
             new ActorSelection(_c21, "../*/hello").GetHashCode().ShouldBe(new ActorSelection(_c21, "../*/hello").GetHashCode());
             new ActorSelection(_c2, "../*/hello").ShouldNotBe(new ActorSelection(_c21, "../*/hello"));
             new ActorSelection(_c2, "../*/hello").GetHashCode().ShouldNotBe(new ActorSelection(_c21, "../*/hello").GetHashCode());
@@ -381,6 +382,30 @@ namespace Akka.Tests.Actor
             d.Recipient.Path.ToStringWithoutAddress().ShouldBe("/user/missing");
         }
 
+        [Theory]
+        [InlineData("/user/foo/*/bar")]
+        [InlineData("/user/foo/bar/*")]
+        public void Bugfix3420_A_wilcard_ActorSelection_that_selects_no_actors_must_go_to_DeadLetters(string actorPathStr)
+        {
+            var actorA = Sys.ActorOf(act =>
+            {
+                act.ReceiveAny((o, context) =>
+                {
+                    context.ActorSelection(actorPathStr).Tell(o);
+                });
+            }, "a");
+
+            Sys.EventStream.Subscribe(TestActor, typeof(DeadLetter));
+
+            // deliver two ActorSelections - one from outside any actors, one from inside
+            // they have different anchors to start with, so the results may differ
+            Sys.ActorSelection(actorPathStr).Tell("foo");
+            ExpectMsg<DeadLetter>().Message.Should().Be("foo");
+
+            actorA.Tell("foo");
+            ExpectMsg<DeadLetter>().Message.Should().Be("foo");
+        }
+
         [Fact]
         public void An_ActorSelection_must_identify_actors_with_wildcard_selection_correctly()
         {
@@ -396,7 +421,7 @@ namespace Akka.Tests.Actor
             probe.ReceiveN(2)
                 .Cast<ActorIdentity>()
                 .Select(i => i.Subject)
-                .ShouldAllBeEquivalentTo(new[] {b1, b2});
+                .ShouldAllBeEquivalentTo(new[] { b1, b2 });
             probe.ExpectNoMsg(TimeSpan.FromMilliseconds(200));
 
             Sys.ActorSelection("/user/a/b1/*").Tell(new Identify(2), probe.Ref);
@@ -502,7 +527,7 @@ namespace Akka.Tests.Actor
                 Receive<SelectPath>(s => Sender.Tell(Context.ActorSelection(s.Path)));
                 Receive<GetSender>(g => g.To.Tell(Sender));
                 Receive<Forward>(f => Context.ActorSelection(f.Path).Tell(f.Message, Sender));
-                ReceiveAny(msg=>Sender.Tell(msg));
+                ReceiveAny(msg => Sender.Tell(msg));
             }
         }
 


### PR DESCRIPTION
close #3420 

No actual bug here. Checked my reproduction in our external app too and... apparently it's fixed there as well. 