### PR TITLE
Allow RestartSource/RestartFlow to restart only on failures

### DIFF
--- a/docs/articles/streams/error-handling.md
+++ b/docs/articles/streams/error-handling.md
@@ -87,8 +87,8 @@ eight
 ## Delayed restarts with a backoff stage
 
 Just as Akka provides the [backoff supervision pattern for actors](xref:supervision#delayed-restarts-with-the-backoffsupervisor-pattern), Akka streams
-also provides a `RestartSource`, `RestartSink` and `RestartFlow` for implementing the so-called *exponential backoff 
-supervision strategy*, starting a stage again when it fails, each time with a growing time delay between restarts.
+also provides a `RestartSource`, `RestartSink` and `RestartFlow` for implementing the so-called *exponential backoff
+supervision strategy*, starting a stage again when it fails or completes, each time with a growing time delay between restarts.
 
 This pattern is useful when the stage fails or completes because some external resource is not available
 and we need to give it some time to start-up again. One of the prime examples when this is useful is

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
@@ -1528,6 +1528,7 @@ namespace Akka.Streams.Dsl
     }
     public class static RestartFlow
     {
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> OnFailuresWithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> WithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
     }
     public class static RestartSink
@@ -1536,6 +1537,7 @@ namespace Akka.Streams.Dsl
     }
     public class static RestartSource
     {
+        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> OnFailuresWithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
     }
     public class static Retry

--- a/src/core/Akka.Streams/Dsl/Restart.cs
+++ b/src/core/Akka.Streams/Dsl/Restart.cs
@@ -6,7 +6,6 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Linq;
 using Akka.Pattern;
 using Akka.Streams.Stage;
 
@@ -35,7 +34,23 @@ namespace Akka.Streams.Dsl
         /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
         /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
         public static Source<T, NotUsed> WithBackoff<T, TMat>(Func<Source<T, TMat>> sourceFactory, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor) 
-            => Source.FromGraph(new RestartWithBackoffSource<T, TMat>(sourceFactory, minBackoff, maxBackoff, randomFactor));
+            => Source.FromGraph(new RestartWithBackoffSource<T, TMat>(sourceFactory, minBackoff, maxBackoff, randomFactor, false));
+
+        /// <summary>
+        /// Wrap the given <see cref="Source"/> with a <see cref="Source"/> that will restart it when it fails using an exponential backoff.
+        /// This <see cref="Source"/> will never emit a failure, since the failure of the wrapped <see cref="Source"/> is always handled by
+        /// restarting. The wrapped <see cref="Source"/> can be cancelled by cancelling this <see cref="Source"/>.
+        /// When that happens, the wrapped <see cref="Source"/>, if currently running will be cancelled, and it will not be restarted.
+        /// This can be triggered simply by the downstream cancelling, or externally by introducing a <see cref="IKillSwitch"/> right
+        /// after this <see cref="Source"/> in the graph.
+        /// This uses the same exponential backoff algorithm as <see cref="Akka.Pattern.Backoff"/>.
+        /// </summary>
+        /// <param name="sourceFactory">A factory for producing the <see cref="Source"/> to wrap.</param>
+        /// <param name="minBackoff">Minimum (initial) duration until the child actor will started again, if it is terminated</param>
+        /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
+        /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
+        public static Source<T, NotUsed> OnFailuresWithBackoff<T, TMat>(Func<Source<T, TMat>> sourceFactory, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor) 
+            => Source.FromGraph(new RestartWithBackoffSource<T, TMat>(sourceFactory, minBackoff, maxBackoff, randomFactor, true));
     }
 
     internal sealed class RestartWithBackoffSource<T, TMat> : GraphStage<SourceShape<T>>
@@ -44,17 +59,20 @@ namespace Akka.Streams.Dsl
         public TimeSpan MinBackoff { get; }
         public TimeSpan MaxBackoff { get; }
         public double RandomFactor { get; }
