### PR TITLE
Fix typo in cluster.conf

### DIFF
--- a/src/core/Akka.Cluster/Configuration/Cluster.conf
+++ b/src/core/Akka.Cluster/Configuration/Cluster.conf
@@ -222,7 +222,7 @@ akka {
         role = ""
       }
 
-      keep-refree {
+      keep-referee {
         # referee address on the form of "akka.tcp://system@hostname:port"
         address = ""
         down-all-if-less-than-nodes = 1


### PR DESCRIPTION
The default cluster config for keep-referee had a typo. This should have no impact whatsoever as the default values in the KeepReferee class were correct.