### PR TITLE
Added async API to Akka.TestKit

### DIFF
--- a/src/core/Akka.TestKit/EventFilter/IEventFilterApplier.cs
+++ b/src/core/Akka.TestKit/EventFilter/IEventFilterApplier.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 
 namespace Akka.TestKit
 {
@@ -24,6 +25,26 @@ namespace Akka.TestKit
         /// </summary>
         /// <param name="action">The action.</param>
         void ExpectOne(Action action);
+        
+        /// <summary>
+        /// Executes <paramref name="action"/> and
+        /// expects one event to be logged during the execution.
+        /// This method fails and throws an exception if more than one event is logged,
+        /// or if a timeout occurs. The timeout is taken from the config value
+        /// "akka.test.filter-leeway", see <see cref="TestKitSettings.TestEventFilterLeeway"/>.
+        /// </summary>
+        /// <param name="action">The action.</param>
+        Task ExpectOneAsync(Action action);
+        
+        /// <summary>
+        /// Executes <paramref name="actionAsync"/> and
+        /// expects one event to be logged during the execution.
+        /// This method fails and throws an exception if more than one event is logged,
+        /// or if a timeout occurs. The timeout is taken from the config value
+        /// "akka.test.filter-leeway", see <see cref="TestKitSettings.TestEventFilterLeeway"/>.
+        /// </summary>
+        /// <param name="actionAsync">The action.</param>
+        Task ExpectOneAsync(Func<Task> actionAsync);
 
         /// <summary>
         /// Executes <paramref name="action"/> and
@@ -34,7 +55,17 @@ namespace Akka.TestKit
         /// <param name="timeout">The time to wait for a log event after executing <paramref name="action"/></param>
         /// <param name="action">The action.</param>
         void ExpectOne(TimeSpan timeout, Action action);
-
+        
+        /// <summary>
+        /// Executes <paramref name="action"/> and
+        /// expects one event to be logged during the execution.
+        /// This method fails and throws an exception if more than one event is logged,
+        /// or if a timeout occurs.
+        /// </summary>
+        /// <param name="timeout">The time to wait for a log event after executing <paramref name="action"/></param>
+        /// <param name="action">The action.</param>
+        Task ExpectOneAsync(TimeSpan timeout, Action action);
+        
         /// <summary>
         /// Executes <paramref name="action"/> and expects the specified number
         /// of events to be logged during the execution.
@@ -45,6 +76,28 @@ namespace Akka.TestKit
         /// <param name="expectedCount">The expected number of events</param>
         /// <param name="action">The action.</param>
         void Expect(int expectedCount, Action action);
+        
+        /// <summary>
+        /// Executes <paramref name="action"/> and expects the specified number
+        /// of events to be logged during the execution.
+        /// This method fails and throws an exception if more events than expected are logged,
+        /// or if a timeout occurs. The timeout is taken from the config value
+        /// "akka.test.filter-leeway", see <see cref="TestKitSettings.TestEventFilterLeeway"/>.
+        /// </summary>
+        /// <param name="expectedCount">The expected number of events</param>
+        /// <param name="action">The action.</param>
+        Task ExpectAsync(int expectedCount, Action action);
+        
+        /// <summary>
+        /// Executes <paramref name="actionAsync"/> task and expects the specified number
+        /// of events to be logged during the execution.
+        /// This method fails and throws an exception if more events than expected are logged,
+        /// or if a timeout occurs. The timeout is taken from the config value
+        /// "akka.test.filter-leeway", see <see cref="TestKitSettings.TestEventFilterLeeway"/>.
+        /// </summary>
+        /// <param name="expectedCount">The expected number of events</param>
+        /// <param name="actionAsync">The async action.</param>
+        Task ExpectAsync(int expectedCount, Func<Task> actionAsync);
 
         /// <summary>
         /// Executes <paramref name="action"/> and expects the specified number
@@ -57,6 +110,18 @@ namespace Akka.TestKit
         /// <param name="expectedCount">The expected number of events</param>
         /// <param name="action">The action.</param>
         void Expect(int expectedCount, TimeSpan timeout, Action action);
+        
+        /// <summary>
+        /// Executes <paramref name="action"/> and expects the specified number
+        /// of events to be logged during the execution.
+        /// This method fails and throws an exception if more events than expected are logged,
+        /// or if a timeout occurs. The timeout is taken from the config value
+        /// "akka.test.filter-leeway", see <see cref="TestKitSettings.TestEventFilterLeeway"/>.
+        /// </summary>
+        /// <param name="timeout">The time to wait for log events after executing <paramref name="action"/></param>
+        /// <param name="expectedCount">The expected number of events</param>
+        /// <param name="action">The action.</param>
+        Task ExpectAsync(int expectedCount, TimeSpan timeout, Action action);
 
         /// <summary>
         /// Executes <paramref name="func"/> and
@@ -69,6 +134,18 @@ namespace Akka.TestKit
         /// <param name="func">The function.</param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
         T ExpectOne<T>(Func<T> func);
+        
+        /// <summary>
+        /// Executes <paramref name="func"/> and
+        /// expects one event to be logged during the execution.
+        /// This function fails and throws an exception if more than one event is logged,
+        /// or if a timeout occurs. The timeout is taken from the config value
+        /// "akka.test.filter-leeway", see <see cref="TestKitSettings.TestEventFilterLeeway"/>.
+        /// </summary>
+        /// <typeparam name="T">The return value of the function</typeparam>
+        /// <param name="func">The function.</param>
+        /// <returns>The returned value from <paramref name="func"/>.</returns>
+        Task<T> ExpectOneAsync<T>(Func<T> func);
 
         /// <summary>
         /// Executes <paramref name="func"/> and
@@ -81,6 +158,18 @@ namespace Akka.TestKit
         /// <param name="func">The function.</param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
         T ExpectOne<T>(TimeSpan timeout, Func<T> func);
+        
+        /// <summary>
+        /// Executes <paramref name="func"/> and
+        /// expects one event to be logged during the execution.
+        /// This function fails and throws an exception if more than one event is logged,
+        /// or if a timeout occurs.
+        /// </summary>
+        /// <typeparam name="T">The return value of the function</typeparam>
+        /// <param name="timeout">The time to wait for a log event after executing <paramref name="func"/></param>
+        /// <param name="func">The function.</param>
+        /// <returns>The returned value from <paramref name="func"/>.</returns>
+        Task<T> ExpectOneAsync<T>(TimeSpan timeout, Func<T> func);
 
         /// <summary>
         /// Executes <paramref name="func"/> and expects the specified number
@@ -94,6 +183,19 @@ namespace Akka.TestKit
         /// <param name="func">The function.</param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
         T Expect<T>(int expectedCount, Func<T> func);
+        
+        /// <summary>
+        /// Executes <paramref name="func"/> and expects the specified number
+        /// of events to be logged during the execution.
+        /// This function fails and throws an exception if more events than expected are logged,
+        /// or if a timeout occurs. The timeout is taken from the config value
+        /// "akka.test.filter-leeway", see <see cref="TestKitSettings.TestEventFilterLeeway"/>.
+        /// </summary>
+        /// <typeparam name="T">The return value of the function</typeparam>
+        /// <param name="expectedCount">The expected number of events</param>
+        /// <param name="func">The function.</param>
+        /// <returns>The returned value from <paramref name="func"/>.</returns>
+        Task<T> ExpectAsync<T>(int expectedCount, Func<T> func);
 
         /// <summary>
         /// Executes <paramref name="func"/> and expects the specified number
@@ -108,6 +210,20 @@ namespace Akka.TestKit
         /// <param name="func">The function.</param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
         T Expect<T>(int expectedCount, TimeSpan timeout, Func<T> func);
+        
+        /// <summary>
+        /// Executes <paramref name="func"/> and expects the specified number
+        /// of events to be logged during the execution.
+        /// This function fails and throws an exception if more events than expected are logged,
+        /// or if a timeout occurs. The timeout is taken from the config value
+        /// "akka.test.filter-leeway", see <see cref="TestKitSettings.TestEventFilterLeeway"/>.
+        /// </summary>
+        /// <typeparam name="T">The return value of the function</typeparam>
+        /// <param name="timeout">The time to wait for log events after executing <paramref name="func"/></param>
+        /// <param name="expectedCount">The expected number of events</param>
+        /// <param name="func">The function.</param>
+        /// <returns>The returned value from <paramref name="func"/>.</returns>
+        Task<T> ExpectAsync<T>(int expectedCount, TimeSpan timeout, Func<T> func);
 
         /// <summary>
         /// Executes <paramref name="func"/> and prevent events from being logged during the execution.
@@ -116,6 +232,14 @@ namespace Akka.TestKit
         /// <param name="func">The function.</param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
         T Mute<T>(Func<T> func);
+        
+        /// <summary>
+        /// Executes <paramref name="func"/> and prevent events from being logged during the execution.
+        /// </summary>
+        /// <typeparam name="T">The return value of the function</typeparam>
+        /// <param name="func">The function.</param>
+        /// <returns>The returned value from <paramref name="func"/>.</returns>
+        Task<T> MuteAsync<T>(Func<T> func);
 
         /// <summary>
         /// Executes <paramref name="action"/> and prevent events from being logged during the execution.
@@ -123,6 +247,13 @@ namespace Akka.TestKit
         /// <param name="action">The function.</param>
         /// <returns>The returned value from <paramref name="action"/>.</returns>
         void Mute(Action action);
+        
+        /// <summary>
+        /// Executes <paramref name="action"/> and prevent events from being logged during the execution.
+        /// </summary>
+        /// <param name="action">The function.</param>
+        /// <returns>The returned value from <paramref name="action"/>.</returns>
+        Task MuteAsync(Action action);
 
         /// <summary>
         /// Prevents events from being logged from now on. To allow events to be logged again, call 

--- a/src/core/Akka.TestKit/EventFilter/Internal/EventFilterApplier.cs
+++ b/src/core/Akka.TestKit/EventFilter/Internal/EventFilterApplier.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
 using Akka.TestKit.TestEvent;
@@ -45,6 +46,20 @@ namespace Akka.TestKit.Internal
             InternalExpect(action, _actorSystem, 1);
         }
 
