### PR TITLE
Fix xunit warnings

### DIFF
--- a/src/common.props
+++ b/src/common.props
@@ -6,7 +6,7 @@
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;xUnit1013</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <XunitVersion>2.3.1</XunitVersion>

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteConfigSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteConfigSpec.cs
@@ -37,7 +37,7 @@ namespace Akka.Persistence.Sqlite.Tests
             Assert.Equal(TimeSpan.FromSeconds(30), config.GetTimeSpan("connection-timeout"));
             Assert.Equal("event_journal", config.GetString("table-name"));
             Assert.Equal("journal_metadata", config.GetString("metadata-table-name"));
-            Assert.Equal(false, config.GetBoolean("auto-initialize"));
+            Assert.False(config.GetBoolean("auto-initialize"));
             Assert.Equal("Akka.Persistence.Sql.Common.Journal.DefaultTimestampProvider, Akka.Persistence.Sql.Common", config.GetString("timestamp-provider"));
         }
 
@@ -55,7 +55,7 @@ namespace Akka.Persistence.Sqlite.Tests
             Assert.Equal(string.Empty, config.GetString("connection-string-name"));
             Assert.Equal(TimeSpan.FromSeconds(30), config.GetTimeSpan("connection-timeout"));
             Assert.Equal("snapshot_store", config.GetString("table-name"));
-            Assert.Equal(false, config.GetBoolean("auto-initialize"));
+            Assert.False(config.GetBoolean("auto-initialize"));
         }
     }
 }

--- a/src/contrib/serializers/Akka.Serialization.Hyperion.Tests/HyperionConfigTests.cs
+++ b/src/contrib/serializers/Akka.Serialization.Hyperion.Tests/HyperionConfigTests.cs
@@ -30,8 +30,8 @@ namespace Akka.Serialization.Hyperion.Tests
             using (var system = ActorSystem.Create(nameof(HyperionConfigTests), config))
             {
                 var serializer = (HyperionSerializer)system.Serialization.FindSerializerForType(typeof(object));
-                Assert.Equal(true, serializer.Settings.VersionTolerance);
-                Assert.Equal(true, serializer.Settings.PreserveObjectReferences);
+                Assert.True(serializer.Settings.VersionTolerance);
+                Assert.True(serializer.Settings.PreserveObjectReferences);
                 Assert.Equal("NoKnownTypes", serializer.Settings.KnownTypesProvider.Name);
             }
         }
@@ -54,8 +54,8 @@ namespace Akka.Serialization.Hyperion.Tests
             using (var system = ActorSystem.Create(nameof(HyperionConfigTests), config))
             {
                 var serializer = (HyperionSerializer)system.Serialization.FindSerializerForType(typeof(object));
-                Assert.Equal(false, serializer.Settings.VersionTolerance);
-                Assert.Equal(false, serializer.Settings.PreserveObjectReferences);
+                Assert.False(serializer.Settings.VersionTolerance);
+                Assert.False(serializer.Settings.PreserveObjectReferences);
                 Assert.Equal("NoKnownTypes", serializer.Settings.KnownTypesProvider.Name);
             }
         }
@@ -77,8 +77,8 @@ namespace Akka.Serialization.Hyperion.Tests
             using (var system = ActorSystem.Create(nameof(HyperionConfigTests), config))
             {
                 var serializer = (HyperionSerializer)system.Serialization.FindSerializerForType(typeof(object));
-                Assert.Equal(true, serializer.Settings.VersionTolerance);
-                Assert.Equal(true, serializer.Settings.PreserveObjectReferences);
+                Assert.True(serializer.Settings.VersionTolerance);
+                Assert.True(serializer.Settings.PreserveObjectReferences);
                 Assert.Equal(typeof(DummyTypesProviderWithDefaultCtor), serializer.Settings.KnownTypesProvider);
             }
         }
@@ -100,8 +100,8 @@ namespace Akka.Serialization.Hyperion.Tests
             using (var system = ActorSystem.Create(nameof(HyperionConfigTests), config))
             {
                 var serializer = (HyperionSerializer)system.Serialization.FindSerializerForType(typeof(object));
-                Assert.Equal(true, serializer.Settings.VersionTolerance);
-                Assert.Equal(true, serializer.Settings.PreserveObjectReferences);
+                Assert.True(serializer.Settings.VersionTolerance);
+                Assert.True(serializer.Settings.PreserveObjectReferences);
                 Assert.Equal(typeof(DummyTypesProvider), serializer.Settings.KnownTypesProvider);
             }
         }

