### PR TITLE
v1.4.2 Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,13 @@
+#### 1.4.2 March 12 2020 ####
+**Maintenance Release for Akka.NET 1.4**
+
+Akka.NET v1.4.2 fixes two issues that affected users as part of the Akka.NET v1.4.1 rollout:
+
+* [Bugfix: Missing v1.4.1 NuGet packages](https://github.com/akkadotnet/akka.net/issues/4332)
+* [Bugfix: App.config loading broken in Akka.NET v1.4.1](https://github.com/akkadotnet/akka.net/issues/4330)
+
+To see the full set of changes for Akka.NET 1.4.2, please [see the 1.4.2 milestone](https://github.com/akkadotnet/akka.net/milestone/32).
+
 #### 1.4.1 March 11 2020 ####
 **Major release for Akka.NET 1.4**
 

--- a/docs/articles/remoting/performance.md
+++ b/docs/articles/remoting/performance.md
@@ -91,3 +91,8 @@ The key to performance tuning the DotNetty TCP transport is picking the best val
 
 > [!IMPORTANT]
 > Later on in the Akka.NET v1.4.0 release cycle we will be releasing some tools built into Akka.Remote that will make it easier to collect profiling data about your application's performance. This should make it much easier to determine what sort of configuration you may want to use with the DotNetty TCP batching system.
+
+## Further Reading
+See [Petabridge](https://petabridge.com/)'s video on the subject, "[Akka.Remote Performance Optimization in Akka.NET v1.4](https://www.youtube.com/watch?v=mP3amXEntmQ)"
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/mP3amXEntmQ" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/src/common.props
+++ b/src/common.props
@@ -20,7 +20,7 @@
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>
     <NetFrameworkLibVersion>net452</NetFrameworkLibVersion>
     <FluentAssertionsVersion>4.14.0</FluentAssertionsVersion>
-    <FsCheckVersion>2.14.1</FsCheckVersion>
+    <FsCheckVersion>2.14.2</FsCheckVersion>
     <HoconVersion>2.0.3</HoconVersion>
     <AkkaPackageTags>akka;actors;actor model;Akka;concurrency</AkkaPackageTags>
   </PropertyGroup>

--- a/src/common.props
+++ b/src/common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2020 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.4.1</VersionPrefix>
+    <VersionPrefix>1.4.2</VersionPrefix>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>
@@ -28,46 +28,11 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Major release for Akka.NET 1.4**
-Akka.NET v1.4 is a non-breaking upgrade for all Akka.NET v1.3 and earlier users. It introduces many new features, all of which can be found in our ["What's new in Akka.NET v1.4" page](https://getakka.net/community/whats-new/akkadotnet-v1.4.html).
-Major changes include:
-Akka.Cluster.Sharding and Akka.DistributedData are now out of beta status and are treated as mature modules.
-Akka.Remote's performance has significantly increased as a function of our new batching mode (see the numbers) - which is tunable via HOCON configuration to best support your needs. [Learn how to performance optimize Akka.Remote here](https://getakka.net/articles/remoting/performance.html).
-Added new Akka.Cluster.Metrics module to measure and broadcast the performance of each node, also includes some routers that can use this information to direct traffic to the "least busy" nodes.
-Added [Stream References to Akka.Streams](https://getakka.net/articles/streams/streamrefs.html),  a feature which allows Akka.Streams graphs to span across the network.
-Moved from .NET Standard 1.6 to .NET Standard 2.0 and dropped support for all versions of .NET Framework that aren't supported by .NET Standard 2.0 - this means issues caused by our polyfills (i.e. SerializableAttribute) should be fully resolved now.
-Moved onto modern C# best practices, such as changing our APIs to support `System.ValueTuple` over regular tuples.
-And hundreds of other fixes and improvements. See the full set of changes for Akka.NET v1.4 here:
-[Akka.NET v1.4 Milestone](https://github.com/akkadotnet/akka.net/milestone/17)
-[Akka.NET v1.4.1 Milestone](https://github.com/akkadotnet/akka.net/milestone/33)
-| COMMITS | LOC+ | LOC- | AUTHOR |
-| --- | --- | --- | --- |
-| 199 | 41324 | 26885 | Aaron Stannard |
-| 46 | 63 | 63 | dependabot-preview[bot] |
-| 34 | 16800 | 6804 | Igor Fedchenko |
-| 13 | 11671 | 1059 | Bartosz Sypytkowski |
-| 10 | 802 | 317 | Ismael Hamed |
-| 7 | 1876 | 362 | zbynek001 |
-| 6 | 897 | 579 | Sean Gilliam |
-| 5 | 95 | 986 | cptjazz |
-| 5 | 4837 | 51 | Valdis Zobēla |
-| 5 | 407 | 95 | Jonathan Nagy |
-| 5 | 116 | 14 | Andre Loker |
-| 3 | 992 | 77 | Gregorius Soedharmo |
-| 3 | 2 | 2 | Arjen Smits |
-| 2 | 7 | 7 | jdsartori |
-| 2 | 4 | 6 | Onur Gumus |
-| 2 | 15 | 1 | Kaiwei Li |
-| 1 | 65 | 47 | Ondrej Pialek |
-| 1 | 62 | 15 | Mathias Feitzinger |
-| 1 | 3 | 3 | Abi |
-| 1 | 3 | 1 | jg11jg |
-| 1 | 18 | 16 | Peter Huang |
-| 1 | 1 | 2 | Maciej Wódke |
-| 1 | 1 | 1 | Wessel Kranenborg |
-| 1 | 1 | 1 | Greatsamps |
-| 1 | 1 | 1 | Christoffer Jedbäck |
-| 1 | 1 | 1 | Andre |</PackageReleaseNotes>
+    <PackageReleaseNotes>Maintenance Release for Akka.NET 1.4**
+Akka.NET v1.4.2 fixes two issues that affected users as part of the Akka.NET v1.4.1 rollout:
+[Bugfix: Missing v1.4.1 NuGet packages](https://github.com/akkadotnet/akka.net/issues/4332)
+[Bugfix: App.config loading broken in Akka.NET v1.4.1](https://github.com/akkadotnet/akka.net/issues/4330)
+To see the full set of changes for Akka.NET 1.4.2, please [see the 1.4.2 milestone(https://github.com/akkadotnet/akka.net/milestone/32).</PackageReleaseNotes>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>

--- a/src/contrib/cluster/Akka.Cluster.Metrics/Akka.Cluster.Metrics.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Metrics/Akka.Cluster.Metrics.csproj
@@ -7,7 +7,6 @@
             The member nodes of the cluster can collect system health metrics and publish that to other cluster nodes 
             and to the registered subscribers on the system event bus with the help of Cluster Metrics Extension.
         </Description>
-        <VersionSuffix>beta</VersionSuffix>
         <TargetFramework>$(NetStandardLibVersion)</TargetFramework>
         <PackageTags>$(AkkaPackageTags);network;cluster;sharding</PackageTags>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/contrib/serializers/Akka.Serialization.Hyperion/Akka.Serialization.Hyperion.csproj
+++ b/src/contrib/serializers/Akka.Serialization.Hyperion/Akka.Serialization.Hyperion.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <AssemblyTitle>Akka.Serialization.Hyperion</AssemblyTitle>
     <Description>Hyperion serializer for Akka.NET</Description>
-    <VersionSuffix>beta</VersionSuffix>
     <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
     <PackageTags>$(AkkaPackageTags);hyperion;serializer;serialize</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
+++ b/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
     <PackageReference Include="FsCheck" Version="2.14.2" />
-    <PackageReference Include="FsCheck.Xunit" Version="2.14.1" />
+    <PackageReference Include="FsCheck.Xunit" Version="2.14.2" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">

--- a/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
+++ b/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
-    <PackageReference Include="FsCheck" Version="2.14.1" />
+    <PackageReference Include="FsCheck" Version="2.14.2" />
     <PackageReference Include="FsCheck.Xunit" Version="2.14.1" />
   </ItemGroup>
 

--- a/src/core/Akka.Tests/App.config
+++ b/src/core/Akka.Tests/App.config
@@ -21,6 +21,7 @@
               }
             }          
           }
+          nonsense.entry = true
       ]]>
     </hocon>
   </akka>

--- a/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
+++ b/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.IO;
 using Akka.Configuration.Hocon;
 using System.Linq;
@@ -74,6 +75,20 @@ namespace Akka.Tests.Configuration
             Assert.False(string.IsNullOrEmpty(section.Hocon.Content));
             var akkaConfig = section.AkkaConfig;
             Assert.NotNull(akkaConfig);
+#else
+            // Skip this test for Linux targets
+            Output.WriteLine("This test is skipped.");
+#endif
+        }
+
+        // unit test for bug #4330
+        [Fact]
+        public void Should_load_config_from_app_config_file()
+        {
+#if !CORECLR
+            var system = ActorSystem.Create(Guid.NewGuid().ToString());
+            system.Settings.Config.GetBoolean("nonsense.entry").ShouldBeTrue();
+            system.Terminate();
 #else
             // Skip this test for Linux targets
             Output.WriteLine("This test is skipped.");

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -302,9 +302,10 @@ namespace Akka.Actor
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            var other = obj as IActorRef;
-            if (other == null) return false;
-            return Equals(other);
+            if (obj is IActorRef other)
+                return Equals(other);
+
+            return false;
         }
 
         /// <inheritdoc/>
@@ -325,14 +326,28 @@ namespace Akka.Actor
         /// </exception>
         public int CompareTo(object obj)
         {
-            if (obj != null && !(obj is IActorRef))
-                throw new ArgumentException("Object must be of type IActorRef.", nameof(obj));
-            return CompareTo((IActorRef)obj);
+            if (obj is null) return 1;
+            if(!(obj is IActorRef other))
+                throw new ArgumentException($"Object must be of type IActorRef, found {obj.GetType()} instead.", nameof(obj));
+
+            return CompareTo(other);
         }
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Checks equality between this instance and another object.
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns>
+        /// <c>true</c> if this <see cref="IActorRef"/> instance have the same reference 
+        /// as the <paramref name="other"/> instance, if this <see cref="ActorPath"/> of 
+        /// this <see cref="IActorRef"/> instance is equal to the <paramref name="other"/> instance, 
+        /// and <paramref name="other"/> is not <c>null</c>; otherwise <c>false</c>.
+        /// </returns>
         public bool Equals(IActorRef other)
         {
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
+
             return Path.Uid == other.Path.Uid
                 && Path.Equals(other.Path);
         }
@@ -340,6 +355,8 @@ namespace Akka.Actor
         /// <inheritdoc/>
         public int CompareTo(IActorRef other)
         {
+            if (other is null) return 1;
+
             var pathComparisonResult = Path.CompareTo(other.Path);
             if (pathComparisonResult != 0) return pathComparisonResult;
             if (Path.Uid < other.Path.Uid) return -1;

--- a/src/core/Akka/Actor/ActorSystem.cs
+++ b/src/core/Akka/Actor/ActorSystem.cs
@@ -112,7 +112,7 @@ namespace Akka.Actor
         /// <returns>A newly created actor system with the given name.</returns>
         public static ActorSystem Create(string name)
         {
-            return CreateAndStartSystem(name, ConfigurationFactory.Default());
+            return CreateAndStartSystem(name, ConfigurationFactory.Load());
         }
 
         private static ActorSystem CreateAndStartSystem(string name, Config withFallback)

--- a/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
@@ -74,7 +74,7 @@ namespace Akka.Actor.Internal
                     $"Invalid ActorSystem name [{name}], must contain only word characters (i.e. [a-zA-Z0-9] plus non-leading '-')", nameof(name));
 
             // Not checking for empty Config here, default values will be substituted in Settings class constructor (called in ConfigureSettings)
-            if(config.IsNullOrEmpty())
+            if(config is null)
                 throw new ArgumentNullException(nameof(config), $"Cannot create {typeof(ActorSystemImpl)}: Configuration must not be null.");
 
             _name = name;            


### PR DESCRIPTION
#### 1.4.2 March 12 2020 ####
**Maintenance Release for Akka.NET 1.4**

Akka.NET v1.4.2 fixes two issues that affected users as part of the Akka.NET v1.4.1 rollout:

* [Bugfix: Missing v1.4.1 NuGet packages](https://github.com/akkadotnet/akka.net/issues/4332)
* [Bugfix: App.config loading broken in Akka.NET v1.4.1](https://github.com/akkadotnet/akka.net/issues/4330)

To see the full set of changes for Akka.NET 1.4.2, please [see the 1.4.2 milestone](https://github.com/akkadotnet/akka.net/milestone/32).
