### PR TITLE
Re-enable dead letter logging after specified duration

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -1624,6 +1624,7 @@ namespace Akka.Actor
         public bool LogConfigOnStart { get; }
         public int LogDeadLetters { get; }
         public bool LogDeadLettersDuringShutdown { get; }
+        public System.TimeSpan LogDeadLettersSuspendDuration { get; }
         public string LogLevel { get; }
         public bool LoggerAsyncStart { get; }
         public System.TimeSpan LoggerStartTimeout { get; }

--- a/src/core/Akka.Tests/Actor/DeadLetterSuspensionSpec.cs
+++ b/src/core/Akka.Tests/Actor/DeadLetterSuspensionSpec.cs
@@ -1,0 +1,69 @@
+﻿//------------------------------------------_-----------------------------
+// <copyright file="DeadLetterSupressionSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Threading;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Tests.Actor
+{
+    public class DeadLetterSuspensionSpec : AkkaSpec
+    {
+        private static readonly Config Config = ConfigurationFactory.ParseString(@"
+            akka.loglevel = INFO
+            akka.log-dead-letters = 3
+            akka.log-dead-letters-suspend-duration = 2s");
+
+        private readonly IActorRef _deadActor;
+
+        public DeadLetterSuspensionSpec()
+            : base(Config)
+        {
+            _deadActor = Sys.ActorOf(Props.Create<TestKit.TestActors.EchoActor>());
+            Watch(_deadActor);
+            _deadActor.Tell(PoisonPill.Instance);
+            ExpectTerminated(_deadActor);
+        }
+
+        private string ExpectedDeadLettersLogMessage(int count) =>
+            $"Message [{count.GetType().Name}] from {TestActor.Path} to {_deadActor.Path} was not delivered. [{count}] dead letters encountered";
+
+        [Fact]
+        public void Must_suspend_dead_letters_logging_when_reaching_akka_log_dead_letters_and_then_re_enable()
+        {
+            EventFilter
+                .Info(start: ExpectedDeadLettersLogMessage(1))
+                .Expect(1, () => _deadActor.Tell(1));
+
+            EventFilter
+                .Info(start: ExpectedDeadLettersLogMessage(2))
+                .Expect(1, () => _deadActor.Tell(2));
+
+            EventFilter
+                .Info(start: ExpectedDeadLettersLogMessage(3) + ", no more dead letters will be logged in next")
+                .Expect(1, () => _deadActor.Tell(3));
+
+            _deadActor.Tell(4);
+            _deadActor.Tell(5);
+
+            // let suspend-duration elapse
+            Thread.Sleep(2050);
+
+            // re-enabled
+            EventFilter
+                .Info(start: ExpectedDeadLettersLogMessage(6) + ", of which 2 were not logged")
+                .Expect(1, () => _deadActor.Tell(6));
+
+            // reset count
+            EventFilter
+                .Info(start: ExpectedDeadLettersLogMessage(1))
+                .Expect(1, () => _deadActor.Tell(7));
+        }
+    }
+}

--- a/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
+++ b/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
@@ -44,7 +44,8 @@ namespace Akka.Tests.Configuration
             settings.StdoutLogLevel.ShouldBe("WARNING");
             settings.LogConfigOnStart.ShouldBeFalse();
             settings.LogDeadLetters.ShouldBe(10);
-            settings.LogDeadLettersDuringShutdown.ShouldBeTrue();
+            settings.LogDeadLettersDuringShutdown.ShouldBeFalse();
+            settings.LogDeadLettersSuspendDuration.ShouldBe(TimeSpan.FromMinutes(5));
 
             settings.ProviderClass.ShouldBe(typeof (LocalActorRefProvider).FullName);
             settings.SupervisorStrategyClass.ShouldBe(typeof (DefaultSupervisorStrategy).FullName);

--- a/src/core/Akka/Actor/Settings.cs
+++ b/src/core/Akka/Actor/Settings.cs
@@ -7,11 +7,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Akka.Actor.Setup;
 using Akka.Configuration;
 using Akka.Dispatch;
 using Akka.Routing;
-using Akka.Util;
 using ConfigurationFactory = Akka.Configuration.ConfigurationFactory;
 
 namespace Akka.Actor
@@ -131,6 +131,10 @@ namespace Akka.Actor
                     break;
             }
             LogDeadLettersDuringShutdown = Config.GetBoolean("akka.log-dead-letters-during-shutdown", false);
