### PR TITLE
File publisher allows opening the same file for reading multiple times

### DIFF
--- a/src/core/Akka.Streams.Tests/IO/FileSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/FileSourceSpec.cs
@@ -202,6 +202,31 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
+        public void FileSource_should_open_file_in_shared_mode_for_reading_multiple_times()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var testFile = TestFile();
+                var p1 = FileIO.FromFile(testFile).RunWith(Sink.AsPublisher<ByteString>(false), _materializer);
+                var p2 = FileIO.FromFile(testFile).RunWith(Sink.AsPublisher<ByteString>(false), _materializer);
+                
+                var c1 = this.CreateManualSubscriberProbe<ByteString>();
+                var c2 = this.CreateManualSubscriberProbe<ByteString>();
+                p1.Subscribe(c1);
+                p2.Subscribe(c2);
+                var s1 = c1.ExpectSubscription();
+                var s2 = c2.ExpectSubscription();
+
+                s1.Request(5000);
+                s2.Request(5000);
+
+                c1.ExpectNext();
+                c2.ExpectNext();
+
+            }, _materializer);
+        }
+
+        [Fact]
         public void FileSource_should_onError_with_failure_and_return_a_failed_IOResult_when_trying_to_read_from_file_which_does_not_exist()
         {
             this.AssertAllStagesStopped(() =>

--- a/src/core/Akka.Streams/Implementation/IO/FilePublisher.cs
+++ b/src/core/Akka.Streams/Implementation/IO/FilePublisher.cs
@@ -107,7 +107,8 @@ namespace Akka.Streams.Implementation.IO
         {
             try
             {
-                _chan = _f.Open(FileMode.Open, FileAccess.Read);
+                // Allow opening the same file for reading multiple times
+                _chan = _f.Open(FileMode.Open, FileAccess.Read, FileShare.Read);
                 if (_startPosition > 0)
                     _chan.Position = _startPosition;
             }


### PR DESCRIPTION
As discussed in Gitter: Fixes bug in `FileIO.FromFile` that the same file can be opened multiple times at the same time