### PR TITLE
v1.4.3 Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,18 @@
+#### 1.4.3 March 18 2020 ####
+**Maintenance Release for Akka.NET 1.4**
+
+Akka.NET v1.4.3 fixes one major issue that affected Akka.Persistence.Sql users as part of the v1.4 rollout:
+
+* [Bugfix: No connection string for Sql Event Journal was specified](https://github.com/akkadotnet/akka.net/issues/4343)
+
+To see the full set of changes for Akka.NET 1.4.3, please [see the 1.4.3 milestone](https://github.com/akkadotnet/akka.net/milestone/34).
+
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 1 | 78 | 2 | Gregorius Soedharmo |
+| 1 | 2 | 2 | dependabot-preview[bot] |
+| 1 | 172 | 11 | Ismael Hamed |
+
 #### 1.4.2 March 12 2020 ####
 **Maintenance Release for Akka.NET 1.4**
 

--- a/docs/articles/utilities/circuit-breaker.md
+++ b/docs/articles/utilities/circuit-breaker.md
@@ -74,3 +74,12 @@ dangerousActor.Tell("is my middle name");
 // My CircuitBreaker is now closed
 // This really isn't that dangerous of a call after all
 ```
+
+### Tell Pattern
+
+The above ``Call Protection`` pattern works well when the return from a remote call is wrapped in a ``Future``. However, when a remote call sends back a message or timeout to the caller ``Actor``, the ``Call Protection`` pattern is awkward. CircuitBreaker doesn't support it natively at the moment, so you need to use below low-level power-user APIs, ``succeed``  and  ``fail`` methods, as well as ``isClose``, ``isOpen``, ``isHalfOpen``.
+
+>[!NOTE]
+>The below examples doesn't make a remote call when the state is `HalfOpen`. Using the power-user APIs, it is your responsibility to judge when to make remote calls in `HalfOpen`.
+
+[!code-csharp[Main](../../../src/core/Akka.Docs.Tests/Utilities/CircuitBreakerDocSpec.cs?name=circuit-breaker-tell-pattern)]

--- a/src/common.props
+++ b/src/common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2020 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.4.2</VersionPrefix>
+    <VersionPrefix>1.4.3</VersionPrefix>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>
@@ -30,10 +30,14 @@
   </PropertyGroup>
   <PropertyGroup>
     <PackageReleaseNotes>Maintenance Release for Akka.NET 1.4**
-Akka.NET v1.4.2 fixes two issues that affected users as part of the Akka.NET v1.4.1 rollout:
-[Bugfix: Missing v1.4.1 NuGet packages](https://github.com/akkadotnet/akka.net/issues/4332)
-[Bugfix: App.config loading broken in Akka.NET v1.4.1](https://github.com/akkadotnet/akka.net/issues/4330)
-To see the full set of changes for Akka.NET 1.4.2, please [see the 1.4.2 milestone(https://github.com/akkadotnet/akka.net/milestone/32).</PackageReleaseNotes>
+Akka.NET v1.4.3 fixes one major issue that affected Akka.Persistence.Sql users as part of the v1.4 rollout:
+[Bugfix: No connection string for Sql Event Journal was specified](https://github.com/akkadotnet/akka.net/issues/4343)
+To see the full set of changes for Akka.NET 1.4.3, please [see the 1.4.3 milestone](https://github.com/akkadotnet/akka.net/milestone/34).
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 1 | 78 | 2 | Gregorius Soedharmo |
+| 1 | 2 | 2 | dependabot-preview[bot] |
+| 1 | 172 | 11 | Ismael Hamed |</PackageReleaseNotes>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>

--- a/src/common.props
+++ b/src/common.props
@@ -22,6 +22,7 @@
     <FluentAssertionsVersion>4.14.0</FluentAssertionsVersion>
     <FsCheckVersion>2.14.2</FsCheckVersion>
     <HoconVersion>2.0.3</HoconVersion>
+    <ConfigurationManagerVersion>4.7.0</ConfigurationManagerVersion>
     <AkkaPackageTags>akka;actors;actor model;Akka;concurrency</AkkaPackageTags>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(ConfigurationManagerVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\..\core\Akka.Persistence\Akka.Persistence.csproj" />
   </ItemGroup>
 
@@ -27,7 +31,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
+    <DefineConstants>$(DefineConstants);CORECLR;CONFIGURATION</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/BatchingSqlJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/BatchingSqlJournal.cs
@@ -259,7 +259,7 @@ namespace Akka.Persistence.Sql.Common.Journal
             if (string.IsNullOrWhiteSpace(connectionString))
             {
                 connectionString = System.Configuration.ConfigurationManager
-                    .ConnectionStrings[config.GetString("connection-string-name", "DefaultConnection")]
+                    .ConnectionStrings[config.GetString("connection-string-name", "DefaultConnection")]?
                     .ConnectionString;
             }
 #endif

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -3813,12 +3813,17 @@ namespace Akka.Pattern
         public CircuitBreaker(int maxFailures, System.TimeSpan callTimeout, System.TimeSpan resetTimeout) { }
         public System.TimeSpan CallTimeout { get; }
         public long CurrentFailureCount { get; }
+        public bool IsClosed { get; }
+        public bool IsHalfOpen { get; }
+        public bool IsOpen { get; }
         public int MaxFailures { get; }
         public System.TimeSpan ResetTimeout { get; }
         public static Akka.Pattern.CircuitBreaker Create(int maxFailures, System.TimeSpan callTimeout, System.TimeSpan resetTimeout) { }
+        public void Fail() { }
         public Akka.Pattern.CircuitBreaker OnClose(System.Action callback) { }
         public Akka.Pattern.CircuitBreaker OnHalfOpen(System.Action callback) { }
         public Akka.Pattern.CircuitBreaker OnOpen(System.Action callback) { }
+        public void Succeed() { }
         public System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.Tasks.Task<T>> body) { }
         public System.Threading.Tasks.Task WithCircuitBreaker(System.Func<System.Threading.Tasks.Task> body) { }
         public void WithSyncCircuitBreaker(System.Action body) { }

--- a/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
+++ b/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.7.0" />
+    <PackageReference Include="FSharp.Core" Version="4.7.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />

--- a/src/core/Akka.FSharp/Akka.FSharp.fsproj
+++ b/src/core/Akka.FSharp/Akka.FSharp.fsproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="FSharp.Quotations.Evaluator" Version="1.1.3" />
     <PackageReference Include="FsPickler" Version="5.3.2" />
-    <PackageReference Include="FSharp.Core" Version="4.7.0" />
+    <PackageReference Include="FSharp.Core" Version="4.7.1" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/core/Akka/Pattern/CircuitBreaker.cs
+++ b/src/core/Akka/Pattern/CircuitBreaker.cs
@@ -191,6 +191,44 @@ namespace Akka.Pattern
         }
 
         /// <summary>
+        /// Mark a successful call through CircuitBreaker. Sometimes the callee of CircuitBreaker sends back a message to the
+        /// caller Actor. In such a case, it is convenient to mark a successful call instead of using Future
+        /// via <see cref="WithCircuitBreaker"/>
+        /// </summary>
+        public void Succeed() => _currentState.CallSucceeds();
+
+        /// <summary>
+        /// Mark a failed call through CircuitBreaker. Sometimes the callee of CircuitBreaker sends back a message to the
+        /// caller Actor. In such a case, it is convenient to mark a failed call instead of using Future
+        /// via <see cref="WithCircuitBreaker"/>
+        /// </summary>
+        public void Fail() => _currentState.CallFails();
+
+        /// <summary>
+        /// Return true if the internal state is Closed. WARNING: It is a "power API" call which you should use with care.
+        /// Ordinal use cases of CircuitBreaker expects a remote call to return Future, as in <see cref="WithCircuitBreaker"/>.
+        /// So, if you check the state by yourself, and make a remote call outside CircuitBreaker, you should
+        /// manage the state yourself.
+        /// </summary>
+        public bool IsClosed => _currentState is Closed;
+
+        /// <summary>
+        /// Return true if the internal state is Open. WARNING: It is a "power API" call which you should use with care.
+        /// Ordinal use cases of CircuitBreaker expects a remote call to return Future, as in <see cref="WithCircuitBreaker"/>.
+        /// So, if you check the state by yourself, and make a remote call outside CircuitBreaker, you should
+        /// manage the state yourself.
+        /// </summary>
+        public bool IsOpen => _currentState is Open;
+
+        /// <summary>
+        /// Return true if the internal state is HalfOpen. WARNING: It is a "power API" call which you should use with care.
+        /// Ordinal use cases of CircuitBreaker expects a remote call to return Future, as in withCircuitBreaker.
+        /// So, if you check the state by yourself, and make a remote call outside CircuitBreaker, you should
+        /// manage the state yourself.
+        /// </summary>
+        public bool IsHalfOpen => _currentState is HalfOpen;
+
+        /// <summary>
         /// Adds a callback to execute when circuit breaker opens
         /// </summary>
         /// <param name="callback"><see cref="Action"/> Handler to be invoked on state change</param>

--- a/src/core/Akka/Pattern/CircuitBreakerState.cs
+++ b/src/core/Akka/Pattern/CircuitBreakerState.cs
@@ -56,17 +56,15 @@ namespace Akka.Pattern
         /// <summary>
         /// No-op for open, calls are never executed so cannot succeed or fail
         /// </summary>
-        protected override void CallFails()
+        protected internal override void CallFails()
         {
-            //throw new NotImplementedException();
         }
 
         /// <summary>
         /// No-op for open, calls are never executed so cannot succeed or fail
         /// </summary>
-        protected override void CallSucceeds()
+        protected internal override void CallSucceeds()
         {
-            //throw new NotImplementedException();
         }
 
         /// <summary>
@@ -77,6 +75,11 @@ namespace Akka.Pattern
         {
             Task.Delay(_breaker.ResetTimeout).ContinueWith(task => _breaker.AttemptReset());
         }
+
+        /// <summary>
+        /// Override for more descriptive toString
+        /// </summary>
+        public override string ToString() => "Open";
     }
 
     /// <summary>
@@ -134,7 +137,7 @@ namespace Akka.Pattern
         /// <summary>
         /// Reopen breaker on failed call.
         /// </summary>
-        protected override void CallFails()
+        protected internal override void CallFails()
         {
             _breaker.TripBreaker(this);
         }
@@ -142,7 +145,7 @@ namespace Akka.Pattern
         /// <summary>
         /// Reset breaker on successful call.
         /// </summary>
-        protected override void CallSucceeds()
+        protected internal override void CallSucceeds()
         {
             _breaker.ResetBreaker();
         }
@@ -207,7 +210,7 @@ namespace Akka.Pattern
         /// On failed call, the failure count is incremented.  The count is checked against the configured maxFailures, and
         /// the breaker is tripped if we have reached maxFailures.
         /// </summary>
-        protected override void CallFails()
+        protected internal override void CallFails()
         {
             if (IncrementAndGet() == _breaker.MaxFailures)
             {
@@ -218,7 +221,7 @@ namespace Akka.Pattern
         /// <summary>
         /// On successful call, the failure count is reset to 0
         /// </summary>
-        protected override void CallSucceeds()
+        protected internal override void CallSucceeds()
         {
             Reset();
         }

--- a/src/core/Akka/Util/Internal/AtomicState.cs
+++ b/src/core/Akka/Util/Internal/AtomicState.cs
@@ -167,12 +167,12 @@ namespace Akka.Util.Internal
         /// <summary>
         /// Invoked when call fails
         /// </summary>
-        protected abstract void CallFails();
+        protected internal abstract void CallFails();
 
         /// <summary>
         /// Invoked when call succeeds
         /// </summary>
-        protected abstract void CallSucceeds();
+        protected internal abstract void CallSucceeds();
 
         /// <summary>
         /// Invoked on the transitioned-to state during transition. Notifies listeners after invoking subclass template method _enter

--- a/src/examples/AppConfig/App.config
+++ b/src/examples/AppConfig/App.config
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+  <configSections>
+    <section name="akka" type="Akka.Configuration.Hocon.AkkaConfigurationSection, Akka" />
+  </configSections>
+
+  <connectionStrings>
+    <clear/>
+    <add name="myConnectionString" connectionString="myDB://MyConnectionString"/>
+  </connectionStrings>
+
+  <akka>
+    <hocon>
+      <![CDATA[
+akka.persistence.journal.sqlite = {
+  connection-string-name = myConnectionString
+  replay-filter = {
+    mode = off
+  }
+}
+      ]]>
+    </hocon>
+  </akka>
+</configuration>

--- a/src/examples/AppConfig/AppConfig.csproj
+++ b/src/examples/AppConfig/AppConfig.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="App.config" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="App.config" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\contrib\persistence\Akka.Persistence.Sqlite\Akka.Persistence.Sqlite.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/examples/AppConfig/Program.cs
+++ b/src/examples/AppConfig/Program.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Persistence.Sql.Common;
+using Akka.Persistence.Sqlite.Journal;
+using Akka.Persistence.Sqlite;
+using Akka.Util.Internal;
+
+namespace AppConfig
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var system = ActorSystem.Create(Guid.NewGuid().ToString(), ConfigurationFactory.Load());
+            SqlitePersistence.Get(system);
+            var config = system.Settings.Config.GetConfig("akka.persistence.journal.sqlite");
+            var setup = new BatchingSqliteJournalSetup(config);
+
+            Console.WriteLine("If running properly, BatchingSqliteJournalSetup.ConnectionString should return 'myDB://MyConnectionString'.");
+            Console.WriteLine($"Connection string is: {setup.ConnectionString}");
+        }
+    }
+}


### PR DESCRIPTION
#### 1.4.3 March 18 2020 ####
**Maintenance Release for Akka.NET 1.4**

Akka.NET v1.4.3 fixes one major issue that affected Akka.Persistence.Sql users as part of the v1.4 rollout:

* [Bugfix: No connection string for Sql Event Journal was specified](https://github.com/akkadotnet/akka.net/issues/4343)

To see the full set of changes for Akka.NET 1.4.3, please [see the 1.4.3 milestone](https://github.com/akkadotnet/akka.net/milestone/34).

| COMMITS | LOC+ | LOC- | AUTHOR |
| --- | --- | --- | --- |
| 1 | 78 | 2 | Gregorius Soedharmo |
| 1 | 2 | 2 | dependabot-preview[bot] |
| 1 | 172 | 11 | Ismael Hamed |
