### PR TITLE
FIX: #4079 sqlite table name was hardcoded

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Settings.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Settings.cs
@@ -68,14 +68,14 @@ namespace Akka.Persistence.Sql.Common
             if (config.IsNullOrEmpty())
                 throw ConfigurationException.NullOrEmptyConfig<JournalSettings>();
 
-            ConnectionString = config.GetString("connection-string", null);
-            ConnectionStringName = config.GetString("connection-string-name", null);
-            ConnectionTimeout = config.GetTimeSpan("connection-timeout", null);
+            ConnectionString = config.GetString("connection-string");
+            ConnectionStringName = config.GetString("connection-string-name");
+            ConnectionTimeout = config.GetTimeSpan("connection-timeout");
             SchemaName = config.GetString("schema-name", null);
-            JournalTableName = config.GetString("table-name", null);
-            MetaTableName = config.GetString("metadata-table-name", null);
-            TimestampProvider = config.GetString("timestamp-provider", null);
-            AutoInitialize = config.GetBoolean("auto-initialize", false);
+            JournalTableName = config.GetString("table-name");
+            MetaTableName = config.GetString("metadata-table-name");
+            TimestampProvider = config.GetString("timestamp-provider");
+            AutoInitialize = config.GetBoolean("auto-initialize");
         }
     }
 
@@ -129,14 +129,14 @@ namespace Akka.Persistence.Sql.Common
         public SnapshotStoreSettings(Config config)
         {
             if (config.IsNullOrEmpty())
-                throw ConfigurationException.NullOrEmptyConfig<SnapshotStoreSettings>(); //($"Failed to create {nameof(SnapshotStoreSettings)}: SqlServer snapshot store settings cannot be initialized, because required HOCON section couldn't been found");
+                throw ConfigurationException.NullOrEmptyConfig<SnapshotStoreSettings>();
 
-            ConnectionString = config.GetString("connection-string", null);
-            ConnectionStringName = config.GetString("connection-string-name", null);
-            ConnectionTimeout = config.GetTimeSpan("connection-timeout", null);
+            ConnectionString = config.GetString("connection-string");
+            ConnectionStringName = config.GetString("connection-string-name");
+            ConnectionTimeout = config.GetTimeSpan("connection-timeout");
             SchemaName = config.GetString("schema-name", null);
-            TableName = config.GetString("table-name", null);
-            AutoInitialize = config.GetBoolean("auto-initialize", false);
+            TableName = config.GetString("table-name");
+            AutoInitialize = config.GetBoolean("auto-initialize");
             DefaultSerializer = config.GetString("serializer", null);
         }
 

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Settings.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Settings.cs
@@ -14,7 +14,7 @@ namespace Akka.Persistence.Sql.Common
     /// <summary>
     /// Configuration settings representation targeting Sql Server journal actor.
     /// </summary>
