### PR TITLE
Coordinated downing improvements

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
@@ -1,0 +1,210 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Cluster.Sharding.Serialization;
+using Akka.Cluster.Tools.Singleton;
+using Akka.Configuration;
+using Akka.TestKit;
+using Akka.TestKit.TestActors;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    public class CoordinatedShutdownShardingSpec : AkkaSpec
+    {
+        private ActorSystem sys1;
+        private ActorSystem sys2;
+        private ActorSystem sys3;
+
+        private IActorRef region1;
+        private IActorRef region2;
+        private IActorRef region3;
+
+        private TestProbe _probe1;
+        private TestProbe _probe2;
+        private TestProbe _probe3;
+
+        private static readonly Config SpecConfig;
+
+        private class EchoActor : ReceiveActor
+        {
+            public EchoActor()
+            {
+                ReceiveAny(_ => Sender.Tell(_));
+            }
+        }
+
+        private readonly ExtractEntityId _extractEntityId = message => Tuple.Create(message.ToString(), message);
+
+        private readonly ExtractShardId _extractShard = message => (message.GetHashCode() % 10).ToString();
+
+        static CoordinatedShutdownShardingSpec()
+        {
+            SpecConfig = ConfigurationFactory.ParseString(@"
+                akka.loglevel = DEBUG
+                akka.actor.provider = cluster
+                akka.remote.dot-netty.tcp.port = 0")
+                .WithFallback(ClusterSingletonManager.DefaultConfig()
+                .WithFallback(ClusterSharding.DefaultConfig()));
+        }
+
+        public CoordinatedShutdownShardingSpec(ITestOutputHelper helper) : base(SpecConfig, helper)
+        {
+            sys1 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
+            sys2 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
+            sys3 = Sys;
+
+            var props = Props.Create(() => new EchoActor());
+            region1 = ClusterSharding.Get(sys1).Start("type1", props, ClusterShardingSettings.Create(sys1),
+                _extractEntityId, _extractShard);
+            region2 = ClusterSharding.Get(sys2).Start("type1", props, ClusterShardingSettings.Create(sys2),
+                _extractEntityId, _extractShard);
+            region3 = ClusterSharding.Get(sys3).Start("type1", props, ClusterShardingSettings.Create(sys3),
+                _extractEntityId, _extractShard);
+
+
+            _probe1 = CreateTestProbe(sys1);
+            _probe2 = CreateTestProbe(sys2);
+            _probe3 = CreateTestProbe(sys3);
+
+            CoordinatedShutdown.Get(sys1).AddTask(CoordinatedShutdown.PhaseBeforeServiceUnbind, "unbind", () =>
+            {
+                _probe1.Ref.Tell("CS-unbind-1");
+                return Task.FromResult(Done.Instance);
+            });
+
+            CoordinatedShutdown.Get(sys2).AddTask(CoordinatedShutdown.PhaseBeforeServiceUnbind, "unbind", () =>
+            {
+                _probe2.Ref.Tell("CS-unbind-2");
+                return Task.FromResult(Done.Instance);
+            });
+
+            CoordinatedShutdown.Get(sys3).AddTask(CoordinatedShutdown.PhaseBeforeServiceUnbind, "unbind", () =>
+            {
+                _probe3.Ref.Tell("CS-unbind-3");
+                return Task.FromResult(Done.Instance);
+            });
+        }
+
+        protected override void BeforeTermination()
+        {
+            Shutdown(sys1);
+            Shutdown(sys2);
+        }
+
+        /// <summary>
+        /// Using region 2 as it is not shutdown in either test.
+        /// </summary>
+        private void PingEntities()
+        {
+            region2.Tell(1, _probe2.Ref);
+            _probe2.ExpectMsg<int>(10.Seconds()).Should().Be(1);
+            region2.Tell(2, _probe2.Ref);
+            _probe2.ExpectMsg<int>(10.Seconds()).Should().Be(2);
+            region2.Tell(3, _probe2.Ref);
+            _probe2.ExpectMsg<int>(10.Seconds()).Should().Be(3);
+        }
+
+        [Fact]
+        public void Sharding_and_CoordinatedShutdown_must_run_successfully()
+        {
+            InitCluster();
+            RunCoordinatedShutdownWhenLeaving();
+        }
+
+        private void InitCluster()
+        {
+            // FIXME this test should also work when coordinator is on the leaving sys1 node,
+            //       but currently there seems to be a race between the CS and the ClusterSingleton observing OldestChanged
+            //       and terminating coordinator singleton before the graceful sharding stop is done.
+
+            Cluster.Get(sys2).Join(Cluster.Get(sys2).SelfAddress); // coordinator will initially run on sys2
+            AwaitAssert(() => Cluster.Get(sys2).SelfMember.Status.Should().Be(MemberStatus.Up));
+
+            Cluster.Get(sys1).Join(Cluster.Get(sys2).SelfAddress);
+            Within(10.Seconds(), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    Cluster.Get(sys1).State.Members.Count.Should().Be(2);
+                    Cluster.Get(sys1).State.Members.All(x => x.Status == MemberStatus.Up).Should().BeTrue();
+                    Cluster.Get(sys2).State.Members.Count.Should().Be(2);
+                    Cluster.Get(sys2).State.Members.All(x => x.Status == MemberStatus.Up).Should().BeTrue();
+                });
+            });
+
+            Cluster.Get(sys3).Join(Cluster.Get(sys1).SelfAddress);
+            Within(10.Seconds(), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    Cluster.Get(sys1).State.Members.Count.Should().Be(3);
+                    Cluster.Get(sys1).State.Members.All(x => x.Status == MemberStatus.Up).Should().BeTrue();
+                    Cluster.Get(sys2).State.Members.Count.Should().Be(3);
+                    Cluster.Get(sys2).State.Members.All(x => x.Status == MemberStatus.Up).Should().BeTrue();
+                    Cluster.Get(sys3).State.Members.Count.Should().Be(3);
+                    Cluster.Get(sys3).State.Members.All(x => x.Status == MemberStatus.Up).Should().BeTrue();
+                });
+            });
+
+            PingEntities();
+        }
+
+        private void RunCoordinatedShutdownWhenLeaving()
+        {
+            Cluster.Get(sys3).Leave(Cluster.Get(sys1).SelfAddress);
+            _probe1.ExpectMsg("CS-unbind-1");
+
+            Within(10.Seconds(), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    Cluster.Get(sys2).State.Members.Count.Should().Be(2);
+                    Cluster.Get(sys3).State.Members.Count.Should().Be(2);
+                });
+            });
+
+            Within(10.Seconds(), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    Cluster.Get(sys1).IsTerminated.Should().BeTrue();
+                    sys1.WhenTerminated.IsCompleted.Should().BeTrue();
+                });
+            });
+
+            PingEntities();
+        }
+
+        private void RunCoordinatedShutdownWhenDowning()
+        {
+            // coordinator is on Sys2
+            Cluster.Get(sys2).Down(Cluster.Get(sys3).SelfAddress);
+            _probe3.ExpectMsg("CS-unbind-3");
+
+            Within(10.Seconds(), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    Cluster.Get(sys2).State.Members.Count.Should().Be(1);
+                });
+            });
+
+            Within(10.Seconds(), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    Cluster.Get(sys3).IsTerminated.Should().BeTrue();
+                    sys3.WhenTerminated.IsCompleted.Should().BeTrue();
+                });
+            });
+
+            PingEntities();
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
@@ -118,6 +118,7 @@ namespace Akka.Cluster.Sharding.Tests
         {
             InitCluster();
             RunCoordinatedShutdownWhenLeaving();
+            RunCoordinatedShutdownWhenDowning();
         }
 
         private void InitCluster()

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
@@ -379,8 +379,15 @@ namespace Akka.Cluster.Sharding
             var self = Self;
             _coordShutdown.AddTask(CoordinatedShutdown.PhaseClusterShardingShutdownRegion, "region-shutdown", () =>
             {
-                self.Tell(GracefulShutdown.Instance);
-                return _gracefulShutdownProgress.Task;
+                if (Cluster.IsTerminated || Cluster.SelfMember.Status == MemberStatus.Down)
+                {
+                    return Task.FromResult(Done.Instance);
+                }
+                else
+                {
+                    self.Tell(GracefulShutdown.Instance);
+                    return _gracefulShutdownProgress.Task;
+                }
             });
         }
 

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/OldestChangedBuffer.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/OldestChangedBuffer.cs
@@ -172,9 +172,13 @@ namespace Akka.Cluster.Tools.Singleton
 
         private void SendFirstChange()
         {
-            object change;
-            _changes = _changes.Dequeue(out change);
-            Context.Parent.Tell(change);
+            // don't send cluster change events if this node is shutting its self down, just wait for SelfExiting
+            if (!_cluster.IsTerminated)
+            {
+                object change;
+                _changes = _changes.Dequeue(out change);
+                Context.Parent.Tell(change);
+            }
         }
 
         /// <inheritdoc cref="ActorBase.PreStart"/>

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/OldestChangedBuffer.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/OldestChangedBuffer.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Util.Internal;
 
