### PR TITLE
fix race conditions with node exits in MNTR

### DIFF
--- a/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
+++ b/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
@@ -363,6 +363,9 @@ namespace Akka.Remote.TestKit
                       @"akka {
                         loglevel = ""WARNING""
                         stdout-loglevel = ""WARNING""
+                        coordinated-shutdown.terminate-actor-system = off
+                        coordinated-shutdown.run-by-actor-system-terminate = off
+                        coordinated-shutdown.run-by-clr-shutdown-hook = off
                         actor {
                           default-dispatcher {
                             executor = ""fork-join-executor""

--- a/src/core/Akka.Remote.TestKit/Player.cs
+++ b/src/core/Akka.Remote.TestKit/Player.cs
@@ -139,10 +139,10 @@ namespace Akka.Remote.TestKit
                     // of a failed operation
                     var result = _client.Ask(new ToServer<EnterBarrier>(new EnterBarrier(name, barrierTimeout)), askTimeout).Result;
                 }
-                catch (AggregateException)
+                catch (AggregateException ex)
                 {
                     _client.Tell(new ToServer<FailBarrier>(new FailBarrier(name)));
-                    throw new TimeoutException("Client timed out while waiting for barrier " + name);
+                    throw new TimeoutException("Client timed out while waiting for barrier " + name, ex);
                 }
                 catch (OperationCanceledException)
                 {


### PR DESCRIPTION
This was a configuration issue that may be responsible for a number of "racy" tests we have in the multi node test runner (MNTR) suite.

Specifically, this fix disables coordinated shutdown so the `ActorSystem` does not terminate by default when a node leaves the cluster - that way the `PlayerFSM` on the node that has left can still successfulyl call `EnterBarrier(string name)` and not blow up the entire test suite.