### PR TITLE
added DDataClusterShardingConfigSpec

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingConfigSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingConfigSpec.cs
@@ -7,12 +7,7 @@
 
 using System;
 using Akka.Configuration;
-using Akka.DistributedData;
-using Akka.DistributedData.Internal;
-using Akka.DistributedData.Serialization;
-using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests
 {
@@ -66,32 +61,6 @@ namespace Akka.Cluster.Sharding.Tests
             Assert.Equal(string.Empty, singletonConfig.GetString("role"));
             Assert.Equal(TimeSpan.FromSeconds(1), singletonConfig.GetTimeSpan("hand-over-retry-interval"));
             Assert.Equal(10, singletonConfig.GetInt("min-number-of-hand-over-retries"));
-        }
-    }
-
-    public class DDataClusterShardingConfigSpec : TestKit.Xunit2.TestKit
-    {
-        public DDataClusterShardingConfigSpec(ITestOutputHelper helper) : base(GetConfig(), output:helper)
-        {
-        }
-
-        public static Config GetConfig()
-        {
-            return ConfigurationFactory.ParseString(@"akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""
-                akka.cluster.sharding.state-store-mode = ddata
-            ");
-        }
-
-        [Fact]
-        public void Should_load_DData_serializers_when_enabled()
-        {
-            ClusterSharding.Get(Sys);
-
-            var rmSerializer = Sys.Serialization.FindSerializerFor(WriteAck.Instance);
-            rmSerializer.Should().BeOfType<ReplicatorMessageSerializer>();
-
-            var rDSerializer = Sys.Serialization.FindSerializerFor(ORDictionary<string, GSet<string>>.Empty);
-            rDSerializer.Should().BeOfType<ReplicatedDataSerializer>();
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/DDataClusterShardingConfigSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/DDataClusterShardingConfigSpec.cs
@@ -1,0 +1,46 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="DDataClusterShardingConfigSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Configuration;
+using Akka.DistributedData;
+using Akka.DistributedData.Internal;
+using Akka.DistributedData.Serialization;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    /// <summary>
+    /// Used to validate that https://github.com/akkadotnet/akka.net/issues/3529 works as expected
+    /// </summary>
+    public class DDataClusterShardingConfigSpec : TestKit.Xunit2.TestKit
+    {
+        public DDataClusterShardingConfigSpec(ITestOutputHelper helper) : base(GetConfig(), output:helper)
+        {
+        }
+
+        public static Config GetConfig()
+        {
+            return ConfigurationFactory.ParseString(@"akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""
+                akka.cluster.sharding.state-store-mode = ddata
+            ");
+        }
+
+        [Fact]
+        public void Should_load_DData_serializers_when_enabled()
+        {
+            ClusterSharding.Get(Sys);
+
+            var rmSerializer = Sys.Serialization.FindSerializerFor(WriteAck.Instance);
+            rmSerializer.Should().BeOfType<ReplicatorMessageSerializer>();
+
+            var rDSerializer = Sys.Serialization.FindSerializerFor(ORDictionary<string, GSet<string>>.Empty);
+            rDSerializer.Should().BeOfType<ReplicatedDataSerializer>();
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.DistributedData/Properties/AssemblyInfo.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Properties/AssemblyInfo.cs
@@ -24,3 +24,4 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("Akka.DistributedData.Tests.MultiNode")]
 [assembly: InternalsVisibleTo("Akka.Cluster.Sharding")]
 [assembly: InternalsVisibleTo("Akka.Cluster.Sharding.Tests.MultiNode")]
+[assembly: InternalsVisibleTo("Akka.Cluster.Sharding.Tests")]


### PR DESCRIPTION
close #3529 

Validates that the DData serialization system gets correctly loaded by the `Cluster.Sharding` runtime when `akka.cluster.sharding.state-store-mode=ddata`. In other words, the current behavior is correct and this spec validates it.