### PR TITLE
Add initializer for console properties

### DIFF
--- a/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
@@ -187,6 +187,9 @@ namespace Akka.Actor.Internal
         {
             try
             {
+                // Force TermInfoDriver to initialize in order to protect us from the issue seen in #2432
+                typeof(Console).GetProperty("BackgroundColor").GetValue(null); // HACK: Only needed for MONO
+
                 RegisterOnTermination(StopScheduler);
                 _provider.Init(this);
                 LoadExtensions();


### PR DESCRIPTION
So long as we are looking to support Mono, this patch will be necessary to help mitigate race conditions within Mono's TermInfoDriver.  I've already got an active PR to fix Mono, but I'm not sure if it's going to be back-merged into other streams.

Please speak up if there's concerns about the way this hack works.  I don't like it, but can't quite think of any less-worse way to do it.