### PR TITLE
Improve racy Clustet.Metrics Metrics_extension_Should_control_collector_on_off_state spec

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Metrics.Tests/ClusterMetricsExtensionSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics.Tests/ClusterMetricsExtensionSpec.cs
@@ -24,6 +24,7 @@ namespace Akka.Cluster.Metrics.Tests
         
         private int MetricsNodeCount => _metricsView.ClusterMetrics.Count;
         private int MetricsHistorySize => _metricsView.MetricsHistory.Count;
+        private TimeSpan SampleCollectTimeout => TimeSpan.FromMilliseconds(_sampleInterval.TotalMilliseconds * 5);
 
         /// <summary>
         /// This is a single node test.
@@ -66,26 +67,39 @@ namespace Akka.Cluster.Metrics.Tests
         [Fact]
         public async Task Metrics_extension_Should_control_collector_on_off_state()
         {
+            int size2 = 0, size3 = 0, size4 = 0;
             for (var i = 0; i < 3; ++i)
             {
                 var size1 = MetricsHistorySize;
                 await AwaitSampleAsync();
-                var size2 = MetricsHistorySize;
-                size1.Should().Be(size2);
+                await AwaitAssertAsync(() =>
+                {
+                    size2 = MetricsHistorySize;
+                    size1.Should().Be(size2);
+                }, SampleCollectTimeout);
             
                 _extension.Supervisor.Tell(ClusterMetricsSupervisorMetadata.CollectionStartMessage.Instance);
                 await AwaitSampleAsync();
-                var size3 = MetricsHistorySize;
-                size3.Should().BeGreaterThan(size2);
+                await AwaitAssertAsync(() =>
+                {
+                    size3 = MetricsHistorySize;
+                    size3.Should().BeGreaterThan(size2);
+                }, SampleCollectTimeout);
             
                 _extension.Supervisor.Tell(ClusterMetricsSupervisorMetadata.CollectionStopMessage.Instance);
                 await AwaitSampleAsync();
-                var size4 = MetricsHistorySize;
-                size4.Should().BeGreaterOrEqualTo(size3);
+                await AwaitAssertAsync(() =>
+                {
+                    size4 = MetricsHistorySize;
+                    size4.Should().BeGreaterOrEqualTo(size3);
+                }, SampleCollectTimeout);
 
                 await AwaitSampleAsync();
-                var size5 = MetricsHistorySize;
-                size5.Should().Be(size4);
+                await AwaitAssertAsync(() =>
+                {
+                    var size5 = MetricsHistorySize;
+                    size5.Should().Be(size4);
+                }, SampleCollectTimeout);
             }
         }
 


### PR DESCRIPTION
Noticed this spec failed due to timeout issues here: https://dev.azure.com/dotnet/Akka.NET/_build/results?buildId=28690&view=logs&j=d83928d8-8bfe-51de-721e-9025f72ee732&t=21d77f07-2bef-56ac-91e9-8618e6456479

So improved the code to be more robust.