### PR TITLE
_lastTemperatureReading should be updatable

### DIFF
--- a/docs/examples/Tutorials/Tutorial2/DeviceInProgress.cs
+++ b/docs/examples/Tutorials/Tutorial2/DeviceInProgress.cs
@@ -58,7 +58,7 @@ namespace Tutorials.Tutorial2
         #region device-with-read
         public class Device : UntypedActor
         {
-            private readonly double? _lastTemperatureReading = null;
+            private  double? _lastTemperatureReading = null;
 
             public Device(string groupId, string deviceId)
             {


### PR DESCRIPTION
private readonly double? _lastTemperatureReading = null;
on line 61 would make this field not editable because of the red only modifier