### PR TITLE
Merge custom config with default config

### DIFF
--- a/src/core/Akka.Persistence.TestKit.Xunit2/PersistenceTestKit.cs
+++ b/src/core/Akka.Persistence.TestKit.Xunit2/PersistenceTestKit.cs
@@ -30,7 +30,7 @@ namespace Akka.Persistence.TestKit
         /// <param name="actorSystemName">Optional: The name of the actor system</param>
         /// <param name="output">TBD</param>
         protected PersistenceTestKit(Config config, string actorSystemName = null, ITestOutputHelper output = null)
-            : base(config, actorSystemName, output)
+            : base(GetConfig(config), actorSystemName, output)
         {
             var persistenceExtension = Persistence.Instance.Apply(Sys);
 
@@ -48,7 +48,7 @@ namespace Akka.Persistence.TestKit
         /// <param name="actorSystemName">Optional: The name of the actor system</param>
         /// <param name="output">TBD</param>
         protected PersistenceTestKit(string actorSystemName = null, ITestOutputHelper output = null)
-            : this(GetConfig(), actorSystemName, output)
+            : this(Config.Empty, actorSystemName, output)
         {
         }
 
@@ -286,14 +286,19 @@ namespace Akka.Persistence.TestKit
                 execution();
                 return Task.FromResult(true);
             });
-        
+
         /// <summary>
         ///     Loads from embedded resources actor system persistence configuration with <see cref="TestJournal"/> and
         ///     <see cref="TestSnapshotStore"/> configured as default persistence plugins.
         /// </summary>
+        /// <param name="customConfig">Custom configuration that was passed in the constructor.</param>
         /// <returns>Actor system configuration object.</returns>
         /// <seealso cref="Config"/>
-        static Config GetConfig()
-            => ConfigurationFactory.FromResource<TestJournal>("Akka.Persistence.TestKit.config.conf");
+        private static Config GetConfig(Config customConfig)
+        {
+            var defaultConfig = ConfigurationFactory.FromResource<TestJournal>("Akka.Persistence.TestKit.config.conf");
+            if (customConfig == Config.Empty) return defaultConfig;
+            else return defaultConfig.SafeWithFallback(customConfig);
+        }        
     }
 }


### PR DESCRIPTION
In a previous commit I added a constructor that takes in a custom configuration. If a custom configuration is passed in that doesn't contain the definitions of the test journal and test snapshot-store, tests will break. 

For defining the default test journal and test snapshot-store we had a default configuration. This commit takes the custom config and merges it with the default configuration so that the client doesn't have to worry about setting up defaults.