+        public bool OnlyOnFailures { get; }
 
         public RestartWithBackoffSource(
             Func<Source<T, TMat>> sourceFactory,
             TimeSpan minBackoff,
             TimeSpan maxBackoff,
-            double randomFactor)
+            double randomFactor,
+            bool onlyOnFailures)
         {
             SourceFactory = sourceFactory;
             MinBackoff = minBackoff;
             MaxBackoff = maxBackoff;
             RandomFactor = randomFactor;
+            OnlyOnFailures = onlyOnFailures;
             Shape = new SourceShape<T>(Out);
         }
 
@@ -69,7 +87,7 @@ namespace Akka.Streams.Dsl
             private readonly RestartWithBackoffSource<T, TMat> _stage;
 
             public Logic(RestartWithBackoffSource<T, TMat> stage, string name) 
-                : base(name, stage.Shape, null, stage.Out, stage.MinBackoff, stage.MaxBackoff, stage.RandomFactor)
+                : base(name, stage.Shape, null, stage.Out, stage.MinBackoff, stage.MaxBackoff, stage.RandomFactor, stage.OnlyOnFailures)
             {
                 _stage = stage;
                 Backoff();
@@ -150,7 +168,7 @@ namespace Akka.Streams.Dsl
             private readonly RestartWithBackoffSink<T, TMat> _stage;
 
             public Logic(RestartWithBackoffSink<T, TMat> stage, string name)
-                : base(name, stage.Shape, stage.In, null, stage.MinBackoff, stage.MaxBackoff, stage.RandomFactor)
+                : base(name, stage.Shape, stage.In, null, stage.MinBackoff, stage.MaxBackoff, stage.RandomFactor, false)
             {
                 _stage = stage;
                 Backoff();
@@ -194,7 +212,27 @@ namespace Akka.Streams.Dsl
         /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
         /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
         public static Flow<TIn, TOut, NotUsed> WithBackoff<TIn, TOut, TMat>(Func<Flow<TIn, TOut, TMat>> flowFactory, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor)
-            => Flow.FromGraph(new RestartWithBackoffFlow<TIn, TOut, TMat>(flowFactory, minBackoff, maxBackoff, randomFactor));
+            => Flow.FromGraph(new RestartWithBackoffFlow<TIn, TOut, TMat>(flowFactory, minBackoff, maxBackoff, randomFactor, false));
+
+        /// <summary>
+        /// Wrap the given <see cref="Flow"/> with a <see cref="Flow"/> that will restart it when it fails using an exponential
+        /// backoff. Notice that this <see cref="Flow"/> will not restart on completion of the wrapped flow. 
+        /// This <see cref="Flow"/> will not emit any failure
+        /// The failures by the wrapped <see cref="Flow"/> will be handled by
+        /// restarting the wrapping <see cref="Flow"/> as long as maxRestarts is not reached.
+        /// Any termination signals sent to this <see cref="Flow"/> however will terminate the wrapped <see cref="Flow"/>, if it's
+        /// running, and then the <see cref="Flow"/> will be allowed to terminate without being restarted. 
+        /// The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
+        /// messages. A termination signal from either end of the wrapped <see cref="Flow"/> will cause the other end to be terminated,
+        /// nd any in transit messages will be lost. During backoff, this <see cref="Flow"/> will backpressure. 
+        /// This uses the same exponential backoff algorithm as <see cref="Akka.Pattern.Backoff"/>.
+        /// </summary>
+        /// <param name="flowFactory">A factory for producing the <see cref="Flow"/>] to wrap.</param>
+        /// <param name="minBackoff">Minimum (initial) duration until the child actor will started again, if it is terminated</param>
+        /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
+        /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
+        public static Flow<TIn, TOut, NotUsed> OnFailuresWithBackoff<TIn, TOut, TMat>(Func<Flow<TIn, TOut, TMat>> flowFactory, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor) 
+            => Flow.FromGraph(new RestartWithBackoffFlow<TIn, TOut, TMat>(flowFactory, minBackoff, maxBackoff, randomFactor, true));
     }
 
     internal sealed class RestartWithBackoffFlow<TIn, TOut, TMat> : GraphStage<FlowShape<TIn, TOut>>
@@ -203,17 +241,20 @@ namespace Akka.Streams.Dsl
         public TimeSpan MinBackoff { get; }
         public TimeSpan MaxBackoff { get; }
         public double RandomFactor { get; }
+        public bool OnlyOnFailures { get; }
 
         public RestartWithBackoffFlow(
             Func<Flow<TIn, TOut, TMat>> flowFactory,
             TimeSpan minBackoff,
             TimeSpan maxBackoff,
-            double randomFactor)
+            double randomFactor,
+            bool onlyOnFailures)
         {
             FlowFactory = flowFactory;
             MinBackoff = minBackoff;
             MaxBackoff = maxBackoff;
             RandomFactor = randomFactor;
+            OnlyOnFailures = onlyOnFailures;
             Shape = new FlowShape<TIn, TOut>(In, Out);
         }
 
