### PR TITLE
Remove restrictions required by netstandard 1.x but available in 2.0

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -25,8 +25,8 @@ let outputPerfTests = __SOURCE_DIRECTORY__ @@ "PerfResults"
 let outputBinaries = output @@ "binaries"
 let outputNuGet = output @@ "nuget"
 let outputMultiNode = outputTests @@ "multinode"
-let outputBinariesNet45 = outputBinaries @@ "net45"
-let outputBinariesNetStandard = outputBinaries @@ "netstandard1.6"
+let outputBinariesNet45 = outputBinaries @@ "net452"
+let outputBinariesNetStandard = outputBinaries @@ "netstandard2.0"
 
 let buildNumber = environVarOrDefault "BUILD_NUMBER" "0"
 let hasTeamCity = (not (buildNumber = "0")) // check if we have the TeamCity environment variable for build # set
@@ -313,7 +313,7 @@ open Fake.TemplateHelper
 Target "PublishMntr" (fun _ ->
     let executableProjects = !! "./src/**/Akka.MultiNodeTestRunner.csproj"
 
-    // Windows .NET 4.5.2
+    // Restore
     executableProjects |> Seq.iter (fun project ->
         DotNetCli.Restore
             (fun p -> 
@@ -322,7 +322,7 @@ Target "PublishMntr" (fun _ ->
                     AdditionalArgs = ["-r win7-x64"; sprintf "/p:VersionSuffix=%s" versionSuffix] })
     )
 
-    // Windows .NET 4.5.2
+    // Windows .NET 4.6.1
     executableProjects |> Seq.iter (fun project ->  
         DotNetCli.Publish
             (fun p ->

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/AsyncWriteProxyEx.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/AsyncWriteProxyEx.cs
@@ -43,7 +43,6 @@ namespace Akka.Cluster.Sharding.Tests
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncReplayTimeoutException"/> class.
         /// </summary>
@@ -53,7 +52,6 @@ namespace Akka.Cluster.Sharding.Tests
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Akka.Cluster.Sharding.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Akka.Cluster.Sharding.csproj
@@ -23,10 +23,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkLibVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>

--- a/src/contrib/cluster/Akka.Cluster.Tools/Akka.Cluster.Tools.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Akka.Cluster.Tools.csproj
@@ -14,10 +14,6 @@
     <ProjectReference Include="..\..\..\core\Akka.Cluster\Akka.Cluster.csproj" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkLibVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManager.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManager.cs
@@ -423,7 +423,6 @@ namespace Akka.Cluster.Tools.Singleton
         /// <param name="message">The message that describes the error.</param>
         public ClusterSingletonManagerIsStuckException(string message) : base(message) { }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="ClusterSingletonManagerIsStuckException"/> class.
         /// </summary>
@@ -432,7 +431,6 @@ namespace Akka.Cluster.Tools.Singleton
         public ClusterSingletonManagerIsStuckException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>

--- a/src/contrib/cluster/Akka.DistributedData/Akka.DistributedData.csproj
+++ b/src/contrib/cluster/Akka.DistributedData/Akka.DistributedData.csproj
@@ -20,10 +20,6 @@
     <PackageReference Include="Hyperion" Version="$(HyperionVersion)" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkLibVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION;CLONABLE</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>

--- a/src/contrib/cluster/Akka.DistributedData/Durable/Messages.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Durable/Messages.cs
@@ -91,11 +91,9 @@ namespace Akka.DistributedData.Durable
         {
         }
 
-#if SERIALIZATION
         public LoadFailedException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 
     public sealed class DurableDataEnvelope : IReplicatorMessage, IEquatable<DurableDataEnvelope>

--- a/src/contrib/dependencyinjection/Akka.DI.Core/Akka.DI.Core.csproj
+++ b/src/contrib/dependencyinjection/Akka.DI.Core/Akka.DI.Core.csproj
@@ -14,10 +14,6 @@
     <ProjectReference Include="..\..\..\core\Akka\Akka.csproj" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkLibVersion)' ">
-    <DefineConstants>$(DefineConstants);APPDOMAIN</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>

--- a/src/contrib/dependencyinjection/Akka.DI.Core/Extensions.cs
+++ b/src/contrib/dependencyinjection/Akka.DI.Core/Extensions.cs
@@ -11,9 +11,6 @@ using System.Linq;
 using System.Reflection;
 using Akka.Actor;
 
-#if CORECLR 
-using Microsoft.Extensions.DependencyModel;
-#endif
 namespace Akka.DI.Core
 {
     /// <summary>
@@ -78,28 +75,7 @@ namespace Akka.DI.Core
         /// <returns>The list of loaded assemblies</returns>
         private static IEnumerable<Assembly> GetLoadedAssemblies()
         {
-#if APPDOMAIN
             return AppDomain.CurrentDomain.GetAssemblies();
-#elif CORECLR 
-            var assemblies = new List<Assembly>();
-            var dependencies = DependencyContext.Default.RuntimeLibraries;
-            foreach (var library in dependencies)
-            {
-                try
-                {
-                    var assembly = Assembly.Load(new AssemblyName(library.Name));
-                    assemblies.Add(assembly);
-                }
-                catch
-                {
-                    //do nothing can't if can't load assembly
-                }
-            }
-            return assemblies;
-#else
-#warning Method not implemented
-            throw new NotImplementedException();
-#endif
         }
     }
 }

--- a/src/contrib/dependencyinjection/Akka.DI.TestKit/Akka.DI.TestKit.csproj
+++ b/src/contrib/dependencyinjection/Akka.DI.TestKit/Akka.DI.TestKit.csproj
@@ -15,10 +15,6 @@
     <ProjectReference Include="..\..\testkits\Akka.TestKit.Xunit2\Akka.TestKit.Xunit2.csproj" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <DefineConstants>$(DefineConstants);APPDOMAIN</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>

--- a/src/contrib/persistence/Akka.Persistence.Query.Sql/Akka.Persistence.Query.Sql.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Query.Sql/Akka.Persistence.Query.Sql.csproj
@@ -22,10 +22,6 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkLibVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkLibVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION;CONFIGURATION</DefineConstants>
+    <DefineConstants>$(DefineConstants);CONFIGURATION</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">

--- a/src/contrib/persistence/Akka.Persistence.Sql.TestKit/Akka.Persistence.Sql.TestKit.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sql.TestKit/Akka.Persistence.Sql.TestKit.csproj
@@ -16,10 +16,6 @@
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkLibVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>

--- a/src/contrib/serializers/Akka.Serialization.Hyperion/Akka.Serialization.Hyperion.csproj
+++ b/src/contrib/serializers/Akka.Serialization.Hyperion/Akka.Serialization.Hyperion.csproj
@@ -21,9 +21,6 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkLibVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION</DefineConstants>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/contrib/serializers/Akka.Serialization.TestKit/Akka.Serialization.TestKit.csproj
+++ b/src/contrib/serializers/Akka.Serialization.TestKit/Akka.Serialization.TestKit.csproj
@@ -14,10 +14,6 @@
     <ProjectReference Include="..\..\..\core\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/contrib/testkits/Akka.TestKit.Xunit/Internals/AkkaEqualException.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit/Internals/AkkaEqualException.cs
@@ -33,7 +33,6 @@ namespace Akka.TestKit.Xunit.Internals
             _args = args;
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="AkkaEqualException"/> class.
         /// </summary>
@@ -43,7 +42,7 @@ namespace Akka.TestKit.Xunit.Internals
             : base(info, context)
         {
         }
-#endif
+
         /// <summary>
         /// The message that describes the error.
         /// </summary>

--- a/src/contrib/testkits/Akka.TestKit.Xunit2/Internals/AkkaEqualException.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit2/Internals/AkkaEqualException.cs
@@ -33,7 +33,6 @@ namespace Akka.TestKit.Xunit2.Internals
             _args = args;
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="AkkaEqualException"/> class.
         /// </summary>
@@ -43,7 +42,7 @@ namespace Akka.TestKit.Xunit2.Internals
             : base(info, context)
         {
         }
-#endif
+
         /// <summary>
         /// The message that describes the error.
         /// </summary>

--- a/src/core/Akka.Cluster.TestKit/Akka.Cluster.TestKit.csproj
+++ b/src/core/Akka.Cluster.TestKit/Akka.Cluster.TestKit.csproj
@@ -14,10 +14,6 @@
     <ProjectReference Include="..\Akka.Cluster\Akka.Cluster.csproj" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkLibVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Cluster/Akka.Cluster.csproj
+++ b/src/core/Akka.Cluster/Akka.Cluster.csproj
@@ -14,10 +14,6 @@
     <ProjectReference Include="..\Akka.Remote\Akka.Remote.csproj" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkLibVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Persistence/VisualizerRuntimeTemplate.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Persistence/VisualizerRuntimeTemplate.cs
@@ -15,10 +15,6 @@
 // </auto-generated>
 // ------------------------------------------------------------------------------
 
-#if CORECLR
-using Akka.MultiNodeTestRunner.Shared.Extensions;
-#endif
-
 namespace Akka.MultiNodeTestRunner.Shared.Persistence
 {
     using System.Linq;

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/ConsoleMessageSinkActor.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/ConsoleMessageSinkActor.cs
@@ -9,9 +9,6 @@ using System;
 using System.Linq;
 using Akka.Actor;
 using Akka.Event;
-#if CORECLR
-using Akka.MultiNodeTestRunner.Shared.Extensions;
-#endif
 using Akka.MultiNodeTestRunner.Shared.Reporting;
 
 namespace Akka.MultiNodeTestRunner.Shared.Sinks

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/SinkCoordinator.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/SinkCoordinator.cs
@@ -186,11 +186,7 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
         {
             foreach (var sink in Sinks)
             {
-#if CORECLR
-                sink.LogRunnerMessage(message.Message, Assembly.GetEntryAssembly().GetName().Name, LogLevel.InfoLevel);
-#else
                 sink.LogRunnerMessage(message.Message, Assembly.GetExecutingAssembly().GetName().Name, LogLevel.InfoLevel);
-#endif
             }
         }
 

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/TeamCityMessageSinkActor.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/TeamCityMessageSinkActor.cs
@@ -13,9 +13,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
-#if CORECLR
-using Akka.MultiNodeTestRunner.Shared.Extensions;
-#endif
 using Akka.MultiNodeTestRunner.Shared.Reporting;
 using JetBrains.TeamCity.ServiceMessages;
 using JetBrains.TeamCity.ServiceMessages.Write.Special;

--- a/src/core/Akka.Persistence.Query/Akka.Persistence.Query.csproj
+++ b/src/core/Akka.Persistence.Query/Akka.Persistence.Query.csproj
@@ -15,14 +15,6 @@
     <ProjectReference Include="..\Akka.Streams\Akka.Streams.csproj" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkLibVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants)</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Persistence.TCK/Akka.Persistence.TCK.csproj
+++ b/src/core/Akka.Persistence.TCK/Akka.Persistence.TCK.csproj
@@ -17,10 +17,6 @@
     <ProjectReference Include="..\Akka.Streams.TestKit\Akka.Streams.TestKit.csproj" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Persistence.TCK/Journal/JournalSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Journal/JournalSpec.cs
@@ -262,7 +262,6 @@ namespace Akka.Persistence.TCK.Journal
             _receiverProbe.ExpectMsg<RecoverySuccess>(m => m.HighestSequenceNr == 5L);
         }
 
