### PR TITLE
MNTR logs representation improvements

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
@@ -376,7 +376,7 @@ namespace Akka.Cluster.Sharding.Tests
         public DDataClusterShardingWithEntityRecoverySpec() : this(new DDataClusterShardingWithEntityRecoverySpecConfig()) { }
         protected DDataClusterShardingWithEntityRecoverySpec(DDataClusterShardingWithEntityRecoverySpecConfig config) : base(config, typeof(DDataClusterShardingWithEntityRecoverySpec)) { }
     }
-    public abstract class ClusterShardingSpec : MultiNodeClusterSpec
+    public abstract class ClusterShardingSpec : MultiNodeClusterSpec 
     {
         // must use different unique name for some tests than the one used in API tests
         public static string TestCounterShardingTypeName => $"Test{Counter.ShardingTypeName}";

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/TimelineLogCollectorActor.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/TimelineLogCollectorActor.cs
@@ -1,0 +1,130 @@
+// //-----------------------------------------------------------------------
+// // <copyright file="TimelineLogCollectorActor.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2019 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2019 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Util.Internal;
+
+namespace Akka.MultiNodeTestRunner.Shared.Sinks
+{
+    public class TimelineLogCollectorActor : ReceiveActor
+    {
+        private readonly SortedList<DateTime, HashSet<LogMessageInfo>> _timeline = new SortedList<DateTime, HashSet<LogMessageInfo>>();
+        
+        public TimelineLogCollectorActor()
+        {
+            Receive<LogMessage>(msg =>
+            {
+                var parsedInfo = new LogMessageInfo(msg);
+                if (_timeline.ContainsKey(parsedInfo.When))
+                    _timeline[parsedInfo.When].Add(parsedInfo);
+                else
+                    _timeline.Add(parsedInfo.When, new HashSet<LogMessageInfo>() { parsedInfo });
+            });
+            
+            Receive<SendMeAll>(_ => Sender.Tell(_timeline.Values.ToList()));
+            
+            Receive<DumpToFile>(dump =>
+            {
+                File.AppendAllLines(dump.FilePath, _timeline.Select(pairs => pairs.Value).SelectMany(msg => msg).Select(m => $"[Node #{m.Node.Index}({m.Node.Role})]{m.OriginalMessage}"));
+                Sender.Tell(Done.Instance);
+            });
+        }
+
+        public class LogMessageInfo
+        {
+            public NodeInfo Node { get; }
+            public string OriginalMessage { get; }
+            public DateTime When { get; }
+            public LogLevel LogLevel { get; }
+            public string Message { get; }
+
+            public LogMessageInfo(LogMessage msg)
+            {
+                OriginalMessage = msg.Message;
+                Node = msg.Node;
+                When = DateTime.UtcNow;
+                LogLevel = LogLevel.InfoLevel; // In case if we could not find log level, assume that it is Info
+                Message = OriginalMessage;
+                
+                var pieces = Regex.Matches(msg.Message, @"\[([^\]]+)\]");
+                foreach (Match piece in pieces)
+                {
+                    Message = Message.Replace(piece.Value, "");
+                    
+                    if (DateTime.TryParseExact(piece.Value, "dd.MM.yyyy HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out var when))
+                        When = when;
+
+                    if (TryParseLogLevel(piece.Value, out var logLevel))
+                        LogLevel = logLevel;
+                }
+            }
+
+            private bool TryParseLogLevel(string str, out LogLevel logLevel)
+            {
+                var enumValues = Enum.GetValues(typeof(LogLevel)).Cast<LogLevel>().ToList();
+                foreach (var logLevelInfo in Enum.GetNames(typeof(LogLevel)).Select((name, i) => (Name: name, Index: i)))
+                {
+                    if (string.Equals(str + "Level", logLevelInfo.Name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        logLevel = enumValues[logLevelInfo.Index];
+                        return true;
+                    }
+                }
+
+                logLevel = default(LogLevel);
+                return false;
+            }
+        }
+        
+        public class NodeInfo
+        {
+            public NodeInfo(int index, string role, string platform, string testName)
+            {
+                Index = index;
+                Role = role;
+                Platform = platform;
+                TestName = testName;
+            }
+
+            public int Index { get; }
+            public string Role { get; }
+            public string Platform { get; }
+            public string TestName { get; set; }
+        }
+        
+        public class LogMessage
+        {
+            public LogMessage(NodeInfo node, string message)
+            {
+                Node = node;
+                Message = message;
+            }
+
+            public NodeInfo Node { get; }
+            public string Message { get; }
+        }
+
+        public class SendMeAll { }
+
+        public class DumpToFile
+        {
+            public DumpToFile(string filePath)
+            {
+                FilePath = filePath;
+            }
+
+            public string FilePath { get; }
+        }
+    }
+}


### PR DESCRIPTION
Working on #4059 here.

So far, added aggregation of all log messages into single `aggregated.txt` file, ordered by timestamp. So, now it should be easier to review what is happening across the nodes.

I guess we will also need to output this aggregated timeline to Azure Pipelines output. This should be as simple as writing all of this logs into a console.