### PR TITLE
Implement UnfoldInfinite + update Unfold to use Option class

### DIFF
--- a/src/core/Akka.Streams.Tests/Dsl/LastElementSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/LastElementSpec.cs
@@ -56,7 +56,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void A_stream_via_LastElement_should_materialize_to_the_last_element_emitted_by_a_source_before_it_failed()
         {
-            var t = Source.Unfold(1, n => n >= 3 ? throw new Exception() : Tuple.Create(n + 1, n + 1))
+            var t = Source.UnfoldInfinite(1, n => n >= 3 ? throw new Exception() : Tuple.Create(n + 1, n + 1))
                 .ViaMaterialized(new LastElement<int>(), Keep.Right)
                 .ToMaterialized(Sink.Aggregate<int, Option<int>>(Option<int>.None, (_, o) => new Option<int>(o)), Keep.Both)
                 .Run(Sys.Materializer());

--- a/src/core/Akka.Streams/Dsl/PagedSource.cs
+++ b/src/core/Akka.Streams/Dsl/PagedSource.cs
@@ -57,9 +57,9 @@ namespace Akka.Streams.Dsl
                         var page = key.HasValue ? await pageFactory(key.Value) : new Page<T, TKey>(Enumerable.Empty<T>(), Option<TKey>.None);
 
                         if (page.Items != null && page.Items.Any())
-                            return Tuple.Create(page.NextKey, page);
+                            return Tuple.Create(page.NextKey, page).AsOption();
                         else
-                            return null;
+                            return Option<Tuple<Option<TKey>, Page<T, TKey>>>.None;
                     }
                 );
 

--- a/src/core/Akka.Streams/Dsl/Source.cs
+++ b/src/core/Akka.Streams/Dsl/Source.cs
@@ -613,12 +613,9 @@ namespace Akka.Streams.Dsl
         /// <typeparam name="TElem">TBD</typeparam>
         /// <param name="state">TBD</param>
         /// <param name="unfold">TBD</param>
-        /// <exception cref="NotImplementedException">TBD</exception>
         /// <returns>TBD</returns>
         public static Source<TElem, NotUsed> UnfoldInfinite<TState, TElem>(TState state, Func<TState, Tuple<TState, TElem>> unfold)
-        {
-            throw new NotImplementedException();
-        }
+            => FromGraph(new UnfoldInfinite<TState, TElem>(state, unfold)).WithAttributes(DefaultAttributes.UnfoldInf);
 
         /// <summary>
         /// A <see cref="Source{TOut,TMat}"/> with no elements, i.e. an empty stream that is completed immediately for every connected <see cref="Sink{TIn,TMat}"/>.

--- a/src/core/Akka.Streams/Dsl/Source.cs
+++ b/src/core/Akka.Streams/Dsl/Source.cs
@@ -550,7 +550,7 @@ namespace Akka.Streams.Dsl
         public static Source<T, NotUsed> Repeat<T>(T element)
         {
             var next = new Tuple<T, T>(element, element);
-            return Unfold(element, _ => next).WithAttributes(DefaultAttributes.Repeat);
+            return Unfold(element, _ => new Option<Tuple<T, T>>(next)).WithAttributes(DefaultAttributes.Repeat);
         }
 
         /// <summary>
@@ -571,7 +571,7 @@ namespace Akka.Streams.Dsl
         /// <param name="state">TBD</param>
         /// <param name="unfold">TBD</param>
         /// <returns>TBD</returns>
-        public static Source<TElem, NotUsed> Unfold<TState, TElem>(TState state, Func<TState, Tuple<TState, TElem>> unfold)
+        public static Source<TElem, NotUsed> Unfold<TState, TElem>(TState state, Func<TState, Option<Tuple<TState, TElem>>> unfold)
             => FromGraph(new Unfold<TState, TElem>(state, unfold)).WithAttributes(DefaultAttributes.Unfold);
 
         /// <summary>
@@ -594,7 +594,7 @@ namespace Akka.Streams.Dsl
         /// <param name="state">TBD</param>
         /// <param name="unfoldAsync">TBD</param>
         /// <returns>TBD</returns>
-        public static Source<TElem, NotUsed> UnfoldAsync<TState, TElem>(TState state, Func<TState, Task<Tuple<TState, TElem>>> unfoldAsync)
+        public static Source<TElem, NotUsed> UnfoldAsync<TState, TElem>(TState state, Func<TState, Task<Option<Tuple<TState, TElem>>>> unfoldAsync)
             => FromGraph(new UnfoldAsync<TState, TElem>(state, unfoldAsync)).WithAttributes(DefaultAttributes.UnfoldAsync);
 
         /// <summary>

--- a/src/core/Akka.Streams/Implementation/Unfold.cs
+++ b/src/core/Akka.Streams/Implementation/Unfold.cs
@@ -9,6 +9,7 @@ using System;
 using System.Threading.Tasks;
 using Akka.Annotations;
 using Akka.Streams.Stage;
+using Akka.Streams.Util;
 using Akka.Util;
 
 namespace Akka.Streams.Implementation