-#if !CORECLR
         /// <summary>
         /// JSON serializer should fail on this
         /// </summary>
@@ -309,6 +308,5 @@ namespace Akka.Persistence.TCK.Journal
                                                       m.Persistent.WriterGuid.Equals(writerGuid) &&
                                                       m.Persistent.Payload.Equals("b-8"));
         }
-#endif
     }
 }

--- a/src/core/Akka.Persistence/Akka.Persistence.csproj
+++ b/src/core/Akka.Persistence/Akka.Persistence.csproj
@@ -14,9 +14,6 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.3.0" />
   </ItemGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkLibVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION</DefineConstants>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Persistence/AtLeastOnceDeliverySemantic.cs
+++ b/src/core/Akka.Persistence/AtLeastOnceDeliverySemantic.cs
@@ -225,7 +225,6 @@ namespace Akka.Persistence
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="MaxUnconfirmedMessagesExceededException"/> class.
         /// </summary>
@@ -234,7 +233,6 @@ namespace Akka.Persistence
         protected MaxUnconfirmedMessagesExceededException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 
     #endregion

--- a/src/core/Akka.Persistence/Journal/AsyncWriteProxy.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteProxy.cs
@@ -37,7 +37,6 @@ namespace Akka.Persistence.Journal
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncReplayTimeoutException"/> class.
         /// </summary>
