### PR TITLE
fix: build fails when SDK 3.0.100 is installed, second attempt (#3967)

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -392,7 +392,7 @@ Target "CreateNuget" (fun _ ->
                     { p with
                         Project = project
                         Configuration = configuration
-                        AdditionalArgs = ["--include-symbols --no-build"]
+                        AdditionalArgs = ["--include-symbols"]
                         VersionSuffix = versionSuffix
                         OutputPath = "\"" + outputNuGet + "\"" })
 


### PR DESCRIPTION
Removes --no-build flag from all NuGet builds to make sure F# projects can be packed when .net Core 3 SDK is used.

refs #3967 
refs #3968
refs #3969 