### PR TITLE
Standardize serialized type manifest lookup process

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Serialization/DistributedPubSubMessageSerializer.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Serialization/DistributedPubSubMessageSerializer.cs
@@ -17,6 +17,7 @@ using Akka.Serialization;
 using Akka.Util;
 using Google.Protobuf;
 using AddressData = Akka.Remote.Serialization.Proto.Msg.AddressData;
+using Status = Akka.Cluster.Tools.PublishSubscribe.Internal.Status;
 
 namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
 {
@@ -66,14 +67,23 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
         /// <returns>A byte array containing the serialized object</returns>
         public override byte[] ToBinary(object obj)
         {
-            if (obj is Internal.Status) return StatusToProto(obj as Internal.Status);
-            if (obj is Internal.Delta) return DeltaToProto(obj as Internal.Delta);
-            if (obj is Send) return SendToProto(obj as Send);
-            if (obj is SendToAll) return SendToAllToProto(obj as SendToAll);
-            if (obj is Publish) return PublishToProto(obj as Publish);
-            if (obj is SendToOneSubscriber) return SendToOneSubscriberToProto(obj as SendToOneSubscriber);
-
-            throw new ArgumentException($"Can't serialize object of type {obj.GetType()} with {nameof(DistributedPubSubMessageSerializer)}");
+            switch (obj)
+            {
+                case Status status:
+                    return StatusToProto(status);
+                case Delta delta:
+                    return DeltaToProto(delta);
+                case Send send:
+                    return SendToProto(send);
+                case SendToAll all:
+                    return SendToAllToProto(all);
+                case Publish publish:
+                    return PublishToProto(publish);
+                case SendToOneSubscriber subscriber:
+                    return SendToOneSubscriberToProto(subscriber);
+                default:
+                    throw new ArgumentException($"Can't serialize object of type {obj.GetType()} with {nameof(DistributedPubSubMessageSerializer)}");
+            }
         }
 
         /// <summary>
@@ -106,14 +116,23 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
         /// <returns>The manifest needed for the deserialization of the specified <paramref name="o" />.</returns>
         public override string Manifest(object o)
         {
-            if (o is Internal.Status) return StatusManifest;
-            if (o is Internal.Delta) return DeltaManifest;
-            if (o is Send) return SendManifest;
-            if (o is SendToAll) return SendToAllManifest;
-            if (o is Publish) return PublishManifest;
-            if (o is SendToOneSubscriber) return SendToOneSubscriberManifest;
-
-            throw new ArgumentException($"Serializer {nameof(DistributedPubSubMessageSerializer)} cannot serialize message of type {o.GetType()}");
+            switch (o)
+            {
+                case Status _:
+                    return StatusManifest;
+                case Delta _:
+                    return DeltaManifest;
+                case Send _:
+                    return SendManifest;
+                case SendToAll _:
+                    return SendToAllManifest;
+                case Publish _:
+                    return PublishManifest;
+                case SendToOneSubscriber _:
+                    return SendToOneSubscriberManifest;
+                default:
+                    throw new ArgumentException($"Serializer {nameof(DistributedPubSubMessageSerializer)} cannot serialize message of type {o.GetType()}");
+            }
         }
 
         private byte[] StatusToProto(Internal.Status status)
@@ -278,16 +297,6 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
             return system.Provider.ResolveActorRef(path);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static string GetObjectManifest(Serializer serializer, object obj)
-        {
-            var manifestSerializer = serializer as SerializerWithStringManifest;
-            if (manifestSerializer != null)
-            {
-                return manifestSerializer.Manifest(obj);
-            }
 
-            return obj.GetType().TypeQualifiedName();
-        }
     }
 }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -4617,6 +4617,7 @@ namespace Akka.Serialization
         public Akka.Serialization.Serializer FindSerializerFor(object obj, string defaultSerializerName = null) { }
         public Akka.Serialization.Serializer FindSerializerForType(System.Type objectType, string defaultSerializerName = null) { }
         public static Akka.Serialization.Information GetCurrentTransportInformation() { }