-    public class JournalSettings
+    public sealed class JournalSettings
     {
         /// <summary>
         /// Connection string used to access a persistent SQL Server instance.
@@ -82,7 +82,7 @@ namespace Akka.Persistence.Sql.Common
     /// <summary>
     /// Configuration settings representation targeting Sql Server snapshot store actor.
     /// </summary>
-    public class SnapshotStoreSettings
+    public sealed class SnapshotStoreSettings
     {
         /// <summary>
         /// Connection string used to access a persistent SQL Server instance.

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/AssemblyVersioning/BackwardsCompatSqliteSnapshotStoreSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/AssemblyVersioning/BackwardsCompatSqliteSnapshotStoreSpec.cs
@@ -46,7 +46,6 @@ namespace Akka.Persistence.Sqlite.Tests.AssemblyVersioning
                         sqlite {
                             class = ""Akka.Persistence.Sqlite.Snapshot.SqliteSnapshotStore, Akka.Persistence.Sqlite""
                             plugin-dispatcher = ""akka.actor.default-dispatcher""
-                            table-name = snapshot_store
                             auto-initialize = on
                             connection-string = """ + connectionString + @"""
                         }

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteConfigSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteConfigSpec.cs
@@ -10,9 +10,11 @@ using System.Collections.Generic;
 using Akka.Actor;
 using Hocon; using Akka.Configuration;
 using Akka.Persistence.Sql.TestKit;
+using Akka.Persistence.Sql.Common;
 using Akka.Util.Internal;
 using Xunit;
 using Xunit.Abstractions;
+using FluentAssertions;
 
 namespace Akka.Persistence.Sqlite.Tests
 {
@@ -30,15 +32,43 @@ namespace Akka.Persistence.Sqlite.Tests
             var config = Sys.Settings.Config.GetConfig("akka.persistence.journal.sqlite");
 
             Assert.False(config.IsNullOrEmpty());
-            Assert.Equal("Akka.Persistence.Sqlite.Journal.SqliteJournal, Akka.Persistence.Sqlite", config.GetString("class", null));
-            Assert.Equal("akka.actor.default-dispatcher", config.GetString("plugin-dispatcher", null));
-            Assert.Equal(string.Empty, config.GetString("connection-string", null));
-            Assert.Equal(string.Empty, config.GetString("connection-string-name", null));
-            Assert.Equal(TimeSpan.FromSeconds(30), config.GetTimeSpan("connection-timeout", null));
-            Assert.Equal("event_journal", config.GetString("table-name", null));
-            Assert.Equal("journal_metadata", config.GetString("metadata-table-name", null));
-            Assert.False(config.GetBoolean("auto-initialize", false));
-            Assert.Equal("Akka.Persistence.Sql.Common.Journal.DefaultTimestampProvider, Akka.Persistence.Sql.Common", config.GetString("timestamp-provider", null));
+            Assert.Equal("Akka.Persistence.Sqlite.Journal.SqliteJournal, Akka.Persistence.Sqlite", config.GetString("class"));
+            Assert.Equal("akka.actor.default-dispatcher", config.GetString("plugin-dispatcher"));
+            Assert.Equal(string.Empty, config.GetString("connection-string"));
+            Assert.Equal(string.Empty, config.GetString("connection-string-name"));
+            Assert.Equal(TimeSpan.FromSeconds(30), config.GetTimeSpan("connection-timeout"));
+            Assert.Equal("event_journal", config.GetString("table-name"));
+            Assert.Equal("journal_metadata", config.GetString("metadata-table-name"));
+            Assert.False(config.GetBoolean("auto-initialize"));
+            Assert.Equal("Akka.Persistence.Sql.Common.Journal.DefaultTimestampProvider, Akka.Persistence.Sql.Common", config.GetString("timestamp-provider"));
+            Assert.False(config.HasPath("schema-name"));
+        }
+
+        [Fact]
+        public void Sqlite_JournalSettings_default_should_contain_default_config()
+        {
+            var config = SqlitePersistence.Get(Sys).DefaultJournalConfig;
+            var settings = new JournalSettings(config);
+
+            // values should be correct
+            settings.ConnectionString.Should().Be(string.Empty);
+            settings.ConnectionStringName.Should().Be(string.Empty);
+            settings.ConnectionTimeout.Should().Equals(TimeSpan.FromSeconds(30));
+            settings.JournalTableName.Should().Equals("event_journal");
+            settings.SchemaName.Should().BeNull();
+            settings.MetaTableName.Should().Equals("journal_metadata");
+            settings.TimestampProvider.Should().Be("Akka.Persistence.Sql.Common.Journal.DefaultTimestampProvider, Akka.Persistence.Sql.Common");
+            settings.AutoInitialize.Should().BeFalse();
+
+            // values should reflect configuration
+            settings.ConnectionString.Should().Equals(config.GetString("connection-string"));
+            settings.ConnectionStringName.Should().Equals(config.GetString("connection-string-name"));
+            settings.ConnectionTimeout.Should().Equals(config.GetTimeSpan("connection-timeout"));
+            settings.JournalTableName.Should().Equals(config.GetString("table-name"));
+            settings.SchemaName.Should().Equals(config.GetString("schema-name", null));
+            settings.MetaTableName.Should().Equals(config.GetString("metadata-table-name"));
+            settings.TimestampProvider.Should().Be(config.GetString("timestamp-provider"));
+            settings.AutoInitialize.Should().Equals(config.GetBoolean("auto-initialize"));
         }
 
         [Fact]
@@ -54,8 +84,36 @@ namespace Akka.Persistence.Sqlite.Tests
             Assert.Equal(string.Empty, config.GetString("connection-string", null));
             Assert.Equal(string.Empty, config.GetString("connection-string-name", null));
             Assert.Equal(TimeSpan.FromSeconds(30), config.GetTimeSpan("connection-timeout", null));
-            Assert.Equal("snapshot_store", config.GetString("table-name", null));
+            // This is changed from "snapshot-store" to "snapshot"
+            Assert.Equal("snapshot", config.GetString("table-name", null));
             Assert.False(config.GetBoolean("auto-initialize", false));
         }
+
+        [Fact]
+        public void Sqlite_SnapshotStoreSettings_default_should_contain_default_config()
+        {
+            var config = SqlitePersistence.Get(Sys).DefaultSnapshotConfig;
+            var settings = new SnapshotStoreSettings(config);
+
+            // values should be correct
+            settings.ConnectionString.Should().Be(string.Empty);
+            settings.ConnectionStringName.Should().Be(string.Empty);
+            settings.ConnectionTimeout.Should().Equals(TimeSpan.FromSeconds(30));
+            settings.SchemaName.Should().BeNull();
+            settings.TableName.Should().Equals("snapshot");
+            settings.AutoInitialize.Should().BeFalse();
+            settings.DefaultSerializer.Should().BeNull();
+            settings.FullTableName.Should().Equals(settings.TableName);
+
+            // values should reflect configuration
+            settings.ConnectionString.Should().Equals(config.GetString("connection-string"));
+            settings.ConnectionStringName.Should().Equals(config.GetString("connection-string-name"));
+            settings.ConnectionTimeout.Should().Equals(config.GetTimeSpan("connection-timeout"));
+            settings.SchemaName.Should().Equals(config.GetString("schema-name", null));
+            settings.TableName.Should().Equals(config.GetString("table-name"));
+            settings.AutoInitialize.Should().Equals(config.GetBoolean("auto-initialize"));
+            settings.DefaultSerializer.Should().Equals(config.GetString("serializer", null));
+        }
+
     }
 }

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteSnapshotStoreConnectionFailureSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteSnapshotStoreConnectionFailureSpec.cs
@@ -28,7 +28,7 @@ namespace Akka.Persistence.Sqlite.Tests
                         sqlite {
                             class = ""Akka.Persistence.Sqlite.Snapshot.SqliteSnapshotStore, Akka.Persistence.Sqlite""
                             plugin-dispatcher = ""akka.actor.default-dispatcher""
-                            table-name = snapshot_store
+                            # table-name = snapshot_store
                             auto-initialize = on
                             connection-string = """ + connectionString + @"""
                         }

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Extension.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Extension.cs
@@ -14,46 +14,11 @@ namespace Akka.Persistence.Sqlite
     /// <summary>
     /// TBD
     /// </summary>
