### PR TITLE
make CoordinatedShutdownShardingSpec use murmur hash for shard distributions

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
@@ -12,6 +12,7 @@ using Akka.Actor;
 using Akka.Cluster.Tools.Singleton;
 using Akka.Configuration;
 using Akka.TestKit;
+using Akka.Util;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -44,7 +45,7 @@ namespace Akka.Cluster.Sharding.Tests
 
         private readonly ExtractEntityId _extractEntityId = message => (message.ToString(), message);
 
-        private readonly ExtractShardId _extractShard = message => (message.GetHashCode() % 10).ToString();
+        private readonly ExtractShardId _extractShard = message => (MurmurHash.StringHash(message.ToString())).ToString();
 
         static CoordinatedShutdownShardingSpec()
         {


### PR DESCRIPTION
Part of #3786 

Still having issues with this spec even after https://github.com/akkadotnet/akka.net/pull/4158 - believe the problem was having multiple shards reply back.

Going to keep this in draft form and run it a few times.