### PR TITLE
just block until lock is available inside BlockingQueue

### DIFF
--- a/src/core/Akka/Dispatch/MessageQueues/BlockingMessageQueue.cs
+++ b/src/core/Akka/Dispatch/MessageQueues/BlockingMessageQueue.cs
@@ -47,14 +47,9 @@ namespace Akka.Dispatch.MessageQueues
         {
             get
             {
-                Monitor.TryEnter(_lock, BlockTimeOut);
-                try
+                lock (_lock)
                 {
                     return LockedCount;
-                }
-                finally
-                {
-                    Monitor.Exit(_lock);
                 }
             }
         }
@@ -66,14 +61,9 @@ namespace Akka.Dispatch.MessageQueues
         /// <param name="envelope">TBD</param>
         public void Enqueue(IActorRef receiver, Envelope envelope)
         {
-            Monitor.TryEnter(_lock, BlockTimeOut);
-            try
+            lock (_lock)
             {
                 LockedEnqueue(envelope);
-            }
-            finally
-            {
-                Monitor.Exit(_lock);
             }
         }
 
@@ -84,14 +74,9 @@ namespace Akka.Dispatch.MessageQueues
         /// <returns>TBD</returns>
         public bool TryDequeue(out Envelope envelope)
         {
-            Monitor.TryEnter(_lock, BlockTimeOut);
-            try
+            lock (_lock)
             {
                 return LockedTryDequeue(out envelope);
-            }
-            finally
-            {
-                Monitor.Exit(_lock);
             }
         }
 


### PR DESCRIPTION
close #3459 

I don't see a point in waiting for the timeout - what are we supposed to do? Not deliver the message? Just block indefinitely until the lock is available.