### PR TITLE
Sharding update

### DIFF
--- a/docs/articles/clustering/cluster-sharding.md
+++ b/docs/articles/clustering/cluster-sharding.md
@@ -55,6 +55,8 @@ In this example, we first specify way to resolve our message recipients in conte
 
 Second part of an example is registering custom actor type as sharded entity using `ClusterSharding.Start` or `ClusterSharding.StartAsync` methods. Result is the `IActorRef` to shard region used to communicate between current actor system and target entities. Shard region must be specified once per each type on each node, that is expected to participate in sharding entities of that type. Keep in mind, that it's recommended to wait for the current node to first fully join the cluster before initializing a shard regions in order to avoid potential timeouts.
 
+In some cases, the actor may need to know the `entityId` associated with it. This can be achieved using the `entityPropsFactory` parameter to `ClusterSharding.Start` or `ClusterSharding.StartAsync`. The entity ID will be passed to the factory as a parameter, which can then be used in the creation of the actor.
+
 In case when you want to send message to entities from specific node, but you don't want that node to participate in sharding itself, you can use `ShardRegionProxy` for that.
 
 Example:

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingFailureSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingFailureSpec.cs
@@ -41,7 +41,7 @@ namespace Akka.Cluster.Sharding.Tests
                         serialization-bindings {{
                             ""System.Object"" = hyperion
                         }}
-                    }}                    
+                    }}
                     akka.loglevel = INFO
                     akka.actor.provider = cluster
                     akka.remote.log-remote-lifecycle-events = off
@@ -176,7 +176,7 @@ namespace Akka.Cluster.Sharding.Tests
         private readonly ClusterShardingFailureSpecConfig _config;
 
         private readonly List<FileInfo> _storageLocations;
-        
+
         protected ClusterShardingFailureSpec(ClusterShardingFailureSpecConfig config, Type type)
             : base(config, type)
         {
@@ -194,7 +194,7 @@ namespace Akka.Cluster.Sharding.Tests
         }
 
         protected bool IsDDataMode { get; }
-        
+
         protected override void AfterTermination()
         {
             base.AfterTermination();
@@ -364,6 +364,13 @@ namespace Akka.Cluster.Sharding.Tests
 
                     //Test the Shard passivate works during a journal failure
                     shard2.Tell(new Passivate(PoisonPill.Instance), entity21);
+
+                    AwaitAssert(() =>
+                    {
+                        region.Tell(new Get("21"));
+                        ExpectMsg<Value>(v => v.Id == "21" && v.N == 0, hint: "Passivating did not reset Value down to 0");
+                    });
+
                     region.Tell(new Add("21", 1));
 
                     region.Tell(new Get("21"));

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
@@ -288,8 +288,6 @@ namespace Akka.Cluster.Sharding.Tests
             return Actor.Props.Create(() => new QualifiedCounter(typeName, id));
         }
 
-        //public static new string ShardingTypeName => "QualifiedCounter";
-
         public readonly string TypeName;
 
         public override string PersistenceId { get { return TypeName + "-" + Self.Path.Name; } }
@@ -307,7 +305,7 @@ namespace Akka.Cluster.Sharding.Tests
         {
             return Actor.Props.Create(() => new AnotherCounter(id));
         }
-        public static new string ShardingTypeName => "AnotherCounter";
+        public static new string ShardingTypeName => nameof(AnotherCounter);
 
         public AnotherCounter(string id)
             : base(AnotherCounter.ShardingTypeName, id)