--- a/src/contrib/serializers/Akka.Serialization.TestKit/AkkaSerializationSpec.cs
+++ b/src/contrib/serializers/Akka.Serialization.TestKit/AkkaSerializationSpec.cs
@@ -403,7 +403,7 @@ akka.actor {
             var aref = ActorOf<BlackHoleActor>();
             var surrogate = aref.ToSurrogate(Sys) as ActorRefBase.Surrogate;
             var uid = aref.Path.Uid;
-            Assert.True(surrogate.Path.Contains("#" + uid));
+            Assert.Contains("#" + uid, surrogate.Path);
         }
 
         [Fact]

--- a/src/core/Akka.MultiNodeTestRunner.Shared.Tests/MultiNodeTestRunnerDiscovery/DiscoverySpec.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared.Tests/MultiNodeTestRunnerDiscovery/DiscoverySpec.cs
@@ -28,7 +28,7 @@ namespace Akka.MultiNodeTestRunner.Shared.Tests.MultiNodeTestRunnerDiscovery
         public void Deeply_inherited_are_ok()
         {
             var discoveredSpecs = DiscoverSpecs();
-            Assert.Equal(discoveredSpecs[KeyFromSpecName(nameof(DiscoveryCases.DeeplyInheritedChildSpec))].First().Role, "DeeplyInheritedChildRole");
+            Assert.Equal("DeeplyInheritedChildRole", discoveredSpecs[KeyFromSpecName(nameof(DiscoveryCases.DeeplyInheritedChildSpec))].First().Role);
         }
 
         [Fact(DisplayName = "Child test class with default constructors are ok")]
@@ -48,9 +48,9 @@ namespace Akka.MultiNodeTestRunner.Shared.Tests.MultiNodeTestRunnerDiscovery
         public void Discovered_count_equals_number_of_roles_mult_specs()
         {
             var discoveredSpecs = DiscoverSpecs();
-            Assert.Equal(discoveredSpecs[KeyFromSpecName(nameof(DiscoveryCases.FloodyChildSpec1))].Count, 5);
-            Assert.Equal(discoveredSpecs[KeyFromSpecName(nameof(DiscoveryCases.FloodyChildSpec2))].Count, 5);
-            Assert.Equal(discoveredSpecs[KeyFromSpecName(nameof(DiscoveryCases.FloodyChildSpec3))].Count, 5);
+            Assert.Equal(5, discoveredSpecs[KeyFromSpecName(nameof(DiscoveryCases.FloodyChildSpec1))].Count);
+            Assert.Equal(5, discoveredSpecs[KeyFromSpecName(nameof(DiscoveryCases.FloodyChildSpec2))].Count);
+            Assert.Equal(5, discoveredSpecs[KeyFromSpecName(nameof(DiscoveryCases.FloodyChildSpec3))].Count);
         }
 
         [Fact(DisplayName = "Only public props and fields are considered when looking for RoleNames")]

--- a/src/core/Akka.Remote.Tests/AccrualFailureDetectorSpec.cs
+++ b/src/core/Akka.Remote.Tests/AccrualFailureDetectorSpec.cs
@@ -76,8 +76,8 @@ namespace Akka.Remote.Tests
         public void AccrualFailureDetector_must_return_phi_value_of_zero_on_startup_for_each_address_when_no_heartbeats()
         {
             var fd = FailureDetectorSpecHelpers.CreateFailureDetector();
-            Assert.Equal(fd.CurrentPhi, 0.0);
-            Assert.Equal(fd.CurrentPhi, 0.0);
+            Assert.Equal(0.0, fd.CurrentPhi);
+            Assert.Equal(0.0, fd.CurrentPhi);
         }
 
         [Fact]

--- a/src/core/Akka.Remote.Tests/EndpointRegistrySpec.cs
+++ b/src/core/Akka.Remote.Tests/EndpointRegistrySpec.cs
@@ -133,7 +133,7 @@ namespace Akka.Remote.Tests
             reg.MarkAsFailed(actorB, farIntheFuture);
             reg.Prune();
 
-            Assert.Equal(null, reg.WritableEndpointWithPolicyFor(address1).AsInstanceOf<EndpointManager.WasGated>().RefuseUid);
+            Assert.Null(reg.WritableEndpointWithPolicyFor(address1).AsInstanceOf<EndpointManager.WasGated>().RefuseUid);
             Assert.Equal(farIntheFuture, reg.WritableEndpointWithPolicyFor(address2).AsInstanceOf<EndpointManager.Gated>().TimeOfRelease);
         }
 

