### PR TITLE
[Akka.Cluster] cleanup and fix event logging

### DIFF
--- a/src/core/Akka.Cluster/Cluster.cs
+++ b/src/core/Akka.Cluster/Cluster.cs
@@ -82,6 +82,11 @@ namespace Akka.Cluster
         public UniqueAddress SelfUniqueAddress { get; }
 
         /// <summary>
+        /// Used to retain the <see cref="InfoLogger"/> instance that decorates the cluster.
+        /// </summary>
+        internal InfoLogger CurrentInfoLogger { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Cluster"/> class.
         /// </summary>
         /// <param name="system">The actor system that hosts the cluster.</param>
@@ -100,12 +105,14 @@ namespace Akka.Cluster
 
             _log = Logging.GetLogger(system, "Cluster");
 
+            CurrentInfoLogger = new InfoLogger(_log, Settings, SelfAddress);
+
             LogInfo("Starting up...");
 
-            _failureDetector = new DefaultFailureDetectorRegistry<Address>(() => FailureDetectorLoader.Load(Settings.FailureDetectorImplementationClass, Settings.FailureDetectorConfig,
+            FailureDetector = new DefaultFailureDetectorRegistry<Address>(() => FailureDetectorLoader.Load(Settings.FailureDetectorImplementationClass, Settings.FailureDetectorConfig,
                 system));
 
-            _scheduler = CreateScheduler(system);
+            Scheduler = CreateScheduler(system);
 
             // it has to be lazy - otherwise if downing provider will init a cluster itself, it will deadlock
             _downingProvider = new Lazy<IDowningProvider>(() => Akka.Cluster.DowningProvider.Load(Settings.DowningProviderType, system), LazyThreadSafetyMode.ExecutionAndPublication);
@@ -481,7 +488,7 @@ namespace Akka.Cluster
         /// </summary>
         public ExtendedActorSystem System { get; }
 
-        private Lazy<IDowningProvider> _downingProvider;
+        private readonly Lazy<IDowningProvider> _downingProvider;
         private readonly ILoggingAdapter _log;
         private readonly ClusterReadView _readView;
 
@@ -490,12 +497,10 @@ namespace Akka.Cluster
         /// </summary>
         internal ClusterReadView ReadView { get { return _readView; } }
 
-        private readonly DefaultFailureDetectorRegistry<Address> _failureDetector;
-
         /// <summary>
         /// The set of failure detectors used for monitoring one or more nodes in the cluster.
         /// </summary>
-        public DefaultFailureDetectorRegistry<Address> FailureDetector { get { return _failureDetector; } }
+        public DefaultFailureDetectorRegistry<Address> FailureDetector { get; }
 
         /// <summary>
         /// TBD
@@ -506,11 +511,10 @@ namespace Akka.Cluster
         // ===================== WORK DAEMONS =====================
         // ========================================================
 
-        readonly IScheduler _scheduler;
         /// <summary>
         /// TBD
         /// </summary>
-        internal IScheduler Scheduler { get { return _scheduler; } }
+        internal IScheduler Scheduler { get; }
 
         private static IScheduler CreateScheduler(ActorSystem system)
         {
@@ -562,12 +566,64 @@ namespace Akka.Cluster
         }
 
         /// <summary>
+        /// INTERNAL API.
+        ///
+        /// Used for logging important messages with the cluster's address appended.
+        /// </summary>
+        internal class InfoLogger
+        {
+            private readonly ILoggingAdapter _log;
+            private readonly ClusterSettings _settings;
+            private readonly Address _selfAddress;
+
+            public InfoLogger(ILoggingAdapter log, ClusterSettings settings, Address selfAddress)
+            {
+                _log = log;
+                _settings = settings;
+                _selfAddress = selfAddress;
+            }
+
+            /// <summary>
+            /// Creates an <see cref="Akka.Event.LogLevel.InfoLevel"/> log entry with the specific message.
+            /// </summary>
+            /// <param name="message">The message being logged.</param>
+            internal void LogInfo(string message)
+            {
+                if(_settings.LogInfo)
+                    _log.Info("Cluster Node [{0}] - {1}", _selfAddress, message);
+            }
+
+            /// <summary>
+            /// Creates an <see cref="Akka.Event.LogLevel.InfoLevel"/> log entry with the specific template and arguments.
+            /// </summary>
+            /// <param name="template">The template being rendered and logged.</param>
+            /// <param name="arg1">The argument that fills in the template placeholder.</param>
+            internal void LogInfo(string template, object arg1)
+            {
+                if (_settings.LogInfo)
+                    _log.Info("Cluster Node [{0}] - " + template, _selfAddress, arg1);
+            }
+
+            /// <summary>
+            /// Creates an <see cref="Akka.Event.LogLevel.InfoLevel"/> log entry with the specific template and arguments.
+            /// </summary>
+            /// <param name="template">The template being rendered and logged.</param>
+            /// <param name="arg1">The first argument that fills in the corresponding template placeholder.</param>
+            /// <param name="arg2">The second argument that fills in the corresponding template placeholder.</param>
+            internal void LogInfo(string template, object arg1, object arg2)
+            {
+                if (_settings.LogInfo)
+                    _log.Info("Cluster Node [{0}] - " + template, _selfAddress, arg1, arg2);
+            }
+        }
+
+        /// <summary>
         /// Creates an <see cref="Akka.Event.LogLevel.InfoLevel"/> log entry with the specific message.
         /// </summary>
         /// <param name="message">The message being logged.</param>
         internal void LogInfo(string message)
         {
-            _log.Info("Cluster Node [{0}] - {1}", SelfAddress, message);
+            CurrentInfoLogger.LogInfo(message);
         }
 
         /// <summary>
@@ -577,7 +633,7 @@ namespace Akka.Cluster
         /// <param name="arg1">The argument that fills in the template placeholder.</param>
         internal void LogInfo(string template, object arg1)
         {
-            _log.Info("Cluster Node [{0}] - " + template, SelfAddress, arg1);
+            CurrentInfoLogger.LogInfo(template, arg1);
         }
 
         /// <summary>
@@ -588,7 +644,7 @@ namespace Akka.Cluster
         /// <param name="arg2">The second argument that fills in the corresponding template placeholder.</param>
         internal void LogInfo(string template, object arg1, object arg2)
         {
-            _log.Info("Cluster Node [{0}] - " + template, SelfAddress, arg1, arg2);
+            CurrentInfoLogger.LogInfo(template, arg1, arg2);
         }
     }
 

--- a/src/core/Akka.Cluster/Cluster.cs
+++ b/src/core/Akka.Cluster/Cluster.cs
@@ -601,7 +601,7 @@ namespace Akka.Cluster
             internal void LogInfo(string template, object arg1)
             {
                 if (_settings.LogInfo)
-                    _log.Info("Cluster Node [{0}] - " + template, _selfAddress, arg1);
+                    _log.Info($"Cluster Node [{_selfAddress}] - " + template, arg1);
             }
 
             /// <summary>
@@ -613,7 +613,7 @@ namespace Akka.Cluster
             internal void LogInfo(string template, object arg1, object arg2)
             {
                 if (_settings.LogInfo)
-                    _log.Info("Cluster Node [{0}] - " + template, _selfAddress, arg1, arg2);
+                    _log.Info($"Cluster Node [{_selfAddress}] - " + template, arg1, arg2);
             }
         }
 

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -1219,19 +1219,16 @@ namespace Akka.Cluster
             {
                 Sender.Tell(new InternalClusterAction.InitJoinNack(_cluster.SelfAddress));
             }
-            else if (message is ClusterUserAction.JoinTo)
+            else if (message is ClusterUserAction.JoinTo jt)
             {
-                var jt = message as ClusterUserAction.JoinTo;
                 Join(jt.Address);
             }
-            else if (message is InternalClusterAction.JoinSeedNodes)
+            else if (message is InternalClusterAction.JoinSeedNodes js)
             {
-                var js = message as InternalClusterAction.JoinSeedNodes;
                 JoinSeedNodes(js.SeedNodes);
             }
-            else if (message is InternalClusterAction.ISubscriptionMessage)
+            else if (message is InternalClusterAction.ISubscriptionMessage isub)
             {
-                var isub = message as InternalClusterAction.ISubscriptionMessage;
                 _publisher.Forward(isub);
             }
             else if (ReceiveExitingCompleted(message)) { }
@@ -1248,30 +1245,26 @@ namespace Akka.Cluster
                 _log.Debug("[TryingToJoin] Received {0}", message);
             }
 
