### PR TITLE
Remove return of force exit task in coordinated shutdown

### DIFF
--- a/src/core/Akka/Actor/CoordinatedShutdown.cs
+++ b/src/core/Akka/Actor/CoordinatedShutdown.cs
@@ -626,13 +626,12 @@ namespace Akka.Actor
                         // We must spawn a separate Task to not block current thread,
                         // since that would have blocked the shutdown of the ActorSystem.
                         var timeout = coord.Timeout(PhaseActorSystemTerminate);
-                        return Task.Run(() =>
+                        Task.Run(() =>
                         {
                             if (!system.WhenTerminated.Wait(timeout) && !coord._runningClrHook)
                             {
                                 Environment.Exit(0);
                             }
-                            return Done.Instance;
                         });
                     }
 


### PR DESCRIPTION
Fixes #3815 

I've removed the return statement in front of force exit task, which was making code responsible for actual terminating of actor system unreachable when both terminate-actor-system and exit-clr are enabled.

Sorry for not writing any tests but I didn't figure out how to write unit test for code containing ```Environment.Exit(0)``` (which causes whole test suite to exit).