@@ -115,8 +116,15 @@ namespace Akka.Cluster.Tools.Singleton
             var self = Self;
             _coordShutdown.AddTask(CoordinatedShutdown.PhaseClusterExiting, "singleton-exiting-1", () =>
             {
-                var timeout = _coordShutdown.Timeout(CoordinatedShutdown.PhaseClusterExiting);
-                return self.Ask(SelfExiting.Instance, timeout).ContinueWith(tr => Done.Instance);
+                if (_cluster.IsTerminated || _cluster.SelfMember.Status == MemberStatus.Down)
+                {
+                    return Task.FromResult(Done.Instance);
+                }
+                else
+                {
+                    var timeout = _coordShutdown.Timeout(CoordinatedShutdown.PhaseClusterExiting);
+                    return self.Ask(SelfExiting.Instance, timeout).ContinueWith(tr => Done.Instance);
+                }
             });
         }
 
@@ -235,7 +243,7 @@ namespace Akka.Cluster.Tools.Singleton
             }
             else if (message is ClusterEvent.MemberRemoved)
             {
-                var removed = (ClusterEvent.MemberRemoved) message;
+                var removed = (ClusterEvent.MemberRemoved)message;
                 Remove(removed.Member);
                 DeliverChanges();
             }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCluster.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCluster.approved.txt
