### PR TITLE
Don't automatically down quarantined nodes

### DIFF
--- a/src/core/Akka.Cluster.Tests.MultiNode/SurviveNetworkInstabilitySpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/SurviveNetworkInstabilitySpec.cs
@@ -157,7 +157,7 @@ namespace Akka.Cluster.Tests.MultiNode
             A_Network_partition_tolerant_cluster_must_heal_after_one_isolated_node();
             A_Network_partition_tolerant_cluster_must_heal_two_isolated_islands();
             A_Network_partition_tolerant_cluster_must_heal_after_unreachable_when_ring_is_changed();
-            A_Network_partition_tolerant_cluster_must_down_and_remove_quarantined_node();
+            A_Network_partition_tolerant_cluster_must_mark_quarantined_node_with_reachability_status_Terminated();
             A_Network_partition_tolerant_cluster_must_continue_and_move_Joining_to_Up_after_downing_of_one_half();
         }
 
@@ -374,7 +374,7 @@ namespace Akka.Cluster.Tests.MultiNode
             });
         }
 
-        public void A_Network_partition_tolerant_cluster_must_down_and_remove_quarantined_node()
+        public void A_Network_partition_tolerant_cluster_must_mark_quarantined_node_with_reachability_status_Terminated()
         {
             Within(60.Seconds(), () =>
             {
@@ -401,7 +401,6 @@ namespace Akka.Cluster.Tests.MultiNode
                     Sys.ActorSelection(Node(_config.Third) / "user" / "watcher").Tell(new SurviveNetworkInstabilitySpecConfig.Targets(refs));
                     ExpectMsg<SurviveNetworkInstabilitySpecConfig.TargetsRegistered>();
                 }, _config.Second);
-
                 EnterBarrier("targets-registered");
 
                 RunOn(() =>
@@ -428,9 +427,30 @@ namespace Akka.Cluster.Tests.MultiNode
 
                 RunOn(() =>
                 {
+                    Thread.Sleep(2000.Milliseconds());
+
+                    var secondUniqueAddress = Cluster.State.Members.SingleOrDefault(m => m.Address == GetAddress(_config.Second));
+                    secondUniqueAddress.Should().NotBeNull(because: "2nd node should stay visible");
+                    secondUniqueAddress?.Status.Should().Be(MemberStatus.Up, because: "2nd node should be Up");
+                    
+                    // second should be marked with reachability status Terminated
+                    AwaitAssert(() => ClusterView.Reachability.Status(secondUniqueAddress?.UniqueAddress).Should().Be(Reachability.ReachabilityStatus.Terminated));
+                }, others.ToArray());
+                EnterBarrier("reachability-terminated");
+
+                RunOn(() =>
+                {
+                    Cluster.Down(GetAddress(_config.Second));
+                }, _config.Fourth);
+
+                RunOn(() =>
+                {
                     // second should be removed because of quarantine
                     AwaitAssert(() => ClusterView.Members.Select(c => c.Address).Should().NotContain(GetAddress(_config.Second)));
+                    // and also removed from reachability table
+                    AwaitAssert(() => ClusterView.Reachability.AllUnreachableOrTerminated.Should().BeEmpty());
                 }, others.ToArray());
+                EnterBarrier("removed-after-down");
 
                 EnterBarrier("after-6");
                 AssertCanTalk(others.ToArray());

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -1754,10 +1754,9 @@ namespace Akka.Cluster
                 var newOverview = localGossip.Overview.Copy(reachability: newReachability);
                 var newGossip = localGossip.Copy(overview: newOverview);
                 UpdateLatestGossip(newGossip);
-                _log.Warning("Cluster Node [{0}] - Marking node as TERMINATED [{1}], due to quarantine. Node roles [{2}]",
+                _log.Warning("Cluster Node [{0}] - Marking node as TERMINATED [{1}], due to quarantine. Node roles [{2}]. It must still be marked as down before it's removed.",
                     Self, node.Address, string.Join(",", _cluster.SelfRoles));
                 Publish(_latestGossip);
-                Downing(node.Address);
             }
         }
 


### PR DESCRIPTION
Currently, a quarantined node will be automatically downed and removed from the cluster without the downing provider being aware of the situation.

Port [#25678](https://github.com/akka/akka/pull/25678)