### PR TITLE
TypeExtensions.TypeQualifiedName like in Hyperion

### DIFF
--- a/src/core/Akka.Tests/Util/TypeExtensionsTests.cs
+++ b/src/core/Akka.Tests/Util/TypeExtensionsTests.cs
@@ -5,10 +5,12 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using Akka.TestKit;
 using Akka.Util;
+using FluentAssertions;
 using Xunit;
 
 namespace Akka.Tests.Util
@@ -32,6 +34,42 @@ namespace Akka.Tests.Util
             typeof(object[]).Implements(typeof(string)).ShouldBe(false);
             typeof(List<string>).Implements(typeof(IEnumerable<string>)).ShouldBe(true);
             typeof(List<string>).Implements(typeof(IEnumerable<int>)).ShouldBe(false);
+        }
+
+        public static IEnumerable<object[]> TargetTypes
+        {
+            get
+            {
+                yield return new object[] { typeof(ParentClass<OtherClassA, OtherClassB, OtherClassC>.ChildClass) };
+                yield return new object[] { typeof(string) };
+                yield return new object[] { typeof(object) };
+                yield return new object[] { typeof(TypeExtensionsTests) };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TargetTypes))]
+        public void Type_qualified_name_includes_only_typename_and_assemblyname(Type targetType)
+        {
+            var manifest = targetType.TypeQualifiedName();
+
+            manifest.Should().NotContain("Version");
+            manifest.Should().NotContain("Culture");
+            manifest.Should().NotContain("PublicKeyToken");
+        }
+
+        public sealed class OtherClassA { }
+
+        public sealed class OtherClassB { }
+
+        public sealed class OtherClassC { }
+
+        public sealed class ParentClass<T1, T2, T3>
+        {
+            public sealed class ChildClass
+            {
+                public string Value { get; set; }
+            }
         }
     }
 }


### PR DESCRIPTION
Ported type name extraction from Hyperion into Akka's `TypeExtensions.TypeQualifiedName`.
This PR resolves #3767