### PR TITLE
Fixed logic on how to get current events by tag in batches

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Query.Sql/EventsByTagPublisher.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.Sql/EventsByTagPublisher.cs
@@ -194,7 +194,7 @@ namespace Akka.Persistence.Query.Sql
             if (highestSequenceNr < ToOffset)
                 _toOffset = highestSequenceNr;
 
-            if (Buffer.IsEmpty && CurrentOffset > ToOffset)
+            if (Buffer.IsEmpty && CurrentOffset >= ToOffset)
                 OnCompleteThenStop();
             else
                 Self.Tell(EventsByTagPublisher.Continue.Instance);

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryExecutor.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryExecutor.cs
@@ -76,7 +76,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// <param name="persistenceId">TBD</param>
         /// <returns>TBD</returns>
         Task<long> SelectHighestSequenceNrAsync(DbConnection connection, CancellationToken cancellationToken, string persistenceId);
-
+        
         /// <summary>
         /// Asynchronously inserts a collection of events and theirs tags into a journal table.
         /// </summary>
@@ -344,6 +344,12 @@ namespace Akka.Persistence.Sql.Common.Journal
                 AND e.{Configuration.SequenceNrColumnName} BETWEEN @FromSequenceNr AND @ToSequenceNr
                 ORDER BY {Configuration.SequenceNrColumnName} ASC;";
 
+            HighestTagOrderingSql =
+                $@"
+                SELECT MAX(e.{Configuration.OrderingColumnName}) as Ordering
+                FROM {Configuration.FullJournalTableName} e
+                WHERE e.{Configuration.OrderingColumnName} > @Ordering AND e.{Configuration.TagsColumnName} LIKE @Tag";
+
             ByTagSql =
                 $@"
                 SELECT {allEventColumnNames}, e.{Configuration.OrderingColumnName} as Ordering
@@ -398,6 +404,10 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// TBD
         /// </summary>
         protected virtual string ByPersistenceIdSql { get; }
+        /// <summary>
+        /// Query to return the highest ordering number for a tag
+        /// </summary>
+        protected virtual string HighestTagOrderingSql { get; }
         /// <summary>
         /// TBD
         /// </summary>
@@ -526,17 +536,21 @@ namespace Akka.Persistence.Sql.Common.Journal
 
                 using (var reader = await command.ExecuteReaderAsync(commandBehavior, cancellationToken))
                 {
-                    var maxSequenceNr = 0L;
                     while (await reader.ReadAsync(cancellationToken))
                     {
                         var persistent = ReadEvent(reader);
                         var ordering = reader.GetInt64(OrderingIndex);
-                        maxSequenceNr = Math.Max(maxSequenceNr, persistent.SequenceNr);
                         callback(new ReplayedTaggedMessage(persistent, tag, ordering));
                     }
-
-                    return maxSequenceNr;
                 }
+            }
+
+            using (var command = GetCommand(connection, HighestTagOrderingSql))
+            {
+                AddParameter(command, "@Tag", DbType.String, "%;" + tag + ";%");
+                AddParameter(command, "@Ordering", DbType.Int64, fromOffset);
+                var maxOrdering = (await command.ExecuteScalarAsync(cancellationToken)) as long? ?? 0L;
+                return maxOrdering;
             }
         }
 

--- a/src/core/Akka.Persistence.TCK/Query/CurrentEventsByTagSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Query/CurrentEventsByTagSpec.cs
@@ -157,5 +157,30 @@ namespace Akka.Persistence.TCK.Query
             probe2.ExpectNext<EventEnvelope>(p => p.PersistenceId == "b" && p.SequenceNr == 2L && p.Event.Equals("a green leaf"));
             probe2.Cancel();
         }
+
+        [Fact]
+        public virtual void ReadJournal_query_CurrentEventsByTag_should_see_all_150_events()
+        {
+            var queries = ReadJournal as ICurrentEventsByTagQuery;
+            var a = Sys.ActorOf(Query.TestActor.Props("a"));
+
+            for (int i = 0; i < 150; ++i) 
+            {
+                a.Tell("a green apple");
+                ExpectMsg("a green apple-done");
+            }
+
+            var greenSrc = queries.CurrentEventsByTag("green", offset: NoOffset());
+            var probe = greenSrc.RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
+            probe.Request(150);
+            for (int i = 0; i < 150; ++i)
+            {
+                probe.ExpectNext<EventEnvelope>(p => 
+                    p.PersistenceId == "a" && p.SequenceNr == (i + 1) && p.Event.Equals("a green apple"));
+            }
+
+            probe.ExpectComplete();
+            probe.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
+        }
     }
 }


### PR DESCRIPTION
#3697 

Looking at the Scala LevelDb implementation, it looks like they have a special "$$$tag" persistence-id that stores the highest sequence number.

Most SQL database are fairly good at getting highest value of an indexed column, so it's done as a separate query.