### PR TITLE
name AzureDevops artifacts per build

### DIFF
--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -47,7 +47,7 @@ jobs:
       - task: PublishBuildArtifacts@1
         inputs:
           pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-          artifactName: ${{ parameters.name }}
+          artifactName: ${{ parameters.artifactName }}
       - script: 'echo 1>&2'
         failOnStderr: true
         displayName: 'If above is partially succeeded, then fail'

--- a/build-system/pr-validation.yaml
+++ b/build-system/pr-validation.yaml
@@ -56,6 +56,7 @@ jobs:
       scriptFileName: build.cmd
       scriptArgs: runTests incremental
       outputDirectory: 'TestResults'
+      artifactName: 'netfx_tests_windows-$(Build.BuildId)'
 
   - template: azure-pipeline.template.yaml
     parameters:
@@ -65,6 +66,7 @@ jobs:
       scriptFileName: build.cmd
       scriptArgs: runTestsNetCore incremental
       outputDirectory: 'TestResults'
+      artifactName: 'net_core_tests_windows-$(Build.BuildId)'
 
   - template: azure-pipeline.template.yaml
     parameters:
@@ -74,6 +76,7 @@ jobs:
       scriptFileName: './build.sh'
       scriptArgs: runTestsNetCore incremental
       outputDirectory: 'TestResults'
+      artifactName: 'net_core_tests_linux-$(Build.BuildId)'
 
   - template: azure-pipeline.template.yaml
     parameters:
@@ -83,6 +86,7 @@ jobs:
       scriptFileName: 'build.cmd'
       scriptArgs: MultiNodeTestsNetCore incremental
       outputDirectory: 'TestResults'
+      artifactName: 'net_core_mntr_windows-$(Build.BuildId)'
 
   - template: azure-pipeline.template.yaml
     parameters:
@@ -92,6 +96,7 @@ jobs:
       scriptFileName: 'build.cmd'
       scriptArgs: MultiNodeTests incremental
       outputDirectory: 'TestResults'
+      artifactName: 'net_fx_mntr_windows-$(Build.BuildId)'
 
   - template: azure-pipeline.template.yaml
     parameters:
@@ -101,3 +106,4 @@ jobs:
       scriptFileName: build.cmd
       scriptArgs: CreateNuget nugetprerelease=dev incremental
       outputDirectory: 'bin/nuget'
+      artifactName: 'nuget_pack-$(Build.BuildId)'


### PR DESCRIPTION
Making it easier to track which artifact means what when you download it.