### PR TITLE
Add "Install-Package" instruction for Akka.Streams

### DIFF
--- a/docs/articles/streams/quickstart.md
+++ b/docs/articles/streams/quickstart.md
@@ -4,6 +4,13 @@ title: Quickstart
 ---
 
 # Streams Quickstart Guide
+
+To use Akka Streams, an additional module is required, so we first make sure ```Akka.Streams``` is added to our project:
+
+```
+Install-Package Akka.Streams
+```
+
 A stream usually begins at a source, so this is also how we start an Akka Stream. Before we create one, we import the full complement of streaming tools:
 
 ```csharp


### PR DESCRIPTION
The Getting Started guide lacks crucial knowledge that is necessary to actually get started, which is the nuget package.  So above the ```using Akka```s paragraph, I've added the ```Install-Package Akka.Streams``` instruction.