### PR TITLE
Akka.Streams tcp transport

### DIFF
--- a/src/Akka.sln
+++ b/src/Akka.sln
@@ -61,9 +61,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Protobuf", "Protobuf", "{98
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{10C5B1E8-15B5-4EB3-81AE-1FC054FE1305}"
-	ProjectSection(SolutionItems) = preProject
-		..\build.fsx = ..\build.fsx
-	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Contrib", "Contrib", "{588C1513-FAB6-42C3-B6FC-3485F13620CF}"
 EndProject

--- a/src/benchmark/RemotePingPong/Program.cs
+++ b/src/benchmark/RemotePingPong/Program.cs
@@ -57,6 +57,7 @@ namespace RemotePingPong
                     port = 0
                     hostname = """"
                     batching {
+                        enabled = false
                         flush-interval = 40ms
                     }
                 }
@@ -140,8 +141,8 @@ namespace RemotePingPong
 
         public static IEnumerable<int> GetClientSettings()
         {
-            yield return 1;
-            yield return 5;
+            //yield return 1;
+            //yield return 5;
             yield return 10;
             yield return 15;
             yield return 20;
@@ -203,7 +204,6 @@ namespace RemotePingPong
             var waiting = Task.WhenAll(tasks);
             await Task.WhenAll(waiting);
             sw.Stop();
-
             // force clean termination
             var termination = Task.WhenAll(new[] { system1.Terminate(), system2.Terminate() }).Wait(TimeSpan.FromSeconds(10));
 

--- a/src/core/Akka.Remote.Tests/RemotingSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemotingSpec.cs
@@ -116,7 +116,7 @@ namespace Akka.Remote.Tests
 
                 enabled-transports = [
                   ""akka.remote.test"",
-                  ""akka.remote.dot-netty.tcp"",
+                  ""akka.remote.streaming.tcp"",
 #""akka.remote.helios.udp""
                 ]
 

--- a/src/core/Akka.Remote/Akka.Remote.csproj
+++ b/src/core/Akka.Remote/Akka.Remote.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyTitle>Akka.Remote</AssemblyTitle>
     <Description>Remote actor support for Akka.NET</Description>
-    <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <PackageTags>$(AkkaPackageTags);network</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/core/Akka.Remote/Akka.Remote.csproj
+++ b/src/core/Akka.Remote/Akka.Remote.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="Configuration\Remote.conf" />
+    <ProjectReference Include="..\Akka.Streams\Akka.Streams.csproj" />
     <ProjectReference Include="..\Akka\Akka.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/core/Akka.Remote/Configuration/Remote.conf
+++ b/src/core/Akka.Remote/Configuration/Remote.conf
@@ -131,8 +131,8 @@ akka {
     # that since remoting can load arbitrary 3rd party drivers (see
     # "enabled-transport" and "adapters" entries) it is not guaranteed that
     # every module will respect this setting.
-    #use-dispatcher = "akka.remote.default-remote-dispatcher"
-    use-dispatcher = "akka.actor.default-dispatcher"
+    use-dispatcher = "akka.remote.default-remote-dispatcher"
+    #use-dispatcher = "akka.actor.default-dispatcher"
     ### Security settings
 
     # Enable untrusted mode for full security of server managed actors, prevents

--- a/src/core/Akka.Remote/Configuration/Remote.conf
+++ b/src/core/Akka.Remote/Configuration/Remote.conf
@@ -341,7 +341,7 @@ akka {
     # pointing to an implementation class of the Transport interface.
     # If multiple transports are provided, the address of the first
     # one will be used as a default address.
-    enabled-transports = ["akka.remote.dot-netty.tcp"]
+    enabled-transports = ["akka.remote.streaming.tcp"]
 
     # Transport drivers can be augmented with adapters by adding their
     # name to the applied-adapters setting in the configuration of a
@@ -359,7 +359,9 @@ akka {
 	helios.tcp.transport-class = "Akka.Remote.Transport.Helios.HeliosTcpTransport, Akka.Remote.Transport.Helios"
 
     ### Default configuration for the DotNetty based transport drivers
-
+streaming.tcp{
+  transport-class = "Akka.Remote.Transport.Streaming.StreamingTcpTransport,Akka.Remote"
+}
     dot-netty.tcp {
       # The class given here must implement the akka.remote.transport.Transport
       # interface and offer a public constructor which takes two arguments:

--- a/src/core/Akka.Remote/Configuration/Remote.conf
+++ b/src/core/Akka.Remote/Configuration/Remote.conf
@@ -131,8 +131,8 @@ akka {
     # that since remoting can load arbitrary 3rd party drivers (see
     # "enabled-transport" and "adapters" entries) it is not guaranteed that
     # every module will respect this setting.
-    use-dispatcher = "akka.remote.default-remote-dispatcher"
-
+    #use-dispatcher = "akka.remote.default-remote-dispatcher"
+    use-dispatcher = "akka.actor.default-dispatcher"
     ### Security settings
 
     # Enable untrusted mode for full security of server managed actors, prevents
@@ -488,11 +488,11 @@ streaming.tcp{
 
       # Sets the send buffer size of the Sockets,
       # set to 0b for platform default
-      send-buffer-size = 256000b
+      send-buffer-size = 512000b
 
       # Sets the receive buffer size of the Sockets,
       # set to 0b for platform default
-      receive-buffer-size = 256000b
+      receive-buffer-size = 512000b
 
       # Maximum message size the transport will accept, but at least
       # 32000 bytes.
@@ -500,7 +500,7 @@ streaming.tcp{
       # so this setting has to be chosen carefully when using UDP.
       # Both send-buffer-size and receive-buffer-size settings has to
       # be adjusted to be able to buffer messages of maximum size.
-      maximum-frame-size = 128000b
+      maximum-frame-size = 256000b
 
       # Sets the size of the connection backlog
       backlog = 4096

--- a/src/core/Akka.Remote/Transport/DotNetty/BatchWriter.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/BatchWriter.cs
@@ -21,7 +21,7 @@ namespace Akka.Remote.Transport.DotNetty
     ///
     /// Configuration object for <see cref="BatchWriter"/>
     /// </summary>
-    internal class BatchWriterSettings
+    public class BatchWriterSettings
     {
         public const int DefaultMaxPendingWrites = 30;
         public const long DefaultMaxPendingBytes = 16 * 1024L;

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
@@ -311,7 +310,7 @@ namespace Akka.Remote.Transport.DotNetty
             //else
             //{
             var addressFamily = Settings.DnsUseIpv6 ? AddressFamily.InterNetworkV6 : AddressFamily.InterNetwork;
-            endpoint = await ResolveNameAsync(dns, addressFamily).ConfigureAwait(false);
+            endpoint = await DnsHelpers.ResolveNameAsync(dns, addressFamily).ConfigureAwait(false);
             //}
             return endpoint;
         }
@@ -421,17 +420,7 @@ namespace Akka.Remote.Transport.DotNetty
             return new IPEndPoint(resolved.AddressList[resolved.AddressList.Length - 1], address.Port);
         }
 
-        internal static async Task<IPEndPoint> ResolveNameAsync(DnsEndPoint address, AddressFamily addressFamily)
-        {
-            var resolved = await Dns.GetHostEntryAsync(address.Host).ConfigureAwait(false);
-            var found = resolved.AddressList.LastOrDefault(a => a.AddressFamily == addressFamily);
-            if (found == null)
-            {
-                throw new KeyNotFoundException($"Couldn't resolve IP endpoint from provided DNS name '{address}' with address family of '{addressFamily}'");
-            }
-
-            return new IPEndPoint(found, address.Port);
-        }
+        
 
         #endregion
 

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransportSettings.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransportSettings.cs
@@ -23,7 +23,7 @@ namespace Akka.Remote.Transport.DotNetty
     ///
     /// Defines the settings for the <see cref="DotNettyTransport"/>.
     /// </summary>
-    internal sealed class DotNettyTransportSettings
+    public sealed class DotNettyTransportSettings
     {
         public static DotNettyTransportSettings Create(ActorSystem system)
         {
@@ -280,13 +280,13 @@ namespace Akka.Remote.Transport.DotNetty
             BatchWriterSettings = batchWriterSettings;
         }
     }
-    internal enum TransportMode
+    public enum TransportMode
     {
         Tcp,
         Udp
     }
 
-    internal sealed class SslSettings
+    public sealed class SslSettings
     {
         public static readonly SslSettings Empty = new SslSettings();
         public static SslSettings Create(Config config)

--- a/src/core/Akka.Remote/Transport/Streaming/StreamingTcpTransport.cs
+++ b/src/core/Akka.Remote/Transport/Streaming/StreamingTcpTransport.cs
@@ -272,7 +272,7 @@ namespace Akka.Remote.Transport.Streaming
                 .Queue<IO.ByteString>(64, OverflowStrategy.DropNew).Async()
                 .Via(
                     Framing.SimpleFramingProtocolEncoder(Settings.MaxFrameSize))
-                .GroupedWithin(128, TimeSpan.FromMilliseconds(30))
+                .GroupedWithin(128, TimeSpan.FromMilliseconds(20))
                 .SelectMany(r => r)
                 .Async()
                 .BatchWeighted(32*1024,

--- a/src/core/Akka.Remote/Transport/Streaming/StreamingTcpTransport.cs
+++ b/src/core/Akka.Remote/Transport/Streaming/StreamingTcpTransport.cs
@@ -1,0 +1,229 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="testTransport.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.IO;
+using Akka.Remote.Transport.DotNetty;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+using ByteString = Google.Protobuf.ByteString;
+using Dns = System.Net.Dns;
+using Tcp = Akka.Streams.Dsl.Tcp;
+
+namespace Akka.Remote.Transport.Streaming
+{
+    class StreamingTcpAssociationHandle : AssociationHandle
+    {
+        private ISourceQueueWithComplete<IO.ByteString> _queue;
+
+        public StreamingTcpAssociationHandle(Address localAddress,
+            Address remoteAddress,
+            ISourceQueueWithComplete<IO.ByteString> queue) : base(localAddress, remoteAddress)
+        {
+            _queue = queue;
+        }
+
+        public override bool Write(ByteString payload)
+        {
+            return _queue.OfferAsync(IO.ByteString.CopyFrom(payload.ToByteArray())).Result is QueueOfferResult
+                .Enqueued;
+        }
+
+        public override void Disassociate()
+        {
+            _queue.Complete();
+        }
+    }
+    class StreamingTcpTransport : Transport
+    {
+        public sealed override string SchemeIdentifier { get; protected set; } =
+            "tcp";
+        private ActorMaterializer _mat;
+        private DotNettyTransportSettings Settings;
+        private Source<Tcp.IncomingConnection, Task<Tcp.ServerBinding>> _connectionSource;
+        protected readonly TaskCompletionSource<IAssociationEventListener> AssociationListenerPromise;
+        private Task<Tcp.ServerBinding> _serverBindingTask;
+        private Source<Tcp.IncomingConnection, NotUsed> _inboundConnectionSource;
+        private Address _addr;
+        private ConcurrentDictionary<Address,int> _clientAddr = new ConcurrentDictionary<Address, int>();
+        private EndPoint _listenAddress;
+        private IHandleEventListener _listner;
+        private EndPoint _outAddr;
+
+        public StreamingTcpTransport(ActorSystem system, Config config)
+        {
+            AssociationListenerPromise = new TaskCompletionSource<IAssociationEventListener>();
+            System = system;
+            _mat = ActorMaterializer.Create(system);
+            if (system.Settings.Config.HasPath("akka.remote.dot-netty.tcp"))
+            {
+                var dotNettyFallbackConfig =
+                    system.Settings.Config.GetConfig(
+                        "akka.remote.dot-netty.tcp");
+                config = dotNettyFallbackConfig.WithFallback(config);
+            }
+            if (system.Settings.Config.HasPath("akka.remote.helios.tcp"))
+            {
+                var heliosFallbackConfig = system.Settings.Config.GetConfig("akka.remote.helios.tcp");
+                config = heliosFallbackConfig.WithFallback(config);
+            }
+
+            Settings = DotNettyTransportSettings.Create(config);
+
+        }
+        public override async Task<(Address, TaskCompletionSource<IAssociationEventListener>)> Listen()
+        {
+            if (IPAddress.TryParse(Settings.Hostname, out IPAddress ip))
+            {
+                _listenAddress = new IPEndPoint(ip, Settings.Port);
+                _outAddr = new IPEndPoint(ip,0);
+            }
+            else
+            {
+                if (string.IsNullOrWhiteSpace(Settings.Hostname))
+                {
+                    var hostName = Dns.GetHostName();
+                    _listenAddress = new DnsEndPoint(hostName, Settings.Port);
+                    _outAddr = new DnsEndPoint(Settings.Hostname,0);
+                }
+                else
+                {
+                    _listenAddress =
+                        new DnsEndPoint(Settings.Hostname, Settings.Port);
+                    _outAddr = new DnsEndPoint(Settings.Hostname,0);
+                }
+            }
+            
+            
+            _connectionSource =
+                System.TcpStream().Bind(Settings.Hostname, Settings.Port,
+                    options: ImmutableList.Create<Inet.SocketOption>(
+                        new Inet.SO.SendBufferSize(Settings.SendBufferSize
+                                                   ?? 256 * 1024),
+                        new Inet.SO.ReceiveBufferSize(
+                            Settings.ReceiveBufferSize ?? 256 * 1024)));
+            var mappedAddr = _listenAddress is IPEndPoint p
+                    ? p
+                    : await DnsToIPEndpoint(_listenAddress as DnsEndPoint)
+                ;            
+            //var sourceSet = _connectionSource.PreMaterialize(_mat);
+            //_serverBindingTask = sourceSet.Item1;
+            //_inboundConnectionSource = sourceSet.Item2;
+            //_inboundConnectionSource.Select()
+            _addr = DotNettyTransport.MapSocketToAddress(
+                socketAddress: mappedAddr, 
+                schemeIdentifier: SchemeIdentifier,
+                systemName: base.System.Name,
+                hostName: Settings.PublicHostname,
+                publicPort: Settings.PublicPort);
+            
+
+            
+            _connectionSource.RunForeach(ic =>
+            {
+                var receiveFlow = this.receiveFlow();
+                var sendFlowPreMat = preMaterializedSendFlow();
+                AssociationListenerPromise.Task.ContinueWith(r =>
+                {
+                    var listener = r.Result;
+                    var remoteAddress =
+                        DotNettyTransport.MapSocketToAddress(
+                            (IPEndPoint)ic.RemoteAddress, "tcp", base.System.Name);
+                    AssociationHandle handle;
+                    handle = new StreamingTcpAssociationHandle(_addr,
+                        remoteAddress,
+                        sendFlowPreMat.Item1);
+                    ic.HandleWith(
+                        Flow.FromSinkAndSource(receiveFlow.Async(),
+                            sendFlowPreMat.Item2.Async()).Async(), _mat);
+                    listener.Notify(new InboundAssociation(handle));
+                });
+            }, _mat);
+            return (_addr, AssociationListenerPromise);
+        }
+        protected async Task<IPEndPoint> DnsToIPEndpoint(DnsEndPoint dns)
+        {
+            IPEndPoint endpoint;
+            //if (!Settings.EnforceIpFamily)
+            //{
+            //    endpoint = await ResolveNameAsync(dns).ConfigureAwait(false);
+            //}
+            //else
+            //{
+            var addressFamily = Settings.DnsUseIpv6 ? AddressFamily.InterNetworkV6 : AddressFamily.InterNetwork;
+            endpoint = await DotNettyTransport.ResolveNameAsync(dns, addressFamily).ConfigureAwait(false);
+            //}
+            return endpoint;
+        }
+        public override bool IsResponsibleFor(Address remote)
+        {
+            return true;
+        }
+
+        public override async Task<AssociationHandle> Associate(Address remoteAddress)
+        {
+            
+            var c =base.System.TcpStream().OutgoingConnection(
+                DotNettyTransport.AddressToSocketAddress(remoteAddress),
+                _outAddr,
+                ImmutableList.Create<Inet.SocketOption>(
+                    new Inet.SO.ReceiveBufferSize(
+                        Settings.ReceiveBufferSize ?? 256 * 1024),
+                    new Inet.SO.SendBufferSize(
+                        Settings.SendBufferSize ?? 256 * 1024)));
+            
+            var receiveFlow = this.receiveFlow();
+
+            var sendFlowPreMat = preMaterializedSendFlow();
+            var handle = new StreamingTcpAssociationHandle(_addr,remoteAddress, sendFlowPreMat.Item1);
+            handle.ReadHandlerSource.Task.ContinueWith(s =>
+            {   
+                var listener = s.Result;
+                RegisterListener(listener, remoteAddress, null);
+            }, TaskContinuationOptions.ExecuteSynchronously);
+            c.Join(Flow.FromSinkAndSource(receiveFlow.Async(), sendFlowPreMat.Item2.Async()).Async()).Run(_mat);
+            return handle;
+        }
+
+        private (ISourceQueueWithComplete<IO.ByteString>, Source<IO.ByteString, NotUsed>) preMaterializedSendFlow()
+        {
+            return Source
+                .Queue<IO.ByteString>(5000, OverflowStrategy.Backpressure)
+                .Via(Framing.SimpleFramingProtocolEncoder(Settings.MaxFrameSize))
+                .PreMaterialize(_mat);
+        }
+
+        private Sink<IO.ByteString, NotUsed> receiveFlow()
+        {
+            return Flow.Create<IO.ByteString>()
+                .Via(Framing.SimpleFramingProtocolDecoder(Settings.MaxFrameSize)).Select(r =>
+                {
+                    _listner?.Notify(
+                        new InboundPayload(ByteString.CopyFrom(r.ToArray())));
+                    return  NotUsed.Instance;
+                } ).ToMaterialized(Sink.Ignore<NotUsed>() ,Keep.Left);
+        }
+
+        private void RegisterListener(IHandleEventListener listener, Address remoteAddress, object o)
+        {
+            this._listner = listener;
+        }
+
+        public override async Task<bool> Shutdown()
+        {
+            await _serverBindingTask.Result.Unbind();
+            return true;
+        }
+    }
+}

--- a/src/core/Akka.Remote/Transport/Tcp/DnsHelpers.cs
+++ b/src/core/Akka.Remote/Transport/Tcp/DnsHelpers.cs
@@ -1,0 +1,95 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="DnsHelpers.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Akka.Actor;
+
+namespace Akka.Remote.Transport
+{
+    public static class DnsHelpers
+    {
+        public static async Task<IPEndPoint> ResolveNameAsync(
+            DnsEndPoint address, AddressFamily addressFamily)
+        {
+
+            var resolved = await Dns.GetHostEntryAsync(address.Host)
+                .ConfigureAwait(false);
+            var found =
+                resolved.AddressList.LastOrDefault(a =>
+                    a.AddressFamily == addressFamily);
+            if (found == null)
+            {
+                throw new KeyNotFoundException(
+                    $"Couldn't resolve IP endpoint from provided DNS name '{address}' with address family of '{addressFamily}'");
+            }
+
+            return new IPEndPoint(found, address.Port);
+        }
+
+        public static Address MapSocketToAddress(IPEndPoint socketAddress,
+            string schemeIdentifier, string systemName, string hostName = null,
+            int? publicPort = null)
+        {
+            try
+            {
+                return socketAddress == null
+                    ? null
+                    : new Address(schemeIdentifier, systemName,
+                        SafeMapHostName(hostName) ??
+                        SafeMapIPv6(socketAddress.Address),
+                        publicPort ?? socketAddress.Port);
+            }
+            catch (Exception e)
+            {
+                global::System.Console.WriteLine(e);
+                throw;
+            }
+
+        }
+
+        internal static string SafeMapHostName(string hostName)
+        {
+            IPAddress ip;
+            return !string.IsNullOrEmpty(hostName) &&
+                   IPAddress.TryParse(hostName, out ip)
+                ? SafeMapIPv6(ip)
+                : hostName;
+        }
+
+        private static string SafeMapIPv6(IPAddress ip) =>
+            ip.AddressFamily == AddressFamily.InterNetworkV6
+                ? "[" + ip + "]"
+                : ip.ToString();
+        /// <summary>
+        /// Maps an Akka.NET address to correlated <see cref="EndPoint"/>.
+        /// </summary>
+        /// <param name="address">Akka.NET fully qualified node address.</param>
+        /// <exception cref="ArgumentException">Thrown if address port was not provided.</exception>
+        /// <returns><see cref="IPEndPoint"/> for IP-based addresses, <see cref="DnsEndPoint"/> for named addresses.</returns>
+        public static EndPoint AddressToSocketAddress(Address address)
+        {
+            if (address.Port == null) throw new ArgumentException($"address port must not be null: {address}");
+            EndPoint listenAddress;
+            IPAddress ip;
+            if (IPAddress.TryParse(address.Host, out ip))
+            {
+                listenAddress = new IPEndPoint(ip, (int)address.Port);
+            }
+            else
+            {
+                // DNS resolution will be performed by the transport
+                listenAddress = new DnsEndPoint(address.Host, (int)address.Port);
+            }
+            return listenAddress;
+        }
+    }
+}

--- a/src/core/Akka.Streams/Akka.Streams.csproj
+++ b/src/core/Akka.Streams/Akka.Streams.csproj
@@ -64,6 +64,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
     <PackageReference Include="Reactive.Streams" Version="1.0.2" />
+    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>

--- a/src/core/Akka.Streams/Dsl/FileIO.cs
+++ b/src/core/Akka.Streams/Dsl/FileIO.cs
@@ -6,14 +6,30 @@
 //-----------------------------------------------------------------------
 
 using System.IO;
+using System.IO.Compression;
 using System.Threading.Tasks;
 using Akka.IO;
 using Akka.Streams.Implementation.IO;
+using Akka.Streams.Implementation.IO.Compression;
 using Akka.Streams.Implementation.Stages;
 using Akka.Streams.IO;
 
 namespace Akka.Streams.Dsl
 {
+    public static class Compression
+    {
+        public static Flow<ByteString, ByteString, NotUsed> Deflate()
+        {
+            return Flow.FromGraph(new CompressorFlow(() =>
+                new DeflateCompressor(CompressionMode.Compress)));
+        }
+
+        public static Flow<ByteString, ByteString, NotUsed> Inflate()
+        {
+            return Flow.FromGraph(new CompressorFlow(() =>
+                new DeflateCompressor(CompressionMode.Decompress)));
+        }
+    }
     // ReSharper disable once InconsistentNaming
     /// <summary>
     /// TBD

--- a/src/core/Akka.Streams/Implementation/IO/Compression/CompressionUtils.cs
+++ b/src/core/Akka.Streams/Implementation/IO/Compression/CompressionUtils.cs
@@ -1,0 +1,191 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="CompressionUtils.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using Akka.IO;
+using Akka.Streams.Dsl;
+using Akka.Streams.Implementation.Fusing;
+using Akka.Streams.Stage;
+using Akka.Streams.Supervision;
+
+namespace Akka.Streams.Implementation.IO.Compression
+{
+    public interface ICompressor
+    {
+        ByteString Compress(ByteString data);
+        
+        ByteString Flush();
+        ByteString Finish();
+        ByteString CompressAndFlush(ByteString input);
+        ByteString CompressAndFinish(ByteString input);
+        void Close();
+    }
+
+    
+    public class DeflateCompressor : ICompressor
+    {
+        private CompressionMode _mode;
+        private MemoryStream _ms = new MemoryStream();
+        public DeflateCompressor(CompressionMode mode)
+        {
+            _mode = mode;
+            
+        }
+        public ByteString Compress(ByteString data)
+        {
+            try
+            {
+                _ms.Position = 0;
+                //using (var _ms = new MemoryStream())
+                {
+                    if (_mode == CompressionMode.Compress)
+                    {
+                 
+
+                            using (var _stream =
+                                new DeflateStream(_ms, CompressionLevel.Fastest,true))
+                            {
+                                data.WriteTo(_stream);
+                            }
+                    }
+                    else
+                    {
+                        using (var inflate = new MemoryStream())
+                        {
+                            data.WriteTo(inflate);
+                            inflate.Position = 0;
+                            using (var _stream = new DeflateStream(inflate, _mode,true))
+                        {
+                            _stream.CopyTo(_ms);
+                        }
+                        }
+                    }
+                    return ByteString.FromBytes(_ms.ToArray(),0,(int)_ms.Position);
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                throw;
+            }
+        }
+
+        protected ByteString compressWithBuffer(ByteString data, byte[] buffer)
+        {
+            using (var ms = new MemoryStream(buffer))
+            {
+                using (var _stream =
+                    new DeflateStream(new MemoryStream(buffer), _mode))
+                {
+                    data.WriteTo(_stream);
+                }   
+                return ByteString.FromBytes(buffer,0,(int)ms.Length);
+            }
+            
+        }
+        
+
+        public ByteString Flush()
+        {
+            return ByteString.Empty;
+        }
+
+        public ByteString Finish()
+        {
+            return ByteString.Empty;
+        }
+
+        public ByteString CompressAndFlush(ByteString input)
+        {
+            return Compress(input);
+        }
+
+        public ByteString CompressAndFinish(ByteString input)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Close()
+        {
+            throw new NotImplementedException();
+        }
+    }
+    public class CompressorFlow : SimpleLinearGraphStage<ByteString>
+    {
+        public CompressorFlow(Func<ICompressor> newCompressor)
+        {
+            _newCompressor = newCompressor;
+        }
+
+        Func<ICompressor> _newCompressor;
+        private sealed class Logic : InAndOutGraphStageLogic, IInHandler, IOutHandler
+        {
+            private readonly CompressorFlow _stage;
+            private readonly Decider _decider;
+            private ICompressor _compressor;
+            public Logic(CompressorFlow stage,ICompressor compressor, Attributes inheritedAttributes) : base(stage.Shape)
+            {
+                _compressor = compressor;
+                _stage = stage;
+                var attr = inheritedAttributes.GetAttribute<ActorAttributes.SupervisionStrategy>(null);
+                _decider = attr != null ? attr.Decider : Deciders.StoppingDecider;
+                SetHandler(stage.Inlet, stage.Outlet, this);
+            }
+
+            public override void OnPush()
+            {
+                try
+                {
+                    var buf = _compressor.CompressAndFlush(Grab(_stage.Inlet));
+                    if (buf.Count > 0)
+                    {
+                        Push(_stage.Outlet,buf);
+                    }
+                    else
+                    {
+                        Pull(_stage.Inlet);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(ex);
+                    if (_decider(ex) == Directive.Stop)
+                        FailStage(ex);
+                    else
+                        Pull(_stage.Inlet);
+                }
+            }
+
+            public void OnUpstreamFinish()
+            {
+                var buf = _compressor.Finish();
+                if (buf.Count > 0)
+                {
+                    Emit(_stage.Outlet,buf);
+                }
+            }
+
+            public void OnUpstreamFailure(Exception e)
+            {
+                
+            }
+
+            public override void OnPull() => Pull(_stage.Inlet);
+            public void OnDownstreamFinish()
+            {
+                
+            }
+        }
+        protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes)
+        {
+            return  new Logic(this,_newCompressor(),inheritedAttributes);
+        }
+    }
+    
+}

--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -574,7 +574,7 @@ akka {
         class = "Akka.IO.Buffers.DisabledBufferPool, Akka"
 
         # Size of a single byte buffer in bytes.
-        buffer-size = 512
+        buffer-size = 65536
       }
 
       # A buffer pool used to acquire and release byte buffers from the managed

--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -574,7 +574,7 @@ akka {
         class = "Akka.IO.Buffers.DisabledBufferPool, Akka"
 
         # Size of a single byte buffer in bytes.
-        buffer-size = 65536
+        buffer-size = 512
       }
 
       # A buffer pool used to acquire and release byte buffers from the managed

--- a/src/core/Akka/IO/Inet.cs
+++ b/src/core/Akka/IO/Inet.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
 
 namespace Akka.IO
 {
@@ -219,6 +220,18 @@ namespace Akka.IO
                 public override void AfterConnect(Socket s)
                 {
                     //TODO: What is the .NET equivalent
+                }
+            }
+
+            public class TlsConnectionOption : SocketOption
+            {
+                public X509Certificate2 Certificate { get;  }
+                public bool SuppressValidation { get; }
+
+                public TlsConnectionOption(X509Certificate2 cert, bool suppressValidation)
+                {
+                    Certificate = cert;
+                    SuppressValidation = suppressValidation;
                 }
             }
         }

--- a/src/core/Akka/IO/Inet.cs
+++ b/src/core/Akka/IO/Inet.cs
@@ -227,6 +227,7 @@ namespace Akka.IO
             {
                 public X509Certificate2 Certificate { get;  }
                 public bool SuppressValidation { get; }
+                public bool ClientAsServer { get; set; }
 
                 public TlsConnectionOption(X509Certificate2 cert, bool suppressValidation)
                 {

--- a/src/core/Akka/IO/Inet.cs
+++ b/src/core/Akka/IO/Inet.cs
@@ -223,6 +223,16 @@ namespace Akka.IO
                 }
             }
 
+            public class ByteBufferPoolSize : SocketOption
+            {
+                public int ByteBufferPoolSizeBytes { get; }
+
+                public ByteBufferPoolSize(int sizeBytes)
+                {
+                    ByteBufferPoolSizeBytes = sizeBytes;
+                }
+            }
+
             public class TlsConnectionOption : SocketOption
             {
                 public X509Certificate2 Certificate { get;  }

--- a/src/core/Akka/IO/SocketEventArgsPool.cs
+++ b/src/core/Akka/IO/SocketEventArgsPool.cs
@@ -135,7 +135,10 @@ namespace Akka.IO
             }
             else
             {
-                args.SetBuffer(null, 0, 0);
+                if (args.Buffer != null)
+                {
+                    args.SetBuffer(null, 0, 0);    
+                }
                 args.BufferList = dataCollection.SelectMany(d => d.Buffers).ToList();
             }
         }

--- a/src/core/Akka/IO/TcpIncomingConnection.cs
+++ b/src/core/Akka/IO/TcpIncomingConnection.cs
@@ -9,6 +9,8 @@ using System.Collections.Generic;
 using System.Net.Sockets;
 using Akka.Actor;
 using System;
+using System.Linq;
+using Akka.IO.Buffers;
 using Akka.Util;
 
 namespace Akka.IO
@@ -38,7 +40,11 @@ namespace Akka.IO
         {
             _bindHandler = bindHandler;
             _options = options;
-
+            var poolOption = _options.OfType<Inet.SO.ByteBufferPoolSize>()
+                .FirstOrDefault();
+            BufferPool = poolOption != null
+                ? new DisabledBufferPool(poolOption.ByteBufferPoolSizeBytes)
+                : Tcp.BufferPool; 
             Context.Watch(bindHandler); // sign death pact
         }
 
@@ -58,5 +64,7 @@ namespace Akka.IO
         {
             throw new NotSupportedException();
         }
+
+        protected override IBufferPool BufferPool { get; }
     }
 }

--- a/src/core/Akka/IO/TlsConnection.cs
+++ b/src/core/Akka/IO/TlsConnection.cs
@@ -1,0 +1,1178 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="TlsConnection.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Dispatch;
+using Akka.Event;
+using Akka.IO.Buffers;
+using Akka.Pattern;
+using Akka.Util;
+
+namespace Akka.IO
+{
+    internal class SendReceiveArgsFake
+    {
+        public byte[] Buffer { get; protected set; }
+        public int Offset { get; protected set; }
+        public int Count { get; protected set; }
+        public int BytesTransferred { get; set; }
+        public SocketError SocketError { get; set; }
+        public object UserToken { get; set; }
+        public IPEndPoint RemoteEndPoint { get; set; }
+
+        public void SetBuffer(byte[] bufferArray, int bufferOffset, int bufferCount)
+        {
+            Buffer = bufferArray;
+            Offset = bufferOffset;
+            Count = bufferCount;
+        }
+    }
+    /// <summary>
+    /// INTERNAL API: Base class for TcpIncomingConnection and TcpOutgoingConnection.
+    /// 
+    /// TcpConnection is an actor abstraction over single connection between TCP server and client. 
+    /// Since actors are processing messages in synchronous fashion, they are way to provide thread 
+    /// safety over sockets and <see cref="SocketAsyncEventArgs"/>.
+    /// 
+    /// Every TcpConnection gets assigned a single socket fields and pair of <see cref="SocketAsyncEventArgs"/>,
+    /// allocated once per lifetime of the connection actor:
+    /// 
+    /// - <see cref="ReceiveArgs"/> used only for receiving data. It has assigned buffer, rent from 
+    ///   <see cref="TcpExt"/> once and recycled back upon actor termination. Once data has been received, it's 
+    ///   copied to a separate <see cref="ByteString"/> object (so it's NOT a zero-copy operation).
+    /// - <see cref="SendArgs"/> used only for sending data. Unlike receive args, it doesn't have any buffer 
+    ///   assigned. Instead it uses treats incoming data as a buffer (it's safe due to immutable nature of
+    ///   <see cref="ByteString"/> object). Therefore writes don't allocate any byte buffers.
+    /// 
+    /// Similar approach can be found on other networking libraries (i.e. System.IO.Pipelines and EventStore).
+    /// Both buffers and <see cref="SocketAsyncEventArgs"/> are pooled to reduce GC pressure.
+    /// </summary>
+    internal abstract class TlsConnection : ActorBase, IRequiresMessageQueue<IUnboundedMessageQueueSemantics>
+    {
+        [Flags]
+        enum ConnectionStatus
+        {
+            /// <summary>
+            /// Marks that connection has invoked <see cref="Socket.ReceiveAsync"/> and that 
+            /// <see cref="TcpConnection.ReceiveArgs"/> are currently trying to receive data.
+            /// </summary>
+            Receiving = 1,
+
+            /// <summary>
+            /// Marks that connection has invoked <see cref="Socket.SendAsync"/> and that 
+            /// <see cref="TcpConnection.SendArgs"/> are currently sending data. It's important as 
+            /// <see cref="SocketAsyncEventArgs"/> will throw exception if another socket operations will
+            /// be called over it as it's performing send request. For that reason we cannot release send args
+            /// back to pool if it's sending (another connection actor could aquire that buffer and try to 
+            /// use it while it's sending the data).
+            /// </summary>
+            Sending = 1 << 1,
+
+            /// <summary>
+            /// Marks that current connection has suspended reading.
+            /// </summary>
+            ReadingSuspended = 1 << 2,
+
+            /// <summary>
+            /// Marks that current connection has suspended writing.
+            /// </summary>
+            WritingSuspended = 1 << 3,
+
+            /// <summary>
+            /// Marks that current connection has been requested for shutdown. It may not occur immediatelly,
+            /// i.e. because underlying <see cref="TcpConnection.SendArgs"/> is actually sending the data.
+            /// </summary>
+            ShutdownRequested = 1 << 4
+        }
+
+        private ConnectionStatus _status;
+        protected readonly TcpExt Tcp;
+        protected readonly Socket Socket;
+        protected readonly SslStream SslStream;
+        protected SendReceiveArgsFake ReceiveArgs;
+        protected SendReceiveArgsFake SendArgs;
+        protected string TargetHost;
+        protected readonly ILoggingAdapter Log = Context.GetLogger();
+        private readonly bool _pullMode;
+        private readonly PendingSimpleWritesQueue _writeCommandsQueue;
+        private readonly bool _traceLogging;
+
+        private bool _isOutputShutdown;
+
+        private readonly ConcurrentQueue<(IActorRef Commander, object Ack)> _pendingAcks = new ConcurrentQueue<(IActorRef, object)>();
+        private bool _peerClosed;
+        private IActorRef _interestedInResume;
+        private CloseInformation _closedMessage;  // for ConnectionClosed message in postStop
+        protected X509Certificate2 Certificate;
+        private IActorRef _watchedActor = Context.System.DeadLetters;
+
+        protected TlsConnection(TcpExt tcp, Socket socket,Inet.SO.TlsConnectionOption opt, bool pullMode, Option<int> writeCommandsBufferMaxSize)
+        {
+            
+            if (socket == null) throw new ArgumentNullException(nameof(socket));
+            Certificate = opt.Certificate;
+            if (opt.SuppressValidation)
+            {
+                SslStream = new SslStream(new NetworkStream(socket), true,
+                    (sender, cert, chain, errors) => true);
+            }
+            SslStream = new SslStream(new NetworkStream(socket));
+            _pullMode = pullMode;
+            _writeCommandsQueue = new PendingSimpleWritesQueue(Log, writeCommandsBufferMaxSize);
+            _traceLogging = tcp.Settings.TraceLogging;
+            
+            Tcp = tcp;
+            Socket = socket;
+            
+            if (pullMode) SetStatus(ConnectionStatus.ReadingSuspended);
+        }
+
+
+        private bool IsWritePending
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return !HasStatus(ConnectionStatus.Sending) && !_writeCommandsQueue.IsEmpty; }
+        }
+
+        private Option<PendingWrite> GetAllowedPendingWrite() => IsWritePending ? GetNextWrite() : Option<PendingWrite>.None;
+
+        protected void SignDeathPact(IActorRef actor)
+        {
+            UnsignDeathPact();
+            _watchedActor = actor;
+            Context.Watch(actor);
+        }
+
+        protected void UnsignDeathPact()
+        {
+            if (!ReferenceEquals(_watchedActor, Context.System.DeadLetters)) Context.Unwatch(_watchedActor);
+        }
+
+        // STATES
+
+        /// <summary>
+        /// Connection established, waiting for registration from user handler.
+        /// </summary>
+        private Receive WaitingForRegistration(IActorRef commander)
+        {
+            return message =>
+            {
+                switch (message)
+                {
+                    case Tcp.Register register:
+                        // up to this point we've been watching the commander,
+                        // but since registration is now complete we only need to watch the handler from here on
+                        if (!Equals(register.Handler, commander))
+                        {
+                            Context.Unwatch(commander);
+                            Context.Watch(register.Handler);
+                        }
+
+                        if (_traceLogging) Log.Debug("[{0}] registered as connection handler", register.Handler);
+
+                        var registerInfo = new ConnectionInfo(register.Handler, register.KeepOpenOnPeerClosed, register.UseResumeWriting);
+
+                        // if we have resumed reading from pullMode while waiting for Register then read
+                        if (_pullMode && !HasStatus(ConnectionStatus.ReadingSuspended)) ResumeReading();
+                        else if (!_pullMode) ReceiveAsync();
+
+                        Context.SetReceiveTimeout(null);
+                        Context.Become(Connected(registerInfo));
+
+                        // If there is something buffered before we got Register message - put it all to the socket
+                        var bufferedWrite = GetNextWrite();
+                        if (bufferedWrite.HasValue)
+                        {
+                            SetStatus(ConnectionStatus.Sending);
+                            DoWrite(registerInfo, bufferedWrite.Value);
+                        } 
+                        
+                        return true;
+                    case Tcp.ResumeReading _: ClearStatus(ConnectionStatus.ReadingSuspended); return true;
+                    case Tcp.SuspendReading _: SetStatus(ConnectionStatus.ReadingSuspended); return true;
+                    case Tcp.CloseCommand cmd:
+                        var info = new ConnectionInfo(commander, keepOpenOnPeerClosed: false, useResumeWriting: false);
+                        HandleClose(info, Sender, cmd.Event);
+                        return true;
+                    case ReceiveTimeout _:
+                        // after sending `Register` user should watch this actor to make sure
+                        // it didn't die because of the timeout
+                        Log.Debug("Configured registration timeout of [{0}] expired, stopping", Tcp.Settings.RegisterTimeout);
+                        Context.Stop(Self);
+                        return true;
+                    case Tcp.WriteCommand write:
+                        // When getting Write before regestered handler, have to buffer writes until registration
+                        var buffered = _writeCommandsQueue.EnqueueSimpleWrites(write, Sender, out var commandSize);
+                        if (!buffered)
+                        {
+                            var writerInfo = new ConnectionInfo(Sender, false, false);
+                            DropWrite(writerInfo, write);
+                        }
+                        else
+                        {
+                            Log.Warning("Received Write command before Register command. " +
+                                        "It will be buffered until Register will be received (buffered write size is {0} bytes)", commandSize);
+                        }
+                        
+                        return true;
+                    default: return false;
+                }
+            };
+        }
+
+        /// <summary>
+        /// Normal connected state.
+        /// </summary>
+        private Receive Connected(ConnectionInfo info)
+        {
+            var handleWrite = HandleWriteMessages(info);
+            return message =>
+            {
+                if (handleWrite(message)) return true;
+                switch (message)
+                {
+                    case Tcp.SuspendReading _: SuspendReading(); return true;
+                    case Tcp.ResumeReading _: ResumeReading(); return true;
+                    case Tcp.SocketReceived _: DoRead(info, null); return true;
+                    case Tcp.CloseCommand cmd: HandleClose(info, Sender, cmd.Event); return true;
+                    default: return false;
+                }
+            };
+        }
+
+        /// <summary>
+        /// The peer sent EOF first, but we may still want to send 
+        /// </summary>
+        private Receive PeerSentEOF(ConnectionInfo info)
+        {
+            var handleWrite = HandleWriteMessages(info);
+            return message =>
+            {
+                if (handleWrite(message)) return true;
+                var cmd = message as Tcp.CloseCommand;
+                if (cmd != null)
+                {
+                    HandleClose(info, Sender, cmd.Event);
+                    return true;
+                }
+                if (message is Tcp.ResumeReading) return true;
+                return false;
+            };
+        }
+
+        /// <summary>
+        /// Connection is closing but a write has to be finished first
+        /// </summary>
+        private Receive ClosingWithPendingWrite(ConnectionInfo info, IActorRef closeCommander, Tcp.ConnectionClosed closedEvent)
+        {
+            return message =>
+            {
+                switch (message)
+                {
+                    case Tcp.SuspendReading _: SuspendReading(); return true;
+                    case Tcp.ResumeReading _: ResumeReading(); return true;
+                    case Tcp.SocketReceived _: DoRead(info, closeCommander); return true;
+                    case Tcp.SocketSent _:
+                        AcknowledgeSent();
+                        if (IsWritePending)
+                            DoWrite(info, GetAllowedPendingWrite());
+                        else 
+                            HandleClose(info, closeCommander, closedEvent);
+                        return true;
+                    case UpdatePendingWriteAndThen updatePendingWrite:
+                        var nextWrite = updatePendingWrite.RemainingWrite;
+                        updatePendingWrite.Work();
+
+                        if (nextWrite.HasValue)
+                            DoWrite(info, nextWrite);
+                        else 
+                            HandleClose(info, closeCommander, closedEvent);
+                        return true;
+                    case WriteFileFailed fail: HandleError(info.Handler, fail.Cause); return true;
+                    case Tcp.Abort _: HandleClose(info, Sender, IO.Tcp.Aborted.Instance); return true;
+                    default: return false;
+                }
+            };
+        }
+
+        /** connection is closed on our side and we're waiting from confirmation from the other side */
+        private Receive Closing(ConnectionInfo info, IActorRef closeCommander)
+        {
+            return message =>
+            {
+                switch (message)
+                {
+                    case Tcp.SuspendReading _: SuspendReading(); return true;
+                    case Tcp.ResumeReading _: ResumeReading(); return true;
+                    case Tcp.SocketReceived _: DoRead(info, closeCommander); return true;
+                    case Tcp.Abort _: HandleClose(info, Sender, IO.Tcp.Aborted.Instance); return true;
+                    default: return false;
+                }
+            };
+        }
+
+        private Receive HandleWriteMessages(ConnectionInfo info)
+        {
+            return message =>
+            {
+                switch (message)
+                {
+                    case Tcp.SocketSent _:
+                        // Send ack to sender
+                        AcknowledgeSent();
+                        
+                        // If there is something to send - send it
+                        var pendingWrite = GetAllowedPendingWrite();
+                        if (pendingWrite.HasValue)
+                        {
+                            SetStatus(ConnectionStatus.Sending);
+                            DoWrite(info, pendingWrite);
+                        }
+                        
+                        // If message is fully sent, notify sender who sent ResumeWriting command
+                        if (!IsWritePending && _interestedInResume != null)
+                        {
+                            _interestedInResume.Tell(IO.Tcp.WritingResumed.Instance);
+                            _interestedInResume = null;
+                        }
+                        
+                        return true;
+                    case Tcp.WriteCommand write:
+                        if (HasStatus(ConnectionStatus.WritingSuspended))
+                        {
+                            if (_traceLogging) Log.Debug("Dropping write because writing is suspended");
+                            Sender.Tell(write.FailureMessage);
+                        }
+
+                        if (HasStatus(ConnectionStatus.Sending))
+                        {
+                            // If we are sending something right now, just enqueue incoming write
+                            if (!_writeCommandsQueue.EnqueueSimpleWrites(write, Sender))
+                            {
+                                DropWrite(info, write);
+                                return true;
+                            }
+                        }
+                        else
+                        {
+                            Option<PendingWrite> nextWrite;
+                            if (_writeCommandsQueue.IsEmpty)
+                            {
+                                // If writes queue is empty, do not enqueue first write - we will send it immidiately
+                                if (!_writeCommandsQueue.EnqueueSimpleWritesExceptFirst(write, Sender, out var simpleWriteCommand))
+                                {
+                                    DropWrite(info, write);
+                                    return true;
+                                }
+                                
+                                nextWrite = GetNextWrite(headCommands: new []{ (simpleWriteCommand, Sender) });
+                            }
+                            else
+                            {
+                                _writeCommandsQueue.EnqueueSimpleWrites(write, Sender);
+                                nextWrite = GetNextWrite();
+                            }
+                            
+                            // If there is something to send and we are allowed to, lets put the next command on the wire
+                            if (nextWrite.HasValue)
+                            {
+                                SetStatus(ConnectionStatus.Sending);
+                                DoWrite(info, nextWrite.Value);
+                            } 
+                        }
+                        
+                        return true;
+                    case Tcp.ResumeWriting _:
+                        /*
+                         * If more than one actor sends Writes then the first to send this
+                         * message might resume too early for the second, leading to a Write of
+                         * the second to go through although it has not been resumed yet; there
+                         * is nothing we can do about this apart from all actors needing to
+                         * register themselves and us keeping track of them, which sounds bad.
+                         *
+                         * Thus it is documented that useResumeWriting is incompatible with
+                         * multiple writers. But we fail as gracefully as we can.
+                         */
+                        ClearStatus(ConnectionStatus.WritingSuspended);
+                        if (IsWritePending)
+                        {
+                            if (_interestedInResume == null) _interestedInResume = Sender;
+                            else Sender.Tell(new Tcp.CommandFailed(IO.Tcp.ResumeWriting.Instance));
+                        }
+                        else Sender.Tell(IO.Tcp.WritingResumed.Instance);
+                        return true;
+                    case UpdatePendingWriteAndThen updatePendingWrite:
+                        var updatedWrite = updatePendingWrite.RemainingWrite;
+                        updatePendingWrite.Work();
+                        if (updatedWrite.HasValue) 
+                            DoWrite(info, updatedWrite.Value);
+                        return true;
+                    case WriteFileFailed fail:
+                        HandleError(info.Handler, fail.Cause);
+                        return true;
+                    default: return false;
+                }
+            };
+        }
+
+        private void DropWrite(ConnectionInfo info, Tcp.WriteCommand write)
+        {
+            if (_traceLogging) Log.Debug("Dropping write because queue is full");
+            Sender.Tell(write.FailureMessage);
+            if (info.UseResumeWriting) SetStatus(ConnectionStatus.WritingSuspended);
+        }
+
+        // AUXILIARIES and IMPLEMENTATION
+
+        /// <summary>
+        /// Used in subclasses to start the common machinery above once a channel is connected
+        /// </summary>
+        protected void CompleteConnect(IActorRef commander, IEnumerable<Inet.SocketOption> options)
+        {
+            // Turn off Nagle's algorithm by default
+            try
+            {
+                Socket.NoDelay = true;
+            }
+            catch (SocketException e)
+            {
+                Log.Debug("Could not enable TcpNoDelay: {0}", e.Message);
+            }
+
+            foreach (var option in options)
+            {
+                option.AfterConnect(Socket);
+            }
+
+            commander.Tell(new Tcp.Connected(Socket.RemoteEndPoint, Socket.LocalEndPoint));
+            Authenticate();
+            Context.SetReceiveTimeout(Tcp.Settings.RegisterTimeout);
+            Context.Become(WaitingForRegistration(commander));
+        }
+
+        protected abstract void Authenticate();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void SuspendReading()
+        {
+            SetStatus(ConnectionStatus.ReadingSuspended);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ResumeReading()
+        {
+            ClearStatus(ConnectionStatus.ReadingSuspended);
+            ReceiveAsync();
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void AcknowledgeSent()
+        {
+            while (_pendingAcks.TryDequeue(out var ackInfo))
+            {
+                ackInfo.Commander.Tell(ackInfo.Ack);
+            }
+           
+            ClearStatus(ConnectionStatus.Sending);
+        }
+
+        private void DoRead(ConnectionInfo info, IActorRef closeCommander)
+        {
+            //TODO: What should we do if reading is suspended with an oustanding read - this will discard the read
+            //      Should probably have an 'oustanding read'
+            if (!HasStatus(ConnectionStatus.ReadingSuspended))
+            {
+                try
+                {
+                    var read = InnerRead(info, Tcp.Settings.ReceivedMessageSizeLimit, ReceiveArgs);
+                    ClearStatus(ConnectionStatus.Receiving);
+                    switch (read.Type)
+                    {
+                        case ReadResultType.AllRead:
+                            if (!_pullMode)
+                                ReceiveAsync();
+                            break;
+                        case ReadResultType.EndOfStream:
+                            if (_isOutputShutdown)
+                            {
+                                if (_traceLogging) Log.Debug("Read returned end-of-stream, our side already closed");
+                                DoCloseConnection(info, closeCommander, IO.Tcp.ConfirmedClosed.Instance);
+                            }
+                            else
+                            {
+                                if (_traceLogging) Log.Debug("Read returned end-of-stream, our side not yet closed");
+                                HandleClose(info, closeCommander, IO.Tcp.PeerClosed.Instance);
+                            }
+                            break;
+                        case ReadResultType.ReadError:
+                            HandleError(info.Handler, new SocketException((int)read.Error));
+                            break;
+                    }
+                }
+                catch (SocketException cause)
+                {
+                    HandleError(info.Handler, cause);
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private ReadResult InnerRead(ConnectionInfo info, int remainingLimit, SendReceiveArgsFake ea)
+        {
+            if (remainingLimit > 0)
+            {
+                //var maxBufferSpace = Math.Min(_tcp.Settings.DirectBufferSize, remainingLimit);
+                var readBytes = ea.BytesTransferred;
+
+                if (_traceLogging) Log.Debug("Read [{0}] bytes.", readBytes);
+                if (ea.SocketError == SocketError.Success && readBytes > 0)
+                    info.Handler.Tell(new Tcp.Received(ByteString.CopyFrom(ea.Buffer, ea.Offset, ea.BytesTransferred)));
+
+                //if (ea.SocketError == SocketError.ConnectionReset) return ReadResult.EndOfStream;
+                if (ea.SocketError != SocketError.Success) return new ReadResult(ReadResultType.ReadError, ea.SocketError);
+                if (readBytes > 0) return ReadResult.AllRead;
+                if (readBytes == 0) return ReadResult.EndOfStream;
+
+                throw new IllegalStateException($"Unexpected value returned from read: {readBytes}");
+            }
+            return ReadResult.AllRead;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void DoWrite(ConnectionInfo info, Option<PendingWrite> write)
+        {
+            if (!write.HasValue)
+                return;
+
+            // Enqueue all acks assigned to this write to be sent once write is finished
+            foreach (var pendingAck in write.Value.PendingAcks.Where(ackInfo => !ackInfo.Ack.Equals(IO.Tcp.NoAck.Instance)))
+            {
+                _pendingAcks.Enqueue(pendingAck);
+            }
+            
+            write.Value.DoWrite(info);
+        }
+
+        private void HandleClose(ConnectionInfo info, IActorRef closeCommander, Tcp.ConnectionClosed closedEvent)
+        {
+            SetStatus(ConnectionStatus.ShutdownRequested);
+
+            if (closedEvent is Tcp.Aborted)
+            {
+                if (_traceLogging) Log.Debug("Got Abort command. RESETing connection.");
+                DoCloseConnection(info, closeCommander, closedEvent);
+            }
+            else if (closedEvent is Tcp.PeerClosed && info.KeepOpenOnPeerClosed)
+            {
+                // report that peer closed the connection
+                info.Handler.Tell(IO.Tcp.PeerClosed.Instance);
+                // used to check if peer already closed its side later
+                _peerClosed = true;
+                Context.Become(PeerSentEOF(info));
+            }
+            else if (IsWritePending)   // finish writing first
+            {
+                UnsignDeathPact();
+                if (_traceLogging) Log.Debug("Got Close command but write is still pending.");
+                Context.Become(ClosingWithPendingWrite(info, closeCommander, closedEvent));
+            }
+            else if (closedEvent is Tcp.ConfirmedClosed) // shutdown output and wait for confirmation
+            {
+                if (_traceLogging) Log.Debug("Got ConfirmedClose command, sending FIN.");
+
+                // If peer closed first, the socket is now fully closed.
+                // Also, if shutdownOutput threw an exception we expect this to be an indication
+                // that the peer closed first or concurrently with this code running.
+                if (_peerClosed || !SafeShutdownOutput())
+                    DoCloseConnection(info, closeCommander, closedEvent);
+                else Context.Become(Closing(info, closeCommander));
+            }
+            // close gracefully now
+            else
+            {
+                if (_traceLogging) Log.Debug("Got Close command, closing connection.");
+                Socket.Shutdown(SocketShutdown.Both);
+                DoCloseConnection(info, closeCommander, closedEvent);
+            }
+        }
+
+        private void DoCloseConnection(ConnectionInfo info, IActorRef closeCommander, Tcp.ConnectionClosed closedEvent)
+        {
+            if (closedEvent is Tcp.Aborted) Abort();
+            else
+            {
+                CloseSocket();
+            }
+
+            var notifications = new HashSet<IActorRef>();
+            if (info.Handler != null) notifications.Add(info.Handler);
+            if (closeCommander != null) notifications.Add(closeCommander);
+            StopWith(new CloseInformation(notifications, closedEvent));
+        }
+
+        private void HandleError(IActorRef handler, SocketException exception)
+        {
+            Log.Debug("Closing connection due to IO error {0}", exception);
+            StopWith(new CloseInformation(new HashSet<IActorRef>(new[] { handler }), new Tcp.ErrorClosed(exception.Message)));
+        }
+
+        private bool SafeShutdownOutput()
+        {
+            try
+            {
+                Socket.Shutdown(SocketShutdown.Send);
+                _isOutputShutdown = true;
+                return true;
+            }
+            catch (SocketException)
+            {
+                return false;
+            }
+        }
+
+        protected void AcquireSocketAsyncEventArgs()
+        {
+            if (ReceiveArgs != null) throw new InvalidOperationException($"Cannot acquire receive SocketAsyncEventArgs. It's already has been initialized");
+            if (SendArgs != null) throw new InvalidOperationException($"Cannot acquire send SocketAsyncEventArgs. It's already has been initialized");
+
+            ReceiveArgs = CreateSocketEventArgs(Self);
+            var buffer = Tcp.BufferPool.Rent();
+            ReceiveArgs.SetBuffer(buffer.Array, buffer.Offset, buffer.Count);
+
+            SendArgs = CreateSocketEventArgs(Self);
+        }
+
+        private void ReleaseSocketAsyncEventArgs()
+        {
+            if (ReceiveArgs != null)
+            {
+                var buffer = new ArraySegment<byte>(ReceiveArgs.Buffer, ReceiveArgs.Offset, ReceiveArgs.Count);
+                ReleaseSocketEventArgs(ReceiveArgs);
+                // TODO: When using DirectBufferPool as a pool impelementation, there is potential risk,
+                // that socket was working while released. In that case releasing buffer may not be safe.
+                Tcp.BufferPool.Release(buffer);
+                ReceiveArgs = null;
+            }
+
+            if (SendArgs != null)
+            {
+                ReleaseSocketEventArgs(SendArgs);
+                SendArgs = null;
+            }
+        }
+
+        public void PushRead(byte[] bytes, int numBytesRead, IActorRef onCompleteNotificationsReceiver)
+        {
+            ReceiveArgs.SetBuffer(bytes,0,numBytesRead);
+            ReceiveArgs.BytesTransferred = 1;
+            onCompleteNotificationsReceiver.Tell(IO.Tcp.SocketReceived.Instance);
+        }
+
+        protected SendReceiveArgsFake CreateSocketEventArgs(IActorRef onCompleteNotificationsReceiver)
+        {
+            //Tcp.SocketCompleted ResolveMessage(SocketAsyncEventArgs e)
+            //{
+            //    switch (e.LastOperation)
+            //    {
+            //        case SocketAsyncOperation.Receive:
+            //        case SocketAsyncOperation.ReceiveFrom:
+            //        case SocketAsyncOperation.ReceiveMessageFrom:
+            //            return IO.Tcp.SocketReceived.Instance;
+            //        case SocketAsyncOperation.Send:
+            //        case SocketAsyncOperation.SendTo:
+            //        case SocketAsyncOperation.SendPackets:
+            //            return IO.Tcp.SocketSent.Instance;
+            //        case SocketAsyncOperation.Accept:
+            //            return IO.Tcp.SocketAccepted.Instance;
+            //        case SocketAsyncOperation.Connect:
+            //            return IO.Tcp.SocketConnected.Instance;
+            //        default:
+            //            throw new NotSupportedException($"Socket operation {e.LastOperation} is not supported");
+            //    }
+            //}
+            //
+            //var args = new SocketAsyncEventArgs();
+            //args.UserToken = onCompleteNotificationsReceiver;
+            //args.Completed += (sender, e) =>
+            //{
+            //    var actorRef = e.UserToken as IActorRef;
+            //    var completeMsg = ResolveMessage(e);
+            //    actorRef?.Tell(completeMsg);
+            //};
+            return  new SendReceiveArgsFake();
+        }
+        
+        protected void ReleaseSocketEventArgs(SendReceiveArgsFake e)
+        {
+            e.UserToken = null;
+            //e.AcceptSocket = null;
+
+            try
+            {
+                e.SetBuffer(null, 0, 0);
+            }
+            // it can be that for some reason socket is in use and haven't closed yet
+            catch (InvalidOperationException) { }
+
+            
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void CloseSocket()
+        {
+            SslStream.Dispose();
+            _isOutputShutdown = true;
+            ReleaseSocketAsyncEventArgs();
+        }
+
+        private void Abort()
+        {
+            try
+            {
+                Socket.LingerState = new LingerOption(true, 0);  // causes the following close() to send TCP RST
+            }
+            catch (Exception e)
+            {
+                if (_traceLogging) Log.Debug("setSoLinger(true, 0) failed with [{0}]", e);
+            }
+
+            CloseSocket();
+        }
+
+        protected void StopWith(CloseInformation closeInfo)
+        {
+            _closedMessage = closeInfo;
+            Context.Stop(Self);
+        }
+
+        private void ReceiveAsync()
+        {
+            if (!HasStatus(ConnectionStatus.Receiving))
+            {
+                SslStream.ReadAsync(ReceiveArgs.Buffer, ReceiveArgs.Offset,
+                    ReceiveArgs.Count).PipeTo(Self,Self, i =>
+                {
+                    ReceiveArgs.SocketError = SocketError.Success;
+                    ReceiveArgs.BytesTransferred = i;
+                    return IO.Tcp.SocketReceived.Instance;
+                }, e =>
+                {
+                    ReceiveArgs.SocketError = SocketError.SocketError;
+                    return IO.Tcp.SocketReceived.Instance;
+                });
+
+                SetStatus(ConnectionStatus.Receiving);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool HasStatus(ConnectionStatus connectionStatus)
+        {
+            // don't use Enum.HasFlag - it's using reflection underneath
+            var s = (int)connectionStatus;
+            return ((int)_status & s) == s;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void SetStatus(ConnectionStatus connectionStatus) => _status |= connectionStatus;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ClearStatus(ConnectionStatus connectionStatus) => _status &= ~connectionStatus;
+
+        protected override void PostStop()
+        {
+            if (Socket.Connected) Abort();
+            else CloseSocket();
+
+            // We do never store pending writes between messages anymore, so nothing is acquired and nothing to release 
+
+            // always try to release SocketAsyncEventArgs to avoid memory leaks
+            ReleaseSocketAsyncEventArgs();
+
+            if (_closedMessage != null)
+            {
+                var interestedInClose = _writeCommandsQueue.TryGetNext(out var pending)
+                    ? _closedMessage.NotificationsTo.Union(_writeCommandsQueue.DequeueAll().Select(cmd => cmd.Sender))
+                    : _closedMessage.NotificationsTo;
+
+                foreach (var listener in interestedInClose)
+                {
+                    listener.Tell(_closedMessage.ClosedEvent);
+                }
+            }
+        }
+
+        protected override void PostRestart(Exception reason)
+        {
+            throw new IllegalStateException("Restarting not supported for connection actors.");
+        }
+
+        private Option<PendingWrite> GetNextWrite(IEnumerable<(Tcp.SimpleWriteCommand Command, IActorRef Sender)> headCommands = null)
+        {
+            headCommands = headCommands ?? ImmutableList<(Tcp.SimpleWriteCommand Command, IActorRef Sender)>.Empty;
+            var writeCommands = new List<(Tcp.Write Command, IActorRef Sender)>(_writeCommandsQueue.ItemsCount);
+            foreach (var commandInfo in headCommands.Concat(_writeCommandsQueue.DequeueAll()))
+            {
+                switch (commandInfo.Command)
+                {
+                    case Tcp.Write w when !w.Data.IsEmpty:
+                        // Have real write - go on and put it to the wire
+                        writeCommands.Add((w, commandInfo.Sender));
+                        break;
+                    case Tcp.Write w:
+                        // Write command is empty, so just sending Ask if required
+                        if (w.WantsAck) commandInfo.Sender.Tell(w.Ack);
+                        break;
+                    default:
+                        //TODO: there's no TransmitFile API - .NET Core doesn't support it at all
+                        throw new InvalidOperationException("Non reachable code");
+                }
+            }
+
+            if (writeCommands.Count > 0)
+            {
+                return CreatePendingBufferWrite(writeCommands);
+            }
+            
+            // No more writes out there
+            return Option<PendingWrite>.None;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private PendingWrite CreatePendingBufferWrite(List<(Tcp.Write Command, IActorRef Sender)> writes)
+        {
+            var acks = writes.Select(w => (w.Sender, (object)w.Command.Ack)).ToImmutableList();
+            var dataList = writes.Select(w => w.Command.Data);
+            return new PendingBufferWrite(this, SendArgs, Self, acks, dataList, Tcp.BufferPool);
+        }
+
+        //TODO: Port File IO - currently .NET Core doesn't support TransmitFile API
+
+        private enum ReadResultType
+        {
+            EndOfStream,
+            AllRead,
+            ReadError,
+        }
+
+        private struct ReadResult
+        {
+            public static readonly ReadResult EndOfStream = new ReadResult(ReadResultType.EndOfStream, SocketError.Success);
+            public static readonly ReadResult AllRead = new ReadResult(ReadResultType.AllRead, SocketError.Success);
+
+            public readonly ReadResultType Type;
+            public readonly SocketError Error;
+
+            public ReadResult(ReadResultType type, SocketError error)
+            {
+                Type = type;
+                Error = error;
+            }
+        }
+
+        /// <summary>
+        /// Used to transport information to the postStop method to notify
+        /// interested party about a connection close.
+        /// </summary>
+        protected sealed class CloseInformation
+        {
+            /// <summary>
+            /// TBD
+            /// </summary>
+            public ISet<IActorRef> NotificationsTo { get; }
+            public Tcp.Event ClosedEvent { get; }
+
+            public CloseInformation(ISet<IActorRef> notificationsTo, Tcp.Event closedEvent)
+            {
+                NotificationsTo = notificationsTo;
+                ClosedEvent = closedEvent;
+            }
+        }
+
+        /// <summary>
+        /// Groups required connection-related data that are only available once the connection has been fully established.
+        /// </summary>
+        private sealed class ConnectionInfo
+        {
+            public readonly IActorRef Handler;
+            public readonly bool KeepOpenOnPeerClosed;
+            public readonly bool UseResumeWriting;
+
+            public ConnectionInfo(IActorRef handler, bool keepOpenOnPeerClosed, bool useResumeWriting)
+            {
+                Handler = handler;
+                KeepOpenOnPeerClosed = keepOpenOnPeerClosed;
+                UseResumeWriting = useResumeWriting;
+            }
+        }
+
+        // INTERNAL MESSAGES
+        private sealed class UpdatePendingWriteAndThen : INoSerializationVerificationNeeded
+        {
+            public Option<PendingWrite> RemainingWrite { get; }
+            public Action Work { get; }
+
+            public UpdatePendingWriteAndThen(Option<PendingWrite> remainingWrite, Action work)
+            {
+                RemainingWrite = remainingWrite;
+                Work = work;
+            }
+        }
+
+        private sealed class WriteFileFailed
+        {
+            public SocketException Cause { get; }
+
+            public WriteFileFailed(SocketException cause)
+            {
+                Cause = cause;
+            }
+        }
+
+        private abstract class PendingWrite
+        {
+            public IImmutableList<(IActorRef Commander, object Ack)> PendingAcks { get; }
+
+            protected PendingWrite(IImmutableList<(IActorRef Commander, object Ack)> pendingAcks)
+            {
+                PendingAcks = pendingAcks;
+            }
+
+            public abstract Task DoWrite(ConnectionInfo info);
+        }
+
+        private sealed class PendingBufferWrite : PendingWrite
+        {
+            private readonly TlsConnection _connection;
+            private readonly IActorRef _self;
+            private readonly IEnumerable<ByteString> _dataToSend;
+            private readonly IBufferPool _bufferPool;
+            private readonly SendReceiveArgsFake _sendArgs;
+
+            public PendingBufferWrite(
+                TlsConnection connection,
+                SendReceiveArgsFake sendArgs,
+                IActorRef self,
+                IImmutableList<(IActorRef Commander, object Ack)> acks,
+                IEnumerable<ByteString> dataToSend,
+                IBufferPool bufferPool) : base(acks)
+            {
+                _connection = connection;
+                _sendArgs = sendArgs;
+                _self = self;
+                _dataToSend = dataToSend;
+                _bufferPool = bufferPool;
+            }
+
+            public override async Task DoWrite(ConnectionInfo info)
+            {
+                try
+                {
+                    //_sendArgs.SetBuffer(_dataToSend);
+                    Task.Run(async () =>
+                    {
+                        foreach (var byteString in _dataToSend)
+                        {
+                            foreach (var buffer in byteString.Buffers)
+                            {
+                                await _connection.SslStream.WriteAsync(
+                                    buffer.Array,
+                                    buffer.Offset, buffer.Count);
+                            }
+                        }
+
+                        return NotUsed.Instance;
+                    }).PipeTo(_self, _self, s =>
+                    {
+                        return IO.Tcp.SocketSent.Instance;
+                    }, e =>
+                    {
+                        _sendArgs.SocketError = SocketError.SocketError;
+                        return IO.Tcp.SocketSent.Instance;
+                    });
+
+
+                }
+                catch (SocketException e)
+                {
+                    _connection.HandleError(info.Handler, e);
+                }
+            }
+        }
+
+        public class PendingSimpleWritesQueue
+        {
+            private readonly ILoggingAdapter _log;
+            private readonly Option<int> _maxQueueSizeInBytes;
+            private readonly Queue<(Tcp.SimpleWriteCommand Command, IActorRef Commander, int Size)> _queue;
+            private int _totalSizeInBytes = 0;
+
+            public PendingSimpleWritesQueue(ILoggingAdapter log, Option<int> maxQueueSizeInBytes)
+            {
+                _log = log;
+                _maxQueueSizeInBytes = maxQueueSizeInBytes;
+                _queue = new Queue<(Tcp.SimpleWriteCommand Command, IActorRef Commander, int Size)>();
+            }
+
+            /// <summary>
+            /// Gets total number of items in queue
+            /// </summary>
+            public int ItemsCount => _queue.Count;
+
+            /// <summary>
+            /// Adds all <see cref="Tcp.SimpleWriteCommand"/> subcommands stored in provided command.
+            /// Performs buffer size checks
+            /// </summary>
+            /// <exception cref="InternalBufferOverflowException">
+            /// Thrown when data to buffer is larger then allowed <see cref="_maxQueueSizeInBytes"/>
+            /// </exception>
+            public bool EnqueueSimpleWrites(Tcp.WriteCommand command, IActorRef sender)
+            {
+                return EnqueueSimpleWrites(command, sender, out _);
+            }
+            
+            /// <summary>
+            /// Adds all <see cref="Tcp.SimpleWriteCommand"/> subcommands stored in provided command.
+            /// Performs buffer size checks
+            /// </summary>
+            /// <exception cref="InternalBufferOverflowException">
+            /// Thrown when data to buffer is larger then allowed <see cref="_maxQueueSizeInBytes"/>
+            /// </exception>
+            public bool EnqueueSimpleWrites(Tcp.WriteCommand command, IActorRef sender, out int bufferedSize)
+            {
+                bufferedSize = 0;
+                
+                foreach (var writeInfo in ExtractFromCommand(command))
+                {
+                    var sizeAfterAppending = _totalSizeInBytes + writeInfo.DataSize;
+                    if (_maxQueueSizeInBytes.HasValue && _maxQueueSizeInBytes.Value < sizeAfterAppending)
+                    {
+                        _log.Warning("Could not receive write command of size {0} bytes, " +
+                                     "because buffer limit is {1} bytes and " +
+                                     "it is already {2} bytes", writeInfo.DataSize, _maxQueueSizeInBytes, _totalSizeInBytes);
+                        return false;
+                    }
+
+                    _totalSizeInBytes = sizeAfterAppending;
+                    _queue.Enqueue((writeInfo.Command, sender, writeInfo.DataSize));
+                    bufferedSize += writeInfo.DataSize;
+                }
+                
+                return true;
+            }
+            
+            /// <summary>
+            /// Adds all <see cref="Tcp.SimpleWriteCommand"/> subcommands stored in provided command.
+            /// Performs buffer size checks for all, except first one, that is not buffered
+            /// </summary>
+            /// <returns>
+            /// Not buffered (and not checked) first <see cref="Tcp.SimpleWriteCommand"/>
+            /// </returns>
+            /// <exception cref="InternalBufferOverflowException">
+            /// Thrown when data to buffer is larger then allowed <see cref="_maxQueueSizeInBytes"/>
+            /// </exception>
+            public bool EnqueueSimpleWritesExceptFirst(Tcp.WriteCommand command, IActorRef sender, out Tcp.SimpleWriteCommand first)
+            {
+                first = null;
+                foreach (var writeInfo in ExtractFromCommand(command))
+                {
+                    if (first == null)
+                    {
+                        first = writeInfo.Command;
+                        continue;
+                    }
+                    
+                    var sizeAfterAppending = _totalSizeInBytes + writeInfo.DataSize;
+                    if (_maxQueueSizeInBytes.HasValue && _maxQueueSizeInBytes.Value < sizeAfterAppending)
+                    {
+                        _log.Warning("Could not receive write command of size {0} bytes, " +
+                                     "because buffer limit is {1} bytes and " +
+                                     "it is already {2} bytes", writeInfo.DataSize, _maxQueueSizeInBytes, _totalSizeInBytes);
+                        return false;
+                    }
+
+                    _totalSizeInBytes = sizeAfterAppending;
+                    _queue.Enqueue((writeInfo.Command, sender, writeInfo.DataSize));
+                }
+
+                return true;
+            }
+
+            /// <summary>
+            /// Gets next command from the queue, if any
+            /// </summary>
+            public (Tcp.SimpleWriteCommand, IActorRef Sender) Dequeue()
+            {
+                if (_queue.Count == 0)
+                    throw new InvalidOperationException("Write commands queue is empty");
+                
+                var (command, sender, size) = _queue.Dequeue();
+                _totalSizeInBytes -= size;
+                return (command, sender);
+            }
+
+            /// <summary>
+            /// Dequeue all elements one by one
+            /// </summary>
+            /// <returns></returns>
+            public IEnumerable<(Tcp.SimpleWriteCommand Command, IActorRef Sender)> DequeueAll()
+            {
+                while (TryGetNext(out var command))
+                    yield return command;
+            }
+            
+            /// <summary>
+            /// Gets next command from the queue, if any
+            /// </summary>
+            public bool TryGetNext(out (Tcp.SimpleWriteCommand Command, IActorRef Sender) command)
+            {
+                command = default;
+                if (_queue.Count == 0)
+                    return false;
+
+                command = Dequeue();
+                return true;
+            }
+
+            /// <summary>
+            /// Checks if commands queue is empty
+            /// </summary>
+            public bool IsEmpty => _totalSizeInBytes == 0;
+
+            private IEnumerable<(Tcp.SimpleWriteCommand Command, int DataSize)> ExtractFromCommand(Tcp.WriteCommand command)
+            {
+                switch (command)
+                {
+                    case Tcp.Write write:
+                        yield return (write, write.Data.Count);
+                        break;
+                    case Tcp.CompoundWrite compoundWrite:
+                        var extractedFromHead = ExtractFromCommand(compoundWrite.Head);
+                        var extractedFromTail = ExtractFromCommand(compoundWrite.TailCommand);
+                        foreach (var extractedSimple in extractedFromHead.Concat(extractedFromTail))
+                        {
+                            yield return extractedSimple;
+                        }
+                        break;
+                    default:
+                        throw new ArgumentException($"Trying to calculate size of unknown write type: {command.GetType().FullName}");
+                }
+            }
+        }
+    }
+}

--- a/src/core/Akka/IO/TlsConnection.cs
+++ b/src/core/Akka/IO/TlsConnection.cs
@@ -126,6 +126,7 @@ namespace Akka.IO
         {
             
             if (socket == null) throw new ArgumentNullException(nameof(socket));
+            TlsOptions = opt;
             Certificate = opt.Certificate;
             if (opt.SuppressValidation)
             {
@@ -142,6 +143,8 @@ namespace Akka.IO
             
             if (pullMode) SetStatus(ConnectionStatus.ReadingSuspended);
         }
+
+        public Inet.SO.TlsConnectionOption TlsOptions { get; protected set; }
 
 
         private bool IsWritePending
@@ -984,6 +987,7 @@ namespace Akka.IO
                 try
                 {
                     //_sendArgs.SetBuffer(_dataToSend);
+#pragma warning disable 4014
                     Task.Run(async () =>
                     {
                         foreach (var byteString in _dataToSend)
@@ -998,6 +1002,7 @@ namespace Akka.IO
 
                         return NotUsed.Instance;
                     }).PipeTo(_self, _self, s =>
+#pragma warning restore 4014
                     {
                         return IO.Tcp.SocketSent.Instance;
                     }, e =>

--- a/src/core/Akka/IO/TlsIncomingConnection.cs
+++ b/src/core/Akka/IO/TlsIncomingConnection.cs
@@ -1,0 +1,69 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="TlsIncomingConnection.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
+using Akka.Actor;
+using Akka.Util;
+
+namespace Akka.IO
+{
+    /// <summary>
+    /// An actor handling the connection state machine for an incoming, already connected SocketChannel.
+    /// </summary>
+    internal sealed class TlsIncomingConnection : TlsConnection
+    {
+        private readonly IActorRef _bindHandler;
+        private readonly IEnumerable<Inet.SocketOption> _options;
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="tcp">TBD</param>
+        /// <param name="socket">TBD</param>
+        /// <param name="bindHandler">TBD</param>
+        /// <param name="options">TBD</param>
+        /// <param name="readThrottling">TBD</param>
+        public TlsIncomingConnection(TcpExt tcp, 
+            Socket socket,
+            IActorRef bindHandler,
+            IEnumerable<Inet.SocketOption> options, 
+            bool readThrottling)
+            : base(tcp, socket, (Inet.SO.TlsConnectionOption)options.FirstOrDefault(r=>r is Inet.SO.TlsConnectionOption),readThrottling, Option<int>.None)
+        {
+            _bindHandler = bindHandler;
+            _options = options;
+
+            Context.Watch(bindHandler); // sign death pact
+        }
+
+        protected override void PreStart()
+        {
+            AcquireSocketAsyncEventArgs();
+
+            CompleteConnect(_bindHandler, _options);
+        }
+
+        protected override void Authenticate()
+        {
+            SslStream.AuthenticateAsClient(this.TargetHost);
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="message">TBD</param>
+        /// <returns>TBD</returns>
+        protected override bool Receive(object message)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/core/Akka/IO/TlsListener.cs
+++ b/src/core/Akka/IO/TlsListener.cs
@@ -1,0 +1,133 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="TlsListener.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Sockets;
+using Akka.Actor;
+using Akka.Dispatch;
+using Akka.Event;
+using Akka.Util.Internal;
+
+namespace Akka.IO
+{
+    partial class TlsListener : ActorBase, IRequiresMessageQueue<IUnboundedMessageQueueSemantics>
+    {
+        private readonly TcpExt _tcp;
+        private readonly IActorRef _bindCommander;
+        private readonly Tcp.Bind _bind;
+        private readonly Socket _socket;
+        private readonly ILoggingAdapter _log = Context.GetLogger();
+        private int _acceptLimit;
+        private SocketAsyncEventArgs[] _saeas;
+        
+        private int acceptLimit;
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="tcp">TBD</param>
+        /// <param name="bindCommander">TBD</param>
+        /// <param name="bind">TBD</param>
+        public TlsListener(TcpExt tcp, IActorRef bindCommander,
+            Tcp.Bind bind)
+        {
+            _tcp = tcp;
+            _bindCommander = bindCommander;
+            _bind = bind;
+
+            Context.Watch(bind.Handler);
+
+            _socket = new Socket(_bind.LocalAddress.AddressFamily, SocketType.Stream, ProtocolType.Tcp) { Blocking = false };
+
+            _acceptLimit = bind.PullMode ? 0 : _tcp.Settings.BatchAcceptLimit;
+            
+            try
+            {
+                bind.Options.ForEach(x => x.BeforeServerSocketBind(_socket));
+                _socket.Bind(bind.LocalAddress);
+                _socket.Listen(bind.Backlog);
+                _saeas = Accept(_acceptLimit).ToArray();
+            }
+            catch (Exception e)
+            {
+                _bindCommander.Tell(bind.FailureMessage);
+                _log.Error(e, "Bind failed for TCP channel on endpoint [{0}]", bind.LocalAddress);
+                Context.Stop(Self);
+            }
+
+            bindCommander.Tell(new Tcp.Bound(_socket.LocalEndPoint));
+        }
+        
+        private IEnumerable<SocketAsyncEventArgs> Accept(int limit)
+        {
+            for(var i = 0; i < _acceptLimit; i++)
+            {
+                var self = Self;
+                var saea = new SocketAsyncEventArgs();
+                saea.Completed += (s, e) => self.Tell(e);
+                if (!_socket.AcceptAsync(saea))
+                    Self.Tell(saea);
+                yield return saea;
+            }
+        }
+
+        protected override SupervisorStrategy SupervisorStrategy()
+        {
+            return Tcp.ConnectionSupervisorStrategy;
+        }
+
+        protected override bool Receive(object message)
+        {
+            if (message is SocketAsyncEventArgs)
+            {
+                var saea = message as SocketAsyncEventArgs;
+                if (saea.SocketError == SocketError.Success)
+                    Context.ActorOf(Props.Create<TlsIncomingConnection>(_tcp, saea.AcceptSocket, _bind.Handler, _bind.Options, _bind.PullMode));
+                saea.AcceptSocket = null;
+
+                if (!_socket.AcceptAsync(saea))
+                    Self.Tell(saea);
+                return true;
+            }
+            var resumeAccepting = message as Tcp.ResumeAccepting;
+            if (resumeAccepting != null)
+            {
+                _acceptLimit = resumeAccepting.BatchSize;
+                _saeas = Accept(_acceptLimit).ToArray();
+                return true;
+            }
+            if (message is Tcp.Unbind)
+            {
+                _log.Debug("Unbinding endpoint {0}", _bind.LocalAddress);
+                _socket.Dispose();
+                Sender.Tell(Tcp.Unbound.Instance);
+                _log.Debug("Unbound endpoint {0}, stopping listener", _bind.LocalAddress);
+                Context.Stop(Self);
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        protected override void PostStop()
+        {
+            try
+            {
+                _socket.Dispose();
+                _saeas?.ForEach(x => x.Dispose());
+            }
+            catch (Exception e)
+            {
+                _log.Debug("Error closing ServerSocketChannel: {0}", e);
+            }
+        }
+    }
+}

--- a/src/core/Akka/IO/TlsOutgoingConnection.cs
+++ b/src/core/Akka/IO/TlsOutgoingConnection.cs
@@ -1,0 +1,243 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="TlsOutgoingConnection.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography.X509Certificates;
+using Akka.Actor;
+using Akka.Util;
+
+namespace Akka.IO
+{
+    /// <summary>
+    /// TBD
+    /// </summary>
+    internal sealed class TlsOutgoingConnection : TlsConnection
+    {
+        private readonly IActorRef _commander;
+        private readonly Tcp.Connect _connect;
+
+        private SendReceiveArgsFake _connectArgs;
+
+        public TlsOutgoingConnection(TcpExt tcp, IActorRef commander, Tcp.Connect connect)
+            : base(
+                tcp,
+                tcp.Settings.OutgoingSocketForceIpv4
+                    ? new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp) { Blocking = false }
+                    : new Socket(SocketType.Stream, ProtocolType.Tcp) { Blocking = false },
+                ((Inet.SO.TlsConnectionOption)connect.Options.FirstOrDefault(r=>r is Inet.SO.TlsConnectionOption)),
+                connect.PullMode,
+                tcp.Settings.WriteCommandsQueueMaxSize >= 0 ? tcp.Settings.WriteCommandsQueueMaxSize : Option<int>.None)
+        {
+            _commander = commander;
+            _connect = connect;
+
+            SignDeathPact(commander);
+
+            foreach (var option in connect.Options)
+            {
+                option.BeforeConnect(Socket);
+            }
+            
+            if (connect.LocalAddress != null)
+                Socket.Bind(connect.LocalAddress);
+
+            if (connect.Timeout.HasValue)
+                Context.SetReceiveTimeout(connect.Timeout.Value);  //Initiate connection timeout if supplied
+        }
+
+        private void ReleaseConnectionSocketArgs()
+        {
+            if (_connectArgs != null)
+            {
+                ReleaseSocketEventArgs(_connectArgs);
+                _connectArgs = null;
+            }
+        }
+
+        private void Stop()
+        {
+            ReleaseConnectionSocketArgs();
+
+            StopWith(new CloseInformation(new HashSet<IActorRef>(new[] {_commander}), _connect.FailureMessage));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ReportConnectFailure(Action thunk)
+        {
+            try
+            {
+                thunk();
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "Could not establish connection to [{0}].", _connect.RemoteAddress);
+                Stop();
+            }
+        }
+        
+        protected override void PreStart()
+        {
+            ReportConnectFailure(() =>
+            {
+                if (_connect.RemoteAddress is DnsEndPoint)
+                {
+                    var remoteAddress = (DnsEndPoint) _connect.RemoteAddress;
+                    Log.Debug("Resolving {0} before connecting", remoteAddress.Host);
+                    var resolved = Dns.ResolveName(remoteAddress.Host, Context.System, Self);
+                    if (resolved == null)
+                        Become(Resolving(remoteAddress));
+                    else if(resolved.Ipv4.Any() && resolved.Ipv6.Any()) // one of both families
+                        Register(new IPEndPoint(resolved.Ipv4.FirstOrDefault(), remoteAddress.Port), new IPEndPoint(resolved.Ipv6.FirstOrDefault(), remoteAddress.Port));
+                    else // one or the other
+                        Register(new IPEndPoint(resolved.Addr, remoteAddress.Port), null);
+                }
+                else if(_connect.RemoteAddress is IPEndPoint)
+                {
+                    Register((IPEndPoint)_connect.RemoteAddress, null);
+                }
+                else throw new NotSupportedException($"Couldn't connect to [{_connect.RemoteAddress}]: only IP and DNS-based endpoints are supported");
+            });
+        }
+
+        protected override void PostStop()
+        {
+            // always try to release SocketAsyncEventArgs to avoid memory leaks
+            ReleaseConnectionSocketArgs();
+
+            base.PostStop();
+        }
+
+        protected override bool Receive(object message)
+        {
+            throw new NotSupportedException();
+        }
+
+        private Receive Resolving(DnsEndPoint remoteAddress)
+        {
+            return message =>
+            {
+                var resolved = message as Dns.Resolved;
+                if (resolved != null)
+                {
+                    if (resolved.Ipv4.Any() && resolved.Ipv6.Any()) // multiple addresses
+                    {
+                        ReportConnectFailure(() => Register(
+                            new IPEndPoint(resolved.Ipv4.FirstOrDefault(), remoteAddress.Port),
+                            new IPEndPoint(resolved.Ipv6.FirstOrDefault(), remoteAddress.Port)));
+                    }
+                    else // only one address family. No fallbacks.
+                    {
+                        ReportConnectFailure(() => Register(
+                            new IPEndPoint(resolved.Addr, remoteAddress.Port),
+                            null));
+                    }
+                    return true;
+                }
+                return false;
+            };
+        }
+
+        protected override void Authenticate()
+        {
+            SslStream.AuthenticateAsServer(this.Certificate);
+        }
+
+        private void Register(IPEndPoint address, IPEndPoint fallbackAddress)
+        {
+            ReportConnectFailure(() =>
+            {
+                Log.Debug("Attempting connection to [{0}]", address);
+
+                _connectArgs = CreateSocketEventArgs(Self);
+                _connectArgs.RemoteEndPoint = address;
+                // we don't setup buffer here, it shouldn't be necessary just for connection
+
+                Socket.ConnectAsync(address).PipeTo(Self, Self,
+                    () => IO.Tcp.SocketConnected.Instance,(e)=>
+                    {
+                        ReportConnectFailure(() => { throw e; });
+                        return NotUsed.Instance;
+                    });
+
+                Become(Connecting(Tcp.Settings.FinishConnectRetries, _connectArgs, fallbackAddress));
+            });
+        }
+
+        private Receive Connecting(int remainingFinishConnectRetries, SendReceiveArgsFake args, IPEndPoint fallbackAddress)
+        {
+            return message =>
+            {
+                if (message is IO.Tcp.SocketConnected)
+                {
+                    if (args.SocketError == SocketError.Success)
+                    {
+                        if (_connect.Timeout.HasValue) Context.SetReceiveTimeout(null);
+                        Log.Debug("Connection established to [{0}]", _connect.RemoteAddress);
+
+                        ReleaseConnectionSocketArgs();
+                        AcquireSocketAsyncEventArgs();
+
+                        CompleteConnect(_commander, _connect.Options);
+                    }
+                    else if (remainingFinishConnectRetries > 0 && fallbackAddress != null) // used only when we've resolved a DNS endpoint.
+                    {
+                        var self = Self;
+                        var previousAddress = (IPEndPoint)args.RemoteEndPoint;
+                        args.RemoteEndPoint = fallbackAddress;
+                        Context.System.Scheduler.Advanced.ScheduleOnce(TimeSpan.FromMilliseconds(1), () =>
+                        {
+                            Socket.ConnectAsync(args.RemoteEndPoint)
+                                .PipeTo(self, self,
+                                    () => IO.Tcp.SocketConnected.Instance,
+                                    (e)=>
+                                    {
+                                        ReportConnectFailure(() => { throw e; });
+                                        return NotUsed.Instance;
+                                    });
+                        });
+                        Context.Become(Connecting(remainingFinishConnectRetries - 1, args, previousAddress));
+                    }
+                    else if (remainingFinishConnectRetries > 0)
+                    {
+                        var self = Self;
+                        Context.System.Scheduler.Advanced.ScheduleOnce(TimeSpan.FromMilliseconds(1), () =>
+                        {
+                            Socket.ConnectAsync(args.RemoteEndPoint)
+                                .PipeTo(self, self,
+                                    () => IO.Tcp.SocketConnected.Instance,
+                                    (e)=>
+                                    {
+                                        ReportConnectFailure(() => { throw e; });
+                                        return NotUsed.Instance;
+                                    });
+                        });
+                        Context.Become(Connecting(remainingFinishConnectRetries - 1, args, null));
+                    }
+                    else
+                    {
+                        Log.Debug("Could not establish connection because finishConnect never returned true (consider increasing akka.io.tcp.finish-connect-retries)");
+                        Stop();
+                    }
+                    return true;
+                }
+                if (message is ReceiveTimeout)
+                {
+                    if (_connect.Timeout.HasValue) Context.SetReceiveTimeout(null);  // Clear the timeout
+                    Log.Error("Connect timeout expired, could not establish connection to [{0}]", _connect.RemoteAddress);
+                    Stop();
+                    return true;
+                }
+                return false;
+            };
+        }
+    }
+}

--- a/src/core/Akka/Util/ByteString.cs
+++ b/src/core/Akka/Util/ByteString.cs
@@ -140,6 +140,11 @@ namespace Akka.IO
             return new ByteString(array, offset, count);
         }
 
+        public static ByteString FromImmutable(byte[] immutableBytes)
+        {
+            return new ByteString(immutableBytes,0,immutableBytes.Length);
+        }
+
         /// <summary>
         /// Creates a new <see cref="ByteString"/> by wrapping raw collection of byte segements. 
         /// WARNING: 
@@ -190,6 +195,12 @@ namespace Akka.IO
 
         private readonly int _count;
         private readonly ByteBuffer[] _buffers;
+
+        public ByteString(IList<ByteString> buffers)
+        {
+            _count = buffers.Sum(s => s.Count);
+            _buffers = buffers.SelectMany(r=>r._buffers).ToArray();
+        }
 
         private ByteString(ByteBuffer[] buffers, int count)
         {

--- a/src/core/Akka/Util/ByteString.cs
+++ b/src/core/Akka/Util/ByteString.cs
@@ -140,10 +140,6 @@ namespace Akka.IO
             return new ByteString(array, offset, count);
         }
 
-        public static ByteString FromImmutable(byte[] immutableBytes)
-        {
-            return new ByteString(immutableBytes,0,immutableBytes.Length);
-        }
 
         /// <summary>
         /// Creates a new <see cref="ByteString"/> by wrapping raw collection of byte segements. 

--- a/src/core/Akka/Util/ByteString.cs
+++ b/src/core/Akka/Util/ByteString.cs
@@ -459,6 +459,12 @@ namespace Akka.IO
             return copy;
         }
 
+        internal ByteBuffer ReadOnlyCompacted()
+        {
+            var c = this.Compact();
+            return c._buffers[0];
+        }
+
         /// <summary>
         /// Appends <paramref name="other"/> <see cref="ByteString"/> at the tail
         /// of a current one, creating a new <see cref="ByteString"/> in result.


### PR DESCRIPTION
This PR Contains:

 - An Akka.Remote transport utilizing Akka.Streams

 - Added IO.SocketOptions for:
   - TLSConnectionOption (WIP)
   - ByteBufferPoolSize to override default settings for Fetch Size (Transport works better at larger buffer sizes and we dont want people defaults in akka.io to trip up stream transport.

 - WIP TLS Support:
   - TLSConnection
   - TLSConnectionListener
   - TLSOutgoingConenection
   - Changes to TCPManager such that these will be created when TLSConnectionOption is opened.

This approach minimizes new code effort to get a working IO.TLS implementation up and running. In theory on newer net standard platforms (2.1+), the approach used for read/write will have SSLStream->NetworkStream utilize SocketAsyncEventArgs as best it can. There may be better potential for deupe here.
 
 - Changes to TcpManager such that when it sees a TLSConnection Option it will create TLS actors instead of TCP Actors
 
 - Changes to TCPConnection such that it will utilize ByteBufferPoolSize

 - Addition of COMPRESS/DECOMPRESS Flows for Akka Streams.
   - This was done while trying to see if pipeline could be optimized. It didn't help but since JVM Akka has it, might be useful.


### Status:
  - On local machine, Remotepingpong is at or ahead of DotNetty for both smaller and larger messages.
  - Dissociation is unclean, you see error logs dumped from stream actors terminating
  - Most of the remote unit tests pass, but there are some that do not, i.e. injected transport tests looking for gremlin in identifier fail, actorleak, etc.
 

This will DROP Dotnetty as a dependency and hopefully solve a lot of other issues we have seen.

### Needs:
  - Tests around SSL Concept
  - Any adaptations necessary for SSL in transport (I think this will actually be minimal thanks to the pattern of it just being an extra Inet.SocketOption)
  - Hardcoded entries moved into configuration (I'll try to work on this if I have time.)
  - Potentially testing/hardening around public/private configuration scenarios. _TCP is not my forte._
  - We do some tricks against `Google.Protobuf.ByteString` to eliminate a copy on write to transport. This should probably have some form of safety switch behind it; even if DepBot catches the issue, it sounds better to users to let them flip a switch rather than force immediate upgrade if they have a problem. We could either make it a config value, or 'test' run it before we decide to use it.
    - This is also a concern because I need to think about whether the way it is initialized could cause problems in that case regardless. Will ponder and if so fix.
  - Checks against dotnetty/helios compatibility. When I squint I'm hopeful the Akka.Streams framing is the same. If it's not we would have to make framing stages for that as well as helios. But it certainly seems simple.

### Nice to have:
  - Someone who knows streams better than I may know a few tricks to make the pipeline better. The places I put Async stages at were based on repeated RemotePingPong benchmarks as well as some debug checks (i.e. checking how many bytes were being pushed in the final `bufferedSelectFlow` stage.)

### Future ideas:
  - Once this is stable... this would not be backwards compatible. But since we are using streams, that would be only thing stopping us from in near future setting up a multi link with partition/mergehub. At that point you could interleave and/or have a channel where smaller messages are prioritized. Put a source.single handshake bytestring on pipe and merge with batching pump, set 100ms delay on batching pump so we know handshake goes first, listener will getoradd `StreamingTcpassociationhandle`/partition/mergehubs based on handshake match and wire up new connection... But, one step at a time. :)