### PR TITLE
Sample Cleanup: Modernize Akka.Remote Chat Sample

### DIFF
--- a/src/examples/Chat/ChatClient/Program.cs
+++ b/src/examples/Chat/ChatClient/Program.cs
@@ -20,7 +20,7 @@ namespace ChatClient
             var config = ConfigurationFactory.ParseString(@"
 akka {  
     actor {
-        provider = ""Akka.Remote.RemoteActorRefProvider, Akka.Remote""
+        provider = remote
     }
     remote {
         dot-netty.tcp {

--- a/src/examples/Chat/ChatMessages/Messages.cs
+++ b/src/examples/Chat/ChatMessages/Messages.cs
@@ -42,17 +42,4 @@ namespace ChatMessages
         public string Username { get; set; }
         public string Text { get; set; }
     }
-
-    public class ChannelsRequest
-    {
-    }
-
-    public class ChannelsResponse
-    {
-        public IActorRef[] channels { get; set; }
-    }
-
-    public class Disconnect
-    {
-    }
 }

--- a/src/examples/Chat/ChatServer/Program.cs
+++ b/src/examples/Chat/ChatServer/Program.cs
@@ -20,7 +20,7 @@ namespace ChatServer
             var config = ConfigurationFactory.ParseString(@"
 akka {  
     actor {
-        provider = ""Akka.Remote.RemoteActorRefProvider, Akka.Remote""
+        provider = remote
     }
     remote {
         dot-netty.tcp {


### PR DESCRIPTION
This has bothered me for years. Removed all instances of `TypedActor` and replaced them with `ReceiveActor` in this sample. Also removed some unused message types and used the HOCON shorthand for `RemoteActorRefProvider`.