### PR TITLE
added ability to publish xrefmap to Akka.NET docs website

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -43,7 +43,8 @@
         "resource": [{
             "files": [
                 "images/**",
-                "web.config"
+                "web.config",
+                "xrefmap.yml"
             ],
             "exclude": [
                 "obj/**",


### PR DESCRIPTION
Allows other websites that use DocFx to refer directly to our API documentation [using the built-in DocFx XREF support](https://dotnet.github.io/docfx/tutorial/links_and_cross_references.html#cross-reference-map-file).

Validated this locally.