-            if (message is InternalClusterAction.Welcome)
+            if (message is InternalClusterAction.Welcome w)
             {
-                var w = message as InternalClusterAction.Welcome;
                 Welcome(joinWith, w.From, w.Gossip);
             }
             else if (message is InternalClusterAction.InitJoin)
             {
                 Sender.Tell(new InternalClusterAction.InitJoinNack(_cluster.SelfAddress));
             }
-            else if (message is ClusterUserAction.JoinTo)
+            else if (message is ClusterUserAction.JoinTo jt)
             {
-                var jt = message as ClusterUserAction.JoinTo;
                 BecomeUninitialized();
                 Join(jt.Address);
             }
-            else if (message is InternalClusterAction.JoinSeedNodes)
+            else if (message is InternalClusterAction.JoinSeedNodes js)
             {
-                var js = message as InternalClusterAction.JoinSeedNodes;
                 BecomeUninitialized();
                 JoinSeedNodes(js.SeedNodes);
             }
-            else if (message is InternalClusterAction.ISubscriptionMessage)
+            else if (message is InternalClusterAction.ISubscriptionMessage isub)
             {
-                var isub = message as InternalClusterAction.ISubscriptionMessage;
                 _publisher.Forward(isub);
             }
             else if (message is InternalClusterAction.ITick)
