### PR TITLE
Enhance OpenCircuitException error reporting

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -3891,10 +3891,11 @@ namespace Akka.Pattern
         public bool IsClosed { get; }
         public bool IsHalfOpen { get; }
         public bool IsOpen { get; }
+        public System.Exception LastCaughtException { get; }
         public int MaxFailures { get; }
         public System.TimeSpan ResetTimeout { get; }
         public static Akka.Pattern.CircuitBreaker Create(int maxFailures, System.TimeSpan callTimeout, System.TimeSpan resetTimeout) { }
-        public void Fail() { }
+        public void Fail(System.Exception cause = null) { }
         public Akka.Pattern.CircuitBreaker OnClose(System.Action callback) { }
         public Akka.Pattern.CircuitBreaker OnHalfOpen(System.Action callback) { }
         public Akka.Pattern.CircuitBreaker OnOpen(System.Action callback) { }
@@ -3917,6 +3918,7 @@ namespace Akka.Pattern
     public class OpenCircuitException : Akka.Actor.AkkaException
     {
         public OpenCircuitException() { }
+        public OpenCircuitException(System.Exception cause) { }
         public OpenCircuitException(string message) { }
         public OpenCircuitException(string message, System.Exception cause) { }
     }
@@ -5056,8 +5058,9 @@ namespace Akka.Util.Internal
     public interface IAtomicState
     {
         bool HasListeners { get; }
+        System.Exception LastCaughtException { get; }
         void AddListener(System.Action listener);
-        void Enter();
+        void Enter(System.Exception lastFailureCause);
         System.Threading.Tasks.Task<T> Invoke<T>(System.Func<System.Threading.Tasks.Task<T>> body);
     }
     public class static InterlockedSpin

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -3895,7 +3895,7 @@ namespace Akka.Pattern
         public int MaxFailures { get; }
         public System.TimeSpan ResetTimeout { get; }
         public static Akka.Pattern.CircuitBreaker Create(int maxFailures, System.TimeSpan callTimeout, System.TimeSpan resetTimeout) { }
-        public void Fail(System.Exception cause = null) { }
+        public void Fail() { }
         public Akka.Pattern.CircuitBreaker OnClose(System.Action callback) { }
         public Akka.Pattern.CircuitBreaker OnHalfOpen(System.Action callback) { }
         public Akka.Pattern.CircuitBreaker OnOpen(System.Action callback) { }
@@ -3921,6 +3921,10 @@ namespace Akka.Pattern
         public OpenCircuitException(System.Exception cause) { }
         public OpenCircuitException(string message) { }
         public OpenCircuitException(string message, System.Exception cause) { }
+    }
+    public class UserCalledFailException : Akka.Actor.AkkaException
+    {
+        public UserCalledFailException() { }
     }
 }
 namespace Akka.Routing

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -5058,9 +5058,8 @@ namespace Akka.Util.Internal
     public interface IAtomicState
     {
         bool HasListeners { get; }
-        System.Exception LastCaughtException { get; }
         void AddListener(System.Action listener);
-        void Enter(System.Exception lastFailureCause);
+        void Enter();
         System.Threading.Tasks.Task<T> Invoke<T>(System.Func<System.Threading.Tasks.Task<T>> body);
     }
     public class static InterlockedSpin

--- a/src/core/Akka/Pattern/CircuitBreaker.cs
+++ b/src/core/Akka/Pattern/CircuitBreaker.cs
@@ -132,6 +132,8 @@ namespace Akka.Pattern
             get { return Closed.Current; }
         }
 
+        public Exception LastCaughtException => _currentState.LastCaughtException;
+
         /// <summary>
         /// Wraps invocation of asynchronous calls that need to be protected
         /// </summary>
@@ -202,7 +204,7 @@ namespace Akka.Pattern
         /// caller Actor. In such a case, it is convenient to mark a failed call instead of using Future
         /// via <see cref="WithCircuitBreaker"/>
         /// </summary>
