### PR TITLE
Change input type for error message relating to open issue 

### DIFF
--- a/src/core/Akka/Dispatch/Mailboxes.cs
+++ b/src/core/Akka/Dispatch/Mailboxes.cs
@@ -283,7 +283,7 @@ namespace Akka.Dispatch
                 if (hasMailboxRequirement && !mailboxRequirement.IsAssignableFrom(mqType.Value))
                     throw new ArgumentException($"produced message queue type [{mqType.Value}] does not fulfill requirement for dispatcher [{id}]." + $"Must be a subclass of [{mailboxRequirement}]");
                 if (HasRequiredType(actorType) && !actorRequirement.Value.IsAssignableFrom(mqType.Value))
-                    throw new ArgumentException($"produced message queue type of [{mqType.Value}] does not fulfill requirement for actor class [{actorType}]." + $"Must be a subclass of [{mqType.Value}]");
+                    throw new ArgumentException($"produced message queue type of [{mqType.Value}] does not fulfill requirement for actor class [{actorType}]." + $"Must be a subclass of [{actorRequirement.Value}]");
                 return mailboxType;
             }
 


### PR DESCRIPTION
Change to exception message in relation to open issue #3292. 

The exception message seems to be taking in the incorrect input at the end of the message. The if statement is making sure `mqType.Value` is a subclass of `actorRequirement.Value` and as such the exception error message should state 
`$"Must be a subclass of [{actorRequirement.Value}]");`
rather than
`$"Must be a subclass of [{mqType.Value}]");`
if this condition is not met.