### PR TITLE
Check if Dependency Resolver is configured to avoid a `NullReferenceException`

### DIFF
--- a/src/contrib/dependencyinjection/Akka.DI.Core/DIActorContextAdapter.cs
+++ b/src/contrib/dependencyinjection/Akka.DI.Core/DIActorContextAdapter.cs
@@ -26,11 +26,15 @@ namespace Akka.DI.Core
         /// <exception cref="ArgumentNullException">
         /// This exception is thrown when the specified <paramref name="context"/> is undefined.
         /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// This exception is thrown when the Dependency Resolver has not been configured in the <see cref="ActorSystem" />.
+        /// </exception>
         public DIActorContextAdapter(IActorContext context)
         {
             if (context == null) throw new ArgumentNullException(nameof(context), $"DIActorContextAdapter requires {nameof(context)} to be provided");
             this.context = context;
             this.producer = context.System.GetExtension<DIExt>();
+            if (producer == null) throw new InvalidOperationException("The Dependency Resolver has not been configured yet");
         }
 
         /// <summary>

--- a/src/contrib/dependencyinjection/Akka.DI.Core/DIActorSystemAdapter.cs
+++ b/src/contrib/dependencyinjection/Akka.DI.Core/DIActorSystemAdapter.cs
@@ -26,11 +26,15 @@ namespace Akka.DI.Core
         /// <exception cref="ArgumentNullException">
         /// This exception is thrown when the specified <paramref name="system"/> is undefined.
         /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// This exception is thrown when the Dependency Resolver has not been configured in the <see cref="ActorSystem" />.
+        /// </exception>
         public DIActorSystemAdapter(ActorSystem system)
         {
             if (system == null) throw new ArgumentNullException(nameof(system), $"DIActorSystemAdapter requires {nameof(system)} to be provided");
             this.system = system;
             this.producer = system.GetExtension<DIExt>();
+            if (producer == null) throw new InvalidOperationException("The Dependency Resolver has not been configured yet");
         }
 
         /// <summary>


### PR DESCRIPTION
When using the `DI()` extension methods on `ActorSystem` or `IActorContext` without having properly configured an `IDependencyResolver` we currently get a `NullReferenceException` (e.g. [1](https://github.com/akkadotnet/akka.net/blob/dev/src/contrib/dependencyinjection/Akka.DI.Core/DIActorSystemAdapter.cs#L43), [2](https://github.com/akkadotnet/akka.net/blob/dev/src/contrib/dependencyinjection/Akka.DI.Core/DIActorContextAdapter.cs#L55)).

```csharp
using (var system = ActorSystem.Create("mySystem"))
{
    var actorRef = system.DI().Props<MyActor>(); // Throws NullReferenceException
    // ...
}
```

This PR adds a check on the constructors of `DIActorSystemAdapter` and `DIActorContextAdapter` to verify if a dependency resolver exists, and throws an `InvalidOperationException` with a clear message of what the problem is.

---

```csharp
using (var system = ActorSystem.Create("mySystem"))
{
    var actorRef = system.DI().Props<MyActor>(); // Throws InvalidOperationException
    // ...
}
```

```
Unhandled Exception: System.InvalidOperationException:
The Dependency Resolver has not been configured yet
```