+        public Task ExpectOneAsync(Func<Task> actionAsync)
+        {
+            return InternalExpectAsync(actionAsync, _actorSystem, 1);
+        }
+
+        /// <summary>
+        /// Async version of <see cref="ExpectOne(System.Action)"/>
+        /// </summary>
+        /// <param name="action"></param>
+        public async Task ExpectOneAsync(Action action)
+        {
+            await InternalExpectAsync(action, _actorSystem, 1);
+        }
+
         /// <summary>
         /// TBD
         /// </summary>
@@ -53,6 +68,15 @@ namespace Akka.TestKit.Internal
         public void ExpectOne(TimeSpan timeout, Action action)
         {
             InternalExpect(action, _actorSystem, 1, timeout);
+        }
+        
+        /// <summary>
+        /// Async version of <see cref="ExpectOne(System.TimeSpan,System.Action) "/>
+        /// </summary>
+        /// <returns></returns>
+        public async Task ExpectOneAsync(TimeSpan timeout, Action action)
+        {
+            await InternalExpectAsync(action, _actorSystem, 1, timeout);
         }
 
         /// <summary>
@@ -66,6 +90,22 @@ namespace Akka.TestKit.Internal
         }
 
         /// <summary>
+        /// Async version of Expect
+        /// </summary>
+        public Task ExpectAsync(int expectedCount, Func<Task> actionAsync)
+        {
+            return InternalExpectAsync(actionAsync, _actorSystem, expectedCount, null);
+        }
+
+        /// <summary>
+        /// Async version of <see cref="Expect(int,System.Action)"/>
+        /// </summary>
+        public async Task ExpectAsync(int expectedCount, Action action)
+        {
+            await InternalExpectAsync(action, _actorSystem, expectedCount, null);
+        }
+
+        /// <summary>
         /// TBD
         /// </summary>
         /// <param name="expectedCount">TBD</param>
