### PR TITLE
Non-blocking task completion source helpers

### DIFF
--- a/src/core/Akka/Util/Internal/TaskEx.cs
+++ b/src/core/Akka/Util/Internal/TaskEx.cs
@@ -18,6 +18,55 @@ namespace Akka.Util.Internal
     /// </summary>
     internal static class TaskEx
     {
+        private const int RunContinuationsAsynchronously = 64;
+        public static readonly bool IsRunContinuationsAsynchronouslyAvailable = Enum.IsDefined(typeof(TaskCreationOptions), RunContinuationsAsynchronously);
+
+        /// <summary>
+        /// Creates a new <see cref="TaskCompletionSource{TResult}"/> which will run in asynchronous,
+        /// non-blocking fashion upon calling <see cref="TaskCompletionSource{TResult}.TrySetResult"/>.
+        ///
+        /// This behavior is not available on all supported versions of .NET framework, in this case it
+        /// should be used only together with <see cref="NonBlockingTrySetResult{T}"/> and
+        /// <see cref="NonBlockingTrySetException{T}"/>.
+        /// </summary>
+        public static TaskCompletionSource<T> NonBlockingTaskCompletionSource<T>()
+        {
+            if (IsRunContinuationsAsynchronouslyAvailable)
+            {
+                return new TaskCompletionSource<T>((TaskCreationOptions)RunContinuationsAsynchronously);
+            }
+            else
+            {
+                return new TaskCompletionSource<T>();
+            }
+        }
+
+        /// <summary>
+        /// Tries to complete given <paramref name="taskCompletionSource"/> in asynchronous, non-blocking
+        /// fashion. For safety reasons, this method should be called only on tasks created via
+        /// <see cref="NonBlockingTaskCompletionSource{T}"/> method.
+        /// </summary>
+        public static void NonBlockingTrySetResult<T>(this TaskCompletionSource<T> taskCompletionSource, T value)
+        {
+            if (IsRunContinuationsAsynchronouslyAvailable)
+                taskCompletionSource.TrySetResult(value);
+            else
+                Task.Run(() => taskCompletionSource.TrySetResult(value));
+        }
+
+        /// <summary>
+        /// Tries to set <paramref name="exception"/> given <paramref name="taskCompletionSource"/>
+        /// in asynchronous, non-blocking fashion. For safety reasons, this method should be called only
+        /// on tasks created via <see cref="NonBlockingTaskCompletionSource{T}"/> method.
+        /// </summary>
+        public static void NonBlockingTrySetException<T>(this TaskCompletionSource<T> taskCompletionSource, Exception exception)
+        {
+            if (IsRunContinuationsAsynchronouslyAvailable)
+                taskCompletionSource.TrySetException(exception);
+            else
+                Task.Run(() => taskCompletionSource.TrySetException(exception));
+        }
+
         /// <summary>
         /// A completed task
         /// </summary>


### PR DESCRIPTION
Fixes #3498 but we need to find a better way to address those issues. Potentially moving to netstandard 2+ compatibility (where async task completion source flags are available by default).