### PR TITLE
[v1.4] Add exception overloads to all logging methods

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -2811,10 +2811,13 @@ namespace Akka.Event
         public override bool IsInfoEnabled { get; }
         public override bool IsWarningEnabled { get; }
         protected override void NotifyDebug(object message) { }
+        protected override void NotifyDebug(System.Exception cause, object message) { }
         protected override void NotifyError(object message) { }
         protected override void NotifyError(System.Exception cause, object message) { }
         protected override void NotifyInfo(object message) { }
+        protected override void NotifyInfo(System.Exception cause, object message) { }
         protected override void NotifyWarning(object message) { }
+        protected override void NotifyWarning(System.Exception cause, object message) { }
     }
     public sealed class DeadLetter : Akka.Event.AllDeadLetters
     {
@@ -2831,6 +2834,7 @@ namespace Akka.Event
     public class Debug : Akka.Event.LogEvent
     {
         public Debug(string logSource, System.Type logClass, object message) { }
+        public Debug(System.Exception cause, string logSource, System.Type logClass, object message) { }
         public override Akka.Event.LogLevel LogLevel() { }
     }
     public class DefaultLogger : Akka.Actor.ActorBase, Akka.Dispatch.IRequiresMessageQueue<Akka.Event.ILoggerMessageQueueSemantics>
@@ -2851,9 +2855,7 @@ namespace Akka.Event
     public class Error : Akka.Event.LogEvent
     {
         public Error(System.Exception cause, string logSource, System.Type logClass, object message) { }
-        public System.Exception Cause { get; }
         public override Akka.Event.LogLevel LogLevel() { }
-        public override string ToString() { }
     }
     public abstract class EventBus<TEvent, TClassifier, TSubscriber>
     {
@@ -2892,12 +2894,16 @@ namespace Akka.Event
         bool IsInfoEnabled { get; }
         bool IsWarningEnabled { get; }
         void Debug(string format, params object[] args);
+        void Debug(System.Exception cause, string format, params object[] args);
         void Error(string format, params object[] args);
         void Error(System.Exception cause, string format, params object[] args);
         void Info(string format, params object[] args);
+        void Info(System.Exception cause, string format, params object[] args);
         bool IsEnabled(Akka.Event.LogLevel logLevel);
         void Log(Akka.Event.LogLevel logLevel, string format, params object[] args);
+        void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format, params object[] args);
         void Warning(string format, params object[] args);
+        void Warning(System.Exception cause, string format, params object[] args);
     }
     public interface ILogMessageFormatter
     {
@@ -2906,6 +2912,7 @@ namespace Akka.Event
     public class Info : Akka.Event.LogEvent
     {
         public Info(string logSource, System.Type logClass, object message) { }
+        public Info(System.Exception cause, string logSource, System.Type logClass, object message) { }
         public override Akka.Event.LogLevel LogLevel() { }
     }
     public class InitializeLogger : Akka.Actor.INoSerializationVerificationNeeded
@@ -2916,6 +2923,7 @@ namespace Akka.Event
     public abstract class LogEvent : Akka.Actor.INoSerializationVerificationNeeded
     {
         protected LogEvent() { }
+        public System.Exception Cause { get; set; }
         public System.Type LogClass { get; set; }
         public string LogSource { get; set; }
         public object Message { get; set; }
@@ -2951,20 +2959,28 @@ namespace Akka.Event
         public abstract bool IsErrorEnabled { get; }
         public abstract bool IsInfoEnabled { get; }
         public abstract bool IsWarningEnabled { get; }
-        public void Debug(string format, params object[] args) { }
-        public void Error(System.Exception cause, string format, params object[] args) { }
-        public void Error(string format, params object[] args) { }
-        public void Info(string format, params object[] args) { }
+        public virtual void Debug(string format, params object[] args) { }
+        public virtual void Debug(System.Exception cause, string format, params object[] args) { }
+        public virtual void Error(System.Exception cause, string format, params object[] args) { }
+        public virtual void Error(string format, params object[] args) { }
+        public virtual void Info(System.Exception cause, string format, params object[] args) { }
+        public virtual void Info(string format, params object[] args) { }
         public bool IsEnabled(Akka.Event.LogLevel logLevel) { }
-        public void Log(Akka.Event.LogLevel logLevel, string format, params object[] args) { }
+        public virtual void Log(Akka.Event.LogLevel logLevel, string format, params object[] args) { }
+        public virtual void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format, params object[] args) { }
         protected abstract void NotifyDebug(object message);
+        protected abstract void NotifyDebug(System.Exception cause, object message);
         protected abstract void NotifyError(object message);
         protected abstract void NotifyError(System.Exception cause, object message);
         protected abstract void NotifyInfo(object message);
+        protected abstract void NotifyInfo(System.Exception cause, object message);
         protected void NotifyLog(Akka.Event.LogLevel logLevel, object message) { }
+        protected void NotifyLog(Akka.Event.LogLevel logLevel, System.Exception cause, object message) { }
         protected abstract void NotifyWarning(object message);
-        public void Warn(string format, params object[] args) { }
-        public void Warning(string format, params object[] args) { }
+        protected abstract void NotifyWarning(System.Exception cause, object message);
+        public virtual void Warn(string format, params object[] args) { }
+        public virtual void Warning(string format, params object[] args) { }
+        public virtual void Warning(System.Exception cause, string format, params object[] args) { }
     }
     public class LoggingBus : Akka.Event.ActorEventBus<object, System.Type>
     {
@@ -2999,13 +3015,17 @@ namespace Akka.Event
         public bool IsInfoEnabled { get; }
         public bool IsWarningEnabled { get; }
         public void Debug(string format, params object[] args) { }
+        public void Debug(System.Exception cause, string format, params object[] args) { }
         public void Error(string format, params object[] args) { }
         public void Error(System.Exception cause, string format, params object[] args) { }
         public void Info(string format, params object[] args) { }
+        public void Info(System.Exception cause, string format, params object[] args) { }
         public bool IsEnabled(Akka.Event.LogLevel logLevel) { }
         public void Log(Akka.Event.LogLevel logLevel, string format, params object[] args) { }
+        public void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format, params object[] args) { }
         public void Warn(string format, params object[] args) { }
         public void Warning(string format, params object[] args) { }