--- a/src/core/Akka.Remote.Tests/RemoteMessageLocalDeliverySpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteMessageLocalDeliverySpec.cs
@@ -56,7 +56,7 @@ namespace Akka.Remote.Tests
         public void RemoteActorRefProvider_default_address_must_include_adapter_schemes()
         {
             var localAddress = RARP.For(Sys).Provider.DefaultAddress;
-            Assert.True(localAddress.ToString().StartsWith("akka.trttl.gremlin.tcp://"));
+            Assert.StartsWith("akka.trttl.gremlin.tcp://", localAddress.ToString());
         }
 
         [Fact]

--- a/src/core/Akka.TestKit.Tests/TestActorRefTests/TestActorRefSpec.cs
+++ b/src/core/Akka.TestKit.Tests/TestActorRefTests/TestActorRefSpec.cs
@@ -53,7 +53,7 @@ namespace Akka.TestKit.Tests.TestActorRefTests
             //creates a StringBuilder and adds adds $. Hence, 2 $$
             var testActorRef = new TestActorRef<ReplyActor>(Sys, Props.Create<ReplyActor>());
 
-            Assert.Equal(testActorRef.Path.Name.Substring(0, 2), "$$");
+            Assert.Equal("$$", testActorRef.Path.Name.Substring(0, 2));
         }
 
         [Fact]

--- a/src/core/Akka.Tests/Actor/ActorPathSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorPathSpec.cs
@@ -52,7 +52,7 @@ namespace Akka.Tests.Actor
             elements.Count.ShouldBe(2,"number of elements in path");
             Assert.True("pAth1".Equals(elements[0], StringComparison.Ordinal), "first path element");
             Assert.True("pAth2".Equals(elements[1], StringComparison.Ordinal), "second path element");
-            Assert.Equal(actorPath.ToString(),"akka://sYstEm/pAth1/pAth2");
+            Assert.Equal("akka://sYstEm/pAth1/pAth2", actorPath.ToString());
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace Akka.Tests.Actor
             elements.Count.ShouldBe(2, "number of elements in path");
             Assert.True("pAth1".Equals(elements[0], StringComparison.Ordinal), "first path element");
             Assert.True("pAth2".Equals(elements[1], StringComparison.Ordinal), "second path element");
-            Assert.Equal(actorPath.ToString(), "akka://sYstEm@host:4711/pAth1/pAth2");
+            Assert.Equal("akka://sYstEm@host:4711/pAth1/pAth2", actorPath.ToString());
         }
 
         [Fact]

--- a/src/core/Akka.Tests/Actor/SupervisorStrategySpecs.cs
+++ b/src/core/Akka.Tests/Actor/SupervisorStrategySpecs.cs
@@ -32,7 +32,7 @@ namespace Akka.Tests.Actor
         };
 
         [Theory]
-        [MemberData("RetriesTestData")]
+        [MemberData(nameof(RetriesTestData))]
         public void A_constructed_OneForOne_supervisor_strategy_with_nullable_retries_has_the_expected_properties(int? retries, int expectedRetries)
         {
             var uut = new OneForOneStrategy(retries, null, exn => Directive.Restart);
@@ -41,7 +41,7 @@ namespace Akka.Tests.Actor
         }
 
         [Theory]
-        [MemberData("TimeoutTestData")]
+        [MemberData(nameof(TimeoutTestData))]
         public void A_constructed_OneForOne_supervisor_strategy_with_nullable_timeouts_has_the_expected_properties(TimeSpan? timeout, int expectedTimeoutMilliseconds)
         {
             var uut = new OneForOneStrategy(-1, timeout, exn => Directive.Restart);
@@ -50,7 +50,7 @@ namespace Akka.Tests.Actor
         }
 
         [Theory]
-        [MemberData("RetriesTestData")]
+        [MemberData(nameof(RetriesTestData))]
         public void A_constructed_OneForOne_supervisor_strategy_with_nullable_retries_and_a_decider_has_the_expected_properties(int? retries, int expectedRetries)
         {
             var uut = new OneForOneStrategy(retries, null, Decider.From(Directive.Restart));
@@ -59,7 +59,7 @@ namespace Akka.Tests.Actor
         }
 
         [Theory]
-        [MemberData("TimeoutTestData")]
+        [MemberData(nameof(TimeoutTestData))]
         public void A_constructed_OneForOne_supervisor_strategy_with_nullable_timeouts_and_a_decider_has_the_expected_properties(TimeSpan? timeout, int expectedTimeoutMilliseconds)
         {
             var uut = new OneForOneStrategy(-1, timeout, Decider.From(Directive.Restart));
@@ -68,7 +68,7 @@ namespace Akka.Tests.Actor
         }
 
         [Theory]
