### PR TITLE
Mark Member.AgeOrdering as public

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
@@ -237,19 +237,6 @@ namespace Akka.Cluster.Sharding
             }
         }
 
-        private class MemberAgeComparer : IComparer<Member>
-        {
-            public static readonly IComparer<Member> Instance = new MemberAgeComparer();
-
-            private MemberAgeComparer() { }
-
-            public int Compare(Member x, Member y)
-            {
-                if (x.IsOlderThan(y)) return -1;
-                return y.IsOlderThan(x) ? 1 : 0;
-            }
-        }
-
         /// <summary>
         /// Factory method for the <see cref="Actor.Props"/> of the <see cref="ShardRegion"/> actor.
         /// </summary>
@@ -321,12 +308,10 @@ namespace Akka.Cluster.Sharding
         /// </summary>
         public readonly Cluster Cluster = Cluster.Get(Context.System);
 
-        // sort by age, oldest first
-        private static readonly IComparer<Member> AgeOrdering = MemberAgeComparer.Instance;
         /// <summary>
         /// TBD
         /// </summary>
-        protected IImmutableSet<Member> MembersByAge = ImmutableSortedSet<Member>.Empty.WithComparer(AgeOrdering);
+        protected IImmutableSet<Member> MembersByAge = ImmutableSortedSet<Member>.Empty.WithComparer(Member.AgeOrdering);
 
         // membersByAge contains members with these status
         private static readonly ImmutableHashSet<MemberStatus> MemberStatusOfInterest = ImmutableHashSet.Create(MemberStatus.Up, MemberStatus.Leaving, MemberStatus.Exiting);
@@ -1003,7 +988,7 @@ namespace Akka.Cluster.Sharding
 
         private void HandleClusterState(ClusterEvent.CurrentClusterState state)
         {
-            var members = ImmutableSortedSet<Member>.Empty.WithComparer(AgeOrdering).Union(state.Members.Where(m => MemberStatusOfInterest.Contains(m.Status) && MatchingRole(m)));
+            var members = ImmutableSortedSet<Member>.Empty.WithComparer(Member.AgeOrdering).Union(state.Members.Where(m => MemberStatusOfInterest.Contains(m.Status) && MatchingRole(m)));
             ChangeMembers(members);
         }
 

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCluster.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCluster.approved.txt
@@ -227,6 +227,7 @@ namespace Akka.Cluster
     public class Member : System.IComparable, System.IComparable<Akka.Cluster.Member>
     {
         public static readonly System.Collections.Generic.IComparer<Akka.Actor.Address> AddressOrdering;
+        public static readonly System.Collections.Generic.IComparer<Akka.Cluster.Member> AgeOrdering;
         public Akka.Actor.Address Address { get; }
         public System.Collections.Immutable.ImmutableHashSet<string> Roles { get; }
         public Akka.Cluster.MemberStatus Status { get; }

--- a/src/core/Akka.Cluster/Member.cs
+++ b/src/core/Akka.Cluster/Member.cs
@@ -224,7 +224,7 @@ namespace Akka.Cluster
         /// <summary>
         /// Compares members by their upNumber to determine which is oldest / youngest.
         /// </summary>
-        internal static readonly AgeComparer AgeOrdering = new AgeComparer();
+        public static readonly IComparer<Member> AgeOrdering = new AgeComparer();
 
         /// <summary>
         ///  INTERNAL API
@@ -334,7 +334,7 @@ namespace Akka.Cluster
 
             if (Member.AllowedTransitions[a.Status].Contains(b.Status))
                 return b;
-            if(Member.AllowedTransitions[b.Status].Contains(a.Status))
+            if (Member.AllowedTransitions[b.Status].Contains(a.Status))
                 return a;
 
             return null; // illegal transition
@@ -410,7 +410,6 @@ namespace Akka.Cluster
                 {MemberStatus.Removed, ImmutableHashSet.Create<MemberStatus>()}
             }.ToImmutableDictionary();
     }
-
 
     /// <summary>
     /// Defines the current status of a cluster member node
@@ -492,7 +491,7 @@ namespace Akka.Cluster
         }
 
         /// <inheritdoc cref="object.Equals(object)"/>
-        public override bool Equals(object obj) => obj is UniqueAddress && Equals((UniqueAddress) obj);
+        public override bool Equals(object obj) => obj is UniqueAddress && Equals((UniqueAddress)obj);
 
         /// <inheritdoc cref="object.GetHashCode"/>
         public override int GetHashCode()


### PR DESCRIPTION
Recently, I needed an AgeComparer to calculate the oldest member of the cluster. `Member` class already has a comparer that could be used, but unlike the `Member.AddressOrdering` public field, the `Member.AgeOrdering` is marked internal. 

I also noticed there's another [AgeComparer](https://github.com/akkadotnet/akka.net/blob/735aafbc7d70948d8f58d770bbbed50908745bc8/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs#L240) inside the `ShardRegion` class that should be safe to remove and replace with the above.