### PR TITLE
Support ClusterSharding passivation in BackoffSupervisor

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/SupervisionSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/SupervisionSpec.cs
@@ -1,0 +1,137 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ProxyShardingSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Globalization;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.Pattern;
+using Xunit;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    public class SupervisionSpec : TestKit.Xunit2.TestKit
+    {
+        #region Protocol
+
+        internal class Msg
+        {
+            public long Id { get; }
+            public object Message { get; }
+
+            public Msg(long id, object message)
+            {
+                Id = id;
+                Message = message;
+            }
+        }
+
+        internal class Response
+        {
+            public IActorRef Self { get; }
+
+            public Response(IActorRef self)
+            {
+                Self = self;
+            }
+        }
+
+        internal class StopMessage
+        {
+            public static readonly StopMessage Instance = new StopMessage();
+            private StopMessage() { }
+        }
+
+        internal class PassivatingActor : UntypedActor
+        {
+            public ILoggingAdapter Log { get; } = Context.GetLogger();
+
+            protected override void PreStart()
+            {
+                Log.Info("Starting");
+                base.PreStart();
+            }
+
+            protected override void PostStop()
+            {
+                Log.Info("Stopping");
+                base.PostStop();
+            }
+
+            protected override void OnReceive(object message)
+            {
+                switch (message)
+                {
+                    case "passivate":
+                        Log.Info("Passivating");
+                        Context.Parent.Tell(new Passivate(StopMessage.Instance));
+                        // simulate another message causing a stop before the region sends the stop message
+                        // e.g. a persistent actor having a persist failure while processing the next message
+                        Context.Stop(Self);
+                        break;
+                    case "hello":
+                        Sender.Tell(new Response(Self));
+                        break;
+                    case StopMessage _:
+                        Log.Info("Received stop from region");
+                        Context.Parent.Tell(PoisonPill.Instance);
+                        break;
+                }
+            }
+        }
+
+        #endregion
+
+        private readonly ExtractEntityId _extractEntityId = message =>
+            message is Msg msg ? new Tuple<string, object>(msg.Id.ToString(), msg.Message) : null;
+
+        private readonly ExtractShardId _extractShard = message =>
+            message is Msg msg ? (msg.Id % 2).ToString(CultureInfo.InvariantCulture) : null;
+
+        public SupervisionSpec() : base(GetConfig())
+        { }
+
+        public static Config GetConfig()
+        {
+            return ConfigurationFactory.ParseString("akka.actor.provider = cluster \r\n akka.loglevel = INFO")
+                .WithFallback(ClusterSharding.DefaultConfig());
+        }
+
+        [Fact]
+        public void SupervisionSpec_for_a_sharded_actor_must_allow_passivation()
+        {
+            var supervisedProps = BackoffSupervisor.Props(Backoff.OnStop(
+                Props.Create<PassivatingActor>(),
+                "child",
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(30),
+                0.2,
+                -1).WithFinalStopMessage(message => message is StopMessage));
+
+            Cluster.Get(Sys).Join(Cluster.Get(Sys).SelfAddress);
+
+            var region = ClusterSharding.Get(Sys).Start(
+                "passy",
+                supervisedProps,
+                ClusterShardingSettings.Create(Sys),
+                _extractEntityId,
+                _extractShard);
+
+            region.Tell(new Msg(10, "hello"));
+            var response = ExpectMsg<Response>(TimeSpan.FromSeconds(5));
+            Watch(response.Self);
+
+            region.Tell(new Msg(10, "passivate"));
+            ExpectTerminated(response.Self);
+
+            // This would fail before as sharded actor would be stuck passivating
+            region.Tell(new Msg(10, "hello"));
+            ExpectMsg<Response>(TimeSpan.FromSeconds(20));
+        }
+    }
+}

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -3767,6 +3767,7 @@ namespace Akka.Pattern
         protected BackoffOptions() { }
         public abstract Akka.Pattern.BackoffOptions WithAutoReset(System.TimeSpan resetBackoff);
         public abstract Akka.Pattern.BackoffOptions WithDefaultStoppingStrategy();
+        public abstract Akka.Pattern.BackoffOptions WithFinalStopMessage(System.Func<object, bool> isFinalStopMessage);
         public abstract Akka.Pattern.BackoffOptions WithManualReset();
         public abstract Akka.Pattern.BackoffOptions WithMaxNrOfRetries(int maxNrOfRetries);
         public abstract Akka.Pattern.BackoffOptions WithReplyWhileStopped(object replyWhileStopped);
