### PR TITLE
added v1.3.18 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,23 +1,13 @@
-#### 1.3.17 December 20 2019 ####
+#### 1.3.18 March 09 2020 ####
 **Maintenance Release for Akka.NET 1.3**
 
-1.3.17 consists of non-breaking bugfixes and additions that have been contributed against the [Akka.NET v1.4.0 milestone](https://github.com/akkadotnet/akka.net/milestone/17) thus far.
+1.3.18 consists of non-breaking bugfixes and additions that have been contributed against the [Akka.NET v1.4.0 milestone](https://github.com/akkadotnet/akka.net/milestone/17) thus far.
 
-This patch includes some important fixes for Akka.Remote and Akka.Cluster users, including
+This patch includes some important fixes for Akka.Remote including
 
-* [Akka.Remote: Fix Endpoint receive buffer stack overflow](https://github.com/akkadotnet/akka.net/pull/4089)
-* [Akka.Remote: Don't log aborted connection as disassociation error](https://github.com/akkadotnet/akka.net/pull/4101)
-* [Akka.Cluster: Added delayed heartbeat logging](https://github.com/akkadotnet/akka.net/pull/4057)
-* [Akka.Cluster: Remove string interpolation from cluster logs](https://github.com/akkadotnet/akka.net/pull/4084)
-* [Akka.Cluster: Add timeout to abort joining of seed nodes](https://github.com/akkadotnet/akka.net/pull/3863)
-* [Akka.Cluster.Sharding: Fix state non-empty check when starting HandOffStopper](https://github.com/akkadotnet/akka.net/pull/4043)
+* [Akka Bugfix: Atomicity bug and bad performance in AddressTerminatedTopic](https://github.com/akkadotnet/akka.net/issues/4306)
+* [Akka Bugfix: Actor reference leak in AddressTerminatedTopic](https://github.com/akkadotnet/akka.net/issues/4304)
+* [Akka.Remote Bugfix: DotNetty.Codecs.CorruptedFrameException: negative pre-adjustment length field](https://github.com/akkadotnet/akka.net/issues/3879)
+* [Akka.Remote Bugfix: "The given key was not present in the dictionary" exception](https://github.com/akkadotnet/akka.net/issues/4246)
 
-To [see the full set of changes in Akka.NET v1.3.17, click here](https://github.com/akkadotnet/akka.net/pull/4112).
-
-| COMMITS | LOC+ | LOC- | AUTHOR |
-| --- | --- | --- | --- |
-| 4 | 231 | 74 | Ismael Hamed |
-| 3 | 72 | 70 | Jonathan Nagy |
-| 2 | 2 | 9 | Aaron Stannard |
-| 1 | 92 | 10 | Valdis Zobēla |
-| 1 | 29 | 2 | Igor Fedchenko |
+To [see the full set of changes in Akka.NET v1.3.18, click here](https://github.com/akkadotnet/akka.net/releases/tag/1.3.18).

--- a/src/common.props
+++ b/src/common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2019 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.3.17</VersionPrefix>
+    <VersionPrefix>1.3.18</VersionPrefix>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>
@@ -28,22 +28,13 @@
   </PropertyGroup>
   <PropertyGroup>
     <PackageReleaseNotes>Maintenance Release for Akka.NET 1.3**
-1.3.17 consists of non-breaking bugfixes and additions that have been contributed against the [Akka.NET v1.4.0 milestone](https://github.com/akkadotnet/akka.net/milestone/17) thus far.
-This patch includes some important fixes for Akka.Remote and Akka.Cluster users, including
-[Akka.Remote: Fix Endpoint receive buffer stack overflow](https://github.com/akkadotnet/akka.net/pull/4089)
-[Akka.Remote: Don't log aborted connection as disassociation error](https://github.com/akkadotnet/akka.net/pull/4101)
-[Akka.Cluster: Added delayed heartbeat logging](https://github.com/akkadotnet/akka.net/pull/4057)
-[Akka.Cluster: Remove string interpolation from cluster logs](https://github.com/akkadotnet/akka.net/pull/4084)
-[Akka.Cluster: Add timeout to abort joining of seed nodes](https://github.com/akkadotnet/akka.net/pull/3863)
-[Akka.Cluster.Sharding: Fix state non-empty check when starting HandOffStopper](https://github.com/akkadotnet/akka.net/pull/4043)
-To [see the full set of changes in Akka.NET v1.3.17, click here](https://github.com/akkadotnet/akka.net/pull/4112).
-| COMMITS | LOC+ | LOC- | AUTHOR |
-| --- | --- | --- | --- |
-| 4 | 231 | 74 | Ismael Hamed |
-| 3 | 72 | 70 | Jonathan Nagy |
-| 2 | 2 | 9 | Aaron Stannard |
-| 1 | 92 | 10 | Valdis Zobēla |
-| 1 | 29 | 2 | Igor Fedchenko |</PackageReleaseNotes>
+1.3.18 consists of non-breaking bugfixes and additions that have been contributed against the [Akka.NET v1.4.0 milestone](https://github.com/akkadotnet/akka.net/milestone/17) thus far.
+This patch includes some important fixes for Akka.Remote including
+[Akka Bugfix: Atomicity bug and bad performance in AddressTerminatedTopic](https://github.com/akkadotnet/akka.net/issues/4306)
+[Akka Bugfix: Actor reference leak in AddressTerminatedTopic](https://github.com/akkadotnet/akka.net/issues/4304)
+[Akka.Remote Bugfix: DotNetty.Codecs.CorruptedFrameException: negative pre-adjustment length field](https://github.com/akkadotnet/akka.net/issues/3879)
+[Akka.Remote Bugfix: "The given key was not present in the dictionary" exception](https://github.com/akkadotnet/akka.net/issues/4246)
+To [see the full set of changes in Akka.NET v1.3.18, click here](https://github.com/akkadotnet/akka.net/releases/tag/1.3.18).</PackageReleaseNotes>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>


### PR DESCRIPTION
#### 1.3.18 March 09 2020 ####
**Maintenance Release for Akka.NET 1.3**

1.3.18 consists of non-breaking bugfixes and additions that have been contributed against the [Akka.NET v1.4.0 milestone](https://github.com/akkadotnet/akka.net/milestone/17) thus far.

This patch includes some important fixes for Akka.Remote including

* [Akka Bugfix: Atomicity bug and bad performance in AddressTerminatedTopic](https://github.com/akkadotnet/akka.net/issues/4306)
* [Akka Bugfix: Actor reference leak in AddressTerminatedTopic](https://github.com/akkadotnet/akka.net/issues/4304)
* [Akka.Remote Bugfix: DotNetty.Codecs.CorruptedFrameException: negative pre-adjustment length field](https://github.com/akkadotnet/akka.net/issues/3879)
* [Akka.Remote Bugfix: "The given key was not present in the dictionary" exception](https://github.com/akkadotnet/akka.net/issues/4246)

To [see the full set of changes in Akka.NET v1.3.18, click here](https://github.com/akkadotnet/akka.net/releases/tag/1.3.18).