@@ -25,6 +25,7 @@ namespace Akka.Cluster
         public Akka.Remote.DefaultFailureDetectorRegistry<Akka.Actor.Address> FailureDetector { get; }
         public bool IsTerminated { get; }
         public Akka.Actor.Address SelfAddress { get; }
+        public Akka.Cluster.Member SelfMember { get; }
         public System.Collections.Immutable.ImmutableHashSet<string> SelfRoles { get; }
         public Akka.Cluster.UniqueAddress SelfUniqueAddress { get; }
         public Akka.Cluster.ClusterSettings Settings { get; }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -503,12 +503,35 @@ namespace Akka.Actor
         public const string PhaseServiceRequestsDone = "service-requests-done";
         public const string PhaseServiceStop = "service-stop";
         public const string PhaseServiceUnbind = "service-unbind";
+        public Akka.Actor.CoordinatedShutdown.Reason ShutdownReason { get; }
         public Akka.Actor.ExtendedActorSystem System { get; }
         public System.TimeSpan TotalTimeout { get; }
         public void AddTask(string phase, string taskName, System.Func<System.Threading.Tasks.Task<Akka.Done>> task) { }
         public static Akka.Actor.CoordinatedShutdown Get(Akka.Actor.ActorSystem sys) { }
+        [System.ObsoleteAttribute("Use the method with \'reason\' parameter instead")]
         public System.Threading.Tasks.Task<Akka.Done> Run(string fromPhase = null) { }
+        public System.Threading.Tasks.Task<Akka.Done> Run(Akka.Actor.CoordinatedShutdown.Reason reason, string fromPhase = null) { }
         public System.TimeSpan Timeout(string phase) { }
