### PR TITLE
Using nonblocking task completion source hack for Source.Queue

### DIFF
--- a/src/core/Akka.Streams/Implementation/Sources.cs
+++ b/src/core/Akka.Streams/Implementation/Sources.cs
@@ -17,6 +17,7 @@ using Akka.Streams.Stage;
 using Akka.Streams.Supervision;
 using Akka.Streams.Util;
 using Akka.Util;
+using Akka.Util.Internal;
 
 namespace Akka.Streams.Implementation
 {
@@ -123,7 +124,7 @@ namespace Akka.Streams.Implementation
                     if (_pendingOffer != null)
                     {
                         Push(_stage.Out, _pendingOffer.Element);
-                        _pendingOffer.CompletionSource.SetResult(QueueOfferResult.Enqueued.Instance);
+                        _pendingOffer.CompletionSource.NonBlockingTrySetResult(QueueOfferResult.Enqueued.Instance);
                         _pendingOffer = null;
                         if (_terminating)
                         {
@@ -153,7 +154,7 @@ namespace Akka.Streams.Implementation
             {
                 if (_pendingOffer != null)
                 {
-                    _pendingOffer.CompletionSource.SetResult(QueueOfferResult.QueueClosed.Instance);
+                    _pendingOffer.CompletionSource.NonBlockingTrySetResult(QueueOfferResult.QueueClosed.Instance);
                     _pendingOffer = null;
                 }
                 _completion.SetResult(new object());
@@ -175,7 +176,7 @@ namespace Akka.Streams.Implementation
                     if (offer != null)
                     {
                         var promise = offer.CompletionSource;
-                        promise.SetException(new IllegalStateException("Stream is terminated. SourceQueue is detached."));
+                        promise.NonBlockingTrySetException(new IllegalStateException("Stream is terminated. SourceQueue is detached."));
                     }
                 });
             }
@@ -183,7 +184,7 @@ namespace Akka.Streams.Implementation
             private void EnqueueAndSuccess(Offer<TOut> offer)
             {
                 _buffer.Enqueue(offer.Element);
-                offer.CompletionSource.SetResult(QueueOfferResult.Enqueued.Instance);
+                offer.CompletionSource.NonBlockingTrySetResult(QueueOfferResult.Enqueued.Instance);
             }
 
             private void BufferElement(Offer<TOut> offer)
@@ -207,18 +208,18 @@ namespace Akka.Streams.Implementation
                             EnqueueAndSuccess(offer);
                             break;
                         case OverflowStrategy.DropNew:
-                            offer.CompletionSource.SetResult(QueueOfferResult.Dropped.Instance);
+                            offer.CompletionSource.NonBlockingTrySetResult(QueueOfferResult.Dropped.Instance);
                             break;
                         case OverflowStrategy.Fail:
                             var bufferOverflowException =
                                 new BufferOverflowException($"Buffer overflow (max capacity was: {_stage._maxBuffer})!");
-                            offer.CompletionSource.SetResult(new QueueOfferResult.Failure(bufferOverflowException));
+                            offer.CompletionSource.NonBlockingTrySetResult(new QueueOfferResult.Failure(bufferOverflowException));
                             _completion.SetException(bufferOverflowException);
                             FailStage(bufferOverflowException);
                             break;
                         case OverflowStrategy.Backpressure:
                             if (_pendingOffer != null)
-                                offer.CompletionSource.SetException(
+                                offer.CompletionSource.NonBlockingTrySetException(
                                     new IllegalStateException(
                                         "You have to wait for previous offer to be resolved to send another request."));
                             else
@@ -245,7 +246,7 @@ namespace Akka.Streams.Implementation
                             else if (IsAvailable(_stage.Out))
                             {
                                 Push(_stage.Out, offer.Element);
-                                offer.CompletionSource.SetResult(QueueOfferResult.Enqueued.Instance);
+                                offer.CompletionSource.NonBlockingTrySetResult(QueueOfferResult.Enqueued.Instance);
                             }
                             else if (_pendingOffer == null)
                                 _pendingOffer = offer;
@@ -255,15 +256,15 @@ namespace Akka.Streams.Implementation
                                 {
                                     case OverflowStrategy.DropHead:
                                     case OverflowStrategy.DropBuffer:
-                                        _pendingOffer.CompletionSource.SetResult(QueueOfferResult.Dropped.Instance);
+                                        _pendingOffer.CompletionSource.NonBlockingTrySetResult(QueueOfferResult.Dropped.Instance);
                                         _pendingOffer = offer;
                                         break;
                                     case OverflowStrategy.DropTail:
                                     case OverflowStrategy.DropNew:
-                                        offer.CompletionSource.SetResult(QueueOfferResult.Dropped.Instance);
+                                        offer.CompletionSource.NonBlockingTrySetResult(QueueOfferResult.Dropped.Instance);
                                         break;
                                     case OverflowStrategy.Backpressure:
-                                        offer.CompletionSource.SetException(
+                                        offer.CompletionSource.NonBlockingTrySetException(
                                             new IllegalStateException(
                                                 "You have to wait for previous offer to be resolved to send another request"));
                                         break;
@@ -271,7 +272,7 @@ namespace Akka.Streams.Implementation
                                         var bufferOverflowException =
                                             new BufferOverflowException(
                                                 $"Buffer overflow (max capacity was: {_stage._maxBuffer})!");
-                                        offer.CompletionSource.SetResult(new QueueOfferResult.Failure(bufferOverflowException));
+                                        offer.CompletionSource.NonBlockingTrySetResult(new QueueOfferResult.Failure(bufferOverflowException));
                                         _completion.SetException(bufferOverflowException);
                                         FailStage(bufferOverflowException);
                                         break;
@@ -331,7 +332,7 @@ namespace Akka.Streams.Implementation
             /// <returns>TBD</returns>
             public Task<IQueueOfferResult> OfferAsync(TOut element)
             {
-                var promise = new TaskCompletionSource<IQueueOfferResult>();
+                var promise = TaskEx.NonBlockingTaskCompletionSource<IQueueOfferResult>(); // new TaskCompletionSource<IQueueOfferResult>();
                 _invokeLogic(new Offer<TOut>(element, promise));
                 return promise.Task;
             }


### PR DESCRIPTION
When we `Source.Queue<>` method, it can be materialized into queue with `OfferAsync` method. Problem is that, awaiting for it may cause a deadlock - it's a classical problem with awaiting on the `TaskCompletionSource<>.Task` and using `SetResult` on that task in the same execution context. We already met it before.

This issue is easy to fix in .NET Standard 2.0 by using special option when creating `TaskCompletionSource<>`. For .NET Standard < 1.6 we already provided a hack around it (which uses `Task.Run` to escape from execution context): it's suboptimal, but it's used only for older framework versions.

This PR uses our fixer method set to overcome this deadlock issue.

Example, I've used to recreate this issue, was a Akka.Streams TCP server:

```csharp
// Server
var connectionHandler =
    Framing.SimpleFramingProtocol(128)
        .Reversed()
        .Join(Flow.Identity<ByteString>()
            .Select(bytes =>
            {
                var text = bytes.ToString(Encoding.UTF8);
                return ByteString.FromString("ECHO" + text);
            }));

var binding =
    await actorSystem.TcpStream()
        .Bind("localhost", 7000)
        .To(Sink.ForEach<Akka.Streams.Dsl.Tcp.IncomingConnection>(connection =>
        {
            connection.Flow.Join(connectionHandler).Run(materializer);
        }))
        .Run(materializer);

Console.WriteLine($"Server listening on {binding.LocalAddress}. Press Enter to stop");
Console.ReadLine();

// close the server
await binding.Unbind();
```
And client:
```csharp
// Client
var input = Source.Queue<string>(100, OverflowStrategy.Backpressure)
    .Select(str =>
    {
        return ByteString.FromString(str);
    });

var output = Flow.Identity<ByteString>()
    .Select(bs => bs.ToString(Encoding.UTF8))
    .To(Sink.ForEach<string>(Console.WriteLine));

var connectionDef = actorSystem.TcpStream()
    .OutgoingConnection(new IPEndPoint(IPAddress.IPv6Loopback, 7000))
    .JoinMaterialized(Framing.SimpleFramingProtocol(128).Reversed(), Keep.Left);

var client = input
    .Log("stdin")
    .ToMaterialized(connectionDef.ToMaterialized(output, Keep.Left), Keep.Both);

var (queue, connectionTask) = client.Run(materializer);

var connection = await connectionTask;

Console.WriteLine($"Connected to: {connection.RemoteAddress}. Start typing:");

while (true)
{
    var data = Console.ReadLine();
    await queue.OfferAsync(data).ConfigureAwait(false); // we'll deadlock here
}
```