@@ -317,7 +315,7 @@ namespace Akka.Cluster.Sharding.Tests
 
     internal class CounterSupervisor : ActorBase
     {
-        public static string ShardingTypeName => "CounterSupervisor";
+        public static string ShardingTypeName => nameof(CounterSupervisor);
 
         public static Props Props(string id)
         {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
@@ -220,9 +220,15 @@ namespace Akka.Cluster.Sharding.Tests
 
         public const int NumberOfShards = 12;
         private int _count = 0;
+        private readonly string id;
 
-        public Counter()
+        public static Props Props(string id) => Actor.Props.Create(() => new Counter(id));
+
+        public static string ShardingTypeName => "Counter";
+
+        public Counter(string id)
         {
+            this.id = id;
             Context.SetReceiveTimeout(TimeSpan.FromMinutes(2));
         }
 
@@ -233,7 +239,7 @@ namespace Akka.Cluster.Sharding.Tests
             Thread.Sleep(500);
         }
 
-        public override string PersistenceId { get { return "Counter-" + Self.Path.Name; } }
+        public override string PersistenceId { get { return $"Counter.{ShardingTypeName}-{id}"; } }
 
         protected override bool ReceiveRecover(object message)
         {
@@ -277,16 +283,19 @@ namespace Akka.Cluster.Sharding.Tests
 
     internal class QualifiedCounter : Counter
     {
-        public static Props Props(string typeName)
+        public static Props Props(string typeName, string id)
         {
-            return Actor.Props.Create(() => new QualifiedCounter(typeName));
+            return Actor.Props.Create(() => new QualifiedCounter(typeName, id));
         }
+
+        //public static new string ShardingTypeName => "QualifiedCounter";
 
         public readonly string TypeName;
 
         public override string PersistenceId { get { return TypeName + "-" + Self.Path.Name; } }
 
-        public QualifiedCounter(string typeName)
+        public QualifiedCounter(string typeName, string id)
+            : base(id)
         {
             TypeName = typeName;
         }
@@ -294,19 +303,34 @@ namespace Akka.Cluster.Sharding.Tests
 
     internal class AnotherCounter : QualifiedCounter
     {
-        public AnotherCounter()
-            : base("AnotherCounter")
+        public static new Props Props(string id)
+        {
+            return Actor.Props.Create(() => new AnotherCounter(id));
+        }
+        public static new string ShardingTypeName => "AnotherCounter";
+
+        public AnotherCounter(string id)
+            : base(AnotherCounter.ShardingTypeName, id)
         {
         }
     }
 
     internal class CounterSupervisor : ActorBase
     {
-        public readonly IActorRef Counter;
+        public static string ShardingTypeName => "CounterSupervisor";
 
-        public CounterSupervisor()
+        public static Props Props(string id)
         {
-            Counter = Context.ActorOf(Props.Create<Counter>(), "theCounter");
+            return Actor.Props.Create(() => new CounterSupervisor(id));
+        }
+
+        public readonly string entityId;
+        public readonly IActorRef counter;
+
+        public CounterSupervisor(string entityId)
+        {
+            this.entityId = entityId;
+            counter = Context.ActorOf(Counter.Props(entityId), "theCounter");
         }
 
         protected override SupervisorStrategy SupervisorStrategy()
@@ -328,7 +352,7 @@ namespace Akka.Cluster.Sharding.Tests
 
         protected override bool Receive(object message)
         {
-            Counter.Forward(message);
+            counter.Forward(message);
             return true;
         }
     }
@@ -355,6 +379,9 @@ namespace Akka.Cluster.Sharding.Tests
     }
     public abstract class ClusterShardingSpec : MultiNodeClusterSpec
     {
+        // must use different unique name for some tests than the one used in API tests
+        public static string TestCounterShardingTypeName => $"Test{Counter.ShardingTypeName}";
+
         #region Setup
 
         private readonly Lazy<IActorRef> _region;
@@ -373,7 +400,7 @@ namespace Akka.Cluster.Sharding.Tests
         {
             _config = config;
 
-            _region = new Lazy<IActorRef>(() => CreateRegion("counter", false));
+            _region = new Lazy<IActorRef>(() => CreateRegion(TestCounterShardingTypeName, false));
             _rebalancingRegion = new Lazy<IActorRef>(() => CreateRegion("rebalancingCounter", false));
 
             _persistentEntitiesRegion = new Lazy<IActorRef>(() => CreateRegion("RememberCounterEntities", true));
@@ -397,7 +424,7 @@ namespace Akka.Cluster.Sharding.Tests
             EnterBarrier("startup");
         }
         protected bool IsDDataMode { get; }
-        
+
         protected override void AfterTermination()
         {
             base.AfterTermination();
@@ -430,7 +457,7 @@ namespace Akka.Cluster.Sharding.Tests
         {
             var typeNames = new[]
             {
-                "counter", "rebalancingCounter", "RememberCounterEntities", "AnotherRememberCounter",
+                TestCounterShardingTypeName, "rebalancingCounter", "RememberCounterEntities", "AnotherRememberCounter",
                 "RememberCounter", "RebalancingRememberCounter", "AutoMigrateRememberRegionTest"
             };
 
@@ -479,7 +506,7 @@ namespace Akka.Cluster.Sharding.Tests
 
             return Sys.ActorOf(Props.Create(() => new ShardRegion(
                 typeName,
-                QualifiedCounter.Props(typeName),
+                entityId => QualifiedCounter.Props(typeName, entityId),
                 settings,
                 "/user/" + typeName + "Coordinator/singleton/coordinator",
                 Counter.ExtractEntityId,
@@ -609,7 +636,7 @@ namespace Akka.Cluster.Sharding.Tests
                     r.Tell(new Counter.EntityEnvelope(2, Counter.Increment.Instance));
                     r.Tell(new Counter.Get(2));
                     ExpectMsg(3);
-                    LastSender.Path.Should().Be(Node(_config.Second) / "user" / "counterRegion" / "2" / "2");
+                    LastSender.Path.Should().Be(Node(_config.Second) / "user" / $"{TestCounterShardingTypeName}Region" / "2" / "2");
 
                     r.Tell(new Counter.Get(11));
                     ExpectMsg(1);
@@ -669,9 +696,9 @@ namespace Akka.Cluster.Sharding.Tests
 
                     var settings = ClusterShardingSettings.Create(cfg, Sys.Settings.Config.GetConfig("akka.cluster.singleton"));
                     var proxy = Sys.ActorOf(ShardRegion.ProxyProps(
-                        typeName: "counter",
+                        typeName: TestCounterShardingTypeName,
                         settings: settings,
-                        coordinatorPath: "/user/counterCoordinator/singleton/coordinator",
+                        coordinatorPath: $"/user/{TestCounterShardingTypeName}Coordinator/singleton/coordinator",
                         extractEntityId: Counter.ExtractEntityId,
                         extractShardId: Counter.ExtractShardId,
                         replicator: Sys.DeadLetters,
@@ -770,12 +797,12 @@ namespace Akka.Cluster.Sharding.Tests
                     r.Tell(new Counter.EntityEnvelope(3, Counter.Increment.Instance));
                     r.Tell(new Counter.Get(3));
                     ExpectMsg(11);
-                    LastSender.Path.Should().Be(Node(_config.Third) / "user" / "counterRegion" / "3" / "3");
+                    LastSender.Path.Should().Be(Node(_config.Third) / "user" / $"{TestCounterShardingTypeName}Region" / "3" / "3");
 
                     r.Tell(new Counter.EntityEnvelope(4, Counter.Increment.Instance));
                     r.Tell(new Counter.Get(4));
                     ExpectMsg(21);
-                    LastSender.Path.Should().Be(Node(_config.Fourth) / "user" / "counterRegion" / "4" / "4");
+                    LastSender.Path.Should().Be(Node(_config.Fourth) / "user" / $"{TestCounterShardingTypeName}Region" / "4" / "4");
                 }, _config.First);
                 EnterBarrier("first-update");
 
@@ -818,7 +845,7 @@ namespace Akka.Cluster.Sharding.Tests
                         {
                             _region.Value.Tell(new Counter.Get(3), probe3.Ref);
                             probe3.ExpectMsg(11);
-                            probe3.LastSender.Path.Should().Be(Node(_config.Third) / "user" / "counterRegion" / "3" / "3");
+                            probe3.LastSender.Path.Should().Be(Node(_config.Third) / "user" / $"{TestCounterShardingTypeName}Region" / "3" / "3");
                         });
                     });
 
@@ -829,7 +856,7 @@ namespace Akka.Cluster.Sharding.Tests
                         {
                             _region.Value.Tell(new Counter.Get(4), probe4.Ref);
                             probe4.ExpectMsg(21);
-                            probe4.LastSender.Path.Should().Be(Node(_config.Fourth) / "user" / "counterRegion" / "4" / "4");
+                            probe4.LastSender.Path.Should().Be(Node(_config.Fourth) / "user" / $"{TestCounterShardingTypeName}Region" / "4" / "4");
                         });
                     });
                 }, _config.Fifth);
