### PR TITLE
update Microsoft.SourceLink.Github to 1.0.0-beta2-19367-01

### DIFF
--- a/src/common.props
+++ b/src/common.props
@@ -49,7 +49,7 @@ We expect to release more beta versions in the future, and if you wish to [get a
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
When compiling Akka.NET locally on some of my development machines, ran into the following known issue with `Microsoft.SourceLink`: https://github.com/dotnet/sourcelink/issues/337

Upgrading to the latest, 1.0.0-beta2-19367-01, should resolve this issue.