+        public static string ManifestFor(Akka.Serialization.Serializer s, object msg) { }
         public byte[] Serialize(object o) { }
         public static string SerializedActorPath(Akka.Actor.IActorRef actorRef) { }
         [System.ObsoleteAttribute("Obsolete. Use the SerializeWithTransport<T>(ExtendedActorSystem) method instead.")]

--- a/src/core/Akka.Persistence/Serialization/PersistenceMessageSerializer.cs
+++ b/src/core/Akka.Persistence/Serialization/PersistenceMessageSerializer.cs
@@ -62,7 +62,7 @@ namespace Akka.Persistence.Serialization
                 var serializer = system.Serialization.FindSerializerFor(obj);
                 var payload = new PersistentPayload();
 
-                var manifest = Akka.Serialization.Serialization.ManifestFor(serializer, payload);
+                var manifest = Akka.Serialization.Serialization.ManifestFor(serializer, obj);
                 if (!string.IsNullOrEmpty(manifest))
                 {
                     payload.PayloadManifest = ByteString.CopyFromUtf8(manifest);

--- a/src/core/Akka.Persistence/Serialization/PersistenceMessageSerializer.cs
+++ b/src/core/Akka.Persistence/Serialization/PersistenceMessageSerializer.cs
@@ -41,7 +41,7 @@ namespace Akka.Persistence.Serialization
 
         private PersistentMessage GetPersistentMessage(IPersistentRepresentation persistent)
         {
-            PersistentMessage message = new PersistentMessage();
+            var message = new PersistentMessage();
 
             if (persistent.PersistenceId != null) message.PersistenceId = persistent.PersistenceId;
             if (persistent.Manifest != null) message.Manifest = persistent.Manifest;
@@ -62,17 +62,10 @@ namespace Akka.Persistence.Serialization
                 var serializer = system.Serialization.FindSerializerFor(obj);
                 var payload = new PersistentPayload();
 
-                if (serializer is SerializerWithStringManifest serializer2)
+                var manifest = Akka.Serialization.Serialization.ManifestFor(serializer, payload);
+                if (string.IsNullOrEmpty(manifest))
                 {
-                    var manifest = serializer2.Manifest(obj);
                     payload.PayloadManifest = ByteString.CopyFromUtf8(manifest);
-                }
-                else
-                {
-                    if (serializer.IncludeManifest)
-                    {
-                        payload.PayloadManifest = ByteString.CopyFromUtf8(obj.GetType().TypeQualifiedName());
-                    }
                 }
 
                 payload.Payload = ByteString.CopyFrom(serializer.ToBinary(obj));

--- a/src/core/Akka.Persistence/Serialization/PersistenceMessageSerializer.cs
+++ b/src/core/Akka.Persistence/Serialization/PersistenceMessageSerializer.cs
@@ -63,7 +63,7 @@ namespace Akka.Persistence.Serialization
                 var payload = new PersistentPayload();
 
                 var manifest = Akka.Serialization.Serialization.ManifestFor(serializer, payload);
-                if (string.IsNullOrEmpty(manifest))
+                if (!string.IsNullOrEmpty(manifest))
                 {
                     payload.PayloadManifest = ByteString.CopyFromUtf8(manifest);
                 }

--- a/src/core/Akka.Persistence/Serialization/PersistenceSnapshotSerializer.cs
+++ b/src/core/Akka.Persistence/Serialization/PersistenceSnapshotSerializer.cs
@@ -36,7 +36,7 @@ namespace Akka.Persistence.Serialization
                 var serializer = system.Serialization.FindSerializerFor(snapshot.Data);
                 var payload = new PersistentPayload();
 
-                var manifest = Akka.Serialization.Serialization.ManifestFor(serializer, payload);
+                var manifest = Akka.Serialization.Serialization.ManifestFor(serializer, snapshot.Data);
                 if (!string.IsNullOrEmpty(manifest))
                 {
                     payload.PayloadManifest = ByteString.CopyFromUtf8(manifest);

--- a/src/core/Akka.Persistence/Serialization/PersistenceSnapshotSerializer.cs
+++ b/src/core/Akka.Persistence/Serialization/PersistenceSnapshotSerializer.cs
@@ -36,18 +36,10 @@ namespace Akka.Persistence.Serialization
                 var serializer = system.Serialization.FindSerializerFor(snapshot.Data);
                 var payload = new PersistentPayload();
 
-                if (serializer is SerializerWithStringManifest stringManifest)
+                var manifest = Akka.Serialization.Serialization.ManifestFor(serializer, payload);
+                if (string.IsNullOrEmpty(manifest))
                 {
-                    var manifest = stringManifest.Manifest(snapshot.Data);
                     payload.PayloadManifest = ByteString.CopyFromUtf8(manifest);
-                }
-                else
-                {
-                    if (serializer.IncludeManifest)
-                    {
-                        var payloadType = snapshot.Data.GetType();
-                        payload.PayloadManifest = ByteString.CopyFromUtf8(payloadType.AssemblyQualifiedName);
-                    }
                 }
 
                 payload.Payload = ByteString.CopyFrom(serializer.ToBinary(snapshot.Data));

--- a/src/core/Akka.Persistence/Serialization/PersistenceSnapshotSerializer.cs
+++ b/src/core/Akka.Persistence/Serialization/PersistenceSnapshotSerializer.cs
@@ -37,7 +37,7 @@ namespace Akka.Persistence.Serialization
                 var payload = new PersistentPayload();
 
                 var manifest = Akka.Serialization.Serialization.ManifestFor(serializer, payload);
-                if (string.IsNullOrEmpty(manifest))
+                if (!string.IsNullOrEmpty(manifest))
                 {
                     payload.PayloadManifest = ByteString.CopyFromUtf8(manifest);
                 }

--- a/src/core/Akka.Remote/Serialization/DaemonMsgCreateSerializer.cs
+++ b/src/core/Akka.Remote/Serialization/DaemonMsgCreateSerializer.cs
@@ -35,8 +35,7 @@ namespace Akka.Remote.Serialization
         /// <inheritdoc />
         public override byte[] ToBinary(object obj)
         {
-            var msg = obj as DaemonMsgCreate;
-            if (msg != null)
+            if (obj is DaemonMsgCreate msg)
             {
                 var message = new Proto.Msg.DaemonMsgCreateData();
                 message.Props = PropsToProto(msg.Props);
@@ -70,7 +69,7 @@ namespace Akka.Remote.Serialization
             var propsBuilder = new Proto.Msg.PropsData();
             propsBuilder.Clazz = props.Type.TypeQualifiedName();
             propsBuilder.Deploy = DeployToProto(props.Deploy);
-            foreach (object arg in props.Arguments)
+            foreach (var arg in props.Arguments)
             {
                 var tuple = Serialize(arg);
 
@@ -207,21 +206,8 @@ namespace Akka.Remote.Serialization
         {
             var serializer = system.Serialization.FindSerializerFor(obj);
 
-            bool hasManifest;
-            string manifest;
-
-            var serializerWithStringManifest = serializer as SerializerWithStringManifest;
-            if (serializerWithStringManifest != null)
-            {
-                var ser = serializerWithStringManifest;
-                hasManifest = true;
-                manifest = ser.Manifest(obj);
-            }
-            else
-            {
-                hasManifest = serializer.IncludeManifest;
-                manifest = obj == null ? "null" : obj.GetType().TypeQualifiedName();
-            }
+            var manifest = Akka.Serialization.Serialization.ManifestFor(serializer, obj);
+            var hasManifest = string.IsNullOrEmpty(manifest);
 
             return (serializer.Identifier, hasManifest, manifest, serializer.ToBinary(obj));
         }

--- a/src/core/Akka.Remote/Serialization/DaemonMsgCreateSerializer.cs
+++ b/src/core/Akka.Remote/Serialization/DaemonMsgCreateSerializer.cs
@@ -207,7 +207,7 @@ namespace Akka.Remote.Serialization
             var serializer = system.Serialization.FindSerializerFor(obj);
 
             var manifest = Akka.Serialization.Serialization.ManifestFor(serializer, obj);
-            var hasManifest = string.IsNullOrEmpty(manifest);
+            var hasManifest = !string.IsNullOrEmpty(manifest);
 
             return (serializer.Identifier, hasManifest, manifest, serializer.ToBinary(obj));
         }

--- a/src/core/Akka.Remote/Serialization/MessageContainerSerializer.cs
+++ b/src/core/Akka.Remote/Serialization/MessageContainerSerializer.cs
@@ -36,8 +36,7 @@ namespace Akka.Remote.Serialization
         /// <inheritdoc />
         public override byte[] ToBinary(object obj)
         {
-            var sel = obj as ActorSelectionMessage;
-            if (sel != null)
+            if (obj is ActorSelectionMessage sel)
             {
                 var envelope = new Proto.Msg.SelectionEnvelope();
                 envelope.Payload = _payloadSupport.PayloadToProto(sel.Message);
@@ -45,14 +44,12 @@ namespace Akka.Remote.Serialization
                 foreach (var element in sel.Elements)
                 {
                     Proto.Msg.Selection selection = null;
-                    if (element is SelectChildName)
+                    if (element is SelectChildName m1)
                     {
-                        var m = (SelectChildName)element;
-                        selection = BuildPattern(m.Name, Proto.Msg.Selection.Types.PatternType.ChildName);
+                        selection = BuildPattern(m1.Name, Proto.Msg.Selection.Types.PatternType.ChildName);
                     }
-                    else if (element is SelectChildPattern)
+                    else if (element is SelectChildPattern m)
                     {
-                        var m = (SelectChildPattern)element;
                         selection = BuildPattern(m.PatternStr, Proto.Msg.Selection.Types.PatternType.ChildPattern);
                     }
                     else if (element is SelectParent)
@@ -62,6 +59,7 @@ namespace Akka.Remote.Serialization
 
                     envelope.Pattern.Add(selection);
                 }
+                
 
                 return envelope.ToByteArray();
             }

--- a/src/core/Akka.Remote/Serialization/WrappedPayloadSupport.cs
+++ b/src/core/Akka.Remote/Serialization/WrappedPayloadSupport.cs
@@ -33,16 +33,10 @@ namespace Akka.Remote.Serialization
             payloadProto.SerializerId = serializer.Identifier;
 
             // get manifest
-            if (serializer is SerializerWithStringManifest manifestSerializer)
+            var manifest = Akka.Serialization.Serialization.ManifestFor(serializer, payload);
+            if (!string.IsNullOrEmpty(manifest))
             {
-                var manifest = manifestSerializer.Manifest(payload);
-                if (!string.IsNullOrEmpty(manifest))
-                    payloadProto.MessageManifest = ByteString.CopyFromUtf8(manifest);
-            }
-            else
-            {
-                if (serializer.IncludeManifest)
-                    payloadProto.MessageManifest = ByteString.CopyFromUtf8(payload.GetType().TypeQualifiedName());
+                payloadProto.MessageManifest = ByteString.CopyFromUtf8(manifest);
             }
 
             return payloadProto;

--- a/src/core/Akka.Streams/Serialization/StreamRefSerializer.cs
+++ b/src/core/Akka.Streams/Serialization/StreamRefSerializer.cs
@@ -170,13 +170,7 @@ namespace Akka.Streams.Serialization
         {
             var payload = onNext.Payload;
             var serializer = _serialization.FindSerializerFor(payload);
-            string manifest = null;
-            if (serializer.IncludeManifest)
-            {
-                manifest = serializer is SerializerWithStringManifest s
-                    ? s.Manifest(payload)
-                    : payload.GetType().TypeQualifiedName();
-            }
+            var manifest = Akka.Serialization.Serialization.ManifestFor(serializer, payload);
 
             var p = new Payload
             {

--- a/src/core/Akka/Actor/ActorCell.Children.cs
+++ b/src/core/Akka/Actor/ActorCell.Children.cs
@@ -467,26 +467,11 @@ namespace Akka.Actor
                             {
                                 var serializer = ser.FindSerializerFor(argument);
                                 var bytes = serializer.ToBinary(argument);
-                                if (serializer is SerializerWithStringManifest manifestSerializer)
-                                {
-                                    var manifest = manifestSerializer.Manifest(argument);
-                                    if (ser.Deserialize(bytes, manifestSerializer.Identifier, manifest) == null)
-                                    {
-                                        throw new ArgumentException(
+                                var ms = Serialization.Serialization.ManifestFor(serializer, argument);
+                                if(ser.Deserialize(bytes, serializer.Identifier, ms) == null)
+                                    throw new ArgumentException(
                                             $"Pre-creation serialization check failed at [${_self.Path}/{name}]",
                                             nameof(name));
-                                    }
-                                }
-                                else
-                                {
-                                    if (ser.Deserialize(bytes, serializer.Identifier,
-                                            argument.GetType().TypeQualifiedName()) == null)
-                                    {
-                                        throw new ArgumentException(
-                                            $"Pre-creation serialization check failed at [${_self.Path}/{name}]",
-                                            nameof(name));
-                                    }
-                                }
                             }
                         }
                     }

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -546,14 +546,8 @@ namespace Akka.Actor
 
                 var bytes = serializer.ToBinary(obj);
 
-                if (serializer is SerializerWithStringManifest manifestSerializer)
-                {
-                    var manifest = manifestSerializer.Manifest(obj);
-                    return _systemImpl.Serialization.Deserialize(bytes, serializer.Identifier, manifest);
-                }
-
-                return _systemImpl.Serialization.Deserialize(bytes, serializer.Identifier,
-                    obj.GetType().TypeQualifiedName());
+                var manifest = Serialization.Serialization.ManifestFor(serializer, obj);
+                return _systemImpl.Serialization.Deserialize(bytes, serializer.Identifier, manifest);
             }
             finally
             {

--- a/src/core/Akka/Serialization/Serialization.cs
+++ b/src/core/Akka/Serialization/Serialization.cs
@@ -14,6 +14,7 @@ using System.Reflection;
 using System.Runtime.Serialization;
 using Akka.Actor;
 using Akka.Annotations;
+using Akka.Util;
 using Akka.Util.Internal;
 using Akka.Util.Reflection;
 
@@ -77,6 +78,28 @@ namespace Akka.Serialization
     /// </summary>
     public class Serialization
     {
+        /// <summary>
+        /// Used to determine the manifest for a message, if applicable.
+        /// </summary>
+        /// <param name="s">The serializer we want to use on the message.</param>
+        /// <param name="msg">The message payload.</param>
+        /// <returns>A populated string is applicable; <see cref="string.Empty"/> otherwise.</returns>
+        /// <remarks>
+        /// WARNING: if you change this method it's likely that the DaemonMsgCreateSerializer and other calls will need changes too.
+        /// </remarks>
+        public static string ManifestFor(Serializer s, object msg)
+        {
+            switch (s)
+            {
+                case SerializerWithStringManifest s2:
+                    return s2.Manifest(msg);
+                case Serializer s3 when s3.IncludeManifest:
+                    return msg.GetType().TypeQualifiedName();
+                default:
+                    return string.Empty;
+            }
+        }
+
         /// <summary>
         /// Needs to be INTERNAL so it can be accessed from tests. Should never be set directly.
         /// </summary>


### PR DESCRIPTION
This PR adds `Serializer.ManifestFor` and calls it wherever it's needed through Akka.NET various serialization areas. This is designed to replace a bunch of boilerplate and inconsistent code used for determining what manifest needs to be included inside an outbound payload.

The functionality matches what we already do today inside Akka.Remote and Akka.Persistence, but now it's standard.

Relates to https://github.com/akkadotnet/akka.net/issues/3811 and https://github.com/akkadotnet/akka.net/issues/3248