### PR TITLE
NBench standardization

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -345,55 +345,28 @@ Target "MultiNodeTestsNetCore" (fun _ ->
 
 Target "NBench" <| fun _ ->
     if not skipBuild.Value then
-        CleanDir outputPerfTests
-
-        let nbenchTestPath = findToolInSubPath "NBench.Runner.exe" (toolsDir @@ "NBench.Runner*")
-        printfn "Using NBench.Runner: %s" nbenchTestPath
-
         let projects = 
             let rawProjects = match (isWindows) with 
-                                | true -> !! "./src/**/*.Tests.Peformance.csproj"
+                                | true -> !! "./src/**/*.Tests.Performance.csproj"
                                 | _ -> !! "./src/**/*.Tests.Performance.csproj" // if you need to filter specs for Linux vs. Windows, do it here
+
+            rawProjects |> Seq.iter log
             rawProjects |> Seq.choose filterProjects
 
-        let nbenchTestAssemblies = 
-            projects |> Seq.choose (getTestAssembly Runtime.NetFramework)
+        let runSingleProject project =
+            let arguments =
+                match (hasTeamCity) with
+                | true -> (sprintf "nbench --nobuild --concurrent true --trace true --output %s --framework %s" outputPerfTests testNetFrameworkVersion)
+                | false -> (sprintf "nbench --nobuild --concurrent true --trace true --output %s --framework %s" outputPerfTests testNetFrameworkVersion)
 
-        let runNBench assembly =
-            let includes = getBuildParam "include"
-            let excludes = getBuildParam "exclude"
-            let teamcityStr = (getBuildParam "teamcity")
-            let enableTeamCity = 
-                match teamcityStr with
-                | null -> false
-                | "" -> false
-                | _ -> bool.Parse teamcityStr
-
-            let args = StringBuilder()
-                    |> append assembly
-                    |> append (sprintf "output-directory=\"%s\"" outputPerfTests)
-                    |> append (sprintf "concurrent=\"%b\"" true)
-                    |> append (sprintf "trace=\"%b\"" true)
-                    |> append (sprintf "teamcity=\"%b\"" enableTeamCity)
-                    |> appendIfNotNullOrEmpty includes "include="
-                    |> appendIfNotNullOrEmpty excludes "include="
-                    |> toText
-
-            let result = ExecProcess(fun info -> 
-                info.FileName <- nbenchTestPath
-                info.WorkingDirectory <- (Path.GetDirectoryName (FullName nbenchTestPath))
-                info.Arguments <- args) (System.TimeSpan.FromMinutes 45.0) (* Reasonably long-running task. *)
-            if result <> 0 then failwithf "%s %s \nexited with code %i" nbenchTestPath args result
+            let result = ExecProcess(fun info ->
+                info.FileName <- "dotnet"
+                info.WorkingDirectory <- (Directory.GetParent project).FullName
+                info.Arguments <- arguments) (TimeSpan.FromMinutes 30.0) 
         
-        let failedRuns =
-            nbenchTestAssemblies
-            |> Seq.map (fun asm -> try runNBench asm; None with e -> Some(e.ToString()))
-            |> Seq.filter Option.isSome
-            |> Seq.map Option.get
-            |> Seq.mapi (fun i s -> sprintf "%i: \"%s\"" (i + 1) s)
-            |> Seq.toArray
-        if failedRuns.Length > 0 then
-            failwithf "NBench.Runner failed for %i run(s):\n%s\n\n" failedRuns.Length (String.concat "\n\n" failedRuns)
+            ResultHandling.failBuildIfXUnitReportedError TestRunnerErrorLevel.DontFailBuild result
+    
+        projects |> Seq.iter runSingleProject
 
 //--------------------------------------------------------------------------------
 // Nuget targets 
@@ -672,6 +645,7 @@ Target "RunTestsNetCoreFull" DoNothing
 // tests dependencies
 "Build" ==> "RunTests"
 "Build" ==> "RunTestsNetCore"
+//"Build" ==> "NBench"
 
 "BuildRelease" ==> "MultiNodeTestsNetCore"
 "BuildRelease" ==> "MultiNodeTests"

--- a/build.ps1
+++ b/build.ps1
@@ -30,7 +30,6 @@ Param(
 )
 
 $FakeVersion = "4.63.0"
-$NBenchVersion = "1.0.1"
 $DotNetChannel = "LTS";
 $DotNetVersion = "2.1.500";
 $DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/v$DotNetVersion/scripts/obtain/dotnet-install.ps1";
@@ -114,20 +113,6 @@ if (!(Test-Path $FakeExePath)) {
     Invoke-Expression "&`"$NugetPath`" install Fake -ExcludeVersion -Version $FakeVersion -OutputDirectory `"$ToolPath`"" | Out-Null;
     if ($LASTEXITCODE -ne 0) {
         Throw "An error occured while restoring Fake from NuGet."
-    }
-}
-
-###########################################################################
-# INSTALL NBench Runner
-###########################################################################
-
-# Make sure NBench Runner has been installed.
-$NBenchDllPath = Join-Path $ToolPath "NBench.Runner/lib/net45/NBench.Runner.exe"
-if (!(Test-Path $NBenchDllPath)) {
-    Write-Host "Installing NBench..."
-    Invoke-Expression "&`"$NugetPath`" install NBench.Runner -ExcludeVersion -Version $NBenchVersion -OutputDirectory `"$ToolPath`"" | Out-Null;
-    if ($LASTEXITCODE -ne 0) {
-        Throw "An error occured while restoring NBench.Runner from NuGet."
     }
 }
 

--- a/src/common.props
+++ b/src/common.props
@@ -12,6 +12,7 @@
     <XunitVersion>2.3.1</XunitVersion>
     <TestSdkVersion>15.9.0</TestSdkVersion>
     <HyperionVersion>0.9.8</HyperionVersion>
+    <NBenchVersion>1.2.2</NBenchVersion>
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
     <NetCoreTestVersion>netcoreapp2.1</NetCoreTestVersion>
     <NetFrameworkTestVersion>net461</NetFrameworkTestVersion>

--- a/src/core/Akka.Remote.Tests.Performance/Akka.Remote.Tests.Performance.csproj
+++ b/src/core/Akka.Remote.Tests.Performance/Akka.Remote.Tests.Performance.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NBench" Version="1.0.1" />
+    <PackageReference Include="NBench" Version="$(NBenchVersion)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/core/Akka.Remote.Tests.Performance/Akka.Remote.Tests.Performance.csproj
+++ b/src/core/Akka.Remote.Tests.Performance/Akka.Remote.Tests.Performance.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="NBench" Version="$(NBenchVersion)" />
+    <DotNetCliToolReference Include="dotnet-nbench" Version="$(NBenchVersion)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/core/Akka.Streams.Tests.Performance/Akka.Streams.Tests.Performance.csproj
+++ b/src/core/Akka.Streams.Tests.Performance/Akka.Streams.Tests.Performance.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="NBench" Version="$(NBenchVersion)" />
+    <DotNetCliToolReference Include="dotnet-nbench" Version="$(NBenchVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">

--- a/src/core/Akka.Streams.Tests.Performance/Akka.Streams.Tests.Performance.csproj
+++ b/src/core/Akka.Streams.Tests.Performance/Akka.Streams.Tests.Performance.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NBench" Version="1.0.1" />
+    <PackageReference Include="NBench" Version="$(NBenchVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">

--- a/src/core/Akka.Tests.Performance/Akka.Tests.Performance.csproj
+++ b/src/core/Akka.Tests.Performance/Akka.Tests.Performance.csproj
@@ -13,7 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NBench" Version="1.0.1" />
+    <PackageReference Include="NBench" Version="$(NBenchVersion)" />
+    <DotNetCliToolReference Include="dotnet-nbench" Version="$(NBenchVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFrameworKTestVersion)' ">


### PR DESCRIPTION
This is the first in a few pull requests aimed at offering better performance testing support for Akka.NET - this upgrades the solution to use NBench 1.2.2 and uses the `dotnet-nbench` command, but I will need to make some changes to NBench in order to make `dotnet-nbench` fully compatible with `common.props` before it can be run officially.

I'll also be submitting another pull request aimed at introducing .NET Core tests for Akka.NET, which NBench 1.2.2 is a pre-requisite for.