### PR TITLE
NuGet: serve Akka.NET logo over HTTPS

### DIFF
--- a/src/common.props
+++ b/src/common.props
@@ -3,7 +3,7 @@
     <Copyright>Copyright © 2013-2020 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
     <VersionPrefix>1.4.11</VersionPrefix>
-    <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
+    <PackageIconUrl>https://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>
     <NoWarn>$(NoWarn);CS1591;xUnit1013</NoWarn>


### PR DESCRIPTION
Updated the `common.props` file to serve the Akka.NET logo over HTTPS by default, now that our site supports it.