### PR TITLE
Optimize allocations in ActorPath.Join()

### DIFF
--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -404,8 +404,31 @@ namespace Akka.Actor
         /// <returns> System.String. </returns>
         private string Join()
         {
-            var joined = String.Join("/", Elements);
-            return "/" + joined;
+            if (this is RootActorPath)
+                return "/";
+
+            // Resolve length of final string
+            int totalLength = 0;
+            ActorPath p = this;
+            while (!(p is RootActorPath))
+            {
+                totalLength += p.Name.Length + 1;
+                p = p.Parent;
+            }
+
+            // Concatenate segments (in reverse order) into buffer with '/' prefixes
+            char[] buffer = new char[totalLength];
+            int offset = buffer.Length;
+            p = this;
+            while (!(p is RootActorPath))
+            {
+                offset -= p.Name.Length + 1;
+                buffer[offset] = '/';
+                p.Name.CopyTo(0, buffer, offset + 1, p.Name.Length);
+                p = p.Parent;
+            }
+
+            return new string(buffer);
         }
 
         /// <summary>


### PR DESCRIPTION
Optimize ActorPath.Join() to perform fewer allocations. Accessing Elements causes quite a bit of garbage to get generated.

In .NET Core or .NET Standard 2.1, the char[] buffer allocation could be avoided, but I'm sure this isn't good enough reason to require either.

The calls are mainly triggered by serialization of ActorRefs when running with Akka.Remote. We have thousands of actors running on each node and sometimes sending ActorRefs over the wire. We're mostly sending unique ActorRefs (each gets sent only once), so the caching doesn't help.