### PR TITLE
Add ToString override to TestProbe.

### DIFF
--- a/src/core/Akka.TestKit/TestProbe.cs
+++ b/src/core/Akka.TestKit/TestProbe.cs
@@ -190,5 +190,11 @@ namespace Akka.TestKit
         {
             return TestActor.GetHashCode();
         }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return $"TestProbe({TestActor})";
+        }
     }
 }


### PR DESCRIPTION
This minimal change adds a `ToString` `override` to `TestProbe` to be able to use it in debug logging of tests.