-    public class SqliteJournalSettings : JournalSettings
-    {
-        /// <summary>
-        /// TBD
-        /// </summary>
-        public const string ConfigPath = "akka.persistence.journal.sqlite";
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="config">TBD</param>
-        public SqliteJournalSettings(Config config) : base(config)
-        {
-        }
-    }
-
-    /// <summary>
-    /// TBD
-    /// </summary>
-    public class SqliteSnapshotSettings : SnapshotStoreSettings
-    {
-        /// <summary>
-        /// TBD
-        /// </summary>
-        public const string ConfigPath = "akka.persistence.snapshot-store.sqlite";
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="config">TBD</param>
-        public SqliteSnapshotSettings(Config config) : base(config)
-        {
-        }
-    }
-
-    /// <summary>
-    /// TBD
-    /// </summary>
     public class SqlitePersistence : IExtension
     {
+        public const string JournalConfigPath = "akka.persistence.journal.sqlite";
+        public const string SnapshotConfigPath = "akka.persistence.snapshot-store.sqlite";
+
         /// <summary>
         /// Returns a default configuration for akka persistence SQLite-based journals and snapshot stores.
         /// </summary>
@@ -92,8 +57,8 @@ namespace Akka.Persistence.Sqlite
             var defaultConfig = DefaultConfiguration();
             system.Settings.InjectTopLevelFallback(defaultConfig);
 
-            DefaultJournalConfig = defaultConfig.GetConfig(SqliteJournalSettings.ConfigPath);
-            DefaultSnapshotConfig = defaultConfig.GetConfig(SqliteSnapshotSettings.ConfigPath);
+            DefaultJournalConfig = defaultConfig.GetConfig(JournalConfigPath);
+            DefaultSnapshotConfig = defaultConfig.GetConfig(SnapshotConfigPath);
         }
     }
 

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/SqliteJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/SqliteJournal.cs
@@ -22,6 +22,7 @@ namespace Akka.Persistence.Sqlite.Journal
         /// TBD
         /// </summary>
         public static readonly SqlitePersistence Extension = SqlitePersistence.Get(Context.System);
