### PR TITLE
Re-enable Akka.Streams.Tests.TCK NUnit tests

### DIFF
--- a/src/core/Akka.Streams.Tests.TCK/Akka.Streams.Tests.TCK.csproj
+++ b/src/core/Akka.Streams.Tests.TCK/Akka.Streams.Tests.TCK.csproj
@@ -18,6 +18,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Reactive.Streams.TCK" Version="1.0.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
   </ItemGroup>

--- a/src/core/Akka.Streams.Tests.TCK/Akka.Streams.Tests.TCK.csproj
+++ b/src/core/Akka.Streams.Tests.TCK/Akka.Streams.Tests.TCK.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\xunitSettings.props" />
   <PropertyGroup>
     <AssemblyName>Akka.Streams.Tests</AssemblyName>
-    <TargetFrameworks>$(NetFrameworkTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
   </PropertyGroup>
  
   <ItemGroup>
@@ -18,10 +18,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Reactive.Streams.TCK" Version="1.0.2" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <!-- !!!WARNING!!! ALWAYS MATCH NUNIT VERSION WITH THE VERSION USED BY REACTIVE TCK !!!WARNING!!! -->
+    <PackageReference Include="NUnit" Version="3.7.1" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">


### PR DESCRIPTION
Some of the Pub-Sub part of `Akka.Streams` do not have their own standalone spec/unit tests and rely on Reactive.Streams.TCK for testing instead. 
I'm re-enabling NUnit because this is quite dangerous.