### PR TITLE
Convert to ImmutableHashSet for consistency in comparison

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ConstantRateEntityRecoveryStrategySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ConstantRateEntityRecoveryStrategySpec.cs
@@ -43,7 +43,7 @@ namespace Akka.Cluster.Sharding.Tests
             scheduledEntities[0].Count.Should().Be(2);
             scheduledEntities[1].Count.Should().Be(2);
             scheduledEntities[2].Count.Should().Be(1);
-            scheduledEntities.SelectMany(s => s).Should().Equal(entities);
+            scheduledEntities.SelectMany(s => s).ToImmutableHashSet().Should().Equal(entities);
 
             var timesMillis = result.Select(pair => pair.Value.TotalMilliseconds).ToArray();
 


### PR DESCRIPTION
This test was giving me a fairly high flip rate locally - and the fix is quite straight forward.

Previous code was equating an IEnumerable<T> to an ImmutableHashSet<T> which yields inconsistent results due to the way a ImmutableHashSet<T> is structured.  For consistency, we now convert to a ImmutableHashSet<T> before the comparison.  