### PR TITLE
added v1.4.1-RC3 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,11 @@
-#### 1.4.1-rc2 March 10 2020 ####
+#### 1.4.1-rc3 March 10 2020 ####
+**Stable release candidate for Akka.NET 1.4**
+
+In Akka.NET v1.4.1-rc2 we rolled back all of the stand-alone HOCON additions and made Akka.NET v1.4 non-breaking. 
+
+* [Akka.Persistence.Sql.Common: Fix, unsealed `JournalSettings` and `SnapshotStoreSettings` classes](https://github.com/akkadotnet/akka.net/pull/4319)
+
+#### 1.4.1-rc3 March 10 2020 ####
 **Stable release candidate for Akka.NET 1.4**
 
 In Akka.NET v1.4.1-rc2 we rolled back all of the stand-alone HOCON additions and made Akka.NET v1.4 non-breaking. 

--- a/src/common.props
+++ b/src/common.props
@@ -30,13 +30,7 @@
   <PropertyGroup>
     <PackageReleaseNotes>Stable release candidate for Akka.NET 1.4**
 In Akka.NET v1.4.1-rc2 we rolled back all of the stand-alone HOCON additions and made Akka.NET v1.4 non-breaking.
-For information on the full set of changes between RC1 and RC2, [please see "What's New in Akka.NET v1.4" on the official Akka.NET website](https://getakka.net/community/whats-new/akkadotnet-v1.4.html)
-| COMMITS | LOC+ | LOC- | AUTHOR |
-| --- | --- | --- | --- |
-| 13 | 9431 | 5347 | Aaron Stannard |
-| 2 | 3 | 3 | dependabot-preview[bot] |
-| 1 | 97 | 73 | Gregorius Soedharmo |
-| 1 | 6 | 1 | Igor Fedchenko |</PackageReleaseNotes>
+[Akka.Persistence.Sql.Common: Fix, unsealed `JournalSettings` and `SnapshotStoreSettings` classes](https://github.com/akkadotnet/akka.net/pull/4319)</PackageReleaseNotes>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>


### PR DESCRIPTION
#### 1.4.1-rc3 March 10 2020 ####
**Stable release candidate for Akka.NET 1.4**

In Akka.NET v1.4.1-rc2 we rolled back all of the stand-alone HOCON additions and made Akka.NET v1.4 non-breaking. 

* [Akka.Persistence.Sql.Common: Fix, unsealed `JournalSettings` and `SnapshotStoreSettings` classes](https://github.com/akkadotnet/akka.net/pull/4319)