### PR TITLE
#3423 SearchBar fix

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -76,7 +76,7 @@
             "default",
             "template"
         ],
-        "postProcessors": [],
+        "postProcessors": ["ExtractSearchIndex"],
         "noLangKeyword": false
     }
 }

--- a/docs/web.config
+++ b/docs/web.config
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <system.webServer>
+        <staticContent>
+            <mimeMap fileExtension=".json" mimeType="application/json" />
+        </staticContent>
         <rewrite>
             <rules>
                 <rule name="rewrite docs to articles" stopProcessing="true">


### PR DESCRIPTION
This PR adds the `application/json` mimetype for `.json` files to the IIS configuration and enables the `ExtractSearchIndex` postrpocessor, in order to re-enable the search bar functionality , which was reported broken in #3423.