### PR TITLE
disable buffer pooling in DotNetty transport

### DIFF
--- a/src/core/Akka.Remote/Configuration/Remote.conf
+++ b/src/core/Akka.Remote/Configuration/Remote.conf
@@ -432,11 +432,6 @@ akka {
       # i.e. how long a connect may take until it is timed out
       connection-timeout = 15 s
 
-      # Toggles buffer pooling on and off inside DotNetty.
-      # Only intended to be a work-around for users who are still running on DotNetty v0.4.6-v0.4.7
-      # for the following bug: https://github.com/akkadotnet/akka.net/issues/3370
-      enable-pooling = true
-
       # PERFORMANCE TUNING
       # 
       # The batching feature of DotNetty is designed to help batch together logical writes into a smaller

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
@@ -275,7 +275,7 @@ namespace Akka.Remote.Transport.DotNetty
                 .Option(ChannelOption.TcpNodelay, Settings.TcpNoDelay)
                 .Option(ChannelOption.ConnectTimeout, Settings.ConnectTimeout)
                 .Option(ChannelOption.AutoRead, false)
-                .Option(ChannelOption.Allocator, Settings.EnableBufferPooling ? (IByteBufferAllocator)PooledByteBufferAllocator.Default : UnpooledByteBufferAllocator.Default)
+                .Option(ChannelOption.Allocator, UnpooledByteBufferAllocator.Default)
                 .ChannelFactory(() => Settings.EnforceIpFamily
                     ? new TcpSocketChannel(addressFamily)
                     : new TcpSocketChannel())
@@ -386,7 +386,7 @@ namespace Akka.Remote.Transport.DotNetty
                 .Option(ChannelOption.TcpNodelay, Settings.TcpNoDelay)
                 .Option(ChannelOption.AutoRead, false)
                 .Option(ChannelOption.SoBacklog, Settings.Backlog)
-                .Option(ChannelOption.Allocator, Settings.EnableBufferPooling ? (IByteBufferAllocator)PooledByteBufferAllocator.Default : UnpooledByteBufferAllocator.Default)
+                .Option(ChannelOption.Allocator, UnpooledByteBufferAllocator.Default)
                 .ChannelFactory(() => Settings.EnforceIpFamily
                     ? new TcpServerSocketChannel(addressFamily)
                     : new TcpServerSocketChannel())

--- a/src/core/Akka.Remote/Transport/DotNetty/TcpTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/TcpTransport.cs
@@ -183,8 +183,6 @@ namespace Akka.Remote.Transport.DotNetty
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static IByteBuffer ToByteBuffer(IChannel channel, ByteString payload)
         {
-            //TODO: optimize DotNetty byte buffer usage 
-            // (maybe custom IByteBuffer working directly on ByteString?)
             var buffer = Unpooled.WrappedBuffer(payload.ToByteArray());
             return buffer;
         }


### PR DESCRIPTION
close #3879 
close #3273 
close #4244 

For reasons that are fundamentally structural, it's not safe for Akka.Remote to use DotNetty's buffer pooling of any kind - the reason being that serialization and deserialization is handled outside of the `ChannelPipeline` itself thus the bytes returned from the channel aren't safe for release until after they're successfully decoded by Akka.Remote's endpoint actors.

In order to take advantage of buffer pooling, Akka.Remote will need to be redesigned with a more integrated serialization pipeline in mind - something we've discussed on #2378 

Ran some local benchmarks on my development machine here - no major changes in observed performance at all.

## Before
```
ProcessorCount:                    8
ClockSpeed:                        0 MHZ
Messages sent/received per client: 200000  (2e5)

Num clients, Total [msg], Msgs/sec, Total [ms]
         1,  200000,     35144,    5691.34
         5, 1000000,     88614,   11285.31
        10, 2000000,     93485,   21394.37
        15, 3000000,     88789,   33788.05
        20, 4000000,     88633,   45130.35
        25, 5000000,     88562,   56458.64
```
## After
```
ProcessorCount:                    8            
ClockSpeed:                        0 MHZ        
Actor Count:                       16           
Messages sent/received per client: 200000  (2e5)
Is Server GC:                      True         
                                                
Num clients, Total [msg], Msgs/sec, Total [ms]  
         1,  200000,      7882,   25375.09      
         5, 1000000,     89159,   11216.35      
        10, 2000000,     89957,   22233.77      
        15, 3000000,     89644,   33466.30      
        20, 4000000,     88131,   45387.95      
        25, 5000000,     87505,   57140.24      
```