### PR TITLE
KillSwitches: flow stage from CancellationToken

### DIFF
--- a/docs/articles/streams/stream-dynamic.md
+++ b/docs/articles/streams/stream-dynamic.md
@@ -66,6 +66,12 @@ by the switch. Refer to the below for usage examples.
 > [!NOTE]
 > A `UniqueKillSwitch` is always a result of a materialization, whilst `SharedKillSwitch` needs to be constructed before any materialization takes place.
 
+### Using `CancellationToken`s as kill switches
+
+Plain old .NET cancellation tokens can also be used as kill switch stages via extension method: `cancellationToken.AsFlow(cancelGracefully: true)`. Their behavior is very similar to what a `SharedKillSwitch` has to offer with one exception - while normal kill switch recognizes difference between closing a stream gracefully (via. `Shutdown()`) and abruptly (via. `Abort(exception)`), .NET cancellation tokens have no such distinction. 
+
+Therefore you need to explicitly specify at the moment of defining a flow stage, if cancellation token call should cause stream to close with completion or failure, by using `cancelGracefully` parameter. If it's set to `false`, calling cancel on a token's source will cause stream to fail with an `OperationCanceledException`.
+
 ## Dynamic fan-in and fan-out with MergeHub and BroadcastHub
 
 There are many cases when consumers or producers of a certain service (represented as a Sink, Source, or possibly Flow) are dynamic and not known in advance. The Graph DSL does not allow to represent this, all connections of the graph must be known in advance and must be connected upfront. To allow dynamic fan-in and fan-out streaming, the Hubs should be used. They provide means to construct Sink and Source pairs that are “attached” to each other, but one of them can be materialized multiple times to implement dynamic fan-in or fan-out.

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
@@ -642,6 +642,7 @@ namespace Akka.Streams
     }
     public class static KillSwitches
     {
+        public static Akka.Streams.IGraph<Akka.Streams.FlowShape<T, T>, Akka.NotUsed> AsFlow<T>(this System.Threading.CancellationToken cancellationToken, bool cancelGracefully = False) { }
         public static Akka.Streams.SharedKillSwitch Shared(string name) { }
         public static Akka.Streams.IGraph<Akka.Streams.FlowShape<T, T>, Akka.Streams.UniqueKillSwitch> Single<T>() { }
         public static Akka.Streams.IGraph<Akka.Streams.BidiShape<T1, T1, T2, T2>, Akka.Streams.UniqueKillSwitch> SingleBidi<T1, T2>() { }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowKillSwitchSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowKillSwitchSpec.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -27,6 +28,8 @@ namespace Akka.Streams.Tests.Dsl
         {
             Materializer = ActorMaterializer.Create(Sys);
         }
+
+        #region unique kill switch
 
         [Fact]
         public void A_UniqueKillSwitch_must_stop_a_stream_if_requested()
@@ -123,6 +126,9 @@ namespace Akka.Streams.Tests.Dsl
             downstream.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
         }
 
+        #endregion
+
+        #region shared kill switch
 
         [Fact]
         public void A_SharedKillSwitch_must_stop_a_stream_if_requested()
@@ -491,5 +497,236 @@ namespace Akka.Streams.Tests.Dsl
                 killSwitch.Flow<int>().ToString().Should().Be("Flow(KillSwitch(MySwitchName))");
             }, Materializer);
         }
