### PR TITLE
[build] Fix CS0162 warnings

### DIFF
--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/GraphInterpreterSpecKit.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/GraphInterpreterSpecKit.cs
@@ -394,6 +394,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
 
                 public Outlet<T> Outlet { get; }
 
+#pragma warning disable CS0162 // Disabled since the flag can be set while debugging
                 public void OnNext(T element, int eventLimit = int.MaxValue)
                 {
                     if (GraphInterpreter.IsDebug)
@@ -417,6 +418,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                     Fail(Outlet, ex);
                     Interpreter.Execute(eventLimit);
                 }
+#pragma warning restore CS0162
 
                 public override string ToString() => _name;
             }
@@ -440,6 +442,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
 
                 public Inlet<T> Inlet { get; }
 
+#pragma warning disable CS0162 // Disabled since the flag can be set while debugging
                 public void RequestOne(int eventLimit = int.MaxValue)
                 {
                     if (GraphInterpreter.IsDebug)
@@ -455,6 +458,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                     Cancel(Inlet);
                     Interpreter.Execute(eventLimit);
                 }
+#pragma warning restore CS0162
 
                 public override string ToString() => _name;
             }

--- a/src/core/Akka.Streams/Implementation/Fusing/ActorGraphInterpreter.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/ActorGraphInterpreter.cs
@@ -224,6 +224,7 @@ namespace Akka.Streams.Implementation.Fusing
             return RunBatch(eventLimit);
         }
 
+#pragma warning disable CS0162 // Disabled since the flag can be set while debugging
         /// <summary>
         /// TBD
         /// </summary>
@@ -321,6 +322,7 @@ namespace Akka.Streams.Implementation.Fusing
 
             return eventLimit;
         }
