### PR TITLE
Fix one typo in Akka Streams configuration doc

### DIFF
--- a/docs/articles/configuration/akka.streams.md
+++ b/docs/articles/configuration/akka.streams.md
@@ -4,6 +4,6 @@ title: Akka.Streams Configuration
 ---
 
 ## Akka.Streams Configuration
-Below is the default HOCON configuration for the base `Akka.Steams` package.
+Below is the default HOCON configuration for the base `Akka.Streams` package.
 
 [!code[Akka.Streams.dll HOCON Configuration](../../../src/core/Akka.Streams/reference.conf)]


### PR DESCRIPTION
I've read your contributing guidelines, but decided not to do create feature branch only for one word typo fix.
If for some reason it's not acceptable, for example because of some _CI/CD_ rules, I don't mind rejecting this pull request and fixing typo some other way :)