### PR TITLE
[xml-docs] Fixed broken xrefs / missing field refs

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
@@ -810,7 +810,7 @@ namespace Akka.Cluster.Sharding
         }
 
         /// <summary>
-        /// Result of <see cref="PersistentShardCoordinator.AllocateShard"/> is piped to self with this message.
+        /// Result of <see cref="IShardAllocationStrategy.AllocateShard(IActorRef, ShardId, IImmutableDictionary{IActorRef, IImmutableList{ShardId}})"/> is piped to self with this message.
         /// </summary>
         [Serializable]
         public sealed class AllocateShardResult
@@ -846,7 +846,7 @@ namespace Akka.Cluster.Sharding
         }
 
         /// <summary>
-        /// Result of `rebalance` is piped to self with this message.
+        /// Result of <see cref="IShardAllocationStrategy.Rebalance(IImmutableDictionary{IActorRef, IImmutableList{ShardId}}, IImmutableSet{ShardId})"/> is piped to self with this message.
         /// </summary>
         [Serializable]
         public sealed class RebalanceResult

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
@@ -188,6 +188,7 @@ namespace Akka.Cluster.Sharding
             /// <param name="replyTo">TBD</param>
             /// <param name="entities">TBD</param>
             /// <param name="stopMessage">TBD</param>
