### PR TITLE
added v1.4.0-beta3 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,42 @@
+#### 1.4.0-beta3 October 30 2019 ####
+**Third pre-release candidate for Akka.NET 1.4**
+This release contains some more significant changes for Akka.NET v1.4.0.
+
+* All APIs in Akka.Streams, Akka, and elsewhere which used to return `Tuple<T1, T2>` now support the equivalent `ValueTuple<T1,T2>` syntax - so new language features such as tuple deconstruction can be used by our users.
+* Upgraded to Hyperion 0.9.10, which properly supports .NET Core 3.0 and cross-platform communication between .NET Framework and .NET Core.
+* All `ILoggingAdapter` instances running inside Akka.NET actors will now include the full Akka.Remote `Address` during logging, which is very helpful for users who aggregate their logs inside consolidated systems.
+* Various Akka.Cluster.Sharding fixes.
+
+To [follow our progress on the Akka.NET v1.4 milestone, click here](https://github.com/akkadotnet/akka.net/milestone/17).
+
+We expect to release more beta versions in the future, and if you wish to [get access to nightly Akka.NET builds then click here](https://getakka.net/community/getting-access-to-nightly-builds.html).
+
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+
+| 115 | 10739 | 8969 | Aaron Stannard |
+| 13 | 11671 | 1059 | Bartosz Sypytkowski |
+| 10 | 16 | 16 | dependabot-preview[bot] |
+| 6 | 897 | 579 | Sean Gilliam |
+| 6 | 1744 | 358 | zbynek001 |
+| 5 | 568 | 240 | Ismael Hamed |
+| 5 | 116 | 14 | Andre Loker |
+| 3 | 4457 | 8 | Valdis Zobēla |
+| 3 | 2 | 2 | Arjen Smits |
+| 3 | 14 | 9 | cptjazz |
+| 2 | 7 | 7 | jdsartori |
+| 2 | 4 | 6 | Onur Gumus |
+| 2 | 1341 | 1182 | Igor Fedchenko |
+| 1 | 65 | 47 | Ondrej Pialek |
+| 1 | 3 | 3 | Abi |
+| 1 | 3 | 1 | jg11jg |
+| 1 | 18 | 16 | Peter Huang |
+| 1 | 1 | 2 | Maciej Wódke |
+| 1 | 1 | 1 | Wessel Kranenborg |
+| 1 | 1 | 1 | Kaiwei Li |
+| 1 | 1 | 1 | Greatsamps |
+| 1 | 1 | 1 | Andre |
+
 #### 1.4.0-beta2 September 23 2019 ####
 **Second pre-release candidate for Akka.NET 1.4**
 Akka.NET v1.4.0 is still moving along and this release contains some new and important changes.


### PR DESCRIPTION
#### 1.4.0-beta3 October 30 2019 ####
**Third pre-release candidate for Akka.NET 1.4**
This release contains some more significant changes for Akka.NET v1.4.0.

* All APIs in Akka.Streams, Akka, and elsewhere which used to return `Tuple<T1, T2>` now support the equivalent `ValueTuple<T1,T2>` syntax - so new language features such as tuple deconstruction can be used by our users.
* Upgraded to Hyperion 0.9.10, which properly supports .NET Core 3.0 and cross-platform communication between .NET Framework and .NET Core.
* All `ILoggingAdapter` instances running inside Akka.NET actors will now include the full Akka.Remote `Address` during logging, which is very helpful for users who aggregate their logs inside consolidated systems.
* Various Akka.Cluster.Sharding fixes.

To [follow our progress on the Akka.NET v1.4 milestone, click here](https://github.com/akkadotnet/akka.net/milestone/17).

We expect to release more beta versions in the future, and if you wish to [get access to nightly Akka.NET builds then click here](https://getakka.net/community/getting-access-to-nightly-builds.html).

| COMMITS | LOC+ | LOC- | AUTHOR |
| --- | --- | --- | --- |
| 115 | 10739 | 8969 | Aaron Stannard |
| 13 | 11671 | 1059 | Bartosz Sypytkowski |
| 10 | 16 | 16 | dependabot-preview[bot] |
| 6 | 897 | 579 | Sean Gilliam |
| 6 | 1744 | 358 | zbynek001 |
| 5 | 568 | 240 | Ismael Hamed |
| 5 | 116 | 14 | Andre Loker |
| 3 | 4457 | 8 | Valdis Zobēla |
| 3 | 2 | 2 | Arjen Smits |
| 3 | 14 | 9 | cptjazz |
| 2 | 7 | 7 | jdsartori |
| 2 | 4 | 6 | Onur Gumus |
| 2 | 1341 | 1182 | Igor Fedchenko |
| 1 | 65 | 47 | Ondrej Pialek |
| 1 | 3 | 3 | Abi |
| 1 | 3 | 1 | jg11jg |
| 1 | 18 | 16 | Peter Huang |
| 1 | 1 | 2 | Maciej Wódke |
| 1 | 1 | 1 | Wessel Kranenborg |
| 1 | 1 | 1 | Kaiwei Li |
| 1 | 1 | 1 | Greatsamps |
| 1 | 1 | 1 | Andre |