+        public class ClrExitReason : Akka.Actor.CoordinatedShutdown.Reason
+        {
+            public static Akka.Actor.CoordinatedShutdown.Reason Instance;
+        }
+        public class ClusterDowningReason : Akka.Actor.CoordinatedShutdown.Reason
+        {
+            public static Akka.Actor.CoordinatedShutdown.Reason Instance;
+        }
+        public class ClusterLeavingReason : Akka.Actor.CoordinatedShutdown.Reason
+        {
+            public static Akka.Actor.CoordinatedShutdown.Reason Instance;
+        }
+        public class Reason
+        {
+            protected Reason() { }
+        }
+        public class UnknownReason : Akka.Actor.CoordinatedShutdown.Reason
+        {
+            public static Akka.Actor.CoordinatedShutdown.Reason Instance;
+        }
     }
     public sealed class CoordinatedShutdownExtension : Akka.Actor.ExtensionIdProvider<Akka.Actor.CoordinatedShutdown>
     {

--- a/src/core/Akka.Cluster.Tests/ClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterSpec.cs
@@ -189,8 +189,9 @@ namespace Akka.Cluster.Tests
 
             leaveTask.IsCompleted.Should().BeFalse();
             probe.ExpectMsg<ClusterEvent.MemberLeft>();
-            probe.ExpectMsg<ClusterEvent.MemberExited>();
-            probe.ExpectMsg<ClusterEvent.MemberRemoved>();
+            // MemberExited might not be published before MemberRemoved
+            var removed = (ClusterEvent.MemberRemoved)probe.FishForMessage(m => m is ClusterEvent.MemberRemoved);
+            removed.PreviousStatus.ShouldBeEquivalentTo(MemberStatus.Exiting);
 
             AwaitCondition(() => leaveTask.IsCompleted);
 
@@ -495,8 +496,9 @@ namespace Akka.Cluster.Tests
                 CoordinatedShutdown.Get(sys2).Run(CoordinatedShutdown.UnknownReason.Instance);
 
                 probe.ExpectMsg<ClusterEvent.MemberLeft>();
-                probe.ExpectMsg<ClusterEvent.MemberExited>();
-                probe.ExpectMsg<ClusterEvent.MemberRemoved>();
+                // MemberExited might not be published before MemberRemoved
+                var removed = (ClusterEvent.MemberRemoved)probe.FishForMessage(m => m is ClusterEvent.MemberRemoved);
+                removed.PreviousStatus.ShouldBeEquivalentTo(MemberStatus.Exiting);
             }
             finally
             {
@@ -527,8 +529,9 @@ namespace Akka.Cluster.Tests
                 CoordinatedShutdown.Get(sys2).Run(CoordinatedShutdown.UnknownReason.Instance);
 
                 probe.ExpectMsg<ClusterEvent.MemberLeft>();
-                probe.ExpectMsg<ClusterEvent.MemberExited>();
-                probe.ExpectMsg<ClusterEvent.MemberRemoved>();
+                // MemberExited might not be published before MemberRemoved
+                var removed = (ClusterEvent.MemberRemoved)probe.FishForMessage(m => m is ClusterEvent.MemberRemoved);
+                removed.PreviousStatus.ShouldBeEquivalentTo(MemberStatus.Exiting);
             }
             finally
             {
@@ -556,8 +559,9 @@ namespace Akka.Cluster.Tests
                 Cluster.Get(sys2).Leave(Cluster.Get(sys2).SelfAddress);
 
                 probe.ExpectMsg<ClusterEvent.MemberLeft>();
-                probe.ExpectMsg<ClusterEvent.MemberExited>();
-                probe.ExpectMsg<ClusterEvent.MemberRemoved>();
+                // MemberExited might not be published before MemberRemoved
+                var removed = (ClusterEvent.MemberRemoved)probe.FishForMessage(m => m is ClusterEvent.MemberRemoved);
+                removed.PreviousStatus.ShouldBeEquivalentTo(MemberStatus.Exiting);
                 AwaitCondition(() => sys2.WhenTerminated.IsCompleted, TimeSpan.FromSeconds(10));
                 Cluster.Get(sys2).IsTerminated.Should().BeTrue();
                 CoordinatedShutdown.Get(sys2).ShutdownReason.Should().BeOfType<CoordinatedShutdown.ClusterLeavingReason>();

--- a/src/core/Akka.Cluster.Tests/ClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterSpec.cs
@@ -492,7 +492,7 @@ namespace Akka.Cluster.Tests
                 Cluster.Get(sys2).Join(Cluster.Get(sys2).SelfAddress);
                 probe.ExpectMsg<ClusterEvent.MemberUp>();
 
-                CoordinatedShutdown.Get(sys2).Run();
+                CoordinatedShutdown.Get(sys2).Run(CoordinatedShutdown.UnknownReason.Instance);
 
                 probe.ExpectMsg<ClusterEvent.MemberLeft>();
                 probe.ExpectMsg<ClusterEvent.MemberExited>();
@@ -528,6 +528,7 @@ namespace Akka.Cluster.Tests
                 probe.ExpectMsg<ClusterEvent.MemberRemoved>();
                 AwaitCondition(() => sys2.WhenTerminated.IsCompleted, TimeSpan.FromSeconds(10));
                 Cluster.Get(sys2).IsTerminated.Should().BeTrue();
+                CoordinatedShutdown.Get(sys2).ShutdownReason.Should().BeOfType<CoordinatedShutdown.ClusterLeavingReason>();
             }
             finally
             {
@@ -559,6 +560,7 @@ namespace Akka.Cluster.Tests
                 probe.ExpectMsg<ClusterEvent.MemberRemoved>();
                 AwaitCondition(() => sys3.WhenTerminated.IsCompleted, TimeSpan.FromSeconds(10));
                 Cluster.Get(sys3).IsTerminated.Should().BeTrue();
+                CoordinatedShutdown.Get(sys3).ShutdownReason.Should().BeOfType<CoordinatedShutdown.ClusterDowningReason>();
             }
             finally
             {

--- a/src/core/Akka.Cluster/Cluster.cs
+++ b/src/core/Akka.Cluster/Cluster.cs
@@ -464,6 +464,11 @@ namespace Akka.Cluster
         /// </summary>
         public ClusterEvent.CurrentClusterState State { get { return _readView._state; } }
 
+        /// <summary>
+        /// Access to the current member info for this node.
+        /// </summary>
+        public Member SelfMember => _readView.Self;
+
         private readonly AtomicBoolean _isTerminated = new AtomicBoolean(false);
 
         /// <summary>

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -898,7 +898,8 @@ namespace Akka.Cluster
             _clusterPromise.TrySetResult(Done.Instance);
             if (_settings.RunCoordinatedShutdownWhenDown)
             {
-                _coordShutdown.Run();
+                // if it was stopped due to leaving CoordinatedShutdown was started earlier
+                _coordShutdown.Run(CoordinatedShutdown.ClusterDowningReason.Instance);
             }
         }
     }
