### PR TITLE
fix: NuGet symbols not published (#3954)

### DIFF
--- a/build-system/windows-release.yaml
+++ b/build-system/windows-release.yaml
@@ -26,7 +26,7 @@ steps:
   displayName: 'FAKE Build'
   inputs:
     filename: build.cmd
-    arguments: 'nuget nugetpublishurl=https://www.nuget.org/api/v2/package nugetkey=$(nugetKey)'
+    arguments: 'nuget nugetpublishurl=https://api.nuget.org/v3/index.json nugetkey=$(nugetKey)'
 
 
 - task: GitHubRelease@0

--- a/build.fsx
+++ b/build.fsx
@@ -486,17 +486,15 @@ Target "PublishNuget" (fun _ ->
     if (shouldPushNugetPackages || shouldPushSymbolsPackages) then
         printfn "Pushing nuget packages"
         if shouldPushNugetPackages then
-            let normalPackages= 
-                !! (outputNuGet @@ "*.nupkg") 
-                -- (outputNuGet @@ "*.symbols.nupkg") |> Seq.sortBy(fun x -> x.ToLower())
+            let normalPackages= !! (outputNuGet @@ "*.nupkg") |> Seq.sortBy(fun x -> x.ToLower())
             for package in normalPackages do
                 try
-                    publishPackage (getBuildParamOrDefault "nugetpublishurl" "") (getBuildParam "nugetkey") 3 package
+                    publishPackage (getBuildParamOrDefault "nugetpublishurl" "https://api.nuget.org/v3/index.json") (getBuildParam "nugetkey") 3 package
                 with exn ->
                     printfn "%s" exn.Message
 
         if shouldPushSymbolsPackages then
-            let symbolPackages= !! (outputNuGet @@ "*.symbols.nupkg") |> Seq.sortBy(fun x -> x.ToLower())
+            let symbolPackages= !! (outputNuGet @@ "*.snupkg") |> Seq.sortBy(fun x -> x.ToLower())
             for package in symbolPackages do
                 try
                     publishPackage (getBuildParam "symbolspublishurl") (getBuildParam "symbolskey") 3 package
@@ -602,14 +600,13 @@ Target "Help" <| fun _ ->
 Target "HelpNuget" <| fun _ ->
     List.iter printfn [
       "usage: "
-      "build Nuget [nugetkey=<key> [nugetpublishurl=<url>]] "
-      "            [symbolspublishurl=<url>] "
+      "build Nuget [nugetkey=<key> [nugetpublishurl=<url>]] [symbolskey=<key> symbolspublishurl=<url>]"
       ""
       "In order to publish a nuget package, keys must be specified."
       "If a key is not specified the nuget packages will only be created on disk"
       "After a build you can find them in build/nuget"
       ""
-      "For pushing nuget packages to nuget.org and symbols to symbolsource.org"
+      "For pushing nuget packages and symbols to nuget.org"
       "you need to specify nugetkey=<key>"
       "   build Nuget nugetKey=<key for nuget.org>"
       ""


### PR DESCRIPTION
Updates the build script to handle the newer snupkg format.

Please try and check if this works - can't test it with the official nuget packages obviously.

refs #3954