-        [MemberData("RetriesTestData")]
+        [MemberData(nameof(RetriesTestData))]
         public void A_constructed_AllForOne_supervisor_strategy_with_nullable_retries_has_the_expected_properties(int? retries, int expectedRetries)
         {
             var uut = new AllForOneStrategy(retries, null, exn => Directive.Restart);
@@ -77,7 +77,7 @@ namespace Akka.Tests.Actor
         }
 
         [Theory]
-        [MemberData("TimeoutTestData")]
+        [MemberData(nameof(TimeoutTestData))]
         public void A_constructed_AllForOne_supervisor_strategy_with_nullable_timeouts_has_the_expected_properties(TimeSpan? timeout, int expectedTimeoutMilliseconds)
         {
             var uut = new AllForOneStrategy(-1, timeout, exn => Directive.Restart);
@@ -86,7 +86,7 @@ namespace Akka.Tests.Actor
         }
 
         [Theory]
-        [MemberData("RetriesTestData")]
+        [MemberData(nameof(RetriesTestData))]
         public void A_constructed_AllForOne_supervisor_strategy_with_nullable_retries_and_a_decider_has_the_expected_properties(int? retries, int expectedRetries)
         {
             var uut = new OneForOneStrategy(retries, null, Decider.From(Directive.Restart));
@@ -95,7 +95,7 @@ namespace Akka.Tests.Actor
         }
 
         [Theory]
-        [MemberData("TimeoutTestData")]
+        [MemberData(nameof(TimeoutTestData))]
         public void A_constructed_AllForOne_supervisor_strategy_with_nullable_timeouts_and_a_decider_has_the_expected_properties(TimeSpan? timeout, int expectedTimeoutMilliseconds)
         {
             var uut = new OneForOneStrategy(-1, timeout, Decider.From(Directive.Restart));

--- a/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
+++ b/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
@@ -88,7 +88,7 @@ namespace Akka.Tests.Configuration
             var config = ConfigurationFactory.FromObject(source);
 
             Assert.Equal("aaa", config.GetString("StringProperty"));
-            Assert.Equal(true, config.GetBoolean("BoolProperty"));
+            Assert.True(config.GetBoolean("BoolProperty"));
 
             Assert.Equal(new[] {1, 2, 3, 4}, config.GetIntList("IntegerArray").ToArray());
         }

--- a/src/core/Akka.Tests/Configuration/HoconTests.cs
+++ b/src/core/Akka.Tests/Configuration/HoconTests.cs
@@ -120,7 +120,7 @@ a {
             var config = ConfigurationFactory.ParseString(hocon);
             var subConfig = config.GetConfig("a");
             Assert.Equal(1, subConfig.GetInt("b.c"));
-            Assert.Equal(true, subConfig.GetBoolean("b.d"));
+            Assert.True(subConfig.GetBoolean("b.d"));
         }
 
 
