### PR TITLE
Revert "Fix nightly-build template"

### DIFF
--- a/build-system/nightly-builds.yaml
+++ b/build-system/nightly-builds.yaml
@@ -5,6 +5,7 @@ pool:
   vmImage: vs2017-win2016
   demands: Cmd
 
+trigger: none
 pr: none
 
 schedules:


### PR DESCRIPTION
Reverts akkadotnet/akka.net#3957

It now runs on merge as well. Template is probably correct and im seriously suspecting an AzureDevops bug