### PR TITLE
Fix address terminated topic atomic updates (#4306)

### DIFF
--- a/src/core/Akka/Event/AddressTerminatedTopic.cs
+++ b/src/core/Akka/Event/AddressTerminatedTopic.cs
@@ -5,7 +5,9 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Akka.Actor;
 using Akka.Util;
 
@@ -35,7 +37,7 @@ namespace Akka.Event
     /// </summary>
     internal sealed class AddressTerminatedTopic : IExtension
     {
-        private readonly AtomicReference<HashSet<IActorRef>> _subscribers = new AtomicReference<HashSet<IActorRef>>(new HashSet<IActorRef>());
+        private readonly HashSet<IActorRef> _subscribers = new HashSet<IActorRef>();
 
         /// <summary>
         /// Retrieves the extension from the specified actor system.
@@ -53,13 +55,8 @@ namespace Akka.Event
         /// <param name="subscriber">The actor that is registering for notifications.</param>
         public void Subscribe(IActorRef subscriber)
         {
-            while (true)
-            {
-                var current = _subscribers;
-                if (!_subscribers.CompareAndSet(current, new HashSet<IActorRef>(current.Value) {subscriber}))
-                    continue;
-                break;
-            }
+            lock (_subscribers)
+                _subscribers.Add(subscriber);
         }
 
         /// <summary>
@@ -68,15 +65,8 @@ namespace Akka.Event
         /// <param name="subscriber">The actor that is unregistering for notifications.</param>
         public void Unsubscribe(IActorRef subscriber)
         {
-            while (true)
-            {
-                var current = _subscribers;
-                var newSet = new HashSet<IActorRef>(_subscribers.Value);
-                newSet.Remove(subscriber);
-                if (!_subscribers.CompareAndSet(current, newSet))
-                    continue;
-                break;
-            }
+            lock (_subscribers)
+                _subscribers.Remove(subscriber);
         }
 
         /// <summary>
@@ -85,7 +75,11 @@ namespace Akka.Event
         /// <param name="msg">The message that is sent to all subscribers.</param>
         public void Publish(AddressTerminated msg)
         {
-            foreach (var subscriber in _subscribers.Value)
+            List<IActorRef> subscribers;
+            lock(_subscribers)
+                subscribers = _subscribers.ToList();
+
+            foreach (var subscriber in subscribers)
             {
                 subscriber.Tell(msg, ActorRefs.NoSender);
             }


### PR DESCRIPTION
Submitting PR against v1.3, as that's what we're using and I was able to test the fix with.

The new implementation fixes both the race condition as well as optimizes the full copies of the _subscribers HashSet during Subscribe() and Unsubscribe(). The updates are protected with locks which makes the code simple and efficient. Publish() only takes a copy under lock to minimize the amount that the data is not available for other threads, which should be ok, as Publish() is only needed when a node is lost, so not too frequently.