### PR TITLE
Optimize some memory allocations from ActorPath.

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -483,6 +483,7 @@ namespace Akka.Actor
         public override Akka.Actor.ActorPath Parent { get; }
         public override Akka.Actor.ActorPath Root { get; }
         public override int CompareTo(Akka.Actor.ActorPath other) { }
+        public override int GetHashCode() { }
         public override Akka.Actor.ActorPath WithUid(long uid) { }
     }
     public sealed class CoordinatedShutdown : Akka.Actor.IExtension


### PR DESCRIPTION
I was seeing a lot of allocations happening in a system with tens of thousands of actors, which was causing the system to slow down over hours or days due to the increase of time spent in GC. This PR optimizes away some allocations from commonly used ActorPath methods, in order of importance.

1. Added ChildActorPath.GetHashCode(), which is able to compute the hash code without invoking ActorPath.Elements, which allocates memory for the segments. The implementation iterates the segments in reverse order compared to the original implementation. It didn't seem to cause any problems, but I might not understand all the repercussions. It is possible to go back to the original order, but it requires some additional trickery.

The GetHashCode() code path is invoked a lot in the code due to the various caches using Dictionary<IActorRef, xxx>. Many of the Dictionary methods invoke GetHashCode() on the key.

I needed to add the newly added GetHashCode() to CoreAPISpec.ApproveCore.approved.txt, though it's not really a public API change.

2. Optimized ActorPath.Equals(ActorPath other) to avoid getting Elements property (which allocates). The new implementation should behave exactly like the old one.

This mostly triggers when comparing identical ActorPaths which are different objects, as the Uid comparison early-exits non-matching comparisons.

3. Changed ActorPath.Validate() to take a string instead of char[]. This avoids an allocation due to not needing to call string.ToCharArray(). Some micro-benchmarks show ToCharArray() a tiny bit faster, but less GC pressure is arguably more desirable behavior. There might be faster still variants if fixed(char* p) -style tricks are used.

4. The ActorPath.SystemElements and UserElements weren't used anywhere, so I removed them.