@@ -74,6 +114,14 @@ namespace Akka.TestKit.Internal
         public void Expect(int expectedCount, TimeSpan timeout, Action action)
         {
             InternalExpect(action, _actorSystem, expectedCount, timeout);
+        }
+        
+        /// <summary>
+        /// Async version of <see cref="Expect(int,System.TimeSpan,System.Action)"/>
+        /// </summary>
+        public async Task ExpectAsync(int expectedCount, TimeSpan timeout, Action action)
+        {
+            await InternalExpectAsync(action, _actorSystem, expectedCount, timeout);
         }
 
         /// <summary>
@@ -86,6 +134,14 @@ namespace Akka.TestKit.Internal
         {
             return Intercept(func, _actorSystem, null, 1);
         }
+        
+        /// <summary>
+        /// Async version of ExpectOne
+        /// </summary>
+        public async Task<T> ExpectOneAsync<T>(Func<T> func)
+        {
+            return await InterceptAsync(func, _actorSystem, null, 1);
+        }
 
         /// <summary>
         /// TBD
@@ -97,6 +153,14 @@ namespace Akka.TestKit.Internal
         public T ExpectOne<T>(TimeSpan timeout, Func<T> func)
         {
             return Intercept(func, _actorSystem, timeout, 1);
+        }
+        
+        /// <summary>
+        /// Async version of ExpectOne
+        /// </summary>
+        public async Task<T> ExpectOneAsync<T>(TimeSpan timeout, Func<T> func)
+        {
+            return await InterceptAsync(func, _actorSystem, timeout, 1);
         }
 
         /// <summary>
@@ -112,6 +176,14 @@ namespace Akka.TestKit.Internal
         }
 
         /// <summary>
+        /// Async version of Expect
+        /// </summary>
+        public async Task<T> ExpectAsync<T>(int expectedCount, Func<T> func)
+        {
+            return await InterceptAsync(func, _actorSystem, null, expectedCount);
+        }
+
+        /// <summary>
         /// TBD
         /// </summary>
         /// <typeparam name="T">TBD</typeparam>
@@ -122,6 +194,14 @@ namespace Akka.TestKit.Internal
         public T Expect<T>(int expectedCount, TimeSpan timeout, Func<T> func)
         {
             return Intercept(func, _actorSystem, timeout, expectedCount);
+        }
+        
+        /// <summary>
+        /// Async version of Expect
+        /// </summary>
+        public async Task<T> ExpectAsync<T>(int expectedCount, TimeSpan timeout, Func<T> func)
+        {
+            return await InterceptAsync(func, _actorSystem, timeout, expectedCount);
         }
 
         /// <summary>
@@ -134,6 +214,14 @@ namespace Akka.TestKit.Internal
         {
             return Intercept(func, _actorSystem, null, null);
         }
+        
+        /// <summary>
+        /// Async version of Mute
+        /// </summary>
+        public async Task<T> MuteAsync<T>(Func<T> func)
+        {
+            return await InterceptAsync(func, _actorSystem, null, null);
+        }
 
         /// <summary>
         /// TBD
@@ -142,6 +230,14 @@ namespace Akka.TestKit.Internal
         public void Mute(Action action)
         {
             Intercept<object>(() => { action(); return null; }, _actorSystem, null, null);
+        }
+        
+        /// <summary>
+        /// Async version of Mute
+        /// </summary>
+        public async Task MuteAsync(Action action)
+        {
+            await InterceptAsync<object>(() => { action(); return null; }, _actorSystem, null, null);
         }
 
         /// <summary>
@@ -228,6 +324,69 @@ namespace Akka.TestKit.Internal
         }
 
         /// <summary>
