### PR TITLE
Add async/await support to TestKit and migrate tests to Async api to reduce racy failures

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
@@ -103,9 +103,9 @@ namespace Akka.Cluster.Sharding.Tests
         /// <summary>
         /// Using region 2 as it is not shutdown in either test.
         /// </summary>
-        private void PingEntities()
+        private async Task PingEntities()
         {
-            AwaitAssert(() =>
+            await AwaitAssertAsync(() =>
             {
                 _region2.Tell(1, _probe2.Ref);
                 _probe2.ExpectMsg<int>(1.Seconds()).Should().Be(1);
@@ -117,22 +117,22 @@ namespace Akka.Cluster.Sharding.Tests
         }
 
         [Fact]
-        public void Sharding_and_CoordinatedShutdown_must_run_successfully()
+        public async Task Sharding_and_CoordinatedShutdown_must_run_successfully()
         {
-            InitCluster();
-            RunCoordinatedShutdownWhenLeaving();
-            RunCoordinatedShutdownWhenDowning();
+            await InitCluster();
+            await RunCoordinatedShutdownWhenLeaving();
+            await RunCoordinatedShutdownWhenDowning();
         }
 
-        private void InitCluster()
+        private async Task InitCluster()
         {
             Cluster.Get(_sys1).Join(Cluster.Get(_sys1).SelfAddress); // coordinator will initially run on sys1
-            AwaitAssert(() => Cluster.Get(_sys1).SelfMember.Status.Should().Be(MemberStatus.Up));
+            await AwaitAssertAsync(() => Cluster.Get(_sys1).SelfMember.Status.Should().Be(MemberStatus.Up));
 
             Cluster.Get(_sys2).Join(Cluster.Get(_sys1).SelfAddress);
-            Within(10.Seconds(), () =>
+            await WithinAsync(10.Seconds(), async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     Cluster.Get(_sys1).State.Members.Count.Should().Be(2);
                     Cluster.Get(_sys1).State.Members.All(x => x.Status == MemberStatus.Up).Should().BeTrue();
@@ -142,9 +142,9 @@ namespace Akka.Cluster.Sharding.Tests
             });
 
             Cluster.Get(_sys3).Join(Cluster.Get(_sys1).SelfAddress);
-            Within(10.Seconds(), () =>
+            await WithinAsync(10.Seconds(), async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     Cluster.Get(_sys1).State.Members.Count.Should().Be(3);
                     Cluster.Get(_sys1).State.Members.All(x => x.Status == MemberStatus.Up).Should().BeTrue();
@@ -155,59 +155,59 @@ namespace Akka.Cluster.Sharding.Tests
                 });
             });
 
-            PingEntities();
+            await PingEntities();
         }
 
-        private void RunCoordinatedShutdownWhenLeaving()
+        private async Task RunCoordinatedShutdownWhenLeaving()
         {
             Cluster.Get(_sys3).Leave(Cluster.Get(_sys1).SelfAddress);
             _probe1.ExpectMsg("CS-unbind-1");
 
-            Within(20.Seconds(), () =>
+            await WithinAsync(20.Seconds(), async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     Cluster.Get(_sys2).State.Members.Count.Should().Be(2);
                     Cluster.Get(_sys3).State.Members.Count.Should().Be(2);
                 });
             });
 
-            Within(10.Seconds(), () =>
+            await WithinAsync(10.Seconds(), async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     Cluster.Get(_sys1).IsTerminated.Should().BeTrue();
                     _sys1.WhenTerminated.IsCompleted.Should().BeTrue();
                 });
             });
 
-            PingEntities();
+            await PingEntities();
         }
 
-        private void RunCoordinatedShutdownWhenDowning()
+        private async Task RunCoordinatedShutdownWhenDowning()
         {
             // coordinator is on Sys2
             Cluster.Get(_sys2).Down(Cluster.Get(_sys3).SelfAddress);
             _probe3.ExpectMsg("CS-unbind-3");
 
-            Within(20.Seconds(), () =>
+            await WithinAsync(20.Seconds(), async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     Cluster.Get(_sys2).State.Members.Count.Should().Be(1);
                 });
             });
 
-            Within(10.Seconds(), () =>
+            await WithinAsync(10.Seconds(), async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     Cluster.Get(_sys3).IsTerminated.Should().BeTrue();
                     _sys3.WhenTerminated.IsCompleted.Should().BeTrue();
                 });
             });
 
-            PingEntities();
+            await PingEntities();
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/PersistentShardSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/PersistentShardSpec.cs
@@ -53,7 +53,7 @@ namespace Akka.Cluster.Sharding.Tests
         }
 
         [Fact]
-        public void Persistent_Shard_must_remember_entities_started_with_StartEntity()
+        public async Task Persistent_Shard_must_remember_entities_started_with_StartEntity()
         {
             Func<string, Props> ep = id => Props.Create(() => new EntityActor(id));
 
@@ -82,7 +82,7 @@ namespace Akka.Cluster.Sharding.Tests
             var secondIncarnation = Sys.ActorOf(props);
 
             secondIncarnation.Tell(Shard.GetShardStats.Instance);
-            AwaitAssert(() =>
+            await AwaitAssertAsync(() =>
             {
                 ExpectMsgAllOf(new Shard.ShardStats("shard-1", 1));
             });

--- a/src/contrib/cluster/Akka.DistributedData.Tests/LocalConcurrencySpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/LocalConcurrencySpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System.Collections.Immutable;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Xunit;
@@ -46,7 +47,7 @@ namespace Akka.DistributedData.Tests
         }
 
         [Fact]
-        public void Updates_from_same_node_should_be_possible_to_do_from_two_actors()
+        public async Task Updates_from_same_node_should_be_possible_to_do_from_two_actors()
         {
             var updater1 = ActorOf(Props.Create<Updater>(), "updater1");
             var updater2 = ActorOf(Props.Create<Updater>(), "updater2");
@@ -64,7 +65,7 @@ namespace Akka.DistributedData.Tests
             }
 
             var expected = b.ToImmutable();
-            AwaitAssert(() =>
+            await AwaitAssertAsync(() =>
             {
                 _replicator.Tell(Dsl.Get(Updater.Key, ReadLocal.Instance));
                 var msg = ExpectMsg<GetSuccess>();

--- a/src/contrib/dependencyinjection/Akka.DI.TestKit/DiResolverSpec.cs
+++ b/src/contrib/dependencyinjection/Akka.DI.TestKit/DiResolverSpec.cs
@@ -331,61 +331,61 @@ namespace Akka.DI.TestKit
         }
 
         [Fact]
-        public void DependencyResolver_should_inject_into_normal_mailbox_Actor()
+        public async Task DependencyResolver_should_inject_into_normal_mailbox_Actor()
         {
             var stashActorProps = Sys.DI().Props<DiPerRequestActor>();
             var stashActor = Sys.ActorOf(stashActorProps);
 
             var internalRef = (RepointableActorRef)stashActor;
-            AwaitCondition(() => internalRef.IsStarted);
+            await AwaitConditionAsync(() => internalRef.IsStarted);
 
             Assert.IsType<UnboundedMessageQueue>(internalRef.Underlying.AsInstanceOf<ActorCell>().Mailbox.MessageQueue);
         }
 
         [Fact]
-        public void DependencyResolver_should_inject_into_UnboundedStash_Actor()
+        public async Task DependencyResolver_should_inject_into_UnboundedStash_Actor()
         {
             var stashActorProps = Sys.DI().Props<UnboundedStashActor>();
             var stashActor = Sys.ActorOf(stashActorProps);
 
             var internalRef = (RepointableActorRef)stashActor;
-            AwaitCondition(() => internalRef.IsStarted);
+            await AwaitConditionAsync(() => internalRef.IsStarted);
 
             Assert.IsType<UnboundedDequeMessageQueue>(internalRef.Underlying.AsInstanceOf<ActorCell>().Mailbox.MessageQueue);
         }
 
         [Fact]
-        public void DependencyResolver_should_inject_into_BoundedStash_Actor()
+        public async Task DependencyResolver_should_inject_into_BoundedStash_Actor()
         {
             var stashActorProps = Sys.DI().Props<BoundedStashActor>();
             var stashActor = Sys.ActorOf(stashActorProps);
 
             var internalRef = (RepointableActorRef)stashActor;
-            AwaitCondition(() => internalRef.IsStarted);
+            await AwaitConditionAsync(() => internalRef.IsStarted);
 
             Assert.IsType<BoundedDequeMessageQueue>(internalRef.Underlying.AsInstanceOf<ActorCell>().Mailbox.MessageQueue);
         }
 
         [Fact]
-        public void DependencyResolver_should_dispose_IDisposable_instances_on_Actor_Termination()
+        public async Task DependencyResolver_should_dispose_IDisposable_instances_on_Actor_Termination()
         {
             var disposableActorProps = Sys.DI().Props<DisposableActor>();
             var disposableActor = Sys.ActorOf(disposableActorProps);
 
             var currentDisposeCounter = _disposeCounter.Current;
             Assert.True(disposableActor.GracefulStop(TimeSpan.FromSeconds(1)).Result);
-            AwaitAssert(() => Assert.True(currentDisposeCounter + 1 == _disposeCounter.Current), TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(50));
+            await AwaitAssertAsync(() => Assert.True(currentDisposeCounter + 1 == _disposeCounter.Current), TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(50));
         }
 
         [Fact]
-        public void DependencyResolver_should_dispose_IDisposable_instances_on_Actor_Restart()
+        public async Task DependencyResolver_should_dispose_IDisposable_instances_on_Actor_Restart()
         {
             var disposableActorProps = Sys.DI().Props<DisposableActor>();
             var disposableActor = Sys.ActorOf(disposableActorProps);
 
             var currentDisposeCounter = _disposeCounter.Current;
             disposableActor.Tell(new DisposableActor.Restart());
-            AwaitAssert(() => Assert.True(currentDisposeCounter + 1 == _disposeCounter.Current), TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(50));
+            await AwaitAssertAsync(() => Assert.True(currentDisposeCounter + 1 == _disposeCounter.Current), TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(50));
         }
 
         #endregion

--- a/src/core/Akka.Cluster.TestKit/MultiNodeClusterSpec.cs
+++ b/src/core/Akka.Cluster.TestKit/MultiNodeClusterSpec.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Cluster.Tests.MultiNode;
 using Akka.Configuration;
@@ -271,13 +272,13 @@ namespace Akka.Cluster.TestKit
             EnterBarrier(roles.Select(r => r.Name).Aggregate((a, b) => a + "-" + b) + "-joined");
         }
 
-        public void JoinWithin(RoleName joinNode, TimeSpan? max = null, TimeSpan? interval = null)
+        public async Task JoinWithinAsync(RoleName joinNode, TimeSpan? max = null, TimeSpan? interval = null)
         {
             if (max == null) max = RemainingOrDefault;
             if (interval == null) interval = TimeSpan.FromSeconds(1);
 
             Cluster.Join(GetAddress(joinNode));
-            AwaitCondition(() =>
+            await AwaitConditionAsync(() =>
             {
                 ClusterView.RefreshCurrentState();
                 if (MemberInState(GetAddress(joinNode), new[] { MemberStatus.Up }) &&
@@ -287,7 +288,6 @@ namespace Akka.Cluster.TestKit
                 Cluster.Join(GetAddress(joinNode));
                 return false;
             }, max, interval);
-
         }
 
         private bool MemberInState(Address member, IEnumerable<MemberStatus> status)

--- a/src/core/Akka.Cluster.Tests/DowningProviderSpec.cs
+++ b/src/core/Akka.Cluster.Tests/DowningProviderSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
@@ -87,7 +88,7 @@ namespace Akka.Cluster.Tests
         }
 
         [Fact]
-        public void Downing_provider_should_use_specified_downing_provider()
+        public async Task Downing_provider_should_use_specified_downing_provider()
         {
             var config = ConfigurationFactory.ParseString(
                 @"akka.cluster.downing-provider-class = ""Akka.Cluster.Tests.DummyDowningProvider, Akka.Cluster.Tests""");
@@ -95,14 +96,14 @@ namespace Akka.Cluster.Tests
             {
                 var downingProvider = Cluster.Get(system).DowningProvider;
                 downingProvider.Should().BeOfType<DummyDowningProvider>();
-                AwaitCondition(() =>
+                await AwaitConditionAsync(() =>
                     (downingProvider as DummyDowningProvider).ActorPropsAccessed.Value,
                     TimeSpan.FromSeconds(3));
             }
         }
 
         [Fact]
-        public void Downing_provider_should_stop_the_cluster_if_the_downing_provider_throws_exception_in_props()
+        public async Task Downing_provider_should_stop_the_cluster_if_the_downing_provider_throws_exception_in_props()
         {
             var config = ConfigurationFactory.ParseString(
                 @"akka.cluster.downing-provider-class = ""Akka.Cluster.Tests.FailingDowningProvider, Akka.Cluster.Tests""");
@@ -112,7 +113,7 @@ namespace Akka.Cluster.Tests
             var cluster = Cluster.Get(system);
             cluster.Join(cluster.SelfAddress);
 
-            AwaitCondition(() => cluster.IsTerminated, TimeSpan.FromSeconds(3));
+            await AwaitConditionAsync(() => cluster.IsTerminated, TimeSpan.FromSeconds(3));
 
             Shutdown(system);
         }

--- a/src/core/Akka.Cluster.Tests/ShutdownAfterJoinSeedNodesSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ShutdownAfterJoinSeedNodesSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
@@ -46,7 +47,7 @@ namespace Akka.Cluster.Tests
         }
 
         [Fact]
-        public void Joining_seed_nodes_must_be_aborted_after_shutdown_after_unsuccessful_join_seed_nodes()
+        public async Task Joining_seed_nodes_must_be_aborted_after_shutdown_after_unsuccessful_join_seed_nodes()
         {
             var seedNodes = ImmutableList.Create(
                 Cluster.Get(_seed1).SelfAddress, 
@@ -57,8 +58,8 @@ namespace Akka.Cluster.Tests
             Cluster.Get(_seed2).JoinSeedNodes(seedNodes);
             Cluster.Get(_ordinary1).JoinSeedNodes(seedNodes);
 
-            AwaitCondition(() => _seed2.WhenTerminated.IsCompleted, Cluster.Get(_seed2).Settings.ShutdownAfterUnsuccessfulJoinSeedNodes + TimeSpan.FromSeconds(10));
-            AwaitCondition(() => _ordinary1.WhenTerminated.IsCompleted, Cluster.Get(_ordinary1).Settings.ShutdownAfterUnsuccessfulJoinSeedNodes + TimeSpan.FromSeconds(10));
+            await AwaitConditionAsync(() => _seed2.WhenTerminated.IsCompleted, Cluster.Get(_seed2).Settings.ShutdownAfterUnsuccessfulJoinSeedNodes + TimeSpan.FromSeconds(10));
+            await AwaitConditionAsync(() => _ordinary1.WhenTerminated.IsCompleted, Cluster.Get(_ordinary1).Settings.ShutdownAfterUnsuccessfulJoinSeedNodes + TimeSpan.FromSeconds(10));
         }
     }
 }

--- a/src/core/Akka.Docs.Tests/Streams/KillSwitchDocTests.cs
+++ b/src/core/Akka.Docs.Tests/Streams/KillSwitchDocTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams;
 using Akka.Streams.Dsl;
 using Akka.TestKit.Xunit2;
@@ -24,7 +25,7 @@ namespace DocsExamples.Streams
         }
 
         [Fact]
-        public void Unique_kill_switch_must_control_graph_completion_with_shutdown()
+        public async Task Unique_kill_switch_must_control_graph_completion_with_shutdown()
         {
             #region unique-shutdown
             var countingSrc = Source.From(Enumerable.Range(1, int.MaxValue)).Delay(1.Seconds(), DelayOverflowStrategy.Backpressure);
@@ -39,7 +40,7 @@ namespace DocsExamples.Streams
 
             killSwitch.Shutdown();
 
-            AwaitCondition(() => last.IsCompleted);
+            await AwaitConditionAsync(() => last.IsCompleted);
             #endregion
         }
 
@@ -64,7 +65,7 @@ namespace DocsExamples.Streams
         }
 
         [Fact]
-        public void Shared_kill_switch_must_control_graph_completion_with_shutdown()
+        public async Task Shared_kill_switch_must_control_graph_completion_with_shutdown()
         {
             #region shared-shutdown
             var countingSrc = Source.From(Enumerable.Range(1, int.MaxValue)).Delay(1.Seconds(), DelayOverflowStrategy.Backpressure);
@@ -84,8 +85,8 @@ namespace DocsExamples.Streams
 
             sharedKillSwitch.Shutdown();
 
-            AwaitCondition(() => last.IsCompleted);
-            AwaitCondition(() => delayedLast.IsCompleted);
+            await AwaitConditionAsync(() => last.IsCompleted);
+            await AwaitConditionAsync(() => delayedLast.IsCompleted);
             #endregion
         }
 

--- a/src/core/Akka.Docs.Tests/Testkit/TestKitSampleTest.cs
+++ b/src/core/Akka.Docs.Tests/Testkit/TestKitSampleTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit.Xunit2;
 using Xunit;
@@ -31,7 +32,7 @@ namespace DocsExamples.Testkit
         private TimeSpan EpsilonValueForWithins => new TimeSpan(0, 0, 1); // https://github.com/akkadotnet/akka.net/issues/2130
 
         [Fact]
-        public void Test()
+        public async Task Test()
         {
             var subject = this.Sys.ActorOf<SomeActor>();
 
@@ -44,12 +45,12 @@ namespace DocsExamples.Testkit
             ExpectMsg("done", TimeSpan.FromSeconds(1));
 
             // the action needs to finish within 3 seconds
-            Within(TimeSpan.FromSeconds(3), () => {
+            await WithinAsync(TimeSpan.FromSeconds(3), async () => {
                 subject.Tell("hello", this.TestActor);
 
                 // This is a demo: would normally use expectMsgEquals().
                 // Wait time is bounded by 3-second deadline above.
-                AwaitCondition(() => probe.HasMessages);
+                await AwaitConditionAsync(() => probe.HasMessages);
 
                 // response must have been enqueued to us before probe
                 ExpectMsg("world", TimeSpan.FromSeconds(0));

--- a/src/core/Akka.Docs.Tutorials/Tutorial3/DeviceGroupSpec.cs
+++ b/src/core/Akka.Docs.Tutorials/Tutorial3/DeviceGroupSpec.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit.Xunit2;
 using FluentAssertions;
@@ -83,7 +84,7 @@ namespace Tutorials.Tutorial3
             }
 
             [Fact]
-            public void DeviceGroup_actor_must_be_able_to_list_active_devices_after_one_shuts_down()
+            public async Task DeviceGroup_actor_must_be_able_to_list_active_devices_after_one_shuts_down()
             {
                 var probe = CreateTestProbe();
                 var groupActor = Sys.ActorOf(DeviceGroup.Props("group"));
@@ -106,7 +107,7 @@ namespace Tutorials.Tutorial3
 
                 // using awaitAssert to retry because it might take longer for the groupActor
                 // to see the Terminated, that order is undefined
-                probe.AwaitAssert(() =>
+                await probe.AwaitAssertAsync(() =>
                 {
                     groupActor.Tell(new RequestDeviceList(requestId: 1), probe.Ref);
                     probe.ExpectMsg<ReplyDeviceList>(s => s.RequestId == 1 && s.Ids.Contains("device2"));

--- a/src/core/Akka.Docs.Tutorials/Tutorial4/DeviceGroupSpec.cs
+++ b/src/core/Akka.Docs.Tutorials/Tutorial4/DeviceGroupSpec.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit.Xunit2;
 using Akka.Util.Internal;
@@ -79,7 +80,7 @@ namespace Tutorials.Tutorial4
             }
 
             [Fact]
-            public void DeviceGroup_actor_must_be_able_to_list_active_devices_after_one_shuts_down()
+            public async Task DeviceGroup_actor_must_be_able_to_list_active_devices_after_one_shuts_down()
             {
                 var probe = CreateTestProbe();
                 var groupActor = Sys.ActorOf(DeviceGroup.Props("group"));
@@ -102,7 +103,7 @@ namespace Tutorials.Tutorial4
 
                 // using awaitAssert to retry because it might take longer for the groupActor
                 // to see the Terminated, that order is undefined
-                probe.AwaitAssert(() =>
+                await probe.AwaitAssertAsync(() =>
                 {
                     groupActor.Tell(new RequestDeviceList(requestId: 1), probe.Ref);
                     probe.ExpectMsg<ReplyDeviceList>(s => s.RequestId == 1 && s.Ids.Contains("device2"));

--- a/src/core/Akka.Persistence.TCK/Query/CurrentEventsByPersistenceIdSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Query/CurrentEventsByPersistenceIdSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Persistence.Query;
@@ -85,39 +86,39 @@ namespace Akka.Persistence.TCK.Query
         }
 
         [Fact]
-        public virtual void ReadJournal_CurrentEventsByPersistenceId_should_return_empty_stream_for_cleaned_journal_from_0_to_MaxLong()
+        public virtual async Task ReadJournal_CurrentEventsByPersistenceId_should_return_empty_stream_for_cleaned_journal_from_0_to_MaxLong()
         {
             var queries = ReadJournal.AsInstanceOf<ICurrentEventsByPersistenceIdQuery>();
             var pref = Setup("g1");
 
             pref.Tell(new TestActor.DeleteCommand(3));
-            AwaitAssert(() => ExpectMsg("3-deleted"));
+            await AwaitAssertAsync(() => ExpectMsg("3-deleted"));
 
             var src = queries.CurrentEventsByPersistenceId("g1", 0, long.MaxValue);
             src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), Materializer).Request(1).ExpectComplete();
         }
 
         [Fact]
-        public virtual void ReadJournal_CurrentEventsByPersistenceId_should_return_empty_stream_for_cleaned_journal_from_0_to_0()
+        public virtual async Task ReadJournal_CurrentEventsByPersistenceId_should_return_empty_stream_for_cleaned_journal_from_0_to_0()
         {
             var queries = ReadJournal.AsInstanceOf<ICurrentEventsByPersistenceIdQuery>();
             var pref = Setup("g2");
 
             pref.Tell(new TestActor.DeleteCommand(3));
-            AwaitAssert(() => ExpectMsg("3-deleted"));
+            await AwaitAssertAsync(() => ExpectMsg("3-deleted"));
 
             var src = queries.CurrentEventsByPersistenceId("g2", 0, 0);
             src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), Materializer).Request(1).ExpectComplete();
         }
 
         [Fact]
-        public virtual void ReadJournal_CurrentEventsByPersistenceId_should_return_remaining_values_after_partial_journal_cleanup()
+        public virtual async Task ReadJournal_CurrentEventsByPersistenceId_should_return_remaining_values_after_partial_journal_cleanup()
         {
             var queries = ReadJournal.AsInstanceOf<ICurrentEventsByPersistenceIdQuery>();
             var pref = Setup("h");
 
             pref.Tell(new TestActor.DeleteCommand(2));
-            AwaitAssert(() => ExpectMsg("2-deleted"));
+            await AwaitAssertAsync(() => ExpectMsg("2-deleted"));
 
             var src = queries.CurrentEventsByPersistenceId("h", 0L, long.MaxValue);
             src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), Materializer)

--- a/src/core/Akka.Persistence.Tests/PersistentActorRecoveryTimeoutSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorRecoveryTimeoutSpec.cs
@@ -100,7 +100,7 @@ namespace Akka.Persistence.Tests
         {
             // initialize journal early
             Persistence.Instance.Apply(Sys).JournalFor("akka.persistence.journal.stepping-inmem");
-            AwaitAssert(() => SteppingMemoryJournal.GetRef(JournalId), TimeSpan.FromSeconds(3));
+            AwaitAssertAsync(() => SteppingMemoryJournal.GetRef(JournalId), TimeSpan.FromSeconds(3)).Wait();
             _journal = SteppingMemoryJournal.GetRef(JournalId);
         }
 

--- a/src/core/Akka.Persistence.Tests/PersistentActorStashingSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorStashingSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Persistence.Tests.Journal;
 using Xunit;
@@ -443,10 +444,10 @@ namespace Akka.Persistence.Tests
         }
 
         [Fact]
-        public void Stashing_in_a_PersistentActor_mixed_with_PersistAsync_should_handle_async_callback_not_happening_until_next_message_has_been_stashed()
+        public async Task Stashing_in_a_PersistentActor_mixed_with_PersistAsync_should_handle_async_callback_not_happening_until_next_message_has_been_stashed()
         {
             var pref = Sys.ActorOf(Props.Create(() => new AsyncStashingActor(Name)));
-            AwaitAssert(() => SteppingMemoryJournal.GetRef("persistence-stash"), TimeSpan.FromSeconds(3));
+            await AwaitAssertAsync(() => SteppingMemoryJournal.GetRef("persistence-stash"), TimeSpan.FromSeconds(3));
             var journal = SteppingMemoryJournal.GetRef("persistence-stash");
 
             // initial read highest
@@ -463,9 +464,9 @@ namespace Akka.Persistence.Tests
             SteppingMemoryJournal.Step(journal);
             SteppingMemoryJournal.Step(journal);
 
-            Within(TimeSpan.FromSeconds(3), () =>
+            await WithinAsync(TimeSpan.FromSeconds(3), async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     pref.Tell(GetState.Instance);
                     ExpectMsgInOrder("a", "c", "b");
@@ -474,10 +475,10 @@ namespace Akka.Persistence.Tests
         }
 
         [Fact]
-        public void Stashing_in_a_PersistentActor_mixed_with_PersistAsync_should_handle_async_callback_not_happening_until_next_message_has_been_stashed_within_handler()
+        public async Task Stashing_in_a_PersistentActor_mixed_with_PersistAsync_should_handle_async_callback_not_happening_until_next_message_has_been_stashed_within_handler()
         {
             var pref = Sys.ActorOf(Props.Create(() => new AsyncStashingWithinHandlerActor(Name)));
-            AwaitAssert(() => SteppingMemoryJournal.GetRef("persistence-stash"), TimeSpan.FromSeconds(3));
+            await AwaitAssertAsync(() => SteppingMemoryJournal.GetRef("persistence-stash"), TimeSpan.FromSeconds(3));
             var journal = SteppingMemoryJournal.GetRef("persistence-stash");
 
             // initial read highest
@@ -494,9 +495,9 @@ namespace Akka.Persistence.Tests
             SteppingMemoryJournal.Step(journal);
             SteppingMemoryJournal.Step(journal);
 
-            Within(TimeSpan.FromSeconds(3), () =>
+            await WithinAsync(TimeSpan.FromSeconds(3), async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     pref.Tell(GetState.Instance);
                     ExpectMsgInOrder("a", "c", "b");

--- a/src/core/Akka.Remote.TestKit.Tests/ControllerSpec.cs
+++ b/src/core/Akka.Remote.TestKit.Tests/ControllerSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
 using Xunit;
@@ -32,7 +33,7 @@ namespace Akka.Remote.TestKit.Tests
         private readonly RoleName B = new RoleName("b");
 
         [Fact]
-        public void Controller_must_publish_its_nodes()
+        public async Task Controller_must_publish_its_nodes()
         {
             var c = Sys.ActorOf(Props.Create(() => new Controller(1, new IPEndPoint(IPAddress.Loopback, 0))));
             c.Tell(new Controller.NodeInfo(A, Address.Parse("akka://sys"), TestActor));
@@ -41,7 +42,7 @@ namespace Akka.Remote.TestKit.Tests
             ExpectMsg<ToClient<Done>>();
             c.Tell(Controller.GetNodes.Instance);
             ExpectMsg<IEnumerable<RoleName>>(names => XAssert.Equivalent(names, new[] {A, B}));
-            AwaitAssert(() =>
+            await AwaitAssertAsync(() =>
             {
                 Watch(c);
                 c.Tell(PoisonPill.Instance);

--- a/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
+++ b/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
@@ -15,7 +15,7 @@ using System.Net.Sockets;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
-
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Configuration.Hocon;
@@ -429,14 +429,16 @@ namespace Akka.Remote.TestKit
             AtStartup();
         }
 
-        public void MultiNodeSpecAfterAll()
+        public async Task MultiNodeSpecAfterAllAsync()
         {
             // wait for all nodes to remove themselves before we shut the conductor down
             if (SelfIndex == 0)
             {
                 TestConductor.RemoveNode(_myself);
                 Within(TestConductor.Settings.BarrierTimeout, () =>
-                    AwaitCondition(() => TestConductor.GetNodes().Result.All(n => n.Equals(_myself))));
+                {
+                    AwaitConditionAsync(() => TestConductor.GetNodes().Result.All(n => n.Equals(_myself))).Wait();
+                });
 
             }
             Shutdown(Sys);

--- a/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
+++ b/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
@@ -429,7 +429,7 @@ namespace Akka.Remote.TestKit
             AtStartup();
         }
 
-        public async Task MultiNodeSpecAfterAllAsync()
+        public void MultiNodeSpecAfterAll()
         {
             // wait for all nodes to remove themselves before we shut the conductor down
             if (SelfIndex == 0)
@@ -437,6 +437,7 @@ namespace Akka.Remote.TestKit
                 TestConductor.RemoveNode(_myself);
                 Within(TestConductor.Settings.BarrierTimeout, () =>
                 {
+                    // Method is used in Dispose method, so have to make it synchronous
                     AwaitConditionAsync(() => TestConductor.GetNodes().Result.All(n => n.Equals(_myself))).Wait();
                 });
 

--- a/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
+++ b/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
@@ -509,6 +509,16 @@ namespace Akka.Remote.TestKit
             if (nodes.Length == 0) throw new ArgumentException("No node given to run on.");
             if (IsNode(nodes)) thunk();
         }
+        
+        /// <summary>
+        /// Execute the given block of code only on the given nodes (names according
+        /// to the `roleMap`).
+        /// </summary>
+        public async Task RunOnAsync(Func<Task> thunkAsync, params RoleName[] nodes)
+        {
+            if (nodes.Length == 0) throw new ArgumentException("No node given to run on.");
+            if (IsNode(nodes)) await thunkAsync();
+        }
 
         /// <summary>
         /// Verify that the running node matches one of the given nodes

--- a/src/core/Akka.Remote.Tests.MultiNode/RemoteGatePiercingSpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/RemoteGatePiercingSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
@@ -73,7 +74,7 @@ namespace Akka.Remote.Tests.MultiNode
         protected override int InitialParticipantsValueFactory { get; } = 2;
 
         [MultiNodeFact]
-        public void RemoteGatePiercing_must_allow_restarted_node_to_pass_through_gate()
+        public async Task RemoteGatePiercing_must_allow_restarted_node_to_pass_through_gate()
         {
             Sys.ActorOf<RemoteGatePiercingMultiNetSpec.Subject>("subject");
             EnterBarrier("actors-started");
@@ -96,15 +97,15 @@ namespace Akka.Remote.Tests.MultiNode
                 EnterBarrier("gate-pierced");
             }, _config.First);
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 EnterBarrier("actors-communicate");
                 EnterBarrier("gated");
 
                 // Pierce the gate
-                Within(TimeSpan.FromSeconds(30), () =>
+                await WithinAsync(TimeSpan.FromSeconds(30), async () =>
                 {
-                    AwaitAssert(() => _identify(_config.First, "subject"));
+                    await AwaitAssertAsync(() => _identify(_config.First, "subject"));
                 });
 
                 EnterBarrier("gate-pierced");

--- a/src/core/Akka.Remote.Tests.MultiNode/RemoteNodeRestartDeathWatchSpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/RemoteNodeRestartDeathWatchSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Text;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
@@ -46,10 +47,9 @@ namespace Akka.Remote.Tests.MultiNode
 
 
         [MultiNodeFact]
-        public void Must_receive_terminated_when_remote_actor_system_is_restarted()
+        public async Task Must_receive_terminated_when_remote_actor_system_is_restarted()
         {
-            
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 var secondAddress = Node(_specConfig.Second).Address;
                 EnterBarrier("actors-started");
@@ -66,10 +66,10 @@ namespace Akka.Remote.Tests.MultiNode
                     .GetResult();
                 TestConductor.Shutdown(_specConfig.Second).GetAwaiter().GetResult();
                 ExpectTerminated(subject, TimeSpan.FromSeconds(15));
-                Within(TimeSpan.FromSeconds(5), () =>
+                await WithinAsync(TimeSpan.FromSeconds(5), async () =>
                 {
                     // retry because the Subject actor might not be started yet
-                    AwaitAssert(() =>
+                    await AwaitAssertAsync(() =>
                     {
                         Sys.ActorSelection(new RootActorPath(secondAddress)/"user"/
                                            "subject").Tell("shutdown");

--- a/src/core/Akka.Remote.Tests.MultiNode/RemoteNodeShutdownAndComesBackSpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/RemoteNodeShutdownAndComesBackSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
@@ -72,9 +73,9 @@ namespace Akka.Remote.Tests.MultiNode
         protected override int InitialParticipantsValueFactory { get; } = 2;
 
         [MultiNodeFact]
-        public void RemoteNodeShutdownAndComesBack_must_properly_reset_system_message_buffer_state_when_new_system_with_same_Address_comes_up()
+        public async Task RemoteNodeShutdownAndComesBack_must_properly_reset_system_message_buffer_state_when_new_system_with_same_Address_comes_up()
         {
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 var secondAddress = Node(_config.Second).Address;
                 Sys.ActorOf<RemoteNodeShutdownAndComesBackMultiNetSpec.Subject>("subject");
@@ -112,10 +113,10 @@ namespace Akka.Remote.Tests.MultiNode
                 // the system message send state
 
                 // Now wait until second system becomes alive again
-                Within(TimeSpan.FromSeconds(30), () =>
+                await WithinAsync(TimeSpan.FromSeconds(30), async () =>
                 {
                     // retry because the Subject actor might not be started yet
-                    AwaitAssert(() =>
+                    await AwaitAssertAsync(() =>
                     {
                         var p = CreateTestProbe();
                         Sys.ActorSelection(new RootActorPath(secondAddress) / "user" / "subject").Tell(new Identify("subject"), p.Ref);

--- a/src/core/Akka.Remote.Tests.MultiNode/RemoteQuarantinePiercingSpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/RemoteQuarantinePiercingSpec.cs
@@ -7,6 +7,7 @@
 
 
 using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
@@ -66,14 +67,14 @@ namespace Akka.Remote.Tests.MultiNode
         }
 
         [MultiNodeFact]
-        public void RemoteQuarantinePiercingSpecs()
+        public async Task RemoteQuarantinePiercingSpecs()
         {
-            RemoteNodeShutdownAndComesBack_must_allow_piercing_through_the_quarantine_when_remote_UID_is_new();
+            await RemoteNodeShutdownAndComesBack_must_allow_piercing_through_the_quarantine_when_remote_UID_is_new();
         }
 
-        private void RemoteNodeShutdownAndComesBack_must_allow_piercing_through_the_quarantine_when_remote_UID_is_new()
+        private async Task RemoteNodeShutdownAndComesBack_must_allow_piercing_through_the_quarantine_when_remote_UID_is_new()
         {
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 var secondAddress = Node(_specConfig.Second).Address;
                 EnterBarrier("actors-started");
@@ -95,10 +96,10 @@ namespace Akka.Remote.Tests.MultiNode
                 TestConductor.Shutdown(_specConfig.Second).Wait(TimeSpan.FromSeconds(30));
 
                 // Now wait until second system becomes alive again
-                Within(30.Seconds(), () =>
+                await WithinAsync(30.Seconds(), async () =>
                 {
                     // retry because the Subject actor might not be started yet
-                    AwaitAssert(() =>
+                    await AwaitAssertAsync(() =>
                     {
                         Sys.ActorSelection(new RootActorPath(secondAddress) / "user" / "subject").Tell("identify");
                         var tuple2 = ExpectMsg<(int, IActorRef)>(TimeSpan.FromSeconds(1));

--- a/src/core/Akka.Remote.Tests.MultiNode/RemoteReDeploymentSpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/RemoteReDeploymentSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Event;
@@ -66,7 +67,7 @@ namespace Akka.Remote.Tests.MultiNode
         }
 
         [MultiNodeFact]
-        public void RemoteReDeployment_must_terminate_the_child_when_its_parent_system_is_replaced_by_a_new_one()
+        public async Task RemoteReDeployment_must_terminate_the_child_when_its_parent_system_is_replaced_by_a_new_one()
         {
             var echo = Sys.ActorOf(EchoProps(TestActor), "echo");
             EnterBarrier("echo-started");
@@ -87,7 +88,7 @@ namespace Akka.Remote.Tests.MultiNode
 
             EnterBarrier("first-deployed");
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 TestConductor.Blackhole(_config.Second, _config.First, ThrottleTransportAdapter.Direction.Both)
                     .Wait();
@@ -106,7 +107,7 @@ namespace Akka.Remote.Tests.MultiNode
                 {
                     ExpectNoMsg(SleepAfterKill);
                 }
-                AwaitAssert(() => Node(_config.Second), TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(100));
+                await AwaitAssertAsync(() => Node(_config.Second), TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(100));
             }, _config.First);
 
             ActorSystem tempSys = null;

--- a/src/core/Akka.Remote.Tests/ActorsLeakSpec.cs
+++ b/src/core/Akka.Remote.Tests/ActorsLeakSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Internal;
 using Akka.Configuration;
@@ -86,7 +87,7 @@ namespace Akka.Remote.Tests
         }
 
         [Fact]
-        public void Remoting_must_not_leak_actors()
+        public async Task Remoting_must_not_leak_actors()
         {
             var actorRef = Sys.ActorOf(EchoActor.Props(this, true), "echo");
             var echoPath = new RootActorPath(RARP.For(Sys).Provider.DefaultAddress)/"user"/"echo";
@@ -231,7 +232,7 @@ namespace Akka.Remote.Tests
              */
             EventFilter.Exception<TimeoutException>().ExpectOne(() => { });
 
-            AwaitAssert(() =>
+            await AwaitAssertAsync(() =>
             {
                 AssertActors(initialActors, targets.SelectMany(CollectLiveActors).ToImmutableHashSet());
             }, 10.Seconds());

--- a/src/core/Akka.Remote.Tests/RemoteWatcherSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteWatcherSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
 using Akka.Util.Internal;
@@ -270,7 +271,7 @@ namespace Akka.Remote.Tests
         }
 
         [Fact]
-        public void A_RemoteWatcher_must_generate_address_terminated_when_missing_heartbeats()
+        public async Task A_RemoteWatcher_must_generate_address_terminated_when_missing_heartbeats()
         {
             var p = CreateTestProbe();
             var q = CreateTestProbe();
@@ -293,9 +294,9 @@ namespace Akka.Remote.Tests
             ExpectMsg<RemoteWatcher.Heartbeat>();
             monitorA.Tell(_heartbeatRspB, monitorB);
 
-            Within(TimeSpan.FromSeconds(10), () =>
+            await WithinAsync(TimeSpan.FromSeconds(10), async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
                     ExpectMsg<RemoteWatcher.Heartbeat>();
@@ -311,7 +312,7 @@ namespace Akka.Remote.Tests
         }
 
         [Fact]
-        public void A_RemoteWatcher_must_generate_address_terminated_when_missing_first_heartbeat()
+        public async Task A_RemoteWatcher_must_generate_address_terminated_when_missing_first_heartbeat()
         {
             var p = CreateTestProbe();
             var q = CreateTestProbe();
@@ -332,9 +333,9 @@ namespace Akka.Remote.Tests
             ExpectMsg<RemoteWatcher.Heartbeat>();
             // no HeartbeatRsp sent
 
-            Within(TimeSpan.FromSeconds(20), () =>
+            await WithinAsync(TimeSpan.FromSeconds(20), async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
                     ExpectMsg<RemoteWatcher.Heartbeat>();
@@ -351,8 +352,7 @@ namespace Akka.Remote.Tests
         }
 
         [Fact]
-        public void
-            A_RemoteWatcher_must_generate_address_terminated_for_new_watch_after_broken_connection_was_reestablished_and_broken_again()
+        public async Task A_RemoteWatcher_must_generate_address_terminated_for_new_watch_after_broken_connection_was_reestablished_and_broken_again()
         {
             var p = CreateTestProbe();
             var q = CreateTestProbe();
@@ -375,9 +375,9 @@ namespace Akka.Remote.Tests
             ExpectMsg<RemoteWatcher.Heartbeat>();
             monitorA.Tell(_heartbeatRspB, monitorB);
 
-            Within(TimeSpan.FromSeconds(10), () =>
+            await WithinAsync(TimeSpan.FromSeconds(10), async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
                     ExpectMsg<RemoteWatcher.Heartbeat>();
@@ -391,7 +391,7 @@ namespace Akka.Remote.Tests
 
             //real AddressTerminated would trigger Terminated for b6, simulate that here
             _remoteSystem.Stop(b);
-            AwaitAssert(() =>
+            await AwaitAssertAsync(() =>
             {
                 monitorA.Tell(RemoteWatcher.Stats.Empty, TestActor);
                 ExpectMsg(RemoteWatcher.Stats.Empty);
@@ -423,9 +423,9 @@ namespace Akka.Remote.Tests
             q.ExpectNoMsg(TimeSpan.FromSeconds(1));
 
             //then stop heartbeating again; should generate a new AddressTerminated
-            Within(TimeSpan.FromSeconds(10), () =>
+            await WithinAsync(TimeSpan.FromSeconds(10), async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
                     ExpectMsg<RemoteWatcher.Heartbeat>();

--- a/src/core/Akka.Remote.Tests/RemotingSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemotingSpec.cs
@@ -628,10 +628,10 @@ namespace Akka.Remote.Tests
         }
 
         [Fact]
-        public void Drop_sent_messages_over_payload_size()
+        public async Task Drop_sent_messages_over_payload_size()
         {
             var oversized = ByteStringOfSize(MaxPayloadBytes + 1);
-            EventFilter.Exception<OversizedPayloadException>(start: "Discarding oversized payload sent to ").ExpectOne(() =>
+            await EventFilter.Exception<OversizedPayloadException>(start: "Discarding oversized payload sent to ").ExpectOneAsync(() =>
             {
                 VerifySend(oversized, () =>
                 {
@@ -641,9 +641,9 @@ namespace Akka.Remote.Tests
         }
 
         [Fact]
-        public void Drop_received_messages_over_payload_size()
+        public async Task Drop_received_messages_over_payload_size()
         {
-            EventFilter.Exception<OversizedPayloadException>(start: "Discarding oversized payload received").ExpectOne(() =>
+            await EventFilter.Exception<OversizedPayloadException>(start: "Discarding oversized payload received").ExpectOneAsync(() =>
             {
                 VerifySend(MaxPayloadBytes + 1, () =>
                 {

--- a/src/core/Akka.Remote.Tests/RemotingSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemotingSpec.cs
@@ -463,7 +463,7 @@ namespace Akka.Remote.Tests
         }
 
         [Fact]
-        public void Stash_inbound_connections_until_UID_is_known_for_pending_outbound()
+        public async Task Stash_inbound_connections_until_UID_is_known_for_pending_outbound()
         {
             var localAddress = new Address("akka.test", "system1", "localhost", 1);
             var rawLocalAddress = new Address("test", "system1", "localhost", 1);
@@ -495,7 +495,7 @@ namespace Akka.Remote.Tests
                     (new ActorAssociationEventListener(remoteTransportProbe)));
 
                 // Hijack associations through the test transport
-                AwaitCondition(() => registry.TransportsReady(rawLocalAddress, rawRemoteAddress));
+                await AwaitConditionAsync(() => registry.TransportsReady(rawLocalAddress, rawRemoteAddress));
                 var testTransport = registry.TransportFor(rawLocalAddress).Value.Item1;
                 testTransport.WriteBehavior.PushConstant(true);
 
@@ -514,7 +514,7 @@ namespace Akka.Remote.Tests
                 var inboundHandle = inboundHandleTask.Result;
                 inboundHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(inboundHandleProbe));
 
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     registry.GetRemoteReadHandlerFor(inboundHandle.AsInstanceOf<TestAssociationHandle>()).Should().NotBeNull();
                 });
@@ -545,7 +545,7 @@ namespace Akka.Remote.Tests
         }
 
         [Fact]
-        public void Properly_quarantine_stashed_inbound_connections()
+        public async Task Properly_quarantine_stashed_inbound_connections()
         {
             var localAddress = new Address("akka.test", "system1", "localhost", 1);
             var rawLocalAddress = new Address("test", "system1", "localhost", 1);
@@ -577,7 +577,7 @@ namespace Akka.Remote.Tests
                     (new ActorAssociationEventListener(remoteTransportProbe)));
 
                 // Hijack associations through the test transport
-                AwaitCondition(() => registry.TransportsReady(rawLocalAddress, rawRemoteAddress));
+                await AwaitConditionAsync(() => registry.TransportsReady(rawLocalAddress, rawRemoteAddress));
                 var testTransport = registry.TransportFor(rawLocalAddress).Value.Item1;
                 testTransport.WriteBehavior.PushConstant(true);
 
@@ -596,7 +596,7 @@ namespace Akka.Remote.Tests
                 var inboundHandle = inboundHandleTask.Result;
                 inboundHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(inboundHandleProbe));
 
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     registry.GetRemoteReadHandlerFor(inboundHandle.AsInstanceOf<TestAssociationHandle>()).Should().NotBeNull();
                 });

--- a/src/core/Akka.Remote.Tests/Transport/AkkaProtocolStressTest.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaProtocolStressTest.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Remote.Transport;
@@ -179,7 +180,7 @@ namespace Akka.Remote.Tests.Transport
         #region Tests
 
         [Fact(Skip = "Extremely racy")]
-        public void AkkaProtocolTransport_must_guarantee_at_most_once_delivery_and_message_ordering_despite_packet_loss()
+        public async Task AkkaProtocolTransport_must_guarantee_at_most_once_delivery_and_message_ordering_despite_packet_loss()
         {
             //todo mute both systems for deadletters for any type of message
             EventFilter.DeadLetter().Mute();
@@ -188,7 +189,7 @@ namespace Akka.Remote.Tests.Transport
                 RARP.For(Sys)
                     .Provider.Transport.ManagementCommand(new FailureInjectorTransportAdapter.One(AddressB,
                         new FailureInjectorTransportAdapter.Drop(0.1, 0.1)));
-            AwaitCondition(() => mc.IsCompleted && mc.Result, TimeSpan.FromSeconds(3));
+            await AwaitConditionAsync(() => mc.IsCompleted && mc.Result, TimeSpan.FromSeconds(3));
 
             var here = Here;
 

--- a/src/core/Akka.Remote.Tests/Transport/DotNettyTransportShutdownSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettyTransportShutdownSpec.cs
@@ -89,8 +89,8 @@ namespace Akka.Remote.Tests.Transport
                 var inboundHandle = p2.ExpectMsg<InboundAssociation>().Association; // wait for the inbound association handle to show up
                 inboundHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p2));
 
-                AwaitCondition(() => t1.ConnectionGroup.Count == 2);
-                AwaitCondition(() => t2.ConnectionGroup.Count == 2);
+                await AwaitConditionAsync(() => t1.ConnectionGroup.Count == 2);
+                await AwaitConditionAsync(() => t2.ConnectionGroup.Count == 2);
 
                 var chan1 = t1.ConnectionGroup.Single(x => !x.Id.Equals(t1.ServerChannel.Id));
                 var chan2 = t2.ConnectionGroup.Single(x => !x.Id.Equals(t2.ServerChannel.Id));
@@ -100,8 +100,8 @@ namespace Akka.Remote.Tests.Transport
 
                 // verify that the connections are terminated
                 p1.ExpectMsg<Disassociated>();
-                AwaitCondition(() => t1.ConnectionGroup.Count == 1);
-                AwaitCondition(() => t2.ConnectionGroup.Count == 1);
+                await AwaitConditionAsync(() => t1.ConnectionGroup.Count == 1);
+                await AwaitConditionAsync(() => t2.ConnectionGroup.Count == 1);
 
                 // verify that the connection channels were terminated on both ends
                 chan1.CloseCompletion.IsCompleted.Should().BeTrue();
@@ -136,8 +136,8 @@ namespace Akka.Remote.Tests.Transport
                 var inboundHandle = p2.ExpectMsg<InboundAssociation>().Association; // wait for the inbound association handle to show up
                 inboundHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p2));
 
-                AwaitCondition(() => t1.ConnectionGroup.Count == 2);
-                AwaitCondition(() => t2.ConnectionGroup.Count == 2);
+                await AwaitConditionAsync(() => t1.ConnectionGroup.Count == 2);
+                await AwaitConditionAsync(() => t2.ConnectionGroup.Count == 2);
 
                 var chan1 = t1.ConnectionGroup.Single(x => !x.Id.Equals(t1.ServerChannel.Id));
                 var chan2 = t2.ConnectionGroup.Single(x => !x.Id.Equals(t2.ServerChannel.Id));
@@ -147,8 +147,8 @@ namespace Akka.Remote.Tests.Transport
 
                 p2.ExpectMsg<Disassociated>();
                 // verify that the connections are terminated
-                AwaitCondition(() => t1.ConnectionGroup.Count == 0, null, message: $"Expected 0 open connection but found {t1.ConnectionGroup.Count}");
-                AwaitCondition(() => t2.ConnectionGroup.Count == 1, null,message: $"Expected 1 open connection but found {t2.ConnectionGroup.Count}");
+                await AwaitConditionAsync(() => t1.ConnectionGroup.Count == 0, null, message: $"Expected 0 open connection but found {t1.ConnectionGroup.Count}");
+                await AwaitConditionAsync(() => t2.ConnectionGroup.Count == 1, null,message: $"Expected 1 open connection but found {t2.ConnectionGroup.Count}");
 
                 // verify that the connection channels were terminated on both ends
                 chan1.CloseCompletion.IsCompleted.Should().BeTrue();
@@ -183,8 +183,8 @@ namespace Akka.Remote.Tests.Transport
                 var inboundHandle = p2.ExpectMsg<InboundAssociation>().Association; // wait for the inbound association handle to show up
                 inboundHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p2));
 
-                AwaitCondition(() => t1.ConnectionGroup.Count == 2);
-                AwaitCondition(() => t2.ConnectionGroup.Count == 2);
+                await AwaitConditionAsync(() => t1.ConnectionGroup.Count == 2);
+                await AwaitConditionAsync(() => t2.ConnectionGroup.Count == 2);
 
                 var chan1 = t1.ConnectionGroup.Single(x => !x.Id.Equals(t1.ServerChannel.Id));
                 var chan2 = t2.ConnectionGroup.Single(x => !x.Id.Equals(t2.ServerChannel.Id));
@@ -193,8 +193,8 @@ namespace Akka.Remote.Tests.Transport
                 inboundHandle.Disassociate();
 
                 // verify that the connections are terminated
-                AwaitCondition(() => t1.ConnectionGroup.Count == 1, null, message: $"Expected 1 open connection but found {t1.ConnectionGroup.Count}");
-                AwaitCondition(() => t2.ConnectionGroup.Count == 1, null, message: $"Expected 1 open connection but found {t2.ConnectionGroup.Count}");
+                await AwaitConditionAsync(() => t1.ConnectionGroup.Count == 1, null, message: $"Expected 1 open connection but found {t1.ConnectionGroup.Count}");
+                await AwaitConditionAsync(() => t2.ConnectionGroup.Count == 1, null, message: $"Expected 1 open connection but found {t2.ConnectionGroup.Count}");
 
                 // verify that the connection channels were terminated on both ends
                 chan1.CloseCompletion.IsCompleted.Should().BeTrue();
@@ -229,8 +229,8 @@ namespace Akka.Remote.Tests.Transport
                 var inboundHandle = p2.ExpectMsg<InboundAssociation>().Association; // wait for the inbound association handle to show up
                 inboundHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p2));
 
-                AwaitCondition(() => t1.ConnectionGroup.Count == 2);
-                AwaitCondition(() => t2.ConnectionGroup.Count == 2);
+                await AwaitConditionAsync(() => t1.ConnectionGroup.Count == 2);
+                await AwaitConditionAsync(() => t2.ConnectionGroup.Count == 2);
 
                 var chan1 = t1.ConnectionGroup.Single(x => !x.Id.Equals(t1.ServerChannel.Id));
                 var chan2 = t2.ConnectionGroup.Single(x => !x.Id.Equals(t2.ServerChannel.Id));
@@ -239,8 +239,8 @@ namespace Akka.Remote.Tests.Transport
                 await t2.Shutdown();
 
                 // verify that the connections are terminated
-                AwaitCondition(() => t1.ConnectionGroup.Count == 1, null, message: $"Expected 1 open connection but found {t1.ConnectionGroup.Count}");
-                AwaitCondition(() => t2.ConnectionGroup.Count == 0, null, message: $"Expected 0 open connection but found {t2.ConnectionGroup.Count}");
+                await AwaitConditionAsync(() => t1.ConnectionGroup.Count == 1, null, message: $"Expected 1 open connection but found {t1.ConnectionGroup.Count}");
+                await AwaitConditionAsync(() => t2.ConnectionGroup.Count == 0, null, message: $"Expected 0 open connection but found {t2.ConnectionGroup.Count}");
 
                 // verify that the connection channels were terminated on both ends
                 chan1.CloseCompletion.IsCompleted.Should().BeTrue();
@@ -272,7 +272,7 @@ namespace Akka.Remote.Tests.Transport
                 });
 
 
-                AwaitCondition(() => t1.ConnectionGroup.Count == 1);
+                await AwaitConditionAsync(() => t1.ConnectionGroup.Count == 1);
             }
             finally
             {

--- a/src/core/Akka.Remote.Tests/Transport/ThrottlerTransportAdapterSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/ThrottlerTransportAdapterSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Remote.Transport;
@@ -195,7 +196,7 @@ namespace Akka.Remote.Tests.Transport
         }
 
         [Fact]
-        public void ThrottlerTransportAdapter_must_survive_blackholing()
+        public async Task ThrottlerTransportAdapter_must_survive_blackholing()
         {
             Here.Tell(new ThrottlingTester.Lost("BlackHole 1"));
             ExpectMsg(new ThrottlingTester.Lost("BlackHole 1"));
@@ -215,7 +216,7 @@ namespace Akka.Remote.Tests.Transport
             // after we remove the Blackhole we can't be certain of the state
             // of the connection, repeat until success
             here.Tell(new ThrottlingTester.Lost("BlackHole 3"));
-            AwaitCondition(() =>
+            await AwaitConditionAsync(() =>
             {
                 var received = ReceiveOne(TimeSpan.Zero);
                 if (received != null && received.Equals(new ThrottlingTester.Lost("BlackHole 3")))

--- a/src/core/Akka.Streams.TestKit.Tests/BaseTwoStreamsSetup.cs
+++ b/src/core/Akka.Streams.TestKit.Tests/BaseTwoStreamsSetup.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.TestKit;
 using FluentAssertions;
@@ -62,9 +63,9 @@ namespace Akka.Streams.TestKit.Tests
         }
 
         [Fact]
-        public void Should_work_with_two_immediately_completed_publishers()
+        public async Task Should_work_with_two_immediately_completed_publishers()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber = Setup(CompletedPublisher<int>(), CompletedPublisher<int>());
                 subscriber.ExpectSubscriptionAndComplete();
@@ -72,9 +73,9 @@ namespace Akka.Streams.TestKit.Tests
         }
 
         [Fact]
-        public void Should_work_with_two_delayed_completed_publishers()
+        public async Task Should_work_with_two_delayed_completed_publishers()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber = Setup(SoonToCompletePublisher<int>(), SoonToCompletePublisher<int>());
                 subscriber.ExpectSubscriptionAndComplete();
@@ -82,9 +83,9 @@ namespace Akka.Streams.TestKit.Tests
         }
 
         [Fact]
-        public void Should_work_with_one_immediately_completed_and_one_delayed_completed_publisher()
+        public async Task Should_work_with_one_immediately_completed_and_one_delayed_completed_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber = Setup(CompletedPublisher<int>(), SoonToCompletePublisher<int>());
                 subscriber.ExpectSubscriptionAndComplete();
@@ -92,9 +93,9 @@ namespace Akka.Streams.TestKit.Tests
         }
 
         [Fact]
-        public void Should_work_with_two_immediately_failed_publishers()
+        public async Task Should_work_with_two_immediately_failed_publishers()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber = Setup(FailedPublisher<int>(), FailedPublisher<int>());
                 subscriber.ExpectSubscriptionAndError().Should().Be(TestException());
@@ -102,9 +103,9 @@ namespace Akka.Streams.TestKit.Tests
         }
 
         [Fact]
-        public void Should_work_with_two_delayed_failed_publishers()
+        public async Task Should_work_with_two_delayed_failed_publishers()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber = Setup(SoonToFailPublisher<int>(), SoonToFailPublisher<int>());
                 subscriber.ExpectSubscriptionAndError().Should().Be(TestException());
@@ -114,9 +115,9 @@ namespace Akka.Streams.TestKit.Tests
         // Warning: The two test cases below are somewhat implementation specific and might fail if the implementation
         // is changed. They are here to be an early warning though.
         [Fact]
-        public void Should_work_with_one_immediately_failed_and_one_delayed_failed_publisher_case_1()
+        public async Task Should_work_with_one_immediately_failed_and_one_delayed_failed_publisher_case_1()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber = Setup(SoonToFailPublisher<int>(), FailedPublisher<int>());
                 subscriber.ExpectSubscriptionAndError().Should().Be(TestException());
@@ -124,9 +125,9 @@ namespace Akka.Streams.TestKit.Tests
         }
 
         [Fact]
-        public void Should_work_with_one_immediately_failed_and_one_delayed_failed_publisher_case_2()
+        public async Task Should_work_with_one_immediately_failed_and_one_delayed_failed_publisher_case_2()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber = Setup(FailedPublisher<int>(), SoonToFailPublisher<int>());
                 subscriber.ExpectSubscriptionAndError().Should().Be(TestException());

--- a/src/core/Akka.Streams.TestKit.Tests/TestPublisherSubscriberSpec.cs
+++ b/src/core/Akka.Streams.TestKit.Tests/TestPublisherSubscriberSpec.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.TestKit;
 using FluentAssertions;
@@ -24,9 +25,9 @@ namespace Akka.Streams.TestKit.Tests
         }
 
         [Fact]
-        public void TestPublisher_and_TestSubscriber_should_have_all_events_accessible_from_manual_probes()
+        public async Task TestPublisher_and_TestSubscriber_should_have_all_events_accessible_from_manual_probes()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var upstream = this.CreateManualPublisherProbe<int>();
                 var downstream = this.CreateManualSubscriberProbe<int>();

--- a/src/core/Akka.Streams.Tests/Actor/ActorPublisherSpec.cs
+++ b/src/core/Akka.Streams.Tests/Actor/ActorPublisherSpec.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Pattern;
@@ -282,10 +283,10 @@ my-dispatcher1 {
         }
 
         [Fact]
-        public void ActorPublisher_should_work_together_with_Flow_and_ActorSubscriber()
+        public async Task ActorPublisher_should_work_together_with_Flow_and_ActorSubscriber()
         {
             var materializer = Sys.Materializer();
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = CreateTestProbe();
                 var source = Source.ActorPublisher<int>(Sender.Props);
@@ -374,10 +375,10 @@ my-dispatcher1 {
         }
 
         [Fact]
-        public void ActorPublisher_should_be_able_to_define_a_subscription_timeout_after_which_it_should_shut_down()
+        public async Task ActorPublisher_should_be_able_to_define_a_subscription_timeout_after_which_it_should_shut_down()
         {
             var materializer = Sys.Materializer();
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var timeout = TimeSpan.FromMilliseconds(150);
                 var a = ActorOf(TimeoutingPublisher.Props(TestActor, timeout));

--- a/src/core/Akka.Streams.Tests/Dsl/ActorRefBackpressureSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/ActorRefBackpressureSinkSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Streams.Dsl;
@@ -78,9 +79,9 @@ namespace Akka.Streams.Tests.Dsl
         private IActorRef CreateActor<T>() => Sys.ActorOf(Props.Create(typeof(T), TestActor).WithDispatcher("akka.test.stream-dispatcher"));
 
         [Fact]
-        public void ActorBackpressureSink_should_send_the_elements_to_the_ActorRef()
+        public async Task ActorBackpressureSink_should_send_the_elements_to_the_ActorRef()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var fw = CreateActor<Fw>();
                 Source.From(Enumerable.Range(1, 3))
@@ -94,9 +95,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void ActorBackpressureSink_should_send_the_elements_to_the_ActorRef2()
+        public async Task ActorBackpressureSink_should_send_the_elements_to_the_ActorRef2()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var fw = CreateActor<Fw>();
                 var probe =
@@ -116,9 +117,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void ActorBackpressureSink_should_cancel_stream_when_actor_terminates()
+        public async Task ActorBackpressureSink_should_cancel_stream_when_actor_terminates()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var fw = CreateActor<Fw>();
                 var publisher =
@@ -134,9 +135,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void ActorBackpressureSink_should_send_message_only_when_backpressure_received()
+        public async Task ActorBackpressureSink_should_send_message_only_when_backpressure_received()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var fw = CreateActor<Fw2>();
                 var publisher = this.SourceProbe<int>()
@@ -161,9 +162,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void ActorBackpressureSink_should_keep_on_sending_even_after_the_buffer_has_been_full()
+        public async Task ActorBackpressureSink_should_keep_on_sending_even_after_the_buffer_has_been_full()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var bufferSize = 16;
                 var streamElementCount = bufferSize + 4;
@@ -192,9 +193,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void ActorBackpressureSink_should_work_with_one_element_buffer()
+        public async Task ActorBackpressureSink_should_work_with_one_element_buffer()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var fw = CreateActor<Fw2>();
                 var publisher =

--- a/src/core/Akka.Streams.Tests/Dsl/ActorRefSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/ActorRefSourceSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
@@ -86,9 +87,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_ActorRefSource_must_terminate_when_the_stream_is_cancelled()
+        public async Task A_ActorRefSource_must_terminate_when_the_stream_is_cancelled()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var s = this.CreateManualSubscriberProbe<int>();
                 var actorRef = Source.ActorRef<int>(0, OverflowStrategy.Fail)
@@ -102,9 +103,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_ActorRefSource_must_not_fail_when_0_buffer_space_and_demand_is_signalled()
+        public async Task A_ActorRefSource_must_not_fail_when_0_buffer_space_and_demand_is_signalled()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var s = this.CreateManualSubscriberProbe<int>();
                 var actorRef = Source.ActorRef<int>(0, OverflowStrategy.DropHead)
@@ -119,9 +120,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_ActorRefSource_must_completes_the_stream_immediately_when_receiving_PoisonPill()
+        public async Task A_ActorRefSource_must_completes_the_stream_immediately_when_receiving_PoisonPill()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var s = this.CreateManualSubscriberProbe<int>();
                 var actorRef = Source.ActorRef<int>(10, OverflowStrategy.Fail)
@@ -134,9 +135,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_ActorRefSource_must_signal_buffered_elements_and_complete_the_stream_after_receiving_Status_Success()
+        public async Task A_ActorRefSource_must_signal_buffered_elements_and_complete_the_stream_after_receiving_Status_Success()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var s = this.CreateManualSubscriberProbe<int>();
                 var actorRef = Source.ActorRef<int>(10, OverflowStrategy.Fail)
@@ -154,9 +155,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_ActorRefSource_must_not_buffer_elements_after_receiving_Status_Success()
+        public async Task A_ActorRefSource_must_not_buffer_elements_after_receiving_Status_Success()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var s = this.CreateManualSubscriberProbe<int>();
                 var actorRef = Source.ActorRef<int>(3, OverflowStrategy.DropBuffer)
@@ -178,9 +179,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_ActorRefSource_must_after_receiving_Status_Success_allow_for_earlier_completion_with_PoisonPill()
+        public async Task A_ActorRefSource_must_after_receiving_Status_Success_allow_for_earlier_completion_with_PoisonPill()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var s = this.CreateManualSubscriberProbe<int>();
                 var actorRef = Source.ActorRef<int>(3, OverflowStrategy.DropBuffer)
@@ -199,9 +200,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_ActorRefSource_must_fail_the_stream_when_receiving_Status_Failure()
+        public async Task A_ActorRefSource_must_fail_the_stream_when_receiving_Status_Failure()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var s = this.CreateManualSubscriberProbe<int>();
                 var actorRef = Source.ActorRef<int>(10, OverflowStrategy.Fail)
@@ -215,9 +216,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_ActorRefSource_must_set_actor_name_equal_to_stage_name()
+        public async Task A_ActorRefSource_must_set_actor_name_equal_to_stage_name()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var s = this.CreateManualSubscriberProbe<int>();
                 const string name = "SomeCustomName";

--- a/src/core/Akka.Streams.Tests/Dsl/BidiFlowSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/BidiFlowSpec.cs
@@ -162,9 +162,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_BidiFlow_must_combine_materialization_values()
+        public async Task A_BidiFlow_must_combine_materialization_values()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var left = Flow.FromGraph(GraphDsl.Create(Sink.First<int>(), (b, sink) =>
                 {

--- a/src/core/Akka.Streams.Tests/Dsl/FlowAggregateAsyncSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowAggregateAsyncSpec.cs
@@ -54,9 +54,9 @@ namespace Akka.Streams.Tests.Dsl
 
 
         [Fact]
-        public void A_AggregateAsync_must_work_when_using_Source_AggregateAsync()
+        public async Task A_AggregateAsync_must_work_when_using_Source_AggregateAsync()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = AggregateSource.RunWith(Sink.First<int>(), Materializer);
                 task.AwaitResult().Should().Be(Expected);
@@ -64,9 +64,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_AggregateAsync_must_work_when_using_Sink_AggregateAsync()
+        public async Task A_AggregateAsync_must_work_when_using_Sink_AggregateAsync()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = InputSource.RunWith(AggregateSink, Materializer);
                 task.AwaitResult().Should().Be(Expected);
@@ -74,10 +74,10 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact(Skip = "Racy on Azure DevOps")]
-        public void A_AggregateAsync_must_work_when_using_Flow_AggregateAsync()
+        public async Task A_AggregateAsync_must_work_when_using_Flow_AggregateAsync()
         {
             var flowTimeout = TimeSpan.FromMilliseconds(FlowDelayInMs*Input.Count()) + TimeSpan.FromSeconds(3);
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = InputSource.Via(AggregateFlow).RunWith(Sink.First<int>(), Materializer);
                 task.AwaitResult(flowTimeout).Should().Be(Expected);
@@ -85,9 +85,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_AggregateAsync_must_work_when_using_Source_AggregateAsync_and_Flow_AggregateAsync_and_Sink_AggregateAsync()
+        public async Task A_AggregateAsync_must_work_when_using_Source_AggregateAsync_and_Flow_AggregateAsync_and_Sink_AggregateAsync()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = AggregateSource.Via(AggregateFlow).RunWith(AggregateSink, Materializer);
                 task.AwaitResult().Should().Be(Expected);
@@ -95,9 +95,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_AggregateAsync_must_propagate_an_error()
+        public async Task A_AggregateAsync_must_propagate_an_error()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var error = new TestException("buh");
                 var future = InputSource.Select(x =>
@@ -114,9 +114,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_AggregateAsync_must_complete_task_with_failure_when_Aggregating_functions_throws()
+        public async Task A_AggregateAsync_must_complete_task_with_failure_when_Aggregating_functions_throws()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var error = new TestException("buh");
                 var future = InputSource.RunAggregateAsync(0, (x, y) =>
@@ -153,9 +153,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_AggregateAsync_must_signal_task_failure()
+        public async Task A_AggregateAsync_must_signal_task_failure()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = this.CreateSubscriberProbe<int>();
                 Source.From(Enumerable.Range(1, 5)).AggregateAsync(0, (_, n) => Task.Run(() =>
@@ -172,9 +172,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_AggregateAsync_must_signal_error_from_AggregateAsync()
+        public async Task A_AggregateAsync_must_signal_error_from_AggregateAsync()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c = this.CreateManualSubscriberProbe<int>();
 
@@ -193,9 +193,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_AggregateAsync_must_resume_after_task_failure()
+        public async Task A_AggregateAsync_must_resume_after_task_failure()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = this.CreateSubscriberProbe<(int, int)>();
                 Source.From(Enumerable.Range(1, 5)).AggregateAsync((0, 1), (t, n) =>
@@ -222,9 +222,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_AggregateAsync_must_restart_after_task_failure()
+        public async Task A_AggregateAsync_must_restart_after_task_failure()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = this.CreateSubscriberProbe<(int, int)>();
                 Source.From(Enumerable.Range(1, 5)).AggregateAsync((0, 1), (t, n) =>
@@ -251,9 +251,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_AggregateAsync_must_resume_after_multiple_failures()
+        public async Task A_AggregateAsync_must_resume_after_multiple_failures()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var tasks = new []
                 {
@@ -281,9 +281,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_AggregateAsync_must_finish_after_task_failure()
+        public async Task A_AggregateAsync_must_finish_after_task_failure()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 3)).AggregateAsync(1, (_, n) => Task.Run(() =>
                     {
@@ -398,9 +398,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_AggregateAsync_must_handle_cancel_properly()
+        public async Task A_AggregateAsync_must_handle_cancel_properly()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var pub = this.CreateManualPublisherProbe<int>();
                 var sub = this.CreateSubscriberProbe<int>();
@@ -419,9 +419,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_AggregateAsync_must_complete_task_and_return_zero_given_an_empty_stream()
+        public async Task A_AggregateAsync_must_complete_task_and_return_zero_given_an_empty_stream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = Source.From(Enumerable.Empty<int>())
                     .RunAggregateAsync(0, (acc, element) => Task.FromResult(acc + element), Materializer);
@@ -430,9 +430,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_AggregateAsync_must_complete_task_and_return_zero_and_item_given_a_stream_of_one_item()
+        public async Task A_AggregateAsync_must_complete_task_and_return_zero_and_item_given_a_stream_of_one_item()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = Source.Single(100)
                     .RunAggregateAsync(5, (acc, element) => Task.FromResult(acc + element), Materializer);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowAggregateSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowAggregateSpec.cs
@@ -36,9 +36,9 @@ namespace Akka.Streams.Tests.Dsl
         private static Sink<int, Task<int>> AggregateSink => Sink.Aggregate<int, int>(0, (sum, i) => sum + i);
 
         [Fact]
-        public void A_Aggregate_must_work_when_using_Source_RunAggregate()
+        public async Task A_Aggregate_must_work_when_using_Source_RunAggregate()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = InputSource.RunAggregate(0, (sum, i) => sum + i, Materializer);
                 task.AwaitResult().Should().Be(Expected);
@@ -46,9 +46,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Aggregate_must_work_when_using_Source_Aggregate()
+        public async Task A_Aggregate_must_work_when_using_Source_Aggregate()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = AggregateSource.RunWith(Sink.First<int>(), Materializer);
                 task.AwaitResult().Should().Be(Expected);
@@ -56,9 +56,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Aggregate_must_work_when_using_Sink_Aggregate()
+        public async Task A_Aggregate_must_work_when_using_Sink_Aggregate()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = InputSource.RunWith(AggregateSink, Materializer);
                 task.AwaitResult().Should().Be(Expected);
@@ -66,9 +66,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Aggregate_must_work_when_using_Flow_Aggregate()
+        public async Task A_Aggregate_must_work_when_using_Flow_Aggregate()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = InputSource.Via(AggregateFlow).RunWith(Sink.First<int>(), Materializer);
                 task.AwaitResult().Should().Be(Expected);
@@ -76,9 +76,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Aggregate_must_work_when_using_Source_Aggregate_and_Flow_Aggregate_and_Sink_Aggregate()
+        public async Task A_Aggregate_must_work_when_using_Source_Aggregate_and_Flow_Aggregate_and_Sink_Aggregate()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = AggregateSource.Via(AggregateFlow).RunWith(AggregateSink, Materializer);
                 task.AwaitResult().Should().Be(Expected);
@@ -86,9 +86,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Aggregate_must_propagate_an_error()
+        public async Task A_Aggregate_must_propagate_an_error()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var error = new TestException("buh");
                 var future = InputSource.Select(x =>
@@ -106,10 +106,10 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void
+        public async Task
             A_Aggregate_must_complete_task_with_failure_when_the_aggregateing_function_throws_and_the_supervisor_strategy_decides_to_stop()
-        {
-            this.AssertAllStagesStopped(() =>
+        { 
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var error = new TestException("buh");
                 var future = InputSource.RunAggregate(0, (x, y) =>
@@ -127,9 +127,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Aggregate_must_resume_with_the_accumulated_state_when_the_aggregating_funtion_throws_and_the_supervisor_strategy_decides_to_resume()
+        public async Task A_Aggregate_must_resume_with_the_accumulated_state_when_the_aggregating_funtion_throws_and_the_supervisor_strategy_decides_to_resume()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var error = new Exception("boom");
                 var aggregate = Sink.Aggregate(0, (int x, int y) =>
@@ -147,9 +147,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Aggregate_must_resume_and_reset_the_state_when_the_aggregating_funtion_throws_and_the_supervisor_strategy_decides_to_restart()
+        public async Task A_Aggregate_must_resume_and_reset_the_state_when_the_aggregating_funtion_throws_and_the_supervisor_strategy_decides_to_restart()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var error = new Exception("boom");
                 var aggregate = Sink.Aggregate(0, (int x, int y) =>
@@ -167,9 +167,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Aggregate_must_complete_task_and_return_zero_given_an_empty_stream()
+        public async Task A_Aggregate_must_complete_task_and_return_zero_given_an_empty_stream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = Source.From(Enumerable.Empty<int>())
                     .RunAggregate(0, (acc, element) => acc + element, Materializer);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowAskSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowAskSpec.cs
@@ -146,7 +146,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Flow_with_ask_must_produce_asked_elements() => this.AssertAllStagesStopped(() =>
+        public async Task Flow_with_ask_must_produce_asked_elements() => await this.AssertAllStagesStoppedAsync(() =>
         {
             var replyOnInts =
                 Sys.ActorOf(Props.Create(() => new Replier()).WithDispatcher("akka.test.stream-dispatcher"),
@@ -168,7 +168,7 @@ namespace Akka.Streams.Tests.Dsl
         }, _materializer);
 
         [Fact]
-        public void Flow_with_ask_must_produce_asked_elements_for_simple_ask() => this.AssertAllStagesStopped(() =>
+        public async Task Flow_with_ask_must_produce_asked_elements_for_simple_ask() => await this.AssertAllStagesStoppedAsync(() =>
         {
             var replyOnInts = Sys.ActorOf(Props.Create(() => new Replier()).WithDispatcher("akka.test.stream-dispatcher"), "replyOnInts");
             var c = this.CreateManualSubscriberProbe<Reply>();
@@ -188,7 +188,7 @@ namespace Akka.Streams.Tests.Dsl
         }, _materializer);
 
         [Fact]
-        public void Flow_with_ask_must_produce_asked_elements_when_response_is_Status_Success() => this.AssertAllStagesStopped(() =>
+        public async Task Flow_with_ask_must_produce_asked_elements_when_response_is_Status_Success() => await this.AssertAllStagesStoppedAsync(() =>
         {
             var statusReplier = Sys.ActorOf(Props.Create(() => new StatusReplier()).WithDispatcher("akka.test.stream-dispatcher"), "statusReplier");
             var c = this.CreateManualSubscriberProbe<Reply>();
@@ -226,7 +226,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Flow_with_ask_must_signal_ask_timeout_failure() => this.AssertAllStagesStopped(() =>
+        public async Task Flow_with_ask_must_signal_ask_timeout_failure() => await this.AssertAllStagesStoppedAsync(() =>
         {
             var dontReply = Sys.ActorOf(BlackHoleActor.Props.WithDispatcher("akka.test.stream-dispatcher"), "dontReply");
             var c = this.CreateManualSubscriberProbe<Reply>();
@@ -243,7 +243,7 @@ namespace Akka.Streams.Tests.Dsl
         }, _materializer);
 
         [Fact(Skip = "Racy on Azure DevOps")]
-        public void Flow_with_ask_must_signal_ask_failure() => this.AssertAllStagesStopped(() =>
+        public async Task Flow_with_ask_must_signal_ask_failure() => await this.AssertAllStagesStoppedAsync(() =>
         {
             var failsOn = ReplierFailOn(1);
             var c = this.CreateManualSubscriberProbe<Reply>();
@@ -258,7 +258,7 @@ namespace Akka.Streams.Tests.Dsl
         }, _materializer);
 
         [Fact]
-        public void Flow_with_ask_signal_failure_when_target_actor_is_terminated() => this.AssertAllStagesStopped(() =>
+        public async Task Flow_with_ask_signal_failure_when_target_actor_is_terminated() => await this.AssertAllStagesStoppedAsync(() =>
         {
             var r = Sys.ActorOf(Props.Create(() => new Replier()).WithDispatcher("akka.test.stream-dispatcher"), "replyRandomDelays");
             var done = Source.Maybe<int>()
@@ -276,7 +276,7 @@ namespace Akka.Streams.Tests.Dsl
         }, _materializer);
 
         [Fact]
-        public void Flow_with_ask_a_failure_mid_stream_must_skip_element_with_resume_strategy() => this.AssertAllStagesStopped(() =>
+        public async Task Flow_with_ask_a_failure_mid_stream_must_skip_element_with_resume_strategy() => await this.AssertAllStagesStoppedAsync(() =>
         {
             var p = CreateTestProbe();
             var input = new[] { "a", "b", "c", "d", "e", "f" };
@@ -310,7 +310,7 @@ namespace Akka.Streams.Tests.Dsl
         }, _materializer);
 
         [Fact]
-        public void Flow_with_ask_must_resume_after_ask_failure() => this.AssertAllStagesStopped(() =>
+        public async Task Flow_with_ask_must_resume_after_ask_failure() => await this.AssertAllStagesStoppedAsync(() =>
         {
             var c = this.CreateManualSubscriberProbe<Reply>();
             var aref = ReplierFailOn(3);
@@ -332,7 +332,7 @@ namespace Akka.Streams.Tests.Dsl
         }, _materializer);
 
         [Fact]
-        public void Flow_with_ask_must_resume_after_multiple_failures() => this.AssertAllStagesStopped(() =>
+        public async Task Flow_with_ask_must_resume_after_multiple_failures() => await this.AssertAllStagesStoppedAsync(() =>
         {
             var aref = ReplierFailAllExceptOn(6);
             var t = Source.From(Enumerable.Range(1, 6))
@@ -345,7 +345,7 @@ namespace Akka.Streams.Tests.Dsl
         }, _materializer);
 
         [Fact]
-        public void Flow_with_ask_should_handle_cancel_properly() => this.AssertAllStagesStopped(() =>
+        public async Task Flow_with_ask_should_handle_cancel_properly() => await this.AssertAllStagesStoppedAsync(() =>
         {
             var dontReply = Sys.ActorOf(BlackHoleActor.Props.WithDispatcher("akka.test.stream-dispatcher"), "dontReply");
             var pub = this.CreateManualPublisherProbe<int>();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowBufferSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowBufferSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -54,9 +55,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Buffer_must_pass_elements_through_a_chain_of_backpressured_buffers_of_different_size()
+        public async Task Buffer_must_pass_elements_through_a_chain_of_backpressured_buffers_of_different_size()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var future = Source.From(Enumerable.Range(1, 1000))
                     .Buffer(1, OverflowStrategy.Backpressure)
@@ -243,9 +244,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Buffer_must_fail_upstream_if_buffer_is_full_and_configured_so()
+        public async Task Buffer_must_fail_upstream_if_buffer_is_full_and_configured_so()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisher = this.CreatePublisherProbe<int>();
                 var subscriber = this.CreateManualSubscriberProbe<int>();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowConcatAllSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowConcatAllSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -33,9 +34,9 @@ namespace Akka.Streams.Tests.Dsl
         private static readonly TestException TestException = new TestException("test");
 
         [Fact]
-        public void ConcatAll_must_work_in_the_happy_case()
+        public async Task ConcatAll_must_work_in_the_happy_case()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var s1 = Source.From(new[] {1, 2});
                 var s2 = Source.From(new int[] {});
@@ -76,9 +77,9 @@ namespace Akka.Streams.Tests.Dsl
             subscriber.ExpectComplete();}
 
         [Fact]
-        public void ConcatAll_must_on_OnError_on_master_stream_cancel_the_current_open_substream_and_signal_error()
+        public async Task ConcatAll_must_on_OnError_on_master_stream_cancel_the_current_open_substream_and_signal_error()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisher = this.CreateManualPublisherProbe<Source<int, NotUsed>>();
                 var subscriber = this.CreateManualSubscriberProbe<int>();
@@ -104,9 +105,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void ConcatAll_must_on_OnError_on_master_stream_cancel_the_currently_opening_substream_and_signal_error()
+        public async Task ConcatAll_must_on_OnError_on_master_stream_cancel_the_currently_opening_substream_and_signal_error()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisher = this.CreateManualPublisherProbe<Source<int, NotUsed>>();
                 var subscriber = this.CreateManualSubscriberProbe<int>();
@@ -135,9 +136,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void ConcatAll_must_on_OnError_on_opening_substream_cancel_the_master_stream_and_signal_error()
+        public async Task ConcatAll_must_on_OnError_on_opening_substream_cancel_the_master_stream_and_signal_error()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisher = this.CreateManualPublisherProbe<Source<int, NotUsed>>();
                 var subscriber = this.CreateManualSubscriberProbe<int>();
@@ -160,9 +161,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void ConcatAll_must_on_OnError_on_open_substream_cancel_the_master_stream_and_signal_error()
+        public async Task ConcatAll_must_on_OnError_on_open_substream_cancel_the_master_stream_and_signal_error()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisher = this.CreateManualPublisherProbe<Source<int, NotUsed>>();
                 var subscriber = this.CreateManualSubscriberProbe<int>();
@@ -188,9 +189,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void ConcatAll_must_on_cancellation_cancel_the_current_open_substream_and_the_master_stream()
+        public async Task ConcatAll_must_on_cancellation_cancel_the_current_open_substream_and_the_master_stream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisher = this.CreateManualPublisherProbe<Source<int, NotUsed>>();
                 var subscriber = this.CreateManualSubscriberProbe<int>();
@@ -217,9 +218,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void ConcatAll_must_on_cancellation_cancel_the_currently_opening_substream_and_the_master_stream()
+        public async Task ConcatAll_must_on_cancellation_cancel_the_currently_opening_substream_and_the_master_stream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisher = this.CreateManualPublisherProbe<Source<int, NotUsed>>();
                 var subscriber = this.CreateManualSubscriberProbe<int>();
@@ -248,9 +249,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void ConcatAll_must_pass_along_early_cancellation()
+        public async Task ConcatAll_must_pass_along_early_cancellation()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var up = this.CreateManualPublisherProbe<Source<int, NotUsed>>();
                 var down = this.CreateManualSubscriberProbe<int>();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowConcatSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowConcatSpec.cs
@@ -75,9 +75,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Concat_for_Flow_must_work_with_one_immediately_completed_and_one_nonempty_publisher()
+        public async Task A_Concat_for_Flow_must_work_with_one_immediately_completed_and_one_nonempty_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber1 = Setup(CompletedPublisher<int>(), NonEmptyPublisher(Enumerable.Range(1, 4)));
                 var subscription1 = subscriber1.ExpectSubscription();
@@ -94,9 +94,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Concat_for_Flow_must_work_with_one_immediately_failed_and_one_nonempty_publisher()
+        public async Task A_Concat_for_Flow_must_work_with_one_immediately_failed_and_one_nonempty_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber = Setup(FailedPublisher<int>(), NonEmptyPublisher(Enumerable.Range(1, 4)));
                 subscriber.ExpectSubscriptionAndError().Should().BeOfType<TestException>();
@@ -104,9 +104,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Concat_for_Flow_must_work_with_one_nonempty_and_one_immediately_failed_publisher()
+        public async Task A_Concat_for_Flow_must_work_with_one_nonempty_and_one_immediately_failed_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber = Setup(NonEmptyPublisher(Enumerable.Range(1, 4)), FailedPublisher<int>());
                 subscriber.ExpectSubscription().Request(5);
@@ -119,9 +119,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Concat_for_Flow_must_work_with_one_delayed_failed_and_one_nonempty_publisher()
+        public async Task A_Concat_for_Flow_must_work_with_one_delayed_failed_and_one_nonempty_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber = Setup(SoonToFailPublisher<int>(), NonEmptyPublisher(Enumerable.Range(1, 4)));
                 subscriber.ExpectSubscriptionAndError().Should().BeOfType<TestException>();
@@ -129,9 +129,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Concat_for_Flow_must_work_with_one_nonempty_and_one_delayed_failed_publisher()
+        public async Task A_Concat_for_Flow_must_work_with_one_nonempty_and_one_delayed_failed_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber = Setup(NonEmptyPublisher(Enumerable.Range(1, 4)), SoonToFailPublisher<int>());
                 subscriber.ExpectSubscription().Request(5);
@@ -144,9 +144,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Concat_for_Flow_must_correctly_handle_async_errors_in_secondary_upstream()
+        public async Task A_Concat_for_Flow_must_correctly_handle_async_errors_in_secondary_upstream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var promise = new TaskCompletionSource<int>();
                 var subscriber = this.CreateManualSubscriberProbe<int>();
@@ -163,9 +163,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Concat_for_Flow_must_work_with_Source_DSL()
+        public async Task A_Concat_for_Flow_must_work_with_Source_DSL()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var testSource =
                     Source.From(Enumerable.Range(1, 5))
@@ -185,9 +185,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Concat_for_Flow_must_work_with_Flow_DSL()
+        public async Task A_Concat_for_Flow_must_work_with_Flow_DSL()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var testFlow = Flow.Create<int>()
                     .ConcatMaterialized(Source.From(Enumerable.Range(6, 5)), Keep.Both)
@@ -209,9 +209,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact(Skip = "ConcatMaterialized type conflict")]
-        public void A_Concat_for_Flow_must_work_with_Flow_DSL2()
+        public async Task A_Concat_for_Flow_must_work_with_Flow_DSL2()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var testFlow = Flow.Create<int>()
                     .ConcatMaterialized(Source.From(Enumerable.Range(6, 5)), Keep.Both)
@@ -238,9 +238,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Concat_for_Flow_must_subscribe_at_one_to_initial_source_and_to_one_that_it_is_concat_to()
+        public async Task A_Concat_for_Flow_must_subscribe_at_one_to_initial_source_and_to_one_that_it_is_concat_to()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisher1 = this.CreatePublisherProbe<int>();
                 var publisher2 = this.CreatePublisherProbe<int>();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowDelaySpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowDelaySpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
@@ -74,9 +75,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Delay_must_deliver_elements_with_delay_for_slow_stream()
+        public async Task A_Delay_must_deliver_elements_with_delay_for_slow_stream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c = this.CreateManualSubscriberProbe<int>();
                 var p = this.CreateManualPublisherProbe<int>();
@@ -100,9 +101,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Delay_must_drop_tail_for_internal_buffer_if_it_is_full_in_DropTail_mode()
+        public async Task A_Delay_must_drop_tail_for_internal_buffer_if_it_is_full_in_DropTail_mode()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = Source.From(Enumerable.Range(1, 20))
                     .Delay(TimeSpan.FromSeconds(1), DelayOverflowStrategy.DropTail)
@@ -118,9 +119,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Delay_must_drop_head_for_internal_buffer_if_it_is_full_in_DropHead_mode()
+        public async Task A_Delay_must_drop_head_for_internal_buffer_if_it_is_full_in_DropHead_mode()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = Source.From(Enumerable.Range(1, 20))
                     .Delay(TimeSpan.FromSeconds(1), DelayOverflowStrategy.DropHead)
@@ -134,9 +135,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Delay_must_clear_all_for_internal_buffer_if_it_is_full_in_DropBuffer_mode()
+        public async Task A_Delay_must_clear_all_for_internal_buffer_if_it_is_full_in_DropBuffer_mode()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = Source.From(Enumerable.Range(1, 20))
                     .Delay(TimeSpan.FromSeconds(1), DelayOverflowStrategy.DropBuffer)
@@ -150,9 +151,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Delay_must_pass_elements_with_delay_through_normally_in_backpressured_mode()
+        public async Task A_Delay_must_pass_elements_with_delay_through_normally_in_backpressured_mode()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 3))
                     .Delay(TimeSpan.FromMilliseconds(300), DelayOverflowStrategy.Backpressure)
@@ -169,9 +170,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Delay_must_fail_on_overflow_in_Fail_mode()
+        public async Task A_Delay_must_fail_on_overflow_in_Fail_mode()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var actualError = Source.From(Enumerable.Range(1, 20))
                     .Delay(TimeSpan.FromMilliseconds(300), DelayOverflowStrategy.Fail)
@@ -186,9 +187,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Delay_must_emit_early_when_buffer_is_full_and_in_EmitEarly_mode()
+        public async Task A_Delay_must_emit_early_when_buffer_is_full_and_in_EmitEarly_mode()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c = this.CreateManualSubscriberProbe<int>();
                 var p = this.CreateManualPublisherProbe<int>();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowDetacherSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowDetacherSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -27,9 +28,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Detacher_must_pass_through_all_elements()
+        public async Task A_Detacher_must_pass_through_all_elements()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 100))
                     .Detach()
@@ -39,9 +40,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Detacher_must_pass_through_failure()
+        public async Task A_Detacher_must_pass_through_failure()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var ex = new TestException("buh");
                 var result = Source.From(Enumerable.Range(1, 100)).Select(x =>
@@ -56,9 +57,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Detacher_must_emit_the_last_element_when_completed_Without_demand()
+        public async Task A_Detacher_must_emit_the_last_element_when_completed_Without_demand()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = Source.Single(42).Detach().RunWith(this.SinkProbe<int>(), Materializer).EnsureSubscription();
                 probe.ExpectNoMsg(TimeSpan.FromMilliseconds(500));

--- a/src/core/Akka.Streams.Tests/Dsl/FlowFlattenMergeSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowFlattenMergeSpec.cs
@@ -267,11 +267,11 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_FlattenMerge_must_propagate_attributes_to_inner_stream()
+        public async Task A_FlattenMerge_must_propagate_attributes_to_inner_stream()
         {
             var attributesSource = Source.FromGraph(new AttibutesSourceStage());
 
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = Source.Single(attributesSource.AddAttributes(Attributes.CreateName("inner")))
                     .MergeMany(1, x => x)
@@ -291,9 +291,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_FlattenMerge_must_bubble_up_substream_materialization_exception()
+        public async Task A_FlattenMerge_must_bubble_up_substream_materialization_exception()
         {
-            this.AssertAllStagesStopped(() => {
+            await this.AssertAllStagesStoppedAsync(() => {
                 var matFail = new TestException("fail!");
 
                 var task = Source.Single("whatever")

--- a/src/core/Akka.Streams.Tests/Dsl/FlowForeachSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowForeachSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
@@ -28,9 +29,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Foreach_must_call_the_procedure_for_each_element()
+        public async Task A_Foreach_must_call_the_procedure_for_each_element()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 3)).RunForeach(i => TestActor.Tell(i), Materializer).ContinueWith(
                     task =>
@@ -47,9 +48,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Foreach_must_complete_the_future_for_an_empty_stream()
+        public async Task A_Foreach_must_complete_the_future_for_an_empty_stream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.Empty<int>().RunForeach(i => TestActor.Tell(i), Materializer).ContinueWith(
                     task =>
@@ -62,9 +63,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Foreach_must_yield_the_first_error()
+        public async Task A_Foreach_must_yield_the_first_error()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p = this.CreateManualPublisherProbe<int>();
                 Source.FromPublisher(p).RunForeach(i => TestActor.Tell(i), Materializer).ContinueWith(task =>
@@ -80,9 +81,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Foreach_must_complete_future_with_failure_when_function_throws()
+        public async Task A_Foreach_must_complete_future_with_failure_when_function_throws()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var error = new TestException("test");
                 var future = Source.Single(1).RunForeach(_ =>

--- a/src/core/Akka.Streams.Tests/Dsl/FlowFromTaskSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowFromTaskSpec.cs
@@ -29,9 +29,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_based_on_a_Task_must_produce_one_element_from_already_successful_Future()
+        public async Task A_Flow_based_on_a_Task_must_produce_one_element_from_already_successful_Future()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
             var c = this.CreateManualSubscriberProbe<int>();
             var p = Source.FromTask(Task.FromResult(1)).RunWith(Sink.AsPublisher<int>(true), Materializer);
@@ -45,9 +45,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_based_on_a_Task_must_produce_error_from_already_failed_Task()
+        public async Task A_Flow_based_on_a_Task_must_produce_error_from_already_failed_Task()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var ex = new TestException("test");
                 var c = this.CreateManualSubscriberProbe<int>();
@@ -60,9 +60,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_based_on_a_Task_must_produce_one_element_when_Task_is_completed()
+        public async Task A_Flow_based_on_a_Task_must_produce_one_element_when_Task_is_completed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var promise = new TaskCompletionSource<int>();
                 var c = this.CreateManualSubscriberProbe<int>();
@@ -94,9 +94,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_based_on_a_Task_must_produce_elements_with_multiple_subscribers()
+        public async Task A_Flow_based_on_a_Task_must_produce_elements_with_multiple_subscribers()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var promise = new TaskCompletionSource<int>();
                 var p = Source.FromTask(promise.Task).RunWith(Sink.AsPublisher<int>(true), Materializer);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowGroupBySpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowGroupBySpec.cs
@@ -96,9 +96,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void GroupBy_must_work_in_the_happy_case()
+        public async Task GroupBy_must_work_in_the_happy_case()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 WithSubstreamsSupport(2, run: (masterSubscriber, masterSubscription, getSubFlow) =>
                 {
@@ -167,9 +167,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void GroupBy_must_support_cancelling_substreams()
+        public async Task GroupBy_must_support_cancelling_substreams()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 WithSubstreamsSupport(2, run: (masterSubscriber, masterSubscription, getSubFlow) =>
                 {
@@ -192,9 +192,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void GroupBy_must_accept_cancellation_of_master_stream_when_not_consume_anything()
+        public async Task GroupBy_must_accept_cancellation_of_master_stream_when_not_consume_anything()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisherProbe = this.CreateManualPublisherProbe<int>();
                 var publisher =
@@ -213,9 +213,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void GroupBy_must_work_with_empty_input_stream()
+        public async Task GroupBy_must_work_with_empty_input_stream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisher =
                     Source.From(new List<int>())
@@ -230,9 +230,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void GroupBy_must_abort_onError_from_upstream()
+        public async Task GroupBy_must_abort_onError_from_upstream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisherProbe = this.CreateManualPublisherProbe<int>();
                 var publisher =
@@ -254,9 +254,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void GroupBy_must_abort_onError_from_upstream_when_substreams_are_running()
+        public async Task GroupBy_must_abort_onError_from_upstream_when_substreams_are_running()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisherProbe = this.CreateManualPublisherProbe<int>();
                 var publisher =
@@ -286,9 +286,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void GroupBy_must_fail_stream_when_GroupBy_function_throws()
+        public async Task GroupBy_must_fail_stream_when_GroupBy_function_throws()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisherProbe = this.CreateManualPublisherProbe<int>();
                 var ex = new TestException("test");
@@ -325,9 +325,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void GroupBy_must_resume_stream_when_GroupBy_function_throws()
+        public async Task GroupBy_must_resume_stream_when_GroupBy_function_throws()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisherProbe = this.CreateManualPublisherProbe<int>();
                 var ex = new TestException("test");
@@ -379,9 +379,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void GroupBy_must_pass_along_early_cancellation()
+        public async Task GroupBy_must_pass_along_early_cancellation()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var up = this.CreateManualPublisherProbe<int>();
                 var down = this.CreateManualSubscriberProbe<(int, Source<int, NotUsed>)>();
@@ -401,9 +401,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void GroupBy_must_fail_when_exceeding_maxSubstreams()
+        public async Task GroupBy_must_fail_when_exceeding_maxSubstreams()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var f = Flow.Create<int>().GroupBy(1, x => x % 2).PrefixAndTail(0).MergeSubstreams();
                 var t = ((Flow<int, (IImmutableList<int>, Source<int, NotUsed>), NotUsed>)f)
@@ -428,9 +428,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void GroupBy_must_emit_subscribe_before_completed()
+        public async Task GroupBy_must_emit_subscribe_before_completed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var source = (Source<Source<int, NotUsed>, NotUsed>)Source.Single(0).GroupBy(1, _ => "all")
                     .PrefixAndTail(0)
@@ -449,9 +449,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void GroupBy_must_work_under_fuzzing_stress_test()
+        public async Task GroupBy_must_work_under_fuzzing_stress_test()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisherProbe = this.CreateManualPublisherProbe<ByteString>();
                 var subscriber = this.CreateManualSubscriberProbe<IEnumerable<byte>>();
@@ -483,9 +483,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void GroupBy_must_Work_if_pull_is_exercised_from_both_substream_and_main()
+        public async Task GroupBy_must_Work_if_pull_is_exercised_from_both_substream_and_main()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var upstream = this.CreatePublisherProbe<int>();
                 var downstreamMaster = this.CreateSubscriberProbe<Source<int, NotUsed>>();
@@ -518,9 +518,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void GroupBy_must_work_with_random_demand()
+        public async Task GroupBy_must_work_with_random_demand()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var settings = ActorMaterializerSettings.Create(Sys).WithInputBuffer(1, 1);
                 var materializer = Sys.Materializer(settings);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowGroupedWithinSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowGroupedWithinSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -34,9 +35,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_GroupedWithin_must_group_elements_within_the_duration()
+        public async Task A_GroupedWithin_must_group_elements_within_the_duration()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var input = new Iterator<int>(Enumerable.Range(1, 10000));
                 var p = this.CreateManualPublisherProbe<int>();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowIdleInjectSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowIdleInjectSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -31,9 +32,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void KeepAlive_must_not_emit_additional_elements_if_upstream_is_fastEnough()
+        public async Task KeepAlive_must_not_emit_additional_elements_if_upstream_is_fastEnough()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var result = Source.From(Enumerable.Range(1, 10))
                     .KeepAlive(TimeSpan.FromSeconds(1), () => 0)
@@ -46,9 +47,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void KeepAlive_must_emit_elements_periodically_after_silent_periods()
+        public async Task KeepAlive_must_emit_elements_periodically_after_silent_periods()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var sourceWithIdleGap = Source.Combine(Source.From(Enumerable.Range(1, 5)),
                     Source.From(Enumerable.Range(6, 5)).InitialDelay(TimeSpan.FromSeconds(2)),

--- a/src/core/Akka.Streams.Tests/Dsl/FlowInitialDelaySpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowInitialDelaySpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -31,9 +32,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Flow_InitialDelay_must_work_with_zero_delay()
+        public async Task Flow_InitialDelay_must_work_with_zero_delay()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = Source.From(Enumerable.Range(1, 10))
                     .InitialDelay(TimeSpan.Zero)
@@ -45,9 +46,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Flow_InitialDelay_must_delay_elements_by_the_specified_time_but_not_more()
+        public async Task Flow_InitialDelay_must_delay_elements_by_the_specified_time_but_not_more()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = Source.From(Enumerable.Range(1, 10))
                     .InitialDelay(TimeSpan.FromSeconds(2))
@@ -58,9 +59,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Flow_InitialDelay_must_properly_ignore_timer_while_backpressured()
+        public async Task Flow_InitialDelay_must_properly_ignore_timer_while_backpressured()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = this.CreateSubscriberProbe<int>();
                 Source.From(Enumerable.Range(1, 10))

--- a/src/core/Akka.Streams.Tests/Dsl/FlowInterleaveSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowInterleaveSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -32,9 +33,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void An_Interleave_for_Flow_must_work_in_the_happy_case()
+        public async Task An_Interleave_for_Flow_must_work_in_the_happy_case()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = this.CreateManualSubscriberProbe<int>();
 
@@ -58,9 +59,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void An_Interleave_for_Flow_must_work_when_segmentSize_is_not_equal_elements_in_stream()
+        public async Task An_Interleave_for_Flow_must_work_when_segmentSize_is_not_equal_elements_in_stream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = this.CreateManualSubscriberProbe<int>();
 
@@ -75,9 +76,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void An_Interleave_for_Flow_must_work_with_segmentSize_1()
+        public async Task An_Interleave_for_Flow_must_work_with_segmentSize_1()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = this.CreateManualSubscriberProbe<int>();
 
@@ -92,9 +93,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void An_Interleave_for_Flow_must_not_work_with_segmentSize_0()
+        public async Task An_Interleave_for_Flow_must_not_work_with_segmentSize_0()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var source = Source.From(Enumerable.Range(0, 3));
                 source.Invoking(s => s.Interleave(Source.From(Enumerable.Range(3, 3)), 0))
@@ -103,9 +104,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void An_Interleave_for_Flow_must_work_when_segmentSize_is_greater_than_stream_elements()
+        public async Task An_Interleave_for_Flow_must_work_when_segmentSize_is_greater_than_stream_elements()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = this.CreateManualSubscriberProbe<int>();
                 Source.From(Enumerable.Range(0, 3))
@@ -130,9 +131,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void An_Interleave_for_Flow_must_work_with_one_immediately_completed_and_one_nonempty_publisher()
+        public async Task An_Interleave_for_Flow_must_work_with_one_immediately_completed_and_one_nonempty_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber1 = Setup(CompletedPublisher<int>(), NonEmptyPublisher(Enumerable.Range(1, 4)));
                 var subscription1 = subscriber1.ExpectSubscription();
@@ -150,9 +151,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void An_Interleave_for_Flow_must_work_with_one_delayed_completed_and_one_nonempty_publisher()
+        public async Task An_Interleave_for_Flow_must_work_with_one_delayed_completed_and_one_nonempty_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber1 = Setup(SoonToCompletePublisher<int>(), NonEmptyPublisher(Enumerable.Range(1, 4)));
                 var subscription1 = subscriber1.ExpectSubscription();
@@ -209,9 +210,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void An_Interleave_for_Flow_must_pass_along_early_cancellation()
+        public async Task An_Interleave_for_Flow_must_pass_along_early_cancellation()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var up1 = this.CreateManualPublisherProbe<int>();
                 var up2 = this.CreateManualPublisherProbe<int>();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowIteratorSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowIteratorSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Pattern;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
@@ -146,9 +147,9 @@ namespace Akka.Streams.Tests.Dsl
         protected abstract Source<int, NotUsed> CreateSource(int elements);
 
         [Fact]
-        public void A_Flow_based_on_an_iterable_must_produce_elements()
+        public async Task A_Flow_based_on_an_iterable_must_produce_elements()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p = CreateSource(3).RunWith(Sink.AsPublisher<int>(false), Materializer);
                 var c = this.CreateManualSubscriberProbe<int>();
@@ -167,9 +168,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_based_on_an_iterable_must_complete_empty()
+        public async Task A_Flow_based_on_an_iterable_must_complete_empty()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p = CreateSource(0).RunWith(Sink.AsPublisher<int>(false), Materializer);
                 var c = this.CreateManualSubscriberProbe<int>();
@@ -181,9 +182,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_based_on_an_iterable_must_produce_elements_with_multiple_subscribers()
+        public async Task A_Flow_based_on_an_iterable_must_produce_elements_with_multiple_subscribers()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p = CreateSource(3).RunWith(Sink.AsPublisher<int>(true), Materializer);
                 var c1 = this.CreateManualSubscriberProbe<int>();
@@ -211,9 +212,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_based_on_an_iterable_must_produce_elements_to_later_subscriber()
+        public async Task A_Flow_based_on_an_iterable_must_produce_elements_to_later_subscriber()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p = CreateSource(3).RunWith(Sink.AsPublisher<int>(true), Materializer);
                 var c1 = this.CreateManualSubscriberProbe<int>();
@@ -241,9 +242,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_based_on_an_iterable_must_produce_elements_with_one_transformation_step()
+        public async Task A_Flow_based_on_an_iterable_must_produce_elements_with_one_transformation_step()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p = CreateSource(3)
                     .Select(x => x*2)
@@ -262,9 +263,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_based_on_an_iterable_must_produce_elements_with_two_transformation_steps()
+        public async Task A_Flow_based_on_an_iterable_must_produce_elements_with_two_transformation_steps()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p = CreateSource(4)
                     .Where(x => x%2 == 0)
@@ -283,9 +284,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_based_on_an_iterable_must_not_produce_after_cancel()
+        public async Task A_Flow_based_on_an_iterable_must_not_produce_after_cancel()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p = CreateSource(3).RunWith(Sink.AsPublisher<int>(false), Materializer);
                 var c = this.CreateManualSubscriberProbe<int>();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowJoinSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowJoinSpec.cs
@@ -31,9 +31,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_using_Join_must_allow_for_cycles()
+        public async Task A_Flow_using_Join_must_allow_for_cycles()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 const int end = 47;
                 var t = Enumerable.Range(0, end + 1).GroupBy(i => i%2 == 0).ToList();
@@ -72,9 +72,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_using_Join_must_allow_for_merge_cycle()
+        public async Task A_Flow_using_Join_must_allow_for_merge_cycle()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var source =
                     Source.Single("lonely traveler").MapMaterializedValue(_ => Task.FromResult(""));
@@ -97,9 +97,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_using_Join_must_allow_for_merge_preferred_cycle()
+        public async Task A_Flow_using_Join_must_allow_for_merge_preferred_cycle()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var source =
                     Source.Single("lonely traveler").MapMaterializedValue(_ => Task.FromResult(""));
@@ -122,9 +122,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_using_Join_must_allow_for_zip_cycle()
+        public async Task A_Flow_using_Join_must_allow_for_zip_cycle()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var source = Source.From(new[] {"traveler1", "traveler2"})
                     .MapMaterializedValue<TestSubscriber.Probe<(string, string)>>(_ => null);
@@ -158,9 +158,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_using_Join_must_allow_for_concat_cycle()
+        public async Task A_Flow_using_Join_must_allow_for_concat_cycle()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var flow = Flow.FromGraph(GraphDsl.Create(TestSource.SourceProbe<string>(this), Sink.First<string>(), Keep.Both, (b, source, sink) =>
                 {
@@ -184,9 +184,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_using_Join_must_allow_for_interleave_cycle()
+        public async Task A_Flow_using_Join_must_allow_for_interleave_cycle()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var source = Source.Single("lonely traveler").MapMaterializedValue(_ => Task.FromResult(""));
                 var flow = Flow.FromGraph(GraphDsl.Create(Sink.First<string>(), (b, sink) =>

--- a/src/core/Akka.Streams.Tests/Dsl/FlowKillSwitchSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowKillSwitchSpec.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -132,9 +133,9 @@ namespace Akka.Streams.Tests.Dsl
         #region shared kill switch
 
         [Fact]
-        public void A_SharedKillSwitch_must_stop_a_stream_if_requested()
+        public async Task A_SharedKillSwitch_must_stop_a_stream_if_requested()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var killSwitch = KillSwitches.Shared("switch");
 
@@ -156,9 +157,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_SharedKillSwitch_must_fail_a_stream_if_requested()
+        public async Task A_SharedKillSwitch_must_fail_a_stream_if_requested()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var killSwitch = KillSwitches.Shared("switch");
 
@@ -181,9 +182,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_SharedKillSwitch_must_pass_through_all_elements_unmodified()
+        public async Task A_SharedKillSwitch_must_pass_through_all_elements_unmodified()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var killSwitch = KillSwitches.Shared("switch");
                 var task = Source.From(Enumerable.Range(1, 100))
@@ -195,9 +196,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_SharedKillSwitch_must_provide_a_flow_that_if_materialized_multiple_times_with_multiple_types_stops_all_streams_if_requested()
+        public async Task A_SharedKillSwitch_must_provide_a_flow_that_if_materialized_multiple_times_with_multiple_types_stops_all_streams_if_requested()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var killSwitch = KillSwitches.Shared("switch");
 
@@ -233,9 +234,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_SharedKillSwitch_must_provide_a_flow_that_if_materialized_multiple_times_with_multiple_types_fails_all_streams_if_requested()
+        public async Task A_SharedKillSwitch_must_provide_a_flow_that_if_materialized_multiple_times_with_multiple_types_fails_all_streams_if_requested()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var killSwitch = KillSwitches.Shared("switch");
 
@@ -272,9 +273,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_SharedKillSwitch_must_ignore_subsequent_aborts_and_shutdowns_after_shutdown()
+        public async Task A_SharedKillSwitch_must_ignore_subsequent_aborts_and_shutdowns_after_shutdown()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var killSwitch = KillSwitches.Shared("switch");
 
@@ -304,9 +305,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_SharedKillSwitch_must_ignore_subsequent_aborts_and_shutdowns_after_abort()
+        public async Task A_SharedKillSwitch_must_ignore_subsequent_aborts_and_shutdowns_after_abort()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var killSwitch = KillSwitches.Shared("switch");
 
@@ -337,9 +338,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_SharedKillSwitch_must_complete_immediately_flows_materialized_after_switch_shutdown()
+        public async Task A_SharedKillSwitch_must_complete_immediately_flows_materialized_after_switch_shutdown()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var killSwitch = KillSwitches.Shared("switch");
                 killSwitch.Shutdown();
@@ -357,9 +358,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_SharedKillSwitch_must_fail_immediately_flows_materialized_after_switch_failure()
+        public async Task A_SharedKillSwitch_must_fail_immediately_flows_materialized_after_switch_failure()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var killSwitch = KillSwitches.Shared("switch");
                 var testException = new TestException("Abort");
@@ -378,9 +379,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_SharedKillSwitch_should_not_cause_problems_if_switch_is_shutdown_after_flow_completed_normally()
+        public async Task A_SharedKillSwitch_should_not_cause_problems_if_switch_is_shutdown_after_flow_completed_normally()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var killSwitch = KillSwitches.Shared("switch");
                 var task = Source.From(Enumerable.Range(1, 10))
@@ -393,9 +394,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_SharedKillSwitch_must_provide_flows_that_materialize_to_its_owner_KillSwitch()
+        public async Task A_SharedKillSwitch_must_provide_flows_that_materialize_to_its_owner_KillSwitch()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var killSwitch = KillSwitches.Shared("switch");
                 var t = Source.Maybe<int>()
@@ -413,9 +414,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_SharedKillSwitch_must_not_affect_streams_corresponding_to_another_KillSwitch()
+        public async Task A_SharedKillSwitch_must_not_affect_streams_corresponding_to_another_KillSwitch()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var killSwitch1 = KillSwitches.Shared("switch");
                 var killSwitch2 = KillSwitches.Shared("switch");
@@ -458,9 +459,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_SharedKillSwitch_must_allow_using_multiple_KillSwitch_in_one_graph()
+        public async Task A_SharedKillSwitch_must_allow_using_multiple_KillSwitch_in_one_graph()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var killSwitch1 = KillSwitches.Shared("switch");
                 var killSwitch2 = KillSwitches.Shared("switch");
@@ -489,9 +490,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_SharedKillSwitch_must_use_its_name_on_the_flows_it_hands_out()
+        public async Task A_SharedKillSwitch_must_use_its_name_on_the_flows_it_hands_out()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var killSwitch = KillSwitches.Shared("MySwitchName");
                 killSwitch.ToString().Should().Be("KillSwitch(MySwitchName)");
@@ -504,9 +505,9 @@ namespace Akka.Streams.Tests.Dsl
         #region cancellable kill switch
 
         [Fact]
-        public void A_CancellationToken_flow_must_stop_a_stream_if_requested()
+        public async Task A_CancellationToken_flow_must_stop_a_stream_if_requested()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var cancel = new CancellationTokenSource();
 
@@ -528,9 +529,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_CancellationToken_flow_must_fail_a_stream_if_requested()
+        public async Task A_CancellationToken_flow_must_fail_a_stream_if_requested()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var cancel = new CancellationTokenSource();
 
@@ -552,9 +553,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_CancellationToken_flow_must_pass_through_all_elements_unmodified()
+        public async Task A_CancellationToken_flow_must_pass_through_all_elements_unmodified()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var cancel = new CancellationTokenSource();
                 var task = Source.From(Enumerable.Range(1, 100))
@@ -566,9 +567,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_CancellationToken_flow_must_provide_a_flow_that_if_materialized_multiple_times_with_multiple_types_stops_all_streams_if_requested()
+        public async Task A_CancellationToken_flow_must_provide_a_flow_that_if_materialized_multiple_times_with_multiple_types_stops_all_streams_if_requested()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var cancel = new CancellationTokenSource();
 
@@ -604,9 +605,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_CancellationToken_flow_must_provide_a_flow_that_if_materialized_multiple_times_with_multiple_types_fails_all_streams_if_requested()
+        public async Task A_CancellationToken_flow_must_provide_a_flow_that_if_materialized_multiple_times_with_multiple_types_fails_all_streams_if_requested()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var cancel = new CancellationTokenSource();
 
@@ -642,9 +643,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_CancellationToken_flow_must_ignore_subsequent_aborts_and_shutdowns_after_shutdown()
+        public async Task A_CancellationToken_flow_must_ignore_subsequent_aborts_and_shutdowns_after_shutdown()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var cancel = new CancellationTokenSource();
 
@@ -674,9 +675,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_CancellationToken_flow_must_complete_immediately_flows_materialized_after_switch_shutdown()
+        public async Task A_CancellationToken_flow_must_complete_immediately_flows_materialized_after_switch_shutdown()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var cancel = new CancellationTokenSource();
                 cancel.Cancel();
@@ -694,9 +695,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_CancellationToken_flow_must_fail_immediately_flows_materialized_after_switch_failure()
+        public async Task A_CancellationToken_flow_must_fail_immediately_flows_materialized_after_switch_failure()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var cancel = new CancellationTokenSource();
                 cancel.Cancel();
@@ -714,9 +715,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_CancellationToken_flow_should_not_cause_problems_if_switch_is_shutdown_after_flow_completed_normally()
+        public async Task A_CancellationToken_flow_should_not_cause_problems_if_switch_is_shutdown_after_flow_completed_normally()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var cancel = new CancellationTokenSource();
                 var task = Source.From(Enumerable.Range(1, 10))

--- a/src/core/Akka.Streams.Tests/Dsl/FlowMergeSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowMergeSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -31,9 +32,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Merge_for_Flow_must_work_in_the_happy_case()
+        public async Task A_Merge_for_Flow_must_work_in_the_happy_case()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 // Different input size (4 and 6)
                 var source1 = Source.From(Enumerable.Range(0, 4));
@@ -64,9 +65,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Merge_for_Flow_must_work_with_one_immediately_completed_and_one_nonempty_publisher()
+        public async Task A_Merge_for_Flow_must_work_with_one_immediately_completed_and_one_nonempty_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber1 = Setup(CompletedPublisher<int>(), NonEmptyPublisher(Enumerable.Range(1,4)));
                 var subscription1 = subscriber1.EnsureSubscription();
@@ -83,9 +84,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Merge_for_Flow_must_work_with_one_delayed_completed_and_one_nonempty_publisher()
+        public async Task A_Merge_for_Flow_must_work_with_one_delayed_completed_and_one_nonempty_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber1 = Setup(SoonToCompletePublisher<int>(), NonEmptyPublisher(Enumerable.Range(1, 4)));
                 var subscription1 = subscriber1.EnsureSubscription();
@@ -112,9 +113,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Merge_for_Flow_must_pass_along_early_cancellation()
+        public async Task A_Merge_for_Flow_must_pass_along_early_cancellation()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var up1 = this.CreateManualPublisherProbe<int>();
                 var up2 = this.CreateManualPublisherProbe<int>();
@@ -139,9 +140,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Merge_for_Flow_must_not_try_to_grab_from_closed_input_previously_enqueued()
+        public async Task A_Merge_for_Flow_must_not_try_to_grab_from_closed_input_previously_enqueued()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var up1 = this.CreatePublisherProbe<int>();
                 var up2 = this.CreatePublisherProbe<int>();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowOnCompleteSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowOnCompleteSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
@@ -26,9 +27,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_OnComplete_must_invoke_callback_on_normal_completion()
+        public async Task A_Flow_with_OnComplete_must_invoke_callback_on_normal_completion()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var onCompleteProbe = CreateTestProbe();
                 var p = this.CreateManualPublisherProbe<int>();
@@ -45,9 +46,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_OnComplete_must_yield_the_first_error()
+        public async Task A_Flow_with_OnComplete_must_yield_the_first_error()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var onCompleteProbe = CreateTestProbe();
                 var p = this.CreateManualPublisherProbe<int>();
@@ -64,9 +65,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_OnComplete_must_invoke_callback_for_an_empty_stream()
+        public async Task A_Flow_with_OnComplete_must_invoke_callback_for_an_empty_stream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var onCompleteProbe = CreateTestProbe();
                 var p = this.CreateManualPublisherProbe<int>();
@@ -82,9 +83,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_OnComplete_must_invoke_callback_after_transform_and_foreach_steps()
+        public async Task A_Flow_with_OnComplete_must_invoke_callback_after_transform_and_foreach_steps()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var onCompleteProbe = CreateTestProbe();
                 var p = this.CreateManualPublisherProbe<int>();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowPrefixAndTailSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowPrefixAndTailSpec.cs
@@ -40,9 +40,9 @@ namespace Akka.Streams.Tests.Dsl
 
 
         [Fact]
-        public void PrefixAndTail_must_work_on_empty_input()
+        public async Task PrefixAndTail_must_work_on_empty_input()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var futureSink = NewHeadSink;
                 var fut = Source.Empty<int>().PrefixAndTail(10).RunWith(futureSink, Materializer);
@@ -55,9 +55,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PrefixAndTail_must_work_on_short_inputs()
+        public async Task PrefixAndTail_must_work_on_short_inputs()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var futureSink = NewHeadSink;
                 var fut = Source.From(new [] {1,2,3}).PrefixAndTail(10).RunWith(futureSink, Materializer);
@@ -71,9 +71,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PrefixAndTail_must_work_on_longer_inputs()
+        public async Task PrefixAndTail_must_work_on_longer_inputs()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var futureSink = NewHeadSink;
                 var fut = Source.From(Enumerable.Range(1, 10)).PrefixAndTail(5).RunWith(futureSink, Materializer);
@@ -90,9 +90,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PrefixAndTail_must_handle_zero_take_count()
+        public async Task PrefixAndTail_must_handle_zero_take_count()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var futureSink = NewHeadSink;
                 var fut = Source.From(Enumerable.Range(1, 10)).PrefixAndTail(0).RunWith(futureSink, Materializer);
@@ -108,9 +108,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PrefixAndTail_must_handle_negative_take_count()
+        public async Task PrefixAndTail_must_handle_negative_take_count()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var futureSink = NewHeadSink;
                 var fut = Source.From(Enumerable.Range(1, 10)).PrefixAndTail(-1).RunWith(futureSink, Materializer);
@@ -126,9 +126,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PrefixAndTail_must_work_if_size_of_tak_is_equal_to_stream_size()
+        public async Task PrefixAndTail_must_work_if_size_of_tak_is_equal_to_stream_size()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var futureSink = NewHeadSink;
                 var fut = Source.From(Enumerable.Range(1,10)).PrefixAndTail(10).RunWith(futureSink, Materializer);
@@ -142,9 +142,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PrefixAndTail_must_throw_if_tail_is_attempted_to_be_materialized_twice()
+        public async Task PrefixAndTail_must_throw_if_tail_is_attempted_to_be_materialized_twice()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var futureSink = NewHeadSink;
                 var fut = Source.From(Enumerable.Range(1, 2)).PrefixAndTail(1).RunWith(futureSink, Materializer);
@@ -166,9 +166,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PrefixAndTail_must_signal_error_if_substream_has_been_not_subscribed_in_time()
+        public async Task PrefixAndTail_must_signal_error_if_substream_has_been_not_subscribed_in_time()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var ms = 300;
 
@@ -195,9 +195,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PrefixAndTail_must_not_fail_the_stream_if_substream_has_not_been_subscribed_in_time_and_configured_subscription_timeout_is_noop()
+        public async Task PrefixAndTail_must_not_fail_the_stream_if_substream_has_not_been_subscribed_in_time_and_configured_subscription_timeout_is_noop()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var settings = ActorMaterializerSettings.Create(Sys)
                     .WithSubscriptionTimeoutSettings(
@@ -220,9 +220,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PrefixAndTail_must_shut_down_main_stage_if_substream_is_empty_even_when_not_subscribed()
+        public async Task PrefixAndTail_must_shut_down_main_stage_if_substream_is_empty_even_when_not_subscribed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var futureSink = NewHeadSink;
                 var fut = Source.Single(1).PrefixAndTail(1).RunWith(futureSink, Materializer);
@@ -232,9 +232,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PrefixAndTail_must_handle_OnError_when_no_substream_is_open()
+        public async Task PrefixAndTail_must_handle_OnError_when_no_substream_is_open()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisher = this.CreateManualPublisherProbe<int>();
                 var subscriber = this.CreateManualSubscriberProbe<(IImmutableList<int>, Source<int, NotUsed>)>();
@@ -258,9 +258,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PrefixAndTail_must_handle_OnError_when_substream_is_open()
+        public async Task PrefixAndTail_must_handle_OnError_when_substream_is_open()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisher = this.CreateManualPublisherProbe<int>();
                 var subscriber = this.CreateManualSubscriberProbe<(IImmutableList<int>, Source<int, NotUsed>)>();
@@ -292,9 +292,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PrefixAndTail_must_handle_master_stream_cancellation()
+        public async Task PrefixAndTail_must_handle_master_stream_cancellation()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisher = this.CreateManualPublisherProbe<int>();
                 var subscriber = this.CreateManualSubscriberProbe<(IImmutableList<int>, Source<int, NotUsed>)>();
@@ -318,9 +318,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PrefixAndTail_must_handle_substream_cancellation()
+        public async Task PrefixAndTail_must_handle_substream_cancellation()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisher = this.CreateManualPublisherProbe<int>();
                 var subscriber = this.CreateManualSubscriberProbe<(IImmutableList<int>, Source<int, NotUsed>)>();
@@ -352,9 +352,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PrefixAndTail_must_pass_along_early_cancellation()
+        public async Task PrefixAndTail_must_pass_along_early_cancellation()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var up = this.CreateManualPublisherProbe<int>();
                 var down = this.CreateManualSubscriberProbe<(IImmutableList<int>, Source<int, NotUsed>)>();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowRecoverSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowRecoverSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -31,9 +32,9 @@ namespace Akka.Streams.Tests.Dsl
         private static readonly TestException Ex = new TestException("test");
 
         [Fact]
-        public void A_Recover_must_recover_when_there_is_a_handler()
+        public async Task A_Recover_must_recover_when_there_is_a_handler()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 4)).Select(x =>
                 {
@@ -53,9 +54,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Recover_must_failed_stream_if_handler_is_not_for_such_exception_type()
+        public async Task A_Recover_must_failed_stream_if_handler_is_not_for_such_exception_type()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 3)).Select(x =>
                 {
@@ -72,9 +73,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Recover_must_not_influence_stream_when_there_is_no_exception()
+        public async Task A_Recover_must_not_influence_stream_when_there_is_no_exception()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 3))
                     .Select(x => x)
@@ -87,9 +88,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Recover_must_finish_stream_if_it_is_empty()
+        public async Task A_Recover_must_finish_stream_if_it_is_empty()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.Empty<int>()
                     .Select(x => x)

--- a/src/core/Akka.Streams.Tests/Dsl/FlowRecoverWithSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowRecoverWithSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.Stage;
 using Akka.Streams.TestKit;
@@ -31,9 +32,9 @@ namespace Akka.Streams.Tests.Dsl
         private static readonly TestException Ex = new TestException("test");
 
         [Fact]
-        public void A_RecoverWith_must_recover_when_there_is_a_handler()
+        public async Task A_RecoverWith_must_recover_when_there_is_a_handler()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = Source.From(Enumerable.Range(1, 4)).Select(x =>
                 {
@@ -59,9 +60,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_RecoverWith_must_cancel_substream_if_parent_is_terminated_when_there_is_a_handler()
+        public async Task A_RecoverWith_must_cancel_substream_if_parent_is_terminated_when_there_is_a_handler()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = Source.From(Enumerable.Range(1, 4)).Select(x =>
                 {
@@ -83,9 +84,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_RecoverWith_must_failed_stream_if_handler_is_not_for_such_exception_type()
+        public async Task A_RecoverWith_must_failed_stream_if_handler_is_not_for_such_exception_type()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = Source.From(Enumerable.Range(1, 3)).Select(x =>
                 {
@@ -105,9 +106,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_RecoverWith_must_be_able_to_recover_with_the_same_unmaterialized_source_if_configured()
+        public async Task A_RecoverWith_must_be_able_to_recover_with_the_same_unmaterialized_source_if_configured()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var src = Source.From(Enumerable.Range(1, 3)).Select(x =>
                 {
@@ -134,9 +135,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_RecoverWith_must_not_influence_stream_when_there_is_no_exception()
+        public async Task A_RecoverWith_must_not_influence_stream_when_there_is_no_exception()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 3))
                     .Select(x => x)
@@ -149,9 +150,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_RecoverWith_must_finish_stream_if_it_is_empty()
+        public async Task A_RecoverWith_must_finish_stream_if_it_is_empty()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.Empty<int>()
                     .Select(x => x)
@@ -163,9 +164,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_RecoverWith_must_switch_the_second_time_if_alternative_source_throws_exception()
+        public async Task A_RecoverWith_must_switch_the_second_time_if_alternative_source_throws_exception()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = Source.From(Enumerable.Range(1, 3)).Select(x =>
                 {
@@ -202,9 +203,9 @@ namespace Akka.Streams.Tests.Dsl
         }
         
         [Fact]
-        public void A_RecoverWith_must_terminate_with_exception_if_partial_function_fails_to_match_after_an_alternative_source_failure()
+        public async Task A_RecoverWith_must_terminate_with_exception_if_partial_function_fails_to_match_after_an_alternative_source_failure()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = Source.From(Enumerable.Range(1, 3))
                     .Select(x =>
@@ -241,9 +242,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_RecoverWith_must_terminate_with_exception_after_set_number_of_retries()
+        public async Task A_RecoverWith_must_terminate_with_exception_after_set_number_of_retries()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = Source.From(Enumerable.Range(1, 3))
                     .Select(x =>
@@ -270,9 +271,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_RecoverWith_must_throw_ArgumentException_if_number_of_retries_is_less_than_minus_one()
+        public async Task A_RecoverWith_must_throw_ArgumentException_if_number_of_retries_is_less_than_minus_one()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Flow.Create<int>()
                     .Invoking(f => f.RecoverWithRetries(exception => Source.Empty<int>(), -2))
@@ -281,9 +282,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_RecoverWith_must_fail_correctly_when_materialization_of_recover_source_fails()
+        public async Task A_RecoverWith_must_fail_correctly_when_materialization_of_recover_source_fails()
         {
-            this.AssertAllStagesStopped(() => 
+            await this.AssertAllStagesStoppedAsync(() => 
             {
                 var matFail = new TestException("fail!");
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowScanSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowScanSpec.cs
@@ -45,7 +45,7 @@ namespace Akka.Streams.Tests.Dsl
         }
         
         [Fact]
-        public void A_Scan_must_Scan()
+        public async Task A_Scan_must_Scan()
         {
             Func<int[], int[]> scan = source =>
             {
@@ -58,7 +58,7 @@ namespace Akka.Streams.Tests.Dsl
                 return result;
             };
 
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var random = new Random();
                 var v = Enumerable.Range(1, random.Next(100, 1000)).Select(_ => random.Next()).ToArray();
@@ -67,9 +67,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Scan_must_Scan_empty_failed()
+        public async Task A_Scan_must_Scan_empty_failed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var error = new TestException("fail!");
                 Action fail = () => Scan(Source.Failed<int>(error));
@@ -78,8 +78,8 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Scan_must_Scan_empty() =>
-            this.AssertAllStagesStopped(() => Scan(Source.Empty<int>()).ShouldAllBeEquivalentTo(new[] {0}), Materializer);
+        public async Task A_Scan_must_Scan_empty() =>
+            await this.AssertAllStagesStoppedAsync(() => Scan(Source.Empty<int>()).ShouldAllBeEquivalentTo(new[] {0}), Materializer);
 
         [Fact]
         public void A_Scan_must_emit_values_promptly()

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncSpec.cs
@@ -40,9 +40,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsync_must_produce_task_elements()
+        public async Task A_Flow_with_SelectAsync_must_produce_task_elements()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c = this.CreateManualSubscriberProbe<int>();
                 Source.From(Enumerable.Range(1, 3))
@@ -113,9 +113,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact(Skip = "Racy on Azure DevOps")]
-        public void A_Flow_with_SelectAsync_must_signal_task_failure()
+        public async Task A_Flow_with_SelectAsync_must_signal_task_failure()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var latch = new TestLatch(1);
                 var c = this.CreateManualSubscriberProbe<int>();
@@ -137,9 +137,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsync_must_signal_task_failure_asap()
+        public async Task A_Flow_with_SelectAsync_must_signal_task_failure_asap()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var latch = CreateTestLatch();
                 var done = Source.From(Enumerable.Range(1, 5))
@@ -168,9 +168,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsync_must_signal_error_from_SelectAsync()
+        public async Task A_Flow_with_SelectAsync_must_signal_error_from_SelectAsync()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var latch = new TestLatch(1);
                 var c = this.CreateManualSubscriberProbe<int>();
@@ -195,11 +195,11 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsync_must_resume_after_task_failure()
+        public async Task A_Flow_with_SelectAsync_must_resume_after_task_failure()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(async () =>
             {
-                this.AssertAllStagesStopped(() =>
+                await this.AssertAllStagesStoppedAsync(() =>
                 {
                     var c = this.CreateManualSubscriberProbe<int>();
                     Source.From(Enumerable.Range(1, 5))
@@ -220,9 +220,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsync_must_resume_after_multiple_failures()
+        public async Task A_Flow_with_SelectAsync_must_resume_after_multiple_failures()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var futures = new[]
                 {
@@ -245,9 +245,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsync_must_finish_after_task_failure()
+        public async Task A_Flow_with_SelectAsync_must_finish_after_task_failure()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = Source.From(Enumerable.Range(1, 3))
                     .SelectAsync(1, n => Task.Run(() =>
@@ -313,9 +313,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsync_must_handle_cancel_properly()
+        public async Task A_Flow_with_SelectAsync_must_handle_cancel_properly()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var pub = this.CreateManualPublisherProbe<int>();
                 var sub = this.CreateManualSubscriberProbe<int>();
@@ -334,9 +334,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact(Skip = "Racy on AzureDevOps")]
-        public void A_Flow_with_SelectAsync_must_not_run_more_futures_than_configured()
+        public async Task A_Flow_with_SelectAsync_must_not_run_more_futures_than_configured()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 const int parallelism = 8;
                 var counter = new AtomicCounter();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncUnorderedSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncUnorderedSpec.cs
@@ -39,9 +39,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsyncUnordered_must_produce_task_elements_in_the_order_they_are_ready()
+        public async Task A_Flow_with_SelectAsyncUnordered_must_produce_task_elements_in_the_order_they_are_ready()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c = this.CreateManualSubscriberProbe<int>();
                 var latch = Enumerable.Range(0, 4).Select(_ => new TestLatch(1)).ToArray();
@@ -111,9 +111,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsyncUnordered_must_signal_task_failure()
+        public async Task A_Flow_with_SelectAsyncUnordered_must_signal_task_failure()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var latch = new TestLatch(1);
                 var c = this.CreateManualSubscriberProbe<int>();
@@ -136,9 +136,9 @@ namespace Akka.Streams.Tests.Dsl
 
 
         [Fact]
-        public void A_Flow_with_SelectAsyncUnordered_must_signal_task_failure_asap()
+        public async Task A_Flow_with_SelectAsyncUnordered_must_signal_task_failure_asap()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var latch = CreateTestLatch();
                 var done = Source.From(Enumerable.Range(1, 5))
@@ -168,9 +168,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsyncUnordered_must_signal_error_from_SelectAsyncUnordered()
+        public async Task A_Flow_with_SelectAsyncUnordered_must_signal_error_from_SelectAsyncUnordered()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var latch = new TestLatch(1);
                 var c = this.CreateManualSubscriberProbe<int>();
@@ -195,11 +195,11 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsyncUnordered_must_resume_after_task_failure()
+        public async Task A_Flow_with_SelectAsyncUnordered_must_resume_after_task_failure()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(async () =>
             {
-                this.AssertAllStagesStopped(() =>
+                await this.AssertAllStagesStoppedAsync(() =>
                 {
                     Source.From(Enumerable.Range(1, 5))
                         .SelectAsyncUnordered(4, n => Task.Run(() =>
@@ -218,9 +218,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsyncUnordered_must_resume_after_multiple_failures()
+        public async Task A_Flow_with_SelectAsyncUnordered_must_resume_after_multiple_failures()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var futures = new[]
                 {
@@ -242,9 +242,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsyncUnordered_must_finish_after_task_failure()
+        public async Task A_Flow_with_SelectAsyncUnordered_must_finish_after_task_failure()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = Source.From(Enumerable.Range(1, 3))
                     .SelectAsyncUnordered(1, n => Task.Run(() =>
@@ -308,9 +308,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SelectAsyncUnordered_must_handle_cancel_properly()
+        public async Task A_Flow_with_SelectAsyncUnordered_must_handle_cancel_properly()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var pub = this.CreateManualPublisherProbe<int>();
                 var sub = this.CreateManualSubscriberProbe<int>();
@@ -329,9 +329,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact(Skip = "Racy on AzureDevOps")]
-        public void A_Flow_with_SelectAsyncUnordered_must_not_run_more_futures_than_configured()
+        public async Task A_Flow_with_SelectAsyncUnordered_must_not_run_more_futures_than_configured()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 const int parallelism = 8;
                 var counter = new AtomicCounter();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSelectErrorSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSelectErrorSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -31,9 +32,9 @@ namespace Akka.Streams.Tests.Dsl
         public ActorMaterializer Materializer { get; }
 
         [Fact]
-        public void A_SelectError_must_select_when_there_is_a_handler()
+        public async Task A_SelectError_must_select_when_there_is_a_handler()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 3))
                     .Select(ThrowOnTwo)
@@ -46,9 +47,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_SelectError_must_fail_the_stream_with_exception_thrown_in_handler_and_log_it()
+        public async Task A_SelectError_must_fail_the_stream_with_exception_thrown_in_handler_and_log_it()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 3))
                     .Select(ThrowOnTwo)
@@ -78,9 +79,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_SelectError_must_not_influence_stream_when_there_is_no_exceptions()
+        public async Task A_SelectError_must_not_influence_stream_when_there_is_no_exceptions()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 3))
                     .Select(x => x)
@@ -94,9 +95,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_SelectError_must_finish_stream_if_it_is_empty()
+        public async Task A_SelectError_must_finish_stream_if_it_is_empty()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.Empty<int>()
                     .Select(x => x)

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSkipWhileSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSkipWhileSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.Supervision;
 using Akka.Streams.TestKit;
@@ -28,9 +29,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_SkipWhile_must_skip_while_predicate_is_true()
+        public async Task A_SkipWhile_must_skip_while_predicate_is_true()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 4))
                     .SkipWhile(x => x < 3)
@@ -42,9 +43,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_SkipWhile_must_complete_the_future_for_an_empty_stream()
+        public async Task A_SkipWhile_must_complete_the_future_for_an_empty_stream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.Empty<int>()
                     .SkipWhile(x => x < 2)
@@ -55,9 +56,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_SkipWhile_must_continue_if_error()
+        public async Task A_SkipWhile_must_continue_if_error()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 4)).SkipWhile(x =>
                 {
@@ -73,9 +74,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_SkipWhile_must_restart_with_strategy()
+        public async Task A_SkipWhile_must_restart_with_strategy()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 4)).SkipWhile(x =>
                 {

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSlidingSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSlidingSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit.Tests;
@@ -84,9 +85,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Sliding_must_behave_just_like_collections_sliding_with_step_lower_than_window()
+        public async Task Sliding_must_behave_just_like_collections_sliding_with_step_lower_than_window()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var random = new Random();
                 var gen = Enumerable.Range(1, 1000)
@@ -101,9 +102,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Sliding_must_behave_just_like_collections_sliding_with_step_equals_window()
+        public async Task Sliding_must_behave_just_like_collections_sliding_with_step_equals_window()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var random = new Random();
                 var gen = Enumerable.Range(1, 1000)
@@ -118,9 +119,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Sliding_must_behave_just_like_collections_sliding_with_step_greater_than_window()
+        public async Task Sliding_must_behave_just_like_collections_sliding_with_step_greater_than_window()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var random = new Random();
                 var gen = Enumerable.Range(1, 1000)
@@ -135,9 +136,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Sliding_must_work_with_empty_sources()
+        public async Task Sliding_must_work_with_empty_sources()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.Empty<int>().Sliding(1).RunForeach(ints => TestActor.Tell(ints), Materializer)
                     .ContinueWith(t =>

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSpec.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Pattern;
@@ -263,9 +264,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_must_be_materializable_several_times_with_fanout_publisher()
+        public async Task A_Flow_must_be_materializable_several_times_with_fanout_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var flow = Source.From(new[] {1, 2, 3}).Select(i => i.ToString());
                 var p1 = flow.RunWith(Sink.AsPublisher<string>(true), Materializer);
@@ -301,7 +302,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_must_be_covariant()
+        public async Task A_Flow_must_be_covariant()
         {
             Source<IFruit, NotUsed> f1 = Source.From<IFruit>(Apples());
             IPublisher<IFruit> p1 = Source.From<IFruit>(Apples()).RunWith(Sink.AsPublisher<IFruit>(false), Materializer);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSplitAfterSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSplitAfterSpec.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.Implementation;
 using Akka.Streams.TestKit;
@@ -87,9 +88,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void SplitAfter_must_work_in_the_happy_case()
+        public async Task SplitAfter_must_work_in_the_happy_case()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 WithSubstreamsSupport(3,5,run: (masterSubscriber, masterSubscription, expectSubFlow) =>
                 {
@@ -117,9 +118,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void SplitAfter_must_work_when_first_element_is_split_by()
+        public async Task SplitAfter_must_work_when_first_element_is_split_by()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 WithSubstreamsSupport(1, 3, run: (masterSubscriber, masterSubscription, expectSubFlow) =>
                 {
@@ -143,9 +144,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void SplitAfter_must_work_with_single_element_splits_by()
+        public async Task SplitAfter_must_work_with_single_element_splits_by()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = Source.From(Enumerable.Range(1, 10))
                     .SplitAfter(_ => true)
@@ -159,9 +160,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void SplitAfter_must_support_cancelling_substreams()
+        public async Task SplitAfter_must_support_cancelling_substreams()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 WithSubstreamsSupport(5, 8, run: (masterSubscriber, masterSubscription, expectSubFlow) =>
                 {
@@ -180,9 +181,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void SplitAfter_must_fail_stream_when_SplitAfter_function_throws()
+        public async Task SplitAfter_must_fail_stream_when_SplitAfter_function_throws()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisherProbe = this.CreateManualPublisherProbe<int>();
                 var ex = new TestException("test");
@@ -220,18 +221,18 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact(Skip = "Supervision is not supported fully by GraphStages yet")]
-        public void SplitAfter_must_resume_stream_when_SplitAfter_function_throws()
+        public async Task SplitAfter_must_resume_stream_when_SplitAfter_function_throws()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
 
             }, Materializer);
         }
 
         [Fact]
-        public void SplitAfter_must_pass_along_early_cancellation()
+        public async Task SplitAfter_must_pass_along_early_cancellation()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var up = this.CreateManualPublisherProbe<int>();
                 var down = this.CreateManualSubscriberProbe<Source<int, NotUsed>>();
@@ -251,9 +252,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void SplitAfter_must_support_eager_cancellation_of_master_stream_on_cancelling_substreams()
+        public async Task SplitAfter_must_support_eager_cancellation_of_master_stream_on_cancelling_substreams()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 WithSubstreamsSupport(5,8,SubstreamCancelStrategy.Propagate,
                     (masterSubscriber, masterSubscription, expectSubFlow) =>
@@ -267,7 +268,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void SplitAfter_should_work_when_last_element_is_split_by() => this.AssertAllStagesStopped(() =>
+        public async Task SplitAfter_should_work_when_last_element_is_split_by() => await this.AssertAllStagesStoppedAsync(() =>
         {
             WithSubstreamsSupport(splitAfter: 3, elementCount: 3,
                 run: (masterSubscriber, masterSubscription, expectSubFlow) =>
@@ -288,7 +289,7 @@ namespace Akka.Streams.Tests.Dsl
         }, Materializer);
 
         [Fact]
-        public void SplitAfter_should_fail_stream_if_substream_not_materialized_in_time() => this.AssertAllStagesStopped(() =>
+        public async Task SplitAfter_should_fail_stream_if_substream_not_materialized_in_time() => await this.AssertAllStagesStoppedAsync(() =>
         {
             var timeout = new StreamSubscriptionTimeoutSettings(StreamSubscriptionTimeoutTerminationMode.CancelTermination, TimeSpan.FromMilliseconds(500));
             var settings = ActorMaterializerSettings.Create(Sys).WithSubscriptionTimeoutSettings(timeout);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSplitWhenSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSplitWhenSpec.cs
@@ -85,9 +85,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void SplitWhen_must_work_in_the_happy_case()
+        public async Task SplitWhen_must_work_in_the_happy_case()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 WithSubstreamsSupport(elementCount: 4, run: (masterSubscriber, masterSubscription, getSubFlow) =>
                 {
@@ -119,9 +119,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void SplitWhen_must_not_emit_substreams_if_the_parent_stream_is_empty()
+        public async Task SplitWhen_must_not_emit_substreams_if_the_parent_stream_is_empty()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task =
                     Source.Empty<int>()
@@ -137,9 +137,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void SplitWhen_must_work_when_first_element_is_split_by()
+        public async Task SplitWhen_must_work_when_first_element_is_split_by()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 WithSubstreamsSupport(1, 3, run: (masterSubscriber, masterSubscription, getSubFlow) =>
                 {
@@ -158,9 +158,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void SplitWhen_must_support_cancelling_substreams()
+        public async Task SplitWhen_must_support_cancelling_substreams()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 WithSubstreamsSupport(5, 8, run: (masterSubscriber, masterSubscription, getSubFlow) =>
                 {
@@ -183,9 +183,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void SplitWhen_must_support_cancelling_both_master_and_substream()
+        public async Task SplitWhen_must_support_cancelling_both_master_and_substream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var inputs = this.CreatePublisherProbe<int>();
 
@@ -253,9 +253,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void SplitWhen_must_support_cancelling_the_master_stream()
+        public async Task SplitWhen_must_support_cancelling_the_master_stream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 WithSubstreamsSupport(5, 8, run: (masterSubscriber, masterSubscription, getSubFlow) =>
                 {
@@ -274,9 +274,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void SplitWhen_must_fail_stream_when_SplitWhen_function_throws()
+        public async Task SplitWhen_must_fail_stream_when_SplitWhen_function_throws()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisherProbe = this.CreateManualPublisherProbe<int>();
                 var ex = new TestException("test");
@@ -314,9 +314,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void SplitWhen_must_work_with_single_element_splits()
+        public async Task SplitWhen_must_work_with_single_element_splits()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = Source.From(Enumerable.Range(1, 100))
                     .SplitWhen(_ => true)
@@ -330,9 +330,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void SplitWhen_must_fail_substream_if_materialized_twice()
+        public async Task SplitWhen_must_fail_substream_if_materialized_twice()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = Source.Single(1).SplitWhen(_ => true).Lift()
                     .SelectAsync(1, source =>
@@ -352,9 +352,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void SplitWhen_must_fail_stream_if_substream_not_materialized_in_time()
+        public async Task SplitWhen_must_fail_stream_if_substream_not_materialized_in_time()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var tightTimeoutMaterializer = ActorMaterializer.Create(Sys,
                     ActorMaterializerSettings.Create(Sys)
@@ -383,18 +383,18 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact(Skip = "Supervision is not supported fully by GraphStages yet")]
-        public void SplitWhen_must_resume_stream_when_splitWhen_function_throws()
+        public async Task SplitWhen_must_resume_stream_when_splitWhen_function_throws()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
 
             }, Materializer);
         }
 
         [Fact]
-        public void SplitWhen_must_pass_along_early_cancellation()
+        public async Task SplitWhen_must_pass_along_early_cancellation()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var up = this.CreateManualPublisherProbe<int>();
                 var down = this.CreateManualSubscriberProbe<Source<int, NotUsed>>();
@@ -414,9 +414,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void SplitWhen_must_support_eager_cancellation_of_master_stream_on_cancelling_substreams()
+        public async Task SplitWhen_must_support_eager_cancellation_of_master_stream_on_cancelling_substreams()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 WithSubstreamsSupport(5, 8, SubstreamCancelStrategy.Propagate,
                       (masterSubscriber, masterSubscription, expectSubFlow) =>

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSumSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSumSpec.cs
@@ -42,9 +42,9 @@ namespace Akka.Streams.Tests.Dsl
         private static Sink<int, Task<int>> SumSink => Sink.Sum<int>((i, i1) => i + i1);
 
         [Fact]
-        public void A_Sum_must_work_when_using_Source_RunSum()
+        public async Task A_Sum_must_work_when_using_Source_RunSum()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = InputSource.RunSum((i, i1) => i + i1, Materializer);
                 t.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
@@ -53,9 +53,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Sum_must_work_when_using_Source_Sum()
+        public async Task A_Sum_must_work_when_using_Source_Sum()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = SumSource.RunWith(Sink.First<int>(), Materializer);
                 t.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
@@ -63,9 +63,9 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
         [Fact]
-        public void A_Sum_must_work_when_using_Sink_Sum()
+        public async Task A_Sum_must_work_when_using_Sink_Sum()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = InputSource.RunWith(SumSink, Materializer);
                 t.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
@@ -75,9 +75,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Sum_must_work_when_using_Flow_Sum()
+        public async Task A_Sum_must_work_when_using_Flow_Sum()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = InputSource.Via(SumFlow).RunWith(Sink.First<int>(), Materializer);
                 t.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
@@ -86,9 +86,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Sum_must_work_when_using_Source_Sum_and_Flow_Sum_and_Sink_Sum()
+        public async Task A_Sum_must_work_when_using_Source_Sum_and_Flow_Sum_and_Sink_Sum()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = SumSource.Via(SumFlow).RunWith(SumSink, Materializer);
                 t.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
@@ -98,9 +98,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Sum_must_propagate_an_error()
+        public async Task A_Sum_must_propagate_an_error()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var error = new TestException("test");
                 var task = InputSource.Select(x =>
@@ -115,9 +115,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Sum_must_complete_task_with_failure_when_reduce_function_throws_and_the_supervisor_strategy_decides_to_stop()
+        public async Task A_Sum_must_complete_task_with_failure_when_reduce_function_throws_and_the_supervisor_strategy_decides_to_stop()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var error = new TestException("test");
                 var task = InputSource.RunSum((x, y) =>
@@ -132,9 +132,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Sum_must_resume_with_the_accumulated_state_when_the_reduce_funtion_throws_and_the_supervisor_strategy_decides_to_resume()
+        public async Task A_Sum_must_resume_with_the_accumulated_state_when_the_reduce_funtion_throws_and_the_supervisor_strategy_decides_to_resume()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var error = new Exception("boom");
                 var sum = Sink.Sum((int x, int y) =>
@@ -152,9 +152,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Aggregate_must_resume_and_reset_the_state_when_the_reduce_funtion_throws_and_the_supervisor_strategy_decides_to_restart()
+        public async Task A_Aggregate_must_resume_and_reset_the_state_when_the_reduce_funtion_throws_and_the_supervisor_strategy_decides_to_restart()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var error = new Exception("boom");
                 var sum = Sink.Sum((int x, int y) =>
@@ -172,9 +172,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Sum_must_fail_on_Empty_stream_using_Source_RunSum()
+        public async Task A_Sum_must_fail_on_Empty_stream_using_Source_RunSum()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var result = Source.Empty<int>().RunSum((i, i1) => i + i1, Materializer);
                 result.Invoking(t => t.Wait(TimeSpan.FromSeconds(3)))
@@ -185,9 +185,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Sum_must_fail_on_Empty_stream_using_Flow_Sum()
+        public async Task A_Sum_must_fail_on_Empty_stream_using_Flow_Sum()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var result = Source.Empty<int>()
                     .Via(SumFlow)
@@ -200,9 +200,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Sum_must_fail_on_Empty_stream_using_Sink_Sum()
+        public async Task A_Sum_must_fail_on_Empty_stream_using_Sink_Sum()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var result = Source.Empty<int>()
                     .RunWith(SumSink, Materializer);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowTakeWhileSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowTakeWhileSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.Supervision;
 using Akka.Streams.TestKit;
@@ -28,9 +29,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_TakeWhile_must_take_while_predicate_is_true()
+        public async Task A_TakeWhile_must_take_while_predicate_is_true()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 4))
                     .TakeWhile(i => i < 3)
@@ -42,9 +43,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_TakeWhile_must_complete_the_future_for_an_empty_stream()
+        public async Task A_TakeWhile_must_complete_the_future_for_an_empty_stream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.Empty<int>()
                     .TakeWhile(i => i < 2)
@@ -55,9 +56,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_TakeWhile_must_continue_if_error()
+        public async Task A_TakeWhile_must_continue_if_error()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var testException = new Exception("test");
 
@@ -76,9 +77,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_TakeWhile_must_emit_the_element_that_caused_the_predicate_to_return_false_and_then_no_more_with_inclusive_set()
+        public async Task A_TakeWhile_must_emit_the_element_that_caused_the_predicate_to_return_false_and_then_no_more_with_inclusive_set()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 10))
                 .TakeWhile(i => i < 3, true)

--- a/src/core/Akka.Streams.Tests/Dsl/FlowTakeWithinSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowTakeWithinSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -52,9 +53,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_TakeWithin_must_deliver_buffered_elements_OnComplete_before_the_timeout()
+        public async Task A_TakeWithin_must_deliver_buffered_elements_OnComplete_before_the_timeout()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c = this.CreateManualSubscriberProbe<int>();
                 Source.From(Enumerable.Range(1, 3))

--- a/src/core/Akka.Streams.Tests/Dsl/FlowThrottleSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowThrottleSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.IO;
 using Akka.Streams.Actors;
 using Akka.Streams.Dsl;
@@ -45,9 +46,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Throttle_for_single_cost_elements_must_work_for_the_happy_case()
+        public async Task Throttle_for_single_cost_elements_must_work_for_the_happy_case()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 5))
                     .Throttle(1, TimeSpan.FromMilliseconds(100), 0, ThrottleMode.Shaping)
@@ -59,9 +60,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Throttle_for_single_cost_elements_must_accept_very_high_rates()
+        public async Task Throttle_for_single_cost_elements_must_accept_very_high_rates()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 5))
                     .Throttle(1, TimeSpan.FromTicks(1), 0, ThrottleMode.Shaping)
@@ -73,9 +74,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Throttle_for_single_cost_elements_must_accept_very_low_rates()
+        public async Task Throttle_for_single_cost_elements_must_accept_very_low_rates()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = Source.From(Enumerable.Range(1, 5))
                     .Throttle(1, TimeSpan.FromDays(100), 1, ThrottleMode.Shaping)
@@ -110,9 +111,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Throttle_for_single_cost_elements_must_emit_single_element_per_tick()
+        public async Task Throttle_for_single_cost_elements_must_emit_single_element_per_tick()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var upstream = this.CreatePublisherProbe<int>();
                 var downstream = this.CreateSubscriberProbe<int>();
@@ -136,9 +137,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Throttle_for_single_cost_elements_must_not_send_downstream_if_upstream_does_not_emit_element()
+        public async Task Throttle_for_single_cost_elements_must_not_send_downstream_if_upstream_does_not_emit_element()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var upstream = this.CreatePublisherProbe<int>();
                 var downstream = this.CreateSubscriberProbe<int>();
@@ -161,9 +162,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Throttle_for_single_cost_elements_must_cancel_when_downstream_cancels()
+        public async Task Throttle_for_single_cost_elements_must_cancel_when_downstream_cancels()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var downstream = this.CreateSubscriberProbe<int>();
                 Source.From(Enumerable.Range(1, 10))
@@ -174,9 +175,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Throttle_for_single_cost_elements_must_send_elements_downstream_as_soon_as_time_comes()
+        public async Task Throttle_for_single_cost_elements_must_send_elements_downstream_as_soon_as_time_comes()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe =
                     Source.From(Enumerable.Range(1, 10))
@@ -195,9 +196,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Throttle_for_single_cost_elements_must_burst_according_to_its_maximum_if_enough_time_passed()
+        public async Task Throttle_for_single_cost_elements_must_burst_according_to_its_maximum_if_enough_time_passed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var ms = TimeSpan.FromMilliseconds(300);
                 var upstream = this.CreatePublisherProbe<int>();
@@ -237,9 +238,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Throttle_for_single_cost_elements_must_burst_some_elements_if_have_enough_time()
+        public async Task Throttle_for_single_cost_elements_must_burst_some_elements_if_have_enough_time()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var upstream = this.CreatePublisherProbe<int>();
                 var downstream = this.CreateSubscriberProbe<int>();
@@ -279,9 +280,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Throttle_for_single_cost_elements_must_throw_exception_when_exceeding_throughtput_in_enforced_mode()
+        public async Task Throttle_for_single_cost_elements_must_throw_exception_when_exceeding_throughtput_in_enforced_mode()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t1 =
                     Source.From(Enumerable.Range(1, 5))
@@ -299,9 +300,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Throttle_for_single_cost_elements_must_properly_combine_shape_and_throttle_modes()
+        public async Task Throttle_for_single_cost_elements_must_properly_combine_shape_and_throttle_modes()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 5))
                     .Throttle(1, TimeSpan.FromMilliseconds(100), 5, ThrottleMode.Shaping)
@@ -316,9 +317,9 @@ namespace Akka.Streams.Tests.Dsl
 
 
         [Fact]
-        public void Throttle_for_various_cost_elements_must_work_for_the_happy_case()
+        public async Task Throttle_for_various_cost_elements_must_work_for_the_happy_case()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 5))
                     .Throttle(1, TimeSpan.FromMilliseconds(100), 0, _ => 1, ThrottleMode.Shaping)
@@ -330,9 +331,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Throttle_for_various_cost_elements_must_emit_elements_according_to_cost()
+        public async Task Throttle_for_various_cost_elements_must_emit_elements_according_to_cost()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var list = Enumerable.Range(1, 4).Select(x => x*2).Select(GenerateByteString).ToList();
 
@@ -352,9 +353,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Throttle_for_various_cost_elements_must_not_send_downstream_if_upstream_does_not_emit_element()
+        public async Task Throttle_for_various_cost_elements_must_not_send_downstream_if_upstream_does_not_emit_element()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var upstream = this.CreatePublisherProbe<int>();
                 var downstream = this.CreateSubscriberProbe<int>();
@@ -377,9 +378,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Throttle_for_various_cost_elements_must_cancel_when_downstream_cancels()
+        public async Task Throttle_for_various_cost_elements_must_cancel_when_downstream_cancels()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var downstream = this.CreateSubscriberProbe<int>();
                 Source.From(Enumerable.Range(1, 10))
@@ -390,9 +391,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Throttle_for_various_cost_elements_must_send_elements_downstream_as_soon_as_time_comes()
+        public async Task Throttle_for_various_cost_elements_must_send_elements_downstream_as_soon_as_time_comes()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe =
                     Source.From(Enumerable.Range(1, 10))
@@ -411,9 +412,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Throttle_for_various_cost_elements_must_burst_according_to_its_maximum_if_enough_time_passed()
+        public async Task Throttle_for_various_cost_elements_must_burst_according_to_its_maximum_if_enough_time_passed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var upstream = this.CreatePublisherProbe<int>();
                 var downstream = this.CreateSubscriberProbe<int>();
@@ -453,9 +454,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Throttle_for_various_cost_elements_must_burst_some_elements_if_have_enough_time()
+        public async Task Throttle_for_various_cost_elements_must_burst_some_elements_if_have_enough_time()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var upstream = this.CreatePublisherProbe<int>();
                 var downstream = this.CreateSubscriberProbe<int>();
@@ -496,9 +497,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Throttle_for_various_cost_elements_must_throw_exception_when_exceeding_throughtput_in_enforced_mode()
+        public async Task Throttle_for_various_cost_elements_must_throw_exception_when_exceeding_throughtput_in_enforced_mode()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t1 =
                     Source.From(Enumerable.Range(1, 4))
@@ -516,9 +517,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Throttle_for_various_cost_elements_must_properly_combine_shape_and_enforce_modes()
+        public async Task Throttle_for_various_cost_elements_must_properly_combine_shape_and_enforce_modes()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 5))
                     .Throttle(2, TimeSpan.FromMilliseconds(200), 0, x => x, ThrottleMode.Shaping)
@@ -531,9 +532,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Throttle_for_various_cost_elements_must_handle_rate_calculation_function_exception()
+        public async Task Throttle_for_various_cost_elements_must_handle_rate_calculation_function_exception()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var ex = new Exception();
                 Source.From(Enumerable.Range(1, 5))

--- a/src/core/Akka.Streams.Tests/Dsl/FlowWatchTerminationSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowWatchTerminationSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -28,9 +29,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_WatchTermination_must_complete_the_future_when_stream_is_completed()
+        public async Task A_WatchTermination_must_complete_the_future_when_stream_is_completed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t =
                     Source.From(Enumerable.Range(1, 4))
@@ -47,9 +48,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_WatchTermination_must_complete_the_future_when_stream_is_cancelled_from_downstream()
+        public async Task A_WatchTermination_must_complete_the_future_when_stream_is_cancelled_from_downstream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t =
                     Source.From(Enumerable.Range(1, 4))
@@ -66,9 +67,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_WatchTermination_must_fail_the_future_when_stream_is_failed()
+        public async Task A_WatchTermination_must_fail_the_future_when_stream_is_failed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var ex = new Exception("Stream failed.");
                 var t = this.SourceProbe<int>().WatchTermination(Keep.Both).To(Sink.Ignore<int>()).Run(Materializer);
@@ -81,9 +82,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_WatchTermination_must_complete_the_future_for_an_empty_stream()
+        public async Task A_WatchTermination_must_complete_the_future_for_an_empty_stream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t =
                     Source.Empty<int>()
@@ -98,9 +99,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact(Skip = "We need a way to combine multiple sources with different materializer types")]
-        public void A_WatchTermination_must_complete_the_future_for_graph()
+        public async Task A_WatchTermination_must_complete_the_future_for_graph()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 //var first = this.SourceProbe<int>().WatchTermination(Keep.Both);
                 //var second = Source.From(Enumerable.Range(2, 4)).MapMaterializedValue(new Func<NotUsed, (TestPublisher.Probe<int>, Task)>(_ => null));

--- a/src/core/Akka.Streams.Tests/Dsl/FlowWhereSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowWhereSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.Supervision;
 using Akka.Streams.TestKit;
@@ -65,9 +66,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Where_must_continue_if_error()
+        public async Task A_Where_must_continue_if_error()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var ex = new TestException("Test");
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowZipSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowZipSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -33,9 +34,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Zip_for_Flow_must_work_in_the_happy_case()
+        public async Task A_Zip_for_Flow_must_work_in_the_happy_case()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = this.CreateManualSubscriberProbe<(int, string)>();
                 Source.From(Enumerable.Range(1, 4))

--- a/src/core/Akka.Streams.Tests/Dsl/GraphBalanceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphBalanceSpec.cs
@@ -31,9 +31,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Balance_must_balance_between_subscribers_which_signal_demand()
+        public async Task A_Balance_must_balance_between_subscribers_which_signal_demand()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c1 = this.CreateManualSubscriberProbe<int>();
                 var c2 = this.CreateManualSubscriberProbe<int>();
@@ -62,9 +62,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Balance_must_support_waiting_for_demand_from_all_downstream_subscriptions()
+        public async Task A_Balance_must_support_waiting_for_demand_from_all_downstream_subscriptions()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var s1 = this.CreateManualSubscriberProbe<int>();
 
@@ -99,9 +99,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact(Skip = "Racy")]
-        public void A_Balance_must_support_waiting_for_demand_from_all_non_cancelled_downstream_subscriptions()
+        public async Task A_Balance_must_support_waiting_for_demand_from_all_non_cancelled_downstream_subscriptions()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var s1 = this.CreateManualSubscriberProbe<int>();
 
@@ -147,9 +147,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Balance_must_work_with_1_way_balance()
+        public async Task A_Balance_must_work_with_1_way_balance()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = Source.FromGraph(GraphDsl.Create(b =>
                 {
@@ -170,9 +170,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Balance_must_work_with_5_way_balance()
+        public async Task A_Balance_must_work_with_5_way_balance()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var sink = Sink.First<IEnumerable<int>>();
                 var t = RunnableGraph.FromGraph(GraphDsl.Create(sink, sink, sink, sink, sink, ValueTuple.Create,
@@ -196,9 +196,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Balance_must_balance_between_all_three_outputs()
+        public async Task A_Balance_must_balance_between_all_three_outputs()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 const int numElementsForSink = 10000;
                 var outputs = Sink.Aggregate<int, int>(0, (sum, i) => sum + i);
@@ -225,9 +225,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Balance_must_fairly_balance_between_three_outputs()
+        public async Task A_Balance_must_fairly_balance_between_three_outputs()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = this.SinkProbe<int>();
                 var t = RunnableGraph.FromGraph(GraphDsl.Create(probe, probe, probe, ValueTuple.Create,
@@ -262,9 +262,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Balance_must_produce_to_second_even_though_first_cancels()
+        public async Task A_Balance_must_produce_to_second_even_though_first_cancels()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c1 = this.CreateManualSubscriberProbe<int>();
                 var c2 = this.CreateManualSubscriberProbe<int>();
@@ -289,9 +289,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Balance_must_produce_to_first_even_though_second_cancels()
+        public async Task A_Balance_must_produce_to_first_even_though_second_cancels()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c1 = this.CreateManualSubscriberProbe<int>();
                 var c2 = this.CreateManualSubscriberProbe<int>();
@@ -316,9 +316,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Balance_must_cancel_upstream_when_downstream_cancel()
+        public async Task A_Balance_must_cancel_upstream_when_downstream_cancel()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p1 = this.CreateManualPublisherProbe<int>();
                 var c1 = this.CreateManualSubscriberProbe<int>();
@@ -354,9 +354,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Balance_must_not_push_output_twice()
+        public async Task A_Balance_must_not_push_output_twice()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p1 = this.CreateManualPublisherProbe<int>();
                 var c1 = this.CreateManualSubscriberProbe<int>();

--- a/src/core/Akka.Streams.Tests/Dsl/GraphBroadcastSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphBroadcastSpec.cs
@@ -31,9 +31,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Broadcast_must_broadcast_to_other_subscriber()
+        public async Task A_Broadcast_must_broadcast_to_other_subscriber()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c1 = this.CreateManualSubscriberProbe<int>();
                 var c2 = this.CreateManualSubscriberProbe<int>();
@@ -67,9 +67,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Broadcast_must_work_with_one_way_broadcast()
+        public async Task A_Broadcast_must_work_with_one_way_broadcast()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = Source.FromGraph(GraphDsl.Create(b =>
                 {
@@ -91,9 +91,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Broadcast_must_work_with_n_way_broadcast()
+        public async Task A_Broadcast_must_work_with_n_way_broadcast()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var headSink = Sink.First<IEnumerable<int>>();
 
@@ -120,9 +120,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact(Skip="We don't have enough overloads for GraphDsl.Create")]
-        public void A_Broadcast_must_with_22_way_broadcast()
+        public async Task A_Broadcast_must_with_22_way_broadcast()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 //var headSink = Sink.First<IEnumerable<int>>();
 
@@ -167,9 +167,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Broadcast_must_produce_to_other_even_though_downstream_cancels()
+        public async Task A_Broadcast_must_produce_to_other_even_though_downstream_cancels()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c1 = this.CreateManualSubscriberProbe<int>();
                 var c2 = this.CreateManualSubscriberProbe<int>();
@@ -197,9 +197,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Broadcast_must_produce_to_downstream_even_though_other_cancels()
+        public async Task A_Broadcast_must_produce_to_downstream_even_though_other_cancels()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c1 = this.CreateManualSubscriberProbe<int>();
                 var c2 = this.CreateManualSubscriberProbe<int>();
@@ -227,9 +227,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Broadcast_must_cancel_upstream_when_downstreams_cancel()
+        public async Task A_Broadcast_must_cancel_upstream_when_downstreams_cancel()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p1 = this.CreateManualPublisherProbe<int>();
                 var c1 = this.CreateManualSubscriberProbe<int>();
@@ -268,9 +268,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Broadcast_must_pass_along_early_cancellation()
+        public async Task A_Broadcast_must_pass_along_early_cancellation()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c1 = this.CreateManualSubscriberProbe<int>();
                 var c2 = this.CreateManualSubscriberProbe<int>();
@@ -299,9 +299,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Broadcast_must_AltoTo_must_broadcast()
+        public async Task A_Broadcast_must_AltoTo_must_broadcast()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p = this.SinkProbe<int>();
                 var p2 = this.SinkProbe<int>();
@@ -325,9 +325,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Broadcast_must_AlsoTo_must_continue_if_sink_cancels()
+        public async Task A_Broadcast_must_AlsoTo_must_continue_if_sink_cancels()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p = this.SinkProbe<int>();
                 var p2 = this.SinkProbe<int>();

--- a/src/core/Akka.Streams.Tests/Dsl/GraphConcatSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphConcatSpec.cs
@@ -45,9 +45,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Concat_must_work_in_the_happy_case()
+        public async Task Concat_must_work_in_the_happy_case()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = this.CreateManualSubscriberProbe<int>();
 
@@ -78,9 +78,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Concat_must_work_with_one_immediately_completed_and_one_nonempty_publisher()
+        public async Task Concat_must_work_with_one_immediately_completed_and_one_nonempty_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber1 = Setup(CompletedPublisher<int>(), NonEmptyPublisher(Enumerable.Range(1, 4)));
                 var subscription1 = subscriber1.ExpectSubscription();
@@ -97,9 +97,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Concat_must_work_with_one_delayed_completed_and_one_nonempty_publisher()
+        public async Task Concat_must_work_with_one_delayed_completed_and_one_nonempty_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber1 = Setup(SoonToCompletePublisher<int>(), NonEmptyPublisher(Enumerable.Range(1, 4)));
                 var subscription1 = subscriber1.ExpectSubscription();
@@ -116,9 +116,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Concat_must_work_with_one_immediately_failed_and_one_nonempty_publisher()
+        public async Task Concat_must_work_with_one_immediately_failed_and_one_nonempty_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber1 = Setup(FailedPublisher<int>(), NonEmptyPublisher(Enumerable.Range(1, 4)));
                 subscriber1.ExpectSubscriptionAndError().Should().Be(TestException());
@@ -140,9 +140,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Concat_must_work_with_one_nonempty_publisher_and_one_delayed_failed_and()
+        public async Task Concat_must_work_with_one_nonempty_publisher_and_one_delayed_failed_and()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber = Setup(NonEmptyPublisher(Enumerable.Range(1, 4)), SoonToFailPublisher<int>());
                 subscriber.ExpectSubscription().Request(5);
@@ -161,9 +161,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Concat_must_work_with_one_delayed_failed_and_one_nonempty_publisher()
+        public async Task Concat_must_work_with_one_delayed_failed_and_one_nonempty_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber1 = Setup(SoonToFailPublisher<int>(), NonEmptyPublisher(Enumerable.Range(1, 4)));
                 subscriber1.ExpectSubscriptionAndError().Should().Be(TestException());
@@ -171,9 +171,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Concat_must_correctly_handle_async_errors_in_secondary_upstream()
+        public async Task Concat_must_correctly_handle_async_errors_in_secondary_upstream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var promise = new TaskCompletionSource<int>();
                 var subscriber = this.CreateManualSubscriberProbe<int>();

--- a/src/core/Akka.Streams.Tests/Dsl/GraphMergeSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphMergeSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -46,9 +47,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Merge_must_work_in_the_happy_case()
+        public async Task A_Merge_must_work_in_the_happy_case()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 // Different input sizes(4 and 6)
                 var source1 = Source.From(Enumerable.Range(0, 4));
@@ -149,9 +150,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Merge_must_work_with_one_immediately_completed_and_one_nonempty_publisher()
+        public async Task A_Merge_must_work_with_one_immediately_completed_and_one_nonempty_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber1 = Setup(CompletedPublisher<int>(), NonEmptyPublisher(Enumerable.Range(1, 4)));
                 var subscription1 = subscriber1.ExpectSubscription();
@@ -166,9 +167,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Merge_must_work_with_one_delayed_completed_and_one_nonempty_publisher()
+        public async Task A_Merge_must_work_with_one_delayed_completed_and_one_nonempty_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber1 = Setup(SoonToCompletePublisher<int>(), NonEmptyPublisher(Enumerable.Range(1, 4)));
                 var subscription1 = subscriber1.ExpectSubscription();
@@ -183,27 +184,27 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact(Skip = "This is nondeterministic, multiple scenarios can happen")]
-        public void A_Merge_must_work_with_one_immediately_failed_and_one_nonempty_publisher()
+        public async Task A_Merge_must_work_with_one_immediately_failed_and_one_nonempty_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
 
             }, Materializer);
         }
 
         [Fact(Skip = "This is nondeterministic, multiple scenarios can happen")]
-        public void A_Merge_must_work_with_one_delayed_failed_and_one_nonempty_publisher()
+        public async Task A_Merge_must_work_with_one_delayed_failed_and_one_nonempty_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
 
             }, Materializer);
         }
 
         [Fact]
-        public void A_Merge_must_pass_along_early_cancellation()
+        public async Task A_Merge_must_pass_along_early_cancellation()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var up1 = this.CreateManualPublisherProbe<int>();
                 var up2 = this.CreateManualPublisherProbe<int>();

--- a/src/core/Akka.Streams.Tests/Dsl/GraphPartitionSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphPartitionSpec.cs
@@ -32,9 +32,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Partition_must_partition_to_three_subscribers()
+        public async Task A_Partition_must_partition_to_three_subscribers()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var s = Sink.Seq<int>();
                 var t = RunnableGraph.FromGraph(GraphDsl.Create(s, s, s, ValueTuple.Create, (b, sink1, sink2, sink3) =>
@@ -61,9 +61,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Partition_must_complete_stage_after_upstream_completes()
+        public async Task A_Partition_must_complete_stage_after_upstream_completes()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c1 = this.CreateSubscriberProbe<string>();
                 var c2 = this.CreateSubscriberProbe<string>();
@@ -90,9 +90,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Partition_must_remember_first_pull_even_thought_first_element_target_another_out()
+        public async Task A_Partition_must_remember_first_pull_even_thought_first_element_target_another_out()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c1 = this.CreateSubscriberProbe<int>();
                 var c2 = this.CreateSubscriberProbe<int>();
@@ -120,9 +120,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Partition_must_cancel_upstream_when_downstreams_cancel()
+        public async Task A_Partition_must_cancel_upstream_when_downstreams_cancel()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p1 = this.CreatePublisherProbe<int>();
                 var c1 = this.CreateSubscriberProbe<int>();
@@ -162,9 +162,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Partition_must_work_with_merge()
+        public async Task A_Partition_must_work_with_merge()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var s = Sink.Seq<int>();
                 var input = new[] {5, 2, 9, 1, 1, 1, 10};
@@ -189,9 +189,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Partition_must_stage_completion_is_waiting_for_pending_output()
+        public async Task A_Partition_must_stage_completion_is_waiting_for_pending_output()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c1 = this.CreateSubscriberProbe<int>();
                 var c2 = this.CreateSubscriberProbe<int>();
@@ -218,9 +218,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Partition_must_fail_stage_if_partitioner_outcome_is_out_of_bound()
+        public async Task A_Partition_must_fail_stage_if_partitioner_outcome_is_out_of_bound()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c1 = this.CreateSubscriberProbe<int>();
 

--- a/src/core/Akka.Streams.Tests/Dsl/GraphUnzipSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphUnzipSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -28,9 +29,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Unzip_must_unzip_to_two_subscribers()
+        public async Task A_Unzip_must_unzip_to_two_subscribers()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c1 = this.CreateManualSubscriberProbe<int>();
                 var c2 = this.CreateManualSubscriberProbe<string>();
@@ -76,9 +77,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Unzip_must_produce_to_right_downstream_even_though_left_downstream_cancels()
+        public async Task A_Unzip_must_produce_to_right_downstream_even_though_left_downstream_cancels()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c1 = this.CreateManualSubscriberProbe<int>();
                 var c2 = this.CreateManualSubscriberProbe<string>();
@@ -112,9 +113,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Unzip_must_produce_to_left_downstream_even_though_right_downstream_cancels()
+        public async Task A_Unzip_must_produce_to_left_downstream_even_though_right_downstream_cancels()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c1 = this.CreateManualSubscriberProbe<int>();
                 var c2 = this.CreateManualSubscriberProbe<string>();
@@ -211,9 +212,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Unzip_must_cancel_upstream_when_downstream_cancel()
+        public async Task A_Unzip_must_cancel_upstream_when_downstream_cancel()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p1 = this.CreateManualPublisherProbe<KeyValuePair<int, string>>();
                 var c1 = this.CreateManualSubscriberProbe<int>();
@@ -251,9 +252,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Unzip_must_work_with_Zip()
+        public async Task A_Unzip_must_work_with_Zip()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c1 = this.CreateManualSubscriberProbe<(int, string)>();
 

--- a/src/core/Akka.Streams.Tests/Dsl/GraphUnzipWithSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphUnzipWithSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -31,9 +32,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void UnzipWith_must_work_with_immediately_completed_publisher()
+        public async Task UnzipWith_must_work_with_immediately_completed_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscribers = Setup(TestPublisher.Empty<int>());
                 ValidateSubscriptionAndComplete(subscribers);
@@ -41,9 +42,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void UnzipWith_must_work_with_delayed_completed_publisher()
+        public async Task UnzipWith_must_work_with_delayed_completed_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscribers = Setup(TestPublisher.LazyEmpty<int>());
                 ValidateSubscriptionAndComplete(subscribers);
@@ -51,9 +52,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void UnzipWith_must_work_with_two_immediately_failed_publisher()
+        public async Task UnzipWith_must_work_with_two_immediately_failed_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscribers = Setup(TestPublisher.Error<int>(TestException));
                 ValidateSubscriptionAndError(subscribers);
@@ -61,9 +62,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void UnzipWith_must_work_with_two_delayed_failed_publisher()
+        public async Task UnzipWith_must_work_with_two_delayed_failed_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscribers = Setup(TestPublisher.LazyError<int>(TestException));
                 ValidateSubscriptionAndError(subscribers);
@@ -71,9 +72,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void UnzipWith_must_work_in_the_happy_case()
+        public async Task UnzipWith_must_work_in_the_happy_case()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var leftProbe = this.CreateManualSubscriberProbe<int>();
                 var rightProbe = this.CreateManualSubscriberProbe<string>();
@@ -127,9 +128,9 @@ namespace Akka.Streams.Tests.Dsl
         }
         
         [Fact]
-        public void UnzipWith_must_work_in_the_sad_case()
+        public async Task UnzipWith_must_work_in_the_sad_case()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var leftProbe = this.CreateManualSubscriberProbe<int>();
                 var rightProbe = this.CreateManualSubscriberProbe<string>();
@@ -174,9 +175,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void UnzipWith_must_unzipWith_expanded_Person_unapply_3_outputs()
+        public async Task UnzipWith_must_unzipWith_expanded_Person_unapply_3_outputs()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe0 = this.CreateManualSubscriberProbe<string>();
                 var probe1 = this.CreateManualSubscriberProbe<string>();
@@ -214,11 +215,11 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void UnzipWith_must_work_with_up_to_6_outputs()
+        public async Task UnzipWith_must_work_with_up_to_6_outputs()
         {
             // the jvm version uses 20 outputs but we have only 7 so changed this spec a little bit
 
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe0 = this.CreateManualSubscriberProbe<int>();
                 var probe1 = this.CreateManualSubscriberProbe<string>();

--- a/src/core/Akka.Streams.Tests/Dsl/GraphZipSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphZipSpec.cs
@@ -44,9 +44,9 @@ namespace Akka.Streams.Tests.Dsl
         }
         
         [Fact]
-        public void Zip_must_work_in_the_happy_case()
+        public async Task Zip_must_work_in_the_happy_case()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = this.CreateManualSubscriberProbe<(int, string)>();
 
@@ -77,9 +77,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Zip_must_complete_if_one_side_is_available_but_other_already_completed()
+        public async Task Zip_must_complete_if_one_side_is_available_but_other_already_completed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var upstream1 = this.CreatePublisherProbe<int>();
                 var upstream2 = this.CreatePublisherProbe<string>();
@@ -108,9 +108,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Zip_must_complete_even_if_no_pending_demand()
+        public async Task Zip_must_complete_even_if_no_pending_demand()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var upstream1 = this.CreatePublisherProbe<int>();
                 var upstream2 = this.CreatePublisherProbe<string>();
@@ -142,9 +142,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Zip_must_complete_if_both_sides_complete_before_requested_with_elements_pending_2()
+        public async Task Zip_must_complete_if_both_sides_complete_before_requested_with_elements_pending_2()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var upstream1 = this.CreatePublisherProbe<int>();
                 var upstream2 = this.CreatePublisherProbe<string>();
@@ -175,9 +175,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Zip_must_complete_if_one_side_complete_before_requested_with_elements_pending()
+        public async Task Zip_must_complete_if_one_side_complete_before_requested_with_elements_pending()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var upstream1 = this.CreatePublisherProbe<int>();
                 var upstream2 = this.CreatePublisherProbe<string>();
@@ -209,9 +209,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Zip_must_complete_if_one_side_complete_before_requested_with_elements_pending_2()
+        public async Task Zip_must_complete_if_one_side_complete_before_requested_with_elements_pending_2()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var upstream1 = this.CreatePublisherProbe<int>();
                 var upstream2 = this.CreatePublisherProbe<string>();
@@ -245,9 +245,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Zip_must_work_with_one_immediately_completed_and_one_nonempty_publisher()
+        public async Task Zip_must_work_with_one_immediately_completed_and_one_nonempty_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber1 = Setup(CompletedPublisher<int>(), NonEmptyPublisher(Enumerable.Range(1, 4)));
                 subscriber1.ExpectSubscriptionAndComplete();
@@ -258,9 +258,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Zip_must_work_with_one_delayed_completed_and_one_nonempty_publisher()
+        public async Task Zip_must_work_with_one_delayed_completed_and_one_nonempty_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber1 = Setup(SoonToCompletePublisher<int>(), NonEmptyPublisher(Enumerable.Range(1, 4)));
                 subscriber1.ExpectSubscriptionAndComplete();
@@ -271,9 +271,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Zip_must_work_with_one_immediately_failed_and_one_nonempty_publisher()
+        public async Task Zip_must_work_with_one_immediately_failed_and_one_nonempty_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber1 = Setup(FailedPublisher<int>(), NonEmptyPublisher(Enumerable.Range(1, 4)));
                 subscriber1.ExpectSubscriptionAndError().Should().Be(TestException());
@@ -284,9 +284,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Zip_must_work_with_one_delayed_failed_and_one_nonempty_publisher()
+        public async Task Zip_must_work_with_one_delayed_failed_and_one_nonempty_publisher()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber1 = Setup(SoonToFailPublisher<int>(), NonEmptyPublisher(Enumerable.Range(1, 4)));
                 subscriber1.ExpectSubscriptionAndError().Should().Be(TestException());

--- a/src/core/Akka.Streams.Tests/Dsl/GraphZipWithSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphZipWithSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -88,9 +89,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void ZipWith_must_work_in_the_happy_case()
+        public async Task ZipWith_must_work_in_the_happy_case()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = this.CreateManualSubscriberProbe<int>();
 
@@ -124,9 +125,9 @@ namespace Akka.Streams.Tests.Dsl
 
 
         [Fact]
-        public void ZipWith_must_work_in_the_sad_case()
+        public async Task ZipWith_must_work_in_the_sad_case()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = this.CreateManualSubscriberProbe<int>();
 
@@ -154,9 +155,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void ZipWith_must_ZipWith_expanded_Person_unapply_3_outputs()
+        public async Task ZipWith_must_ZipWith_expanded_Person_unapply_3_outputs()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = this.CreateManualSubscriberProbe<Person>();
 
@@ -185,11 +186,11 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void ZipWith_must_work_with_up_to_9_inputs()
+        public async Task ZipWith_must_work_with_up_to_9_inputs()
         {
             // the jvm version uses 19 inputs but we have only 9
 
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = this.CreateManualSubscriberProbe<string>();
 

--- a/src/core/Akka.Streams.Tests/Dsl/HeadSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/HeadSinkSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -26,9 +27,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_FLow_with_a_Sink_Head_must_yield_the_first_value()
+        public async Task A_FLow_with_a_Sink_Head_must_yield_the_first_value()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p = this.CreateManualPublisherProbe<int>();
                 var task = Source.FromPublisher(p).Select(x=>x).RunWith(Sink.First<int>(), Materializer);
@@ -61,9 +62,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_FLow_with_a_Sink_Head_must_yield_the_first_error()
+        public async Task A_FLow_with_a_Sink_Head_must_yield_the_first_error()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.Failed<int>(new Exception("ex"))
                     .Invoking(s => s.RunWith(Sink.First<int>(), Materializer).Wait(TimeSpan.FromSeconds(1)))
@@ -74,9 +75,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_FLow_with_a_Sink_Head_must_yield_NoSuchElementException_for_empty_stream()
+        public async Task A_FLow_with_a_Sink_Head_must_yield_NoSuchElementException_for_empty_stream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.Empty<int>()
                     .Invoking(s => s.RunWith(Sink.First<int>(), Materializer).Wait(TimeSpan.FromSeconds(1)))
@@ -89,9 +90,9 @@ namespace Akka.Streams.Tests.Dsl
 
 
         [Fact]
-        public void A_FLow_with_a_Sink_HeadOption_must_yield_the_first_value()
+        public async Task A_FLow_with_a_Sink_HeadOption_must_yield_the_first_value()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p = this.CreateManualPublisherProbe<int>();
                 var task = Source.FromPublisher(p).Select(x => x).RunWith(Sink.FirstOrDefault<int>(), Materializer);
@@ -105,9 +106,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_FLow_with_a_Sink_HeadOption_must_yield_the_first_error()
+        public async Task A_FLow_with_a_Sink_HeadOption_must_yield_the_first_error()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.Failed<int>(new Exception("ex"))
                     .Invoking(s => s.RunWith(Sink.FirstOrDefault<int>(), Materializer).Wait(TimeSpan.FromSeconds(1)))
@@ -118,9 +119,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_FLow_with_a_Sink_HeadOption_must_yield_default_for_empty_stream()
+        public async Task A_FLow_with_a_Sink_HeadOption_must_yield_default_for_empty_stream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = Source.Empty<int>().RunWith(Sink.FirstOrDefault<int>(), Materializer);
                 task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();

--- a/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
@@ -33,9 +33,9 @@ namespace Akka.Streams.Tests.Dsl
         public ActorMaterializer Materializer { get; }
 
         [Fact]
-        public void MergeHub_must_work_in_the_happy_case()
+        public async Task MergeHub_must_work_in_the_happy_case()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = MergeHub.Source<int>(16).Take(20).ToMaterialized(Sink.Seq<int>(), Keep.Both).Run(Materializer);
                 var sink = t.Item1;
@@ -48,9 +48,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void MergeHub_must_notify_new_producers_if_consumer_cancels_before_first_producer()
+        public async Task MergeHub_must_notify_new_producers_if_consumer_cancels_before_first_producer()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var sink = Sink.Cancelled<int>().RunWith(MergeHub.Source<int>(16), Materializer);
                 var upstream = this.CreatePublisherProbe<int>();
@@ -62,9 +62,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void MergeHub_must_notify_existing_producers_if_consumer_cancels_after_a_few_elements()
+        public async Task MergeHub_must_notify_existing_producers_if_consumer_cancels_after_a_few_elements()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = MergeHub.Source<int>(16).Take(5).ToMaterialized(Sink.Seq<int>(), Keep.Both).Run(Materializer);
                 var sink = t.Item1;
@@ -81,9 +81,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void MergeHub_must_notify_new_producers_if_consumer_cancels_after_a_few_elements()
+        public async Task MergeHub_must_notify_new_producers_if_consumer_cancels_after_a_few_elements()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = MergeHub.Source<int>(16).Take(5).ToMaterialized(Sink.Seq<int>(), Keep.Both).Run(Materializer);
                 var sink = t.Item1;
@@ -104,9 +104,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void MergeHub_must_respect_the_buffer_size()
+        public async Task MergeHub_must_respect_the_buffer_size()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var downstream = this.CreateManualSubscriberProbe<int>();
                 var sink = Sink.FromSubscriber(downstream).RunWith(MergeHub.Source<int>(3), Materializer);
@@ -162,9 +162,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void MergeHub_must_work_with_long_streams()
+        public async Task MergeHub_must_work_with_long_streams()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = MergeHub.Source<int>(16).Take(20000).ToMaterialized(Sink.Seq<int>(), Keep.Both)
                     .Run(Materializer);
@@ -179,9 +179,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void MergeHub_must_work_with_long_streams_when_buffer_size_is_1()
+        public async Task MergeHub_must_work_with_long_streams_when_buffer_size_is_1()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = MergeHub.Source<int>(1).Take(20000).ToMaterialized(Sink.Seq<int>(), Keep.Both)
                     .Run(Materializer);
@@ -196,9 +196,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void MergeHub_must_work_with_long_streams_when_consumer_is_slower()
+        public async Task MergeHub_must_work_with_long_streams_when_consumer_is_slower()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = MergeHub.Source<int>(16)
                     .Take(2000)
@@ -217,9 +217,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void MergeHub_must_work_with_long_streams_if_one_of_the_producers_is_slower()
+        public async Task MergeHub_must_work_with_long_streams_if_one_of_the_producers_is_slower()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = MergeHub.Source<int>(16).Take(2000).ToMaterialized(Sink.Seq<int>(), Keep.Both)
                     .Run(Materializer);
@@ -236,9 +236,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void MergeHub_must_work_with_different_producers_separated_over_time()
+        public async Task MergeHub_must_work_with_different_producers_separated_over_time()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var downstream = this.CreateSubscriberProbe<IEnumerable<int>>();
                 var sink = MergeHub.Source<int>(16)
@@ -256,9 +256,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void MergeHub_must_keep_working_even_if_one_of_the_producers_fail()
+        public async Task MergeHub_must_keep_working_even_if_one_of_the_producers_fail()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = MergeHub.Source<int>(16).Take(10).ToMaterialized(Sink.Seq<int>(), Keep.Both).Run(Materializer);
                 var sink = t.Item1;
@@ -275,9 +275,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void BroadcastHub_must_work_in_the_happy_case()
+        public async Task BroadcastHub_must_work_in_the_happy_case()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var source = Source.From(Enumerable.Range(1, 10)).RunWith(BroadcastHub.Sink<int>(8), Materializer);
                 source.RunWith(Sink.Seq<int>(), Materializer)
@@ -287,9 +287,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void BroadcastHub_must_send_the_same_elements_to_consumers_attaching_around_the_same_time()
+        public async Task BroadcastHub_must_send_the_same_elements_to_consumers_attaching_around_the_same_time()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var other = Source.From(Enumerable.Range(2, 9))
                     .MapMaterializedValue<TaskCompletionSource<int>>(_ => null);
@@ -312,9 +312,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void BroadcastHub_must_send_the_same_prefix_to_consumers_attaching_around_the_same_time_if_one_cancels_earlier()
+        public async Task BroadcastHub_must_send_the_same_prefix_to_consumers_attaching_around_the_same_time_if_one_cancels_earlier()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var other = Source.From(Enumerable.Range(2, 19))
                     .MapMaterializedValue<TaskCompletionSource<int>>(_ => null);
@@ -337,9 +337,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void BroadcastHub_must_ensure_that_subsequent_consumers_see_subsequent_elements_without_gap()
+        public async Task BroadcastHub_must_ensure_that_subsequent_consumers_see_subsequent_elements_without_gap()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var source = Source.From(Enumerable.Range(1, 20)).RunWith(BroadcastHub.Sink<int>(8), Materializer);
                 source.Take(10)
@@ -354,9 +354,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void BroadcastHub_must_send_the_same_elements_to_consumers_of_different_speed_attaching_around_the_same_time()
+        public async Task BroadcastHub_must_send_the_same_elements_to_consumers_of_different_speed_attaching_around_the_same_time()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var other = Source.From(Enumerable.Range(2, 9))
                     .MapMaterializedValue<TaskCompletionSource<int>>(_ => null);
@@ -380,9 +380,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void BroadcastHub_must_send_the_same_elements_to_consumers_of_attaching_around_the_same_time_if_the_producer_is_slow()
+        public async Task BroadcastHub_must_send_the_same_elements_to_consumers_of_attaching_around_the_same_time_if_the_producer_is_slow()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var other = Source.From(Enumerable.Range(2, 9))
                     .MapMaterializedValue<TaskCompletionSource<int>>(_ => null);
@@ -406,9 +406,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void BroadcastHub_must_ensure_that_from_two_different_speed_consumers_the_slower_controls_the_rate()
+        public async Task BroadcastHub_must_ensure_that_from_two_different_speed_consumers_the_slower_controls_the_rate()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var other = Source.From(Enumerable.Range(2, 19))
                     .MapMaterializedValue<TaskCompletionSource<int>>(_ => null);
@@ -436,9 +436,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void BroadcastHub_must_send_the_same_elements_to_consumers_attaching_around_the_same_time_with_a_buffer_size_of_one()
+        public async Task BroadcastHub_must_send_the_same_elements_to_consumers_attaching_around_the_same_time_with_a_buffer_size_of_one()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var other = Source.From(Enumerable.Range(2, 9))
                     .MapMaterializedValue<TaskCompletionSource<int>>(_ => null);
@@ -461,9 +461,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void BroadcastHub_must_be_able_to_implement_a_keep_dropping_if_unsubscribed_policy_with_a_simple_SinkIgnore()
+        public async Task BroadcastHub_must_be_able_to_implement_a_keep_dropping_if_unsubscribed_policy_with_a_simple_SinkIgnore()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var killSwitch = KillSwitches.Shared("test-switch");
                 var source = Source.From(Enumerable.Range(1, int.MaxValue))
@@ -514,9 +514,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void BroadcastHub_must_properly_signal_error_to_consumers()
+        public async Task BroadcastHub_must_properly_signal_error_to_consumers()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var upstream = this.CreatePublisherProbe<int>();
                 var source = Source.FromPublisher(upstream).RunWith(BroadcastHub.Sink<int>(8), Materializer);
@@ -544,9 +544,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void BroadcastHub_must_properly_signal_completion_to_consumers_arriving_after_producer_finished()
+        public async Task BroadcastHub_must_properly_signal_completion_to_consumers_arriving_after_producer_finished()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var source = Source.Empty<int>().RunWith(BroadcastHub.Sink<int>(8), Materializer);
                 // Wait enough so the Hub gets the completion. This is racy, but this is fine because both
@@ -558,9 +558,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void BroadcastHub_must_properly_signal_error_to_consumers_arriving_after_producer_finished()
+        public async Task BroadcastHub_must_properly_signal_error_to_consumers_arriving_after_producer_finished()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var source = Source.Failed<int>(new TestException("Fail!"))
                     .RunWith(BroadcastHub.Sink<int>(8), Materializer);
@@ -574,9 +574,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PartitionHub_must_work_in_the_happy_case_with_one_stream()
+        public async Task PartitionHub_must_work_in_the_happy_case_with_one_stream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var items = Enumerable.Range(1, 10).ToList();
                 var source = Source.From(items)
@@ -587,9 +587,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PartitionHub_must_work_in_the_happy_case_with_two_streams()
+        public async Task PartitionHub_must_work_in_the_happy_case_with_two_streams()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var source = Source.From(Enumerable.Range(0, 10))
                     .RunWith(PartitionHub.Sink<int>((size, e) => e % size, 2, 8), Materializer);
@@ -603,9 +603,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PartitionHub_must_be_able_to_use_as_rount_robin_router()
+        public async Task PartitionHub_must_be_able_to_use_as_rount_robin_router()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var source = Source.From(Enumerable.Range(0, 10))
                     .RunWith(PartitionHub.StatefulSink<int>(() =>
@@ -625,9 +625,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PartitionHub_must_be_able_to_use_as__sticky_session_rount_robin_router()
+        public async Task PartitionHub_must_be_able_to_use_as__sticky_session_rount_robin_router()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var source = Source.From(new[] { "usr-1", "usr-2", "usr-1", "usr-3" })
                     .RunWith(PartitionHub.StatefulSink<string>(() =>
@@ -652,9 +652,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PartitionHub_must_be_able_to_use_as_fastest_consumer_router()
+        public async Task PartitionHub_must_be_able_to_use_as_fastest_consumer_router()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var items = Enumerable.Range(0, 999).ToList();
                 var source = Source.From(items)
@@ -670,9 +670,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PartitionHub_must_route_evenly()
+        public async Task PartitionHub_must_route_evenly()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = this.SourceProbe<int>()
                     .ToMaterialized(PartitionHub.Sink<int>((size, e) => e % size, 2, 8), Keep.Both)
@@ -715,9 +715,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PartitionHub_must_route_unevenly()
+        public async Task PartitionHub_must_route_unevenly()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = this.SourceProbe<int>()
                     .ToMaterialized(PartitionHub.Sink<int>((size, e) => (e % 3) % 2, 2, 8), Keep.Both)
@@ -756,9 +756,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PartitionHub_must_backpressure()
+        public async Task PartitionHub_must_backpressure()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = this.SourceProbe<int>()
                     .ToMaterialized(PartitionHub.Sink<int>((size, e) => 0, 2, 4), Keep.Both)
@@ -790,9 +790,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PartitionHub_must_ensure_that_from_two_different_speed_consumers_the_slower_controls_the_rate()
+        public async Task PartitionHub_must_ensure_that_from_two_different_speed_consumers_the_slower_controls_the_rate()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = Source.Maybe<int>().ConcatMaterialized(Source.From(Enumerable.Range(1, 19)), Keep.Left)
                     .ToMaterialized(PartitionHub.Sink<int>((size, e) => e % size, 2, 1), Keep.Both)
@@ -824,9 +824,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PartitionHub_must_properly_signal_error_to_consumer()
+        public async Task PartitionHub_must_properly_signal_error_to_consumer()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var upstream = this.CreatePublisherProbe<int>();
                 var source = Source.FromPublisher(upstream)
@@ -857,9 +857,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PartitionHub_must_properly_signal_completion_to_consumers_arriving_after_producer_finished()
+        public async Task PartitionHub_must_properly_signal_completion_to_consumers_arriving_after_producer_finished()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var source = Source.Empty<int>().RunWith(PartitionHub.Sink<int>((s, e) => e % s, 0), Materializer);
                 // Wait enough so the Hub gets the completion. This is racy, but this is fine because both
@@ -871,7 +871,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PartitionHub_must_remeber_completion_for_materialisations_after_completion()
+        public async Task PartitionHub_must_remeber_completion_for_materialisations_after_completion()
         {
             var t = this.SourceProbe<NotUsed>().ToMaterialized(PartitionHub.Sink<NotUsed>((s, e) => 0, 0), Keep.Both)
                 .Run(Materializer);
@@ -893,9 +893,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void PartitionHub_must_properly_signal_error_to_consumer_arriving_after_producer_finished()
+        public async Task PartitionHub_must_properly_signal_error_to_consumer_arriving_after_producer_finished()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var failure = new TestException("Fail!");
                 var source = Source.Failed<int>(failure).RunWith(PartitionHub.Sink<int>((s, e) => 0, 0), Materializer);

--- a/src/core/Akka.Streams.Tests/Dsl/LastSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/LastSinkSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit.Tests;
 using FluentAssertions;
@@ -26,9 +27,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_Sink_Last_must_yield_the_last_value()
+        public async Task A_Flow_with_Sink_Last_must_yield_the_last_value()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = Source.From(Enumerable.Range(1,42)).Select(x=>x).RunWith(Sink.Last<int>(), Materializer);
                 task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
@@ -37,9 +38,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_Sink_Last_must_yield_the_first_error()
+        public async Task A_Flow_with_Sink_Last_must_yield_the_first_error()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.Failed<int>(new Exception("ex"))
                     .Invoking(s => s.RunWith(Sink.Last<int>(), Materializer).Wait(TimeSpan.FromSeconds(1)))
@@ -50,9 +51,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_Sink_Last_must_yield_NoSuchElementException_for_empty_stream()
+        public async Task A_Flow_with_Sink_Last_must_yield_NoSuchElementException_for_empty_stream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.Empty<int>()
                     .Invoking(s => s.RunWith(Sink.Last<int>(), Materializer).Wait(TimeSpan.FromSeconds(1)))
@@ -64,9 +65,9 @@ namespace Akka.Streams.Tests.Dsl
 
 
         [Fact]
-        public void A_Flow_with_Sink_LastOption_must_yield_the_last_value()
+        public async Task A_Flow_with_Sink_LastOption_must_yield_the_last_value()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = Source.From(Enumerable.Range(1, 42)).Select(x => x).RunWith(Sink.LastOrDefault<int>(), Materializer);
                 task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
@@ -75,9 +76,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_Sink_LastOption_must_yield_the_first_error()
+        public async Task A_Flow_with_Sink_LastOption_must_yield_the_first_error()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.Failed<int>(new Exception("ex"))
                     .Invoking(s => s.RunWith(Sink.LastOrDefault<int>(), Materializer).Wait(TimeSpan.FromSeconds(1)))
@@ -88,9 +89,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_Sink_LastOption_must_yield_default_for_empty_stream()
+        public async Task A_Flow_with_Sink_LastOption_must_yield_default_for_empty_stream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = Source.Empty<int>().RunWith(Sink.LastOrDefault<int>(), Materializer);
                 task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();

--- a/src/core/Akka.Streams.Tests/Dsl/LazySinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/LazySinkSpec.cs
@@ -43,9 +43,9 @@ namespace Akka.Streams.Tests.Dsl
         private static readonly Exception Ex = new TestException("");
 
         [Fact]
-        public void A_LazySink_must_work_in_the_happy_case()
+        public async Task A_LazySink_must_work_in_the_happy_case()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var lazySink = Sink.LazySink((int _) => Task.FromResult(this.SinkProbe<int>()),
                     Fallback<TestSubscriber.Probe<int>>());
@@ -57,9 +57,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_LazySink_must_work_with_slow_sink_init()
+        public async Task A_LazySink_must_work_with_slow_sink_init()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p = new TaskCompletionSource<Sink<int, TestSubscriber.Probe<int>>>();
                 var sourceProbe = this.CreateManualPublisherProbe<int>();
@@ -87,9 +87,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_LazySink_must_complete_when_there_was_no_elements_in_stream()
+        public async Task A_LazySink_must_complete_when_there_was_no_elements_in_stream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var lazySink = Sink.LazySink((int _) => Task.FromResult(Sink.Aggregate(0, (int i, int i2) => i + i2)),
                     () => Task.FromResult(0));
@@ -100,9 +100,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_LazySink_must_complete_normally_when_upstream_is_completed()
+        public async Task A_LazySink_must_complete_normally_when_upstream_is_completed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var lazySink = Sink.LazySink((int _) => Task.FromResult(this.SinkProbe<int>()),
                     Fallback<TestSubscriber.Probe<int>>());
@@ -113,9 +113,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_LazySink_must_fail_gracefully_when_sink_factory_method_failed()
+        public async Task A_LazySink_must_fail_gracefully_when_sink_factory_method_failed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var sourceProbe = this.CreateManualPublisherProbe<int>();
                 var taskProbe = Source.FromPublisher(sourceProbe).RunWith(Sink.LazySink((int _) =>
@@ -132,9 +132,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_LazySink_must_fail_gracefully_when_upstream_failed()
+        public async Task A_LazySink_must_fail_gracefully_when_upstream_failed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var sourceProbe = this.CreateManualPublisherProbe<int>();
                 var lazySink = Sink.LazySink((int _) => Task.FromResult(this.SinkProbe<int>()),
@@ -152,9 +152,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_LazySink_must_fail_gracefully_when_factory_task_failed()
+        public async Task A_LazySink_must_fail_gracefully_when_factory_task_failed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var failedTask = new TaskFactory<Sink<int, TestSubscriber.Probe<int>>>().StartNew(() =>
                 {
@@ -176,9 +176,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_LazySink_must_cancel_upstream_when_internal_sink_is_cancelled()
+        public async Task A_LazySink_must_cancel_upstream_when_internal_sink_is_cancelled()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var sourceProbe = this.CreateManualPublisherProbe<int>();
                 var lazySink = Sink.LazySink((int _) => Task.FromResult(this.SinkProbe<int>()),
@@ -196,9 +196,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_LazySink_must_continue_if_supervision_is_resume()
+        public async Task A_LazySink_must_continue_if_supervision_is_resume()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var sourceProbe = this.CreateManualPublisherProbe<int>();
                 var lazySink = Sink.LazySink((int a) =>
@@ -226,9 +226,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_LazySink_must_fail_task_when_zero_throws_exception()
+        public async Task A_LazySink_must_fail_task_when_zero_throws_exception()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var lazySink = Sink.LazySink((int _) => Task.FromResult(Sink.Aggregate<int, int>(0, (i, i1) => i + i1)),
                     () =>
@@ -241,9 +241,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_LazySink_must_fail_correctly_when_materialization_of_inner_sink_fails()
+        public async Task A_LazySink_must_fail_correctly_when_materialization_of_inner_sink_fails()
         {
-            this.AssertAllStagesStopped(() => 
+            await this.AssertAllStagesStoppedAsync(() => 
             {
                 var matFail = new TestException("fail!");
 

--- a/src/core/Akka.Streams.Tests/Dsl/LazySourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/LazySourceSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.Stage;
 using Akka.Streams.TestKit;
@@ -29,9 +30,9 @@ namespace Akka.Streams.Tests.Dsl
         private ActorMaterializer Materializer { get; }
 
         [Fact]
-        public void A_lazy_source_must_work_like_a_normal_source_happy_path()
+        public async Task A_lazy_source_must_work_like_a_normal_source_happy_path()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var result = Source.Lazily(() => Source.From(new[] { 1, 2, 3 })).RunWith(Sink.Seq<int>(), Materializer);
                 result.AwaitResult().Should().BeEquivalentTo(ImmutableList.Create(1, 2, 3));
@@ -39,9 +40,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_lazy_source_must_work_never_construct_the_source_when_there_was_no_demand()
+        public async Task A_lazy_source_must_work_never_construct_the_source_when_there_was_no_demand()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = this.CreateSubscriberProbe<int>();
                 var constructed = new AtomicBoolean();
@@ -57,9 +58,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_lazy_source_must_fail_the_materialized_value_when_downstream_cancels_without_ever_consuming_any_element()
+        public async Task A_lazy_source_must_fail_the_materialized_value_when_downstream_cancels_without_ever_consuming_any_element()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var result = Source.Lazily(() => Source.From(new[] { 1, 2, 3 }))
                     .ToMaterialized(Sink.Cancelled<int>(), Keep.Left)
@@ -73,9 +74,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_lazy_source_must_stop_consuming_when_downstream_has_cancelled()
+        public async Task A_lazy_source_must_stop_consuming_when_downstream_has_cancelled()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var outProbe = this.CreateSubscriberProbe<int>();
                 var inProbe = this.CreatePublisherProbe<int>();
@@ -92,9 +93,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_lazy_source_must_materialize_when_the_source_has_been_created()
+        public async Task A_lazy_source_must_materialize_when_the_source_has_been_created()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = this.CreateSubscriberProbe<int>();
 
@@ -112,9 +113,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_lazy_source_must_fail_stage_when_upstream_fails()
+        public async Task A_lazy_source_must_fail_stage_when_upstream_fails()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var outProbe = this.CreateSubscriberProbe<int>();
                 var inProbe = this.CreatePublisherProbe<int>();
@@ -133,9 +134,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_lazy_source_must_propagate_attributes_to_inner_stream()
+        public async Task A_lazy_source_must_propagate_attributes_to_inner_stream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var attributesSource = Source.FromGraph(new AttibutesSourceStage())
                     .AddAttributes(Attributes.CreateName("inner"));
@@ -154,9 +155,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_lazy_source_must_fail_correctly_when_materialization_of_inner_source_fails()
+        public async Task A_lazy_source_must_fail_correctly_when_materialization_of_inner_source_fails()
         {
-            this.AssertAllStagesStopped(() => 
+            await this.AssertAllStagesStoppedAsync(() => 
             {
                 var matFail = new TestException("fail!");
 

--- a/src/core/Akka.Streams.Tests/Dsl/ObservableSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/ObservableSourceSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -71,9 +72,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void An_ObservableSource_must_subscribe_to_an_observable()
+        public async Task An_ObservableSource_must_subscribe_to_an_observable()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
 
                 var o = new TestObservable<int>();
@@ -89,9 +90,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void An_ObservableSource_must_receive_events_from_an_observable()
+        public async Task An_ObservableSource_must_receive_events_from_an_observable()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var o = new TestObservable<int>();
                 var s = this.CreateManualSubscriberProbe<int>();
@@ -125,9 +126,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void An_ObservableSource_must_receive_errors_from_an_observable()
+        public async Task An_ObservableSource_must_receive_errors_from_an_observable()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var o = new TestObservable<int>();
                 var s = this.CreateManualSubscriberProbe<int>();
@@ -151,9 +152,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void An_ObservableSource_must_receive_completion_from_an_observable()
+        public async Task An_ObservableSource_must_receive_completion_from_an_observable()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var o = new TestObservable<int>();
                 var s = this.CreateManualSubscriberProbe<int>();
@@ -173,9 +174,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void An_ObservableSource_must_be_able_to_unsubscribe()
+        public async Task An_ObservableSource_must_be_able_to_unsubscribe()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var o = new TestObservable<int>();
                 var s = this.CreateManualSubscriberProbe<int>();
@@ -196,9 +197,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void An_ObservableSource_must_ignore_new_element_on_DropNew_overflow()
+        public async Task An_ObservableSource_must_ignore_new_element_on_DropNew_overflow()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var o = new TestObservable<int>();
                 var s = this.CreateManualSubscriberProbe<int>();
@@ -223,9 +224,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void An_ObservableSource_must_drop_oldest_element_on_DropHead_overflow()
+        public async Task An_ObservableSource_must_drop_oldest_element_on_DropHead_overflow()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var o = new TestObservable<int>();
                 var s = this.CreateManualSubscriberProbe<int>();
@@ -250,9 +251,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void An_ObservableSource_must_drop_newest_element_on_DropTail_overflow()
+        public async Task An_ObservableSource_must_drop_newest_element_on_DropTail_overflow()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var o = new TestObservable<int>();
                 var s = this.CreateManualSubscriberProbe<int>();
@@ -277,9 +278,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void An_ObservableSource_must_fail_on_Fail_overflow()
+        public async Task An_ObservableSource_must_fail_on_Fail_overflow()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var o = new TestObservable<int>();
                 var s = this.CreateManualSubscriberProbe<int>();

--- a/src/core/Akka.Streams.Tests/Dsl/PublisherSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/PublisherSinkSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit.Tests;
 using Akka.TestKit;
@@ -28,9 +29,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_PublisherSink_must_be_unique_when_created_twice()
+        public async Task A_PublisherSink_must_be_unique_when_created_twice()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t =
                     RunnableGraph.FromGraph(

--- a/src/core/Akka.Streams.Tests/Dsl/QueueSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/QueueSinkSpec.cs
@@ -39,9 +39,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void QueueSink_should_send_the_elements_as_result_of_future()
+        public async Task QueueSink_should_send_the_elements_as_result_of_future()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var expected = new List<Option<int>>
                 {
@@ -62,9 +62,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void QueueSink_should_allow_to_have_only_one_future_waiting_for_result_in_each_point_in_time()
+        public async Task QueueSink_should_allow_to_have_only_one_future_waiting_for_result_in_each_point_in_time()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = this.CreateManualPublisherProbe<int>();
                 var queue = Source.FromPublisher(probe).RunWith(Sink.Queue<int>(), _materializer);
@@ -83,9 +83,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void QueueSink_should_wait_for_next_element_from_upstream()
+        public async Task QueueSink_should_wait_for_next_element_from_upstream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = this.CreateManualPublisherProbe<int>();
                 var queue = Source.FromPublisher(probe).RunWith(Sink.Queue<int>(), _materializer);
@@ -102,9 +102,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void QueueSink_should_fail_future_on_stream_failure()
+        public async Task QueueSink_should_fail_future_on_stream_failure()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = this.CreateManualPublisherProbe<int>();
                 var queue = Source.FromPublisher(probe).RunWith(Sink.Queue<int>(), _materializer);
@@ -120,9 +120,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void QueueSink_should_fail_future_when_stream_failed()
+        public async Task QueueSink_should_fail_future_when_stream_failed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = this.CreateManualPublisherProbe<int>();
                 var queue = Source.FromPublisher(probe).RunWith(Sink.Queue<int>(), _materializer);
@@ -135,9 +135,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void QueueSink_should_timeout_future_when_stream_cannot_provide_data()
+        public async Task QueueSink_should_timeout_future_when_stream_cannot_provide_data()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = this.CreateManualPublisherProbe<int>();
                 var queue = Source.FromPublisher(probe).RunWith(Sink.Queue<int>(), _materializer);
@@ -154,9 +154,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void QueueSink_should_fail_pull_future_when_stream_is_completed()
+        public async Task QueueSink_should_fail_pull_future_when_stream_is_completed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = this.CreateManualPublisherProbe<int>();
                 var queue = Source.FromPublisher(probe).RunWith(Sink.Queue<int>(), _materializer);
@@ -179,9 +179,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void QueueSink_should_keep_on_sending_even_after_the_buffer_has_been_full()
+        public async Task QueueSink_should_keep_on_sending_even_after_the_buffer_has_been_full()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 const int bufferSize = 16;
                 const int streamElementCount = bufferSize + 4;
@@ -207,9 +207,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void QueueSink_should_work_with_one_element_buffer()
+        public async Task QueueSink_should_work_with_one_element_buffer()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var sink = Sink.Queue<int>().WithAttributes(Attributes.CreateInputBuffer(1, 1));
                 var probe = this.CreateManualPublisherProbe<int>();

--- a/src/core/Akka.Streams.Tests/Dsl/QueueSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/QueueSourceSpec.cs
@@ -114,9 +114,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void QueueSource_should_not_fail_when_0_buffer_space_and_demand_is_signalled()
+        public async Task QueueSource_should_not_fail_when_0_buffer_space_and_demand_is_signalled()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var s = this.CreateManualSubscriberProbe<int>();
                 var queue =
@@ -133,9 +133,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void QueueSource_should_wait_for_demand_when_buffer_is_0()
+        public async Task QueueSource_should_wait_for_demand_when_buffer_is_0()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var s = this.CreateManualSubscriberProbe<int>();
                 var queue =
@@ -154,9 +154,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void QueueSource_should_finish_offer_and_complete_futures_when_stream_completed()
+        public async Task QueueSource_should_finish_offer_and_complete_futures_when_stream_completed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var s = this.CreateManualSubscriberProbe<int>();
                 var queue =
@@ -178,9 +178,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void QueueSource_should_fail_stream_on_buffer_overflow_in_fail_mode()
+        public async Task QueueSource_should_fail_stream_on_buffer_overflow_in_fail_mode()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var s = this.CreateManualSubscriberProbe<int>();
                 var queue =
@@ -196,9 +196,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void QueueSource_should_remember_pull_from_downstream_to_send_offered_element_immediately()
+        public async Task QueueSource_should_remember_pull_from_downstream_to_send_offered_element_immediately()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var s = this.CreateManualSubscriberProbe<int>();
                 var probe = CreateTestProbe();
@@ -217,9 +217,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void QueueSource_should_fail_offer_future_if_user_does_not_wait_in_backpressure_mode()
+        public async Task QueueSource_should_fail_offer_future_if_user_does_not_wait_in_backpressure_mode()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var tuple =
                     Source.Queue<int>(5, OverflowStrategy.Backpressure)
@@ -245,9 +245,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void QueueSource_should_complete_watching_future_with_failure_if_stream_failed()
+        public async Task QueueSource_should_complete_watching_future_with_failure_if_stream_failed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var s = this.CreateManualSubscriberProbe<int>();
                 var queue =
@@ -262,9 +262,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void QueueSource_should_return_false_when_element_was_not_added_to_buffer()
+        public async Task QueueSource_should_return_false_when_element_was_not_added_to_buffer()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var s = this.CreateManualSubscriberProbe<int>();
                 var queue =
@@ -284,9 +284,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void QueueSource_should_wait_when_buffer_is_full_and_backpressure_is_on()
+        public async Task QueueSource_should_wait_when_buffer_is_full_and_backpressure_is_on()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var s = this.CreateManualSubscriberProbe<int>();
                 var queue =
@@ -311,9 +311,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void QueueSource_should_fail_offer_future_when_stream_is_completed()
+        public async Task QueueSource_should_fail_offer_future_when_stream_is_completed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var s = this.CreateManualSubscriberProbe<int>();
                 var queue =

--- a/src/core/Akka.Streams.Tests/Dsl/RestartSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/RestartSpec.cs
@@ -36,9 +36,9 @@ namespace Akka.Streams.Tests.Dsl
         //
 
         [Fact]
-        public void A_restart_with_backoff_source_should_run_normally()
+        public async Task A_restart_with_backoff_source_should_run_normally()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var created = new AtomicCounter(0);
                 var probe = RestartSource.WithBackoff(() =>
@@ -60,9 +60,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_restart_with_backoff_source_should_restart_on_completion()
+        public async Task A_restart_with_backoff_source_should_restart_on_completion()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var created = new AtomicCounter(0);
                 var probe = RestartSource.WithBackoff(() =>
@@ -84,9 +84,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_restart_with_backoff_source_should_restart_on_failure()
+        public async Task A_restart_with_backoff_source_should_restart_on_failure()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var created = new AtomicCounter(0);
                 var probe = RestartSource.WithBackoff(() =>
@@ -114,9 +114,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_restart_with_backoff_source_should_backoff_before_restart()
+        public async Task A_restart_with_backoff_source_should_backoff_before_restart()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var created = new AtomicCounter(0);
                 var probe = RestartSource.WithBackoff(() =>
@@ -141,9 +141,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_restart_with_backoff_source_should_reset_exponential_backoff_back_to_minimum_when_source_runs_for_at_least_minimum_backoff_without_completing()
+        public async Task A_restart_with_backoff_source_should_reset_exponential_backoff_back_to_minimum_when_source_runs_for_at_least_minimum_backoff_without_completing()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var created = new AtomicCounter(0);
                 var probe = RestartSource.WithBackoff(() =>
@@ -177,9 +177,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_restart_with_backoff_source_should_cancel_the_currently_running_source_when_cancelled()
+        public async Task A_restart_with_backoff_source_should_cancel_the_currently_running_source_when_cancelled()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var created = new AtomicCounter(0);
                 var tcs = new TaskCompletionSource<Done>();
@@ -206,9 +206,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_restart_with_backoff_source_should_not_restart_the_source_when_cancelled_while_backing_off()
+        public async Task A_restart_with_backoff_source_should_not_restart_the_source_when_cancelled_while_backing_off()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var created = new AtomicCounter(0);
                 var probe = RestartSource.WithBackoff(() =>
@@ -229,9 +229,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_restart_with_backoff_source_should_stop_on_completion_if_it_should_only_be_restarted_in_failures()
+        public async Task A_restart_with_backoff_source_should_stop_on_completion_if_it_should_only_be_restarted_in_failures()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var created = new AtomicCounter(0);
                 var probe = RestartSource.OnFailuresWithBackoff(() =>
@@ -262,9 +262,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_restart_with_backoff_source_should_restart_on_failure_when_only_due_to_failures_should_be_restarted()
+        public async Task A_restart_with_backoff_source_should_restart_on_failure_when_only_due_to_failures_should_be_restarted()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var created = new AtomicCounter(0);
                 var probe = RestartSource.OnFailuresWithBackoff(() =>
@@ -292,9 +292,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_restart_with_backoff_source_should_not_restart_the_source_when_maxRestarts_is_reached()
+        public async Task A_restart_with_backoff_source_should_not_restart_the_source_when_maxRestarts_is_reached()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var created = new AtomicCounter(0);
                 var probe = RestartSource.WithBackoff(() =>
@@ -314,9 +314,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_restart_with_backoff_source_should_reset_maxRestarts_when_source_runs_for_at_least_minimum_backoff_without_completing()
+        public async Task A_restart_with_backoff_source_should_reset_maxRestarts_when_source_runs_for_at_least_minimum_backoff_without_completing()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var created = new AtomicCounter(0);
                 var probe = RestartSource.WithBackoff(() =>
@@ -350,9 +350,9 @@ namespace Akka.Streams.Tests.Dsl
         //
 
         [Fact]
-        public void A_restart_with_backoff_sink_should_run_normally()
+        public async Task A_restart_with_backoff_sink_should_run_normally()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var created = new AtomicCounter(0);
                 var tcs = new TaskCompletionSource<IEnumerable<string>>();
@@ -377,9 +377,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_restart_with_backoff_sink_should_restart_on_cancellation()
+        public async Task A_restart_with_backoff_sink_should_restart_on_cancellation()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var created = new AtomicCounter(0);
                 var tuple = this.SourceProbe<string>().ToMaterialized(this.SinkProbe<string>(), Keep.Both).Run(Materializer);
@@ -410,9 +410,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_restart_with_backoff_sink_should_backoff_before_restart()
+        public async Task A_restart_with_backoff_sink_should_backoff_before_restart()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var created = new AtomicCounter(0);
                 var tuple = this.SourceProbe<string>().ToMaterialized(this.SinkProbe<string>(), Keep.Both).Run(Materializer);
@@ -443,9 +443,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_restart_with_backoff_sink_should_reset_exponential_backoff_back_to_minimum_when_source_runs_for_at_least_minimum_backoff_without_completing()
+        public async Task A_restart_with_backoff_sink_should_reset_exponential_backoff_back_to_minimum_when_source_runs_for_at_least_minimum_backoff_without_completing()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var created = new AtomicCounter(0);
                 var tuple = this.SourceProbe<string>().ToMaterialized(this.SinkProbe<string>(), Keep.Both).Run(Materializer);
@@ -491,9 +491,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_restart_with_backoff_sink_should_not_restart_the_sink_when_completed_while_backing_off()
+        public async Task A_restart_with_backoff_sink_should_not_restart_the_sink_when_completed_while_backing_off()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var created = new AtomicCounter(0);
                 var tuple = this.SourceProbe<string>().ToMaterialized(this.SinkProbe<string>(), Keep.Both).Run(Materializer);
@@ -588,9 +588,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_restart_with_backoff_flow_should_run_normally()
+        public async Task A_restart_with_backoff_flow_should_run_normally()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var created = new AtomicCounter(0);
                 var tuple = this.SourceProbe<string>().ViaMaterialized(RestartFlow.WithBackoff(() =>
@@ -734,9 +734,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_restart_with_backoff_flow_should_continue_running_flow_out_port_after_in_has_been_sent_completion()
+        public async Task A_restart_with_backoff_flow_should_continue_running_flow_out_port_after_in_has_been_sent_completion()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var tuple = SetupFlow(TimeSpan.FromMilliseconds(20), TimeSpan.FromMilliseconds(40));
                 var created = tuple.Item1;

--- a/src/core/Akka.Streams.Tests/Dsl/SinkForeachParallelSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SinkForeachParallelSpec.cs
@@ -18,6 +18,7 @@ using Xunit;
 using Xunit.Abstractions;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Akka.Streams.Tests.Dsl
 {
@@ -32,9 +33,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_ForeachParallel_must_produce_elements_in_the_order_they_are_ready()
+        public async Task A_ForeachParallel_must_produce_elements_in_the_order_they_are_ready()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = CreateTestProbe();
                 var latch = Enumerable.Range(1, 4)
@@ -64,9 +65,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact(Skip = "Racy - timing is rather sensitive on Azure DevOps")]
-        public void A_ForeachParallel_must_not_run_more_functions_in_parallel_then_specified()
+        public async Task A_ForeachParallel_must_not_run_more_functions_in_parallel_then_specified()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = CreateTestProbe();
                 var latch = Enumerable.Range(1, 5)
@@ -95,9 +96,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_ForeachParallel_must_resume_after_function_failure()
+        public async Task A_ForeachParallel_must_resume_after_function_failure()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = CreateTestProbe();
                 var latch = new TestLatch(1);
@@ -119,9 +120,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_ForeachParallel_must_finish_after_function_thrown_exception()
+        public async Task A_ForeachParallel_must_finish_after_function_thrown_exception()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = CreateTestProbe();
                 var latch = new TestLatch(1);
@@ -149,9 +150,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_ForeachParallel_must_handle_empty_source()
+        public async Task A_ForeachParallel_must_handle_empty_source()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p = Source.From(new List<int>()).RunWith(Sink.ForEachParallel<int>(3, i => { }), Materializer);
                 p.Wait(TimeSpan.FromSeconds(2)).Should().BeTrue();

--- a/src/core/Akka.Streams.Tests/Dsl/SourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SourceSpec.cs
@@ -91,9 +91,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Maybe_Source_must_complete_materialized_future_with_None_when_stream_cancels()
+        public async Task Maybe_Source_must_complete_materialized_future_with_None_when_stream_cancels()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var neverSource = Source.Maybe<object>();
                 var pubSink = Sink.AsPublisher<object>(false);
@@ -115,9 +115,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Maybe_Source_must_allow_external_triggering_of_empty_completion()
+        public async Task Maybe_Source_must_allow_external_triggering_of_empty_completion()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var neverSource = Source.Maybe<int>().Where(_ => false);
                 var counterSink = Sink.Aggregate<int, int>(0, (acc, _) => acc + 1);
@@ -134,9 +134,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Maybe_Source_must_allow_external_triggering_of_non_empty_completion()
+        public async Task Maybe_Source_must_allow_external_triggering_of_non_empty_completion()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var neverSource = Source.Maybe<int>();
                 var counterSink = Sink.First<int>();
@@ -153,9 +153,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Maybe_Source_must_allow_external_triggering_of_OnError()
+        public async Task Maybe_Source_must_allow_external_triggering_of_OnError()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var neverSource = Source.Maybe<int>();
                 var counterSink = Sink.First<int>();

--- a/src/core/Akka.Streams.Tests/Dsl/SubscriberSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SubscriberSinkSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -26,9 +27,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_with_SubscriberSink_must_publish_elements_to_the_subscriber()
+        public async Task A_Flow_with_SubscriberSink_must_publish_elements_to_the_subscriber()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c = this.CreateManualSubscriberProbe<int>();
                 Source.From(Enumerable.Range(1, 3)).To(Sink.FromSubscriber(c)).Run(Materializer);

--- a/src/core/Akka.Streams.Tests/Dsl/SubstreamSubscriptionTimeoutSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SubstreamSubscriptionTimeoutSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.Implementation;
 using Akka.Streams.TestKit;
@@ -40,9 +41,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void GroupBy_and_SplitWhen_must_timeout_and_cancel_substream_publisher_when_no_one_subscribes_to_them_after_some_time()
+        public async Task GroupBy_and_SplitWhen_must_timeout_and_cancel_substream_publisher_when_no_one_subscribes_to_them_after_some_time()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber = this.CreateManualSubscriberProbe<(int, Source<int, NotUsed>)>();
                 var publisherProbe = this.CreatePublisherProbe<int>();
@@ -88,9 +89,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void GroupBy_and_SplitWhen_must_timeout_and_stop_groupBy_parent_actor_if_none_of_the_substreams_are_actually_consumed()
+        public async Task GroupBy_and_SplitWhen_must_timeout_and_stop_groupBy_parent_actor_if_none_of_the_substreams_are_actually_consumed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber = this.CreateManualSubscriberProbe<(int, Source<int, NotUsed>)>();
                 var publisherProbe = this.CreatePublisherProbe<int>();

--- a/src/core/Akka.Streams.Tests/Dsl/TickSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/TickSourceSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -28,9 +29,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_based_on_a_tick_publisher_must_produce_ticks()
+        public async Task A_Flow_based_on_a_tick_publisher_must_produce_ticks()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c = this.CreateManualSubscriberProbe<string>();
                 Source.Tick(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), "tick")
@@ -68,9 +69,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_based_on_a_tick_publisher_must_reject_multiple_subscribers_but_keep_the_firs()
+        public async Task A_Flow_based_on_a_tick_publisher_must_reject_multiple_subscribers_but_keep_the_firs()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p = Source.Tick(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), "tick")
                     .RunWith(Sink.AsPublisher<string>(false), Materializer);
@@ -90,9 +91,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_based_on_a_tick_publisher_must_be_usable_with_zip_for_a_simple_form_of_rate_limiting()
+        public async Task A_Flow_based_on_a_tick_publisher_must_be_usable_with_zip_for_a_simple_form_of_rate_limiting()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c = this.CreateManualSubscriberProbe<int>();
                 RunnableGraph.FromGraph(GraphDsl.Create(b =>
@@ -117,9 +118,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_based_on_a_tick_publisher_must_be_possible_to_cancel()
+        public async Task A_Flow_based_on_a_tick_publisher_must_be_possible_to_cancel()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(async () =>
             {
                 var c = this.CreateManualSubscriberProbe<string>();
                 var tickSource = Source.Tick(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), "tick");
@@ -131,16 +132,16 @@ namespace Akka.Streams.Tests.Dsl
                 c.ExpectNoMsg(TimeSpan.FromMilliseconds(200));
                 c.ExpectNext("tick");
                 cancelable.Cancel();
-                AwaitCondition(() => cancelable.IsCancellationRequested);
+                await AwaitConditionAsync(() => cancelable.IsCancellationRequested);
                 sub.Request(3);
                 c.ExpectComplete();
             }, Materializer);
         }
         
         [Fact]
-        public void A_Flow_based_on_a_tick_publisher_must_have_IsCancelled_mirror_the_cancellation_state()
+        public async Task A_Flow_based_on_a_tick_publisher_must_have_IsCancelled_mirror_the_cancellation_state()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c = this.CreateManualSubscriberProbe<string>();
                 var tickSource = Source.Tick(TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(500), "tick");
@@ -156,9 +157,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Flow_based_on_a_tick_publisher_must_support_being_cancelled_immediately_after_its_materialization()
+        public async Task A_Flow_based_on_a_tick_publisher_must_support_being_cancelled_immediately_after_its_materialization()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var c = this.CreateManualSubscriberProbe<string>();
                 var tickSource = Source.Tick(TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(500), "tick");

--- a/src/core/Akka.Streams.Tests/Dsl/UnfoldResourceAsyncSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/UnfoldResourceAsyncSourceSpec.cs
@@ -72,9 +72,9 @@ namespace Akka.Streams.Tests.Dsl
 
 
         [Fact]
-        public void A_UnfoldResourceAsyncSource_must_read_contents_from_a_file()
+        public async Task A_UnfoldResourceAsyncSource_must_read_contents_from_a_file()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var createPromise = new TaskCompletionSource<StreamReader>();
                 var readPromise = new TaskCompletionSource<Option<string>>();
@@ -124,9 +124,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_UnfoldResourceAsyncSource_must_close_resource_successfully_right_after_open()
+        public async Task A_UnfoldResourceAsyncSource_must_close_resource_successfully_right_after_open()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var createPromise = new TaskCompletionSource<StreamReader>();
                 var readPromise = new TaskCompletionSource<Option<string>>();
@@ -169,9 +169,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_UnfoldResourceAsyncSource_must_continue_when_strategy_is_resume_and_exception_happened()
+        public async Task A_UnfoldResourceAsyncSource_must_continue_when_strategy_is_resume_and_exception_happened()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p = Source.UnfoldResourceAsync(_open, reader =>
                 {
@@ -198,9 +198,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_UnfoldResourceAsyncSource_must_close_and_open_stream_again_when_strategy_is_restart()
+        public async Task A_UnfoldResourceAsyncSource_must_close_and_open_stream_again_when_strategy_is_restart()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p = Source.UnfoldResourceAsync(_open, reader =>
                 {
@@ -226,9 +226,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_UnfoldResourceAsyncSource_must_work_with_ByteString_as_well()
+        public async Task A_UnfoldResourceAsyncSource_must_work_with_ByteString_as_well()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var chunkSize = 50;
                 var buffer = new char[chunkSize];
@@ -275,9 +275,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_UnfoldResourceAsyncSource_must_use_dedicated_blocking_io_dispatcher_by_default()
+        public async Task A_UnfoldResourceAsyncSource_must_use_dedicated_blocking_io_dispatcher_by_default()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var sys = ActorSystem.Create("dispatcher-testing", Utils.UnboundedMailboxConfig);
                 var materializer = sys.Materializer();
@@ -309,9 +309,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_UnfoldResourceAsyncSource_must_fail_when_create_throws_exception()
+        public async Task A_UnfoldResourceAsyncSource_must_fail_when_create_throws_exception()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var testException = new TestException("");
                 var p = Source.UnfoldResourceAsync(() =>
@@ -327,9 +327,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_UnfoldResourceAsyncSource_must_fail_when_close_throws_exception()
+        public async Task A_UnfoldResourceAsyncSource_must_fail_when_close_throws_exception()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var testException = new TestException("");
                 var p = Source.UnfoldResourceAsync(_open, Read, reader =>

--- a/src/core/Akka.Streams.Tests/Dsl/UnfoldResourceSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/UnfoldResourceSourceSpec.cs
@@ -9,6 +9,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.IO;
 using Akka.Streams.Dsl;
@@ -66,9 +67,9 @@ namespace Akka.Streams.Tests.Dsl
 
 
         [Fact]
-        public void A_UnfoldResourceSource_must_read_contents_from_a_file()
+        public async Task A_UnfoldResourceSource_must_read_contents_from_a_file()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p = Source.UnfoldResource(_open, Read, Close).RunWith(Sink.AsPublisher<string>(false), Materializer);
 
@@ -94,9 +95,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_UnfoldResourceSource_must_continue_when_strategy_is_resume_and_exception_happened()
+        public async Task A_UnfoldResourceSource_must_continue_when_strategy_is_resume_and_exception_happened()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p = Source.UnfoldResource(_open, reader =>
                 {
@@ -123,9 +124,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_UnfoldResourceSource_must_close_and_open_stream_again_when_strategy_is_restart()
+        public async Task A_UnfoldResourceSource_must_close_and_open_stream_again_when_strategy_is_restart()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p = Source.UnfoldResource(_open, reader =>
                 {
@@ -151,9 +152,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_UnfoldResourceSource_must_work_with_ByteString_as_well()
+        public async Task A_UnfoldResourceSource_must_work_with_ByteString_as_well()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var chunkSize = 50;
                 var buffer = new char[chunkSize];
@@ -193,9 +194,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_UnfoldResourceSource_must_use_dedicated_blocking_io_dispatcher_by_default()
+        public async Task A_UnfoldResourceSource_must_use_dedicated_blocking_io_dispatcher_by_default()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var sys = ActorSystem.Create("dispatcher-testing", Utils.UnboundedMailboxConfig);
                 var materializer = sys.Materializer();
@@ -227,9 +228,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_UnfoldResourceSource_must_fail_when_create_throws_exception()
+        public async Task A_UnfoldResourceSource_must_fail_when_create_throws_exception()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var testException = new TestException("");
                 var p = Source.UnfoldResource(() =>
@@ -245,9 +246,9 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_UnfoldResourceSource_must_fail_when_close_throws_exception()
+        public async Task A_UnfoldResourceSource_must_fail_when_close_throws_exception()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var testException = new TestException("");
                 var p = Source.UnfoldResource(_open, Read, reader =>

--- a/src/core/Akka.Streams.Tests/Extra/FlowTimedSpec.cs
+++ b/src/core/Akka.Streams.Tests/Extra/FlowTimedSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Streams.Dsl;
 using Akka.Streams.Extra;
@@ -88,9 +89,9 @@ namespace Akka.Streams.Tests.Extra
 
 
         [Fact]
-        public void Timed_Flow_must_measure_time_it_takes_between_elements_matching_a_predicate()
+        public async Task Timed_Flow_must_measure_time_it_takes_between_elements_matching_a_predicate()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = CreateTestProbe();
 
@@ -113,9 +114,9 @@ namespace Akka.Streams.Tests.Extra
         }
 
         [Fact]
-        public void Timed_Flow_must_measure_time_it_takes_from_start_to_complete_by_wrapping_operations()
+        public async Task Timed_Flow_must_measure_time_it_takes_from_start_to_complete_by_wrapping_operations()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var probe = CreateTestProbe();
 

--- a/src/core/Akka.Streams.Tests/IO/FileSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/FileSinkSpec.cs
@@ -52,9 +52,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void SynchronousFileSink_should_write_lines_to_a_file()
+        public async Task SynchronousFileSink_should_write_lines_to_a_file()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 TargetFile(f =>
                 {
@@ -69,9 +69,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void SynchronousFileSink_should_create_new_file_if_not_exists()
+        public async Task SynchronousFileSink_should_create_new_file_if_not_exists()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 TargetFile(f =>
                 {
@@ -85,9 +85,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void SynchronousFileSink_should_write_into_existing_file_without_wiping_existing_data()
+        public async Task SynchronousFileSink_should_write_into_existing_file_without_wiping_existing_data()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 TargetFile(f =>
                 {
@@ -115,9 +115,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void SynchronousFileSink_should_by_default_replace_the_existing_file()
+        public async Task SynchronousFileSink_should_by_default_replace_the_existing_file()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 TargetFile(f =>
                 {
@@ -137,9 +137,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void SynchronousFileSink_should_allow_appending_to_file()
+        public async Task SynchronousFileSink_should_allow_appending_to_file()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 TargetFile(f =>
                 {
@@ -171,9 +171,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void SynchronousFileSink_should_allow_writing_from_specific_position_to_the_file()
+        public async Task SynchronousFileSink_should_allow_writing_from_specific_position_to_the_file()
         {
-            this.AssertAllStagesStopped(() => 
+            await this.AssertAllStagesStoppedAsync(() => 
             {
                 TargetFile(f => 
                 {
@@ -211,9 +211,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void SynchronousFileSink_should_use_dedicated_blocking_io_dispatcher_by_default()
+        public async Task SynchronousFileSink_should_use_dedicated_blocking_io_dispatcher_by_default()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 TargetFile(f =>
                 {
@@ -242,9 +242,9 @@ namespace Akka.Streams.Tests.IO
 
         // FIXME: overriding dispatcher should be made available with dispatcher alias support in materializer (#17929)
         [Fact(Skip = "overriding dispatcher should be made available with dispatcher alias support in materializer")]
-        public void SynchronousFileSink_should_allow_overriding_the_dispatcher_using_Attributes()
+        public async Task SynchronousFileSink_should_allow_overriding_the_dispatcher_using_Attributes()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 TargetFile(f =>
                 {
@@ -272,9 +272,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void SynchronousFileSink_should_write_single_line_to_a_file_from_lazy_sink()
+        public async Task SynchronousFileSink_should_write_single_line_to_a_file_from_lazy_sink()
         {
-            this.AssertAllStagesStopped(() => 
+            await this.AssertAllStagesStoppedAsync(() => 
             {
                 TargetFile(f => 
                 {

--- a/src/core/Akka.Streams.Tests/IO/FileSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/FileSourceSpec.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.IO;
 using Akka.Streams.Dsl;
@@ -48,9 +49,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void FileSource_should_read_contents_from_a_file()
+        public async Task FileSource_should_read_contents_from_a_file()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var chunkSize = 512;
                 var bufferAttributes = Attributes.CreateInputBuffer(1, 2);
@@ -102,9 +103,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void Filesource_could_read_partial_contents_from_a_file()
+        public async Task Filesource_could_read_partial_contents_from_a_file()
         {
-            this.AssertAllStagesStopped(() => 
+            await this.AssertAllStagesStoppedAsync(() => 
             {
                 var chunkSize = 512;
                 var startPosition = 1000;
@@ -151,9 +152,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void FileSource_should_complete_only_when_all_contents_of_a_file_have_been_signalled()
+        public async Task FileSource_should_complete_only_when_all_contents_of_a_file_have_been_signalled()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var chunkSize = 512;
                 var bufferAttributes = Attributes.CreateInputBuffer(1, 2);
@@ -202,9 +203,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void FileSource_should_open_file_in_shared_mode_for_reading_multiple_times()
+        public async Task FileSource_should_open_file_in_shared_mode_for_reading_multiple_times()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var testFile = TestFile();
                 var p1 = FileIO.FromFile(testFile).RunWith(Sink.AsPublisher<ByteString>(false), _materializer);
@@ -227,9 +228,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void FileSource_should_onError_with_failure_and_return_a_failed_IOResult_when_trying_to_read_from_file_which_does_not_exist()
+        public async Task FileSource_should_onError_with_failure_and_return_a_failed_IOResult_when_trying_to_read_from_file_which_does_not_exist()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = FileIO.FromFile(NotExistingFile())
                     .ToMaterialized(Sink.AsPublisher<ByteString>(false), Keep.Both)
@@ -265,9 +266,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void FileSource_should_use_dedicated_blocking_io_dispatcher_by_default()
+        public async Task FileSource_should_use_dedicated_blocking_io_dispatcher_by_default()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var sys = ActorSystem.Create("dispatcher-testing", Utils.UnboundedMailboxConfig);
                 var materializer = sys.Materializer();

--- a/src/core/Akka.Streams.Tests/IO/InputStreamSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/InputStreamSinkSpec.cs
@@ -37,9 +37,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void InputStreamSink_should_read_bytes_from_input_stream()
+        public async Task InputStreamSink_should_read_bytes_from_input_stream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var inputStream = Source.Single(_byteString).RunWith(StreamConverters.AsInputStream(), _materializer);
                 var result = ReadN(inputStream, _byteString.Count);
@@ -51,9 +51,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void InputStreamSink_should_read_bytes_correctly_if_requested_by_input_stream_not_in_chunk_size()
+        public async Task InputStreamSink_should_read_bytes_correctly_if_requested_by_input_stream_not_in_chunk_size()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var sinkProbe = CreateTestProbe();
                 var byteString2 = RandomByteString(3);
@@ -80,9 +80,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void InputStreamSink_should_return_less_than_was_expected_when_data_source_has_provided_some_but_not_enough_data()
+        public async Task InputStreamSink_should_return_less_than_was_expected_when_data_source_has_provided_some_but_not_enough_data()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var inputStream = Source.Single(_byteString).RunWith(StreamConverters.AsInputStream(), _materializer);
 
@@ -95,9 +95,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void InputStreamSink_should_block_read_until_get_requested_number_of_bytes_from_upstream()
+        public async Task InputStreamSink_should_block_read_until_get_requested_number_of_bytes_from_upstream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var run =
                     this.SourceProbe<ByteString>()
@@ -121,9 +121,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void InputStreamSink_should_throw_error_when_reactive_stream_is_closed()
+        public async Task InputStreamSink_should_throw_error_when_reactive_stream_is_closed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = this.SourceProbe<ByteString>()
                         .ToMaterialized(StreamConverters.AsInputStream(), Keep.Both)
@@ -141,9 +141,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void InputStreamSink_should_return_all_data_when_upstream_is_completed()
+        public async Task InputStreamSink_should_return_all_data_when_upstream_is_completed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var sinkProbe = CreateTestProbe();
                 var t = this.SourceProbe<ByteString>().ToMaterialized(TestSink(sinkProbe), Keep.Both).Run(_materializer);
@@ -164,9 +164,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void InputStreamSink_should_work_when_read_chunks_smaller_then_stream_chunks()
+        public async Task InputStreamSink_should_work_when_read_chunks_smaller_then_stream_chunks()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var bytes = RandomByteString(10);
                 var inputStream = Source.Single(bytes).RunWith(StreamConverters.AsInputStream(), _materializer);
@@ -186,9 +186,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void InputStreamSink_should_throw_exception_when_call_read_With_wrong_parameters()
+        public async Task InputStreamSink_should_throw_exception_when_call_read_With_wrong_parameters()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var inputStream = Source.Single(_byteString).RunWith(StreamConverters.AsInputStream(), _materializer);
                 var buf = new byte[3];
@@ -203,9 +203,9 @@ namespace Akka.Streams.Tests.IO
         private Action Action(Action a) => a;
 
         [Fact]
-        public void InputStreamSink_should_successfully_read_several_chunks_at_once()
+        public async Task InputStreamSink_should_successfully_read_several_chunks_at_once()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var bytes = Enumerable.Range(1, 4).Select(_ => RandomByteString(4)).ToList();
                 var sinkProbe = CreateTestProbe();
@@ -226,9 +226,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void InputStreamSink_should_work_when_read_chunks_bigger_than_stream_chunks()
+        public async Task InputStreamSink_should_work_when_read_chunks_bigger_than_stream_chunks()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var bytes1 = RandomByteString(10);
                 var bytes2 = RandomByteString(10);
@@ -251,9 +251,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void InputStreamSink_should_return_minus_1_when_read_after_stream_is_completed()
+        public async Task InputStreamSink_should_return_minus_1_when_read_after_stream_is_completed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var inputStream = Source.Single(_byteString).RunWith(StreamConverters.AsInputStream(), _materializer);
 
@@ -267,9 +267,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void InputStreamSink_should_return_Exception_when_stream_is_failed()
+        public async Task InputStreamSink_should_return_Exception_when_stream_is_failed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var sinkProbe = CreateTestProbe();
                 var t = this.SourceProbe<ByteString>().ToMaterialized(TestSink(sinkProbe), Keep.Both).Run(_materializer);
@@ -298,9 +298,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void InputStreamSink_should_use_dedicated_default_blocking_io_dispatcher_by_default()
+        public async Task InputStreamSink_should_use_dedicated_default_blocking_io_dispatcher_by_default()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var sys = ActorSystem.Create("dispatcher-testing", Utils.UnboundedMailboxConfig);
                 var materializer = ActorMaterializer.Create(sys);
@@ -320,9 +320,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void InputStreamSink_should_work_when_more_bytes_pulled_from_input_stream_than_available()
+        public async Task InputStreamSink_should_work_when_more_bytes_pulled_from_input_stream_than_available()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var inputStream = Source.Single(_byteString).RunWith(StreamConverters.AsInputStream(), _materializer);
 
@@ -336,9 +336,9 @@ namespace Akka.Streams.Tests.IO
 
 
         [Fact]
-        public void InputStreamSink_should_read_next_byte_as_an_int_from_InputStream()
+        public async Task InputStreamSink_should_read_next_byte_as_an_int_from_InputStream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var bytes = ByteString.CopyFrom(new byte[] { 0, 100, 200, 255 });
                 var inputStream = Source.Single(bytes).RunWith(StreamConverters.AsInputStream(), _materializer);

--- a/src/core/Akka.Streams.Tests/IO/InputStreamSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/InputStreamSourceSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.IO;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
@@ -175,9 +176,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void InputStreamSource_must_read_bytes_from_InputStream()
+        public async Task InputStreamSource_must_read_bytes_from_InputStream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var f = StreamConverters.FromInputStream(() => new ListInputStream(new[] {"a", "b", "c"}))
                     .RunWith(Sink.First<ByteString>(), _materializer);
@@ -188,9 +189,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void InputStreamSource_must_emit_as_soon_as_read()
+        public async Task InputStreamSource_must_emit_as_soon_as_read()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var latch = new TestLatch(1);
                 var probe = StreamConverters.FromInputStream(() => new EmittedInputStream(latch), chunkSize: 1)

--- a/src/core/Akka.Streams.Tests/IO/OutputStreamSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/OutputStreamSinkSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.IO;
 using Akka.Streams.Dsl;
@@ -164,9 +165,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void OutputStreamSink_must_write_bytes_to_void_OutputStream()
+        public async Task OutputStreamSink_must_write_bytes_to_void_OutputStream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p = CreateTestProbe();
                 var datas = new List<ByteString>
@@ -187,9 +188,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void OutputStreamSink_must_close_underlying_stream_when_error_received()
+        public async Task OutputStreamSink_must_close_underlying_stream_when_error_received()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p = CreateTestProbe();
                 Source.Failed<ByteString>(new Exception("Boom!"))
@@ -200,9 +201,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void OutputStreamSink_must_close_underlying_stream_when_completion_received()
+        public async Task OutputStreamSink_must_close_underlying_stream_when_completion_received()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var p = CreateTestProbe();
                 Source.Empty<ByteString>()

--- a/src/core/Akka.Streams.Tests/IO/OutputStreamSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/OutputStreamSourceSpec.cs
@@ -60,9 +60,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void OutputStreamSource_must_read_bytes_from_OutputStream()
+        public async Task OutputStreamSource_must_read_bytes_from_OutputStream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = StreamConverters.AsOutputStream()
                         .ToMaterialized(this.SinkProbe<ByteString>(), Keep.Both)
@@ -80,9 +80,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void OutputStreamSource_must_block_flush_call_until_send_all_buffer_to_downstream()
+        public async Task OutputStreamSource_must_block_flush_call_until_send_all_buffer_to_downstream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = StreamConverters.AsOutputStream()
                         .ToMaterialized(this.SinkProbe<ByteString>(), Keep.Both)
@@ -111,9 +111,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void OutputStreamSource_must_not_block_flushes_when_buffer_is_empty()
+        public async Task OutputStreamSource_must_not_block_flushes_when_buffer_is_empty()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = StreamConverters.AsOutputStream()
                         .ToMaterialized(this.SinkProbe<ByteString>(), Keep.Both)
@@ -146,9 +146,9 @@ namespace Akka.Streams.Tests.IO
         }
         
         [Fact]
-        public void OutputStreamSource_must_block_writes_when_buffer_is_full()
+        public async Task OutputStreamSource_must_block_writes_when_buffer_is_full()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = StreamConverters.AsOutputStream()
                     .WithAttributes(Attributes.CreateInputBuffer(16, 16))
@@ -180,9 +180,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void OutputStreamSource_must_throw_error_when_writer_after_stream_is_closed()
+        public async Task OutputStreamSource_must_throw_error_when_writer_after_stream_is_closed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = StreamConverters.AsOutputStream()
                         .ToMaterialized(this.SinkProbe<ByteString>(), Keep.Both)
@@ -199,9 +199,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void OutputStreamSource_must_use_dedicated_default_blocking_io_dispatcher_by_default()
+        public async Task OutputStreamSource_must_use_dedicated_default_blocking_io_dispatcher_by_default()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var sys = ActorSystem.Create("dispatcher-testing", Utils.UnboundedMailboxConfig);
                 var materializer = sys.Materializer();
@@ -224,9 +224,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void OutputStreamSource_must_throw_IOException_when_writing_to_the_stream_after_the_subscriber_has_cancelled_the_reactive_stream()
+        public async Task OutputStreamSource_must_throw_IOException_when_writing_to_the_stream_after_the_subscriber_has_cancelled_the_reactive_stream()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var sourceProbe = CreateTestProbe();
                 var t =

--- a/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
@@ -34,9 +34,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void Outgoing_TCP_stream_must_work_in_the_happy_case()
+        public async Task Outgoing_TCP_stream_must_work_in_the_happy_case()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var testData = ByteString.FromBytes(new byte[] {1, 2, 3, 4, 5});
 
@@ -105,9 +105,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact(Skip="FIXME .net core / linux")]
-        public void Outgoing_TCP_stream_must_fail_the_materialized_task_when_the_connection_fails()
+        public async Task Outgoing_TCP_stream_must_fail_the_materialized_task_when_the_connection_fails()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var tcpWriteProbe = new TcpWriteProbe(this);
                 var task =
@@ -127,9 +127,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void Outgoing_TCP_stream_must_work_when_client_closes_write_then_remote_closes_write()
+        public async Task Outgoing_TCP_stream_must_work_when_client_closes_write_then_remote_closes_write()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var testData = ByteString.FromBytes(new byte[] { 1, 2, 3, 4, 5 });
                 var server = new Server(this);
@@ -165,9 +165,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void Outgoing_TCP_stream_must_work_when_remote_closes_write_then_client_closes_write()
+        public async Task Outgoing_TCP_stream_must_work_when_remote_closes_write_then_client_closes_write()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var testData = ByteString.FromBytes(new byte[] {1, 2, 3, 4, 5});
                 var server = new Server(this);
@@ -201,9 +201,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact(Skip = "FIXME: actually this is about half-open connection. No other .NET socket lib supports that")]
-        public void Outgoing_TCP_stream_must_work_when_client_closes_read_then_client_closes_write()
+        public async Task Outgoing_TCP_stream_must_work_when_client_closes_read_then_client_closes_write()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(async () =>
             {
                 var testData = ByteString.FromBytes(new byte[] { 1, 2, 3, 4, 5 });
                 var server = new Server(this);
@@ -232,7 +232,7 @@ namespace Akka.Streams.Tests.IO
                 tcpWriteProbe.Close();
 
                 // Need a write on the server side to detect the close event
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     serverConnection.Write(testData);
                     serverConnection.ExpectClosed(c => c.IsErrorClosed, TimeSpan.FromMilliseconds(500));
@@ -243,9 +243,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void Outgoing_TCP_stream_must_work_when_client_closes_read_then_server_closes_write_then_client_closes_write()
+        public async Task Outgoing_TCP_stream_must_work_when_client_closes_read_then_server_closes_write_then_client_closes_write()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var testData = ByteString.FromBytes(new byte[] { 1, 2, 3, 4, 5 });
                 var server = new Server(this);
@@ -280,9 +280,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void Outgoing_TCP_stream_must_shut_everything_down_if_client_signals_error()
+        public async Task Outgoing_TCP_stream_must_shut_everything_down_if_client_signals_error()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var testData = ByteString.FromBytes(new byte[] { 1, 2, 3, 4, 5 });
                 var server = new Server(this);
@@ -314,9 +314,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void Outgoing_TCP_stream_must_shut_everything_down_if_client_signals_error_after_remote_has_closed_write()
+        public async Task Outgoing_TCP_stream_must_shut_everything_down_if_client_signals_error_after_remote_has_closed_write()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var testData = ByteString.FromBytes(new byte[] { 1, 2, 3, 4, 5 });
                 var server = new Server(this);
@@ -349,9 +349,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void Outgoing_TCP_stream_must_shut_down_both_streams_when_connection_is_aborted_remotely()
+        public async Task Outgoing_TCP_stream_must_shut_down_both_streams_when_connection_is_aborted_remotely()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 // Client gets a PeerClosed event and does not know that the write side is also closed
                 var server = new Server(this);
@@ -415,9 +415,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void Outgoing_TCP_stream_must_properly_full_close_if_requested()
+        public async Task Outgoing_TCP_stream_must_properly_full_close_if_requested()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var serverAddress = TestUtils.TemporaryServerAddress();
                 var writeButIgnoreRead = Flow.FromSinkAndSource(Sink.Ignore<ByteString>(),
@@ -640,9 +640,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact(Skip = "FIXME: unexpected ErrorClosed")]
-        public void Tcp_listen_stream_must_not_shut_down_connections_after_the_connection_stream_cancelled()
+        public async Task Tcp_listen_stream_must_not_shut_down_connections_after_the_connection_stream_cancelled()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var thousandByteStrings = Enumerable.Range(0, 1000)
                     .Select(_ => ByteString.FromBytes(new byte[] { 0 }))
@@ -676,9 +676,9 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact(Skip="FIXME")]
-        public void Tcp_listen_stream_must_shut_down_properly_even_if_some_accepted_connection_Flows_have_not_been_subscribed_to ()
+        public async Task Tcp_listen_stream_must_shut_down_properly_even_if_some_accepted_connection_Flows_have_not_been_subscribed_to ()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var serverAddress = TestUtils.TemporaryServerAddress();
                 var firstClientConnected = new TaskCompletionSource<NotUsed>();

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/ActorGraphInterpreterSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/ActorGraphInterpreterSpec.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Pattern;
 using Akka.Streams.Dsl;
 using Akka.Streams.Implementation;
@@ -35,9 +36,9 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         }
 
         [Fact]
-        public void ActorGraphInterpreter_should_be_able_to_interpret_a_simple_identity_graph_stage()
+        public async Task ActorGraphInterpreter_should_be_able_to_interpret_a_simple_identity_graph_stage()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var identity = GraphStages.Identity<int>();
 
@@ -51,9 +52,9 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         }
 
         [Fact]
-        public void ActorGraphInterpreter_should_be_able_to_reuse_a_simple_identity_graph_stage()
+        public async Task ActorGraphInterpreter_should_be_able_to_reuse_a_simple_identity_graph_stage()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var identity = GraphStages.Identity<int>();
 
@@ -69,9 +70,9 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         }
 
         [Fact]
-        public void ActorGraphInterpreter_should_be_able_to_interpret_a_simple_bidi_stage()
+        public async Task ActorGraphInterpreter_should_be_able_to_interpret_a_simple_bidi_stage()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var identityBidi = new IdentityBidiGraphStage();
                 var identity = BidiFlow.FromGraph(identityBidi).Join(Flow.Identity<int>().Select(x => x));
@@ -86,9 +87,9 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         }
 
         [Fact]
-        public void ActorGraphInterpreter_should_be_able_to_interpret_and_reuse_a_simple_bidi_stage()
+        public async Task ActorGraphInterpreter_should_be_able_to_interpret_and_reuse_a_simple_bidi_stage()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var identityBidi = new IdentityBidiGraphStage();
                 var identityBidiFlow = BidiFlow.FromGraph(identityBidi);
@@ -104,9 +105,9 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         }
 
         [Fact]
-        public void ActorGraphInterpreter_should_be_able_to_interpret_a_rotated_identity_bidi_stage()
+        public async Task ActorGraphInterpreter_should_be_able_to_interpret_a_rotated_identity_bidi_stage()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var rotatedBidi = new RotatedIdentityBidiGraphStage();
                 var takeAll = Flow.Identity<int>()
@@ -147,13 +148,13 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         }
 
         [Fact]
-        public void ActorGraphInterpreter_should_be_able_to_properly_handle_case_where_a_stage_fails_before_subscription_happens()
+        public async Task ActorGraphInterpreter_should_be_able_to_properly_handle_case_where_a_stage_fails_before_subscription_happens()
         {
             // Fuzzing needs to be off, so that the failure can propagate to the output boundary
             // before the ExposedPublisher message.
             var noFuzzMaterializer = ActorMaterializer.Create(Sys,
                 ActorMaterializerSettings.Create(Sys).WithFuzzingMode(false));
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
 
                 var evilLatch = new CountdownEvent(1);
@@ -203,9 +204,9 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         }
         
         [Fact]
-        public void ActorGraphInterpreter_should_be_to_handle_Publisher_spec_violations_without_leaking()
+        public async Task ActorGraphInterpreter_should_be_to_handle_Publisher_spec_violations_without_leaking()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var upstream = this.CreatePublisherProbe<int>();
                 var downstream = this.CreateSubscriberProbe<int>();
@@ -241,9 +242,9 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         }
 
         [Fact]
-        public void ActorGraphInterpreter_should_be_to_handle_Subscriber_spec_violations_without_leaking()
+        public async Task ActorGraphInterpreter_should_be_to_handle_Subscriber_spec_violations_without_leaking()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var upstream = this.CreatePublisherProbe<int>();
                 var downstream = this.CreateSubscriberProbe<int>();
@@ -263,9 +264,9 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         }
 
         [Fact]
-        public void ActorGraphInterpreter_should_trigger_PostStop_in_all_stages_when_abruptly_terminated_and_no_upstream_boundaries()
+        public async Task ActorGraphInterpreter_should_trigger_PostStop_in_all_stages_when_abruptly_terminated_and_no_upstream_boundaries()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var materializer = ActorMaterializer.Create(Sys);
                 var gotStop = new TestLatch(1);

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/KeepGoingStageSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/KeepGoingStageSpec.cs
@@ -194,9 +194,9 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         }
 
         [Fact]
-        public void A_stage_with_keep_going_must_still_be_alive_after_all_ports_have_been_closed_until_explicity_closed()
+        public async Task A_stage_with_keep_going_must_still_be_alive_after_all_ports_have_been_closed_until_explicity_closed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = Source.Maybe<int>().ToMaterialized(new PingableSink(true), Keep.Both).Run(Materializer);
                 var maybePromise = t.Item1;
@@ -229,9 +229,9 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         }
 
         [Fact]
-        public void A_stage_with_keep_going_must_still_be_alive_after_all_ports_have_been_closed_until_explicitly_failed()
+        public async Task A_stage_with_keep_going_must_still_be_alive_after_all_ports_have_been_closed_until_explicitly_failed()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = Source.Maybe<int>().ToMaterialized(new PingableSink(true), Keep.Both).Run(Materializer);
                 var maybePromise = t.Item1;
@@ -268,9 +268,9 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         }
 
         [Fact]
-        public void A_stage_with_keep_going_must_still_be_alive_after_all_ports_have_been_closed_until_implicity_failed_via_exception()
+        public async Task A_stage_with_keep_going_must_still_be_alive_after_all_ports_have_been_closed_until_implicity_failed_via_exception()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = Source.Maybe<int>().ToMaterialized(new PingableSink(true), Keep.Both).Run(Materializer);
                 var maybePromise = t.Item1;
@@ -309,9 +309,9 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         }
 
         [Fact]
-        public void A_stage_with_keep_going_must_close_down_earls_if_keepAlive_is_not_requested()
+        public async Task A_stage_with_keep_going_must_close_down_earls_if_keepAlive_is_not_requested()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = Source.Maybe<int>().ToMaterialized(new PingableSink(false), Keep.Both).Run(Materializer);
                 var maybePromise = t.Item1;

--- a/src/core/Akka.Streams.Tests/Implementation/GraphStageLogicSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/GraphStageLogicSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Pattern;
@@ -272,9 +273,9 @@ namespace Akka.Streams.Tests.Implementation
         }
 
         [Fact]
-        public void A_GraphStageLogic_must_read_N_and_emit_N_before_completing()
+        public async Task A_GraphStageLogic_must_read_N_and_emit_N_before_completing()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 10))
                 .Via(new ReadNEmitN(2))
@@ -286,9 +287,9 @@ namespace Akka.Streams.Tests.Implementation
         }
 
         [Fact]
-        public void A_GraphStageLogic_must_read_N_should_not_emit_if_upstream_completes_before_N_is_sent()
+        public async Task A_GraphStageLogic_must_read_N_should_not_emit_if_upstream_completes_before_N_is_sent()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 5))
                     .Via(new ReadNEmitN(6))
@@ -299,9 +300,9 @@ namespace Akka.Streams.Tests.Implementation
         }
 
         [Fact]
-        public void A_GraphStageLogic_must_read_N_should_not_emit_if_upstream_fails_before_N_is_sent()
+        public async Task A_GraphStageLogic_must_read_N_should_not_emit_if_upstream_fails_before_N_is_sent()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var error = new ArgumentException("Don't argue like that!");
                 Source.From(Enumerable.Range(1, 5))
@@ -319,9 +320,9 @@ namespace Akka.Streams.Tests.Implementation
         }
 
         [Fact]
-        public void A_GraphStageLogic_must_read_N_should_provide_elements_read_if_OnComplete_happens_before_N_elements_have_been_seen()
+        public async Task A_GraphStageLogic_must_read_N_should_provide_elements_read_if_OnComplete_happens_before_N_elements_have_been_seen()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 5))
                     .Via(new ReadNEmitRestOnComplete(6))
@@ -333,9 +334,9 @@ namespace Akka.Streams.Tests.Implementation
         }
 
         [Fact]
-        public void A_GraphStageLogic_must_emit_all_things_before_completing()
+        public async Task A_GraphStageLogic_must_emit_all_things_before_completing()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.Empty<int>()
                     .Via(new Emit1234().Named("testStage"))
@@ -350,9 +351,9 @@ namespace Akka.Streams.Tests.Implementation
         }
         
         [Fact]
-        public void A_GraphStageLogic_must_emit_all_things_before_completing_with_two_fused_stages()
+        public async Task A_GraphStageLogic_must_emit_all_things_before_completing_with_two_fused_stages()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var flow = Flow.Create<int>().Via(new Emit1234()).Via(new Emit5678());
                 var g = Streams.Implementation.Fusing.Fusing.Aggressive(flow);
@@ -374,9 +375,9 @@ namespace Akka.Streams.Tests.Implementation
         }
 
         [Fact]
-        public void A_GraphStageLogic_must_emit_all_things_before_completing_with_three_fused_stages()
+        public async Task A_GraphStageLogic_must_emit_all_things_before_completing_with_three_fused_stages()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var flow = Flow.Create<int>().Via(new Emit1234()).Via(new PassThrough()).Via(new Emit5678());
                 var g = Streams.Implementation.Fusing.Fusing.Aggressive(flow);
@@ -398,9 +399,9 @@ namespace Akka.Streams.Tests.Implementation
         }
 
         [Fact]
-        public void A_GraphStageLogic_must_emit_properly_after_empty_iterable()
+        public async Task A_GraphStageLogic_must_emit_properly_after_empty_iterable()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.FromGraph(new EmitEmptyIterable())
                     .RunWith(Sink.Seq<int>(), Materializer)
@@ -424,9 +425,9 @@ namespace Akka.Streams.Tests.Implementation
         }
 
         [Fact]
-        public void A_GraphStageLogic_must_invoke_livecycle_hooks_in_the_right_order()
+        public async Task A_GraphStageLogic_must_invoke_livecycle_hooks_in_the_right_order()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var g = new LifecycleStage(TestActor);
 

--- a/src/core/Akka.Streams.Tests/Implementation/TimeoutsSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/TimeoutsSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -29,9 +30,9 @@ namespace Akka.Streams.Tests.Implementation
         }
 
         [Fact]
-        public void InitialTimeout_must_pass_through_elements_unmodified()
+        public async Task InitialTimeout_must_pass_through_elements_unmodified()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = Source.From(Enumerable.Range(1, 100))
                     .InitialTimeout(TimeSpan.FromSeconds(2)).Grouped(200)
@@ -43,9 +44,9 @@ namespace Akka.Streams.Tests.Implementation
         }
         
         [Fact]
-        public void InitialTimeout_must_pass_through_error_unmodified()
+        public async Task InitialTimeout_must_pass_through_error_unmodified()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = Source.From(Enumerable.Range(1, 100))
                     .Concat(Source.Failed<int>(new TestException("test")))
@@ -59,9 +60,9 @@ namespace Akka.Streams.Tests.Implementation
         }
 
         [Fact]
-        public void InitialTimeout_must_fail_if_no_initial_element_passes_until_timeout()
+        public async Task InitialTimeout_must_fail_if_no_initial_element_passes_until_timeout()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var downstreamProbe = this.CreateSubscriberProbe<int>();
                 Source.Maybe<int>()
@@ -78,9 +79,9 @@ namespace Akka.Streams.Tests.Implementation
 
 
         [Fact]
-        public void CompletionTimeout_must_pass_through_elements_unmodified()
+        public async Task CompletionTimeout_must_pass_through_elements_unmodified()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = Source.From(Enumerable.Range(1, 100))
                     .CompletionTimeout(TimeSpan.FromSeconds(2)).Grouped(200)
@@ -92,9 +93,9 @@ namespace Akka.Streams.Tests.Implementation
         }
 
         [Fact]
-        public void CompletionTimeout_must_pass_through_error_unmodified()
+        public async Task CompletionTimeout_must_pass_through_error_unmodified()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = Source.From(Enumerable.Range(1, 100))
                     .Concat(Source.Failed<int>(new TestException("test")))
@@ -107,9 +108,9 @@ namespace Akka.Streams.Tests.Implementation
         }
         
         [Fact]
-        public void CompletionTimeout_must_fail_if_not_completed_until_timeout()
+        public async Task CompletionTimeout_must_fail_if_not_completed_until_timeout()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var upstreamProbe = this.CreatePublisherProbe<int>();
                 var downstreamProbe = this.CreateSubscriberProbe<int>();
@@ -134,9 +135,9 @@ namespace Akka.Streams.Tests.Implementation
 
 
         [Fact]
-        public void IdleTimeout_must_pass_through_elements_unmodified()
+        public async Task IdleTimeout_must_pass_through_elements_unmodified()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var t = Source.From(Enumerable.Range(1, 100))
                     .IdleTimeout(TimeSpan.FromSeconds(2)).Grouped(200)
@@ -148,9 +149,9 @@ namespace Akka.Streams.Tests.Implementation
         }
 
         [Fact]
-        public void IdleTimeout_must_pass_through_error_unmodified()
+        public async Task IdleTimeout_must_pass_through_error_unmodified()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var task = Source.From(Enumerable.Range(1, 100))
                     .Concat(Source.Failed<int>(new TestException("test")))
@@ -163,9 +164,9 @@ namespace Akka.Streams.Tests.Implementation
         }
 
         [Fact]
-        public void IdleTimeout_must_fail_if_time_between_elements_is_too_large()
+        public async Task IdleTimeout_must_fail_if_time_between_elements_is_too_large()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var upstreamProbe = this.CreatePublisherProbe<int>();
                 var downstreamProbe = this.CreateSubscriberProbe<int>();
@@ -190,9 +191,9 @@ namespace Akka.Streams.Tests.Implementation
         
 
         [Fact]
-        public void BackpressureTimeout_must_pass_through_elements_unmodified()
+        public async Task BackpressureTimeout_must_pass_through_elements_unmodified()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 Source.From(Enumerable.Range(1, 100))
                     .BackpressureTimeout(TimeSpan.FromSeconds(1))
@@ -204,9 +205,9 @@ namespace Akka.Streams.Tests.Implementation
         }
 
         [Fact]
-        public void BackpressureTimeout_must_succeed_if_subscriber_demand_arrives()
+        public async Task BackpressureTimeout_must_succeed_if_subscriber_demand_arrives()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var subscriber = this.CreateSubscriberProbe<int>();
 
@@ -226,9 +227,9 @@ namespace Akka.Streams.Tests.Implementation
         }
         
         [Fact]
-        public void BackpressureTimeout_must_not_throw_if_publisher_is_less_frequent_than_timeout()
+        public async Task BackpressureTimeout_must_not_throw_if_publisher_is_less_frequent_than_timeout()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisher = this.CreatePublisherProbe<string>();
                 var subscriber = this.CreateSubscriberProbe<string>();
@@ -252,9 +253,9 @@ namespace Akka.Streams.Tests.Implementation
         }
         
         [Fact]
-        public void BackpressureTimeout_must_not_throw_if_publisher_wont_perform_emission_ever()
+        public async Task BackpressureTimeout_must_not_throw_if_publisher_wont_perform_emission_ever()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisher = this.CreatePublisherProbe<string>();
                 var subscriber = this.CreateSubscriberProbe<string>();
@@ -271,9 +272,9 @@ namespace Akka.Streams.Tests.Implementation
         }
 
         [Fact]
-        public void BackpressureTimeout_must_throw_if_subscriber_wont_generate_demand_on_time()
+        public async Task BackpressureTimeout_must_throw_if_subscriber_wont_generate_demand_on_time()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisher = this.CreatePublisherProbe<int>();
                 var subscriber = this.CreateSubscriberProbe<int>();
@@ -293,9 +294,9 @@ namespace Akka.Streams.Tests.Implementation
         }
         
         [Fact]
-        public void BackpressureTimeout_must_throw_if_subscriber_never_generate_demand()
+        public async Task BackpressureTimeout_must_throw_if_subscriber_never_generate_demand()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisher = this.CreatePublisherProbe<int>();
                 var subscriber = this.CreateSubscriberProbe<int>();
@@ -313,9 +314,9 @@ namespace Akka.Streams.Tests.Implementation
         }
         
         [Fact]
-        public void BackpressureTimeout_must_not_throw_if_publisher_completes_without_fulfilling_subscribers_demand()
+        public async Task BackpressureTimeout_must_not_throw_if_publisher_completes_without_fulfilling_subscribers_demand()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var publisher = this.CreatePublisherProbe<int>();
                 var subscriber = this.CreateSubscriberProbe<int>();
@@ -337,9 +338,9 @@ namespace Akka.Streams.Tests.Implementation
 
 
         [Fact]
-        public void IdleTimeoutBidi_must_not_signal_error_in_simple_loopback_case_and_pass_through_elements_unmodified()
+        public async Task IdleTimeoutBidi_must_not_signal_error_in_simple_loopback_case_and_pass_through_elements_unmodified()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var timeoutIdentity = BidiFlow.BidirectionalIdleTimeout<int, int>(TimeSpan.FromSeconds(2)).Join(Flow.Create<int>());
 
@@ -353,9 +354,9 @@ namespace Akka.Streams.Tests.Implementation
         }
 
         [Fact]
-        public void IdleTimeoutBidi_must_not_signal_error_if_traffic_is_one_way()
+        public async Task IdleTimeoutBidi_must_not_signal_error_if_traffic_is_one_way()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var upstreamWriter = this.CreatePublisherProbe<int>();
                 var downstreamWriter = this.CreatePublisherProbe<string>();
@@ -388,9 +389,9 @@ namespace Akka.Streams.Tests.Implementation
         }
 
         [Fact]
-        public void IdleTimeoutBidi_must_be_able_to_signal_timeout_once_no_traffic_on_either_sides()
+        public async Task IdleTimeoutBidi_must_be_able_to_signal_timeout_once_no_traffic_on_either_sides()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var upWrite = this.CreatePublisherProbe<string>();
                 var upRead = this.CreateSubscriberProbe<int>();
@@ -443,9 +444,9 @@ namespace Akka.Streams.Tests.Implementation
         }
 
         [Fact]
-        public void IdleTimeoutBidi_must_signal_error_to_all_outputs()
+        public async Task IdleTimeoutBidi_must_signal_error_to_all_outputs()
         {
-            this.AssertAllStagesStopped(() =>
+            await this.AssertAllStagesStoppedAsync(() =>
             {
                 var upWrite = this.CreatePublisherProbe<string>();
                 var upRead = this.CreateSubscriberProbe<int>();

--- a/src/core/Akka.TestKit.Tests/TestEventListenerTests/AllTestForEventFilterBase.cs
+++ b/src/core/Akka.TestKit.Tests/TestEventListenerTests/AllTestForEventFilterBase.cs
@@ -175,9 +175,9 @@ namespace Akka.TestKit.Tests.Xunit2.TestEventListenerTests
 
 
         [Fact]
-        public void Make_sure_async_works()
+        public async Task Make_sure_async_works()
         {
-            _testingEventFilter.ForLogLevel(LogLevel).Expect(1, TimeSpan.FromMilliseconds(100), () =>
+            await _testingEventFilter.ForLogLevel(LogLevel).ExpectAsync(1, TimeSpan.FromMilliseconds(100), () =>
             {
                 Task.Delay(TimeSpan.FromMilliseconds(10)).ContinueWith(t => { LogMessage("whatever"); });
             });

--- a/src/core/Akka.TestKit.Tests/TestFSMRefTests!/TestFSMRefSpec.cs
+++ b/src/core/Akka.TestKit.Tests/TestFSMRefTests!/TestFSMRefSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
 using Xunit;
@@ -15,7 +16,7 @@ namespace Akka.Testkit.Tests.TestFSMRefTests
     public class TestFSMRefSpec : AkkaSpec
     {
         [Fact]
-        public void A_TestFSMRef_must_allow_access_to_internal_state()
+        public async Task A_TestFSMRef_must_allow_access_to_internal_state()
         {
             var fsm = ActorOfAsTestFSMRef<StateTestFsm, int, string>("test-fsm-ref-1");
 
@@ -35,9 +36,9 @@ namespace Akka.Testkit.Tests.TestFSMRefTests
             fsm.StateData.ShouldBe("buh");
 
             fsm.SetStateTimeout(TimeSpan.FromMilliseconds(100));
-            Within(TimeSpan.FromMilliseconds(80), TimeSpan.FromMilliseconds(500), () =>
-                AwaitCondition(() => fsm.StateName == 2 && fsm.StateData == "timeout")
-                );
+            await WithinAsync(TimeSpan.FromMilliseconds(80), TimeSpan.FromMilliseconds(500), async () =>
+                await AwaitConditionAsync(() => fsm.StateName == 2 && fsm.StateData == "timeout")
+            );
         }
 
         [Fact]

--- a/src/core/Akka.TestKit.Tests/TestKitBaseTests/AwaitAssertTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestKitBaseTests/AwaitAssertTests.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Sdk;
 
@@ -18,18 +19,20 @@ namespace Akka.TestKit.Tests.Xunit2.TestKitBaseTests
         }
 
         [Fact]
-        public void AwaitAssert_must_not_throw_any_exception_when_assertion_is_valid()
+        public async Task AwaitAssert_must_not_throw_any_exception_when_assertion_is_valid()
         {
-            AwaitAssert(() => Assert.Equal("foo", "foo"));
+            await AwaitAssertAsync(() => Assert.Equal("foo", "foo"));
         }
 
         [Fact]
-        public void AwaitAssert_must_throw_exception_when_assertion_is_invalid()
+        public async Task AwaitAssert_must_throw_exception_when_assertion_is_invalid()
         {
-            Within(TimeSpan.FromMilliseconds(300), TimeSpan.FromSeconds(1), () =>
+            await WithinAsync(TimeSpan.FromMilliseconds(300), TimeSpan.FromSeconds(1), async () =>
             {
-                Assert.Throws<EqualException>(() =>
-                    AwaitAssert(() => Assert.Equal("foo", "bar"), TimeSpan.FromMilliseconds(500), TimeSpan.FromMilliseconds(300)));
+                await Assert.ThrowsAsync<EqualException>(async () =>
+                {
+                    await AwaitAssertAsync(() => Assert.Equal("foo", "bar"), TimeSpan.FromMilliseconds(500), TimeSpan.FromMilliseconds(300));
+                });
             });
         }
     }

--- a/src/core/Akka.TestKit.Tests/TestKitBaseTests/DilatedTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestKitBaseTests/DilatedTests.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.TestKit;
 using Xunit;
 
@@ -30,10 +31,10 @@ namespace Akka.Testkit.Tests.TestKitBaseTests
         }
 
         [Fact]
-        public void AwaitCondition_should_dilate_timeout()
+        public async Task AwaitCondition_should_dilate_timeout()
         {
             var before = Now;
-            Intercept(() => AwaitCondition(() => false, TimeSpan.FromMilliseconds(Timeout)));
+            await InterceptAsync(async () => await AwaitConditionAsync(() => false, TimeSpan.FromMilliseconds(Timeout)));
             var after = Now;
             var diff = (after - before).TotalMilliseconds;
             Assert.True(Math.Abs(diff - ExpectedTimeout) <= DiffDelta);

--- a/src/core/Akka.TestKit/EventFilter/IEventFilterApplier.cs
+++ b/src/core/Akka.TestKit/EventFilter/IEventFilterApplier.cs
@@ -24,6 +24,7 @@ namespace Akka.TestKit
         /// "akka.test.filter-leeway", see <see cref="TestKitSettings.TestEventFilterLeeway"/>.
         /// </summary>
         /// <param name="action">The action.</param>
+        [Obsolete("Use async version instead")]
         void ExpectOne(Action action);
         
         /// <summary>
@@ -34,6 +35,16 @@ namespace Akka.TestKit
         /// "akka.test.filter-leeway", see <see cref="TestKitSettings.TestEventFilterLeeway"/>.
         /// </summary>
         /// <param name="action">The action.</param>
+        Task ExpectOneAsync(Action action);
+        
+        /// <summary>
+        /// Executes <paramref name="actionAsync"/> and
+        /// expects one event to be logged during the execution.
+        /// This method fails and throws an exception if more than one event is logged,
+        /// or if a timeout occurs. The timeout is taken from the config value
+        /// "akka.test.filter-leeway", see <see cref="TestKitSettings.TestEventFilterLeeway"/>.
+        /// </summary>
+        /// <param name="actionAsync">The action.</param>
         Task ExpectOneAsync(Func<Task> actionAsync);
 
         /// <summary>
@@ -44,8 +55,19 @@ namespace Akka.TestKit
         /// </summary>
         /// <param name="timeout">The time to wait for a log event after executing <paramref name="action"/></param>
         /// <param name="action">The action.</param>
+        [Obsolete("Use async version instead")]
         void ExpectOne(TimeSpan timeout, Action action);
-
+        
+        /// <summary>
+        /// Executes <paramref name="action"/> and
+        /// expects one event to be logged during the execution.
+        /// This method fails and throws an exception if more than one event is logged,
+        /// or if a timeout occurs.
+        /// </summary>
+        /// <param name="timeout">The time to wait for a log event after executing <paramref name="action"/></param>
+        /// <param name="action">The action.</param>
+        Task ExpectOneAsync(TimeSpan timeout, Action action);
+        
         /// <summary>
         /// Executes <paramref name="action"/> and expects the specified number
         /// of events to be logged during the execution.
@@ -55,7 +77,19 @@ namespace Akka.TestKit
         /// </summary>
         /// <param name="expectedCount">The expected number of events</param>
         /// <param name="action">The action.</param>
+        [Obsolete("Use async version instead")]
         void Expect(int expectedCount, Action action);
+        
+        /// <summary>
+        /// Executes <paramref name="action"/> and expects the specified number
+        /// of events to be logged during the execution.
+        /// This method fails and throws an exception if more events than expected are logged,
+        /// or if a timeout occurs. The timeout is taken from the config value
+        /// "akka.test.filter-leeway", see <see cref="TestKitSettings.TestEventFilterLeeway"/>.
+        /// </summary>
+        /// <param name="expectedCount">The expected number of events</param>
+        /// <param name="action">The action.</param>
+        Task ExpectAsync(int expectedCount, Action action);
         
         /// <summary>
         /// Executes <paramref name="actionAsync"/> task and expects the specified number
@@ -78,7 +112,20 @@ namespace Akka.TestKit
         /// <param name="timeout">The time to wait for log events after executing <paramref name="action"/></param>
         /// <param name="expectedCount">The expected number of events</param>
         /// <param name="action">The action.</param>
+        [Obsolete("Use async version instead")]
         void Expect(int expectedCount, TimeSpan timeout, Action action);
+        
+        /// <summary>
+        /// Executes <paramref name="action"/> and expects the specified number
+        /// of events to be logged during the execution.
+        /// This method fails and throws an exception if more events than expected are logged,
+        /// or if a timeout occurs. The timeout is taken from the config value
+        /// "akka.test.filter-leeway", see <see cref="TestKitSettings.TestEventFilterLeeway"/>.
+        /// </summary>
+        /// <param name="timeout">The time to wait for log events after executing <paramref name="action"/></param>
+        /// <param name="expectedCount">The expected number of events</param>
+        /// <param name="action">The action.</param>
+        Task ExpectAsync(int expectedCount, TimeSpan timeout, Action action);
 
         /// <summary>
         /// Executes <paramref name="func"/> and
@@ -90,7 +137,20 @@ namespace Akka.TestKit
         /// <typeparam name="T">The return value of the function</typeparam>
         /// <param name="func">The function.</param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
+        [Obsolete("Use async version instead")]
         T ExpectOne<T>(Func<T> func);
+        
+        /// <summary>
+        /// Executes <paramref name="func"/> and
+        /// expects one event to be logged during the execution.
+        /// This function fails and throws an exception if more than one event is logged,
+        /// or if a timeout occurs. The timeout is taken from the config value
+        /// "akka.test.filter-leeway", see <see cref="TestKitSettings.TestEventFilterLeeway"/>.
+        /// </summary>
+        /// <typeparam name="T">The return value of the function</typeparam>
+        /// <param name="func">The function.</param>
+        /// <returns>The returned value from <paramref name="func"/>.</returns>
+        Task<T> ExpectOneAsync<T>(Func<T> func);
 
         /// <summary>
         /// Executes <paramref name="func"/> and
@@ -102,7 +162,21 @@ namespace Akka.TestKit
         /// <param name="timeout">The time to wait for a log event after executing <paramref name="func"/></param>
         /// <param name="func">The function.</param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
+        [Obsolete("Use async version instead")]
         T ExpectOne<T>(TimeSpan timeout, Func<T> func);
+        
+        /// <summary>
+        /// Executes <paramref name="func"/> and
+        /// expects one event to be logged during the execution.
+        /// This function fails and throws an exception if more than one event is logged,
+        /// or if a timeout occurs.
+        /// </summary>
+        /// <typeparam name="T">The return value of the function</typeparam>
+        /// <param name="timeout">The time to wait for a log event after executing <paramref name="func"/></param>
+        /// <param name="func">The function.</param>
+        /// <returns>The returned value from <paramref name="func"/>.</returns>
+        [Obsolete("Use async version instead")]
+        Task<T> ExpectOneAsync<T>(TimeSpan timeout, Func<T> func);
 
         /// <summary>
         /// Executes <paramref name="func"/> and expects the specified number
@@ -115,6 +189,7 @@ namespace Akka.TestKit
         /// <param name="expectedCount">The expected number of events</param>
         /// <param name="func">The function.</param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
+        [Obsolete("Use async version instead")]
         T Expect<T>(int expectedCount, Func<T> func);
         
         /// <summary>
@@ -126,9 +201,9 @@ namespace Akka.TestKit
         /// </summary>
         /// <typeparam name="T">The return value of the function</typeparam>
         /// <param name="expectedCount">The expected number of events</param>
-        /// <param name="func">The async function.</param>
+        /// <param name="func">The function.</param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
-        Task<T> ExpectAsync<T>(int expectedCount, Func<Task<T>> funcAsync);
+        Task<T> ExpectAsync<T>(int expectedCount, Func<T> func);
 
         /// <summary>
         /// Executes <paramref name="func"/> and expects the specified number
@@ -142,7 +217,22 @@ namespace Akka.TestKit
         /// <param name="expectedCount">The expected number of events</param>
         /// <param name="func">The function.</param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
+        [Obsolete("Use async version instead")]
         T Expect<T>(int expectedCount, TimeSpan timeout, Func<T> func);
+        
+        /// <summary>
+        /// Executes <paramref name="func"/> and expects the specified number
+        /// of events to be logged during the execution.
+        /// This function fails and throws an exception if more events than expected are logged,
+        /// or if a timeout occurs. The timeout is taken from the config value
+        /// "akka.test.filter-leeway", see <see cref="TestKitSettings.TestEventFilterLeeway"/>.
+        /// </summary>
+        /// <typeparam name="T">The return value of the function</typeparam>
+        /// <param name="timeout">The time to wait for log events after executing <paramref name="func"/></param>
+        /// <param name="expectedCount">The expected number of events</param>
+        /// <param name="func">The function.</param>
+        /// <returns>The returned value from <paramref name="func"/>.</returns>
+        Task<T> ExpectAsync<T>(int expectedCount, TimeSpan timeout, Func<T> func);
 
         /// <summary>
         /// Executes <paramref name="func"/> and prevent events from being logged during the execution.
@@ -150,14 +240,31 @@ namespace Akka.TestKit
         /// <typeparam name="T">The return value of the function</typeparam>
         /// <param name="func">The function.</param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
+        [Obsolete("Use async version instead")]
         T Mute<T>(Func<T> func);
+        
+        /// <summary>
+        /// Executes <paramref name="func"/> and prevent events from being logged during the execution.
+        /// </summary>
+        /// <typeparam name="T">The return value of the function</typeparam>
+        /// <param name="func">The function.</param>
+        /// <returns>The returned value from <paramref name="func"/>.</returns>
+        Task<T> MuteAsync<T>(Func<T> func);
 
         /// <summary>
         /// Executes <paramref name="action"/> and prevent events from being logged during the execution.
         /// </summary>
         /// <param name="action">The function.</param>
         /// <returns>The returned value from <paramref name="action"/>.</returns>
+        [Obsolete("Use async version instead")]
         void Mute(Action action);
+        
+        /// <summary>
+        /// Executes <paramref name="action"/> and prevent events from being logged during the execution.
+        /// </summary>
+        /// <param name="action">The function.</param>
+        /// <returns>The returned value from <paramref name="action"/>.</returns>
+        Task MuteAsync(Action action);
 
         /// <summary>
         /// Prevents events from being logged from now on. To allow events to be logged again, call 

--- a/src/core/Akka.TestKit/EventFilter/IEventFilterApplier.cs
+++ b/src/core/Akka.TestKit/EventFilter/IEventFilterApplier.cs
@@ -24,7 +24,6 @@ namespace Akka.TestKit
         /// "akka.test.filter-leeway", see <see cref="TestKitSettings.TestEventFilterLeeway"/>.
         /// </summary>
         /// <param name="action">The action.</param>
-        [Obsolete("Use async version instead")]
         void ExpectOne(Action action);
         
         /// <summary>
@@ -55,7 +54,6 @@ namespace Akka.TestKit
         /// </summary>
         /// <param name="timeout">The time to wait for a log event after executing <paramref name="action"/></param>
         /// <param name="action">The action.</param>
-        [Obsolete("Use async version instead")]
         void ExpectOne(TimeSpan timeout, Action action);
         
         /// <summary>
@@ -77,7 +75,6 @@ namespace Akka.TestKit
         /// </summary>
         /// <param name="expectedCount">The expected number of events</param>
         /// <param name="action">The action.</param>
-        [Obsolete("Use async version instead")]
         void Expect(int expectedCount, Action action);
         
         /// <summary>
@@ -112,7 +109,6 @@ namespace Akka.TestKit
         /// <param name="timeout">The time to wait for log events after executing <paramref name="action"/></param>
         /// <param name="expectedCount">The expected number of events</param>
         /// <param name="action">The action.</param>
-        [Obsolete("Use async version instead")]
         void Expect(int expectedCount, TimeSpan timeout, Action action);
         
         /// <summary>
@@ -137,7 +133,6 @@ namespace Akka.TestKit
         /// <typeparam name="T">The return value of the function</typeparam>
         /// <param name="func">The function.</param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
-        [Obsolete("Use async version instead")]
         T ExpectOne<T>(Func<T> func);
         
         /// <summary>
@@ -162,7 +157,6 @@ namespace Akka.TestKit
         /// <param name="timeout">The time to wait for a log event after executing <paramref name="func"/></param>
         /// <param name="func">The function.</param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
-        [Obsolete("Use async version instead")]
         T ExpectOne<T>(TimeSpan timeout, Func<T> func);
         
         /// <summary>
@@ -175,7 +169,6 @@ namespace Akka.TestKit
         /// <param name="timeout">The time to wait for a log event after executing <paramref name="func"/></param>
         /// <param name="func">The function.</param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
-        [Obsolete("Use async version instead")]
         Task<T> ExpectOneAsync<T>(TimeSpan timeout, Func<T> func);
 
         /// <summary>
@@ -189,7 +182,6 @@ namespace Akka.TestKit
         /// <param name="expectedCount">The expected number of events</param>
         /// <param name="func">The function.</param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
-        [Obsolete("Use async version instead")]
         T Expect<T>(int expectedCount, Func<T> func);
         
         /// <summary>
@@ -217,7 +209,6 @@ namespace Akka.TestKit
         /// <param name="expectedCount">The expected number of events</param>
         /// <param name="func">The function.</param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
-        [Obsolete("Use async version instead")]
         T Expect<T>(int expectedCount, TimeSpan timeout, Func<T> func);
         
         /// <summary>
@@ -240,7 +231,6 @@ namespace Akka.TestKit
         /// <typeparam name="T">The return value of the function</typeparam>
         /// <param name="func">The function.</param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
-        [Obsolete("Use async version instead")]
         T Mute<T>(Func<T> func);
         
         /// <summary>
@@ -256,7 +246,6 @@ namespace Akka.TestKit
         /// </summary>
         /// <param name="action">The function.</param>
         /// <returns>The returned value from <paramref name="action"/>.</returns>
-        [Obsolete("Use async version instead")]
         void Mute(Action action);
         
         /// <summary>

--- a/src/core/Akka.TestKit/EventFilter/IEventFilterApplier.cs
+++ b/src/core/Akka.TestKit/EventFilter/IEventFilterApplier.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 
 namespace Akka.TestKit
 {
@@ -24,6 +25,16 @@ namespace Akka.TestKit
         /// </summary>
         /// <param name="action">The action.</param>
         void ExpectOne(Action action);
+        
+        /// <summary>
+        /// Executes <paramref name="action"/> and
+        /// expects one event to be logged during the execution.
+        /// This method fails and throws an exception if more than one event is logged,
+        /// or if a timeout occurs. The timeout is taken from the config value
+        /// "akka.test.filter-leeway", see <see cref="TestKitSettings.TestEventFilterLeeway"/>.
+        /// </summary>
+        /// <param name="action">The action.</param>
+        Task ExpectOneAsync(Func<Task> actionAsync);
 
         /// <summary>
         /// Executes <paramref name="action"/> and
@@ -45,6 +56,17 @@ namespace Akka.TestKit
         /// <param name="expectedCount">The expected number of events</param>
         /// <param name="action">The action.</param>
         void Expect(int expectedCount, Action action);
+        
+        /// <summary>
+        /// Executes <paramref name="actionAsync"/> task and expects the specified number
+        /// of events to be logged during the execution.
+        /// This method fails and throws an exception if more events than expected are logged,
+        /// or if a timeout occurs. The timeout is taken from the config value
+        /// "akka.test.filter-leeway", see <see cref="TestKitSettings.TestEventFilterLeeway"/>.
+        /// </summary>
+        /// <param name="expectedCount">The expected number of events</param>
+        /// <param name="actionAsync">The async action.</param>
+        Task ExpectAsync(int expectedCount, Func<Task> actionAsync);
 
         /// <summary>
         /// Executes <paramref name="action"/> and expects the specified number
@@ -94,6 +116,19 @@ namespace Akka.TestKit
         /// <param name="func">The function.</param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
         T Expect<T>(int expectedCount, Func<T> func);
+        
+        /// <summary>
+        /// Executes <paramref name="func"/> and expects the specified number
+        /// of events to be logged during the execution.
+        /// This function fails and throws an exception if more events than expected are logged,
+        /// or if a timeout occurs. The timeout is taken from the config value
+        /// "akka.test.filter-leeway", see <see cref="TestKitSettings.TestEventFilterLeeway"/>.
+        /// </summary>
+        /// <typeparam name="T">The return value of the function</typeparam>
+        /// <param name="expectedCount">The expected number of events</param>
+        /// <param name="func">The async function.</param>
+        /// <returns>The returned value from <paramref name="func"/>.</returns>
+        Task<T> ExpectAsync<T>(int expectedCount, Func<Task<T>> funcAsync);
 
         /// <summary>
         /// Executes <paramref name="func"/> and expects the specified number

--- a/src/core/Akka.TestKit/EventFilter/Internal/EventFilterApplier.cs
+++ b/src/core/Akka.TestKit/EventFilter/Internal/EventFilterApplier.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
 using Akka.TestKit.TestEvent;
@@ -40,30 +41,59 @@ namespace Akka.TestKit.Internal
         /// TBD
         /// </summary>
         /// <param name="action">TBD</param>
+        [Obsolete("Use async version instead", true)]
         public void ExpectOne(Action action)
         {
             InternalExpect(action, _actorSystem, 1);
         }
+        
+        /// <summary>
+        /// Async version of <see cref="ExpectOne(System.Action)"/>
+        /// </summary>
+        /// <param name="action"></param>
+        public async Task ExpectOneAsync(Action action)
+        {
+            await InternalExpectAsync(action, _actorSystem, 1);
+        }
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="timeout">TBD</param>
         /// <param name="action">TBD</param>
+        [Obsolete("Use async version instead", true)]
         public void ExpectOne(TimeSpan timeout, Action action)
         {
             InternalExpect(action, _actorSystem, 1, timeout);
         }
+        
+        /// <summary>
+        /// Async version of <see cref="ExpectOne(System.TimeSpan,System.Action) "/>
+        /// </summary>
+        /// <returns></returns>
+        public async Task ExpectOneAsync(TimeSpan timeout, Action action)
+        {
+            await InternalExpectAsync(action, _actorSystem, 1, timeout);
+        }
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="expectedCount">TBD</param>
         /// <param name="action">TBD</param>
+        [Obsolete("Use async version instead", true)]
         public void Expect(int expectedCount, Action action)
         {
             InternalExpect(action, _actorSystem, expectedCount, null);
         }
+        
+        /// <summary>
+        /// Async version of <see cref="Expect(int,System.Action)"/>
+        /// </summary>
+        public async Task ExpectAsync(int expectedCount, Action action)
+        {
+            await InternalExpectAsync(action, _actorSystem, expectedCount, null);
+        }
 
         /// <summary>
         /// TBD
@@ -71,10 +101,19 @@ namespace Akka.TestKit.Internal
         /// <param name="expectedCount">TBD</param>
         /// <param name="timeout">TBD</param>
         /// <param name="action">TBD</param>
+        [Obsolete("Use async version instead", true)]
         public void Expect(int expectedCount, TimeSpan timeout, Action action)
         {
             InternalExpect(action, _actorSystem, expectedCount, timeout);
         }
+        
+        /// <summary>
+        /// Async version of <see cref="Expect(int,System.TimeSpan,System.Action)"/>
+        /// </summary>
+        public async Task ExpectAsync(int expectedCount, TimeSpan timeout, Action action)
+        {
+            await InternalExpectAsync(action, _actorSystem, expectedCount, timeout);
+        }
 
         /// <summary>
         /// TBD
@@ -82,10 +121,19 @@ namespace Akka.TestKit.Internal
         /// <typeparam name="T">TBD</typeparam>
         /// <param name="func">TBD</param>
         /// <returns>TBD</returns>
+        [Obsolete("Use async version instead", true)]
         public T ExpectOne<T>(Func<T> func)
         {
             return Intercept(func, _actorSystem, null, 1);
         }
+        
+        /// <summary>
+        /// Async version of ExpectOne
+        /// </summary>
+        public async Task<T> ExpectOneAsync<T>(Func<T> func)
+        {
+            return await InterceptAsync(func, _actorSystem, null, 1);
+        }
 
         /// <summary>
         /// TBD
@@ -94,10 +142,19 @@ namespace Akka.TestKit.Internal
         /// <param name="timeout">TBD</param>
         /// <param name="func">TBD</param>
         /// <returns>TBD</returns>
+        [Obsolete("Use async version instead", true)]
         public T ExpectOne<T>(TimeSpan timeout, Func<T> func)
         {
             return Intercept(func, _actorSystem, timeout, 1);
         }
+        
+        /// <summary>
+        /// Async version of ExpectOne
+        /// </summary>
+        public async Task<T> ExpectOneAsync<T>(TimeSpan timeout, Func<T> func)
+        {
+            return await InterceptAsync(func, _actorSystem, timeout, 1);
+        }
 
         /// <summary>
         /// TBD
@@ -106,9 +163,18 @@ namespace Akka.TestKit.Internal
         /// <param name="expectedCount">TBD</param>
         /// <param name="func">TBD</param>
         /// <returns>TBD</returns>
+        [Obsolete("Use async version instead", true)]
         public T Expect<T>(int expectedCount, Func<T> func)
         {
             return Intercept(func, _actorSystem, null, expectedCount);
+        }
+        
+        /// <summary>
+        /// Async version of Expect
+        /// </summary>
+        public async Task<T> ExpectAsync<T>(int expectedCount, Func<T> func)
+        {
+            return await InterceptAsync(func, _actorSystem, null, expectedCount);
         }
 
         /// <summary>
@@ -119,9 +185,18 @@ namespace Akka.TestKit.Internal
         /// <param name="expectedCount">TBD</param>
         /// <param name="func">TBD</param>
         /// <returns>TBD</returns>
+        [Obsolete("Use async version instead", true)]
         public T Expect<T>(int expectedCount, TimeSpan timeout, Func<T> func)
         {
             return Intercept(func, _actorSystem, timeout, expectedCount);
+        }
+        
+        /// <summary>
+        /// Async version of Expect
+        /// </summary>
+        public async Task<T> ExpectAsync<T>(int expectedCount, TimeSpan timeout, Func<T> func)
+        {
+            return await InterceptAsync(func, _actorSystem, timeout, expectedCount);
         }
 
         /// <summary>
@@ -130,18 +205,36 @@ namespace Akka.TestKit.Internal
         /// <typeparam name="T">TBD</typeparam>
         /// <param name="func">TBD</param>
         /// <returns>TBD</returns>
+        [Obsolete("Use async version instead", true)]
         public T Mute<T>(Func<T> func)
         {
             return Intercept(func, _actorSystem, null, null);
+        }
+        
+        /// <summary>
+        /// Async version of Mute
+        /// </summary>
+        public async Task<T> MuteAsync<T>(Func<T> func)
+        {
+            return await InterceptAsync(func, _actorSystem, null, null);
         }
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="action">TBD</param>
+        [Obsolete("Use async version instead", true)]
         public void Mute(Action action)
         {
             Intercept<object>(() => { action(); return null; }, _actorSystem, null, null);
+        }
+        
+        /// <summary>
+        /// Async version of Mute
+        /// </summary>
+        public async Task MuteAsync(Action action)
+        {
+            await InterceptAsync<object>(() => { action(); return null; }, _actorSystem, null, null);
         }
 
         /// <summary>
@@ -175,6 +268,7 @@ namespace Akka.TestKit.Internal
         /// <param name="expectedOccurrences">TBD</param>
         /// <param name="matchedEventHandler">TBD</param>
         /// <returns>TBD</returns>
+        [Obsolete("Use async version instead", true)]
         protected T Intercept<T>(Func<T> func, ActorSystem system, TimeSpan? timeout, int? expectedOccurrences, MatchedEventHandler matchedEventHandler = null)
         {
             var leeway = system.HasExtension<TestKitSettings>()
@@ -226,6 +320,61 @@ namespace Akka.TestKit.Internal
                 system.EventStream.Publish(new Unmute(_filters));
             }
         }
+        
+        /// <summary>
+        /// Async version of <see cref="Intercept{T}"/>
+        /// </summary>
+        protected async Task<T> InterceptAsync<T>(Func<T> func, ActorSystem system, TimeSpan? timeout, int? expectedOccurrences, MatchedEventHandler matchedEventHandler = null)
+        {
+            var leeway = system.HasExtension<TestKitSettings>()
+                ? TestKitExtension.For(system).TestEventFilterLeeway
+                : _testkit.TestKitSettings.TestEventFilterLeeway;
+
+            var timeoutValue = timeout.HasValue ? _testkit.Dilated(timeout.Value) : leeway;
+            matchedEventHandler = matchedEventHandler ?? new MatchedEventHandler();
+            system.EventStream.Publish(new Mute(_filters));
+            try
+            {
+                foreach(var filter in _filters)
+                {
+                    filter.EventMatched += matchedEventHandler.HandleEvent;
+                }
+                var result = func();
+
+                if(!await AwaitDoneAsync(timeoutValue, expectedOccurrences, matchedEventHandler))
+                {
+                    var actualNumberOfEvents = matchedEventHandler.ReceivedCount;
+                    string msg;
+                    if(expectedOccurrences.HasValue)
+                    {
+                        var expectedNumberOfEvents = expectedOccurrences.Value;
+                        if(actualNumberOfEvents < expectedNumberOfEvents)
+                            msg = string.Format("Timeout ({0}) while waiting for messages. Only received {1}/{2} messages that matched filter [{3}]", timeoutValue, actualNumberOfEvents, expectedNumberOfEvents, string.Join(",", _filters));
+                        else
+                        {
+                            var tooMany = actualNumberOfEvents - expectedNumberOfEvents;
+                            msg = string.Format("Received {0} {1} too many. Expected {2} {3} but received {4} that matched filter [{5}]", tooMany, GetMessageString(tooMany), expectedNumberOfEvents, GetMessageString(expectedNumberOfEvents), actualNumberOfEvents, string.Join(",", _filters));
+                        }
+                    }
+                    else
+                        msg = string.Format("Timeout ({0}) while waiting for messages that matched filter [{1}]", timeoutValue, _filters);
+
+                    var assertionsProvider = system.HasExtension<TestKitAssertionsProvider>()
+                        ? TestKitAssertionsExtension.For(system)
+                        : TestKitAssertionsExtension.For(_testkit.Sys);
+                    assertionsProvider.Assertions.Fail(msg);
+                }
+                return result;
+            }
+            finally
+            {
+                foreach(var filter in _filters)
+                {
+                    filter.EventMatched -= matchedEventHandler.HandleEvent;
+                }
+                system.EventStream.Publish(new Unmute(_filters));
+            }
+        }
 
         /// <summary>
         /// TBD
@@ -234,12 +383,27 @@ namespace Akka.TestKit.Internal
         /// <param name="expectedOccurrences">TBD</param>
         /// <param name="matchedEventHandler">TBD</param>
         /// <returns>TBD</returns>
+        [Obsolete("Use async version instead", true)]
         protected bool AwaitDone(TimeSpan timeout, int? expectedOccurrences, MatchedEventHandler matchedEventHandler)
         {
             if(expectedOccurrences.HasValue)
             {
                 var expected = expectedOccurrences.GetValueOrDefault();
-                _testkit.AwaitConditionNoThrow(() => matchedEventHandler.ReceivedCount >= expected, timeout);
+                _testkit.AwaitConditionNoThrowAsync(() => matchedEventHandler.ReceivedCount >= expected, timeout);
+                return matchedEventHandler.ReceivedCount == expected;
+            }
+            return true;
+        }
+        
+        /// <summary>
+        /// Async version of <see cref="AwaitDone"/>
+        /// </summary>
+        protected async Task<bool> AwaitDoneAsync(TimeSpan timeout, int? expectedOccurrences, MatchedEventHandler matchedEventHandler)
+        {
+            if(expectedOccurrences.HasValue)
+            {
+                var expected = expectedOccurrences.GetValueOrDefault();
+                await _testkit.AwaitConditionNoThrowAsync(() => matchedEventHandler.ReceivedCount >= expected, timeout);
                 return matchedEventHandler.ReceivedCount == expected;
             }
             return true;
@@ -255,9 +419,18 @@ namespace Akka.TestKit.Internal
             return number == 1 ? "message" : "messages";
         }
 
+        [Obsolete("Use async version instead", true)]
         private void InternalExpect(Action action, ActorSystem actorSystem, int expectedCount, TimeSpan? timeout = null)
         {
             Intercept<object>(() => { action(); return null; }, actorSystem, timeout, expectedCount);
+        }
+        
+        /// <summary>
+        /// Async version of <see cref="InternalExpect"/>
+        /// </summary>
+        private async Task InternalExpectAsync(Action action, ActorSystem actorSystem, int expectedCount, TimeSpan? timeout = null)
+        {
+            await InterceptAsync<object>(() => { action(); return null; }, actorSystem, timeout, expectedCount);
         }
 
         /// <summary>

--- a/src/core/Akka.TestKit/EventFilter/Internal/EventFilterApplier.cs
+++ b/src/core/Akka.TestKit/EventFilter/Internal/EventFilterApplier.cs
@@ -418,7 +418,7 @@ namespace Akka.TestKit.Internal
             if(expectedOccurrences.HasValue)
             {
                 var expected = expectedOccurrences.GetValueOrDefault();
-                _testkit.AwaitConditionNoThrowAsync(() => matchedEventHandler.ReceivedCount >= expected, timeout);
+                _testkit.AwaitConditionNoThrowAsync(() => matchedEventHandler.ReceivedCount >= expected, timeout).Wait();
                 return matchedEventHandler.ReceivedCount == expected;
             }
             return true;

--- a/src/core/Akka.TestKit/EventFilter/Internal/EventFilterApplier.cs
+++ b/src/core/Akka.TestKit/EventFilter/Internal/EventFilterApplier.cs
@@ -41,7 +41,7 @@ namespace Akka.TestKit.Internal
         /// TBD
         /// </summary>
         /// <param name="action">TBD</param>
-        [Obsolete("Use async version instead", true)]
+        [Obsolete("Use async version instead")]
         public void ExpectOne(Action action)
         {
             InternalExpect(action, _actorSystem, 1);
@@ -66,7 +66,7 @@ namespace Akka.TestKit.Internal
         /// </summary>
         /// <param name="timeout">TBD</param>
         /// <param name="action">TBD</param>
-        [Obsolete("Use async version instead", true)]
+        [Obsolete("Use async version instead")]
         public void ExpectOne(TimeSpan timeout, Action action)
         {
             InternalExpect(action, _actorSystem, 1, timeout);
@@ -86,7 +86,7 @@ namespace Akka.TestKit.Internal
         /// </summary>
         /// <param name="expectedCount">TBD</param>
         /// <param name="action">TBD</param>
-        [Obsolete("Use async version instead", true)]
+        [Obsolete("Use async version instead")]
         public void Expect(int expectedCount, Action action)
         {
             InternalExpect(action, _actorSystem, expectedCount, null);
@@ -114,7 +114,7 @@ namespace Akka.TestKit.Internal
         /// <param name="expectedCount">TBD</param>
         /// <param name="timeout">TBD</param>
         /// <param name="action">TBD</param>
-        [Obsolete("Use async version instead", true)]
+        [Obsolete("Use async version instead")]
         public void Expect(int expectedCount, TimeSpan timeout, Action action)
         {
             InternalExpect(action, _actorSystem, expectedCount, timeout);
@@ -134,7 +134,7 @@ namespace Akka.TestKit.Internal
         /// <typeparam name="T">TBD</typeparam>
         /// <param name="func">TBD</param>
         /// <returns>TBD</returns>
-        [Obsolete("Use async version instead", true)]
+        [Obsolete("Use async version instead")]
         public T ExpectOne<T>(Func<T> func)
         {
             return Intercept(func, _actorSystem, null, 1);
@@ -155,7 +155,7 @@ namespace Akka.TestKit.Internal
         /// <param name="timeout">TBD</param>
         /// <param name="func">TBD</param>
         /// <returns>TBD</returns>
-        [Obsolete("Use async version instead", true)]
+        [Obsolete("Use async version instead")]
         public T ExpectOne<T>(TimeSpan timeout, Func<T> func)
         {
             return Intercept(func, _actorSystem, timeout, 1);
@@ -176,7 +176,7 @@ namespace Akka.TestKit.Internal
         /// <param name="expectedCount">TBD</param>
         /// <param name="func">TBD</param>
         /// <returns>TBD</returns>
-        [Obsolete("Use async version instead", true)]
+        [Obsolete("Use async version instead")]
         public T Expect<T>(int expectedCount, Func<T> func)
         {
             return Intercept(func, _actorSystem, null, expectedCount);
@@ -206,7 +206,7 @@ namespace Akka.TestKit.Internal
         /// <param name="expectedCount">TBD</param>
         /// <param name="func">TBD</param>
         /// <returns>TBD</returns>
-        [Obsolete("Use async version instead", true)]
+        [Obsolete("Use async version instead")]
         public T Expect<T>(int expectedCount, TimeSpan timeout, Func<T> func)
         {
             return Intercept(func, _actorSystem, timeout, expectedCount);
@@ -226,7 +226,7 @@ namespace Akka.TestKit.Internal
         /// <typeparam name="T">TBD</typeparam>
         /// <param name="func">TBD</param>
         /// <returns>TBD</returns>
-        [Obsolete("Use async version instead", true)]
+        [Obsolete("Use async version instead")]
         public T Mute<T>(Func<T> func)
         {
             return Intercept(func, _actorSystem, null, null);
@@ -244,7 +244,7 @@ namespace Akka.TestKit.Internal
         /// TBD
         /// </summary>
         /// <param name="action">TBD</param>
-        [Obsolete("Use async version instead", true)]
+        [Obsolete("Use async version instead")]
         public void Mute(Action action)
         {
             Intercept<object>(() => { action(); return null; }, _actorSystem, null, null);
@@ -289,7 +289,7 @@ namespace Akka.TestKit.Internal
         /// <param name="expectedOccurrences">TBD</param>
         /// <param name="matchedEventHandler">TBD</param>
         /// <returns>TBD</returns>
-        [Obsolete("Use async version instead", true)]
+        [Obsolete("Use async version instead")]
         protected T Intercept<T>(Func<T> func, ActorSystem system, TimeSpan? timeout, int? expectedOccurrences, MatchedEventHandler matchedEventHandler = null)
         {
             var leeway = system.HasExtension<TestKitSettings>()
@@ -412,7 +412,7 @@ namespace Akka.TestKit.Internal
         /// <param name="expectedOccurrences">TBD</param>
         /// <param name="matchedEventHandler">TBD</param>
         /// <returns>TBD</returns>
-        [Obsolete("Use async version instead", true)]
+        [Obsolete("Use async version instead")]
         protected bool AwaitDone(TimeSpan timeout, int? expectedOccurrences, MatchedEventHandler matchedEventHandler)
         {
             if(expectedOccurrences.HasValue)
@@ -448,7 +448,7 @@ namespace Akka.TestKit.Internal
             return number == 1 ? "message" : "messages";
         }
 
-        [Obsolete("Use async version instead", true)]
+        [Obsolete("Use async version instead")]
         private void InternalExpect(Action action, ActorSystem actorSystem, int expectedCount, TimeSpan? timeout = null)
         {
             Intercept<object>(() => { action(); return null; }, actorSystem, timeout, expectedCount);

--- a/src/core/Akka.TestKit/EventFilter/Internal/EventFilterApplier.cs
+++ b/src/core/Akka.TestKit/EventFilter/Internal/EventFilterApplier.cs
@@ -185,14 +185,6 @@ namespace Akka.TestKit.Internal
         /// <summary>
         /// Async version of Expect
         /// </summary>
-        public Task<T> ExpectAsync<T>(int expectedCount, Func<Task<T>> funcAsync)
-        {
-            return InterceptAsync(funcAsync, _actorSystem, null, expectedCount);
-        }
-
-        /// <summary>
-        /// Async version of Expect
-        /// </summary>
         public async Task<T> ExpectAsync<T>(int expectedCount, Func<T> func)
         {
             return await InterceptAsync(func, _actorSystem, null, expectedCount);

--- a/src/core/Akka.TestKit/EventFilter/Internal/EventFilterApplier.cs
+++ b/src/core/Akka.TestKit/EventFilter/Internal/EventFilterApplier.cs
@@ -41,7 +41,6 @@ namespace Akka.TestKit.Internal
         /// TBD
         /// </summary>
         /// <param name="action">TBD</param>
-        [Obsolete("Use async version instead")]
         public void ExpectOne(Action action)
         {
             InternalExpect(action, _actorSystem, 1);
@@ -66,7 +65,6 @@ namespace Akka.TestKit.Internal
         /// </summary>
         /// <param name="timeout">TBD</param>
         /// <param name="action">TBD</param>
-        [Obsolete("Use async version instead")]
         public void ExpectOne(TimeSpan timeout, Action action)
         {
             InternalExpect(action, _actorSystem, 1, timeout);
@@ -86,7 +84,6 @@ namespace Akka.TestKit.Internal
         /// </summary>
         /// <param name="expectedCount">TBD</param>
         /// <param name="action">TBD</param>
-        [Obsolete("Use async version instead")]
         public void Expect(int expectedCount, Action action)
         {
             InternalExpect(action, _actorSystem, expectedCount, null);
@@ -114,7 +111,6 @@ namespace Akka.TestKit.Internal
         /// <param name="expectedCount">TBD</param>
         /// <param name="timeout">TBD</param>
         /// <param name="action">TBD</param>
-        [Obsolete("Use async version instead")]
         public void Expect(int expectedCount, TimeSpan timeout, Action action)
         {
             InternalExpect(action, _actorSystem, expectedCount, timeout);
@@ -134,7 +130,6 @@ namespace Akka.TestKit.Internal
         /// <typeparam name="T">TBD</typeparam>
         /// <param name="func">TBD</param>
         /// <returns>TBD</returns>
-        [Obsolete("Use async version instead")]
         public T ExpectOne<T>(Func<T> func)
         {
             return Intercept(func, _actorSystem, null, 1);
@@ -155,7 +150,6 @@ namespace Akka.TestKit.Internal
         /// <param name="timeout">TBD</param>
         /// <param name="func">TBD</param>
         /// <returns>TBD</returns>
-        [Obsolete("Use async version instead")]
         public T ExpectOne<T>(TimeSpan timeout, Func<T> func)
         {
             return Intercept(func, _actorSystem, timeout, 1);
@@ -176,7 +170,6 @@ namespace Akka.TestKit.Internal
         /// <param name="expectedCount">TBD</param>
         /// <param name="func">TBD</param>
         /// <returns>TBD</returns>
-        [Obsolete("Use async version instead")]
         public T Expect<T>(int expectedCount, Func<T> func)
         {
             return Intercept(func, _actorSystem, null, expectedCount);
@@ -198,7 +191,6 @@ namespace Akka.TestKit.Internal
         /// <param name="expectedCount">TBD</param>
         /// <param name="func">TBD</param>
         /// <returns>TBD</returns>
-        [Obsolete("Use async version instead")]
         public T Expect<T>(int expectedCount, TimeSpan timeout, Func<T> func)
         {
             return Intercept(func, _actorSystem, timeout, expectedCount);
@@ -218,7 +210,6 @@ namespace Akka.TestKit.Internal
         /// <typeparam name="T">TBD</typeparam>
         /// <param name="func">TBD</param>
         /// <returns>TBD</returns>
-        [Obsolete("Use async version instead")]
         public T Mute<T>(Func<T> func)
         {
             return Intercept(func, _actorSystem, null, null);
@@ -236,7 +227,6 @@ namespace Akka.TestKit.Internal
         /// TBD
         /// </summary>
         /// <param name="action">TBD</param>
-        [Obsolete("Use async version instead")]
         public void Mute(Action action)
         {
             Intercept<object>(() => { action(); return null; }, _actorSystem, null, null);
@@ -281,7 +271,6 @@ namespace Akka.TestKit.Internal
         /// <param name="expectedOccurrences">TBD</param>
         /// <param name="matchedEventHandler">TBD</param>
         /// <returns>TBD</returns>
-        [Obsolete("Use async version instead")]
         protected T Intercept<T>(Func<T> func, ActorSystem system, TimeSpan? timeout, int? expectedOccurrences, MatchedEventHandler matchedEventHandler = null)
         {
             var leeway = system.HasExtension<TestKitSettings>()
@@ -404,7 +393,6 @@ namespace Akka.TestKit.Internal
         /// <param name="expectedOccurrences">TBD</param>
         /// <param name="matchedEventHandler">TBD</param>
         /// <returns>TBD</returns>
-        [Obsolete("Use async version instead")]
         protected bool AwaitDone(TimeSpan timeout, int? expectedOccurrences, MatchedEventHandler matchedEventHandler)
         {
             if(expectedOccurrences.HasValue)
@@ -440,7 +428,6 @@ namespace Akka.TestKit.Internal
             return number == 1 ? "message" : "messages";
         }
 
-        [Obsolete("Use async version instead")]
         private void InternalExpect(Action action, ActorSystem actorSystem, int expectedCount, TimeSpan? timeout = null)
         {
             Intercept<object>(() => { action(); return null; }, actorSystem, timeout, expectedCount);

--- a/src/core/Akka.TestKit/TestKitBase.cs
+++ b/src/core/Akka.TestKit/TestKitBase.cs
@@ -135,11 +135,12 @@ namespace Akka.TestKit
 
             var testActor = CreateTestActor(system, testActorName);
             //Wait for the testactor to start
-            AwaitConditionAsync(() =>
+            // Calling sync version here, since .Wait() causes deadlock
+            AwaitCondition(() =>
             {
                 var repRef = testActor as IRepointableRef;
                 return repRef == null || repRef.IsStarted;
-            }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(10)).Wait();
+            }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(10));
 
             if (!(this is INoImplicitSender))
             {

--- a/src/core/Akka.TestKit/TestKitBase.cs
+++ b/src/core/Akka.TestKit/TestKitBase.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Internal;
 using Akka.Configuration;
@@ -134,11 +135,11 @@ namespace Akka.TestKit
 
             var testActor = CreateTestActor(system, testActorName);
             //Wait for the testactor to start
-            AwaitCondition(() =>
+            AwaitConditionAsync(() =>
             {
                 var repRef = testActor as IRepointableRef;
                 return repRef == null || repRef.IsStarted;
-            }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(10));
+            }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(10)).Wait();
 
             if (!(this is INoImplicitSender))
             {
@@ -155,7 +156,7 @@ namespace Akka.TestKit
 
             _testState.TestActor = testActor;
         }
-
+        
         private TimeSpan SingleExpectDefaultTimeout { get { return _testState.TestKitSettings.SingleExpectDefault; } }
 
         /// <summary>

--- a/src/core/Akka.TestKit/TestKitBase_AwaitAssert.cs
+++ b/src/core/Akka.TestKit/TestKitBase_AwaitAssert.cs
@@ -31,6 +31,7 @@ namespace Akka.TestKit
         /// <param name="assertion">The action.</param>
         /// <param name="duration">The timeout.</param>
         /// <param name="interval">The interval to wait between executing the assertion.</param>
+        [Obsolete("Use async version instead", true)]
         public void AwaitAssert(Action assertion, TimeSpan? duration=null, TimeSpan? interval=null)
         {
             var intervalValue = interval.GetValueOrDefault(TimeSpan.FromMilliseconds(800));

--- a/src/core/Akka.TestKit/TestKitBase_AwaitAssert.cs
+++ b/src/core/Akka.TestKit/TestKitBase_AwaitAssert.cs
@@ -31,7 +31,7 @@ namespace Akka.TestKit
         /// <param name="assertion">The action.</param>
         /// <param name="duration">The timeout.</param>
         /// <param name="interval">The interval to wait between executing the assertion.</param>
-        [Obsolete("Use async version instead", true)]
+        [Obsolete("Use async version instead")]
         public void AwaitAssert(Action assertion, TimeSpan? duration=null, TimeSpan? interval=null)
         {
             var intervalValue = interval.GetValueOrDefault(TimeSpan.FromMilliseconds(800));

--- a/src/core/Akka.TestKit/TestKitBase_AwaitAssert.cs
+++ b/src/core/Akka.TestKit/TestKitBase_AwaitAssert.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.TestKit.Internal;
 
 namespace Akka.TestKit
@@ -51,6 +52,45 @@ namespace Akka.TestKit
                         throw;
                 }
                 Thread.Sleep(t);
+                t = (stop - Now).Min(intervalValue);
+            }
+        }
+        
+        /// <summary>
+        /// <para>Await until the given assertion does not throw an exception or the timeout
+        /// expires, whichever comes first. If the timeout expires the last exception
+        /// is thrown.</para>
+        /// <para>The action is called, and if it throws an exception the thread sleeps
+        /// the specified interval before retrying.</para>
+        /// <para>If no timeout is given, take it from the innermost enclosing `within`
+        /// block.</para>
+        /// <para>Note that the timeout is scaled using <see cref="Dilated" />,
+        /// which uses the configuration entry "akka.test.timefactor".</para>
+        /// </summary>
+        /// <param name="assertion">The action.</param>
+        /// <param name="duration">The timeout.</param>
+        /// <param name="interval">The interval to wait between executing the assertion.</param>
+        public async Task AwaitAssertAsync(Action assertion, TimeSpan? duration=null, TimeSpan? interval=null)
+        {
+            var intervalValue = interval.GetValueOrDefault(TimeSpan.FromMilliseconds(800));
+            if(intervalValue == Timeout.InfiniteTimeSpan) intervalValue = TimeSpan.MaxValue;
+            intervalValue.EnsureIsPositiveFinite("interval");
+            var max = RemainingOrDilated(duration);
+            var stop = Now + max;
+            var t = max.Min(intervalValue);
+            while(true)
+            {
+                try
+                {
+                    assertion();
+                    return;
+                }
+                catch(Exception)
+                {
+                    if(Now + t >= stop)
+                        throw;
+                }
+                await Task.Delay(t);
                 t = (stop - Now).Min(intervalValue);
             }
         }

--- a/src/core/Akka.TestKit/TestKitBase_AwaitAssert.cs
+++ b/src/core/Akka.TestKit/TestKitBase_AwaitAssert.cs
@@ -31,7 +31,6 @@ namespace Akka.TestKit
         /// <param name="assertion">The action.</param>
         /// <param name="duration">The timeout.</param>
         /// <param name="interval">The interval to wait between executing the assertion.</param>
-        [Obsolete("Use async version instead")]
         public void AwaitAssert(Action assertion, TimeSpan? duration=null, TimeSpan? interval=null)
         {
             var intervalValue = interval.GetValueOrDefault(TimeSpan.FromMilliseconds(800));

--- a/src/core/Akka.TestKit/TestKitBase_AwaitConditions.cs
+++ b/src/core/Akka.TestKit/TestKitBase_AwaitConditions.cs
@@ -31,7 +31,6 @@ namespace Akka.TestKit
         /// </para>
         /// </summary>
         /// <param name="conditionIsFulfilled">The condition that must be fulfilled within the duration.</param>
-        [Obsolete("Use async version instead")]
         public void AwaitCondition(Func<bool> conditionIsFulfilled)
         {
             var maxDur = RemainingOrDefault;
@@ -79,7 +78,6 @@ namespace Akka.TestKit
         /// (if inside a `within` block) or the value specified in config value "akka.test.single-expect-default". 
         /// The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
         /// specified in config value "akka.test.timefactor".</param>
-        [Obsolete("Use async version instead")]
         public void AwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan? max)
         {
             var maxDur = RemainingOrDilated(max);
@@ -133,7 +131,6 @@ namespace Akka.TestKit
         /// The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
         /// specified in config value "akka.test.timefactor".</param>
         /// <param name="message">The message used if the timeout expires.</param>
-        [Obsolete("Use async version instead")]
         public void AwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan? max, string message)
         {
             var maxDur = RemainingOrDilated(max);
@@ -196,7 +193,6 @@ namespace Akka.TestKit
         /// instead set it to a relatively small value.</para>
         /// </param>
         /// <param name="message">The message used if the timeout expires.</param>
-        [Obsolete("Use async version instead")]
         public void AwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan? max, TimeSpan? interval, string message = null)
         {
             var maxDur = RemainingOrDilated(max);
@@ -255,7 +251,6 @@ namespace Akka.TestKit
         /// if the condition is fulfilled. Between calls the thread sleeps. If undefined, 100 ms is used
         /// </param>
         /// <returns>TBD</returns>
-        [Obsolete("Use async version instead")]
         public bool AwaitConditionNoThrow(Func<bool> conditionIsFulfilled, TimeSpan max, TimeSpan? interval = null)
         {
             var intervalDur = interval.GetValueOrDefault(TimeSpan.FromMilliseconds(100));
@@ -307,7 +302,6 @@ namespace Akka.TestKit
         /// <param name="fail">Action that is called when the timeout expired. 
         /// The parameters conforms to <see cref="string.Format(string,object[])"/></param>
         /// <returns>TBD</returns>
-        [Obsolete("Use async version instead")]
         protected static bool InternalAwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan max, TimeSpan? interval, Action<string, object[]> fail)
         {
             return InternalAwaitCondition(conditionIsFulfilled, max, interval, fail, null);
@@ -354,7 +348,6 @@ namespace Akka.TestKit
         /// The parameters conforms to <see cref="string.Format(string,object[])"/></param>
         /// <param name="logger">If a <see cref="ILoggingAdapter"/> is specified, debug messages will be logged using it. If <c>null</c> nothing will be logged</param>
         /// <returns>TBD</returns>
-        [Obsolete("Use async version instead")]
         protected static bool InternalAwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan max, TimeSpan? interval, Action<string, object[]> fail, ILoggingAdapter logger)
         {
             max.EnsureIsPositiveFinite("max");

--- a/src/core/Akka.TestKit/TestKitBase_AwaitConditions.cs
+++ b/src/core/Akka.TestKit/TestKitBase_AwaitConditions.cs
@@ -31,7 +31,7 @@ namespace Akka.TestKit
         /// </para>
         /// </summary>
         /// <param name="conditionIsFulfilled">The condition that must be fulfilled within the duration.</param>
-        [Obsolete("Use async version instead", true)]
+        [Obsolete("Use async version instead")]
         public void AwaitCondition(Func<bool> conditionIsFulfilled)
         {
             var maxDur = RemainingOrDefault;
@@ -79,7 +79,7 @@ namespace Akka.TestKit
         /// (if inside a `within` block) or the value specified in config value "akka.test.single-expect-default". 
         /// The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
         /// specified in config value "akka.test.timefactor".</param>
-        [Obsolete("Use async version instead", true)]
+        [Obsolete("Use async version instead")]
         public void AwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan? max)
         {
             var maxDur = RemainingOrDilated(max);
@@ -133,7 +133,7 @@ namespace Akka.TestKit
         /// The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
         /// specified in config value "akka.test.timefactor".</param>
         /// <param name="message">The message used if the timeout expires.</param>
-        [Obsolete("Use async version instead", true)]
+        [Obsolete("Use async version instead")]
         public void AwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan? max, string message)
         {
             var maxDur = RemainingOrDilated(max);
@@ -196,7 +196,7 @@ namespace Akka.TestKit
         /// instead set it to a relatively small value.</para>
         /// </param>
         /// <param name="message">The message used if the timeout expires.</param>
-        [Obsolete("Use async version instead", true)]
+        [Obsolete("Use async version instead")]
         public void AwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan? max, TimeSpan? interval, string message = null)
         {
             var maxDur = RemainingOrDilated(max);
@@ -255,7 +255,7 @@ namespace Akka.TestKit
         /// if the condition is fulfilled. Between calls the thread sleeps. If undefined, 100 ms is used
         /// </param>
         /// <returns>TBD</returns>
-        [Obsolete("Use async version instead", true)]
+        [Obsolete("Use async version instead")]
         public bool AwaitConditionNoThrow(Func<bool> conditionIsFulfilled, TimeSpan max, TimeSpan? interval = null)
         {
             var intervalDur = interval.GetValueOrDefault(TimeSpan.FromMilliseconds(100));
@@ -307,7 +307,7 @@ namespace Akka.TestKit
         /// <param name="fail">Action that is called when the timeout expired. 
         /// The parameters conforms to <see cref="string.Format(string,object[])"/></param>
         /// <returns>TBD</returns>
-        [Obsolete("Use async version instead", true)]
+        [Obsolete("Use async version instead")]
         protected static bool InternalAwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan max, TimeSpan? interval, Action<string, object[]> fail)
         {
             return InternalAwaitCondition(conditionIsFulfilled, max, interval, fail, null);
@@ -354,7 +354,7 @@ namespace Akka.TestKit
         /// The parameters conforms to <see cref="string.Format(string,object[])"/></param>
         /// <param name="logger">If a <see cref="ILoggingAdapter"/> is specified, debug messages will be logged using it. If <c>null</c> nothing will be logged</param>
         /// <returns>TBD</returns>
-        [Obsolete("Use async version instead", true)]
+        [Obsolete("Use async version instead")]
         protected static bool InternalAwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan max, TimeSpan? interval, Action<string, object[]> fail, ILoggingAdapter logger)
         {
             max.EnsureIsPositiveFinite("max");

--- a/src/core/Akka.TestKit/TestKitBase_AwaitConditions.cs
+++ b/src/core/Akka.TestKit/TestKitBase_AwaitConditions.cs
@@ -31,6 +31,7 @@ namespace Akka.TestKit
         /// </para>
         /// </summary>
         /// <param name="conditionIsFulfilled">The condition that must be fulfilled within the duration.</param>
+        [Obsolete("Use async version instead", true)]
         public void AwaitCondition(Func<bool> conditionIsFulfilled)
         {
             var maxDur = RemainingOrDefault;
@@ -78,6 +79,7 @@ namespace Akka.TestKit
         /// (if inside a `within` block) or the value specified in config value "akka.test.single-expect-default". 
         /// The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
         /// specified in config value "akka.test.timefactor".</param>
+        [Obsolete("Use async version instead", true)]
         public void AwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan? max)
         {
             var maxDur = RemainingOrDilated(max);
@@ -131,6 +133,7 @@ namespace Akka.TestKit
         /// The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
         /// specified in config value "akka.test.timefactor".</param>
         /// <param name="message">The message used if the timeout expires.</param>
+        [Obsolete("Use async version instead", true)]
         public void AwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan? max, string message)
         {
             var maxDur = RemainingOrDilated(max);
@@ -193,6 +196,7 @@ namespace Akka.TestKit
         /// instead set it to a relatively small value.</para>
         /// </param>
         /// <param name="message">The message used if the timeout expires.</param>
+        [Obsolete("Use async version instead", true)]
         public void AwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan? max, TimeSpan? interval, string message = null)
         {
             var maxDur = RemainingOrDilated(max);
@@ -251,6 +255,7 @@ namespace Akka.TestKit
         /// if the condition is fulfilled. Between calls the thread sleeps. If undefined, 100 ms is used
         /// </param>
         /// <returns>TBD</returns>
+        [Obsolete("Use async version instead", true)]
         public bool AwaitConditionNoThrow(Func<bool> conditionIsFulfilled, TimeSpan max, TimeSpan? interval = null)
         {
             var intervalDur = interval.GetValueOrDefault(TimeSpan.FromMilliseconds(100));
@@ -274,7 +279,6 @@ namespace Akka.TestKit
             var intervalDur = interval.GetValueOrDefault(TimeSpan.FromMilliseconds(100));
             return InternalAwaitConditionAsync(conditionIsFulfilled, max, intervalDur, (f, a) => { });
         }
-
 
         /// <summary>
         /// <para>Await until the given condition evaluates to <c>true</c> or the timeout
@@ -303,6 +307,7 @@ namespace Akka.TestKit
         /// <param name="fail">Action that is called when the timeout expired. 
         /// The parameters conforms to <see cref="string.Format(string,object[])"/></param>
         /// <returns>TBD</returns>
+        [Obsolete("Use async version instead", true)]
         protected static bool InternalAwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan max, TimeSpan? interval, Action<string, object[]> fail)
         {
             return InternalAwaitCondition(conditionIsFulfilled, max, interval, fail, null);
@@ -349,6 +354,7 @@ namespace Akka.TestKit
         /// The parameters conforms to <see cref="string.Format(string,object[])"/></param>
         /// <param name="logger">If a <see cref="ILoggingAdapter"/> is specified, debug messages will be logged using it. If <c>null</c> nothing will be logged</param>
         /// <returns>TBD</returns>
+        [Obsolete("Use async version instead", true)]
         protected static bool InternalAwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan max, TimeSpan? interval, Action<string, object[]> fail, ILoggingAdapter logger)
         {
             max.EnsureIsPositiveFinite("max");

--- a/src/core/Akka.TestKit/TestKitBase_AwaitConditions.cs
+++ b/src/core/Akka.TestKit/TestKitBase_AwaitConditions.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Event;
 using Akka.TestKit.Internal;
 
@@ -37,6 +38,27 @@ namespace Akka.TestKit
             var logger = _testState.TestKitSettings.LogTestKitCalls ? _testState.Log : null;
             InternalAwaitCondition(conditionIsFulfilled, maxDur, interval, (format, args) => _assertions.Fail(format, args), logger);
         }
+        
+        /// <summary>
+        /// <para>Await until the given condition evaluates to <c>true</c> or until a timeout</para>
+        /// <para>The timeout is taken from the innermost enclosing `within`
+        /// block (if inside a `within` block) or the value specified in config value "akka.test.single-expect-default". 
+        /// The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
+        /// specified in config value "akka.test.timefactor"..</para>
+        /// <para>A call to <paramref name="conditionIsFulfilled"/> is done immediately, then the threads sleep
+        /// for about a tenth of the timeout value, before it checks the condition again. This is repeated until
+        /// timeout or the condition evaluates to <c>true</c>. To specify another interval, use the overload
+        /// <see cref="AwaitCondition(System.Func{bool},System.Nullable{System.TimeSpan},System.Nullable{System.TimeSpan},string)"/>
+        /// </para>
+        /// </summary>
+        /// <param name="conditionIsFulfilled">The condition that must be fulfilled within the duration.</param>
+        public async Task AwaitConditionAsync(Func<bool> conditionIsFulfilled)
+        {
+            var maxDur = RemainingOrDefault;
+            var interval = new TimeSpan(maxDur.Ticks / 10);
+            var logger = _testState.TestKitSettings.LogTestKitCalls ? _testState.Log : null;
+            await InternalAwaitConditionAsync(conditionIsFulfilled, maxDur, interval, (format, args) => _assertions.Fail(format, args), logger);
+        }
 
         /// <summary>
         /// <para>Await until the given condition evaluates to <c>true</c> or the timeout
@@ -62,6 +84,32 @@ namespace Akka.TestKit
             var interval = new TimeSpan(maxDur.Ticks / 10);
             var logger = _testState.TestKitSettings.LogTestKitCalls ? _testState.Log : null;
             InternalAwaitCondition(conditionIsFulfilled, maxDur, interval, (format, args) => _assertions.Fail(format, args), logger);
+        }
+        
+        /// <summary>
+        /// <para>Await until the given condition evaluates to <c>true</c> or the timeout
+        /// expires, whichever comes first.</para>
+        /// <para>If no timeout is given, take it from the innermost enclosing `within`
+        /// block (if inside a `within` block) or the value specified in config value "akka.test.single-expect-default". 
+        /// The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
+        /// specified in config value "akka.test.timefactor"..</para>
+        /// <para>A call to <paramref name="conditionIsFulfilled"/> is done immediately, then the threads sleep
+        /// for about a tenth of the timeout value, before it checks the condition again. This is repeated until
+        /// timeout or the condition evaluates to <c>true</c>. To specify another interval, use the overload
+        /// <see cref="AwaitCondition(System.Func{bool},System.Nullable{System.TimeSpan},System.Nullable{System.TimeSpan},string)"/>
+        /// </para>
+        /// </summary>
+        /// <param name="conditionIsFulfilled">The condition that must be fulfilled within the duration.</param>
+        /// <param name="max">The maximum duration. If undefined, uses the remaining time 
+        /// (if inside a `within` block) or the value specified in config value "akka.test.single-expect-default". 
+        /// The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
+        /// specified in config value "akka.test.timefactor".</param>
+        public async Task AwaitConditionAsync(Func<bool> conditionIsFulfilled, TimeSpan? max)
+        {
+            var maxDur = RemainingOrDilated(max);
+            var interval = new TimeSpan(maxDur.Ticks / 10);
+            var logger = _testState.TestKitSettings.LogTestKitCalls ? _testState.Log : null;
+            await InternalAwaitConditionAsync(conditionIsFulfilled, maxDur, interval, (format, args) => _assertions.Fail(format, args), logger);
         }
 
         /// <summary>
@@ -89,6 +137,33 @@ namespace Akka.TestKit
             var interval = new TimeSpan(maxDur.Ticks / 10);
             var logger = _testState.TestKitSettings.LogTestKitCalls ? _testState.Log : null;
             InternalAwaitCondition(conditionIsFulfilled, maxDur, interval, (format, args) => AssertionsFail(format, args, message), logger);
+        }
+        
+        /// <summary>
+        /// <para>Await until the given condition evaluates to <c>true</c> or the timeout
+        /// expires, whichever comes first.</para>
+        /// <para>If no timeout is given, take it from the innermost enclosing `within`
+        /// block (if inside a `within` block) or the value specified in config value "akka.test.single-expect-default". 
+        /// The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
+        /// specified in config value "akka.test.timefactor"..</para>
+        /// <para>A call to <paramref name="conditionIsFulfilled"/> is done immediately, then the threads sleep
+        /// for about a tenth of the timeout value, before it checks the condition again. This is repeated until
+        /// timeout or the condition evaluates to <c>true</c>. To specify another interval, use the overload
+        /// <see cref="AwaitCondition(System.Func{bool},System.Nullable{System.TimeSpan},System.Nullable{System.TimeSpan},string)"/>
+        /// </para>
+        /// </summary>
+        /// <param name="conditionIsFulfilled">The condition that must be fulfilled within the duration.</param>
+        /// <param name="max">The maximum duration. If undefined, uses the remaining time 
+        /// (if inside a `within` block) or the value specified in config value "akka.test.single-expect-default". 
+        /// The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
+        /// specified in config value "akka.test.timefactor".</param>
+        /// <param name="message">The message used if the timeout expires.</param>
+        public async Task AwaitConditionAsync(Func<bool> conditionIsFulfilled, TimeSpan? max, string message)
+        {
+            var maxDur = RemainingOrDilated(max);
+            var interval = new TimeSpan(maxDur.Ticks / 10);
+            var logger = _testState.TestKitSettings.LogTestKitCalls ? _testState.Log : null;
+            await InternalAwaitConditionAsync(conditionIsFulfilled, maxDur, interval, (format, args) => AssertionsFail(format, args, message), logger);
         }
 
         /// <summary>
@@ -124,12 +199,45 @@ namespace Akka.TestKit
             var logger = _testState.TestKitSettings.LogTestKitCalls ? _testState.Log : null;
             InternalAwaitCondition(conditionIsFulfilled, maxDur, interval, (format, args) => AssertionsFail(format, args, message), logger);
         }
+        
+        /// <summary>
+        /// <para>Await until the given condition evaluates to <c>true</c> or the timeout
+        /// expires, whichever comes first.</para>
+        /// <para>If no timeout is given, take it from the innermost enclosing `within`
+        /// block.</para>
+        /// <para>Note that the timeout is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
+        /// specified in config value "akka.test.timefactor".</para>
+        /// <para>The parameter <paramref name="interval"/> specifies the time between calls to <paramref name="conditionIsFulfilled"/>
+        /// Between calls the thread sleeps. If <paramref name="interval"/> is undefined the thread only sleeps 
+        /// one time, using the <paramref name="max"/> as duration, and then rechecks the condition and ultimately 
+        /// succeeds or fails.</para>
+        /// <para>To make sure that tests run as fast as possible, make sure you do not leave this value as undefined,
+        /// instead set it to a relatively small value.</para>
+        /// </summary>
+        /// <param name="conditionIsFulfilled">The condition that must be fulfilled within the duration.</param>
+        /// <param name="max">The maximum duration. If undefined, uses the remaining time 
+        /// (if inside a `within` block) or the value specified in config value "akka.test.single-expect-default". 
+        /// The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
+        /// specified in config value "akka.test.timefactor".</param>
+        /// <param name="interval">The time between calls to <paramref name="conditionIsFulfilled"/> to check
+        /// if the condition is fulfilled. Between calls the thread sleeps. If undefined, negative or 
+        /// <see cref="Timeout.InfiniteTimeSpan"/>the thread only sleeps one time, using the <paramref name="max"/>, 
+        /// and then rechecks the condition and ultimately succeeds or fails.
+        /// <para>To make sure that tests run as fast as possible, make sure you do not set this value as undefined,
+        /// instead set it to a relatively small value.</para>
+        /// </param>
+        /// <param name="message">The message used if the timeout expires.</param>
+        public async Task AwaitConditionAsync(Func<bool> conditionIsFulfilled, TimeSpan? max, TimeSpan? interval, string message = null)
+        {
+            var maxDur = RemainingOrDilated(max);
+            var logger = _testState.TestKitSettings.LogTestKitCalls ? _testState.Log : null;
+            await InternalAwaitConditionAsync(conditionIsFulfilled, maxDur, interval, (format, args) => AssertionsFail(format, args, message), logger);
+        }
 
         private void AssertionsFail(string format, object[] args, string message = null)
         {
             _assertions.Fail(format + (message ?? ""), args);
         }
-
 
         /// <summary>
         /// <para>Await until the given condition evaluates to <c>true</c> or the timeout
@@ -147,6 +255,24 @@ namespace Akka.TestKit
         {
             var intervalDur = interval.GetValueOrDefault(TimeSpan.FromMilliseconds(100));
             return InternalAwaitCondition(conditionIsFulfilled, max, intervalDur, (f, a) => { });
+        }
+        
+        /// <summary>
+        /// <para>Await until the given condition evaluates to <c>true</c> or the timeout
+        /// expires, whichever comes first. Returns <c>true</c> if the condition was fulfilled.</para>        
+        /// <para>The parameter <paramref name="interval"/> specifies the time between calls to <paramref name="conditionIsFulfilled"/>
+        /// Between calls the thread sleeps. If <paramref name="interval"/> is not specified or <c>null</c> 100 ms is used.</para>
+        /// </summary>
+        /// <param name="conditionIsFulfilled">The condition that must be fulfilled within the duration.</param>
+        /// <param name="max">The maximum duration.</param>
+        /// <param name="interval">Optional. The time between calls to <paramref name="conditionIsFulfilled"/> to check
+        /// if the condition is fulfilled. Between calls the thread sleeps. If undefined, 100 ms is used
+        /// </param>
+        /// <returns>TBD</returns>
+        public Task<bool> AwaitConditionNoThrowAsync(Func<bool> conditionIsFulfilled, TimeSpan max, TimeSpan? interval = null)
+        {
+            var intervalDur = interval.GetValueOrDefault(TimeSpan.FromMilliseconds(100));
+            return InternalAwaitConditionAsync(conditionIsFulfilled, max, intervalDur, (f, a) => { });
         }
 
 
@@ -180,6 +306,19 @@ namespace Akka.TestKit
         protected static bool InternalAwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan max, TimeSpan? interval, Action<string, object[]> fail)
         {
             return InternalAwaitCondition(conditionIsFulfilled, max, interval, fail, null);
+        }
+        
+        /// <summary>
+        /// Async version of <see cref="InternalAwaitCondition(System.Func{bool},System.TimeSpan,System.Nullable{System.TimeSpan},System.Action{string,object[]})"/>
+        /// </summary>
+        /// <param name="conditionIsFulfilled"></param>
+        /// <param name="max"></param>
+        /// <param name="interval"></param>
+        /// <param name="fail"></param>
+        /// <returns></returns>
+        protected static Task<bool> InternalAwaitConditionAsync(Func<bool> conditionIsFulfilled, TimeSpan max, TimeSpan? interval, Action<string, object[]> fail)
+        {
+            return InternalAwaitConditionAsync(conditionIsFulfilled, max, interval, fail, null);
         }
 
         /// <summary>
@@ -230,6 +369,34 @@ namespace Akka.TestKit
                 }
                 var sleepDuration = (stop - now).Min(interval);
                 Thread.Sleep(sleepDuration);
+            }
+            ConditionalLog(logger, "Condition fulfilled after {0}", Now-start);
+            return true;
+        }
+        
+        /// <summary>
+        /// Async version of <see cref="InternalAwaitCondition(System.Func{bool},System.TimeSpan,System.Nullable{System.TimeSpan},System.Action{string,object[]})"/>
+        /// </summary>
+        protected static async Task<bool> InternalAwaitConditionAsync(Func<bool> conditionIsFulfilled, TimeSpan max, TimeSpan? interval, Action<string, object[]> fail, ILoggingAdapter logger)
+        {
+            max.EnsureIsPositiveFinite("max");
+            var start = Now;
+            var stop = start + max;
+            ConditionalLog(logger, "Awaiting condition for {0}.{1}", max, interval.HasValue ? " Will sleep " + interval.Value + " between checks" : "");
+
+            while (!conditionIsFulfilled())
+            {
+                var now = Now;
+
+                if (now > stop)
+                {
+                    const string message = "Timeout {0} expired while waiting for condition.";
+                    ConditionalLog(logger, message, max);
+                    fail(message, new object[] { max });
+                    return false;
+                }
+                var sleepDuration = (stop - now).Min(interval);
+                await Task.Delay(sleepDuration);
             }
             ConditionalLog(logger, "Condition fulfilled after {0}", Now-start);
             return true;

--- a/src/core/Akka.TestKit/TestKitBase_Within.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Within.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.TestKit.Internal;
 
 namespace Akka.TestKit
@@ -48,7 +49,6 @@ namespace Akka.TestKit
             Within<object>(min, max, () => { action(); return null; }, hint, epsilonValue);
         }
 
-
         /// <summary>
         /// Execute code block while bounding its execution time between 0 seconds and <paramref name="max"/>.
         /// <para>`within` blocks may be nested. All methods in this class which take maximum wait times 
@@ -64,6 +64,23 @@ namespace Akka.TestKit
         public T Within<T>(TimeSpan max, Func<T> function, TimeSpan? epsilonValue = null)
         {
             return Within(TimeSpan.Zero, max, function, epsilonValue: epsilonValue);
+        }
+        
+        /// <summary>
+        /// Execute code block while bounding its execution time between 0 seconds and <paramref name="max"/>.
+        /// <para>`within` blocks may be nested. All methods in this class which take maximum wait times 
+        /// are available in a version which implicitly uses the remaining time governed by 
+        /// the innermost enclosing `within` block.</para>
+        /// <remarks>Note that the max duration is scaled using <see cref="Dilated(TimeSpan)"/> which uses the config value "akka.test.timefactor"</remarks>
+        /// </summary>
+        /// <typeparam name="T">TBD</typeparam>
+        /// <param name="max">TBD</param>
+        /// <param name="function">TBD</param>
+        /// <param name="epsilonValue">TBD</param>
+        /// <returns>TBD</returns>
+        public Task<T> WithinAsync<T>(TimeSpan max, Func<Task<T>> function, TimeSpan? epsilonValue = null)
+        {
+            return WithinAsync(TimeSpan.Zero, max, function, epsilonValue: epsilonValue);
         }
 
         /// <summary>
@@ -128,5 +145,66 @@ namespace Akka.TestKit
             return ret;
         }
 
+        /// <summary>
+        /// Execute code block while bounding its execution time between <paramref name="min"/> and <paramref name="max"/>.
+        /// <para>`within` blocks may be nested. All methods in this class which take maximum wait times 
+        /// are available in a version which implicitly uses the remaining time governed by 
+        /// the innermost enclosing `within` block.</para>
+        /// <remarks>Note that the max duration is scaled using <see cref="Dilated(TimeSpan)"/> which uses the config value "akka.test.timefactor"</remarks>
+        /// </summary>
+        /// <typeparam name="T">TBD</typeparam>
+        /// <param name="min">TBD</param>
+        /// <param name="max">TBD</param>
+        /// <param name="function">TBD</param>
+        /// <param name="hint">TBD</param>
+        /// <param name="epsilonValue">TBD</param>
+        /// <returns>TBD</returns>
+        public async Task<T> WithinAsync<T>(TimeSpan min, TimeSpan max, Func<Task<T>> function, string hint = null, TimeSpan? epsilonValue = null)
+        {
+            min.EnsureIsPositiveFinite("min");
+            min.EnsureIsPositiveFinite("max");
+            max = Dilated(max);
+            var start = Now;
+            var rem = _testState.End.HasValue ? _testState.End.Value - start : Timeout.InfiniteTimeSpan;
+            _assertions.AssertTrue(rem.IsInfiniteTimeout() || rem >= min, "Required min time {0} not possible, only {1} left. {2}", min, rem, hint ?? "");
+
+            _testState.LastWasNoMsg = false;
+
+            var maxDiff = max.Min(rem);
+            var prevEnd = _testState.End;
+            _testState.End = start + maxDiff;
+
+            T ret;
+            try
+            {
+                ret = await function();
+            }
+            finally
+            {
+                _testState.End = prevEnd;
+            }
+
+            var elapsed = Now - start;
+            var wasTooFast = elapsed < min;
+            if(wasTooFast)
+            {
+                const string failMessage = "Failed: Block took {0}, should have at least been {1}. {2}";
+                ConditionalLog(failMessage, elapsed, min, hint ?? "");
+                _assertions.Fail(failMessage, elapsed, min, hint ?? "");
+            }
+            if (!_testState.LastWasNoMsg)
+            {
+                epsilonValue = epsilonValue ?? TimeSpan.Zero;
+                var tookTooLong = elapsed > maxDiff + epsilonValue;
+                if(tookTooLong)
+                {
+                    const string failMessage = "Failed: Block took {0}, exceeding {1}. {2}";
+                    ConditionalLog(failMessage, elapsed, maxDiff, hint ?? "");
+                    _assertions.Fail(failMessage, elapsed, maxDiff, hint ?? "");
+                }
+            }
+
+            return ret;
+        }
     }
 }

--- a/src/core/Akka.TestKit/TestKitBase_Within.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Within.cs
@@ -31,6 +31,14 @@ namespace Akka.TestKit
         {
             Within(TimeSpan.Zero, max, action, epsilonValue: epsilonValue);
         }
+        
+        /// <summary>
+        /// Async version of Within
+        /// </summary>
+        public Task WithinAsync(TimeSpan max, Func<Task> actionAsync, TimeSpan? epsilonValue = null)
+        {
+            return WithinAsync(TimeSpan.Zero, max, actionAsync, epsilonValue: epsilonValue);
+        }
 
         /// <summary>
         /// Execute code block while bounding its execution time between <paramref name="min"/> and <paramref name="max"/>.
@@ -47,6 +55,14 @@ namespace Akka.TestKit
         public void Within(TimeSpan min, TimeSpan max, Action action, string hint = null, TimeSpan? epsilonValue = null)
         {
             Within<object>(min, max, () => { action(); return null; }, hint, epsilonValue);
+        }
+        
+        /// <summary>
+        /// Async version of <see cref="Within(System.TimeSpan,System.Action,System.Nullable{System.TimeSpan})"/>
+        /// </summary>
+        public Task WithinAsync(TimeSpan min, TimeSpan max, Func<Task> actionAsync, string hint = null, TimeSpan? epsilonValue = null)
+        {
+            return WithinAsync<object>(min, max, async () => { await actionAsync(); return null; }, hint, epsilonValue);
         }
 
         /// <summary>

--- a/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit.Internal.StringMatcher;
@@ -143,6 +144,19 @@ namespace Akka.TestKit
             try
             {
                 actionThatThrows();
+            }
+            catch(Exception)
+            {
+                return;
+            }
+            throw new ThrowsException(typeof(Exception));
+        }
+        
+        protected async Task InterceptAsync(Func<Task> asyncActionThatThrows)
+        {
+            try
+            {
+                await asyncActionThatThrows();
             }
             catch(Exception)
             {

--- a/src/core/Akka.Tests/Actor/ActorLookupSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorLookupSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Internal;
 using Akka.TestKit;
@@ -159,7 +160,7 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
-        public void ActorSystem_must_find_temporary_actors()
+        public async Task ActorSystem_must_find_temporary_actors()
         {
             var f = c1.Ask(new GetSender(TestActor));
             var a = ExpectMsg<IInternalActorRef>();
@@ -170,8 +171,8 @@ namespace Akka.Tests.Actor
             f.IsCompleted.Should().Be(false);
             a.IsTerminated.Should().Be(false);
             a.Tell(42);
-            AwaitAssert(() => f.IsCompleted.Should().Be(true));
-            AwaitAssert(() => f.Result.Should().Be(42));
+            await AwaitAssertAsync(() => f.IsCompleted.Should().Be(true));
+            await AwaitAssertAsync(() => f.Result.Should().Be(42));
         }
 
         /*

--- a/src/core/Akka.Tests/Actor/ActorRefSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorRefSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Internal;
 using Akka.Serialization;
@@ -107,9 +108,7 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
-        public void
-            An_ActoRef_should_return_EmptyLocalActorRef_on_deserialize_if_not_present_in_actor_hierarchy_and_remoting_is_not_enabled
-            ()
+        public async Task An_ActoRef_should_return_EmptyLocalActorRef_on_deserialize_if_not_present_in_actor_hierarchy_and_remoting_is_not_enabled()
         {
             var aref = ActorOf<BlackHoleActor>("non-existing");
             var aserializer = Sys.Serialization.FindSerializerForType(typeof (IActorRef));
@@ -123,7 +122,7 @@ namespace Akka.Tests.Actor
 
             var bserializer = Sys.Serialization.FindSerializerForType(typeof (IActorRef));
 
-            AwaitCondition(() =>
+            await AwaitConditionAsync(() =>
             {
                 var bref = (IActorRef) bserializer.FromBinary(binary, typeof (IActorRef));
                 try

--- a/src/core/Akka.Tests/Actor/AskSpec.cs
+++ b/src/core/Akka.Tests/Actor/AskSpec.cs
@@ -192,14 +192,14 @@ namespace Akka.Tests.Actor
             });
         }
 
-        private void Are_Temp_Actors_Removed(IActorRef actor)
+        private async Task Are_Temp_Actors_Removed(IActorRef actor)
         {
             var actorCell = actor as ActorRefWithCell;
             Assert.True(actorCell != null, "Test method only valid with ActorRefWithCell actors.");
             // ReSharper disable once PossibleNullReferenceException
             var container = actorCell.Provider.TempContainer as VirtualPathContainer;
 
-            AwaitAssert(() =>
+            await AwaitAssertAsync(() =>
             {
                 var childCounter = 0;
                 // ReSharper disable once PossibleNullReferenceException

--- a/src/core/Akka.Tests/Actor/Dispatch/ActorModelSpec.cs
+++ b/src/core/Akka.Tests/Actor/Dispatch/ActorModelSpec.cs
@@ -418,9 +418,9 @@ namespace Akka.Tests.Actor.Dispatch
             return Sys.ActorOf(Props.Create<DispatcherActor>().WithDispatcher(dispatcher));
         }
 
-        void AwaitStarted(IActorRef actorRef)
+        async Task AwaitStartedAsync(IActorRef actorRef)
         {
-            AwaitCondition(() =>
+            await AwaitConditionAsync(() =>
             {
                 if (actorRef is RepointableActorRef)
                     return actorRef.AsInstanceOf<RepointableActorRef>().IsStarted;
@@ -453,13 +453,13 @@ namespace Akka.Tests.Actor.Dispatch
         }
 
         [Fact]
-        public void A_dispatcher_must_process_messages_one_at_a_time()
+        public async Task A_dispatcher_must_process_messages_one_at_a_time()
         {
             var dispatcher = InterceptedDispatcher();
             var start = new CountdownEvent(1);
             var oneAtTime = new CountdownEvent(1);
             var a = NewTestActor(dispatcher.Id);
-            AwaitStarted(a);
+            await AwaitStartedAsync(a);
 
             a.Tell(new CountDown(start));
             AssertCountdown(start, (int)Dilated(TimeSpan.FromSeconds(3.0)).TotalMilliseconds, "Should process first message within 3 seconds");
@@ -499,11 +499,11 @@ namespace Akka.Tests.Actor.Dispatch
         }
 
         [Fact]
-        public void A_dispatcher_should_not_process_messages_for_a_suspended_actor()
+        public async Task A_dispatcher_should_not_process_messages_for_a_suspended_actor()
         {
             var dispatcher = InterceptedDispatcher();
             var a = NewTestActor(dispatcher.Id).AsInstanceOf<IInternalActorRef>();
-            AwaitStarted(a);
+            await AwaitStartedAsync(a);
             var done = new CountdownEvent(1);
             a.Suspend();
             a.Tell(new CountDown(done));
@@ -613,7 +613,7 @@ namespace Akka.Tests.Actor.Dispatch
         }
 
         [Fact]
-        public void A_dispatcher_must_not_double_deregister()
+        public async Task A_dispatcher_must_not_double_deregister()
         {
             var dispatcher = InterceptedDispatcher();
             for (var i = 1; i <= 1000; i++)
@@ -622,8 +622,8 @@ namespace Akka.Tests.Actor.Dispatch
             }
             var a = NewTestActor(dispatcher.Id);
             a.Tell(DoubleStop.Instance);
-            AwaitCondition(() => StatsFor(a, dispatcher).Registers.Current == 1);
-            AwaitCondition(() => StatsFor(a, dispatcher).Unregisters.Current == 1);
+            await AwaitConditionAsync(() => StatsFor(a, dispatcher).Registers.Current == 1);
+            await AwaitConditionAsync(() => StatsFor(a, dispatcher).Unregisters.Current == 1);
         }
     }
 

--- a/src/core/Akka.Tests/Actor/Dispatch/Bug2640Spec.cs
+++ b/src/core/Akka.Tests/Actor/Dispatch/Bug2640Spec.cs
@@ -78,12 +78,12 @@ namespace Akka.Tests.Actor.Dispatch
                 .ToDictionary(x => x.Key, grouping => grouping.First());
 
             await Sys.Terminate();
-            AwaitAssert(() =>
+            await AwaitAssertAsync(() =>
                 threads.Values.All(x => x.IsAlive == false).Should().BeTrue("All threads should be stopped"));
         }
 
         [Fact(DisplayName = "ForkJoinExecutor should terminate all threads upon all attached actors shutting down")]
-        public void ForkJoinExecutorShouldShutdownUponAllActorsTerminating()
+        public async Task ForkJoinExecutorShouldShutdownUponAllActorsTerminating()
         {
             var actor = Sys.ActorOf(Props.Create(() => new ThreadReporterActor())
                 .WithDispatcher("myapp.my-fork-join-dispatcher").WithRouter(new RoundRobinPool(4)));
@@ -99,12 +99,12 @@ namespace Akka.Tests.Actor.Dispatch
 
             Sys.Stop(actor);
             ExpectTerminated(actor);
-            AwaitAssert(() =>
+            await AwaitAssertAsync(() =>
                 threads.Values.All(x => x.IsAlive == false).Should().BeTrue("All threads should be stopped"));
         }
 
         [Fact(DisplayName = "PinnedDispatcher should terminate its thread upon actor shutdown")]
-        public void PinnedDispatcherShouldShutdownUponActorTermination()
+        public async Task PinnedDispatcherShouldShutdownUponActorTermination()
         {
             var actor = Sys.ActorOf(Props.Create(() => new ThreadReporterActor())
                 .WithDispatcher("myapp.my-pinned-dispatcher"));
@@ -116,7 +116,7 @@ namespace Akka.Tests.Actor.Dispatch
 
             Sys.Stop(actor);
             ExpectTerminated(actor);
-            AwaitCondition(() => !thread.IsAlive); // wait for thread to terminate
+            await AwaitConditionAsync(() => !thread.IsAlive); // wait for thread to terminate
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/FSMTimingSpec.cs
+++ b/src/core/Akka.Tests/Actor/FSMTimingSpec.cs
@@ -274,7 +274,7 @@ namespace Akka.Tests.Actor
 
         public static void StaticAwaitCond(Func<bool> evaluator, TimeSpan max, TimeSpan? interval)
         {
-            InternalAwaitCondition(evaluator, max, interval,(format,args)=> XAssert.Fail(string.Format(format,args)));
+            InternalAwaitConditionAsync(evaluator, max, interval,(format,args)=> XAssert.Fail(string.Format(format,args))).Wait();
         }
 
         public class StateMachine : FSM<FsmState, int>, ILoggingFSM

--- a/src/core/Akka.Tests/Actor/HotSwapSpec.cs
+++ b/src/core/Akka.Tests/Actor/HotSwapSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
 using Xunit;
@@ -81,7 +82,8 @@ namespace Akka.Tests.Actor {
         }
 
         [Fact]
-        public void Must_be_able_to_revert_to_initial_state_on_restart() {
+        public async Task Must_be_able_to_revert_to_initial_state_on_restart() 
+        {
             var a = Sys.ActorOf<RevertToInitialState>();
 
             a.Tell("state");
@@ -93,7 +95,7 @@ namespace Akka.Tests.Actor {
             a.Tell("state");
             ExpectMsg("1");
 
-            EventFilter.Exception<Exception>("Crash (expected)!").Expect(1, () => {
+            await EventFilter.Exception<Exception>("Crash (expected)!").ExpectAsync(1, () => {
                 a.Tell("crash");
             });
 

--- a/src/core/Akka.Tests/Actor/LocalActorRefProviderSpec.cs
+++ b/src/core/Akka.Tests/Actor/LocalActorRefProviderSpec.cs
@@ -19,7 +19,7 @@ namespace Akka.Tests.Actor
     public class LocalActorRefProviderSpec : AkkaSpec
     {
         [Fact]
-        public void A_LocalActorRefs_ActorCell_must_not_retain_its_original_Props_when_Terminated()
+        public async Task A_LocalActorRefs_ActorCell_must_not_retain_its_original_Props_when_Terminated()
         {
             var parent = Sys.ActorOf(Props.Create(() => new ParentActor()));
             parent.Tell("GetChild", TestActor);
@@ -29,7 +29,7 @@ namespace Akka.Tests.Actor
             Watch(parent);
             Sys.Stop(parent);
             ExpectTerminated(parent);
-            AwaitAssert(() =>
+            await AwaitAssertAsync(() =>
                 {
                     var childPropsAfterTermination = ((LocalActorRef)child).Underlying.Props;
                     Assert.NotEqual(childPropsBeforeTermination, childPropsAfterTermination);

--- a/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_ActionScheduler_Schedule_Tests.cs
+++ b/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_ActionScheduler_Schedule_Tests.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
 using Akka.Util.Internal;
@@ -273,7 +274,7 @@ namespace Akka.Tests.Actor.Scheduler
         }
 
         [Fact]
-        public void When_ScheduleRepeatedly_action_crashes_Then_no_more_calls_will_be_scheduled()
+        public async Task When_ScheduleRepeatedly_action_crashes_Then_no_more_calls_will_be_scheduled()
         {
             IActionScheduler testScheduler = new HashedWheelTimerScheduler(Sys.Settings.Config, Log);
 
@@ -285,7 +286,7 @@ namespace Akka.Tests.Actor.Scheduler
                     Interlocked.Increment(ref timesCalled);
                     throw new Exception("Crash");
                 });
-                AwaitCondition(() => timesCalled >= 1);
+                await AwaitConditionAsync(() => timesCalled >= 1);
                 Thread.Sleep(200); //Allow any scheduled actions to be fired. 
 
                 //We expect only one of the scheduled actions to actually fire

--- a/src/core/Akka.Tests/Actor/SupervisorHierarchySpec.cs
+++ b/src/core/Akka.Tests/Actor/SupervisorHierarchySpec.cs
@@ -262,17 +262,17 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
-        public void A_supervisor_hierarchy_must_handle_failure_in_creation_when_supervision_strategy_returns_Resume_and_Restart()
+        public async Task A_supervisor_hierarchy_must_handle_failure_in_creation_when_supervision_strategy_returns_Resume_and_Restart()
         {
             var createAttempt = new AtomicCounter(0);
             var preStartCalled = new AtomicCounter(0);
             var postRestartCalled = new AtomicCounter(0);
 
-            EventFilter.Exception<Failure>()
+            await EventFilter.Exception<Failure>()
                 .And.Exception<InvalidOperationException>("OH NO!")
                 .And.Error(start: "changing Recreate into Create")
                 .And.Error(start: "changing Resume into Create")
-                .Mute(() =>
+                .MuteAsync(() =>
                 {
                     //Create:
                     // failresumer

--- a/src/core/Akka.Tests/Dispatch/MailboxesSpec.cs
+++ b/src/core/Akka.Tests/Dispatch/MailboxesSpec.cs
@@ -178,7 +178,7 @@ stable-prio-mailbox{
             {
                 pq.Enqueue(ActorRefs.Nobody, new Envelope(i, ActorRefs.NoSender));
             });
-            AwaitCondition(() => loop.IsCompleted);
+            await AwaitConditionAsync(() => loop.IsCompleted);
 
             Envelope e;
 
@@ -195,7 +195,7 @@ stable-prio-mailbox{
 #endif
 
         [Fact]
-        public void Can_use_unbounded_priority_mailbox()
+        public async Task Can_use_unbounded_priority_mailbox()
         {
             var actor = (IInternalActorRef)Sys.ActorOf(EchoActor.Props(this).WithMailbox("string-prio-mailbox"), "echo");
 
@@ -203,7 +203,7 @@ stable-prio-mailbox{
             actor.SendSystemMessage(new Suspend());
 
             // wait until we can confirm that the mailbox is suspended before we begin sending messages
-            AwaitCondition(() => (((ActorRefWithCell)actor).Underlying is ActorCell) && ((ActorRefWithCell)actor).Underlying.AsInstanceOf<ActorCell>().Mailbox.IsSuspended());
+            await AwaitConditionAsync(() => (((ActorRefWithCell)actor).Underlying is ActorCell) && ((ActorRefWithCell)actor).Underlying.AsInstanceOf<ActorCell>().Mailbox.IsSuspended());
 
             actor.Tell(true);
             for (var i = 0; i < 30; i++)
@@ -233,7 +233,7 @@ stable-prio-mailbox{
         }
 
         [Fact]
-        public void Can_use_unbounded_stable_priority_mailbox()
+        public async Task Can_use_unbounded_stable_priority_mailbox()
         {
             var actor = (IInternalActorRef)Sys.ActorOf(EchoActor.Props(this).WithMailbox("stable-prio-mailbox"), "echo");
 
@@ -241,7 +241,7 @@ stable-prio-mailbox{
             actor.SendSystemMessage(new Suspend());
 
             // wait until we can confirm that the mailbox is suspended before we begin sending messages
-            AwaitCondition(() => (((ActorRefWithCell)actor).Underlying is ActorCell) && ((ActorRefWithCell)actor).Underlying.AsInstanceOf<ActorCell>().Mailbox.IsSuspended());
+            await AwaitConditionAsync(() => (((ActorRefWithCell)actor).Underlying is ActorCell) && ((ActorRefWithCell)actor).Underlying.AsInstanceOf<ActorCell>().Mailbox.IsSuspended());
 
             actor.Tell(true);
             for (var i = 0; i < 30; i++)
@@ -271,14 +271,14 @@ stable-prio-mailbox{
         }
 
         [Fact]
-        public void Priority_mailbox_keeps_ordering_with_many_priority_values()
+        public async Task Priority_mailbox_keeps_ordering_with_many_priority_values()
         {
             var actor = (IInternalActorRef)Sys.ActorOf(EchoActor.Props(this).WithMailbox("int-prio-mailbox"), "echo");
 
             //pause mailbox until all messages have been told
             actor.SendSystemMessage(new Suspend());
 
-            AwaitCondition(()=> (((ActorRefWithCell)actor).Underlying is ActorCell) && ((ActorRefWithCell)actor).Underlying.AsInstanceOf<ActorCell>().Mailbox.IsSuspended());
+            await AwaitConditionAsync(()=> (((ActorRefWithCell)actor).Underlying is ActorCell) && ((ActorRefWithCell)actor).Underlying.AsInstanceOf<ActorCell>().Mailbox.IsSuspended());
             // creates 50 messages with values spanning from Int32.MinValue to Int32.MaxValue
             var values = new int[50];
             var increment = (int)(UInt32.MaxValue / values.Length);
@@ -309,14 +309,14 @@ stable-prio-mailbox{
         }
 
         [Fact]
-        public void Unbounded_Priority_Mailbox_Supports_Unbounded_Stashing()
+        public async Task Unbounded_Priority_Mailbox_Supports_Unbounded_Stashing()
         {
             var actor = (IInternalActorRef)Sys.ActorOf(StashingActor.Props(this).WithMailbox("int-prio-mailbox"), "echo");
 
             //pause mailbox until all messages have been told
             actor.SendSystemMessage(new Suspend());
 
-            AwaitCondition(() => (((ActorRefWithCell)actor).Underlying is ActorCell) && ((ActorRefWithCell)actor).Underlying.AsInstanceOf<ActorCell>().Mailbox.IsSuspended());
+            await AwaitConditionAsync(() => (((ActorRefWithCell)actor).Underlying is ActorCell) && ((ActorRefWithCell)actor).Underlying.AsInstanceOf<ActorCell>().Mailbox.IsSuspended());
 
             var values = new int[10];
             var increment = (int)(UInt32.MaxValue / values.Length);
@@ -352,14 +352,14 @@ stable-prio-mailbox{
         }
 
         [Fact]
-        public void Unbounded_Stable_Priority_Mailbox_Supports_Unbounded_Stashing()
+        public async Task Unbounded_Stable_Priority_Mailbox_Supports_Unbounded_Stashing()
         {
             var actor = (IInternalActorRef)Sys.ActorOf(StashingActor.Props(this).WithMailbox("stable-prio-mailbox"), "echo");
 
             //pause mailbox until all messages have been told
             actor.SendSystemMessage(new Suspend());
 
-            AwaitCondition(() => (((ActorRefWithCell)actor).Underlying is ActorCell) && ((ActorRefWithCell)actor).Underlying.AsInstanceOf<ActorCell>().Mailbox.IsSuspended());
+            await AwaitConditionAsync(() => (((ActorRefWithCell)actor).Underlying is ActorCell) && ((ActorRefWithCell)actor).Underlying.AsInstanceOf<ActorCell>().Mailbox.IsSuspended());
 
             var values = new int[10];
             var increment = (int)(UInt32.MaxValue / values.Length);

--- a/src/core/Akka.Tests/IO/TcpIntegrationSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpIntegrationSpec.cs
@@ -471,9 +471,9 @@ namespace Akka.Tests.IO
         }
 
         [Fact]
-        public void The_TCP_transport_implementation_handle_tcp_connection_actor_death_properly()
+        public async Task The_TCP_transport_implementation_handle_tcp_connection_actor_death_properly()
         {
-            new TestSetup(this, shouldBindServer:false).Run(x =>
+            await new TestSetup(this, shouldBindServer:false).RunAsync(async x =>
             {
                 var serverSocket = new Socket(SocketType.Stream, ProtocolType.Tcp);
                 serverSocket.Bind(x.Endpoint);
@@ -488,7 +488,7 @@ namespace Akka.Tests.IO
                 var connectionActor = connectCommander.LastSender;
                 connectCommander.Send(connectionActor, PoisonPill.Instance);
 
-                AwaitConditionNoThrow(() =>
+                await AwaitConditionNoThrowAsync(() =>
                 {
                     try
                     {
@@ -590,6 +590,12 @@ namespace Akka.Tests.IO
             {
                 if (_shouldBindServer) BindServer();
                 action(this);
+            }
+            
+            public Task RunAsync(Func<TestSetup, Task> actionAsync)
+            {
+                if (_shouldBindServer) BindServer();
+                return actionAsync(this);
             }
         }
 

--- a/src/core/Akka.Tests/Pattern/BackoffOnRestartSupervisorSpec.cs
+++ b/src/core/Akka.Tests/Pattern/BackoffOnRestartSupervisorSpec.cs
@@ -12,6 +12,7 @@ using Akka.TestKit;
 using Xunit;
 using FluentAssertions;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Akka.Tests.Pattern
 {
@@ -219,7 +220,7 @@ namespace Akka.Tests.Pattern
         }
 
         [Fact]
-        public void BackoffOnRestartSupervisor_must_accept_commands_while_child_is_terminating()
+        public async Task BackoffOnRestartSupervisor_must_accept_commands_while_child_is_terminating()
         {
             var postStopLatch = CreateTestLatch(1);
             var options = Backoff.OnFailure(SlowlyFailingActor.Props(postStopLatch), "someChildName", 1.Ticks(), 1.Ticks(), 0.0, -1)
@@ -250,7 +251,7 @@ namespace Akka.Tests.Pattern
             postStopLatch.CountDown();
 
             // New child is ready
-            AwaitAssert(() =>
+            await AwaitAssertAsync(() =>
             {
                 supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
                 // new instance

--- a/src/core/Akka.Tests/Pattern/BackoffSupervisorSpec.cs
+++ b/src/core/Akka.Tests/Pattern/BackoffSupervisorSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Pattern;
 using Akka.TestKit;
@@ -90,7 +91,7 @@ namespace Akka.Tests.Pattern
         #endregion
 
         [Fact(Skip = "Racy on Azure DevOps")]
-        public void BackoffSupervisor_must_start_child_again_when_it_stops_when_using_Backoff_OnStop()
+        public async Task BackoffSupervisor_must_start_child_again_when_it_stops_when_using_Backoff_OnStop()
         {
             var supervisor = Create(OnStopOptions());
             supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
@@ -98,7 +99,7 @@ namespace Akka.Tests.Pattern
             Watch(c1);
             c1.Tell(PoisonPill.Instance);
             ExpectTerminated(c1);
-            AwaitAssert(() =>
+            await AwaitAssertAsync(() =>
             {
                 supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
                 // new instance
@@ -120,16 +121,16 @@ namespace Akka.Tests.Pattern
         }
 
         [Fact]
-        public void BackoffSupervisor_must_support_custom_supervision_strategy()
+        public async Task BackoffSupervisor_must_support_custom_supervision_strategy()
         {
-            Action<IActorRef> assertCustomStrategy = supervisor =>
+            Func<IActorRef, Task> assertCustomStrategy = async supervisor =>
             {
                 supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
                 var c1 = ExpectMsg<BackoffSupervisor.CurrentChild>().Ref;
                 Watch(c1);
                 c1.Tell("boom");
                 ExpectTerminated(c1);
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
                     // new instance
@@ -138,7 +139,7 @@ namespace Akka.Tests.Pattern
             };
 
             // TODO: use FilterException
-            EventFilter.Exception<TestException>().Expect(2, () =>
+            await EventFilter.Exception<TestException>().ExpectAsync(2, async () =>
             {
                 var stoppingStrategy = new OneForOneStrategy(ex =>
                 {
@@ -160,16 +161,16 @@ namespace Akka.Tests.Pattern
                     return Directive.Escalate;
                 });
 
-                assertCustomStrategy(Create(OnStopOptions().WithSupervisorStrategy(stoppingStrategy)));
-                assertCustomStrategy(Create(OnFailureOptions().WithSupervisorStrategy(restartingStrategy)));
+                await assertCustomStrategy(Create(OnStopOptions().WithSupervisorStrategy(stoppingStrategy)));
+                await assertCustomStrategy(Create(OnFailureOptions().WithSupervisorStrategy(restartingStrategy)));
             });
         }
 
         [Fact]
-        public void BackoffSupervisor_must_support_default_stopping_strategy_when_using_Backoff_OnStop()
+        public async Task BackoffSupervisor_must_support_default_stopping_strategy_when_using_Backoff_OnStop()
         {
             // TODO: use FilterException
-            EventFilter.Exception<TestException>().Expect(1, () =>
+            await EventFilter.Exception<TestException>().ExpectAsync(1, async () =>
             {
                 var supervisor = Create(OnStopOptions().WithDefaultStoppingStrategy());
                 supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
@@ -180,7 +181,7 @@ namespace Akka.Tests.Pattern
 
                 c1.Tell("boom");
                 ExpectTerminated(c1);
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
                     // new instance
@@ -192,9 +193,9 @@ namespace Akka.Tests.Pattern
         }
 
         [Fact]
-        public void BackoffSupervisor_must_support_manual_reset()
+        public async Task BackoffSupervisor_must_support_manual_reset()
         {
-            Action<IActorRef> assertManualReset = supervisor =>
+            Func<IActorRef, Task> assertManualReset = async supervisor =>
             {
                 supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
                 var c1 = ExpectMsg<BackoffSupervisor.CurrentChild>().Ref;
@@ -202,13 +203,13 @@ namespace Akka.Tests.Pattern
                 c1.Tell("boom");
                 ExpectTerminated(c1);
 
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     supervisor.Tell(BackoffSupervisor.GetRestartCount.Instance);
                     ExpectMsg<BackoffSupervisor.RestartCount>().Count.Should().Be(1);
                 });
 
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
                     // new instance
@@ -230,7 +231,7 @@ namespace Akka.Tests.Pattern
             };
 
             // TODO: use FilterException
-            EventFilter.Exception<TestException>().Expect(2, () =>
+            await EventFilter.Exception<TestException>().ExpectAsync(2, async () =>
             {
                 var stoppingStrategy = new OneForOneStrategy(ex =>
                 {
@@ -254,12 +255,12 @@ namespace Akka.Tests.Pattern
                     return Directive.Restart;
                 });
 
-                assertManualReset(
+                await assertManualReset(
                     Create(OnStopOptions(ManualChild.Props(TestActor))
                         .WithManualReset()
                         .WithSupervisorStrategy(stoppingStrategy)));
 
-                assertManualReset(
+                await assertManualReset(
                     Create(OnFailureOptions(ManualChild.Props(TestActor))
                         .WithManualReset()
                         .WithSupervisorStrategy(restartingStrategy)));
@@ -267,9 +268,9 @@ namespace Akka.Tests.Pattern
         }
 
         [Fact]
-        public void BackoffSupervisor_must_reply_to_sender_if_replyWhileStopped_is_specified()
+        public async Task BackoffSupervisor_must_reply_to_sender_if_replyWhileStopped_is_specified()
         {
-            EventFilter.Exception<TestException>().Expect(1, () =>
+            await EventFilter.Exception<TestException>().ExpectAsync(1, async () =>
             {
                 var supervisor = Create(Backoff.OnFailure(Child.Props(TestActor), "c1", TimeSpan.FromSeconds(100), TimeSpan.FromSeconds(300), 0.2, -1)
                     .WithReplyWhileStopped("child was stopped"));
@@ -283,7 +284,7 @@ namespace Akka.Tests.Pattern
                 c1.Tell("boom");
                 ExpectTerminated(c1);
 
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     supervisor.Tell(BackoffSupervisor.GetRestartCount.Instance);
                     ExpectMsg<BackoffSupervisor.RestartCount>().Count.Should().Be(1);
@@ -295,9 +296,9 @@ namespace Akka.Tests.Pattern
         }
 
         [Fact]
-        public void BackoffSupervisor_must_not_reply_to_sender_if_replyWhileStopped_is_not_specified()
+        public async Task BackoffSupervisor_must_not_reply_to_sender_if_replyWhileStopped_is_not_specified()
         {
-            EventFilter.Exception<TestException>().Expect(1, () =>
+            await EventFilter.Exception<TestException>().ExpectAsync(1, async () =>
             {
                 var supervisor = Create(Backoff.OnFailure(Child.Props(TestActor), "c1", TimeSpan.FromSeconds(100), TimeSpan.FromSeconds(300), 0.2, -1));
                 supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
@@ -310,7 +311,7 @@ namespace Akka.Tests.Pattern
                 c1.Tell("boom");
                 ExpectTerminated(c1);
 
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     supervisor.Tell(BackoffSupervisor.GetRestartCount.Instance);
                     ExpectMsg<BackoffSupervisor.RestartCount>().Count.Should().Be(1);
@@ -345,13 +346,13 @@ namespace Akka.Tests.Pattern
         }
 
         [Fact(Skip = "Racy on Azure DevOps")]
-        public void BackoffSupervisor_must_stop_restarting_the_child_after_reaching_maxNrOfRetries_limit_using_BackOff_OnStop()
+        public async Task BackoffSupervisor_must_stop_restarting_the_child_after_reaching_maxNrOfRetries_limit_using_BackOff_OnStop()
         {
             var supervisor = Create(OnStopOptions(maxNrOfRetries: 2));
 
-            IActorRef WaitForChild()
+            async Task<IActorRef> WaitForChild()
             {
-                AwaitCondition(() =>
+                await AwaitConditionAsync(() =>
                 {
                     supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
                     var c = ExpectMsg<BackoffSupervisor.CurrentChild>().Ref;
@@ -376,8 +377,8 @@ namespace Akka.Tests.Pattern
             supervisor.Tell(BackoffSupervisor.GetRestartCount.Instance);
             ExpectMsg<BackoffSupervisor.RestartCount>().Count.Should().Be(1);
 
-            var c2 = WaitForChild();
-            AwaitAssert(() => c2.ShouldNotBe(c1));
+            var c2 = await WaitForChild();
+            await AwaitAssertAsync(() => c2.ShouldNotBe(c1));
             Watch(c2);
             c2.Tell(PoisonPill.Instance);
             ExpectTerminated(c2);
@@ -385,8 +386,8 @@ namespace Akka.Tests.Pattern
             supervisor.Tell(BackoffSupervisor.GetRestartCount.Instance);
             ExpectMsg<BackoffSupervisor.RestartCount>().Count.Should().Be(2);
 
-            var c3 = WaitForChild();
-            AwaitAssert(() => c3.ShouldNotBe(c2));
+            var c3 = await WaitForChild();
+            await AwaitAssertAsync(() => c3.ShouldNotBe(c2));
             Watch(c3);
             c3.Tell(PoisonPill.Instance);
             ExpectTerminated(c3);
@@ -394,15 +395,15 @@ namespace Akka.Tests.Pattern
         }
 
         [Fact(Skip = "Racy on Azure DevOps")]
-        public void BackoffSupervisor_must_stop_restarting_the_child_after_reaching_maxNrOfRetries_limit_using_BackOff_OnFailure()
+        public async Task BackoffSupervisor_must_stop_restarting_the_child_after_reaching_maxNrOfRetries_limit_using_BackOff_OnFailure()
         {
-            EventFilter.Exception<TestException>().Expect(3, () =>
+            await EventFilter.Exception<TestException>().ExpectAsync(3, async () =>
             {
                 var supervisor = Create(OnFailureOptions(maxNrOfRetries: 2));
 
-                IActorRef WaitForChild()
+                async Task<IActorRef> WaitForChild()
                 {
-                    AwaitCondition(() =>
+                    await AwaitConditionAsync(() =>
                     {
                         supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
                         var c = ExpectMsg<BackoffSupervisor.CurrentChild>().Ref;
@@ -427,8 +428,8 @@ namespace Akka.Tests.Pattern
                 supervisor.Tell(BackoffSupervisor.GetRestartCount.Instance);
                 ExpectMsg<BackoffSupervisor.RestartCount>().Count.Should().Be(1);
 
-                var c2 = WaitForChild();
-                AwaitAssert(() => c2.ShouldNotBe(c1));
+                var c2 = await WaitForChild();
+                await AwaitAssertAsync(() => c2.ShouldNotBe(c1));
                 Watch(c2);
                 c2.Tell("boom");
                 ExpectTerminated(c2);
@@ -436,8 +437,8 @@ namespace Akka.Tests.Pattern
                 supervisor.Tell(BackoffSupervisor.GetRestartCount.Instance);
                 ExpectMsg<BackoffSupervisor.RestartCount>().Count.Should().Be(2);
 
-                var c3 = WaitForChild();
-                AwaitAssert(() => c3.ShouldNotBe(c2));
+                var c3 = await WaitForChild();
+                await AwaitAssertAsync(() => c3.ShouldNotBe(c2));
                 Watch(c3);
                 c3.Tell("boom");
                 ExpectTerminated(c3);

--- a/src/core/Akka.Tests/Routing/ConfiguredLocalRoutingSpec.cs
+++ b/src/core/Akka.Tests/Routing/ConfiguredLocalRoutingSpec.cs
@@ -127,7 +127,7 @@ namespace Akka.Tests.Routing
             }
         }
 
-        private RouterConfig RouterConfig(IActorRef actor)
+        private async Task<RouterConfig> RouterConfigAsync(IActorRef actor)
         {
             var routedActor = (RoutedActorRef)actor;
             if (routedActor != null)
@@ -139,8 +139,8 @@ namespace Akka.Tests.Routing
                 }
                 else
                 {
-                    AwaitCondition(() => routedActor.IsStarted, TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(10));
-                    return RouterConfig(actor);
+                    await AwaitConditionAsync(() => routedActor.IsStarted, TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(10));
+                    return await RouterConfigAsync(actor);
                 }
             }
 
@@ -201,7 +201,7 @@ namespace Akka.Tests.Routing
         public async Task RouterConfig_must_be_picked_up_from_Props()
         {
             var actor = Sys.ActorOf(new RoundRobinPool(12).Props(Props.Create<EchoProps>()), "someOther");
-            var routerConfig = RouterConfig(actor);
+            var routerConfig = await RouterConfigAsync(actor);
 
             routerConfig.Should().BeOfType<RoundRobinPool>();
             var roundRobinPool = (RoundRobinPool)routerConfig;
@@ -215,7 +215,7 @@ namespace Akka.Tests.Routing
         public async Task RouterConfig_must_be_overridable_in_config()
         {
             var actor = Sys.ActorOf(new RoundRobinPool(12).Props(Props.Create<EchoProps>()), "config");
-            var routerConfig = RouterConfig(actor);
+            var routerConfig = await RouterConfigAsync(actor);
 
             routerConfig.Should().BeOfType<RandomPool>();
             var randomPool = (RandomPool)routerConfig;
@@ -230,7 +230,7 @@ namespace Akka.Tests.Routing
         public async Task RouterConfig_must_use_routeesPaths_from_config()
         {
             var actor = Sys.ActorOf(new RandomPool(12).Props(Props.Create<EchoProps>()), "paths");
-            var routerConfig = RouterConfig(actor);
+            var routerConfig = await RouterConfigAsync(actor);
 
             routerConfig.Should().BeOfType<RandomGroup>();
             var randomGroup = (RandomGroup)routerConfig;
@@ -244,7 +244,7 @@ namespace Akka.Tests.Routing
         public async Task RouterConfig_must_be_overridable_in_explicit_deployment()
         {
             var actor = Sys.ActorOf(FromConfig.Instance.Props(Props.Create<EchoProps>()).WithDeploy(new Deploy(new RoundRobinPool(12))), "someOther");
-            var routerConfig = RouterConfig(actor);
+            var routerConfig = await RouterConfigAsync(actor);
 
             routerConfig.Should().BeOfType<RoundRobinPool>();
             var roundRobinPool = (RoundRobinPool)routerConfig;
@@ -258,7 +258,7 @@ namespace Akka.Tests.Routing
         public async Task RouterConfig_must_be_overridable_in_config_even_with_explicit_deployment()
         {
             var actor = Sys.ActorOf(FromConfig.Instance.Props(Props.Create<EchoProps>()).WithDeploy(new Deploy(new RoundRobinPool(12))), "config");
-            var routerConfig = RouterConfig(actor);
+            var routerConfig = await RouterConfigAsync(actor);
 
             routerConfig.GetType().ShouldBe(typeof(RandomPool));
             var randomPool = (RandomPool)routerConfig;

--- a/src/core/Akka.Tests/Routing/ResizerSpec.cs
+++ b/src/core/Akka.Tests/Routing/ResizerSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Routing;
@@ -266,9 +267,9 @@ namespace Akka.Tests.Routing
         }
 
         [Fact(Skip = "Racy due to Resizer / Mailbox impl")]
-        public void DefaultResizer_must_backoff()
+        public async Task DefaultResizer_must_backoff()
         {
-            Within(10.Seconds(), () =>
+            await WithinAsync(10.Seconds(), async () =>
             {
                 var resizer = new DefaultResizer(
                     lower: 2,
@@ -296,7 +297,7 @@ namespace Akka.Tests.Routing
                 Thread.Sleep(Dilated(300.Milliseconds()));
 
                 // let it cool down
-                AwaitCondition(() =>
+                await AwaitConditionAsync(() =>
                 {
                     router.Tell(0); //trigger resize
                     Thread.Sleep(Dilated(20.Milliseconds()));

--- a/src/core/Akka.Tests/Routing/RoutingSpec.cs
+++ b/src/core/Akka.Tests/Routing/RoutingSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Dispatch;
@@ -160,7 +161,7 @@ namespace Akka.Tests.Routing
         }
 
         [Fact]
-        public void Routers_in_general_must_evict_terminated_routees()
+        public async Task Routers_in_general_must_evict_terminated_routees()
         {
             var router = Sys.ActorOf(new RoundRobinPool(2).Props(Props.Create<Echo>()));
             router.Tell("");
@@ -175,7 +176,7 @@ namespace Akka.Tests.Routing
             ExpectTerminated(c2).ExistenceConfirmed.Should().BeTrue();
 
             // it might take a while until the Router has actually processed the Terminated message
-            AwaitCondition(() =>
+            await AwaitConditionAsync(() =>
             {
                 router.Tell("");
                 router.Tell("");


### PR DESCRIPTION
This PR is pretty big from the changed files count point of view. But the core idea is very simple: 
we are blocking execution thread with `Thread.Sleep` each time when `AwaitAssert` or `AwaitCondition` is used. This is what #3854 is about. When lots of tests in multiple assemblies are running in parallel jobs on single machine, each test sometimes blocks execution thread. And there might be moments when too much threads are sleeping, which could lead to thread starvation, leak of free memory and so on.

So the idea is that until all Akka.NET tests are using blocking testkit API, each test that uses blocking api may become racy, because OS is becoming slow, `Thread.Sleep` takes much more time to awake then requested, etc.

Migration to async API should increase overall test performance pretty much, because this is the same as migration of ASP.NET Core server from blocking connections handling to async/await operations (in our case tests are the clients that taking resources from the system).

To make migration simpler, I marked sync method versions as obsolete (with compiler error enabled), and then fixed all compiler errors in solution. Well, almost all - there are MNTR tests, that are still using sync API right now (disabled compiler error for `Obsolete` methods), but I will update them later (and will add async specs handling to MNTR itself) if CI will show that there are less or none of racy failures after update.

Before merging this PR, I think I will remove `Obsolete` attributes from sync API methods, because there is nothing that much wrong with them, and they are pretty handy sometimes. At the moment, they are marked as `Obsolete` for simpler detection.

Close #3854 
Close #3774 