@@ -153,8 +153,8 @@ root {
             var config = ConfigurationFactory.ParseString(hocon);
             Assert.Equal("1", config.GetString("root.int"));
             Assert.Equal("1.23", config.GetString("root.double"));
-            Assert.Equal(true, config.GetBoolean("root.bool"));
-            Assert.Equal(true, config.GetBoolean("root.object.hasContent"));
+            Assert.True(config.GetBoolean("root.bool"));
+            Assert.True(config.GetBoolean("root.object.hasContent"));
             Assert.Equal(null, config.GetString("root.null"));
             Assert.Equal("foo", config.GetString("root.quoted-string"));
             Assert.Equal("bar", config.GetString("root.unquoted-string"));
@@ -188,8 +188,8 @@ root {
             var config = ConfigurationFactory.ParseString(hocon);
             Assert.Equal("1", config.GetString("root.int"));
             Assert.Equal("1.23", config.GetString("root.double"));
-            Assert.Equal(true, config.GetBoolean("root.bool"));
-            Assert.Equal(true, config.GetBoolean("root.object.hasContent"));
+            Assert.True(config.GetBoolean("root.bool"));
+            Assert.True(config.GetBoolean("root.object.hasContent"));
             Assert.Equal(null, config.GetString("root.null"));
             Assert.Equal("foo", config.GetString("root.string"));
             Assert.True(new[] {1, 2, 3}.SequenceEqual(ConfigurationFactory.ParseString(hocon).GetIntList("root.array")));
@@ -359,14 +359,14 @@ a.b.e.f=3
         public void Can_assign_boolean_to_field()
         {
             var hocon = @"a=true";
-            Assert.Equal(true, ConfigurationFactory.ParseString(hocon).GetBoolean("a"));
+            Assert.True(ConfigurationFactory.ParseString(hocon).GetBoolean("a"));
             hocon = @"a=false";
-            Assert.Equal(false, ConfigurationFactory.ParseString(hocon).GetBoolean("a"));
+            Assert.False(ConfigurationFactory.ParseString(hocon).GetBoolean("a"));
 
             hocon = @"a=on";
-            Assert.Equal(true, ConfigurationFactory.ParseString(hocon).GetBoolean("a"));
+            Assert.True(ConfigurationFactory.ParseString(hocon).GetBoolean("a"));
             hocon = @"a=off";
-            Assert.Equal(false, ConfigurationFactory.ParseString(hocon).GetBoolean("a"));
+            Assert.False(ConfigurationFactory.ParseString(hocon).GetBoolean("a"));
         }
 
         [Fact]

--- a/src/core/Akka.Tests/Configuration/HoconTests.cs
+++ b/src/core/Akka.Tests/Configuration/HoconTests.cs
@@ -155,7 +155,7 @@ root {
             Assert.Equal("1.23", config.GetString("root.double"));
             Assert.True(config.GetBoolean("root.bool"));
             Assert.True(config.GetBoolean("root.object.hasContent"));
-            Assert.Equal(null, config.GetString("root.null"));
+            Assert.Null(config.GetString("root.null"));
             Assert.Equal("foo", config.GetString("root.quoted-string"));
             Assert.Equal("bar", config.GetString("root.unquoted-string"));
             Assert.Equal("foo bar", config.GetString("root.concat-string"));
@@ -190,7 +190,7 @@ root {
             Assert.Equal("1.23", config.GetString("root.double"));
             Assert.True(config.GetBoolean("root.bool"));
             Assert.True(config.GetBoolean("root.object.hasContent"));
-            Assert.Equal(null, config.GetString("root.null"));
+            Assert.Null(config.GetString("root.null"));
             Assert.Equal("foo", config.GetString("root.string"));
             Assert.True(new[] {1, 2, 3}.SequenceEqual(ConfigurationFactory.ParseString(hocon).GetIntList("root.array")));
         }
@@ -222,7 +222,7 @@ a = null
 a.c = 3
 ";
             var config = ConfigurationFactory.ParseString(hocon);
-            Assert.Equal(null, config.GetString("a.b"));
+            Assert.Null(config.GetString("a.b"));
             Assert.Equal("3", config.GetString("a.c"));
         }
 
@@ -746,7 +746,7 @@ test.value = 456
         public void Can_assign_null_string_to_field()
         {
             var hocon = @"a=null";
-            Assert.Equal(null, ConfigurationFactory.ParseString(hocon).GetString("a"));
+            Assert.Null(ConfigurationFactory.ParseString(hocon).GetString("a"));
         }
 
         [Fact(Skip = "we currently do not make any distinction between quoted and unquoted strings once parsed")]

--- a/src/core/Akka.Tests/MatchHandler/MatchExpressionBuilder_BuildLambdaExpression_Tests.cs
+++ b/src/core/Akka.Tests/MatchHandler/MatchExpressionBuilder_BuildLambdaExpression_Tests.cs
@@ -95,7 +95,7 @@ namespace Akka.Tests.MatchHandler
             //Compile the expression and test it
             var lambda = (Func<object, Action<String>, Predicate<string>, bool>)result.LambdaExpression.Compile();
             lambda("short", action, predicate);
-            Assert.Equal(null, updatedValue);
+            Assert.Null(updatedValue);
             lambda("longer value", action, predicate);
             Assert.Equal("longer value", updatedValue);
             lambda(4711, action, predicate);
@@ -133,7 +133,7 @@ namespace Akka.Tests.MatchHandler
             //Compile the expression and test it
             var lambda = (Func<object, Action<String>, Predicate<string>, Action<String>, Predicate<string>, bool>)result.LambdaExpression.Compile();
             lambda("short", action1, predicate1, action2, predicate2);
-            Assert.Equal(null, updatedValue);
+            Assert.Null(updatedValue);
             lambda("longer value", action1, predicate1, action2, predicate2);
             Assert.Equal("longer value", updatedValue);
             lambda("1234567890123456789", action1, predicate1, action2, predicate2);
@@ -177,7 +177,7 @@ namespace Akka.Tests.MatchHandler
             //Compile the expression and test it
             var lambda = (Func<object, Action<String>, Predicate<string>, Action<int>, Predicate<int>, bool>)result.LambdaExpression.Compile();
             lambda("short", action1, predicate1, action2, predicate2);
-            Assert.Equal(null, updatedValue);
+            Assert.Null(updatedValue);
             lambda("longer value", action1, predicate1, action2, predicate2);
             Assert.Equal("longer value", updatedValue);
             lambda("12345678901234567890", action1, predicate1, action2, predicate2);
@@ -236,7 +236,7 @@ namespace Akka.Tests.MatchHandler
             //Compile the expression and test it
             var lambda = (Func<object, Func<String, bool>, Func<int, bool>, bool>)result.LambdaExpression.Compile();
             lambda("short", func1, func2);
-            Assert.Equal(null, updatedValue);
+            Assert.Null(updatedValue);
             lambda("longer value", func1, func2);
             Assert.Equal("longer value", updatedValue);
             lambda(2, func1, func2);
@@ -355,7 +355,7 @@ namespace Akka.Tests.MatchHandler
                 result.LambdaExpression.Compile();
 
             lambda("some value", actionString, predicateString, actionString, predicateString, actionString, predicateString, actionString, predicateString, actionString, predicateString, actionString, predicateString, actionString, predicateString, actionInt);
-            Assert.Equal(null, updatedValue);
+            Assert.Null(updatedValue);
             lambda(4711, actionString, predicateString, actionString, predicateString, actionString, predicateString, actionString, predicateString, actionString, predicateString, actionString, predicateString, actionString, predicateString, actionInt);
             Assert.Equal("4711", updatedValue);
         }
@@ -407,9 +407,9 @@ namespace Akka.Tests.MatchHandler
                 result.LambdaExpression.Compile();
 
             lambda("some value", actionString, predicateString, actionString, predicateString, actionString, predicateString, actionString, predicateString, actionString, predicateString, actionString, predicateString, actionString, predicateString, extraParamsArray);
-            Assert.Equal(null, updatedValue);
+            Assert.Null(updatedValue);
             lambda(4711, actionString, predicateString, actionString, predicateString, actionString, predicateString, actionString, predicateString, actionString, predicateString, actionString, predicateString, actionString, predicateString, extraParamsArray);
-            Assert.Equal(null, updatedValue);
+            Assert.Null(updatedValue);
             lambda(42, actionString, predicateString, actionString, predicateString, actionString, predicateString, actionString, predicateString, actionString, predicateString, actionString, predicateString, actionString, predicateString, extraParamsArray);
             Assert.Equal("42", updatedValue);
 
@@ -438,7 +438,7 @@ namespace Akka.Tests.MatchHandler
             //Compile the expression and test it
             var lambda = (Func<object, Action<object>, bool>)result.LambdaExpression.Compile();
             lambda(4711, action);
-            Assert.Equal(null, updatedValue);
+            Assert.Null(updatedValue);
             lambda("the value", action);
             Assert.Equal("WasString:the value", updatedValue);
         }
