### PR TITLE
Remove string interpolation from cluster logs

### DIFF
--- a/src/core/Akka.Cluster/Cluster.cs
+++ b/src/core/Akka.Cluster/Cluster.cs
@@ -601,7 +601,7 @@ namespace Akka.Cluster
             internal void LogInfo(string template, object arg1)
             {
                 if (_settings.LogInfo)
-                    _log.Info($"Cluster Node [{_selfAddress}] - " + template, arg1);
+                    _log.Info("Cluster Node [{1}] - " + template, arg1, _selfAddress);
             }
 
             /// <summary>
@@ -613,7 +613,7 @@ namespace Akka.Cluster
             internal void LogInfo(string template, object arg1, object arg2)
             {
                 if (_settings.LogInfo)
-                    _log.Info($"Cluster Node [{_selfAddress}] - " + template, arg1, arg2);
+                    _log.Info("Cluster Node [{2}] - " + template, arg1, arg2, _selfAddress);
             }
         }
 


### PR DESCRIPTION
Usage of string interpolation prevents some loggers (i.e., Serilog) from applying the correct format to the output template.