@@ -1973,7 +1974,7 @@ namespace Akka.Cluster
                 _exitingTasksInProgress = true;
                 _log.Info("Exiting, starting coordinated shutdown.");
                 _selfExiting.TrySetResult(Done.Instance);
-                _coordShutdown.Run();
+                _coordShutdown.Run(CoordinatedShutdown.ClusterLeavingReason.Instance);
             }
 
             if (talkback)
@@ -2319,7 +2320,7 @@ namespace Akka.Cluster
                     _exitingTasksInProgress = true;
                     _log.Info("Exiting (leader), starting coordinated shutdown.");
                     _selfExiting.TrySetResult(Done.Instance);
-                    _coordShutdown.Run();
+                    _coordShutdown.Run(CoordinatedShutdown.ClusterLeavingReason.Instance);
                 }
 
                 UpdateLatestGossip(newGossip);

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -398,7 +398,7 @@ namespace Akka.Cluster
             {
                 if (ReferenceEquals(null, obj)) return false;
                 if (ReferenceEquals(this, obj)) return true;
-                return obj is ExitingConfirmed && Equals((ExitingConfirmed) obj);
+                return obj is ExitingConfirmed && Equals((ExitingConfirmed)obj);
             }
 
             /// <inheritdoc/>
@@ -1320,7 +1320,7 @@ namespace Akka.Cluster
             {
                 var ge = message as GossipEnvelope;
                 var receivedType = ReceiveGossip(ge);
-                if(_cluster.Settings.VerboseGossipReceivedLogging)
+                if (_cluster.Settings.VerboseGossipReceivedLogging)
                     _log.Debug("Cluster Node [{0}] - Received gossip from [{1}] which was {2}.", _cluster.SelfAddress, ge.From, receivedType);
             }
             else if (message is GossipStatus)
@@ -1394,7 +1394,7 @@ namespace Akka.Cluster
             }
             else if (message is InternalClusterAction.ExitingConfirmed)
             {
-                var c = (InternalClusterAction.ExitingConfirmed) message;
+                var c = (InternalClusterAction.ExitingConfirmed)message;
                 ReceiveExitingConfirmed(c.Address);
             }
             else if (ReceiveExitingCompleted(message)) { }
