### PR TITLE
fix concurrency bug in CircuitBreaker

### DIFF
--- a/src/core/Akka/Pattern/CircuitBreaker.cs
+++ b/src/core/Akka/Pattern/CircuitBreaker.cs
@@ -15,29 +15,29 @@ using Akka.Util.Internal;
 namespace Akka.Pattern
 {
     /// <summary>
-    /// Provides circuit breaker functionality to provide stability when working with 
+    /// Provides circuit breaker functionality to provide stability when working with
     /// "dangerous" operations, e.g. calls to remote systems
-    /// 
+    ///
     ///<list type="bullet">
     ///<listheader>
     ///    <description>Transitions through three states:</description>
     ///</listheader>
     ///<item>
     ///    <term>In *Closed* state, </term>
-    ///    <description>calls pass through until the maxFailures count is reached. 
-    ///         This causes the circuit breaker to open. Both exceptions and calls exceeding 
+    ///    <description>calls pass through until the maxFailures count is reached.
+    ///         This causes the circuit breaker to open. Both exceptions and calls exceeding
     ///         callTimeout are considered failures.</description>
     ///</item>
     ///<item>
     ///    <term>In *Open* state, </term>
-    ///    <description>calls fail-fast with an exception. After resetTimeout, 
+    ///    <description>calls fail-fast with an exception. After resetTimeout,
     ///         circuit breaker transitions to half-open state.</description>
     ///</item>
     ///<item>
     ///    <term>In *Half-Open* state, </term>
-    ///    <description>the first call will be allowed through, if it succeeds 
-    ///         the circuit breaker will reset to closed state. If it fails, the circuit 
-    ///         breaker will re-open to open state. All calls beyond the first that execute 
+    ///    <description>the first call will be allowed through, if it succeeds
+    ///         the circuit breaker will reset to closed state. If it fails, the circuit
+    ///         breaker will re-open to open state. All calls beyond the first that execute
     ///         while the first is running will fail-fast with an exception.</description>
     ///</item>
     ///</list>
@@ -173,7 +173,7 @@ namespace Akka.Pattern
         /// <summary>
         /// Wraps invocations of asynchronous calls that need to be protected
         /// If this does not complete within the time allotted, it should return default(<typeparamref name="T"/>)
-        /// 
+        ///
         /// <code>
         ///  Await.result(
         ///      withCircuitBreaker(try Future.successful(body) catch { case NonFatal(t) ⇒ Future.failed(t) }),
@@ -238,10 +238,7 @@ namespace Akka.Pattern
                 Debug.WriteLine("Successful transition from {0} to {1}", fromState, toState);
                 toState.Enter();
             }
-            else
-            {
-                throw new IllegalStateException($"Illegal transition attempted from {fromState} to {toState}");
-            }
+            // else some other thread already swapped state
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes concurrency issue in CircuitBreaker
Migrated from: https://github.com/akka/akka/issues/17415

Didn't include the CircuitBreakerStressSpec, because I was not able to reproduce the issue with it