+        public void Warning(System.Exception cause, string format, params object[] args) { }
     }
     public class StandardOutLogger : Akka.Actor.MinimalActorRef
     {
@@ -3046,6 +3066,7 @@ namespace Akka.Event
     public class Warning : Akka.Event.LogEvent
     {
         public Warning(string logSource, System.Type logClass, object message) { }
+        public Warning(System.Exception cause, string logSource, System.Type logClass, object message) { }
         public override Akka.Event.LogLevel LogLevel() { }
     }
 }

--- a/src/core/Akka.Tests/Event/LoggerSpec.cs
+++ b/src/core/Akka.Tests/Event/LoggerSpec.cs
@@ -16,11 +16,75 @@ using Akka.Event;
 using Akka.TestKit;
 using Xunit;
 using Xunit.Abstractions;
+using FluentAssertions;
 
 namespace Akka.Tests.Event
 {
     public class LoggerSpec : AkkaSpec
     {
+        public static readonly Config Config = @"akka.loglevel = DEBUG";
+
+        public LoggerSpec(ITestOutputHelper helper) : base(Config, helper) { }
+
+        [Theory]
+        [InlineData(LogLevel.ErrorLevel, false, "foo", new object[] { })]
+        [InlineData(LogLevel.ErrorLevel, true, "foo", new object[] { })]
+        [InlineData(LogLevel.ErrorLevel, false, "foo {0}", new object[] { 1 })]
+        [InlineData(LogLevel.ErrorLevel, true, "foo {0}", new object[] { 1 })]
+        [InlineData(LogLevel.WarningLevel, false, "foo", new object[] { })]
+        [InlineData(LogLevel.WarningLevel, true, "foo", new object[] { })]
+        [InlineData(LogLevel.WarningLevel, false, "foo {0}", new object[] { 1 })]
+        [InlineData(LogLevel.WarningLevel, true, "foo {0}", new object[] { 1 })]
+        [InlineData(LogLevel.InfoLevel, false, "foo", new object[] { })]
+        [InlineData(LogLevel.InfoLevel, true, "foo", new object[] { })]
+        [InlineData(LogLevel.InfoLevel, false, "foo {0}", new object[] { 1 })]
+        [InlineData(LogLevel.InfoLevel, true, "foo {0}", new object[] { 1 })]
+        [InlineData(LogLevel.DebugLevel, false, "foo", new object[]{})]
+        [InlineData(LogLevel.DebugLevel, true, "foo", new object[] { })]
+        [InlineData(LogLevel.DebugLevel, false, "foo {0}", new object[] { 1 })]
+        [InlineData(LogLevel.DebugLevel, true, "foo {0}", new object[] { 1 })]
+        public void LoggingAdapter_should_log_all_information(LogLevel logLevel, bool includeException, string formatStr, object [] args)
+        {
+            Sys.EventStream.Subscribe(TestActor, typeof(LogEvent));
+            var msg = args != null ? string.Format(formatStr, args) : formatStr;
+            var ex = new Exception();
+            switch (logLevel)
+            {
+                case LogLevel.DebugLevel when includeException:
+                    Log.Debug(ex, formatStr, args);
+                    break;
+                case LogLevel.DebugLevel:
+                    Log.Debug(formatStr, args);
+                    break;
+                case LogLevel.InfoLevel when includeException:
+                    Log.Info(ex, formatStr, args);
+                    break;
+                case LogLevel.InfoLevel:
+                    Log.Info(formatStr, args);
+                    break;
+                case LogLevel.WarningLevel when includeException:
+                    Log.Warning(ex, formatStr, args);
+                    break;
+                case LogLevel.WarningLevel:
+                    Log.Warning(formatStr, args);
+                    break;
+                case LogLevel.ErrorLevel when includeException:
+                    Log.Error(ex, formatStr, args);
+                    break;
+                case LogLevel.ErrorLevel:
+                    Log.Error(formatStr, args);
+                    break;
+            }
+
+            var log = ExpectMsg<LogEvent>();
+            log.Message.ToString().Should().Be(msg);
+            log.LogLevel().Should().Be(logLevel);
+            if (includeException)
+                log.Cause.Should().Be(ex);
+            else
+                log.Cause.Should().BeNull();
+        }
+
         [Fact]
         public async Task LoggingBus_should_stop_all_loggers_on_termination()
         {
@@ -46,3 +110,4 @@ namespace Akka.Tests.Event
         }
     }
 }
