### PR TITLE
Akka.Persistence.TCK fix - check Persistent.Sender == DeadLetters

### DIFF
--- a/src/core/Akka.Persistence.TCK/Journal/JournalSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Journal/JournalSpec.cs
@@ -294,7 +294,7 @@ namespace Akka.Persistence.TCK.Journal
                 Assertions.AssertEqual(writerGuid, o.Persistent.WriterGuid);
                 Assertions.AssertEqual(pid, o.Persistent.PersistenceId);
                 Assertions.AssertEqual(6L, o.Persistent.SequenceNr);
-                Assertions.AssertEqual(ActorRefs.NoSender, o.Persistent.Sender);
+                Assertions.AssertTrue(o.Persistent.Sender.Equals(ActorRefs.NoSender) || o.Persistent.Sender.Equals(Sys.DeadLetters), $"Expected WriteMessagesSuccess.Persistent.Sender to be null or {Sys.DeadLetters}, but found {o.Persistent.Sender}");
                 Assertions.AssertEqual(@event, o.Persistent.Payload);
             });
 
@@ -305,7 +305,7 @@ namespace Akka.Persistence.TCK.Journal
                 Assertions.AssertEqual(writerGuid, o.Persistent.WriterGuid);
                 Assertions.AssertEqual(pid, o.Persistent.PersistenceId);
                 Assertions.AssertEqual(6L, o.Persistent.SequenceNr);
-                Assertions.AssertEqual(ActorRefs.NoSender, o.Persistent.Sender);
+                Assertions.AssertTrue(o.Persistent.Sender.Equals(ActorRefs.NoSender) || o.Persistent.Sender.Equals(Sys.DeadLetters), $"Expected WriteMessagesSuccess.Persistent.Sender to be null or {Sys.DeadLetters}, but found {o.Persistent.Sender}");
                 Assertions.AssertEqual(@event, o.Persistent.Payload);
             });
 

--- a/src/core/Akka.Persistence.TCK/Journal/JournalSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Journal/JournalSpec.cs
@@ -294,7 +294,7 @@ namespace Akka.Persistence.TCK.Journal
                 Assertions.AssertEqual(writerGuid, o.Persistent.WriterGuid);
                 Assertions.AssertEqual(pid, o.Persistent.PersistenceId);
                 Assertions.AssertEqual(6L, o.Persistent.SequenceNr);
-                Assertions.AssertTrue(o.Persistent.Sender.Equals(ActorRefs.NoSender) || o.Persistent.Sender.Equals(Sys.DeadLetters), $"Expected WriteMessagesSuccess.Persistent.Sender to be null or {Sys.DeadLetters}, but found {o.Persistent.Sender}");
+                Assertions.AssertTrue(o.Persistent.Sender == ActorRefs.NoSender || o.Persistent.Sender.Equals(Sys.DeadLetters), $"Expected WriteMessagesSuccess.Persistent.Sender to be null or {Sys.DeadLetters}, but found {o.Persistent.Sender}");
                 Assertions.AssertEqual(@event, o.Persistent.Payload);
             });
 
@@ -305,7 +305,7 @@ namespace Akka.Persistence.TCK.Journal
                 Assertions.AssertEqual(writerGuid, o.Persistent.WriterGuid);
                 Assertions.AssertEqual(pid, o.Persistent.PersistenceId);
                 Assertions.AssertEqual(6L, o.Persistent.SequenceNr);
-                Assertions.AssertTrue(o.Persistent.Sender.Equals(ActorRefs.NoSender) || o.Persistent.Sender.Equals(Sys.DeadLetters), $"Expected WriteMessagesSuccess.Persistent.Sender to be null or {Sys.DeadLetters}, but found {o.Persistent.Sender}");
+                Assertions.AssertTrue(o.Persistent.Sender == ActorRefs.NoSender || o.Persistent.Sender.Equals(Sys.DeadLetters), $"Expected WriteMessagesSuccess.Persistent.Sender to be null or {Sys.DeadLetters}, but found {o.Persistent.Sender}");
                 Assertions.AssertEqual(@event, o.Persistent.Payload);
             });
 


### PR DESCRIPTION
`DeadLetters` is the correct output from `IActorRef` deserialization when `null` is found - needed to add a check for that inside the Akka.Persistence.TCK. Found this while working on https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/71