+        /// Async version of <see cref="Intercept{T}"/>
+        /// </summary>
+        protected Task<T> InterceptAsync<T>(Func<T> func, ActorSystem system, TimeSpan? timeout, int? expectedOccurrences, MatchedEventHandler matchedEventHandler = null)
+        {
+            return InterceptAsync(() => Task.FromResult(func()), system, timeout, expectedOccurrences, matchedEventHandler);
+        }
+        
+        /// <summary>
+        /// Async version of <see cref="Intercept{T}"/>
+        /// </summary>
+        protected async Task<T> InterceptAsync<T>(Func<Task<T>> func, ActorSystem system, TimeSpan? timeout, int? expectedOccurrences, MatchedEventHandler matchedEventHandler = null)
+        {
+            var leeway = system.HasExtension<TestKitSettings>()
+                ? TestKitExtension.For(system).TestEventFilterLeeway
+                : _testkit.TestKitSettings.TestEventFilterLeeway;
+
+            var timeoutValue = timeout.HasValue ? _testkit.Dilated(timeout.Value) : leeway;
+            matchedEventHandler = matchedEventHandler ?? new MatchedEventHandler();
+            system.EventStream.Publish(new Mute(_filters));
+            try
+            {
+                foreach(var filter in _filters)
+                {
+                    filter.EventMatched += matchedEventHandler.HandleEvent;
+                }
+                var result = await func();
+
+                if(!await AwaitDoneAsync(timeoutValue, expectedOccurrences, matchedEventHandler))
+                {
+                    var actualNumberOfEvents = matchedEventHandler.ReceivedCount;
+                    string msg;
+                    if(expectedOccurrences.HasValue)
+                    {
+                        var expectedNumberOfEvents = expectedOccurrences.Value;
+                        if(actualNumberOfEvents < expectedNumberOfEvents)
+                            msg = string.Format("Timeout ({0}) while waiting for messages. Only received {1}/{2} messages that matched filter [{3}]", timeoutValue, actualNumberOfEvents, expectedNumberOfEvents, string.Join(",", _filters));
+                        else
+                        {
+                            var tooMany = actualNumberOfEvents - expectedNumberOfEvents;
+                            msg = string.Format("Received {0} {1} too many. Expected {2} {3} but received {4} that matched filter [{5}]", tooMany, GetMessageString(tooMany), expectedNumberOfEvents, GetMessageString(expectedNumberOfEvents), actualNumberOfEvents, string.Join(",", _filters));
+                        }
+                    }
+                    else
+                        msg = string.Format("Timeout ({0}) while waiting for messages that matched filter [{1}]", timeoutValue, _filters);
+
+                    var assertionsProvider = system.HasExtension<TestKitAssertionsProvider>()
+                        ? TestKitAssertionsExtension.For(system)
+                        : TestKitAssertionsExtension.For(_testkit.Sys);
+                    assertionsProvider.Assertions.Fail(msg);
+                }
+                return result;
+            }
+            finally
+            {
+                foreach(var filter in _filters)
+                {
+                    filter.EventMatched -= matchedEventHandler.HandleEvent;
+                }
+                system.EventStream.Publish(new Unmute(_filters));
+            }
+        }
+
+        /// <summary>
         /// TBD
         /// </summary>
         /// <param name="timeout">TBD</param>
@@ -240,6 +399,20 @@ namespace Akka.TestKit.Internal
             {
                 var expected = expectedOccurrences.GetValueOrDefault();
                 _testkit.AwaitConditionNoThrow(() => matchedEventHandler.ReceivedCount >= expected, timeout);
+                return matchedEventHandler.ReceivedCount == expected;
+            }
+            return true;
+        }
+        
+        /// <summary>
+        /// Async version of <see cref="AwaitDone"/>
+        /// </summary>
+        protected async Task<bool> AwaitDoneAsync(TimeSpan timeout, int? expectedOccurrences, MatchedEventHandler matchedEventHandler)
+        {
+            if(expectedOccurrences.HasValue)
+            {
+                var expected = expectedOccurrences.GetValueOrDefault();
+                await _testkit.AwaitConditionNoThrowAsync(() => matchedEventHandler.ReceivedCount >= expected, timeout);
                 return matchedEventHandler.ReceivedCount == expected;
             }
             return true;
@@ -258,6 +431,22 @@ namespace Akka.TestKit.Internal
         private void InternalExpect(Action action, ActorSystem actorSystem, int expectedCount, TimeSpan? timeout = null)
         {
             Intercept<object>(() => { action(); return null; }, actorSystem, timeout, expectedCount);
+        }
+        
+        /// <summary>
+        /// Async version of <see cref="InternalExpect"/>
+        /// </summary>
+        private async Task InternalExpectAsync(Func<Task> actionAsync, ActorSystem actorSystem, int expectedCount, TimeSpan? timeout = null)
+        {
+            await InterceptAsync<object>(() => { actionAsync(); return Task.FromResult<object>(null); }, actorSystem, timeout, expectedCount);
+        }
+        
+        /// <summary>
+        /// Async version of <see cref="InternalExpect"/>
+        /// </summary>
+        private async Task InternalExpectAsync(Action action, ActorSystem actorSystem, int expectedCount, TimeSpan? timeout = null)
+        {
+            await InterceptAsync<object>(() => { action(); return Task.FromResult<object>(null); }, actorSystem, timeout, expectedCount);
         }
 
         /// <summary>

--- a/src/core/Akka.TestKit/TestKitBase.cs
+++ b/src/core/Akka.TestKit/TestKitBase.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="TestKitBase.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2019 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2019 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -7,6 +7,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Internal;
 using Akka.Configuration;
@@ -134,6 +135,7 @@ namespace Akka.TestKit
 
             var testActor = CreateTestActor(system, testActorName);
             //Wait for the testactor to start
+            // Calling sync version here, since .Wait() causes deadlock
             AwaitCondition(() =>
             {
                 var repRef = testActor as IRepointableRef;

--- a/src/core/Akka.TestKit/TestKitBase_AwaitAssert.cs
+++ b/src/core/Akka.TestKit/TestKitBase_AwaitAssert.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.TestKit.Internal;
 
 namespace Akka.TestKit
@@ -51,6 +52,45 @@ namespace Akka.TestKit
                         throw;
                 }
                 Thread.Sleep(t);
+                t = (stop - Now).Min(intervalValue);
+            }
+        }
+        
+        /// <summary>
+        /// <para>Await until the given assertion does not throw an exception or the timeout
+        /// expires, whichever comes first. If the timeout expires the last exception
+        /// is thrown.</para>
+        /// <para>The action is called, and if it throws an exception the thread sleeps
+        /// the specified interval before retrying.</para>
+        /// <para>If no timeout is given, take it from the innermost enclosing `within`
+        /// block.</para>
+        /// <para>Note that the timeout is scaled using <see cref="Dilated" />,
+        /// which uses the configuration entry "akka.test.timefactor".</para>
+        /// </summary>
+        /// <param name="assertion">The action.</param>
+        /// <param name="duration">The timeout.</param>
+        /// <param name="interval">The interval to wait between executing the assertion.</param>
+        public async Task AwaitAssertAsync(Action assertion, TimeSpan? duration=null, TimeSpan? interval=null)
+        {
+            var intervalValue = interval.GetValueOrDefault(TimeSpan.FromMilliseconds(800));
+            if(intervalValue == Timeout.InfiniteTimeSpan) intervalValue = TimeSpan.MaxValue;
+            intervalValue.EnsureIsPositiveFinite("interval");
+            var max = RemainingOrDilated(duration);
+            var stop = Now + max;
+            var t = max.Min(intervalValue);
+            while(true)
+            {
+                try
+                {
+                    assertion();
+                    return;
+                }
+                catch(Exception)
+                {
+                    if(Now + t >= stop)
+                        throw;
+                }
+                await Task.Delay(t);
                 t = (stop - Now).Min(intervalValue);
             }
         }

