### PR TITLE
increase Akka.Remote.TestKit TestConductor timeout to 30s by default

### DIFF
--- a/src/core/Akka.Remote.TestKit/Internals/Reference.conf
+++ b/src/core/Akka.Remote.TestKit/Internals/Reference.conf
@@ -13,7 +13,7 @@ akka {
     barrier-timeout = 30s
     
     # Timeout for interrogation of TestConductor’s Controller actor
-    query-timeout = 5s
+    query-timeout = 30s
     
     # Threshold for packet size in time unit above which the failure injector will
     # split the packet and deliver in smaller portions; do not give value smaller


### PR DESCRIPTION
close #3868 