@@ -231,7 +272,7 @@ namespace Akka.Streams.Dsl
             private Tuple<SubSourceOutlet<TIn>, SubSinkInlet<TOut>> _activeOutIn;
 
             public Logic(RestartWithBackoffFlow<TIn, TOut, TMat> stage, string name)
-                : base(name, stage.Shape, stage.In, stage.Out, stage.MinBackoff, stage.MaxBackoff, stage.RandomFactor)
+                : base(name, stage.Shape, stage.In, stage.Out, stage.MinBackoff, stage.MaxBackoff, stage.RandomFactor, stage.OnlyOnFailures)
             {
                 _stage = stage;
                 Backoff();
@@ -285,6 +326,7 @@ namespace Akka.Streams.Dsl
         private readonly TimeSpan _minBackoff;
         private readonly TimeSpan _maxBackoff;
         private readonly double _randomFactor;
+        private readonly bool _onlyOnFailures;
 
         protected Inlet<TIn> In { get; }
         protected Outlet<TOut> Out { get; }
@@ -302,12 +344,14 @@ namespace Akka.Streams.Dsl
             Outlet<TOut> outlet,
             TimeSpan minBackoff,
             TimeSpan maxBackoff,
-            double randomFactor) : base(shape)
+            double randomFactor,
+            bool onlyOnFailures) : base(shape)
         {
             _name = name;
             _minBackoff = minBackoff;
             _maxBackoff = maxBackoff;
             _randomFactor = randomFactor;
+            _onlyOnFailures = onlyOnFailures;
 
             _resetDeadline = minBackoff.FromNow();
 
@@ -327,12 +371,12 @@ namespace Akka.Streams.Dsl
                 onPush: () => Push(Out, sinkIn.Grab()),
                 onUpstreamFinish: () =>
                 {
-                    if (_finishing)
+                    if (_finishing || _onlyOnFailures)
                         Complete(Out);
                     else
                     {
-                        Log.Debug("Graph out finished");
-                        OnCompleteOrFailure();
+                        Log.Debug("Restarting graph due to finished upstream");
+                        ScheduleRestartTimer();
                     }
                 },
                 onUpstreamFailure: ex =>
@@ -342,7 +386,7 @@ namespace Akka.Streams.Dsl
                     else
                     {
                         Log.Error(ex, "Restarting graph due to failure");
-                        OnCompleteOrFailure();
+                        ScheduleRestartTimer();
                     }
                 }));
 
@@ -373,12 +417,12 @@ namespace Akka.Streams.Dsl
                 },
                 onDownstreamFinish: () =>
                 {
-                    if (_finishing)
+                    if (_finishing || _onlyOnFailures)
                         Cancel(In);
                     else
                     {
                         Log.Debug("Graph in finished");
-                        OnCompleteOrFailure();
+                        ScheduleRestartTimer();
                     }
                 }
             ));
@@ -403,7 +447,7 @@ namespace Akka.Streams.Dsl
             return sourceOut;
         }
 
-        internal void OnCompleteOrFailure()
+        internal void ScheduleRestartTimer()
         {
             // Check if the last start attempt was more than the minimum backoff
             if (_resetDeadline.IsOverdue)


### PR DESCRIPTION
Adds a new method signature to both RestartSource and RestartFlow to control if they should restart wrapped Source in only failures, or also in completions.