### PR TITLE
sharding - release shard lease when shard stopped

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingLeaseSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingLeaseSpec.cs
@@ -184,6 +184,20 @@ namespace Akka.Cluster.Sharding.Tests
                 ExpectMsg(4, TimeSpan.FromSeconds(1));
             }, TimeSpan.FromSeconds(5));
         }
+
+        [Fact]
+        public void Cluster_sharding_with_lease_should_release_lease_when_shard_stopped()
+        {
+            region.Tell(5);
+            ExpectNoMsg(shortDuration);
+            var testLease = LeaseForShard(5);
+            testLease.InitialPromise.SetResult(true);
+            testLease.Probe.ExpectMsg(new TestLease.AcquireReq(leaseOwner));
+            ExpectMsg(5);
+
+            region.Tell(new PersistentShardCoordinator.HandOff("5"));
+            testLease.Probe.ExpectMsg(new TestLease.ReleaseReq(leaseOwner));
+        }
     }
 
     public class PersistenceClusterShardingLeaseSpec : ClusterShardingLeaseSpec

--- a/src/contrib/cluster/Akka.Cluster.Sharding/DDataShard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/DDataShard.cs
@@ -164,6 +164,7 @@ namespace Akka.Cluster.Sharding
 
         protected override void PostStop()
         {
+            this.ReleaseLeaseIfNeeded();
             PassivateIdleTask?.Cancel();
             base.PostStop();
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShard.cs
@@ -102,6 +102,7 @@ namespace Akka.Cluster.Sharding
 
         protected override void PostStop()
         {
+            this.ReleaseLeaseIfNeeded();
             PassivateIdleTask?.Cancel();
             base.PostStop();
         }

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/TestLease.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/TestLease.cs
@@ -16,7 +16,7 @@ namespace Akka.Cluster.Tools.Tests
 {
     public class TestLease : Lease
     {
-        internal sealed class AcquireReq : IEquatable<AcquireReq>
+        public sealed class AcquireReq : IEquatable<AcquireReq>
         {
             public string Owner { get; }
 
@@ -40,7 +40,7 @@ namespace Akka.Cluster.Tools.Tests
             public override string ToString() => $"AcquireReq({Owner})";
         }
 
-        internal sealed class ReleaseReq : IEquatable<ReleaseReq>
+        public sealed class ReleaseReq : IEquatable<ReleaseReq>
         {
             public string Owner { get; }
 


### PR DESCRIPTION
sharding is currently not releasing lease when shard is moved to another server.
Added fix & test for this scenario

Not sure how it works in scala implementation, because I don't see there lease being released anywhere, so maybe there is the same issue. It's released only for singletons.