@@ -1316,16 +1309,14 @@ namespace Akka.Cluster
                 _log.Debug("[Initialized] Received {0}", message);
             }
 
-            if (message is GossipEnvelope)
+            if (message is GossipEnvelope ge)
             {
-                var ge = message as GossipEnvelope;
                 var receivedType = ReceiveGossip(ge);
                 if (_cluster.Settings.VerboseGossipReceivedLogging)
                     _log.Debug("Cluster Node [{0}] - Received gossip from [{1}] which was {2}.", _cluster.SelfAddress, ge.From, receivedType);
             }
-            else if (message is GossipStatus)
+            else if (message is GossipStatus gs)
             {
-                var gs = message as GossipStatus;
                 ReceiveGossipStatus(gs);
             }
             else if (message is InternalClusterAction.GossipTick)
@@ -1352,49 +1343,41 @@ namespace Akka.Cluster
             {
                 InitJoin();
             }
-            else if (message is InternalClusterAction.Join)
+            else if (message is InternalClusterAction.Join @join)
             {
-                var join = message as InternalClusterAction.Join;
-                Joining(join.Node, join.Roles);
+                Joining(@join.Node, @join.Roles);
             }
-            else if (message is ClusterUserAction.Down)
+            else if (message is ClusterUserAction.Down down)
             {
-                var down = message as ClusterUserAction.Down;
                 Downing(down.Address);
             }
-            else if (message is ClusterUserAction.Leave)
+            else if (message is ClusterUserAction.Leave leave)
             {
-                var leave = message as ClusterUserAction.Leave;
                 Leaving(leave.Address);
             }
-            else if (message is InternalClusterAction.SendGossipTo)
+            else if (message is InternalClusterAction.SendGossipTo sendGossipTo)
             {
-                var sendGossipTo = message as InternalClusterAction.SendGossipTo;
                 SendGossipTo(sendGossipTo.Address);
             }
             else if (message is InternalClusterAction.ISubscriptionMessage)
             {
                 _publisher.Forward(message);
             }
-            else if (message is QuarantinedEvent)
+            else if (message is QuarantinedEvent q)
             {
-                var q = message as QuarantinedEvent;
                 Quarantined(new UniqueAddress(q.Address, q.Uid));
             }
-            else if (message is ClusterUserAction.JoinTo)
+            else if (message is ClusterUserAction.JoinTo jt)
             {
-                var jt = message as ClusterUserAction.JoinTo;
                 _log.Info("Trying to join [{0}] when already part of a cluster, ignoring", jt.Address);
             }
-            else if (message is InternalClusterAction.JoinSeedNodes)
+            else if (message is InternalClusterAction.JoinSeedNodes joinSeedNodes)
             {
-                var joinSeedNodes = message as InternalClusterAction.JoinSeedNodes;
                 _log.Info("Trying to join seed nodes [{0}] when already part of a cluster, ignoring",
                     joinSeedNodes.SeedNodes.Select(a => a.ToString()).Aggregate((a, b) => a + ", " + b));
             }
-            else if (message is InternalClusterAction.ExitingConfirmed)
+            else if (message is InternalClusterAction.ExitingConfirmed c)
             {
-                var c = (InternalClusterAction.ExitingConfirmed)message;
                 ReceiveExitingConfirmed(c.Address);
             }
             else if (ReceiveExitingCompleted(message)) { }

--- a/src/core/Akka.Cluster/ClusterSettings.cs
+++ b/src/core/Akka.Cluster/ClusterSettings.cs
@@ -57,8 +57,7 @@ namespace Akka.Cluster
 
             Roles = cc.GetStringList("roles").ToImmutableHashSet();
             MinNrOfMembers = cc.GetInt("min-nr-of-members");
-            //TODO:
-            //_minNrOfMembersOfRole = cc.GetConfig("role").Root.GetArray().ToImmutableDictionary(o => o. )
+
             _useDispatcher = cc.GetString("use-dispatcher");
             if (String.IsNullOrEmpty(_useDispatcher)) _useDispatcher = Dispatchers.DefaultDispatcherId;
             GossipDifferentViewProbability = cc.GetDouble("gossip-different-view-probability");


### PR DESCRIPTION
Resolves #3635 and implements a bunch of more helpful, useful log messages inside the cluster which properly attribute the NODE ADDRESS to each logged message. Should be a nice usability improvement to what we have already.