### PR TITLE
increased RemotePingPong by an order of magnitude

### DIFF
--- a/src/benchmark/RemotePingPong/Program.cs
+++ b/src/benchmark/RemotePingPong/Program.cs
@@ -81,7 +81,7 @@ namespace RemotePingPong
 
         private static async void Start(uint timesToRun)
         {
-            const long repeat = 10000L;
+            const long repeat = 100000L;
 
             var processorCount = Environment.ProcessorCount;
             if (processorCount == 0)


### PR DESCRIPTION
In order to capture changes in the overall performance of the system, especially with upcoming changes like flush batching, it's necessary to run the benchmark for longer periods of time.