### PR TITLE
Deprecate PersistentFSM+State.Using (#3955)

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
@@ -809,6 +809,8 @@ namespace Akka.Persistence.Fsm
             public Akka.Persistence.Fsm.PersistentFSM.State<TS, TD, TE> ForMax(System.TimeSpan timeout) { }
             public Akka.Persistence.Fsm.PersistentFSM.State<TS, TD, TE> Replying(object replyValue) { }
             public override string ToString() { }
+            [System.ObsoleteAttribute("Internal API easily to be confused with regular FSM\'s using. Use regular events (" +
+                "`Applying`). Internally, `copy` can be used instead.")]
             public Akka.Persistence.Fsm.PersistentFSM.State<TS, TD, TE> Using(TD nextStateData) { }
         }
         public class StateChangeEvent : Akka.Persistence.Serialization.IMessage

--- a/src/core/Akka.Persistence/Fsm/PersistentFSM.cs
+++ b/src/core/Akka.Persistence/Fsm/PersistentFSM.cs
@@ -131,7 +131,7 @@ namespace Akka.Persistence.Fsm
                     handlersExecutedCounter++;
                     if (handlersExecutedCounter == eventsToPersist.Count)
                     {
-                        base.ApplyState(nextState.Using(nextData));
+                        base.ApplyState(nextState.Copy(stateData: nextData));
                         CurrentStateTimeout = nextState.Timeout;
                         nextState.AfterTransitionDo?.Invoke(StateData);
                         if (doSnapshot)
@@ -384,6 +384,9 @@ namespace Akka.Persistence.Fsm
             /// </summary>
             /// <param name="nextStateData">TBD</param>
             /// <returns>TBD</returns>
+            [Obsolete("Internal API easily to be confused with regular FSM's using. " +
+                "Use regular events (`Applying`). " +
+                "Internally, `copy` can be used instead.")]
             public State<TS, TD, TE> Using(TD nextStateData)
             {
                 return Copy(stateData: nextStateData);

--- a/src/core/Akka.Persistence/Fsm/PersistentFSMBase.cs
+++ b/src/core/Akka.Persistence/Fsm/PersistentFSMBase.cs
@@ -128,7 +128,7 @@ namespace Akka.Persistence.Fsm
         /// <returns>TBD</returns>
         public State<TState, TData, TEvent> Stop(FSMBase.Reason reason, TData stateData)
         {
-            return Stay().Using(stateData).WithStopReason(reason);
+            return Stay().Copy(stateData: stateData, stopReason: reason);
         }
 
         /// <summary>


### PR DESCRIPTION
Also replaces all internal calls with calls to Copy, so Using can safely be removed in the future.