### PR TITLE
Syntactic sugar to make the "create if not exist" pattern more idiomatic

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
@@ -172,10 +172,9 @@ namespace Akka.Cluster.Sharding
                     var encName = Uri.EscapeDataString(start.TypeName);
                     var coordinatorSingletonManagerName = CoordinatorSingletonManagerName(encName);
                     var coordinatorPath = CoordinatorPath(encName);
-                    var shardRegion = Context.Child(encName);
                     var replicator = Replicator(settings);
 
-                    if (Equals(shardRegion, ActorRefs.Nobody))
+                    var shardRegion = Context.Child(encName).GetOrElse(() =>
                     {
                         if (Equals(Context.Child(coordinatorSingletonManagerName), ActorRefs.Nobody))
                         {
@@ -189,7 +188,7 @@ namespace Akka.Cluster.Sharding
                             var singletonSettings = settings.CoordinatorSingletonSettings.WithSingletonName("singleton").WithRole(settings.Role);
                             Context.ActorOf(ClusterSingletonManager.Props(singletonProps, PoisonPill.Instance, singletonSettings).WithDispatcher(Context.Props.Dispatcher), coordinatorSingletonManagerName);
                         }
-                        shardRegion = Context.ActorOf(ShardRegion.Props(
+                        return Context.ActorOf(ShardRegion.Props(
                             typeName: start.TypeName,
                             entityProps: start.EntityProps,
                             settings: settings,
@@ -199,7 +198,7 @@ namespace Akka.Cluster.Sharding
                             handOffStopMessage: start.HandOffStopMessage,
                             replicator: replicator,
                             majorityMinCap: _majorityMinCap).WithDispatcher(Context.Props.Dispatcher), encName);
-                    }
+                    });
 
                     Sender.Tell(new Started(shardRegion));
                 }
@@ -220,20 +219,14 @@ namespace Akka.Cluster.Sharding
                     var settings = startProxy.Settings;
                     var encName = Uri.EscapeDataString(startProxy.TypeName + "Proxy");
                     var coordinatorPath = CoordinatorPath(Uri.EscapeDataString(startProxy.TypeName));
-                    var shardRegion = Context.Child(encName);
-
-                    if (Equals(shardRegion, ActorRefs.Nobody))
-                    {
-
-                        shardRegion = Context.ActorOf(ShardRegion.ProxyProps(
-                            typeName: startProxy.TypeName,
-                            settings: settings,
-                            coordinatorPath: coordinatorPath,
-                            extractEntityId: startProxy.ExtractEntityId,
-                            extractShardId: startProxy.ExtractShardId,
-                            replicator: Context.System.DeadLetters,
-                            majorityMinCap: _majorityMinCap).WithDispatcher(Context.Props.Dispatcher), encName);
-                    }
+                    var shardRegion = Context.Child(encName).GetOrElse(() => Context.ActorOf(ShardRegion.ProxyProps(
+                        typeName: startProxy.TypeName,
+                        settings: settings,
+                        coordinatorPath: coordinatorPath,
+                        extractEntityId: startProxy.ExtractEntityId,
+                        extractShardId: startProxy.ExtractShardId,
+                        replicator: Context.System.DeadLetters,
+                        majorityMinCap: _majorityMinCap).WithDispatcher(Context.Props.Dispatcher), encName));
 
                     Sender.Tell(new Started(shardRegion));
                 }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -262,6 +262,7 @@ namespace Akka.Actor
     }
     public class static ActorRefExtensions
     {
+        public static Akka.Actor.IActorRef GetOrElse(this Akka.Actor.IActorRef actorRef, System.Func<Akka.Actor.IActorRef> elseValue) { }
         public static bool IsNobody(this Akka.Actor.IActorRef actorRef) { }
     }
     public class static ActorRefFactoryExtensions

--- a/src/core/Akka/Actor/ActorRef.Extensions.cs
+++ b/src/core/Akka/Actor/ActorRef.Extensions.cs
@@ -5,6 +5,8 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
+
 namespace Akka.Actor
 {
     /// <summary>
@@ -22,6 +24,17 @@ namespace Akka.Actor
         public static bool IsNobody(this IActorRef actorRef)
         {
             return actorRef == null || actorRef is Nobody || actorRef is DeadLetterActorRef;
+        }
+
+        /// <summary>
+        /// Returns the <paramref name="actorRef"/>'s value if it's not <see langword="null"/>, <see cref="Nobody"/>, 
+        /// or <see cref="DeadLetterActorRef"/>. Otherwise return the result of evaluating `elseValue`.
+        /// </summary>
+        /// <param name="actorRef">The actor that is being tested.</param>
+        /// <param name="elseValue">TBD</param>
+        public static IActorRef GetOrElse(this IActorRef actorRef, Func<IActorRef> elseValue)
+        {
+            return actorRef.IsNobody() ? elseValue() : actorRef;
         }
     }
 }


### PR DESCRIPTION
So we can now do something like this:
```
var child = Context.Child(actorName).GetOrElse(() => Context.ActorOf(...));
```
In the JVM this method is part of the OptionVal object, but I thought it made sense to it put along with the IsNobody extension method.