+

--- a/src/core/Akka/Event/BusLogging.cs
+++ b/src/core/Akka/Event/BusLogging.cs
@@ -90,6 +90,11 @@ namespace Akka.Event
             _bus.Publish(new Warning(_logSource, _logClass, message));
         }
 
+        protected override void NotifyWarning(Exception cause, object message)
+        {
+            _bus.Publish(new Warning(cause, _logSource, _logClass, message));
+        }
+
         /// <summary>
         /// Publishes the info message onto the LoggingBus.
         /// </summary>
@@ -99,6 +104,11 @@ namespace Akka.Event
             _bus.Publish(new Info(_logSource, _logClass, message));
         }
 
+        protected override void NotifyInfo(Exception cause, object message)
+        {
+            _bus.Publish(new Info(cause, _logSource, _logClass, message));
+        }
+
         /// <summary>
         /// Publishes the debug message onto the LoggingBus.
         /// </summary>
@@ -106,6 +116,11 @@ namespace Akka.Event
         protected override void NotifyDebug(object message)
         {
             _bus.Publish(new Debug(_logSource, _logClass, message));
+        }
+
+        protected override void NotifyDebug(Exception cause, object message)
+        {
+            _bus.Publish(new Debug(cause, _logSource, _logClass, message));
         }
     }
 }