@@ -468,9 +468,9 @@ namespace Akka.Tests.MatchHandler
             //Compile the expression and test it
             var lambda = (Func<object, Action<object>, Predicate<Object>, bool>)result.LambdaExpression.Compile();
             lambda(4711, action, predicate);
-            Assert.Equal(null, updatedValue);
+            Assert.Null(updatedValue);
             lambda("short", action, predicate);
-            Assert.Equal(null, updatedValue);
+            Assert.Null(updatedValue);
             lambda("the value", action, predicate);
             Assert.Equal("the value", updatedValue);
         }
@@ -507,9 +507,9 @@ namespace Akka.Tests.MatchHandler
             //Compile the expression and test it
             var lambda = (Func<object, Func<object, bool>, bool>)result.LambdaExpression.Compile();
             lambda(4711, func);
-            Assert.Equal(null, updatedValue);
+            Assert.Null(updatedValue);
             lambda("short", func);
-            Assert.Equal(null, updatedValue);
+            Assert.Null(updatedValue);
             lambda("the value", func);
             Assert.Equal("the value", updatedValue);
         }

--- a/src/core/Akka.Tests/Pattern/CircuitBreakerSpec.cs
+++ b/src/core/Akka.Tests/Pattern/CircuitBreakerSpec.cs
@@ -33,7 +33,7 @@ namespace Akka.Tests.Pattern
         {
             var breaker = LongCallTimeoutCb( );
 
-            Assert.Equal( breaker.Instance.CurrentFailureCount, 0 );
+            Assert.Equal(0, breaker.Instance.CurrentFailureCount);
             Assert.True( InterceptExceptionType<TestException>( ( ) => breaker.Instance.WithSyncCircuitBreaker( ThrowException ) ) );
             Assert.True( CheckLatch( breaker.OpenLatch ) );
             Assert.Equal( 1, breaker.Instance.CurrentFailureCount );
@@ -44,9 +44,9 @@ namespace Akka.Tests.Pattern
         {
             var breaker = MultiFailureCb( );
 
-            Assert.Equal( breaker.Instance.CurrentFailureCount, 0 );
+            Assert.Equal(0, breaker.Instance.CurrentFailureCount);
             Assert.True( InterceptExceptionType<TestException>( ( ) => breaker.Instance.WithSyncCircuitBreaker( ThrowException ) ) );
-            Assert.Equal( breaker.Instance.CurrentFailureCount, 1 );
+            Assert.Equal(1, breaker.Instance.CurrentFailureCount);
 
             breaker.Instance.WithSyncCircuitBreaker( ( ) => "Test" );
 
@@ -132,7 +132,7 @@ namespace Akka.Tests.Pattern
         {
             var breaker = LongCallTimeoutCb( );
 
-            Assert.Equal( breaker.Instance.CurrentFailureCount, 0 );
+            Assert.Equal(0, breaker.Instance.CurrentFailureCount);
             Assert.True( InterceptExceptionType<TestException>( ( ) => breaker.Instance.WithCircuitBreaker( () => Task.Run( ( ) => ThrowException( ) ) ).Wait( AwaitTimeout ) ) );
             Assert.True( CheckLatch( breaker.OpenLatch ) );
             Assert.Equal( 1, breaker.Instance.CurrentFailureCount );
@@ -143,7 +143,7 @@ namespace Akka.Tests.Pattern
         {
             var breaker = MultiFailureCb( );
 
-            Assert.Equal( breaker.Instance.CurrentFailureCount, 0 );
+            Assert.Equal(0, breaker.Instance.CurrentFailureCount);
 
             var whenall = Task.WhenAll(
                 breaker.Instance.WithCircuitBreaker(() => Task.Factory.StartNew(ThrowException))
@@ -153,7 +153,7 @@ namespace Akka.Tests.Pattern
 
             Assert.True( InterceptExceptionType<TestException>( ( ) => whenall.Wait( AwaitTimeout ) ) );
 
-            Assert.Equal( breaker.Instance.CurrentFailureCount, 4 );
+            Assert.Equal(4, breaker.Instance.CurrentFailureCount);
 
             var result = breaker.Instance.WithCircuitBreaker(() => Task.Run( ( ) => SayTest( ) ) ).Result;
 

--- a/src/core/Akka.Tests/Serialization/NewtonsoftJsonConfigSpec.cs
+++ b/src/core/Akka.Tests/Serialization/NewtonsoftJsonConfigSpec.cs
@@ -27,8 +27,8 @@ namespace Akka.Tests.Serialization
                 Assert.Equal(TypeNameHandling.All, serializer.Settings.TypeNameHandling);
                 Assert.Equal(PreserveReferencesHandling.Objects, serializer.Settings.PreserveReferencesHandling);
                 Assert.Equal(2, serializer.Settings.Converters.Count);
-                Assert.True(serializer.Settings.Converters.Any(x => x is DiscriminatedUnionConverter));
-                Assert.True(serializer.Settings.Converters.Any(x => x is NewtonSoftJsonSerializer.SurrogateConverter));
+                Assert.Contains(serializer.Settings.Converters, x => x is DiscriminatedUnionConverter);
+                Assert.Contains(serializer.Settings.Converters, x => x is NewtonSoftJsonSerializer.SurrogateConverter);
             }
         }
 
@@ -49,8 +49,8 @@ namespace Akka.Tests.Serialization
                 Assert.Equal(TypeNameHandling.None, serializer.Settings.TypeNameHandling);
                 Assert.Equal(PreserveReferencesHandling.None, serializer.Settings.PreserveReferencesHandling);
                 Assert.Equal(2, serializer.Settings.Converters.Count);
-                Assert.True(serializer.Settings.Converters.Any(x => x is DiscriminatedUnionConverter));
-                Assert.True(serializer.Settings.Converters.Any(x => x is NewtonSoftJsonSerializer.SurrogateConverter));
+                Assert.Contains(serializer.Settings.Converters, x => x is DiscriminatedUnionConverter);
+                Assert.Contains(serializer.Settings.Converters, x => x is NewtonSoftJsonSerializer.SurrogateConverter);
             }
         }
 
@@ -73,10 +73,10 @@ namespace Akka.Tests.Serialization
                 Assert.Equal(TypeNameHandling.All, serializer.Settings.TypeNameHandling);
                 Assert.Equal(PreserveReferencesHandling.Objects, serializer.Settings.PreserveReferencesHandling);
                 Assert.Equal(4, serializer.Settings.Converters.Count);
-                Assert.True(serializer.Settings.Converters.Any(x => x is DiscriminatedUnionConverter));
-                Assert.True(serializer.Settings.Converters.Any(x => x is NewtonSoftJsonSerializer.SurrogateConverter));
-                Assert.True(serializer.Settings.Converters.Any(x => x is DummyConverter));
-                Assert.True(serializer.Settings.Converters.Any(x => x is DummyConverter2));
+                Assert.Contains(serializer.Settings.Converters, x => x is DiscriminatedUnionConverter);
+                Assert.Contains(serializer.Settings.Converters, x => x is NewtonSoftJsonSerializer.SurrogateConverter);
+                Assert.Contains(serializer.Settings.Converters, x => x is DummyConverter);
+                Assert.Contains(serializer.Settings.Converters, x => x is DummyConverter2);
             }
         }
     }

