### PR TITLE
re-enabled DData serialization specs

### DIFF
--- a/src/contrib/cluster/Akka.DistributedData.Tests/Serialization/ReplicatedDataSerializerSpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/Serialization/ReplicatedDataSerializerSpec.cs
@@ -35,7 +35,7 @@ namespace Akka.DistributedData.Tests.Serialization
         {
         }
 
-        [Fact(Skip = "Need https://github.com/akkadotnet/akka.net/pull/3668 merged")]
+        [Fact()]
         public void ReplicatedDataSerializer_should_serialize_GSet()
         {
             CheckSerialization(GSet<string>.Empty);
@@ -51,7 +51,7 @@ namespace Akka.DistributedData.Tests.Serialization
             CheckSameContent(GSet.Create(_address1, _address2, _address3), GSet.Create(_address3, _address2, _address1));
         }
 
-        [Fact(Skip = "Need https://github.com/akkadotnet/akka.net/pull/3668 merged")]
+        [Fact()]
         public void ReplicatedDataSerializer_should_serialize_ORSet()
         {
             CheckSerialization(ORSet<string>.Empty);
@@ -74,7 +74,7 @@ namespace Akka.DistributedData.Tests.Serialization
             CheckSameContent(s3.Merge(s4), s4.Merge(s3));
         }
 
-        [Fact(Skip = "Need https://github.com/akkadotnet/akka.net/pull/3668 merged")]
+        [Fact()]
         public void ReplicatedDataSerializer_should_serialize_ORSet_delta()
         {
             CheckSerialization(ORSet<string>.Empty.Add(_address1, "a").Delta);
@@ -84,21 +84,21 @@ namespace Akka.DistributedData.Tests.Serialization
             CheckSerialization(ORSet<string>.Empty.Add(_address1, "a").Clear(_address2).Delta);
         }
 
-        [Fact(Skip = "Need https://github.com/akkadotnet/akka.net/pull/3668 merged")]
+        [Fact()]
         public void ReplicatedDataSerializer_should_serialize_Flag()
         {
             CheckSerialization(Flag.False);
             CheckSerialization(Flag.False.SwitchOn());
         }
 
-        [Fact(Skip = "Need https://github.com/akkadotnet/akka.net/pull/3668 merged")]
+        [Fact()]
         public void ReplicatedDataSerializer_should_serialize_LWWRegister()
         {
             CheckSerialization(new LWWRegister<string>(_address1, "value1"));
             CheckSerialization(new LWWRegister<string>(_address2, "value2").WithValue(_address2, "value3"));
         }
 
-        [Fact(Skip = "Need https://github.com/akkadotnet/akka.net/pull/3668 merged")]
+        [Fact()]
         public void ReplicatedDataSerializer_should_serialize_GCounter()
         {
             CheckSerialization(GCounter.Empty);
@@ -113,7 +113,7 @@ namespace Akka.DistributedData.Tests.Serialization
                 GCounter.Empty.Increment(_address3, 5).Increment(_address1, 2));
         }
 
-        [Fact(Skip = "Need https://github.com/akkadotnet/akka.net/pull/3668 merged")]
+        [Fact()]
         public void ReplicatedDataSerializer_should_serialize_PNCounter()
         {
             CheckSerialization(PNCounter.Empty);
@@ -133,7 +133,7 @@ namespace Akka.DistributedData.Tests.Serialization
                 PNCounter.Empty.Increment(_address3, 5).Increment(_address1, 2).Decrement(_address1, 1));
         }
 
-        [Fact(Skip = "Need https://github.com/akkadotnet/akka.net/pull/3668 merged")]
+        [Fact()]
         public void ReplicatedDataSerializer_should_serialize_ORDictionary()
         {
             CheckSerialization(ORDictionary<string, GSet<string>>.Empty);
@@ -141,7 +141,7 @@ namespace Akka.DistributedData.Tests.Serialization
             CheckSerialization(ORDictionary<string, GSet<string>>.Empty.SetItem(_address1, "a", GSet.Create("A")).SetItem(_address2, "b", GSet.Create("B")));
         }
 
-        [Fact(Skip = "Need https://github.com/akkadotnet/akka.net/pull/3668 merged")]
+        [Fact()]
         public void ReplicatedDataSerializer_should_serialize_ORDictionary_delta()
         {
             CheckSerialization(ORDictionary<string, GSet<string>>.Empty
@@ -172,7 +172,7 @@ namespace Akka.DistributedData.Tests.Serialization
                 .Delta);
         }
 
-        [Fact(Skip = "Need https://github.com/akkadotnet/akka.net/pull/3668 merged")]
+        [Fact()]
         public void ReplicatedDataSerializer_should_serialize_LWWDictionary()
         {
             CheckSerialization(LWWDictionary<string, string>.Empty);
@@ -180,7 +180,7 @@ namespace Akka.DistributedData.Tests.Serialization
             CheckSerialization(LWWDictionary<string, object>.Empty.SetItem(_address1, "a", "value1").SetItem(_address2, "b", 17));
         }
 
-        [Fact(Skip = "Need https://github.com/akkadotnet/akka.net/pull/3668 merged")]
+        [Fact()]
         public void ReplicatedDataSerializer_should_serialize_PNCounterDictionary()
         {
             CheckSerialization(PNCounterDictionary<string>.Empty);
@@ -191,7 +191,7 @@ namespace Akka.DistributedData.Tests.Serialization
                 .Increment(_address2, "b", 5));
         }
 
-        [Fact(Skip = "Need https://github.com/akkadotnet/akka.net/pull/3668 merged")]
+        [Fact()]
         public void ReplicatedDataSerializer_should_serialize_ORMultiDictionary()
         {
             CheckSerialization(ORMultiValueDictionary<string, string>.Empty);
@@ -206,13 +206,13 @@ namespace Akka.DistributedData.Tests.Serialization
             CheckSameContent(m1.Merge(m2), m2.Merge(m1));
         }
 
-        [Fact(Skip = "Need https://github.com/akkadotnet/akka.net/pull/3668 merged")]
+        [Fact()]
         public void ReplicatedDataSerializer_should_serialize_DeletedData()
         {
             CheckSerialization(DeletedData.Instance);
         }
 
-        [Fact(Skip = "Need https://github.com/akkadotnet/akka.net/pull/3668 merged")]
+        [Fact()]
         public void ReplicatedDataSerializer_should_serialize_VersionVector()
         {
             CheckSerialization(VersionVector.Empty);

--- a/src/contrib/cluster/Akka.DistributedData.Tests/Serialization/ReplicatorMessageSerializerSpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/Serialization/ReplicatorMessageSerializerSpec.cs
@@ -38,7 +38,7 @@ namespace Akka.DistributedData.Tests.Serialization
         {
         }
 
-        [Fact(Skip = "Need https://github.com/akkadotnet/akka.net/pull/3668 merged")]
+        [Fact()]
         public void ReplicatorMessageSerializer_should_serialize_Replicator_message()
         {
             var ref1 = Sys.ActorOf(Props.Empty, "ref1");


### PR DESCRIPTION
Now that #3668 has been merged, these specs should be able to run normally on CI again.