--- a/src/core/Akka/Event/Debug.cs
+++ b/src/core/Akka/Event/Debug.cs
@@ -20,11 +20,24 @@ namespace Akka.Event
         /// <param name="logSource">The source that generated the log event.</param>
         /// <param name="logClass">The type of logger used to log the event.</param>
         /// <param name="message">The message that is being logged.</param>
-        public Debug(string logSource, Type logClass, object message)
+        public Debug(string logSource, Type logClass, object message) 
+            : this(null, logSource, logClass, message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Debug" /> class.
+        /// </summary>
+        /// <param name="cause">The exception that generated the log event.</param>
+        /// <param name="logSource">The source that generated the log event.</param>
+        /// <param name="logClass">The type of logger used to log the event.</param>
+        /// <param name="message">The message that is being logged.</param>
+        public Debug(Exception cause, string logSource, Type logClass, object message)
         {
             LogSource = logSource;
             LogClass = logClass;
             Message = message;
+            Cause = cause;
         }
 
         /// <summary>

--- a/src/core/Akka/Event/Error.cs
+++ b/src/core/Akka/Event/Error.cs
@@ -30,31 +30,12 @@ namespace Akka.Event
         }
 
         /// <summary>
-        /// The exception that caused the log event.
-        /// </summary>
-        public Exception Cause { get; private set; }
-
-        /// <summary>
         /// Retrieves the <see cref="Akka.Event.LogLevel" /> used to classify this event.
         /// </summary>
         /// <returns>The <see cref="Akka.Event.LogLevel" /> used to classify this event.</returns>
         public override LogLevel LogLevel()
         {
             return Event.LogLevel.ErrorLevel;
-        }
-
-        /// <summary>
-        /// Returns a <see cref="System.String" /> that represents this instance.
-        /// </summary>
-        /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
-        public override string ToString()
-        {
-            var cause = Cause;
-            var causeStr = cause == null ? "Unknown" : cause.ToString();
-            var errorStr = string.Format("[{0}][{1}][Thread {2}][{3}] {4}{5}Cause: {6}",
-                LogLevel().ToString().Replace("Level", "").ToUpperInvariant(), Timestamp,
-                Thread.ManagedThreadId.ToString().PadLeft(4, '0'), LogSource, Message, Environment.NewLine, causeStr);
-            return errorStr;
         }
     }
 }

--- a/src/core/Akka/Event/ILoggingAdapter.cs
+++ b/src/core/Akka/Event/ILoggingAdapter.cs
@@ -108,6 +108,15 @@ namespace Akka.Event
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
         void Log(LogLevel logLevel, string format, params object[] args);
+
+        /// <summary>
+        /// Logs a message with a specified level.
+        /// </summary>
+        /// <param name="logLevel">The level used to log the message.</param>
+        /// <param name="cause">The exception that caused this log message.</param>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        void Log(LogLevel logLevel, Exception cause, string format, params object[] args);
     }
 
     /// <summary>
@@ -227,5 +236,16 @@ namespace Akka.Event
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
         public void Log(LogLevel logLevel, string format, params object[] args) { }
+
+        /// <summary>
+        /// Logs a message with a specified level.
+        /// </summary>
+        /// <param name="logLevel">The level used to log the message.</param>
+        /// <param name="cause">The exception that caused this log message.</param>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        public void Log(LogLevel logLevel, Exception cause, string format, params object[] args)
+        {
+        }
     }
 }

--- a/src/core/Akka/Event/ILoggingAdapter.cs
+++ b/src/core/Akka/Event/ILoggingAdapter.cs
@@ -49,6 +49,14 @@ namespace Akka.Event
         void Debug(string format, params object[] args);
 
         /// <summary>
+        /// Logs a <see cref="LogLevel.DebugLevel"/> message and associated exception.
+        /// </summary>
+        /// <param name="cause">The exception associated with this message.</param>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        void Debug(Exception cause, string format, params object[] args);
+
+        /// <summary>
         /// Logs a <see cref="LogLevel.InfoLevel"/> message.
         /// </summary>
         /// <param name="format">The message that is being logged.</param>
