### PR TITLE
Actor selection #3128

### DIFF
--- a/src/core/Akka/Util/StringLike.cs
+++ b/src/core/Akka/Util/StringLike.cs
@@ -9,12 +9,15 @@ using System.Text.RegularExpressions;
 
 namespace Akka.Util
 {
+    using System.Text;
+
     /// <summary>
     /// TBD
     /// </summary>
     public static class WildcardMatch
     {
         #region Public Methods
+
         /// <summary>
         /// TBD
         /// </summary>
@@ -22,15 +25,45 @@ namespace Akka.Util
         /// <param name="pattern">TBD</param>
         /// <param name="caseSensitive">TBD</param>
         /// <returns>TBD</returns>
-        public static bool Like(this string text,string pattern, bool caseSensitive = false)
+        public static bool Like(this string text, string pattern, bool caseSensitive = false)
         {
-            pattern = pattern.Replace(".", @"\.");
-            pattern = pattern.Replace("?", ".");
-            pattern = pattern.Replace("*", ".*?");
-            pattern = pattern.Replace(@"\", @"\\");
-            pattern = pattern.Replace(" ", @"\s");
+            var sb = new StringBuilder("^");
+            for (int index = 0; index < pattern.Length; index++)
+            {
+                var c = pattern[index];
+                switch (c)
+                {
+                    case '.':
+                        sb.Append(@"\.");
+                        break;
+                    case '?':
+                        sb.Append('.');
+                        break;
+                    case '*':
+                        sb.Append(".*?");
+                        break;
+                    case '\\':
+                        sb.Append(@"\\");
+                        break;
+                    case '$':
+                        sb.Append(@"\$");
+                        break;
+                    case '^':
+                        sb.Append(@"\^");
+                        break;
+                    case ' ':
+                        sb.Append(@"\s");
+                        break;
+                    default:
+                        sb.Append(c);
+                        break;
+                }
+            }
+
+            pattern = sb.Append('$').ToString();
             return new Regex(pattern, caseSensitive ? RegexOptions.None : RegexOptions.IgnoreCase).IsMatch(text);
         }
+
         #endregion
     }
 }


### PR DESCRIPTION
Addressing [up for grabs #3128](https://github.com/akkadotnet/akka.net/issues/3128)

Stops the following from matching the selection:

```var sys = ActorSystem.Create("sys");
var worker = sys.ActorOf<Worker>("worker");
sys.ActorSelection("akka://sys/user/ker*").Tell(42);```