--- a/src/core/Akka.TestKit/TestKitBase_AwaitConditions.cs
+++ b/src/core/Akka.TestKit/TestKitBase_AwaitConditions.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Event;
 using Akka.TestKit.Internal;
 
@@ -37,6 +38,27 @@ namespace Akka.TestKit
             var logger = _testState.TestKitSettings.LogTestKitCalls ? _testState.Log : null;
             InternalAwaitCondition(conditionIsFulfilled, maxDur, interval, (format, args) => _assertions.Fail(format, args), logger);
         }
+        
+        /// <summary>
+        /// <para>Await until the given condition evaluates to <c>true</c> or until a timeout</para>
+        /// <para>The timeout is taken from the innermost enclosing `within`
+        /// block (if inside a `within` block) or the value specified in config value "akka.test.single-expect-default". 
+        /// The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
+        /// specified in config value "akka.test.timefactor"..</para>
+        /// <para>A call to <paramref name="conditionIsFulfilled"/> is done immediately, then the threads sleep
+        /// for about a tenth of the timeout value, before it checks the condition again. This is repeated until
+        /// timeout or the condition evaluates to <c>true</c>. To specify another interval, use the overload
+        /// <see cref="AwaitCondition(System.Func{bool},System.Nullable{System.TimeSpan},System.Nullable{System.TimeSpan},string)"/>
+        /// </para>
+        /// </summary>
+        /// <param name="conditionIsFulfilled">The condition that must be fulfilled within the duration.</param>
+        public async Task AwaitConditionAsync(Func<bool> conditionIsFulfilled)
+        {
+            var maxDur = RemainingOrDefault;
+            var interval = new TimeSpan(maxDur.Ticks / 10);
+            var logger = _testState.TestKitSettings.LogTestKitCalls ? _testState.Log : null;
+            await InternalAwaitConditionAsync(conditionIsFulfilled, maxDur, interval, (format, args) => _assertions.Fail(format, args), logger);
+        }
 
         /// <summary>
         /// <para>Await until the given condition evaluates to <c>true</c> or the timeout
@@ -62,6 +84,32 @@ namespace Akka.TestKit
             var interval = new TimeSpan(maxDur.Ticks / 10);
             var logger = _testState.TestKitSettings.LogTestKitCalls ? _testState.Log : null;
             InternalAwaitCondition(conditionIsFulfilled, maxDur, interval, (format, args) => _assertions.Fail(format, args), logger);
+        }
+        
+        /// <summary>
+        /// <para>Await until the given condition evaluates to <c>true</c> or the timeout
+        /// expires, whichever comes first.</para>
+        /// <para>If no timeout is given, take it from the innermost enclosing `within`
+        /// block (if inside a `within` block) or the value specified in config value "akka.test.single-expect-default". 
+        /// The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
+        /// specified in config value "akka.test.timefactor"..</para>
+        /// <para>A call to <paramref name="conditionIsFulfilled"/> is done immediately, then the threads sleep
+        /// for about a tenth of the timeout value, before it checks the condition again. This is repeated until
+        /// timeout or the condition evaluates to <c>true</c>. To specify another interval, use the overload
+        /// <see cref="AwaitCondition(System.Func{bool},System.Nullable{System.TimeSpan},System.Nullable{System.TimeSpan},string)"/>
+        /// </para>
+        /// </summary>
+        /// <param name="conditionIsFulfilled">The condition that must be fulfilled within the duration.</param>
+        /// <param name="max">The maximum duration. If undefined, uses the remaining time 
+        /// (if inside a `within` block) or the value specified in config value "akka.test.single-expect-default". 
+        /// The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
+        /// specified in config value "akka.test.timefactor".</param>
+        public async Task AwaitConditionAsync(Func<bool> conditionIsFulfilled, TimeSpan? max)
+        {
+            var maxDur = RemainingOrDilated(max);
+            var interval = new TimeSpan(maxDur.Ticks / 10);
+            var logger = _testState.TestKitSettings.LogTestKitCalls ? _testState.Log : null;
+            await InternalAwaitConditionAsync(conditionIsFulfilled, maxDur, interval, (format, args) => _assertions.Fail(format, args), logger);
         }
 
         /// <summary>
