### PR TITLE
V1.4.1 rc2 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,17 @@
+#### 1.4.1-rc2 March 10 2020 ####
+**Stable release candidate for Akka.NET 1.4**
+
+In Akka.NET v1.4.1-rc2 we rolled back all of the stand-alone HOCON additions and made Akka.NET v1.4 non-breaking. 
+
+For information on the full set of changes between RC1 and RC2, [please see "What's New in Akka.NET v1.4" on the official Akka.NET website](https://getakka.net/community/whats-new/akkadotnet-v1.4.html) 
+
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 13 | 9431 | 5347 | Aaron Stannard |
+| 2 | 3 | 3 | dependabot-preview[bot] |
+| 1 | 97 | 73 | Gregorius Soedharmo |
+| 1 | 6 | 1 | Igor Fedchenko |
+
 #### 1.4.1-rc1 February 28 2020 ####
 **Stable release candidate for Akka.NET 1.4**
 

--- a/docs/community/whats-new/akkadotnet-v1.4.md
+++ b/docs/community/whats-new/akkadotnet-v1.4.md
@@ -10,166 +10,47 @@ Akka.NET v1.4.0 is the culmination of many major architectural changes, improvem
 ## Summary
 The high-level summary of changes:
 
-1. All HOCON `Config` objects have been moved from the `Akka.Configuration` namespace within the core `Akka` library to the stand-alone [HOCON project](https://github.com/akkadotnet/HOCON) and its subsequent [HOCON.Configuration NuGet package](https://www.nuget.org/packages/Hocon.Configuration/). See ["HOCON Syntax and Practices in Akka.NET"](../../articles/hocon/index.md) for a full guide on all of the different APIs, standards, and syntax supported. **This is a breaking change**, so [follow the Akka.NET v1.4.0 migration guide](#migration) below.
-2. [Akka.Cluster.Sharding](../../articles/clustering/cluster-sharding.md) and [Akka.DistributedData](../../articles/clustering/distributed-data.md) are now out of beta status, have stable wire formats, and all sharding functionality is fully supported using either `akka.cluster.sharding.state-store-mode = "persistence"` or `akka.cluster.sharding.state-store-mode = "ddata"`.
-3. Akka.Remote's performance has significantly increased as a function of our new batching mode ([see the numbers](../../articles/remoting/performance.md#no-io-batching)) - which is tunable via HOCON configuration to best support your needs. [Learn how to performance optimize Akka.Remote here](../../articles/remoting/performance.md).
-4. Added a new module, [Akka.Cluster.Metrics](../../articles/cluster/cluster-metrics.md), which allows clustering users to receive performance data about each of the nodes in their cluster and even create some routers that can direct the flow of messages based on these metrics. 
-5. Added ["Stream References" to Akka.Streams](../../articles/streams/streamrefs.md), a feature which allows Akka.Streams graphs to span across the network.
-6. Moved from .NET Standard 1.6 to .NET Standard 2.0 and dropped support for all versions of .NET Framework that aren't supported by .NET Standard 2.0 - this means issues caused by our polyfills (i.e. `SerializableAttribute`) should be fully resolved now.
-7. Moved onto modern C# best practices, such as changing our APIs to support `System.ValueTuple` over regular tuples.
+
+1. [Akka.Cluster.Sharding](../../articles/clustering/cluster-sharding.md) and [Akka.DistributedData](../../articles/clustering/distributed-data.md) are now out of beta status, have stable wire formats, and all sharding functionality is fully supported using either `akka.cluster.sharding.state-store-mode = "persistence"` or `akka.cluster.sharding.state-store-mode = "ddata"`.
+2. Akka.Remote's performance has significantly increased as a function of our new batching mode ([see the numbers](../../articles/remoting/performance.md#no-io-batching)) - which is tunable via HOCON configuration to best support your needs. [Learn how to performance optimize Akka.Remote here](../../articles/remoting/performance.md).
+3. Added a new module, [Akka.Cluster.Metrics](../../articles/cluster/cluster-metrics.md), which allows clustering users to receive performance data about each of the nodes in their cluster and even create some routers that can direct the flow of messages based on these metrics. 
+4. Added ["Stream References" to Akka.Streams](../../articles/streams/streamrefs.md), a feature which allows Akka.Streams graphs to span across the network.
+5. Moved from .NET Standard 1.6 to .NET Standard 2.0 and dropped support for all versions of .NET Framework that aren't supported by .NET Standard 2.0 - this means issues caused by our polyfills (i.e. `SerializableAttribute`) should be fully resolved now.
+6. Moved onto modern C# best practices, such as changing our APIs to support `System.ValueTuple` over regular tuples.
 
 If you want a detailed summary of changes and numerous bug fixes, [please see the Akka.NET v1.4.0 milestone, which has over 140 resolved issues attached to it](https://github.com/akkadotnet/akka.net/milestone/17).
 
-### Stand-alone HOCON Library Features
-The motivating factors for moving HOCON out of Akka core and into its own library were:
+### Changes Between Akka.NET v1.4.1-RC1 and Akka.NET v1.4.1-RC2
+In Akka.NET v1.4.1-RC1 we introduced an ambitious change to migrate all HOCON configuration from an internal namespace (`Akka.Configuration`, defined inside the core `Akka` NuGet package) to a stand-alone library:
 
-1. The allow for a greater amount of innovation / experimentation on HOCON, and in general, Akka.NET configuration management - HOCON is a _much_ smaller project than Akka.NET.
-2. Allow for HOCON to be adopted in more places outside of Akka.NET itself.
+> All HOCON `Config` objects have been moved from the `Akka.Configuration` namespace within the core `Akka` library to the stand-alone [HOCON project](https://github.com/akkadotnet/HOCON) and its subsequent [HOCON.Configuration NuGet package](https://www.nuget.org/packages/Hocon.Configuration/). See ["HOCON Syntax and Practices in Akka.NET"](../../articles/hocon/index.md) for a full guide on all of the different APIs, standards, and syntax supported. **This is a breaking change**, so [follow the Akka.NET v1.4.0 migration guide](#migration) below.
 
-In Akka.NET v1.4.0 we try to realize some of this value right away for Akka.NET users by automating away annoying tasks that resulted in large amount of boilerplate code.
+In Akka.NET v1.4.1-RC2 we rolled this change back in order to:
 
-Some examples:
+1. Make Akka.NET v1.4 a non-breaking change for all users and
+2. Resolve stability and performance issues that were discovered with stand-alone HOCON after release.
 
-#### Native Environment Variable Substitution
-Akka.NET v1.4.0 should largely eliminate the need for custom libraries like [Akka.Bootstrap.Docker](https://github.com/petabridge/akkadotnet-bootstrap/tree/dev/src/Akka.Bootstrap.Docker), because environment substitution can now be handled natively via HOCON itself:
+More details in the next section below.
 
-[!code-csharp[ConfigurationSample](../../../src/core/Akka.Docs.Tests/Configuration/ConfigurationSample.cs?name=EnvironmentVariableSample)]
+#### Post Mortem: Stand-alone HOCON
+In the previous releases of HOCON, we let the OSS project do its own thing without any real top-down plan for integrating it into Akka.NET and replacing the stand-alone HOCON engine built into the `Akka.Configuration.Config` class. 
 
-#### Automatic HOCON Config File Reference Loading for .NET Core
-In .NET Framework HOCON and Akka.NET still supports the classic `App.config` and `Web.config` sections, but until Akka.NET v1.4.0 we've never had a way of loading HOCON files by default.
+This was a mistake and led to us having to drop stand-alone HOCON integration as part of the Akka.NET v1.4.1 milestone.
 
-At the time of release, Akka.NET v1.4.0 will look for the following HOCON files in the root of your Akka.NET application and load them automatically if any of them are detected:
+The specific problems we had with stand-alone HOCON were:
 
-1. [.NET Core / .NET Framework] An `app.conf` or an `app.hocon` file in the current working directory of the executable when it loads;
-2. [.NET Framework] - the `<hocon>` `ConfigurationSection` inside `App.config` or `Web.config`; or
-3. [.NET Framework] - and a legacy option, to load the old `<akka>` HOCON section for backwards compatibility purposes with all users who have been using HOCON with Akka.NET.
+1. Mutability - we couldn't guarantee that the object model was immutable following a parse operation, because the same architecture that was used for object construction during parse was also used for reads after parse, a fundamental architectural mistake. In addition to some performance problems, this also lead to 
+2. Performance - appending a new fallback to a `HOCON.Config` object kicked off a processes of recursive deep-copying, and this was quickly found to be non-performant.
+3. Inadequacies in the Akka.NET test suite - the Akka.NET test suite is very extensive, but as we discovered during the Akka.NET v1.4.1-RC1 process: our test configurations are not nearly as complex as real-world test cases are. 
 
-We [will likely expand this support to include more default HOCON sources in the future](https://github.com/akkadotnet/HOCON/blob/dev/README.md#default-hocon-configuration-sources).
+#### Stand-alone HOCON Future
+Over the course of the Akka.NET v1.4 development cycle, where we will begin introducing lots of the usual bug fixes, feature additions, and performance improvements we will begin the process of gradually introducing abstractions to make it desirable, safe, and backwards-compatible to introduce stand-alone HOCON.
 
-Also, if you're running on .NET Core and want to programmatically load + parse HOCON, there's a convenient method for that too:
+If you want to learn more, [read the HOCON 3.0 specification and development plan here](https://github.com/akkadotnet/HOCON/issues/267).
 
-```csharp
-Config c = HoconConfigurationFactory.FromFile("myHocon.conf");
-```
+In addition to that, we're in the process of [developing automated integration tests](https://github.com/akkadotnet/akka.net-integration-tests) that mimic what Akka.NET users do in the real world using [Akka.NET nightly builds](../getting-access-to-nightly-builds.md). This should address the deficiencies discovered in our testing process following Akka.NET v1.4.1-RC1.
 
-## Migration
-Akka.NET v1.4.0 introduces some breaking changes, although they're minor. Here's how to mitigate those and work around them.
-
-### HOCON Migrations
-Most users will only need to worry about the `Hocon` namespace change described below - most of the other changes affect plugin authors or developers who were using `Config` objects outside of what's built-in to Akka.NET itself.
-
-#### Updating HOCON Namespaces from `Akka.Configuration` to `Hocon`
-The biggest source of changes are going to be changing your HOCON namespaces, but thankfully these are localized to only the areas of your code where you accessed `Akka.Configuration.Config` objects explicitly. It's straightforward to update these references:
-
-1. Change all `Akka.Configuration.Config` calls to `Hocon.Config` and
-2. Add `using Hocon;` statements to wherever you work with HOCON directly.
-
-If you run into any other areas where HOCON isn't 100% compatiable with what you've done in the past, [please report an issue on the Akka.NET repository](https://github.com/akkadotnet/HOCON/issues).
-
-#### HOCON Validation Changes
-The new HOCON parser introduced in the stand-alone HOCON library is much more strict and provides clearer error messages when invalid HOCON is parsed from its textual form.
-
-For instance, in Akka.NET v1.3.17 the following HOCON parsed just fine:
-
-```
-akka{
- actor{
- 	provider = remote
- }
-
- remote{
- 	dot-netty.tcp.port = 8110
- 	dot-netty.tcp.hostname = "localhost"
- }
-# missing }
-```
-
-The HOCON parser in HOCON 2.0.3 and later will throw a `Hocon.HoconParserException` when attempting to parse this. So please make sure all of your curly braces are closed.
-
-#### Parsing Empty HOCON Blocks
-In Akka.NET v1.3.17 and earlier the following block of code would work just fine:
-
-```csharp
-// get an empty block of HOCON
-// works in Akka.NET (-, 1.3.17] - fails starting in 1.4
-Config empty = ConfigurationFactory.ParseString("");
-```
-
-Running that same code in Akka.NET v1.4 will throw an error:
-
-```
-Hocon.HoconParserException : Parameter text is null or empty.
-
-If you want to create an empty Hocon HoconRoot, use "{}" instead.
-```
-
-To resolve this type of issue, you should do exactly what the error message suggests:
-
-```csharp
-// get an empty block of HOCON
-// works in all versions of Akka.NET
-Config empty = HoconConfigurationFactory.ParseString("{}");
-
-// this will also work
-Config empty = HoconConfigurationFactory.Empty;
-```
-#### HOCON Throws When Loading Missing Keys
-In previous versions of Akka.NET the following HOCON:
-
-```
-akka{
-	foo = "bar"
-	baz = 2	
-}
-```
-
-Would produce the following results when consumed via the `Config` class:
-
-```
-var akkaString = @"
-	akka{
-		foo = ""bar""
-		baz = 2	
-	}
-";
-var config = ConfigurationFactory.ParseString(akkaString);
-Console.WriteLine(config.GetString("akka.foo")); // will print "bar" (correct)
-Console.WriteLine(config.GetInt("akka.baz")); // will print "2" (correct)
-Console.WriteLine(config.GetString("akka.biz")); // will print null, since key does not exist
-Console.WriteLine(config.GetInt("akka.biz")); // will print default(int), since key does not exist
-```
-
-The previous HOCON parser erred on the side of no-throw, so it would simply provide a default value using `default(type)` when a user attempted to access a missing HOCON key. This resulted in, historically, a lot of very difficult to track down and find bugs.
-
-In stand-alone HOCON, we opted to take things in a different approach with the ultimate goal of being able to develop HOCON lint-ing, validation, and Intellisense functionality in the future.
-
-In Akka.NET v1.4 by default `HoconConfigurationFactory.ParseString` will throw an `Hocon.HoconValueException` if you attempt to read a HOCON key that is unpopulated:
-
-```csharp
-var akkaString = @"
-	akka{
-		foo = ""bar""
-		baz = 2	
-	}
-";
-var config = ConfigurationFactory.ParseString(akkaString);
-Console.WriteLine(config.GetString("akka.foo")); // will print "bar" (correct)
-Console.WriteLine(config.GetInt("akka.baz")); // will print "2" (correct)
-Console.WriteLine(config.GetString("akka.biz")); // throws Hocon.HoconValueException
-Console.WriteLine(config.GetInt("akka.biz")); // throws Hocon.HoconValueException
-```
-
-The interpretation is, that your HOCON doesn't have the content that you're looking for and therefore we should fail fast and alert the developer that the specified HOCON key couldn't be found in the current `Config` object _or any of its fallbacks_.
-
-If this isn't what you need in your use case and you prefer the old behavior, that's easy to restore - provide an explicit default value in the second parameter on `Config.Get_(string hoconKey)` methods:
-
-```csharp
-var config = HoconConfigurationFactory.Empty; // empty config
-Console.WriteLine(config.GetString("akka.foo", "empty")); // will print "empty" (default value)
-Console.WriteLine(config.GetInt("akka.baz", 0)); // will print "0" (default value)
-Console.WriteLine(config.GetString("akka.biz", string.Empty)); // will print string.Empty (default value)
-Console.WriteLine(config.GetInt("akka.biz", 0)); // will print "0" (default value)
-```
+## Akka.NET v1.4 Migration Guide and Key Changes
 
 ### Performance Tuning Akka.Remote
 Akka.Remote's performance has significantly increased as a function of our new batching mode ([see the numbers](../../articles/remoting/performance.md#no-io-batching)) - which is tunable via HOCON configuration to best support your needs. 

--- a/src/common.props
+++ b/src/common.props
@@ -29,37 +29,14 @@
   </PropertyGroup>
   <PropertyGroup>
     <PackageReleaseNotes>Stable release candidate for Akka.NET 1.4**
-Akka.NET v1.4.0-rc1 represents [the completion of the entire Akka.NET v1.4.0 milestone](https://github.com/akkadotnet/akka.net/milestone/17).
-Provided that there are no major bugs, architectural issues, performance regressions, or stability issues reported as we begin the process of moving all of our plugins onto Akka.NET v1.4.0-RC1, Akka.NET v1.4.0 final will ship within two weeks.
-For information on the full set of changes, [please see "What's New in Akka.NET v1.4" on the official Akka.NET website](https://getakka.net/community/whats-new/akkadotnet-v1.4.html).
+In Akka.NET v1.4.1-rc2 we rolled back all of the stand-alone HOCON additions and made Akka.NET v1.4 non-breaking.
+For information on the full set of changes between RC1 and RC2, [please see "What's New in Akka.NET v1.4" on the official Akka.NET website](https://getakka.net/community/whats-new/akkadotnet-v1.4.html)
 | COMMITS | LOC+ | LOC- | AUTHOR |
 | --- | --- | --- | --- |
-| 206 | 33015 | 24489 | Aaron Stannard |
-| 47 | 63 | 63 | dependabot-preview[bot] |
-| 33 | 16794 | 6803 | Igor Fedchenko |
-| 15 | 1370 | 557 | Ismael Hamed |
-| 13 | 11671 | 1059 | Bartosz Sypytkowski |
-| 10 | 3451 | 706 | zbynek001 |
-| 8 | 224 | 25 | Andre Loker |
-| 6 | 897 | 579 | Sean Gilliam |
-| 6 | 101 | 987 | cptjazz |
-| 5 | 4837 | 51 | Valdis Zobēla |
-| 5 | 407 | 95 | Jonathan Nagy |
-| 3 | 8 | 8 | jdsartori |
-| 3 | 2 | 2 | Arjen Smits |
-| 3 | 16 | 2 | Kaiwei Li |
-| 2 | 6 | 6 | Abi |
-| 2 | 4 | 6 | Onur Gumus |
-| 2 | 36 | 32 | Peter Huang |
-| 2 | 2 | 4 | Maciej Wódke |
-| 2 | 2 | 2 | Wessel Kranenborg |
-| 2 | 130 | 94 | Ondrej Pialek |
-| 1 | 633 | 1 | Gregorius Soedharmo |
-| 1 | 62 | 15 | Mathias Feitzinger |
-| 1 | 3 | 1 | jg11jg |
-| 1 | 1 | 1 | Greatsamps |
-| 1 | 1 | 1 | Christoffer Jedbäck |
-| 1 | 1 | 1 | Andre |</PackageReleaseNotes>
+| 13 | 9431 | 5347 | Aaron Stannard |
+| 2 | 3 | 3 | dependabot-preview[bot] |
+| 1 | 97 | 73 | Gregorius Soedharmo |
+| 1 | 6 | 1 | Igor Fedchenko |</PackageReleaseNotes>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>


### PR DESCRIPTION
#### 1.4.1-rc2 March 10 2020 ####
**Stable release candidate for Akka.NET 1.4**

In Akka.NET v1.4.1-rc2 we rolled back all of the stand-alone HOCON additions and made Akka.NET v1.4 non-breaking. 

For information on the full set of changes between RC1 and RC2, [please see "What's New in Akka.NET v1.4" on the official Akka.NET website](https://getakka.net/community/whats-new/akkadotnet-v1.4.html) 

| COMMITS | LOC+ | LOC- | AUTHOR |
| --- | --- | --- | --- |
| 13 | 9431 | 5347 | Aaron Stannard |
| 2 | 3 | 3 | dependabot-preview[bot] |
| 1 | 97 | 73 | Gregorius Soedharmo |
| 1 | 6 | 1 | Igor Fedchenko |