### PR TITLE
Fix premature reset of the 'writeInProgress' flag in case of persistence failure

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
@@ -709,8 +709,12 @@ namespace Akka.Persistence
     }
     public sealed class WriteMessagesFailed : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalResponse, Akka.Persistence.IPersistenceMessage, System.IEquatable<Akka.Persistence.WriteMessagesFailed>
     {
+        [System.ObsoleteAttribute("Deprecated since Akka 1.4.11, use the overloaded one which accepts the number of " +
+            "failed atomic writes instead.")]
         public WriteMessagesFailed(System.Exception cause) { }
+        public WriteMessagesFailed(System.Exception cause, int writeCount) { }
         public System.Exception Cause { get; }
+        public int WriteCount { get; }
         public bool Equals(Akka.Persistence.WriteMessagesFailed other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }

--- a/src/core/Akka.Persistence/Eventsourced.Recovery.cs
+++ b/src/core/Akka.Persistence/Eventsourced.Recovery.cs
@@ -462,9 +462,9 @@ namespace Akka.Persistence
                     _isWriteInProgress = false;
                     FlushJournalBatch();
                     break;
-                case WriteMessagesFailed _:
-                    _isWriteInProgress = false;
-                    // it will be stopped by the first WriteMessageFailure message
+                case WriteMessagesFailed failed:
+                    // if writeCount > 0 then WriteMessageFailure will follow that will stop the actor
+                    if (failed.WriteCount == 0) _isWriteInProgress = false;
                     break;
                 case RecoveryTick _:
                     // we may have one of these in the mailbox before the scheduled timeout

--- a/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
@@ -406,7 +406,7 @@ namespace Akka.Persistence.Journal
                                 ? TryUnwrapException(t.Exception)
                                 : new OperationCanceledException(
                                     "WriteMessagesAsync canceled, possibly due to timing out."));
-                        _resequencer.Tell(new Desequenced(new WriteMessagesFailed(exception), counter, message.PersistentActor, self));
+                        _resequencer.Tell(new Desequenced(new WriteMessagesFailed(exception, atomicWriteCount), counter, message.PersistentActor, self));
                         resequence((x, _) => new WriteMessageFailure(x, exception, message.ActorInstanceId), null);
                     }
                 }, _continuationOptions);

--- a/src/core/Akka.Persistence/JournalProtocol.cs
+++ b/src/core/Akka.Persistence/JournalProtocol.cs
@@ -287,18 +287,35 @@ namespace Akka.Persistence
         /// <exception cref="ArgumentNullException">
         /// This exception is thrown when the specified <paramref name="cause"/> is undefined.
         /// </exception>
+        [Obsolete("Deprecated since Akka 1.4.11, use the overloaded one which accepts the number of failed atomic writes instead.")]
         public WriteMessagesFailed(Exception cause)
         {
-            if (cause == null)
-                throw new ArgumentNullException(nameof(cause), "WriteMessagesFailed cause exception cannot be null");
+            Cause = cause ?? throw new ArgumentNullException(nameof(cause), "WriteMessagesFailed cause exception cannot be null");
+        }
 
-            Cause = cause;
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WriteMessagesFailed"/> class.
+        /// </summary>
+        /// <param name="cause">The cause of the failed <see cref="WriteMessages"/> request.</param>
+        /// <param name="writeCount">The number of atomic writes that failed.</param>
+        /// <exception cref="ArgumentNullException">
+        /// This exception is thrown when the specified <paramref name="cause"/> is undefined.
+        /// </exception>
+        public WriteMessagesFailed(Exception cause, int writeCount)
+        {
+            Cause = cause ?? throw new ArgumentNullException(nameof(cause), "WriteMessagesFailed cause exception cannot be null");
+            WriteCount = writeCount;
         }
 
         /// <summary>
         /// The cause of the failed <see cref="WriteMessages"/> request.
         /// </summary>
         public Exception Cause { get; }
+
+        /// <summary>
+        /// The number of atomic writes that failed.
+        /// </summary>
+        public int WriteCount { get; }
 
         /// <inheritdoc/>
         public bool Equals(WriteMessagesFailed other)


### PR DESCRIPTION
A fix for:

> Possible race condition in Akka Persistence that can lead to lost events when using persistAsync() [#28629](https://github.com/akka/akka/issues/28629)

The idea is not to reset the writeInProgress flag prematurely before the actor gets stopped by WriteMessageFailure.