### PR TITLE
Akka.IO.Tcp benchmark with parallel clients

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Actor/PingPongBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/PingPongBenchmarks.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Benchmarks.Configurations;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Attributes.Jobs;
 using BenchmarkDotNet.Engines;
 
 namespace Akka.Benchmarks.Actor

--- a/src/benchmark/Akka.Benchmarks/Actor/SpawnActorBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/SpawnActorBenchmarks.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Benchmarks.Configurations;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Attributes.Jobs;
 using BenchmarkDotNet.Engines;
 
 namespace Akka.Benchmarks.Actor

--- a/src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj
+++ b/src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
   </ItemGroup>

--- a/src/benchmark/Akka.Benchmarks/Configurations/Configs.cs
+++ b/src/benchmark/Akka.Benchmarks/Configurations/Configs.cs
@@ -18,7 +18,7 @@ namespace Akka.Benchmarks.Configurations
     {
         public MicroBenchmarkConfig()
         {
-            this.Add(new MemoryDiagnoser());
+            this.Add(MemoryDiagnoser.Default);
             this.Add(MarkdownExporter.GitHub);
         }
     }

--- a/src/benchmark/Akka.Benchmarks/IO/TcpOperationsBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/IO/TcpOperationsBenchmarks.cs
@@ -31,7 +31,7 @@ namespace Akka.Benchmarks
         private IActorRef _server;
         private IActorRef _clientCoordinator;
 
-        [Params(100, 1000)]
+        [Params(100, 1000, 10000)]
         public int MessageCount { get; set; }
         [Params(10, 100)]
         public int MessageLength { get; set; }


### PR DESCRIPTION
This is improvement of #4015 benchmark, which adds support for multiple parallel clients sending requests to server actor.

Also, I had to increase `BenchmarkDotNet` package version to `0.12.0`, because current version `0.10.14` is a year old and does not contain some issue fixes (like it was failing to perform benchmark if there was any output to a console).