### PR TITLE
made ThrottleTransportAdapter messages public

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### 1.4.0 March 14 2019 ####
+#### 1.3.13 March 14 2019 ####
 **Placeholder for nightlies**
 
 

--- a/src/common.props
+++ b/src/common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2018 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.4.0</VersionPrefix>
+    <VersionPrefix>1.3.13</VersionPrefix>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveRemote.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveRemote.approved.txt
@@ -609,6 +609,19 @@ namespace Akka.Remote.Transport
         public string RemoveScheme(string scheme) { }
         public Akka.Actor.Address RemoveScheme(Akka.Actor.Address address) { }
     }
+    public sealed class SetThrottle
+    {
+        public SetThrottle(Akka.Actor.Address address, Akka.Remote.Transport.ThrottleTransportAdapter.Direction direction, Akka.Remote.Transport.ThrottleMode mode) { }
+        public Akka.Actor.Address Address { get; }
+        public Akka.Remote.Transport.ThrottleTransportAdapter.Direction Direction { get; }
+        public Akka.Remote.Transport.ThrottleMode Mode { get; }
+        public override bool Equals(object obj) { }
+        public override int GetHashCode() { }
+    }
+    public sealed class SetThrottleAck
+    {
+        public static Akka.Remote.Transport.SetThrottleAck Instance { get; }
+    }
     public sealed class ShutdownAttempt : Akka.Remote.Transport.Activity
     {
         public ShutdownAttempt(Akka.Actor.Address boundAddress) { }

--- a/src/core/Akka.Remote/Transport/ThrottleTransportAdapter.cs
+++ b/src/core/Akka.Remote/Transport/ThrottleTransportAdapter.cs
@@ -773,7 +773,7 @@ namespace Akka.Remote.Transport
     /// <summary>
     /// Applies a throttle to the underlying conneciton
     /// </summary>
-    internal sealed class SetThrottle
+    public sealed class SetThrottle
     {
         readonly Address _address;
         /// <summary>
@@ -856,7 +856,7 @@ namespace Akka.Remote.Transport
     /// <summary>
     /// ACKs a throttle command
     /// </summary>
-    internal sealed class SetThrottleAck
+    public sealed class SetThrottleAck
     {
         private SetThrottleAck() { }
         // ReSharper disable once InconsistentNaming


### PR DESCRIPTION
Brings our API in-line with JVM Akka, but more importantly - makes the `ThrottleTransportAdapter` usable outside of internal Akka.NET tests and tools.