### PR TITLE
skip call to LogSource.FromActorRef to prevent NRE during RemotingTerminator startup

### DIFF
--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -698,7 +698,9 @@ namespace Akka.Remote
             public RemotingTerminator(IActorRef systemGuardian)
             {
                 _systemGuardian = systemGuardian;
-                _log = Context.GetLogger();
+
+                // can't use normal Logger.GetLogger(this IActorContext) here due to https://github.com/akkadotnet/akka.net/issues/4530
+                _log = Logging.GetLogger(Context.System.EventStream, "remoting-terminator");
                 InitFSM();
             }
 


### PR DESCRIPTION
close #4530 