### PR TITLE
Update IotApp.cs sample code for tutorial 1 documentation.

### DIFF
--- a/docs/examples/Tutorials/Tutorial1/IotApp.cs
+++ b/docs/examples/Tutorials/Tutorial1/IotApp.cs
@@ -11,7 +11,7 @@ namespace Tutorials.Tutorial1
             using (var system = ActorSystem.Create("iot-system"))
             {
                 // Create top level supervisor
-                var supervisor = system.ActorOf(Props.Create<IotSupervisor>(), "iot-supervisor");
+                var supervisor = system.ActorOf(IotSupervisor.Props(), "iot-supervisor");
                 // Exit the system after ENTER is pressed
                 Console.ReadLine();
             }


### PR DESCRIPTION
edit the code sample of the main app to properly utilize the "...recommended creational pattern for actors; define a static Props() method".
i.e. using the static Props method instead of Props.Create.

I read the Contributing guide for Akka.NET after I made the edits in the browser so I'm not sure if the edits are inline with the guide. If not, I can issue a new, more correct, pull request.