@@ -56,11 +64,27 @@ namespace Akka.Event
         void Info(string format, params object[] args);
 
         /// <summary>
+        /// Logs a <see cref="LogLevel.InfoLevel"/> message and associated exception.
+        /// </summary>
+        /// <param name="cause">The exception associated with this message.</param>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        void Info(Exception cause, string format, params object[] args);
+
+        /// <summary>
         /// Logs a <see cref="LogLevel.WarningLevel"/> message.
         /// </summary>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
         void Warning(string format, params object[] args);
+
+        /// <summary>
+        /// Logs a <see cref="LogLevel.WarningLevel"/> message and associated exception.
+        /// </summary>
+        /// <param name="cause">The exception associated with this message.</param>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        void Warning(Exception cause, string format, params object[] args);
 
         /// <summary>
         /// Logs a <see cref="LogLevel.ErrorLevel"/> message.
@@ -137,11 +161,27 @@ namespace Akka.Event
         public void Debug(string format, params object[] args) { }
 
         /// <summary>
+        /// Logs a <see cref="LogLevel.ErrorLevel" /> message and associated exception.
+        /// </summary>
+        /// <param name="cause">The exception associated with this message.</param>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        public void Debug(Exception cause, string format, params object[] args){ }
+
+        /// <summary>
         /// Logs a <see cref="LogLevel.InfoLevel" /> message.
         /// </summary>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
         public void Info(string format, params object[] args) { }
+
+        /// <summary>
+        /// Logs a <see cref="LogLevel.InfoLevel" /> message and associated exception.
+        /// </summary>
+        /// <param name="cause">The exception associated with this message.</param>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        public void Info(Exception cause, string format, params object[] args){ }
 
         /// <summary>
         /// Obsolete. Use <see cref="Warning" /> instead!
@@ -156,6 +196,14 @@ namespace Akka.Event
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
         public void Warning(string format, params object[] args) { }
+
+        /// <summary>
+        /// Logs a <see cref="LogLevel.WarningLevel" /> message and associated exception.
+        /// </summary>
+        /// <param name="cause">The exception associated with this message.</param>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        public void Warning(Exception cause, string format, params object[] args){ }
 
         /// <summary>
         /// Logs a <see cref="LogLevel.ErrorLevel" /> message.

--- a/src/core/Akka/Event/Info.cs
+++ b/src/core/Akka/Event/Info.cs
@@ -20,8 +20,21 @@ namespace Akka.Event
         /// <param name="logSource">The source that generated the log event.</param>
         /// <param name="logClass">The type of logger used to log the event.</param>
         /// <param name="message">The message that is being logged.</param>
-        public Info(string logSource, Type logClass, object message)
+        public Info(string logSource, Type logClass, object message) 
+            : this(null, logSource, logClass, message)
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Info" /> class.
+        /// </summary>
+        /// <param name="cause">The exception that generated the log event.</param>
+        /// <param name="logSource">The source that generated the log event.</param>
+        /// <param name="logClass">The type of logger used to log the event.</param>
+        /// <param name="message">The message that is being logged.</param>
+        public Info(Exception cause, string logSource, Type logClass, object message)
+        {
+            Cause = cause;
             LogSource = logSource;
             LogClass = logClass;
             Message = message;

--- a/src/core/Akka/Event/LogEvent.cs
+++ b/src/core/Akka/Event/LogEvent.cs
@@ -53,6 +53,11 @@ namespace Akka.Event
         }
 
         /// <summary>
+        /// The exception that caused the log event. Can be <c>null</c>
+        /// </summary>
+        public Exception Cause { get; protected set; }
+
+        /// <summary>
         /// The timestamp that this event occurred.
         /// </summary>
         public DateTime Timestamp { get; private set; }
