### PR TITLE
Refactor TaskEx API to deprecate pre-4.6.1 methods

### DIFF
--- a/src/common.props
+++ b/src/common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2019 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.3.16</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>
@@ -28,37 +28,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <PackageReleaseNotes>Third pre-release candidate for Akka.NET 1.4**
-This release contains some more significant changes for Akka.NET v1.4.0.
-All APIs in Akka.Streams, Akka, and elsewhere which used to return `Tuple&lt;T1, T2&gt;` now support the equivalent `ValueTuple&lt;T1,T2&gt;` syntax - so new language features such as tuple deconstruction can be used by our users.
-Upgraded to Hyperion 0.9.10, which properly supports .NET Core 3.0 and cross-platform communication between .NET Framework and .NET Core.
-All `ILoggingAdapter` instances running inside Akka.NET actors will now include the full Akka.Remote `Address` during logging, which is very helpful for users who aggregate their logs inside consolidated systems.
-Various Akka.Cluster.Sharding fixes.
-To [follow our progress on the Akka.NET v1.4 milestone, click here](https://github.com/akkadotnet/akka.net/milestone/17).
-We expect to release more beta versions in the future, and if you wish to [get access to nightly Akka.NET builds then click here](https://getakka.net/community/getting-access-to-nightly-builds.html).
-| COMMITS | LOC+ | LOC- | AUTHOR |
-| --- | --- | --- | --- |
-| 115 | 10739 | 8969 | Aaron Stannard |
-| 13 | 11671 | 1059 | Bartosz Sypytkowski |
-| 10 | 16 | 16 | dependabot-preview[bot] |
-| 6 | 897 | 579 | Sean Gilliam |
-| 6 | 1744 | 358 | zbynek001 |
-| 5 | 568 | 240 | Ismael Hamed |
-| 5 | 116 | 14 | Andre Loker |
-| 3 | 4457 | 8 | Valdis Zobēla |
-| 3 | 2 | 2 | Arjen Smits |
-| 3 | 14 | 9 | cptjazz |
-| 2 | 7 | 7 | jdsartori |
-| 2 | 4 | 6 | Onur Gumus |
-| 2 | 1341 | 1182 | Igor Fedchenko |
-| 1 | 65 | 47 | Ondrej Pialek |
-| 1 | 3 | 3 | Abi |
-| 1 | 3 | 1 | jg11jg |
-| 1 | 18 | 16 | Peter Huang |
-| 1 | 1 | 2 | Maciej Wódke |
-| 1 | 1 | 1 | Wessel Kranenborg |
-| 1 | 1 | 1 | Kaiwei Li |
-| 1 | 1 | 1 | Greatsamps |
-| 1 | 1 | 1 | Andre |</PackageReleaseNotes>
+Placeholder</PackageReleaseNotes>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -901,7 +901,6 @@ namespace Akka.Actor
     public class FutureActorRef : Akka.Actor.MinimalActorRef
     {
         public FutureActorRef(System.Threading.Tasks.TaskCompletionSource<object> result, System.Action unregister, Akka.Actor.ActorPath path) { }
-        public FutureActorRef(System.Threading.Tasks.TaskCompletionSource<object> result, System.Action unregister, Akka.Actor.ActorPath path, bool tcsWasCreatedWithRunContinuationsAsynchronouslyAvailable) { }
         public override Akka.Actor.ActorPath Path { get; }
         public override Akka.Actor.IActorRefProvider Provider { get; }
         public override void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message) { }

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -64,41 +64,29 @@ namespace Akka.Actor
     }
 
     /// <summary>
-    /// TBD
+    /// INTERNAL API.
+    /// 
+    /// ActorRef implementation used for one-off tasks.
     /// </summary>
     public class FutureActorRef : MinimalActorRef
     {
         private readonly TaskCompletionSource<object> _result;
-        private readonly bool _tcsWasCreatedWithRunContinuationsAsynchronouslyAvailable;
         private readonly Action _unregister;
         private readonly ActorPath _path;
 
         /// <summary>
-        /// TBD
+        /// INTERNAL API
         /// </summary>
         /// <param name="result">TBD</param>
         /// <param name="unregister">TBD</param>
         /// <param name="path">TBD</param>
         public FutureActorRef(TaskCompletionSource<object> result, Action unregister, ActorPath path)
-            : this(result, unregister, path, false)
-        {
-        }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="result">TBD</param>
-        /// <param name="unregister">TBD</param>
-        /// <param name="path">TBD</param>
-        /// <param name="tcsWasCreatedWithRunContinuationsAsynchronouslyAvailable">TBD</param>
-        public FutureActorRef(TaskCompletionSource<object> result, Action unregister, ActorPath path, bool tcsWasCreatedWithRunContinuationsAsynchronouslyAvailable)
         {
             if (ActorCell.Current != null)
             {
                 _actorAwaitingResultSender = ActorCell.Current.Sender;
             }
             _result = result;
-            _tcsWasCreatedWithRunContinuationsAsynchronouslyAvailable = tcsWasCreatedWithRunContinuationsAsynchronouslyAvailable;
             _unregister = unregister;
             _path = path;
             _result.Task.ContinueWith(_ => _unregister());
@@ -135,18 +123,15 @@ namespace Akka.Actor
         protected override void TellInternal(object message, IActorRef sender)
         {
 
-            if (message is ISystemMessage) //we have special handling for system messages
+            if (message is ISystemMessage sysM) //we have special handling for system messages
             {
-                SendSystemMessage(message.AsInstanceOf<ISystemMessage>());
+                SendSystemMessage(sysM);
             }
             else
             {
                 if (Interlocked.Exchange(ref status, COMPLETED) == INITIATED)
                 {
-                    if (_tcsWasCreatedWithRunContinuationsAsynchronouslyAvailable)
-                        _result.TrySetResult(message);
-                    else
-                        Task.Run(() => _result.TrySetResult(message));
+                    _result.TrySetResult(message);
                 }
             }
         }
@@ -310,7 +295,7 @@ namespace Akka.Actor
         /// <inheritdoc/>
         public override string ToString()
         {
-            if(Path.Uid == ActorCell.UndefinedUid) return $"[{Path}]";
+            if (Path.Uid == ActorCell.UndefinedUid) return $"[{Path}]";
             return $"[{Path}#{Path.Uid}]";
         }
 
@@ -342,13 +327,13 @@ namespace Akka.Actor
         {
             if (obj != null && !(obj is IActorRef))
                 throw new ArgumentException("Object must be of type IActorRef.", nameof(obj));
-            return CompareTo((IActorRef) obj);
+            return CompareTo((IActorRef)obj);
         }
 
         /// <inheritdoc/>
         public bool Equals(IActorRef other)
         {
-            return Path.Uid == other.Path.Uid 
+            return Path.Uid == other.Path.Uid
                 && Path.Equals(other.Path);
         }
 
@@ -553,7 +538,7 @@ namespace Akka.Actor
         /// <inheritdoc cref="InternalActorRefBase"/>
         public override void SendSystemMessage(ISystemMessage message)
         {
-           
+
         }
 
         /// <inheritdoc cref="InternalActorRefBase"/>
@@ -748,12 +733,12 @@ namespace Akka.Actor
         /// </summary>
         /// <param name="name">TBD</param>
         /// <param name="child">TBD</param>
-        public void RemoveChild(string name,IActorRef child)
+        public void RemoveChild(string name, IActorRef child)
         {
             IInternalActorRef tmp;
             if (!_children.TryRemove(name, out tmp))
             {
-                Log.Warning("{0} trying to remove non-child {1}",Path,name);
+                Log.Warning("{0} trying to remove non-child {1}", Path, name);
             }
         }
 
@@ -863,7 +848,7 @@ override def getChild(name: Iterator[String]): InternalActorRef = {
     {
         private readonly EventStream _eventStream;
         private readonly Action<IActorRef, object> _tell;
-        
+
         private ImmutableHashSet<IActorRef> _watching = ImmutableHashSet<IActorRef>.Empty;
         private ImmutableHashSet<IActorRef> _watchedBy = ImmutableHashSet<IActorRef>.Empty;
 
@@ -893,7 +878,7 @@ override def getChild(name: Iterator[String]): InternalActorRef = {
             var internalRef = (IInternalActorRef)actorRef;
             internalRef.SendSystemMessage(new Watch(internalRef, this));
         }
-        
+
         /// <summary>
         /// Have this FunctionRef unwatch the given Actor. This method must not be
         /// called concurrently from different threads, it should only be called by
@@ -904,7 +889,7 @@ override def getChild(name: Iterator[String]): InternalActorRef = {
             _watching = _watching.Remove(actorRef);
             var internalRef = (IInternalActorRef)actorRef;
             internalRef.SendSystemMessage(new Unwatch(internalRef, this));
-            
+
         }
 
         /// <summary>
@@ -947,7 +932,7 @@ override def getChild(name: Iterator[String]): InternalActorRef = {
                 {
                     foreach (var watched in _watching)
                         UnwatchWatched(watched);
-                    
+
                     _watching = ImmutableHashSet<IActorRef>.Empty;
                 }
             }
@@ -1041,5 +1026,5 @@ override def getChild(name: Iterator[String]): InternalActorRef = {
             }
             catch (Exception) { }
         }
-    } 
+    }
 }

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -176,7 +176,7 @@ namespace Akka.Actor
             //create a new tempcontainer path
             ActorPath path = provider.TempPath();
 
-            var future = new FutureActorRef(result, () => { }, path, TaskEx.IsRunContinuationsAsynchronouslyAvailable);
+            var future = new FutureActorRef(result, () => { }, path);
             //The future actor needs to be registered in the temp container
             provider.RegisterTempActor(future, path);
             var message = messageFactory(future);

--- a/src/core/Akka/Util/Internal/TaskEx.cs
+++ b/src/core/Akka/Util/Internal/TaskEx.cs
@@ -18,9 +18,6 @@ namespace Akka.Util.Internal
     /// </summary>
     internal static class TaskEx
     {
-        private const int RunContinuationsAsynchronously = 64;
-        public static readonly bool IsRunContinuationsAsynchronouslyAvailable = Enum.IsDefined(typeof(TaskCreationOptions), RunContinuationsAsynchronously);
-
         /// <summary>
         /// Creates a new <see cref="TaskCompletionSource{TResult}"/> which will run in asynchronous,
         /// non-blocking fashion upon calling <see cref="TaskCompletionSource{TResult}.TrySetResult"/>.
@@ -31,14 +28,7 @@ namespace Akka.Util.Internal
         /// </summary>
         public static TaskCompletionSource<T> NonBlockingTaskCompletionSource<T>()
         {
-            if (IsRunContinuationsAsynchronouslyAvailable)
-            {
-                return new TaskCompletionSource<T>((TaskCreationOptions)RunContinuationsAsynchronously);
-            }
-            else
-            {
-                return new TaskCompletionSource<T>();
-            }
+            return new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
         }
 
         /// <summary>
@@ -48,10 +38,7 @@ namespace Akka.Util.Internal
         /// </summary>
         public static void NonBlockingTrySetResult<T>(this TaskCompletionSource<T> taskCompletionSource, T value)
         {
-            if (IsRunContinuationsAsynchronouslyAvailable)
-                taskCompletionSource.TrySetResult(value);
-            else
-                Task.Run(() => taskCompletionSource.TrySetResult(value));
+            taskCompletionSource.TrySetResult(value);
         }
 
         /// <summary>
@@ -61,10 +48,7 @@ namespace Akka.Util.Internal
         /// </summary>
         public static void NonBlockingTrySetException<T>(this TaskCompletionSource<T> taskCompletionSource, Exception exception)
         {
-            if (IsRunContinuationsAsynchronouslyAvailable)
-                taskCompletionSource.TrySetException(exception);
-            else
-                Task.Run(() => taskCompletionSource.TrySetException(exception));
+            taskCompletionSource.TrySetException(exception);
         }
 
         /// <summary>
@@ -79,9 +63,7 @@ namespace Akka.Util.Internal
         /// <returns>A failed task.</returns>
         public static Task FromException(Exception ex)
         {
-            var c = new TaskCompletionSource<Done>();
-            c.SetException(ex);
-            return c.Task;
+            return Task.FromException(ex);
         }
 
         /// <summary>
@@ -92,9 +74,7 @@ namespace Akka.Util.Internal
         /// <typeparam name="T">The type of <see cref="Task{T}"/></typeparam>
         public static Task<T> FromException<T>(Exception ex)
         {
-            var c = new TaskCompletionSource<T>();
-            c.SetException(ex);
-            return c.Task;
+            return Task.FromException<T>(ex);
         }
     }
 }


### PR DESCRIPTION
Still need to:

1. [x] Add API approvals
2. [x] Possibly mark some of these APIs are obsolete and / or remove them, since they're no longer needed.