### PR TITLE
fixed NuGet issue with DocsExamples

### DIFF
--- a/docs/examples/DocsExamples/DocsExamples.csproj
+++ b/docs/examples/DocsExamples/DocsExamples.csproj
@@ -16,7 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />


### PR DESCRIPTION
`DocsExamples.csproj` referenced its own version of System.Collections.Immutable. Removed that NuGet reference so now it just uses whatever `Akka.csproj` depends on. The upgrade to System.Collections.Immutable 1.5 in #3633 caused our docs to not compile due to the NuGet downgrade errors this caused.