### PR TITLE
Update Akka.IO to use System.IO.Pipelines for reading from socket

### DIFF
--- a/src/common.props
+++ b/src/common.props
@@ -18,7 +18,7 @@
     <NetCoreTestVersion>netcoreapp2.1</NetCoreTestVersion>
     <NetFrameworkTestVersion>net461</NetFrameworkTestVersion>
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>
-    <NetFrameworkLibVersion>net452</NetFrameworkLibVersion>
+    <NetFrameworkLibVersion>net461</NetFrameworkLibVersion>
     <FluentAssertionsVersion>4.14.0</FluentAssertionsVersion>
     <FsCheckVersion>2.9.0</FsCheckVersion>
     <AkkaPackageTags>akka;actors;actor model;Akka;concurrency</AkkaPackageTags>

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\common.props" />
 
   <PropertyGroup>
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
+    <PackageReference Include="System.IO.Pipelines" Version="4.6.0" />
   </ItemGroup>
     
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkLibVersion)'">


### PR DESCRIPTION
This is going to be a major part of work (if not the whole part) on the issue #3328 .

In particular, currently all sockets communication is implemented in `TcpConnection` actor class (with some helpers involved), and uses `SocketAsyncEventArgs` to handle connections. In this PR I am going to substitute this logic with using `Pipe` class from `System.IO.Pipelines`, which helps reading network stream.