### PR TITLE
Akka.Persistence.TCK.SnapshotStoreSpec ignores ShouldSerializeSnapshots if SupportsSerialization == false

### DIFF
--- a/src/core/Akka.Persistence.TCK/Snapshot/SnapshotStoreSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Snapshot/SnapshotStoreSpec.cs
@@ -257,6 +257,8 @@ namespace Akka.Persistence.TCK.Snapshot
         [Fact]
         public void ShouldSerializeSnapshots()
         {
+            if (!SupportsSerialization) return;
+
             var probe = CreateTestProbe();
             var metadata = new SnapshotMetadata(Pid, 100L);
             var snap = new TestPayload(probe.Ref);


### PR DESCRIPTION
Found this bug while working on https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/108

Need to be able to skip the `ShouldSerializeSnapshots` spec if `SupportsSerialization` is set to `false`.