### PR TITLE
fix: build fails when SDK 3.0.100 is installed (#3967)

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -451,7 +451,7 @@ Target "CreateMntrNuget" (fun _ ->
                     { p with
                         Project = project
                         Configuration = configuration
-                        AdditionalArgs = ["--include-symbols"]
+                        AdditionalArgs = ["--include-symbols"] @ if System.IO.Path.GetExtension(project) = ".fsproj" then [] else ["--no-build"]                        
                         VersionSuffix = versionSuffix
                         OutputPath = "\"" + outputNuGet + "\"" } )
         )


### PR DESCRIPTION
Disables the --no-build flag when packing NuGet packages of F# projects as that causes build errors when .net core SDK 3.0.100 is installed.

refs #3967