### PR TITLE
Sharding update

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGracefulShutdownSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGracefulShutdownSpec.cs
@@ -82,7 +82,7 @@ namespace Akka.Cluster.Sharding.Tests
     public class DDataClusterShardingGracefulShutdownSpec : ClusterShardingGracefulShutdownSpec
     {
         public DDataClusterShardingGracefulShutdownSpec() : this(new DDataClusterShardingGracefulShutdownSpecConfig()) { }
-        protected DDataClusterShardingGracefulShutdownSpec(DDataClusterShardingGracefulShutdownSpecConfig config) : base(config, typeof(PersistentClusterShardingGracefulShutdownSpec)) { }
+        protected DDataClusterShardingGracefulShutdownSpec(DDataClusterShardingGracefulShutdownSpecConfig config) : base(config, typeof(DDataClusterShardingGracefulShutdownSpec)) { }
     }
     public abstract class ClusterShardingGracefulShutdownSpec : MultiNodeClusterSpec
     {
@@ -132,7 +132,7 @@ namespace Akka.Cluster.Sharding.Tests
             EnterBarrier("startup");
         }
         protected bool IsDDataMode { get; }
-        
+
         protected override void AfterTermination()
         {
             base.AfterTermination();

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRegistrationCoordinatedShutdownSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRegistrationCoordinatedShutdownSpec.cs
@@ -1,0 +1,201 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ClusterShardingRegistrationCoordinatedShutdownSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Akka.Actor;
+using Akka.Cluster.TestKit;
+using Akka.Configuration;
+using Akka.Remote.TestKit;
+using System.Collections.Immutable;
+using System.IO;
+using Akka.Util;
+using FluentAssertions;
+using System.Threading.Tasks;
+using System.Threading;
+using Akka.Event;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    public class ClusterShardingRegistrationCoordinatedShutdownSpecConfig : MultiNodeConfig
+    {
+        public RoleName First { get; }
+        public RoleName Second { get; }
+        public RoleName Third { get; }
+
+        public ClusterShardingRegistrationCoordinatedShutdownSpecConfig()
+        {
+            First = Role("first");
+            Second = Role("second");
+            Third = Role("third");
+
+            CommonConfig = DebugConfig(false)
+                .WithFallback(ConfigurationFactory.ParseString($@"
+                    akka.actor {{
+                        serializers {{
+                            hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                        }}
+                        serialization-bindings {{
+                            ""System.Object"" = hyperion
+                        }}
+                    }}
+                    akka.loglevel = DEBUG
+                    akka.actor.provider = cluster
+                    akka.remote.log-remote-lifecycle-events = off
+                    akka.cluster.sharding.state-store-mode = ""ddata""
+                    "))
+                .WithFallback(Sharding.ClusterSharding.DefaultConfig())
+                .WithFallback(Tools.Singleton.ClusterSingletonManager.DefaultConfig())
+                .WithFallback(MultiNodeClusterSpec.ClusterConfig());
+        }
+    }
+
+    public class ClusterShardingRegistrationCoordinatedShutdownSpec : MultiNodeClusterSpec
+    {
+        #region setup
+
+        internal sealed class StopEntity
+        {
+            public static readonly StopEntity Instance = new StopEntity();
+
+            private StopEntity()
+            {
+            }
+        }
+
+        internal class Entity : ActorBase
+        {
+            private readonly ILoggingAdapter _log = Context.GetLogger();
+            protected override bool Receive(object message)
+            {
+                _log.Warning("Entity received [{0}]", message);
+                switch (message)
+                {
+                    case int id:
+                        Sender.Tell(id);
+                        return true;
+                    case StopEntity _:
+                        Context.Stop(Self);
+                        return true;
+                }
+                return false;
+            }
+        }
+
+        internal ExtractEntityId extractEntityId = message => message is int ? (message.ToString(), message) : Option<(string, object)>.None;
+
+        internal ExtractShardId extractShardId = message => message is int ? message.ToString() : null;
+
+        private readonly Lazy<IActorRef> _region;
+
+        private readonly ClusterShardingRegistrationCoordinatedShutdownSpecConfig _config;
+
+        public ClusterShardingRegistrationCoordinatedShutdownSpec()
+            : this(new ClusterShardingRegistrationCoordinatedShutdownSpecConfig())
+        {
+        }
+
+        protected ClusterShardingRegistrationCoordinatedShutdownSpec(ClusterShardingRegistrationCoordinatedShutdownSpecConfig config)
+            : base(config, typeof(ClusterShardingRegistrationCoordinatedShutdownSpec))
+        {
+            _config = config;
+            _region = new Lazy<IActorRef>(() => ClusterSharding.Get(Sys).ShardRegion("Entity"));
+            EnterBarrier("startup");
+        }
+
+        #endregion
+
+        private void Join(RoleName from, RoleName to)
+        {
+            RunOn(() =>
+            {
+                Cluster.Join(GetAddress(to));
+                StartSharding();
+            }, from);
+            EnterBarrier(from.Name + "-joined");
+        }
+
+        private void StartSharding()
+        {
+            var allocationStrategy = new LeastShardAllocationStrategy(2, 1);
+            ClusterSharding.Get(Sys).Start(
+                typeName: "Entity",
+                entityProps: Props.Create<Entity>(),
+                settings: ClusterShardingSettings.Create(Sys),
+                extractEntityId: extractEntityId,
+                extractShardId: extractShardId,
+                allocationStrategy: allocationStrategy,
+                handOffStopMessage: StopEntity.Instance);
+        }
+
+        [MultiNodeFact]
+        public void ClusterShardingRegistrationCoordinatedShutdownSpecs()
+        {
+            ClusterSharding_Region_registration_during_CoordinatedShutdown_must_try_next_oldest();
+        }
+
+        public void ClusterSharding_Region_registration_during_CoordinatedShutdown_must_try_next_oldest()
+        {
+            Within(TimeSpan.FromSeconds(30), () =>
+            {
+                // second should be oldest
+                Join(_config.Second, _config.Second);
+                Join(_config.First, _config.Second);
+                Join(_config.Third, _config.Second);
+
+                AwaitAssert(() =>
+                {
+                    Cluster.State.Members.Count(m => m.Status == MemberStatus.Up).Should().Be(3);
+                });
+
+                var probe = CreateTestProbe();
+                var csTaskDone = CreateTestProbe();
+                RunOn(() =>
+                {
+                    CoordinatedShutdown.Get(Sys).AddTask(CoordinatedShutdown.PhaseBeforeClusterShutdown, "test", () =>
+                    {
+                        Thread.Sleep(200);
+                        _region.Value.Tell(1, probe.Ref);
+                        probe.ExpectMsg(1);
+                        csTaskDone.Ref.Tell(Done.Instance);
+                        return Task.FromResult(Done.Instance);
+                    });
+                }, _config.Third);
+
+
+                StartSharding();
+
+                EnterBarrier("before-shutdown");
+
+                RunOn(() =>
+                {
+                    CoordinatedShutdown.Get(Sys).Run(CoordinatedShutdown.UnknownReason.Instance);
+                    AwaitCondition(() => Cluster.IsTerminated);
+                }, _config.Second);
+
+                RunOn(() =>
+                {
+                    CoordinatedShutdown.Get(Sys).Run(CoordinatedShutdown.UnknownReason.Instance);
+                    AwaitCondition(() => Cluster.IsTerminated);
+                    csTaskDone.ExpectMsg<Done>();
+                }, _config.Third);
+
+                EnterBarrier("after-shutdown");
+
+                RunOn(() =>
+                {
+                    _region.Value.Tell(2);
+                    ExpectMsg(2);
+                    LastSender.Path.Address.HasLocalScope.Should().BeTrue();
+                }, _config.First);
+
+                EnterBarrier("after-1");
+            });
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
@@ -376,7 +376,7 @@ namespace Akka.Cluster.Sharding.Tests
         public DDataClusterShardingWithEntityRecoverySpec() : this(new DDataClusterShardingWithEntityRecoverySpecConfig()) { }
         protected DDataClusterShardingWithEntityRecoverySpec(DDataClusterShardingWithEntityRecoverySpecConfig config) : base(config, typeof(DDataClusterShardingWithEntityRecoverySpec)) { }
     }
-    public abstract class ClusterShardingSpec : MultiNodeClusterSpec 
+    public abstract class ClusterShardingSpec : MultiNodeClusterSpec
     {
         // must use different unique name for some tests than the one used in API tests
         public static string TestCounterShardingTypeName => $"Test{Counter.ShardingTypeName}";
@@ -474,7 +474,7 @@ namespace Akka.Cluster.Sharding.Tests
 
                 Sys.ActorOf(ClusterSingletonManager.Props(
                     singletonProps,
-                    PoisonPill.Instance,
+                    Terminate.Instance,
                     ClusterSingletonManagerSettings.Create(Sys)),
                     typeName + "Coordinator");
             }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
@@ -1244,7 +1244,7 @@ namespace Akka.Cluster.Sharding
     /// <see cref="PersistentShardCoordinator"/>. If the process takes longer than the `handOffTimeout` it
     /// also sends <see cref="RebalanceDone"/>.
     /// </summary>
-    internal class RebalanceWorker : ActorBase
+    internal class RebalanceWorker : ActorBase, IWithTimers
     {
         /// <summary>
         /// TBD
@@ -1270,6 +1270,8 @@ namespace Akka.Cluster.Sharding
 
         private ILoggingAdapter Log { get { return _log ?? (_log = Context.GetLogger()); } }
 
+        public ITimerScheduler Timers { get; set; }
+
         /// <summary>
         /// TBD
         /// </summary>
@@ -1290,7 +1292,7 @@ namespace Akka.Cluster.Sharding
             foreach (var region in _remaining)
                 region.Tell(new PersistentShardCoordinator.BeginHandOff(shard));
 
-            Context.System.Scheduler.ScheduleTellOnce(handOffTimeout, Self, ReceiveTimeout.Instance, Self);
+            Timers.StartSingleTimer("hand-off-timeout", ReceiveTimeout.Instance, handOffTimeout);
         }
 
         /// <summary>

--- a/src/contrib/cluster/Akka.Cluster.Sharding/DDataShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/DDataShardCoordinator.cs
@@ -47,6 +47,7 @@ namespace Akka.Cluster.Sharding
         private bool _allRegionsRegistered = false;
         private ImmutableHashSet<IKey<IReplicatedData>> _allKeys;
         private IImmutableSet<string> _shards = ImmutableHashSet<string>.Empty;
+        private bool _terminating = false;
 
         public DDataShardCoordinator(string typeName, ClusterShardingSettings settings, IShardAllocationStrategy allocationStrategy, IActorRef replicator, int majorityMinCap, bool rememberEntities)
         {
@@ -156,6 +157,11 @@ namespace Akka.Cluster.Sharding
                             Context.Become(WaitingForState(newRemainingKeys));
                         return true;
                     }
+                case Terminate _:
+                    Log.Debug("Received termination message while waiting for state");
+                    Context.Stop(Self);
+                    return true;
+
                 default: return this.ReceiveTerminated(message);
             }
         };
@@ -183,6 +189,10 @@ namespace Akka.Cluster.Sharding
                     this.StateInitialized();
                     Activate();
                     return true;
+                case Terminate _:
+                    Log.Debug("Received termination message while waiting for state initialized");
+                    Context.Stop(Self);
+                    return true;
                 default:
                     Stash.Stash();
                     return true;
@@ -203,8 +213,18 @@ namespace Akka.Cluster.Sharding
                         return true;
 
                     case UpdateTimeout timeout when timeout.Key.Equals(_coordinatorStateKey) && timeout.Request.Equals(e):
-                        Log.Error("The ShardCoordinator was unable to update a distributed state within 'updating-state-timeout': {0} (retrying), event={1}", _writeConsistency.Timeout, e);
-                        SendCoordinatorStateUpdate(e);
+                        Log.Error("The ShardCoordinator was unable to update a distributed state within 'updating-state-timeout': {0} ({1}), event={2}", _writeConsistency.Timeout, _terminating ? "terminating" : "retrying", e);
+
+                        if (_terminating)
+                        {
+                            Context.Stop(Self);
+                        }
+                        else
+                        {
+                            // repeat until UpdateSuccess
+                            SendCoordinatorStateUpdate(e);
+                        }
+
                         return true;
 
                     case UpdateSuccess success when success.Key.Equals(_allShardsKey) && success.Request is string newShard:
@@ -217,18 +237,43 @@ namespace Akka.Cluster.Sharding
                         return true;
 
                     case UpdateTimeout timeout when timeout.Key.Equals(_allShardsKey) && timeout.Request is string newShard:
-                        Log.Error("The ShardCoordinator was unable to update shards distributed state within 'updating-state-timeout': {0} (retrying), event={1}", _writeConsistency.Timeout, e);
-                        SendShardsUpdate(newShard);
+                        Log.Error("The ShardCoordinator was unable to update shards distributed state within 'updating-state-timeout': {0} ({1}), event={2}", _writeConsistency.Timeout, _terminating ? "terminating" : "retrying", e);
+
+                        if (_terminating)
+                        {
+                            Context.Stop(Self);
+                        }
+                        else
+                        {
+                            // repeat until UpdateSuccess
+                            SendShardsUpdate(newShard);
+                        }
+
                         return true;
 
                     case ModifyFailure failure:
-                        Log.Error("The ShardCoordinator was unable to update a distributed state {0} with error {1} and event {2}.Coordinator will be restarted", failure.Key, failure.Cause, e);
-                        ExceptionDispatchInfo.Capture(failure.Cause).Throw();
+                        Log.Error("The ShardCoordinator was unable to update a distributed state {0} with error {1} and event {2}. {3}", failure.Key, failure.Cause, e, _terminating ? "Coordinator will be terminated due to Terminate message received" : "Coordinator will be restarted");
+
+                        if (_terminating)
+                        {
+                            Context.Stop(Self);
+                        }
+                        else
+                        {
+                            ExceptionDispatchInfo.Capture(failure.Cause).Throw();
+                        }
+
                         return true;
 
                     case PersistentShardCoordinator.GetShardHome getShardHome:
                         if (!this.HandleGetShardHome(getShardHome)) 
                             Stash.Stash();
+                        return true;
+
+                    case Terminate _:
+                        Log.Debug("Received termination message while waiting for update");
+                        _terminating = true;
+                        Stash.Stash();
                         return true;
 
                     default:

--- a/src/contrib/cluster/Akka.Cluster.Sharding/DDataShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/DDataShardCoordinator.cs
@@ -60,7 +60,7 @@ namespace Akka.Cluster.Sharding
             RemovalMargin = Cluster.DowningProvider.DownRemovalMargin;
             MinMembers = string.IsNullOrEmpty(settings.Role)
                 ? Cluster.Settings.MinNrOfMembers
-                : (Cluster.Settings.MinNrOfMembersOfRole.TryGetValue(settings.Role, out var min) ? min : Cluster.Settings.MinNrOfMembers);
+                : Cluster.Settings.MinNrOfMembersOfRole.GetValueOrDefault(settings.Role, 1);
             RebalanceTask = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(Settings.TunningParameters.RebalanceInterval, Settings.TunningParameters.RebalanceInterval, Self, RebalanceTick.Instance, Self);
 
             _readConsistency = new ReadMajority(settings.TunningParameters.WaitingForStateTimeout, majorityMinCap);

--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
@@ -1292,7 +1292,7 @@ namespace Akka.Cluster.Sharding
             if (string.IsNullOrEmpty(settings.Role))
                 MinMembers = Cluster.Settings.MinNrOfMembers;
             else
-                MinMembers = Cluster.Settings.MinNrOfMembersOfRole.GetValueOrDefault(settings.Role, Cluster.Settings.MinNrOfMembers);
+                MinMembers = Cluster.Settings.MinNrOfMembersOfRole.GetValueOrDefault(settings.Role, 1);
 
             JournalPluginId = Settings.JournalPluginId;
             SnapshotPluginId = Settings.SnapshotPluginId;

--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
@@ -1396,13 +1396,20 @@ namespace Akka.Cluster.Sharding
 
         private bool WaitingForStateInitialized(object message)
         {
-            if (message is StateInitialized)
+            switch (message)
             {
-                this.StateInitialized();
-                Context.Become(msg => this.Active(msg) || HandleSnapshotResult(msg));
-                return true;
+                case Terminate _:
+                    Log.Debug("Received termination message before state was initialized");
+                    Context.Stop(Self);
+                    return true;
+
+                case StateInitialized _:
+                    this.StateInitialized();
+                    Context.Become(msg => this.Active(msg) || HandleSnapshotResult(msg));
+                    return true;
             }
-            else if (this.ReceiveTerminated(message)) return true;
+
+            if (this.ReceiveTerminated(message)) return true;
             else return HandleSnapshotResult(message);
         }
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardCoordinator.cs
@@ -228,7 +228,10 @@ namespace Akka.Cluster.Sharding
 
         private static void HandleRebalanceDone<TCoordinator>(this TCoordinator coordinator, string shard, bool ok) where TCoordinator : IShardCoordinator
         {
-            coordinator.Log.Debug("Rebalance shard [{0}] done [{1}]", shard, ok);
+            if (ok)
+                coordinator.Log.Debug("Rebalance shard [{0}] completed successfully", shard);
+            else
+                coordinator.Log.Warning("Rebalance shard [{0}] didn't complete within [{1}]", shard, coordinator.Settings.TunningParameters.HandOffTimeout);
 
             // The shard could have been removed by ShardRegionTerminated
             if (coordinator.CurrentState.Shards.TryGetValue(shard, out var region))

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardCoordinator.cs
@@ -110,6 +110,11 @@ namespace Akka.Cluster.Sharding
                 case ClusterEvent.CurrentClusterState _:
                     /* ignore */
                     return true;
+
+                case Terminate _:
+                    coordinator.Log.Debug("Received termination message");
+                    coordinator.Context.Stop(coordinator.Self);
+                    return true;
                 default: return ReceiveTerminated(coordinator, message);
             }
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
@@ -328,6 +328,9 @@ namespace Akka.Cluster.Sharding
         /// </summary>
         protected IImmutableSet<Member> MembersByAge = ImmutableSortedSet<Member>.Empty.WithComparer(AgeOrdering);
 
+        // membersByAge contains members with these status
+        private static readonly HashSet<MemberStatus> MemberStatusOfInterest = new HashSet<MemberStatus> { MemberStatus.Up, MemberStatus.Leaving, MemberStatus.Exiting };
+
         /// <summary>
         /// TBD
         /// </summary>
@@ -426,14 +429,27 @@ namespace Akka.Cluster.Sharding
         public int TotalBufferSize { get { return ShardBuffers.Aggregate(0, (acc, entity) => acc + entity.Value.Count); } }
 
         /// <summary>
-        /// TBD
+        /// When leaving the coordinator singleton is started rather quickly on next
+        /// oldest node and therefore it is good to send the Register and GracefulShutdownReq to
+        /// the likely locations of the coordinator.
         /// </summary>
-        protected ActorSelection CoordinatorSelection
+        /// <returns></returns>
+        private List<ActorSelection> CoordinatorSelection
         {
             get
             {
-                var firstMember = MembersByAge.FirstOrDefault();
-                return firstMember == null ? null : Context.ActorSelection(firstMember.Address + CoordinatorPath);
+                IEnumerable<Member> SelectMembers()
+                {
+                    foreach (var m in MembersByAge)
+                    {
+                        yield return m;
+                        if (m.Status == MemberStatus.Up)
+                            break;
+                    }
+                }
+
+                return SelectMembers()
+                    .Select(m => Context.ActorSelection(new RootActorPath(m.Address) + CoordinatorPath)).ToList();
             }
         }
 
@@ -557,16 +573,18 @@ namespace Akka.Cluster.Sharding
 
         private void Register()
         {
-            var coordinator = CoordinatorSelection;
-            coordinator?.Tell(RegistrationMessage);
+            var actorSelections = CoordinatorSelection;
+            foreach (var coordinator in actorSelections)
+                coordinator.Tell(RegistrationMessage);
+
             if (ShardBuffers.Count != 0 && _retryCount >= RetryCountThreshold)
             {
-                if (coordinator != null)
+                if (actorSelections.Count > 0)
                 {
                     var coordinatorMessage = Cluster.State.Unreachable.Contains(MembersByAge.First()) ? $"Coordinator [{MembersByAge.First()}] is unreachable." : $"Coordinator [{MembersByAge.First()}] is reachable.";
 
                     Log.Warning("Trying to register to coordinator at [{0}], but no acknowledgement. Total [{1}] buffered messages. [{2}]",
-                        coordinator != null ? coordinator.PathString : string.Empty, TotalBufferSize, coordinatorMessage);
+                       string.Join(", ", actorSelections.Select(i => i.PathString)), TotalBufferSize, coordinatorMessage);
                 }
                 else
                 {
@@ -797,17 +815,6 @@ namespace Akka.Cluster.Sharding
             return Task.WhenAll(tasks);
         }
 
-        private List<ActorSelection> GracefulShutdownCoordinatorSelections
-        {
-            get
-            {
-                return
-                    MembersByAge.Take(2)
-                        .Select(m => Context.ActorSelection(new RootActorPath(m.Address) + CoordinatorPath))
-                        .ToList();
-            }
-        }
-
         private void TryCompleteGracefulShutdown()
         {
             if (GracefulShutdownInProgress && Shards.Count == 0 && ShardBuffers.Count == 0)
@@ -817,7 +824,7 @@ namespace Akka.Cluster.Sharding
         private void SendGracefulShutdownToCoordinator()
         {
             if (GracefulShutdownInProgress)
-                GracefulShutdownCoordinatorSelections
+                CoordinatorSelection
                     .ForEach(c => c.Tell(new PersistentShardCoordinator.GracefulShutdownRequest(Self)));
         }
 
@@ -996,7 +1003,7 @@ namespace Akka.Cluster.Sharding
 
         private void HandleClusterState(ClusterEvent.CurrentClusterState state)
         {
-            var members = ImmutableSortedSet<Member>.Empty.WithComparer(AgeOrdering).Union(state.Members.Where(m => m.Status == MemberStatus.Up && MatchingRole(m)));
+            var members = ImmutableSortedSet<Member>.Empty.WithComparer(AgeOrdering).Union(state.Members.Where(m => MemberStatusOfInterest.Contains(m.Status) && MatchingRole(m)));
             ChangeMembers(members);
         }
 
@@ -1004,14 +1011,16 @@ namespace Akka.Cluster.Sharding
         {
             switch (e)
             {
-
                 case ClusterEvent.MemberUp mu:
-                    {
-                        var m = mu.Member;
-                        if (MatchingRole(m))
-                            ChangeMembers(MembersByAge.Remove(m).Add(m)); // replace
-                    }
+                    AddMember(mu.Member);
                     break;
+                case ClusterEvent.MemberLeft ml:
+                    AddMember(ml.Member);
+                    break;
+                case ClusterEvent.MemberExited me:
+                    AddMember(me.Member);
+                    break;
+
                 case ClusterEvent.MemberRemoved mr:
                     {
                         var m = mr.Member;
@@ -1035,6 +1044,15 @@ namespace Akka.Cluster.Sharding
                 default:
                     Unhandled(e);
                     break;
+            }
+        }
+
+        private void AddMember(Member m)
+        {
+            if (MatchingRole(m) && MemberStatusOfInterest.Contains(m.Status))
+            {
+                // replace, it's possible that the status, or upNumber is changed
+                ChangeMembers(MembersByAge.Remove(m).Add(m));
             }
         }
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
@@ -570,8 +570,14 @@ namespace Akka.Cluster.Sharding
                 }
                 else
                 {
-                    Log.Warning("No coordinator found to register. Probably, no seed-nodes configured and manual cluster join not performed? Total [{0}] buffered messages.",
-                        TotalBufferSize);
+                    // Members start off as "Removed"
+                    var partOfCluster = Cluster.SelfMember.Status != MemberStatus.Removed;
+                    var possibleReason = partOfCluster ?
+                        "Has Cluster Sharding been started on every node and nodes been configured with the correct role(s)?" :
+                        "Probably, no seed-nodes configured and manual cluster join not performed?";
+
+                    Log.Warning("No coordinator found to register. {0} Total [{1}] buffered messages.",
+                        possibleReason, TotalBufferSize);
                 }
             }
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
@@ -329,7 +329,7 @@ namespace Akka.Cluster.Sharding
         protected IImmutableSet<Member> MembersByAge = ImmutableSortedSet<Member>.Empty.WithComparer(AgeOrdering);
 
         // membersByAge contains members with these status
-        private static readonly HashSet<MemberStatus> MemberStatusOfInterest = new HashSet<MemberStatus> { MemberStatus.Up, MemberStatus.Leaving, MemberStatus.Exiting };
+        private static readonly ImmutableHashSet<MemberStatus> MemberStatusOfInterest = ImmutableHashSet.Create(MemberStatus.Up, MemberStatus.Leaving, MemberStatus.Exiting);
 
         /// <summary>
         /// TBD

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardingMessages.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardingMessages.cs
@@ -24,7 +24,7 @@ namespace Akka.Cluster.Sharding
     public interface IShardRegionQuery { }
 
     /// <summary>
-    /// Used as a special termination message from <see cref="ClusterSharding"/>
+    /// Used as a special termination message for <see cref="ShardCoordinator"/> singleton actor
     /// </summary>
     internal sealed class Terminate : IDeadLetterSuppression
     {
@@ -90,7 +90,7 @@ namespace Akka.Cluster.Sharding
     /// Shard could be terminated during initialization.
     /// </summary>
     [Serializable]
-    public sealed class ShardInitialized: IEquatable<ShardInitialized>
+    public sealed class ShardInitialized : IEquatable<ShardInitialized>
     {
         /// <summary>
         /// TBD

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardingMessages.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardingMessages.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using Akka.Actor;
 using System.Collections.Immutable;
 using System.Linq;
+using Akka.Event;
 
 namespace Akka.Cluster.Sharding
 {
@@ -21,6 +22,18 @@ namespace Akka.Cluster.Sharding
     /// TBD
     /// </summary>
     public interface IShardRegionQuery { }
+
+    /// <summary>
+    /// Used as a special termination message from <see cref="ClusterSharding"/>
+    /// </summary>
+    internal sealed class Terminate : IDeadLetterSuppression
+    {
+        public static readonly Terminate Instance = new Terminate();
+
+        private Terminate()
+        {
+        }
+    }
 
     /// <summary>
     /// If the state of the entries are persistent you may stop entries that are not used to

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveClusterSharding.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveClusterSharding.approved.txt
@@ -175,7 +175,6 @@ namespace Akka.Cluster.Sharding
         protected System.Collections.Immutable.IImmutableSet<string> StartingShards;
         public readonly string TypeName;
         public ShardRegion(string typeName, System.Func<string, Akka.Actor.Props> entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, string coordinatorPath, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId, object handOffStopMessage, Akka.Actor.IActorRef replicator, int majorityMinCap) { }
-        protected Akka.Actor.ActorSelection CoordinatorSelection { get; }
         public bool GracefulShutdownInProgress { get; }
         public Akka.Event.ILoggingAdapter Log { get; }
         protected object RegistrationMessage { get; }


### PR DESCRIPTION
multiple sharding updates

* Log non-completed rebalance at warning level
migrated from https://github.com/akka/akka/pull/28335

* Shard region registration to more potential oldest
migrated from https://github.com/akka/akka/pull/28470

* Improve error message when coordinator not found
migrated from https://github.com/akka/akka/pull/28576

* Don't initialize durable keys when rememberEntities not used
migrated from https://github.com/akka/akka/pull/28568

* Use dedicated message for PersistentShardCoodinator termination instead of PoisonPill
migrated from https://github.com/akka/akka/pull/28104

* Reconsider cluster.role.<role-name>.min-nr-of-members fallback
migrated from https://github.com/akka/akka/pull/28203

* Avoid dead letter for rebalance timeout msg
migrated from https://github.com/akka/akka/pull/28274
