### PR TITLE
Update docs on Autofac wiring to use new extension method

### DIFF
--- a/docs/articles/actors/dependency-injection.md
+++ b/docs/articles/actors/dependency-injection.md
@@ -91,7 +91,7 @@ var container = builder.Build();
 
 // Create the ActorSystem and Dependency Resolver
 var system = ActorSystem.Create("MySystem");
-var propsResolver = new AutoFacDependencyResolver(container, system);
+system.UseAutofac(container);
 ```
 
 ### CastleWindsor


### PR DESCRIPTION
Update docs on Autofac wiring to use the new extension method, now that https://github.com/akkadotnet/Akka.DI.AutoFac/pull/16 has been merged.