### PR TITLE
added ActorSystemSetup overload for TestKits

### DIFF
--- a/src/contrib/testkits/Akka.TestKit.Xunit/TestKit.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit/TestKit.cs
@@ -7,6 +7,7 @@
 
 using System;
 using Akka.Actor;
+using Akka.Actor.Setup;
 using Akka.Configuration;
 using Akka.Event;
 using Akka.TestKit.Xunit.Internals;
@@ -40,6 +41,19 @@ namespace Akka.TestKit.Xunit
         /// <param name="output">The provider used to write test output. The default value is <see langword="null"/>.</param>
         public TestKit(ActorSystem system = null, ITestOutputHelper output = null)
             : base(Assertions, system)
+        {
+            Output = output;
+            InitializeLogger(Sys);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestKit"/> class.
+        /// </summary>
+        /// <param name="config">The <see cref="Setup"/> to use for configuring the ActorSystem.</param>
+        /// <param name="actorSystemName">The name of the system. The default name is "test".</param>
+        /// <param name="output">The provider used to write test output. The default value is <see langword="null"/>.</param>
+        public TestKit(ActorSystemSetup config, string actorSystemName = null, ITestOutputHelper output = null)
+            : base(Assertions, config, actorSystemName)
         {
             Output = output;
             InitializeLogger(Sys);

--- a/src/contrib/testkits/Akka.TestKit.Xunit2/TestKit.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit2/TestKit.cs
@@ -7,6 +7,7 @@
 
 using System;
 using Akka.Actor;
+using Akka.Actor.Setup;
 using Akka.Configuration;
 using Akka.Event;
 using Akka.TestKit.Xunit2.Internals;
@@ -40,6 +41,19 @@ namespace Akka.TestKit.Xunit2
         /// <param name="output">The provider used to write test output. The default value is <see langword="null"/>.</param>
         public TestKit(ActorSystem system = null, ITestOutputHelper output = null)
             : base(Assertions, system)
+        {
+            Output = output;
+            InitializeLogger(Sys);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestKit"/> class.
+        /// </summary>
+        /// <param name="config">The <see cref="Setup"/> to use for configuring the ActorSystem.</param>
+        /// <param name="actorSystemName">The name of the system. The default name is "test".</param>
+        /// <param name="output">The provider used to write test output. The default value is <see langword="null"/>.</param>
+        public TestKit(ActorSystemSetup config, string actorSystemName = null, ITestOutputHelper output = null)
+            : base(Assertions, config, actorSystemName)
         {
             Output = output;
             InitializeLogger(Sys);

--- a/src/core/Akka.TestKit.Tests/ActorSystemSetupSpecs.cs
+++ b/src/core/Akka.TestKit.Tests/ActorSystemSetupSpecs.cs
@@ -1,0 +1,30 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ActorSystemSetupSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Actor;
+using Akka.Actor.Setup;
+using Xunit;
+
+namespace Akka.TestKit.Tests
+{
+    /// <summary>
+    /// Validate that an <see cref="ActorSystem"/> inside the testkit
+    /// can be configured using an <see cref="ActorSystemSetup"/> instance.
+    /// </summary>
+    public class ActorSystemSetupSpecs : AkkaSpec
+    {
+        public static readonly ActorSystemSetup Setup = ActorSystemSetup.Create().WithSetup(BootstrapSetup.Create().WithConfig(@"akka.hi = true"));
+
+        public ActorSystemSetupSpecs() : base(Setup) { }
+
+        [Fact]
+        public void ShouldReadConfigFromActorSystemSetup()
+        {
+            Assert.True(Sys.Settings.Config.HasPath("akka.hi"));
+        }
+    }
+}

--- a/src/core/Akka.TestKit/TestKitBase.cs
+++ b/src/core/Akka.TestKit/TestKitBase.cs
@@ -133,7 +133,7 @@ namespace Akka.TestKit
             {
                 var boostrap = config.Get<BootstrapSetup>();
                 var configWithDefaultFallback = boostrap.HasValue
-                    ? boostrap.Value.Config.Select(c => c.WithFallback(_defaultConfig))
+                    ? boostrap.Value.Config.Select(c => c == _defaultConfig ? c : c.WithFallback(_defaultConfig))
                     : _defaultConfig;
 
                 var newBootstrap = BootstrapSetup.Create().WithConfig(configWithDefaultFallback.Value);

--- a/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
@@ -13,6 +13,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Actor.Setup;
 using Akka.Configuration;
 using Akka.TestKit.Internal.StringMatcher;
 using Akka.TestKit.TestEvent;
@@ -56,6 +57,12 @@ namespace Akka.TestKit
 
         public AkkaSpec(Config config = null, ITestOutputHelper output = null)
             : base(config.SafeWithFallback(_akkaSpecConfig), GetCallerName(), output)
+        {
+            BeforeAll();
+        }
+
+        public AkkaSpec(ActorSystemSetup setup, ITestOutputHelper output = null)
+            : base(setup, GetCallerName(), output)
         {
             BeforeAll();
         }


### PR DESCRIPTION
Allows the TestKit to take an `ActorSystemSetup` object we added in v1.4.7 as an input instead of `Config` 