### PR TITLE
Akka.NET v1.4.7 Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 1.4.7 May 12 2020 ####
+**Placeholder for nightlies**
+
 #### 1.4.6 May 12 2020 ####
 **Maintenance Release for Akka.NET 1.4**
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
-#### 1.4.7 May 12 2020 ####
-**Placeholder for nightlies**
+#### 1.4.7 May 26 2020 ####
+**Maintenance Release for Akka.NET 1.4**
+
+Akka.NET v1.4.7 is a fairly sizable path that introduces some significant new features and changes:
+
+* [Akka: added `akka.logger-async-start` HOCON setting to allow loggers to start without blocking `ActorSystem` creation](https://github.com/akkadotnet/akka.net/pull/4424) - useful for developers running Akka.NET on Xamarin or in other environments with low CPU counts;
+* [Akka: ported `ActorSystemSetup` to allow programmatic config of serializers and other `ActorSystem` properties](https://github.com/akkadotnet/akka.net/issues/4426)
+* [Akka.Streams: update and modernize Attributes](https://github.com/akkadotnet/akka.net/pull/4437)
+* [Akka.DistributedData.LightningDb: Wire format stabilized](https://github.com/akkadotnet/akka.net/issues/4261) - Akka.Distributed.Data.LightningDb is now ready for production use.
+
+To see the full set of changes for Akka.NET 1.4.7, please [see the 1.4.7 milestone](https://github.com/akkadotnet/akka.net/milestone/38).
 
 #### 1.4.6 May 12 2020 ####
 **Maintenance Release for Akka.NET 1.4**

--- a/docs/articles/actors/finite-state-machine.md
+++ b/docs/articles/actors/finite-state-machine.md
@@ -16,15 +16,15 @@ using Akka.Event;
 
 The contract of our `Buncher` actor is that it accepts or produces the following messages:
 
-[!code-csharp[Main](../../../src/core/Akka.Docs.Tests/Actors/FiniteStateMachine/FiniteStateMachine.Messages.cs#L11-L43)]
+[!code-csharp[Main](../../../src/core/Akka.Docs.Tests/Actors/FiniteStateMachine/FiniteStateMachine.Messages.cs#L16-L50)]
 
 `SetTarget` is needed for starting it up, setting the destination for the Batches to be passed on; `Queue` will add to the internal queue while `Flush` will mark the end of a burst.
 
-[!code-csharp[Main](../../../src/core/Akka.Docs.Tests/Actors/FiniteStateMachine/FiniteStateMachine.Messages.cs#L46-L78)]
+[!code-csharp[Main](../../../src/core/Akka.Docs.Tests/Actors/FiniteStateMachine/FiniteStateMachine.Messages.cs#L52-L86)]
 
 The actor can be in two states: no message queued (aka `Idle`) or some message queued (aka `Active`). It will stay in the active state as long as messages keep arriving and no flush is requested. The internal state data of the actor is made up of the target actor reference to send the batches to and the actual queue of messages.
 
-[!code-csharp[Main](../../../src/core/Akka.Docs.Tests/Actors/FiniteStateMachine/ExampleFSMActor.cs?range=8-35,64-67)]
+[!code-csharp[Main](../../../src/core/Akka.Docs.Tests/Actors/FiniteStateMachine/ExampleFSMActor.cs?range=8-42,72-75)]
 
 The basic strategy is to declare the actor, inherit from `FSM` class and specifying the possible states and data values as type parameters. Within the body of the actor a DSL is used for declaring the state machine:
 
@@ -34,13 +34,13 @@ The basic strategy is to declare the actor, inherit from `FSM` class and specify
 
 In this case, we start out in the `Idle` and `Uninitialized` state, where only the `SetTarget()` message is handled; stay prepares to end this event’s processing for not leaving the current state, while the using modifier makes the `FSM` replace the internal state (which is `Uninitialized` at this point) with a fresh `Todo()` object containing the target actor reference. The `Active` state has a state timeout declared, which means that if no message is received for 1 second, a `FSM.StateTimeout` message will be generated. This has the same effect as receiving the `Flush` command in this case, namely to transition back into the Idle state and resetting the internal queue to the empty vector. But how do messages get queued? Since this shall work identically in both states, we make use of the fact that any event which is not handled by the `When()` block is passed to the `WhenUnhandled()` block:
 
-[!code-csharp[Main](../../../src/core/Akka.Docs.Tests/Actors/FiniteStateMachine/ExampleFSMActor.cs?range=37-48)]
+[!code-csharp[Main](../../../src/core/Akka.Docs.Tests/Actors/FiniteStateMachine/ExampleFSMActor.cs?range=44-55)]
 
 The first case handled here is adding `Queue()` requests to the internal queue and going to the `Active` state (this does the obvious thing of staying in the `Active` state if already there), but only if the `FSM` data are not `Uninitialized` when the `Queue()` event is received. Otherwise—and in all other non-handled cases—the second case just logs a warning and does not change the internal state.
 
 The only missing piece is where the `Batches` are actually sent to the target, for which we use the `OnTransition` mechanism: you can declare multiple such blocks and all of them will be tried for matching behavior in case a state transition occurs (i.e. only when the state actually changes).
 
-[!code-csharp[Main](../../../src/core/Akka.Docs.Tests/Actors/FiniteStateMachine/ExampleFSMActor.cs?range=50-63)]
+[!code-csharp[Main](../../../src/core/Akka.Docs.Tests/Actors/FiniteStateMachine/ExampleFSMActor.cs?range=57-70)]
 
 The transition callback is a function which takes as input a pair of states—the current and the next state. The `FSM` class includes a convenience extractor for these in form of an arrow operator, which conveniently reminds you of the direction of the state change which is being matched. During the state change, the old state data is available via `StateData` as shown, and the new state data would be available as `NextStateData`.
 

--- a/docs/articles/clustering/cluster-sharding.md
+++ b/docs/articles/clustering/cluster-sharding.md
@@ -132,7 +132,7 @@ This can be resolved by getting information about shard/entity ids directly from
 >
 > Therefore, this design gives the sharding system a chance to hand over all of the sharded entity actors running on the terminating node over to the other remaining nodes in the cluster.
 
-Given these values we can build consistent, unique `PersistenceId`s on the fly like on the following example:
+Given these values we can build consistent, unique `PersistenceId`s on the fly using the `entityId` (the expectation is that `entityId` are globally unique) as in the following example:
 
 ```csharp
 public class Aggregate : PersistentActor
@@ -141,7 +141,7 @@ public class Aggregate : PersistentActor
 
     public Aggregate()
     {
-        PersistenceId = Context.Parent.Path.Name + "-" + Self.Path.Name;
+        PersistenceId = Self.Path.Name;
     }
 
     ...

--- a/docs/articles/clustering/distributed-data.md
+++ b/docs/articles/clustering/distributed-data.md
@@ -7,13 +7,10 @@ title: Distributed Data
 Akka.DistributedData plugin can be used as in-memory, highly-available, distributed key-value store, where values conform to so called [Conflict-Free Replicated Data Types](http://hal.upmc.fr/inria-00555588/document) (CRDT). Those data types can have replicas across multiple nodes in the cluster, where DistributedData plugin has been initialized. We are free to perform concurrent updates on replicas with the same corresponding key without need of coordination (distributed locks or transactions) - all state changes will eventually converge with conflicts being automatically resolved, thanks to the nature of CRDTs. To use distributed data plugin, simply install it via NuGet:
 
 ```
-install-package Akka.DistributedData -pre
+install-package Akka.DistributedData
 ```
 
 Keep in mind, that CRDTs are intended for high-availability, non-blocking read/write scenarios. However they are not a good fit, when you need strong consistency or are operating on big data. If you want to have millions of data entries, this is NOT a way to go. Keep in mind, that all data is kept in memory and, as state-based CRDTs, whole object state is replicated remotely across the nodes, when an update happens. A more efficient implementations (delta-based CRDTs) are considered for the future implementations.
-
-> [!WARNING]
->  At the present moment, Akka.DistributedData plugin is in state of flux. This means, that its API is unstable and the performance is yet to improve.
 
 ## Basic operations
 

--- a/src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj
+++ b/src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/common.props
+++ b/src/common.props
@@ -14,7 +14,7 @@
     <HyperionVersion>0.9.15</HyperionVersion>
     <NewtonsoftJsonVersion>12.0.3</NewtonsoftJsonVersion>
     <NBenchVersion>2.0.1</NBenchVersion>
-    <ProtobufVersion>3.11.4</ProtobufVersion>
+    <ProtobufVersion>3.12.1</ProtobufVersion>
     <NetCoreTestVersion>netcoreapp3.1</NetCoreTestVersion>
     <NetFrameworkTestVersion>net461</NetFrameworkTestVersion>
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Akka.Cluster.Sharding.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Akka.Cluster.Sharding.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\..\..\core\Akka.Coordination\Akka.Coordination.csproj" />
     <ProjectReference Include="..\..\..\core\Akka.Persistence\Akka.Persistence.csproj" />
     <ProjectReference Include="..\Akka.Cluster.Tools\Akka.Cluster.Tools.csproj" />
+    <ProjectReference Include="..\Akka.DistributedData.LightningDB\Akka.DistributedData.LightningDB.csproj" />
     <ProjectReference Include="..\Akka.DistributedData\Akka.DistributedData.csproj" />
   </ItemGroup>
 

--- a/src/contrib/cluster/Akka.DistributedData.LightningDB/Akka.DistributedData.LightningDB.csproj
+++ b/src/contrib/cluster/Akka.DistributedData.LightningDB/Akka.DistributedData.LightningDB.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <AssemblyTitle>Akka.DistributedData.LightningDB</AssemblyTitle>
     <Description>Replicated data using CRDT structures</Description>
-    <VersionSuffix>beta</VersionSuffix>
     <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
     <PackageTags>$(AkkaPackageTags);network;cluster;crdt;replication;lightningdb;lmdb</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/contrib/cluster/Akka.DistributedData.LightningDB/LmdbDurableStore.cs
+++ b/src/contrib/cluster/Akka.DistributedData.LightningDB/LmdbDurableStore.cs
@@ -15,7 +15,9 @@ using Akka.Configuration;
 using Akka.DistributedData.Durable;
 using Akka.Event;
 using Akka.Serialization;
+using Akka.DistributedData.Internal;
 using LightningDB;
+using System.Diagnostics;
 
 namespace Akka.DistributedData.LightningDB
 {
@@ -36,73 +38,96 @@ namespace Akka.DistributedData.LightningDB
     /// </summary>
     public sealed class LmdbDurableStore : ReceiveActor
     {
+        public static Actor.Props Props(Config config) => Actor.Props.Create(() => new LmdbDurableStore(config));
+
         public const string DatabaseName = "ddata";
+
         private sealed class WriteBehind
         {
             public static readonly WriteBehind Instance = new WriteBehind();
             private WriteBehind() { }
         }
 
-        public static Actor.Props Props(Config config) => Actor.Props.Create(() => new LmdbDurableStore(config));
+        private readonly Config _config;
+        private readonly Akka.Serialization.Serialization _serialization;
+        private readonly SerializerWithStringManifest _serializer;
+        private readonly string _manifest;
 
         private readonly TimeSpan _writeBehindInterval;
+        private readonly string _dir;
+
         private readonly Dictionary<string, DurableDataEnvelope> _pending = new Dictionary<string, DurableDataEnvelope>();
-        private readonly LightningEnvironment _environment;
         private readonly ILoggingAdapter _log;
-        private readonly Serializer _serializer;
+
+        private (LightningEnvironment env, LightningDatabase db, bool initialized) _lmdb;
+        // Lazy init
+        private (LightningEnvironment env, LightningDatabase db, bool initialized) Lmdb
+        {
+            get
+            {
+                if (_lmdb.initialized)
+                    return _lmdb;
+
+                var t0 = Stopwatch.StartNew();
+                _log.Info($"Using durable data in LMDB directory [{_dir}]");
+
+                if (!Directory.Exists(_dir))
+                    Directory.CreateDirectory(_dir);
+
+                var mapSize = _config.GetByteSize("map-size", 100 * 1024 * 1024);
+                var env = new LightningEnvironment(_dir)
+                {
+                    MapSize = mapSize.Value,
+                    MaxDatabases = 1
+                };
+                env.Open(EnvironmentOpenFlags.NoLock);
+
+                using (var tx = env.BeginTransaction())
+                {
+                    var db = tx.OpenDatabase(DatabaseName, new DatabaseConfiguration
+                    {
+                        Flags = DatabaseOpenFlags.Create
+                    });
+                    tx.Commit();
+
+                    t0.Stop();
+                    if (_log.IsDebugEnabled)
+                        _log.Debug($"Init of LMDB in directory [{_dir}] took [{t0.ElapsedMilliseconds} ms]");
+
+                    _lmdb = (env, db, true);
+                    return _lmdb;
+                }
+            }
+        }
+
+        public bool IsDbInitialized => _lmdb.initialized;
 
         public LmdbDurableStore(Config config)
         {
-            config = config.GetConfig("lmdb");
-            if (config.IsNullOrEmpty())
+            _config = config.GetConfig("lmdb");
+            if (_config.IsNullOrEmpty())
                 throw ConfigurationException.NullOrEmptyConfig<LmdbDurableStore>("akka.cluster.distributed-data.durable.lmdb");
 
             _log = Context.GetLogger();
 
-            var useWriteBehind = config.GetString("write-behind-interval", "").ToLowerInvariant();
+            _serialization = Context.System.Serialization;
+            _serializer = (SerializerWithStringManifest) _serialization.FindSerializerForType(typeof(DurableDataEnvelope));
+            _manifest = _serializer.Manifest(new DurableDataEnvelope(GCounter.Empty));
+
+            var useWriteBehind = _config.GetString("write-behind-interval", "").ToLowerInvariant();
             _writeBehindInterval = 
                 useWriteBehind == "off" ||
                 useWriteBehind == "false" ||
                 useWriteBehind == "no" ? 
-                    TimeSpan.Zero : 
-                    config.GetTimeSpan("write-behind-interval");
+                    TimeSpan.Zero :
+                    _config.GetTimeSpan("write-behind-interval");
 
-            var mapSize = config.GetByteSize("map-size");
-            var dirPath = config.GetString("dir");
-            if (dirPath.EndsWith("ddata"))
-            {
-                dirPath = $"path-{Context.System.Name}-{Self.Path.Parent.Name}-{Cluster.Cluster.Get(Context.System).SelfAddress.Port}";
-            }
-
-            if (!Directory.Exists(dirPath))
-            {
-                Directory.CreateDirectory(dirPath);
-            }
-
-            _environment = new LightningEnvironment(dirPath, new EnvironmentConfiguration
-            {
-                MapSize = mapSize ?? (100 * 1024 * 1024),
-                MaxDatabases = 1
-            });
-            _environment.Open(EnvironmentOpenFlags.NoLock);
-
-            using (var tx = _environment.BeginTransaction())
-            using (var db = tx.OpenDatabase(configuration: new DatabaseConfiguration { Flags = DatabaseOpenFlags.Create }))
-            {
-                // just create
-            }
-            
-            _serializer = Context.System.Serialization.FindSerializerForType(typeof(DurableDataEnvelope));
+            var path = _config.GetString("dir");
+            _dir = path.EndsWith(DatabaseName)
+                ? Path.GetFullPath($"{path}-{Context.System.Name}-{Self.Path.Parent.Name}-{Cluster.Cluster.Get(Context.System).SelfAddress.Port}")
+                : Path.GetFullPath(path);
 
             Init();
-        }
-
-        protected override void PostStop()
-        {
-            base.PostStop();
-            DoWriteBehind();
-            //_db.Dispose();
-            _environment.Dispose();
         }
 
         protected override void PostRestart(Exception reason)
@@ -112,20 +137,31 @@ namespace Akka.DistributedData.LightningDB
             Become(Active);
         }
 
+        protected override void PostStop()
+        {
+            base.PostStop();
+            DoWriteBehind();
+
+            if(IsDbInitialized)
+            {
+                var (env, db, _) = Lmdb;
+                try { db.Dispose(); } catch { }
+                try { env.Dispose(); } catch { }
+            }
+        }
+
         private void Active()
         {
             Receive<Store>(store =>
             {
-                var reply = store.Reply;
-
                 try
                 {
+                    var l = Lmdb; // init
                     if (_writeBehindInterval == TimeSpan.Zero)
                     {
-                        using (var tx = _environment.BeginTransaction())
-                        using (var db = tx.OpenDatabase())
+                        using (var tx = l.env.BeginTransaction())
                         {
-                            DbPut(tx, db, store.Key, store.Data);
+                            DbPut(tx, store.Key, store.Data);
                             tx.Commit();
                         }
                     }
@@ -136,14 +172,15 @@ namespace Akka.DistributedData.LightningDB
                         _pending[store.Key] = store.Data;
                     }
 
-                    reply?.ReplyTo.Tell(reply.SuccessMessage);
+                    store.Reply?.ReplyTo.Tell(store.Reply.SuccessMessage);
                 }
                 catch (Exception cause)
                 {
-                    _log.Error(cause, "Failed to store [{0}]", store.Key);
-                    reply?.ReplyTo.Tell(reply.FailureMessage);
+                    _log.Error(cause, "Failed to store [{0}]:{1}", store.Key, cause);
+                    store.Reply?.ReplyTo.Tell(store.Reply.FailureMessage);
                 }
             });
+
             Receive<WriteBehind>(_ => DoWriteBehind());
         }
 
@@ -151,21 +188,29 @@ namespace Akka.DistributedData.LightningDB
         {
             Receive<LoadAll>(loadAll =>
             {
-                var t0 = System.DateTime.UtcNow;
-                using (var tx = _environment.BeginTransaction(TransactionBeginFlags.ReadOnly))
-                using (var db = tx.OpenDatabase())
-                using (var cursor = tx.CreateCursor(db))
+                if(_dir.Length == 0 || !Directory.Exists(_dir))
+                {
+                    // no files to load
+                    Sender.Tell(LoadAllCompleted.Instance);
+                    Become(Active);
+                    return;
+                }
+
+                var l = Lmdb;
+                var t0 = Stopwatch.StartNew();
+                using (var tx = l.env.BeginTransaction(TransactionBeginFlags.ReadOnly))
+                using (var cursor = tx.CreateCursor(l.db))
                 {
                     try
                     {
                         var n = 0;
-                        var builder = ImmutableDictionary<string, DurableDataEnvelope>.Empty.ToBuilder();
+                        var builder = ImmutableDictionary.CreateBuilder<string, DurableDataEnvelope>();
                         foreach (var entry in cursor)
                         {
                             n++;
                             var key = Encoding.UTF8.GetString(entry.Key);
-                            var envelope = (DurableDataEnvelope)_serializer.FromBinary(entry.Value, typeof(DurableDataEnvelope));
-                            builder.Add(new KeyValuePair<string, DurableDataEnvelope>(key, envelope));
+                            var envelope = (DurableDataEnvelope)_serializer.FromBinary(entry.Value, _manifest);
+                            builder.Add(key, envelope);
                         }
 
                         if (builder.Count > 0)
@@ -176,45 +221,50 @@ namespace Akka.DistributedData.LightningDB
 
                         Sender.Tell(LoadAllCompleted.Instance);
 
+                        t0.Stop();
                         if (_log.IsDebugEnabled)
-                            _log.Debug("Load all of [{0}] entries took [{1}]", n, DateTime.UtcNow - t0);
+                            _log.Debug($"Load all of [{n}] entries took [{t0.ElapsedMilliseconds}]");
 
                         Become(Active);
                     }
                     catch (Exception e)
                     {
+                        if (t0.IsRunning) t0.Stop();
                         throw new LoadFailedException("failed to load durable distributed-data", e);
                     }
                 }
             });
         }
 
-        private void DbPut(LightningTransaction tx, LightningDatabase db, string key, DurableDataEnvelope data)
+        private void DbPut(LightningTransaction tx, string key, DurableDataEnvelope data)
         {
             var byteKey = Encoding.UTF8.GetBytes(key);
             var byteValue = _serializer.ToBinary(data);
-            tx.Put(db, byteKey, byteValue);
+
+            var l = Lmdb;
+            tx.Put(l.db, byteKey, byteValue);
         }
 
         private void DoWriteBehind()
         {
             if (_pending.Count > 0)
             {
-                var t0 = DateTime.UtcNow;
-                using (var tx = _environment.BeginTransaction())
-                using (var db = tx.OpenDatabase())
+                var (env, _, _) = Lmdb;
+                var t0 = Stopwatch.StartNew();
+                using (var tx = env.BeginTransaction())
                 {
                     try
                     {
                         foreach (var entry in _pending)
                         {
-                            DbPut(tx, db, entry.Key, entry.Value);
+                            DbPut(tx, entry.Key, entry.Value);
                         }
                         tx.Commit();
 
+                        t0.Stop();
                         if (_log.IsDebugEnabled)
                         {
-                            _log.Debug("store and commit of [{0}] entries took {1} ms", _pending.Count, (DateTime.UtcNow - t0).TotalMilliseconds);
+                            _log.Debug($"store and commit of [{_pending.Count}] entries took {t0.ElapsedMilliseconds} ms");
                         }
                     }
                     catch (Exception cause)

--- a/src/contrib/cluster/Akka.DistributedData.Tests.MultiNode/Akka.DistributedData.Tests.MultiNode.csproj
+++ b/src/contrib/cluster/Akka.DistributedData.Tests.MultiNode/Akka.DistributedData.Tests.MultiNode.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
  
   <ItemGroup>
+    <ProjectReference Include="..\Akka.DistributedData.LightningDB\Akka.DistributedData.LightningDB.csproj" />
     <ProjectReference Include="..\Akka.DistributedData\Akka.DistributedData.csproj" />
     <ProjectReference Include="..\..\..\core\Akka.Cluster.TestKit\Akka.Cluster.TestKit.csproj" />
     <ProjectReference Include="..\..\..\core\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj" />

--- a/src/contrib/cluster/Akka.DistributedData.Tests.MultiNode/DurableDataSpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests.MultiNode/DurableDataSpec.cs
@@ -7,12 +7,15 @@
 
 using System;
 using System.Collections.Immutable;
+using System.IO;
 using Akka.Actor;
+using Akka.Cluster;
 using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.DistributedData.Durable;
 using Akka.Remote.TestKit;
 using Akka.TestKit;
+using FluentAssertions;
 
 namespace Akka.DistributedData.Tests.MultiNode
 {
@@ -28,18 +31,24 @@ namespace Akka.DistributedData.Tests.MultiNode
             First = Role("first");
             Second = Role("second");
 
-            var writeBehindInterval = writeBehind ? "200ms" : "off";
-            CommonConfig = ConfigurationFactory.ParseString(@"
-            akka.loglevel = INFO
-            akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""
-            akka.log-dead-letters-during-shutdown = off
-            akka.cluster.distributed-data.durable.keys = [""durable*""]
-            akka.cluster.distributed-data.durable.lmdb {
-              dir = ""target/DurableDataSpec-" + DateTime.UtcNow.Ticks + @"-ddata""
-              map-size = 10 MiB
-              write-behind-interval = " + writeBehindInterval + @"
-            }
-            akka.test.single-expect-default = 5s").WithFallback(DistributedData.DefaultConfig());
+            var tempDir = Path.Combine(Path.GetTempPath(), "target", $"DurableDataSpec-{DateTime.UtcNow.Ticks}-ddata");
+            CommonConfig = DebugConfig(false)
+                .WithFallback(ConfigurationFactory.ParseString($@"
+                akka.loglevel = INFO
+                akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""
+                akka.log-dead-letters-during-shutdown = off
+                akka.cluster.distributed-data.durable.keys = [""durable*""]
+                akka.cluster.distributed-data.durable.lmdb {{
+                    dir = """"""{tempDir}""""""
+                    map-size = 10 MiB
+                    write-behind-interval = {(writeBehind ? "200ms" : "off")}
+                }}
+                akka.cluster.distributed-data.durable.store-actor-class = ""Akka.DistributedData.LightningDB.LmdbDurableStore, Akka.DistributedData.LightningDB""
+                # initialization of lmdb can be very slow in CI environment
+                akka.test.single-expect-default = 15s"))
+                .WithFallback(DistributedData.DefaultConfig());
+
+            TestTransport = true;
         }
     }
 
@@ -60,7 +69,7 @@ namespace Akka.DistributedData.Tests.MultiNode
         }
     }
 
-    public abstract class DurableDataSpec : MultiNodeClusterSpec
+    public abstract class DurableDataSpecBase : MultiNodeClusterSpec
     {
         public static Props TestDurableStoreProps(bool failLoad = false, bool failStore = false)
         {
@@ -70,7 +79,6 @@ namespace Akka.DistributedData.Tests.MultiNode
         private readonly RoleName first;
         private readonly RoleName second;
         private readonly Cluster.Cluster cluster;
-        private readonly TimeSpan timeout = TimeSpan.FromSeconds(5);
         private readonly IWriteConsistency writeTwo;
         private readonly IReadConsistency readTwo;
 
@@ -80,19 +88,18 @@ namespace Akka.DistributedData.Tests.MultiNode
 
         private int testStepCounter = 0;
 
-        protected DurableDataSpec(DurableDataSpecConfig config, Type type) : base(config, type)
+        protected DurableDataSpecBase(DurableDataSpecConfig config, Type type) : base(config, type)
         {
-            InitialParticipantsValueFactory = Roles.Count;
             cluster = Akka.Cluster.Cluster.Get(Sys);
+            var timeout = Dilated(14.Seconds()); // initialization of lmdb can be very slow in CI environment
             writeTwo = new WriteTo(2, timeout);
             readTwo = new ReadFrom(2, timeout);
+
             first = config.First;
             second = config.Second;
         }
 
-        protected override int InitialParticipantsValueFactory { get; }
-
-        [MultiNodeFact(Skip = "FIXME")]
+        [MultiNodeFact]
         public void DurableDataSpec_Tests()
         {
             Durable_CRDT_should_work_in_a_single_node_cluster();
@@ -105,41 +112,59 @@ namespace Akka.DistributedData.Tests.MultiNode
 
         public void Durable_CRDT_should_work_in_a_single_node_cluster()
         {
-            Join(first, second);
+            Join(first, first);
 
             RunOn(() =>
             {
-                var r = NewReplicator(Sys);
+                var r = NewReplicator();
                 Within(TimeSpan.FromSeconds(10), () =>
-               {
-                   AwaitAssert(() =>
-                   {
-                       r.Tell(Dsl.GetReplicaCount);
-                       ExpectMsg(new ReplicaCount(1));
-                   });
-               });
+                {
+                    AwaitAssert(() =>
+                    {
+                        r.Tell(Dsl.GetReplicaCount);
+                        ExpectMsg(new ReplicaCount(1));
+                    });
+                });
 
-                r.Tell(Dsl.Get(keyA, ReadLocal.Instance));
-                ExpectMsg(new NotFound(keyA, null));
+                Within(TimeSpan.FromSeconds(10), () =>
+                {
+                    AwaitAssert(() =>
+                    {
+                        r.Tell(Dsl.Get(keyA, ReadLocal.Instance));
+                        ExpectMsg(new NotFound(keyA, null));
+                    });
+                });
 
-                r.Tell(Dsl.Update(keyA, GCounter.Empty, WriteLocal.Instance, c => c.Increment(cluster)));
-                r.Tell(Dsl.Update(keyA, GCounter.Empty, WriteLocal.Instance, c => c.Increment(cluster)));
-                r.Tell(Dsl.Update(keyA, GCounter.Empty, WriteLocal.Instance, c => c.Increment(cluster)));
+                Within(TimeSpan.FromSeconds(10), () =>
+                {
+                    AwaitAssert(() =>
+                    {
+                        r.Tell(Dsl.Update(keyA, GCounter.Empty, WriteLocal.Instance, c => c.Increment(cluster)));
+                        r.Tell(Dsl.Update(keyA, GCounter.Empty, WriteLocal.Instance, c => c.Increment(cluster)));
+                        r.Tell(Dsl.Update(keyA, GCounter.Empty, WriteLocal.Instance, c => c.Increment(cluster)));
 
-                ExpectMsg(new UpdateSuccess(keyA, null));
-                ExpectMsg(new UpdateSuccess(keyA, null));
-                ExpectMsg(new UpdateSuccess(keyA, null));
+                        ExpectMsg(new UpdateSuccess(keyA, null));
+                        ExpectMsg(new UpdateSuccess(keyA, null));
+                        ExpectMsg(new UpdateSuccess(keyA, null));
+                    });
+                });
 
                 Watch(r);
                 Sys.Stop(r);
                 ExpectTerminated(r);
 
                 var r2 = default(IActorRef);
-                AwaitAssert(() => r2 = NewReplicator(Sys)); // try until name is free
+                AwaitAssert(() => r2 = NewReplicator()); // try until name is free
 
-                // note that it will stash the commands until loading completed
-                r2.Tell(Dsl.Get(keyA, ReadLocal.Instance));
-                ExpectMsg<GetSuccess>().Get(keyA).Value.ShouldBe(3UL);
+                Within(TimeSpan.FromSeconds(10), () =>
+                {
+                    AwaitAssert(() =>
+                    {
+                        // note that it will stash the commands until loading completed
+                        r2.Tell(Dsl.Get(keyA, ReadLocal.Instance));
+                        ExpectMsg<GetSuccess>().Get(keyA).Value.ShouldBe(3UL);
+                    });
+                });
 
                 Watch(r2);
                 Sys.Stop(r2);
@@ -152,9 +177,10 @@ namespace Akka.DistributedData.Tests.MultiNode
 
         public void Durable_CRDT_should_work_in_a_multi_node_cluster()
         {
+            Join(first, first);
             Join(second, first);
 
-            var r = NewReplicator(Sys);
+            var r = NewReplicator();
             Within(TimeSpan.FromSeconds(10), () =>
             {
                 AwaitAssert(() =>
@@ -166,19 +192,43 @@ namespace Akka.DistributedData.Tests.MultiNode
 
             EnterBarrier("both-initialized");
 
-            r.Tell(Dsl.Update(keyA, GCounter.Empty, writeTwo, c => c.Increment(cluster)));
-            ExpectMsg(new UpdateSuccess(keyA, null));
+            Within(TimeSpan.FromSeconds(10), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    r.Tell(Dsl.Update(keyA, GCounter.Empty, writeTwo, c => c.Increment(cluster)));
+                    ExpectMsg(new UpdateSuccess(keyA, null));
+                });
+            });
 
-            r.Tell(Dsl.Update(keyC, ORSet<string>.Empty, writeTwo, c => c.Add(cluster, Myself.Name)));
-            ExpectMsg(new UpdateSuccess(keyC, null));
+            Within(TimeSpan.FromSeconds(10), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    r.Tell(Dsl.Update(keyC, ORSet<string>.Empty, writeTwo, c => c.Add(cluster, Myself.Name)));
+                    ExpectMsg(new UpdateSuccess(keyC, null));
+                });
+            });
 
             EnterBarrier("update-done-" + testStepCounter);
 
-            r.Tell(Dsl.Get(keyA, readTwo));
-            ExpectMsg<GetSuccess>().Get(keyA).Value.ShouldBe(2UL);
+            Within(TimeSpan.FromSeconds(10), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    r.Tell(Dsl.Get(keyA, readTwo));
+                    ExpectMsg<GetSuccess>().Get(keyA).Value.ShouldBe(2UL);
+                });
+            });
 
-            r.Tell(Dsl.Get(keyC, readTwo));
-            ExpectMsg<GetSuccess>().Get(keyC).Elements.ShouldBe(ImmutableHashSet.CreateRange(new[] { first.Name, second.Name }));
+            Within(TimeSpan.FromSeconds(10), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    r.Tell(Dsl.Get(keyC, readTwo));
+                    ExpectMsg<GetSuccess>().Get(keyC).Elements.ShouldBe(ImmutableHashSet.CreateRange(new[] { first.Name, second.Name }));
+                });
+            });
 
             EnterBarrier("values-verified-" + testStepCounter);
 
@@ -187,56 +237,92 @@ namespace Akka.DistributedData.Tests.MultiNode
             ExpectTerminated(r);
 
             var r2 = default(IActorRef);
-            AwaitAssert(() => r2 = NewReplicator(Sys)); // try until name is free
+            AwaitAssert(() => r2 = NewReplicator()); // try until name is free
             AwaitAssert(() =>
             {
                 r2.Tell(Dsl.GetKeyIds);
                 ExpectMsg<GetKeysIdsResult>().Keys.ShouldNotBe(ImmutableHashSet<string>.Empty);
             });
 
-            r2.Tell(Dsl.Get(keyA, ReadLocal.Instance));
-            ExpectMsg<GetSuccess>().Get(keyA).Value.ShouldBe(2UL);
+            Within(TimeSpan.FromSeconds(10), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    r2.Tell(Dsl.Get(keyA, ReadLocal.Instance));
+                    ExpectMsg<GetSuccess>().Get(keyA).Value.ShouldBe(2UL);
+                });
+            });
 
-            r2.Tell(Dsl.Get(keyC, ReadLocal.Instance));
-            ExpectMsg<GetSuccess>().Get(keyC).Elements.ShouldBe(ImmutableHashSet.CreateRange(new[] { first.Name, second.Name }));
+            Within(TimeSpan.FromSeconds(10), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    r2.Tell(Dsl.Get(keyC, ReadLocal.Instance));
+                    ExpectMsg<GetSuccess>().Get(keyC).Elements.ShouldBe(ImmutableHashSet.CreateRange(new[] { first.Name, second.Name }));
+                });
+            });
 
             EnterBarrierAfterTestStep();
         }
 
         public void Durable_CRDT_should_be_durable_after_gossip_update()
         {
-            var r = NewReplicator(Sys);
+            var r = NewReplicator();
 
             RunOn(() =>
             {
-                r.Tell(Dsl.Update(keyC, ORSet<string>.Empty, WriteLocal.Instance, c => c.Add(cluster, Myself.Name)));
-                ExpectMsg(new UpdateSuccess(keyC, null));
+                Within(TimeSpan.FromSeconds(10), () =>
+                {
+                    AwaitAssert(() =>
+                    {
+                        r.Tell(Dsl.Update(keyC, ORSet<string>.Empty, WriteLocal.Instance, c => c.Add(cluster, Myself.Name)));
+                        ExpectMsg(new UpdateSuccess(keyC, null));
+                    });
+                });
             }, first);
 
             RunOn(() =>
             {
-                r.Tell(Dsl.Subscribe(keyC, TestActor));
-                ExpectMsg<Changed>().Get(keyC).Elements.ShouldBe(ImmutableHashSet.Create(first.Name));
+                Within(TimeSpan.FromSeconds(10), () =>
+                {
+                    AwaitAssert(() =>
+                    {
+                        r.Tell(Dsl.Subscribe(keyC, TestActor));
+                        ExpectMsg<Changed>().Get(keyC).Elements.ShouldBe(ImmutableHashSet.Create(first.Name));
+                    });
+                });
 
-                // must do one more roundtrip to be sure that it keyB is stored, since Changed might have
-                // been sent out before storage
-                r.Tell(Dsl.Update(keyA, GCounter.Empty, WriteLocal.Instance, c => c.Increment(cluster)));
-                ExpectMsg(new UpdateSuccess(keyA, null));
+                Within(TimeSpan.FromSeconds(10), () =>
+                {
+                    AwaitAssert(() =>
+                    {
+                        // must do one more roundtrip to be sure that it keyB is stored, since Changed might have
+                        // been sent out before storage
+                        r.Tell(Dsl.Update(keyA, GCounter.Empty, WriteLocal.Instance, c => c.Increment(cluster)));
+                        ExpectMsg(new UpdateSuccess(keyA, null));
+                    });
+                });
 
                 Watch(r);
                 Sys.Stop(r);
                 ExpectTerminated(r);
 
                 var r2 = default(IActorRef);
-                AwaitAssert(() => r2 = NewReplicator(Sys));
+                AwaitAssert(() => r2 = NewReplicator());
                 AwaitAssert(() =>
                 {
                     r2.Tell(Dsl.GetKeyIds);
                     ExpectMsg<GetKeysIdsResult>().Keys.ShouldNotBe(ImmutableHashSet<string>.Empty);
                 });
 
-                r2.Tell(Dsl.Get(keyC, ReadLocal.Instance));
-                ExpectMsg<GetSuccess>().Get(keyC).Elements.ShouldBe(ImmutableHashSet.Create(first.Name));
+                Within(TimeSpan.FromSeconds(10), () =>
+                {
+                    AwaitAssert(() =>
+                    {
+                        r2.Tell(Dsl.Get(keyC, ReadLocal.Instance));
+                        ExpectMsg<GetSuccess>().Get(keyC).Elements.ShouldBe(ImmutableHashSet.Create(first.Name));
+                    });
+                });
 
             }, second);
 
@@ -265,18 +351,30 @@ namespace Akka.DistributedData.Tests.MultiNode
                             });
                         });
 
-                        r.Tell(Dsl.Get(keyA, ReadLocal.Instance));
-                        ExpectMsg(new NotFound(keyA, null));
+                        Within(TimeSpan.FromSeconds(10), () =>
+                        {
+                            AwaitAssert(() =>
+                            {
+                                r.Tell(Dsl.Get(keyA, ReadLocal.Instance));
+                                ExpectMsg(new NotFound(keyA, null));
+                            });
+                        });
 
-                        r.Tell(Dsl.Update(keyA, GCounter.Empty, WriteLocal.Instance, c => c.Increment(cluster1)));
-                        r.Tell(Dsl.Update(keyA, GCounter.Empty, WriteLocal.Instance, c => c.Increment(cluster1)));
-                        r.Tell(Dsl.Update(keyA, GCounter.Empty, WriteLocal.Instance, c => c.Increment(cluster1)));
-                        r.Tell(Dsl.Update(keyB, GCounter.Empty, WriteLocal.Instance, c => c.Increment(cluster1)));
+                        Within(TimeSpan.FromSeconds(10), () =>
+                        {
+                            AwaitAssert(() =>
+                            {
+                                r.Tell(Dsl.Update(keyA, GCounter.Empty, WriteLocal.Instance, c => c.Increment(cluster1)));
+                                r.Tell(Dsl.Update(keyA, GCounter.Empty, WriteLocal.Instance, c => c.Increment(cluster1)));
+                                r.Tell(Dsl.Update(keyA, GCounter.Empty, WriteLocal.Instance, c => c.Increment(cluster1)));
+                                r.Tell(Dsl.Update(keyB, GCounter.Empty, WriteLocal.Instance, c => c.Increment(cluster1)));
 
-                        ExpectMsg(new UpdateSuccess(keyA, null));
-                        ExpectMsg(new UpdateSuccess(keyA, null));
-                        ExpectMsg(new UpdateSuccess(keyA, null));
-                        ExpectMsg(new UpdateSuccess(keyB, null));
+                                ExpectMsg(new UpdateSuccess(keyA, null));
+                                ExpectMsg(new UpdateSuccess(keyA, null));
+                                ExpectMsg(new UpdateSuccess(keyA, null));
+                                ExpectMsg(new UpdateSuccess(keyB, null));
+                            });
+                        });
 
                         Watch(r);
                         sys1.Stop(r);
@@ -288,17 +386,28 @@ namespace Akka.DistributedData.Tests.MultiNode
                     sys1.Terminate().Wait(TimeSpan.FromSeconds(10));
                 }
 
-                var sys2 = ActorSystem.Create("AdditionalSys", Sys.Settings.Config);
+                
+                var sys2 = ActorSystem.Create(
+                    "AdditionalSys", 
+                    ConfigurationFactory.ParseString($"akka.remote.dot-netty.tcp.port = {addr.Port}")
+                    .WithFallback(Sys.Settings.Config));
                 try
                 {
-                    Akka.Cluster.Cluster.Get(sys2).Join(addr);
+                    var cluster2 = Akka.Cluster.Cluster.Get(sys2);
+                    cluster2.Join(addr);
                     /* new TestKit(sys1) with ImplicitSender */
                     {
                         var r2 = NewReplicator(sys2);
 
-                        // it should be possible to update while loading is in progress
-                        r2.Tell(Dsl.Update(keyB, GCounter.Empty, WriteLocal.Instance, c => c.Increment(Akka.Cluster.Cluster.Get(sys2))));
-                        ExpectMsg(new UpdateSuccess(keyB, null));
+                        Within(TimeSpan.FromSeconds(10), () =>
+                        {
+                            AwaitAssert(() =>
+                            {
+                                // it should be possible to update while loading is in progress
+                                r2.Tell(Dsl.Update(keyB, GCounter.Empty, WriteLocal.Instance, c => c.Increment(cluster2)));
+                                ExpectMsg(new UpdateSuccess(keyB, null));
+                            });
+                        });
 
                         // wait until all loaded
                         AwaitAssert(() =>
@@ -307,20 +416,34 @@ namespace Akka.DistributedData.Tests.MultiNode
                             ExpectMsg<GetKeysIdsResult>().Keys.ShouldBe(ImmutableHashSet.CreateRange(new [] { keyA.Id, keyB.Id }));   
                         });
 
-                        r2.Tell(Dsl.Get(keyA, ReadLocal.Instance));
-                        ExpectMsg<GetSuccess>().Get(keyA).Value.ShouldBe(3UL);
+                        Within(TimeSpan.FromSeconds(10), () =>
+                        {
+                            AwaitAssert(() =>
+                            {
+                                r2.Tell(Dsl.Get(keyA, ReadLocal.Instance));
+                                ExpectMsg<GetSuccess>().Get(keyA).Value.ShouldBe(3UL);
+                            });
+                        });
 
-                        r2.Tell(Dsl.Get(keyB, ReadLocal.Instance));
-                        ExpectMsg<GetSuccess>().Get(keyB).Value.ShouldBe(2UL);
+                        Within(TimeSpan.FromSeconds(10), () =>
+                        {
+                            AwaitAssert(() =>
+                            {
+                                r2.Tell(Dsl.Get(keyB, ReadLocal.Instance));
+                                ExpectMsg<GetSuccess>().Get(keyB).Value.ShouldBe(2UL);
+                            });
+                        });
                     }
                 }
                 finally
                 {
-                    sys1.Terminate().Wait(TimeSpan.FromSeconds(10));
+                    sys2.Terminate().Wait(TimeSpan.FromSeconds(10));
                 }
 
             }, first);
+            Log.Info("Setup complete");
             EnterBarrierAfterTestStep();
+            Log.Info("All setup complete");
         }
 
         public void Durable_CRDT_should_stop_Replicator_if_Load_fails()
@@ -357,8 +480,10 @@ namespace Akka.DistributedData.Tests.MultiNode
             EnterBarrier("after-" + testStepCounter);
         }
 
-        private IActorRef NewReplicator(ActorSystem system)
+        private IActorRef NewReplicator(ActorSystem system = null)
         {
+            if (system == null) system = Sys;
+
             return system.ActorOf(Replicator.Props(
                     ReplicatorSettings.Create(system).WithGossipInterval(TimeSpan.FromSeconds(1))),
                 "replicator-" + testStepCounter);
@@ -374,13 +499,13 @@ namespace Akka.DistributedData.Tests.MultiNode
         }
     }
 
-    public class DurableDataSpecNode1 : DurableDataSpec
+    public class DurableDataSpec : DurableDataSpecBase
     {
-        public DurableDataSpecNode1() : base(new DurableDataSpecConfig(writeBehind: false), typeof(DurableDataSpecNode1)) { }
+        public DurableDataSpec() : base(new DurableDataSpecConfig(writeBehind: false), typeof(DurableDataSpec)) { }
     }
 
-    public class DurableDataWriteBehindSpecNode1 : DurableDataSpec
+    public class DurableDataWriteBehindSpec : DurableDataSpecBase
     {
-        public DurableDataWriteBehindSpecNode1() : base(new DurableDataSpecConfig(writeBehind: true), typeof(DurableDataWriteBehindSpecNode1)) { }
+        public DurableDataWriteBehindSpec() : base(new DurableDataSpecConfig(writeBehind: true), typeof(DurableDataWriteBehindSpec)) { }
     }
 }

--- a/src/contrib/cluster/Akka.DistributedData.Tests/Serialization/ReplicatorMessageSerializerSpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/Serialization/ReplicatorMessageSerializerSpec.cs
@@ -14,8 +14,12 @@ using Akka.DistributedData.Internal;
 using Google.Protobuf;
 using Xunit;
 using Xunit.Abstractions;
+using FluentAssertions;
 using Address = Akka.Actor.Address;
 using UniqueAddress = Akka.Cluster.UniqueAddress;
+using Akka.DistributedData.Serialization;
+using Akka.DistributedData.Durable;
+using System.Linq;
 
 namespace Akka.DistributedData.Tests.Serialization
 {
@@ -28,17 +32,29 @@ namespace Akka.DistributedData.Tests.Serialization
             }
             akka.remote.dot-netty.tcp.port = 0").WithFallback(DistributedData.DefaultConfig());
 
+        private readonly ReplicatorMessageSerializer _serializer;
+
+        private readonly string _protocol;
+
         private readonly UniqueAddress _address1;
         private readonly UniqueAddress _address2;
         private readonly UniqueAddress _address3;
 
-        private readonly GSetKey<string> _keyA = new GSetKey<string>("A");
+        private readonly GSetKey<string> _keyA;
 
         public ReplicatorMessageSerializerSpec(ITestOutputHelper output) : base(BaseConfig, "ReplicatorMessageSerializerSpec", output)
         {
+            _serializer = new ReplicatorMessageSerializer((ExtendedActorSystem)Sys);
+
+            // We dont have Artery implementation
+            // _protocol = ((RemoteActorRefProvider) ((ExtendedActorSystem)Sys).Provider).RemoteSettings.Artery.Enabled 
+            _protocol = "akka.tcp";
+
             _address1 = new UniqueAddress(new Address("akka.tcp", Sys.Name, "some.host.org", 4711), 1);
             _address2 = new UniqueAddress(new Address("akka.tcp", Sys.Name, "other.host.org", 4711), 2);
             _address3 = new UniqueAddress(new Address("akka.tcp", Sys.Name, "some.host.org", 4711), 3);
+
+            _keyA = new GSetKey<string>("A");
         }
 
         [Fact()]
@@ -46,9 +62,22 @@ namespace Akka.DistributedData.Tests.Serialization
         {
             var ref1 = Sys.ActorOf(Props.Empty, "ref1");
             var data1 = GSet.Create("a");
+            var delta1 = GCounter.Empty.Increment(_address1, 17).Increment(_address2, 2).Delta;
+            var delta2 = delta1.Increment(_address2, 1).Delta;
+            var delta3 = ORSet<string>.Empty.Add(_address1, "a").Delta;
+            var delta4 = ORMultiValueDictionary<string, string>.Empty.AddItem(_address1, "a", "b").Delta;
 
             CheckSerialization(new Get(_keyA, ReadLocal.Instance));
             CheckSerialization(new Get(_keyA, new ReadMajority(TimeSpan.FromSeconds(2)), "x"));
+            CheckSerialization(new Get(_keyA, new ReadMajority(TimeSpan.FromMilliseconds(((double)int.MaxValue) + 50)), "x"));
+            CheckSerialization(new Get(_keyA, new ReadMajority(TimeSpan.FromSeconds(2), 3), "x"));
+            _serializer.Invoking(s =>
+            {
+                s.ToBinary(new Get(_keyA, new ReadMajority(TimeSpan.FromMilliseconds(((double)int.MaxValue) * 3)), "x"));
+            })
+                .ShouldThrow<ArgumentOutOfRangeException>("Our protobuf protocol does not support timeouts larger than unsigned ints")
+                .Which.Message.Contains("unsigned int");
+
             CheckSerialization(new GetSuccess(_keyA, null, data1));
             CheckSerialization(new GetSuccess(_keyA, "x", data1));
             CheckSerialization(new NotFound(_keyA, "x"));
@@ -62,31 +91,73 @@ namespace Akka.DistributedData.Tests.Serialization
                 { _address1, new PruningPerformed(DateTime.UtcNow) },
                 { _address3, new PruningInitialized(_address2, _address1.Address) },
             })));
-            CheckSerialization(new Write("A", new DataEnvelope(data1)));
+            CheckSerialization(new Write("A", new DataEnvelope(data1), _address1));
             CheckSerialization(WriteAck.Instance);
-            CheckSerialization(new Read("A"));
+            CheckSerialization(WriteNack.Instance);
+            CheckSerialization(DeltaNack.Instance);
+            CheckSerialization(new Read("A", _address1));
             CheckSerialization(new ReadResult(new DataEnvelope(data1)));
             CheckSerialization(new ReadResult(null));
+
             CheckSerialization(new Internal.Status(ImmutableDictionary.CreateRange(new[]
             {
                 new KeyValuePair<string, ByteString>("A", ByteString.CopyFromUtf8("a")),
                 new KeyValuePair<string, ByteString>("B", ByteString.CopyFromUtf8("b")),
-            }), 3, 10));
+            }), 3, 10, 17, 19));
+
+            CheckSerialization(new Internal.Status(ImmutableDictionary.CreateRange(new[]
+            {
+                new KeyValuePair<string, ByteString>("A", ByteString.CopyFromUtf8("a")),
+                new KeyValuePair<string, ByteString>("B", ByteString.CopyFromUtf8("b")),
+            }), 3, 10, null, 19)); // (from scala code) can be None when sending back to a node of version 2.5.21
+
             CheckSerialization(new Gossip(ImmutableDictionary.CreateRange(new[]
             {
                 new KeyValuePair<string, DataEnvelope>("A", new DataEnvelope(data1)),
-                new KeyValuePair<string, DataEnvelope>("B", new DataEnvelope(GSet.Create("b").Add("b"))),
-            }), true));
+                new KeyValuePair<string, DataEnvelope>("B", new DataEnvelope(GSet.Create("b").Add("c"))),
+            }), true, 17, 19));
+
+            CheckSerialization(new Gossip(ImmutableDictionary.CreateRange(new[]
+            {
+                new KeyValuePair<string, DataEnvelope>("A", new DataEnvelope(data1)),
+                new KeyValuePair<string, DataEnvelope>("B", new DataEnvelope(GSet.Create("b").Add("c"))),
+            }), true, null, 19)); // (from scala code) can be None when sending back to a node of version 2.5.21
+
+            CheckSerialization(new DeltaPropagation(_address1, true,
+                ImmutableDictionary.CreateRange(new Dictionary<string, Delta>
+                {
+                    { "A", new Delta(new DataEnvelope(delta1), 1, 1) },
+                    { "B", new Delta(new DataEnvelope(delta2), 3, 5) },
+                    { "C", new Delta(new DataEnvelope(delta3), 1, 1) },
+                    { "DC", new Delta(new DataEnvelope(delta4), 1, 1) }
+                })));
+
+            CheckSerialization(new DurableDataEnvelope(data1));
+
+            var pruning = ImmutableDictionary.CreateRange(new Dictionary<UniqueAddress, IPruningState>
+                {
+                    { _address1, new PruningPerformed(DateTime.UtcNow) },
+                    { _address3, new PruningInitialized(_address2, _address1.Address) },
+                });
+            var deserializedDurableDataEnvelope = CheckSerialization(
+                new DurableDataEnvelope(new DataEnvelope(data1, pruning, new SingleVersionVector(_address1, 13))));
+            var expectedPruning = pruning
+                .Where(kvp => kvp.Value is PruningPerformed)
+                .ToDictionary(k => k.Key, v => v.Value);
+            deserializedDurableDataEnvelope.DataEnvelope.Pruning.ShouldAllBeEquivalentTo(expectedPruning);
+            deserializedDurableDataEnvelope.DataEnvelope.DeltaVersions.Count.Should().Be(0);
         }
 
-        private void CheckSerialization(object expected)
+        private T CheckSerialization<T>(T expected)
         {
-            var serializer = Sys.Serialization.FindSerializerFor(expected);
-            var manifest = Akka.Serialization.Serialization.ManifestFor(serializer, expected);
-            var blob = serializer.ToBinary(expected);
-            var actual = Sys.Serialization.Deserialize(blob, serializer.Identifier, manifest);
+            var blob = _serializer.ToBinary(expected);
+            var manifest = _serializer.Manifest(expected);
+            var actual = _serializer.FromBinary(blob, manifest);
 
-            Assert.True(expected.Equals(actual), $"Expected: {expected}\nActual: {actual}");
+            //actual.ShouldBeEquivalentTo(expected);
+            actual.Should().Be(expected);
+            actual.Should().BeOfType(typeof(T));
+            return (T)actual;
         }
     }
 }

--- a/src/contrib/cluster/Akka.DistributedData/DistributedData.cs
+++ b/src/contrib/cluster/Akka.DistributedData/DistributedData.cs
@@ -12,6 +12,7 @@ using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Cluster;
 using Akka.Configuration;
 
 namespace Akka.DistributedData

--- a/src/contrib/cluster/Akka.DistributedData/Durable/Messages.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Durable/Messages.cs
@@ -100,12 +100,16 @@ namespace Akka.DistributedData.Durable
 
     public sealed class DurableDataEnvelope : IReplicatorMessage, IEquatable<DurableDataEnvelope>
     {
-        public readonly DataEnvelope Data;
+        internal DataEnvelope DataEnvelope { get; }
+        public IReplicatedData Data => DataEnvelope.Data;
 
-        public DurableDataEnvelope(DataEnvelope data)
+        public DurableDataEnvelope(DataEnvelope dataEnvelope)
         {
-            Data = data;
+            DataEnvelope = dataEnvelope;
         }
+
+        public DurableDataEnvelope(IReplicatedData data):this(new DataEnvelope(data))
+        { }
 
         public override int GetHashCode()
         {
@@ -116,7 +120,7 @@ namespace Akka.DistributedData.Durable
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return Equals(Data, other.Data);
+            return Data.Equals(other.Data);
         }
 
         public override bool Equals(object obj)

--- a/src/contrib/cluster/Akka.DistributedData/Internal/Internal.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Internal/Internal.cs
@@ -99,16 +99,22 @@ namespace Akka.DistributedData.Internal
         /// TBD
         /// </summary>
         public DataEnvelope Envelope { get; }
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public UniqueAddress FromNode { get; }
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="key">TBD</param>
         /// <param name="envelope">TBD</param>
-        public Write(string key, DataEnvelope envelope)
+        /// <param name="fromNode">TBD</param>
+        public Write(string key, DataEnvelope envelope, UniqueAddress fromNode = null)
         {
             Key = key;
             Envelope = envelope;
+            FromNode = fromNode;
         }
 
         /// <inheritdoc/>
@@ -117,7 +123,7 @@ namespace Akka.DistributedData.Internal
             if (ReferenceEquals(other, null)) return false;
             if (ReferenceEquals(this, other)) return true;
 
-            return Key == other.Key && Equals(Envelope, other.Envelope);
+            return Key == other.Key && Equals(Envelope, other.Envelope) && Equals(FromNode, other.FromNode);
         }
 
         /// <inheritdoc/>
@@ -209,10 +215,17 @@ namespace Akka.DistributedData.Internal
         /// <summary>
         /// TBD
         /// </summary>
+        public UniqueAddress FromNode { get; }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
         /// <param name="key">TBD</param>
-        public Read(string key)
+        /// <param name="fromNode">TBD</param>
+        public Read(string key, UniqueAddress fromNode = null)
         {
             Key = key;
+            FromNode = fromNode;
         }
 
         /// <inheritdoc/>
@@ -644,6 +657,14 @@ namespace Akka.DistributedData.Internal
         /// TBD
         /// </summary>
         public int TotalChunks { get; }
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public long? ToSystemUid { get; }
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public long? FromSystemUid { get; }
 
         /// <summary>
         /// TBD
@@ -651,11 +672,15 @@ namespace Akka.DistributedData.Internal
         /// <param name="digests">TBD</param>
         /// <param name="chunk">TBD</param>
         /// <param name="totalChunks">TBD</param>
-        public Status(IImmutableDictionary<string, ByteString> digests, int chunk, int totalChunks)
+        /// <param name="toSystemUid">TBD</param>
+        /// <param name="fromSystemUid">TBD</param>
+        public Status(IImmutableDictionary<string, ByteString> digests, int chunk, int totalChunks, long? toSystemUid = null, long? fromSystemUid = null)
         {
             Digests = digests;
             Chunk = chunk;
             TotalChunks = totalChunks;
+            ToSystemUid = toSystemUid;
+            FromSystemUid = fromSystemUid;
         }
 
         /// <inheritdoc/>
@@ -664,7 +689,11 @@ namespace Akka.DistributedData.Internal
             if (ReferenceEquals(other, null)) return false;
             if (ReferenceEquals(this, other)) return true;
 
-            return other.Chunk.Equals(Chunk) && other.TotalChunks.Equals(TotalChunks) && Digests.SequenceEqual(other.Digests);
+            return other.Chunk.Equals(Chunk) 
+                && other.TotalChunks.Equals(TotalChunks) 
+                && Digests.SequenceEqual(other.Digests)
+                && ToSystemUid.Equals(other.ToSystemUid)
+                && FromSystemUid.Equals(other.FromSystemUid);
         }
 
         /// <inheritdoc/>
@@ -711,16 +740,28 @@ namespace Akka.DistributedData.Internal
         /// TBD
         /// </summary>
         public bool SendBack { get; }
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public long? ToSystemUid { get; }
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public long? FromSystemUid { get; }
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="updatedData">TBD</param>
         /// <param name="sendBack">TBD</param>
-        public Gossip(IImmutableDictionary<string, DataEnvelope> updatedData, bool sendBack)
+        /// <param name="toSystemUid">TBD</param>
+        /// <param name="fromSystemUid">TBD</param>
+        public Gossip(IImmutableDictionary<string, DataEnvelope> updatedData, bool sendBack, long? toSystemUid = null, long? fromSystemUid = null)
         {
             UpdatedData = updatedData;
             SendBack = sendBack;
+            ToSystemUid = toSystemUid;
+            FromSystemUid = fromSystemUid;
         }
 
         /// <inheritdoc/>
@@ -729,7 +770,10 @@ namespace Akka.DistributedData.Internal
             if (ReferenceEquals(other, null)) return false;
             if (ReferenceEquals(this, other)) return true;
 
-            return other.SendBack.Equals(SendBack) && UpdatedData.SequenceEqual(other.UpdatedData);
+            return other.SendBack.Equals(SendBack) 
+                && UpdatedData.SequenceEqual(other.UpdatedData)
+                && ToSystemUid.Equals(other.ToSystemUid)
+                && FromSystemUid.Equals(other.FromSystemUid);
         }
 
         /// <inheritdoc/>

--- a/src/contrib/cluster/Akka.DistributedData/Replicator.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Replicator.cs
@@ -448,9 +448,9 @@ namespace Akka.DistributedData
                 count += load.Data.Count;
                 foreach (var entry in load.Data)
                 {
-                    var envelope = entry.Value.Data;
+                    var envelope = entry.Value.DataEnvelope;
                     var newEnvelope = Write(entry.Key, envelope);
-                    if (!ReferenceEquals(newEnvelope.Data, envelope.Data))
+                    if (!ReferenceEquals(newEnvelope, envelope))
                     {
                         _durableStore.Tell(new Store(entry.Key, new DurableDataEnvelope(newEnvelope), null));
                     }
@@ -694,34 +694,29 @@ namespace Akka.DistributedData
 
         private DataEnvelope Write(string key, DataEnvelope writeEnvelope)
         {
-            var envelope = GetData(key);
-            if (envelope != null)
+            switch(GetData(key))
             {
-                if (envelope.Equals(writeEnvelope))
-                {
+                case DataEnvelope envelope when envelope.Equals(writeEnvelope):
                     return envelope;
-                }
-                if (envelope.Data is DeletedData) return DeletedEnvelope; // already deleted
-
-                try
-                {
-                   
-                    // DataEnvelope will mergeDelta when needed
-                    var merged = envelope.Merge(writeEnvelope).AddSeen(_selfAddress);
-
-                    return SetData(key, merged);
-                }
-                catch (ArgumentException e)
-                {
-                    _log.Warning("Couldn't merge [{0}] due to: {1}", key, e.Message);
-                    return null;
-                }
-            }
-            else
-            {
-                // no existing data for the key
-                if (writeEnvelope.Data is IReplicatedDelta withDelta)
-                    writeEnvelope = writeEnvelope.WithData(withDelta.Zero.MergeDelta(withDelta));
+                case DataEnvelope envelope when envelope.Data is DeletedData:
+                    // already deleted
+                    return DeletedEnvelope;
+                case DataEnvelope envelope:
+                    try
+                    {
+                        // DataEnvelope will mergeDelta when needed
+                        var merged = envelope.Merge(writeEnvelope).AddSeen(_selfAddress);
+                        return SetData(key, merged);
+                    }
+                    catch (ArgumentException e)
+                    {
+                        _log.Warning("Couldn't merge [{0}] due to: {1}", key, e.Message);
+                        return null;
+                    }
+                default:
+                    // no existing data for the key
+                    if (writeEnvelope.Data is IReplicatedDelta withDelta)
+                        writeEnvelope = writeEnvelope.WithData(withDelta.Zero.MergeDelta(withDelta));
 
                 return SetData(key, writeEnvelope.AddSeen(_selfAddress));
             }

--- a/src/contrib/cluster/Akka.DistributedData/ReplicatorSettings.cs
+++ b/src/contrib/cluster/Akka.DistributedData/ReplicatorSettings.cs
@@ -49,13 +49,19 @@ namespace Akka.DistributedData
             var durableKeys = durableConfig.GetStringList("keys");
             var durableStoreProps = Props.Empty;
             var durableStoreTypeName = durableConfig.GetString("store-actor-class", null);
-            var isDurableStoreConfigured = !string.IsNullOrEmpty(durableStoreTypeName);
+
             if (durableKeys.Count != 0)
             {
                 Type durableStoreType;
-                if (!isDurableStoreConfigured || (durableStoreType = Type.GetType(durableStoreTypeName)) == null)
+                if (string.IsNullOrEmpty(durableStoreTypeName))
                 {
                     throw new ArgumentException($"`akka.cluster.distributed-data.durable.store-actor-class` must be set when `akka.cluster.distributed-data.durable.keys` have been configured.");
+                }
+
+                durableStoreType = Type.GetType(durableStoreTypeName);
+                if (durableStoreType is null)
+                {
+                    throw new ArgumentException($"`akka.cluster.distributed-data.durable.store-actor-class` is set to an invalid class {durableStoreType}.");
                 }
                 durableStoreProps = Props.Create(durableStoreType, durableConfig).WithDispatcher(durableConfig.GetString("use-dispatcher"));
             }

--- a/src/contrib/cluster/Akka.DistributedData/Serialization/Proto/ReplicatorMessages.g.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Serialization/Proto/ReplicatorMessages.g.cs
@@ -16,7 +16,7 @@ using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
 namespace Akka.DistributedData.Serialization.Proto.Msg {
 
-  /// <summary>Holder for reflection information generated from ReplicatorMessages.proto</summary>
+  /// <summary>Holder for reflection information generated from replicatormessages.proto</summary>
   internal static partial class ReplicatorMessagesReflection {
 
     #region Descriptor
@@ -29,90 +29,95 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
     static ReplicatorMessagesReflection() {
       byte[] descriptorData = global::System.Convert.FromBase64String(
           string.Concat(
-            "ChhSZXBsaWNhdG9yTWVzc2FnZXMucHJvdG8SLEFra2EuRGlzdHJpYnV0ZWRE",
-            "YXRhLlNlcmlhbGl6YXRpb24uUHJvdG8uTXNnIsEBCgNHZXQSRwoDa2V5GAEg",
+            "ChhyZXBsaWNhdG9ybWVzc2FnZXMucHJvdG8SLEFra2EuRGlzdHJpYnV0ZWRE",
+            "YXRhLlNlcmlhbGl6YXRpb24uUHJvdG8uTXNnIp0CCgNHZXQSRwoDa2V5GAEg",
             "ASgLMjouQWtrYS5EaXN0cmlidXRlZERhdGEuU2VyaWFsaXphdGlvbi5Qcm90",
             "by5Nc2cuT3RoZXJNZXNzYWdlEhMKC2NvbnNpc3RlbmN5GAIgASgREg8KB3Rp",
             "bWVvdXQYAyABKA0SSwoHcmVxdWVzdBgEIAEoCzI6LkFra2EuRGlzdHJpYnV0",
-            "ZWREYXRhLlNlcmlhbGl6YXRpb24uUHJvdG8uTXNnLk90aGVyTWVzc2FnZSLs",
-            "AQoKR2V0U3VjY2VzcxJHCgNrZXkYASABKAsyOi5Ba2thLkRpc3RyaWJ1dGVk",
-            "RGF0YS5TZXJpYWxpemF0aW9uLlByb3RvLk1zZy5PdGhlck1lc3NhZ2USSAoE",
-            "ZGF0YRgCIAEoCzI6LkFra2EuRGlzdHJpYnV0ZWREYXRhLlNlcmlhbGl6YXRp",
-            "b24uUHJvdG8uTXNnLk90aGVyTWVzc2FnZRJLCgdyZXF1ZXN0GAQgASgLMjou",
-            "QWtrYS5EaXN0cmlidXRlZERhdGEuU2VyaWFsaXphdGlvbi5Qcm90by5Nc2cu",
-            "T3RoZXJNZXNzYWdlIqABCghOb3RGb3VuZBJHCgNrZXkYASABKAsyOi5Ba2th",
-            "LkRpc3RyaWJ1dGVkRGF0YS5TZXJpYWxpemF0aW9uLlByb3RvLk1zZy5PdGhl",
-            "ck1lc3NhZ2USSwoHcmVxdWVzdBgCIAEoCzI6LkFra2EuRGlzdHJpYnV0ZWRE",
-            "YXRhLlNlcmlhbGl6YXRpb24uUHJvdG8uTXNnLk90aGVyTWVzc2FnZSKiAQoK",
-            "R2V0RmFpbHVyZRJHCgNrZXkYASABKAsyOi5Ba2thLkRpc3RyaWJ1dGVkRGF0",
-            "YS5TZXJpYWxpemF0aW9uLlByb3RvLk1zZy5PdGhlck1lc3NhZ2USSwoHcmVx",
-            "dWVzdBgCIAEoCzI6LkFra2EuRGlzdHJpYnV0ZWREYXRhLlNlcmlhbGl6YXRp",
-            "b24uUHJvdG8uTXNnLk90aGVyTWVzc2FnZSJhCglTdWJzY3JpYmUSRwoDa2V5",
-            "GAEgASgLMjouQWtrYS5EaXN0cmlidXRlZERhdGEuU2VyaWFsaXphdGlvbi5Q",
-            "cm90by5Nc2cuT3RoZXJNZXNzYWdlEgsKA3JlZhgCIAEoCSJjCgtVbnN1YnNj",
-            "cmliZRJHCgNrZXkYASABKAsyOi5Ba2thLkRpc3RyaWJ1dGVkRGF0YS5TZXJp",
-            "YWxpemF0aW9uLlByb3RvLk1zZy5PdGhlck1lc3NhZ2USCwoDcmVmGAIgASgJ",
-            "IpwBCgdDaGFuZ2VkEkcKA2tleRgBIAEoCzI6LkFra2EuRGlzdHJpYnV0ZWRE",
-            "YXRhLlNlcmlhbGl6YXRpb24uUHJvdG8uTXNnLk90aGVyTWVzc2FnZRJICgRk",
-            "YXRhGAIgASgLMjouQWtrYS5EaXN0cmlidXRlZERhdGEuU2VyaWFsaXphdGlv",
-            "bi5Qcm90by5Nc2cuT3RoZXJNZXNzYWdlIrEBCgVXcml0ZRILCgNrZXkYASAB",
-            "KAkSTAoIZW52ZWxvcGUYAiABKAsyOi5Ba2thLkRpc3RyaWJ1dGVkRGF0YS5T",
-            "ZXJpYWxpemF0aW9uLlByb3RvLk1zZy5EYXRhRW52ZWxvcGUSTQoIZnJvbU5v",
-            "ZGUYAyABKAsyOy5Ba2thLkRpc3RyaWJ1dGVkRGF0YS5TZXJpYWxpemF0aW9u",
-            "LlByb3RvLk1zZy5VbmlxdWVBZGRyZXNzIgcKBUVtcHR5ImIKBFJlYWQSCwoD",
-            "a2V5GAEgASgJEk0KCGZyb21Ob2RlGAIgASgLMjsuQWtrYS5EaXN0cmlidXRl",
-            "ZERhdGEuU2VyaWFsaXphdGlvbi5Qcm90by5Nc2cuVW5pcXVlQWRkcmVzcyJa",
-            "CgpSZWFkUmVzdWx0EkwKCGVudmVsb3BlGAEgASgLMjouQWtrYS5EaXN0cmli",
-            "dXRlZERhdGEuU2VyaWFsaXphdGlvbi5Qcm90by5Nc2cuRGF0YUVudmVsb3Bl",
-            "Iq0ECgxEYXRhRW52ZWxvcGUSSAoEZGF0YRgBIAEoCzI6LkFra2EuRGlzdHJp",
-            "YnV0ZWREYXRhLlNlcmlhbGl6YXRpb24uUHJvdG8uTXNnLk90aGVyTWVzc2Fn",
-            "ZRJYCgdwcnVuaW5nGAIgAygLMkcuQWtrYS5EaXN0cmlidXRlZERhdGEuU2Vy",
-            "aWFsaXphdGlvbi5Qcm90by5Nc2cuRGF0YUVudmVsb3BlLlBydW5pbmdFbnRy",
-            "eRJSCg1kZWx0YVZlcnNpb25zGAMgASgLMjsuQWtrYS5EaXN0cmlidXRlZERh",
-            "dGEuU2VyaWFsaXphdGlvbi5Qcm90by5Nc2cuVmVyc2lvblZlY3RvchqkAgoM",
-            "UHJ1bmluZ0VudHJ5ElMKDnJlbW92ZWRBZGRyZXNzGAEgASgLMjsuQWtrYS5E",
-            "aXN0cmlidXRlZERhdGEuU2VyaWFsaXphdGlvbi5Qcm90by5Nc2cuVW5pcXVl",
-            "QWRkcmVzcxJRCgxvd25lckFkZHJlc3MYAiABKAsyOy5Ba2thLkRpc3RyaWJ1",
+            "ZWREYXRhLlNlcmlhbGl6YXRpb24uUHJvdG8uTXNnLk90aGVyTWVzc2FnZRIZ",
+            "ChFjb25zaXN0ZW5jeU1pbkNhcBgFIAEoBRIgChhoYXNDb25zaXN0ZW5jeUFk",
+            "ZGl0aW9uYWwYBiABKAgSHQoVY29uc2lzdGVuY3lBZGRpdGlvbmFsGAcgASgF",
+            "IuwBCgpHZXRTdWNjZXNzEkcKA2tleRgBIAEoCzI6LkFra2EuRGlzdHJpYnV0",
+            "ZWREYXRhLlNlcmlhbGl6YXRpb24uUHJvdG8uTXNnLk90aGVyTWVzc2FnZRJI",
+            "CgRkYXRhGAIgASgLMjouQWtrYS5EaXN0cmlidXRlZERhdGEuU2VyaWFsaXph",
+            "dGlvbi5Qcm90by5Nc2cuT3RoZXJNZXNzYWdlEksKB3JlcXVlc3QYBCABKAsy",
+            "Oi5Ba2thLkRpc3RyaWJ1dGVkRGF0YS5TZXJpYWxpemF0aW9uLlByb3RvLk1z",
+            "Zy5PdGhlck1lc3NhZ2UioAEKCE5vdEZvdW5kEkcKA2tleRgBIAEoCzI6LkFr",
+            "a2EuRGlzdHJpYnV0ZWREYXRhLlNlcmlhbGl6YXRpb24uUHJvdG8uTXNnLk90",
+            "aGVyTWVzc2FnZRJLCgdyZXF1ZXN0GAIgASgLMjouQWtrYS5EaXN0cmlidXRl",
+            "ZERhdGEuU2VyaWFsaXphdGlvbi5Qcm90by5Nc2cuT3RoZXJNZXNzYWdlIqIB",
+            "CgpHZXRGYWlsdXJlEkcKA2tleRgBIAEoCzI6LkFra2EuRGlzdHJpYnV0ZWRE",
+            "YXRhLlNlcmlhbGl6YXRpb24uUHJvdG8uTXNnLk90aGVyTWVzc2FnZRJLCgdy",
+            "ZXF1ZXN0GAIgASgLMjouQWtrYS5EaXN0cmlidXRlZERhdGEuU2VyaWFsaXph",
+            "dGlvbi5Qcm90by5Nc2cuT3RoZXJNZXNzYWdlImEKCVN1YnNjcmliZRJHCgNr",
+            "ZXkYASABKAsyOi5Ba2thLkRpc3RyaWJ1dGVkRGF0YS5TZXJpYWxpemF0aW9u",
+            "LlByb3RvLk1zZy5PdGhlck1lc3NhZ2USCwoDcmVmGAIgASgJImMKC1Vuc3Vi",
+            "c2NyaWJlEkcKA2tleRgBIAEoCzI6LkFra2EuRGlzdHJpYnV0ZWREYXRhLlNl",
+            "cmlhbGl6YXRpb24uUHJvdG8uTXNnLk90aGVyTWVzc2FnZRILCgNyZWYYAiAB",
+            "KAkinAEKB0NoYW5nZWQSRwoDa2V5GAEgASgLMjouQWtrYS5EaXN0cmlidXRl",
+            "ZERhdGEuU2VyaWFsaXphdGlvbi5Qcm90by5Nc2cuT3RoZXJNZXNzYWdlEkgK",
+            "BGRhdGEYAiABKAsyOi5Ba2thLkRpc3RyaWJ1dGVkRGF0YS5TZXJpYWxpemF0",
+            "aW9uLlByb3RvLk1zZy5PdGhlck1lc3NhZ2UisQEKBVdyaXRlEgsKA2tleRgB",
+            "IAEoCRJMCghlbnZlbG9wZRgCIAEoCzI6LkFra2EuRGlzdHJpYnV0ZWREYXRh",
+            "LlNlcmlhbGl6YXRpb24uUHJvdG8uTXNnLkRhdGFFbnZlbG9wZRJNCghmcm9t",
+            "Tm9kZRgDIAEoCzI7LkFra2EuRGlzdHJpYnV0ZWREYXRhLlNlcmlhbGl6YXRp",
+            "b24uUHJvdG8uTXNnLlVuaXF1ZUFkZHJlc3MiBwoFRW1wdHkiYgoEUmVhZBIL",
+            "CgNrZXkYASABKAkSTQoIZnJvbU5vZGUYAiABKAsyOy5Ba2thLkRpc3RyaWJ1",
             "dGVkRGF0YS5TZXJpYWxpemF0aW9uLlByb3RvLk1zZy5VbmlxdWVBZGRyZXNz",
-            "EhEKCXBlcmZvcm1lZBgDIAEoCBJDCgRzZWVuGAQgAygLMjUuQWtrYS5EaXN0",
-            "cmlidXRlZERhdGEuU2VyaWFsaXphdGlvbi5Qcm90by5Nc2cuQWRkcmVzcxIU",
-            "CgxvYnNvbGV0ZVRpbWUYBSABKBIiyQEKBlN0YXR1cxINCgVjaHVuaxgBIAEo",
-            "DRIRCgl0b3RDaHVua3MYAiABKA0SSwoHZW50cmllcxgDIAMoCzI6LkFra2Eu",
-            "RGlzdHJpYnV0ZWREYXRhLlNlcmlhbGl6YXRpb24uUHJvdG8uTXNnLlN0YXR1",
-            "cy5FbnRyeRITCgt0b1N5c3RlbVVpZBgEIAEoEBIVCg1mcm9tU3lzdGVtVWlk",
-            "GAUgASgQGiQKBUVudHJ5EgsKA2tleRgBIAEoCRIOCgZkaWdlc3QYAiABKAwi",
-            "9wEKBkdvc3NpcBIQCghzZW5kQmFjaxgBIAEoCBJLCgdlbnRyaWVzGAIgAygL",
-            "MjouQWtrYS5EaXN0cmlidXRlZERhdGEuU2VyaWFsaXphdGlvbi5Qcm90by5N",
-            "c2cuR29zc2lwLkVudHJ5EhMKC3RvU3lzdGVtVWlkGAMgASgQEhUKDWZyb21T",
-            "eXN0ZW1VaWQYBCABKBAaYgoFRW50cnkSCwoDa2V5GAEgASgJEkwKCGVudmVs",
+            "IloKClJlYWRSZXN1bHQSTAoIZW52ZWxvcGUYASABKAsyOi5Ba2thLkRpc3Ry",
+            "aWJ1dGVkRGF0YS5TZXJpYWxpemF0aW9uLlByb3RvLk1zZy5EYXRhRW52ZWxv",
+            "cGUirQQKDERhdGFFbnZlbG9wZRJICgRkYXRhGAEgASgLMjouQWtrYS5EaXN0",
+            "cmlidXRlZERhdGEuU2VyaWFsaXphdGlvbi5Qcm90by5Nc2cuT3RoZXJNZXNz",
+            "YWdlElgKB3BydW5pbmcYAiADKAsyRy5Ba2thLkRpc3RyaWJ1dGVkRGF0YS5T",
+            "ZXJpYWxpemF0aW9uLlByb3RvLk1zZy5EYXRhRW52ZWxvcGUuUHJ1bmluZ0Vu",
+            "dHJ5ElIKDWRlbHRhVmVyc2lvbnMYAyABKAsyOy5Ba2thLkRpc3RyaWJ1dGVk",
+            "RGF0YS5TZXJpYWxpemF0aW9uLlByb3RvLk1zZy5WZXJzaW9uVmVjdG9yGqQC",
+            "CgxQcnVuaW5nRW50cnkSUwoOcmVtb3ZlZEFkZHJlc3MYASABKAsyOy5Ba2th",
+            "LkRpc3RyaWJ1dGVkRGF0YS5TZXJpYWxpemF0aW9uLlByb3RvLk1zZy5Vbmlx",
+            "dWVBZGRyZXNzElEKDG93bmVyQWRkcmVzcxgCIAEoCzI7LkFra2EuRGlzdHJp",
+            "YnV0ZWREYXRhLlNlcmlhbGl6YXRpb24uUHJvdG8uTXNnLlVuaXF1ZUFkZHJl",
+            "c3MSEQoJcGVyZm9ybWVkGAMgASgIEkMKBHNlZW4YBCADKAsyNS5Ba2thLkRp",
+            "c3RyaWJ1dGVkRGF0YS5TZXJpYWxpemF0aW9uLlByb3RvLk1zZy5BZGRyZXNz",
+            "EhQKDG9ic29sZXRlVGltZRgFIAEoEiL7AQoGU3RhdHVzEg0KBWNodW5rGAEg",
+            "ASgNEhEKCXRvdENodW5rcxgCIAEoDRJLCgdlbnRyaWVzGAMgAygLMjouQWtr",
+            "YS5EaXN0cmlidXRlZERhdGEuU2VyaWFsaXphdGlvbi5Qcm90by5Nc2cuU3Rh",
+            "dHVzLkVudHJ5EhMKC3RvU3lzdGVtVWlkGAQgASgQEhUKDWZyb21TeXN0ZW1V",
+            "aWQYBSABKBASFgoOaGFzVG9TeXN0ZW1VaWQYBiABKAgSGAoQaGFzRnJvbVN5",
+            "c3RlbVVpZBgHIAEoCBokCgVFbnRyeRILCgNrZXkYASABKAkSDgoGZGlnZXN0",
+            "GAIgASgMIqkCCgZHb3NzaXASEAoIc2VuZEJhY2sYASABKAgSSwoHZW50cmll",
+            "cxgCIAMoCzI6LkFra2EuRGlzdHJpYnV0ZWREYXRhLlNlcmlhbGl6YXRpb24u",
+            "UHJvdG8uTXNnLkdvc3NpcC5FbnRyeRITCgt0b1N5c3RlbVVpZBgDIAEoEBIV",
+            "Cg1mcm9tU3lzdGVtVWlkGAQgASgQEhYKDmhhc1RvU3lzdGVtVWlkGAUgASgI",
+            "EhgKEGhhc0Zyb21TeXN0ZW1VaWQYBiABKAgaYgoFRW50cnkSCwoDa2V5GAEg",
+            "ASgJEkwKCGVudmVsb3BlGAIgASgLMjouQWtrYS5EaXN0cmlidXRlZERhdGEu",
+            "U2VyaWFsaXphdGlvbi5Qcm90by5Nc2cuRGF0YUVudmVsb3BlItACChBEZWx0",
+            "YVByb3BhZ2F0aW9uEk0KCGZyb21Ob2RlGAEgASgLMjsuQWtrYS5EaXN0cmli",
+            "dXRlZERhdGEuU2VyaWFsaXphdGlvbi5Qcm90by5Nc2cuVW5pcXVlQWRkcmVz",
+            "cxJVCgdlbnRyaWVzGAIgAygLMkQuQWtrYS5EaXN0cmlidXRlZERhdGEuU2Vy",
+            "aWFsaXphdGlvbi5Qcm90by5Nc2cuRGVsdGFQcm9wYWdhdGlvbi5FbnRyeRIN",
+            "CgVyZXBseRgDIAEoCBqGAQoFRW50cnkSCwoDa2V5GAEgASgJEkwKCGVudmVs",
             "b3BlGAIgASgLMjouQWtrYS5EaXN0cmlidXRlZERhdGEuU2VyaWFsaXphdGlv",
-            "bi5Qcm90by5Nc2cuRGF0YUVudmVsb3BlItACChBEZWx0YVByb3BhZ2F0aW9u",
-            "Ek0KCGZyb21Ob2RlGAEgASgLMjsuQWtrYS5EaXN0cmlidXRlZERhdGEuU2Vy",
-            "aWFsaXphdGlvbi5Qcm90by5Nc2cuVW5pcXVlQWRkcmVzcxJVCgdlbnRyaWVz",
-            "GAIgAygLMkQuQWtrYS5EaXN0cmlidXRlZERhdGEuU2VyaWFsaXphdGlvbi5Q",
-            "cm90by5Nc2cuRGVsdGFQcm9wYWdhdGlvbi5FbnRyeRINCgVyZXBseRgDIAEo",
-            "CBqGAQoFRW50cnkSCwoDa2V5GAEgASgJEkwKCGVudmVsb3BlGAIgASgLMjou",
-            "QWtrYS5EaXN0cmlidXRlZERhdGEuU2VyaWFsaXphdGlvbi5Qcm90by5Nc2cu",
-            "RGF0YUVudmVsb3BlEhEKCWZyb21TZXFOchgDIAEoAxIPCgd0b1NlcU5yGAQg",
-            "ASgDImQKDVVuaXF1ZUFkZHJlc3MSRgoHYWRkcmVzcxgBIAEoCzI1LkFra2Eu",
-            "RGlzdHJpYnV0ZWREYXRhLlNlcmlhbGl6YXRpb24uUHJvdG8uTXNnLkFkZHJl",
-            "c3MSCwoDdWlkGAIgASgDIikKB0FkZHJlc3MSEAoIaG9zdG5hbWUYASABKAkS",
-            "DAoEcG9ydBgCIAEoBSLIAQoNVmVyc2lvblZlY3RvchJSCgdlbnRyaWVzGAEg",
-            "AygLMkEuQWtrYS5EaXN0cmlidXRlZERhdGEuU2VyaWFsaXphdGlvbi5Qcm90",
-            "by5Nc2cuVmVyc2lvblZlY3Rvci5FbnRyeRpjCgVFbnRyeRJJCgRub2RlGAEg",
-            "ASgLMjsuQWtrYS5EaXN0cmlidXRlZERhdGEuU2VyaWFsaXphdGlvbi5Qcm90",
-            "by5Nc2cuVW5pcXVlQWRkcmVzcxIPCgd2ZXJzaW9uGAIgASgDIlYKDE90aGVy",
-            "TWVzc2FnZRIXCg9lbmNsb3NlZE1lc3NhZ2UYASABKAwSFAoMc2VyaWFsaXpl",
-            "cklkGAIgASgFEhcKD21lc3NhZ2VNYW5pZmVzdBgEIAEoDCIeCgpTdHJpbmdH",
-            "U2V0EhAKCGVsZW1lbnRzGAEgAygJIrkBChNEdXJhYmxlRGF0YUVudmVsb3Bl",
-            "EkgKBGRhdGEYASABKAsyOi5Ba2thLkRpc3RyaWJ1dGVkRGF0YS5TZXJpYWxp",
-            "emF0aW9uLlByb3RvLk1zZy5PdGhlck1lc3NhZ2USWAoHcHJ1bmluZxgCIAMo",
-            "CzJHLkFra2EuRGlzdHJpYnV0ZWREYXRhLlNlcmlhbGl6YXRpb24uUHJvdG8u",
-            "TXNnLkRhdGFFbnZlbG9wZS5QcnVuaW5nRW50cnlCAkgBYgZwcm90bzM="));
+            "bi5Qcm90by5Nc2cuRGF0YUVudmVsb3BlEhEKCWZyb21TZXFOchgDIAEoAxIP",
+            "Cgd0b1NlcU5yGAQgASgDImQKDVVuaXF1ZUFkZHJlc3MSRgoHYWRkcmVzcxgB",
+            "IAEoCzI1LkFra2EuRGlzdHJpYnV0ZWREYXRhLlNlcmlhbGl6YXRpb24uUHJv",
+            "dG8uTXNnLkFkZHJlc3MSCwoDdWlkGAIgASgDIikKB0FkZHJlc3MSEAoIaG9z",
+            "dG5hbWUYASABKAkSDAoEcG9ydBgCIAEoBSLIAQoNVmVyc2lvblZlY3RvchJS",
+            "CgdlbnRyaWVzGAEgAygLMkEuQWtrYS5EaXN0cmlidXRlZERhdGEuU2VyaWFs",
+            "aXphdGlvbi5Qcm90by5Nc2cuVmVyc2lvblZlY3Rvci5FbnRyeRpjCgVFbnRy",
+            "eRJJCgRub2RlGAEgASgLMjsuQWtrYS5EaXN0cmlidXRlZERhdGEuU2VyaWFs",
+            "aXphdGlvbi5Qcm90by5Nc2cuVW5pcXVlQWRkcmVzcxIPCgd2ZXJzaW9uGAIg",
+            "ASgDIlYKDE90aGVyTWVzc2FnZRIXCg9lbmNsb3NlZE1lc3NhZ2UYASABKAwS",
+            "FAoMc2VyaWFsaXplcklkGAIgASgFEhcKD21lc3NhZ2VNYW5pZmVzdBgEIAEo",
+            "DCIeCgpTdHJpbmdHU2V0EhAKCGVsZW1lbnRzGAEgAygJIrkBChNEdXJhYmxl",
+            "RGF0YUVudmVsb3BlEkgKBGRhdGEYASABKAsyOi5Ba2thLkRpc3RyaWJ1dGVk",
+            "RGF0YS5TZXJpYWxpemF0aW9uLlByb3RvLk1zZy5PdGhlck1lc3NhZ2USWAoH",
+            "cHJ1bmluZxgCIAMoCzJHLkFra2EuRGlzdHJpYnV0ZWREYXRhLlNlcmlhbGl6",
+            "YXRpb24uUHJvdG8uTXNnLkRhdGFFbnZlbG9wZS5QcnVuaW5nRW50cnlCAkgB",
+            "YgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::Akka.DistributedData.Serialization.Proto.Msg.Get), global::Akka.DistributedData.Serialization.Proto.Msg.Get.Parser, new[]{ "Key", "Consistency", "Timeout", "Request" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Akka.DistributedData.Serialization.Proto.Msg.Get), global::Akka.DistributedData.Serialization.Proto.Msg.Get.Parser, new[]{ "Key", "Consistency", "Timeout", "Request", "ConsistencyMinCap", "HasConsistencyAdditional", "ConsistencyAdditional" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Akka.DistributedData.Serialization.Proto.Msg.GetSuccess), global::Akka.DistributedData.Serialization.Proto.Msg.GetSuccess.Parser, new[]{ "Key", "Data", "Request" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Akka.DistributedData.Serialization.Proto.Msg.NotFound), global::Akka.DistributedData.Serialization.Proto.Msg.NotFound.Parser, new[]{ "Key", "Request" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Akka.DistributedData.Serialization.Proto.Msg.GetFailure), global::Akka.DistributedData.Serialization.Proto.Msg.GetFailure.Parser, new[]{ "Key", "Request" }, null, null, null),
@@ -124,8 +129,8 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
             new pbr::GeneratedClrTypeInfo(typeof(global::Akka.DistributedData.Serialization.Proto.Msg.Read), global::Akka.DistributedData.Serialization.Proto.Msg.Read.Parser, new[]{ "Key", "FromNode" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Akka.DistributedData.Serialization.Proto.Msg.ReadResult), global::Akka.DistributedData.Serialization.Proto.Msg.ReadResult.Parser, new[]{ "Envelope" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Akka.DistributedData.Serialization.Proto.Msg.DataEnvelope), global::Akka.DistributedData.Serialization.Proto.Msg.DataEnvelope.Parser, new[]{ "Data", "Pruning", "DeltaVersions" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Akka.DistributedData.Serialization.Proto.Msg.DataEnvelope.Types.PruningEntry), global::Akka.DistributedData.Serialization.Proto.Msg.DataEnvelope.Types.PruningEntry.Parser, new[]{ "RemovedAddress", "OwnerAddress", "Performed", "Seen", "ObsoleteTime" }, null, null, null)}),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Akka.DistributedData.Serialization.Proto.Msg.Status), global::Akka.DistributedData.Serialization.Proto.Msg.Status.Parser, new[]{ "Chunk", "TotChunks", "Entries", "ToSystemUid", "FromSystemUid" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Akka.DistributedData.Serialization.Proto.Msg.Status.Types.Entry), global::Akka.DistributedData.Serialization.Proto.Msg.Status.Types.Entry.Parser, new[]{ "Key", "Digest" }, null, null, null)}),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Akka.DistributedData.Serialization.Proto.Msg.Gossip), global::Akka.DistributedData.Serialization.Proto.Msg.Gossip.Parser, new[]{ "SendBack", "Entries", "ToSystemUid", "FromSystemUid" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Akka.DistributedData.Serialization.Proto.Msg.Gossip.Types.Entry), global::Akka.DistributedData.Serialization.Proto.Msg.Gossip.Types.Entry.Parser, new[]{ "Key", "Envelope" }, null, null, null)}),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Akka.DistributedData.Serialization.Proto.Msg.Status), global::Akka.DistributedData.Serialization.Proto.Msg.Status.Parser, new[]{ "Chunk", "TotChunks", "Entries", "ToSystemUid", "FromSystemUid", "HasToSystemUid", "HasFromSystemUid" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Akka.DistributedData.Serialization.Proto.Msg.Status.Types.Entry), global::Akka.DistributedData.Serialization.Proto.Msg.Status.Types.Entry.Parser, new[]{ "Key", "Digest" }, null, null, null)}),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Akka.DistributedData.Serialization.Proto.Msg.Gossip), global::Akka.DistributedData.Serialization.Proto.Msg.Gossip.Parser, new[]{ "SendBack", "Entries", "ToSystemUid", "FromSystemUid", "HasToSystemUid", "HasFromSystemUid" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Akka.DistributedData.Serialization.Proto.Msg.Gossip.Types.Entry), global::Akka.DistributedData.Serialization.Proto.Msg.Gossip.Types.Entry.Parser, new[]{ "Key", "Envelope" }, null, null, null)}),
             new pbr::GeneratedClrTypeInfo(typeof(global::Akka.DistributedData.Serialization.Proto.Msg.DeltaPropagation), global::Akka.DistributedData.Serialization.Proto.Msg.DeltaPropagation.Parser, new[]{ "FromNode", "Entries", "Reply" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Akka.DistributedData.Serialization.Proto.Msg.DeltaPropagation.Types.Entry), global::Akka.DistributedData.Serialization.Proto.Msg.DeltaPropagation.Types.Entry.Parser, new[]{ "Key", "Envelope", "FromSeqNr", "ToSeqNr" }, null, null, null)}),
             new pbr::GeneratedClrTypeInfo(typeof(global::Akka.DistributedData.Serialization.Proto.Msg.UniqueAddress), global::Akka.DistributedData.Serialization.Proto.Msg.UniqueAddress.Parser, new[]{ "Address", "Uid" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Akka.DistributedData.Serialization.Proto.Msg.Address), global::Akka.DistributedData.Serialization.Proto.Msg.Address.Parser, new[]{ "Hostname", "Port" }, null, null, null),
@@ -167,6 +172,9 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
       consistency_ = other.consistency_;
       timeout_ = other.timeout_;
       Request = other.request_ != null ? other.Request.Clone() : null;
+      consistencyMinCap_ = other.consistencyMinCap_;
+      hasConsistencyAdditional_ = other.hasConsistencyAdditional_;
+      consistencyAdditional_ = other.consistencyAdditional_;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -218,6 +226,39 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
       }
     }
 
+    /// <summary>Field number for the "consistencyMinCap" field.</summary>
+    public const int ConsistencyMinCapFieldNumber = 5;
+    private int consistencyMinCap_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int ConsistencyMinCap {
+      get { return consistencyMinCap_; }
+      set {
+        consistencyMinCap_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "hasConsistencyAdditional" field.</summary>
+    public const int HasConsistencyAdditionalFieldNumber = 6;
+    private bool hasConsistencyAdditional_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool HasConsistencyAdditional {
+      get { return hasConsistencyAdditional_; }
+      set {
+        hasConsistencyAdditional_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "consistencyAdditional" field.</summary>
+    public const int ConsistencyAdditionalFieldNumber = 7;
+    private int consistencyAdditional_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int ConsistencyAdditional {
+      get { return consistencyAdditional_; }
+      set {
+        consistencyAdditional_ = value;
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Get);
@@ -235,6 +276,9 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
       if (Consistency != other.Consistency) return false;
       if (Timeout != other.Timeout) return false;
       if (!object.Equals(Request, other.Request)) return false;
+      if (ConsistencyMinCap != other.ConsistencyMinCap) return false;
+      if (HasConsistencyAdditional != other.HasConsistencyAdditional) return false;
+      if (ConsistencyAdditional != other.ConsistencyAdditional) return false;
       return true;
     }
 
@@ -245,6 +289,9 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
       if (Consistency != 0) hash ^= Consistency.GetHashCode();
       if (Timeout != 0) hash ^= Timeout.GetHashCode();
       if (request_ != null) hash ^= Request.GetHashCode();
+      if (ConsistencyMinCap != 0) hash ^= ConsistencyMinCap.GetHashCode();
+      if (HasConsistencyAdditional != false) hash ^= HasConsistencyAdditional.GetHashCode();
+      if (ConsistencyAdditional != 0) hash ^= ConsistencyAdditional.GetHashCode();
       return hash;
     }
 
@@ -271,6 +318,18 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
         output.WriteRawTag(34);
         output.WriteMessage(Request);
       }
+      if (ConsistencyMinCap != 0) {
+        output.WriteRawTag(40);
+        output.WriteInt32(ConsistencyMinCap);
+      }
+      if (HasConsistencyAdditional != false) {
+        output.WriteRawTag(48);
+        output.WriteBool(HasConsistencyAdditional);
+      }
+      if (ConsistencyAdditional != 0) {
+        output.WriteRawTag(56);
+        output.WriteInt32(ConsistencyAdditional);
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -287,6 +346,15 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
       }
       if (request_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Request);
+      }
+      if (ConsistencyMinCap != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(ConsistencyMinCap);
+      }
+      if (HasConsistencyAdditional != false) {
+        size += 1 + 1;
+      }
+      if (ConsistencyAdditional != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(ConsistencyAdditional);
       }
       return size;
     }
@@ -313,6 +381,15 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
           request_ = new global::Akka.DistributedData.Serialization.Proto.Msg.OtherMessage();
         }
         Request.MergeFrom(other.Request);
+      }
+      if (other.ConsistencyMinCap != 0) {
+        ConsistencyMinCap = other.ConsistencyMinCap;
+      }
+      if (other.HasConsistencyAdditional != false) {
+        HasConsistencyAdditional = other.HasConsistencyAdditional;
+      }
+      if (other.ConsistencyAdditional != 0) {
+        ConsistencyAdditional = other.ConsistencyAdditional;
       }
     }
 
@@ -344,6 +421,18 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
               request_ = new global::Akka.DistributedData.Serialization.Proto.Msg.OtherMessage();
             }
             input.ReadMessage(request_);
+            break;
+          }
+          case 40: {
+            ConsistencyMinCap = input.ReadInt32();
+            break;
+          }
+          case 48: {
+            HasConsistencyAdditional = input.ReadBool();
+            break;
+          }
+          case 56: {
+            ConsistencyAdditional = input.ReadInt32();
             break;
           }
         }
@@ -2310,6 +2399,8 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
       entries_ = other.entries_.Clone();
       toSystemUid_ = other.toSystemUid_;
       fromSystemUid_ = other.fromSystemUid_;
+      hasToSystemUid_ = other.hasToSystemUid_;
+      hasFromSystemUid_ = other.hasFromSystemUid_;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2371,6 +2462,28 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
       }
     }
 
+    /// <summary>Field number for the "hasToSystemUid" field.</summary>
+    public const int HasToSystemUidFieldNumber = 6;
+    private bool hasToSystemUid_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool HasToSystemUid {
+      get { return hasToSystemUid_; }
+      set {
+        hasToSystemUid_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "hasFromSystemUid" field.</summary>
+    public const int HasFromSystemUidFieldNumber = 7;
+    private bool hasFromSystemUid_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool HasFromSystemUid {
+      get { return hasFromSystemUid_; }
+      set {
+        hasFromSystemUid_ = value;
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Status);
@@ -2389,6 +2502,8 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
       if(!entries_.Equals(other.entries_)) return false;
       if (ToSystemUid != other.ToSystemUid) return false;
       if (FromSystemUid != other.FromSystemUid) return false;
+      if (HasToSystemUid != other.HasToSystemUid) return false;
+      if (HasFromSystemUid != other.HasFromSystemUid) return false;
       return true;
     }
 
@@ -2400,6 +2515,8 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
       hash ^= entries_.GetHashCode();
       if (ToSystemUid != 0L) hash ^= ToSystemUid.GetHashCode();
       if (FromSystemUid != 0L) hash ^= FromSystemUid.GetHashCode();
+      if (HasToSystemUid != false) hash ^= HasToSystemUid.GetHashCode();
+      if (HasFromSystemUid != false) hash ^= HasFromSystemUid.GetHashCode();
       return hash;
     }
 
@@ -2427,6 +2544,14 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
         output.WriteRawTag(41);
         output.WriteSFixed64(FromSystemUid);
       }
+      if (HasToSystemUid != false) {
+        output.WriteRawTag(48);
+        output.WriteBool(HasToSystemUid);
+      }
+      if (HasFromSystemUid != false) {
+        output.WriteRawTag(56);
+        output.WriteBool(HasFromSystemUid);
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2444,6 +2569,12 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
       }
       if (FromSystemUid != 0L) {
         size += 1 + 8;
+      }
+      if (HasToSystemUid != false) {
+        size += 1 + 1;
+      }
+      if (HasFromSystemUid != false) {
+        size += 1 + 1;
       }
       return size;
     }
@@ -2465,6 +2596,12 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
       }
       if (other.FromSystemUid != 0L) {
         FromSystemUid = other.FromSystemUid;
+      }
+      if (other.HasToSystemUid != false) {
+        HasToSystemUid = other.HasToSystemUid;
+      }
+      if (other.HasFromSystemUid != false) {
+        HasFromSystemUid = other.HasFromSystemUid;
       }
     }
 
@@ -2494,6 +2631,14 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
           }
           case 41: {
             FromSystemUid = input.ReadSFixed64();
+            break;
+          }
+          case 48: {
+            HasToSystemUid = input.ReadBool();
+            break;
+          }
+          case 56: {
+            HasFromSystemUid = input.ReadBool();
             break;
           }
         }
@@ -2682,6 +2827,8 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
       entries_ = other.entries_.Clone();
       toSystemUid_ = other.toSystemUid_;
       fromSystemUid_ = other.fromSystemUid_;
+      hasToSystemUid_ = other.hasToSystemUid_;
+      hasFromSystemUid_ = other.hasFromSystemUid_;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2732,6 +2879,28 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
       }
     }
 
+    /// <summary>Field number for the "hasToSystemUid" field.</summary>
+    public const int HasToSystemUidFieldNumber = 5;
+    private bool hasToSystemUid_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool HasToSystemUid {
+      get { return hasToSystemUid_; }
+      set {
+        hasToSystemUid_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "hasFromSystemUid" field.</summary>
+    public const int HasFromSystemUidFieldNumber = 6;
+    private bool hasFromSystemUid_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool HasFromSystemUid {
+      get { return hasFromSystemUid_; }
+      set {
+        hasFromSystemUid_ = value;
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Gossip);
@@ -2749,6 +2918,8 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
       if(!entries_.Equals(other.entries_)) return false;
       if (ToSystemUid != other.ToSystemUid) return false;
       if (FromSystemUid != other.FromSystemUid) return false;
+      if (HasToSystemUid != other.HasToSystemUid) return false;
+      if (HasFromSystemUid != other.HasFromSystemUid) return false;
       return true;
     }
 
@@ -2759,6 +2930,8 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
       hash ^= entries_.GetHashCode();
       if (ToSystemUid != 0L) hash ^= ToSystemUid.GetHashCode();
       if (FromSystemUid != 0L) hash ^= FromSystemUid.GetHashCode();
+      if (HasToSystemUid != false) hash ^= HasToSystemUid.GetHashCode();
+      if (HasFromSystemUid != false) hash ^= HasFromSystemUid.GetHashCode();
       return hash;
     }
 
@@ -2782,6 +2955,14 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
         output.WriteRawTag(33);
         output.WriteSFixed64(FromSystemUid);
       }
+      if (HasToSystemUid != false) {
+        output.WriteRawTag(40);
+        output.WriteBool(HasToSystemUid);
+      }
+      if (HasFromSystemUid != false) {
+        output.WriteRawTag(48);
+        output.WriteBool(HasFromSystemUid);
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2796,6 +2977,12 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
       }
       if (FromSystemUid != 0L) {
         size += 1 + 8;
+      }
+      if (HasToSystemUid != false) {
+        size += 1 + 1;
+      }
+      if (HasFromSystemUid != false) {
+        size += 1 + 1;
       }
       return size;
     }
@@ -2814,6 +3001,12 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
       }
       if (other.FromSystemUid != 0L) {
         FromSystemUid = other.FromSystemUid;
+      }
+      if (other.HasToSystemUid != false) {
+        HasToSystemUid = other.HasToSystemUid;
+      }
+      if (other.HasFromSystemUid != false) {
+        HasFromSystemUid = other.HasFromSystemUid;
       }
     }
 
@@ -2839,6 +3032,14 @@ namespace Akka.DistributedData.Serialization.Proto.Msg {
           }
           case 33: {
             FromSystemUid = input.ReadSFixed64();
+            break;
+          }
+          case 40: {
+            HasToSystemUid = input.ReadBool();
+            break;
+          }
+          case 48: {
+            HasFromSystemUid = input.ReadBool();
             break;
           }
         }

--- a/src/contrib/cluster/Akka.DistributedData/reference.conf
+++ b/src/contrib/cluster/Akka.DistributedData/reference.conf
@@ -78,10 +78,10 @@ akka.cluster.distributed-data {
     pruning-marker-time-to-live = 10 d
     
     # Fully qualified class name of the durable store actor. It must be a subclass
-    # of akka.actor.Actor and handle the protocol defined in 
-    # akka.cluster.ddata.DurableStore. The class must have a constructor with 
-    # com.typesafe.config.Config parameter.
-    store-actor-class = ""
+    # of Akka.Actor.ActorBase and handle the protocol defined in 
+    # Akka.DistributedData.Durable.Messages.cs. The class must have a constructor with 
+    # Akka.Configuration.Config parameter.
+    store-actor-class = "Akka.DistributedData.LightningDB.LmdbDurableStore, Akka.DistributedData.LightningDB"
     
     use-dispatcher = akka.cluster.distributed-data.durable.pinned-store
     

--- a/src/contrib/dependencyinjection/Akka.DI.Core/Akka.DI.Core.csproj
+++ b/src/contrib/dependencyinjection/Akka.DI.Core/Akka.DI.Core.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.4" />
   </ItemGroup>
 
 </Project>

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Akka.Persistence.Sqlite.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Akka.Persistence.Sqlite.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SQLite" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Data.SQLite" Version="3.1.4" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -1625,6 +1625,7 @@ namespace Akka.Actor
         public int LogDeadLetters { get; }
         public bool LogDeadLettersDuringShutdown { get; }
         public string LogLevel { get; }
+        public bool LoggerAsyncStart { get; }
         public System.TimeSpan LoggerStartTimeout { get; }
         public System.Collections.Generic.IList<string> Loggers { get; }
         public string LoggersDispatcher { get; }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -352,6 +352,8 @@ namespace Akka.Actor
         public abstract Akka.Actor.ActorSelection ActorSelection(Akka.Actor.ActorPath actorPath);
         public abstract Akka.Actor.ActorSelection ActorSelection(string actorPath);
         public static Akka.Actor.ActorSystem Create(string name, Akka.Configuration.Config config) { }
+        public static Akka.Actor.ActorSystem Create(string name, Akka.Actor.BootstrapSetup setup) { }
+        public static Akka.Actor.ActorSystem Create(string name, Akka.Actor.Setup.ActorSystemSetup setup) { }
         public static Akka.Actor.ActorSystem Create(string name) { }
         public void Dispose() { }
         public abstract object GetExtension(Akka.Actor.IExtensionId extensionId);
@@ -452,6 +454,14 @@ namespace Akka.Actor
     public class AskTimeoutException : Akka.Actor.AkkaException
     {
         public AskTimeoutException(string message) { }
+    }
+    public sealed class BootstrapSetup : Akka.Actor.Setup.Setup
+    {
+        public Akka.Util.Option<Akka.Actor.ProviderSelection> ActorRefProvider { get; }
+        public Akka.Util.Option<Akka.Configuration.Config> Config { get; }
+        public static Akka.Actor.BootstrapSetup Create() { }
+        public Akka.Actor.BootstrapSetup WithActorRefProvider(Akka.Actor.ProviderSelection name) { }
+        public Akka.Actor.BootstrapSetup WithConfig(Akka.Configuration.Config config) { }
     }
     public class Cancelable : Akka.Actor.ICancelable, System.IDisposable
     {
@@ -1403,6 +1413,25 @@ namespace Akka.Actor
             public Akka.Util.ISurrogated FromSurrogate(Akka.Actor.ActorSystem system) { }
         }
     }
+    public abstract class ProviderSelection
+    {
+        public sealed class Cluster : Akka.Actor.ProviderSelection
+        {
+            public static readonly Akka.Actor.ProviderSelection.Cluster Instance;
+        }
+        public sealed class Custom : Akka.Actor.ProviderSelection
+        {
+            public Custom(string fqn, string identifier = null, bool hasCluster = False) { }
+        }
+        public sealed class Local : Akka.Actor.ProviderSelection
+        {
+            public static readonly Akka.Actor.ProviderSelection.Local Instance;
+        }
+        public sealed class Remote : Akka.Actor.ProviderSelection
+        {
+            public static readonly Akka.Actor.ProviderSelection.Remote Instance;
+        }
+    }
     public delegate bool Receive(object message);
     public abstract class ReceiveActor : Akka.Actor.UntypedActor, Akka.Actor.Internal.IInitializableActor
     {
@@ -1575,6 +1604,7 @@ namespace Akka.Actor
     public class Settings
     {
         public Settings(Akka.Actor.ActorSystem system, Akka.Configuration.Config config) { }
+        public Settings(Akka.Actor.ActorSystem system, Akka.Configuration.Config config, Akka.Actor.Setup.ActorSystemSetup setup) { }
         public bool AddLoggingReceive { get; }
         public System.TimeSpan AskTimeout { get; }
         public Akka.Configuration.Config Config { get; }
@@ -1589,6 +1619,7 @@ namespace Akka.Actor
         public bool DebugUnhandledMessage { get; }
         public int DefaultVirtualNodesFactor { get; }
         public bool FsmDebugEvent { get; }
+        public bool HasCluster { get; }
         public string Home { get; }
         public bool LogConfigOnStart { get; }
         public int LogDeadLetters { get; }
@@ -1598,10 +1629,12 @@ namespace Akka.Actor
         public System.Collections.Generic.IList<string> Loggers { get; }
         public string LoggersDispatcher { get; }
         public string ProviderClass { get; }
+        public Akka.Actor.ProviderSelection ProviderSelectionType { get; }
         public string SchedulerClass { get; }
         public System.TimeSpan SchedulerShutdownTimeout { get; }
         public bool SerializeAllCreators { get; }
         public bool SerializeAllMessages { get; }
+        public Akka.Actor.Setup.ActorSystemSetup Setup { get; }
         public string StdoutLogLevel { get; }
         public string SupervisorStrategyClass { get; }
         public Akka.Actor.ActorSystem System { get; }
@@ -1806,7 +1839,7 @@ namespace Akka.Actor.Internal
     public class ActorSystemImpl : Akka.Actor.ExtendedActorSystem
     {
         public ActorSystemImpl(string name) { }
-        public ActorSystemImpl(string name, Akka.Configuration.Config config) { }
+        public ActorSystemImpl(string name, Akka.Configuration.Config config, Akka.Actor.Setup.ActorSystemSetup setup) { }
         public override Akka.Actor.ActorProducerPipelineResolver ActorPipelineResolver { get; }
         public override Akka.Actor.IActorRef DeadLetters { get; }
         public override Akka.Dispatch.Dispatchers Dispatchers { get; }
@@ -1993,6 +2026,27 @@ namespace Akka.Actor.Internal
     public class UnboundedStashImpl : Akka.Actor.Internal.AbstractStash
     {
         public UnboundedStashImpl(Akka.Actor.IActorContext context) { }
+    }
+}
+namespace Akka.Actor.Setup
+{
+    [Akka.Annotations.InternalApiAttribute()]
+    public sealed class ActorSystemSetup
+    {
+        public static readonly Akka.Actor.Setup.ActorSystemSetup Empty;
+        public Akka.Actor.Setup.ActorSystemSetup And<T>(T setup)
+            where T : Akka.Actor.Setup.Setup { }
+        public static Akka.Actor.Setup.ActorSystemSetup Create(params Akka.Actor.Setup.Setup[] setup) { }
+        public Akka.Util.Option<T> Get<T>()
+            where T : Akka.Actor.Setup.Setup { }
+        public override string ToString() { }
+        public Akka.Actor.Setup.ActorSystemSetup WithSetup<T>(T setup)
+            where T : Akka.Actor.Setup.Setup { }
+    }
+    public abstract class Setup
+    {
+        protected Setup() { }
+        public Akka.Actor.Setup.ActorSystemSetup And(Akka.Actor.Setup.Setup other) { }
     }
 }
 namespace Akka.Annotations
@@ -4564,6 +4618,11 @@ namespace Akka.Serialization
         public static T WithTransport<T>(Akka.Actor.ActorSystem system, Akka.Actor.Address address, System.Func<T> action) { }
         public static T WithTransport<T>(Akka.Actor.ExtendedActorSystem system, System.Func<T> action) { }
     }
+    public sealed class SerializationSetup : Akka.Actor.Setup.Setup
+    {
+        public System.Func<Akka.Actor.ExtendedActorSystem, System.Collections.Immutable.ImmutableHashSet<Akka.Serialization.SerializerDetails>> CreateSerializers { get; }
+        public static Akka.Serialization.SerializationSetup Create(System.Func<Akka.Actor.ExtendedActorSystem, System.Collections.Immutable.ImmutableHashSet<Akka.Serialization.SerializerDetails>> createSerializers) { }
+    }
     public abstract class Serializer
     {
         protected readonly Akka.Actor.ExtendedActorSystem system;
@@ -4574,6 +4633,13 @@ namespace Akka.Serialization
         public T FromBinary<T>(byte[] bytes) { }
         public abstract byte[] ToBinary(object obj);
         public byte[] ToBinaryWithAddress(Akka.Actor.Address address, object obj) { }
+    }
+    public sealed class SerializerDetails
+    {
+        public string Alias { get; }
+        public Akka.Serialization.Serializer Serializer { get; }
+        public System.Collections.Immutable.ImmutableHashSet<System.Type> UseFor { get; }
+        public static Akka.Serialization.SerializerDetails Create(string alias, Akka.Serialization.Serializer serializer, System.Collections.Immutable.ImmutableHashSet<System.Type> useFor) { }
     }
     [Akka.Annotations.InternalApiAttribute()]
     public class static SerializerIdentifierHelper
@@ -4758,12 +4824,15 @@ namespace Akka.Util
         public T Value { get; }
         public bool Equals(Akka.Util.Option<T> other) { }
         public override bool Equals(object obj) { }
+        public Akka.Util.Option<TNew> FlatSelect<TNew>(System.Func<T, Akka.Util.Option<TNew>> mapper) { }
         public override int GetHashCode() { }
         public T GetOrElse(T fallbackValue) { }
         public void OnSuccess(System.Action<T> action) { }
         public Akka.Util.Option<TNew> Select<TNew>(System.Func<T, TNew> selector) { }
         public override string ToString() { }
+        public static bool ==(Akka.Util.Option<T> left, Akka.Util.Option<T> right) { }
         public static Akka.Util.Option<T> op_Implicit(T value) { }
+        public static bool !=(Akka.Util.Option<T> left, Akka.Util.Option<T> right) { }
     }
     public abstract class Resolve : Akka.Actor.IIndirectActorProducer
     {

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveDistributedData.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveDistributedData.approved.txt
@@ -952,8 +952,9 @@ namespace Akka.DistributedData.Durable
 {
     public sealed class DurableDataEnvelope : Akka.DistributedData.IReplicatorMessage, System.IEquatable<Akka.DistributedData.Durable.DurableDataEnvelope>
     {
-        public readonly Akka.DistributedData.Internal.DataEnvelope Data;
-        public DurableDataEnvelope(Akka.DistributedData.Internal.DataEnvelope data) { }
+        public DurableDataEnvelope(Akka.DistributedData.Internal.DataEnvelope dataEnvelope) { }
+        public DurableDataEnvelope(Akka.DistributedData.IReplicatedData data) { }
+        public Akka.DistributedData.IReplicatedData Data { get; }
         public bool Equals(Akka.DistributedData.Durable.DurableDataEnvelope other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
@@ -17,9 +17,24 @@ namespace Akka.Streams
     }
     public class static ActorAttributes
     {
+        public static Akka.Streams.Attributes CreateDebugLogging(bool enabled) { }
         public static Akka.Streams.Attributes CreateDispatcher(string dispatcherName) { }
+        public static Akka.Streams.Attributes CreateFuzzingMode(bool enabled) { }
+        public static Akka.Streams.Attributes CreateMaxFixedBufferSize(int size) { }
+        public static Akka.Streams.Attributes CreateOutputBurstLimit(int limit) { }
+        public static Akka.Streams.Attributes CreateStreamSubscriptionTimeout(System.TimeSpan timeout, Akka.Streams.StreamSubscriptionTimeoutTerminationMode mode) { }
         public static Akka.Streams.Attributes CreateSupervisionStrategy(Akka.Streams.Supervision.Decider strategy) { }
-        public sealed class Dispatcher : Akka.Streams.Attributes.IAttribute, System.IEquatable<Akka.Streams.ActorAttributes.Dispatcher>
+        public static Akka.Streams.Attributes CreateSyncProcessingLimit(int limit) { }
+        public sealed class DebugLogging : Akka.Streams.Attributes.IAttribute, Akka.Streams.Attributes.IMandatoryAttribute, System.IEquatable<Akka.Streams.ActorAttributes.DebugLogging>
+        {
+            public DebugLogging(bool enabled) { }
+            public bool Enabled { get; }
+            public bool Equals(Akka.Streams.ActorAttributes.DebugLogging other) { }
+            public override bool Equals(object obj) { }
+            public override int GetHashCode() { }
+            public override string ToString() { }
+        }
+        public sealed class Dispatcher : Akka.Streams.Attributes.IAttribute, Akka.Streams.Attributes.IMandatoryAttribute, System.IEquatable<Akka.Streams.ActorAttributes.Dispatcher>
         {
             public readonly string Name;
             public Dispatcher(string name) { }
@@ -28,10 +43,56 @@ namespace Akka.Streams
             public override int GetHashCode() { }
             public override string ToString() { }
         }
-        public sealed class SupervisionStrategy : Akka.Streams.Attributes.IAttribute
+        public sealed class FuzzingMode : Akka.Streams.Attributes.IAttribute, Akka.Streams.Attributes.IMandatoryAttribute, System.IEquatable<Akka.Streams.ActorAttributes.FuzzingMode>
+        {
+            public FuzzingMode(bool enabled) { }
+            public bool Enabled { get; }
+            public bool Equals(Akka.Streams.ActorAttributes.FuzzingMode other) { }
+            public override bool Equals(object obj) { }
+            public override int GetHashCode() { }
+            public override string ToString() { }
+        }
+        public sealed class MaxFixedBufferSize : Akka.Streams.Attributes.IAttribute, Akka.Streams.Attributes.IMandatoryAttribute, System.IEquatable<Akka.Streams.ActorAttributes.MaxFixedBufferSize>
+        {
+            public MaxFixedBufferSize(int size) { }
+            public int Size { get; }
+            public bool Equals(Akka.Streams.ActorAttributes.MaxFixedBufferSize other) { }
+            public override bool Equals(object obj) { }
+            public override int GetHashCode() { }
+            public override string ToString() { }
+        }
+        public sealed class OutputBurstLimit : Akka.Streams.Attributes.IAttribute, Akka.Streams.Attributes.IMandatoryAttribute, System.IEquatable<Akka.Streams.ActorAttributes.OutputBurstLimit>
+        {
+            public OutputBurstLimit(int limit) { }
+            public int Limit { get; }
+            public bool Equals(Akka.Streams.ActorAttributes.OutputBurstLimit other) { }
+            public override bool Equals(object obj) { }
+            public override int GetHashCode() { }
+            public override string ToString() { }
+        }
+        public sealed class StreamSubscriptionTimeout : Akka.Streams.Attributes.IAttribute, Akka.Streams.Attributes.IMandatoryAttribute, System.IEquatable<Akka.Streams.ActorAttributes.StreamSubscriptionTimeout>
+        {
+            public StreamSubscriptionTimeout(System.TimeSpan timeout, Akka.Streams.StreamSubscriptionTimeoutTerminationMode mode) { }
+            public Akka.Streams.StreamSubscriptionTimeoutTerminationMode Mode { get; }
+            public System.TimeSpan Timeout { get; }
+            public bool Equals(Akka.Streams.ActorAttributes.StreamSubscriptionTimeout other) { }
+            public override bool Equals(object obj) { }
+            public override int GetHashCode() { }
+            public override string ToString() { }
+        }
+        public sealed class SupervisionStrategy : Akka.Streams.Attributes.IAttribute, Akka.Streams.Attributes.IMandatoryAttribute
         {
             public readonly Akka.Streams.Supervision.Decider Decider;
             public SupervisionStrategy(Akka.Streams.Supervision.Decider decider) { }
+            public override string ToString() { }
+        }
+        public sealed class SyncProcessingLimit : Akka.Streams.Attributes.IAttribute, Akka.Streams.Attributes.IMandatoryAttribute, System.IEquatable<Akka.Streams.ActorAttributes.SyncProcessingLimit>
+        {
+            public SyncProcessingLimit(int limit) { }
+            public int Limit { get; }
+            public bool Equals(Akka.Streams.ActorAttributes.SyncProcessingLimit other) { }
+            public override bool Equals(object obj) { }
+            public override int GetHashCode() { }
             public override string ToString() { }
         }
     }
@@ -116,10 +177,14 @@ namespace Akka.Streams
             where TAttr :  class, Akka.Streams.Attributes.IAttribute { }
         public System.Collections.Generic.IEnumerable<TAttr> GetAttributeList<TAttr>()
             where TAttr : Akka.Streams.Attributes.IAttribute { }
+        [System.ObsoleteAttribute("Attributes should always be most specific, use GetAttribute<TAttr>()")]
         public TAttr GetFirstAttribute<TAttr>(TAttr defaultIfNotFound)
             where TAttr :  class, Akka.Streams.Attributes.IAttribute { }
+        [System.ObsoleteAttribute("Attributes should always be most specific, use GetAttribute<TAttr>()")]
         public TAttr GetFirstAttribute<TAttr>()
             where TAttr :  class, Akka.Streams.Attributes.IAttribute { }
+        public TAttr GetMandatoryAttribute<TAttr>()
+            where TAttr :  class, Akka.Streams.Attributes.IMandatoryAttribute { }
         public string GetNameLifted() { }
         public string GetNameOrDefault(string defaultIfNotFound = "unknown-operation") { }
         public override string ToString() { }
@@ -130,8 +195,33 @@ namespace Akka.Streams
             public override bool Equals(object obj) { }
             public override string ToString() { }
         }
+        public sealed class CancellationStrategy : Akka.Streams.Attributes.IAttribute, Akka.Streams.Attributes.IMandatoryAttribute
+        {
+            public CancellationStrategy(Akka.Streams.Attributes.CancellationStrategy.IStrategy strategy) { }
+            public Akka.Streams.Attributes.CancellationStrategy.IStrategy Strategy { get; }
+            public class AfterDelay : Akka.Streams.Attributes.CancellationStrategy.IStrategy
+            {
+                public AfterDelay(System.TimeSpan delay, Akka.Streams.Attributes.CancellationStrategy.IStrategy strategy) { }
+                public System.TimeSpan Delay { get; }
+                public Akka.Streams.Attributes.CancellationStrategy.IStrategy Strategy { get; }
+            }
+            public class CompleteStage : Akka.Streams.Attributes.CancellationStrategy.IStrategy
+            {
+                public CompleteStage() { }
+            }
+            public class FailStage : Akka.Streams.Attributes.CancellationStrategy.IStrategy
+            {
+                public FailStage() { }
+            }
+            public interface IStrategy { }
+            public class PropagateFailure : Akka.Streams.Attributes.CancellationStrategy.IStrategy
+            {
+                public PropagateFailure() { }
+            }
+        }
         public interface IAttribute { }
-        public sealed class InputBuffer : Akka.Streams.Attributes.IAttribute, System.IEquatable<Akka.Streams.Attributes.InputBuffer>
+        public interface IMandatoryAttribute : Akka.Streams.Attributes.IAttribute { }
+        public sealed class InputBuffer : Akka.Streams.Attributes.IAttribute, Akka.Streams.Attributes.IMandatoryAttribute, System.IEquatable<Akka.Streams.Attributes.InputBuffer>
         {
             public readonly int Initial;
             public readonly int Max;
@@ -800,12 +890,46 @@ namespace Akka.Streams
     }
     public class static StreamRefAttributes
     {
+        public static Akka.Streams.Attributes CreateBufferCapacity(int capacity) { }
+        public static Akka.Streams.Attributes CreateDemandRedeliveryInterval(System.TimeSpan timeout) { }
+        public static Akka.Streams.Attributes CreateFinalTerminationSignalDeadline(System.TimeSpan timeout) { }
         public static Akka.Streams.Attributes CreateSubscriptionTimeout(System.TimeSpan timeout) { }
+        public sealed class BufferCapacity : Akka.Streams.Attributes.IAttribute, Akka.Streams.StreamRefAttributes.IStreamRefAttribute, System.IEquatable<Akka.Streams.StreamRefAttributes.BufferCapacity>
+        {
+            public BufferCapacity(int capacity) { }
+            public int Capacity { get; }
+            public bool Equals(Akka.Streams.StreamRefAttributes.BufferCapacity other) { }
+            public override bool Equals(object obj) { }
+            public override int GetHashCode() { }
+            public override string ToString() { }
+        }
+        public sealed class DemandRedeliveryInterval : Akka.Streams.Attributes.IAttribute, Akka.Streams.StreamRefAttributes.IStreamRefAttribute, System.IEquatable<Akka.Streams.StreamRefAttributes.DemandRedeliveryInterval>
+        {
+            public DemandRedeliveryInterval(System.TimeSpan timeout) { }
+            public System.TimeSpan Timeout { get; }
+            public bool Equals(Akka.Streams.StreamRefAttributes.DemandRedeliveryInterval other) { }
+            public override bool Equals(object obj) { }
+            public override int GetHashCode() { }
+            public override string ToString() { }
+        }
+        public sealed class FinalTerminationSignalDeadline : Akka.Streams.Attributes.IAttribute, Akka.Streams.StreamRefAttributes.IStreamRefAttribute, System.IEquatable<Akka.Streams.StreamRefAttributes.FinalTerminationSignalDeadline>
+        {
+            public FinalTerminationSignalDeadline(System.TimeSpan timeout) { }
+            public System.TimeSpan Timeout { get; }
+            public bool Equals(Akka.Streams.StreamRefAttributes.FinalTerminationSignalDeadline other) { }
+            public override bool Equals(object obj) { }
+            public override int GetHashCode() { }
+            public override string ToString() { }
+        }
         public interface IStreamRefAttribute : Akka.Streams.Attributes.IAttribute { }
-        public sealed class SubscriptionTimeout : Akka.Streams.Attributes.IAttribute, Akka.Streams.StreamRefAttributes.IStreamRefAttribute
+        public sealed class SubscriptionTimeout : Akka.Streams.Attributes.IAttribute, Akka.Streams.StreamRefAttributes.IStreamRefAttribute, System.IEquatable<Akka.Streams.StreamRefAttributes.SubscriptionTimeout>
         {
             public SubscriptionTimeout(System.TimeSpan timeout) { }
             public System.TimeSpan Timeout { get; }
+            public bool Equals(Akka.Streams.StreamRefAttributes.SubscriptionTimeout other) { }
+            public override bool Equals(object obj) { }
+            public override int GetHashCode() { }
+            public override string ToString() { }
         }
     }
     public sealed class StreamRefSubscriptionTimeoutException : Akka.Pattern.IllegalStateException

--- a/src/core/Akka.Cluster.Tests.MultiNode/NodeChurnSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/NodeChurnSpec.cs
@@ -105,7 +105,7 @@ namespace Akka.Cluster.Tests.MultiNode
             for (var n = 1; n <= Rounds; n++)
             {
                 Log.Info("round-" + n);
-                var systems = Enumerable.Repeat(0,2).Select(_ => Actor.ActorSystem.Create(Sys.Name, Sys.Settings.Config)).ToImmutableList();
+                var systems = Enumerable.Repeat(0,2).Select(_ => ActorSystem.Create(Sys.Name, Sys.Settings.Config)).ToImmutableList();
                 
                 foreach (var s in systems)
                 {

--- a/src/core/Akka.Docs.Tests/Streams/StreamRefsDocTests.cs
+++ b/src/core/Akka.Docs.Tests/Streams/StreamRefsDocTests.cs
@@ -101,7 +101,7 @@ namespace DocsExamples.Streams
                     StreamRefs.SinkRef<string>()
                         .To(sink)
                         .Run(Context.System.Materializer())
-                        .PipeTo(Sender, success: sinkRef => new MeasurementsSinkReady(prepare.Id, sinkRef));
+                        .PipeTo(Sender, success: sinkRef => sinkRef);
                 });
             }
 
@@ -135,12 +135,12 @@ namespace DocsExamples.Streams
             #region sink-ref-materialization
             var receiver = Sys.ActorOf(Props.Create<DataReceiver>(), "receiver");
 
-            var ready = await receiver.Ask<MeasurementsSinkReady>(new PrepareUpload("id"), timeout: TimeSpan.FromSeconds(30));
+            var ready = await receiver.Ask<ISinkRef<string>>(new PrepareUpload("id"), timeout: TimeSpan.FromSeconds(30));
 
             // stream local metrics to Sink's origin:
             Source.From(Enumerable.Range(1, 100))
                 .Select(i => i.ToString())
-                .RunWith(ready.SinkRef.Sink, Materializer);
+                .RunWith(ready.Sink, Materializer);
             #endregion
         }
     }

--- a/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
+++ b/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.7.1" />
+    <PackageReference Include="FSharp.Core" Version="4.7.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />

--- a/src/core/Akka.FSharp/Akka.FSharp.fsproj
+++ b/src/core/Akka.FSharp/Akka.FSharp.fsproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="FSharp.Quotations.Evaluator" Version="1.1.3" />
     <PackageReference Include="FsPickler" Version="5.3.2" />
-    <PackageReference Include="FSharp.Core" Version="4.7.1" />
+    <PackageReference Include="FSharp.Core" Version="4.7.2" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/core/Akka.NodeTestRunner/Akka.NodeTestRunner.csproj
+++ b/src/core/Akka.NodeTestRunner/Akka.NodeTestRunner.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreTestVersion)'">
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.4" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' ">

--- a/src/core/Akka.Streams.TestKit/TestSubscriber.cs
+++ b/src/core/Akka.Streams.TestKit/TestSubscriber.cs
@@ -258,6 +258,15 @@ namespace Akka.Streams.TestKit
             }
 
             /// <summary>
+            /// Fluent DSL. Expect completion with a timeout.
+            /// </summary>
+            public ManualProbe<T> ExpectComplete(TimeSpan timeout)
+            {
+                _probe.ExpectMsg<OnComplete>(timeout);
+                return this;
+            }
+
+            /// <summary>
             /// Expect and return the signalled <see cref="Exception"/>.
             /// </summary>
             public Exception ExpectError() => _probe.ExpectMsg<OnError>().Cause;

--- a/src/core/Akka.Streams.Tests/Dsl/DelayFlowSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/DelayFlowSpec.cs
@@ -63,7 +63,7 @@ namespace Akka.Streams.Tests.Dsl
                 .ExpectComplete();
         }
 
-        [Fact]
+        [Fact(Skip ="Racy")]
         public void DelayFlow_should_work_with_linear_increasing_delay()
         {
             var elems = Enumerable.Range(1, 10);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowBatchSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowBatchSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.TestKit;
@@ -75,17 +76,17 @@ namespace Akka.Streams.Tests.Dsl
             sub.Cancel();
         }
 
-        [Fact(Skip ="Racy")]
-        public void Batch_must_work_on_a_variable_rate_chain()
+        [Fact(Skip = "Racy")]
+        public async Task Batch_must_work_on_a_variable_rate_chain()
         {
-            var future = Source.From(Enumerable.Range(1, 1000)).Batch(100, i => i, (sum, i) => sum + i).Select(i =>
+            var result = Source.From(Enumerable.Range(1, 1000)).Batch(100, i => i, (sum, i) => sum + i).Select(i =>
             {
                 if (ThreadLocalRandom.Current.Next(1, 3) == 1)
                     Thread.Sleep(10);
                 return i;
             }).RunAggregate(0, (i, i1) => i + i1, Materializer);
-            future.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
-            future.Result.Should().Be(500500);
+            result.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+            result.Should().Be(500500);
         }
 
         [Fact]

--- a/src/core/Akka.Streams.Tests/Dsl/FlowBatchSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowBatchSpec.cs
@@ -75,7 +75,7 @@ namespace Akka.Streams.Tests.Dsl
             sub.Cancel();
         }
 
-        [Fact]
+        [Fact(Skip ="Racy")]
         public void Batch_must_work_on_a_variable_rate_chain()
         {
             var future = Source.From(Enumerable.Range(1, 1000)).Batch(100, i => i, (sum, i) => sum + i).Select(i =>

--- a/src/core/Akka.Streams.Tests/Dsl/FlowDelaySpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowDelaySpec.cs
@@ -31,7 +31,7 @@ namespace Akka.Streams.Tests.Dsl
             Materializer = ActorMaterializer.Create(Sys);
         }
 
-        [Fact]
+        [Fact(Skip ="Racy")]
         public void A_Delay_must_deliver_elements_with_some_time_shift()
         {
             var task =
@@ -61,7 +61,7 @@ namespace Akka.Streams.Tests.Dsl
             probe.ExpectComplete();
         }
 
-        [Fact]
+        [Fact(Skip ="Racy")]
         public void A_Delay_must_deliver_element_after_time_passed_from_actual_receiving_element()
         {
             var probe = Source.From(Enumerable.Range(1, 3))
@@ -77,7 +77,7 @@ namespace Akka.Streams.Tests.Dsl
                 .ExpectComplete();
         }
 
-        [Fact]
+        [Fact(Skip ="Racy")]
         public void A_Delay_must_deliver_elements_with_delay_for_slow_stream()
         {
             this.AssertAllStagesStopped(() =>
@@ -143,10 +143,7 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
 
-        // Was marked as racy. 
-        // Raised task.Wait() from 1200 to 1800. 1200 is flaky when CPU resources are scarce.
-        // Passed 500 consecutive local test runs with no fail with very heavy load after modification
-        [Fact]
+        [Fact(Skip ="Racy")]
         public void A_Delay_must_clear_all_for_internal_buffer_if_it_is_full_in_DropBuffer_mode()
         {
             this.AssertAllStagesStopped(() =>
@@ -157,7 +154,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Grouped(100)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-                task.Wait(TimeSpan.FromMilliseconds(1800)).Should().BeTrue();
+                task.Wait(TimeSpan.FromMilliseconds(1200)).Should().BeTrue();
                 task.Result.ShouldAllBeEquivalentTo(Enumerable.Range(17, 4));
             }, Materializer);
         }
@@ -198,7 +195,7 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
 
-        [Fact]
+        [Fact(Skip ="Racy")]
         public void A_Delay_must_emit_early_when_buffer_is_full_and_in_EmitEarly_mode()
         {
             this.AssertAllStagesStopped(() =>
@@ -224,9 +221,8 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
 
-        // Was marked as racy. 
         // Passed 500 consecutive local test runs with no fail with very heavy load without modification
-        [Fact]
+        [Fact(Skip ="Racy")]
         public void A_Delay_must_properly_delay_according_to_buffer_size()
         {
             // With a buffer size of 1, delays add up 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowDelaySpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowDelaySpec.cs
@@ -13,6 +13,7 @@ using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
 using Akka.TestKit;
+using Akka.Tests.Shared.Internals;
 using Akka.Util.Internal;
 using FluentAssertions;
 using Xunit;
@@ -42,7 +43,10 @@ namespace Akka.Streams.Tests.Dsl
             task.Result.Should().BeEquivalentTo(Enumerable.Range(1, 10));
         }
 
-        [Fact(Skip = "Racy")]
+        // Was marked as racy.
+        // Raised probe.ExpectNext from 300 to 600. 300 is flaky when CPU resources are scarce.
+        // Passed 500 consecutive local test runs with no fail with very heavy load after modification
+        [Fact]
         public void A_Delay_must_add_delay_to_initialDelay_if_exists_upstream()
         {
             var probe = Source.From(Enumerable.Range(1, 10))
@@ -52,7 +56,7 @@ namespace Akka.Streams.Tests.Dsl
 
             probe.Request(10);
             probe.ExpectNoMsg(TimeSpan.FromMilliseconds(1800));
-            probe.ExpectNext(1, TimeSpan.FromMilliseconds(300));
+            probe.ExpectNext(1, TimeSpan.FromMilliseconds(600));
             probe.ExpectNextN(Enumerable.Range(2, 9));
             probe.ExpectComplete();
         }
@@ -99,7 +103,10 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
 
-        [Fact(Skip = "Racy")]
+        // Was marked as racy.
+        // Raised task.Wait() from 1200 to 1800. 1200 is flaky when CPU resources are scarce.
+        // Passed 500 consecutive local test runs with no fail with very heavy load after modification
+        [Fact]
         public void A_Delay_must_drop_tail_for_internal_buffer_if_it_is_full_in_DropTail_mode()
         {
             this.AssertAllStagesStopped(() =>
@@ -110,14 +117,17 @@ namespace Akka.Streams.Tests.Dsl
                     .Grouped(100)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-                task.Wait(TimeSpan.FromMilliseconds(1200)).Should().BeTrue();
+                task.Wait(TimeSpan.FromMilliseconds(1800)).Should().BeTrue();
                 var expected = Enumerable.Range(1, 15).ToList();
                 expected.Add(20);
                 task.Result.Should().BeEquivalentTo(expected);
             }, Materializer);
         }
 
-        [Fact(Skip = "Racy")]
+        // Was marked as racy.
+        // Raised task.Wait() from 1200 to 1800. 1200 is flaky when CPU resources are scarce.
+        // Passed 500 consecutive local test runs with no fail with very heavy load after modification
+        [Fact]
         public void A_Delay_must_drop_head_for_internal_buffer_if_it_is_full_in_DropHead_mode()
         {
             this.AssertAllStagesStopped(() =>
@@ -128,12 +138,15 @@ namespace Akka.Streams.Tests.Dsl
                     .Grouped(100)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-                task.Wait(TimeSpan.FromMilliseconds(1200)).Should().BeTrue();
+                task.Wait(TimeSpan.FromMilliseconds(1800)).Should().BeTrue();
                 task.Result.ShouldAllBeEquivalentTo(Enumerable.Range(5, 16));
             }, Materializer);
         }
 
-        [Fact(Skip = "Racy")]
+        // Was marked as racy. 
+        // Raised task.Wait() from 1200 to 1800. 1200 is flaky when CPU resources are scarce.
+        // Passed 500 consecutive local test runs with no fail with very heavy load after modification
+        [Fact]
         public void A_Delay_must_clear_all_for_internal_buffer_if_it_is_full_in_DropBuffer_mode()
         {
             this.AssertAllStagesStopped(() =>
@@ -144,12 +157,12 @@ namespace Akka.Streams.Tests.Dsl
                     .Grouped(100)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-                task.Wait(TimeSpan.FromMilliseconds(1200)).Should().BeTrue();
+                task.Wait(TimeSpan.FromMilliseconds(1800)).Should().BeTrue();
                 task.Result.ShouldAllBeEquivalentTo(Enumerable.Range(17, 4));
             }, Materializer);
         }
 
-        [Fact(Skip = "Racy")]
+        [Fact(Skip = "Extremely flaky because of the interleaved ExpectNext and ExpectNoMsg with a very tight timing requirement. .Net timer implementation is not consistent enough to maintain accurate timing under heavy CPU load.")]
         public void A_Delay_must_pass_elements_with_delay_through_normally_in_backpressured_mode()
         {
             this.AssertAllStagesStopped(() =>
@@ -211,7 +224,9 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
 
-        [Fact(Skip = "Racy")]
+        // Was marked as racy. 
+        // Passed 500 consecutive local test runs with no fail with very heavy load without modification
+        [Fact]
         public void A_Delay_must_properly_delay_according_to_buffer_size()
         {
             // With a buffer size of 1, delays add up 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncUnorderedSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncUnorderedSpec.cs
@@ -38,7 +38,7 @@ namespace Akka.Streams.Tests.Dsl
             Materializer = ActorMaterializer.Create(Sys);
         }
 
-        [Fact]
+        [Fact(Skip ="Racy in Linux")]
         public void A_Flow_with_SelectAsyncUnordered_must_produce_task_elements_in_the_order_they_are_ready()
         {
             this.AssertAllStagesStopped(() =>

--- a/src/core/Akka.Streams.Tests/Dsl/FlowThrottleSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowThrottleSpec.cs
@@ -109,9 +109,7 @@ namespace Akka.Streams.Tests.Dsl
             t.Result.Should().Be(2);
         }
 
-        [Fact]
-        // Unit test became flaky when it didn't get enough CPU resource,
-        // need to raise the throttle time to compensate.
+        [Fact(Skip ="Racy")]
         public void Throttle_for_single_cost_elements_must_emit_single_element_per_tick()
         {
             this.AssertAllStagesStopped(() =>
@@ -196,7 +194,7 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
 
-        [Fact]
+        [Fact(Skip ="Racy")]
         public void Throttle_for_single_cost_elements_must_burst_according_to_its_maximum_if_enough_time_passed()
         {
             this.AssertAllStagesStopped(() =>
@@ -238,7 +236,7 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
 
-        [Fact]
+        [Fact(Skip ="Racy")]
         public void Throttle_for_single_cost_elements_must_burst_some_elements_if_have_enough_time()
         {
             this.AssertAllStagesStopped(() =>
@@ -331,7 +329,7 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
 
-        [Fact]
+        [Fact(Skip ="Racy")]
         public void Throttle_for_various_cost_elements_must_emit_elements_according_to_cost()
         {
             this.AssertAllStagesStopped(() =>
@@ -454,7 +452,7 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
 
-        [Fact]
+        [Fact(Skip ="Racy")]
         public void Throttle_for_various_cost_elements_must_burst_some_elements_if_have_enough_time()
         {
             this.AssertAllStagesStopped(() =>

--- a/src/core/Akka.Streams.Tests/Dsl/FlowThrottleSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowThrottleSpec.cs
@@ -329,7 +329,7 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
 
-        [Fact(Skip ="Racy")]
+        [Fact(Skip = "Racy, see https://github.com/akkadotnet/akka.net/pull/4424#issuecomment-632284459")]
         public void Throttle_for_various_cost_elements_must_emit_elements_according_to_cost()
         {
             this.AssertAllStagesStopped(() =>

--- a/src/core/Akka.Streams.Tests/Dsl/FlowThrottleSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowThrottleSpec.cs
@@ -110,6 +110,8 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
+        // Unit test became flaky when it didn't get enough CPU resource,
+        // need to raise the throttle time to compensate.
         public void Throttle_for_single_cost_elements_must_emit_single_element_per_tick()
         {
             this.AssertAllStagesStopped(() =>
@@ -118,7 +120,7 @@ namespace Akka.Streams.Tests.Dsl
                 var downstream = this.CreateSubscriberProbe<int>();
 
                 Source.FromPublisher(upstream)
-                    .Throttle(1, TimeSpan.FromMilliseconds(300), 0, ThrottleMode.Shaping)
+                    .Throttle(1, TimeSpan.FromMilliseconds(500), 0, ThrottleMode.Shaping)
                     .RunWith(Sink.FromSubscriber(downstream), Materializer);
 
                 downstream.Request(2);

--- a/src/core/Akka.Streams.Tests/Dsl/GraphStageTimersSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphStageTimersSpec.cs
@@ -45,7 +45,7 @@ namespace Akka.Streams.Tests.Dsl
             return channel;
         }
 
-        [Fact]
+        [Fact(Skip ="Racy")]
         public void GraphStage_timer_support_must_receive_single_shot_timer()
         {
             var driver = SetupIsolatedStage();
@@ -62,7 +62,7 @@ namespace Akka.Streams.Tests.Dsl
             driver.StopStage();
         }
 
-        [Fact]
+        [Fact(Skip ="Racy")]
         public void GraphStage_timer_support_must_resubmit_single_shot_timer()
         {
             var driver = SetupIsolatedStage();

--- a/src/core/Akka.Streams.Tests/Dsl/GraphStageTimersSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphStageTimersSpec.cs
@@ -46,17 +46,13 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact(Skip ="Racy")]
-        public void GraphStage_timer_support_must_receive_single_shot_timer()
+        public async Task GraphStage_timer_support_must_receive_single_shot_timer()
         {
             var driver = SetupIsolatedStage();
-            Within(TimeSpan.FromSeconds(2), () =>
+            await AwaitAssertAsync(() =>
             {
-                Within(TimeSpan.FromMilliseconds(500), TimeSpan.FromSeconds(1), () =>
-                {
-                    driver.Tell(TestSingleTimer.Instance);
-                    ExpectMsg(new Tick(1));
-                });
-
+                driver.Tell(TestSingleTimer.Instance);
+                ExpectMsg(new Tick(1), TimeSpan.FromSeconds(10));
                 ExpectNoMsg(TimeSpan.FromSeconds(1));
             });
             driver.StopStage();

--- a/src/core/Akka.Streams.Tests/Dsl/QueueSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/QueueSinkSpec.cs
@@ -153,7 +153,7 @@ namespace Akka.Streams.Tests.Dsl
             }, _materializer);
         }
 
-        [Fact]
+        [Fact(Skip = "Racy, see https://github.com/akkadotnet/akka.net/pull/4424#issuecomment-632284459")]
         public void QueueSink_should_fail_pull_future_when_stream_is_completed()
         {
             this.AssertAllStagesStopped(() =>
@@ -167,14 +167,13 @@ namespace Akka.Streams.Tests.Dsl
                 ExpectMsg(new Option<int>(1));
 
                 sub.SendComplete();
-                var future = queue.PullAsync();
-                future.Wait(_pause).Should().BeTrue();
-                future.Result.Should().Be(Option<int>.None);
+                var result = queue.PullAsync().Result;
+                result.Should().Be(Option<int>.None);
 
                 ((Task)queue.PullAsync()).ContinueWith(t =>
                 {
                     t.Exception.InnerException.Should().BeOfType<IllegalStateException>();
-                }, TaskContinuationOptions.OnlyOnFaulted).Wait(TimeSpan.FromMilliseconds(300));
+                }, TaskContinuationOptions.OnlyOnFaulted).Wait();
             }, _materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/RestartSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/RestartSpec.cs
@@ -113,7 +113,7 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
 
-        [Fact]
+        [Fact(Skip ="Racy")]
         public void A_restart_with_backoff_source_should_backoff_before_restart()
         {
             this.AssertAllStagesStopped(() =>
@@ -140,7 +140,7 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
 
-        [Fact]
+        [Fact(Skip ="Racy")]
         public void A_restart_with_backoff_source_should_reset_exponential_backoff_back_to_minimum_when_source_runs_for_at_least_minimum_backoff_without_completing()
         {
             this.AssertAllStagesStopped(() =>
@@ -291,6 +291,8 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
 
+        // Flaky test, ExpectComplete times out with the default 3 seconds value under heavy load.
+        // Fail rate was 1:500
         [Fact]
         public void A_restart_with_backoff_source_should_not_restart_the_source_when_maxRestarts_is_reached()
         {
@@ -305,7 +307,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 probe.RequestNext("a");
                 probe.RequestNext("a");
-                probe.ExpectComplete();
+                probe.ExpectComplete(TimeSpan.FromSeconds(5));
 
                 created.Current.Should().Be(2);
 
@@ -409,7 +411,7 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
 
-        [Fact]
+        [Fact(Skip ="Racy")]
         public void A_restart_with_backoff_sink_should_backoff_before_restart()
         {
             this.AssertAllStagesStopped(() =>
@@ -442,7 +444,7 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
 
-        [Fact]
+        [Fact(Skip ="Racy")]
         public void A_restart_with_backoff_sink_should_reset_exponential_backoff_back_to_minimum_when_source_runs_for_at_least_minimum_backoff_without_completing()
         {
             this.AssertAllStagesStopped(() =>
@@ -703,7 +705,7 @@ namespace Akka.Streams.Tests.Dsl
             created.Current.Should().Be(2);
         }
 
-        [Fact]
+        [Fact(Skip ="Racy")]
         public void A_restart_with_backoff_flow_should_backoff_before_restart()
         {
             var tuple = SetupFlow(TimeSpan.FromMilliseconds(200), TimeSpan.FromSeconds(2));

--- a/src/core/Akka.Streams.Tests/Dsl/StreamRefsSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/StreamRefsSpec.cs
@@ -311,7 +311,7 @@ namespace Akka.Streams.Tests
             ex.Message.Should().Contain("has terminated unexpectedly");
         }
 
-        [Fact]
+        [Fact(Skip ="Racy")]
         public void SourceRef_must_not_receive_subscription_timeout_when_got_subscribed()
         {
             _remoteActor.Tell("give-subscribe-timeout");
@@ -405,7 +405,7 @@ namespace Akka.Streams.Tests
             probe.ExpectCancellation();
         }
 
-        [Fact]
+        [Fact(Skip ="Racy")]
         public void SinkRef_must_not_receive_timeout_if_subscribing_is_already_done_to_the_sink_ref()
         {
             _remoteActor.Tell("receive-subscribe-timeout");

--- a/src/core/Akka.Streams.Tests/Dsl/SubstreamSubscriptionTimeoutSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SubstreamSubscriptionTimeoutSpec.cs
@@ -112,7 +112,7 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
 
-        [Fact]
+        [Fact(Skip ="Racy")]
         public void GroupBy_and_SplitWhen_must_not_timeout_and_cancel_substream_publisher_when_they_have_been_subscribed_to()
         {
             var subscriber = this.CreateManualSubscriberProbe<(int, Source<int, NotUsed>)>();

--- a/src/core/Akka.Streams.Tests/Dsl/TickSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/TickSourceSpec.cs
@@ -89,7 +89,7 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
 
-        [Fact]
+        [Fact(Skip = "Racy. See https://github.com/akkadotnet/akka.net/pull/4424#issuecomment-632284459")]
         public void A_Flow_based_on_a_tick_publisher_must_be_usable_with_zip_for_a_simple_form_of_rate_limiting()
         {
             this.AssertAllStagesStopped(() =>

--- a/src/core/Akka.Streams.Tests/Dsl/UnfoldFlowSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/UnfoldFlowSpec.cs
@@ -134,7 +134,7 @@ namespace Akka.Streams.Tests.Dsl
                 snk.ExpectError().Should().Be(kill);
             }
 
-            [Fact]
+            [Fact(Skip ="Racy")]
             public void UnfoldFlow_should_increment_integers_and_handle_KillSwitch_and_fail_after_timeout_when_aborted()
             {
                 var t = _source.ToMaterialized(this.SinkProbe<int>(), Keep.Both).Run(Sys.Materializer());
@@ -234,7 +234,7 @@ namespace Akka.Streams.Tests.Dsl
                 snk.ExpectComplete();
             }
 
-            [Fact]
+            [Fact(Skip ="Racy")]
             public void UnfoldFlow_should_increment_integers_and_handle_KillSwitch_and_complete_gracefully_after_timeout_when_stopped()
             {
                 var t = _source.ToMaterialized(this.SinkProbe<int>(), Keep.Both).Run(Sys.Materializer());
@@ -333,7 +333,7 @@ namespace Akka.Streams.Tests.Dsl
                 snk.ExpectError().Should().Be(kill);
             }
 
-            [Fact]
+            [Fact(Skip ="Racy")]
             public void UnfoldFlow_should_increment_integers_and_handle_KillSwitch_and_fail_after_timeout_when_aborted()
             {
                 var t = _source.ToMaterialized(this.SinkProbe<int>(), Keep.Both).Run(Sys.Materializer());

--- a/src/core/Akka.Streams.Tests/IO/InputStreamSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/InputStreamSinkSpec.cs
@@ -94,7 +94,7 @@ namespace Akka.Streams.Tests.IO
             }, _materializer);
         }
 
-        [Fact]
+        [Fact(Skip ="Racy in Linux")]
         public void InputStreamSink_should_block_read_until_get_requested_number_of_bytes_from_upstream()
         {
             this.AssertAllStagesStopped(() =>

--- a/src/core/Akka.Streams/Attributes.cs
+++ b/src/core/Akka.Streams/Attributes.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Akka.Event;
+using Akka.Pattern;
 using Akka.Streams.Dsl;
 using Akka.Streams.Implementation;
 using Akka.Streams.Supervision;
@@ -31,7 +32,16 @@ namespace Akka.Streams
         public interface IAttribute { }
 
         /// <summary>
-        /// TBD
+        /// Attributes that are always present (is defined with default values by the materializer)
+        /// 
+        /// Not for user extension
+        /// </summary>
+        public interface IMandatoryAttribute : IAttribute { }
+
+        /// <summary>
+        /// Specifies the name of the operation.
+        /// 
+        /// Use factory method <see cref="CreateName(string)"/> to create instances.
         /// </summary>
         public sealed class Name : IAttribute, IEquatable<Name>
         {
@@ -67,9 +77,13 @@ namespace Akka.Streams
         }
 
         /// <summary>
-        /// TBD
+        /// Each asynchronous piece of a materialized stream topology is executed by one Actor
+        /// that manages an input buffer for all inlets of its shape. This attribute configures
+        /// the initial and maximal input buffer in number of elements for each inlet.
+        /// 
+        /// Use factory method <see cref="CreateInputBuffer(int, int)"/> to create instances.
         /// </summary>
-        public sealed class InputBuffer : IAttribute, IEquatable<InputBuffer>
+        public sealed class InputBuffer : IMandatoryAttribute, IEquatable<InputBuffer>
         {
             /// <summary>
             /// TBD
@@ -193,13 +207,94 @@ namespace Akka.Streams
             private AsyncBoundary() { }
 
             /// <inheritdoc/>
-            public bool Equals(AsyncBoundary other) => true;
+            public bool Equals(AsyncBoundary other) => other is AsyncBoundary;
 
             /// <inheritdoc/>
             public override bool Equals(object obj) => obj is AsyncBoundary;
 
             /// <inheritdoc/>
             public override string ToString() => "AsyncBoundary";
+        }
+
+        /// <summary>
+        /// Cancellation strategies provide a way to configure the behavior of a stage 
+        /// when `cancelStage` is called.
+        /// 
+        /// It is only relevant for stream components that have more than one output 
+        /// and do not define a custom cancellation behavior by overriding `onDownstreamFinish`. 
+        /// In those cases, if the first output is cancelled, the default behavior
+        /// is to call `cancelStage` which shuts down the stage completely. 
+        /// The given strategy will allow customization of how the shutdown procedure should be done precisely.
+        /// </summary>
+        public sealed class CancellationStrategy:IMandatoryAttribute
+        {
+            internal CancellationStrategy Default { get; } = new CancellationStrategy(new PropagateFailure());
+
+            public IStrategy Strategy { get; }
+
+            public CancellationStrategy(IStrategy strategy)
+            {
+                Strategy = strategy;
+            }
+
+            public interface IStrategy { }
+
+            /// <summary>
+            /// Strategy that treats `cancelStage` the same as `completeStage`, i.e. all inlets are cancelled (propagating the
+            /// cancellation cause) and all outlets are regularly completed.
+            /// 
+            /// This used to be the default behavior before Akka 2.6.
+            ///
+            /// This behavior can be problematic in stacks of BidiFlows where different layers of the stack are both connected
+            /// through inputs and outputs. In this case, an error in a doubly connected component triggers both a cancellation
+            /// going upstream and an error going downstream.Since the stack might be connected to those components with inlets and
+            /// outlets, a race starts whether the cancellation or the error arrives first.If the error arrives first, that's usually
+            /// good because then the error can be propagated both on inlets and outlets.However, if the cancellation arrives first,
+            /// the previous default behavior to complete the stage will lead other outputs to be completed regularly.The error
+            /// which arrive late at the other hand will just be ignored (that connection will have been cancelled already and also
+            /// the paths through which the error could propagates are already shut down).
+            /// </summary>
+            public class CompleteStage : IStrategy { }
+
+            /// <summary>
+            /// Strategy that treats `cancelStage` the same as `failStage`, i.e. all inlets are cancelled (propagating the
+            /// cancellation cause) and all outlets are failed propagating the cause from cancellation.
+            /// </summary>
+            public class FailStage : IStrategy { }
+
+            /// <summary>
+            /// Strategy that treats `cancelStage` in different ways depending on the cause that was given to the cancellation.
+            /// 
+            /// If the cause was a regular, active cancellation (`SubscriptionWithCancelException.NoMoreElementsNeeded`), the stage
+            /// receiving this cancellation is completed regularly.
+            /// 
+            /// If another cause was given, this is treated as an error and the behavior is the same as with `failStage`.
+            /// 
+            /// This is a good default strategy.
+            /// </summary>
+            public class PropagateFailure : IStrategy { }
+
+            /// <summary>
+            /// Strategy that allows to delay any action when `cancelStage` is invoked.
+            /// 
+            /// The idea of this strategy is to delay any action on cancellation because it is expected that the stage is completed
+            /// through another path in the meantime. The downside is that a stage and a stream may live longer than expected if no
+            /// such signal is received and cancellation is invoked later on. In streams with many stages that all apply this strategy,
+            /// this strategy might significantly delay the propagation of a cancellation signal because each upstream stage might impose
+            /// such a delay. During this time, the stream will be mostly "silent", i.e. it cannot make progress because of backpressure,
+            /// but you might still be able observe a long delay at the ultimate source.
+            /// </summary>
+            public class AfterDelay : IStrategy 
+            { 
+                public TimeSpan Delay { get; }
+                public IStrategy Strategy { get; }
+
+                public AfterDelay(TimeSpan delay, IStrategy strategy)
+                {
+                    Delay = delay;
+                    Strategy = strategy;
+                }
+            }
         }
 
         /// <summary>
@@ -219,12 +314,32 @@ namespace Akka.Streams
         }
 
         /// <summary>
-        /// TBD
+        /// The list is ordered with the most specific attribute first, least specific last.
+        /// 
+        /// Note that operators in general should not inspect the whole hierarchy but instead use
+        /// <see cref="GetAttribute{TAttr}"/> to get the most specific attribute value.
         /// </summary>
         public IEnumerable<IAttribute> AttributeList => _attributes;
 
         /// <summary>
-        /// Get all attributes of a given type or subtype thereof
+        /// Note that this must only be used during traversal building and not during materialization
+        /// as it will then always return true because of the defaults from the ActorMaterializerSettings
+        /// 
+        /// INTERNAL API
+        /// </summary>
+        internal bool IsAsync
+            => _attributes.Count() > 0 && 
+                _attributes.Any(
+                    attr => attr is AsyncBoundary || 
+                    attr is ActorAttributes.Dispatcher);
+
+        /// <summary>
+        /// Get all attributes of a given type (or subtypes thereof).
+        /// 
+        /// Note that operators in general should not inspect the whole hierarchy but instead use
+        /// <see cref="GetAttribute{TAttr}"/> to get the most specific attribute value.
+        /// 
+        /// The list is ordered with the most specific attribute first, least specific last.
         /// </summary>
         /// <typeparam name="TAttr">TBD</typeparam>
         /// <returns>TBD</returns>
@@ -248,6 +363,7 @@ namespace Akka.Streams
         /// <typeparam name="TAttr">TBD</typeparam>
         /// <param name="defaultIfNotFound">TBD</param>
         /// <returns>TBD</returns>
+        [Obsolete("Attributes should always be most specific, use GetAttribute<TAttr>()")]
         public TAttr GetFirstAttribute<TAttr>(TAttr defaultIfNotFound) where TAttr : class, IAttribute
             => GetFirstAttribute<TAttr>() ?? defaultIfNotFound;
 
@@ -264,8 +380,22 @@ namespace Akka.Streams
         /// </summary>
         /// <typeparam name="TAttr">TBD</typeparam>
         /// <returns>TBD</returns>
+        [Obsolete("Attributes should always be most specific, use GetAttribute<TAttr>()")]
         public TAttr GetFirstAttribute<TAttr>() where TAttr : class, IAttribute
             => _attributes.FirstOrDefault(attr => attr is TAttr) as TAttr;
+
+        /// <summary>
+        /// Get the most specific of one of the mandatory attributes. Mandatory attributes are guaranteed
+        /// to always be among the attributes when the attributes are coming from a materialization.
+        /// </summary>
+        /// <typeparam name="TAttr"></typeparam>
+        /// <returns></returns>
+        public TAttr GetMandatoryAttribute<TAttr>() where TAttr : class, IMandatoryAttribute
+        {
+            if (!(_attributes.First(attr => attr is TAttr) is TAttr result))
+                throw new IllegalStateException($"Mandatory attribute [{typeof(TAttr)}] not found.");
+            return result;
+        }
 
         /// <summary>
         /// Adds given attributes to the end of these attributes.
@@ -321,6 +451,9 @@ namespace Akka.Streams
 
         /// <summary>
         /// Test whether the given attribute is contained within this attributes list.
+        /// 
+        /// Note that operators in general should not inspect the whole hierarchy but instead use
+        /// `get` to get the most specific attribute value.
         /// </summary>
         /// <typeparam name="TAttr">TBD</typeparam>
         /// <param name="attribute">TBD</param>
@@ -330,14 +463,22 @@ namespace Akka.Streams
         /// <summary>
         /// Specifies the name of the operation.
         /// If the name is null or empty the name is ignored, i.e. <see cref="None"/> is returned.
+        /// 
+        /// When using this method the name is encoded with `Uri.EscapeUriString` because
+        /// the name is sometimes used as part of actor name. If that is not desired
+        /// the name can be added in it's raw format using `.And(new Attributes(new Name(name)))`.
         /// </summary>
         /// <param name="name">TBD</param>
         /// <returns>TBD</returns>
         public static Attributes CreateName(string name)
-            => string.IsNullOrEmpty(name) ? None : new Attributes(new Name(name));
+            => string.IsNullOrEmpty(name) ? 
+                None : 
+                new Attributes(new Name(Uri.EscapeUriString(name)));
 
         /// <summary>
-        /// Specifies the initial and maximum size of the input buffer.
+        /// Each asynchronous piece of a materialized stream topology is executed by one Actor
+        /// that manages an input buffer for all inlets of its shape. This attribute configures
+        /// the initial and maximal input buffer in number of elements for each inlet.
         /// </summary>
         /// <param name="initial">TBD</param>
         /// <param name="max">TBD</param>
@@ -365,6 +506,7 @@ namespace Akka.Streams
             LogLevel onFinish = LogLevel.DebugLevel, LogLevel onError = LogLevel.ErrorLevel)
             => new Attributes(new LogLevels(onElement, onFinish, onError));
 
+        // TODO: different than scala code, investigate later.
         /// <summary>
         /// Compute a name by concatenating all Name attributes that the given module
         /// has, returning the given default value if none are found.
@@ -386,14 +528,16 @@ namespace Akka.Streams
     }
 
     /// <summary>
-    /// Attributes for the <see cref="ActorMaterializer"/>. Note that more attributes defined in <see cref="ActorAttributes"/>.
+    /// Attributes for the <see cref="ActorMaterializer"/>. Note that more attributes defined in <see cref="Attributes"/>.
     /// </summary>
     public static class ActorAttributes
     {
         /// <summary>
-        /// TBD
+        /// Configures the dispatcher to be used by streams.
+        /// 
+        /// Use factory method <see cref="CreateDispatcher(string)"/> to create instances.
         /// </summary>
-        public sealed class Dispatcher : Attributes.IAttribute, IEquatable<Dispatcher>
+        public sealed class Dispatcher : Attributes.IMandatoryAttribute, IEquatable<Dispatcher>
         {
             /// <summary>
             /// TBD
@@ -432,7 +576,7 @@ namespace Akka.Streams
         /// <summary>
         /// TBD
         /// </summary>
-        public sealed class SupervisionStrategy : Attributes.IAttribute
+        public sealed class SupervisionStrategy : Attributes.IMandatoryAttribute
         {
             /// <summary>
             /// TBD
@@ -453,7 +597,221 @@ namespace Akka.Streams
         }
 
         /// <summary>
-        /// Specifies the name of the dispatcher.
+        /// Enables additional low level troubleshooting logging at DEBUG log level
+        /// 
+        /// Use factory method `CreateDebugLogging` to create.
+        /// </summary>
+        public sealed class DebugLogging :
+            Attributes.IMandatoryAttribute,
+            IEquatable<DebugLogging>
+        {
+            public bool Enabled { get; }
+
+            public DebugLogging(bool enabled)
+            {
+                Enabled = enabled;
+            }
+
+            /// <inheritdoc/>
+            public bool Equals(DebugLogging other)
+            {
+                if (other is null) return false;
+                if (ReferenceEquals(this, other)) return true;
+                return Enabled == other.Enabled;
+            }
+
+            /// <inheritdoc/>
+            public override bool Equals(object obj) => obj is DebugLogging attr && Equals(attr);
+
+            /// <inheritdoc/>
+            public override int GetHashCode() => Enabled.GetHashCode();
+
+            /// <inheritdoc/>
+            public override string ToString() => $"DebugLogging(enabled={Enabled})";
+        }
+
+        /// <summary>
+        /// Defines a timeout for stream subscription and what action to take when that hits.
+        /// 
+        /// Use factory method `CreateStreamSubscriptionTimeout` to create.
+        /// </summary>
+        public sealed class StreamSubscriptionTimeout :
+            Attributes.IMandatoryAttribute,
+            IEquatable<StreamSubscriptionTimeout>
+        {
+            public TimeSpan Timeout { get; }
+            public StreamSubscriptionTimeoutTerminationMode Mode { get; }
+
+            public StreamSubscriptionTimeout(TimeSpan timeout, StreamSubscriptionTimeoutTerminationMode mode)
+            {
+                if (timeout.Ticks < 0)
+                    throw new ArgumentException("Timeout must be finite.", nameof(timeout));
+                Timeout = timeout;
+                Mode = mode;
+            }
+
+            public bool Equals(StreamSubscriptionTimeout other)
+            {
+                if (other is null) return false;
+                if (ReferenceEquals(this, other)) return true;
+                return Timeout.Equals(other.Timeout) && Mode.Equals(other.Mode);
+            }
+
+            /// <inheritdoc/>
+            public override bool Equals(object obj) => obj is StreamSubscriptionTimeout attr && Equals(attr);
+
+            /// <inheritdoc/>
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var initial = Timeout.GetHashCode();
+                    return (initial * 397) ^ Mode.GetHashCode();
+                }
+            }
+
+            /// <inheritdoc/>
+            public override string ToString() => $"StreamSubscriptionTimeout(timeout={Timeout.TotalMilliseconds}ms, mode={Mode})";
+        }
+
+        /// <summary>
+        /// Maximum number of elements emitted in batch if downstream signals large demand.
+        /// 
+        /// Use factory method `CreateOutputBurstLimit` to create.
+        /// </summary>
+        public sealed class OutputBurstLimit :
+            Attributes.IMandatoryAttribute,
+            IEquatable<OutputBurstLimit>
+        {
+            public int Limit { get; }
+
+            public OutputBurstLimit(int limit)
+            {
+                Limit = limit;
+            }
+
+            public bool Equals(OutputBurstLimit other)
+            {
+                if (other is null) return false;
+                if (ReferenceEquals(this, other)) return true;
+                return Limit == other.Limit;
+            }
+
+            /// <inheritdoc/>
+            public override bool Equals(object obj) => obj is OutputBurstLimit attr && Equals(attr);
+
+            /// <inheritdoc/>
+            public override int GetHashCode() => Limit.GetHashCode();
+
+            /// <inheritdoc/>
+            public override string ToString() => $"OutputBurstLimit(limit={Limit})";
+        }
+
+        /// <summary>
+        /// Test utility: fuzzing mode means that GraphStage events are not processed
+        /// in FIFO order within a fused subgraph, but randomized.
+        /// 
+        /// Use factory method `CreateFuzzingMode` to create.
+        /// </summary>
+        public sealed class FuzzingMode :
+            Attributes.IMandatoryAttribute,
+            IEquatable<FuzzingMode>
+        {
+            public bool Enabled { get; }
+
+            public FuzzingMode(bool enabled)
+            {
+                Enabled = enabled;
+            }
+
+            public bool Equals(FuzzingMode other)
+            {
+                if (other is null) return false;
+                if (ReferenceEquals(this, other)) return true;
+                return Enabled == other.Enabled;
+            }
+
+            /// <inheritdoc/>
+            public override bool Equals(object obj) => obj is FuzzingMode attr && Equals(attr);
+
+            /// <inheritdoc/>
+            public override int GetHashCode() => Enabled.GetHashCode();
+
+            /// <inheritdoc/>
+            public override string ToString() => $"FuzzingMode(enabled={Enabled})";
+        }
+
+        /// <summary>
+        /// Configure the maximum buffer size for which a FixedSizeBuffer will be preallocated.
+        /// This defaults to a large value because it is usually better to fail early when
+        /// system memory is not sufficient to hold the buffer.
+        /// 
+        /// Use factory method `CreateMaxFixedBufferSize` to create.
+        /// </summary>
+        public sealed class MaxFixedBufferSize :
+            Attributes.IMandatoryAttribute,
+            IEquatable<MaxFixedBufferSize>
+        {
+            public int Size { get; }
+
+            public MaxFixedBufferSize(int size)
+            {
+                Size = size;
+            }
+
+            public bool Equals(MaxFixedBufferSize other)
+            {
+                if (other is null) return false;
+                if (ReferenceEquals(this, other)) return true;
+                return Size == other.Size;
+            }
+
+            /// <inheritdoc/>
+            public override bool Equals(object obj) => obj is MaxFixedBufferSize attr && Equals(attr);
+
+            /// <inheritdoc/>
+            public override int GetHashCode() => Size.GetHashCode();
+
+            /// <inheritdoc/>
+            public override string ToString() => $"MaxFixedBufferSize(size={Size})";
+        }
+
+        /// <summary>
+        /// Limit for number of messages that can be processed synchronously 
+        /// in stream to substream communication.
+        /// 
+        /// Use factory method `CreateSyncProcessingLimit` to create.
+        /// </summary>
+        public sealed class SyncProcessingLimit :
+            Attributes.IMandatoryAttribute,
+            IEquatable<SyncProcessingLimit>
+        {
+            public int Limit { get; }
+
+            public SyncProcessingLimit(int limit)
+            {
+                Limit = limit;
+            }
+
+            public bool Equals(SyncProcessingLimit other)
+            {
+                if (other is null) return false;
+                if (ReferenceEquals(this, other)) return true;
+                return Limit == other.Limit;
+            }
+
+            /// <inheritdoc/>
+            public override bool Equals(object obj) => obj is SyncProcessingLimit attr && Equals(attr);
+
+            /// <inheritdoc/>
+            public override int GetHashCode() => Limit.GetHashCode();
+
+            /// <inheritdoc/>
+            public override string ToString() => $"SyncProcessingLimit(limit={Limit})";
+        }
+
+        /// <summary>
+        /// Specifies the name of the dispatcher. This also adds an async boundary.
         /// </summary>
         /// <param name="dispatcherName">TBD</param>
         /// <returns>TBD</returns>
@@ -470,6 +828,60 @@ namespace Akka.Streams
         /// <returns>TBD</returns>
         public static Attributes CreateSupervisionStrategy(Decider strategy)
             => new Attributes(new SupervisionStrategy(strategy));
+
+        /// <summary>
+        /// Enables additional low level troubleshooting logging at DEBUG log level
+        /// </summary>
+        /// <param name="enabled"></param>
+        /// <returns></returns>
+        public static Attributes CreateDebugLogging(bool enabled)
+            => new Attributes(new DebugLogging(enabled));
+
+        /// <summary>
+        /// Defines a timeout for stream subscription and what action to take when that hits.
+        /// </summary>
+        /// <param name="timeout"></param>
+        /// <param name="mode"></param>
+        /// <returns></returns>
+        public static Attributes CreateStreamSubscriptionTimeout(
+            TimeSpan timeout, 
+            StreamSubscriptionTimeoutTerminationMode mode)
+            => new Attributes(new StreamSubscriptionTimeout(timeout, mode));
+
+        /// <summary>
+        /// Maximum number of elements emitted in batch if downstream signals large demand.
+        /// </summary>
+        /// <param name="limit"></param>
+        /// <returns></returns>
+        public static Attributes CreateOutputBurstLimit(int limit)
+            => new Attributes(new OutputBurstLimit(limit));
+
+        /// <summary>
+        /// Test utility: fuzzing mode means that GraphStage events are not processed
+        /// in FIFO order within a fused subgraph, but randomized.
+        /// </summary>
+        /// <param name="enabled"></param>
+        /// <returns></returns>
+        public static Attributes CreateFuzzingMode(bool enabled)
+            => new Attributes(new FuzzingMode(enabled));
+
+        /// <summary>
+        /// Configure the maximum buffer size for which a FixedSizeBuffer will be preallocated.
+        /// This defaults to a large value because it is usually better to fail early when
+        /// system memory is not sufficient to hold the buffer.
+        /// </summary>
+        /// <param name="size"></param>
+        /// <returns></returns>
+        public static Attributes CreateMaxFixedBufferSize(int size)
+            => new Attributes(new MaxFixedBufferSize(size));
+
+        /// <summary>
+        /// Limit for number of messages that can be processed synchronously in stream to substream communication
+        /// </summary>
+        /// <param name="limit"></param>
+        /// <returns></returns>
+        public static Attributes CreateSyncProcessingLimit(int limit)
+            => new Attributes(new SyncProcessingLimit(limit));
     }
     
     /// <summary>
@@ -480,22 +892,159 @@ namespace Akka.Streams
     {
         /// <summary>
         /// Attributes specific to stream refs.
+        /// 
+        /// Not for user extension.
         /// </summary>
         public interface IStreamRefAttribute : Attributes.IAttribute { }
 
-        public sealed class SubscriptionTimeout : IStreamRefAttribute
+        /// <summary>
+        /// Specifies the subscription timeout within which the remote side MUST subscribe to the handed out stream reference.
+        /// </summary>
+        public sealed class SubscriptionTimeout : IStreamRefAttribute, IEquatable<SubscriptionTimeout>
         {
             public TimeSpan Timeout { get; }
 
             public SubscriptionTimeout(TimeSpan timeout)
             {
+                if (timeout.Ticks < 0)
+                    throw new ArgumentException("Timeout must be finite.", nameof(timeout));
+
                 Timeout = timeout;
             }
+
+            public bool Equals(SubscriptionTimeout other)
+            {
+                if (other is null) return false;
+                if (ReferenceEquals(this, other)) return true;
+                return Timeout.Equals(other.Timeout);
+            }
+
+            /// <inheritdoc/>
+            public override bool Equals(object obj) => obj is SubscriptionTimeout attr && Equals(attr);
+
+            /// <inheritdoc/>
+            public override int GetHashCode() => Timeout.GetHashCode();
+
+            /// <inheritdoc/>
+            public override string ToString() => $"SubscriptionTimeout(timeout={Timeout.TotalMilliseconds}ms)";
         }
-        
+
+        /// <summary>
+        /// Specifies the size of the buffer on the receiving side that is eagerly filled even without demand.
+        /// </summary>
+        public sealed class BufferCapacity : IStreamRefAttribute, IEquatable<BufferCapacity>
+        {
+            public int Capacity { get; }
+            public BufferCapacity (int capacity)
+            {
+                if (capacity <= 0)
+                    throw new ArgumentException("Capacity must be greater than zero", nameof(capacity));
+                Capacity = capacity;
+            }
+
+            public bool Equals(BufferCapacity other)
+            {
+                if (other is null) return false;
+                if (ReferenceEquals(this, other)) return true;
+                return Capacity == other.Capacity;
+            }
+
+            /// <inheritdoc/>
+            public override bool Equals(object obj) => obj is BufferCapacity attr && Equals(attr);
+
+            /// <inheritdoc/>
+            public override int GetHashCode() => Capacity.GetHashCode();
+
+            /// <inheritdoc/>
+            public override string ToString() => $"BufferCapacity(capacity={Capacity})";
+        }
+
+        /// <summary>
+        /// If no new elements arrive within this timeout, demand is redelivered.
+        /// </summary>
+        public sealed class DemandRedeliveryInterval : IStreamRefAttribute, IEquatable<DemandRedeliveryInterval>
+        {
+            public TimeSpan Timeout { get; }
+
+            public DemandRedeliveryInterval(TimeSpan timeout)
+            {
+                if (timeout.Ticks < 0)
+                    throw new ArgumentException("Timeout must be finite.", nameof(timeout));
+
+                Timeout = timeout;
+            }
+
+            public bool Equals(DemandRedeliveryInterval other)
+            {
+                if (other is null) return false;
+                if (ReferenceEquals(this, other)) return true;
+                return Timeout.Equals(other.Timeout);
+            }
+
+            /// <inheritdoc/>
+            public override bool Equals(object obj) => obj is DemandRedeliveryInterval attr && Equals(attr);
+
+            /// <inheritdoc/>
+            public override int GetHashCode() => Timeout.GetHashCode();
+
+            /// <inheritdoc/>
+            public override string ToString() => $"DemandRedeliveryInterval(timeout={Timeout.TotalMilliseconds}ms)";
+        }
+
+        /// <summary>
+        /// The time between the Terminated signal being received and when the local SourceRef determines to fail itself
+        /// </summary>
+        public sealed class FinalTerminationSignalDeadline : IStreamRefAttribute, IEquatable<FinalTerminationSignalDeadline>
+        {
+            public TimeSpan Timeout { get; }
+
+            public FinalTerminationSignalDeadline(TimeSpan timeout)
+            {
+                if (timeout.Ticks < 0)
+                    throw new ArgumentException("Timeout must be finite.", nameof(timeout));
+
+                Timeout = timeout;
+            }
+
+            public bool Equals(FinalTerminationSignalDeadline other)
+            {
+                if (other is null) return false;
+                if (ReferenceEquals(this, other)) return true;
+                return Timeout.Equals(other.Timeout);
+            }
+
+            /// <inheritdoc/>
+            public override bool Equals(object obj) => obj is FinalTerminationSignalDeadline attr && Equals(attr);
+
+            /// <inheritdoc/>
+            public override int GetHashCode() => Timeout.GetHashCode();
+
+            /// <inheritdoc/>
+            public override string ToString() => $"FinalTerminationSignalDeadline(timeout={Timeout.TotalMilliseconds}ms)";
+        }
+
         /// <summary>
         /// Specifies the subscription timeout within which the remote side MUST subscribe to the handed out stream reference.
         /// </summary>
         public static Attributes CreateSubscriptionTimeout(TimeSpan timeout) => new Attributes(new SubscriptionTimeout(timeout));
+
+        /// <summary>
+        /// Specifies the size of the buffer on the receiving side that is eagerly filled even without demand.
+        /// </summary>
+        public static Attributes CreateBufferCapacity(int capacity)
+            => new Attributes(new BufferCapacity(capacity));
+
+
+        /// <summary>
+        /// If no new elements arrive within this timeout, demand is redelivered.
+        /// </summary>
+        public static Attributes CreateDemandRedeliveryInterval(TimeSpan timeout) 
+            => new Attributes(new DemandRedeliveryInterval(timeout));
+
+        /// <summary>
+        /// The time between the Terminated signal being received and when the local SourceRef determines to fail itself
+        /// </summary>
+        public static Attributes CreateFinalTerminationSignalDeadline(TimeSpan timeout) 
+            => new Attributes(new FinalTerminationSignalDeadline(timeout));
     }
 }

--- a/src/core/Akka.Tests.Shared.Internals/RepeatAttribute.cs
+++ b/src/core/Akka.Tests.Shared.Internals/RepeatAttribute.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Xunit.Sdk;
+
+namespace Akka.Tests.Shared.Internals
+{
+    /// <summary>
+    /// This is an internal utility to test flaky/racy unit tests. 
+    /// It allows the test runner to run a single unit test repeatedly to test for flaky situations.
+    /// 
+    /// NOTE:
+    /// Make sure that this attribute are _NOT_ used in the unit test when it is ready to be committed, 
+    /// because it creates artificial load that can bind the CI/CD PR validation process.
+    /// </summary>
+    /// <example>
+    /// // This will repeatedly run MyUnitTest 500 times
+    /// // Note that you NEED to use [Theory], and the unit test requires a single integer parameter.
+    /// [Theory]
+    /// [Repeat(500)]
+    /// public void MyUnitTest(int _)
+    /// { }
+    /// </example>
+    public sealed class RepeatAttribute : DataAttribute
+    {
+        private readonly int _count;
+
+        public RepeatAttribute(int count)
+        {
+            if (count < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count),
+                      "Repeat count must be greater than 0.");
+            }
+            _count = count;
+        }
+
+        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+        {
+            foreach(var x in Enumerable.Range(1, _count))
+            {
+                yield return new object[] { x };
+            }
+        }
+    }
+}

--- a/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using Akka.Actor.Setup;
 using Akka.Configuration;
 using Akka.Dispatch;
 using Akka.Event;
@@ -67,7 +68,7 @@ namespace Akka.Tests.Actor
             var config = ConfigurationFactory.ParseString("akka.log-config-on-start = on")
                 .WithFallback(DefaultConfig);
 
-            var system = new ActorSystemImpl(Guid.NewGuid().ToString(), config);
+            var system = new ActorSystemImpl(Guid.NewGuid().ToString(), config, ActorSystemSetup.Empty);
             // Actor system should be started to attach the EventFilterFactory
             system.Start();
 
@@ -86,7 +87,7 @@ namespace Akka.Tests.Actor
             var config = ConfigurationFactory.ParseString("akka.log-config-on-start = off")
                 .WithFallback(DefaultConfig);
 
-            var system = new ActorSystemImpl(Guid.NewGuid().ToString(), config);
+            var system = new ActorSystemImpl(Guid.NewGuid().ToString(), config, ActorSystemSetup.Empty);
             // Actor system should be started to attach the EventFilterFactory
             system.Start();
 

--- a/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_ActionScheduler_Cancellation_Tests.cs
+++ b/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_ActionScheduler_Cancellation_Tests.cs
@@ -121,6 +121,8 @@ namespace Akka.Tests.Actor.Scheduler
             }
         }
 
+        // Might be racy, failed at least once in Azure Pipelines.
+        // Passed 500 consecutive local test runs with no fail with very heavy load without modification
         [Fact]
         public void When_canceling_existing_running_repeaters_by_scheduling_the_cancellation_ahead_of_time_Then_their_future_actions_should_not_be_invoked()
         {

--- a/src/core/Akka.Tests/Actor/Setup/ActorSystemSetupSpec.cs
+++ b/src/core/Akka.Tests/Actor/Setup/ActorSystemSetupSpec.cs
@@ -1,0 +1,111 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ActorSystemSetupSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.Actor.Setup;
+using Akka.TestKit;
+using Akka.Util;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Tests.Actor.Setup
+{
+    public class DummySetup : Akka.Actor.Setup.Setup
+    {
+        public DummySetup(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+    }
+
+    public class DummySetup2 : Akka.Actor.Setup.Setup
+    {
+        public DummySetup2(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+    }
+
+    public class DummySetup3 : Akka.Actor.Setup.Setup
+    {
+        public DummySetup3(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+    }
+
+    public class ActorSystemSetupSpec
+    {
+        [Fact]
+        public void ActorSystemSettingsShouldStoreAndRetrieveSetup()
+        {
+            var setup = new DummySetup("Ardbeg");
+            var setups = ActorSystemSetup.Create(setup);
+
+            setups.Get<DummySetup>().Should().Be(new Option<DummySetup>(setup));
+            setups.Get<DummySetup2>().Should().Be(Option<DummySetup2>.None);
+        }
+
+        [Fact]
+        public void ActorSystemSettingsShouldReplaceSetupIfAlreadyDefined()
+        {
+            var setup1 = new DummySetup("Ardbeg");
+            var setup2 = new DummySetup("Ledaig");
+            var setups = ActorSystemSetup.Empty.WithSetup(setup1).WithSetup(setup2);
+
+            setups.Get<DummySetup>().Should().Be(new Option<DummySetup>(setup2));
+        }
+
+        [Fact]
+        public void ActorSystemSettingsShouldProvideFluentInterface()
+        {
+            var setup1 = new DummySetup("Ardbeg");
+            var setup2 = new DummySetup("Ledaig");
+            var setup3 = new DummySetup2("Blantons");
+            var setups = setup1.And(setup2).And(setup3);
+
+            setups.Get<DummySetup>().Should().Be(new Option<DummySetup>(setup2));
+            setups.Get<DummySetup2>().Should().Be(new Option<DummySetup2>(setup3));
+        }
+
+        [Fact]
+        public void ActorSystemSettingsShouldBeCreatedWithSetOfSetups()
+        {
+            var setup1 = new DummySetup("Ardbeg");
+            var setup2 = new DummySetup2("Ledaig");
+            var setups = ActorSystemSetup.Create(setup1, setup2);
+
+            setups.Get<DummySetup>().HasValue.Should().BeTrue();
+            setups.Get<DummySetup2>().HasValue.Should().BeTrue();
+            setups.Get<DummySetup3>().HasValue.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ActorSystemSettingsShouldBeAvailableFromExtendedActorSystem()
+        {
+            ActorSystem system = null;
+            try
+            {
+                var setup = new DummySetup("Eagle Rare");
+                system = ActorSystem.Create("name", ActorSystemSetup.Create(setup));
+
+                system.Settings.Setup.Get<DummySetup>().Should().Be(new Option<DummySetup>(setup));
+            }
+            finally
+            {
+                system?.Terminate().Wait(TimeSpan.FromSeconds(5));
+            }
+        }
+    }
+}

--- a/src/core/Akka.Tests/Event/LoggerSpec.cs
+++ b/src/core/Akka.Tests/Event/LoggerSpec.cs
@@ -117,9 +117,12 @@ namespace Akka.Tests.Event
             system.EventStream.Subscribe(TestActor, typeof(Debug));
             await system.Terminate();
 
-            var shutdownInitiated = ExpectMsg<Debug>(TestKitSettings.DefaultTimeout);
-            shutdownInitiated.Message.ShouldBe("System shutdown initiated");
-
+            await AwaitAssertAsync(() =>
+            {
+                var shutdownInitiated = ExpectMsg<Debug>(TestKitSettings.DefaultTimeout);
+                shutdownInitiated.Message.ShouldBe("System shutdown initiated");
+            });
+            
             var loggerStarted = ExpectMsg<Debug>(TestKitSettings.DefaultTimeout);
             loggerStarted.Message.ShouldBe("Shutting down: StandardOutLogger started");
             loggerStarted.LogClass.ShouldBe(typeof(EventStream));

--- a/src/core/Akka.Tests/Loggers/LoggerStartupSpec.cs
+++ b/src/core/Akka.Tests/Loggers/LoggerStartupSpec.cs
@@ -1,0 +1,56 @@
+// //-----------------------------------------------------------------------
+// // <copyright file="LoggerStartupSpec.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Tests.Loggers
+{
+    public class LoggerStartupSpec : TestKit.Xunit2.TestKit
+    {
+        private const int LoggerResponseDelayMs = 10_000;
+        
+        [Fact]
+        public async Task Logger_async_start_configuration_helps_to_ignore_hanging_loggers()
+        {
+            var loggerAsyncStartDisabledConfig = ConfigurationFactory.ParseString($"akka.logger-async-start = false");
+            var loggerAsyncStartEnabledConfig = ConfigurationFactory.ParseString($"akka.logger-async-start = true");
+            
+            var slowLoggerConfig = ConfigurationFactory.ParseString($"akka.loggers = [\"{typeof(SlowLoggerActor).FullName}, {typeof(SlowLoggerActor).Assembly.GetName().Name}\"]");
+
+            // Without logger async start, ActorSystem creation will hang
+            this.Invoking(_ => ActorSystem.Create("handing", slowLoggerConfig.WithFallback(loggerAsyncStartDisabledConfig)))
+                .ShouldThrow<Exception>("System can not start - logger timed out");
+            
+            // With logger async start, ActorSystem is created without issues
+             // Created without timeouts
+            var system = ActorSystem.Create("working", slowLoggerConfig.WithFallback(loggerAsyncStartEnabledConfig));
+        }
+        
+        public class SlowLoggerActor : ReceiveActor
+        {
+            public SlowLoggerActor()
+            {
+                ReceiveAsync<InitializeLogger>(async _ =>
+                {
+                    // Ooops... Logger is responding too slow
+                    await Task.Delay(LoggerResponseDelayMs);
+                    Sender.Tell(new LoggerInitialized());
+                });
+            }
+
+            private void Log(LogLevel level, string str)
+            {
+            }
+        }
+    }
+}

--- a/src/core/Akka.Tests/Serialization/SerializationSetupSpec.cs
+++ b/src/core/Akka.Tests/Serialization/SerializationSetupSpec.cs
@@ -1,0 +1,105 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SerializationSetupSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using Akka.Actor;
+using Akka.Actor.Setup;
+using Akka.Configuration;
+using Akka.Serialization;
+using Akka.TestKit;
+using Akka.TestKit.Configs;
+using Akka.Util.Internal;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Tests.Serialization
+{
+    public class ProgammaticDummy { }
+    public class ConfigurationDummy { }
+
+    public class SerializationSetupSpec : AkkaSpec
+    {
+        public class TestSerializer : Serializer
+        {
+            public TestSerializer(ExtendedActorSystem system) : base(system)
+            {
+                IncludeManifest = false;
+            }
+
+            public override bool IncludeManifest { get; }
+
+            public override int Identifier => 666;
+
+            private AtomicCounter Counter { get; } = new AtomicCounter(0);
+            private ConcurrentDictionary<int, object> Registry { get; } = new ConcurrentDictionary<int, object>();
+
+            public override byte[] ToBinary(object obj)
+            {
+                var id = Counter.AddAndGet(1);
+                Registry.Put(id, obj);
+                return BitConverter.GetBytes(id);
+            }
+
+            public override object FromBinary(byte[] bytes, Type type)
+            {
+                if (bytes.Length != 1)
+                    throw new ArgumentOutOfRangeException(nameof(bytes));
+                var id = BitConverter.ToInt32(bytes, 0);
+                return Registry[id];
+            }
+        }
+
+
+        public static SerializationSetup SerializationSettings = new SerializationSetup(_ => 
+            ImmutableHashSet<SerializerDetails>.Empty.Add(SerializerDetails.Create("test", new TestSerializer(_), 
+                ImmutableHashSet<Type>.Empty.Add(typeof(ProgammaticDummy)))));
+
+        public static readonly BootstrapSetup Bootstrap = BootstrapSetup.Create().WithConfig(
+            ConfigurationFactory.ParseString(@"
+            akka{
+                actor{
+                    serialize-messages = off
+                    serialization-bindings {
+                      ""Akka.Tests.Serialization.ConfigurationDummy, Akka.Tests"" = test
+                    }
+                }
+            }
+        ").WithFallback(TestConfigs.DefaultConfig));
+
+        public static readonly ActorSystemSetup ActorSystemSettings = ActorSystemSetup.Create(SerializationSettings, Bootstrap);
+
+        public SerializationSetupSpec(ITestOutputHelper output) 
+            : base(ActorSystem.Create("SerializationSettingsSpec", ActorSystemSettings), output) { }
+
+        private void VerifySerialization(ActorSystem sys, object obj)
+        {
+            var serialization = sys.Serialization;
+            var bytes = serialization.Serialize(obj);
+            var serializer = serialization.FindSerializerFor(obj);
+            var manifest = Akka.Serialization.Serialization.ManifestFor(serializer, obj);
+            var deserialized = serialization.Deserialize(bytes, serializer.Identifier, manifest);
+            deserialized.Should().Be(obj);
+        }
+
+        [Fact]
+        public void SerializationSettingsShouldAllowForProgrammaticConfigurationOfSerializers()
+        {
+            var serializer = Sys.Serialization.FindSerializerFor(new ProgammaticDummy());
+            serializer.Should().BeOfType<TestSerializer>();
+        }
+
+        [Fact]
+        public void SerializationSettingsShouldAllowConfiguredBindingToHookupToProgrammaticSerializer()
+        {
+            var serializer = Sys.Serialization.FindSerializerFor(new ConfigurationDummy());
+            serializer.Should().BeOfType<TestSerializer>();
+        }
+    }
+}

--- a/src/core/Akka.Tests/Serialization/SerializationSpec.cs
+++ b/src/core/Akka.Tests/Serialization/SerializationSpec.cs
@@ -515,9 +515,6 @@ namespace Akka.Tests.Serialization
             Assert.Equal(decider.DefaultDirective, sdecider.DefaultDirective);
         }
 
-
-        //TODO: find out why this fails on build server
-
         [Fact]
         public void Can_serialize_FutureActorRef()
         {

--- a/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
+++ b/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
@@ -64,6 +64,7 @@ namespace Akka.Actor
                 // Akka JVM doesn't have these lines
                 CurrentMessage = envelope.Message;
                 _currentEnvelopeId++;
+                if (_currentEnvelopeId == int.MaxValue) _currentEnvelopeId = 0;
 
                 Sender = MatchSender(envelope);
 

--- a/src/core/Akka/Actor/ActorSystem.cs
+++ b/src/core/Akka/Actor/ActorSystem.cs
@@ -6,19 +6,137 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor.Internal;
-using Akka.Configuration;
+using Akka.Actor.Setup;
 using Akka.Dispatch;
 using Akka.Event;
 using Akka.Util;
-using Akka.Configuration;
 using ConfigurationFactory = Akka.Configuration.ConfigurationFactory;
 using Config = Akka.Configuration.Config;
 
 namespace Akka.Actor
 {
+    /// <summary>
+    /// INTERNAL API
+    /// </summary>
+    public abstract class ProviderSelection
+    {
+        private ProviderSelection(string identifier, string fqn, bool hasCluster)
+        {
+            Identifier = identifier;
+            Fqn = fqn;
+            HasCluster = hasCluster;
+        }
+
+        internal string Identifier { get; }
+        internal string Fqn { get; }
+        internal bool HasCluster { get; }
+
+        internal const string RemoteActorRefProvider = "Akka.Remote.RemoteActorRefProvider, Akka.Remote";
+        internal const string ClusterActorRefProvider = "Akka.Cluster.ClusterActorRefProvider, Akka.Cluster";
+
+        public sealed class Local : ProviderSelection
+        {
+            private Local() : base("local", typeof(LocalActorRefProvider).FullName, false)
+            {
+            }
+
+            public static readonly Local Instance = new Local();
+        }
+
+        public sealed class Remote : ProviderSelection
+        {
+            private Remote() : base("remote", RemoteActorRefProvider, false)
+            {
+            }
+
+            public static readonly Remote Instance = new Remote();
+        }
+
+        public sealed class Cluster : ProviderSelection
+        {
+            private Cluster() : base("cluster", ClusterActorRefProvider, true)
+            {
+            }
+
+            public static readonly Cluster Instance = new Cluster();
+        }
+
+        public sealed class Custom : ProviderSelection
+        {
+            public Custom(string fqn, string identifier = null, bool hasCluster = false) : base(
+                identifier ?? string.Empty, fqn, hasCluster)
+            {
+            }
+        }
+
+        internal static ProviderSelection GetProvider(string providerClass)
+        {
+            switch (providerClass)
+            {
+                case "local":
+                    return Local.Instance;
+                case "remote":
+                case RemoteActorRefProvider: // additional case for older configurations
+                    return Remote.Instance;
+                case "cluster":
+                case ClusterActorRefProvider: // additional case for older configurations
+                    return Cluster.Instance;
+                default:
+                    return new Custom(providerClass);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Core boostrap settings for the <see cref="ActorSystem"/>, which can be created using one of the static factory methods
+    /// on this class.
+    /// </summary>
+    public sealed class BootstrapSetup : Setup.Setup
+    {
+        internal BootstrapSetup() : this(Option<Config>.None, Option<ProviderSelection>.None)
+        {
+        }
+
+        internal BootstrapSetup(Option<Config> config, Option<ProviderSelection> actorRefProvider)
+        {
+            Config = config;
+            ActorRefProvider = actorRefProvider;
+        }
+
+        /// <summary>
+        /// Configuration to use for the <see cref="ActorSystem"/>. If no <see cref="Config"/> is given, the default reference
+        /// configuration will be loaded via <see cref="ConfigurationFactory.Load"/>.
+        /// </summary>
+        public Option<Config> Config { get; }
+
+        /// <summary>
+        /// Overrides the 'akka.actor.provider' setting in config. Can be 'local' (default), 'remote', or cluster.
+        ///
+        /// It can also be the fully qualified class name of an ActorRefProvider.
+        /// </summary>
+        public Option<ProviderSelection> ActorRefProvider { get; }
+
+        /// <summary>
+        /// Create a new <see cref="BootstrapSetup"/> instance.
+        /// </summary>
+        public static BootstrapSetup Create()
+        {
+            return new BootstrapSetup();
+        }
+
+        public BootstrapSetup WithActorRefProvider(ProviderSelection name)
+        {
+            return new BootstrapSetup(Config, name);
+        }
+
+        public BootstrapSetup WithConfig(Config config)
+        {
+            return new BootstrapSetup(config, ActorRefProvider);
+        }
+    }
+
     /// <summary>
     ///     An actor system is a hierarchical group of actors which share common
     ///     configuration, e.g. dispatchers, deployments, remote capabilities and
@@ -99,8 +217,36 @@ namespace Akka.Actor
         /// <returns>A newly created actor system with the given name and configuration.</returns>
         public static ActorSystem Create(string name, Config config)
         {
-            // var withFallback = config.WithFallback(ConfigurationFactory.Default());
-            return CreateAndStartSystem(name, config);
+            return CreateAndStartSystem(name, config, ActorSystemSetup.Empty);
+        }
+
+        /// <summary>
+        /// Shortcut for creating a new actor system with the specified name and settings.
+        /// </summary>
+        /// <param name="name">The name of the actor system to create. The name must be uri friendly.
+        /// <remarks>Must contain only word characters (i.e. [a-zA-Z0-9] plus non-leading '-'</remarks>
+        /// </param>
+        /// <param name="setup">The bootstrap setup used to help programmatically initialize the <see cref="ActorSystem"/>.</param>
+        /// <returns>A newly created actor system with the given name and configuration.</returns>
+        public static ActorSystem Create(string name, BootstrapSetup setup)
+        {
+            return Create(name, ActorSystemSetup.Create(setup));
+        }
+
+        /// <summary>
+        /// Shortcut for creating a new actor system with the specified name and settings.
+        /// </summary>
+        /// <param name="name">The name of the actor system to create. The name must be uri friendly.
+        /// <remarks>Must contain only word characters (i.e. [a-zA-Z0-9] plus non-leading '-'</remarks>
+        /// </param>
+        /// <param name="setup">The bootstrap setup used to help programmatically initialize the <see cref="ActorSystem"/>.</param>
+        /// <returns>A newly created actor system with the given name and configuration.</returns>
+        public static ActorSystem Create(string name, ActorSystemSetup setup)
+        {
+            var bootstrapSetup = setup.Get<BootstrapSetup>();
+            var appConfig = bootstrapSetup.FlatSelect(_ => _.Config).GetOrElse(ConfigurationFactory.Load());
+
+            return CreateAndStartSystem(name, appConfig, setup);
         }
 
         /// <summary>
@@ -112,12 +258,12 @@ namespace Akka.Actor
         /// <returns>A newly created actor system with the given name.</returns>
         public static ActorSystem Create(string name)
         {
-            return CreateAndStartSystem(name, ConfigurationFactory.Load());
+            return Create(name, ActorSystemSetup.Empty);
         }
 
-        private static ActorSystem CreateAndStartSystem(string name, Config withFallback)
+        private static ActorSystem CreateAndStartSystem(string name, Config withFallback, ActorSystemSetup setup)
         {
-            var system = new ActorSystemImpl(name, withFallback);
+            var system = new ActorSystemImpl(name, withFallback, setup);
             system.Start();
             return system;
         }
@@ -249,13 +395,15 @@ namespace Akka.Actor
                         Log.Debug("Disposing system");
                         Terminate().Wait(); // System needs to be disposed before method returns
                     }
+
                     //Clean up unmanaged resources
                 }
+
                 _isDisposed = true;
             }
             finally
             {
-                
+
             }
         }
 
@@ -276,4 +424,3 @@ namespace Akka.Actor
         public abstract ActorSelection ActorSelection(string actorPath);
     }
 }
-

--- a/src/core/Akka/Actor/Settings.cs
+++ b/src/core/Akka/Actor/Settings.cs
@@ -7,9 +7,11 @@
 
 using System;
 using System.Collections.Generic;
+using Akka.Actor.Setup;
 using Akka.Configuration;
 using Akka.Dispatch;
 using Akka.Routing;
+using Akka.Util;
 using ConfigurationFactory = Akka.Configuration.ConfigurationFactory;
 
 namespace Akka.Actor
@@ -54,22 +56,45 @@ namespace Akka.Actor
         /// <exception cref="ConfigurationException">
         /// This exception is thrown if the 'akka.actor.provider' configuration item is not a valid type name or a valid actor ref provider.
         /// </exception>
-        public Settings(ActorSystem system, Config config)
+        public Settings(ActorSystem system, Config config) : this(system, config, ActorSystemSetup.Empty)
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Settings" /> class.
+        /// </summary>
+        /// <param name="system">The system.</param>
+        /// <param name="config">The configuration.</param>
+        /// <param name="setup">The setup class used to help bootstrap the <see cref="ActorSystem"/></param>
+        /// <exception cref="ConfigurationException">
+        /// This exception is thrown if the 'akka.actor.provider' configuration item is not a valid type name or a valid actor ref provider.
+        /// </exception>
+        public Settings(ActorSystem system, Config config, ActorSystemSetup setup)
+        {
+            Setup = setup;
             _userConfig = config;
             _fallbackConfig = ConfigurationFactory.Default();
             RebuildConfig();
 
             System = system;
-            
+
+            var providerSelectionSetup = Setup.Get<BootstrapSetup>()
+                .FlatSelect(_ => _.ActorRefProvider)
+                .Select(_ => _.Identifier)
+                .GetOrElse(Config.GetString("akka.actor.provider", null));
+
+            ProviderSelectionType = ProviderSelection.GetProvider(providerSelectionSetup);
+
             ConfigVersion = Config.GetString("akka.version", null);
-            ProviderClass = GetProviderClass(Config.GetString("akka.actor.provider", null));
+            ProviderClass = ProviderSelectionType.Fqn;
+            HasCluster = ProviderSelectionType.HasCluster;
+
             var providerType = Type.GetType(ProviderClass);
             if (providerType == null)
                 throw new ConfigurationException($"'akka.actor.provider' is not a valid type name : '{ProviderClass}'");
             if (!typeof(IActorRefProvider).IsAssignableFrom(providerType))
                 throw new ConfigurationException($"'akka.actor.provider' is not a valid actor ref provider: '{ProviderClass}'");
-            
+
             SupervisorStrategyClass = Config.GetString("akka.actor.guardian-supervisor-strategy", null);
 
             AskTimeout = Config.GetTimeSpan("akka.actor.ask-timeout", null, allowInfinite: true);
@@ -125,24 +150,6 @@ namespace Akka.Actor
                 throw new ConfigurationException(
                   "akka.coordinated-shutdown.run-by-actor-system-terminate=on and " +
                   "akka.coordinated-shutdown.terminate-actor-system=off is not a supported configuration combination.");
-
-            //TODO: dunno.. we don't have FiniteStateMachines, don't know what the rest is
-            /*              
-                final val SchedulerClass: String = getString("akka.scheduler.implementation")
-                final val Daemonicity: Boolean = getBoolean("akka.daemonic")                
-                final val DefaultVirtualNodesFactor: Int = getInt("akka.actor.deployment.default.virtual-nodes-factor")
-             */
-        }
-
-        private static string GetProviderClass(string provider)
-        {
-            switch (provider)
-            {
-                case "local": return typeof(LocalActorRefProvider).FullName;
-                case "remote": return "Akka.Remote.RemoteActorRefProvider, Akka.Remote";
-                case "cluster": return "Akka.Cluster.ClusterActorRefProvider, Akka.Cluster";
-                default: return provider;
-            }
         }
 
         /// <summary>
@@ -156,6 +163,21 @@ namespace Akka.Actor
         /// </summary>
         /// <value>The configuration.</value>
         public Config Config { get; private set; }
+
+        /// <summary>
+        /// The setup used to help bootstrap this <see cref="ActorSystem"/>.
+        /// </summary>
+        public ActorSystemSetup Setup { get; }
+
+        /// <summary>
+        /// Used to indicate whether or not clustering is enabled for this <see cref="ActorSystem"/>.
+        /// </summary>
+        public bool HasCluster { get; }
+
+        /// <summary>
+        /// INTENRAL API
+        /// </summary>
+        public ProviderSelection ProviderSelectionType { get; }
 
         /// <summary>
         ///     Gets the configuration version.

--- a/src/core/Akka/Actor/Settings.cs
+++ b/src/core/Akka/Actor/Settings.cs
@@ -109,6 +109,7 @@ namespace Akka.Actor
             Loggers = Config.GetStringList("akka.loggers", new string[] { });
             LoggersDispatcher = Config.GetString("akka.loggers-dispatcher", null);
             LoggerStartTimeout = Config.GetTimeSpan("akka.logger-startup-timeout", null);
+            LoggerAsyncStart = Config.GetBoolean("akka.logger-async-start", false);
 
             //handled
             LogConfigOnStart = Config.GetBoolean("akka.log-config-on-start", false);
@@ -256,6 +257,12 @@ namespace Akka.Actor
         /// </summary>
         /// <value>The logger start timeout.</value>
         public TimeSpan LoggerStartTimeout { get; private set; }
+        
+        /// <summary>
+        ///     Gets the logger start timeout.
+        /// </summary>
+        /// <value>The logger start timeout.</value>
+        public bool LoggerAsyncStart { get; private set; }
 
         /// <summary>
         ///     Gets a value indicating whether [log configuration on start].

--- a/src/core/Akka/Actor/Setup/ActorSystemSetup.cs
+++ b/src/core/Akka/Actor/Setup/ActorSystemSetup.cs
@@ -1,0 +1,98 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ActorSystemSetup.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Akka.Annotations;
+using Akka.Util;
+
+namespace Akka.Actor.Setup
+{
+    /// <summary>
+    /// Marker base class for a setup part that can be put inside <see cref="ActorSystemSetup"/>, if a specific concrete setup
+    /// is not specified in the actor system setup that means defaults are used(usually from the config file) - no concrete
+    /// setup instance should be mandatory in the <see cref="ActorSystemSetup"/> that an <see cref="ActorSystem"/> is created with.
+    /// </summary>
+    public abstract class Setup
+    {
+        /// <summary>
+        /// Construct an <see cref="ActorSystemSetup"/> with this setup combined with another one.
+        ///
+        /// Allows for fluent creation of settings.
+        /// </summary>
+        /// <param name="other">If other is of the same concrete <see cref="Setup"/> type as this, it will replace this.</param>
+        /// <returns>A new <see cref="ActorSystemSetup"/> instance.</returns>
+        public ActorSystemSetup And(Setup other)
+        {
+            return ActorSystemSetup.Create(this, other);
+        }
+    }
+
+    /// <summary>
+    /// A set of setup classes to allow for programmatic configuration of the <see cref="ActorSystem"/>
+    /// </summary>
+    /// <remarks>
+    /// The constructor is internal. Use <see cref="ActorSystemSetup.Create"/> or <see cref="ActorSystemSetup.WithSetup{T}"/>
+    /// to create instances.
+    /// </remarks>
+    [InternalApi]
+    public sealed class ActorSystemSetup
+    {
+        public static readonly ActorSystemSetup Empty = new ActorSystemSetup(ImmutableDictionary<Type, Setup>.Empty);
+
+        public static ActorSystemSetup Create(params Setup[] setup)
+        {
+            return new ActorSystemSetup(setup
+                .Select(x => new KeyValuePair<Type, Setup>(x.GetType(), x))
+                .Aggregate(ImmutableDictionary<Type, Setup>.Empty, (setups, pair) => setups.SetItem(pair.Key, pair.Value)));
+        }
+
+        internal ActorSystemSetup(ImmutableDictionary<Type, Setup> setups)
+        {
+            _setups = setups;
+        }
+
+        private readonly ImmutableDictionary<Type, Setup> _setups;
+
+        public Option<T> Get<T>() where T:Setup
+        {
+            return _setups.ContainsKey(typeof(T)) ? new Option<T>((T)_setups[typeof(T)]) : Option<T>.None;
+        }
+        
+        /// <summary>
+        /// Add a concrete <see cref="Setup"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of <see cref="Setup"/></typeparam>
+        /// <param name="setup">Setup input. If a setting of the same type is already present it will be replaced.</param>
+        /// <returns>A new, immutable <see cref="ActorSystemSetup"/> instance.</returns>
+        public ActorSystemSetup WithSetup<T>(T setup) where T : Setup
+        {
+            return new ActorSystemSetup(_setups.SetItem(typeof(T), setup));
+        }
+
+        /// <summary>
+        /// Shortcut for <see cref="Setup.And"/> to make it easier to chain the fluent interface together.
+        /// </summary>
+        /// <typeparam name="T">The type of <see cref="Setup"/></typeparam>
+        /// <param name="setup">Setup input. If a setting of the same type is already present it will be replaced.</param>
+        /// <returns>A new, immutable <see cref="ActorSystemSetup"/> instance.</returns>
+        /// <remarks>
+        /// Calls <see cref="WithSetup{T}"/> internally.
+        /// </remarks>
+        public ActorSystemSetup And<T>(T setup) where T : Setup
+        {
+            return WithSetup(setup);
+        }
+
+        public override string ToString()
+        {
+            return $"ActorSystemSetup({string.Join(",", _setups.Keys.Select(x => x.FullName))})";
+        }
+    }
+}

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
   </ItemGroup>
     
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkLibVersion)'">

--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -24,6 +24,11 @@ akka {
   # start-up, and since they are actors, this timeout is used to bound the
   # waiting time
   logger-startup-timeout = 5s
+  
+  # You can enable asynchronous loggers creation by setting this to `true`.
+  # This may be useful in cases when ActorSystem creation takes more time
+  # then it should, or for whatever other reason
+  logger-async-start = false
  
   # Log level used by the configured loggers (see "loggers") as soon
   # as they have been started; before that, see "stdout-loglevel"

--- a/src/core/Akka/Event/LoggingBus.cs
+++ b/src/core/Akka/Event/LoggingBus.cs
@@ -91,6 +91,7 @@ namespace Akka.Event
             var logLevel = Logging.LogLevelFor(system.Settings.LogLevel);
             var loggerTypes = system.Settings.Loggers;
             var timeout = system.Settings.LoggerStartTimeout;
+            var asyncStart = system.Settings.LoggerAsyncStart;
             var shouldRemoveStandardOutLogger = true;
 
             foreach (var strLoggerType in loggerTypes)
@@ -106,14 +107,29 @@ namespace Akka.Event
                     shouldRemoveStandardOutLogger = false;
                     continue;
                 }
-                
-                try
+
+                if (asyncStart)
                 {
-                    AddLogger(system, loggerType, logLevel, logName, timeout);
+                    // Not awaiting for result, and not depending on current thread context
+                    Task.Run(() => AddLogger(system, loggerType, logLevel, logName, timeout))
+                        .ContinueWith(t =>
+                        {
+                            if (t.Exception != null)
+                            {
+                                Console.WriteLine($"Logger [{strLoggerType}] specified in config cannot be loaded: {t.Exception}");
+                            }
+                        });
                 }
-                catch (Exception e)
+                else
                 {
-                    throw new ConfigurationException($"Logger [{strLoggerType}] specified in config cannot be loaded: {e}", e);
+                    try
+                    {
+                        AddLogger(system, loggerType, logLevel, logName, timeout);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new ConfigurationException($"Logger [{strLoggerType}] specified in config cannot be loaded: {ex}", ex);
+                    }
                 }
             }
 

--- a/src/core/Akka/Serialization/SerializationSetup.cs
+++ b/src/core/Akka/Serialization/SerializationSetup.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+using Akka.Actor;
+using Akka.Actor.Setup;
+
+namespace Akka.Serialization
+{
+    /// <summary>
+    /// Setup for the <see cref="ActorSystem"/> serialization subsystem.
+    ///
+    /// Constructor is INTERNAL API. Use the factory method <see cref="Create"/>.
+    /// </summary>
+    public sealed class SerializationSetup : Setup
+    {
+        internal SerializationSetup(Func<ExtendedActorSystem, ImmutableHashSet<SerializerDetails>> createSerializers)
+        {
+            CreateSerializers = createSerializers;
+        }
+
+        public Func<ExtendedActorSystem, ImmutableHashSet<SerializerDetails>> CreateSerializers { get; }
+
+        /// <summary>
+        /// create pairs of serializer and the set of classes it should be used for
+        /// </summary>
+        public static SerializationSetup Create(
+            Func<ExtendedActorSystem, ImmutableHashSet<SerializerDetails>> createSerializers)
+        {
+            return new SerializationSetup(createSerializers);
+        }
+    }
+
+    /// <summary>
+    /// Constructor is internal API.
+    ///
+    /// Use the <see cref="SerializerDetails.Create"/> factory method instead
+    /// </summary>
+    public sealed class SerializerDetails
+    {
+        internal SerializerDetails(string @alias, Serializer serializer, ImmutableHashSet<Type> useFor)
+        {
+            Alias = alias;
+            Serializer = serializer;
+            UseFor = useFor;
+        }
+
+        /// <summary>
+        /// The name of the serializer - must be unique.
+        /// </summary>
+        /// <example>
+        /// i.e. "json" for the global JSON.NET serializer
+        /// "IDomainSerializer" for a custom serializer that serializes "IDomain" messages, etc.
+        /// </example>
+        public string Alias { get; }
+
+        /// <summary>
+        /// The serializer that belongs to this <see cref="Alias"/>.
+        /// </summary>
+        public Serializer Serializer { get; }
+
+        /// <summary>
+        /// The types of messages that this 
+        /// </summary>
+        public ImmutableHashSet<Type> UseFor { get; }
+
+        /// <summary>
+        /// Factory method for creating programmatic setups for Serializers.
+        /// </summary>
+        /// <param name="alias">Register the serializer under this alias (this allows it to be used by bindings in the config)</param>
+        /// <param name="serializer">The serializer implementation.</param>
+        /// <param name="useFor">A set of types (classes, base classes, or interfaces) that will be bound to this serializer.
+        /// This is the programmatic equivalent of the `akka.actor.serialization.serialization-bindings` HOCON section.</param>
+        public static SerializerDetails Create(string alias, Serializer serializer, ImmutableHashSet<Type> useFor)
+        {
+            return new SerializerDetails(alias, serializer, useFor);
+        }
+    }
+
+}

--- a/src/core/Akka/Util/Internal/Extensions.cs
+++ b/src/core/Akka/Util/Internal/Extensions.cs
@@ -61,7 +61,7 @@ namespace Akka.Util.Internal
             var j = 0;
             while (true)
             {
-                if (j > path.Length) yield break;
+                if (j >= path.Length) yield break;
                 else if (path[j] == '\"')
                 {
                     i = path.IndexOf('\"', j + 1);

--- a/src/core/Akka/Util/Option.cs
+++ b/src/core/Akka/Util/Option.cs
@@ -19,7 +19,7 @@ namespace Akka.Util
     public struct Option<T>
     {
         /// <summary>
-        /// TBD
+        /// None.
         /// </summary>
         public static readonly Option<T> None = new Option<T>();
 
@@ -66,6 +66,19 @@ namespace Akka.Util
             return selector(Value);
         }
 
+        /// <summary>
+        /// Unwraps the option value and returns it without converting it into an option.
+        /// </summary>
+        /// <typeparam name="TNew">The output type.</typeparam>
+        /// <param name="mapper">The mapping method.</param>
+        public Option<TNew> FlatSelect<TNew>(Func<T, Option<TNew>> mapper)
+        {
+            if (!HasValue)
+                return Option<TNew>.None;
+
+            return mapper(Value);
+        }
+
         /// <inheritdoc/>
         public bool Equals(Option<T> other)
             => HasValue == other.HasValue && EqualityComparer<T>.Default.Equals(Value, other.Value);
@@ -98,6 +111,16 @@ namespace Akka.Util
         {
             if (HasValue)
                 action(Value);
+        }
+
+        public static bool operator ==(Option<T> left, Option<T> right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(Option<T> left, Option<T> right)
+        {
+            return !(left == right);
         }
     }
 }

--- a/src/protobuf/ReplicatorMessages.proto
+++ b/src/protobuf/ReplicatorMessages.proto
@@ -14,6 +14,9 @@ message Get {
    sint32 consistency = 2;
    uint32 timeout = 3;
    OtherMessage request = 4;
+   int32 consistencyMinCap = 5;
+   bool hasConsistencyAdditional = 6;
+   int32 consistencyAdditional = 7;
 }
 
 message GetSuccess {
@@ -92,6 +95,8 @@ message Status {
   repeated Entry entries = 3;
    sfixed64 toSystemUid = 4;
    sfixed64 fromSystemUid = 5;
+   bool hasToSystemUid = 6;
+   bool hasFromSystemUid = 7;
 }
 
 message Gossip {
@@ -104,6 +109,8 @@ message Gossip {
   repeated Entry entries = 2;
    sfixed64 toSystemUid = 3;
    sfixed64 fromSystemUid = 4;
+   bool hasToSystemUid = 5;
+   bool hasFromSystemUid = 6;
 }
 
 message DeltaPropagation {


### PR DESCRIPTION
#### 1.4.7 May 26 2020 ####
**Maintenance Release for Akka.NET 1.4**

Akka.NET v1.4.7 is a fairly sizable path that introduces some significant new features and changes:

* [Akka: added `akka.logger-async-start` HOCON setting to allow loggers to start without blocking `ActorSystem` creation](https://github.com/akkadotnet/akka.net/pull/4424) - useful for developers running Akka.NET on Xamarin or in other environments with low CPU counts;
* [Akka: ported `ActorSystemSetup` to allow programmatic config of serializers and other `ActorSystem` properties](https://github.com/akkadotnet/akka.net/issues/4426)
* [Akka.Streams: update and modernize Attributes](https://github.com/akkadotnet/akka.net/pull/4437)
* [Akka.DistributedData.LightningDb: Wire format stabilized](https://github.com/akkadotnet/akka.net/issues/4261) - Akka.Distributed.Data.LightningDb is now ready for production use.

To see the full set of changes for Akka.NET 1.4.7, please [see the 1.4.7 milestone](https://github.com/akkadotnet/akka.net/milestone/38).

| COMMITS | LOC+ | LOC- | AUTHOR |
| --- | --- | --- | --- |
| 7 | 1742 | 436 | Gregorius Soedharmo |
| 5 | 8 | 8 | dependabot-preview[bot] |
| 2 | 726 | 50 | Aaron Stannard |
| 1 | 6 | 6 | gantokun |
| 1 | 3 | 3 | Chris Barker |
| 1 | 112 | 28 | Igor Fedchenko |