### PR TITLE
Akka.Cluster SplitBrainResolver: don't down oldest if alone in cluster

### DIFF
--- a/src/core/Akka.Cluster.Tests/SplitBrainStrategySpec.cs
+++ b/src/core/Akka.Cluster.Tests/SplitBrainStrategySpec.cs
@@ -198,6 +198,16 @@ namespace Akka.Cluster.Tests
         }
 
         [Fact]
+        public void KeepOldest_when_downIfAlone_must_keep_oldest_up_if_is_reachable_and_only_node_in_cluster()
+        {
+            var unreachable = Members();
+            var remaining = Members(Member(a, upNumber: 1));
+
+            var strategy = new KeepOldest(downIfAlone: true);
+            strategy.Apply(new NetworkPartitionContext(unreachable, remaining)).Should().Equal(unreachable);
+        }
+
+        [Fact]
         public void KeepReferee_must_down_remaining_if_referee_node_was_unreachable()
         {
             var referee = a;

--- a/src/core/Akka.Cluster/SplitBrainResolver.cs
+++ b/src/core/Akka.Cluster/SplitBrainResolver.cs
@@ -179,7 +179,7 @@ namespace Akka.Cluster
             var oldest = remaining.Union(unreachable).ToImmutableSortedSet(Member.AgeOrdering).First();
             if (remaining.Contains(oldest))
             {
-                return DownIfAlone && context.Remaining.Count == 1 // oldest is current node, and it's alone
+                return DownIfAlone && context.Remaining.Count == 1 && context.Unreachable.Count > 0 // oldest is current node, and it's alone, but not the only node in the cluster
                     ? context.Remaining 
                     : context.Unreachable;
             }


### PR DESCRIPTION
In [the Lightbend docs for the split brain resolver](https://developer.lightbend.com/docs/akka-commercial-addons/current/split-brain-resolver.html#keep-oldest), it mentions (emphasis mine):

> There is one exception to this rule if down-if-alone is configured to on. Then, if the oldest node has partitioned from all other nodes the oldest will down itself and keep all other nodes running. **The strategy will not down the single oldest node when it is the only remaining node in the cluster.**

I noticed that this bit didn't seem to be included in the [corresponding Akka.NET docs](https://getakka.net/articles/clustering/split-brain-resolver.html#keep-oldest) for the resolver. Was it an intentional choice not to implement that aspect of it? 

I've included a test and a possible tweak to the logic to account for not downing the oldest node if it's alone in the cluster. I've been staring at this for too long tonight and will take another pass in the morning, but wanted to throw this up in the meantime for conversation and to see if I was missing something here in how all this should work.
