### PR TITLE
1.4.2 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,13 @@
+#### 1.4.2 March 12 2020 ####
+**Maintenance Release for Akka.NET 1.4**
+
+Akka.NET v1.4.2 fixes two issues that affected users as part of the Akka.NET v1.4.1 rollout:
+
+* [Bugfix: Missing v1.4.1 NuGet packages](https://github.com/akkadotnet/akka.net/issues/4332)
+* [Bugfix: App.config loading broken in Akka.NET v1.4.1](https://github.com/akkadotnet/akka.net/issues/4330)
+
+To see the full set of changes for Akka.NET 1.4.2, please [see the 1.4.2 milestone(https://github.com/akkadotnet/akka.net/milestone/32).
+
 #### 1.4.1 March 11 2020 ####
 **Major release for Akka.NET 1.4**
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@ Akka.NET v1.4.2 fixes two issues that affected users as part of the Akka.NET v1.
 * [Bugfix: Missing v1.4.1 NuGet packages](https://github.com/akkadotnet/akka.net/issues/4332)
 * [Bugfix: App.config loading broken in Akka.NET v1.4.1](https://github.com/akkadotnet/akka.net/issues/4330)
 
-To see the full set of changes for Akka.NET 1.4.2, please [see the 1.4.2 milestone(https://github.com/akkadotnet/akka.net/milestone/32).
+To see the full set of changes for Akka.NET 1.4.2, please [see the 1.4.2 milestone](https://github.com/akkadotnet/akka.net/milestone/32).
 
 #### 1.4.1 March 11 2020 ####
 **Major release for Akka.NET 1.4**

--- a/src/common.props
+++ b/src/common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2020 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.4.1</VersionPrefix>
+    <VersionPrefix>1.4.2</VersionPrefix>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>
@@ -28,46 +28,11 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Major release for Akka.NET 1.4**
-Akka.NET v1.4 is a non-breaking upgrade for all Akka.NET v1.3 and earlier users. It introduces many new features, all of which can be found in our ["What's new in Akka.NET v1.4" page](https://getakka.net/community/whats-new/akkadotnet-v1.4.html).
-Major changes include:
-Akka.Cluster.Sharding and Akka.DistributedData are now out of beta status and are treated as mature modules.
-Akka.Remote's performance has significantly increased as a function of our new batching mode (see the numbers) - which is tunable via HOCON configuration to best support your needs. [Learn how to performance optimize Akka.Remote here](https://getakka.net/articles/remoting/performance.html).
-Added new Akka.Cluster.Metrics module to measure and broadcast the performance of each node, also includes some routers that can use this information to direct traffic to the "least busy" nodes.
-Added [Stream References to Akka.Streams](https://getakka.net/articles/streams/streamrefs.html),  a feature which allows Akka.Streams graphs to span across the network.
-Moved from .NET Standard 1.6 to .NET Standard 2.0 and dropped support for all versions of .NET Framework that aren't supported by .NET Standard 2.0 - this means issues caused by our polyfills (i.e. SerializableAttribute) should be fully resolved now.
-Moved onto modern C# best practices, such as changing our APIs to support `System.ValueTuple` over regular tuples.
-And hundreds of other fixes and improvements. See the full set of changes for Akka.NET v1.4 here:
-[Akka.NET v1.4 Milestone](https://github.com/akkadotnet/akka.net/milestone/17)
-[Akka.NET v1.4.1 Milestone](https://github.com/akkadotnet/akka.net/milestone/33)
-| COMMITS | LOC+ | LOC- | AUTHOR |
-| --- | --- | --- | --- |
-| 199 | 41324 | 26885 | Aaron Stannard |
-| 46 | 63 | 63 | dependabot-preview[bot] |
-| 34 | 16800 | 6804 | Igor Fedchenko |
-| 13 | 11671 | 1059 | Bartosz Sypytkowski |
-| 10 | 802 | 317 | Ismael Hamed |
-| 7 | 1876 | 362 | zbynek001 |
-| 6 | 897 | 579 | Sean Gilliam |
-| 5 | 95 | 986 | cptjazz |
-| 5 | 4837 | 51 | Valdis Zobēla |
-| 5 | 407 | 95 | Jonathan Nagy |
-| 5 | 116 | 14 | Andre Loker |
-| 3 | 992 | 77 | Gregorius Soedharmo |
-| 3 | 2 | 2 | Arjen Smits |
-| 2 | 7 | 7 | jdsartori |
-| 2 | 4 | 6 | Onur Gumus |
-| 2 | 15 | 1 | Kaiwei Li |
-| 1 | 65 | 47 | Ondrej Pialek |
-| 1 | 62 | 15 | Mathias Feitzinger |
-| 1 | 3 | 3 | Abi |
-| 1 | 3 | 1 | jg11jg |
-| 1 | 18 | 16 | Peter Huang |
-| 1 | 1 | 2 | Maciej Wódke |
-| 1 | 1 | 1 | Wessel Kranenborg |
-| 1 | 1 | 1 | Greatsamps |
-| 1 | 1 | 1 | Christoffer Jedbäck |
-| 1 | 1 | 1 | Andre |</PackageReleaseNotes>
+    <PackageReleaseNotes>Maintenance Release for Akka.NET 1.4**
+Akka.NET v1.4.2 fixes two issues that affected users as part of the Akka.NET v1.4.1 rollout:
+[Bugfix: Missing v1.4.1 NuGet packages](https://github.com/akkadotnet/akka.net/issues/4332)
+[Bugfix: App.config loading broken in Akka.NET v1.4.1](https://github.com/akkadotnet/akka.net/issues/4330)
+To see the full set of changes for Akka.NET 1.4.2, please [see the 1.4.2 milestone(https://github.com/akkadotnet/akka.net/milestone/32).</PackageReleaseNotes>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>


### PR DESCRIPTION
#### 1.4.2 March 12 2020 ####
**Maintenance Release for Akka.NET 1.4**

Akka.NET v1.4.2 fixes two issues that affected users as part of the Akka.NET v1.4.1 rollout:

* [Bugfix: Missing v1.4.1 NuGet packages](https://github.com/akkadotnet/akka.net/issues/4332)
* [Bugfix: App.config loading broken in Akka.NET v1.4.1](https://github.com/akkadotnet/akka.net/issues/4330)

To see the full set of changes for Akka.NET 1.4.2, please [see the 1.4.2 milestone(https://github.com/akkadotnet/akka.net/milestone/32).