### PR TITLE
Fix ByteString.Empty throws when ToArray was called

### DIFF
--- a/src/core/Akka.Streams.Tests/BugSpec.cs
+++ b/src/core/Akka.Streams.Tests/BugSpec.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO.Pipes;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.IO;
+using Akka.Streams.Dsl;
+using Akka.Streams.IO;
+using Akka.TestKit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Streams.Tests
+{
+    public class BugSpec : AkkaSpec
+    {
+        private ActorMaterializer Materializer { get; }
+
+        public BugSpec(ITestOutputHelper helper) : base(helper)
+        {
+            Materializer = ActorMaterializer.Create(Sys);
+        }
+
+        [Fact]
+        public async Task Issue_4580_EmptyByteStringCausesPipeToBeClosed()
+        {
+            var serverPipe = new NamedPipeServerStream("unique-pipe-name", PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous, 20, 20);
+            var serverPipeConnectionTask = serverPipe.WaitForConnectionAsync();
+
+            var clientPipe = new NamedPipeClientStream(".", "unique-pipe-name", PipeDirection.In, PipeOptions.Asynchronous);
+            clientPipe.Connect();
+
+            await serverPipeConnectionTask;
+            var cnt = 0;
+
+            var writeToStreamTask = Source.From(Enumerable.Range(0, 100))
+                .Select(i => ByteString.FromString(i.ToString()))
+                .Select(bs => cnt++ == 10 ? ByteString.Empty : bs) // ByteString.Empty.ToArray() failed in original bug
+                .ToMaterialized(StreamConverters.FromOutputStream(() => serverPipe), Keep.Right)
+                .Run(Materializer);
+
+            var result = new List<string>();
+            var readFromStreamTask = StreamConverters.FromInputStream(() => clientPipe, 1)
+                .RunForeach(bs =>
+                {
+                    var str = bs.ToString(Encoding.ASCII);
+                    result.Add(str);
+                    Output.WriteLine(str);
+                }, Materializer);
+
+            await Task.WhenAll(writeToStreamTask, readFromStreamTask);
+
+            var expected = Enumerable.Range(0, 100)
+                .SelectMany(i =>
+                {
+                    return i == 10 ? Array.Empty<string>() : i.ToString().Select(c => c.ToString());
+                });
+            expected.SequenceEqual(result).ShouldBeTrue();
+        }
+    }
+}

--- a/src/core/Akka.Streams.Tests/BugSpec.cs
+++ b/src/core/Akka.Streams.Tests/BugSpec.cs
@@ -42,20 +42,12 @@ namespace Akka.Streams.Tests
 
             var result = new List<string>();
             var readFromStreamTask = StreamConverters.FromInputStream(() => clientPipe, 1)
-                .RunForeach(bs =>
-                {
-                    var str = bs.ToString(Encoding.ASCII);
-                    result.Add(str);
-                    Output.WriteLine(str);
-                }, Materializer);
+                .RunForeach(bs => result.Add(bs.ToString(Encoding.ASCII)), Materializer);
 
             await Task.WhenAll(writeToStreamTask, readFromStreamTask);
 
             var expected = Enumerable.Range(0, 100)
-                .SelectMany(i =>
-                {
-                    return i == 10 ? Array.Empty<string>() : i.ToString().Select(c => c.ToString());
-                });
+                .SelectMany(i => i == 10 ? Array.Empty<string>() : i.ToString().Select(c => c.ToString()));
             expected.SequenceEqual(result).ShouldBeTrue();
         }
     }

--- a/src/core/Akka/Util/ByteString.cs
+++ b/src/core/Akka/Util/ByteString.cs
@@ -443,6 +443,9 @@ namespace Akka.IO
         /// <returns>TBD</returns>
         public byte[] ToArray()
         {
+            if (_count == 0)
+                return Array.Empty<byte>();
+
             var copy = new byte[_count];
             this.CopyTo(copy, 0, _count);
             return copy;


### PR DESCRIPTION
Closes #4580

The problem was an empty byte array buffer passed into the `CopyTo` function. `CopyTo` failed immediately with an `ArgumentOutOfRangeException`.
Fixed by immediately returning `Array.Empty<byte>()` when `ToArray()` is called on an empty `ByteString`.