### PR TITLE
Revert "explicitly support CI for the v1.3 branch"

### DIFF
--- a/build-system/pr-validation.yaml
+++ b/build-system/pr-validation.yaml
@@ -4,13 +4,13 @@ trigger:
   branches:
     include:
       - dev
-      - v1.3
+      - v1.*
       - master
 
 pr:
   autoCancel: true # indicates whether additional pushes to a PR should cancel in-progress runs for the same PR. Defaults to true
   branches:
-    include: [ dev, v1.3, master ] # branch names which will trigger a build
+    include: [ dev, v1.*, master ] # branch names which will trigger a build
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 


### PR DESCRIPTION
Reverts akkadotnet/akka.net#4294

Turns out this was wrong - worked fine. Had to update the v1.3 branch to trigger CI, which I've done here: https://github.com/akkadotnet/akka.net/pull/4296