@@ -89,6 +137,33 @@ namespace Akka.TestKit
             var interval = new TimeSpan(maxDur.Ticks / 10);
             var logger = _testState.TestKitSettings.LogTestKitCalls ? _testState.Log : null;
             InternalAwaitCondition(conditionIsFulfilled, maxDur, interval, (format, args) => AssertionsFail(format, args, message), logger);
+        }
+        
+        /// <summary>
+        /// <para>Await until the given condition evaluates to <c>true</c> or the timeout
+        /// expires, whichever comes first.</para>
+        /// <para>If no timeout is given, take it from the innermost enclosing `within`
+        /// block (if inside a `within` block) or the value specified in config value "akka.test.single-expect-default". 
+        /// The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
+        /// specified in config value "akka.test.timefactor"..</para>
+        /// <para>A call to <paramref name="conditionIsFulfilled"/> is done immediately, then the threads sleep
+        /// for about a tenth of the timeout value, before it checks the condition again. This is repeated until
+        /// timeout or the condition evaluates to <c>true</c>. To specify another interval, use the overload
+        /// <see cref="AwaitCondition(System.Func{bool},System.Nullable{System.TimeSpan},System.Nullable{System.TimeSpan},string)"/>
+        /// </para>
+        /// </summary>
+        /// <param name="conditionIsFulfilled">The condition that must be fulfilled within the duration.</param>
+        /// <param name="max">The maximum duration. If undefined, uses the remaining time 
+        /// (if inside a `within` block) or the value specified in config value "akka.test.single-expect-default". 
+        /// The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
+        /// specified in config value "akka.test.timefactor".</param>
+        /// <param name="message">The message used if the timeout expires.</param>
+        public async Task AwaitConditionAsync(Func<bool> conditionIsFulfilled, TimeSpan? max, string message)
+        {
+            var maxDur = RemainingOrDilated(max);
+            var interval = new TimeSpan(maxDur.Ticks / 10);
+            var logger = _testState.TestKitSettings.LogTestKitCalls ? _testState.Log : null;
+            await InternalAwaitConditionAsync(conditionIsFulfilled, maxDur, interval, (format, args) => AssertionsFail(format, args, message), logger);
         }
 
         /// <summary>
@@ -124,12 +199,45 @@ namespace Akka.TestKit
             var logger = _testState.TestKitSettings.LogTestKitCalls ? _testState.Log : null;
             InternalAwaitCondition(conditionIsFulfilled, maxDur, interval, (format, args) => AssertionsFail(format, args, message), logger);
         }
+        
+        /// <summary>
+        /// <para>Await until the given condition evaluates to <c>true</c> or the timeout
+        /// expires, whichever comes first.</para>
+        /// <para>If no timeout is given, take it from the innermost enclosing `within`
+        /// block.</para>
+        /// <para>Note that the timeout is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
+        /// specified in config value "akka.test.timefactor".</para>
+        /// <para>The parameter <paramref name="interval"/> specifies the time between calls to <paramref name="conditionIsFulfilled"/>
+        /// Between calls the thread sleeps. If <paramref name="interval"/> is undefined the thread only sleeps 
+        /// one time, using the <paramref name="max"/> as duration, and then rechecks the condition and ultimately 
+        /// succeeds or fails.</para>
+        /// <para>To make sure that tests run as fast as possible, make sure you do not leave this value as undefined,
+        /// instead set it to a relatively small value.</para>
+        /// </summary>
+        /// <param name="conditionIsFulfilled">The condition that must be fulfilled within the duration.</param>
+        /// <param name="max">The maximum duration. If undefined, uses the remaining time 
+        /// (if inside a `within` block) or the value specified in config value "akka.test.single-expect-default". 
+        /// The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
+        /// specified in config value "akka.test.timefactor".</param>
+        /// <param name="interval">The time between calls to <paramref name="conditionIsFulfilled"/> to check
+        /// if the condition is fulfilled. Between calls the thread sleeps. If undefined, negative or 
+        /// <see cref="Timeout.InfiniteTimeSpan"/>the thread only sleeps one time, using the <paramref name="max"/>, 
+        /// and then rechecks the condition and ultimately succeeds or fails.
+        /// <para>To make sure that tests run as fast as possible, make sure you do not set this value as undefined,
+        /// instead set it to a relatively small value.</para>
+        /// </param>
+        /// <param name="message">The message used if the timeout expires.</param>
+        public async Task AwaitConditionAsync(Func<bool> conditionIsFulfilled, TimeSpan? max, TimeSpan? interval, string message = null)
+        {
+            var maxDur = RemainingOrDilated(max);
+            var logger = _testState.TestKitSettings.LogTestKitCalls ? _testState.Log : null;
+            await InternalAwaitConditionAsync(conditionIsFulfilled, maxDur, interval, (format, args) => AssertionsFail(format, args, message), logger);
+        }
 
         private void AssertionsFail(string format, object[] args, string message = null)
         {
             _assertions.Fail(format + (message ?? ""), args);
         }
