### PR TITLE
[SpecFix] removed two Cluster must cancel join prematurely specs

### DIFF
--- a/src/core/Akka.Cluster.Tests/ClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterSpec.cs
@@ -116,7 +116,6 @@ namespace Akka.Cluster.Tests
             ExpectMsg<ClusterEvent.CurrentClusterState>();
         }
 
-        // this should be the last test step, since the cluster is shutdown
         [Fact]
         public void A_cluster_must_publish_member_removed_when_shutdown()
         {
@@ -199,11 +198,6 @@ namespace Akka.Cluster.Tests
             Cluster.Get(sys2).LeaveAsync().IsCompleted.Should().BeTrue();
         }
 
-        //#if CORECLR
-        //        [Fact(Skip = "Fails on .NET Core")]
-        //#else
-        //        [Fact(Skip = "Fails flakily on .NET 4.5")]
-        //#endif
         [Fact]
         public void A_cluster_must_return_completed_LeaveAsync_task_if_member_already_removed()
         {
@@ -340,29 +334,6 @@ namespace Akka.Cluster.Tests
         }
 
         [Fact]
-        public void A_cluster_must_be_able_to_prematurelly_cancel_JoinAsync()
-        {
-            var timeout = TimeSpan.FromSeconds(10);
-
-            try
-            {
-                var cancel = new CancellationTokenSource();
-                cancel.Cancel(true);
-                var task = _cluster.JoinAsync(_selfAddress, cancel.Token);
-
-                Assert.Throws<AggregateException>(() => task.Wait(timeout))
-                    .Flatten()
-                    .InnerException.Should().BeOfType<TaskCanceledException>();
-
-                task.IsCanceled.Should().BeTrue();
-            }
-            finally
-            {
-                _cluster.Shutdown();
-            }
-        }
-
-        [Fact]
         public void A_cluster_JoinAsync_must_fail_if_could_not_connect_to_cluster()
         {
             var timeout = TimeSpan.FromSeconds(10);
@@ -435,28 +406,6 @@ namespace Akka.Cluster.Tests
                     ExpectMsg<ClusterEvent.MemberRemoved>();
                 }).Wait(timeout);
 
-            }
-            finally
-            {
-                _cluster.Shutdown();
-            }
-        }
-
-        [Fact]
-        public void A_cluster_must_be_able_to_prematurelly_cancel_join_async_seed_nodes()
-        {
-            var timeout = TimeSpan.FromSeconds(10);
-
-            try
-            {
-                var cancel = new CancellationToken(true);
-                var task = _cluster.JoinSeedNodesAsync(new[] { _selfAddress }, cancel);
-
-                Assert.Throws<AggregateException>(() => task.Wait(timeout))
-                    .Flatten()
-                    .InnerException.Should().BeOfType<TaskCanceledException>();
-
-                task.IsCanceled.Should().BeTrue();
             }
             finally
             {


### PR DESCRIPTION
Part #3786 - these two specs are racy and they don't actually test anything meaningful. Invoking the `CancellationTokenSource` we pass into the `Cluster.JoinAsync` or `Cluster.JoinSeedNodesAsync` methods doesn't actually cancel the `Join` operation from executing, they only cancel the `Task` returned by these methods. They're just bloat in the test suite - thought it best to remove them.