### PR TITLE
    Added constructor that takes a configuration for PersistenceTestKit

### DIFF
--- a/src/core/Akka.Persistence.TestKit.Xunit2/PersistenceTestKit.cs
+++ b/src/core/Akka.Persistence.TestKit.Xunit2/PersistenceTestKit.cs
@@ -26,10 +26,11 @@ namespace Akka.Persistence.TestKit
         /// Create a new instance of the <see cref="PersistenceTestKit"/> class.
         /// A new system with the specified configuration will be created.
         /// </summary>
+        /// <param name="config">Test ActorSystem configuration</param>
         /// <param name="actorSystemName">Optional: The name of the actor system</param>
         /// <param name="output">TBD</param>
-        protected PersistenceTestKit(string actorSystemName = null, ITestOutputHelper output = null)
-            : base(GetConfig(), actorSystemName, output)
+        protected PersistenceTestKit(Config config, string actorSystemName = null, ITestOutputHelper output = null)
+            : base(config, actorSystemName, output)
         {
             var persistenceExtension = Persistence.Instance.Apply(Sys);
 
@@ -38,6 +39,17 @@ namespace Akka.Persistence.TestKit
 
             SnapshotsActorRef = persistenceExtension.SnapshotStoreFor(null);
             Snapshots = TestSnapshotStore.FromRef(SnapshotsActorRef);
+        }
+
+        /// <summary>
+        /// Create a new instance of the <see cref="PersistenceTestKit"/> class.
+        /// A new system with the default configuration will be created.
+        /// </summary>
+        /// <param name="actorSystemName">Optional: The name of the actor system</param>
+        /// <param name="output">TBD</param>
+        protected PersistenceTestKit(string actorSystemName = null, ITestOutputHelper output = null)
+            : this(GetConfig(), actorSystemName, output)
+        {
         }
 
         /// <summary>


### PR DESCRIPTION
Added constructor for PersistenceTestKit class that takes a configuration. Added this so we can pass in custom configurations similar to what is possible for the TestKit class.