### PR TITLE
Log rebalance progress at INFO per rebalance info

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardCoordinator.cs
@@ -462,6 +462,13 @@ namespace Akka.Cluster.Sharding
 
         private static void ContinueRebalance<TCoordinator>(this TCoordinator coordinator, IImmutableSet<ShardId> shards) where TCoordinator : IShardCoordinator
         {
+            if (coordinator.Log.IsInfoEnabled && (shards.Count > 0 || !coordinator.RebalanceInProgress.IsEmpty))
+            {
+                coordinator.Log.Info("Starting rebalance for shards [{0}]. Current shards rebalancing: [{1}]",
+                    string.Join(",", shards),
+                    string.Join(",", coordinator.RebalanceInProgress.Keys));
+            }
+
             foreach (var shard in shards)
             {
                 if (!coordinator.RebalanceInProgress.ContainsKey(shard))

--- a/src/contrib/cluster/Akka.Cluster.Sharding/reference.conf
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/reference.conf
@@ -97,6 +97,7 @@ akka.cluster.sharding {
     # The difference between number of shards in the region with most shards and
     # the region with least shards must be greater than (>) the `rebalanceThreshold`
     # for the rebalance to occur.
+    # It is also the maximum number of shards that will start rebalancing per rebalance-interval
     # 1 gives the best distribution and therefore typically the best choice.
     # Increasing the threshold can result in quicker rebalance but has the
     # drawback of increased difference between number of shards (and therefore load)


### PR DESCRIPTION
> For cases where rebalance takes a long time due to a relatively large cluster change
> e.g. when doubling number of nodes (common for 1-2, 3-6 etc) there is
> little insignt into what is happening unless DEBUG logging is enabled.
> 
> This adds an INFO log per rebalance-interval (default is 10s) to show
> what is in progress and which new shards are starting rebalancing.