### PR TITLE
Stop DeadLetterListener on terminate if LogDeadLettersDuringShutdown is disabled

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -2878,6 +2878,7 @@ namespace Akka.Event
         public DeadLetterListener() { }
         protected override void PostRestart(System.Exception reason) { }
         protected override void PostStop() { }
+        protected override void PreRestart(System.Exception reason, object message) { }
         protected override void PreStart() { }
         protected override bool Receive(object message) { }
     }

--- a/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
@@ -106,6 +106,26 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
+        public void Log_dead_letters()
+        {
+            var sys = ActorSystem.Create("LogDeadLetters", ConfigurationFactory.ParseString("akka.loglevel=INFO")
+                .WithFallback(DefaultConfig));
+
+            try
+            {
+                var a = sys.ActorOf(Props.Create<Terminater>());
+
+                var eventFilter = new EventFilterFactory(new TestKit.Xunit2.TestKit(sys));
+                eventFilter.Info(contains: "not delivered").Expect(1, () =>
+                {
+                    a.Tell("run");
+                    a.Tell("boom");
+                });
+            }
+            finally { Shutdown(sys); }
+        }
+
+        [Fact]
         public void Block_until_exit()
         {
             var actorSystem = ActorSystem

--- a/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
@@ -493,6 +493,8 @@ namespace Akka.Actor.Internal
         public override Task Terminate()
         {
             Log.Debug("System shutdown initiated");
+            if (!Settings.LogDeadLettersDuringShutdown && _logDeadLetterListener != null) 
+                Stop(_logDeadLetterListener);
             _provider.Guardian.Stop();
             return WhenTerminated;
         }

--- a/src/core/Akka/Event/DeadLetterListener.cs
+++ b/src/core/Akka/Event/DeadLetterListener.cs
@@ -20,10 +20,16 @@ namespace Akka.Event
         private int _count;
 
         /// <summary>
-        /// TBD
+        /// Don't re-subscribe, skip call to preStart
         /// </summary>
-        /// <param name="reason">TBD</param>
         protected override void PostRestart(Exception reason)
+        {
+        }
+
+        /// <summary>
+        /// Don't remove subscription, skip call to postStop, no children to stop
+        /// </summary>
+        protected override void PreRestart(Exception reason, object message)
         {
         }
 
@@ -55,7 +61,7 @@ namespace Akka.Event
             var rcp = deadLetter.Recipient;
 
             _count++;
-            
+
             var done = _maxCount != int.MaxValue && _count >= _maxCount;
             var doneMsg = done ? ", no more dead letters will be logged" : "";
 
@@ -65,15 +71,12 @@ namespace Akka.Event
                 var sndPath = snd == ActorRefs.NoSender ? "NoSender" : snd.Path.ToString();
 
                 _eventStream.Publish(new Info(rcpPath, rcp.GetType(),
-                    string.Format("Message {0} from {1} to {2} was not delivered. {3} dead letters encountered.{4}",
-                        deadLetter.Message.GetType().Name, sndPath, rcpPath, _count, doneMsg)));
+                    $"Message [{deadLetter.Message.GetType().Name}] from {sndPath} to {rcpPath} was not delivered. [{_count}] dead letters encountered {doneMsg}." +
+                    "This logging can be turned off or adjusted with configuration settings 'akka.log-dead-letters' " +
+                    "and 'akka.log-dead-letters-during-shutdown'."));
             }
 
-            if (done)
-            {
-                ((IInternalActorRef) Self).Stop();
-            }
-
+            if (done) Context.Stop(Self);
             return true;
         }
     }


### PR DESCRIPTION
Looks like we never had a chance of disabling `log-dead-letters-during-shutdown`