### PR TITLE
Mark public LoggingAdapterBase methods as virtual

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -2951,20 +2951,20 @@ namespace Akka.Event
         public abstract bool IsErrorEnabled { get; }
         public abstract bool IsInfoEnabled { get; }
         public abstract bool IsWarningEnabled { get; }
-        public void Debug(string format, params object[] args) { }
-        public void Error(System.Exception cause, string format, params object[] args) { }
-        public void Error(string format, params object[] args) { }
-        public void Info(string format, params object[] args) { }
+        public virtual void Debug(string format, params object[] args) { }
+        public virtual void Error(System.Exception cause, string format, params object[] args) { }
+        public virtual void Error(string format, params object[] args) { }
+        public virtual void Info(string format, params object[] args) { }
         public bool IsEnabled(Akka.Event.LogLevel logLevel) { }
-        public void Log(Akka.Event.LogLevel logLevel, string format, params object[] args) { }
+        public virtual void Log(Akka.Event.LogLevel logLevel, string format, params object[] args) { }
         protected abstract void NotifyDebug(object message);
         protected abstract void NotifyError(object message);
         protected abstract void NotifyError(System.Exception cause, object message);
         protected abstract void NotifyInfo(object message);
         protected void NotifyLog(Akka.Event.LogLevel logLevel, object message) { }
         protected abstract void NotifyWarning(object message);
-        public void Warn(string format, params object[] args) { }
-        public void Warning(string format, params object[] args) { }
+        public virtual void Warn(string format, params object[] args) { }
+        public virtual void Warning(string format, params object[] args) { }
     }
     public class LoggingBus : Akka.Event.ActorEventBus<object, System.Type>
     {

--- a/src/core/Akka/Event/LoggingAdapterBase.cs
+++ b/src/core/Akka/Event/LoggingAdapterBase.cs
@@ -135,7 +135,7 @@ namespace Akka.Event
         /// </summary>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public void Debug(string format, params object[] args)
+        public virtual void Debug(string format, params object[] args)
         {
             if (!IsDebugEnabled) 
                 return;
@@ -155,7 +155,7 @@ namespace Akka.Event
         /// </summary>
         /// <param name="format">N/A</param>
         /// <param name="args">N/A</param>
-        public void Warn(string format, params object[] args)
+        public virtual void Warn(string format, params object[] args)
         {
             Warning(format, args);
         }
@@ -165,7 +165,7 @@ namespace Akka.Event
         /// </summary>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public void Warning(string format, params object[] args)
+        public virtual void Warning(string format, params object[] args)
         {
             if (!IsWarningEnabled) 
                 return;
@@ -186,7 +186,7 @@ namespace Akka.Event
         /// <param name="cause">The exception associated with this message.</param>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public void Error(Exception cause, string format, params object[] args)
+        public virtual void Error(Exception cause, string format, params object[] args)
         {
             if (!IsErrorEnabled) 
                 return;
@@ -206,7 +206,7 @@ namespace Akka.Event
         /// </summary>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public void Error(string format, params object[] args)
+        public virtual void Error(string format, params object[] args)
         {
             if (!IsErrorEnabled) 
                 return;
@@ -226,7 +226,7 @@ namespace Akka.Event
         /// </summary>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public void Info(string format, params object[] args)
+        public virtual void Info(string format, params object[] args)
         {
             if (!IsInfoEnabled) 
                 return;
@@ -247,7 +247,7 @@ namespace Akka.Event
         /// <param name="logLevel">The level used to log the message.</param>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public void Log(LogLevel logLevel, string format, params object[] args)
+        public virtual void Log(LogLevel logLevel, string format, params object[] args)
         {
             if (args == null || args.Length == 0)
             {


### PR DESCRIPTION
Designed to help fix https://github.com/akkadotnet/Akka.Logger.Serilog/issues/51 by making LoggingAdapterBase methods `virtual` so they can be overridden at the point in time where the formatting arguments are supplied to the `LogEvent`.

I have a reproduction spec which demonstrates how not having this created some issues in the 1.3.6 version of Akka.Logger.Serilog: https://github.com/akkadotnet/Akka.Logger.Serilog/pull/52 - this PR along with a subsequent update to Akka.Logger.Serilog should fix that.