### PR TITLE
DData: Use SetItem() instead of Add() for InitRemovedNodePruning

### DIFF
--- a/src/contrib/cluster/Akka.DistributedData/Internal/Internal.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Internal/Internal.cs
@@ -425,7 +425,7 @@ namespace Akka.DistributedData.Internal
         /// <param name="owner">TBD</param>
         /// <returns>TBD</returns>
         internal DataEnvelope InitRemovedNodePruning(UniqueAddress removed, UniqueAddress owner) =>
-            new DataEnvelope(Data, Pruning.Add(removed, new PruningInitialized(owner, ImmutableHashSet<Address>.Empty)));
+            new DataEnvelope(Data, Pruning.SetItem(removed, new PruningInitialized(owner, ImmutableHashSet<Address>.Empty)));
 
         /// <summary>
         /// TBD


### PR DESCRIPTION
Seeing some "An Item with the same key but different value already exists" exceptions in an App on InitRemovedNodePruning. Usually see this happen after rotating nodes during a deployment.

No tests added, but all existing tests pass. Also This change appears to be in line with Scala codebase, they use `.updated`: https://github.com/akka/akka/blob/142a63f600af6b8b805a10f0f401a4615237be48/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala#L937