@@ -47,7 +46,6 @@ namespace Akka.Persistence.Journal
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>

--- a/src/core/Akka.Persistence/PersistentActor.cs
+++ b/src/core/Akka.Persistence/PersistentActor.cs
@@ -136,7 +136,6 @@ namespace Akka.Persistence
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="RecoveryTimedOutException"/> class.
         /// </summary>
@@ -145,7 +144,6 @@ namespace Akka.Persistence
         public RecoveryTimedOutException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>

--- a/src/core/Akka.Persistence/Snapshot/NoSnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/NoSnapshotStore.cs
@@ -49,7 +49,6 @@ namespace Akka.Persistence.Snapshot
             {
             }
 
-#if SERIALIZATION
             /// <summary>
             /// Initializes a new instance of the <see cref="NoSnapshotStoreException"/> class.
             /// </summary>
@@ -58,7 +57,6 @@ namespace Akka.Persistence.Snapshot
             protected NoSnapshotStoreException(SerializationInfo info, StreamingContext context) : base(info, context)
             {
             }
-#endif
         }
 
         /// <summary>

--- a/src/core/Akka.Remote.TestKit/Akka.Remote.TestKit.csproj
+++ b/src/core/Akka.Remote.TestKit/Akka.Remote.TestKit.csproj
@@ -23,11 +23,6 @@
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
   </ItemGroup>
   
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkLibVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Remote.TestKit/Controller.cs
+++ b/src/core/Akka.Remote.TestKit/Controller.cs
@@ -98,7 +98,6 @@ namespace Akka.Remote.TestKit
             /// <param name="message">The message that describes the error.</param>
             public ClientDisconnectedException(string message) : base(message){}
 
-#if SERIALIZATION
             /// <summary>
             /// Initializes a new instance of the <see cref="ClientDisconnectedException"/> class.
             /// </summary>
@@ -107,7 +106,6 @@ namespace Akka.Remote.TestKit
             protected ClientDisconnectedException(SerializationInfo info, StreamingContext context) : base(info, context)
             {
             }
-#endif
         }
 
         public class GetNodes

--- a/src/core/Akka.Remote.TestKit/Internals/TestConductorConfigFactory.cs
+++ b/src/core/Akka.Remote.TestKit/Internals/TestConductorConfigFactory.cs
@@ -36,11 +36,7 @@ namespace Akka.Remote.TestKit.Internals
         /// <returns>The configuration defined in the current executing assembly.</returns>
         internal static Config FromResource(string resourceName)
         {
-#if CORECLR
-            var assembly = typeof(TestConductorConfigFactory).GetTypeInfo().Assembly;
-#else
             var assembly = typeof(TestConductorConfigFactory).Assembly;
-#endif
 
             using (var stream = assembly.GetManifestResourceStream(resourceName))
             {

--- a/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
+++ b/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
@@ -403,13 +403,7 @@ namespace Akka.Remote.TestKit
             _roles = roles;
             _deployments = deployments;
 
-#if CORECLR
-            var dnsTask = Dns.GetHostAddressesAsync(ServerName);
-            dnsTask.Wait();
-            var node = new IPEndPoint(dnsTask.Result[0], ServerPort);
-#else
             var node = new IPEndPoint(Dns.GetHostAddresses(ServerName)[0], ServerPort);
-#endif
             _controllerAddr = node;
 
             AttachConductor(new TestConductor(system));

--- a/src/core/Akka.Remote.Tests/Transport/DotNettySslSupportSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettySslSupportSpec.cs
@@ -194,12 +194,8 @@ namespace Akka.Remote.Tests.Transport
             }
             finally
             {
-#if NET452 //netstandard 1.6 doesn't have close on store
                 store.Close();
-#else
-#endif
             }
-
         }
 
 
