### PR TITLE
Fix racy test: Akka.Cluster.Sharding.Tests.CoordinatedShutdownShardingSpec.Sharding_and_CoordinatedShutdown_must_run_successfully

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
@@ -103,9 +103,9 @@ namespace Akka.Cluster.Sharding.Tests
         /// <summary>
         /// Using region 2 as it is not shutdown in either test.
         /// </summary>
-        private void PingEntities()
+        private async Task PingEntities()
         {
-            AwaitAssert(() =>
+            await AwaitAssertAsync(() =>
             {
                 _region2.Tell(1, _probe2.Ref);
                 _probe2.ExpectMsg<int>(1.Seconds()).Should().Be(1);
@@ -117,22 +117,22 @@ namespace Akka.Cluster.Sharding.Tests
         }
 
         [Fact]
-        public void Sharding_and_CoordinatedShutdown_must_run_successfully()
+        public async Task Sharding_and_CoordinatedShutdown_must_run_successfully()
         {
-            InitCluster();
-            RunCoordinatedShutdownWhenLeaving();
-            RunCoordinatedShutdownWhenDowning();
+            await InitCluster();
+            await RunCoordinatedShutdownWhenLeaving();
+            await RunCoordinatedShutdownWhenDowning();
         }
 
-        private void InitCluster()
+        private async Task InitCluster()
         {
             Cluster.Get(_sys1).Join(Cluster.Get(_sys1).SelfAddress); // coordinator will initially run on sys1
-            AwaitAssert(() => Cluster.Get(_sys1).SelfMember.Status.Should().Be(MemberStatus.Up));
+            await AwaitAssertAsync(() => Cluster.Get(_sys1).SelfMember.Status.Should().Be(MemberStatus.Up));
 
             Cluster.Get(_sys2).Join(Cluster.Get(_sys1).SelfAddress);
-            Within(10.Seconds(), () =>
+            await WithinAsync(10.Seconds(),async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     Cluster.Get(_sys1).State.Members.Count.Should().Be(2);
                     Cluster.Get(_sys1).State.Members.All(x => x.Status == MemberStatus.Up).Should().BeTrue();
@@ -142,9 +142,9 @@ namespace Akka.Cluster.Sharding.Tests
             });
 
             Cluster.Get(_sys3).Join(Cluster.Get(_sys1).SelfAddress);
-            Within(10.Seconds(), () =>
+            await WithinAsync(10.Seconds(), async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     Cluster.Get(_sys1).State.Members.Count.Should().Be(3);
                     Cluster.Get(_sys1).State.Members.All(x => x.Status == MemberStatus.Up).Should().BeTrue();
@@ -155,59 +155,59 @@ namespace Akka.Cluster.Sharding.Tests
                 });
             });
 
-            PingEntities();
+            await PingEntities();
         }
 
-        private void RunCoordinatedShutdownWhenLeaving()
+        private async Task RunCoordinatedShutdownWhenLeaving()
         {
             Cluster.Get(_sys3).Leave(Cluster.Get(_sys1).SelfAddress);
             _probe1.ExpectMsg("CS-unbind-1");
 
-            Within(20.Seconds(), () =>
+            await WithinAsync(20.Seconds(), async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     Cluster.Get(_sys2).State.Members.Count.Should().Be(2);
                     Cluster.Get(_sys3).State.Members.Count.Should().Be(2);
                 });
             });
 
-            Within(10.Seconds(), () =>
+            await WithinAsync(10.Seconds(), async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     Cluster.Get(_sys1).IsTerminated.Should().BeTrue();
                     _sys1.WhenTerminated.IsCompleted.Should().BeTrue();
                 });
             });
 
-            PingEntities();
+            await PingEntities();
         }
 
-        private void RunCoordinatedShutdownWhenDowning()
+        private async Task RunCoordinatedShutdownWhenDowning()
         {
             // coordinator is on Sys2
             Cluster.Get(_sys2).Down(Cluster.Get(_sys3).SelfAddress);
             _probe3.ExpectMsg("CS-unbind-3");
 
-            Within(20.Seconds(), () =>
+            await WithinAsync(20.Seconds(), async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     Cluster.Get(_sys2).State.Members.Count.Should().Be(1);
                 });
             });
 
