### PR TITLE
setting Newtonsoft.Json version back to 9.0.1

### DIFF
--- a/src/common.props
+++ b/src/common.props
@@ -12,7 +12,7 @@
     <XunitVersion>2.3.1</XunitVersion>
     <TestSdkVersion>15.9.0</TestSdkVersion>
     <HyperionVersion>0.9.8</HyperionVersion>
-    <NewtonsoftJsonVersion>12.0.2</NewtonsoftJsonVersion>
+    <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
     <NBenchVersion>1.2.2</NBenchVersion>
     <ProtobufVersion>3.9.1</ProtobufVersion>
     <NetCoreTestVersion>netcoreapp2.1</NetCoreTestVersion>


### PR DESCRIPTION
reverts #3671 

Per https://github.com/akkadotnet/akka.net/issues/3891