@@ -38,12 +39,12 @@ namespace Akka.Streams.Implementation
             public override void OnPull()
             {
                 var t = _stage.UnfoldFunc(_state);
-                if (t == null)
+                if (!t.HasValue)
                     Complete(_stage.Out);
                 else
                 {
-                    Push(_stage.Out, t.Item2);
-                    _state = t.Item1;
+                    Push(_stage.Out, t.Value.Item2);
+                    _state = t.Value.Item1;
                 }
             }
         }
@@ -56,7 +57,7 @@ namespace Akka.Streams.Implementation
         /// <summary>
         /// TBD
         /// </summary>
-        public readonly Func<TState, Tuple<TState, TElement>> UnfoldFunc;
+        public readonly Func<TState, Option<Tuple<TState, TElement>>> UnfoldFunc;
         /// <summary>
         /// TBD
         /// </summary>
@@ -67,7 +68,7 @@ namespace Akka.Streams.Implementation
         /// </summary>
         /// <param name="state">TBD</param>
         /// <param name="unfoldFunc">TBD</param>
-        public Unfold(TState state, Func<TState, Tuple<TState, TElement>> unfoldFunc)
+        public Unfold(TState state, Func<TState, Option<Tuple<TState, TElement>>> unfoldFunc)
         {
             State = state;
             UnfoldFunc = unfoldFunc;
@@ -100,7 +101,7 @@ namespace Akka.Streams.Implementation
         {
             private readonly UnfoldAsync<TState, TElement> _stage;
             private TState _state;
-            private Action<Result<Tuple<TState, TElement>>> _asyncHandler;
+            private Action<Result<Option<Tuple<TState, TElement>>>> _asyncHandler;
 
             public Logic(UnfoldAsync<TState, TElement> stage) : base(stage.Shape)
             {
@@ -119,16 +120,20 @@ namespace Akka.Streams.Implementation
 
             public override void PreStart()
             {
-                var ac = GetAsyncCallback<Result<Tuple<TState, TElement>>>(result =>
+                var ac = GetAsyncCallback<Result<Option<Tuple<TState, TElement>>>>(result =>
                 {
                     if (!result.IsSuccess)
                         Fail(_stage.Out, result.Exception);
-                    else if (result.Value == null)
-                        Complete(_stage.Out);
                     else
                     {
-                        Push(_stage.Out, result.Value.Item2);
-                        _state = result.Value.Item1;
+                        var option = result.Value;
+                        if (!option.HasValue)
+                            Complete(_stage.Out);
+                        else
+                        {
+                            Push(_stage.Out, option.Value.Item2);
+                            _state = option.Value.Item1;
+                        }
                     }
                 });
                 _asyncHandler = ac;
@@ -143,7 +148,7 @@ namespace Akka.Streams.Implementation
         /// <summary>
         /// TBD
         /// </summary>
-        public readonly Func<TState, Task<Tuple<TState, TElement>>> UnfoldFunc;
+        public readonly Func<TState, Task<Option<Tuple<TState, TElement>>>> UnfoldFunc;
         /// <summary>
         /// TBD
         /// </summary>
@@ -154,7 +159,7 @@ namespace Akka.Streams.Implementation
         /// </summary>
         /// <param name="state">TBD</param>
         /// <param name="unfoldFunc">TBD</param>
-        public UnfoldAsync(TState state, Func<TState, Task<Tuple<TState, TElement>>> unfoldFunc)
+        public UnfoldAsync(TState state, Func<TState, Task<Option<Tuple<TState, TElement>>>> unfoldFunc)
         {
             State = state;
             UnfoldFunc = unfoldFunc;

--- a/src/core/Akka.Streams/Util/ObjectExtensions.cs
+++ b/src/core/Akka.Streams/Util/ObjectExtensions.cs
@@ -21,5 +21,10 @@ namespace Akka.Streams.Util
         /// <param name="obj">TBD</param>
         /// <returns>TBD</returns>
         public static bool IsDefaultForType<T>(this T obj) => EqualityComparer<T>.Default.Equals(obj, default(T));
+        
+        /// <summary>
+        /// Wraps object to the <see cref="Option{T}"/> monade
+        /// </summary>
+        public static Option<T> AsOption<T>(this T obj) => new Option<T>(obj);
     }
 }


### PR DESCRIPTION
This is going to close #3977, because implements `UnfoldInfinite` method.

The point of this method in scala is to skip `Option` class usage when returning `Unfold` conversion function result, which makes code simpler. Useful for sequences that are not going to finish or when sequence is going to be finished with exception.

One more thing this PR adds is updating `Unfold` and `UnfoldAsync` methods to use `Option<Tuple>` instead of `Tuple` as a conversion function result. We are trying to avoid using `null` values as tuple values (this is also useful from the #3973 point of view), so the source should be finished when it gets `Option.None` value.

As a useful addition, `.AsOption()` extension method is implemented in `Akka.Stream.Utils` namespace, which helps to update existing code that uses `Unfold`/`UnfoldAsync`. 

Close #3977