### PR TITLE
Provide static GetRoutees.Instance property that holds a singleton in…

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -4143,6 +4143,7 @@ namespace Akka.Routing
     public sealed class GetRoutees : Akka.Routing.RouterManagementMessage
     {
         public GetRoutees() { }
+        public static Akka.Routing.GetRoutees Instance { get; }
     }
     public abstract class Group : Akka.Routing.RouterConfig, System.IEquatable<Akka.Routing.Group>
     {

--- a/src/core/Akka/Routing/RouterMsg.cs
+++ b/src/core/Akka/Routing/RouterMsg.cs
@@ -20,7 +20,7 @@ namespace Akka.Routing
         /// Sends a <see cref="RouterManagementMessage"/> to a <see cref="Router"/>
         /// to retrieve a list of routees that the router is currently using.
         /// </summary>
-        public static readonly GetRoutees GetRoutees = new GetRoutees();
+        public static readonly GetRoutees GetRoutees = GetRoutees.Instance;
     }
 
     /// <summary>
@@ -39,6 +39,10 @@ namespace Akka.Routing
     /// </summary>
     public sealed class GetRoutees : RouterManagementMessage
     {
+        /// <summary>
+        /// The singleton instance of GetRoutees.
+        /// </summary>
+        public static GetRoutees Instance { get; } = new GetRoutees();
     }
 
     /// <summary>


### PR DESCRIPTION
…stance of this message.

This mimics the behaviour of `PoisonPill.Instance` and `Kill.Instance` and feels a bit more natural to use than `RouterMessage.GetRoutees`.