### PR TITLE
fail JournalSerializationSpec.Journal_should_serialize_Persistent_with_EventAdapter_manifes

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryExecutor.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryExecutor.cs
@@ -691,19 +691,22 @@ namespace Akka.Persistence.Sql.Common.Journal
             var serializer = Serialization.FindSerializerForType(payloadType, Configuration.DefaultSerializer);
 
             // TODO: hack. Replace when https://github.com/akkadotnet/akka.net/issues/3811
-            string manifest = "";
+            string manifest = e.Manifest;
             var binary = Akka.Serialization.Serialization.WithTransport(Serialization.System, () =>
             {
-                
-                if (serializer is SerializerWithStringManifest stringManifest)
+
+                if (string.IsNullOrEmpty(manifest))
                 {
-                    manifest = stringManifest.Manifest(e.Payload);
-                }
-                else
-                {
-                    if (serializer.IncludeManifest)
+                    if (serializer is SerializerWithStringManifest stringManifest)
                     {
-                        manifest = e.Payload.GetType().TypeQualifiedName();
+                        manifest = stringManifest.Manifest(e.Payload);
+                    }
+                    else
+                    {
+                        if (serializer.IncludeManifest)
+                        {
+                            manifest = e.Payload.GetType().TypeQualifiedName();
+                        }
                     }
                 }
 

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Serialization/SqliteJournalSerializationSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Serialization/SqliteJournalSerializationSpec.cs
@@ -46,10 +46,5 @@ namespace Akka.Persistence.Sqlite.Tests.Serialization
                     }
                 }");
         }
-
-        [Fact(Skip = "Sql plugin does not support EventAdapter.Manifest")]
-        public override void Journal_should_serialize_Persistent_with_EventAdapter_manifest()
-        {
-        }
     }
 }


### PR DESCRIPTION
Reproduction to show that this spec doesn't make sense right now.