+            /// <param name="handoffTimeout">TBD</param>
             /// <returns>TBD</returns>
             public static Props Props(ShardId shard, IActorRef replyTo, IEnumerable<IActorRef> entities, object stopMessage, TimeSpan handoffTimeout)
             {
@@ -203,6 +204,7 @@ namespace Akka.Cluster.Sharding
             /// <param name="replyTo">TBD</param>
             /// <param name="entities">TBD</param>
             /// <param name="stopMessage">TBD</param>
+            /// <param name="handoffTimeout">TBD</param>
             public HandOffStopper(ShardId shard, IActorRef replyTo, IEnumerable<IActorRef> entities, object stopMessage, TimeSpan handoffTimeout)
             {
                 var remaining = new HashSet<IActorRef>(entities);

--- a/src/contrib/cluster/Akka.DistributedData/Replicator.Messages.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Replicator.Messages.cs
@@ -65,7 +65,7 @@ namespace Akka.DistributedData
 
     /// <summary>
     /// Send this message to the local <see cref="Replicator"/> to retrieve a data value for the
-    /// given `key`. The `Replicator` will reply with one of the <see cref="GetResponse"/> messages.
+    /// given `key`. The `Replicator` will reply with one of the <see cref="IGetResponse"/> messages.
     /// 
     /// The optional `request` context is included in the reply messages. This is a convenient
     /// way to pass contextual information (e.g. original sender) without having to use `ask`

--- a/src/core/Akka.Persistence.TestKit.Xunit2/PersistenceTestKit.cs
+++ b/src/core/Akka.Persistence.TestKit.Xunit2/PersistenceTestKit.cs
@@ -25,6 +25,7 @@ namespace Akka.Persistence.TestKit
         /// A new system with the specified configuration will be created.
         /// </summary>
         /// <param name="actorSystemName">Optional: The name of the actor system</param>
+        /// <param name="output">TBD</param>
         protected PersistenceTestKit(string actorSystemName = null, ITestOutputHelper output = null)
             : base(GetConfig(), actorSystemName, output)
         {

--- a/src/core/Akka.Persistence.TestKit/Journal/JournalRecoveryBehavior.cs
+++ b/src/core/Akka.Persistence.TestKit/Journal/JournalRecoveryBehavior.cs
@@ -63,7 +63,7 @@ namespace Akka.Persistence.TestKit
         /// </summary>
         /// <remarks>
         ///     <para>
-        ///         Journal will crash and <see cref="UntypedPersistentActor.OnPersistFailure"/> will be called on persistent actor.
+        ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
         ///     </para>
         ///     <para>
         ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
@@ -77,7 +77,7 @@ namespace Akka.Persistence.TestKit
         /// </summary>
         /// <remarks>
         ///     <para>
-        ///         Journal will crash and <see cref="UntypedPersistentActor.OnPersistFailure"/> will be called on persistent actor.
+        ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
         ///     </para>
         ///     <para>
         ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
@@ -98,7 +98,7 @@ namespace Akka.Persistence.TestKit
         /// </summary>
         /// <remarks>
         ///     <para>
-        ///         Journal will crash and <see cref="UntypedPersistentActor.OnPersistFailure"/> will be called on persistent actor.
+        ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
         ///     </para>
         ///     <para>
         ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
@@ -125,7 +125,7 @@ namespace Akka.Persistence.TestKit
         /// </summary>
         /// <remarks>
         ///     <para>
-        ///         Journal will crash and <see cref="UntypedPersistentActor.OnPersistFailure"/> will be called on persistent actor.
+        ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
         ///     </para>
         ///     <para>
         ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
@@ -146,7 +146,7 @@ namespace Akka.Persistence.TestKit
         /// </summary>
         /// <remarks>
         ///     <para>
-        ///         Journal will crash and <see cref="UntypedPersistentActor.OnPersistFailure"/> will be called on persistent actor.
+        ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
         ///     </para>
         ///     <para>
         ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
@@ -167,7 +167,7 @@ namespace Akka.Persistence.TestKit
         /// </summary>
         /// <remarks>
         ///     <para>
-        ///         Journal will crash and <see cref="UntypedPersistentActor.OnPersistFailure"/> will be called on persistent actor.
+        ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
         ///     </para>
         ///     <para>
         ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
@@ -188,7 +188,7 @@ namespace Akka.Persistence.TestKit
         /// </summary>
         /// <remarks>
         ///     <para>
-        ///         Journal will crash and <see cref="UntypedPersistentActor.OnPersistFailure"/> will be called on persistent actor.
+        ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
         ///     </para>
         ///     <para>
         ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
@@ -212,7 +212,7 @@ namespace Akka.Persistence.TestKit
         ///         Each message will be delayed individually.
         ///     </para>
         ///     <para>
-        ///         Journal will crash and <see cref="UntypedPersistentActor.OnPersistFailure"/> will be called on persistent actor.
+        ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
         ///     </para>
         ///     <para>
         ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
@@ -237,7 +237,7 @@ namespace Akka.Persistence.TestKit
         ///         Each message will be delayed individually.
         ///     </para>
         ///     <para>
-        ///         Journal will crash and <see cref="UntypedPersistentActor.OnPersistFailure"/> will be called on persistent actor.
+        ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
         ///     </para>
         ///     <para>
         ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
@@ -268,7 +268,7 @@ namespace Akka.Persistence.TestKit
         ///         Each message will be delayed individually.
         ///     </para>
         ///     <para>
-        ///         Journal will crash and <see cref="UntypedPersistentActor.OnPersistFailure"/> will be called on persistent actor.
+        ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
         ///     </para>
         ///     <para>
         ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
@@ -299,7 +299,7 @@ namespace Akka.Persistence.TestKit
         ///         Each message will be delayed individually.
         ///     </para>
         ///     <para>
-        ///         Journal will crash and <see cref="UntypedPersistentActor.OnPersistFailure"/> will be called on persistent actor.
+        ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
         ///     </para>
         ///     <para>
         ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
@@ -331,7 +331,7 @@ namespace Akka.Persistence.TestKit
         ///         Each message will be delayed individually.
         ///     </para>
         ///     <para>
-        ///         Journal will crash and <see cref="UntypedPersistentActor.OnPersistFailure"/> will be called on persistent actor.
+        ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
         ///     </para>
         ///     <para>
         ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
@@ -362,7 +362,7 @@ namespace Akka.Persistence.TestKit
         ///         Each message will be delayed individually.
         ///     </para>
         ///     <para>
-        ///         Journal will crash and <see cref="UntypedPersistentActor.OnPersistFailure"/> will be called on persistent actor.
+        ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
         ///     </para>
         ///     <para>
         ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems
@@ -388,7 +388,7 @@ namespace Akka.Persistence.TestKit
         ///         Each message will be delayed individually.
         ///     </para>
         ///     <para>
-        ///         Journal will crash and <see cref="UntypedPersistentActor.OnPersistFailure"/> will be called on persistent actor.
+        ///         Journal will crash and <see cref="Eventsourced.OnPersistFailure">UntypedPersistentActor.OnPersistFailure</see> will be called on persistent actor.
         ///     </para>
         ///     <para>
         ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle network problems

--- a/src/core/Akka.Persistence.TestKit/Journal/JournalWriteBehavior.cs
+++ b/src/core/Akka.Persistence.TestKit/Journal/JournalWriteBehavior.cs
@@ -22,7 +22,7 @@ namespace Akka.Persistence.TestKit
         /// </summary>
         /// <remarks>
         ///     <para>
-        ///         Journal will **NOT** crash, but <see cref="UntypedPersistentActor.OnPersistRejected"/> will be called
+        ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
         ///         on each rejected message.
         ///     </para>
         ///     <para>
@@ -37,7 +37,7 @@ namespace Akka.Persistence.TestKit
         /// </summary>
         /// <remarks>
         ///     <para>
-        ///         Journal will **NOT** crash, but <see cref="UntypedPersistentActor.OnPersistRejected"/> will be called
+        ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
         ///         on each rejected message.
         ///     </para>
         ///     <para>
@@ -59,7 +59,7 @@ namespace Akka.Persistence.TestKit
         /// </summary>
         /// <remarks>
         ///     <para>
-        ///         Journal will **NOT** crash, but <see cref="UntypedPersistentActor.OnPersistRejected"/> will be called
+        ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see>> will be called
         ///         on each rejected message.
         ///     </para>
         ///     <para>
@@ -87,7 +87,7 @@ namespace Akka.Persistence.TestKit
         /// </summary>
         /// <remarks>
         ///     <para>
-        ///         Journal will **NOT** crash, but <see cref="UntypedPersistentActor.OnPersistRejected"/> will be called
+        ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
         ///         on each rejected message.
         ///     </para>
         ///     <para>
@@ -109,7 +109,7 @@ namespace Akka.Persistence.TestKit
         /// </summary>
         /// <remarks>
         ///     <para>
-        ///         Journal will **NOT** crash, but <see cref="UntypedPersistentActor.OnPersistRejected"/> will be called
+        ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
         ///         on each rejected message.
         ///     </para>
         ///     <para>
@@ -131,7 +131,7 @@ namespace Akka.Persistence.TestKit
         /// </summary>
         /// <remarks>
         ///     <para>
-        ///         Journal will **NOT** crash, but <see cref="UntypedPersistentActor.OnPersistRejected"/> will be called
+        ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
         ///         on each rejected message.
         ///     </para>
         ///     <para>
@@ -153,7 +153,7 @@ namespace Akka.Persistence.TestKit
         /// </summary>
         /// <remarks>
         ///     <para>
-        ///         Journal will **NOT** crash, but <see cref="UntypedPersistentActor.OnPersistRejected"/> will be called
+        ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
         ///         on each rejected message.
         ///     </para>
         ///     <para>
@@ -178,7 +178,7 @@ namespace Akka.Persistence.TestKit
         ///         Each message will be delayed individually.
         ///     </para>
         ///     <para>
-        ///         Journal will **NOT** crash, but <see cref="UntypedPersistentActor.OnPersistRejected"/> will be called
+        ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
         ///         on each rejected message.
         ///     </para>
         ///     <para>
@@ -204,7 +204,7 @@ namespace Akka.Persistence.TestKit
         ///         Each message will be delayed individually.
         ///     </para>
         ///     <para>
-        ///         Journal will **NOT** crash, but <see cref="UntypedPersistentActor.OnPersistRejected"/> will be called
+        ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
         ///         on each rejected message.
         ///     </para>
         ///     <para>
@@ -236,7 +236,7 @@ namespace Akka.Persistence.TestKit
         ///         Each message will be delayed individually.
         ///     </para>
         ///     <para>
-        ///         Journal will **NOT** crash, but <see cref="UntypedPersistentActor.OnPersistRejected"/> will be called
+        ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
         ///         on each rejected message.
         ///     </para>
         ///     <para>
@@ -268,7 +268,7 @@ namespace Akka.Persistence.TestKit
         ///         Each message will be delayed individually.
         ///     </para>
         ///     <para>
-        ///         Journal will **NOT** crash, but <see cref="UntypedPersistentActor.OnPersistRejected"/> will be called
+        ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
         ///         on each rejected message.
         ///     </para>
         ///     <para>
@@ -301,7 +301,7 @@ namespace Akka.Persistence.TestKit
         ///         Each message will be delayed individually.
         ///     </para>
         ///     <para>
-        ///         Journal will **NOT** crash, but <see cref="UntypedPersistentActor.OnPersistRejected"/> will be called
+        ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
         ///         on each rejected message.
         ///     </para>
         ///     <para>
@@ -333,7 +333,7 @@ namespace Akka.Persistence.TestKit
         ///         Each message will be delayed individually.
         ///     </para>
         ///     <para>
-        ///         Journal will **NOT** crash, but <see cref="UntypedPersistentActor.OnPersistRejected"/> will be called
+        ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
         ///         on each rejected message.
         ///     </para>
         ///     <para>
@@ -360,7 +360,7 @@ namespace Akka.Persistence.TestKit
         ///         Each message will be delayed individually.
         ///     </para>
         ///     <para>
-        ///         Journal will **NOT** crash, but <see cref="UntypedPersistentActor.OnPersistRejected"/> will be called
+        ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
         ///         on each rejected message.
         ///     </para>
         ///     <para>

--- a/src/core/Akka.Persistence/PersistentView.Recovery.cs
+++ b/src/core/Akka.Persistence/PersistentView.Recovery.cs
@@ -95,7 +95,7 @@ namespace Akka.Persistence
         /// then switch it switches to <see cref="Idle"/> state.
         /// 
         /// 
-        /// If replay succeeds the <see cref="OnReplaySuccess"/> callback method is called, otherwise
+        /// If replay succeeds the <see cref="OnReplayComplete"/> callback method is called, otherwise
         /// <see cref="OnReplayError"/> is called and remaining replay events are consumed (ignored).
         /// 
         /// All incoming messages are stashed when <paramref name="shouldAwait"/> is true.

--- a/src/core/Akka.Remote/EndpointRegistry.cs
+++ b/src/core/Akka.Remote/EndpointRegistry.cs
@@ -38,7 +38,7 @@ namespace Akka.Remote
         /// an <see cref="EndpointManager.EndpointPolicy"/> of <see cref="EndpointManager.Pass"/>
         /// in the registry.
         /// </exception>
-        /// <returns>The <see cref="endpoint"/> actor reference.</returns>
+        /// <returns>The <paramref name="endpoint"/> actor reference.</returns>
         public IActorRef RegisterWritableEndpoint(Address address, IActorRef endpoint, int? uid)
         {
             if (_addressToWritable.TryGetValue(address, out var existing))
@@ -88,7 +88,7 @@ namespace Akka.Remote
         /// <param name="address">The remote address.</param>>
         /// <param name="endpoint">The local endpoint actor who owns this connection.</param>
         /// <param name="uid">The UID of the remote actor system. Can be <c>null</c>.</param>
-        /// <returns>The <see cref="endpoint"/> actor reference.</returns>
+        /// <returns>The <paramref name="endpoint"/> actor reference.</returns>
         public IActorRef RegisterReadOnlyEndpoint(Address address, IActorRef endpoint, int uid)
         {
             _addressToReadonly[address] = Tuple.Create(endpoint, uid);
@@ -126,7 +126,7 @@ namespace Akka.Remote
         /// Get the endpoint address for the selected endpoint writer actor.
         /// </summary>
         /// <param name="writer">The endpoint writer actor reference.</param>
-        /// <returns>The remote system address owned by <see cref="writer"/>.</returns>
+        /// <returns>The remote system address owned by <paramref name="writer"/>.</returns>
         public Address AddressForWriter(IActorRef writer)
         {
             // Needs to return null if the key is not in the dictionary, instead of throwing.
@@ -169,7 +169,7 @@ namespace Akka.Remote
         /// Checks to see if the specified address is already quarantined or not.
         /// </summary>
         /// <param name="address">The address to check.</param>
-        /// <param name="uid">The current UID of <see cref="address"/>.</param>
+        /// <param name="uid">The current UID of <paramref name="address"/>.</param>
         /// <returns><c>true</c> if this system is under quarantine with its current UID, <c>false</c> otherwise.</returns>
         public bool IsQuarantined(Address address, int uid)
         {

--- a/src/core/Akka.Remote/Transport/Transport.cs
+++ b/src/core/Akka.Remote/Transport/Transport.cs
@@ -382,7 +382,7 @@ namespace Akka.Remote.Transport
         /// transports may not support it. Remote endpoint of the channel or connection MAY be notified, but this is not
         /// guaranteed.
         /// 
-        /// The transport that provides the handle MUST guarantee that <see cref="Disassociate"/> could be called arbitrarily many times.
+        /// The transport that provides the handle MUST guarantee that <see cref="Disassociate()"/> could be called arbitrarily many times.
         /// </summary>
         [Obsolete("Use the method that states reasons to make sure disassociation reasons are logged.")]
         public abstract void Disassociate();

--- a/src/core/Akka.Streams/ActorMaterializer.cs
+++ b/src/core/Akka.Streams/ActorMaterializer.cs
@@ -381,6 +381,7 @@ namespace Akka.Streams
         /// <param name="dispatcher">TBD</param>
         /// <param name="supervisionDecider">TBD</param>
         /// <param name="subscriptionTimeoutSettings">TBD</param>
+        /// <param name="streamRefSettings">TBD</param>
         /// <param name="isDebugLogging">TBD</param>
         /// <param name="outputBurstLimit">TBD</param>
         /// <param name="isFuzzingMode">TBD</param>

--- a/src/core/Akka.Streams/Dsl/Flow.cs
+++ b/src/core/Akka.Streams/Dsl/Flow.cs
@@ -189,7 +189,7 @@ namespace Akka.Streams.Dsl
         /// 
         /// Parallelism limits the number of how many asks can be "in flight" at the same time.
         /// Please note that the elements emitted by this operator are in-order with regards to the asks being issued
-        /// (i.e. same behaviour as <see cref="SelectAsync{TIn,TOut,TMat}"/>).
+        /// (i.e. same behaviour as <see cref="SourceOperations.SelectAsync{TIn,TOut,TMat}"/>).
         /// 
         /// The operator fails with an <see cref="WatchedActorTerminatedException"/> if the target actor is terminated,
         /// or with an <see cref="TimeoutException"/> in case the ask exceeds the timeout passed in.

--- a/src/core/Akka.Streams/Dsl/Source.cs
+++ b/src/core/Akka.Streams/Dsl/Source.cs
@@ -167,7 +167,7 @@ namespace Akka.Streams.Dsl
         /// 
         /// Parallelism limits the number of how many asks can be "in flight" at the same time.
         /// Please note that the elements emitted by this operator are in-order with regards to the asks being issued
-        /// (i.e. same behaviour as <see cref="SelectAsync{TIn,TOut,TMat}"/>).
+        /// (i.e. same behaviour as <see cref="SourceOperations.SelectAsync{TIn,TOut,TMat}"/>).
         /// 
         /// The operator fails with an <see cref="WatchedActorTerminatedException"/> if the target actor is terminated,
         /// or with an <see cref="TimeoutException"/> in case the ask exceeds the timeout passed in.

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -183,7 +183,7 @@ namespace Akka.Actor
     /// If you receive a reference to an actor, that actor is guaranteed to have existed at some point
     /// in the past. However, an actor can always be terminated in the future.
     /// 
-    /// If you want to be notified about an actor terminating, call <see cref="IActorContext.Watch"/>
+    /// If you want to be notified about an actor terminating, call <see cref="ICanWatch.Watch(IActorRef)">IActorContext.Watch</see>
     /// on this actor and you'll receive a <see cref="Terminated"/> message when the actor dies or if it
     /// is already dead.
     /// </summary>
@@ -850,8 +850,8 @@ override def getChild(name: Iterator[String]): InternalActorRef = {
     /// This kind of ActorRef passes all received messages to the given function for
     /// performing a non-blocking side-effect. The intended use is to transform the
     /// message before sending to the real target actor. Such references can be created
-    /// by calling <see cref="ActorCell.AddFunctionRef()"/> and must be deregistered when no longer
-    /// needed by calling <see cref="ActorCell.RemoveFunctionRef()"/>. FunctionRefs do not count
+    /// by calling <see cref="ActorCell.AddFunctionRef(Action{IActorRef, object}, string)"/> and must be deregistered when no longer
+    /// needed by calling <see cref="ActorCell.RemoveFunctionRef(FunctionRef)"/>. FunctionRefs do not count
     /// towards the live children of an actor, they do not receive the Terminate command
     /// and do not prevent the parent from terminating. FunctionRef is properly
     /// registered for remote lookup and ActorSelection.

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -488,7 +488,7 @@ namespace Akka.Actor
             }
         }
 
-        /// <inheritdoc cref="InternalActorRefBase.TellInternal"/>
+        /// <inheritdoc cref="ActorRefBase.TellInternal">InternalActorRefBase.TellInternal</inheritdoc>
         protected override void TellInternal(object message, IActorRef sender)
         {
             if (State is Stopped || State is StoppedWithPath) Provider.DeadLetters.Tell(message);

--- a/src/core/Akka/Event/ILoggingAdapter.cs
+++ b/src/core/Akka/Event/ILoggingAdapter.cs
@@ -193,7 +193,7 @@ namespace Akka.Event
         public void Info(Exception cause, string format, params object[] args){ }
 
         /// <summary>
-        /// Obsolete. Use <see cref="Warning" /> instead!
+        /// Obsolete. Use <see cref="Warning(string, object[])" /> instead!
         /// </summary>
         /// <param name="format">N/A</param>
         /// <param name="args">N/A</param>

--- a/src/core/Akka/Event/LoggingAdapterBase.cs
+++ b/src/core/Akka/Event/LoggingAdapterBase.cs
@@ -219,7 +219,7 @@ namespace Akka.Event
         }
 
         /// <summary>
-        /// Obsolete. Use <see cref="Warning" /> instead!
+        /// Obsolete. Use <see cref="Warning(string, object[])" /> instead!
         /// </summary>
         /// <param name="format">N/A</param>
         /// <param name="args">N/A</param>

--- a/src/core/Akka/IO/Tcp.cs
+++ b/src/core/Akka/IO/Tcp.cs
@@ -357,7 +357,7 @@ namespace Akka.IO
 
         /// <summary>
         /// Each <see cref="WriteCommand" /> can optionally request a positive acknowledgment to be sent
-        /// to the commanding actor. If such notification is not desired the <see cref="WriteCommand#ack" />
+        /// to the commanding actor. If such notification is not desired the <see cref="Write.Ack" />
         /// must be set to an instance of this class. The token contained within can be used
         /// to recognize which write failed when receiving a <see cref="CommandFailed" /> message.
         /// </summary>
@@ -472,8 +472,8 @@ namespace Akka.IO
         /// <summary>
         /// Write data to the TCP connection. If no ack is needed use the special
         /// `NoAck` object. The connection actor will reply with a <see cref="CommandFailed" />
-        /// message if the write could not be enqueued. If <see cref="WriteCommand#wantsAck" />
-        /// returns true, the connection actor will reply with the supplied <see cref="WriteCommand#ack" />
+        /// message if the write could not be enqueued. If <see cref="SimpleWriteCommand.WantsAck">Write.WantsAck</see>
+        /// returns true, the connection actor will reply with the supplied <see cref="Write.Ack" />
         /// token once the write has been successfully enqueued to the O/S kernel.
         /// <b>Note that this does not in any way guarantee that the data will be
         /// or have been sent!</b> Unfortunately there is no way to determine whether
@@ -585,7 +585,7 @@ namespace Akka.IO
         */
         /// <summary>
         /// A write command which aggregates two other write commands. Using this construct
-        /// you can chain a number of <see cref="Akka.IO.Tcp.Write" /> and/or <see cref="Akka.IO.Tcp.WriteFile" /> commands together in a way
+        /// you can chain a number of <see cref="Akka.IO.Tcp.Write" /> commands together in a way
         /// that allows them to be handled as a single write which gets written out to the
         /// network as quickly as possible.
         /// If the sub commands contain `ack` requests they will be honored as soon as the

--- a/src/core/Akka/Pattern/BackoffOnRestartSupervisor.cs
+++ b/src/core/Akka/Pattern/BackoffOnRestartSupervisor.cs
@@ -13,7 +13,8 @@ namespace Akka.Pattern
 {
     /// <summary>
     /// Back-off supervisor that stops and starts a child actor when the child actor restarts. 
-    /// This back-off supervisor is created by using <see cref="BackoffSupervisor.Props"/> with <see cref="Backoff.OnFailure"/>
+    /// This back-off supervisor is created by using <see cref="BackoffSupervisor.Props(Props, string, TimeSpan, TimeSpan, double)">BackoffSupervisor.Props</see>
+    /// with <see cref="Backoff.OnFailure(Props, string, TimeSpan, TimeSpan, double)">Backoff.OnFailure</see>
     /// </summary>
     internal sealed class BackoffOnRestartSupervisor : BackoffSupervisorBase
     {

--- a/src/core/Akka/Util/Base64Encoding.cs
+++ b/src/core/Akka/Util/Base64Encoding.cs
@@ -30,6 +30,7 @@ namespace Akka.Util
         /// TBD
         /// </summary>
         /// <param name="value">TBD</param>
+        /// <param name="sb">TBD</param>
         /// <returns>TBD</returns>
         public static StringBuilder Base64Encode(this long value, StringBuilder sb)
         {


### PR DESCRIPTION
This PR fixes a number of broken cross references and adds a couple of missing parameter references.

Most of the cross references were referencing fields in the subclass. For some reason MSBuild doesnt like that. The fix was to reference the fields of the base class and the link text pointed to the correct subclass field.