### PR TITLE
disable parallelism in Akka.Cluster.Sharding.Tests

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Akka.Cluster.Sharding.Tests.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Akka.Cluster.Sharding.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\..\common.props" />
+  <Import Project="..\..\xunitSettings.props" />
 
   <PropertyGroup>
     <AssemblyTitle>Akka.Cluster.Sharding.Tests</AssemblyTitle>

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Akka.Cluster.Sharding.Tests.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Akka.Cluster.Sharding.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\..\common.props" />
-  <Import Project="..\..\xunitSettings.props" />
+  <Import Project="..\..\..\xunitSettings.props" />
 
   <PropertyGroup>
     <AssemblyTitle>Akka.Cluster.Sharding.Tests</AssemblyTitle>

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Akka.Cluster.Sharding.Tests.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Akka.Cluster.Sharding.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\..\common.props" />
-  <Import Project="..\..\..\xunitSettings.props" />
 
   <PropertyGroup>
     <AssemblyTitle>Akka.Cluster.Sharding.Tests</AssemblyTitle>
@@ -37,4 +36,11 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>
+
+  <!-- use the xunit JSON settings file -->
+  <ItemGroup>
+    <Content Include="..\..\..\xunit.runner.json" Link="xunit.runner.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/LeastShardAllocationStrategySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/LeastShardAllocationStrategySpec.cs
@@ -18,7 +18,7 @@ using System;
 
 namespace Akka.Cluster.Sharding.Tests
 {
-    public class LeastShardAllocationStrategySpec : TestKitBase
+    public class LeastShardAllocationStrategySpec : TestKit.Xunit2.TestKit
     {
         /// <summary>
         /// Test dictionary, will keep the order of items as they were added
@@ -132,7 +132,7 @@ namespace Akka.Cluster.Sharding.Tests
         private readonly IActorRef _regionB;
         private readonly IActorRef _regionC;
 
-        public LeastShardAllocationStrategySpec() : base(new XunitAssertions(), "LeastShardAllocationStrategySpec")
+        public LeastShardAllocationStrategySpec() 
         {
             _regionA = Sys.ActorOf(Props.Empty, "regionA");
             _regionB = Sys.ActorOf(Props.Empty, "regionB");

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/SupervisionSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/SupervisionSpec.cs
@@ -134,8 +134,11 @@ namespace Akka.Cluster.Sharding.Tests
             ExpectTerminated(response.Self);
 
             // This would fail before as sharded actor would be stuck passivating
-            region.Tell(new Msg(10, "hello"));
-            ExpectMsg<Response>(TimeSpan.FromSeconds(20));
+            AwaitAssert(() =>
+            {
+                region.Tell(new Msg(10, "hello"));
+                ExpectMsg<Response>();
+            });
         }
     }
 }

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetStandardLibVersion)'">
       <PackageReference Include="System.Configuration.ConfigurationManager">
-          <Version>4.5.0</Version>
+          <Version>4.7.0</Version>
       </PackageReference>
   </ItemGroup>
   


### PR DESCRIPTION
These tests are long-running, access shard memory journals, et al... We'd get better results running them serially rather than in parallel.