@@ -220,10 +216,7 @@ namespace Akka.Remote.Tests.Transport
             }
             finally
             {
-#if NET452 //NetStandard1.6 doesn't have close on store.
                 store.Close();
-#else
-#endif
             }
         }
         public class Echo : ReceiveActor

--- a/src/core/Akka.Remote/AckedDelivery.cs
+++ b/src/core/Akka.Remote/AckedDelivery.cs
@@ -336,7 +336,6 @@ namespace Akka.Remote
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="ResendBufferCapacityReachedException"/> class.
         /// </summary>
@@ -346,7 +345,6 @@ namespace Akka.Remote
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>

--- a/src/core/Akka.Remote/Akka.Remote.csproj
+++ b/src/core/Akka.Remote/Akka.Remote.csproj
@@ -16,9 +16,6 @@
     <PackageReference Include="DotNetty.Handlers" Version="0.6.0" />
     <PackageReference Include="Google.Protobuf" Version="3.3.0" />
   </ItemGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkLibVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION</DefineConstants>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -191,7 +191,6 @@ namespace Akka.Remote
         /// <param name="cause">The exception that is the cause of the current exception.</param>
         public EndpointException(string message, Exception cause = null) : base(message, cause) { }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="EndpointException"/> class.
         /// </summary>
@@ -201,7 +200,6 @@ namespace Akka.Remote
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>

--- a/src/core/Akka.Remote/RemoteTransport.cs
+++ b/src/core/Akka.Remote/RemoteTransport.cs
@@ -132,7 +132,6 @@ namespace Akka.Remote
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="RemoteTransportException"/> class.
         /// </summary>
@@ -142,7 +141,6 @@ namespace Akka.Remote
             : base(info, context)
         {
         }
-#endif
     }
 }
 

--- a/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
+++ b/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
@@ -28,7 +28,6 @@ namespace Akka.Remote.Transport
         /// <param name="cause">The exception that is the cause of the current exception.</param>
         public PduCodecException(string message, Exception cause = null) : base(message, cause) { }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="PduCodecException"/> class.
         /// </summary>
@@ -38,7 +37,6 @@ namespace Akka.Remote.Transport
             : base(info, context)
         {
         }
