### PR TITLE
v1.3.12 Production Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 1.3.12 December 18 2018 ####
+*Placeholder for nightlies*
+
 #### 1.3.11 December 17 2018 ####
 **Maintenance Release for Akka.NET 1.3**
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,28 @@
-#### 1.3.11 November 2 2018 ####
-*Placholder for nightlies*
+#### 1.3.11 December 17 2018 ####
+**Maintenance Release for Akka.NET 1.3**
+
+Akka.NET v1.3.11 is a bugfix patch primarily aimed at solving the following issue: [DotNetty Remote Transport Issues with .NET Core 2.1](https://github.com/akkadotnet/akka.net/issues/3506).
+
+.NET Core 2.1 exposed some issues with the DotNetty connection methods in DotNetty v0.4.8 that have since been fixed in subsequent releases. In Akka.NET v1.3.11 we've resolved this issue by upgrading to DotNetty v0.6.0.
+
+In addition to the above, we've introduced some additional fixes and changes in Akka.NET v1.3.11:
+
+* [Akka.FSharp: Akka.Fsharp spawning an actor results in Exception](https://github.com/akkadotnet/akka.net/issues/3402)
+* [Akka.Remote: tcp-reuse-addr = off-for-windows prevents actorsystem from starting](https://github.com/akkadotnet/akka.net/issues/3293)
+* [Akka.Remote: tcp socket address reuse - default configuration](https://github.com/akkadotnet/akka.net/issues/2477)
+* [Akka.Cluster.Tools: 
+Actor still receiving messages from mediator after termination](https://github.com/akkadotnet/akka.net/issues/3658)
+* [Akka.Persistence: Provide minSequenceNr for snapshot deletion](https://github.com/akkadotnet/akka.net/pull/3641)
+
+To [see the full set of changes for Akka.NET 1.3.11, click here](https://github.com/akkadotnet/akka.net/milestone/29)
+
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 5 | 123 | 71 | Aaron Stannard |
+| 3 | 96 | 10 | Ismael Hamed |
+| 2 | 4 | 3 | Oleksandr Kobylianskyi |
+| 1 | 5 | 1 | Ruben Mamo |
+| 1 | 23 | 6 | Chris Hoare |
 
 #### 1.3.10 November 1 2018 ####
 **Maintenance Release for Akka.NET 1.3**

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,32 @@
-#### 1.3.12 December 18 2018 ####
-*Placeholder for nightlies*
+#### 1.3.12 March 13 2019 ####
+**Maintenance Release for Akka.NET 1.3**
+This will be the final bugfix release for Akka.NET v1.3.* - going forward we will be working on releasing Akka.NET v1.4.
+
+This patch contains many important bug fixes and improvements:
+* [Akka.Cluster.Sharding: Automatic passivation for sharding](https://github.com/akkadotnet/akka.net/pull/3718)
+* [Akka.Persistence: Optimize AtLeastOnceDelivery by not scheduling ticks when not needed](https://github.com/akkadotnet/akka.net/pull/3704)
+* [Akka.Persistence.Sql.Common: Bugfix CurrentEventsByTag does not return more than a 100 events](https://github.com/akkadotnet/akka.net/issues/3697)
+* [Akka.Persistence.Sql.Common: DeleteMessages when journal is empty causes duplicate key SQL exception](https://github.com/akkadotnet/akka.net/issues/3721)
+* [Akka.Cluster: SplitBrainResolver: don't down oldest if alone in cluster](https://github.com/akkadotnet/akka.net/pull/3690)
+* [Akka: Include manifest or class in missing serializer failure if possible](https://github.com/akkadotnet/akka.net/pull/3701)
+* [Akka: Memory leak when disposing actor system with non default ActorRefProvider](https://github.com/akkadotnet/akka.net/issues/2640)
+
+To [see the full set of changes for Akka.NET v1.3.12, click here](https://github.com/akkadotnet/akka.net/milestone/30).
+
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 8 | 1487 | 357 | Ismael Hamed |
+| 7 | 126 | 120 | jdsartori |
+| 3 | 198 | 4 | JSartori |
+| 3 | 155 | 22 | Aaron Stannard |
+| 2 | 11 | 2 | Peter Lin |
+| 1 | 8 | 4 | Raimund Hirz |
+| 1 | 7 | 0 | Warren Falk |
+| 1 | 45 | 6 | Peter Huang |
+| 1 | 14 | 13 | Bartosz Sypytkowski |
+| 1 | 11 | 1 | Greg Shackles |
+| 1 | 10 | 10 | Jill D. Headen |
+| 1 | 1 | 1 | Isaac Z |
 
 #### 1.3.11 December 17 2018 ####
 **Maintenance Release for Akka.NET 1.3**

--- a/docs/articles/actors/coordinated-shutdown.md
+++ b/docs/articles/actors/coordinated-shutdown.md
@@ -105,7 +105,7 @@ The default phases are defined in a linear order, but in practice the phases are
 
 ## Registering Tasks to a Phase
 
-For instance, if you're using [Akka.Cluster](../clustering/cluster-overview) it's commonplace to register application-specific cleanup tasks during the `cluster-leave` and `cluster-exiting` phases. Here's an example:
+For instance, if you're using [Akka.Cluster](../clustering/cluster-overview.md) it's commonplace to register application-specific cleanup tasks during the `cluster-leave` and `cluster-exiting` phases. Here's an example:
 
 ```
 var coordShutdown = CoordinatedShutdown.Get(myActorSystem);

--- a/docs/articles/actors/di-core.md
+++ b/docs/articles/actors/di-core.md
@@ -1,0 +1,192 @@
+---
+uid: di-core
+title: DI Core
+---
+
+# Akka.DI.Core
+
+**Actor Producer Extension** library is used to create a Dependency Injection Container for the [Akka.NET](https://github.com/akkadotnet/akka.net) framework.
+
+# What is it?
+
+**Akka.DI.Core** is an **ActorSystem extension** library for the Akka.NET
+framework that provides a simple way to create an Actor Dependency Resolver
+that can be used an alternative to the basic capabilities of [Props](Props)
+when you have actors with multiple dependencies.
+
+# How do you create an Extension?
+
+- Create a new class library
+- Reference your favorite IoC Container, the Akka.DI.Core, and of course Akka
+- Create a class and implement the `IDependencyResolver`
+
+Let's walk through the process of creating one for the CastleWindsor container.
+You need to create  a new project named Akka.DI.CastleWindsor with all the necessary references including Akka.DI.Core, Akka, and CastleWindosor.
+Name the initial class `WindsorDependencyResolver`.
+
+```csharp
+public class WindsorDependencyResolver : IDependencyResolver
+{
+    // we'll implement IDependencyResolver in the following steps
+}
+```
+
+Add a constructor and private fields.
+
+```csharp
+private IWindsorContainer _container;
+private ConcurrentDictionary<string, Type> _typeCache;
+private ActorSystem _system;
+
+public WindsorDependencyResolver(IWindsorContainer container, ActorSystem system)
+{
+    if (system == null) throw new ArgumentNullException("system");
+    if (container == null) throw new ArgumentNullException("container");
+    _container = container;
+    _typeCache = new ConcurrentDictionary<string, Type>(StringComparer.InvariantCultureIgnoreCase);
+    _system = system;
+    _system.AddDependencyResolver(this);
+}
+```
+
+You have defined three private fields
+
+- ```IWindsorContainer _container``` is a reference to the CastleWindsor container.
+- ```ConcurrentDictionary<string, Type> _typeCache``` is a thread safe map that contains actor name/type associations.
+- ```ActorSystem _system``` is a reference to the ActorSystem.
+
+First you need to implement ```GetType```. This is a basic implementation and
+is just for demonstration purposes. Essentially this is used by the extension
+to get the type of the actor from it's type name.
+
+```csharp
+public Type GetType(string actorName)
+{
+    _typeCache.
+        TryAdd(actorName,
+            actorName.GetTypeValue() ??
+            _container.Kernel
+            .GetAssignableHandlers(typeof(object))
+            .Where(handler => handler.ComponentModel.Name.Equals(actorName, StringComparison.InvariantCultureIgnoreCase))
+            .Select(handler => handler.ComponentModel.Implementation)
+            .FirstOrDefault());
+
+     return _typeCache[actorName];
+}
+```
+
+Secondly you need to implement the ```CreateActorFactory``` method which will be
+used by the extension to create the actor. This implementation will depend upon
+the API of the container.
+
+```csharp
+public Func<ActorBase> CreateActorFactory(Type actorType)
+{
+    return () => (ActorBase)container.Resolve(actorType);
+}
+```
+
+Thirdly, you implement the ```Create<TActor>``` which is used register the
+`Props` configuration for the referenced actor type with the `ActorSystem`.
+This method will always be the same implementation.
+
+```csharp
+public Props Create<TActor>() where TActor : ActorBase
+{
+    return system.GetExtension<DIExt>().Props(typeof(TActor).Name);
+}
+```
+
+Lastly, you implement the Release method which, in this instance, is very simple.
+This method is used to remove the actor from the underlying container.
+
+```csharp
+public void Release(ActorBase actor)
+{
+    this.container.Release(actor);
+}
+```
+
+**Note: For further details on the importance of the release method please read
+the following blog [post](http://blog.ploeh.dk/2014/05/19/di-friendly-framework/).**
+
+The resulting class should look similar to the following:
+
+```csharp
+public class WindsorDependencyResolver : IDependencyResolver
+{
+    private IWindsorContainer container;
+    private ConcurrentDictionary<string, Type> typeCache;
+    private ActorSystem system;
+
+    public WindsorDependencyResolver(IWindsorContainer container, ActorSystem system)
+    {
+        if (system == null) throw new ArgumentNullException("system");
+        if (container == null) throw new ArgumentNullException("container");
+        this.container = container;
+        typeCache = new ConcurrentDictionary<string, Type>(StringComparer.InvariantCultureIgnoreCase);
+        this.system = system;
+        this.system.AddDependencyResolver(this);
+    }
+
+    public Type GetType(string actorName)
+    {
+        typeCache.TryAdd(actorName, actorName.GetTypeValue() ??
+            container.Kernel
+              .GetAssignableHandlers(typeof(object))
+              .Where(handler => handler.ComponentModel.Name.Equals(actorName, StringComparison.InvariantCultureIgnoreCase))
+              .Select(handler => handler.ComponentModel.Implementation)
+              .FirstOrDefault());
+
+        return typeCache[actorName];
+    }
+
+    public Func<ActorBase> CreateActorFactory(Type actorType)
+    {
+        return () => (ActorBase)container.Resolve(actorType);
+    }
+
+    public Props Create<TActor>() where TActor : ActorBase
+    {
+        return system.GetExtension<DIExt>().Props(typeof(TActor));
+    }
+
+    public void Release(ActorBase actor)
+    {
+        this.container.Release(actor);
+    }
+}
+```
+
+Now, with the preceding class, you can do something like the following example:
+
+```csharp
+// Setup CastleWindsor
+IWindsorContainer container = new WindsorContainer();
+container.Register(Component.For<IWorkerService>().ImplementedBy<WorkerService>());
+container.Register(Component.For<TypedWorker>().Named("TypedWorker").LifestyleTransient());
+
+// Create the ActorSystem
+using (var system = ActorSystem.Create("MySystem"))
+{
+    // Create the dependency resolver
+    IDependencyResolver resolver = new WindsorDependencyResolver(container, system);
+
+    // Register the actors with the system
+    system.ActorOf(system.DI().Props<TypedWorker>(), "Worker1");
+    system.ActorOf(system.DI().Props<TypedWorker>(), "Worker2");
+
+    // Create the router
+    IActorRef router = system.ActorOf(Props.Empty.WithRouter(new ConsistentHashingGroup(config)));
+
+    // Create the message to send
+    TypedActorMessage message = new TypedActorMessage
+    {
+       Id = 1,
+       Name = Guid.NewGuid().ToString()
+    };
+
+    // Send the message to the router
+    router.Tell(message);
+}
+```

--- a/docs/articles/clustering/cluster-sharding.md
+++ b/docs/articles/clustering/cluster-sharding.md
@@ -78,7 +78,11 @@ By default rebalancing process always happens from nodes with the highest number
 
 ## Passivation
 
-To reduce memory consumption, you may decide to stop entities after some period of inactivity using `Context.SetReceiveTimeout(timeout)`. In order to make cluster sharding aware of stopping entities, **DON'T use `Context.Stop(Self)` on the entities**, as this may result in losing messages. Instead send a `Passivate` message message to current entity `Context.Parent` (which is shard itself in this case). This will inform shard to stop forwarding messages to target entity, and buffer them instead until it's terminated. Once that happens, if there are still some messages buffered, entity will be reincarnated and messages flushed to it automatically.
+To reduce memory consumption, you may decide to stop entities after some period of inactivity using `Context.SetReceiveTimeout(timeout)`. In order to make cluster sharding aware of stopping entities, **DON'T use `Context.Stop(Self)` on the entities**, as this may result in losing messages. Instead send a `ShardRegion.Passivate` message to current entity `Context.Parent` (which is shard itself in this case). This will inform shard to stop forwarding messages to target entity, and buffer them instead until it's terminated. Once that happens, if there are still some messages buffered, entity will be reincarnated and messages flushed to it automatically.
+
+### Automatic Passivation
+
+The entities can be configured to be automatically passivated if they haven't received a message for a while using the `akka.cluster.sharding.passivate-idle-entity-after` setting, or by explicitly setting `ClusterShardingSettings.passivateIdleEntityAfter` to a suitable time to keep the actor alive. Note that only messages sent through sharding are counted, so direct messages to the `ActorRef` of the actor or messages that it sends to itself are not counted as activity. By default automatic passivation is disabled.
 
 ## Remembering entities
 

--- a/docs/articles/concepts/terminology.md
+++ b/docs/articles/concepts/terminology.md
@@ -5,20 +5,21 @@ title: Terminology and Concepts
 
 # Terminology and Concepts
 
-In this chapter we attempt to establish a common terminology to define a solid ground for communicating about concurrent, distributed systems which Akka.NET targets. Please note that, for many of these terms, there is no single agreed definition. We simply seek to give working definitions that will be used in the scope of the Akka.NET documentation.
+In this chapter we attempt to establish a common terminology to define a solid ground for communicating about concurrent, distributed systems which Akka.NET targets. Please note that, for many of these terms, there is no single agreed-upon definition. We simply seek to give working definitions that will be used in the scope of the Akka.NET documentation.
 
 ## Concurrency vs. Parallelism
-Concurrency and parallelism are related concepts, but there are small differences. Concurrency means that two or more tasks are making progress even though they might not be executing simultaneously. This can for example be realized with time slicing where parts of tasks are executed sequentially and mixed with parts of other tasks. Parallelism on the other hand arise when the execution can be truly simultaneous.
+Concurrency and parallelism are related concepts, but there are small differences. Concurrency means that two or more tasks are making progress even though they might not be executing simultaneously. For example, this can be realized with time slicing where parts of tasks are executed sequentially and mixed with parts of other tasks. By contrast, Parallelism arises when the execution can be truly simultaneous.
 
 #### Concurrency
 ![Concurrency](/images/concurrency.png)
 
 #### Parallelism
 ![Parallelism](/images/parallelism.png)
-## Asynchronous vs. Synchronous
-A method call is considered synchronous if the caller cannot make progress until the method returns a value or throws an exception. On the other hand, an asynchronous call allows the caller to progress after a finite number of steps, and the completion of the method may be signalled via some additional mechanism (it might be a registered callback, a Task, or a message).
 
-A synchronous API may use blocking to implement synchrony, but this is not a necessity. A very CPU intensive task might give a similar behavior as blocking. In general, it is preferred to use asynchronous APIs, as they guarantee that the system is able to progress. Actors are asynchronous by nature: an actor can progress after a message send without waiting for the actual delivery to happen.
+## Asynchronous vs. Synchronous
+A method call is considered synchronous if the caller cannot make progress until the method returns a value or throws an exception. An asynchronous call allows the caller to progress after a finite number of steps, and the completion of the method may be signalled via some additional mechanism, such as a registered callback, Task, or message.
+
+A synchronous API may use blocking to implement synchrony, but this is not a necessity. A very CPU intensive task might give a similar behavior as blocking. In general, it is preferred to use asynchronous APIs, as they guarantee that the system is able to progress. Actors are asynchronous by nature: an actor can progress after sending a message without waiting for the delivery to happen.
 
 ## Non-blocking vs. Blocking
 We talk about blocking if the delay of one thread can indefinitely delay some of the other threads. A good example is a resource which can be used exclusively by one thread using mutual exclusion. If a thread holds on to the resource indefinitely (for example accidentally running an infinite loop) other threads waiting on the resource can not progress. In contrast, non-blocking means that no thread is able to indefinitely delay others.
@@ -26,23 +27,23 @@ We talk about blocking if the delay of one thread can indefinitely delay some of
 Non-blocking operations are preferred to blocking ones, as the overall progress of the system is not trivially guaranteed when it contains blocking operations.
 
 ## Deadlock vs. Starvation vs. Live-lock
-Deadlock arises when several participants are waiting on each other to reach a specific state to be able to progress. As none of them can progress without some other participant to reach a certain state (a "Catch-22" problem) all affected subsystems stall. Deadlock is closely related to blocking, as it is necessary that a participant thread be able to delay the progression of other threads indefinitely.
+Deadlock arises when several participants are waiting on each other to reach a specific state to be able to progress. As none of them can progress without some other participant to reach a certain state (a "Catch-22" problem), all affected subsystems stall. Deadlock is closely related to blocking, as it is necessary that a participant thread be able to delay the progression of other threads indefinitely.
 
-In the case of deadlock, no participants can make progress, while in contrast Starvation happens, when there are participants that can make progress, but there might be one or more that cannot. Typical scenario is the case of a naive scheduling algorithm that always selects high-priority tasks over low-priority ones. If the number of incoming high-priority tasks is constantly high enough, no low-priority ones will be ever finished.
+In the case of Deadlock, no participants can make progress. In the case of Starvation, there are participants that can make progress but there might be one or more that cannot. One typical scenario is the case of a naive scheduling algorithm that always selects high-priority tasks over low-priority ones. If the number of incoming high-priority tasks is high enough, no low-priority ones will be ever finished.
 
-Livelock is similar to deadlock as none of the participants make progress. The difference though is that instead of being frozen in a state of waiting for others to progress, the participants continuously change their state. An example scenario when two participants have two identical resources available. They each try to get the resource, but they also check if the other needs the resource, too. If the resource is requested by the other participant, they try to get the other instance of the resource. In the unfortunate case it might happen that the two participants "bounce" between the two resources, never acquiring it, but always yielding to the other.
+Live-lock is similar to deadlock as none of the participants make progress, but instead of being frozen in a state of waiting for others to progress, the participants continuously change their state. An example scenario is when two participants have two identical resources available. They each try to get the resource, but they also check if the other needs the resource, too. If the resource is requested by the other participant, they try to get the other instance of the resource. In the worst case, the two participants "bounce" between the two resources, never acquiring it, but always yielding to the other.
 
 ## Race Condition
-We call it a Race condition when an assumption about the ordering of a set of events might be violated by external non-deterministic effects. Race conditions often arise when multiple threads have a shared mutable state, and the operations of thread on the state might be interleaved causing unexpected behavior. While this is a common case, shared state is not necessary to have race conditions. One example could be a client sending unordered packets (e.g UDP datagrams) P1, P2 to a server. As the packets might potentially travel via different network routes, it is possible that the server receives P2 first and P1 afterwards. If the messages contain no information about their sending order it is impossible to determine by the server that they were sent in a different order. Depending on the meaning of the packets this can cause race conditions.
+A Race condition is when an assumption about the ordering of a set of events might be violated by external non-deterministic effects. Race conditions often arise when multiple threads have a shared mutable state, and the operations of threads on the state might be interleaved, causing unexpected behavior. While this is a common case, shared state is not necessary to have race conditions. One example would be a client sending unordered packets P1, P2 to a server. Because the packets might travel via different network routes, it is possible that the server receives P2 first and P1 afterwards. If the messages contain no information about their sending order, then it is impossible for the server to deterine that they were sent in a different order. Depending on the meaning of the packets, this can cause race conditions.
 
 > [!NOTE]
 > The only guarantee that Akka.NET provides about messages sent between a given pair of actors is that their order is always preserved. see [Message Delivery Reliability](message-delivery-reliability.md)
 
 ## Non-blocking Guarantees (Progress Conditions)
-As discussed in the previous sections blocking is undesirable for several reasons, including the dangers of deadlocks and reduced throughput in the system. In the following sections we discuss various non-blocking properties with different strength.
+As discussed in the previous sections, blocking is undesirable for several reasons, including the dangers of deadlocks and reduced throughput in the system. In the following sections we discuss various non-blocking properties with different strength.
 
 ### Wait-freedom
-A method is wait-free if every call is guaranteed to finish in a finite number of steps. If a method is bounded wait-free then the number of steps has a finite upper bound.
+A method is wait-free if every call is guaranteed to finish in a finite number of steps. If a method is bounded wait-free, then the number of steps has a finite upper bound.
 
 From this definition it follows that wait-free methods are never blocking, therefore deadlock can not happen. Additionally, as each participant can progress after a finite number of steps (when the call finishes), wait-free methods are free of starvation.
 
@@ -52,4 +53,4 @@ Lock-freedom is a weaker property than wait-freedom. In the case of lock-free ca
 ### Obstruction-freedom
 Obstruction-freedom is the weakest non-blocking guarantee discussed here. A method is called obstruction-free if there is a point in time after which it executes in isolation (other threads make no steps, e.g.: become suspended), it finishes in a bounded number of steps. All lock-free objects are obstruction-free, but the opposite is generally not true.
 
-Optimistic concurrency control (OCC) methods are usually obstruction-free. The OCC approach is that every participant tries to execute its operation on the shared object, but if a participant detects conflicts from others, it rolls back the modifications, and tries again according to some schedule. If there is a point in time, where one of the participants is the only one trying, the operation will succeed.
+Optimistic concurrency control (OCC) methods are usually obstruction-free. The OCC approach is that every participant tries to execute its operation on the shared object, but if a participant detects conflicts from others, it rolls back the modifications, and tries again according to some schedule. If there is a point in time where one of the participants is the only one trying, the operation will succeed.

--- a/docs/articles/intro/akka-users.md
+++ b/docs/articles/intro/akka-users.md
@@ -47,8 +47,8 @@ Scale up, scale out, fault-tolerance / HA
 #### Blockchain
 NEO is the use of blockchain technology and digital identity to digitize assets, the use of smart contracts for digital assets to be self-managed, to achieve "smart economy" with a distributed network.
 
-* [Website](https://neo.org/)
-* [Documentation](https://neo.org/)
+* [Website](https://neo.org)
+* [Documentation](http://docs.neo.org/en-us/index.html)
 * [Github](https://github.com/neo-project)
 * [Protocol](https://github.com/neo-project/neo)
 * [Video](https://www.youtube.com/channel/UCl1AwEDN0w5lTmfJEMsY5Vw)

--- a/docs/articles/intro/akka-users.md
+++ b/docs/articles/intro/akka-users.md
@@ -43,3 +43,12 @@ Scale up, scale out, fault-tolerance / HA
 #### Complex Event Stream Processing
 
 * [MarkedUp Analytics: Real-time Marketing Automation with Distributed Actor Systems and Akka.NET](http://www.aaronstannard.com/markedup-akkadotnet/)
+
+#### Blockchain
+NEO is the use of blockchain technology and digital identity to digitize assets, the use of smart contracts for digital assets to be self-managed, to achieve "smart economy" with a distributed network.
+
+* [Website](https://neo.org/)
+* [Documentation](https://neo.org/)
+* [Github](https://github.com/neo-project)
+* [Protocol](https://github.com/neo-project/neo)
+* [Video](https://www.youtube.com/channel/UCl1AwEDN0w5lTmfJEMsY5Vw)

--- a/docs/articles/intro/akka-users.md
+++ b/docs/articles/intro/akka-users.md
@@ -3,9 +3,10 @@ layout: docs.hbs
 title: Akka.NET Users and Use Cases
 ---
 
-Akka.NET is used by many large organizations in a big range of industries all from investment and merchant banking, retail and social media, simulation, gaming and betting, automobile and traffic systems, health care, data analytics and much more. Any system that have the need for high-throughput and low latency is a good candidate for using Akka.NET.
+# Akka.NET Users and Use Cases
 
-There is a great discussion on use-cases for Akka.NET with some good write-ups by production users here
+Akka.NET is used by many large organizations and in industries such as investment and merchant banking, retail and social media, simulation, gaming and betting, automobile and traffic systems, health care, data analytics, and much more. 
+Any system that has the need for high-throughput and low latency is a good candidate for using Akka.NET.
 
 ## Akka.NET Users
 
@@ -19,6 +20,7 @@ There is a great discussion on use-cases for Akka.NET with some good write-ups b
 > Sam Covington, IVC Business Systems: We had an in-house "Actor" system that we replaced with Akka.Net, which allowed us to innovate and be productive elsewhere, and not reinvent the wheel(not to mention test it to death). This back end of Microservices forms the basis of all of our products and services. We're using it in our Enterprise Social Product, and our new Livescan Office product for Livescan fingerprinting customers.
 
 #### Concurrency/parallelism (any app)
+Share of an article by Joel Mueller, Software Architect, SNL Financial
 * [SNL Financial (a subsidiary of McGraw Hill): Akka.NET Goes to Wall Street](https://petabridge.com/blog/akkadotnet-goes-to-wall-street/)
 
 #### Simulation
@@ -34,18 +36,19 @@ Camel integration to hook up with batch data sources Actors divide and conquer t
 Scale up, scale out, fault-tolerance / HA
 
 #### Business Intelligence/Data Mining/general purpose crunching
+Tweet from Philip Laureano with links.
 * [Real-time Clickstream Processing at Domain.au with Octopus Deploy and Akka.NET](https://twitter.com/philiplaureano/status/735976018993778688)
-
 
 #### Internet of Things
 * [Synchromatics: Real-time public transit tracking and analytics using Akka.NET](https://youtu.be/YuY1ziEqifU?t=3m38s)
 
 #### Complex Event Stream Processing
+Archive of a blog post by Aaron Stannard from July 2014.
 
 * [MarkedUp Analytics: Real-time Marketing Automation with Distributed Actor Systems and Akka.NET](http://www.aaronstannard.com/markedup-akkadotnet/)
 
 #### Blockchain
-NEO is the use of blockchain technology and digital identity to digitize assets, the use of smart contracts for digital assets to be self-managed, to achieve "smart economy" with a distributed network.
+"NEO is a non-profit community-driven blockchain project. It utilizes blockchain technology and digital identity to digitize assets and automate the management of digital assets using smart contracts." (source: neo.org)
 
 * [Website](https://neo.org)
 * [Documentation](http://docs.neo.org/en-us/index.html)

--- a/docs/articles/intro/use-case-and-deployment-scenarios.md
+++ b/docs/articles/intro/use-case-and-deployment-scenarios.md
@@ -67,7 +67,7 @@ public class MvcApplication : System.Web.HttpApplication
 As you can see the main point here is keeping a static reference to your `ActorSystem` . This ensures it won't be accidentally garbage collected and gets disposed and created with the start and stop events of your web application. 
 
 > [!WARNING]
-> Although hosting inside an ASP.NET Application is easy. A **word of caution**: When you are hosting inside of `IIS` the applicationpool your app lives in could be stopped and started at the whim of `IIS`. This in turn means your `ActorSystem` could be stopped at any given time.
+> When you are hosting inside of `IIS`, the applicationpool your app lives in could be stopped and started at the whim of `IIS`. This means your `ActorSystem` could be stopped at any given time.
 
 Typically you use a very lightweight `ActorSystem` inside ASP.NET applications, and offload heavy-duty work to a seperate Windows Service via Akka.Remote / Akka.Cluster
 
@@ -89,12 +89,10 @@ public class SomeController  : ApiController
 
 ## Windows Service
 
-For windows service deployment its recommended to use
-[TopShelf](http://topshelf.readthedocs.org/en/latest/index.html)
+For windows service deployment it is recommended to use [TopShelf](http://topshelf.readthedocs.org/en/latest/index.html)
 to build your Windows Services. It radically simplifies hosting Windows Services.
 
-The quickest way to get started with TopShelf is by creating a Console
-Application. Which would look like this:
+The quickest way to get started with TopShelf is by creating a Console Application. Which would look like this:
 
 #### Program.cs
 ```csharp
@@ -143,14 +141,11 @@ public class MyActorService
 }
 ```
 
-The above example is the simplest way imaginable. However there are also other
-styles of integration with TopShelf that give you more control.
+The above example is the simplest way imaginable, but there are other styles of integration with TopShelf that give you more control.
 
-Installing with Topshelf is as easy as calling `myConsoleApp.exe install` on
-the command line.
+Installing with Topshelf is as easy as calling `myConsoleApp.exe install` on the command line.
 
-For all the options and settings check out their
-[docs](http://topshelf.readthedocs.org/en/latest/index.html).
+For all the options and settings check out their [docs](http://topshelf.readthedocs.org/en/latest/index.html).
 
 ## Azure PaaS Worker Role
 

--- a/docs/articles/intro/what-problems-does-actor-model-solve.md
+++ b/docs/articles/intro/what-problems-does-actor-model-solve.md
@@ -1,6 +1,6 @@
 ---
 uid: what-are-actors
-title: What Are Actors
+title: What problems does the actor model solve?
 ---
 # What problems does the actor model solve?
 

--- a/docs/articles/networking/serialization.md
+++ b/docs/articles/networking/serialization.md
@@ -5,30 +5,24 @@ title: Serialization
 
 # Serialization
 
-One of the core concepts of any actor system like Akka.NET is the notion of
-message passing between actors. Since Akka.NET is network transparent, these
-actors can be located locally or remotely. As such the system needs a common
-exchange format to package messages into so that it can send them to receiving
-actors. In Akka.NET, messages are plain objects and thus easily converted to a
-byte array. The process of converting objects into byte arrays is known as
-serialization.
+One of the core concepts of any actor system like Akka.NET is the notion of message passing between actors.
+Since Akka.NET is network transparent, these actors can be located locally or remotely. As such the system needs a common
+exchange format to package messages into so that it can send them to receiving actors. 
+In Akka.NET, messages are plain objects and thus easily converted to a byte array. 
+The process of converting objects into byte arrays is known as serialization.
 
-Akka.NET itself uses `Protocol Buffers` to serialize internal messages (i.e.
-cluster gossip messages). However, the serialization mechanism in Akka.NET allows
-you to write custom serializers and to define which serializer to use for what.
-As shown in the examples further down this page, these serializers can be mixed
-and matched depending on preference or need.
+Akka.NET itself uses `Protocol Buffers` to serialize internal messages (i.e. cluster gossip messages). 
+However, the serialization mechanism in Akka.NET allows you to write custom serializers and to define which serializer to use for what.
+As shown in the examples further down this page, these serializers can be mixed and matched depending on preference or need.
 
-There are many other uses for serialization other than messaging. It's possible
-to use these serializers for ad-hoc purposes as well.
+There are many other uses for serialization other than messaging. 
+It's possible to use these serializers for ad-hoc purposes as well.
 
 ## Usage
 
 ### Configuration
-For Akka.NET to know which `Serializer` to use when (de-)serializing objects,
-two sections need to be defined in the application's configuration. The
-`akka.actor.serializers` section is where names are associated to
-implementations of the `Serializer` to use.
+For Akka.NET to know which `Serializer` to use when (de-)serializing objects, two sections need to be defined in the application's configuration. 
+The `akka.actor.serializers` section is where names are associated to implementations of the `Serializer` to use.
 
 ```hocon
 akka {
@@ -41,8 +35,7 @@ akka {
 }
 ```
 
-The `akka.actor.serialization-bindings` section is where object types are
-associated to a `Serializer` by the names defined in the previous section.
+The `akka.actor.serialization-bindings` section is where object types are associated to a `Serializer` by the names defined in the previous section.
 
 ```hocon
 akka {
@@ -62,21 +55,17 @@ akka {
 }
 ```
 
-In case of ambiguity, a message implements several of the configured
-classes, the most specific configured class will be used, i.e. the one of
-which all other candidates are superclasses. If this condition cannot be met,
-because e.g. `ISerializable` and `MyOwnSerializable` both apply and neither is a
+In case of ambiguity, such as a message implements several of the configured classes, the most specific configured class will be used, i.e. the one of which all other candidates are superclasses. 
+If this condition cannot be met, because e.g. `ISerializable` and `MyOwnSerializable` both apply and neither is a
 subtype of the other, a warning will be issued.
 
-Akka.NET provides serializers for POCO's (Plain Old C# Objects) and for
-`Google.Protobuf.IMessage` by default, so normally you don't need to add
-configuration for that.
+Akka.NET provides serializers for POCO's (Plain Old C# Objects) and for `Google.Protobuf.IMessage` by default, so you don't usually need to add configuration for that.
 
 ### Verification
 Normally, messages sent between local actors (i.e. same CLR) do not undergo serialization.
-For testing, sometimes, it may be desirable to force serialization on all messages 
-(both remote and local). If you want to do this in order to verify that your messages
-are serializable you can enable the following config option:
+For testing, it may be desirable to force serialization on all messages, both remote and local. 
+If you want to do this to verify that your messages are serializable, you can enable the following config option:
+
 ```hocon
 akka {
   actor {
@@ -84,7 +73,7 @@ akka {
   }
 }
 ```
-If you want to verify that your `Props` are serializable you can enable the following config option:
+If you want to verify that your `Props` are serializable, you can enable the following config option:
 
 ```hocon
 akka {
@@ -95,13 +84,13 @@ akka {
 ```
 
 > [!WARNING]
-> We recommend having these config options turned on only when you're running tests. Turning these options on in production is pointless, as it would negatively impact the performance of local message passing without giving any gain.
+> We recommend having these config options turned on only when you're running tests. 
+Turning these options on in production is pointless, as it would negatively impact the performance of local message passing without giving any gain.
 
 ### Programmatic
 As mentioned previously, Akka.NET uses serialization for message passing.
-However the system is much more robust than that. To programmatically
-(de-)serialize objects using Akka.NET serialization, a reference to the
-main serialization class is all that is needed.
+However the system is much more robust than that. 
+To programmatically (de-)serialize objects using Akka.NET serialization, a reference to the main serialization class is all that is needed.
 
 ```csharp
 using Akka.Actor;
@@ -129,30 +118,30 @@ Assert.AreEqual(original, back);
 ```
 
 ## Customization
-Akka.NET makes it extremely easy to create custom serializers to handle a wide
-variety of scenarios. All serializers in Akka.NET inherit from
-`Akka.Serialization.Serializer`. So to create a custom serializer, all that is
-needed is a class that inherits from this base class.
+Akka.NET makes it extremely easy to create custom serializers to handle a wide variety of scenarios. 
+All serializers in Akka.NET inherit from `Akka.Serialization.Serializer`. 
+So, to create a custom serializer, all that is needed is a class that inherits from this base class.
 
 ### Creating new Serializers
-A custom `Serializer` has to inherit from `Akka.Serialization.Serializer` and can be defined like the following:
+A custom `Serializer` has to inherit from `Akka.Serialization.Serializer` and can be defined like this:
 
 [!code-csharp[Main](../../examples/DocsExamples/Networking/Serialization/CreateCustomSerializer.cs?range=7-42)]
 
-The only thing left to do for this class would be to fill in the serialization
-logic in the ``ToBinary(object)`` method and the deserialization logic in the
-``FromBinary(byte[], Type)``. Afterwards the configuration would need to be
-updated to reflect which name to bind to and the classes that use this
+The only thing left to do for this class would be to fill in the serialization logic in the ``ToBinary(object)`` method and the deserialization logic in the ``FromBinary(byte[], Type)``. 
+Afterwards the configuration would need to be updated to reflect which name to bind to and the classes that use this
 serializer.
 
 ### Serializer with String Manifest
-The `Serializer` illustrated above supports a class based manifest (type hint). For serialization of data that need to evolve over time the `SerializerWithStringManifest` is recommended instead of `Serializer` because the manifest (type hint) is a `String` instead of a `Type`. That means that the class can be moved/removed and the serializer can still deserialize old data by matching on the String. This is especially useful for `Persistence`.
+The `Serializer` illustrated above supports a class-based manifest (type hint). 
+For serialization of data that need to evolve over time, the `SerializerWithStringManifest` is recommended instead of `Serializer` because the manifest (type hint) is a `String` instead of a `Type`. 
+This means that the class can be moved/removed and the serializer can still deserialize old data by matching on the String. 
+This is especially useful for `Persistence`.
 
 The manifest string can also encode a version number that can be used in `FromBinary` to deserialize in different ways to migrate old data to new domain objects.
 
-If the data was originally serialized with `Serializer` and in a later version of the system you change to `SerializerWithStringManifest` the manifest string will be the full class name if you used `IncludeManifest=true`, otherwise it will be the empty string.
+If the data was originally serialized with `Serializer`, and in a later version of the system you change to `SerializerWithStringManifest`, the manifest string will be the full class name if you used `IncludeManifest=true`, otherwise it will be the empty string.
 
-This is how a `SerializerWithStringManifest` looks like:
+This is how a `SerializerWithStringManifest` looks:
 [!code-csharp[Main](../../examples/DocsExamples/Networking/Serialization/MyOwnSerializer2.cs?range=9-66)]
 
 You must also bind it to a name in your `Configuration` and then list which classes that should be serialized using it.
@@ -160,11 +149,10 @@ You must also bind it to a name in your `Configuration` and then list which clas
 It's recommended to throw `SerializationException` in `FromBinary` if the manifest is unknown. This makes it possible to introduce new message types and send them to nodes that don't know about them. This is typically needed when performing rolling upgrades, i.e. running a cluster with mixed versions for while. `SerializationException` is treated as a transient problem in the TCP based remoting layer. The problem will be logged and message is dropped. Other exceptions will tear down the TCP connection because it can be an indication of corrupt bytes from the underlying transport.
 
 ### Serializing ActorRefs
-All actors are serializable using the default protobuf serializer, but in cases were
-custom serializers are used, we need to know how to (de-)serialize them
-properly. In the general case, the local address to be used depends on the
-type of remote address which shall be the recipient of the serialized
-information. Use `Serialization.SerializedActorPath(actorRef)` like this:
+All actors are serializable using the default protobuf serializer, but in cases where custom serializers are used, we need to know how to (de-)serialize them properly. 
+In the general case, the local address to be used depends on the type of remote address which shall be the recipient of the serialized
+information.
+Use `Serialization.SerializedActorPath(actorRef)` like this:
 
 ```csharp
 using Akka.Actor;
@@ -181,41 +169,58 @@ IActorRef deserializedActorRef = extendedSystem.Provider.ResolveActorRef(id);
 // Then just use the IActorRef
 ```
 
-This assumes that serialization happens in the context of sending a message
-through the remote transport. There are other uses of serialization, though,
-e.g. storing actor references outside of an actor application (database, etc.).
-In this case, it is important to keep in mind that the address part of an
-actor's path determines how that actor is communicated with. Storing a local
-actor path might be the right choice if the retrieval happens in the same
-logical context, but it is not enough when deserializing it on a different
-network host: for that it would need to include the system's remote transport
-address. An actor system is not limited to having just one remote transport
-per se, which makes this question a bit more interesting. To find out the
-appropriate address to use when sending to `remoteAddr` you can use  
-`IActorRefProvider.GetExternalAddressFor(remoteAddr)` like this:
+This assumes that serialization happens in the context of sending a message through the remote transport. 
+There are other uses of serialization, though, e.g. storing actor references outside of an actor application (database, etc.).
+In this case, it is important to keep in mind that the address part of an actor's path determines how that actor is communicated with. Storing a local actor path might be the right choice if the retrieval happens in the same logical context, but it is not enough when deserializing it on a different network host: for that it would need to include the system's remote transport address.
+An actor system is not limited to having just one remote transport per se, which makes this question a bit more interesting. 
+To find out the appropriate address to use when sending to `remoteAddr` you can use `IActorRefProvider.GetExternalAddressFor(remoteAddr)` like this:
 
-.[!code-csharp[Main](../../examples/DocsExamples/Networking/Serialization/ExternalAddressProvider.cs?range=7-66)]
+```csharp
+public class ExternalAddress : ExtensionIdProvider<ExternalAddressExtension>
+{
+    public override ExternalAddressExtension CreateExtension(ExtendedActorSystem system) =>
+        new ExternalAddressExtension(system);
+}
+
+public class ExternalAddressExtension : IExtension
+{
+    private readonly ExtendedActorSystem _system;
+
+     public ExternalAddressExtension(ExtendedActorSystem system)
+     {
+        _system = system;
+     }
+
+    public Address AddressFor(Address remoteAddr)
+    {
+        return _system.Provider.GetExternalAddressFor(remoteAddr) 
+             ?? throw new InvalidOperationException($"cannot send to {remoteAddr}");
+    }
+}
+
+public class Test
+{
+    private ExtendedActorSystem ExtendedSystem =>
+        ActorSystem.Create("test").AsInstanceOf<ExtendedActorSystem>();
+
+    public string SerializeTo(IActorRef actorRef, Address remote)
+    {
+        return actorRef.Path.ToSerializationFormatWithAddress(
+            new ExternalAddress().Get(ExtendedSystem).AddressFor(remote));
+    }
+}
+
+```
 
 > [!NOTE]
-> `ActorPath.ToSerializationFormatWithAddress` differs from `ToString` if the address
-does not already have `host` and `port` components, i.e. it only inserts address
-information for local addresses.
-> `ToSerializationFormatWithAddress` also adds the unique id of the actor, which
-will change when the actor is stopped and then created again with the same name.
-Sending messages to a reference pointing the old actor will not be delivered to
-the new actor. If you do not want this behavior, e.g. in case of long term
-storage of the reference, you can use `ToStringWithAddress`, which does not
-include the unique id.
+> `ActorPath.ToSerializationFormatWithAddress` differs from `ToString` if the address does not already have `host` and `port` components, i.e. it only inserts address information for local addresses.
+> `ToSerializationFormatWithAddress` also adds the unique id of the actor, which will change when the actor is stopped and then created again with the same name.
+Sending messages to a reference pointing the old actor will not be delivered to the new actor. If you do not want this behavior, e.g. in case of long term storage of the reference, you can use `ToStringWithAddress`, which does not include the unique id.
 
-This requires that you know at least which type of address will be supported by
-the system which will deserialize the resulting actor reference; if you have no
-concrete address handy you can create a dummy one for the right protocol using
-`new Address(protocol, "", "", 0)` (assuming that the actual transport used is as
-lenient as Akka's `RemoteActorRefProvider`).
+This requires that you know at least which type of address will be supported by the system which will deserialize the resulting actor reference; if you have no concrete address handy you can create a dummy one for the right protocol using `new Address(protocol, "", "", 0)` (assuming that the actual transport used is as lenient as Akka's `RemoteActorRefProvider`).
 
 ### Deep serialization of Actors
-The recommended approach to do deep serialization of internal actor state is
-to use [Akka Persistence](xref:persistence-architecture).
+The recommended approach to do deep serialization of internal actor state is to use [Akka Persistence](xref:persistence-architecture).
 
 ## How to setup Hyperion as default serializer
 

--- a/docs/articles/streams/error-handling.md
+++ b/docs/articles/streams/error-handling.md
@@ -87,8 +87,8 @@ eight
 ## Delayed restarts with a backoff stage
 
 Just as Akka provides the [backoff supervision pattern for actors](xref:supervision#delayed-restarts-with-the-backoffsupervisor-pattern), Akka streams
-also provides a `RestartSource`, `RestartSink` and `RestartFlow` for implementing the so-called *exponential backoff 
-supervision strategy*, starting a stage again when it fails, each time with a growing time delay between restarts.
+also provides a `RestartSource`, `RestartSink` and `RestartFlow` for implementing the so-called *exponential backoff
+supervision strategy*, starting a stage again when it fails or completes, each time with a growing time delay between restarts.
 
 This pattern is useful when the stage fails or completes because some external resource is not available
 and we need to give it some time to start-up again. One of the prime examples when this is useful is

--- a/docs/articles/streams/quickstart.md
+++ b/docs/articles/streams/quickstart.md
@@ -4,6 +4,13 @@ title: Quickstart
 ---
 
 # Streams Quickstart Guide
+
+To use Akka Streams, an additional module is required, so we first make sure ```Akka.Streams``` is added to our project:
+
+```
+Install-Package Akka.Streams
+```
+
 A stream usually begins at a source, so this is also how we start an Akka Stream. Before we create one, we import the full complement of streaming tools:
 
 ```csharp

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -55,7 +55,11 @@
   - name: Fault Tolerance
     href: actors/fault-tolerance.md
   - name: Dependency Injection
+    href: actors/dependency-injection.
+  - name: Dependency Injection
     href: actors/dependency-injection.md
+  - name: DI Core
+    href: di-core.md
   - name: Testing Actor Systems
     href: actors/testing-actor-systems.md
   - name: Coordinated Shutdown

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -58,8 +58,8 @@
     href: actors/dependency-injection.
   - name: Dependency Injection
     href: actors/dependency-injection.md
-  - name: DI Core
-    href: di-core.md
+  - name: Dependency Injection Core
+    href: actors/di-core.md
   - name: Testing Actor Systems
     href: actors/testing-actor-systems.md
   - name: Coordinated Shutdown

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -55,8 +55,6 @@
   - name: Fault Tolerance
     href: actors/fault-tolerance.md
   - name: Dependency Injection
-    href: actors/dependency-injection.
-  - name: Dependency Injection
     href: actors/dependency-injection.md
   - name: Dependency Injection Core
     href: actors/di-core.md

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -43,7 +43,8 @@
         "resource": [{
             "files": [
                 "images/**",
-                "web.config"
+                "web.config",
+                "xrefmap.yml"
             ],
             "exclude": [
                 "obj/**",

--- a/docs/examples/DocsExamples/DocsExamples.csproj
+++ b/docs/examples/DocsExamples/DocsExamples.csproj
@@ -16,7 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />

--- a/src/common.props
+++ b/src/common.props
@@ -18,6 +18,23 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Placholder for nightlies*</PackageReleaseNotes>
+    <PackageReleaseNotes>Maintenance Release for Akka.NET 1.3**
+Akka.NET v1.3.11 is a bugfix patch primarily aimed at solving the following issue: [DotNetty Remote Transport Issues with .NET Core 2.1](https://github.com/akkadotnet/akka.net/issues/3506).
+.NET Core 2.1 exposed some issues with the DotNetty connection methods in DotNetty v0.4.8 that have since been fixed in subsequent releases. In Akka.NET v1.3.11 we've resolved this issue by upgrading to DotNetty v0.6.0.
+In addition to the above, we've introduced some additional fixes and changes in Akka.NET v1.3.11:
+[Akka.FSharp: Akka.Fsharp spawning an actor results in Exception](https://github.com/akkadotnet/akka.net/issues/3402)
+[Akka.Remote: tcp-reuse-addr = off-for-windows prevents actorsystem from starting](https://github.com/akkadotnet/akka.net/issues/3293)
+[Akka.Remote: tcp socket address reuse - default configuration](https://github.com/akkadotnet/akka.net/issues/2477)
+[Akka.Cluster.Tools:
+Actor still receiving messages from mediator after termination](https://github.com/akkadotnet/akka.net/issues/3658)
+[Akka.Persistence: Provide minSequenceNr for snapshot deletion](https://github.com/akkadotnet/akka.net/pull/3641)
+To [see the full set of changes for Akka.NET 1.3.11, click here](https://github.com/akkadotnet/akka.net/milestone/29)
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 5 | 123 | 71 | Aaron Stannard |
+| 3 | 96 | 10 | Ismael Hamed |
+| 2 | 4 | 3 | Oleksandr Kobylianskyi |
+| 1 | 5 | 1 | Ruben Mamo |
+| 1 | 23 | 6 | Chris Hoare |</PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/src/common.props
+++ b/src/common.props
@@ -18,6 +18,30 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Placeholder for nightlies*</PackageReleaseNotes>
+    <PackageReleaseNotes>Maintenance Release for Akka.NET 1.3**
+This will be the final bugfix release for Akka.NET v1.3.* - going forward we will be working on releasing Akka.NET v1.4.
+This patch contains many important bug fixes and improvements:
+[Akka.Cluster.Sharding: Automatic passivation for sharding](https://github.com/akkadotnet/akka.net/pull/3718)
+[Akka.Persistence: Optimize AtLeastOnceDelivery by not scheduling ticks when not needed](https://github.com/akkadotnet/akka.net/pull/3704)
+[Akka.Persistence.Sql.Common: Bugfix CurrentEventsByTag does not return more than a 100 events](https://github.com/akkadotnet/akka.net/issues/3697)
+[Akka.Persistence.Sql.Common: DeleteMessages when journal is empty causes duplicate key SQL exception](https://github.com/akkadotnet/akka.net/issues/3721)
+[Akka.Cluster: SplitBrainResolver: don't down oldest if alone in cluster](https://github.com/akkadotnet/akka.net/pull/3690)
+[Akka: Include manifest or class in missing serializer failure if possible](https://github.com/akkadotnet/akka.net/pull/3701)
+[Akka: Memory leak when disposing actor system with non default ActorRefProvider](https://github.com/akkadotnet/akka.net/issues/2640)
+To [see the full set of changes for Akka.NET v1.3.12, click here](https://github.com/akkadotnet/akka.net/milestone/30).
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 8 | 1487 | 357 | Ismael Hamed |
+| 7 | 126 | 120 | jdsartori |
+| 3 | 198 | 4 | JSartori |
+| 3 | 155 | 22 | Aaron Stannard |
+| 2 | 11 | 2 | Peter Lin |
+| 1 | 8 | 4 | Raimund Hirz |
+| 1 | 7 | 0 | Warren Falk |
+| 1 | 45 | 6 | Peter Huang |
+| 1 | 14 | 13 | Bartosz Sypytkowski |
+| 1 | 11 | 1 | Greg Shackles |
+| 1 | 10 | 10 | Jill D. Headen |
+| 1 | 1 | 1 | Isaac Z |</PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/src/common.props
+++ b/src/common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2018 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.3.11</VersionPrefix>
+    <VersionPrefix>1.3.12</VersionPrefix>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>
@@ -18,23 +18,6 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Maintenance Release for Akka.NET 1.3**
-Akka.NET v1.3.11 is a bugfix patch primarily aimed at solving the following issue: [DotNetty Remote Transport Issues with .NET Core 2.1](https://github.com/akkadotnet/akka.net/issues/3506).
-.NET Core 2.1 exposed some issues with the DotNetty connection methods in DotNetty v0.4.8 that have since been fixed in subsequent releases. In Akka.NET v1.3.11 we've resolved this issue by upgrading to DotNetty v0.6.0.
-In addition to the above, we've introduced some additional fixes and changes in Akka.NET v1.3.11:
-[Akka.FSharp: Akka.Fsharp spawning an actor results in Exception](https://github.com/akkadotnet/akka.net/issues/3402)
-[Akka.Remote: tcp-reuse-addr = off-for-windows prevents actorsystem from starting](https://github.com/akkadotnet/akka.net/issues/3293)
-[Akka.Remote: tcp socket address reuse - default configuration](https://github.com/akkadotnet/akka.net/issues/2477)
-[Akka.Cluster.Tools:
-Actor still receiving messages from mediator after termination](https://github.com/akkadotnet/akka.net/issues/3658)
-[Akka.Persistence: Provide minSequenceNr for snapshot deletion](https://github.com/akkadotnet/akka.net/pull/3641)
-To [see the full set of changes for Akka.NET 1.3.11, click here](https://github.com/akkadotnet/akka.net/milestone/29)
-| COMMITS | LOC+ | LOC- | AUTHOR |
-| --- | --- | --- | --- |
-| 5 | 123 | 71 | Aaron Stannard |
-| 3 | 96 | 10 | Ismael Hamed |
-| 2 | 4 | 3 | Oleksandr Kobylianskyi |
-| 1 | 5 | 1 | Ruben Mamo |
-| 1 | 23 | 6 | Chris Hoare |</PackageReleaseNotes>
+    <PackageReleaseNotes>Placeholder for nightlies*</PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
@@ -468,7 +468,8 @@ namespace Akka.Cluster.Sharding.Tests
                     "coordinator",
                     TimeSpan.FromSeconds(5),
                     TimeSpan.FromSeconds(5),
-                    0.1).WithDeploy(Deploy.Local);
+                    0.1, 
+                    -1).WithDeploy(Deploy.Local);
 
                 Sys.ActorOf(ClusterSingletonManager.Props(
                     singletonProps,

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/InactiveEntityPassivationSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/InactiveEntityPassivationSpec.cs
@@ -1,0 +1,149 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ProxyShardingSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using Akka.Actor;
+using Akka.Cluster.Tools.Singleton;
+using Akka.Configuration;
+using Akka.TestKit;
+using Akka.TestKit.Xunit2;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    public class InactiveEntityPassivationSpec : AkkaSpec
+    {
+        #region Protocol
+
+        internal class Passivate
+        {
+            public static readonly Passivate Instance = new Passivate();
+            private Passivate() { }
+        }
+
+        internal class Entity : UntypedActor
+        {
+            private readonly string _id = Context.Self.Path.Name;
+
+            public IActorRef Probe { get; }
+
+            public static Props Props(IActorRef probe) =>
+                Actor.Props.Create(() => new Entity(probe));
+
+            public Entity(IActorRef probe)
+            {
+                Probe = probe;
+            }
+
+            protected override void OnReceive(object message)
+            {
+                switch (message)
+                {
+                    case Passivate _:
+                        Probe.Tell($"{_id} passivating");
+                        Context.Stop(Self);
+                        break;
+                    default:
+                        Probe.Tell(new GotIt(_id, message, DateTime.Now.Ticks));
+                        break;
+                }
+            }
+
+            public class GotIt
+            {
+                public string Id { get; }
+                public object Msg { get; }
+                public long When { get; }
+
+                public GotIt(string id, object msg, long when)
+                {
+                    Id = id;
+                    Msg = msg;
+                    When = when;
+                }
+            }
+        }
+
+        #endregion
+
+        private readonly ExtractEntityId _extractEntityId = message =>
+            message is int msg ? Tuple.Create(msg.ToString(), message) : null;
+
+        private readonly ExtractShardId _extractShard = message =>
+            message is int msg ? (msg % 10).ToString(CultureInfo.InvariantCulture) : null;
+
+        public InactiveEntityPassivationSpec()
+            : base(GetConfig())
+        { }
+
+        public static Config GetConfig()
+        {
+            return ConfigurationFactory.ParseString(@"
+                akka.loglevel = INFO
+                akka.actor.provider = cluster
+                akka.cluster.sharding.passivate-idle-entity-after = 3s")
+                .WithFallback(ClusterSharding.DefaultConfig())
+                .WithFallback(ClusterSingletonManager.DefaultConfig());
+        }
+
+        [Fact]
+        public void Passivation_of_inactive_entities_must_passivate_entities_when_they_have_not_seen_messages_for_the_configured_duration()
+        {
+            // Single node cluster
+            Cluster.Get(Sys).Join(Cluster.Get(Sys).SelfAddress);
+
+            var probe = new TestProbe(Sys, new XunitAssertions());
+            var settings = ClusterShardingSettings.Create(Sys);
+            var region = ClusterSharding.Get(Sys).Start(
+                "myType",
+                Entity.Props(probe.Ref),
+                settings,
+                _extractEntityId,
+                _extractShard,
+                new LeastShardAllocationStrategy(10, 3),
+                Passivate.Instance);
+            
+            region.Tell(1);
+            region.Tell(2);
+
+            var responses = new[]
+            {
+                probe.ExpectMsg<Entity.GotIt>(),
+                probe.ExpectMsg<Entity.GotIt>()
+            };
+            responses.Select(r => r.Id).Should().BeEquivalentTo("1", "2");
+            var timeOneSawMessage = responses.Single(r => r.Id == "1").When;
+
+            Thread.Sleep(1000);
+            region.Tell(2);
+            probe.ExpectMsg<Entity.GotIt>().Id.ShouldBe("2");
+            Thread.Sleep(1000);
+            region.Tell(2);
+            probe.ExpectMsg<Entity.GotIt>().Id.ShouldBe("2");
+
+            // Make sure "1" hasn't seen a message in 3 seconds and passivates
+            var timeSinceOneSawAMessage = DateTime.Now.Ticks - timeOneSawMessage;
+            probe.ExpectNoMsg(TimeSpan.FromSeconds(3) - TimeSpan.FromTicks(timeSinceOneSawAMessage));
+            probe.ExpectMsg("1 passivating");
+
+            // But it can be re-activated just fine
+            region.Tell(1);
+            region.Tell(2);
+
+            responses = new[]
+            {
+                probe.ExpectMsg<Entity.GotIt>(),
+                probe.ExpectMsg<Entity.GotIt>()
+            };
+            responses.Select(r => r.Id).Should().BeEquivalentTo("1", "2");
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/SupervisionSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/SupervisionSpec.cs
@@ -1,0 +1,137 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ProxyShardingSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Globalization;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.Pattern;
+using Xunit;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    public class SupervisionSpec : TestKit.Xunit2.TestKit
+    {
+        #region Protocol
+
+        internal class Msg
+        {
+            public long Id { get; }
+            public object Message { get; }
+
+            public Msg(long id, object message)
+            {
+                Id = id;
+                Message = message;
+            }
+        }
+
+        internal class Response
+        {
+            public IActorRef Self { get; }
+
+            public Response(IActorRef self)
+            {
+                Self = self;
+            }
+        }
+
+        internal class StopMessage
+        {
+            public static readonly StopMessage Instance = new StopMessage();
+            private StopMessage() { }
+        }
+
+        internal class PassivatingActor : UntypedActor
+        {
+            public ILoggingAdapter Log { get; } = Context.GetLogger();
+
+            protected override void PreStart()
+            {
+                Log.Info("Starting");
+                base.PreStart();
+            }
+
+            protected override void PostStop()
+            {
+                Log.Info("Stopping");
+                base.PostStop();
+            }
+
+            protected override void OnReceive(object message)
+            {
+                switch (message)
+                {
+                    case "passivate":
+                        Log.Info("Passivating");
+                        Context.Parent.Tell(new Passivate(StopMessage.Instance));
+                        // simulate another message causing a stop before the region sends the stop message
+                        // e.g. a persistent actor having a persist failure while processing the next message
+                        Context.Stop(Self);
+                        break;
+                    case "hello":
+                        Sender.Tell(new Response(Self));
+                        break;
+                    case StopMessage _:
+                        Log.Info("Received stop from region");
+                        Context.Parent.Tell(PoisonPill.Instance);
+                        break;
+                }
+            }
+        }
+
+        #endregion
+
+        private readonly ExtractEntityId _extractEntityId = message =>
+            message is Msg msg ? new Tuple<string, object>(msg.Id.ToString(), msg.Message) : null;
+
+        private readonly ExtractShardId _extractShard = message =>
+            message is Msg msg ? (msg.Id % 2).ToString(CultureInfo.InvariantCulture) : null;
+
+        public SupervisionSpec() : base(GetConfig())
+        { }
+
+        public static Config GetConfig()
+        {
+            return ConfigurationFactory.ParseString("akka.actor.provider = cluster \r\n akka.loglevel = INFO")
+                .WithFallback(ClusterSharding.DefaultConfig());
+        }
+
+        [Fact]
+        public void SupervisionSpec_for_a_sharded_actor_must_allow_passivation()
+        {
+            var supervisedProps = BackoffSupervisor.Props(Backoff.OnStop(
+                Props.Create<PassivatingActor>(),
+                "child",
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(30),
+                0.2,
+                -1).WithFinalStopMessage(message => message is StopMessage));
+
+            Cluster.Get(Sys).Join(Cluster.Get(Sys).SelfAddress);
+
+            var region = ClusterSharding.Get(Sys).Start(
+                "passy",
+                supervisedProps,
+                ClusterShardingSettings.Create(Sys),
+                _extractEntityId,
+                _extractShard);
+
+            region.Tell(new Msg(10, "hello"));
+            var response = ExpectMsg<Response>(TimeSpan.FromSeconds(5));
+            Watch(response.Self);
+
+            region.Tell(new Msg(10, "passivate"));
+            ExpectTerminated(response.Self);
+
+            // This would fail before as sharded actor would be stuck passivating
+            region.Tell(new Msg(10, "hello"));
+            ExpectMsg<Response>(TimeSpan.FromSeconds(20));
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
@@ -172,10 +172,9 @@ namespace Akka.Cluster.Sharding
                     var encName = Uri.EscapeDataString(start.TypeName);
                     var coordinatorSingletonManagerName = CoordinatorSingletonManagerName(encName);
                     var coordinatorPath = CoordinatorPath(encName);
-                    var shardRegion = Context.Child(encName);
                     var replicator = Replicator(settings);
 
-                    if (Equals(shardRegion, ActorRefs.Nobody))
+                    var shardRegion = Context.Child(encName).GetOrElse(() =>
                     {
                         if (Equals(Context.Child(coordinatorSingletonManagerName), ActorRefs.Nobody))
                         {
@@ -189,7 +188,7 @@ namespace Akka.Cluster.Sharding
                             var singletonSettings = settings.CoordinatorSingletonSettings.WithSingletonName("singleton").WithRole(settings.Role);
                             Context.ActorOf(ClusterSingletonManager.Props(singletonProps, PoisonPill.Instance, singletonSettings).WithDispatcher(Context.Props.Dispatcher), coordinatorSingletonManagerName);
                         }
-                        shardRegion = Context.ActorOf(ShardRegion.Props(
+                        return Context.ActorOf(ShardRegion.Props(
                             typeName: start.TypeName,
                             entityProps: start.EntityProps,
                             settings: settings,
@@ -199,7 +198,7 @@ namespace Akka.Cluster.Sharding
                             handOffStopMessage: start.HandOffStopMessage,
                             replicator: replicator,
                             majorityMinCap: _majorityMinCap).WithDispatcher(Context.Props.Dispatcher), encName);
-                    }
+                    });
 
                     Sender.Tell(new Started(shardRegion));
                 }
@@ -220,20 +219,14 @@ namespace Akka.Cluster.Sharding
                     var settings = startProxy.Settings;
                     var encName = Uri.EscapeDataString(startProxy.TypeName + "Proxy");
                     var coordinatorPath = CoordinatorPath(Uri.EscapeDataString(startProxy.TypeName));
-                    var shardRegion = Context.Child(encName);
-
-                    if (Equals(shardRegion, ActorRefs.Nobody))
-                    {
-
-                        shardRegion = Context.ActorOf(ShardRegion.ProxyProps(
-                            typeName: startProxy.TypeName,
-                            settings: settings,
-                            coordinatorPath: coordinatorPath,
-                            extractEntityId: startProxy.ExtractEntityId,
-                            extractShardId: startProxy.ExtractShardId,
-                            replicator: Context.System.DeadLetters,
-                            majorityMinCap: _majorityMinCap).WithDispatcher(Context.Props.Dispatcher), encName);
-                    }
+                    var shardRegion = Context.Child(encName).GetOrElse(() => Context.ActorOf(ShardRegion.ProxyProps(
+                        typeName: startProxy.TypeName,
+                        settings: settings,
+                        coordinatorPath: coordinatorPath,
+                        extractEntityId: startProxy.ExtractEntityId,
+                        extractShardId: startProxy.ExtractShardId,
+                        replicator: Context.System.DeadLetters,
+                        majorityMinCap: _majorityMinCap).WithDispatcher(Context.Props.Dispatcher), encName));
 
                     Sender.Tell(new Started(shardRegion));
                 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
@@ -184,7 +184,7 @@ namespace Akka.Cluster.Sharding
                                 ? PersistentShardCoordinator.Props(start.TypeName, settings, start.AllocationStrategy)
                                 : DDataShardCoordinator.Props(start.TypeName, settings, start.AllocationStrategy, replicator, _majorityMinCap, settings.RememberEntities);
 
-                            var singletonProps = BackoffSupervisor.Props(coordinatorProps, "coordinator", minBackoff, maxBackoff, 0.2).WithDeploy(Deploy.Local);
+                            var singletonProps = BackoffSupervisor.Props(coordinatorProps, "coordinator", minBackoff, maxBackoff, 0.2, -1).WithDeploy(Deploy.Local);
                             var singletonSettings = settings.CoordinatorSingletonSettings.WithSingletonName("singleton").WithRole(settings.Role);
                             Context.ActorOf(ClusterSingletonManager.Props(singletonProps, PoisonPill.Instance, singletonSettings).WithDispatcher(Context.Props.Dispatcher), coordinatorSingletonManagerName);
                         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingSettings.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingSettings.cs
@@ -157,7 +157,6 @@ namespace Akka.Cluster.Sharding
     [Serializable]
     public sealed class ClusterShardingSettings : INoSerializationVerificationNeeded
     {
-
         /// <summary>
         /// Specifies that this entity type requires cluster nodes with a specific role.
         /// If the role is not specified all nodes in the cluster are used.
@@ -184,10 +183,18 @@ namespace Akka.Cluster.Sharding
         /// </summary>
         public readonly string SnapshotPluginId;
 
+        /// <summary>
+        /// Passivate entities that have not received any message in this interval.
+        /// Note that only messages sent through sharding are counted, so direct messages
+        /// to the <see cref="IActorRef"/> of the actor or messages that it sends to itself are not counted as activity.
+        /// Use 0 to disable automatic passivation.
+        /// </summary>
+        public readonly TimeSpan PassivateIdleEntityAfter;
+        
         public readonly StateStoreMode StateStoreMode;
 
         /// <summary>
-        /// TBD
+        /// Additional tuning parameters, see descriptions in reference.conf
         /// </summary>
         public readonly TunningParameters TunningParameters;
 
@@ -240,11 +247,16 @@ namespace Akka.Cluster.Sharding
             var role = config.GetString("role");
             if (role == string.Empty) role = null;
 
+            var passivateIdleAfter = config.GetString("passivate-idle-entity-after").ToLower() == "off" 
+                ? TimeSpan.Zero 
+                : config.GetTimeSpan("passivate-idle-entity-after");
+
             return new ClusterShardingSettings(
                 role: role,
                 rememberEntities: config.GetBoolean("remember-entities"),
                 journalPluginId: config.GetString("journal-plugin-id"),
                 snapshotPluginId: config.GetString("snapshot-plugin-id"),
+                passivateIdleEntityAfter: passivateIdleAfter,
                 stateStoreMode: (StateStoreMode)Enum.Parse(typeof(StateStoreMode), config.GetString("state-store-mode"), ignoreCase: true),
                 tunningParameters: tuningParameters,
                 coordinatorSingletonSettings: coordinatorSingletonSettings);
@@ -257,6 +269,7 @@ namespace Akka.Cluster.Sharding
         /// <param name="rememberEntities">TBD</param>
         /// <param name="journalPluginId">TBD</param>
         /// <param name="snapshotPluginId">TBD</param>
+        /// <param name="passivateIdleEntityAfter">TBD</param>
         /// <param name="stateStoreMode">TBD</param>
         /// <param name="tunningParameters">TBD</param>
         /// <param name="coordinatorSingletonSettings">TBD</param>
@@ -265,6 +278,7 @@ namespace Akka.Cluster.Sharding
             bool rememberEntities,
             string journalPluginId,
             string snapshotPluginId,
+            TimeSpan passivateIdleEntityAfter,
             StateStoreMode stateStoreMode,
             TunningParameters tunningParameters,
             ClusterSingletonManagerSettings coordinatorSingletonSettings)
@@ -273,6 +287,7 @@ namespace Akka.Cluster.Sharding
             RememberEntities = rememberEntities;
             JournalPluginId = journalPluginId;
             SnapshotPluginId = snapshotPluginId;
+            PassivateIdleEntityAfter = passivateIdleEntityAfter;
             StateStoreMode = stateStoreMode;
             TunningParameters = tunningParameters;
             CoordinatorSingletonSettings = coordinatorSingletonSettings;
@@ -300,6 +315,7 @@ namespace Akka.Cluster.Sharding
                 rememberEntities: RememberEntities,
                 journalPluginId: JournalPluginId,
                 snapshotPluginId: SnapshotPluginId,
+                passivateIdleEntityAfter: PassivateIdleEntityAfter,
                 stateStoreMode: StateStoreMode,
                 tunningParameters: TunningParameters,
                 coordinatorSingletonSettings: CoordinatorSingletonSettings);
@@ -356,6 +372,11 @@ namespace Akka.Cluster.Sharding
             return Copy(tunningParameters: tunningParameters);
         }
 
+        public ClusterShardingSettings WithPassivateIdleAfter(TimeSpan duration)
+        {
+            return Copy(passivateIdleAfter: duration);
+        }
+
         /// <summary>
         /// TBD
         /// </summary>
@@ -377,6 +398,7 @@ namespace Akka.Cluster.Sharding
             bool? rememberEntities = null,
             string journalPluginId = null,
             string snapshotPluginId = null,
+            TimeSpan? passivateIdleAfter = null,
             StateStoreMode? stateStoreMode = null,
             TunningParameters tunningParameters = null,
             ClusterSingletonManagerSettings coordinatorSingletonSettings = null)
@@ -386,6 +408,7 @@ namespace Akka.Cluster.Sharding
                 rememberEntities: rememberEntities ?? RememberEntities,
                 journalPluginId: journalPluginId ?? JournalPluginId,
                 snapshotPluginId: snapshotPluginId ?? SnapshotPluginId,
+                passivateIdleEntityAfter: passivateIdleAfter ?? PassivateIdleEntityAfter,
                 stateStoreMode: stateStoreMode ?? StateStoreMode,
                 tunningParameters: tunningParameters ?? TunningParameters,
                 coordinatorSingletonSettings: coordinatorSingletonSettings ?? CoordinatorSingletonSettings);

--- a/src/contrib/cluster/Akka.Cluster.Sharding/DDataShard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/DDataShard.cs
@@ -45,8 +45,10 @@ namespace Akka.Cluster.Sharding
         public Shard.ShardState State { get; set; } = Shard.ShardState.Empty;
         public ImmutableDictionary<string, IActorRef> RefById { get; set; } = ImmutableDictionary<string, IActorRef>.Empty;
         public ImmutableDictionary<IActorRef, string> IdByRef { get; set; } = ImmutableDictionary<IActorRef, string>.Empty;
+        public ImmutableDictionary<string, long> LastMessageTimestamp { get; set; }
         public ImmutableHashSet<IActorRef> Passivating { get; set; } = ImmutableHashSet<IActorRef>.Empty;
         public ImmutableDictionary<string, ImmutableList<Tuple<object, IActorRef>>> MessageBuffers { get; set; } = ImmutableDictionary<string, ImmutableList<Tuple<object, IActorRef>>>.Empty;
+        public ICancelable PassivateIdleTask { get; }
 
         private EntityRecoveryStrategy RememberedEntitiesRecoveryStrategy { get; }
         public Cluster Cluster { get; } = Cluster.Get(Context.System);
@@ -97,6 +99,11 @@ namespace Akka.Cluster.Sharding
                     Settings.TunningParameters.EntityRecoveryConstantRateStrategyNumberOfEntities)
                 : EntityRecoveryStrategy.AllStrategy;
 
+            var idleInterval = TimeSpan.FromTicks(Settings.PassivateIdleEntityAfter.Ticks / 2);
+            PassivateIdleTask = Settings.PassivateIdleEntityAfter > TimeSpan.Zero
+                ? Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(idleInterval, idleInterval, Self, Shard.PassivateIdleTick.Instance, Self)
+                : null;
+
             _readConsistency = new ReadMajority(settings.TunningParameters.WaitingForStateTimeout, majorityCap);
             _writeConsistency = new WriteMajority(settings.TunningParameters.UpdatingStateTimeout, majorityCap);
             _stateKeys = Enumerable.Range(0, NrOfKeys).Select(i => new ORSetKey<EntryId>($"shard-{typeName}-{shardId}-{i}")).ToImmutableArray();
@@ -106,6 +113,7 @@ namespace Akka.Cluster.Sharding
 
         public void EntityTerminated(IActorRef tref) => this.BaseEntityTerminated(tref);
         public void DeliverTo(string id, object message, object payload, IActorRef sender) => this.BaseDeliverTo(id, message, payload, sender);
+        
 
         protected override bool Receive(object message) => WaitingForState(ImmutableHashSet<int>.Empty)(message);
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShard.cs
@@ -42,8 +42,10 @@ namespace Akka.Cluster.Sharding
         public Shard.ShardState State { get; set; } = Shard.ShardState.Empty;
         public ImmutableDictionary<string, IActorRef> RefById { get; set; } = ImmutableDictionary<string, IActorRef>.Empty;
         public ImmutableDictionary<IActorRef, string> IdByRef { get; set; } = ImmutableDictionary<IActorRef, string>.Empty;
+        public ImmutableDictionary<string, long> LastMessageTimestamp { get; set; } = ImmutableDictionary<string, long>.Empty;
         public ImmutableHashSet<IActorRef> Passivating { get; set; } = ImmutableHashSet<IActorRef>.Empty;
         public ImmutableDictionary<string, ImmutableList<Tuple<object, IActorRef>>> MessageBuffers { get; set; } = ImmutableDictionary<string, ImmutableList<Tuple<object, IActorRef>>>.Empty;
+        public ICancelable PassivateIdleTask { get; }
 
         private EntityRecoveryStrategy RememberedEntitiesRecoveryStrategy { get; }
 
@@ -73,6 +75,11 @@ namespace Akka.Cluster.Sharding
                     Settings.TunningParameters.EntityRecoveryConstantRateStrategyFrequency,
                     Settings.TunningParameters.EntityRecoveryConstantRateStrategyNumberOfEntities)
                 : EntityRecoveryStrategy.AllStrategy;
+
+            var idleInterval = TimeSpan.FromTicks(Settings.PassivateIdleEntityAfter.Ticks / 2);
+            PassivateIdleTask = Settings.PassivateIdleEntityAfter > TimeSpan.Zero
+                ? Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(idleInterval, idleInterval, Self, Shard.PassivateIdleTick.Instance, Self)
+                : null;
         }
 
         public override string PersistenceId { get; }
@@ -166,31 +173,34 @@ namespace Akka.Cluster.Sharding
 
         public void EntityTerminated(IActorRef tref)
         {
-            if (IdByRef.TryGetValue(tref, out var id))
-            {
-                IdByRef = IdByRef.Remove(tref);
-                RefById = RefById.Remove(id);
+            if (!IdByRef.TryGetValue(tref, out var id)) return;
+            IdByRef = IdByRef.Remove(tref);
+            RefById = RefById.Remove(id);
 
-                if (MessageBuffers.TryGetValue(id, out var buffer) && buffer.Count != 0)
+            if (PassivateIdleTask != null)
+            {
+                LastMessageTimestamp = LastMessageTimestamp.Remove(id);
+            }
+
+            if (MessageBuffers.TryGetValue(id, out var buffer) && buffer.Count != 0)
+            {
+                //Note; because we're not persisting the EntityStopped, we don't need
+                // to persist the EntityStarted either.
+                Log.Debug("Starting entity [{0}] again, there are buffered messages for it", id);
+                this.SendMessageBuffer(new Shard.EntityStarted(id));
+            }
+            else
+            {
+                if (!Passivating.Contains(tref))
                 {
-                    //Note; because we're not persisting the EntityStopped, we don't need
-                    // to persist the EntityStarted either.
-                    Log.Debug("Starting entity [{0}] again, there are buffered messages for it", id);
-                    this.SendMessageBuffer(new Shard.EntityStarted(id));
+                    Log.Debug("Entity [{0}] stopped without passivating, will restart after backoff", id);
+                    Context.System.Scheduler.ScheduleTellOnce(Settings.TunningParameters.EntityRestartBackoff, Self, new Shard.RestartEntity(id), ActorRefs.NoSender);
                 }
                 else
-                {
-                    if (!Passivating.Contains(tref))
-                    {
-                        Log.Debug("Entity [{0}] stopped without passivating, will restart after backoff", id);
-                        Context.System.Scheduler.ScheduleTellOnce(Settings.TunningParameters.EntityRestartBackoff, Self, new Shard.RestartEntity(id), ActorRefs.NoSender);
-                    }
-                    else
-                        ProcessChange(new Shard.EntityStopped(id), this.PassivateCompleted);
-                }
-
-                Passivating = Passivating.Remove(tref);
+                    ProcessChange(new Shard.EntityStopped(id), this.PassivateCompleted);
             }
+
+            Passivating = Passivating.Remove(tref);
         }
 
         public void DeliverTo(string id, object message, object payload, IActorRef sender)

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
@@ -10,14 +10,12 @@ using System.Collections.Immutable;
 using System.Linq;
 using Akka.Actor;
 using Akka.Event;
-using Akka.Persistence;
-using Akka.Util.Internal;
 
 namespace Akka.Cluster.Sharding
 {
-    using ShardId = String;
     using EntityId = String;
     using Msg = Object;
+    using ShardId = String;
 
     internal interface IShard
     {
@@ -36,12 +34,14 @@ namespace Akka.Cluster.Sharding
         Shard.ShardState State { get; set; }
         ImmutableDictionary<EntityId, IActorRef> RefById { get; set; }
         ImmutableDictionary<IActorRef, EntityId> IdByRef { get; set; }
+        ImmutableDictionary<string, long> LastMessageTimestamp { get; set; }
         ImmutableHashSet<IActorRef> Passivating { get; set; }
         ImmutableDictionary<EntityId, ImmutableList<Tuple<Msg, IActorRef>>> MessageBuffers { get; set; }
         void Unhandled(object message);
         void ProcessChange<T>(T evt, Action<T> handler) where T : Shard.StateChange;
         void EntityTerminated(IActorRef tref);
         void DeliverTo(string id, object message, object payload, IActorRef sender);
+        ICancelable PassivateIdleTask { get; }
     }
 
     internal sealed class Shard : ActorBase, IShard
@@ -350,6 +350,13 @@ namespace Akka.Cluster.Sharding
             #endregion
         }
 
+        [Serializable]
+        public sealed class PassivateIdleTick : INoSerializationVerificationNeeded
+        {
+            public static readonly PassivateIdleTick Instance = new PassivateIdleTick();
+            private PassivateIdleTick() { }
+        }
+
         #endregion
 
         IActorContext IShard.Context => Context;
@@ -366,11 +373,13 @@ namespace Akka.Cluster.Sharding
         public ExtractShardId ExtractShardId { get; }
         public object HandOffStopMessage { get; }
         public IActorRef HandOffStopper { get; set; }
-        public Shard.ShardState State { get; set; } = Shard.ShardState.Empty;
+        public ShardState State { get; set; } = ShardState.Empty;
         public ImmutableDictionary<string, IActorRef> RefById { get; set; } = ImmutableDictionary<string, IActorRef>.Empty;
         public ImmutableDictionary<IActorRef, string> IdByRef { get; set; } = ImmutableDictionary<IActorRef, string>.Empty;
+        public ImmutableDictionary<string, long> LastMessageTimestamp { get; set; } = ImmutableDictionary<string, long>.Empty;
         public ImmutableHashSet<IActorRef> Passivating { get; set; } = ImmutableHashSet<IActorRef>.Empty;
         public ImmutableDictionary<string, ImmutableList<Tuple<object, IActorRef>>> MessageBuffers { get; set; } = ImmutableDictionary<string, ImmutableList<Tuple<object, IActorRef>>>.Empty;
+        public ICancelable PassivateIdleTask { get; }
 
         private EntityRecoveryStrategy RememberedEntitiesRecoveryStrategy { get; }
 
@@ -397,7 +406,18 @@ namespace Akka.Cluster.Sharding
                     Settings.TunningParameters.EntityRecoveryConstantRateStrategyNumberOfEntities)
                 : EntityRecoveryStrategy.AllStrategy;
 
+            var idleInterval = TimeSpan.FromTicks(Settings.PassivateIdleEntityAfter.Ticks / 2);
+            PassivateIdleTask = Settings.PassivateIdleEntityAfter > TimeSpan.Zero
+                ? Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(idleInterval, idleInterval, Self, PassivateIdleTick.Instance, Self)
+                : null;
+
             this.Initialized();
+        }
+
+        protected override void PostStop()
+        {
+            PassivateIdleTask?.Cancel();
+            base.PostStop();
         }
 
         protected override bool Receive(object message) => this.HandleCommand(message);
@@ -452,6 +472,9 @@ namespace Akka.Cluster.Sharding
                     return true;
                 case ShardRegion.RestartShard _:
                     return true;
+                case Shard.PassivateIdleTick _:
+                    shard.PassivateIdleEntities();
+                    return true;
                 case var _ when shard.ExtractEntityId(message) != null:
                     shard.DeliverMessage(message, shard.Context.Sender);
                     return true;
@@ -472,25 +495,6 @@ namespace Akka.Cluster.Sharding
             }
         }
 
-        public static void BaseEntityTerminated<TShard>(this TShard shard, IActorRef tref) where TShard : IShard
-        {
-            if (shard.IdByRef.TryGetValue(tref, out var id))
-            {
-                shard.IdByRef = shard.IdByRef.Remove(tref);
-                shard.RefById = shard.RefById.Remove(id);
-
-                if (shard.MessageBuffers.TryGetValue(id, out var buffer) && buffer.Count != 0)
-                {
-                    shard.Log.Debug("Starting entity [{0}] again, there are buffered messages for it", id);
-                    shard.SendMessageBuffer(new Shard.EntityStarted(id));
-                }
-                else
-                    shard.ProcessChange(new Shard.EntityStopped(id), stopped => shard.PassivateCompleted(stopped));
-
-                shard.Passivating = shard.Passivating.Remove(tref);
-            }
-        }
-
         private static void HandleShardCommand<TShard>(this TShard shard, Shard.IShardCommand message) where TShard : IShard
         {
             switch (message)
@@ -507,6 +511,10 @@ namespace Akka.Cluster.Sharding
         private static void HandleStartEntity<TShard>(this TShard shard, ShardRegion.StartEntity start) where TShard : IShard
         {
             shard.Log.Debug("Got a request from [{0}] to start entity [{1}] in shard [{2}]", shard.Sender, start.EntityId, shard.ShardId);
+            if (shard.PassivateIdleTask != null)
+            {
+                shard.LastMessageTimestamp = shard.LastMessageTimestamp.SetItem(start.EntityId, DateTime.Now.Ticks);
+            }
             shard.GetEntity(start.EntityId);
             shard.Context.Sender.Tell(new ShardRegion.StartEntityAck(start.EntityId, shard.ShardId));
         }
@@ -528,7 +536,6 @@ namespace Akka.Cluster.Sharding
         {
             shard.Context.ActorOf(RememberEntityStarter.Props(shard.Context.Parent, shard.TypeName, shard.ShardId, ids, shard.Settings, shard.Sender));
         }
-
 
         private static void HandleShardRegionCommand<TShard>(this TShard shard, IShardRegionCommand message) where TShard : IShard
         {
@@ -554,7 +561,7 @@ namespace Akka.Cluster.Sharding
             }
         }
 
-        private static void HandOff<TShard>(this TShard shard, IActorRef replyTo) where TShard: IShard
+        private static void HandOff<TShard>(this TShard shard, IActorRef replyTo) where TShard : IShard
         {
             if (shard.HandOffStopper != null) shard.Log.Warning("HandOff shard [{0}] received during existing handOff", shard.ShardId);
             else
@@ -617,14 +624,28 @@ namespace Akka.Cluster.Sharding
             }
         }
 
-        public static void PassivateCompleted<TShard>(this TShard shard, Shard.EntityStopped evt) where TShard: IShard
+        private static void PassivateIdleEntities<TShard>(this TShard shard) where TShard : IShard
+        {
+            var idleEntitiesCount = 0;
+            var deadline = DateTime.Now.Ticks - shard.Settings.PassivateIdleEntityAfter.Ticks;
+            foreach (var pair in shard.LastMessageTimestamp)
+            {
+                if (pair.Value >= deadline) continue;
+                Passivate(shard, shard.RefById[pair.Key], shard.HandOffStopMessage);
+                idleEntitiesCount++;
+            }
+
+            shard.Log.Debug($"Passivating [{idleEntitiesCount}] idle entities");
+        }
+
+        public static void PassivateCompleted<TShard>(this TShard shard, Shard.EntityStopped evt) where TShard : IShard
         {
             shard.Log.Debug("Entity stopped after passivation [{0}]", evt.EntityId);
             shard.State = new Shard.ShardState(shard.State.Entries.Remove(evt.EntityId));
             shard.MessageBuffers = shard.MessageBuffers.Remove(evt.EntityId);
         }
 
-        public static void SendMessageBuffer<TShard>(this TShard shard, Shard.EntityStarted message) where TShard: IShard
+        public static void SendMessageBuffer<TShard>(this TShard shard, Shard.EntityStarted message) where TShard : IShard
         {
             var id = message.EntityId;
 
@@ -660,26 +681,60 @@ namespace Akka.Cluster.Sharding
             }
             else
             {
-                if (shard.MessageBuffers.TryGetValue(id, out var buffer))
+                if (payload is ShardRegion.StartEntity start)
+                    shard.HandleStartEntity(start);
+                else
                 {
-                    if (shard.TotalBufferSize() >= shard.Settings.TunningParameters.BufferSize)
+                    if (shard.MessageBuffers.TryGetValue(id, out var buffer))
                     {
-                        shard.Log.Warning("Buffer is full, dropping message for entity [{0}]", id);
-                        shard.Context.System.DeadLetters.Tell(message);
+                        if (shard.TotalBufferSize() >= shard.Settings.TunningParameters.BufferSize)
+                        {
+                            shard.Log.Warning("Buffer is full, dropping message for entity [{0}]", id);
+                            shard.Context.System.DeadLetters.Tell(message);
+                        }
+                        else
+                        {
+                            shard.Log.Debug("Message for entity [{0}] buffered", id);
+                            shard.MessageBuffers = shard.MessageBuffers.SetItem(id, buffer.Add(Tuple.Create(message, sender)));
+                        }
                     }
                     else
-                    {
-                        shard.Log.Debug("Message for entity [{0}] buffered", id);
-                        shard.MessageBuffers = shard.MessageBuffers.SetItem(id, buffer.Add(Tuple.Create(message, sender)));
-                    }
+                        shard.DeliverTo(id, message, payload, sender);
                 }
-                else
-                    shard.DeliverTo(id, message, payload, sender);
             }
+        }
+
+        public static void BaseEntityTerminated<TShard>(this TShard shard, IActorRef tref) where TShard : IShard
+        {
+            if (!shard.IdByRef.TryGetValue(tref, out var id)) return;
+            shard.IdByRef = shard.IdByRef.Remove(tref);
+            shard.RefById = shard.RefById.Remove(id);
+
+            if (shard.PassivateIdleTask != null)
+            {
+                shard.LastMessageTimestamp = shard.LastMessageTimestamp.Remove(id);
+            }
+
+            if (shard.MessageBuffers.TryGetValue(id, out var buffer) && buffer.Count != 0)
+            {
+                shard.Log.Debug("Starting entity [{0}] again, there are buffered messages for it", id);
+                shard.SendMessageBuffer(new Shard.EntityStarted(id));
+            }
+            else
+            {
+                shard.ProcessChange(new Shard.EntityStopped(id), stopped => shard.PassivateCompleted(stopped));
+            }
+
+            shard.Passivating = shard.Passivating.Remove(tref);
         }
 
         internal static void BaseDeliverTo<TShard>(this TShard shard, string id, object message, object payload, IActorRef sender) where TShard : IShard
         {
+            if (shard.PassivateIdleTask != null)
+            {
+                shard.LastMessageTimestamp = shard.LastMessageTimestamp.SetItem(id, DateTime.Now.Ticks);
+            }
+
             var name = Uri.EscapeDataString(id);
             var child = shard.Context.Child(name);
 
@@ -689,19 +744,23 @@ namespace Akka.Cluster.Sharding
                 child.Tell(payload, sender);
         }
 
-        internal static IActorRef GetEntity<TShard>(this TShard shard, string id) where TShard: IShard
+        internal static IActorRef GetEntity<TShard>(this TShard shard, string id) where TShard : IShard
         {
             var name = Uri.EscapeDataString(id);
-            var child = shard.Context.Child(name);
-            if (Equals(child, ActorRefs.Nobody))
+            var child = shard.Context.Child(name).GetOrElse(() =>
             {
                 shard.Log.Debug("Starting entity [{0}] in shard [{1}]", id, shard.ShardId);
 
-                child = shard.Context.Watch(shard.Context.ActorOf(shard.EntityProps(id), name));
-                shard.IdByRef = shard.IdByRef.SetItem(child, id);
-                shard.RefById = shard.RefById.SetItem(id, child);
+                var a = shard.Context.Watch(shard.Context.ActorOf(shard.EntityProps(id), name));
+                shard.IdByRef = shard.IdByRef.SetItem(a, id);
+                shard.RefById = shard.RefById.SetItem(id, a);
+                if (shard.PassivateIdleTask != null)
+                {
+                    shard.LastMessageTimestamp = shard.LastMessageTimestamp.SetItem(id, DateTime.Now.Ticks);
+                }
                 shard.State = new Shard.ShardState(shard.State.Entries.Add(id));
-            }
+                return a;
+            });
 
             return child;
         }
@@ -782,8 +841,6 @@ namespace Akka.Cluster.Sharding
             var resendInterval = settings.TunningParameters.RetryInterval;
             _tickTask = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(resendInterval, resendInterval, Self, Tick.Instance, ActorRefs.NoSender);
         }
-
-
 
         private void SendStart(IImmutableSet<EntityId> ids)
         {

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
@@ -430,10 +430,18 @@ namespace Akka.Cluster.Sharding
             }
         }
 
+
         /// <inheritdoc cref="ActorBase.PreStart"/>
+        /// <summary>
+        /// Subscribe to MemberEvent, re-subscribe when restart
+        /// </summary>
         protected override void PreStart()
         {
             Cluster.Subscribe(Self, typeof(ClusterEvent.IMemberEvent));
+            if (Settings.PassivateIdleEntityAfter > TimeSpan.Zero)
+            {
+                Log.Info($"Idle entities will be passivated after [{Settings.PassivateIdleEntityAfter}]"); 
+            }
         }
 
         /// <inheritdoc cref="ActorBase.PostStop"/>

--- a/src/contrib/cluster/Akka.Cluster.Sharding/reference.conf
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/reference.conf
@@ -23,6 +23,10 @@ akka.cluster.sharding {
   # due to rebalance or crash.
   remember-entities = off
 
+  # Set this to a time duration to have sharding passivate entities when they have not
+  # gotten any message in this long time. Set to 'off' to disable.
+  passivate-idle-entity-after = off
+
   # If the coordinator can't store state changes it will be stopped
   # and started again after this duration, with an exponential back-off
   # of up to 5 times this duration.

--- a/src/contrib/persistence/Akka.Persistence.Query.Sql/EventsByTagPublisher.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.Sql/EventsByTagPublisher.cs
@@ -194,7 +194,7 @@ namespace Akka.Persistence.Query.Sql
             if (highestSequenceNr < ToOffset)
                 _toOffset = highestSequenceNr;
 
-            if (Buffer.IsEmpty && CurrentOffset > ToOffset)
+            if (Buffer.IsEmpty && CurrentOffset >= ToOffset)
                 OnCompleteThenStop();
             else
                 Self.Tell(EventsByTagPublisher.Continue.Instance);

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/BatchingSqlJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/BatchingSqlJournal.cs
@@ -570,7 +570,9 @@ namespace Akka.Persistence.Sql.Common.Journal
                     SELECT m.{conventions.SequenceNrColumnName} as SeqNr FROM {conventions.FullMetaTableName} m WHERE m.{conventions.PersistenceIdColumnName} = @PersistenceId) as u";
 
             DeleteBatchSql = $@"
-                DELETE FROM {conventions.FullJournalTableName} 
+                DELETE FROM {conventions.FullJournalTableName}
+                WHERE {conventions.PersistenceIdColumnName} = @PersistenceId AND {conventions.SequenceNrColumnName} <= @ToSequenceNr;
+                DELETE FROM {conventions.FullMetaTableName}
                 WHERE {conventions.PersistenceIdColumnName} = @PersistenceId AND {conventions.SequenceNrColumnName} <= @ToSequenceNr;";
 
             UpdateSequenceNrSql = $@"
@@ -908,8 +910,8 @@ namespace Akka.Persistence.Sql.Common.Journal
 
                 command.CommandText = DeleteBatchSql;
                 command.Parameters.Clear();
-                AddParameter(command, "PersistenceId", DbType.String, persistenceId);
-                AddParameter(command, "ToSequenceNr", DbType.Int64, toSequenceNr);
+                AddParameter(command, "@PersistenceId", DbType.String, persistenceId);
+                AddParameter(command, "@ToSequenceNr", DbType.Int64, toSequenceNr);
 
                 await command.ExecuteNonQueryAsync();
 

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryExecutor.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryExecutor.cs
@@ -76,7 +76,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// <param name="persistenceId">TBD</param>
         /// <returns>TBD</returns>
         Task<long> SelectHighestSequenceNrAsync(DbConnection connection, CancellationToken cancellationToken, string persistenceId);
-
+        
         /// <summary>
         /// Asynchronously inserts a collection of events and theirs tags into a journal table.
         /// </summary>
@@ -344,6 +344,12 @@ namespace Akka.Persistence.Sql.Common.Journal
                 AND e.{Configuration.SequenceNrColumnName} BETWEEN @FromSequenceNr AND @ToSequenceNr
                 ORDER BY {Configuration.SequenceNrColumnName} ASC;";
 
+            HighestTagOrderingSql =
+                $@"
+                SELECT MAX(e.{Configuration.OrderingColumnName}) as Ordering
+                FROM {Configuration.FullJournalTableName} e
+                WHERE e.{Configuration.OrderingColumnName} > @Ordering AND e.{Configuration.TagsColumnName} LIKE @Tag";
+
             ByTagSql =
                 $@"
                 SELECT {allEventColumnNames}, e.{Configuration.OrderingColumnName} as Ordering
@@ -398,6 +404,10 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// TBD
         /// </summary>
         protected virtual string ByPersistenceIdSql { get; }
+        /// <summary>
+        /// Query to return the highest ordering number for a tag
+        /// </summary>
+        protected virtual string HighestTagOrderingSql { get; }
         /// <summary>
         /// TBD
         /// </summary>
@@ -526,17 +536,21 @@ namespace Akka.Persistence.Sql.Common.Journal
 
                 using (var reader = await command.ExecuteReaderAsync(commandBehavior, cancellationToken))
                 {
-                    var maxSequenceNr = 0L;
                     while (await reader.ReadAsync(cancellationToken))
                     {
                         var persistent = ReadEvent(reader);
                         var ordering = reader.GetInt64(OrderingIndex);
-                        maxSequenceNr = Math.Max(maxSequenceNr, persistent.SequenceNr);
                         callback(new ReplayedTaggedMessage(persistent, tag, ordering));
                     }
-
-                    return maxSequenceNr;
                 }
+            }
+
+            using (var command = GetCommand(connection, HighestTagOrderingSql))
+            {
+                AddParameter(command, "@Tag", DbType.String, "%;" + tag + ";%");
+                AddParameter(command, "@Ordering", DbType.Int64, fromOffset);
+                var maxOrdering = (await command.ExecuteScalarAsync(cancellationToken)) as long? ?? 0L;
+                return maxOrdering;
             }
         }
 

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryExecutor.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryExecutor.cs
@@ -329,7 +329,9 @@ namespace Akka.Persistence.Sql.Common.Journal
                     SELECT m.{Configuration.SequenceNrColumnName} as SeqNr FROM {Configuration.FullMetaTableName} m WHERE m.{Configuration.PersistenceIdColumnName} = @PersistenceId) as u";
 
             DeleteBatchSql = $@"
-                DELETE FROM {Configuration.FullJournalTableName} 
+                DELETE FROM {Configuration.FullJournalTableName}
+                WHERE {Configuration.PersistenceIdColumnName} = @PersistenceId AND {Configuration.SequenceNrColumnName} <= @ToSequenceNr;
+                DELETE FROM {Configuration.FullMetaTableName}
                 WHERE {Configuration.PersistenceIdColumnName} = @PersistenceId AND {Configuration.SequenceNrColumnName} <= @ToSequenceNr;";
 
             UpdateSequenceNrSql = $@"

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -262,6 +262,7 @@ namespace Akka.Actor
     }
     public class static ActorRefExtensions
     {
+        public static Akka.Actor.IActorRef GetOrElse(this Akka.Actor.IActorRef actorRef, System.Func<Akka.Actor.IActorRef> elseValue) { }
         public static bool IsNobody(this Akka.Actor.IActorRef actorRef) { }
     }
     public class static ActorRefFactoryExtensions

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -1366,6 +1366,7 @@ namespace Akka.Actor
         protected override void ProcessFailure(Akka.Actor.IActorContext context, bool restart, System.Exception cause, Akka.Actor.Internal.ChildRestartStats failedChildStats, System.Collections.Generic.IReadOnlyCollection<Akka.Actor.Internal.ChildRestartStats> allChildren) { }
         protected override void ProcessFailure(Akka.Actor.IActorContext context, bool restart, Akka.Actor.IActorRef child, System.Exception cause, Akka.Actor.Internal.ChildRestartStats stats, System.Collections.Generic.IReadOnlyCollection<Akka.Actor.Internal.ChildRestartStats> children) { }
         public override Akka.Util.ISurrogate ToSurrogate(Akka.Actor.ActorSystem system) { }
+        public Akka.Actor.OneForOneStrategy WithMaxNrOfRetries(int maxNrOfRetries) { }
         public class OneForOneStrategySurrogate : Akka.Util.ISurrogate
         {
             public OneForOneStrategySurrogate() { }
@@ -3754,8 +3755,12 @@ namespace Akka.Pattern
 {
     public class static Backoff
     {
+        [System.ObsoleteAttribute("Use the overloaded one which accepts maxNrOfRetries instead.")]
         public static Akka.Pattern.BackoffOptions OnFailure(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        public static Akka.Pattern.BackoffOptions OnFailure(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxNrOfRetries) { }
+        [System.ObsoleteAttribute("Use the overloaded one which accepts maxNrOfRetries instead.")]
         public static Akka.Pattern.BackoffOptions OnStop(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        public static Akka.Pattern.BackoffOptions OnStop(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxNrOfRetries) { }
     }
     public abstract class BackoffOptions
     {
@@ -3763,13 +3768,16 @@ namespace Akka.Pattern
         public abstract Akka.Pattern.BackoffOptions WithAutoReset(System.TimeSpan resetBackoff);
         public abstract Akka.Pattern.BackoffOptions WithDefaultStoppingStrategy();
         public abstract Akka.Pattern.BackoffOptions WithManualReset();
+        public abstract Akka.Pattern.BackoffOptions WithMaxNrOfRetries(int maxNrOfRetries);
+        public abstract Akka.Pattern.BackoffOptions WithReplyWhileStopped(object replyWhileStopped);
         public abstract Akka.Pattern.BackoffOptions WithSupervisorStrategy(Akka.Actor.OneForOneStrategy supervisorStrategy);
     }
     public sealed class BackoffSupervisor : Akka.Pattern.BackoffSupervisorBase
     {
         public BackoffSupervisor(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
-        public BackoffSupervisor(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, Akka.Pattern.IBackoffReset reset, double randomFactor, Akka.Actor.SupervisorStrategy strategy) { }
+        public BackoffSupervisor(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, Akka.Pattern.IBackoffReset reset, double randomFactor, Akka.Actor.SupervisorStrategy strategy, object replyWhileStopped = null) { }
         public static Akka.Actor.Props Props(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        public static Akka.Actor.Props Props(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxNrOfRetries) { }
         public static Akka.Actor.Props Props(Akka.Pattern.BackoffOptions options) { }
         public static Akka.Actor.Props PropsWithSupervisorStrategy(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, Akka.Actor.SupervisorStrategy strategy) { }
         protected override bool Receive(object message) { }
@@ -3811,6 +3819,7 @@ namespace Akka.Pattern
         protected Akka.Actor.IActorRef Child { get; set; }
         protected string ChildName { get; }
         protected Akka.Actor.Props ChildProps { get; }
+        protected object ReplyWhileStopped { get; }
         protected Akka.Pattern.IBackoffReset Reset { get; }
         protected int RestartCountN { get; set; }
         protected bool HandleBackoff(object message) { }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -3767,6 +3767,7 @@ namespace Akka.Pattern
         protected BackoffOptions() { }
         public abstract Akka.Pattern.BackoffOptions WithAutoReset(System.TimeSpan resetBackoff);
         public abstract Akka.Pattern.BackoffOptions WithDefaultStoppingStrategy();
+        public abstract Akka.Pattern.BackoffOptions WithFinalStopMessage(System.Func<object, bool> isFinalStopMessage);
         public abstract Akka.Pattern.BackoffOptions WithManualReset();
         public abstract Akka.Pattern.BackoffOptions WithMaxNrOfRetries(int maxNrOfRetries);
         public abstract Akka.Pattern.BackoffOptions WithReplyWhileStopped(object replyWhileStopped);
@@ -3775,7 +3776,7 @@ namespace Akka.Pattern
     public sealed class BackoffSupervisor : Akka.Pattern.BackoffSupervisorBase
     {
         public BackoffSupervisor(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
-        public BackoffSupervisor(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, Akka.Pattern.IBackoffReset reset, double randomFactor, Akka.Actor.SupervisorStrategy strategy, object replyWhileStopped = null) { }
+        public BackoffSupervisor(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, Akka.Pattern.IBackoffReset reset, double randomFactor, Akka.Actor.SupervisorStrategy strategy, object replyWhileStopped = null, System.Func<object, bool> finalStopMessage = null) { }
         public static Akka.Actor.Props Props(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
         public static Akka.Actor.Props Props(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxNrOfRetries) { }
         public static Akka.Actor.Props Props(Akka.Pattern.BackoffOptions options) { }
@@ -3819,6 +3820,8 @@ namespace Akka.Pattern
         protected Akka.Actor.IActorRef Child { get; set; }
         protected string ChildName { get; }
         protected Akka.Actor.Props ChildProps { get; }
+        protected System.Func<object, bool> FinalStopMessage { get; }
+        protected bool FinalStopMessageReceived { get; set; }
         protected object ReplyWhileStopped { get; }
         protected Akka.Pattern.IBackoffReset Reset { get; }
         protected int RestartCountN { get; set; }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
@@ -77,7 +77,7 @@ namespace Akka.Persistence
             public Akka.Persistence.AtLeastOnceDeliverySemantic.Delivery IncrementedCopy() { }
             public override string ToString() { }
         }
-        public sealed class RedeliveryTick : Akka.Actor.INotInfluenceReceiveTimeout
+        public sealed class RedeliveryTick : Akka.Actor.INotInfluenceReceiveTimeout, Akka.Event.IDeadLetterSuppression
         {
             public static Akka.Persistence.AtLeastOnceDeliverySemantic.RedeliveryTick Instance { get; }
             public override bool Equals(object obj) { }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
@@ -1528,6 +1528,7 @@ namespace Akka.Streams.Dsl
     }
     public class static RestartFlow
     {
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> OnFailuresWithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> WithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
     }
     public class static RestartSink
@@ -1536,6 +1537,7 @@ namespace Akka.Streams.Dsl
     }
     public class static RestartSource
     {
+        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> OnFailuresWithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
     }
     public class static Retry

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
@@ -1529,16 +1529,21 @@ namespace Akka.Streams.Dsl
     public class static RestartFlow
     {
         public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> OnFailuresWithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> OnFailuresWithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> WithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> WithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
     }
     public class static RestartSink
     {
         public static Akka.Streams.Dsl.Sink<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Sink<T, TMat>> sinkFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        public static Akka.Streams.Dsl.Sink<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Sink<T, TMat>> sinkFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
     }
     public class static RestartSource
     {
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> OnFailuresWithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> OnFailuresWithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
     }
     public class static Retry
     {

--- a/src/core/Akka.Cluster.Tests/SplitBrainStrategySpec.cs
+++ b/src/core/Akka.Cluster.Tests/SplitBrainStrategySpec.cs
@@ -198,6 +198,16 @@ namespace Akka.Cluster.Tests
         }
 
         [Fact]
+        public void KeepOldest_when_downIfAlone_must_keep_oldest_up_if_is_reachable_and_only_node_in_cluster()
+        {
+            var unreachable = Members();
+            var remaining = Members(Member(a, upNumber: 1));
+
+            var strategy = new KeepOldest(downIfAlone: true);
+            strategy.Apply(new NetworkPartitionContext(unreachable, remaining)).Should().Equal(unreachable);
+        }
+
+        [Fact]
         public void KeepReferee_must_down_remaining_if_referee_node_was_unreachable()
         {
             var referee = a;

--- a/src/core/Akka.Cluster/SplitBrainResolver.cs
+++ b/src/core/Akka.Cluster/SplitBrainResolver.cs
@@ -179,7 +179,7 @@ namespace Akka.Cluster
             var oldest = remaining.Union(unreachable).ToImmutableSortedSet(Member.AgeOrdering).First();
             if (remaining.Contains(oldest))
             {
-                return DownIfAlone && context.Remaining.Count == 1 // oldest is current node, and it's alone
+                return DownIfAlone && context.Remaining.Count == 1 && context.Unreachable.Count > 0 // oldest is current node, and it's alone, but not the only node in the cluster
                     ? context.Remaining 
                     : context.Unreachable;
             }

--- a/src/core/Akka.Persistence.TCK/Query/CurrentEventsByTagSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Query/CurrentEventsByTagSpec.cs
@@ -157,5 +157,30 @@ namespace Akka.Persistence.TCK.Query
             probe2.ExpectNext<EventEnvelope>(p => p.PersistenceId == "b" && p.SequenceNr == 2L && p.Event.Equals("a green leaf"));
             probe2.Cancel();
         }
+
+        [Fact]
+        public virtual void ReadJournal_query_CurrentEventsByTag_should_see_all_150_events()
+        {
+            var queries = ReadJournal as ICurrentEventsByTagQuery;
+            var a = Sys.ActorOf(Query.TestActor.Props("a"));
+
+            for (int i = 0; i < 150; ++i) 
+            {
+                a.Tell("a green apple");
+                ExpectMsg("a green apple-done");
+            }
+
+            var greenSrc = queries.CurrentEventsByTag("green", offset: NoOffset());
+            var probe = greenSrc.RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
+            probe.Request(150);
+            for (int i = 0; i < 150; ++i)
+            {
+                probe.ExpectNext<EventEnvelope>(p => 
+                    p.PersistenceId == "a" && p.SequenceNr == (i + 1) && p.Event.Equals("a green apple"));
+            }
+
+            probe.ExpectComplete();
+            probe.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
+        }
     }
 }

--- a/src/core/Akka.Persistence/AtLeastOnceDeliverySemantic.cs
+++ b/src/core/Akka.Persistence/AtLeastOnceDeliverySemantic.cs
@@ -11,6 +11,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.Serialization;
 using Akka.Actor;
+using Akka.Event;
 using Akka.Persistence.Serialization;
 
 namespace Akka.Persistence
@@ -296,7 +297,7 @@ namespace Akka.Persistence
         }
 
         [Serializable]
-        public sealed class RedeliveryTick : INotInfluenceReceiveTimeout
+        public sealed class RedeliveryTick : INotInfluenceReceiveTimeout, IDeadLetterSuppression
         {
             /// <summary>
             /// The singleton instance of the redelivery tick
@@ -378,7 +379,8 @@ namespace Akka.Persistence
 
         private void StartRedeliverTask()
         {
-            var interval = new TimeSpan(RedeliverInterval.Ticks/2);
+            if (_redeliverScheduleCancelable != null) return;
+            var interval = new TimeSpan(RedeliverInterval.Ticks / 2);
             _redeliverScheduleCancelable = _context.System.Scheduler.ScheduleTellRepeatedlyCancelable(interval, interval, _context.Self,
                 RedeliveryTick.Instance, _context.Self);
         }
@@ -429,6 +431,7 @@ namespace Akka.Persistence
         {
             var before = _unconfirmed;
             _unconfirmed = _unconfirmed.Remove(deliveryId);
+            if (_unconfirmed.IsEmpty) Cancel();
             return _unconfirmed.Count < before.Count;
         }
 
@@ -462,11 +465,9 @@ namespace Akka.Persistence
 
         private void Send(long deliveryId, Delivery delivery, DateTime timestamp)
         {
-            ActorSelection destination = _context.ActorSelection(delivery.Destination);
-            destination.Tell(delivery.Message);
-
-            _unconfirmed = _unconfirmed.SetItem(deliveryId,
-                new Delivery(delivery.Destination, delivery.Message, timestamp, delivery.Attempt + 1));
+            _context.ActorSelection(delivery.Destination).Tell(delivery.Message);
+            _unconfirmed = _unconfirmed.SetItem(deliveryId, new Delivery(delivery.Destination, delivery.Message, timestamp, delivery.Attempt + 1));
+            StartRedeliverTask();
         }
 
         /// <summary>
@@ -513,6 +514,7 @@ namespace Akka.Persistence
         {
             // need a null check here, in case actor is terminated before StartRedeliverTask() is called
             _redeliverScheduleCancelable?.Cancel();
+            _redeliverScheduleCancelable = null;
         }
 
 
@@ -521,6 +523,7 @@ namespace Akka.Persistence
         /// </summary>
         public void OnReplaySuccess()
         {
+            if (_unconfirmed.IsEmpty) return;
             RedeliverOverdue();
             StartRedeliverTask();
         }

--- a/src/core/Akka.Streams/Dsl/Restart.cs
+++ b/src/core/Akka.Streams/Dsl/Restart.cs
@@ -6,7 +6,6 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Linq;
 using Akka.Pattern;
 using Akka.Streams.Stage;
 
@@ -35,7 +34,23 @@ namespace Akka.Streams.Dsl
         /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
         /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
         public static Source<T, NotUsed> WithBackoff<T, TMat>(Func<Source<T, TMat>> sourceFactory, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor) 
-            => Source.FromGraph(new RestartWithBackoffSource<T, TMat>(sourceFactory, minBackoff, maxBackoff, randomFactor));
+            => Source.FromGraph(new RestartWithBackoffSource<T, TMat>(sourceFactory, minBackoff, maxBackoff, randomFactor, false));
+
+        /// <summary>
+        /// Wrap the given <see cref="Source"/> with a <see cref="Source"/> that will restart it when it fails using an exponential backoff.
+        /// This <see cref="Source"/> will never emit a failure, since the failure of the wrapped <see cref="Source"/> is always handled by
+        /// restarting. The wrapped <see cref="Source"/> can be cancelled by cancelling this <see cref="Source"/>.
+        /// When that happens, the wrapped <see cref="Source"/>, if currently running will be cancelled, and it will not be restarted.
+        /// This can be triggered simply by the downstream cancelling, or externally by introducing a <see cref="IKillSwitch"/> right
+        /// after this <see cref="Source"/> in the graph.
+        /// This uses the same exponential backoff algorithm as <see cref="Akka.Pattern.Backoff"/>.
+        /// </summary>
+        /// <param name="sourceFactory">A factory for producing the <see cref="Source"/> to wrap.</param>
+        /// <param name="minBackoff">Minimum (initial) duration until the child actor will started again, if it is terminated</param>
+        /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
+        /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
+        public static Source<T, NotUsed> OnFailuresWithBackoff<T, TMat>(Func<Source<T, TMat>> sourceFactory, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor) 
+            => Source.FromGraph(new RestartWithBackoffSource<T, TMat>(sourceFactory, minBackoff, maxBackoff, randomFactor, true));
     }
 
     internal sealed class RestartWithBackoffSource<T, TMat> : GraphStage<SourceShape<T>>
@@ -44,17 +59,20 @@ namespace Akka.Streams.Dsl
         public TimeSpan MinBackoff { get; }
         public TimeSpan MaxBackoff { get; }
         public double RandomFactor { get; }
+        public bool OnlyOnFailures { get; }
 
         public RestartWithBackoffSource(
             Func<Source<T, TMat>> sourceFactory,
             TimeSpan minBackoff,
             TimeSpan maxBackoff,
-            double randomFactor)
+            double randomFactor,
+            bool onlyOnFailures)
         {
             SourceFactory = sourceFactory;
             MinBackoff = minBackoff;
             MaxBackoff = maxBackoff;
             RandomFactor = randomFactor;
+            OnlyOnFailures = onlyOnFailures;
             Shape = new SourceShape<T>(Out);
         }
 
@@ -69,7 +87,7 @@ namespace Akka.Streams.Dsl
             private readonly RestartWithBackoffSource<T, TMat> _stage;
 
             public Logic(RestartWithBackoffSource<T, TMat> stage, string name) 
-                : base(name, stage.Shape, null, stage.Out, stage.MinBackoff, stage.MaxBackoff, stage.RandomFactor)
+                : base(name, stage.Shape, null, stage.Out, stage.MinBackoff, stage.MaxBackoff, stage.RandomFactor, stage.OnlyOnFailures)
             {
                 _stage = stage;
                 Backoff();
@@ -150,7 +168,7 @@ namespace Akka.Streams.Dsl
             private readonly RestartWithBackoffSink<T, TMat> _stage;
 
             public Logic(RestartWithBackoffSink<T, TMat> stage, string name)
-                : base(name, stage.Shape, stage.In, null, stage.MinBackoff, stage.MaxBackoff, stage.RandomFactor)
+                : base(name, stage.Shape, stage.In, null, stage.MinBackoff, stage.MaxBackoff, stage.RandomFactor, false)
             {
                 _stage = stage;
                 Backoff();
@@ -194,7 +212,27 @@ namespace Akka.Streams.Dsl
         /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
         /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
         public static Flow<TIn, TOut, NotUsed> WithBackoff<TIn, TOut, TMat>(Func<Flow<TIn, TOut, TMat>> flowFactory, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor)
-            => Flow.FromGraph(new RestartWithBackoffFlow<TIn, TOut, TMat>(flowFactory, minBackoff, maxBackoff, randomFactor));
+            => Flow.FromGraph(new RestartWithBackoffFlow<TIn, TOut, TMat>(flowFactory, minBackoff, maxBackoff, randomFactor, false));
+
+        /// <summary>
+        /// Wrap the given <see cref="Flow"/> with a <see cref="Flow"/> that will restart it when it fails using an exponential
+        /// backoff. Notice that this <see cref="Flow"/> will not restart on completion of the wrapped flow. 
+        /// This <see cref="Flow"/> will not emit any failure
+        /// The failures by the wrapped <see cref="Flow"/> will be handled by
+        /// restarting the wrapping <see cref="Flow"/> as long as maxRestarts is not reached.
+        /// Any termination signals sent to this <see cref="Flow"/> however will terminate the wrapped <see cref="Flow"/>, if it's
+        /// running, and then the <see cref="Flow"/> will be allowed to terminate without being restarted. 
+        /// The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
+        /// messages. A termination signal from either end of the wrapped <see cref="Flow"/> will cause the other end to be terminated,
+        /// nd any in transit messages will be lost. During backoff, this <see cref="Flow"/> will backpressure. 
+        /// This uses the same exponential backoff algorithm as <see cref="Akka.Pattern.Backoff"/>.
+        /// </summary>
+        /// <param name="flowFactory">A factory for producing the <see cref="Flow"/>] to wrap.</param>
+        /// <param name="minBackoff">Minimum (initial) duration until the child actor will started again, if it is terminated</param>
+        /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
+        /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
+        public static Flow<TIn, TOut, NotUsed> OnFailuresWithBackoff<TIn, TOut, TMat>(Func<Flow<TIn, TOut, TMat>> flowFactory, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor) 
+            => Flow.FromGraph(new RestartWithBackoffFlow<TIn, TOut, TMat>(flowFactory, minBackoff, maxBackoff, randomFactor, true));
     }
 
     internal sealed class RestartWithBackoffFlow<TIn, TOut, TMat> : GraphStage<FlowShape<TIn, TOut>>
@@ -203,17 +241,20 @@ namespace Akka.Streams.Dsl
         public TimeSpan MinBackoff { get; }
         public TimeSpan MaxBackoff { get; }
         public double RandomFactor { get; }
+        public bool OnlyOnFailures { get; }
 
         public RestartWithBackoffFlow(
             Func<Flow<TIn, TOut, TMat>> flowFactory,
             TimeSpan minBackoff,
             TimeSpan maxBackoff,
-            double randomFactor)
+            double randomFactor,
+            bool onlyOnFailures)
         {
             FlowFactory = flowFactory;
             MinBackoff = minBackoff;
             MaxBackoff = maxBackoff;
             RandomFactor = randomFactor;
+            OnlyOnFailures = onlyOnFailures;
             Shape = new FlowShape<TIn, TOut>(In, Out);
         }
 
@@ -231,7 +272,7 @@ namespace Akka.Streams.Dsl
             private Tuple<SubSourceOutlet<TIn>, SubSinkInlet<TOut>> _activeOutIn;
 
             public Logic(RestartWithBackoffFlow<TIn, TOut, TMat> stage, string name)
-                : base(name, stage.Shape, stage.In, stage.Out, stage.MinBackoff, stage.MaxBackoff, stage.RandomFactor)
+                : base(name, stage.Shape, stage.In, stage.Out, stage.MinBackoff, stage.MaxBackoff, stage.RandomFactor, stage.OnlyOnFailures)
             {
                 _stage = stage;
                 Backoff();
@@ -285,6 +326,7 @@ namespace Akka.Streams.Dsl
         private readonly TimeSpan _minBackoff;
         private readonly TimeSpan _maxBackoff;
         private readonly double _randomFactor;
+        private readonly bool _onlyOnFailures;
 
         protected Inlet<TIn> In { get; }
         protected Outlet<TOut> Out { get; }
@@ -302,12 +344,14 @@ namespace Akka.Streams.Dsl
             Outlet<TOut> outlet,
             TimeSpan minBackoff,
             TimeSpan maxBackoff,
-            double randomFactor) : base(shape)
+            double randomFactor,
+            bool onlyOnFailures) : base(shape)
         {
             _name = name;
             _minBackoff = minBackoff;
             _maxBackoff = maxBackoff;
             _randomFactor = randomFactor;
+            _onlyOnFailures = onlyOnFailures;
 
             _resetDeadline = minBackoff.FromNow();
 
@@ -327,12 +371,12 @@ namespace Akka.Streams.Dsl
                 onPush: () => Push(Out, sinkIn.Grab()),
                 onUpstreamFinish: () =>
                 {
-                    if (_finishing)
+                    if (_finishing || _onlyOnFailures)
                         Complete(Out);
                     else
                     {
-                        Log.Debug("Graph out finished");
-                        OnCompleteOrFailure();
+                        Log.Debug("Restarting graph due to finished upstream");
+                        ScheduleRestartTimer();
                     }
                 },
                 onUpstreamFailure: ex =>
@@ -342,7 +386,7 @@ namespace Akka.Streams.Dsl
                     else
                     {
                         Log.Error(ex, "Restarting graph due to failure");
-                        OnCompleteOrFailure();
+                        ScheduleRestartTimer();
                     }
                 }));
 
@@ -373,12 +417,12 @@ namespace Akka.Streams.Dsl
                 },
                 onDownstreamFinish: () =>
                 {
-                    if (_finishing)
+                    if (_finishing || _onlyOnFailures)
                         Cancel(In);
                     else
                     {
                         Log.Debug("Graph in finished");
-                        OnCompleteOrFailure();
+                        ScheduleRestartTimer();
                     }
                 }
             ));
@@ -403,7 +447,7 @@ namespace Akka.Streams.Dsl
             return sourceOut;
         }
 
-        internal void OnCompleteOrFailure()
+        internal void ScheduleRestartTimer()
         {
             // Check if the last start attempt was more than the minimum backoff
             if (_resetDeadline.IsOverdue)

--- a/src/core/Akka.Streams/Dsl/Restart.cs
+++ b/src/core/Akka.Streams/Dsl/Restart.cs
@@ -33,8 +33,26 @@ namespace Akka.Streams.Dsl
         /// <param name="minBackoff">Minimum (initial) duration until the child actor will started again, if it is terminated</param>
         /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
         /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
-        public static Source<T, NotUsed> WithBackoff<T, TMat>(Func<Source<T, TMat>> sourceFactory, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor) 
-            => Source.FromGraph(new RestartWithBackoffSource<T, TMat>(sourceFactory, minBackoff, maxBackoff, randomFactor, false));
+        public static Source<T, NotUsed> WithBackoff<T, TMat>(Func<Source<T, TMat>> sourceFactory, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor)
+            => Source.FromGraph(new RestartWithBackoffSource<T, TMat>(sourceFactory, minBackoff, maxBackoff, randomFactor, false, int.MaxValue));
+
+        /// <summary>
+        /// Wrap the given <see cref="Source"/> with a <see cref="Source"/> that will restart it when it fails or complete using an exponential
+        /// backoff.
+        /// This <see cref="Source"/> will never emit a complete or failure, since the completion or failure of the wrapped <see cref="Source"/>
+        /// is always handled by restarting it. The wrapped <see cref="Source"/> can however be cancelled by cancelling this <see cref="Source"/>.
+        /// When that happens, the wrapped <see cref="Source"/>, if currently running will be cancelled, and it will not be restarted.
+        /// This can be triggered simply by the downstream cancelling, or externally by introducing a <see cref="IKillSwitch"/> right
+        /// after this <see cref="Source"/> in the graph.
+        /// This uses the same exponential backoff algorithm as <see cref="Akka.Pattern.Backoff"/>.
+        /// </summary>
+        /// <param name="sourceFactory">A factory for producing the <see cref="Source"/> to wrap.</param>
+        /// <param name="minBackoff">Minimum (initial) duration until the child actor will started again, if it is terminated</param>
+        /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
+        /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
+        /// <param name="maxRestarts">The amount of restarts is capped to this amount within a time frame of minBackoff. Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.</param>
+        public static Source<T, NotUsed> WithBackoff<T, TMat>(Func<Source<T, TMat>> sourceFactory, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor, int maxRestarts)
+            => Source.FromGraph(new RestartWithBackoffSource<T, TMat>(sourceFactory, minBackoff, maxBackoff, randomFactor, false, maxRestarts));
 
         /// <summary>
         /// Wrap the given <see cref="Source"/> with a <see cref="Source"/> that will restart it when it fails using an exponential backoff.
@@ -49,8 +67,25 @@ namespace Akka.Streams.Dsl
         /// <param name="minBackoff">Minimum (initial) duration until the child actor will started again, if it is terminated</param>
         /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
         /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
-        public static Source<T, NotUsed> OnFailuresWithBackoff<T, TMat>(Func<Source<T, TMat>> sourceFactory, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor) 
-            => Source.FromGraph(new RestartWithBackoffSource<T, TMat>(sourceFactory, minBackoff, maxBackoff, randomFactor, true));
+        public static Source<T, NotUsed> OnFailuresWithBackoff<T, TMat>(Func<Source<T, TMat>> sourceFactory, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor)
+            => Source.FromGraph(new RestartWithBackoffSource<T, TMat>(sourceFactory, minBackoff, maxBackoff, randomFactor, true, int.MaxValue));
+
+        /// <summary>
+        /// Wrap the given <see cref="Source"/> with a <see cref="Source"/> that will restart it when it fails using an exponential backoff.
+        /// This <see cref="Source"/> will never emit a failure, since the failure of the wrapped <see cref="Source"/> is always handled by
+        /// restarting. The wrapped <see cref="Source"/> can be cancelled by cancelling this <see cref="Source"/>.
+        /// When that happens, the wrapped <see cref="Source"/>, if currently running will be cancelled, and it will not be restarted.
+        /// This can be triggered simply by the downstream cancelling, or externally by introducing a <see cref="IKillSwitch"/> right
+        /// after this <see cref="Source"/> in the graph.
+        /// This uses the same exponential backoff algorithm as <see cref="Akka.Pattern.Backoff"/>.
+        /// </summary>
+        /// <param name="sourceFactory">A factory for producing the <see cref="Source"/> to wrap.</param>
+        /// <param name="minBackoff">Minimum (initial) duration until the child actor will started again, if it is terminated</param>
+        /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
+        /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
+        /// <param name="maxRestarts">The amount of restarts is capped to this amount within a time frame of minBackoff. Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.</param>
+        public static Source<T, NotUsed> OnFailuresWithBackoff<T, TMat>(Func<Source<T, TMat>> sourceFactory, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor, int maxRestarts)
+            => Source.FromGraph(new RestartWithBackoffSource<T, TMat>(sourceFactory, minBackoff, maxBackoff, randomFactor, true, maxRestarts));
     }
 
     internal sealed class RestartWithBackoffSource<T, TMat> : GraphStage<SourceShape<T>>
@@ -60,19 +95,22 @@ namespace Akka.Streams.Dsl
         public TimeSpan MaxBackoff { get; }
         public double RandomFactor { get; }
         public bool OnlyOnFailures { get; }
+        public int MaxRestarts { get; }
 
         public RestartWithBackoffSource(
             Func<Source<T, TMat>> sourceFactory,
             TimeSpan minBackoff,
             TimeSpan maxBackoff,
             double randomFactor,
-            bool onlyOnFailures)
+            bool onlyOnFailures,
+            int maxRestarts)
         {
             SourceFactory = sourceFactory;
             MinBackoff = minBackoff;
             MaxBackoff = maxBackoff;
             RandomFactor = randomFactor;
             OnlyOnFailures = onlyOnFailures;
+            MaxRestarts = maxRestarts;
             Shape = new SourceShape<T>(Out);
         }
 
@@ -82,12 +120,12 @@ namespace Akka.Streams.Dsl
 
         protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes) => new Logic(this, "Source");
 
-        private class Logic : RestartWithBackoffLogic<SourceShape<T>, T, T>
+        private sealed class Logic : RestartWithBackoffLogic<SourceShape<T>, T, T>
         {
             private readonly RestartWithBackoffSource<T, TMat> _stage;
 
-            public Logic(RestartWithBackoffSource<T, TMat> stage, string name) 
-                : base(name, stage.Shape, null, stage.Out, stage.MinBackoff, stage.MaxBackoff, stage.RandomFactor, stage.OnlyOnFailures)
+            public Logic(RestartWithBackoffSource<T, TMat> stage, string name)
+                : base(name, stage.Shape, null, stage.Out, stage.MinBackoff, stage.MaxBackoff, stage.RandomFactor, stage.OnlyOnFailures, stage.MaxRestarts)
             {
                 _stage = stage;
                 Backoff();
@@ -133,8 +171,29 @@ namespace Akka.Streams.Dsl
         /// <param name="minBackoff">Minimum (initial) duration until the child actor will started again, if it is terminated</param>
         /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
         /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
-        public static Sink<T, NotUsed> WithBackoff<T, TMat>(Func<Sink<T, TMat>> sinkFactory, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor) 
-            => Sink.FromGraph(new RestartWithBackoffSink<T, TMat>(sinkFactory, minBackoff, maxBackoff, randomFactor));
+        public static Sink<T, NotUsed> WithBackoff<T, TMat>(Func<Sink<T, TMat>> sinkFactory, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor)
+            => Sink.FromGraph(new RestartWithBackoffSink<T, TMat>(sinkFactory, minBackoff, maxBackoff, randomFactor, int.MaxValue));
+
+        /// <summary>
+        /// Wrap the given <see cref="Sink"/> with a <see cref="Sink"/> that will restart it when it fails or complete using an exponential
+        /// backoff.
+        /// This <see cref="Sink"/> will never cancel, since cancellation by the wrapped <see cref="Sink"/> is always handled by restarting it.
+        /// The wrapped <see cref="Sink"/> can however be completed by feeding a completion or error into this <see cref="Sink"/>. When that
+        /// happens, the <see cref="Sink"/>, if currently running, will terminate and will not be restarted. This can be triggered
+        /// simply by the upstream completing, or externally by introducing a <see cref="IKillSwitch"/> right before this <see cref="Sink"/> in the
+        /// graph.
+        /// The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
+        /// messages. When the wrapped <see cref="Sink"/> does cancel, this <see cref="Sink"/> will backpressure, however any elements already
+        /// sent may have been lost.
+        /// This uses the same exponential backoff algorithm as <see cref="Akka.Pattern.Backoff"/>.
+        /// </summary>
+        /// <param name="sinkFactory">A factory for producing the <see cref="Sink"/> to wrap.</param>
+        /// <param name="minBackoff">Minimum (initial) duration until the child actor will started again, if it is terminated</param>
+        /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
+        /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
+        /// <param name="maxRestarts">The amount of restarts is capped to this amount within a time frame of minBackoff. Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.</param>
+        public static Sink<T, NotUsed> WithBackoff<T, TMat>(Func<Sink<T, TMat>> sinkFactory, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor, int maxRestarts)
+            => Sink.FromGraph(new RestartWithBackoffSink<T, TMat>(sinkFactory, minBackoff, maxBackoff, randomFactor, maxRestarts));
     }
 
     internal sealed class RestartWithBackoffSink<T, TMat> : GraphStage<SinkShape<T>>
@@ -143,17 +202,20 @@ namespace Akka.Streams.Dsl
         public TimeSpan MinBackoff { get; }
         public TimeSpan MaxBackoff { get; }
         public double RandomFactor { get; }
+        public int MaxRestarts { get; }
 
         public RestartWithBackoffSink(
             Func<Sink<T, TMat>> sinkFactory,
             TimeSpan minBackoff,
             TimeSpan maxBackoff,
-            double randomFactor)
+            double randomFactor,
+            int maxRestarts)
         {
             SinkFactory = sinkFactory;
             MinBackoff = minBackoff;
             MaxBackoff = maxBackoff;
             RandomFactor = randomFactor;
+            MaxRestarts = maxRestarts;
             Shape = new SinkShape<T>(In);
         }
 
@@ -163,12 +225,12 @@ namespace Akka.Streams.Dsl
 
         protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes) => new Logic(this, "Sink");
 
-        private class Logic : RestartWithBackoffLogic<SinkShape<T>, T, T>
+        private sealed class Logic : RestartWithBackoffLogic<SinkShape<T>, T, T>
         {
             private readonly RestartWithBackoffSink<T, TMat> _stage;
 
             public Logic(RestartWithBackoffSink<T, TMat> stage, string name)
-                : base(name, stage.Shape, stage.In, null, stage.MinBackoff, stage.MaxBackoff, stage.RandomFactor, false)
+                : base(name, stage.Shape, stage.In, null, stage.MinBackoff, stage.MaxBackoff, stage.RandomFactor, false, stage.MaxRestarts)
             {
                 _stage = stage;
                 Backoff();
@@ -212,7 +274,27 @@ namespace Akka.Streams.Dsl
         /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
         /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
         public static Flow<TIn, TOut, NotUsed> WithBackoff<TIn, TOut, TMat>(Func<Flow<TIn, TOut, TMat>> flowFactory, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor)
-            => Flow.FromGraph(new RestartWithBackoffFlow<TIn, TOut, TMat>(flowFactory, minBackoff, maxBackoff, randomFactor, false));
+            => Flow.FromGraph(new RestartWithBackoffFlow<TIn, TOut, TMat>(flowFactory, minBackoff, maxBackoff, randomFactor, false, int.MaxValue));
+
+        /// <summary>
+        /// Wrap the given <see cref="Flow"/> with a <see cref="Flow"/> that will restart it when it fails or complete using an exponential
+        /// backoff.
+        /// This <see cref="Flow"/> will not cancel, complete or emit a failure, until the opposite end of it has been cancelled or
+        /// completed.Any termination by the <see cref="Flow"/> before that time will be handled by restarting it. Any termination
+        /// signals sent to this <see cref="Flow"/> however will terminate the wrapped <see cref="Flow"/>, if it's running, and then the <see cref="Flow"/>
+        /// will be allowed to terminate without being restarted.
+        /// The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
+        /// messages. A termination signal from either end of the wrapped <see cref="Flow"/> will cause the other end to be terminated,
+        /// and any in transit messages will be lost. During backoff, this <see cref="Flow"/> will backpressure.
+        /// This uses the same exponential backoff algorithm as <see cref="Akka.Pattern.Backoff"/>.
+        /// </summary>
+        /// <param name="flowFactory">A factory for producing the <see cref="Flow"/>] to wrap.</param>
+        /// <param name="minBackoff">Minimum (initial) duration until the child actor will started again, if it is terminated</param>
+        /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
+        /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
+        /// <param name="maxRestarts">The amount of restarts is capped to this amount within a time frame of minBackoff. Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.</param>
+        public static Flow<TIn, TOut, NotUsed> WithBackoff<TIn, TOut, TMat>(Func<Flow<TIn, TOut, TMat>> flowFactory, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor, int maxRestarts)
+            => Flow.FromGraph(new RestartWithBackoffFlow<TIn, TOut, TMat>(flowFactory, minBackoff, maxBackoff, randomFactor, false, maxRestarts));
 
         /// <summary>
         /// Wrap the given <see cref="Flow"/> with a <see cref="Flow"/> that will restart it when it fails using an exponential
@@ -231,8 +313,29 @@ namespace Akka.Streams.Dsl
         /// <param name="minBackoff">Minimum (initial) duration until the child actor will started again, if it is terminated</param>
         /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
         /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
-        public static Flow<TIn, TOut, NotUsed> OnFailuresWithBackoff<TIn, TOut, TMat>(Func<Flow<TIn, TOut, TMat>> flowFactory, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor) 
-            => Flow.FromGraph(new RestartWithBackoffFlow<TIn, TOut, TMat>(flowFactory, minBackoff, maxBackoff, randomFactor, true));
+        public static Flow<TIn, TOut, NotUsed> OnFailuresWithBackoff<TIn, TOut, TMat>(Func<Flow<TIn, TOut, TMat>> flowFactory, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor)
+            => Flow.FromGraph(new RestartWithBackoffFlow<TIn, TOut, TMat>(flowFactory, minBackoff, maxBackoff, randomFactor, true, int.MaxValue));
+
+        /// <summary>
+        /// Wrap the given <see cref="Flow"/> with a <see cref="Flow"/> that will restart it when it fails using an exponential
+        /// backoff. Notice that this <see cref="Flow"/> will not restart on completion of the wrapped flow. 
+        /// This <see cref="Flow"/> will not emit any failure
+        /// The failures by the wrapped <see cref="Flow"/> will be handled by
+        /// restarting the wrapping <see cref="Flow"/> as long as maxRestarts is not reached.
+        /// Any termination signals sent to this <see cref="Flow"/> however will terminate the wrapped <see cref="Flow"/>, if it's
+        /// running, and then the <see cref="Flow"/> will be allowed to terminate without being restarted. 
+        /// The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
+        /// messages. A termination signal from either end of the wrapped <see cref="Flow"/> will cause the other end to be terminated,
+        /// nd any in transit messages will be lost. During backoff, this <see cref="Flow"/> will backpressure. 
+        /// This uses the same exponential backoff algorithm as <see cref="Akka.Pattern.Backoff"/>.
+        /// </summary>
+        /// <param name="flowFactory">A factory for producing the <see cref="Flow"/>] to wrap.</param>
+        /// <param name="minBackoff">Minimum (initial) duration until the child actor will started again, if it is terminated</param>
+        /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
+        /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
+        /// <param name="maxRestarts">The amount of restarts is capped to this amount within a time frame of minBackoff. Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.</param>
+        public static Flow<TIn, TOut, NotUsed> OnFailuresWithBackoff<TIn, TOut, TMat>(Func<Flow<TIn, TOut, TMat>> flowFactory, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor, int maxRestarts)
+            => Flow.FromGraph(new RestartWithBackoffFlow<TIn, TOut, TMat>(flowFactory, minBackoff, maxBackoff, randomFactor, true, maxRestarts));
     }
 
     internal sealed class RestartWithBackoffFlow<TIn, TOut, TMat> : GraphStage<FlowShape<TIn, TOut>>
@@ -242,19 +345,22 @@ namespace Akka.Streams.Dsl
         public TimeSpan MaxBackoff { get; }
         public double RandomFactor { get; }
         public bool OnlyOnFailures { get; }
+        public int MaxRestarts { get; }
 
         public RestartWithBackoffFlow(
             Func<Flow<TIn, TOut, TMat>> flowFactory,
             TimeSpan minBackoff,
             TimeSpan maxBackoff,
             double randomFactor,
-            bool onlyOnFailures)
+            bool onlyOnFailures,
+            int maxRestarts)
         {
             FlowFactory = flowFactory;
             MinBackoff = minBackoff;
             MaxBackoff = maxBackoff;
             RandomFactor = randomFactor;
             OnlyOnFailures = onlyOnFailures;
+            MaxRestarts = maxRestarts;
             Shape = new FlowShape<TIn, TOut>(In, Out);
         }
 
@@ -266,13 +372,13 @@ namespace Akka.Streams.Dsl
 
         protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes) => new Logic(this, "Flow");
 
-        private class Logic : RestartWithBackoffLogic<FlowShape<TIn, TOut>, TIn, TOut>
+        private sealed class Logic : RestartWithBackoffLogic<FlowShape<TIn, TOut>, TIn, TOut>
         {
             private readonly RestartWithBackoffFlow<TIn, TOut, TMat> _stage;
             private Tuple<SubSourceOutlet<TIn>, SubSinkInlet<TOut>> _activeOutIn;
 
             public Logic(RestartWithBackoffFlow<TIn, TOut, TMat> stage, string name)
-                : base(name, stage.Shape, stage.In, stage.Out, stage.MinBackoff, stage.MaxBackoff, stage.RandomFactor, stage.OnlyOnFailures)
+                : base(name, stage.Shape, stage.In, stage.Out, stage.MinBackoff, stage.MaxBackoff, stage.RandomFactor, stage.OnlyOnFailures, stage.MaxRestarts)
             {
                 _stage = stage;
                 Backoff();
@@ -327,6 +433,7 @@ namespace Akka.Streams.Dsl
         private readonly TimeSpan _maxBackoff;
         private readonly double _randomFactor;
         private readonly bool _onlyOnFailures;
+        private readonly int _maxRestarts;
 
         protected Inlet<TIn> In { get; }
         protected Outlet<TOut> Out { get; }
@@ -345,13 +452,15 @@ namespace Akka.Streams.Dsl
             TimeSpan minBackoff,
             TimeSpan maxBackoff,
             double randomFactor,
-            bool onlyOnFailures) : base(shape)
+            bool onlyOnFailures,
+            int maxRestarts) : base(shape)
         {
             _name = name;
             _minBackoff = minBackoff;
             _maxBackoff = maxBackoff;
             _randomFactor = randomFactor;
             _onlyOnFailures = onlyOnFailures;
+            _maxRestarts = maxRestarts;
 
             _resetDeadline = minBackoff.FromNow();
 
@@ -371,17 +480,17 @@ namespace Akka.Streams.Dsl
                 onPush: () => Push(Out, sinkIn.Grab()),
                 onUpstreamFinish: () =>
                 {
-                    if (_finishing || _onlyOnFailures)
+                    if (_finishing || MaxRestartsReached() || _onlyOnFailures)
                         Complete(Out);
                     else
                     {
-                        Log.Debug("Restarting graph due to finished upstream");
+                        Log.Debug("Restarting graph due to finished upstream"); 
                         ScheduleRestartTimer();
                     }
                 },
                 onUpstreamFailure: ex =>
                 {
-                    if (_finishing)
+                    if (_finishing || MaxRestartsReached())
                         Fail(Out, ex);
                     else
                     {
@@ -390,14 +499,14 @@ namespace Akka.Streams.Dsl
                     }
                 }));
 
-            SetHandler(Out, 
+            SetHandler(Out,
                 onPull: () => sinkIn.Pull(),
                 onDownstreamFinish: () =>
                 {
                     _finishing = true;
                     sinkIn.Cancel();
                 });
-            
+
             return sinkIn;
         }
 
@@ -417,7 +526,7 @@ namespace Akka.Streams.Dsl
                 },
                 onDownstreamFinish: () =>
                 {
-                    if (_finishing || _onlyOnFailures)
+                    if (_finishing || MaxRestartsReached() || _onlyOnFailures)
                         Cancel(In);
                     else
                     {
@@ -427,7 +536,7 @@ namespace Akka.Streams.Dsl
                 }
             ));
 
-            SetHandler(In, 
+            SetHandler(In,
                 onPush: () =>
                 {
                     if (sourceOut.IsAvailable)
@@ -445,6 +554,17 @@ namespace Akka.Streams.Dsl
                 });
 
             return sourceOut;
+        }
+
+        internal bool MaxRestartsReached()
+        {
+            // Check if the last start attempt was more than the minimum backoff
+            if (_resetDeadline.IsOverdue)
+            {
+                Log.Debug($"Last restart attempt was more than {_minBackoff} ago, resetting restart count");
+                _restartCount = 0;
+            }
+            return _restartCount == _maxRestarts;
         }
 
         internal void ScheduleRestartTimer()

--- a/src/core/Akka.Streams/Implementation/Sources.cs
+++ b/src/core/Akka.Streams/Implementation/Sources.cs
@@ -17,6 +17,7 @@ using Akka.Streams.Stage;
 using Akka.Streams.Supervision;
 using Akka.Streams.Util;
 using Akka.Util;
+using Akka.Util.Internal;
 
 namespace Akka.Streams.Implementation
 {
@@ -123,7 +124,7 @@ namespace Akka.Streams.Implementation
                     if (_pendingOffer != null)
                     {
                         Push(_stage.Out, _pendingOffer.Element);
-                        _pendingOffer.CompletionSource.SetResult(QueueOfferResult.Enqueued.Instance);
+                        _pendingOffer.CompletionSource.NonBlockingTrySetResult(QueueOfferResult.Enqueued.Instance);
                         _pendingOffer = null;
                         if (_terminating)
                         {
@@ -153,7 +154,7 @@ namespace Akka.Streams.Implementation
             {
                 if (_pendingOffer != null)
                 {
-                    _pendingOffer.CompletionSource.SetResult(QueueOfferResult.QueueClosed.Instance);
+                    _pendingOffer.CompletionSource.NonBlockingTrySetResult(QueueOfferResult.QueueClosed.Instance);
                     _pendingOffer = null;
                 }
                 _completion.SetResult(new object());
@@ -175,7 +176,7 @@ namespace Akka.Streams.Implementation
                     if (offer != null)
                     {
                         var promise = offer.CompletionSource;
-                        promise.SetException(new IllegalStateException("Stream is terminated. SourceQueue is detached."));
+                        promise.NonBlockingTrySetException(new IllegalStateException("Stream is terminated. SourceQueue is detached."));
                     }
                 });
             }
@@ -183,7 +184,7 @@ namespace Akka.Streams.Implementation
             private void EnqueueAndSuccess(Offer<TOut> offer)
             {
                 _buffer.Enqueue(offer.Element);
-                offer.CompletionSource.SetResult(QueueOfferResult.Enqueued.Instance);
+                offer.CompletionSource.NonBlockingTrySetResult(QueueOfferResult.Enqueued.Instance);
             }
 
             private void BufferElement(Offer<TOut> offer)
@@ -207,18 +208,18 @@ namespace Akka.Streams.Implementation
                             EnqueueAndSuccess(offer);
                             break;
                         case OverflowStrategy.DropNew:
-                            offer.CompletionSource.SetResult(QueueOfferResult.Dropped.Instance);
+                            offer.CompletionSource.NonBlockingTrySetResult(QueueOfferResult.Dropped.Instance);
                             break;
                         case OverflowStrategy.Fail:
                             var bufferOverflowException =
                                 new BufferOverflowException($"Buffer overflow (max capacity was: {_stage._maxBuffer})!");
-                            offer.CompletionSource.SetResult(new QueueOfferResult.Failure(bufferOverflowException));
+                            offer.CompletionSource.NonBlockingTrySetResult(new QueueOfferResult.Failure(bufferOverflowException));
                             _completion.SetException(bufferOverflowException);
                             FailStage(bufferOverflowException);
                             break;
                         case OverflowStrategy.Backpressure:
                             if (_pendingOffer != null)
-                                offer.CompletionSource.SetException(
+                                offer.CompletionSource.NonBlockingTrySetException(
                                     new IllegalStateException(
                                         "You have to wait for previous offer to be resolved to send another request."));
                             else
@@ -245,7 +246,7 @@ namespace Akka.Streams.Implementation
                             else if (IsAvailable(_stage.Out))
                             {
                                 Push(_stage.Out, offer.Element);
-                                offer.CompletionSource.SetResult(QueueOfferResult.Enqueued.Instance);
+                                offer.CompletionSource.NonBlockingTrySetResult(QueueOfferResult.Enqueued.Instance);
                             }
                             else if (_pendingOffer == null)
                                 _pendingOffer = offer;
@@ -255,15 +256,15 @@ namespace Akka.Streams.Implementation
                                 {
                                     case OverflowStrategy.DropHead:
                                     case OverflowStrategy.DropBuffer:
-                                        _pendingOffer.CompletionSource.SetResult(QueueOfferResult.Dropped.Instance);
+                                        _pendingOffer.CompletionSource.NonBlockingTrySetResult(QueueOfferResult.Dropped.Instance);
                                         _pendingOffer = offer;
                                         break;
                                     case OverflowStrategy.DropTail:
                                     case OverflowStrategy.DropNew:
-                                        offer.CompletionSource.SetResult(QueueOfferResult.Dropped.Instance);
+                                        offer.CompletionSource.NonBlockingTrySetResult(QueueOfferResult.Dropped.Instance);
                                         break;
                                     case OverflowStrategy.Backpressure:
-                                        offer.CompletionSource.SetException(
+                                        offer.CompletionSource.NonBlockingTrySetException(
                                             new IllegalStateException(
                                                 "You have to wait for previous offer to be resolved to send another request"));
                                         break;
@@ -271,7 +272,7 @@ namespace Akka.Streams.Implementation
                                         var bufferOverflowException =
                                             new BufferOverflowException(
                                                 $"Buffer overflow (max capacity was: {_stage._maxBuffer})!");
-                                        offer.CompletionSource.SetResult(new QueueOfferResult.Failure(bufferOverflowException));
+                                        offer.CompletionSource.NonBlockingTrySetResult(new QueueOfferResult.Failure(bufferOverflowException));
                                         _completion.SetException(bufferOverflowException);
                                         FailStage(bufferOverflowException);
                                         break;
@@ -331,7 +332,7 @@ namespace Akka.Streams.Implementation
             /// <returns>TBD</returns>
             public Task<IQueueOfferResult> OfferAsync(TOut element)
             {
-                var promise = new TaskCompletionSource<IQueueOfferResult>();
+                var promise = TaskEx.NonBlockingTaskCompletionSource<IQueueOfferResult>(); // new TaskCompletionSource<IQueueOfferResult>();
                 _invokeLogic(new Offer<TOut>(element, promise));
                 return promise.Task;
             }

--- a/src/core/Akka.Tests/Actor/Dispatch/Bug2640Spec.cs
+++ b/src/core/Akka.Tests/Actor/Dispatch/Bug2640Spec.cs
@@ -1,0 +1,123 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="Bug2640Spec.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2019 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2019 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Dispatch;
+using Akka.Routing;
+using Akka.TestKit;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Tests.Actor.Dispatch
+{
+    /// <summary>
+    ///     Bugfix and verification spec for https://github.com/akkadotnet/akka.net/issues/2640
+    ///     Used to verify that the <see cref="ForkJoinExecutor" /> gets properly disposed upon shutdown.
+    /// </summary>
+    public class Bug2640Spec : AkkaSpec
+    {
+        public Bug2640Spec(ITestOutputHelper helper) : base(DispatcherConfig, helper)
+        {
+        }
+
+        private class GetThread
+        {
+            public static readonly GetThread Instance = new GetThread();
+
+            private GetThread()
+            {
+            }
+        }
+
+        /// <summary>
+        ///     Used to pass back data on the current thread.
+        /// </summary>
+        public class ThreadReporterActor : ReceiveActor
+        {
+            public ThreadReporterActor()
+            {
+                Receive<GetThread>(_ => Sender.Tell(Thread.CurrentThread));
+            }
+        }
+
+        public static readonly Config DispatcherConfig = @"
+            myapp{
+                my-pinned-dispatcher {
+                    type = PinnedDispatcher
+                }
+                my-fork-join-dispatcher{
+                    type = ForkJoinDispatcher
+                    throughput = 60
+                    dedicated-thread-pool.thread-count = 4
+                }
+            }
+        ";
+
+        [Fact(DisplayName = "ForkJoinExecutor should terminate all threads upon ActorSystem.Terminate")]
+        public async Task ForkJoinExecutorShouldShutdownUponActorSystemTermination()
+        {
+            var actor = Sys.ActorOf(Props.Create(() => new ThreadReporterActor())
+                .WithDispatcher("myapp.my-fork-join-dispatcher").WithRouter(new RoundRobinPool(4)));
+
+            Dictionary<int, Thread> threads = null;
+            Watch(actor);
+            for (var i = 0; i < 100; i++)
+                actor.Tell(GetThread.Instance);
+
+            threads = ReceiveN(100).Cast<Thread>().GroupBy(x => x.ManagedThreadId)
+                .ToDictionary(x => x.Key, grouping => grouping.First());
+            threads.Count.Should().Be(4, "Expected 4 distinct threads in this example");
+
+            await Sys.Terminate();
+            AwaitAssert(() =>
+                threads.Values.All(x => x.IsAlive == false).Should().BeTrue("All threads should be stopped"));
+        }
+
+        [Fact(DisplayName = "ForkJoinExecutor should terminate all threads upon all attached actors shutting down")]
+        public void ForkJoinExecutorShouldShutdownUponAllActorsTerminating()
+        {
+            var actor = Sys.ActorOf(Props.Create(() => new ThreadReporterActor())
+                .WithDispatcher("myapp.my-fork-join-dispatcher").WithRouter(new RoundRobinPool(4)));
+
+            Dictionary<int, Thread> threads = null;
+            Watch(actor);
+            for (var i = 0; i < 100; i++)
+                actor.Tell(GetThread.Instance);
+
+            threads = ReceiveN(100).Cast<Thread>().GroupBy(x => x.ManagedThreadId)
+                .ToDictionary(x => x.Key, grouping => grouping.First());
+            threads.Count.Should().Be(4, "Expected 4 distinct threads in this example");
+
+            Sys.Stop(actor);
+            ExpectTerminated(actor);
+            AwaitAssert(() =>
+                threads.Values.All(x => x.IsAlive == false).Should().BeTrue("All threads should be stopped"));
+        }
+
+        [Fact(DisplayName = "PinnedDispatcher should terminate its thread upon actor shutdown")]
+        public void PinnedDispatcherShouldShutdownUponActorTermination()
+        {
+            var actor = Sys.ActorOf(Props.Create(() => new ThreadReporterActor())
+                .WithDispatcher("myapp.my-pinned-dispatcher"));
+
+            Watch(actor);
+            actor.Tell(GetThread.Instance);
+            var thread = ExpectMsg<Thread>();
+            thread.IsAlive.Should().BeTrue();
+
+            Sys.Stop(actor);
+            ExpectTerminated(actor);
+            AwaitCondition(() => !thread.IsAlive); // wait for thread to terminate
+        }
+    }
+}

--- a/src/core/Akka.Tests/Dispatch/DispatchersSpec.cs
+++ b/src/core/Akka.Tests/Dispatch/DispatchersSpec.cs
@@ -60,9 +60,11 @@ namespace Akka.Tests.Dispatch
             "); }
         }
 
+        #endregion
+
         public DispatchersSpec() : base(DispatcherConfiguration) { }
 
-        #endregion
+        
 
         #region Tests
 

--- a/src/core/Akka.Tests/Pattern/BackoffSupervisorSpec.cs
+++ b/src/core/Akka.Tests/Pattern/BackoffSupervisorSpec.cs
@@ -6,12 +6,14 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
 using Akka.Actor;
 using Akka.Pattern;
 using Akka.TestKit;
-using Xunit;
 using FluentAssertions;
-using System.Threading;
+using Xunit;
 
 namespace Akka.Tests.Pattern
 {
@@ -75,10 +77,10 @@ namespace Akka.Tests.Pattern
             }
         }
 
-        private BackoffOptions OnStopOptions() => OnStopOptions(Child.Props(TestActor));
-        private BackoffOptions OnStopOptions(Props props) => Backoff.OnStop(props, "c1", 100.Milliseconds(), 3.Seconds(), 0.2);
-        private BackoffOptions OnFailureOptions() => OnFailureOptions(Child.Props(TestActor));
-        private BackoffOptions OnFailureOptions(Props props) => Backoff.OnFailure(props, "c1", 100.Milliseconds(), 3.Seconds(), 0.2);
+        private BackoffOptions OnStopOptions(int maxNrOfRetries = -1) => OnStopOptions(Child.Props(TestActor), maxNrOfRetries);
+        private BackoffOptions OnStopOptions(Props props, int maxNrOfRetries = -1) => Backoff.OnStop(props, "c1", 100.Milliseconds(), 3.Seconds(), 0.2, maxNrOfRetries);
+        private BackoffOptions OnFailureOptions(int maxNrOfRetries = -1) => OnFailureOptions(Child.Props(TestActor), maxNrOfRetries);
+        private BackoffOptions OnFailureOptions(Props props, int maxNrOfRetries = -1) => Backoff.OnFailure(props, "c1", 100.Milliseconds(), 3.Seconds(), 0.2, maxNrOfRetries);
         private IActorRef Create(BackoffOptions options) => Sys.ActorOf(BackoffSupervisor.Props(options));
         #endregion
 
@@ -256,6 +258,185 @@ namespace Akka.Tests.Pattern
                     Create(OnFailureOptions(ManualChild.Props(TestActor))
                         .WithManualReset()
                         .WithSupervisorStrategy(restartingStrategy)));
+            });
+        }
+
+        [Fact]
+        public void BackoffSupervisor_reply_to_sender_if_replyWhileStopped_is_specified()
+        {
+            EventFilter.Exception<TestException>().Expect(1, () =>
+            {
+                var supervisor = Create(Backoff.OnFailure(Child.Props(TestActor), "c1", TimeSpan.FromSeconds(100), TimeSpan.FromSeconds(300), 0.2, -1)
+                    .WithReplyWhileStopped("child was stopped"));
+                supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
+
+                var c1 = ExpectMsg<BackoffSupervisor.CurrentChild>().Ref;
+                Watch(c1);
+                supervisor.Tell(BackoffSupervisor.GetRestartCount.Instance);
+                ExpectMsg<BackoffSupervisor.RestartCount>().Count.Should().Be(0);
+
+                c1.Tell("boom");
+                ExpectTerminated(c1);
+
+                AwaitAssert(() =>
+                {
+                    supervisor.Tell(BackoffSupervisor.GetRestartCount.Instance);
+                    ExpectMsg<BackoffSupervisor.RestartCount>().Count.Should().Be(1);
+                });
+
+                supervisor.Tell("boom");
+                ExpectMsg("child was stopped");
+            });
+        }
+
+        [Fact]
+        public void BackoffSupervisor_not_reply_to_sender_if_replyWhileStopped_is_not_specified()
+        {
+            EventFilter.Exception<TestException>().Expect(1, () =>
+            {
+                var supervisor = Create(Backoff.OnFailure(Child.Props(TestActor), "c1", TimeSpan.FromSeconds(100), TimeSpan.FromSeconds(300), 0.2, -1));
+                supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
+
+                var c1 = ExpectMsg<BackoffSupervisor.CurrentChild>().Ref;
+                Watch(c1);
+                supervisor.Tell(BackoffSupervisor.GetRestartCount.Instance);
+                ExpectMsg<BackoffSupervisor.RestartCount>().Count.Should().Be(0);
+
+                c1.Tell("boom");
+                ExpectTerminated(c1);
+
+                AwaitAssert(() =>
+                {
+                    supervisor.Tell(BackoffSupervisor.GetRestartCount.Instance);
+                    ExpectMsg<BackoffSupervisor.RestartCount>().Count.Should().Be(1);
+                });
+
+                supervisor.Tell("boom"); //this will be sent to deadLetters
+                ExpectNoMsg(500);
+            });
+        }
+
+        [Theory, ClassData(typeof(DelayTable))]
+        public void BackoffSupervisor_correctly_calculate_the_delay(int restartCount, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor, TimeSpan expectedResult)
+        {
+            Assert.Equal(expectedResult, BackoffSupervisor.CalculateDelay(restartCount, minBackoff, maxBackoff, randomFactor));
+        }
+
+        internal class DelayTable : IEnumerable<object[]>
+        {
+            private readonly List<object[]> delayTable = new List<object[]>
+            {
+                new object[] { 0, TimeSpan.Zero, TimeSpan.Zero, 0.0, TimeSpan.Zero },
+                new object[] { 0, TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(7), 0d, TimeSpan.FromMinutes(5) },
+                new object[] { 2, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(7), 0d, TimeSpan.FromSeconds(7) },
+                new object[] { 2, TimeSpan.FromSeconds(5), TimeSpan.FromDays(7), 0d, TimeSpan.FromSeconds(20) },
+                new object[] { 29, TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(10), 0d, TimeSpan.FromMinutes(10) },
+                new object[] { 29, TimeSpan.FromDays(10000), TimeSpan.FromDays(10000), 0d, TimeSpan.FromDays(10000) },
+                new object[] { int.MaxValue, TimeSpan.FromDays(10000), TimeSpan.FromDays(10000), 0d, TimeSpan.FromDays(10000) }
+            };
+
+            public IEnumerator<object[]> GetEnumerator() => delayTable.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        [Fact]
+        public void BackoffSupervisor_stop_restarting_the_child_after_reaching_maxNrOfRetries_limit_using_BackOff_OnStop()
+        {
+            var supervisor = Create(OnStopOptions(maxNrOfRetries: 2));
+
+            IActorRef WaitForChild()
+            {
+                AwaitCondition(() =>
+                {
+                    supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
+                    var c = ExpectMsg<BackoffSupervisor.CurrentChild>().Ref;
+                    return !c.IsNobody();
+                }, TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(50));
+
+                supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
+                return ExpectMsg<BackoffSupervisor.CurrentChild>().Ref;
+            }
+
+            Watch(supervisor);
+
+            supervisor.Tell(BackoffSupervisor.GetRestartCount.Instance);
+            ExpectMsg<BackoffSupervisor.RestartCount>().Count.Should().Be(0);
+
+            supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
+            var c1 = ExpectMsg<BackoffSupervisor.CurrentChild>().Ref;
+            Watch(c1);
+            c1.Tell(PoisonPill.Instance);
+            ExpectTerminated(c1);
+
+            supervisor.Tell(BackoffSupervisor.GetRestartCount.Instance);
+            ExpectMsg<BackoffSupervisor.RestartCount>().Count.Should().Be(1);
+
+            var c2 = WaitForChild();
+            AwaitAssert(() => c2.ShouldNotBe(c1));
+            Watch(c2);
+            c2.Tell(PoisonPill.Instance);
+            ExpectTerminated(c2);
+
+            supervisor.Tell(BackoffSupervisor.GetRestartCount.Instance);
+            ExpectMsg<BackoffSupervisor.RestartCount>().Count.Should().Be(2);
+
+            var c3 = WaitForChild();
+            AwaitAssert(() => c3.ShouldNotBe(c2));
+            Watch(c3);
+            c3.Tell(PoisonPill.Instance);
+            ExpectTerminated(c3);
+            ExpectTerminated(supervisor);
+        }
+
+        [Fact]
+        public void BackoffSupervisor_stop_restarting_the_child_after_reaching_maxNrOfRetries_limit_using_BackOff_OnFailure()
+        {
+            EventFilter.Exception<TestException>().Expect(3, () =>
+            {
+                var supervisor = Create(OnFailureOptions(maxNrOfRetries: 2));
+
+                IActorRef WaitForChild()
+                {
+                    AwaitCondition(() =>
+                    {
+                        supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
+                        var c = ExpectMsg<BackoffSupervisor.CurrentChild>().Ref;
+                        return !c.IsNobody();
+                    }, TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(50));
+
+                    supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
+                    return ExpectMsg<BackoffSupervisor.CurrentChild>().Ref;
+                }
+
+                Watch(supervisor);
+
+                supervisor.Tell(BackoffSupervisor.GetRestartCount.Instance);
+                ExpectMsg<BackoffSupervisor.RestartCount>().Count.Should().Be(0);
+
+                supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
+                var c1 = ExpectMsg<BackoffSupervisor.CurrentChild>().Ref;
+                Watch(c1);
+                c1.Tell("boom");
+                ExpectTerminated(c1);
+
+                supervisor.Tell(BackoffSupervisor.GetRestartCount.Instance);
+                ExpectMsg<BackoffSupervisor.RestartCount>().Count.Should().Be(1);
+
+                var c2 = WaitForChild();
+                AwaitAssert(() => c2.ShouldNotBe(c1));
+                Watch(c2);
+                c2.Tell("boom");
+                ExpectTerminated(c2);
+
+                supervisor.Tell(BackoffSupervisor.GetRestartCount.Instance);
+                ExpectMsg<BackoffSupervisor.RestartCount>().Count.Should().Be(2);
+
+                var c3 = WaitForChild();
+                AwaitAssert(() => c3.ShouldNotBe(c2));
+                Watch(c3);
+                c3.Tell("boom");
+                ExpectTerminated(c3);
+                ExpectTerminated(supervisor);
             });
         }
     }

--- a/src/core/Akka/Actor/ActorRef.Extensions.cs
+++ b/src/core/Akka/Actor/ActorRef.Extensions.cs
@@ -5,6 +5,8 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
+
 namespace Akka.Actor
 {
     /// <summary>
@@ -22,6 +24,17 @@ namespace Akka.Actor
         public static bool IsNobody(this IActorRef actorRef)
         {
             return actorRef == null || actorRef is Nobody || actorRef is DeadLetterActorRef;
+        }
+
+        /// <summary>
+        /// Returns the <paramref name="actorRef"/>'s value if it's not <see langword="null"/>, <see cref="Nobody"/>, 
+        /// or <see cref="DeadLetterActorRef"/>. Otherwise return the result of evaluating `elseValue`.
+        /// </summary>
+        /// <param name="actorRef">The actor that is being tested.</param>
+        /// <param name="elseValue">TBD</param>
+        public static IActorRef GetOrElse(this IActorRef actorRef, Func<IActorRef> elseValue)
+        {
+            return actorRef.IsNobody() ? elseValue() : actorRef;
         }
     }
 }

--- a/src/core/Akka/Actor/Scheduler/HashedWheelTimerScheduler.cs
+++ b/src/core/Akka/Actor/Scheduler/HashedWheelTimerScheduler.cs
@@ -387,7 +387,28 @@ namespace Akka.Actor
                 return;
             }
 
-            // todo: log unprocessed scheduler registrations?
+            // Execute all outstanding work items
+            foreach (var task in stopped.Result)
+            {
+                try
+                {
+                    task.Action.Run();
+                }
+                catch (SchedulerException)
+                {
+                    // ignore, this is from terminated actors
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Exception while executing timer task.");
+                }
+                finally
+                {
+                    // free the object from bucket
+                    task.Reset();
+                }
+            }
+            
             _unprocessedRegistrations.Clear();
         }
 

--- a/src/core/Akka/Actor/SupervisorStrategy.cs
+++ b/src/core/Akka/Actor/SupervisorStrategy.cs
@@ -371,6 +371,11 @@ namespace Akka.Actor
         {
         }
 
+        public OneForOneStrategy WithMaxNrOfRetries(int maxNrOfRetries)
+        {
+            return new OneForOneStrategy(maxNrOfRetries, _withinTimeRangeMilliseconds, _decider);
+        }
+
         /// <summary>
         /// Determines which <see cref="Directive"/> this strategy uses to handle <paramref name="exception">exceptions</paramref>
         /// that occur in the <paramref name="child"/> actor.

--- a/src/core/Akka/Dispatch/Mailboxes.cs
+++ b/src/core/Akka/Dispatch/Mailboxes.cs
@@ -283,7 +283,7 @@ namespace Akka.Dispatch
                 if (hasMailboxRequirement && !mailboxRequirement.IsAssignableFrom(mqType.Value))
                     throw new ArgumentException($"produced message queue type [{mqType.Value}] does not fulfill requirement for dispatcher [{id}]." + $"Must be a subclass of [{mailboxRequirement}]");
                 if (HasRequiredType(actorType) && !actorRequirement.Value.IsAssignableFrom(mqType.Value))
-                    throw new ArgumentException($"produced message queue type of [{mqType.Value}] does not fulfill requirement for actor class [{actorType}]." + $"Must be a subclass of [{mqType.Value}]");
+                    throw new ArgumentException($"produced message queue type of [{mqType.Value}] does not fulfill requirement for actor class [{actorType}]." + $"Must be a subclass of [{actorRequirement.Value}]");
                 return mailboxType;
             }
 

--- a/src/core/Akka/Pattern/BackoffOnRestartSupervisor.cs
+++ b/src/core/Akka/Pattern/BackoffOnRestartSupervisor.cs
@@ -11,6 +11,10 @@ using Akka.Event;
 
 namespace Akka.Pattern
 {
+    /// <summary>
+    /// Back-off supervisor that stops and starts a child actor when the child actor restarts. 
+    /// This back-off supervisor is created by using <see cref="BackoffSupervisor.Props"/> with <see cref="Backoff.OnFailure"/>
+    /// </summary>
     internal sealed class BackoffOnRestartSupervisor : BackoffSupervisorBase
     {
         private readonly TimeSpan _minBackoff;
@@ -26,7 +30,8 @@ namespace Akka.Pattern
             TimeSpan maxBackoff,
             IBackoffReset reset,
             double randomFactor,
-            OneForOneStrategy strategy) : base(childProps, childName, reset)
+            OneForOneStrategy strategy,
+            object replyWhileStopped = null) : base(childProps, childName, reset, replyWhileStopped)
         {
             _minBackoff = minBackoff;
             _maxBackoff = maxBackoff;

--- a/src/core/Akka/Pattern/BackoffOnRestartSupervisor.cs
+++ b/src/core/Akka/Pattern/BackoffOnRestartSupervisor.cs
@@ -31,7 +31,8 @@ namespace Akka.Pattern
             IBackoffReset reset,
             double randomFactor,
             OneForOneStrategy strategy,
-            object replyWhileStopped = null) : base(childProps, childName, reset, replyWhileStopped)
+            object replyWhileStopped = null,
+            Func<object, bool> finalStopMessage = null) : base(childProps, childName, reset, replyWhileStopped, finalStopMessage)
         {
             _minBackoff = minBackoff;
             _maxBackoff = maxBackoff;
@@ -89,22 +90,22 @@ namespace Akka.Pattern
 
         private bool WaitChildTerminatedBeforeBackoff(object message, IActorRef childRef)
         {
-            var terminated = message as Terminated;
-            if (terminated != null && terminated.ActorRef.Equals(childRef))
+            switch (message)
             {
-                Become(Receive);
-                Child = null;
-                var restartDelay = BackoffSupervisor.CalculateDelay(RestartCountN, _minBackoff, _maxBackoff, _randomFactor);
-                Context.System.Scheduler.ScheduleTellOnce(restartDelay, Self, BackoffSupervisor.StartChild.Instance, Self);
-                RestartCountN++;
-            }
-            else if (message is BackoffSupervisor.StartChild)
-            {
-                // Ignore it, we will schedule a new one once current child terminated.
-            }
-            else
-            {
-                return false;
+                case Terminated terminated when terminated.ActorRef.Equals(childRef):
+                {
+                    Become(Receive);
+                    Child = null;
+                    var restartDelay = BackoffSupervisor.CalculateDelay(RestartCountN, _minBackoff, _maxBackoff, _randomFactor);
+                    Context.System.Scheduler.ScheduleTellOnce(restartDelay, Self, BackoffSupervisor.StartChild.Instance, Self);
+                    RestartCountN++;
+                    break;
+                }
+                case BackoffSupervisor.StartChild _:
+                    // Ignore it, we will schedule a new one once current child terminated.
+                    break;
+                default:
+                    return false;
             }
 
             return true;
@@ -112,8 +113,7 @@ namespace Akka.Pattern
 
         private bool OnTerminated(object message)
         {
-            var terminated = message as Terminated;
-            if (terminated != null && terminated.ActorRef.Equals(Child))
+            if (message is Terminated terminated && terminated.ActorRef.Equals(Child))
             {
                 _log.Debug($"Terminating, because child {Child} terminated itself");
                 Context.Stop(Self);

--- a/src/core/Akka/Pattern/BackoffOptions.cs
+++ b/src/core/Akka/Pattern/BackoffOptions.cs
@@ -11,7 +11,7 @@ using Akka.Actor;
 namespace Akka.Pattern
 {
     /// <summary>
-    /// Builds back-off options for creating a back-off supervisor. You can pass <see cref="Akka.Pattern.BackoffOptions"/> to <see cref="Akka.Pattern.BackoffSupervisor.Props(BackoffOptions)"/>.
+    /// Builds back-off options for creating a back-off supervisor. You can pass <see cref="BackoffOptions"/> to <see cref="BackoffSupervisor.Props"/>.
     /// </summary>
     public static class Backoff
     {
@@ -23,9 +23,25 @@ namespace Akka.Pattern
         /// <param name="minBackoff">Minimum (initial) duration until the child actor will started again, if it is terminated</param>
         /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
         /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
+        [Obsolete("Use the overloaded one which accepts maxNrOfRetries instead.")]
         public static BackoffOptions OnFailure(Props childProps, string childName, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor)
         {
-            return new BackoffOptionsImpl(RestartImpliesFailure.Instance, childProps, childName, minBackoff, maxBackoff, randomFactor);
+            return OnFailure(childProps, childName, minBackoff, maxBackoff, randomFactor, -1);
+        }
+
+        /// <summary>
+        /// Back-off options for creating a back-off supervisor actor that expects a child actor to restart on failure.
+        /// </summary>
+        /// <param name="childProps">The <see cref="Akka.Actor.Props"/> of the child actor that will be started and supervised</param>
+        /// <param name="childName">Name of the child actor</param>
+        /// <param name="minBackoff">Minimum (initial) duration until the child actor will started again, if it is terminated</param>
+        /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
+        /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
+        /// <param name="maxNrOfRetries">Maximum number of attempts to restart the child actor. The supervisor will terminate itself after the maxNoOfRetries is reached. In order to restart infinitely pass in `-1`</param>
+        public static BackoffOptions OnFailure(Props childProps, string childName, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor, int maxNrOfRetries)
+        {
+            return new BackoffOptionsImpl(RestartImpliesFailure.Instance, childProps, childName, minBackoff, maxBackoff, randomFactor)
+                .WithMaxNrOfRetries(maxNrOfRetries);
         }
 
         /// <summary>
@@ -36,9 +52,25 @@ namespace Akka.Pattern
         /// <param name="minBackoff">Minimum (initial) duration until the child actor will started again, if it is terminated</param>
         /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
         /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
+        [Obsolete("Use the overloaded one which accepts maxNrOfRetries instead.")]
         public static BackoffOptions OnStop(Props childProps, string childName, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor)
         {
-            return new BackoffOptionsImpl(StopImpliesFailure.Instance, childProps, childName, minBackoff, maxBackoff, randomFactor);
+            return OnStop(childProps, childName, minBackoff, maxBackoff, randomFactor, -1);
+        }
+
+        /// <summary>
+        /// Back-off options for creating a back-off supervisor actor that expects a child actor to stop on failure.
+        /// </summary>
+        /// <param name="childProps">The <see cref="Akka.Actor.Props"/> of the child actor that will be started and supervised</param>
+        /// <param name="childName">Name of the child actor</param>
+        /// <param name="minBackoff">Minimum (initial) duration until the child actor will started again, if it is terminated</param>
+        /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
+        /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
+        /// <param name="maxNrOfRetries">Maximum number of attempts to restart the child actor. The supervisor will terminate itself after the maxNoOfRetries is reached. In order to restart infinitely pass in `-1`</param>
+        public static BackoffOptions OnStop(Props childProps, string childName, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor, int maxNrOfRetries)
+        {
+            return new BackoffOptionsImpl(StopImpliesFailure.Instance, childProps, childName, minBackoff, maxBackoff, randomFactor)
+                .WithMaxNrOfRetries(maxNrOfRetries);
         }
     }
 
@@ -67,6 +99,19 @@ namespace Akka.Pattern
         public abstract BackoffOptions WithDefaultStoppingStrategy();
 
         /// <summary>
+        /// Returns a new BackoffOptions with a constant reply to messages that the supervisor receives while its child is stopped. By default, a message received while the child is stopped is forwarded to `deadLetters`. With this option, the supervisor will reply to the sender instead.
+        /// </summary>
+        /// <param name="replyWhileStopped">The message that the supervisor will send in response to all messages while its child is stopped.</param>
+        public abstract BackoffOptions WithReplyWhileStopped(object replyWhileStopped);
+
+        /// <summary>
+        /// Returns a new BackoffOptions with a maximum number of retries to restart the child actor. By default, the supervisor will retry infinitely. With this option, the supervisor will terminate itself after the maxNoOfRetries is reached.
+        /// </summary>
+        /// <param name="maxNrOfRetries">The number of times a child actor is allowed to be restarted, negative value means no limit, if the limit is exceeded the child actor is stopped</param>
+        /// <returns></returns>
+        public abstract BackoffOptions WithMaxNrOfRetries(int maxNrOfRetries);
+
+        /// <summary>
         /// Returns the props to create the back-off supervisor.
         /// </summary>
         internal abstract Props Props { get; }
@@ -82,13 +127,14 @@ namespace Akka.Pattern
         private readonly double _randomFactor;
         private readonly IBackoffReset _reset;
         private readonly OneForOneStrategy _strategy;
+        private readonly object _replyWhileStopped;
 
         public BackoffOptionsImpl(IBackoffType backoffType, Props childProps, string childName, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor, IBackoffReset reset = null) 
             : this(backoffType, childProps, childName, minBackoff, maxBackoff, randomFactor, reset, new OneForOneStrategy(SupervisorStrategy.DefaultDecider))
         {
         }
 
-        public BackoffOptionsImpl(IBackoffType backoffType, Props childProps, string childName, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor, IBackoffReset reset, OneForOneStrategy strategy)
+        public BackoffOptionsImpl(IBackoffType backoffType, Props childProps, string childName, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor, IBackoffReset reset, OneForOneStrategy strategy, object replyWhileStopped = null)
         {
             _backoffType = backoffType ?? RestartImpliesFailure.Instance;
             _childProps = childProps;
@@ -98,42 +144,49 @@ namespace Akka.Pattern
             _randomFactor = randomFactor;
             _reset = reset ?? new AutoReset(_minBackoff);
             _strategy = strategy;
+            _replyWhileStopped = replyWhileStopped;
         }
 
         public override BackoffOptions WithAutoReset(TimeSpan resetBackoff)
         {
-            return new BackoffOptionsImpl(_backoffType, _childProps, _childName, _minBackoff, _maxBackoff, _randomFactor, new AutoReset(resetBackoff), _strategy);
+            return new BackoffOptionsImpl(_backoffType, _childProps, _childName, _minBackoff, _maxBackoff, _randomFactor, new AutoReset(resetBackoff), _strategy, _replyWhileStopped);
         }
 
         public override BackoffOptions WithManualReset()
         {
-            return new BackoffOptionsImpl(_backoffType, _childProps, _childName, _minBackoff, _maxBackoff, _randomFactor, new ManualReset(), _strategy);
+            return new BackoffOptionsImpl(_backoffType, _childProps, _childName, _minBackoff, _maxBackoff, _randomFactor, new ManualReset(), _strategy, _replyWhileStopped);
         }
 
         public override BackoffOptions WithSupervisorStrategy(OneForOneStrategy supervisorStrategy)
         {
-            return new BackoffOptionsImpl(_backoffType, _childProps, _childName, _minBackoff, _maxBackoff, _randomFactor, _reset, supervisorStrategy);
+            return new BackoffOptionsImpl(_backoffType, _childProps, _childName, _minBackoff, _maxBackoff, _randomFactor, _reset, supervisorStrategy, _replyWhileStopped);
         }
 
         public override BackoffOptions WithDefaultStoppingStrategy()
         {
-            return new BackoffOptionsImpl(_backoffType, _childProps, _childName, _minBackoff, _maxBackoff, _randomFactor, _reset, SupervisorStrategy.StoppingStrategy);
+            return new BackoffOptionsImpl(_backoffType, _childProps, _childName, _minBackoff, _maxBackoff, _randomFactor, _reset, new OneForOneStrategy(_strategy.MaxNumberOfRetries, null, SupervisorStrategy.StoppingStrategy.Decider), _replyWhileStopped);            
+        }
+
+        public override BackoffOptions WithReplyWhileStopped(object replyWhileStopped)
+        {
+            return new BackoffOptionsImpl(_backoffType, _childProps, _childName, _minBackoff, _maxBackoff, _randomFactor, _reset, _strategy, replyWhileStopped);
+        }
+
+        public override BackoffOptions WithMaxNrOfRetries(int maxNrOfRetries)
+        {
+            return new BackoffOptionsImpl(_backoffType, _childProps, _childName, _minBackoff, _maxBackoff, _randomFactor, _reset, _strategy.WithMaxNrOfRetries(maxNrOfRetries), _replyWhileStopped);
         }
 
         internal override Props Props
         {
             get
             {
-                if (_minBackoff <= TimeSpan.Zero)
-                    throw new ArgumentException("MinBackoff must be greater than 0");
-                if (_maxBackoff < _minBackoff)
-                    throw new ArgumentException("MaxBackoff must be greater than MinBackoff");
-                if (_randomFactor < 0.0 || _randomFactor > 1.0)
-                    throw new ArgumentException("RandomFactor must be between 0.0 and 1.0");
+                if (_minBackoff <= TimeSpan.Zero) throw new ArgumentException("MinBackoff must be greater than 0");
+                if (_maxBackoff < _minBackoff) throw new ArgumentException("MaxBackoff must be greater than MinBackoff");
+                if (_randomFactor < 0.0 || _randomFactor > 1.0) throw new ArgumentException("RandomFactor must be between 0.0 and 1.0");
                 
-                if (_reset is AutoReset)
+                if (_reset is AutoReset autoReset)
                 {
-                    var autoReset = (AutoReset)_reset;
                     if (_minBackoff > autoReset.ResetBackoff && autoReset.ResetBackoff > _maxBackoff)
                         throw new ArgumentException();
                 }
@@ -142,19 +195,14 @@ namespace Akka.Pattern
                     // ignore
                 }
 
-                if (_backoffType is RestartImpliesFailure)
+                switch (_backoffType)
                 {
-                    return Props.Create(
-                         () => new BackoffOnRestartSupervisor(_childProps, _childName, _minBackoff, _maxBackoff, _reset, _randomFactor, _strategy));
-                }
-                else if (_backoffType is StopImpliesFailure)
-                {
-                    return Props.Create(
-                        () => new BackoffSupervisor(_childProps, _childName, _minBackoff, _maxBackoff, _reset, _randomFactor, _strategy));
-                }
-                else
-                {
-                    return Props.Empty;
+                    case RestartImpliesFailure _:
+                        return Props.Create(() => new BackoffOnRestartSupervisor(_childProps, _childName, _minBackoff, _maxBackoff, _reset, _randomFactor, _strategy, _replyWhileStopped));
+                    case StopImpliesFailure _:
+                        return Props.Create(() => new BackoffSupervisor(_childProps, _childName, _minBackoff, _maxBackoff, _reset, _randomFactor, _strategy, _replyWhileStopped));
+                    default:
+                        return Props.Empty;
                 }
             }
         }

--- a/src/core/Akka/Pattern/BackoffSupervisor.cs
+++ b/src/core/Akka/Pattern/BackoffSupervisor.cs
@@ -6,9 +6,11 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.ComponentModel;
 using Akka.Actor;
 using Akka.Event;
 using Akka.Util;
+using Akka.Util.Internal;
 
 namespace Akka.Pattern
 {
@@ -124,7 +126,8 @@ namespace Akka.Pattern
             TimeSpan maxBackoff,
             IBackoffReset reset,
             double randomFactor,
-            SupervisorStrategy strategy) : base(childProps, childName, reset)
+            SupervisorStrategy strategy,
+            object replyWhileStopped = null) : base(childProps, childName, reset, replyWhileStopped)
         {
             _minBackoff = minBackoff;
             _maxBackoff = maxBackoff;
@@ -144,13 +147,22 @@ namespace Akka.Pattern
 
         private bool OnTerminated(object message)
         {
-            var terminated = message as Terminated;
-            if (terminated != null && terminated.ActorRef.Equals(Child))
+            if (message is Terminated terminated && terminated.ActorRef.Equals(Child))
             {
                 Child = null;
-                var restartDelay = CalculateDelay(RestartCountN, _minBackoff, _maxBackoff, _randomFactor);
-                Context.System.Scheduler.ScheduleTellOnce(restartDelay, Self, StartChild.Instance, Self);
-                RestartCountN++;
+                var maxNrOfRetries = _strategy is OneForOneStrategy oneForOne ? oneForOne.MaxNumberOfRetries : -1;
+                var nextRestartCount = RestartCountN + 1;
+                if (maxNrOfRetries == -1 || nextRestartCount <= maxNrOfRetries)
+                {
+                    var restartDelay = CalculateDelay(RestartCountN, _minBackoff, _maxBackoff, _randomFactor);
+                    Context.System.Scheduler.ScheduleTellOnce(restartDelay, Self, StartChild.Instance, Self);
+                    RestartCountN = nextRestartCount;
+                }
+                else
+                {
+                    Log.Debug($"Terminating on restart #{nextRestartCount} which exceeds max allowed restarts ({maxNrOfRetries})");
+                    Context.Stop(Self);
+                }
                 return true;
             }
 
@@ -172,8 +184,36 @@ namespace Akka.Pattern
             TimeSpan maxBackoff,
             double randomFactor)
         {
-            return PropsWithSupervisorStrategy(childProps, childName, minBackoff, maxBackoff, randomFactor,
-                Actor.SupervisorStrategy.DefaultStrategy);
+            return PropsWithSupervisorStrategy(childProps, childName, minBackoff, maxBackoff, randomFactor, Actor.SupervisorStrategy.DefaultStrategy);
+        }
+
+        /// <summary>
+        /// Props for creating a <see cref="BackoffSupervisor"/> actor.
+        /// 
+        /// Exceptions in the child are handled with the default supervision strategy, i.e.
+        /// most exceptions will immediately restart the child. You can define another
+        /// supervision strategy by using [[#propsWithSupervisorStrategy]].
+        /// </summary>
+        /// <param name="childProps">The <see cref="Akka.Actor.Props"/> of the child actor that will be started and supervised</param>
+        /// <param name="childName">Name of the child actor</param>
+        /// <param name="minBackoff">Minimum (initial) duration until the child actor will started again, if it is terminated</param>
+        /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
+        /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
+        /// <param name="maxNrOfRetries">Maximum number of attempts to restart the child actor. The supervisor will terminate itself after the maxNoOfRetries is reached. In order to restart infinitely pass in `-1`.</param>
+        /// <returns></returns>
+        public static Props Props(
+            Props childProps,
+            string childName,
+            TimeSpan minBackoff,
+            TimeSpan maxBackoff,
+            double randomFactor,
+            int maxNrOfRetries)
+        {
+            var supervisionStrategy = Actor.SupervisorStrategy.DefaultStrategy is OneForOneStrategy oneForOne
+                ? oneForOne.WithMaxNrOfRetries(maxNrOfRetries)
+                : Actor.SupervisorStrategy.DefaultStrategy;
+
+            return PropsWithSupervisorStrategy(childProps, childName, minBackoff, maxBackoff, randomFactor, supervisionStrategy);
         }
 
         /// <summary>
@@ -203,10 +243,13 @@ namespace Akka.Pattern
             double randomFactor,
             SupervisorStrategy strategy)
         {
-             return Actor.Props.Create(
-                () => new BackoffSupervisor(childProps, childName, minBackoff, maxBackoff, new AutoReset(minBackoff), randomFactor, strategy));
+            return Actor.Props.Create(
+               () => new BackoffSupervisor(childProps, childName, minBackoff, maxBackoff, new AutoReset(minBackoff), randomFactor, strategy, null));
         }
 
+        /// <summary>
+        /// Calculates an exponential back off delay.
+        /// </summary>
         internal static TimeSpan CalculateDelay(
             int restartCount,
             TimeSpan minBackoff,
@@ -214,22 +257,8 @@ namespace Akka.Pattern
             double randomFactor)
         {
             var rand = 1.0 + ThreadLocalRandom.Current.NextDouble() * randomFactor;
-            if (restartCount >= 30)
-            {
-                return maxBackoff; // duration overflow protection (> 100 years)
-            }
-            else
-            {
-                var max = Math.Min(maxBackoff.Ticks, minBackoff.Ticks * Math.Pow(2, restartCount)) * rand;
-                if (max >= double.MaxValue)
-                {
-                    return maxBackoff;
-                }
-                else
-                {
-                    return new TimeSpan((long)max);
-                }
-            }
+            var calculateDuration = Math.Min(maxBackoff.Ticks, minBackoff.Ticks * Math.Pow(2, restartCount)) * rand;
+            return calculateDuration < 0d || calculateDuration >= long.MaxValue ? maxBackoff : new TimeSpan((long)calculateDuration);
         }
     }
 }

--- a/src/core/Akka/Pattern/BackoffSupervisorBase.cs
+++ b/src/core/Akka/Pattern/BackoffSupervisorBase.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using Akka.Actor;
+using Akka.Event;
 
 namespace Akka.Pattern
 {
@@ -14,18 +15,23 @@ namespace Akka.Pattern
     /// </summary>
     public abstract class BackoffSupervisorBase : ActorBase
     {
-        internal BackoffSupervisorBase(Props childProps, string childName, IBackoffReset reset)
+        internal BackoffSupervisorBase(Props childProps, string childName, IBackoffReset reset, object replyWhileStopped = null)
         {
             ChildProps = childProps;
             ChildName = childName;
             Reset = reset;
+            ReplyWhileStopped = replyWhileStopped;
+            Log = Logging.GetLogger(Context.System, GetType());
         }
 
         protected Props ChildProps { get; }
         protected string ChildName { get; }
         protected IBackoffReset Reset { get; }
-        protected IActorRef Child { get; set; } = null;
-        protected int RestartCountN { get; set; } = 0;
+        protected object ReplyWhileStopped { get; }
+        protected IActorRef Child { get; set; }
+        protected int RestartCountN { get; set; }
+
+        internal ILoggingAdapter Log { get; }
 
         protected override void PreStart()
         {
@@ -96,7 +102,14 @@ namespace Akka.Pattern
                 }
                 else
                 {
-                    Context.System.DeadLetters.Forward(message);
+                    if (ReplyWhileStopped != null)
+                    {
+                        Sender.Tell(ReplyWhileStopped);
+                    }
+                    else
+                    {
+                        Context.System.DeadLetters.Forward(message);
+                    }
                 }
             }
 

--- a/src/core/Akka/Serialization/Serialization.cs
+++ b/src/core/Akka/Serialization/Serialization.cs
@@ -183,7 +183,7 @@ namespace Akka.Serialization
         {
             if (!_serializersById.TryGetValue(serializerId, out var serializer))
                 throw new SerializationException(
-                    $"Cannot find serializer with id [{serializerId}]. The most probable reason" +
+                    $"Cannot find serializer with id [{serializerId}] (class [{type?.Name}]). The most probable reason" +
                     " is that the configuration entry 'akka.actor.serializers' is not in sync between the two systems.");
 
             return serializer.FromBinary(bytes, type);
@@ -204,7 +204,7 @@ namespace Akka.Serialization
         {
             if (!_serializersById.TryGetValue(serializerId, out var serializer))
                 throw new SerializationException(
-                    $"Cannot find serializer with id [{serializerId}]. The most probable reason" +
+                    $"Cannot find serializer with id [{serializerId}] (manifest [{manifest}]). The most probable reason" +
                     " is that the configuration entry 'akka.actor.serializers' is not in sync between the two systems.");
 
             if (serializer is SerializerWithStringManifest)


### PR DESCRIPTION
#### 1.3.12 March 13 2019 ####
**Maintenance Release for Akka.NET 1.3**
This will be the final bugfix release for Akka.NET v1.3.* - going forward we will be working on releasing Akka.NET v1.4.

This patch contains many important bug fixes and improvements:
* [Akka.Cluster.Sharding: Automatic passivation for sharding](https://github.com/akkadotnet/akka.net/pull/3718)
* [Akka.Persistence: Optimize AtLeastOnceDelivery by not scheduling ticks when not needed](https://github.com/akkadotnet/akka.net/pull/3704)
* [Akka.Persistence.Sql.Common: Bugfix CurrentEventsByTag does not return more than a 100 events](https://github.com/akkadotnet/akka.net/issues/3697)
* [Akka.Persistence.Sql.Common: DeleteMessages when journal is empty causes duplicate key SQL exception](https://github.com/akkadotnet/akka.net/issues/3721)
* [Akka.Cluster: SplitBrainResolver: don't down oldest if alone in cluster](https://github.com/akkadotnet/akka.net/pull/3690)
* [Akka: Include manifest or class in missing serializer failure if possible](https://github.com/akkadotnet/akka.net/pull/3701)
* [Akka: Memory leak when disposing actor system with non default ActorRefProvider](https://github.com/akkadotnet/akka.net/issues/2640)

To [see the full set of changes for Akka.NET v1.3.12, click here](https://github.com/akkadotnet/akka.net/milestone/30).

| COMMITS | LOC+ | LOC- | AUTHOR |
| --- | --- | --- | --- |
| 8 | 1487 | 357 | Ismael Hamed |
| 7 | 126 | 120 | jdsartori |
| 3 | 198 | 4 | JSartori |
| 3 | 155 | 22 | Aaron Stannard |
| 2 | 11 | 2 | Peter Lin |
| 1 | 8 | 4 | Raimund Hirz |
| 1 | 7 | 0 | Warren Falk |
| 1 | 45 | 6 | Peter Huang |
| 1 | 14 | 13 | Bartosz Sypytkowski |
| 1 | 11 | 1 | Greg Shackles |
| 1 | 10 | 10 | Jill D. Headen |
| 1 | 1 | 1 | Isaac Z |