+
         /// <summary>
         /// TBD
         /// </summary>
@@ -57,7 +58,7 @@ namespace Akka.Persistence.Sqlite.Journal
         /// <summary>
         /// TBD
         /// </summary>
-        protected override string JournalConfigPath => SqliteJournalSettings.ConfigPath;
+        protected override string JournalConfigPath => SqlitePersistence.JournalConfigPath;
 
         /// <summary>
         /// TBD

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Snapshot/SqliteSnapshotStore.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Snapshot/SqliteSnapshotStore.cs
@@ -102,13 +102,14 @@ namespace Akka.Persistence.Sqlite.Snapshot
         /// <summary>
         /// TBD
         /// </summary>
-        protected readonly SqlitePersistence Extension = SqlitePersistence.Get(Context.System);
+        protected static readonly SqlitePersistence Extension = SqlitePersistence.Get(Context.System);
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="snapshotConfig">TBD</param>
-        public SqliteSnapshotStore(Config snapshotConfig) : base(snapshotConfig)
+        public SqliteSnapshotStore(Config snapshotConfig) : 
+            base(snapshotConfig.WithFallback(Extension.DefaultSnapshotConfig))
         {
             var config = snapshotConfig.WithFallback(Extension.DefaultSnapshotConfig);
             QueryExecutor = new SqliteSnapshotQueryExecutor(new QueryConfiguration(

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Snapshot/SqliteSnapshotStore.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Snapshot/SqliteSnapshotStore.cs
@@ -114,14 +114,14 @@ namespace Akka.Persistence.Sqlite.Snapshot
             var config = snapshotConfig.WithFallback(Extension.DefaultSnapshotConfig);
             QueryExecutor = new SqliteSnapshotQueryExecutor(new QueryConfiguration(
                 schemaName: null,
-                snapshotTableName: "snapshot",
+                snapshotTableName: config.GetString("table-name"),
                 persistenceIdColumnName: "persistence_id",
                 sequenceNrColumnName: "sequence_nr",
                 payloadColumnName: "payload",
                 manifestColumnName: "manifest",
                 timestampColumnName: "created_at",
                 serializerIdColumnName: "serializer_id",
-                timeout: config.GetTimeSpan("connection-timeout", null),
+                timeout: config.GetTimeSpan("connection-timeout"),
                 defaultSerializer: config.GetString("serializer", null),
                 useSequentialAccess: config.GetBoolean("use-sequential-access", false)),
                 Context.System.Serialization);

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/sqlite.conf
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/sqlite.conf
@@ -59,7 +59,7 @@
 			connection-timeout = 30s
 			
 			# SQLite table corresponding with persistent journal
-			table-name = snapshot_store
+			table-name = snapshot
 
 			# should corresponding journal table be initialized automatically
 			auto-initialize = off


### PR DESCRIPTION
Closes #4079 

Extra bug fix: Sqlite plugin default config was not applied as a fallback to populate `JournalSettings` instance in `SqlJournal` constructor

### NOTE ###
This might be a breaking change for users that copy pasted sqlite journal configuration from a sample that contains a `table-name = not_called_snapshot` entry because it will start to use the property declaration instead of using the hard coded `snapshot` table.