### PR TITLE
Akka.Remote.Artery port - Base code changes

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -4751,6 +4751,10 @@ namespace Akka.Util
         public bool IsValueCreated { get; }
         public T Value { get; }
     }
+    public class static Helpers
+    {
+        public static T Requiring<T>(this T obj, System.Func<T, bool> cond, string msg) { }
+    }
     public interface IResolver
     {
         T Resolve<T>(object[] args);

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
@@ -1,4 +1,5 @@
 ﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Benchmarks")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Streams.TestKit")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Streams.Tests")]
 [assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]

--- a/src/core/Akka.Remote/Akka.Remote.csproj
+++ b/src/core/Akka.Remote/Akka.Remote.csproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="..\Akka\Akka.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Agrona" Version="1.21.2.2" />
     <PackageReference Include="DotNetty.Handlers" Version="0.6.0" />
     <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
   </ItemGroup>

--- a/src/core/Akka.Remote/Akka.Remote.csproj
+++ b/src/core/Akka.Remote/Akka.Remote.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="Configuration\Remote.conf" />
+    <ProjectReference Include="..\Akka.Streams\Akka.Streams.csproj" />
     <ProjectReference Include="..\Akka\Akka.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/core/Akka.Remote/UniqueAddress.cs
+++ b/src/core/Akka.Remote/UniqueAddress.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using Akka.Actor;
+
+namespace Akka.Remote
+{
+    // ARTERY: Document that UniqueAddress is a copy of the same class from Akka.Cluster.Member
+    // ARTERY: Temporarily use internal for now, so we don't break API approval list
+    /// <summary>
+    /// Member identifier consisting of address and random `uid`.
+    /// The `uid` is needed to be able to distinguish different
+    /// incarnations of a member with same hostname and port.
+    /// </summary>
+    internal class UniqueAddress : IComparable<UniqueAddress>, IEquatable<UniqueAddress>, IComparable
+    {
+        /// <summary>
+        /// The bound listening address for Akka.Remote.
+        /// </summary>
+        public Address Address { get; }
+
+        /// <summary>
+        /// A random long integer used to signal the incarnation of this cluster instance.
+        /// </summary>
+        public int Uid { get; }
+
+        /// <summary>
+        /// Creates a new unique address instance.
+        /// </summary>
+        /// <param name="address">The original Akka <see cref="Address"/></param>
+        /// <param name="uid">The UID for the cluster instance.</param>
+        public UniqueAddress(Address address, int uid)
+        {
+            Uid = uid;
+            Address = address;
+        }
+
+        /// <summary>
+        /// Compares two unique address instances to each other.
+        /// </summary>
+        /// <param name="other">The other address to compare to.</param>
+        /// <returns><c>true</c> if equal, <c>false</c> otherwise.</returns>
+        public bool Equals(UniqueAddress other)
+        {
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            return Uid == other.Uid && Address.Equals(other.Address);
+        }
+
+        /// <inheritdoc cref="object.Equals(object)"/>
+        public override bool Equals(object obj) => obj is UniqueAddress addr && Equals(addr);
+
+        /// <inheritdoc cref="object.GetHashCode"/>
+        public override int GetHashCode()
+        {
+            return Uid.GetHashCode();
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="uniqueAddress">TBD</param>
+        /// <returns>TBD</returns>
+        public int CompareTo(UniqueAddress uniqueAddress) => CompareTo(uniqueAddress, Address.Comparer);
+
+        int IComparable.CompareTo(object obj)
+        {
+            if (obj is UniqueAddress address) return CompareTo(address);
+
+            throw new ArgumentException($"Cannot compare {nameof(UniqueAddress)} with instance of type '{obj?.GetType().FullName ?? "null"}'.");
+        }
+
+        internal int CompareTo(UniqueAddress uniqueAddress, IComparer<Address> addresComparer)
+        {
+            if (uniqueAddress is null) throw new ArgumentNullException(nameof(uniqueAddress));
+
+            var result = addresComparer.Compare(Address, uniqueAddress.Address);
+            return result == 0 ? Uid.CompareTo(uniqueAddress.Uid) : result;
+        }
+
+        /// <inheritdoc cref="object.ToString"/>
+        public override string ToString() => $"UniqueAddress: ({Address}, {Uid})";
+
+        #region operator overloads
+
+        /// <summary>
+        /// Compares two specified unique addresses for equality.
+        /// </summary>
+        /// <param name="left">The first unique address used for comparison</param>
+        /// <param name="right">The second unique address used for comparison</param>
+        /// <returns><c>true</c> if both unique addresses are equal; otherwise <c>false</c></returns>
+        public static bool operator ==(UniqueAddress left, UniqueAddress right)
+            => Equals(left, right);
+
+        /// <summary>
+        /// Compares two specified unique addresses for inequality.
+        /// </summary>
+        /// <param name="left">The first unique address used for comparison</param>
+        /// <param name="right">The second unique address used for comparison</param>
+        /// <returns><c>true</c> if both unique addresses are not equal; otherwise <c>false</c></returns>
+        public static bool operator !=(UniqueAddress left, UniqueAddress right)
+            => !Equals(left, right);
+
+        public static bool operator <(UniqueAddress left, UniqueAddress right)
+            => left is null ? right is object : left.CompareTo(right) < 0;
+
+        public static bool operator <=(UniqueAddress left, UniqueAddress right)
+            => left is null || left.CompareTo(right) <= 0;
+
+        public static bool operator >(UniqueAddress left, UniqueAddress right)
+            => left is object && left.CompareTo(right) > 0;
+
+        public static bool operator >=(UniqueAddress left, UniqueAddress right)
+            => left is null ? right is null : left.CompareTo(right) >= 0;
+
+        #endregion
+    }
+}

--- a/src/core/Akka.Streams/ActorMaterializer.cs
+++ b/src/core/Akka.Streams/ActorMaterializer.cs
@@ -315,7 +315,7 @@ namespace Akka.Streams
         }
 
         // NOTE: Make sure that this class can handle empty Config
-        private static ActorMaterializerSettings Create(Config config)
+        internal static ActorMaterializerSettings Create(Config config)
         {
             // No need to check for Config.IsEmpty because this function expects empty Config.
             if (config == null)

--- a/src/core/Akka.Streams/Properties/AssemblyInfo.cs
+++ b/src/core/Akka.Streams/Properties/AssemblyInfo.cs
@@ -15,6 +15,7 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("Akka.Streams.Tests")]
 [assembly: InternalsVisibleTo("Akka.Streams.TestKit")]
 [assembly: InternalsVisibleTo("Akka.Benchmarks")]
+[assembly: InternalsVisibleTo("Akka.Remote")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/src/core/Akka/Util/Helpers.cs
+++ b/src/core/Akka/Util/Helpers.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Akka.Util
+{
+    public static class Helpers
+    {
+        public static T Requiring<T>(this T obj, Func<T, bool> cond, string msg)
+        {
+            if (!cond(obj))
+                throw new ArgumentException(msg);
+            return obj;
+        }
+    }
+}


### PR DESCRIPTION
Needed changes in the base code (outside of `Akka.Remote.Artery`) needed by `Artery` to make `Artery` port work.