-
 
         /// <summary>
         /// <para>Await until the given condition evaluates to <c>true</c> or the timeout
@@ -148,7 +256,24 @@ namespace Akka.TestKit
             var intervalDur = interval.GetValueOrDefault(TimeSpan.FromMilliseconds(100));
             return InternalAwaitCondition(conditionIsFulfilled, max, intervalDur, (f, a) => { });
         }
-
+        
+        /// <summary>
+        /// <para>Await until the given condition evaluates to <c>true</c> or the timeout
+        /// expires, whichever comes first. Returns <c>true</c> if the condition was fulfilled.</para>        
+        /// <para>The parameter <paramref name="interval"/> specifies the time between calls to <paramref name="conditionIsFulfilled"/>
+        /// Between calls the thread sleeps. If <paramref name="interval"/> is not specified or <c>null</c> 100 ms is used.</para>
+        /// </summary>
+        /// <param name="conditionIsFulfilled">The condition that must be fulfilled within the duration.</param>
+        /// <param name="max">The maximum duration.</param>
+        /// <param name="interval">Optional. The time between calls to <paramref name="conditionIsFulfilled"/> to check
+        /// if the condition is fulfilled. Between calls the thread sleeps. If undefined, 100 ms is used
+        /// </param>
+        /// <returns>TBD</returns>
+        public Task<bool> AwaitConditionNoThrowAsync(Func<bool> conditionIsFulfilled, TimeSpan max, TimeSpan? interval = null)
+        {
+            var intervalDur = interval.GetValueOrDefault(TimeSpan.FromMilliseconds(100));
+            return InternalAwaitConditionAsync(conditionIsFulfilled, max, intervalDur, (f, a) => { });
+        }
 
         /// <summary>
         /// <para>Await until the given condition evaluates to <c>true</c> or the timeout
@@ -180,6 +305,19 @@ namespace Akka.TestKit
         protected static bool InternalAwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan max, TimeSpan? interval, Action<string, object[]> fail)
         {
             return InternalAwaitCondition(conditionIsFulfilled, max, interval, fail, null);
+        }
+        
+        /// <summary>
+        /// Async version of <see cref="InternalAwaitCondition(System.Func{bool},System.TimeSpan,System.Nullable{System.TimeSpan},System.Action{string,object[]})"/>
+        /// </summary>
+        /// <param name="conditionIsFulfilled"></param>
+        /// <param name="max"></param>
+        /// <param name="interval"></param>
+        /// <param name="fail"></param>
+        /// <returns></returns>
+        protected static Task<bool> InternalAwaitConditionAsync(Func<bool> conditionIsFulfilled, TimeSpan max, TimeSpan? interval, Action<string, object[]> fail)
+        {
+            return InternalAwaitConditionAsync(conditionIsFulfilled, max, interval, fail, null);
         }
 
         /// <summary>
@@ -230,6 +368,34 @@ namespace Akka.TestKit
                 }
                 var sleepDuration = (stop - now).Min(interval);
                 Thread.Sleep(sleepDuration);
+            }
+            ConditionalLog(logger, "Condition fulfilled after {0}", Now-start);
+            return true;
+        }
+        
+        /// <summary>
+        /// Async version of <see cref="InternalAwaitCondition(System.Func{bool},System.TimeSpan,System.Nullable{System.TimeSpan},System.Action{string,object[]})"/>
+        /// </summary>
+        protected static async Task<bool> InternalAwaitConditionAsync(Func<bool> conditionIsFulfilled, TimeSpan max, TimeSpan? interval, Action<string, object[]> fail, ILoggingAdapter logger)
+        {
+            max.EnsureIsPositiveFinite("max");
+            var start = Now;
+            var stop = start + max;
+            ConditionalLog(logger, "Awaiting condition for {0}.{1}", max, interval.HasValue ? " Will sleep " + interval.Value + " between checks" : "");
+
+            while (!conditionIsFulfilled())
+            {
+                var now = Now;
+
+                if (now > stop)
+                {
+                    const string message = "Timeout {0} expired while waiting for condition.";
+                    ConditionalLog(logger, message, max);
+                    fail(message, new object[] { max });
+                    return false;
+                }
+                var sleepDuration = (stop - now).Min(interval);
+                await Task.Delay(sleepDuration);
             }
             ConditionalLog(logger, "Condition fulfilled after {0}", Now-start);
             return true;

--- a/src/core/Akka.TestKit/TestKitBase_Within.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Within.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.TestKit.Internal;
 
 namespace Akka.TestKit
@@ -30,6 +31,14 @@ namespace Akka.TestKit
         {
             Within(TimeSpan.Zero, max, action, epsilonValue: epsilonValue);
         }
+        
+        /// <summary>
+        /// Async version of Within
+        /// </summary>
+        public Task WithinAsync(TimeSpan max, Func<Task> actionAsync, TimeSpan? epsilonValue = null)
+        {
+            return WithinAsync(TimeSpan.Zero, max, actionAsync, epsilonValue: epsilonValue);
+        }
 
         /// <summary>
         /// Execute code block while bounding its execution time between <paramref name="min"/> and <paramref name="max"/>.
@@ -47,7 +56,14 @@ namespace Akka.TestKit
         {
             Within<object>(min, max, () => { action(); return null; }, hint, epsilonValue);
         }
-
+        
+        /// <summary>
+        /// Async version of <see cref="Within(System.TimeSpan,System.Action,System.Nullable{System.TimeSpan})"/>
+        /// </summary>
+        public Task WithinAsync(TimeSpan min, TimeSpan max, Func<Task> actionAsync, string hint = null, TimeSpan? epsilonValue = null)
+        {
+            return WithinAsync<object>(min, max, async () => { await actionAsync(); return null; }, hint, epsilonValue);
+        }
 
         /// <summary>
         /// Execute code block while bounding its execution time between 0 seconds and <paramref name="max"/>.
@@ -64,6 +80,23 @@ namespace Akka.TestKit
         public T Within<T>(TimeSpan max, Func<T> function, TimeSpan? epsilonValue = null)
         {
             return Within(TimeSpan.Zero, max, function, epsilonValue: epsilonValue);
+        }
+        
+        /// <summary>
+        /// Execute code block while bounding its execution time between 0 seconds and <paramref name="max"/>.
+        /// <para>`within` blocks may be nested. All methods in this class which take maximum wait times 
+        /// are available in a version which implicitly uses the remaining time governed by 
+        /// the innermost enclosing `within` block.</para>
+        /// <remarks>Note that the max duration is scaled using <see cref="Dilated(TimeSpan)"/> which uses the config value "akka.test.timefactor"</remarks>
+        /// </summary>
+        /// <typeparam name="T">TBD</typeparam>
+        /// <param name="max">TBD</param>
+        /// <param name="function">TBD</param>
+        /// <param name="epsilonValue">TBD</param>
+        /// <returns>TBD</returns>
+        public Task<T> WithinAsync<T>(TimeSpan max, Func<Task<T>> function, TimeSpan? epsilonValue = null)
+        {
+            return WithinAsync(TimeSpan.Zero, max, function, epsilonValue: epsilonValue);
         }
 
         /// <summary>
@@ -128,5 +161,66 @@ namespace Akka.TestKit
             return ret;
         }
 
