### PR TITLE
CONFIGURATION compiler directive is missing from Akka.Persistence.Sql.Common netstandard2.0 build target

### DIFF
--- a/src/common.props
+++ b/src/common.props
@@ -22,6 +22,7 @@
     <FluentAssertionsVersion>4.14.0</FluentAssertionsVersion>
     <FsCheckVersion>2.14.2</FsCheckVersion>
     <HoconVersion>2.0.3</HoconVersion>
+    <ConfigurationManagerVersion>4.7.0</ConfigurationManagerVersion>
     <AkkaPackageTags>akka;actors;actor model;Akka;concurrency</AkkaPackageTags>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(ConfigurationManagerVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\..\core\Akka.Persistence\Akka.Persistence.csproj" />
   </ItemGroup>
 
@@ -27,7 +31,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
+    <DefineConstants>$(DefineConstants);CORECLR;CONFIGURATION</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/BatchingSqlJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/BatchingSqlJournal.cs
@@ -259,7 +259,7 @@ namespace Akka.Persistence.Sql.Common.Journal
             if (string.IsNullOrWhiteSpace(connectionString))
             {
                 connectionString = System.Configuration.ConfigurationManager
-                    .ConnectionStrings[config.GetString("connection-string-name", "DefaultConnection")]
+                    .ConnectionStrings[config.GetString("connection-string-name", "DefaultConnection")]?
                     .ConnectionString;
             }
 #endif

--- a/src/examples/AppConfig/App.config
+++ b/src/examples/AppConfig/App.config
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+  <configSections>
+    <section name="akka" type="Akka.Configuration.Hocon.AkkaConfigurationSection, Akka" />
+  </configSections>
+
+  <connectionStrings>
+    <clear/>
+    <add name="myConnectionString" connectionString="myDB://MyConnectionString"/>
+  </connectionStrings>
+
+  <akka>
+    <hocon>
+      <![CDATA[
+akka.persistence.journal.sqlite = {
+  connection-string-name = myConnectionString
+  replay-filter = {
+    mode = off
+  }
+}
+      ]]>
+    </hocon>
+  </akka>
+</configuration>

--- a/src/examples/AppConfig/AppConfig.csproj
+++ b/src/examples/AppConfig/AppConfig.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="App.config" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="App.config" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\contrib\persistence\Akka.Persistence.Sqlite\Akka.Persistence.Sqlite.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/examples/AppConfig/Program.cs
+++ b/src/examples/AppConfig/Program.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Persistence.Sql.Common;
+using Akka.Persistence.Sqlite.Journal;
+using Akka.Persistence.Sqlite;
+using Akka.Util.Internal;
+
+namespace AppConfig
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var system = ActorSystem.Create(Guid.NewGuid().ToString(), ConfigurationFactory.Load());
+            SqlitePersistence.Get(system);
+            var config = system.Settings.Config.GetConfig("akka.persistence.journal.sqlite");
+            var setup = new BatchingSqliteJournalSetup(config);
+
+            Console.WriteLine("If running properly, BatchingSqliteJournalSetup.ConnectionString should return 'myDB://MyConnectionString'.");
+            Console.WriteLine($"Connection string is: {setup.ConnectionString}");
+        }
+    }
+}


### PR DESCRIPTION
Closes #4343 
Bugfix:
* Add System.Configuration.ConfigurationManager support for NET standard 2.0 build.