+        
+        #endregion
+
+        #region cancellable kill switch
+
+        [Fact]
+        public void A_CancellationToken_flow_must_stop_a_stream_if_requested()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var cancel = new CancellationTokenSource();
+
+                var t = this.SourceProbe<int>()
+                    .Via(cancel.Token.AsFlow<int>(cancelGracefully: true))
+                    .ToMaterialized(this.SinkProbe<int>(), Keep.Both)
+                    .Run(Materializer);
+                var upstream = t.Item1;
+                var downstream = t.Item2;
+
+                downstream.Request(1);
+                upstream.SendNext(1);
+                downstream.ExpectNext(1);
+
+                cancel.Cancel();
+                upstream.ExpectCancellation();
+                downstream.ExpectComplete();
+            }, Materializer);
+        }
+
+        [Fact]
+        public void A_CancellationToken_flow_must_fail_a_stream_if_requested()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var cancel = new CancellationTokenSource();
+
+                var t = this.SourceProbe<int>()
+                    .Via(cancel.Token.AsFlow<int>(cancelGracefully: false))
+                    .ToMaterialized(this.SinkProbe<int>(), Keep.Both)
+                    .Run(Materializer);
+                var upstream = t.Item1;
+                var downstream = t.Item2;
+
+                downstream.Request(1);
+                upstream.SendNext(1);
+                downstream.ExpectNext(1);
+
+                cancel.Cancel();
+                upstream.ExpectCancellation();
+                downstream.ExpectError().Should().BeOfType<OperationCanceledException>();
+            }, Materializer);
+        }
+
+        [Fact]
+        public void A_CancellationToken_flow_must_pass_through_all_elements_unmodified()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var cancel = new CancellationTokenSource();
+                var task = Source.From(Enumerable.Range(1, 100))
+                    .Via(cancel.Token.AsFlow<int>())
+                    .RunWith(Sink.Seq<int>(), Materializer);
+                task.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
+                task.Result.ShouldAllBeEquivalentTo(Enumerable.Range(1, 100));
+            }, Materializer);
+        }
+
+        [Fact]
+        public void A_CancellationToken_flow_must_provide_a_flow_that_if_materialized_multiple_times_with_multiple_types_stops_all_streams_if_requested()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var cancel = new CancellationTokenSource();
+
+                var t1 = this.SourceProbe<int>()
+                    .Via(cancel.Token.AsFlow<int>(cancelGracefully: true))
+                    .ToMaterialized(this.SinkProbe<int>(), Keep.Both)
+                    .Run(Materializer);
+                var t2 = this.SourceProbe<string>()
+                    .Via(cancel.Token.AsFlow<string>(cancelGracefully: true))
+                    .ToMaterialized(this.SinkProbe<string>(), Keep.Both)
+                    .Run(Materializer);
+
+                var upstream1 = t1.Item1;
+                var downstream1 = t1.Item2;
+                var upstream2 = t2.Item1;
+                var downstream2 = t2.Item2;
+
+                downstream1.Request(1);
+                upstream1.SendNext(1);
+                downstream1.ExpectNext(1);
+
+                downstream2.Request(2);
+                upstream2.SendNext("A").SendNext("B");
+                downstream2.ExpectNext("A", "B");
+
+                cancel.Cancel();
+
+                upstream1.ExpectCancellation();
+                upstream2.ExpectCancellation();
+                downstream1.ExpectComplete();
+                downstream2.ExpectComplete();
+            }, Materializer);
+        }
+
+        [Fact]
+        public void A_CancellationToken_flow_must_provide_a_flow_that_if_materialized_multiple_times_with_multiple_types_fails_all_streams_if_requested()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var cancel = new CancellationTokenSource();
+
+                var t1 = this.SourceProbe<int>()
+                    .Via(cancel.Token.AsFlow<int>(cancelGracefully: false))
+                    .ToMaterialized(this.SinkProbe<int>(), Keep.Both)
+                    .Run(Materializer);
+                var t2 = this.SourceProbe<string>()
+                    .Via(cancel.Token.AsFlow<string>(cancelGracefully: false))
+                    .ToMaterialized(this.SinkProbe<string>(), Keep.Both)
+                    .Run(Materializer);
+
+                var upstream1 = t1.Item1;
+                var downstream1 = t1.Item2;
+                var upstream2 = t2.Item1;
+                var downstream2 = t2.Item2;
+
+                downstream1.Request(1);
+                upstream1.SendNext(1);
+                downstream1.ExpectNext(1);
+
+                downstream2.Request(2);
+                upstream2.SendNext("A").SendNext("B");
+                downstream2.ExpectNext("A", "B");
+
+                cancel.Cancel();
+                upstream1.ExpectCancellation();
+                upstream2.ExpectCancellation();
+
+                downstream1.ExpectError().Should().BeOfType<OperationCanceledException>();
+                downstream2.ExpectError().Should().BeOfType<OperationCanceledException>();
+            }, Materializer);
+        }
+
+        [Fact]
+        public void A_CancellationToken_flow_must_ignore_subsequent_aborts_and_shutdowns_after_shutdown()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var cancel = new CancellationTokenSource();
+
+                var t = this.SourceProbe<int>()
+                    .Via(cancel.Token.AsFlow<int>(cancelGracefully: true))
+                    .ToMaterialized(this.SinkProbe<int>(), Keep.Both)
+                    .Run(Materializer);
+                var upstream = t.Item1;
+                var downstream = t.Item2;
+
+                downstream.Request(1);
+                upstream.SendNext(1);
+                downstream.ExpectNext(1);
+
+                cancel.Cancel();
+                upstream.ExpectCancellation();
+                downstream.ExpectComplete();
+
+                cancel.Cancel();
+                upstream.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+                downstream.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+
+                cancel.Cancel();
+                upstream.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+                downstream.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+            }, Materializer);
+        }
+
+        [Fact]
+        public void A_CancellationToken_flow_must_complete_immediately_flows_materialized_after_switch_shutdown()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var cancel = new CancellationTokenSource();
+                cancel.Cancel();
+
+                var t = this.SourceProbe<int>()
+                    .Via(cancel.Token.AsFlow<int>(cancelGracefully: true))
+                    .ToMaterialized(this.SinkProbe<int>(), Keep.Both)
+                    .Run(Materializer);
+                var upstream = t.Item1;
+                var downstream = t.Item2;
+
+                upstream.ExpectCancellation();
+                downstream.ExpectSubscriptionAndComplete();
+            }, Materializer);
+        }
+
+        [Fact]
+        public void A_CancellationToken_flow_must_fail_immediately_flows_materialized_after_switch_failure()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var cancel = new CancellationTokenSource();
+                cancel.Cancel();
+
+                var t = this.SourceProbe<int>()
+                    .Via(cancel.Token.AsFlow<int>(cancelGracefully: false))
+                    .ToMaterialized(this.SinkProbe<int>(), Keep.Both)
+                    .Run(Materializer);
+                var upstream = t.Item1;
+                var downstream = t.Item2;
+
+                upstream.ExpectCancellation();
+                downstream.ExpectSubscriptionAndError().Should().BeOfType<OperationCanceledException>();
+            }, Materializer);
+        }
+
+        [Fact]
+        public void A_CancellationToken_flow_should_not_cause_problems_if_switch_is_shutdown_after_flow_completed_normally()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var cancel = new CancellationTokenSource();
+                var task = Source.From(Enumerable.Range(1, 10))
+                    .Via(cancel.Token.AsFlow<int>(cancelGracefully: true))
+                    .RunWith(Sink.Seq<int>(), Materializer);
+                task.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
+                task.Result.ShouldAllBeEquivalentTo(Enumerable.Range(1, 10));
+                cancel.Cancel();
+            }, Materializer);
+        }
+
+        #endregion
     }
 }

