### PR TITLE
MNTR NRE fix for #4035

### DIFF
--- a/src/core/Akka.MultiNodeTestRunner.Shared/TrxReporter/TrxSinkActor.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/TrxReporter/TrxSinkActor.cs
@@ -133,7 +133,7 @@ namespace Akka.MultiNodeTestRunner.Shared.AzureDevOps
 
                 result.Output.StdErr.Add(message.Message);
                 result.Output.DebugTrace.Add(message.Message);
-                result.Output.ErrorInfo.Message = message.Message;
+                result.Output.ErrorInfo = new ErrorInfo() { Message = message.Message };
             }
         }
 


### PR DESCRIPTION
Close #4035 

Here is the code that is failing with NRE:
```csharp
private static void ReportFailure(SpecSession session, Dictionary<int, UnitTestResult> nodeResults)
{
	foreach (var (time, message) in session.Fails)
	{
		var result = nodeResults[message.NodeIndex];
		result.Outcome = TestOutcome.Failed;
		result.EndTime = time;
		result.Output = new Output();

		result.Output.StdErr.Add(message.Message);
		result.Output.DebugTrace.Add(message.Message);
		result.Output.ErrorInfo.Message = message.Message;
	}
}
```

Since we do not have exact like, there are few candidates to throw NRE (expressions that could be `null` in this case): 
`session`
`noreResults
`message` from `var (time, message) in session.Fails`
`nodeResults[message.NodeIndex]`
`result.Output.StdErr` or `result.Output.DebugTrace` or `result.Output.ErrorInfo`

Luckily, the code is pretty simple here and all of this is initialized in this class or somewhere near in the call tree. So after some careful check, I have verified that nobody could be `null` except  `result.Output.ErrorInfo` (either because it is just impossible, or it should throw somewhere before this `ReportFailure` invocation). And `result.Output.ErrorInfo` is just not initialized, so the fix is simple.