### PR TITLE
Update tutorial-1.md

### DIFF
--- a/docs/articles/intro/tutorial-1.md
+++ b/docs/articles/intro/tutorial-1.md
@@ -113,8 +113,68 @@ Creating a non-top-level actor is possible from any actor, by invoking
 `Context.ActorOf()` which has the exact same signature as its top-level
 counterpart. This is how it looks like in practice:
 
-[!code-csharp[Main](../../../src/core/Akka.Docs.Tutorials/Tutorial1/ActorHierarchyExperiments.cs?name=print-refs)]
-[!code-csharp[Main](../../../src/core/Akka.Docs.Tutorials/Tutorial1/ActorHierarchyExperiments.cs?name=print-refs2)]
+```code-csharp
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AkkaSandbox
+{
+  public class Program
+  {
+    static void Main(string[] args)
+    {
+      CreateHostBuilder(args).Build().Run();
+    }
+
+    public static IHostBuilder CreateHostBuilder(string[] args) =>
+    Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder(args)
+    .ConfigureServices((hostContext, services) =>
+    {
+      services.AddHostedService<HelloWorldHostedService>();
+    });
+  }
+
+  public class HelloWorldHostedService : IHostedService
+  {
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+      Console.WriteLine("Starting the host.");
+
+      var system = ActorSystem.Create("testSystem");
+      var firstRef = system.ActorOf(Props.Create<PrintMyActorRefActor>(), "first-actor");
+      Console.WriteLine($"First: {firstRef}");
+      firstRef.Tell("printit", ActorRefs.NoSender);
+
+      return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+      Console.WriteLine("Stopping the host.");
+
+      return Task.CompletedTask;
+    }
+  }
+
+  public class PrintMyActorRefActor : UntypedActor
+  {
+    protected override void OnReceive(object message)
+    {
+      switch (message)
+      {
+        case "printit":
+          IActorRef secondRef = Context.ActorOf(Props.Empty, "second-actor");
+          Console.WriteLine($"Second: {secondRef}");
+          break;
+      }
+    }
+  }
+}
+```
 
 We see that the following two lines are printed
 


### PR DESCRIPTION
Added a standalone, working code example for the `Structure of an IActorRef and Paths of Actors` section. Looking at the documentation trend, it should ideally be made a into a reference to a github-hosted piece of code. Looking at how tutorials are organised at the moment, the structure doesn't really encourage individual contributions - the linked examples are a part of a larger project and a larger group of examples, which are not standalone. To contribute, one would have to build the entire solution and modify the entire `Akka.Docs.Tutorials.csproj` project. What I would advise would encourage community contributions/engagement are more standalone, solution-independent examples that illustrate sections/problems clearer.