### PR TITLE
enable loggers to start asynchronously

### DIFF
--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -119,13 +119,11 @@ namespace Akka.Actor
         /// <returns>TBD</returns>
         public static async Task<T> Ask<T>(this ICanTell self, Func<IActorRef,object> messageFactory, TimeSpan? timeout, CancellationToken cancellationToken)
         {
-            await SynchronizationContextManager.RemoveContext;
-
             IActorRefProvider provider = ResolveProvider(self);
             if (provider == null)
                 throw new ArgumentException("Unable to resolve the target Provider", nameof(self));
 
-            return (T)await Ask(self, messageFactory, provider, timeout, cancellationToken);
+            return (T)await Ask(self, messageFactory, provider, timeout, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/core/Akka/Event/LoggingBus.cs
+++ b/src/core/Akka/Event/LoggingBus.cs
@@ -85,7 +85,7 @@ namespace Akka.Event
         /// <exception cref="LoggerInitializationException">
         /// This exception is thrown if the logger doesn't respond with a <see cref="LoggerInitialized"/> message when initialized.
         /// </exception>
-        internal void StartDefaultLoggers(ActorSystemImpl system)
+        internal async void StartDefaultLoggers(ActorSystemImpl system)
         {
             var logName = SimpleName(this) + "(" + system.Name + ")";
             var logLevel = Logging.LogLevelFor(system.Settings.LogLevel);
@@ -163,7 +163,7 @@ namespace Akka.Event
             Publish(new Debug(SimpleName(this), GetType(), "All default loggers stopped"));
         }
 
-        private void AddLogger(ActorSystemImpl system, Type loggerType, LogLevel logLevel, string loggingBusName, TimeSpan timeout)
+        private async Task AddLogger(ActorSystemImpl system, Type loggerType, LogLevel logLevel, string loggingBusName, TimeSpan timeout)
         {
             var loggerName = CreateLoggerName(loggerType);
             var logger = system.SystemActorOf(Props.Create(loggerType).WithDispatcher(system.Settings.LoggersDispatcher), loggerName);
@@ -172,7 +172,7 @@ namespace Akka.Event
             object response = null;
             try
             {
-                response = askTask.Result;
+                response = await askTask;
             }
             catch (Exception ex) when (ex is TaskCanceledException || ex is AskTimeoutException)
             {


### PR DESCRIPTION
close #4054

This is an experiment to see if we can avoid thread starvation issues starting up the logging system on machines with low core counts.