### PR TITLE
Akka.NET v1.3.12 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,32 @@
-#### 1.3.12 December 18 2018 ####
-*Placeholder for nightlies*
+#### 1.3.12 March 13 2019 ####
+**Maintenance Release for Akka.NET 1.3**
+This will be the final bugfix release for Akka.NET v1.3.* - going forward we will be working on releasing Akka.NET v1.4.
+
+This patch contains many important bug fixes and improvements:
+* [Akka.Cluster.Sharding: Automatic passivation for sharding](https://github.com/akkadotnet/akka.net/pull/3718)
+* [Akka.Persistence: Optimize AtLeastOnceDelivery by not scheduling ticks when not needed](https://github.com/akkadotnet/akka.net/pull/3704)
+* [Akka.Persistence.Sql.Common: Bugfix CurrentEventsByTag does not return more than a 100 events](https://github.com/akkadotnet/akka.net/issues/3697)
+* [Akka.Persistence.Sql.Common: DeleteMessages when journal is empty causes duplicate key SQL exception](https://github.com/akkadotnet/akka.net/issues/3721)
+* [Akka.Cluster: SplitBrainResolver: don't down oldest if alone in cluster](https://github.com/akkadotnet/akka.net/pull/3690)
+* [Akka: Include manifest or class in missing serializer failure if possible](https://github.com/akkadotnet/akka.net/pull/3701)
+* [Akka: Memory leak when disposing actor system with non default ActorRefProvider](https://github.com/akkadotnet/akka.net/issues/2640)
+
+To [see the full set of changes for Akka.NET v1.3.12, click here](https://github.com/akkadotnet/akka.net/milestone/30).
+
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 8 | 1487 | 357 | Ismael Hamed |
+| 7 | 126 | 120 | jdsartori |
+| 3 | 198 | 4 | JSartori |
+| 3 | 155 | 22 | Aaron Stannard |
+| 2 | 11 | 2 | Peter Lin |
+| 1 | 8 | 4 | Raimund Hirz |
+| 1 | 7 | 0 | Warren Falk |
+| 1 | 45 | 6 | Peter Huang |
+| 1 | 14 | 13 | Bartosz Sypytkowski |
+| 1 | 11 | 1 | Greg Shackles |
+| 1 | 10 | 10 | Jill D. Headen |
+| 1 | 1 | 1 | Isaac Z |
 
 #### 1.3.11 December 17 2018 ####
 **Maintenance Release for Akka.NET 1.3**

--- a/src/common.props
+++ b/src/common.props
@@ -18,6 +18,30 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Placeholder for nightlies*</PackageReleaseNotes>
+    <PackageReleaseNotes>Maintenance Release for Akka.NET 1.3**
+This will be the final bugfix release for Akka.NET v1.3.* - going forward we will be working on releasing Akka.NET v1.4.
+This patch contains many important bug fixes and improvements:
+[Akka.Cluster.Sharding: Automatic passivation for sharding](https://github.com/akkadotnet/akka.net/pull/3718)
+[Akka.Persistence: Optimize AtLeastOnceDelivery by not scheduling ticks when not needed](https://github.com/akkadotnet/akka.net/pull/3704)
+[Akka.Persistence.Sql.Common: Bugfix CurrentEventsByTag does not return more than a 100 events](https://github.com/akkadotnet/akka.net/issues/3697)
+[Akka.Persistence.Sql.Common: DeleteMessages when journal is empty causes duplicate key SQL exception](https://github.com/akkadotnet/akka.net/issues/3721)
+[Akka.Cluster: SplitBrainResolver: don't down oldest if alone in cluster](https://github.com/akkadotnet/akka.net/pull/3690)
+[Akka: Include manifest or class in missing serializer failure if possible](https://github.com/akkadotnet/akka.net/pull/3701)
+[Akka: Memory leak when disposing actor system with non default ActorRefProvider](https://github.com/akkadotnet/akka.net/issues/2640)
+To [see the full set of changes for Akka.NET v1.3.12, click here](https://github.com/akkadotnet/akka.net/milestone/30).
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 8 | 1487 | 357 | Ismael Hamed |
+| 7 | 126 | 120 | jdsartori |
+| 3 | 198 | 4 | JSartori |
+| 3 | 155 | 22 | Aaron Stannard |
+| 2 | 11 | 2 | Peter Lin |
+| 1 | 8 | 4 | Raimund Hirz |
+| 1 | 7 | 0 | Warren Falk |
+| 1 | 45 | 6 | Peter Huang |
+| 1 | 14 | 13 | Bartosz Sypytkowski |
+| 1 | 11 | 1 | Greg Shackles |
+| 1 | 10 | 10 | Jill D. Headen |
+| 1 | 1 | 1 | Isaac Z |</PackageReleaseNotes>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
#### 1.3.12 March 13 2019 ####
**Maintenance Release for Akka.NET 1.3**
This will be the final bugfix release for Akka.NET v1.3.* - going forward we will be working on releasing Akka.NET v1.4.

This patch contains many important bug fixes and improvements:
* [Akka.Cluster.Sharding: Automatic passivation for sharding](https://github.com/akkadotnet/akka.net/pull/3718)
* [Akka.Persistence: Optimize AtLeastOnceDelivery by not scheduling ticks when not needed](https://github.com/akkadotnet/akka.net/pull/3704)
* [Akka.Persistence.Sql.Common: Bugfix CurrentEventsByTag does not return more than a 100 events](https://github.com/akkadotnet/akka.net/issues/3697)
* [Akka.Persistence.Sql.Common: DeleteMessages when journal is empty causes duplicate key SQL exception](https://github.com/akkadotnet/akka.net/issues/3721)
* [Akka.Cluster: SplitBrainResolver: don't down oldest if alone in cluster](https://github.com/akkadotnet/akka.net/pull/3690)
* [Akka: Include manifest or class in missing serializer failure if possible](https://github.com/akkadotnet/akka.net/pull/3701)
* [Akka: Memory leak when disposing actor system with non default ActorRefProvider](https://github.com/akkadotnet/akka.net/issues/2640)

To [see the full set of changes for Akka.NET v1.3.12, click here](https://github.com/akkadotnet/akka.net/milestone/30).

| COMMITS | LOC+ | LOC- | AUTHOR |
| --- | --- | --- | --- |
| 8 | 1487 | 357 | Ismael Hamed |
| 7 | 126 | 120 | jdsartori |
| 3 | 198 | 4 | JSartori |
| 3 | 155 | 22 | Aaron Stannard |
| 2 | 11 | 2 | Peter Lin |
| 1 | 8 | 4 | Raimund Hirz |
| 1 | 7 | 0 | Warren Falk |
| 1 | 45 | 6 | Peter Huang |
| 1 | 14 | 13 | Bartosz Sypytkowski |
| 1 | 11 | 1 | Greg Shackles |
| 1 | 10 | 10 | Jill D. Headen |
| 1 | 1 | 1 | Isaac Z |