+#pragma warning restore CS0162
 
         /**
          * Attempts to abort execution, by first propagating the reason given until either
@@ -1218,6 +1220,7 @@ namespace Akka.Streams.Implementation.Fusing
                 }
             }
 
+#pragma warning disable CS0162 // Disabled since the flag can be set while debugging
             /// <summary>
             /// TBD
             /// </summary>
@@ -1235,6 +1238,7 @@ namespace Akka.Streams.Implementation.Fusing
                     else ReactiveStreamsCompliance.RejectAdditionalSubscriber(subscriber, GetType().FullName);
                 }
             }
+#pragma warning restore CS0162
 
             void IActorOutputBoundary.ExposedPublisher(IActorPublisher publisher) => ExposedPublisher((ActorPublisher<T>) publisher);
 
@@ -1350,6 +1354,7 @@ namespace Akka.Streams.Implementation.Fusing
             _shortCircuitBuffer.Enqueue(input);
         }
 
+#pragma warning disable CS0162 // Disabled since the flag can be set while debugging
         private bool TryInit(GraphInterpreterShell shell)
         {
             try
@@ -1369,6 +1374,7 @@ namespace Akka.Streams.Implementation.Fusing
                 return false;
             }
         }
+#pragma warning restore CS0162
 
         /// <summary>
         /// TBD

--- a/src/core/Akka.Streams/Implementation/Fusing/GraphInterpreter.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/GraphInterpreter.cs
@@ -533,6 +533,7 @@ namespace Akka.Streams.Implementation.Fusing
         public void AttachDownstreamBoundary(int connection, DownstreamBoundaryStageLogic logic)
             => AttachDownstreamBoundary(Connections[connection], logic);
 
+#pragma warning disable CS0162 // Disabled since the flag can be set while debugging
         /// <summary>
         /// Dynamic handler changes are communicated from a GraphStageLogic by this method.
         /// </summary>
@@ -554,6 +555,7 @@ namespace Akka.Streams.Implementation.Fusing
             if (IsDebug) Console.WriteLine($"{Name} SETHANDLER {OutOwnerName(connection)} (out) {handler}");
             connection.OutHandler = handler;
         }
+#pragma warning restore CS0162
 
         /// <summary>
         /// Returns true if there are pending unprocessed events in the event queue.
@@ -636,6 +638,7 @@ namespace Akka.Streams.Implementation.Fusing
         private string ShutdownCounters() => string.Join(",",
             _shutdownCounter.Select(x => x >= KeepGoingFlag ? $"{x & KeepGoingMask}(KeepGoing)" : x.ToString()));
 
+#pragma warning disable CS0162 // Disabled since the flag can be set while debugging
         /// <summary>
         /// Executes pending events until the given limit is met. If there were remaining events, <see cref="IsSuspended"/> will return true.
         /// </summary>
@@ -749,6 +752,7 @@ namespace Akka.Streams.Implementation.Fusing
             // TODO: deadlock detection
             return eventsRemaining;
         }
+#pragma warning restore CS0162
 
         private void ReportStageError(Exception e)
         {
@@ -778,6 +782,7 @@ namespace Akka.Streams.Implementation.Fusing
         }
 
 
+#pragma warning disable CS0162 // Disabled since the flag can be set while debugging
         /// <summary>
         /// TBD
         /// </summary>
@@ -866,7 +871,8 @@ namespace Akka.Streams.Implementation.Fusing
                 }
             }
         }
-        
+#pragma warning restore CS0162
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ProcessPush(Connection connection)
         {
@@ -1004,6 +1010,7 @@ namespace Akka.Streams.Implementation.Fusing
                 Enqueue(connection);
         }
 
+#pragma warning disable CS0162 // Disabled since the flag can be set while debugging
         /// <summary>
         /// TBD
         /// </summary>
@@ -1082,6 +1089,7 @@ namespace Akka.Streams.Implementation.Fusing
             if ((currentState & InClosed) == 0)
                 CompleteConnection(connection.InOwnerId);
         }
+#pragma warning restore CS0162
 
         /// <summary>
         /// Debug utility to dump the "waits-on" relationships in DOT format to the console for analysis of deadlocks.

--- a/src/core/Akka.Tests/Pattern/BackoffOnRestartSupervisorSpec.cs
+++ b/src/core/Akka.Tests/Pattern/BackoffOnRestartSupervisorSpec.cs
@@ -43,6 +43,7 @@ namespace Akka.Tests.Pattern
         {
             private readonly IActorRef _probe;
 
+#pragma warning disable CS0162 // Disabled because without the return, the compiler complains about ambigious reference between Receive<T>(Action<T>,Predicate<T>) and Receive<T>(Predicate<T>,Action<T>)
             public TestActor(IActorRef probe)
             {
                 _probe = probe;
@@ -70,6 +71,7 @@ namespace Akka.Tests.Pattern
 
                 ReceiveAny(other => _probe.Tell(other));
             }
+#pragma warning restore CS0162
 
             public static Props Props(IActorRef probe)
             {
@@ -99,6 +101,7 @@ namespace Akka.Tests.Pattern
         {
             private readonly TestLatch _latch;
 
+#pragma warning disable CS0162 // Disabled because without the return, the compiler complains about ambigious reference between Receive<T>(Action<T>,Predicate<T>) and Receive<T>(Predicate<T>,Action<T>)
             public SlowlyFailingActor(TestLatch latch)
             {
                 _latch = latch;
@@ -115,6 +118,7 @@ namespace Akka.Tests.Pattern
                     Sender.Tell("PONG");
                 });
             }
+#pragma warning restore CS0162
 
             protected override void PostStop()
             {

--- a/src/core/Akka.Tests/Pattern/BackoffSupervisorSpec.cs
+++ b/src/core/Akka.Tests/Pattern/BackoffSupervisorSpec.cs
@@ -29,6 +29,7 @@ namespace Akka.Tests.Pattern
         {
             private readonly IActorRef _probe;
 
+#pragma warning disable CS0162 // Disabled because without the return, the compiler complains about ambigious reference between Receive<T>(Action<T>,Predicate<T>) and Receive<T>(Predicate<T>,Action<T>)
             public Child(IActorRef probe)
             {
                 _probe = probe;
@@ -44,6 +45,7 @@ namespace Akka.Tests.Pattern
                     _probe.Tell(msg);
                 });
             }
+#pragma warning restore CS0162
 
             public static Props Props(IActorRef probe)
             {
@@ -55,6 +57,7 @@ namespace Akka.Tests.Pattern
         {
             private readonly IActorRef _probe;
 
+#pragma warning disable CS0162 // Disabled because without the return, the compiler complains about ambigious reference between Receive<T>(Action<T>,Predicate<T>) and Receive<T>(Predicate<T>,Action<T>)
             public ManualChild(IActorRef probe)
             {
                 _probe = probe;
@@ -71,6 +74,7 @@ namespace Akka.Tests.Pattern
                     Context.Parent.Tell(BackoffSupervisor.Reset.Instance);
                 });
             }
+#pragma warning restore CS0162
 
             public static Props Props(IActorRef probe)
             {

--- a/src/core/Akka/Actor/Props.cs
+++ b/src/core/Akka/Actor/Props.cs
@@ -105,11 +105,13 @@ namespace Akka.Actor
             return Deploy.Equals(other.Deploy);
         }
 
+#pragma warning disable CS0162 // Disabled because it's marked as a TODO
         private bool CompareSupervisorStrategy(Props other)
         {
             return true; //TODO: fix https://github.com/akkadotnet/akka.net/issues/599
             return Equals(SupervisorStrategy, other.SupervisorStrategy);
         }
+#pragma warning restore CS0162
 
         private bool CompareArguments(Props other)
         {

--- a/src/core/Akka/Dispatch/AbstractDispatcher.cs
+++ b/src/core/Akka/Dispatch/AbstractDispatcher.cs
@@ -330,6 +330,7 @@ namespace Akka.Dispatch
         /// </summary>
         internal static readonly Lazy<Index<MessageDispatcher, IInternalActorRef>> Actors = new Lazy<Index<MessageDispatcher, IInternalActorRef>>(() => new Index<MessageDispatcher, IInternalActorRef>(), LazyThreadSafetyMode.PublicationOnly);
 
+#pragma warning disable CS0162 // Disabled since the flag can be set while debugging
         /// <summary>
         /// INTERNAL API - Debugging purposes only! Should be elided by compiler in release builds.
         /// </summary>
@@ -353,6 +354,7 @@ namespace Akka.Dispatch
                 }
             }
         }
+#pragma warning restore CS0162
 
         /// <summary>
         ///     The default throughput
@@ -645,6 +647,7 @@ namespace Akka.Dispatch
             RegisterForExecution(cell.Mailbox, false, true);
         }
 
+#pragma warning disable CS0162 // Disabled since the flag can be set while debugging
         /// <summary>
         /// INTERNAL API 
         /// 
@@ -656,6 +659,7 @@ namespace Akka.Dispatch
             if (DebugDispatcher) Actors.Value.Put(this, (IInternalActorRef)actor.Self);
             AddInhabitants(1);
         }
+#pragma warning restore CS0162
 
         /// <summary>
         /// INTERNAL API
@@ -700,6 +704,7 @@ namespace Akka.Dispatch
             }
         }
 
+#pragma warning disable CS0162 // Disabled since the flag can be set while debugging
         /// <summary>
         /// INTERNAL API
         /// 
@@ -714,6 +719,7 @@ namespace Akka.Dispatch
             mailbox.BecomeClosed();
             mailbox.CleanUp();
         }
+#pragma warning restore CS0162
 
         /// <summary>
         /// After the call to this method, the dispatcher mustn't begin any new message processing for the specified reference 


### PR DESCRIPTION
This PR fixes a number of warnings related to CS0162 (Unreachable code detected).

Most of these are related to conditional debugging flags that aren't necessarrily set during a normal compilation. There are some however that are there as to clear any compile errors that would happen due to ambigious references.

The pragmas are added to the function boundaries so as not to pollute the logic in the function.