### PR TITLE
Expose success and fail methods in CircuitBreaker

### DIFF
--- a/docs/articles/utilities/circuit-breaker.md
+++ b/docs/articles/utilities/circuit-breaker.md
@@ -74,3 +74,12 @@ dangerousActor.Tell("is my middle name");
 // My CircuitBreaker is now closed
 // This really isn't that dangerous of a call after all
 ```
+
+### Tell Pattern
+
+The above ``Call Protection`` pattern works well when the return from a remote call is wrapped in a ``Future``. However, when a remote call sends back a message or timeout to the caller ``Actor``, the ``Call Protection`` pattern is awkward. CircuitBreaker doesn't support it natively at the moment, so you need to use below low-level power-user APIs, ``succeed``  and  ``fail`` methods, as well as ``isClose``, ``isOpen``, ``isHalfOpen``.
+
+>[!NOTE]
+>The below examples doesn't make a remote call when the state is `HalfOpen`. Using the power-user APIs, it is your responsibility to judge when to make remote calls in `HalfOpen`.
+
+[!code-csharp[Main](../../../src/core/Akka.Docs.Tests/Utilities/CircuitBreakerDocSpec.cs?name=circuit-breaker-tell-pattern)]

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -3813,12 +3813,17 @@ namespace Akka.Pattern
         public CircuitBreaker(int maxFailures, System.TimeSpan callTimeout, System.TimeSpan resetTimeout) { }
         public System.TimeSpan CallTimeout { get; }
         public long CurrentFailureCount { get; }
+        public bool IsClosed { get; }
+        public bool IsHalfOpen { get; }
+        public bool IsOpen { get; }
         public int MaxFailures { get; }
         public System.TimeSpan ResetTimeout { get; }
         public static Akka.Pattern.CircuitBreaker Create(int maxFailures, System.TimeSpan callTimeout, System.TimeSpan resetTimeout) { }
+        public void Fail() { }
         public Akka.Pattern.CircuitBreaker OnClose(System.Action callback) { }
         public Akka.Pattern.CircuitBreaker OnHalfOpen(System.Action callback) { }
         public Akka.Pattern.CircuitBreaker OnOpen(System.Action callback) { }
+        public void Succeed() { }
         public System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.Tasks.Task<T>> body) { }
         public System.Threading.Tasks.Task WithCircuitBreaker(System.Func<System.Threading.Tasks.Task> body) { }
         public void WithSyncCircuitBreaker(System.Action body) { }

--- a/src/core/Akka/Pattern/CircuitBreaker.cs
+++ b/src/core/Akka/Pattern/CircuitBreaker.cs
@@ -191,6 +191,44 @@ namespace Akka.Pattern
         }
 
         /// <summary>
+        /// Mark a successful call through CircuitBreaker. Sometimes the callee of CircuitBreaker sends back a message to the
+        /// caller Actor. In such a case, it is convenient to mark a successful call instead of using Future
+        /// via <see cref="WithCircuitBreaker"/>
+        /// </summary>
+        public void Succeed() => _currentState.CallSucceeds();
+
+        /// <summary>
+        /// Mark a failed call through CircuitBreaker. Sometimes the callee of CircuitBreaker sends back a message to the
+        /// caller Actor. In such a case, it is convenient to mark a failed call instead of using Future
+        /// via <see cref="WithCircuitBreaker"/>
+        /// </summary>
+        public void Fail() => _currentState.CallFails();
+
+        /// <summary>
+        /// Return true if the internal state is Closed. WARNING: It is a "power API" call which you should use with care.
+        /// Ordinal use cases of CircuitBreaker expects a remote call to return Future, as in <see cref="WithCircuitBreaker"/>.
+        /// So, if you check the state by yourself, and make a remote call outside CircuitBreaker, you should
+        /// manage the state yourself.
+        /// </summary>
+        public bool IsClosed => _currentState is Closed;
+
+        /// <summary>
+        /// Return true if the internal state is Open. WARNING: It is a "power API" call which you should use with care.
+        /// Ordinal use cases of CircuitBreaker expects a remote call to return Future, as in <see cref="WithCircuitBreaker"/>.
+        /// So, if you check the state by yourself, and make a remote call outside CircuitBreaker, you should
+        /// manage the state yourself.
+        /// </summary>
+        public bool IsOpen => _currentState is Open;
+
+        /// <summary>
+        /// Return true if the internal state is HalfOpen. WARNING: It is a "power API" call which you should use with care.
+        /// Ordinal use cases of CircuitBreaker expects a remote call to return Future, as in withCircuitBreaker.
+        /// So, if you check the state by yourself, and make a remote call outside CircuitBreaker, you should
+        /// manage the state yourself.
+        /// </summary>
+        public bool IsHalfOpen => _currentState is HalfOpen;
+
+        /// <summary>
         /// Adds a callback to execute when circuit breaker opens
         /// </summary>
         /// <param name="callback"><see cref="Action"/> Handler to be invoked on state change</param>

--- a/src/core/Akka/Pattern/CircuitBreakerState.cs
+++ b/src/core/Akka/Pattern/CircuitBreakerState.cs
@@ -56,17 +56,15 @@ namespace Akka.Pattern
         /// <summary>
         /// No-op for open, calls are never executed so cannot succeed or fail
         /// </summary>
-        protected override void CallFails()
+        protected internal override void CallFails()
         {
-            //throw new NotImplementedException();
         }
 
         /// <summary>
         /// No-op for open, calls are never executed so cannot succeed or fail
         /// </summary>
-        protected override void CallSucceeds()
+        protected internal override void CallSucceeds()
         {
-            //throw new NotImplementedException();
         }
 
         /// <summary>
@@ -77,6 +75,11 @@ namespace Akka.Pattern
         {
             Task.Delay(_breaker.ResetTimeout).ContinueWith(task => _breaker.AttemptReset());
         }
+
+        /// <summary>
+        /// Override for more descriptive toString
+        /// </summary>
+        public override string ToString() => "Open";
     }
 
     /// <summary>
@@ -134,7 +137,7 @@ namespace Akka.Pattern
         /// <summary>
         /// Reopen breaker on failed call.
         /// </summary>
-        protected override void CallFails()
+        protected internal override void CallFails()
         {
             _breaker.TripBreaker(this);
         }
@@ -142,7 +145,7 @@ namespace Akka.Pattern
         /// <summary>
         /// Reset breaker on successful call.
         /// </summary>
-        protected override void CallSucceeds()
+        protected internal override void CallSucceeds()
         {
             _breaker.ResetBreaker();
         }
@@ -207,7 +210,7 @@ namespace Akka.Pattern
         /// On failed call, the failure count is incremented.  The count is checked against the configured maxFailures, and
         /// the breaker is tripped if we have reached maxFailures.
         /// </summary>
-        protected override void CallFails()
+        protected internal override void CallFails()
         {
             if (IncrementAndGet() == _breaker.MaxFailures)
             {
@@ -218,7 +221,7 @@ namespace Akka.Pattern
         /// <summary>
         /// On successful call, the failure count is reset to 0
         /// </summary>
-        protected override void CallSucceeds()
+        protected internal override void CallSucceeds()
         {
             Reset();
         }

--- a/src/core/Akka/Util/Internal/AtomicState.cs
+++ b/src/core/Akka/Util/Internal/AtomicState.cs
@@ -167,12 +167,12 @@ namespace Akka.Util.Internal
         /// <summary>
         /// Invoked when call fails
         /// </summary>
-        protected abstract void CallFails();
+        protected internal abstract void CallFails();
 
         /// <summary>
         /// Invoked when call succeeds
         /// </summary>
-        protected abstract void CallSucceeds();
+        protected internal abstract void CallSucceeds();
 
         /// <summary>
         /// Invoked on the transitioned-to state during transition. Notifies listeners after invoking subclass template method _enter


### PR DESCRIPTION
> Current implementation works great when the call is wrapping a future with direct response. However, if the actor is expecting a message back or ReceiveTimeout, then using the circuit breaker is awkward -- there's no way to access the circuit breaker's current state, or signal a failure or success directly.

PR [#21074](https://github.com/akka/akka/pull/21074)