@@ -89,7 +94,11 @@ namespace Akka.Event
         /// <returns>A <see cref="System.String" /> that represents this LogEvent.</returns>
         public override string ToString()
         {
-            return string.Format("[{0}][{1}][Thread {2}][{3}] {4}", LogLevel().PrettyNameFor(), Timestamp, Thread.ManagedThreadId.ToString().PadLeft(4, '0'), LogSource, Message);
+            if(Cause == null)
+                return
+                    $"[{LogLevel().PrettyNameFor()}][{Timestamp}][Thread {Thread.ManagedThreadId.ToString().PadLeft(4, '0')}][{LogSource}] {Message}";
+            return
+                $"[{LogLevel().PrettyNameFor()}][{Timestamp}][Thread {Thread.ManagedThreadId.ToString().PadLeft(4, '0')}][{LogSource}] {Message}{Environment.NewLine}Cause: {Cause}";
         }
     }
 }

--- a/src/core/Akka/Event/LoggingAdapterBase.cs
+++ b/src/core/Akka/Event/LoggingAdapterBase.cs
@@ -149,6 +149,35 @@ namespace Akka.Event
         }
 
         /// <summary>
+        /// Notifies all subscribers that a log event occurred for a particular level.
+        /// </summary>
+        /// <param name="logLevel">The log level associated with the log event.</param>
+        /// <param name="cause">The exception that caused the log event.</param>
+        /// <param name="message">The message related to the log event.</param>
+        /// <exception cref="NotSupportedException">This exception is thrown when the given <paramref name="logLevel"/> is unknown.</exception>
+        protected void NotifyLog(LogLevel logLevel, Exception cause, object message)
+        {
+            switch (logLevel)
+            {
+                case LogLevel.DebugLevel:
+                    if (IsDebugEnabled) NotifyDebug(cause, message);
+                    break;
+                case LogLevel.InfoLevel:
+                    if (IsInfoEnabled) NotifyInfo(cause, message);
+                    break;
+                case LogLevel.WarningLevel:
+                    if (IsWarningEnabled) NotifyWarning(cause, message);
+                    break;
+                case LogLevel.ErrorLevel:
+                    if (IsErrorEnabled) NotifyError(cause, message);
+                    break;
+                default:
+                    throw new NotSupportedException($"Unknown LogLevel {logLevel}");
+            }
+        }
+
+
+        /// <summary>
         /// Logs a <see cref="LogLevel.DebugLevel" /> message.
         /// </summary>
         /// <param name="format">The message that is being logged.</param>
@@ -337,6 +366,25 @@ namespace Akka.Event
             else
             {
                 NotifyLog(logLevel, new LogMessage(_logMessageFormatter, format, args));
+            }
+        }
+
+        /// <summary>
+        /// Logs a message with a specified level.
+        /// </summary>
+        /// <param name="logLevel">The level used to log the message.</param>
+        /// <param name="cause">The exception associated with this message.</param>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        public void Log(LogLevel logLevel, Exception cause, string format, params object[] args)
+        {
+            if (args == null || args.Length == 0)
+            {
+                NotifyLog(logLevel, cause, format);
+            }
+            else
+            {
+                NotifyLog(logLevel, cause, new LogMessage(_logMessageFormatter, format, args));
             }
         }
     }

--- a/src/core/Akka/Event/LoggingAdapterBase.cs
+++ b/src/core/Akka/Event/LoggingAdapterBase.cs
@@ -135,7 +135,7 @@ namespace Akka.Event
         /// </summary>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public void Debug(string format, params object[] args)
+        public virtual void Debug(string format, params object[] args)
         {
             if (!IsDebugEnabled) 
                 return;
@@ -150,14 +150,24 @@ namespace Akka.Event
             }
         }
 
+        public virtual void Debug(Exception cause, string format, params object[] args)
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// Obsolete. Use <see cref="Warning" /> instead!
         /// </summary>
         /// <param name="format">N/A</param>
         /// <param name="args">N/A</param>
