### PR TITLE
Fix dotnet SDK to 3.1.100 on all Azure Pipelines YAML script

### DIFF
--- a/build-system/azure-pipeline.mntr-template.yaml
+++ b/build-system/azure-pipeline.mntr-template.yaml
@@ -16,6 +16,11 @@ jobs:
     pool:
       vmImage: ${{ parameters.vmImage }}
     steps:
+      - task: UseDotNet@2
+        displayName: 'Use .NET Core SDK 3.1.100'
+        inputs:
+          packageType: sdk
+          version: 3.1.100
       - task: Bash@3 
         displayName: Linux / OSX Build
         inputs:

--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -16,6 +16,11 @@ jobs:
     pool:
       vmImage: ${{ parameters.vmImage }}
     steps:
+      - task: UseDotNet@2
+        displayName: 'Use .NET Core SDK 3.1.100'
+        inputs:
+          packageType: sdk
+          version: 3.1.100
       - task: Bash@3 
         displayName: Linux / OSX Build
         inputs:

--- a/build-system/nightly-builds.yaml
+++ b/build-system/nightly-builds.yaml
@@ -19,6 +19,11 @@ variables:
   - group: nugetKeys #create this group with SECRET variables `nugetKey`
 
 steps:
+- task: UseDotNet@2
+  displayName: 'Use .NET Core SDK 3.1.100'
+  inputs:
+    packageType: sdk
+    version: 3.1.100
 - task: BatchScript@1
   displayName: 'FAKE Build'
   inputs:

--- a/build-system/pr-validation.yaml
+++ b/build-system/pr-validation.yaml
@@ -25,6 +25,11 @@ jobs:
         clean: false  # whether to fetch clean each time
         submodules: recursive  # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: true
+      - task: UseDotNet@2
+        displayName: 'Use .NET Core SDK 3.1.100'
+        inputs:
+          packageType: sdk
+          version: 3.1.100
       - task: BatchScript@1
         displayName: Windows Build
         inputs:

--- a/build-system/windows-release.yaml
+++ b/build-system/windows-release.yaml
@@ -22,6 +22,11 @@ variables:
   - name: githubRepositoryName
     value: akkadotnet/akka.net
 steps:
+- task: UseDotNet@2
+  displayName: 'Use .NET Core SDK 3.1.100'
+  inputs:
+    packageType: sdk
+    version: 3.1.100
 - task: BatchScript@1
   displayName: 'FAKE Build'
   inputs:


### PR DESCRIPTION
Azure Pipelines are not using the .NET SDK installed by the build script, it is using the .NET SDK installed by the system and is cached across the workers. 

By default, it is set to `LATEST` version, the latest version causes a `Duplicate 'global::System.Runtime.Versioning.TargetFrameworkAttribute'` error inside the `AssemblyAttributes.cs`  auto-generated file

Fixed by forcing the cached SDK version to 3.1.100 by using `UseDotNet@2` azure pipeline task