### PR TITLE
upgraded to Incrementalist v0.1.5

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -38,7 +38,7 @@ $NugetUrl = "https://dist.nuget.org/win-x86-commandline/v$NugetVersion/nuget.exe
 $ProtobufVersion = "3.4.0"
 $DocfxVersion = "2.43.2"
 
-$IncrementalistVersion = "0.1.4";
+$IncrementalistVersion = "0.1.5";
 
 # Make sure tools folder exists
 $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent

--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ DOTNET_VERSION=2.1.500
 DOTNET_INSTALLER_URL=https://raw.githubusercontent.com/dotnet/cli/v$DOTNET_VERSION/scripts/obtain/dotnet-install.sh
 DOTNET_CHANNEL=LTS
 PROTOBUF_VERSION=3.4.0
-INCREMENTALIST_VERSION=0.1.4
+INCREMENTALIST_VERSION=0.1.5
 
 # Define default arguments.
 TARGET="Default"


### PR DESCRIPTION
Has a bugfix which should ensure that CI runs when someone changes only an embedded resource file, like the timeout settings here https://github.com/akkadotnet/akka.net/pull/3897