### PR TITLE
Revert "fix: build fails when SDK 3.0.100 is installed (#3967) (#3968)"

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -451,7 +451,7 @@ Target "CreateMntrNuget" (fun _ ->
                     { p with
                         Project = project
                         Configuration = configuration
-                        AdditionalArgs = ["--include-symbols"] @ if System.IO.Path.GetExtension(project) = ".fsproj" then [] else ["--no-build"]                        
+                        AdditionalArgs = ["--include-symbols"]
                         VersionSuffix = versionSuffix
                         OutputPath = "\"" + outputNuGet + "\"" } )
         )


### PR DESCRIPTION
Reverts akkadotnet/akka.net#3968

I think this may have caused an issue with building our NuGet packages. We might need to take another whack at it.