--- a/src/core/Akka.Tests/Serialization/NewtonsoftJsonConfigSpec.cs
+++ b/src/core/Akka.Tests/Serialization/NewtonsoftJsonConfigSpec.cs
@@ -27,8 +27,8 @@ namespace Akka.Tests.Serialization
                 Assert.Equal(TypeNameHandling.All, serializer.Settings.TypeNameHandling);
                 Assert.Equal(PreserveReferencesHandling.Objects, serializer.Settings.PreserveReferencesHandling);
                 Assert.Equal(2, serializer.Settings.Converters.Count);
-                Assert.Equal(true, serializer.Settings.Converters.Any(x => x is DiscriminatedUnionConverter));
-                Assert.Equal(true, serializer.Settings.Converters.Any(x => x is NewtonSoftJsonSerializer.SurrogateConverter));
+                Assert.True(serializer.Settings.Converters.Any(x => x is DiscriminatedUnionConverter));
+                Assert.True(serializer.Settings.Converters.Any(x => x is NewtonSoftJsonSerializer.SurrogateConverter));
             }
         }
 
@@ -49,8 +49,8 @@ namespace Akka.Tests.Serialization
                 Assert.Equal(TypeNameHandling.None, serializer.Settings.TypeNameHandling);
                 Assert.Equal(PreserveReferencesHandling.None, serializer.Settings.PreserveReferencesHandling);
                 Assert.Equal(2, serializer.Settings.Converters.Count);
