### PR TITLE
Increase default number of nodes for cluster failure detection

### DIFF
--- a/src/core/Akka.Cluster.Tests/ClusterConfigSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterConfigSpec.cs
@@ -34,7 +34,7 @@ namespace Akka.Cluster.Tests
             settings.GossipInterval.Should().Be(1.Seconds());
             settings.GossipTimeToLive.Should().Be(2.Seconds());
             settings.HeartbeatInterval.Should().Be(1.Seconds());
-            settings.MonitoredByNrOfMembers.Should().Be(5);
+            settings.MonitoredByNrOfMembers.Should().Be(9);
             settings.HeartbeatExpectedResponseAfter.Should().Be(1.Seconds());
             settings.LeaderActionsInterval.Should().Be(1.Seconds());
             settings.UnreachableNodesReaperInterval.Should().Be(1.Seconds());
@@ -55,7 +55,7 @@ namespace Akka.Cluster.Tests
             settings.FailureDetectorConfig.GetInt("max-sample-size").Should().Be(1000);
             settings.FailureDetectorConfig.GetTimeSpan("min-std-deviation").Should().Be(100.Milliseconds());
             settings.FailureDetectorConfig.GetTimeSpan("acceptable-heartbeat-pause").Should().Be(3.Seconds());
-            settings.FailureDetectorConfig.GetInt("monitored-by-nr-of-members").Should().Be(5);
+            settings.FailureDetectorConfig.GetInt("monitored-by-nr-of-members").Should().Be(9);
             settings.FailureDetectorConfig.GetTimeSpan("expected-response-after").Should().Be(1.Seconds());
 
             settings.SchedulerTickDuration.Should().Be(33.Milliseconds());

--- a/src/core/Akka.Cluster/Configuration/Cluster.conf
+++ b/src/core/Akka.Cluster/Configuration/Cluster.conf
@@ -178,7 +178,7 @@ akka {
 
       # Number of member nodes that each member will send heartbeat messages to,
       # i.e. each node will be monitored by this number of other nodes.
-      monitored-by-nr-of-members = 5
+      monitored-by-nr-of-members = 9
       
       # After the heartbeat request has been sent the first failure detection
       # will start after this period, even though no heartbeat mesage has


### PR DESCRIPTION
> Default number of nodes that each node is observing for failure detection has increased from 5 to 9. The reason is to have better coverage and unreachability information for downing decisions.

Port: [#27173](https://github.com/akka/akka/pull/27173)