@@ -888,24 +915,24 @@ namespace Akka.Cluster.Sharding.Tests
                 {
                     //#counter-start
                     ClusterSharding.Get(Sys).Start(
-                        typeName: "Counter",
-                        entityProps: Props.Create<Counter>(),
+                        typeName: Counter.ShardingTypeName,
+                        entityPropsFactory: entityId => Counter.Props(entityId),
                         settings: ClusterShardingSettings.Create(Sys),
                         extractEntityId: Counter.ExtractEntityId,
                         extractShardId: Counter.ExtractShardId);
 
                     //#counter-start
                     ClusterSharding.Get(Sys).Start(
-                        typeName: "AnotherCounter",
-                        entityProps: Props.Create<AnotherCounter>(),
+                        typeName: AnotherCounter.ShardingTypeName,
+                        entityPropsFactory: entityId => AnotherCounter.Props(entityId),
                         settings: ClusterShardingSettings.Create(Sys),
                         extractEntityId: Counter.ExtractEntityId,
                         extractShardId: Counter.ExtractShardId);
 
                     //#counter-supervisor-start
                     ClusterSharding.Get(Sys).Start(
-                      typeName: "SupervisedCounter",
-                      entityProps: Props.Create<CounterSupervisor>(),
+                      typeName: CounterSupervisor.ShardingTypeName,
+                      entityPropsFactory: entityId => CounterSupervisor.Props(entityId),
                       settings: ClusterShardingSettings.Create(Sys),
                       extractEntityId: Counter.ExtractEntityId,
                       extractShardId: Counter.ExtractShardId);
@@ -915,18 +942,19 @@ namespace Akka.Cluster.Sharding.Tests
                 RunOn(() =>
                 {
                     //#counter-usage
-                    var counterRegion = ClusterSharding.Get(Sys).ShardRegion("Counter");
-                    counterRegion.Tell(new Counter.Get(123));
+                    var counterRegion = ClusterSharding.Get(Sys).ShardRegion(Counter.ShardingTypeName);
+                    var entityId = 999;
+                    counterRegion.Tell(new Counter.Get(entityId));
                     ExpectMsg(0);
 
-                    counterRegion.Tell(new Counter.EntityEnvelope(123, Counter.Increment.Instance));
-                    counterRegion.Tell(new Counter.Get(123));
+                    counterRegion.Tell(new Counter.EntityEnvelope(entityId, Counter.Increment.Instance));
+                    counterRegion.Tell(new Counter.Get(entityId));
                     ExpectMsg(1);
                     //#counter-usage
 
-                    var anotherCounterRegion = ClusterSharding.Get(Sys).ShardRegion("AnotherCounter");
-                    anotherCounterRegion.Tell(new Counter.EntityEnvelope(123, Counter.Decrement.Instance));
-                    anotherCounterRegion.Tell(new Counter.Get(123));
+                    var anotherCounterRegion = ClusterSharding.Get(Sys).ShardRegion(AnotherCounter.ShardingTypeName);
+                    anotherCounterRegion.Tell(new Counter.EntityEnvelope(entityId, Counter.Decrement.Instance));
+                    anotherCounterRegion.Tell(new Counter.Get(entityId));
                     ExpectMsg(-1);
                 }, _config.Fifth);
                 EnterBarrier("extension-used");
@@ -936,8 +964,8 @@ namespace Akka.Cluster.Sharding.Tests
                 {
                     for (int i = 1000; i <= 1010; i++)
                     {
-                        ClusterSharding.Get(Sys).ShardRegion("Counter").Tell(new Counter.EntityEnvelope(i, Counter.Increment.Instance));
-                        ClusterSharding.Get(Sys).ShardRegion("Counter").Tell(new Counter.Get(i));
+                        ClusterSharding.Get(Sys).ShardRegion(Counter.ShardingTypeName).Tell(new Counter.EntityEnvelope(i, Counter.Increment.Instance));
+                        ClusterSharding.Get(Sys).ShardRegion(Counter.ShardingTypeName).Tell(new Counter.Get(i));
                         ExpectMsg(1);
                         LastSender.Path.Address.Should().NotBe(Cluster.SelfAddress);
                     }
@@ -954,7 +982,7 @@ namespace Akka.Cluster.Sharding.Tests
                 {
                     var counterRegionViaStart = ClusterSharding.Get(Sys).Start(
                         typeName: "ApiTest",
-                        entityProps: Props.Create<Counter>(),
+                        entityPropsFactory: Counter.Props,
                         settings: ClusterShardingSettings.Create(Sys),
                         extractEntityId: Counter.ExtractEntityId,
                         extractShardId: Counter.ExtractShardId);

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingInternalsSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingInternalsSpec.cs
@@ -1,0 +1,82 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ClusterShardingInternalsSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.Cluster.Tools.Singleton;
+using Akka.Configuration;
+using Akka.TestKit.TestActors;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    public class ClusterShardingInternalsSpec : Akka.TestKit.Xunit2.TestKit
+    {
+        ClusterSharding clusterSharding;
+
+        public ClusterShardingInternalsSpec() : base(GetConfig())
+        {
+            clusterSharding = ClusterSharding.Get(Sys);
+        }
+
+        private Tuple<string, object> ExtractEntityId(object message)
+        {
+            switch (message)
+            {
+                case int i:
+                    return new Tuple<string, object>(i.ToString(), message);
+            }
+            throw new NotSupportedException();
+        }
+
+        private string ExtractShardId(object message)
+        {
+            switch (message)
+            {
+                case int i:
+                    return (i % 10).ToString();
+            }
+            throw new NotSupportedException();
+        }
+
+
+        public static Config GetConfig()
+        {
+            return ConfigurationFactory.ParseString("akka.actor.provider = cluster")
+
+                .WithFallback(Sharding.ClusterSharding.DefaultConfig())
+                .WithFallback(DistributedData.DistributedData.DefaultConfig())
+                .WithFallback(ClusterSingletonManager.DefaultConfig());
+        }
+
+        [Fact]
+        public void ClusterSharding_must_start_a_region_in_proxy_mode_in_case_of_node_role_mismatch()
+        {
+            var settingsWithRole = ClusterShardingSettings.Create(Sys).WithRole("nonExistingRole");
+            var typeName = "typeName";
+
+            var region = clusterSharding.Start(
+                  typeName: typeName,
+                  entityProps: Props.Empty,
+                  settings: settingsWithRole,
+                  extractEntityId: ExtractEntityId,
+                  extractShardId: ExtractShardId,
+                  allocationStrategy: new LeastShardAllocationStrategy(0, 0),
+                  handOffStopMessage: PoisonPill.Instance);
+
+            var proxy = clusterSharding.StartProxy(
+                  typeName: typeName,
+                  role: settingsWithRole.Role,
+                  extractEntityId: ExtractEntityId,
+                  extractShardId: ExtractShardId
+                );
+
+            region.Should().BeSameAs(proxy);
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/GetShardTypeNamesSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/GetShardTypeNamesSpec.cs
@@ -22,7 +22,7 @@ namespace Akka.Cluster.Sharding.Tests
 
         public static Config GetConfig()
         {
-            return ConfigurationFactory.ParseString("akka.actor.provider = \"Akka.Cluster.ClusterActorRefProvider, Akka.Cluster\"")
+            return ConfigurationFactory.ParseString("akka.actor.provider = cluster")
 
                 .WithFallback(Sharding.ClusterSharding.DefaultConfig())
                 .WithFallback(DistributedData.DistributedData.DefaultConfig())

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/GetShardTypeNamesSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/GetShardTypeNamesSpec.cs
@@ -1,0 +1,69 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ClusterShardingConfigSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Cluster.Tools.Singleton;
+using Akka.Configuration;
+using Akka.TestKit.TestActors;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    public class GetShardTypeNamesSpec : Akka.TestKit.Xunit2.TestKit
+    {
+        public GetShardTypeNamesSpec() : base(GetConfig())
+        {
+        }
+
+        public static Config GetConfig()
+        {
+            return ConfigurationFactory.ParseString("akka.actor.provider = \"Akka.Cluster.ClusterActorRefProvider, Akka.Cluster\"")
+
+                .WithFallback(Sharding.ClusterSharding.DefaultConfig())
+                .WithFallback(DistributedData.DistributedData.DefaultConfig())
+                .WithFallback(ClusterSingletonManager.DefaultConfig());
+        }
+
+        [Fact]
+        public void GetShardTypeNames_must_contain_empty_when_join_cluster_without_shards()
+        {
+            ClusterSharding.Get(Sys).ShardTypeNames.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GetShardTypeNames_must_contain_started_shards_when_started_2_shards()
+        {
+            Cluster.Get(Sys).Join(Cluster.Get(Sys).SelfAddress);
+            var settings = ClusterShardingSettings.Create(Sys);
+            ClusterSharding.Get(Sys).Start("type1", EchoActor.Props(this), settings, ExtractEntityId, ExtractShardId);
+            ClusterSharding.Get(Sys).Start("type2", EchoActor.Props(this), settings, ExtractEntityId, ExtractShardId);
+
+            ClusterSharding.Get(Sys).ShardTypeNames.ShouldBeEquivalentTo(new string[] { "type1", "type2" });
+        }
+
+        private Tuple<string, object> ExtractEntityId(object message)
+        {
+            switch (message)
+            {
+                case int i:
+                    return new Tuple<string, object>(i.ToString(), message);
+            }
+            throw new NotSupportedException();
+        }
+
+        private string ExtractShardId(object message)
+        {
+            switch (message)
+            {
+                case int i:
+                    return (i % 10).ToString();
+            }
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/GetShardTypeNamesSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/GetShardTypeNamesSpec.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="ClusterShardingConfigSpec.cs" company="Akka.NET Project">
+// <copyright file="GetShardTypeNamesSpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ProxyShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ProxyShardingSpec.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="ClusterShardingConfigSpec.cs" company="Akka.NET Project">
+// <copyright file="ProxyShardingSpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ProxyShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ProxyShardingSpec.cs
@@ -1,0 +1,105 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ClusterShardingConfigSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.Cluster.Tools.Singleton;
+using Akka.Configuration;
+using Akka.TestKit.TestActors;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    public class ProxyShardingSpec : Akka.TestKit.Xunit2.TestKit
+    {
+        ClusterSharding clusterSharding;
+        ClusterShardingSettings shardingSettings;
+        private MessageExtractor messageExtractor = new MessageExtractor(10);
+
+        public ProxyShardingSpec() : base(GetConfig())
+        {
+            var role = "Shard";
+            clusterSharding = ClusterSharding.Get(Sys);
+            shardingSettings = ClusterShardingSettings.Create(Sys);
+            clusterSharding.StartProxy("myType", role, IdExtractor, ShardResolver);
+        }
+
+        private class MessageExtractor : HashCodeMessageExtractor
+        {
+            public MessageExtractor(int maxNumberOfShards) : base(maxNumberOfShards)
+            {
+            }
+
+            public override string EntityId(object message)
+            {
+                return "dummyId";
+            }
+        }
+
+        private Tuple<string, object> IdExtractor(object message)
+        {
+            switch (message)
+            {
+                case int i:
+                    return new Tuple<string, object>(i.ToString(), message);
+            }
+            throw new NotSupportedException();
+        }
+
+        private string ShardResolver(object message)
+        {
+            switch (message)
+            {
+                case int i:
+                    return (i % 10).ToString();
+            }
+            throw new NotSupportedException();
+        }
+
+
+        public static Config GetConfig()
+        {
+            return ConfigurationFactory.ParseString("akka.actor.provider = \"Akka.Cluster.ClusterActorRefProvider, Akka.Cluster\"")
+
+                .WithFallback(Sharding.ClusterSharding.DefaultConfig())
+                .WithFallback(DistributedData.DistributedData.DefaultConfig())
+                .WithFallback(ClusterSingletonManager.DefaultConfig());
+        }
+
+        [Fact]
+        public void ProxyShardingSpec_Proxy_should_be_found()
+        {
+            IActorRef proxyActor = Sys.ActorSelection("akka://test/system/sharding/myTypeProxy")
+                    .ResolveOne(TimeSpan.FromSeconds(5)).Result;
+
+            proxyActor.Path.Should().NotBeNull();
+            proxyActor.Path.ToString().Should().EndWith("Proxy");
+        }
+
+        [Fact]
+        public void ProxyShardingSpec_Shard_region_should_be_found()
+        {
+            var shardRegion = clusterSharding.Start("myType", EchoActor.Props(this), shardingSettings, messageExtractor);
+
+            shardRegion.Path.Should().NotBeNull();
+            shardRegion.Path.ToString().Should().EndWith("myType");
+        }
+
+        [Fact]
+        public void ProxyShardingSpec_Shard_coordinator_should_be_found()
+        {
+            var shardRegion = clusterSharding.Start("myType", EchoActor.Props(this), shardingSettings, messageExtractor);
+
+            IActorRef shardCoordinator = Sys.ActorSelection("akka://test/system/sharding/myTypeCoordinator")
+                    .ResolveOne(TimeSpan.FromSeconds(5)).Result;
+
+            shardCoordinator.Path.Should().NotBeNull();
+            shardCoordinator.Path.ToString().Should().EndWith("Coordinator");
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ProxyShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ProxyShardingSpec.cs
@@ -64,7 +64,7 @@ namespace Akka.Cluster.Sharding.Tests
 
         public static Config GetConfig()
         {
-            return ConfigurationFactory.ParseString("akka.actor.provider = \"Akka.Cluster.ClusterActorRefProvider, Akka.Cluster\"")
+            return ConfigurationFactory.ParseString("akka.actor.provider = cluster")
 
                 .WithFallback(Sharding.ClusterSharding.DefaultConfig())
                 .WithFallback(DistributedData.DistributedData.DefaultConfig())

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Akka.Actor;
@@ -330,7 +331,7 @@ namespace Akka.Cluster.Sharding
                     ExceptionDispatchInfo.Capture(failure.Cause).Throw();
                     return ActorRefs.Nobody;
 
-                default: 
+                default:
                     throw new ActorInitializationException($"Unsupported guardian response: {reply}");
             }
         }
@@ -702,6 +703,11 @@ namespace Akka.Cluster.Sharding
 
             return StartProxyAsync(typeName, role, extractEntityId, messageExtractor.ShardId);
         }
+
+        /// <summary>
+        /// get all currently defined sharding type names.
+        /// </summary>
+        public ImmutableHashSet<EntityId> ShardTypeNames => _regions.Keys.ToImmutableHashSet();
 
         /// <summary>
         /// Retrieve the actor reference of the <see cref="Sharding.ShardRegion"/> actor responsible for the named entity type.

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
@@ -218,9 +218,8 @@ namespace Akka.Cluster.Sharding
                 try
                 {
                     var settings = startProxy.Settings;
-                    var encName = Uri.EscapeDataString(startProxy.TypeName);
-                    var coordinatorSingletonManagerName = CoordinatorSingletonManagerName(encName);
-                    var coordinatorPath = CoordinatorPath(encName);
+                    var encName = Uri.EscapeDataString(startProxy.TypeName + "Proxy");
+                    var coordinatorPath = CoordinatorPath(Uri.EscapeDataString(startProxy.TypeName));
                     var shardRegion = Context.Child(encName);
 
                     if (Equals(shardRegion, ActorRefs.Nobody))

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
@@ -55,7 +55,7 @@ namespace Akka.Cluster.Sharding
             /// <summary>
             /// TBD
             /// </summary>
-            public readonly Props EntityProps;
+            public readonly Func<string, Props> EntityProps;
             /// <summary>
             /// TBD
             /// </summary>
@@ -90,7 +90,7 @@ namespace Akka.Cluster.Sharding
             /// <exception cref="ArgumentNullException">
             /// This exception is thrown when the specified <paramref name="typeName"/> or <paramref name="entityProps"/> is undefined.
             /// </exception>
-            public Start(string typeName, Props entityProps, ClusterShardingSettings settings,
+            public Start(string typeName, Func<string, Props> entityProps, ClusterShardingSettings settings,
                 ExtractEntityId extractEntityId, ExtractShardId extractShardId, IShardAllocationStrategy allocationStrategy, object handOffStopMessage)
             {
                 if (string.IsNullOrEmpty(typeName)) throw new ArgumentNullException(nameof(typeName), "ClusterSharding start requires type name to be provided");

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingSettings.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingSettings.cs
@@ -279,6 +279,16 @@ namespace Akka.Cluster.Sharding
         }
 
         /// <summary>
+        /// If true, this node should run the shard region, otherwise just a shard proxy should started on this node.
+        /// </summary>
+        /// <param name="cluster"></param>
+        /// <returns></returns>
+        internal bool ShouldHostShard(Cluster cluster)
+        {
+            return string.IsNullOrEmpty(Role) || cluster.SelfRoles.Contains(Role);
+        }
+
+        /// <summary>
         /// TBD
         /// </summary>
         /// <param name="role">TBD</param>

--- a/src/contrib/cluster/Akka.Cluster.Sharding/DDataShard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/DDataShard.cs
@@ -35,7 +35,7 @@ namespace Akka.Cluster.Sharding
 
         public string TypeName { get; }
         public string ShardId { get; }
-        public Props EntityProps { get; }
+        public Func<string, Props> EntityProps { get; }
         public ClusterShardingSettings Settings { get; }
         public ExtractEntityId ExtractEntityId { get; }
         public ExtractShardId ExtractShardId { get; }
@@ -72,7 +72,7 @@ namespace Akka.Cluster.Sharding
         public DDataShard(
             string typeName,
             ShardId shardId,
-            Props entityProps,
+            Func<string, Props> entityProps,
             ClusterShardingSettings settings,
             ExtractEntityId extractEntityId,
             ExtractShardId extractShardId,
@@ -100,7 +100,7 @@ namespace Akka.Cluster.Sharding
             _readConsistency = new ReadMajority(settings.TunningParameters.WaitingForStateTimeout, majorityCap);
             _writeConsistency = new WriteMajority(settings.TunningParameters.UpdatingStateTimeout, majorityCap);
             _stateKeys = Enumerable.Range(0, NrOfKeys).Select(i => new ORSetKey<EntryId>($"shard-{typeName}-{shardId}-{i}")).ToImmutableArray();
-            
+
             GetState();
         }
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShard.cs
@@ -33,7 +33,7 @@ namespace Akka.Cluster.Sharding
 
         public string TypeName { get; }
         public string ShardId { get; }
-        public Props EntityProps { get; }
+        public Func<string, Props> EntityProps { get; }
         public ClusterShardingSettings Settings { get; }
         public ExtractEntityId ExtractEntityId { get; }
         public ExtractShardId ExtractShardId { get; }
@@ -45,12 +45,12 @@ namespace Akka.Cluster.Sharding
         public ImmutableHashSet<IActorRef> Passivating { get; set; } = ImmutableHashSet<IActorRef>.Empty;
         public ImmutableDictionary<string, ImmutableList<Tuple<object, IActorRef>>> MessageBuffers { get; set; } = ImmutableDictionary<string, ImmutableList<Tuple<object, IActorRef>>>.Empty;
 
-        private EntityRecoveryStrategy RememberedEntitiesRecoveryStrategy { get; } 
+        private EntityRecoveryStrategy RememberedEntitiesRecoveryStrategy { get; }
 
         public PersistentShard(
             string typeName,
             string shardId,
-            Props entityProps,
+            Func<string, Props> entityProps,
             ClusterShardingSettings settings,
             ExtractEntityId extractEntityId,
             ExtractShardId extractShardId,

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
@@ -18,7 +18,7 @@ namespace Akka.Cluster.Sharding
     using ShardId = String;
     using EntityId = String;
     using Msg = Object;
-    
+
     internal interface IShard
     {
         IActorContext Context { get; }
@@ -26,7 +26,7 @@ namespace Akka.Cluster.Sharding
         IActorRef Sender { get; }
         string TypeName { get; }
         ShardId ShardId { get; }
-        Props EntityProps { get; }
+        Func<string, Props> EntityProps { get; }
         ClusterShardingSettings Settings { get; }
         ExtractEntityId ExtractEntityId { get; }
         ExtractShardId ExtractShardId { get; }
@@ -360,7 +360,7 @@ namespace Akka.Cluster.Sharding
         public ILoggingAdapter Log { get; } = Context.GetLogger();
         public string TypeName { get; }
         public string ShardId { get; }
-        public Props EntityProps { get; }
+        public Func<string, Props> EntityProps { get; }
         public ClusterShardingSettings Settings { get; }
         public ExtractEntityId ExtractEntityId { get; }
         public ExtractShardId ExtractShardId { get; }
@@ -377,7 +377,7 @@ namespace Akka.Cluster.Sharding
         public Shard(
             string typeName,
             string shardId,
-            Props entityProps,
+            Func<string, Props> entityProps,
             ClusterShardingSettings settings,
             ExtractEntityId extractEntityId,
             ExtractShardId extractShardId,
@@ -417,14 +417,14 @@ namespace Akka.Cluster.Sharding
         {
             shard.Context.Parent.Tell(new ShardInitialized(shard.ShardId));
         }
-        
+
         public static void BaseProcessChange<TShard, T>(this TShard shard, T evt, Action<T> handler)
             where TShard : IShard
             where T : Shard.StateChange
         {
             handler(evt);
         }
-        
+
         public static bool HandleCommand<TShard>(this TShard shard, object message) where TShard : IShard
         {
             switch (message)
@@ -471,7 +471,7 @@ namespace Akka.Cluster.Sharding
                     break;
             }
         }
-        
+
         public static void BaseEntityTerminated<TShard>(this TShard shard, IActorRef tref) where TShard : IShard
         {
             if (shard.IdByRef.TryGetValue(tref, out var id))
@@ -616,14 +616,14 @@ namespace Akka.Cluster.Sharding
                 shard.Log.Debug("Unknown entity {0}. Not sending stopMessage back to entity.", entity);
             }
         }
-        
+
         public static void PassivateCompleted<TShard>(this TShard shard, Shard.EntityStopped evt) where TShard: IShard
         {
             shard.Log.Debug("Entity stopped after passivation [{0}]", evt.EntityId);
             shard.State = new Shard.ShardState(shard.State.Entries.Remove(evt.EntityId));
             shard.MessageBuffers = shard.MessageBuffers.Remove(evt.EntityId);
         }
-        
+
         public static void SendMessageBuffer<TShard>(this TShard shard, Shard.EntityStarted message) where TShard: IShard
         {
             var id = message.EntityId;
@@ -677,7 +677,7 @@ namespace Akka.Cluster.Sharding
                     shard.DeliverTo(id, message, payload, sender);
             }
         }
-        
+
         internal static void BaseDeliverTo<TShard>(this TShard shard, string id, object message, object payload, IActorRef sender) where TShard : IShard
         {
             var name = Uri.EscapeDataString(id);
@@ -688,7 +688,7 @@ namespace Akka.Cluster.Sharding
             else
                 child.Tell(payload, sender);
         }
-        
+
         internal static IActorRef GetEntity<TShard>(this TShard shard, string id) where TShard: IShard
         {
             var name = Uri.EscapeDataString(id);
@@ -697,7 +697,7 @@ namespace Akka.Cluster.Sharding
             {
                 shard.Log.Debug("Starting entity [{0}] in shard [{1}]", id, shard.ShardId);
 
-                child = shard.Context.Watch(shard.Context.ActorOf(shard.EntityProps, name));
+                child = shard.Context.Watch(shard.Context.ActorOf(shard.EntityProps(id), name));
                 shard.IdByRef = shard.IdByRef.SetItem(child, id);
                 shard.RefById = shard.RefById.SetItem(id, child);
                 shard.State = new Shard.ShardState(shard.State.Entries.Add(id));
@@ -706,12 +706,12 @@ namespace Akka.Cluster.Sharding
             return child;
         }
 
-        internal static int TotalBufferSize<TShard>(this TShard shard) where TShard : IShard => 
+        internal static int TotalBufferSize<TShard>(this TShard shard) where TShard : IShard =>
             shard.MessageBuffers.Aggregate(0, (sum, entity) => sum + entity.Value.Count);
 
         #endregion
 
-        public static Props Props(string typeName, ShardId shardId, Props entityProps, ClusterShardingSettings settings, ExtractEntityId extractEntityId, ExtractShardId extractShardId, object handOffStopMessage, IActorRef replicator, int majorityMinCap)
+        public static Props Props(string typeName, ShardId shardId, Func<string, Props> entityProps, ClusterShardingSettings settings, ExtractEntityId extractEntityId, ExtractShardId extractShardId, object handOffStopMessage, IActorRef replicator, int majorityMinCap)
         {
             switch (settings.StateStoreMode)
             {
@@ -724,7 +724,7 @@ namespace Akka.Cluster.Sharding
             }
         }
     }
-    
+
     class RememberEntityStarter : ActorBase
     {
         private class Tick : INoSerializationVerificationNeeded

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
@@ -243,7 +243,7 @@ namespace Akka.Cluster.Sharding
         /// <param name="replicator"></param>
         /// <param name="majorityMinCap"></param>
         /// <returns>TBD</returns>
-        internal static Props Props(string typeName, Props entityProps, ClusterShardingSettings settings, string coordinatorPath, ExtractEntityId extractEntityId, ExtractShardId extractShardId, object handOffStopMessage, IActorRef replicator, int majorityMinCap)
+        internal static Props Props(string typeName, Func<string, Props> entityProps, ClusterShardingSettings settings, string coordinatorPath, ExtractEntityId extractEntityId, ExtractShardId extractShardId, object handOffStopMessage, IActorRef replicator, int majorityMinCap)
         {
             return Actor.Props.Create(() => new ShardRegion(typeName, entityProps, settings, coordinatorPath, extractEntityId, extractShardId, handOffStopMessage, replicator, majorityMinCap)).WithDeploy(Deploy.Local);
         }
@@ -271,7 +271,7 @@ namespace Akka.Cluster.Sharding
         /// <summary>
         /// TBD
         /// </summary>
-        public readonly Props EntityProps;
+        public readonly Func<string, Props> EntityProps;
         /// <summary>
         /// TBD
         /// </summary>
@@ -358,7 +358,7 @@ namespace Akka.Cluster.Sharding
         /// <param name="handOffStopMessage">TBD</param>
         /// <param name="replicator"></param>
         /// <param name="majorityMinCap"></param>
-        public ShardRegion(string typeName, Props entityProps, ClusterShardingSettings settings, string coordinatorPath, ExtractEntityId extractEntityId, ExtractShardId extractShardId, object handOffStopMessage, IActorRef replicator, int majorityMinCap)
+        public ShardRegion(string typeName, Func<string, Props> entityProps, ClusterShardingSettings settings, string coordinatorPath, ExtractEntityId extractEntityId, ExtractShardId extractShardId, object handOffStopMessage, IActorRef replicator, int majorityMinCap)
         {
             TypeName = typeName;
             EntityProps = entityProps;
@@ -417,7 +417,7 @@ namespace Akka.Cluster.Sharding
         {
             get
             {
-                if (EntityProps != null && !EntityProps.Equals(Actor.Props.None))
+                if (EntityProps != null)
                     return new PersistentShardCoordinator.Register(Self);
                 return new PersistentShardCoordinator.RegisterProxy(Self);
             }
@@ -913,7 +913,7 @@ namespace Akka.Cluster.Sharding
             //TODO: change on ConcurrentDictionary.GetOrAdd?
             if (!Shards.TryGetValue(id, out var region))
             {
-                if (EntityProps == null || EntityProps.Equals(Actor.Props.Empty))
+                if (EntityProps == null)
                     throw new IllegalStateException("Shard must not be allocated to a proxy only ShardRegion");
 
                 if (ShardsByRef.Values.All(shardId => shardId != id))


### PR DESCRIPTION
Contains following changes:

- Provide access to known shard types
https://github.com/akka/akka/issues/23912

- Separate sharding regions and proxies
https://github.com/akka/akka/issues/23472
Fix lookup of coordinator for sharding proxies
https://github.com/akka/akka/pull/23995

- Fix race in ClusterShardingFailureSpec
AFAICT there was nothing ensuring the order of messages when sent to the
shard and the region so first checkthat the passivation has happened
before sending another add in the test
https://github.com/akka/akka/issues/24013

- Better warning message on cluster sharding registration
https://github.com/akka/akka/pull/24906

- entityId => Behavior in ClusterSharding API
mixture of
https://github.com/akka/akka/issues/24053
https://github.com/akka/akka/issues/21809
https://github.com/akka/akka/issues/24470

- ClusterSharding: automatically choose start or startProxy by a node role
https://github.com/akka/akka/issues/23934