+
+            const string key = "akka.log-dead-letters-suspend-duration";
+            LogDeadLettersSuspendDuration = Config.GetString(key, null) == "infinite" ? Timeout.InfiniteTimeSpan : Config.GetTimeSpan(key);
+
             AddLoggingReceive = Config.GetBoolean("akka.actor.debug.receive", false);
             DebugAutoReceive = Config.GetBoolean("akka.actor.debug.autoreceive", false);
             DebugLifecycle = Config.GetBoolean("akka.actor.debug.lifecycle", false);
@@ -257,7 +261,7 @@ namespace Akka.Actor
         /// </summary>
         /// <value>The logger start timeout.</value>
         public TimeSpan LoggerStartTimeout { get; private set; }
-        
+
         /// <summary>
         ///     Gets the logger start timeout.
         /// </summary>
@@ -281,6 +285,11 @@ namespace Akka.Actor
         /// </summary>
         /// <value><c>true</c> if [log dead letters during shutdown]; otherwise, <c>false</c>.</value>
         public bool LogDeadLettersDuringShutdown { get; private set; }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public TimeSpan LogDeadLettersSuspendDuration { get; }
 
         /// <summary>
         ///     Gets a value indicating whether [add logging receive].

--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -57,7 +57,12 @@ akka {
   # Possibility to turn off logging of dead letters while the actor system
   # is shutting down. Logging is only done when enabled by 'log-dead-letters'
   # setting.
-  log-dead-letters-during-shutdown = on
+  log-dead-letters-during-shutdown = off
+
+  # When log-dead-letters is enabled, this will re-enable the logging after configured duration.
+  # infinite: suspend the logging forever;
+  # or a duration (eg: 5 minutes), after which the logging will be re-enabled.
+  log-dead-letters-suspend-duration = 5 minutes
  
   # List FQCN of extensions which shall be loaded at actor system startup.
   # Should be on the format: 'extensions = ["foo", "bar"]' etc.

--- a/src/core/Akka/Event/DeadLetterListener.cs
+++ b/src/core/Akka/Event/DeadLetterListener.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using Akka.Actor;
 
 namespace Akka.Event
@@ -16,6 +17,7 @@ namespace Akka.Event
     public class DeadLetterListener : ActorBase
     {
         private readonly EventStream _eventStream = Context.System.EventStream;
+        private readonly bool _isAlwaysLoggingDeadLetters = Context.System.Settings.LogDeadLetters == int.MaxValue;
         private readonly int _maxCount = Context.System.Settings.LogDeadLetters;
         private int _count;
 
@@ -38,7 +40,7 @@ namespace Akka.Event
         /// </summary>
         protected override void PreStart()
         {
-            _eventStream.Subscribe(Self, typeof (DeadLetter));
+            _eventStream.Subscribe(Self, typeof(DeadLetter));
         }
 
         /// <summary>
@@ -49,6 +51,19 @@ namespace Akka.Event
             _eventStream.Unsubscribe(Self);
         }
 
+        private void IncrementCount()
+        {
+            if (_count == int.MaxValue)
+            {
+                Logging.GetLogger(Context.System, this).Info("Resetting DeadLetterListener counter after reaching Int.MaxValue.");
+                _count = 1;
+            }
+            else
+            {
+                _count++;
+            }
+        }
+
         /// <summary>
         /// TBD
         /// </summary>
@@ -56,28 +71,187 @@ namespace Akka.Event
         /// <returns>TBD</returns>
         protected override bool Receive(object message)
         {
-            var deadLetter = (DeadLetter)message;
-            var snd = deadLetter.Sender;
-            var rcp = deadLetter.Recipient;
-
-            _count++;
-
-            var done = _maxCount != int.MaxValue && _count >= _maxCount;
-            var doneMsg = done ? ", no more dead letters will be logged" : "";
-
-            if (!done)
+            if (_isAlwaysLoggingDeadLetters)
             {
-                var rcpPath = rcp == ActorRefs.NoSender ? "NoSender" : rcp.Path.ToString();
-                var sndPath = snd == ActorRefs.NoSender ? "NoSender" : snd.Path.ToString();
-
-                _eventStream.Publish(new Info(rcpPath, rcp.GetType(),
-                    $"Message [{deadLetter.Message.GetType().Name}] from {sndPath} to {rcpPath} was not delivered. [{_count}] dead letters encountered {doneMsg}." +
-                    "This logging can be turned off or adjusted with configuration settings 'akka.log-dead-letters' " +
-                    "and 'akka.log-dead-letters-during-shutdown'."));
+                return ReceiveWithAlwaysLogging()(message);
             }
 
-            if (done) Context.Stop(Self);
-            return true;
+            return Context.System.Settings.LogDeadLettersSuspendDuration != Timeout.InfiniteTimeSpan
+                ? ReceiveWithSuspendLogging(Context.System.Settings.LogDeadLettersSuspendDuration)(message)
+                : ReceiveWithMaxCountLogging()(message);
+        }
+
+        private Receive ReceiveWithAlwaysLogging()
+        {
+            return message =>
+            {
+                if (message is DeadLetter deadLetter)
+                {
+                    IncrementCount();
+                    LogDeadLetter(deadLetter.Message, deadLetter.Sender, deadLetter.Recipient, "");
+                    return true;
+                }
+                return false;
+            };
+        }
+
+        private Receive ReceiveWithMaxCountLogging()
+        {
+            return message =>
+            {
+                if (message is DeadLetter deadLetter)
+                {
+                    IncrementCount();
+                    if (_count == _maxCount)
+                    {
+                        LogDeadLetter(deadLetter.Message, deadLetter.Sender, deadLetter.Recipient, ", no more dead letters will be logged");
+                        Context.Stop(Self);
+                    }
+                    else
+                    {
+                        LogDeadLetter(deadLetter.Message, deadLetter.Sender, deadLetter.Recipient, "");
+                    }
+                    return true;
+                }
+                return false;
+            };
+        }
+
+        private Receive ReceiveWithSuspendLogging(TimeSpan suspendDuration)
+        {
+            return message =>
+            {
+                if (message is DeadLetter deadLetter)
+                {
+                    IncrementCount();
+                    if (_count == _maxCount)
+                    {
+                        var doneMsg = $", no more dead letters will be logged in next [{suspendDuration}]";
+                        LogDeadLetter(deadLetter.Message, deadLetter.Sender, deadLetter.Recipient, doneMsg);
+                        Context.Become(ReceiveWhenSuspended(suspendDuration, Deadline.Now + suspendDuration));
+                    }
+                    else
+                    {
+                        LogDeadLetter(deadLetter.Message, deadLetter.Sender, deadLetter.Recipient, "");
+                    }
+                    return true;
+                }
+                return false;
+            };
+        }
+
+        private Receive ReceiveWhenSuspended(TimeSpan suspendDuration, Deadline suspendDeadline)
+        {
+            return message =>
+            {
+                if (message is DeadLetter deadLetter)
+                {
+                    IncrementCount();
+                    if (suspendDeadline.IsOverdue)
+                    {
+                        var doneMsg = $", of which {(_count - _maxCount - 1).ToString()} were not logged. The counter will be reset now";
+                        LogDeadLetter(deadLetter.Message, deadLetter.Sender, deadLetter.Recipient, doneMsg);
+                        _count = 0;
+                        Context.Become(ReceiveWithSuspendLogging(suspendDuration));
+                    }
+                    return true;
+                }
+                return false;
+            };
+        }
+
+        private void LogDeadLetter(object message, IActorRef snd, IActorRef recipient, string doneMsg)
+        {
+            var origin = ReferenceEquals(snd, Context.System.DeadLetters) ? "without sender" : $"from {snd.Path}";
+            _eventStream.Publish(new Info(
+                recipient.Path.ToString(),
+                recipient.GetType(),
+                $"Message [{message.GetType().Name}] {origin} to {recipient.Path} was not delivered. [{_count.ToString()}] dead letters encountered{doneMsg}. " +
+                $"If this is not an expected behavior then {recipient.Path} may have terminated unexpectedly. " +
+                "This logging can be turned off or adjusted with configuration settings 'akka.log-dead-letters' " +
+                "and 'akka.log-dead-letters-during-shutdown'."));
+        }
+
+        /// <summary>
+        /// This class represents the latest date or time by which an operation should be completed.
+        /// </summary>
+        private readonly struct Deadline : IEquatable<Deadline>
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="Deadline"/> class.
+            /// </summary>
+            /// <param name="when">The <see cref="DateTime"/> that the deadline is due.</param>
+            private Deadline(DateTime when) => When = when;
+
+            /// <summary>
+            /// Determines whether the deadline has past.
+            /// </summary>
+            public bool IsOverdue => DateTime.UtcNow > When;
+
+            /// <summary>
+            /// Determines whether there is still time left until the deadline.
+            /// </summary>
+            public bool HasTimeLeft => DateTime.UtcNow < When;
+
+            /// <summary>
+            /// The <see cref="DateTime"/> that the deadline is due.
+            /// </summary>
+            public DateTime When { get; }
+
+            /// <summary>
+            /// <para>
+            /// The amount of time left until the deadline is reached.
+            /// </para>
+            /// <note>
+            /// Warning: creates a new <see cref="TimeSpan"/> instance each time it's used
+            /// </note>
+            /// </summary>
+            public TimeSpan TimeLeft { get { return When - DateTime.UtcNow; } }
+
+            #region Overrides
+            
+            /// <inheritdoc/>
+            public override bool Equals(object obj) => 
+                obj is Deadline deadline && Equals(deadline);
+
+            /// <inheritdoc/>
+            public bool Equals(Deadline other) => When == other.When;
+
+            /// <inheritdoc/>
+            public override int GetHashCode() => When.GetHashCode();
+
+            #endregion
+
+            #region Static members
+
+            /// <summary>
+            /// A deadline that is due <see cref="DateTime.UtcNow"/>
+            /// </summary>
+            public static Deadline Now => new Deadline(DateTime.UtcNow);
+
+            /// <summary>
+            /// Adds a given <see cref="TimeSpan"/> to the due time of this <see cref="Deadline"/>
+            /// </summary>
+            /// <param name="deadline">The deadline whose time is being extended</param>
+            /// <param name="duration">The amount of time being added to the deadline</param>
+            /// <returns>A new deadline with the specified duration added to the due time</returns>
+            public static Deadline operator +(Deadline deadline, TimeSpan duration)
+            {
+                return new Deadline(deadline.When.Add(duration));
+            }
+
+            /// <summary>
+            /// Adds a given <see cref="Nullable{TimeSpan}"/> to the due time of this <see cref="Deadline"/>
+            /// </summary>
+            /// <param name="deadline">The deadline whose time is being extended</param>
+            /// <param name="duration">The amount of time being added to the deadline</param>
+            /// <returns>A new deadline with the specified duration added to the due time</returns>
+            public static Deadline operator +(Deadline deadline, TimeSpan? duration)
+            {
+                return duration.HasValue ? new Deadline(deadline.When.Add(duration.Value)) : deadline;
+            }
+
+            #endregion
         }
     }
 }


### PR DESCRIPTION
This could be added to the release notes:

>#### Logging of dead letters
>
>When the number of dead letters have reached configured `akka.log-dead-letters` value it didn't log
>more dead letters in previous version. In Akka.NET 1.4.9 the count is reset after configured `akka.log-dead-letters-suspend-duration`.
>
>`akka.log-dead-letters-during-shutdown` default configuration changed from `on` to `off`.