### PR TITLE
Sharding - RestartShard escapes into userspace

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
@@ -450,6 +450,8 @@ namespace Akka.Cluster.Sharding
                 case Shard.IShardQuery sq:
                     shard.HandleShardRegionQuery(sq);
                     return true;
+                case ShardRegion.RestartShard _:
+                    return true;
                 case var _ when shard.ExtractEntityId(message) != null:
                     shard.DeliverMessage(message, shard.Context.Sender);
                     return true;


### PR DESCRIPTION
there is a possibility that the `ShardRegion.RestartShard` message escapes into userspace. This can cause issues in custom `ExtractEntityId` implementations.

This can happen, when the `RestartShard` message gets into ShardBuffers here: https://github.com/akkadotnet/akka.net/blob/d732274b0fa9cb6863fabbdf9d1d2c447d61d6f3/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs#L560
and later is send to `Shard`