### PR TITLE
sharding rebalance small fix

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardCoordinator.cs
@@ -223,7 +223,6 @@ namespace Akka.Cluster.Sharding
 
         private static void HandleRebalanceDone<TCoordinator>(this TCoordinator coordinator, string shard, bool ok) where TCoordinator : IShardCoordinator
         {
-            coordinator.RebalanceInProgress = coordinator.RebalanceInProgress.Remove(shard);
             coordinator.Log.Debug("Rebalance shard [{0}] done [{1}]", shard, ok);
 
             // The shard could have been removed by ShardRegionTerminated


### PR DESCRIPTION
`RebalanceInProgress` removal is handled in `ClearRebalanceInProgress`, should not be here.
Also checked against akka, also doesn't have it