### PR TITLE
[WIP] Akka.Serializer performance fixes

### DIFF
--- a/src/core/Akka/Serialization/Serializer.cs
+++ b/src/core/Akka/Serialization/Serializer.cs
@@ -75,10 +75,10 @@ namespace Akka.Serialization
         /// </summary>
         /// <param name="address">The address to use when serializing local ActorRef´s</param>
         /// <param name="obj">The object to serialize</param>
-        /// <returns>TBD</returns>
+        /// <returns>A serialized message</returns>
         public byte[] ToBinaryWithAddress(Address address, object obj)
         {
-            return Serialization.SerializeWithTransport(system, address, () => ToBinary(obj));
+            return Serialization.SerializeWithTransport(system, address, this, obj);
         }
 
         /// <summary>


### PR DESCRIPTION
Noticed some unnecessary allocations inside the `Serializer` class while I was doing some other work today (working on an Akka.Persistence) plugin. Redesigned those portions to prevent garbage collection.

This code affects not just Akka.Remote, but also the Akka.Persistence and any other serializer that might need to serialize an `IActorRef`.

When I ran the RemotePingPong numbers I didn't see a significant material difference - not sure why yet.

WIP-ing this because I want to see some of the build server numbers and because I think it may be worth benchmarking this specific method independently from the entire Akka.Remote messaging pipeline.