### PR TITLE
resolved lock-up with DistributedPubSubMediatorSpecs

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubMediatorSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubMediatorSpec.cs
@@ -41,6 +41,7 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.PublishSubscribe
                 akka.remote.log-remote-lifecycle-events = off
                 akka.cluster.auto-down-unreachable-after = 0s
                 akka.cluster.pub-sub.max-delta-elements = 500
+                akka.testconductor.query-timeout = 1m # we were having timeouts shutting down nodes with 5s default
             ").WithFallback(DistributedPubSub.DefaultConfig());
         }
     }
@@ -747,8 +748,7 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.PublishSubscribe
 
                 RunOn(() =>
                 {
-                    // added timeout in order to avoid locking up specs
-                    TestConductor.Exit(_third, 0).Wait(TimeSpan.FromSeconds(10));
+                    TestConductor.Exit(_third, 0).Wait();
                 }, _first);
                 EnterBarrier("third-shutdown");
 

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubMediatorSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubMediatorSpec.cs
@@ -747,7 +747,8 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.PublishSubscribe
 
                 RunOn(() =>
                 {
-                    TestConductor.Exit(_third, 0).Wait();
+                    // added timeout in order to avoid locking up specs
+                    TestConductor.Exit(_third, 0).Wait(TimeSpan.FromSeconds(10));
                 }, _first);
                 EnterBarrier("third-shutdown");
 


### PR DESCRIPTION
Looks like an indefinitely waiting `Task` was the issue causing persistent failures with https://github.com/akkadotnet/akka.net/pull/3881#issuecomment-525392481