@@ -3775,7 +3776,7 @@ namespace Akka.Pattern
     public sealed class BackoffSupervisor : Akka.Pattern.BackoffSupervisorBase
     {
         public BackoffSupervisor(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
-        public BackoffSupervisor(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, Akka.Pattern.IBackoffReset reset, double randomFactor, Akka.Actor.SupervisorStrategy strategy, object replyWhileStopped = null) { }
+        public BackoffSupervisor(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, Akka.Pattern.IBackoffReset reset, double randomFactor, Akka.Actor.SupervisorStrategy strategy, object replyWhileStopped = null, System.Func<object, bool> finalStopMessage = null) { }
         public static Akka.Actor.Props Props(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
         public static Akka.Actor.Props Props(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxNrOfRetries) { }
         public static Akka.Actor.Props Props(Akka.Pattern.BackoffOptions options) { }
@@ -3819,6 +3820,8 @@ namespace Akka.Pattern
         protected Akka.Actor.IActorRef Child { get; set; }
         protected string ChildName { get; }
         protected Akka.Actor.Props ChildProps { get; }
+        protected System.Func<object, bool> FinalStopMessage { get; }
+        protected bool FinalStopMessageReceived { get; set; }
         protected object ReplyWhileStopped { get; }
         protected Akka.Pattern.IBackoffReset Reset { get; }
         protected int RestartCountN { get; set; }

--- a/src/core/Akka/Pattern/BackoffOnRestartSupervisor.cs
+++ b/src/core/Akka/Pattern/BackoffOnRestartSupervisor.cs
@@ -31,7 +31,8 @@ namespace Akka.Pattern
             IBackoffReset reset,
             double randomFactor,
             OneForOneStrategy strategy,
-            object replyWhileStopped = null) : base(childProps, childName, reset, replyWhileStopped)
+            object replyWhileStopped = null,
+            Func<object, bool> finalStopMessage = null) : base(childProps, childName, reset, replyWhileStopped, finalStopMessage)
         {
             _minBackoff = minBackoff;
             _maxBackoff = maxBackoff;
@@ -89,22 +90,22 @@ namespace Akka.Pattern
 
         private bool WaitChildTerminatedBeforeBackoff(object message, IActorRef childRef)
         {
-            var terminated = message as Terminated;
-            if (terminated != null && terminated.ActorRef.Equals(childRef))
+            switch (message)
             {
-                Become(Receive);
-                Child = null;
-                var restartDelay = BackoffSupervisor.CalculateDelay(RestartCountN, _minBackoff, _maxBackoff, _randomFactor);
-                Context.System.Scheduler.ScheduleTellOnce(restartDelay, Self, BackoffSupervisor.StartChild.Instance, Self);
-                RestartCountN++;
-            }
-            else if (message is BackoffSupervisor.StartChild)
-            {
-                // Ignore it, we will schedule a new one once current child terminated.
-            }
-            else
-            {
-                return false;
+                case Terminated terminated when terminated.ActorRef.Equals(childRef):
+                {
+                    Become(Receive);
+                    Child = null;
+                    var restartDelay = BackoffSupervisor.CalculateDelay(RestartCountN, _minBackoff, _maxBackoff, _randomFactor);
+                    Context.System.Scheduler.ScheduleTellOnce(restartDelay, Self, BackoffSupervisor.StartChild.Instance, Self);
+                    RestartCountN++;
+                    break;
+                }
+                case BackoffSupervisor.StartChild _:
+                    // Ignore it, we will schedule a new one once current child terminated.
+                    break;
+                default:
+                    return false;
             }
 
             return true;
@@ -112,8 +113,7 @@ namespace Akka.Pattern
 
         private bool OnTerminated(object message)
         {
-            var terminated = message as Terminated;
-            if (terminated != null && terminated.ActorRef.Equals(Child))
+            if (message is Terminated terminated && terminated.ActorRef.Equals(Child))
             {
                 _log.Debug($"Terminating, because child {Child} terminated itself");
                 Context.Stop(Self);


### PR DESCRIPTION
> Can be used to allow cluster sharding to work with a back off on stop supervisor which is typically what you want for sharded persistent actors

[#25933](https://github.com/akka/akka/pull/25933)
[#26142](https://github.com/akka/akka/pull/26142)