### PR TITLE
Implemented DI property injection in addition to used dependency provider

### DIFF
--- a/src/contrib/dependencyinjection/Akka.DI.Core/DIActorContextAdapter.cs
+++ b/src/contrib/dependencyinjection/Akka.DI.Core/DIActorContextAdapter.cs
@@ -46,7 +46,7 @@ namespace Akka.DI.Core
         [Obsolete("Use Props methods for actor creation. This method will be removed in future versions")]
         public IActorRef ActorOf<TActor>(string name = null) where TActor : ActorBase
         {
-            return context.ActorOf(producer.Props(typeof(TActor)), name);
+            return context.ActorOf(producer.Props(typeof(TActor), null), name);
         }
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace Akka.DI.Core
         /// <returns>A <see cref="Akka.Actor.Props"/> configuration object for the given actor type.</returns>
         public Props Props(Type actorType) 
         {
-            return producer.Props(actorType);
+            return producer.Props(actorType, null);
         }
 
         /// <summary>

--- a/src/contrib/dependencyinjection/Akka.DI.Core/DIActorProducer.cs
+++ b/src/contrib/dependencyinjection/Akka.DI.Core/DIActorProducer.cs
@@ -57,8 +57,7 @@ namespace Akka.DI.Core
         {
             var actor = actorFactory();
 
-            // set additional properties here
-            // independent of DI provider
+            // set additional properties here independent of DI provider
             if (_diProperties != null)
             {
                 foreach (var propertyEntry in _diProperties.Properties)

--- a/src/contrib/dependencyinjection/Akka.DI.Core/DIExt.cs
+++ b/src/contrib/dependencyinjection/Akka.DI.Core/DIExt.cs
@@ -35,10 +35,11 @@ namespace Akka.DI.Core
         /// Creates a <see cref="Akka.Actor.Props"/> configuration object for a given actor type.
         /// </summary>
         /// <param name="actorType">The actor type for which to create the <see cref="Akka.Actor.Props"/> configuration.</param>
+        /// <param name="diProperties"></param>
         /// <returns>A <see cref="Akka.Actor.Props"/> configuration object for the given actor type.</returns>
-        public Props Props(Type actorType)
+        public Props Props(Type actorType, DIActorSystemAdapter.IDIProperties diProperties)
         {
-            return new Props(typeof(DIActorProducer), new object[] { dependencyResolver, actorType });
+            return new Props(typeof(DIActorProducer), new object[] { dependencyResolver, actorType, diProperties });
         }
     }
 }

--- a/src/contrib/dependencyinjection/Akka.DI.Core/ExpressionExtensions.cs
+++ b/src/contrib/dependencyinjection/Akka.DI.Core/ExpressionExtensions.cs
@@ -1,0 +1,60 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="ExpressionExtensions.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2019 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2019 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+// //-----------------------------------------------------------------------
+// // <copyright file="ExpressionExtensions.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2019 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2019 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Akka.DI.Core
+{
+    internal static class ExpressionExtensions
+    {
+        public static Type PropertyType<T>(this Expression<Func<T, object>> selector)
+        {
+            return PropertyType((LambdaExpression)selector);
+        }
+
+        public static Type PropertyType(this LambdaExpression selector)
+        {
+            return selector.PropertyInfo().PropertyType;
+        }
+
+        public static PropertyInfo PropertyInfo(this LambdaExpression selector)
+        {
+            if (selector == null)
+                throw new ArgumentNullException("selector");
+            var memberExpression = GetMemberExpression(selector);
+            if (memberExpression == null)
+                throw new ArgumentException("Must be a MemberExpression.", "selector");
+
+            switch (memberExpression.Member.MemberType)
+            {
+                case MemberTypes.Property:
+                    return (PropertyInfo)memberExpression.Member;
+                default:
+                    throw new ArgumentException("MemberExpression must use a property or field.", "selector");
+            }
+        }
+
+        private static MemberExpression GetMemberExpression(LambdaExpression property)
+        {
+            if (property.Body.NodeType == ExpressionType.Convert)
+                return ((UnaryExpression)property.Body).Operand as MemberExpression;
+            if (property.Body.NodeType == ExpressionType.MemberAccess)
+                return property.Body as MemberExpression;
+
+            return null;
+        }
+    }
+}

--- a/src/contrib/dependencyinjection/Akka.DI.TestKit/DiResolverSpec.cs
+++ b/src/contrib/dependencyinjection/Akka.DI.TestKit/DiResolverSpec.cs
@@ -402,7 +402,7 @@ namespace Akka.DI.TestKit
             });
             var diActorProps2 = Sys.DI().Props<DiPerRequestActor>(x =>
             {
-                x.Set(a => a.TestProperty, "TestValue2");
+                x.Set(nameof(DiPerRequestActor.TestProperty), "TestValue2");
             });
 
             var diActor1 = Sys.ActorOf(diActorProps1);


### PR DESCRIPTION
The current implementation of Akka.DI only allows injection of services via a dependency resolver (e.g. AutoFac).
But when instantiating actors it would be nice to also allow creating props not only via IoC but also set properties for an actor (e.g. an entity guid).

Here is a proposal to inject properties which are provided on actor props creation time.
These properties will be set after the dependency provider has resolved the required services.

The API proposal can be checked out in the unit test "DependencyResolver_should_inject_property_values_into_DiPerRequestActor"

Requirements:
-  The property has to be an instance property
-  The property has to have a public setter
-  The value of the property has to be serializable like all other props arguments
-  If the property was set via dependency provider it would be overwritten. (We could also implement a check and set only null/default properties)
- Unknown properties will be skipped (or we throw an exception to catch programming errors early)


The current implementation should be independent of the used dependency resolver because here we just try to mimic additional ctor arguments for an actor.
Our current workaround was to send a "Initalize" message directly after creating an actor via DI and take care to resend this message in case of actor restart. But this is error prone and unnecessary.

What do you think?