--- a/src/core/Akka.Streams/KillSwitch.cs
+++ b/src/core/Akka.Streams/KillSwitch.cs
@@ -67,12 +67,12 @@ namespace Akka.Streams
         /// When set to false, will close stream by failing the stage with <see cref="OperationCanceledException"/>.
         /// </param>
         /// <returns></returns>
-        public static IGraph<FlowShape<T, T>, CancellationToken> AsFlow<T>(this CancellationToken cancellationToken, bool cancelGracefully = false)
+        public static IGraph<FlowShape<T, T>, NotUsed> AsFlow<T>(this CancellationToken cancellationToken, bool cancelGracefully = false)
         {
             return new CancellableKillSwitchStage<T>(cancellationToken, cancelGracefully);
         }
 
-        internal sealed class CancellableKillSwitchStage<T> : GraphStageWithMaterializedValue<FlowShape<T, T>, CancellationToken>
+        internal sealed class CancellableKillSwitchStage<T> : GraphStage<FlowShape<T, T>>
         {
             #region logic
 
@@ -143,8 +143,7 @@ namespace Akka.Streams
             public Outlet<T> Outlet { get; } = new Outlet<T>("cancel.out");
 
             public override FlowShape<T, T> Shape { get; }
-            public override ILogicAndMaterializedValue<CancellationToken> CreateLogicAndMaterializedValue(Attributes inheritedAttributes) => 
-                new LogicAndMaterializedValue<CancellationToken>(new Logic(this), _cancellationToken);
+            protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes) => new Logic(this);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR introduces an extension method, that allows to produce a stage (similar in design to `SharedKillSwitch`) from `CancellationToken`:

```csharp
var cts = new CancellationTokenSource();

source
.Via(cts.Token.AsFlow<string>(cancelGracefully: true))
.RunForEach(Console.WriteLine, materializer)
```

`cancelGracefully` parameter defines if calling Cancel on token should cause stream shutdown in graceful way (via Complete) or as a failure (via OperationCanceledException).