### PR TITLE
Update Azure PaaS Worker Role example to use the provided `CancellationToken`

### DIFF
--- a/docs/articles/intro/use-case-and-deployment-scenarios.md
+++ b/docs/articles/intro/use-case-and-deployment-scenarios.md
@@ -219,7 +219,7 @@ namespace MyActorWorkerRole
 
             while (!cancellationToken.IsCancellationRequested)
             {
-                await Task.Delay(1000);
+                await Task.Delay(1000, cancellationToken);
             }
         }
     }


### PR DESCRIPTION
Update the [Azure PaaS Worker Role example](https://getakka.net/articles/intro/use-case-and-deployment-scenarios.html#azure-paas-worker-role) to use the provided `CancellationToken` when _awaiting_.