### PR TITLE
Added Capability for Dotnetty to use Thumbprint for SSL

### DIFF
--- a/src/core/Akka.Remote/Configuration/Remote.conf
+++ b/src/core/Akka.Remote/Configuration/Remote.conf
@@ -527,6 +527,25 @@ akka {
 			# Available flags include: 
 			#     default-key-set | exportable | machine-key-set | persist-key-set | user-key-set | user-protected
 			# flags = [ "default-key-set" ]
+
+			# To use a Thumbprint instead of a file, set this to true
+			# And specify a thumprint and it's storage location below
+			use-thumprint-over-file = false
+
+			# Valid Thumprint required (if use-thumbprint-over-file is true)
+			# A typical thumbprint is a format similar to: "45df32e258c92a7abf6c112e54912ab15bbb9eb0"
+			# On Windows machines, The thumprint for an installed certificate can be located
+			# By using certlm.msc and opening the certificate under the 'Details' tab.
+			thumpbrint = ""
+
+			# The Store name. Under windows The most common option is "My", which indicates the personal store.
+			# See System.Security.Cryptography.X509Certificates.StoreName for other common values.
+			store-name = ""
+
+			# Valid options : local-machine or current-user
+			# current-user indicates a certificate stored under the user's account
+			# local-machine indicates a certificate stored at an operating system level (potentially shared by users)
+			store-location = "current-user"
 		}
 		suppress-validation = false
     }


### PR DESCRIPTION
In certain environments, it is preferred to have certificates installed on the local machine by system administrators, and having applications use said certificates via thumbprint.

This pull request contains changes to allow thumbprints to be used by dotnetty,, via a new set of configuration options; backwards compatibility is maintained by this being 'opt in' behavior.