### PR TITLE
Reducing log level of restarting to WARN

### DIFF
--- a/src/core/Akka.Streams/Dsl/Restart.cs
+++ b/src/core/Akka.Streams/Dsl/Restart.cs
@@ -494,7 +494,7 @@ namespace Akka.Streams.Dsl
                         Fail(Out, ex);
                     else
                     {
-                        Log.Error(ex, "Restarting graph due to failure");
+                        Log.Warning($"Restarting graph due to failure. Stacktrace: {ex.StackTrace}");
                         ScheduleRestartTimer();
                     }
                 }));


### PR DESCRIPTION
> That seems reasonable, failing streams do not necessarily require operator attention.

Port [#25023](https://github.com/akka/akka/pull/25023)