@@ -1668,7 +1668,7 @@ namespace Akka.Cluster
         public void Leaving(Address address)
         {
             // only try to update if the node is available (in the member ring)
-            if (_latestGossip.Members.Any(m => m.Address.Equals(address) && m.Status == MemberStatus.Up))
+            if (_latestGossip.Members.Any(m => m.Address.Equals(address) && (m.Status == MemberStatus.Joining || m.Status == MemberStatus.WeaklyUp || m.Status == MemberStatus.Up)))
             {
                 // mark node as LEAVING
                 var newMembers = _latestGossip.Members.Select(m =>

--- a/src/core/Akka.Cluster/Member.cs
+++ b/src/core/Akka.Cluster/Member.cs
@@ -18,7 +18,7 @@ namespace Akka.Cluster
     /// Represents the address, current status, and roles of a cluster member node.
     /// </summary>
     /// <remarks>
-    /// NOTE: <see cref="GetHashCode"/> and <see cref="Equals"/> are solely based on the underlying <see cref="Address"/>, 
+    /// NOTE: <see cref="GetHashCode"/> and <see cref="Equals"/> are solely based on the underlying <see cref="Address"/>,
     /// not its <see cref="MemberStatus"/> and roles.
     /// </remarks>
     public class Member : IComparable<Member>, IComparable
@@ -169,7 +169,7 @@ namespace Akka.Cluster
             //TODO: Akka exception?
             if (!AllowedTransitions[oldStatus].Contains(status))
                 throw new InvalidOperationException($"Invalid member status transition {Status} -> {status}");
-            
+
             return new Member(UniqueAddress, UpNumber, status, Roles);
         }
 
@@ -305,7 +305,7 @@ namespace Akka.Cluster
         /// </summary>
         /// <param name="a">First member instance.</param>
         /// <param name="b">Second member instance.</param>
-        /// <returns>If a and b are different members, this method will return <c>null</c>. 
+        /// <returns>If a and b are different members, this method will return <c>null</c>.
         /// Otherwise, will return a or b depending on which one is a valid transition of the other.
         /// If neither are a valid transition, we return <c>null</c></returns>
         public static Member PickNextTransition(Member a, Member b)
@@ -386,8 +386,8 @@ namespace Akka.Cluster
         internal static readonly ImmutableDictionary<MemberStatus, ImmutableHashSet<MemberStatus>> AllowedTransitions =
             new Dictionary<MemberStatus, ImmutableHashSet<MemberStatus>>
             {
-                {MemberStatus.Joining, ImmutableHashSet.Create(MemberStatus.WeaklyUp, MemberStatus.Up, MemberStatus.Down, MemberStatus.Removed)},
-                {MemberStatus.WeaklyUp, ImmutableHashSet.Create(MemberStatus.Up, MemberStatus.Down, MemberStatus.Removed) },
+                {MemberStatus.Joining, ImmutableHashSet.Create(MemberStatus.WeaklyUp, MemberStatus.Up,MemberStatus.Leaving, MemberStatus.Down, MemberStatus.Removed)},
+                {MemberStatus.WeaklyUp, ImmutableHashSet.Create(MemberStatus.Up, MemberStatus.Leaving, MemberStatus.Down, MemberStatus.Removed) },
                 {MemberStatus.Up, ImmutableHashSet.Create(MemberStatus.Leaving, MemberStatus.Down, MemberStatus.Removed)},
                 {MemberStatus.Leaving, ImmutableHashSet.Create(MemberStatus.Exiting, MemberStatus.Down, MemberStatus.Removed)},
                 {MemberStatus.Down, ImmutableHashSet.Create(MemberStatus.Removed)},
@@ -399,7 +399,7 @@ namespace Akka.Cluster
 
     /// <summary>
     /// Defines the current status of a cluster member node
-    /// 
+    ///
     /// Can be one of: Joining, Up, WeaklyUp, Leaving, Exiting and Down.
     /// </summary>
     public enum MemberStatus

--- a/src/core/Akka/Actor/CoordinatedShutdown.cs
+++ b/src/core/Akka/Actor/CoordinatedShutdown.cs
@@ -152,6 +152,76 @@ namespace Akka.Actor
         public const string PhaseBeforeActorSystemTerminate = "before-actor-system-terminate";
         public const string PhaseActorSystemTerminate = "actor-system-terminate";
 
+
+
+        /// <summary>
+        /// Reason for the shutdown, which can be used by tasks in case they need to do
+        /// different things depending on what caused the shutdown. There are some
+        /// predefined reasons, but external libraries applications may also define
+        /// other reasons.
+        /// </summary>
+        public class Reason
+        {
+            protected Reason()
+            {
+
+            }
+        }
+
+        /// <summary>
+        /// The reason for the shutdown was unknown. Needed for backwards compatibility.
+        /// </summary>
+        public class UnknownReason : Reason
+        {
+            public static Reason Instance = new UnknownReason();
+
+            private UnknownReason()
+            {
+
+            }
+        }
+
+        /// <summary>
+        /// The shutdown was initiated by a CLR shutdown hook
+        /// </summary>
+        public class ClrExitReason : Reason
+        {
+            public static Reason Instance = new ClrExitReason();
+
+            private ClrExitReason()
+            {
+
+            }
+        }
+
+
+        /// <summary>
+        /// The shutdown was initiated by Cluster downing.
+        /// </summary>
+        public class ClusterDowningReason : Reason
+        {
+            public static Reason Instance = new ClusterDowningReason();
+
+            private ClusterDowningReason()
+            {
+
+            }
+        }
+
+
+        /// <summary>
+        /// The shutdown was initiated by Cluster leaving.
+        /// </summary>
+        public class ClusterLeavingReason : Reason
+        {
+            public static Reason Instance = new ClusterLeavingReason();
+
+            private ClusterLeavingReason()
+            {
+
+            }
+        }
+
         /// <summary>
         /// The <see cref="ActorSystem"/>
         /// </summary>
@@ -176,7 +246,7 @@ namespace Akka.Actor
 
         private readonly ConcurrentBag<Func<Task<Done>>> _clrShutdownTasks = new ConcurrentBag<Func<Task<Done>>>();
         private readonly ConcurrentDictionary<string, ImmutableList<Tuple<string, Func<Task<Done>>>>> _tasks = new ConcurrentDictionary<string, ImmutableList<Tuple<string, Func<Task<Done>>>>>();
-        private readonly AtomicBoolean _runStarted = new AtomicBoolean(false);
+        private readonly AtomicReference<Reason> _runStarted = new AtomicReference<Reason>(null);
         private readonly AtomicBoolean _clrHooksStarted = new AtomicBoolean(false);
         private readonly TaskCompletionSource<Done> _runPromise = new TaskCompletionSource<Done>();
         private readonly TaskCompletionSource<Done> _hooksRunPromise = new TaskCompletionSource<Done>();
@@ -185,14 +255,14 @@ namespace Akka.Actor
 
         /// <summary>
         /// INTERNAL API
-        /// 
+        ///
         /// Signals when CLR shutdown hooks have been completed
         /// </summary>
         internal Task<Done> ClrShutdownTask => _hooksRunPromise.Task;
 
         /// <summary>
         /// Add a task to a phase. It doesn't remove previously added tasks.
-        /// 
+        ///
         /// Tasks added to the same phase are executed in parallel without any
         /// ordering assumptions. Next phase will not start until all tasks of
         /// previous phase have completed.
@@ -204,8 +274,8 @@ namespace Akka.Actor
         /// Tasks should typically be registered as early as possible after system
         /// startup. When running the <see cref="CoordinatedShutdown"/> tasks that have been
         /// registered will be performed but tasks that are added too late will not be run.
-        /// 
-        /// 
+        ///
+        ///
         /// It is possible to add a task to a later phase from within a task in an earlier phase
         /// and it will be performed.
         /// </remarks>
@@ -230,7 +300,7 @@ namespace Akka.Actor
         /// <summary>
         /// Add a shutdown hook that will execute when the CLR process begins
         /// its shutdown sequence, invoked via <see cref="AppDomain.ProcessExit"/>.
-        /// 
+        ///
         /// Added hooks may run in any order concurrently, but they are run before
         /// the Akka.NET internal shutdown hooks execute.
         /// </summary>
@@ -246,10 +316,10 @@ namespace Akka.Actor
 
         /// <summary>
         /// INTERNAL API
-        /// 
+        ///
         /// Should only be called directly by the <see cref="AppDomain.ProcessExit"/> event
         /// in production.
-        /// 
+        ///
         /// Safe to call multiple times, but hooks will only be run once.
         /// </summary>
         /// <returns>Returns a <see cref="Task"/> that will be completed once the process exits.</returns>
@@ -284,17 +354,39 @@ namespace Akka.Actor
         }
 
         /// <summary>
+        /// The <see cref="Reason"/> for the shutdown as passed to the <see cref="Run(Reason, string)"/> method. <see langword="null"/> if the shutdown
+        /// has not been started.
+        /// </summary>
+        public Reason ShutdownReason => _runStarted.Value;
+
+        /// <summary>
         /// Run tasks of all phases including and after the given phase.
         /// </summary>
         /// <param name="fromPhase">Optional. The phase to start the run from.</param>
         /// <returns>A task that is completed when all such tasks have been completed, or
         /// there is failure when <see cref="Phase.Recover"/> is disabled.</returns>
         /// <remarks>
-        /// It is safe to call this method multiple times. It will only run once.
+        /// It is safe to call this method multiple times. It will only run the shutdown sequence once.
         /// </remarks>
+        [Obsolete("Use the method with 'reason' parameter instead")]
         public Task<Done> Run(string fromPhase = null)
         {
-            if (_runStarted.CompareAndSet(false, true))
+            return Run(UnknownReason.Instance, fromPhase);
+        }
+
+        /// <summary>
+        /// Run tasks of all phases including and after the given phase.
+        /// </summary>
+        /// <param name="reason">Reason of the shutdown</param>
+        /// <param name="fromPhase">Optional. The phase to start the run from.</param>
+        /// <returns>A task that is completed when all such tasks have been completed, or
+        /// there is failure when <see cref="Phase.Recover"/> is disabled.</returns>
+        /// <remarks>
+        /// It is safe to call this method multiple times. It will only run the shutdown sequence once.
+        /// </remarks>
+        public Task<Done> Run(Reason reason, string fromPhase = null)
+        {
+            if (_runStarted.CompareAndSet(null, reason))
             {
                 var debugEnabled = Log.IsDebugEnabled;
 
@@ -412,7 +504,7 @@ namespace Akka.Actor
                 var done = Loop(runningPhases);
                 done.ContinueWith(tr =>
                 {
-                    if(!tr.IsFaulted && !tr.IsCanceled)
+                    if (!tr.IsFaulted && !tr.IsCanceled)
                         _runPromise.SetResult(tr.Result);
                     else
                     {
@@ -511,7 +603,7 @@ namespace Akka.Actor
 
         /// <summary>
         /// INTERNAL API
-        /// 
+        ///
         /// Primes the <see cref="CoordinatedShutdown"/> with the default phase for
         /// <see cref="ActorSystem.Terminate"/>
         /// </summary>
@@ -554,7 +646,8 @@ namespace Akka.Actor
                             }
                             return Done.Instance;
                         });
-                    } else if (exitClr)
+                    }
+                    else if (exitClr)
                     {
                         Environment.Exit(0);
                         return TaskEx.Completed;
@@ -599,7 +692,7 @@ namespace Akka.Actor
                             coord.Log.Info("Starting coordinated shutdown from CLR termination hook.");
                             try
                             {
-                                coord.Run().Wait(coord.TotalTimeout);
+                                coord.Run(ClrExitReason.Instance).Wait(coord.TotalTimeout);
                             }
                             catch (Exception ex)
                             {


### PR DESCRIPTION
contains 

https://github.com/akkadotnet/akka.net/pull/3263
- ClusterSingletonManager should ignore FSM events during shutdown

https://github.com/akka/akka/issues/24048
- Run all CoordinatedShutdown phases also when downing
- add Reason to CoordinatedShutdown

https://github.com/akka/akka/issues/24140
- Allow member to leave a cluster via CoordinatedShutdown.run when MemberStatus is Joining/WeaklyUp/Up.

https://github.com/akka/akka/issues/23449
- ClusterSpec, race between MemberRemoved and MemberExited