-                Assert.Equal(true, serializer.Settings.Converters.Any(x => x is DiscriminatedUnionConverter));
-                Assert.Equal(true, serializer.Settings.Converters.Any(x => x is NewtonSoftJsonSerializer.SurrogateConverter));
+                Assert.True(serializer.Settings.Converters.Any(x => x is DiscriminatedUnionConverter));
+                Assert.True(serializer.Settings.Converters.Any(x => x is NewtonSoftJsonSerializer.SurrogateConverter));
             }
         }
 
@@ -73,10 +73,10 @@ namespace Akka.Tests.Serialization
                 Assert.Equal(TypeNameHandling.All, serializer.Settings.TypeNameHandling);
                 Assert.Equal(PreserveReferencesHandling.Objects, serializer.Settings.PreserveReferencesHandling);
                 Assert.Equal(4, serializer.Settings.Converters.Count);
-                Assert.Equal(true, serializer.Settings.Converters.Any(x => x is DiscriminatedUnionConverter));
-                Assert.Equal(true, serializer.Settings.Converters.Any(x => x is NewtonSoftJsonSerializer.SurrogateConverter));
-                Assert.Equal(true, serializer.Settings.Converters.Any(x => x is DummyConverter));
-                Assert.Equal(true, serializer.Settings.Converters.Any(x => x is DummyConverter2));
+                Assert.True(serializer.Settings.Converters.Any(x => x is DiscriminatedUnionConverter));
+                Assert.True(serializer.Settings.Converters.Any(x => x is NewtonSoftJsonSerializer.SurrogateConverter));
+                Assert.True(serializer.Settings.Converters.Any(x => x is DummyConverter));
+                Assert.True(serializer.Settings.Converters.Any(x => x is DummyConverter2));
             }
         }
     }


### PR DESCRIPTION
This PR fixes a number of issues caught by the xunit analyzer.


* xunit1013 - these were false positives due to how we run the MNTK tests
* xunit1014 - basically changing hardcoded string references to nameof
* xunit2000 - basically changing the order so that expected value is first
* xunit2003 - use the xunit Null() check instead of Equals()
* xunit2004 - use the xunit True()/False() check instead of Equal()
* xunit2009 - use the xunit Contains()/StartsWith() check instead of Equals() + string methods
* xunit2012 - use the xunit Contains() check instead of Equals() + Any()

Anecdotal data, but I was able to shave off a minute from the build time and the build log was a bit nicer to look at.
