### PR TITLE
V1.3.16 backport

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,14 +1,10 @@
-#### 1.3.15 September 23 2019 ####
+#### 1.3.16 October 30 2019 ####
 **Maintenance Release for Akka.NET 1.3**
 
-1.3.15 consists of non-breaking bugfixes and additions that have been contributed against the [Akka.NET v1.4.0 milestone](https://github.com/akkadotnet/akka.net/milestone/17) thus far.
+1.3.16 is a minor change, brought about by the introduction of [Hyperion v0.9.10](https://github.com/akkadotnet/Hyperion/releases/tag/0.9.10). This fixes a breaking change introduced by .NET Core 3.0, which could cause Akka.Cluster.Sharding users some problems when running apps on .NET Core 3.0.
 
-This really only includes one major fix: [a major issue with Akka.Remote, which caused unnecessary `Quarantine` events](https://github.com/akkadotnet/akka.net/issues/3905).
-
-We highly recommend upgrading to this build if you're using Akka.Remote or Akka.Cluster.
-
-To [see the full set of changes in Akka.NET v1.3.15, click here](https://github.com/akkadotnet/akka.net/pull/3931).
+Hyperion v0.9.10 also allows for full x-plat communciation between .NET Framework and .NET Core on all supported versions of each.
 
 | COMMITS | LOC+ | LOC- | AUTHOR |
 | --- | --- | --- | --- |
-| 3 | 443 | 196 | Aaron Stannard |
+| 2 | 10 | 40 | Aaron Stannard |

--- a/src/common.props
+++ b/src/common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2019 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.4.0</VersionPrefix>
+    <VersionPrefix>1.3.16</VersionPrefix>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>
@@ -27,32 +27,12 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Second pre-release candidate for Akka.NET 1.4**
-Akka.NET v1.4.0 is still moving along and this release contains some new and important changes.
-We've added a new package, the Akka.Persistence.TestKit - this is designed to allow users to test their `PersistentActor` implementations under real-world conditions such as database connection failures, serialization errors, and so forth. It works alongside the standard Akka.NET TestKit distributions and offers a simple, in-place API to do so.
-Akka.Streams now supports [Stream Context propagation](https://github.com/akkadotnet/akka.net/pull/3741), designed to make it really easy to work with tools such as Kafka, Amazon SQS, and more - where you might want to have one piece of context (such as the partition offset in Kafka) and propagate it from the very front of an Akka.Stream all the way to the end, and then finally process it once the rest of the stream has completed processing. In the case of Kakfa, this might be updating the local consumer's partition offset only once we've been able to fully guarantee the processing of the message.
-Fixed
-To [follow our progress on the Akka.NET v1.4 milestone, click here](https://github.com/akkadotnet/akka.net/milestone/17).
-We expect to release more beta versions in the future, and if you wish to [get access to nightly Akka.NET builds then click here](https://getakka.net/community/getting-access-to-nightly-builds.html).
+    <PackageReleaseNotes>Maintenance Release for Akka.NET 1.3**
+1.3.16 is a minor change, brought about by the introduction of [Hyperion v0.9.10](https://github.com/akkadotnet/Hyperion/releases/tag/0.9.10). This fixes a breaking change introduced by .NET Core 3.0, which could cause Akka.Cluster.Sharding users some problems when running apps on .NET Core 3.0.
+Hyperion v0.9.10 also allows for full x-plat communciation between .NET Framework and .NET Core on all supported versions of each.
 | COMMITS | LOC+ | LOC- | AUTHOR |
 | --- | --- | --- | --- |
-| 97 | 6527 | 3729 | Aaron Stannard |
-| 13 | 11671 | 1059 | Bartosz Sypytkowski |
-| 4 | 1708 | 347 | zbynek001 |
-| 2 | 7 | 7 | jdsartori |
-| 2 | 4 | 6 | Onur Gumus |
-| 2 | 37 | 114 | Ismael Hamed |
-| 1 | 65 | 47 | Ondrej Pialek |
-| 1 | 3020 | 2 | Valdis Zobēla |
-| 1 | 3 | 3 | Abi |
-| 1 | 3 | 1 | jg11jg |
-| 1 | 18 | 16 | Peter Huang |
-| 1 | 1 | 2 | Maciej Wódke |
-| 1 | 1 | 1 | Wessel Kranenborg |
-| 1 | 1 | 1 | Kaiwei Li |
-| 1 | 1 | 1 | Greatsamps |
-| 1 | 1 | 1 | Arjen Smits |
-| 1 | 1 | 1 | Andre |</PackageReleaseNotes>
+| 2 | 10 | 40 | Aaron Stannard |</PackageReleaseNotes>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>

--- a/src/common.props
+++ b/src/common.props
@@ -11,7 +11,7 @@
   <PropertyGroup>
     <XunitVersion>2.3.1</XunitVersion>
     <TestSdkVersion>15.9.0</TestSdkVersion>
-    <HyperionVersion>0.9.8</HyperionVersion>
+    <HyperionVersion>0.9.9</HyperionVersion>
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
     <NBenchVersion>1.2.2</NBenchVersion>
     <ProtobufVersion>3.9.1</ProtobufVersion>

--- a/src/contrib/cluster/Akka.DistributedData/Akka.DistributedData.csproj
+++ b/src/contrib/cluster/Akka.DistributedData/Akka.DistributedData.csproj
@@ -8,7 +8,6 @@
     <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
     <PackageTags>$(AkkaPackageTags);network;cluster;crdt;replication</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/contrib/serializers/Akka.Serialization.Hyperion/Akka.Serialization.Hyperion.csproj
+++ b/src/contrib/serializers/Akka.Serialization.Hyperion/Akka.Serialization.Hyperion.csproj
@@ -18,6 +18,8 @@
     <PackageReference Include="System.Runtime" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkLibVersion)' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>


### PR DESCRIPTION
#### 1.3.16 September 23 2019 ####
**Maintenance Release for Akka.NET 1.3**

1.3.16 is a minor change, brought about by the introduction of [Hyperion v0.9.10](https://github.com/akkadotnet/Hyperion/releases/tag/0.9.10). This fixes a breaking change introduced by .NET Core 3.0, which could cause Akka.Cluster.Sharding users some problems when running apps on .NET Core 3.0.

Hyperion v0.9.10 also allows for full x-plat communciation between .NET Framework and .NET Core on all supported versions of each.

| COMMITS | LOC+ | LOC- | AUTHOR |
| --- | --- | --- | --- |
| 2 | 10 | 40 | Aaron Stannard |