### PR TITLE
SAEA already in use error fix

### DIFF
--- a/src/core/Akka/IO/TcpConnection.cs
+++ b/src/core/Akka/IO/TcpConnection.cs
@@ -314,7 +314,12 @@ namespace Akka.IO
                         AcknowledgeSent();
                         
                         // If there is something to send - send it
-                        DoWrite(info, GetAllowedPendingWrite());
+                        var pendingWrite = GetAllowedPendingWrite();
+                        if (pendingWrite.HasValue)
+                        {
+                            SetStatus(ConnectionStatus.Sending);
+                            DoWrite(info, pendingWrite);
+                        }
                         
                         // If message is fully sent, notify sender who sent ResumeWriting command
                         if (!IsWritePending && _interestedInResume != null)


### PR DESCRIPTION
Close #4264

Issue was that after socket operation was completed, we started sending pending packages without setting "Sending" status. So it was only a matter of time when there will be some sender that will send his package at the same time last "pending" package was sent, and we got this error.

Setting "Sending" status in both cases, and all is running smooth.