-        public void Warn(string format, params object[] args)
+        public virtual void Warn(string format, params object[] args)
         {
             Warning(format, args);
+        }
+
+        public virtual void Info(Exception cause, string format, params object[] args)
+        {
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -165,7 +175,7 @@ namespace Akka.Event
         /// </summary>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public void Warning(string format, params object[] args)
+        public virtual void Warning(string format, params object[] args)
         {
             if (!IsWarningEnabled) 
                 return;
@@ -180,13 +190,18 @@ namespace Akka.Event
             }
         }
 
+        public virtual void Warning(Exception cause, string format, params object[] args)
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// Logs a <see cref="LogLevel.ErrorLevel" /> message and associated exception.
         /// </summary>
         /// <param name="cause">The exception associated with this message.</param>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public void Error(Exception cause, string format, params object[] args)
+        public virtual void Error(Exception cause, string format, params object[] args)
         {
             if (!IsErrorEnabled) 
                 return;
@@ -206,7 +221,7 @@ namespace Akka.Event
         /// </summary>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public void Error(string format, params object[] args)
+        public virtual void Error(string format, params object[] args)
         {
             if (!IsErrorEnabled) 
                 return;
@@ -226,7 +241,7 @@ namespace Akka.Event
         /// </summary>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public void Info(string format, params object[] args)
+        public virtual void Info(string format, params object[] args)
         {
             if (!IsInfoEnabled) 
                 return;
@@ -247,7 +262,7 @@ namespace Akka.Event
         /// <param name="logLevel">The level used to log the message.</param>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public void Log(LogLevel logLevel, string format, params object[] args)
+        public virtual void Log(LogLevel logLevel, string format, params object[] args)
         {
             if (args == null || args.Length == 0)
             {

--- a/src/core/Akka/Event/LoggingAdapterBase.cs
+++ b/src/core/Akka/Event/LoggingAdapterBase.cs
@@ -56,10 +56,24 @@ namespace Akka.Event
         protected abstract void NotifyWarning(object message);
 
         /// <summary>
+        /// Notifies all subscribers that an <see cref="LogLevel.WarningLevel" /> log event occurred.
+        /// </summary>
+        /// <param name="cause">The exception that caused the log event.</param>
+        /// <param name="message">The message related to the log event.</param>
+        protected abstract void NotifyWarning(Exception cause, object message);
+
+        /// <summary>
         /// Notifies all subscribers that an <see cref="LogLevel.InfoLevel" /> log event occurred.
         /// </summary>
         /// <param name="message">The message related to the log event.</param>
         protected abstract void NotifyInfo(object message);
+
+        /// <summary>
+        /// Notifies all subscribers that an <see cref="LogLevel.InfoLevel" /> log event occurred.
+        /// </summary>
+        /// <param name="cause">The exception that caused the log event.</param>
+        /// <param name="message">The message related to the log event.</param>
+        protected abstract void NotifyInfo(Exception cause, object message);
 
         /// <summary>
         /// Notifies all subscribers that an <see cref="LogLevel.DebugLevel" /> log event occurred.
@@ -68,16 +82,20 @@ namespace Akka.Event
         protected abstract void NotifyDebug(object message);
 
         /// <summary>
+        /// Notifies all subscribers that an <see cref="LogLevel.DebugLevel" /> log event occurred.
+        /// </summary>
+        /// <param name="cause">The exception that caused the log event.</param>
+        /// <param name="message">The message related to the log event.</param>
+        protected abstract void NotifyDebug(Exception cause, object message);
+
+        /// <summary>
         /// Creates an instance of the LoggingAdapterBase.
         /// </summary>
         /// <param name="logMessageFormatter">The log message formatter used by this logging adapter.</param>
         /// <exception cref="ArgumentNullException">This exception is thrown when the given <paramref name="logMessageFormatter"/> is undefined.</exception>
         protected LoggingAdapterBase(ILogMessageFormatter logMessageFormatter)
         {
-            if(logMessageFormatter == null)
-                throw new ArgumentNullException(nameof(logMessageFormatter), "The message formatter must not be null.");
-
-            _logMessageFormatter = logMessageFormatter;
+            _logMessageFormatter = logMessageFormatter ?? throw new ArgumentNullException(nameof(logMessageFormatter), "The message formatter must not be null.");
         }
 
         /// <summary>
@@ -150,9 +168,25 @@ namespace Akka.Event
             }
         }
 
+        /// <summary>
+        /// Logs a <see cref="LogLevel.DebugLevel" /> message.
+        /// </summary>
+        /// <param name="cause">The exception associated with this message.</param>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
         public virtual void Debug(Exception cause, string format, params object[] args)
         {
-            throw new NotImplementedException();
+            if (!IsDebugEnabled)
+                return;
+
+            if (args == null || args.Length == 0)
+            {
+                NotifyDebug(cause, format);
+            }
+            else
+            {
+                NotifyDebug(cause, new LogMessage(_logMessageFormatter, format, args));
+            }
         }
 
         /// <summary>
@@ -165,9 +199,25 @@ namespace Akka.Event
             Warning(format, args);
         }
 
+        /// <summary>
+        /// Logs a <see cref="LogLevel.InfoLevel" /> message.
+        /// </summary>
+        /// <param name="cause">The exception associated with this message.</param>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
         public virtual void Info(Exception cause, string format, params object[] args)
         {
-            throw new NotImplementedException();
+            if (!IsInfoEnabled)
+                return;
+
+            if (args == null || args.Length == 0)
+            {
+                NotifyInfo(cause, format);
+            }
+            else
+            {
+                NotifyInfo(cause, new LogMessage(_logMessageFormatter, format, args));
+            }
         }
 
         /// <summary>
@@ -190,9 +240,25 @@ namespace Akka.Event
             }
         }
 
