### PR TITLE
updated MNTR NuGet to correctly target .NET Core 2.1 and .NET Framework 4.6.1

### DIFF
--- a/src/core/Akka.MultiNodeTestRunner/Akka.MultiNodeTestRunner.nuspec.template
+++ b/src/core/Akka.MultiNodeTestRunner/Akka.MultiNodeTestRunner.nuspec.template
@@ -15,7 +15,7 @@
     <tags>akka actors actor model Akka concurrency</tags>
   </metadata>
   <files>
-    <file src="bin\Release\net461\win7-x64\publish\*.*" target="lib\net452\" />
-    <file src="bin\Release\netcoreapp2.1\win7-x64\publish\*.*" target="lib\netcoreapp1.1\" />
+    <file src="bin\Release\net461\win7-x64\publish\*.*" target="lib\net461\" />
+    <file src="bin\Release\netcoreapp2.1\win7-x64\publish\*.*" target="lib\netcoreapp2.1\" />
   </files>
 </package>


### PR DESCRIPTION
This bug caused issues with being able to consume the Akka.MultiNodeTestRunner NuGet package for v1.4.0-beta1.