+        /// <summary>
+        /// Execute code block while bounding its execution time between <paramref name="min"/> and <paramref name="max"/>.
+        /// <para>`within` blocks may be nested. All methods in this class which take maximum wait times 
+        /// are available in a version which implicitly uses the remaining time governed by 
+        /// the innermost enclosing `within` block.</para>
+        /// <remarks>Note that the max duration is scaled using <see cref="Dilated(TimeSpan)"/> which uses the config value "akka.test.timefactor"</remarks>
+        /// </summary>
+        /// <typeparam name="T">TBD</typeparam>
+        /// <param name="min">TBD</param>
+        /// <param name="max">TBD</param>
+        /// <param name="function">TBD</param>
+        /// <param name="hint">TBD</param>
+        /// <param name="epsilonValue">TBD</param>
+        /// <returns>TBD</returns>
+        public async Task<T> WithinAsync<T>(TimeSpan min, TimeSpan max, Func<Task<T>> function, string hint = null, TimeSpan? epsilonValue = null)
+        {
+            min.EnsureIsPositiveFinite("min");
+            min.EnsureIsPositiveFinite("max");
+            max = Dilated(max);
+            var start = Now;
+            var rem = _testState.End.HasValue ? _testState.End.Value - start : Timeout.InfiniteTimeSpan;
+            _assertions.AssertTrue(rem.IsInfiniteTimeout() || rem >= min, "Required min time {0} not possible, only {1} left. {2}", min, rem, hint ?? "");
+
+            _testState.LastWasNoMsg = false;
+
+            var maxDiff = max.Min(rem);
+            var prevEnd = _testState.End;
+            _testState.End = start + maxDiff;
+
+            T ret;
+            try
+            {
+                ret = await function();
+            }
+            finally
+            {
+                _testState.End = prevEnd;
+            }
+
+            var elapsed = Now - start;
+            var wasTooFast = elapsed < min;
+            if(wasTooFast)
+            {
+                const string failMessage = "Failed: Block took {0}, should have at least been {1}. {2}";
+                ConditionalLog(failMessage, elapsed, min, hint ?? "");
+                _assertions.Fail(failMessage, elapsed, min, hint ?? "");
+            }
+            if (!_testState.LastWasNoMsg)
+            {
+                epsilonValue = epsilonValue ?? TimeSpan.Zero;
+                var tookTooLong = elapsed > maxDiff + epsilonValue;
+                if(tookTooLong)
+                {
+                    const string failMessage = "Failed: Block took {0}, exceeding {1}. {2}";
+                    ConditionalLog(failMessage, elapsed, maxDiff, hint ?? "");
+                    _assertions.Fail(failMessage, elapsed, maxDiff, hint ?? "");
+                }
+            }
+
+            return ret;
+        }
     }
 }

--- a/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit.Internal.StringMatcher;
@@ -143,6 +144,19 @@ namespace Akka.TestKit
             try
             {
                 actionThatThrows();
+            }
+            catch(Exception)
+            {
+                return;
+            }
+            throw new ThrowsException(typeof(Exception));
+        }
+        
+        protected async Task InterceptAsync(Func<Task> asyncActionThatThrows)
+        {
+            try
+            {
+                await asyncActionThatThrows();
             }
             catch(Exception)
             {


### PR DESCRIPTION
Close #3854
Close #3774

The core of #4072 PR - adding async overloads for TestKit API to avoid blocking threads.