-        public void Fail() => _currentState.CallFails();
+        public void Fail(Exception cause = null) => _currentState.CallFails(cause);
 
         /// <summary>
         /// Return true if the internal state is Closed. WARNING: It is a "power API" call which you should use with care.
@@ -274,7 +276,7 @@ namespace Akka.Pattern
             if (SwapState(fromState, toState))
             {
                 Debug.WriteLine("Successful transition from {0} to {1}", fromState, toState);
-                toState.Enter();
+                toState.Enter(fromState.LastCaughtException);
             }
             // else some other thread already swapped state
         }

--- a/src/core/Akka/Pattern/CircuitBreaker.cs
+++ b/src/core/Akka/Pattern/CircuitBreaker.cs
@@ -207,7 +207,7 @@ namespace Akka.Pattern
         /// caller Actor. In such a case, it is convenient to mark a failed call instead of using Future
         /// via <see cref="WithCircuitBreaker"/>
         /// </summary>
-        public void Fail(Exception cause = null) => _currentState.CallFails(cause);
+        public void Fail() => _currentState.CallFails(new UserCalledFailException());
 
         internal void OnFail(Exception cause) => LastCaughtException = cause;
 

--- a/src/core/Akka/Pattern/CircuitBreakerState.cs
+++ b/src/core/Akka/Pattern/CircuitBreakerState.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Diagnostics;
 using System.Globalization;
 using System.Threading.Tasks;
 using Akka.Util;
@@ -60,7 +61,7 @@ namespace Akka.Pattern
         {
             // This is a no-op, but CallFails() can be called from CircuitBreaker
             // (The function summary is a lie)
-            _breaker.OnFail(cause);
+            Debug.WriteLine($"Ignoring calls to [CallFails()] because {nameof(CircuitBreaker)} is in open state. Exception cause was: {cause}");
         }
 
         /// <summary>
@@ -70,7 +71,7 @@ namespace Akka.Pattern
         {
             // This is a no-op, but CallSucceeds() can be called from CircuitBreaker
             // (The function summary is a lie)
-            _breaker.OnSuccess();
+            Debug.WriteLine($"Ignoring calls to [CallSucceeds()] because {nameof(CircuitBreaker)} is in open state.");
         }
 
         /// <summary>

--- a/src/core/Akka/Pattern/OpenCircuitException.cs
+++ b/src/core/Akka/Pattern/OpenCircuitException.cs
@@ -21,6 +21,11 @@ namespace Akka.Pattern
         /// </summary>
         public OpenCircuitException() : base("Circuit Breaker is open; calls are failing fast") { }
 
+        public OpenCircuitException(Exception cause)
+            : base("Circuit Breaker is open; calls are failing fast", cause)
+        {
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="OpenCircuitException"/> class.
         /// </summary>

--- a/src/core/Akka/Pattern/UserCalledFailException.cs
+++ b/src/core/Akka/Pattern/UserCalledFailException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Akka.Actor;
+
+namespace Akka.Pattern
+{
+    public class UserCalledFailException : AkkaException
+    {
+        public UserCalledFailException() : base($"User code caused [{nameof(CircuitBreaker)}] to fail because it calls the [{nameof(CircuitBreaker.Fail)}()] method.")
+        { }
+    }
+}

--- a/src/core/Akka/Util/Internal/AtomicState.cs
+++ b/src/core/Akka/Util/Internal/AtomicState.cs
@@ -199,8 +199,6 @@ namespace Akka.Util.Internal
     /// </summary>
     public interface IAtomicState
     {
-        Exception LastCaughtException { get; }
-
         /// <summary>
         /// TBD
         /// </summary>


### PR DESCRIPTION
Closes #4314

- `CircuitBreaker` remembers the last exception that passes it inside the `LastCaughtException` property. 
  This exception is passed to the `OpenCircuitException` whenever it is thrown.
- Changed the `OpenCircuitException` message when it is thrown because of a half-open circuit breaker state.