-            Within(10.Seconds(), () =>
+            await WithinAsync(10.Seconds(), async () =>
             {
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     Cluster.Get(_sys3).IsTerminated.Should().BeTrue();
                     _sys3.WhenTerminated.IsCompleted.Should().BeTrue();
                 });
             });
 
-            PingEntities();
+            await PingEntities();
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
@@ -108,12 +108,12 @@ namespace Akka.Cluster.Sharding.Tests
             await AwaitAssertAsync(() =>
             {
                 _region2.Tell(1, _probe2.Ref);
-                _probe2.ExpectMsg<int>(1.Seconds()).Should().Be(1);
+                _probe2.ExpectMsg<int>(10.Seconds()).Should().Be(1);
                 _region2.Tell(2, _probe2.Ref);
-                _probe2.ExpectMsg<int>(1.Seconds()).Should().Be(2);
+                _probe2.ExpectMsg<int>(10.Seconds()).Should().Be(2);
                 _region2.Tell(3, _probe2.Ref);
-                _probe2.ExpectMsg<int>(1.Seconds()).Should().Be(3);
-            }, TimeSpan.FromSeconds(10));
+                _probe2.ExpectMsg<int>(10.Seconds()).Should().Be(3);
+            }, TimeSpan.FromSeconds(60));
         }
 
         [Fact]
@@ -161,7 +161,7 @@ namespace Akka.Cluster.Sharding.Tests
         private async Task RunCoordinatedShutdownWhenLeaving()
         {
             Cluster.Get(_sys3).Leave(Cluster.Get(_sys1).SelfAddress);
-            _probe1.ExpectMsg("CS-unbind-1");
+            _probe1.ExpectMsg("CS-unbind-1", TimeSpan.FromSeconds(10));
 
             await WithinAsync(20.Seconds(), async () =>
             {
@@ -188,7 +188,7 @@ namespace Akka.Cluster.Sharding.Tests
         {
             // coordinator is on Sys2
             Cluster.Get(_sys2).Down(Cluster.Get(_sys3).SelfAddress);
-            _probe3.ExpectMsg("CS-unbind-3");
+            _probe3.ExpectMsg("CS-unbind-3", TimeSpan.FromSeconds(10));
 
             await WithinAsync(20.Seconds(), async () =>
             {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
@@ -108,11 +108,11 @@ namespace Akka.Cluster.Sharding.Tests
             await AwaitAssertAsync(() =>
             {
                 _region2.Tell(1, _probe2.Ref);
-                _probe2.ExpectMsg<int>(10.Seconds()).Should().Be(1);
+                _probe2.ExpectMsg<int>(1.Seconds()).Should().Be(1);
                 _region2.Tell(2, _probe2.Ref);
-                _probe2.ExpectMsg<int>(10.Seconds()).Should().Be(2);
+                _probe2.ExpectMsg<int>(1.Seconds()).Should().Be(2);
                 _region2.Tell(3, _probe2.Ref);
-                _probe2.ExpectMsg<int>(10.Seconds()).Should().Be(3);
+                _probe2.ExpectMsg<int>(1.Seconds()).Should().Be(3);
             }, TimeSpan.FromSeconds(60));
         }
 

--- a/src/core/Akka/ActorState.cs
+++ b/src/core/Akka/ActorState.cs
@@ -13,7 +13,7 @@ namespace Akka.Actor
     /// <summary>
     /// This interface represents the parts of the internal actor state; the behavior stack, watched by, watching and termination queue
     /// </summary>
-    internal interface IActorState
+    internal interface IActorState 
     {
         /// <summary>
         /// Removes the provided <see cref="IActorRef"/> from the `Watching` set


### PR DESCRIPTION
Related to #3786

This PR should improve/fix flip rate of this test:  Akka.Cluster.Sharding.Tests.CoordinatedShutdownShardingSpec.Sharding_and_CoordinatedShutdown_must_run_successfully

It is time sensitive and failing due to timeouts (because of remote address gating). Seems like the test is correct by itself, so lets start with using `async` test APIs and increasing timeouts.