-#endif
     }
 
     /*

--- a/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
+++ b/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
@@ -63,7 +63,6 @@ namespace Akka.Remote.Transport
         /// <param name="cause">The exception that is the cause of the current exception.</param>
         public AkkaProtocolException(string message, Exception cause = null) : base(message, cause) { }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="AkkaProtocolException"/> class.
         /// </summary>
@@ -73,7 +72,6 @@ namespace Akka.Remote.Transport
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
@@ -104,7 +104,6 @@ namespace Akka.Remote.Transport.DotNetty
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="DotNettyTransportException"/> class.
         /// </summary>
@@ -113,7 +112,6 @@ namespace Akka.Remote.Transport.DotNetty
         protected DotNettyTransportException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 
     internal abstract class DotNettyTransport : Transport

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransportSettings.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransportSettings.cs
@@ -362,13 +362,8 @@ namespace Akka.Remote.Transport.DotNetty
             }
             finally
             {
-#if  NET45 //netstandard1.6 doesn't have close on store.
                 store.Close();
-#else
-#endif
-
             }
-
         }
             
         public SslSettings(string certificatePath, string certificatePassword, X509KeyStorageFlags flags, bool suppressValidation)

--- a/src/core/Akka.Remote/Transport/FailureInjectorTransportAdapter.cs
+++ b/src/core/Akka.Remote/Transport/FailureInjectorTransportAdapter.cs
@@ -48,7 +48,6 @@ namespace Akka.Remote.Transport
             Msg = msg;
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="FailureInjectorException"/> class.
         /// </summary>
@@ -58,7 +57,6 @@ namespace Akka.Remote.Transport
             : base(info, context)
         {
         }
-#endif
 
         /// <summary>
         /// Retrieves the message of the simulated failure.

--- a/src/core/Akka.Remote/Transport/Transport.cs
+++ b/src/core/Akka.Remote/Transport/Transport.cs
@@ -99,7 +99,6 @@ namespace Akka.Remote.Transport
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="InvalidAssociationException"/> class.
         /// </summary>
@@ -109,7 +108,6 @@ namespace Akka.Remote.Transport
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>

--- a/src/core/Akka.Streams.TestKit.Tests/Akka.Streams.TestKit.Tests.csproj
+++ b/src/core/Akka.Streams.TestKit.Tests/Akka.Streams.TestKit.Tests.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION;AKKAIO</DefineConstants>
+    <DefineConstants>$(DefineConstants);AKKAIO</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' ">

--- a/src/core/Akka.Streams.TestKit.Tests/ScriptedTest.cs
+++ b/src/core/Akka.Streams.TestKit.Tests/ScriptedTest.cs
@@ -27,10 +27,7 @@ namespace Akka.Streams.TestKit.Tests
         public ScriptException() { }
         public ScriptException(string message) : base(message) { }
         public ScriptException(string message, Exception inner) : base(message, inner) { }
-
-#if SERIALIZATION
         protected ScriptException(SerializationInfo info, StreamingContext context) : base(info, context) { }
-#endif
     }
 
     public abstract class ScriptedTest : AkkaSpec

--- a/src/core/Akka.Streams.TestKit/TestSubscriber.cs
+++ b/src/core/Akka.Streams.TestKit/TestSubscriber.cs
@@ -34,7 +34,7 @@ namespace Akka.Streams.TestKit
             public override string ToString() => $"TestSubscriber.OnSubscribe({Subscription})";
         }
 
-        public struct OnNext<T> : ISubscriberEvent
+        public struct OnNext<T> : ISubscriberEvent, IEquatable<OnNext<T>>
         {
             public readonly T Element;
 
@@ -44,6 +44,21 @@ namespace Akka.Streams.TestKit
             }
 
             public override string ToString() => $"TestSubscriber.OnNext({Element})";
+
+            public bool Equals(OnNext<T> other)
+            {
+                return EqualityComparer<T>.Default.Equals(Element, other.Element);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is OnNext<T> other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                return EqualityComparer<T>.Default.GetHashCode(Element);
+            }
         }
 
         public sealed class OnComplete: ISubscriberEvent

--- a/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
+++ b/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
@@ -37,8 +37,8 @@
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
-    <!--<DefineConstants>TRACE;DEBUG;SERIALIZATION;CONFIGURATION;UNSAFE_THREADING;NET452;NET452</DefineConstants>-->
-    <DefineConstants>$(DefineConstants);SERIALIZATION;CONFIGURATION;UNSAFE_THREADING;AKKAIO</DefineConstants>
+    <!--<DefineConstants>TRACE;DEBUG;CONFIGURATION;UNSAFE_THREADING;NET452;NET452</DefineConstants>-->
+    <DefineConstants>$(DefineConstants);CONFIGURATION;UNSAFE_THREADING;AKKAIO</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' ">

--- a/src/core/Akka.Streams/ActorMaterializer.cs
+++ b/src/core/Akka.Streams/ActorMaterializer.cs
@@ -238,7 +238,6 @@ namespace Akka.Streams
             Actor = actor;
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="AbruptTerminationException" /> class.
         /// </summary>
@@ -248,7 +247,6 @@ namespace Akka.Streams
         {
             Actor = (IActorRef)info.GetValue("Actor", typeof(IActorRef));
         }
-#endif
     }
 
     /// <summary>
@@ -263,14 +261,12 @@ namespace Akka.Streams
         /// <param name="innerException">The exception that is the cause of the current exception.</param>
         public MaterializationException(string message, Exception innerException) : base(message, innerException) { }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="MaterializationException"/> class.
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
         protected MaterializationException(SerializationInfo info, StreamingContext context) : base(info, context) { }
-#endif
     }
 
     /// <summary>

--- a/src/core/Akka.Streams/Akka.Streams.csproj
+++ b/src/core/Akka.Streams/Akka.Streams.csproj
@@ -65,7 +65,7 @@
     <PackageReference Include="Reactive.Streams" Version="1.0.2" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkLibVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION;CLONEABLE;AKKAIO</DefineConstants>
+    <DefineConstants>$(DefineConstants);AKKAIO</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>

--- a/src/core/Akka.Streams/Dsl/Keep.cs
+++ b/src/core/Akka.Streams/Dsl/Keep.cs
@@ -56,11 +56,7 @@ namespace Akka.Streams.Dsl
         /// <returns>TBD</returns>
         public static NotUsed None<TLeft, TRight>(TLeft left, TRight right) => NotUsed.Instance;
 
-#if !CORECLR
         private static readonly RuntimeMethodHandle KeepRightMethodhandle = typeof(Keep).GetMethod(nameof(Right)).MethodHandle;
-#else
-        private static readonly MethodInfo KeepRightMethodInfo = typeof(Keep).GetMethod(nameof(Right));
-#endif
 
         /// <summary>
         /// TBD
@@ -72,18 +68,10 @@ namespace Akka.Streams.Dsl
         /// <returns>TBD</returns>
         public static bool IsRight<T1, T2, T3>(Func<T1, T2, T3> fn)
         {
-#if !CORECLR
             return fn.GetMethodInfo().IsGenericMethod && fn.GetMethodInfo().GetGenericMethodDefinition().MethodHandle.Value == KeepRightMethodhandle.Value;
-#else
-            return fn.GetMethodInfo().IsGenericMethod && fn.GetMethodInfo().GetGenericMethodDefinition().Equals(KeepRightMethodInfo);
-#endif
         }
 
-#if !CORECLR
         private static readonly RuntimeMethodHandle KeepLeftMethodhandle = typeof(Keep).GetMethod(nameof(Left)).MethodHandle;
-#else
-        private static readonly MethodInfo KeepLeftMethodInfo = typeof(Keep).GetMethod(nameof(Left));
-#endif
 
         /// <summary>
         /// TBD
@@ -95,11 +83,7 @@ namespace Akka.Streams.Dsl
         /// <returns>TBD</returns>
         public static bool IsLeft<T1, T2, T3>(Func<T1, T2, T3> fn)
         {
-#if !CORECLR
             return fn.GetMethodInfo().IsGenericMethod && fn.GetMethodInfo().GetGenericMethodDefinition().MethodHandle.Value == KeepLeftMethodhandle.Value;
-#else
-            return fn.GetMethodInfo().IsGenericMethod && fn.GetMethodInfo().GetGenericMethodDefinition().Equals(KeepLeftMethodInfo);
-#endif
         }
     }
 }

--- a/src/core/Akka.Streams/Implementation/ActorPublisher.cs
+++ b/src/core/Akka.Streams/Implementation/ActorPublisher.cs
@@ -114,14 +114,12 @@ namespace Akka.Streams.Implementation
         /// <param name="message">The message that describes the error.</param>
         public NormalShutdownException(string message) : base(message) { }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="NormalShutdownException"/> class.
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
         protected NormalShutdownException(SerializationInfo info, StreamingContext context) : base(info, context) { }
-#endif
     }
 
     /// <summary>

--- a/src/core/Akka.Streams/Implementation/ReactiveStreamsCompliance.cs
+++ b/src/core/Akka.Streams/Implementation/ReactiveStreamsCompliance.cs
@@ -30,14 +30,12 @@ namespace Akka.Streams.Implementation
         /// <param name="cause">The exception that is the cause of the current exception.</param>
         public SignalThrewException(string message, Exception cause) : base(message, cause) { }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="SignalThrewException"/> class.
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
         protected SignalThrewException(SerializationInfo info, StreamingContext context) : base(info, context) { }
-#endif
     }
 
     /// <summary>

--- a/src/core/Akka.Streams/Implementation/ResizableMultiReaderRingBuffer.cs
+++ b/src/core/Akka.Streams/Implementation/ResizableMultiReaderRingBuffer.cs
@@ -29,7 +29,6 @@ namespace Akka.Streams.Implementation
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="NothingToReadException"/> class.
         /// </summary>
@@ -39,7 +38,6 @@ namespace Akka.Streams.Implementation
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>

--- a/src/core/Akka.Streams/Implementation/StreamLayout.cs
+++ b/src/core/Akka.Streams/Implementation/StreamLayout.cs
@@ -2142,7 +2142,6 @@ namespace Akka.Streams.Implementation
             {
             }
 
-#if SERIALIZATION
             /// <summary>
             /// Initializes a new instance of the <see cref="MaterializationPanicException" /> class.
             /// </summary>
@@ -2152,7 +2151,6 @@ namespace Akka.Streams.Implementation
                 : base(info, context)
             {
             }
-#endif
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Implementation/StreamSubscriptionTimeout.cs
+++ b/src/core/Akka.Streams/Implementation/StreamSubscriptionTimeout.cs
@@ -36,7 +36,6 @@ namespace Akka.Streams.Implementation
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="SubscriptionTimeoutException"/> class.
         /// </summary>
@@ -45,7 +44,6 @@ namespace Akka.Streams.Implementation
         protected SubscriptionTimeoutException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>

--- a/src/core/Akka.Streams/OverflowStrategy.cs
+++ b/src/core/Akka.Streams/OverflowStrategy.cs
@@ -110,7 +110,6 @@ namespace Akka.Streams
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="BufferOverflowException"/> class.
         /// </summary>
@@ -119,6 +118,5 @@ namespace Akka.Streams
         protected BufferOverflowException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 }

--- a/src/core/Akka.Streams/Shape.cs
+++ b/src/core/Akka.Streams/Shape.cs
@@ -173,10 +173,7 @@ namespace Akka.Streams
     /// matters from the outside are the connections that can be made with it,
     /// otherwise it is just a black box.
     /// </summary>
-    public abstract class Shape
-#if CLONEABLE
-     : ICloneable
-#endif
+    public abstract class Shape : ICloneable
     {
         /// <summary>
         /// Gets list of all input ports.

--- a/src/core/Akka.Streams/Stage/GraphStage.cs
+++ b/src/core/Akka.Streams/Stage/GraphStage.cs
@@ -2177,14 +2177,12 @@ namespace Akka.Streams.Stage
         public static readonly StageActorRefNotInitializedException Instance = new StageActorRefNotInitializedException();
         private StageActorRefNotInitializedException() : base("You must first call GetStageActorRef(StageActorRef.Receive), to initialize the actor's behavior") { }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="StageActorRefNotInitializedException"/> class.
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
         protected StageActorRefNotInitializedException(SerializationInfo info, StreamingContext context) : base(info, context) { }
-#endif
     }
 
     /// <summary>

--- a/src/core/Akka.Streams/StreamLimitReachedException.cs
+++ b/src/core/Akka.Streams/StreamLimitReachedException.cs
@@ -23,7 +23,6 @@ namespace Akka.Streams
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="StreamLimitReachedException"/> class.
         /// </summary>
@@ -32,6 +31,5 @@ namespace Akka.Streams
         protected StreamLimitReachedException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 }

--- a/src/core/Akka.Streams/StreamTcpException.cs
+++ b/src/core/Akka.Streams/StreamTcpException.cs
@@ -32,7 +32,6 @@ namespace Akka.Streams
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="StreamTcpException"/> class.
         /// </summary>
@@ -41,7 +40,6 @@ namespace Akka.Streams
         protected StreamTcpException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>
@@ -58,7 +56,6 @@ namespace Akka.Streams
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="BindFailedException"/> class.
         /// </summary>
@@ -67,7 +64,6 @@ namespace Akka.Streams
         protected BindFailedException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>
@@ -92,7 +88,6 @@ namespace Akka.Streams
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="ConnectionException"/> class.
         /// </summary>
@@ -101,6 +96,5 @@ namespace Akka.Streams
         protected ConnectionException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 }

--- a/src/core/Akka.TestKit.Tests/Akka.TestKit.Tests.csproj
+++ b/src/core/Akka.TestKit.Tests/Akka.TestKit.Tests.csproj
@@ -19,9 +19,6 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION</DefineConstants>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
@@ -90,10 +90,6 @@ namespace Akka.TestKit
 
         private static string GetCallerName()
         {
-#if CORECLR
-            // TODO: CORECLR FIX IT
-            var name = "AkkaSpec";
-#else
             var systemNumber = Interlocked.Increment(ref _systemNumber);
             var stackTrace = new StackTrace(0);
             var name = stackTrace.GetFrames().
@@ -102,7 +98,7 @@ namespace Akka.TestKit
                 SkipWhile(m => m.DeclaringType.Name == "AkkaSpec").
                 Select(m => _nameReplaceRegex.Replace(m.DeclaringType.Name + "-" + systemNumber, "-")).
                 FirstOrDefault() ?? "test";
-#endif
+
             return name;
         }
 

--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION;CONFIGURATION;UNSAFE_THREADING</DefineConstants>
+    <DefineConstants>$(DefineConstants);CONFIGURATION;UNSAFE_THREADING</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' ">

--- a/src/core/Akka.Tests/Pattern/CircuitBreakerSpec.cs
+++ b/src/core/Akka.Tests/Pattern/CircuitBreakerSpec.cs
@@ -342,12 +342,10 @@ namespace Akka.Tests.Pattern
         {
         }
 
-#if SERIALIZATION
         protected TestException( SerializationInfo info, StreamingContext context )
             : base( info, context )
         {
         }
-#endif
     }
 
 }

--- a/src/core/Akka/Actor/Address.cs
+++ b/src/core/Akka/Actor/Address.cs
@@ -23,10 +23,7 @@ namespace Akka.Actor
     /// for example a remote transport would want to associate additional
     /// information with an address, then this must be done externally.
     /// </summary>
-    public sealed class Address : IEquatable<Address>, IComparable<Address>, IComparable, ISurrogated
-#if CLONEABLE
-        , ICloneable
-#endif
+    public sealed class Address : IEquatable<Address>, IComparable<Address>, IComparable, ISurrogated, ICloneable
     {
         #region comparer
 

--- a/src/core/Akka/Actor/CoordinatedShutdown.cs
+++ b/src/core/Akka/Actor/CoordinatedShutdown.cs
@@ -671,16 +671,12 @@ namespace Akka.Actor
             var runByClrShutdownHook = conf.GetBoolean("run-by-clr-shutdown-hook");
             if (runByClrShutdownHook)
             {
-#if APPDOMAIN
                 // run all hooks during termination sequence
                 AppDomain.CurrentDomain.ProcessExit += (sender, args) =>
                 {
                     // have to block, because if this method exits the process exits.
                     coord.RunClrHooks().Wait(coord.TotalTimeout);
                 };
-#else
-                // TODO: what to do for NetCore?
-#endif
 
                 coord.AddClrShutdownHook(() =>
                 {

--- a/src/core/Akka/Actor/Exceptions.cs
+++ b/src/core/Akka/Actor/Exceptions.cs
@@ -32,7 +32,6 @@ namespace Akka.Actor
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="AkkaException"/> class.
         /// </summary>
@@ -42,7 +41,6 @@ namespace Akka.Actor
             : base(info, context)
         {
         }
-#endif
 
         /// <summary>
         /// The exception that is the cause of the current exception.
@@ -74,7 +72,6 @@ namespace Akka.Actor
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="InvalidActorNameException"/> class.
         /// </summary>
@@ -84,7 +81,6 @@ namespace Akka.Actor
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>
@@ -101,7 +97,6 @@ namespace Akka.Actor
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="AskTimeoutException"/> class.
         /// </summary>
@@ -111,7 +106,6 @@ namespace Akka.Actor
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>
@@ -173,7 +167,6 @@ namespace Akka.Actor
             Actor = actor;
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="ActorInitializationException"/> class.
         /// </summary>
@@ -191,7 +184,6 @@ namespace Akka.Actor
             info.AddValue("Actor", Actor);
             base.GetObjectData(info, context);
         }
-#endif
 
         /// <summary>
         /// Retrieves the actor whose initialization logic failed.
@@ -243,7 +235,6 @@ namespace Akka.Actor
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="LoggerInitializationException"/> class.
         /// </summary>
@@ -253,7 +244,6 @@ namespace Akka.Actor
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>
@@ -275,7 +265,6 @@ namespace Akka.Actor
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="ActorKilledException"/> class.
         /// </summary>
@@ -285,7 +274,6 @@ namespace Akka.Actor
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>
@@ -303,7 +291,6 @@ namespace Akka.Actor
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="IllegalActorStateException"/> class.
         /// </summary>
@@ -313,7 +300,6 @@ namespace Akka.Actor
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>
@@ -330,7 +316,6 @@ namespace Akka.Actor
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="IllegalActorNameException"/> class.
         /// </summary>
@@ -340,7 +325,6 @@ namespace Akka.Actor
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>
@@ -361,7 +345,6 @@ namespace Akka.Actor
             _deadActor = deadActor;
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="DeathPactException"/> class.
         /// </summary>
@@ -371,7 +354,6 @@ namespace Akka.Actor
             : base(info, context)
         {
         }
-#endif
 
         /// <summary>
         /// Retrieves the actor that has been terminated.
@@ -412,7 +394,6 @@ namespace Akka.Actor
             this.optionalMessage = optionalMessage;
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="PreRestartException"/> class.
         /// </summary>
@@ -422,7 +403,6 @@ namespace Akka.Actor
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>
@@ -445,7 +425,6 @@ namespace Akka.Actor
             _originalCause = originalCause;
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="PostRestartException"/> class.
         /// </summary>
@@ -455,7 +434,6 @@ namespace Akka.Actor
             : base(info, context)
         {
         }
-#endif
 
         ///<summary>
         /// Retrieves the exception which caused the restart in the first place.
@@ -476,7 +454,6 @@ namespace Akka.Actor
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="ActorNotFoundException"/> class.
         /// </summary>
@@ -486,7 +463,6 @@ namespace Akka.Actor
             : base(info, context)
         {
         }
-#endif
 
         /// <summary>
         /// <see cref="ActorNotFoundException"/> that takes a descriptive <paramref name="message"/> and optional <paramref name="innerException"/>.
@@ -522,7 +498,6 @@ namespace Akka.Actor
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="InvalidMessageException"/> class.
         /// </summary>
@@ -532,7 +507,6 @@ namespace Akka.Actor
             : base(info, context)
         {
         }
-#endif
     }
 }
 

--- a/src/core/Akka/Actor/Props.cs
+++ b/src/core/Akka/Actor/Props.cs
@@ -770,13 +770,8 @@ namespace Akka.Actor
         /// <returns>The newly created <see cref="Akka.Actor.Props"/></returns>
         protected override Props Copy()
         {
-            Props initialCopy = base.Copy();
-#if CLONEABLE
+            var initialCopy = base.Copy();
             var invokerCopy = (Func<TActor>)invoker.Clone();
-#else
-            // TODO: CORECLR FIX IT
-            var invokerCopy = (Func<TActor>)invoker;
-#endif
             return new DynamicProps<TActor>(initialCopy, invokerCopy);
         }
 

--- a/src/core/Akka/Actor/Stash/StashOverflowException.cs
+++ b/src/core/Akka/Actor/Stash/StashOverflowException.cs
@@ -22,7 +22,6 @@ namespace Akka.Actor
         /// <param name="cause">The exception that is the cause of the current exception.</param>
         public StashOverflowException(string message, Exception cause = null) : base(message, cause) { }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="StashOverflowException"/> class.
         /// </summary>
@@ -32,6 +31,5 @@ namespace Akka.Actor
             : base(info, context)
         {
         }
-#endif
     }
 }

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkLibVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION;CONFIGURATION;UNSAFE_THREADING;CLONEABLE;APPDOMAIN</DefineConstants>
+    <DefineConstants>$(DefineConstants);CONFIGURATION;UNSAFE_THREADING</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">

--- a/src/core/Akka/Configuration/ConfigurationException.cs
+++ b/src/core/Akka/Configuration/ConfigurationException.cs
@@ -33,7 +33,6 @@ namespace Akka.Configuration
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfigurationException"/> class.
         /// </summary>
@@ -43,7 +42,6 @@ namespace Akka.Configuration
             : base(info, context)
         {
         }
-#endif
     }
 }
 

--- a/src/core/Akka/Dispatch/AbstractDispatcher.cs
+++ b/src/core/Akka/Dispatch/AbstractDispatcher.cs
@@ -213,9 +213,7 @@ namespace Akka.Dispatch
     /// </summary>
     internal sealed class ThreadPoolExecutorServiceFactory : ExecutorServiceConfigurator
     {
-#if APPDOMAIN
         private static readonly bool IsFullTrusted = AppDomain.CurrentDomain.IsFullyTrusted;
-#endif
 
         /// <summary>
         /// TBD
@@ -224,7 +222,7 @@ namespace Akka.Dispatch
         /// <returns>TBD</returns>
         public override ExecutorService Produce(string id)
         {
-#if APPDOMAIN
+#if UNSAFE_THREADING
             if (IsFullTrusted)
                 return new FullThreadPoolExecutorServiceImpl(id);
 #endif

--- a/src/core/Akka/Pattern/IllegalStateException.cs
+++ b/src/core/Akka/Pattern/IllegalStateException.cs
@@ -33,7 +33,6 @@ namespace Akka.Pattern
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="IllegalStateException"/> class.
         /// </summary>
@@ -43,6 +42,5 @@ namespace Akka.Pattern
             : base(info, context)
         {
         }
-#endif
     }
 }

--- a/src/core/Akka/Pattern/OpenCircuitException.cs
+++ b/src/core/Akka/Pattern/OpenCircuitException.cs
@@ -40,7 +40,6 @@ namespace Akka.Pattern
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="OpenCircuitException"/> class.
         /// </summary>
@@ -50,6 +49,5 @@ namespace Akka.Pattern
             : base(info, context)
         {
         }
-#endif
     }
 }

--- a/src/core/Akka/Routing/TailChopping.cs
+++ b/src/core/Akka/Routing/TailChopping.cs
@@ -122,7 +122,14 @@ namespace Akka.Routing
                     try
                     {
 
-                        completion.TrySetResult(await (_routees[currentIndex].Ask(message, _within)).ConfigureAwait(false));
+                        completion.TrySetResult(
+                            await (_routees[currentIndex].Ask(message, _within)).ConfigureAwait(false));
+                    }
+                    catch (AskTimeoutException)
+                    {
+                        completion.TrySetResult(
+                            new Status.Failure(
+                                new AskTimeoutException($"Ask timed out on {sender} after {_within}")));
                     }
                     catch (TaskCanceledException)
                     {


### PR DESCRIPTION
The serialization attribute, appdomains and cloneable interfaces are now supported in the netstandard2.0 libraries so can be re-enabled for dotnet core targets.

Also noticed that I included a fix in the TailChopping Router to catch AskTimeoutException and handle that in the same way as a TaskCanceledException. The associated unit test was routinely breaking without this change for me.