### PR TITLE
made it easier to generate local beta packages of Akka.NET

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -29,7 +29,7 @@ let outputBinariesNet45 = outputBinaries @@ "net45"
 let outputBinariesNetStandard = outputBinaries @@ "netstandard1.6"
 
 let buildNumber = environVarOrDefault "BUILD_NUMBER" "0"
-let preReleaseVersionSuffix = "beta" + (if (not (buildNumber = "0")) then (buildNumber) else "")
+let preReleaseVersionSuffix = "beta" + (if (not (buildNumber = "0")) then (buildNumber) else DateTime.UtcNow.Ticks.ToString())
 let versionSuffix = 
     match (getBuildParam "nugetprerelease") with
     | "dev" -> preReleaseVersionSuffix


### PR DESCRIPTION
If TeamCity isn't available to pass in a build number environment variable, beta NuGet packages will now be named using the following convention:

```
[PackageName].[VerisonInReleaseNotes]-beta[DateTime.UtcNow.Ticks]
```

If the `BUILD_NUMBER` environment variable is available, NuGet packages will be built the same way they are now:

```
[PackageName].[VerisonInReleaseNotes]-beta[BUILD_NUMBER]
```

Ported the strategy over from NBench and Hyperion: https://github.com/akkadotnet/Hyperion/pull/103