### PR TITLE
[xunit] Fix xunit warnings

### DIFF
--- a/src/contrib/cluster/Akka.DistributedData.Tests/GSetSpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/GSetSpec.cs
@@ -32,10 +32,10 @@ namespace Akka.DistributedData.Tests
             var c4 = c3.Add(user3);
             var c5 = c4.Add(user4);
 
-            Assert.Equal(true, c5.Contains(user1));
-            Assert.Equal(true, c5.Contains(user2));
-            Assert.Equal(true, c5.Contains(user3));
-            Assert.Equal(true, c5.Contains(user4));
+            Assert.True(c5.Contains(user1));
+            Assert.True(c5.Contains(user2));
+            Assert.True(c5.Contains(user3));
+            Assert.True(c5.Contains(user4));
         }
 
         [Fact]

--- a/src/contrib/cluster/Akka.DistributedData.Tests/PNCounterSpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/PNCounterSpec.cs
@@ -162,17 +162,17 @@ namespace Akka.DistributedData.Tests
             var c2 = c1.Increment(_address1);
             var c3 = c2.Decrement(_address2);
 
-            Assert.Equal(true, c2.NeedPruningFrom(_address1));
-            Assert.Equal(false, c2.NeedPruningFrom(_address2));
-            Assert.Equal(true, c3.NeedPruningFrom(_address1));
-            Assert.Equal(true, c3.NeedPruningFrom(_address2));
+            Assert.True(c2.NeedPruningFrom(_address1));
+            Assert.False(c2.NeedPruningFrom(_address2));
+            Assert.True(c3.NeedPruningFrom(_address1));
+            Assert.True(c3.NeedPruningFrom(_address2));
 
             var c4 = c3.Prune(_address1, _address2);
-            Assert.Equal(true, c4.NeedPruningFrom(_address2));
-            Assert.Equal(false, c4.NeedPruningFrom(_address1));
+            Assert.True(c4.NeedPruningFrom(_address2));
+            Assert.False(c4.NeedPruningFrom(_address1));
 
             var c5 = (c4.Increment(_address1)).PruningCleanup(_address1);
-            Assert.Equal(false, c5.NeedPruningFrom(_address1));
+            Assert.False(c5.NeedPruningFrom(_address1));
         }
     }
 }

--- a/src/core/Akka.Tests.Shared.Internals/AkkaSpecExtensions.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AkkaSpecExtensions.cs
@@ -87,7 +87,7 @@ namespace Akka.TestKit
         /// <param name="message">TBD</param>
         public static void ShouldBeSame<T>(this T self, T expected, string message = null)
         {
-            Assert.Same(expected, self);
+            Assert.Equal(expected, self);
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace Akka.TestKit
         /// <param name="message">TBD</param>
         public static void ShouldNotBeSame<T>(this T self, T expected, string message = null)
         {
-            Assert.NotSame(expected, self);
+            Assert.NotEqual(expected, self);
         }
 
         /// <summary>

--- a/src/core/Akka.Tests/Actor/LocalActorRefProviderSpec.cs
+++ b/src/core/Akka.Tests/Actor/LocalActorRefProviderSpec.cs
@@ -79,7 +79,6 @@ namespace Akka.Tests.Actor
         [InlineData("%1t","Illegal actor name")]
         [InlineData("a?","Illegal actor name")]
         [InlineData("üß","include only ASCII")]
-        [InlineData("a?", "Illegal actor name")]
         [InlineData("åäö", "Illegal actor name")]
         public void An_ActorRefFactory_must_throw_suitable_exceptions_for_malformed_actor_names(string name, string expectedExceptionMessageSubstring)
         {


### PR DESCRIPTION
This PR fixes a few xunit warnings.

Most of these warnings were in the form of Assert.Equals(<bool>, <some value>) where xunit suggests the more readable Assert.<bool>(<some value>).

Also removed a duplicate InlineData entry that wasn't testing duplicates.