### PR TITLE
[build system] fix NuGet package dependency version overrides

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -298,15 +298,6 @@ Target "NBench" <| fun _ ->
 // Nuget targets 
 //--------------------------------------------------------------------------------
 
-let overrideVersionSuffix (project:string) =
-    match project with
-    | p when p.Contains("Akka.Serialization.Wire") -> preReleaseVersionSuffix
-    | p when p.Contains("Akka.Serialization.Hyperion") -> preReleaseVersionSuffix
-    | p when p.Contains("Akka.Cluster.Sharding") -> preReleaseVersionSuffix
-    | p when p.Contains("Akka.DistributedData") -> preReleaseVersionSuffix
-    | p when p.Contains("Akka.DistributedData.LightningDB") -> preReleaseVersionSuffix
-    | _ -> versionSuffix
-
 Target "CreateNuget" (fun _ ->    
     let projects = !! "src/**/*.*sproj"
                    -- "src/**/*.Tests*.*sproj"
@@ -323,7 +314,7 @@ Target "CreateNuget" (fun _ ->
                     Project = project
                     Configuration = configuration
                     AdditionalArgs = ["--include-symbols"]
-                    VersionSuffix = overrideVersionSuffix project
+                    VersionSuffix = versionSuffix
                     OutputPath = outputNuGet })
 
     projects |> Seq.iter (runSingleProject)
@@ -380,7 +371,7 @@ Target "CreateMntrNuget" (fun _ ->
                     Project = project
                     Configuration = configuration
                     AdditionalArgs = ["--include-symbols"]
-                    VersionSuffix = overrideVersionSuffix project
+                    VersionSuffix = versionSuffix
                     OutputPath = outputNuGet } )
     )
 


### PR DESCRIPTION
resolves issue with production beta packages like Cluster.Sharding depending on the wrong version, i.e.:

![image](https://user-images.githubusercontent.com/326939/44620714-dcd2e100-a85e-11e8-9829-acaca5ba6f06.png)

All of those packages, except for DData, should be references to the stable version. Not beta packages. This PR resolves that issue for all beta packages we still publish.