+        /// <summary>
+        /// Logs a <see cref="LogLevel.WarningLevel" /> message.
+        /// </summary>
+        /// <param name="cause">The exception associated with this message.</param>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
         public virtual void Warning(Exception cause, string format, params object[] args)
         {
-            throw new NotImplementedException();
+            if (!IsWarningEnabled)
+                return;
+
+            if (args == null || args.Length == 0)
+            {
+                NotifyWarning(cause, format);
+            }
+            else
+            {
+                NotifyWarning(cause, new LogMessage(_logMessageFormatter, format, args));
+            }
         }
 
         /// <summary>

--- a/src/core/Akka/Event/LoggingAdapterBase.cs
+++ b/src/core/Akka/Event/LoggingAdapterBase.cs
@@ -376,7 +376,7 @@ namespace Akka.Event
         /// <param name="cause">The exception associated with this message.</param>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public void Log(LogLevel logLevel, Exception cause, string format, params object[] args)
+        public virtual void Log(LogLevel logLevel, Exception cause, string format, params object[] args)
         {
             if (args == null || args.Length == 0)
             {

--- a/src/core/Akka/Event/Warning.cs
+++ b/src/core/Akka/Event/Warning.cs
@@ -21,10 +21,23 @@ namespace Akka.Event
         /// <param name="logClass">The type of logger used to log the event.</param>
         /// <param name="message">The message that is being logged.</param>
         public Warning(string logSource, Type logClass, object message)
+            : this(null, logSource, logClass, message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Warning" /> class.
+        /// </summary>
+        /// <param name="cause">The exception that caused the log event.</param>
+        /// <param name="logSource">The source that generated the log event.</param>
+        /// <param name="logClass">The type of logger used to log the event.</param>
+        /// <param name="message">The message that is being logged.</param>
+        public Warning(Exception cause, string logSource, Type logClass, object message)
         {
             LogSource = logSource;
             LogClass = logClass;
             Message = message;
+            Cause = cause;
         }
 
         /// <summary>


### PR DESCRIPTION
Implements #3424 

Introduces a bunch of API changes to the surface area of `ILoggingAdapter` - it's a backwards compatible change, but not a binary compatible change since we've added new methods to the interface. Users will need to recompile any logging plugins in order to consume these changes.