### PR TITLE
akka.cluster.sharding - batch update

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGracefulShutdownSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGracefulShutdownSpec.cs
@@ -154,16 +154,16 @@ namespace Akka.Cluster.Sharding.Tests
             RunOn(() =>
             {
                 Cluster.Join(GetAddress(to));
-                StartSharding();
+                StartSharding("Entity");
             }, from);
             EnterBarrier(from.Name + "-joined");
         }
 
-        private void StartSharding()
+        private IActorRef StartSharding(string typeName)
         {
-            var allocationStrategy = new LeastShardAllocationStrategy(2, 1);
-            ClusterSharding.Get(Sys).Start(
-                typeName: "Entity",
+            var allocationStrategy = ShardAllocationStrategy.LeastShardAllocationStrategy(absoluteLimit: 2, relativeLimit: 1.0);
+            return ClusterSharding.Get(Sys).Start(
+                typeName: typeName,
                 entityProps: Props.Create<Entity>(),
                 settings: ClusterShardingSettings.Create(Sys),
                 extractEntityId: extractEntityId,
@@ -280,15 +280,7 @@ namespace Akka.Cluster.Sharding.Tests
             {
                 RunOn(() =>
                 {
-                    var allocationStrategy = new LeastShardAllocationStrategy(2, 1);
-                    var regionEmpty = ClusterSharding.Get(Sys).Start(
-                        typeName: "EntityEmpty",
-                        entityProps: Props.Create<Entity>(),
-                        settings: ClusterShardingSettings.Create(Sys),
-                        extractEntityId: extractEntityId,
-                        extractShardId: extractShardId,
-                        allocationStrategy: allocationStrategy,
-                        handOffStopMessage: StopEntity.Instance);
+                    var regionEmpty = StartSharding(typeName: "EntityEmpty");
 
                     Watch(regionEmpty);
                     regionEmpty.Tell(GracefulShutdown.Instance);

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingLeavingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingLeavingSpec.cs
@@ -45,7 +45,7 @@ namespace Akka.Cluster.Sharding.Tests
                             ""System.Object"" = hyperion
                         }}
                     }}
-                    akka.loglevel = INFO
+                    akka.loglevel = DEBUG
                     akka.actor.provider = cluster
                     akka.remote.log-remote-lifecycle-events = off
                     akka.cluster.auto-down-unreachable-after = 0s
@@ -60,6 +60,7 @@ namespace Akka.Cluster.Sharding.Tests
                         plugin-dispatcher = ""akka.actor.default-dispatcher""
                         timeout = 5s
                     }}
+                    akka.cluster.sharding.rebalance-interval = 1s # make rebalancing more likely to happen to test for RebalanceWorker.ShardRegionTerminated
                     akka.cluster.sharding.state-store-mode = ""{mode}""
                     akka.cluster.sharding.distributed-data.durable.lmdb {{
                       dir = ""target/ClusterShardinLeavingSpec/sharding-ddata""
@@ -80,17 +81,17 @@ namespace Akka.Cluster.Sharding.Tests
         public DDataClusterShardingLeavingSpecConfig() : base("ddata") { }
     }
 
-    public class PersistentClusterShardingLeavingSpec : ClusterShardinLeavingSpec
+    public class PersistentClusterShardingLeavingSpec : ClusterShardingLeavingSpec
     {
         public PersistentClusterShardingLeavingSpec() : this(new PersistentClusterShardingLeavingSpecConfig()) { }
         protected PersistentClusterShardingLeavingSpec(PersistentClusterShardingLeavingSpecConfig config) : base(config, typeof(PersistentClusterShardingLeavingSpec)) { }
     }
-    public class DDataClusterShardingLeavingSpec : ClusterShardinLeavingSpec
+    public class DDataClusterShardingLeavingSpec : ClusterShardingLeavingSpec
     {
         public DDataClusterShardingLeavingSpec() : this(new DDataClusterShardingLeavingSpecConfig()) { }
         protected DDataClusterShardingLeavingSpec(DDataClusterShardingLeavingSpecConfig config) : base(config, typeof(DDataClusterShardingLeavingSpec)) { }
     }
-    public abstract class ClusterShardinLeavingSpec : MultiNodeClusterSpec
+    public abstract class ClusterShardingLeavingSpec : MultiNodeClusterSpec
     {
         #region setup
 
@@ -153,7 +154,7 @@ namespace Akka.Cluster.Sharding.Tests
 
         private readonly List<FileInfo> _storageLocations;
 
-        protected ClusterShardinLeavingSpec(ClusterShardingLeavingSpecConfig config, Type type) : base(config, type)
+        protected ClusterShardingLeavingSpec(ClusterShardingLeavingSpecConfig config, Type type) : base(config, type)
         {
             _config = config;
             _region = new Lazy<IActorRef>(() => ClusterSharding.Get(Sys).ShardRegion("Entity"));
@@ -169,7 +170,7 @@ namespace Akka.Cluster.Sharding.Tests
 
         protected override int InitialParticipantsValueFactory => Roles.Count;
         protected bool IsDDataMode { get; }
-        
+
         protected override void AfterTermination()
         {
             base.AfterTermination();
@@ -286,7 +287,6 @@ namespace Akka.Cluster.Sharding.Tests
 
         public void ClusterSharding_with_leaving_member_should__recover_after_leaving_coordinator_node()
         {
-
             Sys.ActorSelection(Node(_config.First) / "user" / "shardLocations").Tell(GetLocations.Instance);
             var originalLocations = ExpectMsg<Locations>();
             var firstAddress = Node(_config.First).Address;

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingMinMembersSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingMinMembersSpec.cs
@@ -82,7 +82,7 @@ namespace Akka.Cluster.Sharding.Tests
 
     public class PersistentClusterShardingMinMembersSpec : ClusterShardingMinMembersSpec
     {
-        public PersistentClusterShardingMinMembersSpec() :this(new PersistentClusterShardingMinMembersSpecConfig()) { }
+        public PersistentClusterShardingMinMembersSpec() : this(new PersistentClusterShardingMinMembersSpecConfig()) { }
         protected PersistentClusterShardingMinMembersSpec(PersistentClusterShardingMinMembersSpecConfig config) : base(config, typeof(PersistentClusterShardingMinMembersSpec)) { }
     }
     public class DDataClusterShardingMinMembersSpec : ClusterShardingMinMembersSpec
@@ -119,7 +119,7 @@ namespace Akka.Cluster.Sharding.Tests
         private Lazy<IActorRef> _region;
 
         private readonly ClusterShardingMinMembersSpecConfig _config;
-        
+
         private readonly List<FileInfo> _storageLocations;
 
         protected ClusterShardingMinMembersSpec(ClusterShardingMinMembersSpecConfig config, Type type)
@@ -138,7 +138,7 @@ namespace Akka.Cluster.Sharding.Tests
             EnterBarrier("startup");
         }
         protected bool IsDDataMode { get; }
-        
+
         protected override void AfterTermination()
         {
             base.AfterTermination();
@@ -166,7 +166,7 @@ namespace Akka.Cluster.Sharding.Tests
 
         private void StartSharding()
         {
-            var allocationStrategy = new LeastShardAllocationStrategy(2, 1);
+            var allocationStrategy = ShardAllocationStrategy.LeastShardAllocationStrategy(absoluteLimit: 2, relativeLimit: 1.0);
             ClusterSharding.Get(Sys).Start(
                 typeName: "Entity",
                 entityProps: Props.Create<EchoActor>(),

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRegistrationCoordinatedShutdownSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRegistrationCoordinatedShutdownSpec.cs
@@ -122,7 +122,7 @@ namespace Akka.Cluster.Sharding.Tests
 
         private void StartSharding()
         {
-            var allocationStrategy = new LeastShardAllocationStrategy(2, 1);
+            var allocationStrategy = ShardAllocationStrategy.LeastShardAllocationStrategy(absoluteLimit: 1, relativeLimit: 0.1);
             ClusterSharding.Get(Sys).Start(
                 typeName: "Entity",
                 entityProps: Props.Create<Entity>(),

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesSpec.cs
@@ -191,7 +191,7 @@ namespace Akka.Cluster.Sharding.Tests
 
         private void StartSharding(ActorSystem sys, IActorRef probe)
         {
-            var allocationStrategy = new LeastShardAllocationStrategy(2, 1);
+            var allocationStrategy = ShardAllocationStrategy.LeastShardAllocationStrategy(absoluteLimit: 1, relativeLimit: 0.1);
             ClusterSharding.Get(sys).Start(
                 typeName: "Entity",
                 entityProps: Props.Create(() => new TestEntity(probe)),

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
@@ -78,8 +78,8 @@ namespace Akka.Cluster.Sharding.Tests
                             number-of-entities = 1
                         }}
                         least-shard-allocation-strategy {{
-                            rebalance-threshold = 1
-                            max-simultaneous-rebalance = 1
+                            rebalance-absolute-limit = 1
+                            rebalance-relative-limit = 1.0
                         }}
                         distributed-data.durable.lmdb {{
                           dir = ""target/ClusterShardingSpec/sharding-ddata""
@@ -482,7 +482,8 @@ namespace Akka.Cluster.Sharding.Tests
 
         private Props CoordinatorProps(string typeName, bool rebalanceEntities, bool rememberEntities)
         {
-            var allocationStrategy = new LeastShardAllocationStrategy(2, 1);
+            var allocationStrategy = ShardAllocationStrategy.LeastShardAllocationStrategy(absoluteLimit: 2, relativeLimit: 1.0);
+
             var config = ConfigurationFactory.ParseString(string.Format(@"
                 handoff-timeout = 10s
                 shard-start-timeout = 10s

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/MultiNodeClusterShardingConfig.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/MultiNodeClusterShardingConfig.cs
@@ -64,7 +64,6 @@ namespace Akka.Cluster.Sharding.Tests
                 ConfigurationFactory
                     .ParseString($@"""
                         akka.actor.provider = ""cluster""
-                        akka.cluster.downing-provider-class = akka.cluster.testkit.AutoDowning
                         akka.cluster.testkit.auto-down-unreachable-after = 0s
                         akka.cluster.sharding.state-store-mode = ""{mode}""
                         akka.cluster.sharding.remember-entities = {rememberEntities}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/MultiNodeClusterShardingConfig.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/MultiNodeClusterShardingConfig.cs
@@ -1,0 +1,92 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="MultiNodeClusterShardingConfig.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Text.RegularExpressions;
+using Akka.Cluster.TestKit;
+using Akka.Configuration;
+using Akka.Remote.TestKit;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    public abstract class MultiNodeClusterShardingConfig : MultiNodeConfig
+    {
+        protected static Config PersistenceConfig()
+        {
+            return ConfigurationFactory.ParseString($@"""
+                akka.actor {{
+                    serializers {{
+                        hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                    }}
+                    serialization-bindings {{
+                        ""System.Object"" = hyperion
+                    }}
+                }}
+                akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.inmem""
+                akka.persistence.journal.plugin = ""akka.persistence.journal.memory-journal-shared""
+
+                akka.persistence.journal.MemoryJournal {{
+                    class = ""Akka.Persistence.Journal.MemoryJournal, Akka.Persistence""
+                    plugin-dispatcher = ""akka.actor.default-dispatcher""
+                }}
+                akka.persistence.journal.memory-journal-shared {{
+                    class = ""Akka.Cluster.Sharding.Tests.MemoryJournalShared, Akka.Cluster.Sharding.Tests.MultiNode""
+                    plugin-dispatcher = ""akka.actor.default-dispatcher""
+                    timeout = 5s
+                }}
+                """);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="mode">mode the state store mode</param>
+        /// <param name="rememberEntities">rememberEntities defaults to off</param>
+        /// <param name="additionalConfig">additionalConfig additional config</param>
+        /// <param name="loglevel">loglevel defaults to INFO</param>
+        protected MultiNodeClusterShardingConfig(
+            string mode = ClusterShardingSettings.StateStoreModeDData,
+            bool rememberEntities = false,
+            string additionalConfig = "",
+            string loglevel = "INFO")
+        {
+            Mode = mode;
+            RememberEntities = rememberEntities;
+            AdditionalConfig = additionalConfig;
+            Loglevel = loglevel;
+
+            Config persistenceConfig = (mode == ClusterShardingSettings.StateStoreModeDData) ? ConfigurationFactory.Empty : PersistenceConfig();
+
+            Config common =
+                ConfigurationFactory
+                    .ParseString($@"""
+                        akka.actor.provider = ""cluster""
+                        akka.cluster.downing-provider-class = akka.cluster.testkit.AutoDowning
+                        akka.cluster.testkit.auto-down-unreachable-after = 0s
+                        akka.cluster.sharding.state-store-mode = ""{mode}""
+                        akka.cluster.sharding.remember-entities = {rememberEntities}
+                        akka.cluster.sharding.fail-on-invalid-entity-state-transition = on
+                        akka.loglevel = {loglevel}
+                        akka.remote.log-remote-lifecycle-events = off
+
+                        akka.cluster.sharding {{
+                            updating-state-timeout = 2s
+                            waiting-for-state-timeout = 2s
+                        }}
+                        """)
+                    .WithFallback(Sharding.ClusterSharding.DefaultConfig())
+                    .WithFallback(Tools.Singleton.ClusterSingletonManager.DefaultConfig())
+                    .WithFallback(MultiNodeClusterSpec.ClusterConfig());
+
+            CommonConfig = (ConfigurationFactory.ParseString(additionalConfig).WithFallback(persistenceConfig).WithFallback(common));
+        }
+
+        public string Mode { get; }
+        public bool RememberEntities { get; }
+        public string AdditionalConfig { get; }
+        public string Loglevel { get; }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/MultiNodeClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/MultiNodeClusterShardingSpec.cs
@@ -1,0 +1,286 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="MultiNodeClusterShardingSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.Cluster.TestKit;
+using Akka.Event;
+using Akka.Remote.TestKit;
+using Akka.TestKit.TestActors;
+using Akka.Util;
+using FluentAssertions;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    public abstract class MultiNodeClusterShardingSpec : MultiNodeClusterSpec
+    {
+        protected class EntityActor : ActorBase
+        {
+            public sealed class Started
+            {
+                public Started(IActorRef @ref)
+                {
+                    Ref = @ref;
+                }
+                public IActorRef Ref { get; }
+            }
+
+            public EntityActor(IActorRef probe)
+            {
+                Probe = probe;
+                probe.Tell(new Started(Self));
+            }
+
+            public IActorRef Probe { get; }
+
+            protected override bool Receive(object message)
+            {
+                Sender.Tell(message);
+                return true;
+            }
+        }
+
+        protected class PingPongActor : ActorBase
+        {
+            public class Stop
+            {
+                public static readonly Stop Instance = new Stop();
+
+                private Stop()
+                {
+                }
+            }
+
+            public class Ping
+            {
+                public Ping(long id)
+                {
+                    Id = id;
+                }
+
+                public long Id { get; }
+            }
+
+            public class Pong
+            {
+                public static readonly Pong Instance = new Pong();
+
+                private Pong()
+                {
+                }
+            }
+
+            public PingPongActor()
+            {
+                Log.Info($"entity started {0}", Self.Path);
+            }
+
+            private ILoggingAdapter _log;
+            private ILoggingAdapter Log => _log ?? (_log = Context.GetLogger());
+
+            protected override bool Receive(object message)
+            {
+                switch (message)
+                {
+                    case Stop _:
+                        Context.Stop(Self);
+                        return true;
+                    case Ping _:
+                        Sender.Tell(Pong.Instance);
+                        return true;
+                }
+                return false;
+            }
+        }
+
+        protected class ShardedEntity : ActorBase
+        {
+            public class Stop
+            {
+                public static readonly Stop Instance = new Stop();
+
+                private Stop()
+                {
+                }
+            }
+
+            public ShardedEntity()
+            {
+            }
+
+            protected override bool Receive(object message)
+            {
+                switch (message)
+                {
+                    case int id:
+                        Sender.Tell(id);
+                        return true;
+                    case Stop _:
+                        Context.Stop(Self);
+                        return true;
+                }
+                return false;
+            }
+        }
+
+        internal ExtractEntityId IntExtractEntityId = message =>
+        {
+            if (message is int id)
+                return (id.ToString(), message);
+            return Option<(string, object)>.None;
+        };
+
+        internal ExtractShardId IntExtractShardId = message =>
+        {
+            switch (message)
+            {
+                case int id:
+                    return id.ToString();
+                case ShardRegion.StartEntity se:
+                    return se.EntityId;
+            }
+            return null;
+        };
+
+        private readonly MultiNodeClusterShardingConfig config;
+
+        private readonly Lazy<ClusterShardingSettings> settings;
+
+        private readonly Lazy<IShardAllocationStrategy> defaultShardAllocationStrategy;
+
+        protected MultiNodeClusterShardingSpec(MultiNodeClusterShardingConfig config, Type type)
+            : base(config, type)
+        {
+            this.config = config;
+            settings = new Lazy<ClusterShardingSettings>(() =>
+            {
+                return ClusterShardingSettings.Create(Sys).WithRememberEntities(config.RememberEntities);
+            });
+            defaultShardAllocationStrategy = new Lazy<IShardAllocationStrategy>(() =>
+            {
+                return ClusterSharding.Get(Sys).DefaultShardAllocationStrategy(settings.Value);
+            });
+        }
+
+        protected override int InitialParticipantsValueFactory => Roles.Count;
+
+
+        protected bool IsDdataMode => config.Mode == ClusterShardingSettings.StateStoreModeDData;
+
+        protected bool PersistenceIsNeeded => config.Mode == ClusterShardingSettings.StateStoreModePersistence;
+
+        /// <summary>
+        /// Flexible cluster join pattern usage.
+        /// </summary>
+        /// <param name="from">the node the `Cluster.join` is `runOn`</param>
+        /// <param name="to">to the node to join to</param>
+        /// <param name="onJoinedRunOnFrom">optionally execute a function after join validation is successful, e.g. start sharding or create coordinator</param>
+        /// <param name="assertNodeUp">if disabled - false, the joining member's `MemberStatus.Up`
+        ///     and similar assertions are not run. This allows tests that were
+        ///     not doing assertions (e.g. ClusterShardingMinMembersSpec) or
+        ///     doing them after `onJoinedRunOnFrom` more flexibility.
+        ///     Defaults to true, running member status checks.</param>
+        /// <param name="max"></param>
+        protected void Join(
+               RoleName from,
+               RoleName to,
+               Action onJoinedRunOnFrom = null,
+               bool assertNodeUp = true,
+               TimeSpan? max = null)
+        {
+            RunOn(() =>
+            {
+                Cluster.Join(Node(to).Address);
+                if (assertNodeUp)
+                {
+                    Within(max ?? TimeSpan.FromSeconds(20), () =>
+                     {
+                         AwaitAssert(() =>
+                         {
+                             Cluster.State.IsMemberUp(Node(from).Address).Should().BeTrue();
+                         });
+                     });
+                }
+                onJoinedRunOnFrom?.Invoke();
+            }, from);
+            EnterBarrier(from.Name + "-joined");
+        }
+
+        protected IActorRef StartSharding(
+            ActorSystem sys,
+            string typeName,
+            Props entityProps = null,
+            ClusterShardingSettings settings = null,
+            ExtractEntityId extractEntityId = null,
+            ExtractShardId extractShardId = null,
+            IShardAllocationStrategy allocationStrategy = null,
+            object handOffStopMessage = null)
+        {
+            return ClusterSharding.Get(sys).Start(
+                typeName,
+                entityProps ?? EchoActor.Props(this),
+                settings ?? this.settings.Value,
+                extractEntityId ?? IntExtractEntityId,
+                extractShardId ?? IntExtractShardId,
+                allocationStrategy ?? defaultShardAllocationStrategy.Value,
+                handOffStopMessage ?? PoisonPill.Instance);
+        }
+
+        protected IActorRef StartProxy(
+            ActorSystem sys,
+            string typeName,
+            string role,
+            ExtractEntityId extractEntityId,
+            ExtractShardId extractShardId)
+        {
+            return ClusterSharding.Get(sys).StartProxy(typeName, role, extractEntityId, extractShardId);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="startOn">the node to start the `MemoryJournalShared` store on</param>
+        protected void StartPersistenceIfNeeded(RoleName startOn)
+        {
+            if (PersistenceIsNeeded)
+                StartPersistence(startOn);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="startOn">the node to start the `MemoryJournalShared` store on</param>
+        protected void StartPersistence(RoleName startOn)
+        {
+            Log.Info("Setting up setup shared journal.");
+
+            // start the Persistence extension
+            Persistence.Persistence.Instance.Apply(Sys);
+            RunOn(() =>
+            {
+                Persistence.Persistence.Instance.Apply(Sys).JournalFor("akka.persistence.journal.MemoryJournal");
+            }, startOn);
+            EnterBarrier("persistence-started");
+
+            Sys.ActorSelection(Node(startOn) / "system" / "akka.persistence.journal.MemoryJournal").Tell(new Identify(null));
+            var sharedStore = ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
+            sharedStore.Should().NotBeNull();
+
+            MemoryJournalShared.SetStore(sharedStore, Sys);
+
+            EnterBarrier("persistence-started-test");
+
+            //check persistence running
+            var probe = CreateTestProbe(Sys);
+            var journal = Persistence.Persistence.Instance.Get(Sys).JournalFor(null);
+            journal.Tell(new Persistence.ReplayMessages(0, 0, long.MaxValue, Guid.NewGuid().ToString(), probe.Ref));
+            probe.ExpectMsg<Persistence.RecoverySuccess>(TimeSpan.FromSeconds(10));
+
+            EnterBarrier($"after-{startOn.Name}");
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/RollingUpdateShardAllocationSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/RollingUpdateShardAllocationSpec.cs
@@ -1,0 +1,339 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RollingUpdateShardAllocationSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.Remote.TestKit;
+using Akka.Util;
+using FluentAssertions;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    public class RollingUpdateShardAllocationSpecConfig : MultiNodeClusterShardingConfig
+    {
+        public RoleName First { get; }
+        public RoleName Second { get; }
+        public RoleName Third { get; }
+        public RoleName Fourth { get; }
+
+        public RollingUpdateShardAllocationSpecConfig()
+            : base(additionalConfig: @"
+                akka.cluster.sharding {
+                    # speed up forming and handovers a bit
+                    retry-interval = 500ms
+                    waiting-for-state-timeout = 500ms
+                    rebalance-interval = 1s
+                    # we are leaving cluster nodes but they need to stay in test
+                    akka.coordinated-shutdown.terminate-actor-system = off
+                    # use the new LeastShardAllocationStrategy
+                    akka.cluster.sharding.least-shard-allocation-strategy.rebalance-absolute-limit = 1
+                }")
+        {
+            First = Role("first");
+            Second = Role("second");
+            Third = Role("third");
+            Fourth = Role("fourth");
+
+            NodeConfig(new[] { First, Second }, new[] { ConfigurationFactory.ParseString("akka.cluster.app-version = 1.0.0") });
+            NodeConfig(new[] { Third, Fourth }, new[] { ConfigurationFactory.ParseString("akka.cluster.app-version = 1.0.1") });
+        }
+    }
+
+
+    public class RollingUpdateShardAllocationSpecMultiNode1 : RollingUpdateShardAllocationSpec
+    {
+        public RollingUpdateShardAllocationSpecMultiNode1() : this(new RollingUpdateShardAllocationSpecConfig())
+        {
+        }
+
+        protected RollingUpdateShardAllocationSpecMultiNode1(RollingUpdateShardAllocationSpecConfig config) : base(config, typeof(RollingUpdateShardAllocationSpecMultiNode1))
+        {
+        }
+    }
+
+    public class RollingUpdateShardAllocationSpecMultiNode2 : RollingUpdateShardAllocationSpec
+    {
+        public RollingUpdateShardAllocationSpecMultiNode2() : this(new RollingUpdateShardAllocationSpecConfig())
+        {
+        }
+
+        protected RollingUpdateShardAllocationSpecMultiNode2(RollingUpdateShardAllocationSpecConfig config) : base(config, typeof(RollingUpdateShardAllocationSpecMultiNode2))
+        {
+        }
+    }
+
+    public class RollingUpdateShardAllocationSpecMultiNode3 : RollingUpdateShardAllocationSpec
+    {
+        public RollingUpdateShardAllocationSpecMultiNode3() : this(new RollingUpdateShardAllocationSpecConfig())
+        {
+        }
+
+        protected RollingUpdateShardAllocationSpecMultiNode3(RollingUpdateShardAllocationSpecConfig config) : base(config, typeof(RollingUpdateShardAllocationSpecMultiNode3))
+        {
+        }
+    }
+
+    public class RollingUpdateShardAllocationSpecMultiNode4 : RollingUpdateShardAllocationSpec
+    {
+        public RollingUpdateShardAllocationSpecMultiNode4() : this(new RollingUpdateShardAllocationSpecConfig())
+        {
+        }
+
+        protected RollingUpdateShardAllocationSpecMultiNode4(RollingUpdateShardAllocationSpecConfig config) : base(config, typeof(RollingUpdateShardAllocationSpecMultiNode4))
+        {
+        }
+    }
+
+    public abstract class RollingUpdateShardAllocationSpec : MultiNodeClusterShardingSpec
+    {
+        protected class GiveMeYourHome : ActorBase
+        {
+            public class Get
+            {
+                public Get(string id)
+                {
+                    Id = id;
+                }
+
+                public string Id { get; }
+            }
+
+            public class Home
+            {
+                public Home(Address address)
+                {
+                    Address = address;
+                }
+
+                public Address Address { get; }
+            }
+
+            static internal ExtractEntityId ExtractEntityId = message =>
+            {
+                if (message is Get get)
+                    return (get.Id, get);
+                return Option<(string, object)>.None;
+            };
+
+            static internal ExtractShardId ExtractShardId = message =>
+            {
+                switch (message)
+                {
+                    case Get get:
+                        return get.Id;
+                }
+                return null;
+            };
+
+            private ILoggingAdapter _log;
+            private ILoggingAdapter Log => _log ?? (_log = Context.GetLogger());
+
+            private Address SelfAddress => Cluster.Get(Context.System).SelfAddress;
+
+            public GiveMeYourHome()
+            {
+                Log.Info("Started on {0}", SelfAddress);
+            }
+
+            protected override bool Receive(object message)
+            {
+                switch (message)
+                {
+                    case Get _:
+                        Sender.Tell(new Home(SelfAddress));
+                        return true;
+                }
+                return false;
+            }
+        }
+
+
+        private const string TypeName = "home";
+        private readonly RollingUpdateShardAllocationSpecConfig config;
+        private readonly Lazy<IActorRef> shardRegion;
+
+        protected RollingUpdateShardAllocationSpec(RollingUpdateShardAllocationSpecConfig config, Type type)
+            : base(config, type)
+        {
+            this.config = config;
+
+            shardRegion = new Lazy<IActorRef>(() =>
+                StartSharding(
+                    Sys,
+                    typeName: TypeName,
+                    entityProps: Props.Create(() => new GiveMeYourHome()),
+                    extractEntityId: GiveMeYourHome.ExtractEntityId,
+                    extractShardId: GiveMeYourHome.ExtractShardId));
+        }
+
+        private IEnumerable<Member> UpMembers => Cluster.State.Members.Where(m => m.Status == MemberStatus.Up);
+
+
+        [MultiNodeFact]
+        public void ClusterSharding_with_rolling_update_specs()
+        {
+            ClusterSharding_must_form_cluster();
+            ClusterSharding_must_start_cluster_sharding_on_first();
+            ClusterSharding_must_start_a_rolling_upgrade();
+            ClusterSharding_must_complete_a_rolling_upgrade();
+        }
+
+        public void ClusterSharding_must_form_cluster()
+        {
+            AwaitClusterUp(config.First, config.Second);
+            EnterBarrier("cluster-started");
+        }
+
+        public void ClusterSharding_must_start_cluster_sharding_on_first()
+        {
+            RunOn(() =>
+            {
+                // make sure both regions have completed registration before triggering entity allocation
+                // so the folloing allocations end up as one on each node
+                AwaitAssert(() =>
+                {
+                    shardRegion.Value.Tell(GetCurrentRegions.Instance);
+                    ExpectMsg<CurrentRegions>().Regions.Should().HaveCount(2);
+                });
+
+                shardRegion.Value.Tell(new GiveMeYourHome.Get("id1"));
+                // started on either of the nodes
+                var address1 = ExpectMsg<GiveMeYourHome.Home>().Address;
+
+                shardRegion.Value.Tell(new GiveMeYourHome.Get("id2"));
+                // started on the other of the nodes (because least
+                var address2 = ExpectMsg<GiveMeYourHome.Home>().Address;
+
+                // one on each node
+                ImmutableHashSet.Create(address1, address2).Should().HaveCount(2);
+            }, config.First, config.Second);
+            EnterBarrier("first-version-started");
+        }
+
+        public void ClusterSharding_must_start_a_rolling_upgrade()
+        {
+            Join(config.Third, config.First);
+
+            RunOn(() =>
+            {
+                _ = shardRegion.Value;
+
+                // new shards should now go on third since that is the highest version,
+                // however there is a race where the shard has not yet completed registration
+                // with the coordinator and shards will be allocated on the old nodes, so we need
+                // to make sure the third region has completed registration before trying
+                // if we didn't the strategy will default it back to the old nodes
+                AwaitAssert(() =>
+                {
+                    shardRegion.Value.Tell(GetCurrentRegions.Instance);
+                    ExpectMsg<CurrentRegions>().Regions.Should().HaveCount(3);
+                });
+            }, config.First, config.Second, config.Third);
+
+            EnterBarrier("third-region-registered");
+            RunOn(() =>
+            {
+                shardRegion.Value.Tell(new GiveMeYourHome.Get("id3"));
+                ExpectMsg<GiveMeYourHome.Home>();
+            }, config.First, config.Second);
+            RunOn(() =>
+            {
+                // now third region should be only option as the other two are old versions
+                // but first new allocated shard would anyway go there because of balance, so we
+                // need to do more than one
+
+                for (int n = 3; n <= 5; n++)
+                {
+                    shardRegion.Value.Tell(new GiveMeYourHome.Get($"id{n}"));
+                    ExpectMsg<GiveMeYourHome.Home>().Address.Should().Be(Cluster.Get(Sys).SelfAddress);
+                }
+            }, config.Third);
+            EnterBarrier("rolling-upgrade-in-progress");
+        }
+
+        public void ClusterSharding_must_complete_a_rolling_upgrade()
+        {
+            Join(config.Fourth, config.First);
+
+            RunOn(() =>
+            {
+                var cluster = Cluster.Get(Sys);
+                cluster.Leave(cluster.SelfAddress);
+            }, config.First);
+            RunOn(() =>
+            {
+                AwaitAssert(() =>
+                {
+                    UpMembers.Count().Should().Be(3);
+                });
+            }, config.Second, config.Third, config.Fourth);
+            EnterBarrier("first-left");
+
+            RunOn(() =>
+            {
+                AwaitAssert(() =>
+                {
+                    shardRegion.Value.Tell(GetCurrentRegions.Instance);
+                    ExpectMsg<CurrentRegions>().Regions.Should().HaveCount(3);
+
+                }, TimeSpan.FromSeconds(30));
+            }, config.Second, config.Third, config.Fourth);
+            EnterBarrier("sharding-handed-off");
+
+            // trigger allocation (no verification because we don't know which id was on node 1)
+            RunOn(() =>
+            {
+                AwaitAssert(() =>
+                {
+                    shardRegion.Value.Tell(new GiveMeYourHome.Get($"id1"));
+                    ExpectMsg<GiveMeYourHome.Home>();
+
+                    shardRegion.Value.Tell(new GiveMeYourHome.Get($"id2"));
+                    ExpectMsg<GiveMeYourHome.Home>();
+                });
+            }, config.Second, config.Third, config.Fourth);
+            EnterBarrier("first-allocated");
+
+            RunOn(() =>
+            {
+                var cluster = Cluster.Get(Sys);
+                cluster.Leave(cluster.SelfAddress);
+            }, config.Second);
+            RunOn(() =>
+            {
+                // make sure coordinator has noticed there are only two regions
+                AwaitAssert(() =>
+                {
+                    shardRegion.Value.Tell(GetCurrentRegions.Instance);
+                    ExpectMsg<CurrentRegions>().Regions.Should().HaveCount(2);
+                }, TimeSpan.FromSeconds(30));
+            }, config.Third, config.Fourth);
+            EnterBarrier("second-left");
+
+            // trigger allocation and verify where each was started
+            RunOn(() =>
+            {
+                AwaitAssert(() =>
+                {
+                    shardRegion.Value.Tell(new GiveMeYourHome.Get($"id1"));
+                    var address1 = ExpectMsg<GiveMeYourHome.Home>().Address;
+                    UpMembers.Select(i => i.Address).Should().Contain(address1);
+
+                    shardRegion.Value.Tell(new GiveMeYourHome.Get($"id2"));
+                    var address2 = ExpectMsg<GiveMeYourHome.Home>().Address;
+                    UpMembers.Select(i => i.Address).Should().Contain(address2);
+                });
+            }, config.Third, config.Fourth);
+            EnterBarrier("completo");
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingInternalsSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingInternalsSpec.cs
@@ -67,7 +67,7 @@ namespace Akka.Cluster.Sharding.Tests
                   settings: settingsWithRole,
                   extractEntityId: ExtractEntityId,
                   extractShardId: ExtractShardId,
-                  allocationStrategy: new LeastShardAllocationStrategy(0, 0),
+                  allocationStrategy: ShardAllocationStrategy.LeastShardAllocationStrategy(3, 0.1),
                   handOffStopMessage: PoisonPill.Instance);
 
             var proxy = clusterSharding.StartProxy(

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingInternalsSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingInternalsSpec.cs
@@ -84,16 +84,17 @@ namespace Akka.Cluster.Sharding.Tests
         public void ClusterSharding_must_stop_entities_from_HandOffStopper_even_if_the_entity_doesnt_handle_handOffStopMessage()
         {
             var probe = CreateTestProbe();
-            var shardName = "test";
+            var typeName = "typeName";
+            var shard = "7";
             var emptyHandlerActor = Sys.ActorOf(Props.Create(() => new EmptyHandlerActor()));
             var handOffStopper = Sys.ActorOf(
-                Props.Create(() => new ShardRegion.HandOffStopper(shardName, probe.Ref, new IActorRef[] { emptyHandlerActor }, HandOffStopMessage.Instance, TimeSpan.FromMilliseconds(10)))
+                Props.Create(() => new ShardRegion.HandOffStopper(typeName, shard, probe.Ref, new IActorRef[] { emptyHandlerActor }, HandOffStopMessage.Instance, TimeSpan.FromMilliseconds(10)))
               );
 
             Watch(emptyHandlerActor);
             ExpectTerminated(emptyHandlerActor, TimeSpan.FromSeconds(1));
 
-            probe.ExpectMsg(new PersistentShardCoordinator.ShardStopped(shardName), TimeSpan.FromSeconds(1));
+            probe.ExpectMsg(new PersistentShardCoordinator.ShardStopped(shard), TimeSpan.FromSeconds(1));
             probe.LastSender.Should().BeSameAs(handOffStopper);
 
             Watch(handOffStopper);

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/DeprecatedLeastShardAllocationStrategySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/DeprecatedLeastShardAllocationStrategySpec.cs
@@ -1,0 +1,191 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="DeprecatedLeastShardAllocationStrategySpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Akka.Actor;
+using Akka.TestKit;
+using Akka.TestKit.Xunit2;
+using Xunit;
+using FluentAssertions;
+using System.Collections;
+using System;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    public class DeprecatedLeastShardAllocationStrategySpec : TestKit.Xunit2.TestKit
+    {
+        private readonly IShardAllocationStrategy _allocationStrategy;
+        private readonly IActorRef _regionA;
+        private readonly IActorRef _regionB;
+        private readonly IActorRef _regionC;
+
+        public DeprecatedLeastShardAllocationStrategySpec()
+        {
+            _regionA = Sys.ActorOf(Props.Empty, "regionA");
+            _regionB = Sys.ActorOf(Props.Empty, "regionB");
+            _regionC = Sys.ActorOf(Props.Empty, "regionC");
+
+            _allocationStrategy = new LeastShardAllocationStrategy(3, 2);
+        }
+
+        private IImmutableDictionary<IActorRef, IImmutableList<string>> CreateAllocations(int aCount, int bCount = 0, int cCount = 0)
+        {
+            var shards = Enumerable.Range(1, (aCount + bCount + cCount)).Select(i => i.ToString("000"));
+
+            IImmutableDictionary<IActorRef, IImmutableList<string>> allocations = LeastShardAllocationStrategySpec.ImmutableDictionaryKeepOrder<IActorRef, IImmutableList<string>>.Empty;
+            allocations = allocations.Add(_regionA, shards.Take(aCount).ToImmutableList());
+            allocations = allocations.Add(_regionB, shards.Skip(aCount).Take(bCount).ToImmutableList());
+            allocations = allocations.Add(_regionC, shards.Skip(aCount + bCount).Take(cCount).ToImmutableList());
+            return allocations;
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_must_allocate_to_region_with_least_number_of_shards()
+        {
+            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 3, maxSimultaneousRebalance: 10);
+            var allocations = CreateAllocations(aCount: 1, bCount: 1);
+            allocationStrategy.AllocateShard(_regionA, "003", allocations).Result.Should().Be(_regionC);
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_2_0_0_rebalanceThreshold_1()
+        {
+            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 1, maxSimultaneousRebalance: 10);
+            var allocations = CreateAllocations(aCount: 2);
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("001");
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001")).Result.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_must_not_rebalance_when_diff_equal_to_threshold_1_1_0_rebalanceThreshold_1()
+        {
+            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 1, maxSimultaneousRebalance: 10);
+            var allocations = CreateAllocations(aCount: 1, bCount: 1);
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_1_2_0_rebalanceThreshold_1()
+        {
+            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 1, maxSimultaneousRebalance: 10);
+            var allocations = CreateAllocations(aCount: 1, bCount: 2);
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("002");
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("002")).Result.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_3_0_0_rebalanceThreshold_1()
+        {
+            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 1, maxSimultaneousRebalance: 10);
+            var allocations = CreateAllocations(aCount: 3);
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("001");
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001")).Result.Should().BeEquivalentTo("002");
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_4_4_0_rebalanceThreshold_1()
+        {
+            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 1, maxSimultaneousRebalance: 10);
+            var allocations = CreateAllocations(aCount: 4, bCount: 4);
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("001");
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001")).Result.Should().BeEquivalentTo("005");
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_4_4_2_rebalanceThreshold_1()
+        {
+            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 1, maxSimultaneousRebalance: 10);
+            var allocations = CreateAllocations(aCount: 4, bCount: 4, cCount: 2);
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("001");
+            // not optimal, 005 stopped and started again, but ok
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001")).Result.Should().BeEquivalentTo("005");
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_must_rebalance_rebalance_from_region_with_most_number_of_shards_1_3_0_rebalanceThreshold_2()
+        {
+            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 2, maxSimultaneousRebalance: 10);
+            var allocations = CreateAllocations(aCount: 1, bCount: 2);
+
+            // so far regionB has 2 shards and regionC has 0 shards, but the diff is <= rebalanceThreshold
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEmpty();
+
+            var allocations2 = CreateAllocations(aCount: 1, bCount: 3);
+            allocationStrategy.Rebalance(allocations2, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("002");
+            allocationStrategy.Rebalance(allocations2, ImmutableHashSet<string>.Empty.Add("002")).Result.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_must_not_rebalance_when_diff_equal_to_threshold_2_2_0_rebalanceThreshold_2()
+        {
+            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 2, maxSimultaneousRebalance: 10);
+            var allocations = CreateAllocations(aCount: 2, bCount: 2);
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_3_3_0_rebalanceThreshold_2()
+        {
+            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 2, maxSimultaneousRebalance: 10);
+            var allocations = CreateAllocations(aCount: 3, bCount: 3);
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("001");
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001")).Result.Should().BeEquivalentTo("004");
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001").Add("004")).Result.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_4_4_0_rebalanceThreshold_2()
+        {
+            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 2, maxSimultaneousRebalance: 10);
+            var allocations = CreateAllocations(aCount: 4, bCount: 4);
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("001", "002");
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001").Add("002")).Result.Should().BeEquivalentTo("005", "006");
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001").Add("002").Add("005").Add("006")).Result.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_5_5_0_rebalanceThreshold_2()
+        {
+            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 2, maxSimultaneousRebalance: 10);
+            var allocations = CreateAllocations(aCount: 5, bCount: 5);
+            // optimal would => [4, 4, 2] or even => [3, 4, 3]
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("001", "002");
+            // if 001 and 002 are not started quickly enough this is stopping more than optimal
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001").Add("002")).Result.Should().BeEquivalentTo("006", "007");
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001").Add("002").Add("006").Add("007")).Result.Should().BeEquivalentTo("003");
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_50_50_0_rebalanceThreshold_2()
+        {
+            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 2, maxSimultaneousRebalance: 100);
+            var allocations = CreateAllocations(aCount: 50, bCount: 50);
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("001", "002");
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001").Add("002")).Result.Should().BeEquivalentTo("051", "052");
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001").Add("002").Add("051").Add("052")).Result.Should().BeEquivalentTo("003", "004");
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_must_limit_number_of_simultaneous_rebalance()
+        {
+            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 3, maxSimultaneousRebalance: 2);
+            var allocations = CreateAllocations(aCount: 1, bCount: 10);
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("002", "003");
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("002").Add("003")).Result.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_must_not_pick_shards_that_are_in_progress()
+        {
+            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 3, maxSimultaneousRebalance: 4);
+            var allocations = CreateAllocations(aCount: 10);
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("002").Add("003")).Result.Should().BeEquivalentTo("001", "004");
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/DeprecatedLeastShardAllocationStrategySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/DeprecatedLeastShardAllocationStrategySpec.cs
@@ -15,23 +15,50 @@ using Xunit;
 using FluentAssertions;
 using System.Collections;
 using System;
+using static Akka.Cluster.ClusterEvent;
+using Akka.Util;
 
 namespace Akka.Cluster.Sharding.Tests
 {
     public class DeprecatedLeastShardAllocationStrategySpec : TestKit.Xunit2.TestKit
     {
-        private readonly IShardAllocationStrategy _allocationStrategy;
-        private readonly IActorRef _regionA;
-        private readonly IActorRef _regionB;
-        private readonly IActorRef _regionC;
+        internal class TestLeastShardAllocationStrategy : LeastShardAllocationStrategy
+        {
+            private readonly Func<CurrentClusterState> clusterState;
+            private readonly Func<Member> selfMember;
+
+            public TestLeastShardAllocationStrategy(int rebalanceThreshold, int maxSimultaneousRebalance, Func<CurrentClusterState> clusterState, Func<Member> selfMember) :
+                base(rebalanceThreshold, maxSimultaneousRebalance)
+            {
+                this.clusterState = clusterState;
+                this.selfMember = selfMember;
+            }
+
+            protected override CurrentClusterState ClusterState => clusterState();
+            protected override Member SelfMember => selfMember();
+        }
+
+        internal static Member NewUpMember(string host, int port = 252525, AppVersion version = null) => LeastShardAllocationStrategySpec.NewUpMember(host, port, version);
+
+        internal static IActorRef NewFakeRegion(string idForDebug, Member member) => LeastShardAllocationStrategySpec.NewFakeRegion(idForDebug, member);
+
+        private Member memberA;
+        private Member memberB;
+        private Member memberC;
+
+        private readonly IActorRef regionA;
+        private readonly IActorRef regionB;
+        private readonly IActorRef regionC;
 
         public DeprecatedLeastShardAllocationStrategySpec()
         {
-            _regionA = Sys.ActorOf(Props.Empty, "regionA");
-            _regionB = Sys.ActorOf(Props.Empty, "regionB");
-            _regionC = Sys.ActorOf(Props.Empty, "regionC");
+            memberA = NewUpMember("127.0.0.1");
+            memberB = NewUpMember("127.0.0.2");
+            memberC = NewUpMember("127.0.0.3");
 
-            _allocationStrategy = new LeastShardAllocationStrategy(3, 2);
+            regionA = NewFakeRegion("regionA", memberA);
+            regionB = NewFakeRegion("regionB", memberB);
+            regionC = NewFakeRegion("regionC", memberC);
         }
 
         private IImmutableDictionary<IActorRef, IImmutableList<string>> CreateAllocations(int aCount, int bCount = 0, int cCount = 0)
@@ -39,24 +66,30 @@ namespace Akka.Cluster.Sharding.Tests
             var shards = Enumerable.Range(1, (aCount + bCount + cCount)).Select(i => i.ToString("000"));
 
             IImmutableDictionary<IActorRef, IImmutableList<string>> allocations = LeastShardAllocationStrategySpec.ImmutableDictionaryKeepOrder<IActorRef, IImmutableList<string>>.Empty;
-            allocations = allocations.Add(_regionA, shards.Take(aCount).ToImmutableList());
-            allocations = allocations.Add(_regionB, shards.Skip(aCount).Take(bCount).ToImmutableList());
-            allocations = allocations.Add(_regionC, shards.Skip(aCount + bCount).Take(cCount).ToImmutableList());
+            allocations = allocations.Add(regionA, shards.Take(aCount).ToImmutableList());
+            allocations = allocations.Add(regionB, shards.Skip(aCount).Take(bCount).ToImmutableList());
+            allocations = allocations.Add(regionC, shards.Skip(aCount + bCount).Take(cCount).ToImmutableList());
             return allocations;
         }
 
-        [Fact]
-        public void LeastShardAllocationStrategy_must_allocate_to_region_with_least_number_of_shards()
+        private IShardAllocationStrategy AllocationStrategyWithFakeCluster(int rebalanceThreshold, int maxSimultaneousRebalance)
         {
-            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 3, maxSimultaneousRebalance: 10);
+            // we don't really "start" it as we fake the cluster access
+            return new TestLeastShardAllocationStrategy(rebalanceThreshold, maxSimultaneousRebalance, () => new CurrentClusterState().Copy(members: ImmutableSortedSet.Create(memberA, memberB, memberC)), () => memberA);
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_must_allocate_to_region_with_least_number_of_shards_1_1_0()
+        {
+            var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 3, maxSimultaneousRebalance: 10);
             var allocations = CreateAllocations(aCount: 1, bCount: 1);
-            allocationStrategy.AllocateShard(_regionA, "003", allocations).Result.Should().Be(_regionC);
+            allocationStrategy.AllocateShard(regionA, "003", allocations).Result.Should().Be(regionC);
         }
 
         [Fact]
         public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_2_0_0_rebalanceThreshold_1()
         {
-            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 1, maxSimultaneousRebalance: 10);
+            var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 1, maxSimultaneousRebalance: 10);
             var allocations = CreateAllocations(aCount: 2);
             allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("001");
             allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001")).Result.Should().BeEmpty();
@@ -65,7 +98,7 @@ namespace Akka.Cluster.Sharding.Tests
         [Fact]
         public void LeastShardAllocationStrategy_must_not_rebalance_when_diff_equal_to_threshold_1_1_0_rebalanceThreshold_1()
         {
-            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 1, maxSimultaneousRebalance: 10);
+            var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 1, maxSimultaneousRebalance: 10);
             var allocations = CreateAllocations(aCount: 1, bCount: 1);
             allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEmpty();
         }
@@ -73,7 +106,7 @@ namespace Akka.Cluster.Sharding.Tests
         [Fact]
         public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_1_2_0_rebalanceThreshold_1()
         {
-            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 1, maxSimultaneousRebalance: 10);
+            var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 1, maxSimultaneousRebalance: 10);
             var allocations = CreateAllocations(aCount: 1, bCount: 2);
             allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("002");
             allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("002")).Result.Should().BeEmpty();
@@ -82,7 +115,7 @@ namespace Akka.Cluster.Sharding.Tests
         [Fact]
         public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_3_0_0_rebalanceThreshold_1()
         {
-            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 1, maxSimultaneousRebalance: 10);
+            var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 1, maxSimultaneousRebalance: 10);
             var allocations = CreateAllocations(aCount: 3);
             allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("001");
             allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001")).Result.Should().BeEquivalentTo("002");
@@ -91,7 +124,7 @@ namespace Akka.Cluster.Sharding.Tests
         [Fact]
         public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_4_4_0_rebalanceThreshold_1()
         {
-            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 1, maxSimultaneousRebalance: 10);
+            var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 1, maxSimultaneousRebalance: 10);
             var allocations = CreateAllocations(aCount: 4, bCount: 4);
             allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("001");
             allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001")).Result.Should().BeEquivalentTo("005");
@@ -100,7 +133,7 @@ namespace Akka.Cluster.Sharding.Tests
         [Fact]
         public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_4_4_2_rebalanceThreshold_1()
         {
-            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 1, maxSimultaneousRebalance: 10);
+            var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 1, maxSimultaneousRebalance: 10);
             var allocations = CreateAllocations(aCount: 4, bCount: 4, cCount: 2);
             allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("001");
             // not optimal, 005 stopped and started again, but ok
@@ -110,7 +143,7 @@ namespace Akka.Cluster.Sharding.Tests
         [Fact]
         public void LeastShardAllocationStrategy_must_rebalance_rebalance_from_region_with_most_number_of_shards_1_3_0_rebalanceThreshold_2()
         {
-            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 2, maxSimultaneousRebalance: 10);
+            var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 2, maxSimultaneousRebalance: 10);
             var allocations = CreateAllocations(aCount: 1, bCount: 2);
 
             // so far regionB has 2 shards and regionC has 0 shards, but the diff is <= rebalanceThreshold
@@ -124,7 +157,7 @@ namespace Akka.Cluster.Sharding.Tests
         [Fact]
         public void LeastShardAllocationStrategy_must_not_rebalance_when_diff_equal_to_threshold_2_2_0_rebalanceThreshold_2()
         {
-            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 2, maxSimultaneousRebalance: 10);
+            var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 2, maxSimultaneousRebalance: 10);
             var allocations = CreateAllocations(aCount: 2, bCount: 2);
             allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEmpty();
         }
@@ -132,7 +165,7 @@ namespace Akka.Cluster.Sharding.Tests
         [Fact]
         public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_3_3_0_rebalanceThreshold_2()
         {
-            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 2, maxSimultaneousRebalance: 10);
+            var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 2, maxSimultaneousRebalance: 10);
             var allocations = CreateAllocations(aCount: 3, bCount: 3);
             allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("001");
             allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001")).Result.Should().BeEquivalentTo("004");
@@ -142,7 +175,7 @@ namespace Akka.Cluster.Sharding.Tests
         [Fact]
         public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_4_4_0_rebalanceThreshold_2()
         {
-            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 2, maxSimultaneousRebalance: 10);
+            var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 2, maxSimultaneousRebalance: 10);
             var allocations = CreateAllocations(aCount: 4, bCount: 4);
             allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("001", "002");
             allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001").Add("002")).Result.Should().BeEquivalentTo("005", "006");
@@ -152,7 +185,7 @@ namespace Akka.Cluster.Sharding.Tests
         [Fact]
         public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_5_5_0_rebalanceThreshold_2()
         {
-            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 2, maxSimultaneousRebalance: 10);
+            var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 2, maxSimultaneousRebalance: 10);
             var allocations = CreateAllocations(aCount: 5, bCount: 5);
             // optimal would => [4, 4, 2] or even => [3, 4, 3]
             allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("001", "002");
@@ -164,7 +197,7 @@ namespace Akka.Cluster.Sharding.Tests
         [Fact]
         public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_50_50_0_rebalanceThreshold_2()
         {
-            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 2, maxSimultaneousRebalance: 100);
+            var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 2, maxSimultaneousRebalance: 100);
             var allocations = CreateAllocations(aCount: 50, bCount: 50);
             allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("001", "002");
             allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001").Add("002")).Result.Should().BeEquivalentTo("051", "052");
@@ -172,20 +205,113 @@ namespace Akka.Cluster.Sharding.Tests
         }
 
         [Fact]
-        public void LeastShardAllocationStrategy_must_limit_number_of_simultaneous_rebalance()
+        public void LeastShardAllocationStrategy_must_limit_number_of_simultaneous_rebalance_1_10_0()
         {
-            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 3, maxSimultaneousRebalance: 2);
+            var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 3, maxSimultaneousRebalance: 2);
             var allocations = CreateAllocations(aCount: 1, bCount: 10);
             allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("002", "003");
             allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("002").Add("003")).Result.Should().BeEmpty();
         }
 
         [Fact]
-        public void LeastShardAllocationStrategy_must_not_pick_shards_that_are_in_progress()
+        public void LeastShardAllocationStrategy_must_not_pick_shards_that_are_in_progress_10_0_0()
         {
-            var allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold: 3, maxSimultaneousRebalance: 4);
+            var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 3, maxSimultaneousRebalance: 4);
             var allocations = CreateAllocations(aCount: 10);
             allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("002").Add("003")).Result.Should().BeEquivalentTo("001", "004");
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_must_prefer_least_shards_latest_version_non_downed_leaving_or_exiting_nodes()
+        {
+            // old version, up
+            var oldMember = NewUpMember("127.0.0.1", version: AppVersion.Create("1.0.0"));
+            // leaving, new version
+            var leavingMember = NewUpMember("127.0.0.2", version: AppVersion.Create("1.0.0")).Copy(MemberStatus.Leaving);
+            // new version, up
+            var newVersionMember1 = NewUpMember("127.0.0.3", version: AppVersion.Create("1.0.1"));
+            // new version, up
+            var newVersionMember2 = NewUpMember("127.0.0.4", version: AppVersion.Create("1.0.1"));
+            // new version, up
+            var newVersionMember3 = NewUpMember("127.0.0.5", version: AppVersion.Create("1.0.1"));
+
+            var fakeLocalRegion = NewFakeRegion("oldapp", oldMember);
+            var fakeRegionA = NewFakeRegion("leaving", leavingMember);
+            var fakeRegionB = NewFakeRegion("fewest", newVersionMember1);
+            var fakeRegionC = NewFakeRegion("oneshard", newVersionMember2);
+            var fakeRegionD = NewFakeRegion("most", newVersionMember3);
+
+            var shardsAndMembers = ImmutableList.Create(
+                new Internal.AbstractLeastShardAllocationStrategy.RegionEntry(fakeRegionB, newVersionMember1, ImmutableList<string>.Empty),
+                new Internal.AbstractLeastShardAllocationStrategy.RegionEntry(fakeRegionA, leavingMember, ImmutableList<string>.Empty),
+                new Internal.AbstractLeastShardAllocationStrategy.RegionEntry(fakeRegionD, newVersionMember3, ImmutableList.Create("ShardId2", "ShardId3")),
+                new Internal.AbstractLeastShardAllocationStrategy.RegionEntry(fakeLocalRegion, oldMember, ImmutableList<string>.Empty),
+                new Internal.AbstractLeastShardAllocationStrategy.RegionEntry(fakeRegionC, newVersionMember2, ImmutableList.Create("ShardId1"))
+                );
+
+            var sortedRegions =
+                shardsAndMembers.Sort(Internal.AbstractLeastShardAllocationStrategy.ShardSuitabilityOrdering.Instance).Select(i => i.Region);
+
+            // only node b has the new version
+            sortedRegions.Should().Equal(
+                fakeRegionB, // fewest shards, newest version, up
+                fakeRegionC, // newest version, up
+                fakeRegionD, // most shards, up
+                fakeLocalRegion, // old app version
+                fakeRegionA); // leaving
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_must_not_rebalance_when_rolling_update_in_progress()
+        {
+            var member1 = NewUpMember("127.0.0.1", version: AppVersion.Create("1.0.0"));
+            var member2 = NewUpMember("127.0.0.1", version: AppVersion.Create("1.0.1"));
+
+            // multiple versions to simulate rolling update in progress
+            var allocationStrategy =
+                new TestLeastShardAllocationStrategy(rebalanceThreshold: 2, maxSimultaneousRebalance: 100, () => new CurrentClusterState().Copy(members: ImmutableSortedSet.Create(member1, member2)), () => member1);
+
+            var allocations = CreateAllocations(aCount: 5, bCount: 5);
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEmpty();
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("001", "002")).Result.Should().BeEmpty();
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("001", "002", "051", "052")).Result.Should().BeEmpty();
+        }
+
+
+        [Fact]
+        public void LeastShardAllocationStrategy_must_not_rebalance_when_regions_are_unreachable()
+        {
+            var member1 = NewUpMember("127.0.0.1");
+            var member2 = NewUpMember("127.0.0.2");
+
+            // multiple versions to simulate rolling update in progress
+            var allocationStrategy =
+                new TestLeastShardAllocationStrategy(rebalanceThreshold: 2, maxSimultaneousRebalance: 100, () => new CurrentClusterState().Copy(members: ImmutableSortedSet.Create(member1, member2), unreachable: ImmutableHashSet.Create(member2)), () => member2);
+
+            var allocations = CreateAllocations(aCount: 5, bCount: 5);
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEmpty();
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("001", "002")).Result.Should().BeEmpty();
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("001", "002", "051", "052")).Result.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_must_not_rebalance_when_members_are_joining_dc()
+        {
+            var member1 = NewUpMember("127.0.0.1");
+            var member2 =
+                Member.Create(
+                    new UniqueAddress(new Address("akka", "myapp", "127.0.0.2", 252525), 1),
+                    ImmutableHashSet<string>.Empty,
+                    member1.AppVersion);
+
+            // multiple versions to simulate rolling update in progress
+            var allocationStrategy =
+                new TestLeastShardAllocationStrategy(rebalanceThreshold: 2, maxSimultaneousRebalance: 100, () => new CurrentClusterState().Copy(members: ImmutableSortedSet.Create(member1, member2), unreachable: ImmutableHashSet.Create(member2)), () => member2);
+
+            var allocations = CreateAllocations(aCount: 5, bCount: 5);
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEmpty();
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("001", "002")).Result.Should().BeEmpty();
+            allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("001", "002", "051", "052")).Result.Should().BeEmpty();
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/LeastShardAllocationStrategyRandomizedSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/LeastShardAllocationStrategyRandomizedSpec.cs
@@ -1,0 +1,148 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="LeastShardAllocationStrategyRandomizedSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Akka.Actor;
+using Akka.TestKit;
+using Akka.TestKit.Xunit2;
+using Xunit;
+using FluentAssertions;
+using System.Collections;
+using System;
+using FluentAssertions.Execution;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    public class LeastShardAllocationStrategyRandomizedSpec : TestKit.Xunit2.TestKit
+    {
+        private readonly IShardAllocationStrategy strategyWithoutLimits = ShardAllocationStrategy.LeastShardAllocationStrategy(absoluteLimit: 100000, relativeLimit: 1.0);
+        private int rndSeed;
+        private Random rnd;
+        private int iteration = 1;
+        private int iterationsPerTest = 10;
+
+        public LeastShardAllocationStrategyRandomizedSpec()
+        {
+            rndSeed = DateTime.UtcNow.Millisecond;
+            rnd = new Random(rndSeed);
+            Log.Info($"Random seed: {rndSeed}");
+        }
+
+        private IImmutableDictionary<IActorRef, IImmutableList<string>> CreateAllocations(IImmutableDictionary<IActorRef, int> countPerRegion)
+        {
+            return countPerRegion.ToImmutableDictionary(i => i.Key, i => (IImmutableList<string>)Enumerable.Range(1, i.Value).Select(n => n.ToString("000")).Select(n => $"{i.Key.Path.Name}-{n}").ToImmutableList());
+        }
+
+
+        private void TestRebalance(
+            IShardAllocationStrategy allocationStrategy,
+            int maxRegions,
+            int maxShardsPerRegion,
+            int expectedMaxSteps)
+        {
+            foreach (var i in Enumerable.Range(1, iterationsPerTest))
+            {
+                iteration += 1;
+                var numberOfRegions = rnd.Next(maxRegions) + 1;
+                var regions = Enumerable.Range(1, numberOfRegions).Select(n => Sys.ActorOf(Props.Empty, $"{iteration}-R{n}")).ToImmutableList();
+                var countPerRegion = regions.ToImmutableDictionary(region => region, region => rnd.Next(maxShardsPerRegion));
+                var allocations = CreateAllocations(countPerRegion);
+                TestRebalance(allocationStrategy, allocations, ImmutableList.Create(allocations), expectedMaxSteps);
+                foreach (var region in regions)
+                    Sys.Stop(region);
+            }
+        }
+
+
+        private void TestRebalance(
+              IShardAllocationStrategy allocationStrategy,
+              IImmutableDictionary<IActorRef, IImmutableList<string>> allocations,
+              ImmutableList<IImmutableDictionary<IActorRef, IImmutableList<string>>> steps,
+              int maxSteps)
+        {
+            var round = steps.Count;
+            var rebalanceResult = allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result;
+            var newAllocations = LeastShardAllocationStrategySpec.AfterRebalance(allocationStrategy, allocations, rebalanceResult);
+
+            LeastShardAllocationStrategySpec.CountShards(newAllocations).Should().Be(LeastShardAllocationStrategySpec.CountShards(allocations), $"test {allocationStrategy}[{ string.Join(", ", LeastShardAllocationStrategySpec.CountShardsPerRegion(allocations))}]: ");
+            var min = LeastShardAllocationStrategySpec.CountShardsPerRegion(newAllocations).Min();
+            var max = LeastShardAllocationStrategySpec.CountShardsPerRegion(newAllocations).Max();
+            var diff = max - min;
+            var newSteps = steps.Add(newAllocations);
+            if (diff <= 1)
+            {
+                if (round >= 3 && maxSteps <= 10)
+                {
+                    // Should be very rare (I have not seen it)
+                    Sys.Log.Info($"rebalance solved in round {round}, [{string.Join(" => ", newSteps.Select(step => string.Join(", ", LeastShardAllocationStrategySpec.CountShardsPerRegion(step))))}]");
+                }
+            }
+            else if (round == maxSteps)
+            {
+                throw new AssertionFailedException($"Couldn't solve rebalance in $round rounds, [{string.Join(" => ", newSteps.Select(step => string.Join(", ", LeastShardAllocationStrategySpec.CountShardsPerRegion(step))))}]");
+            }
+            else
+            {
+                TestRebalance(allocationStrategy, newAllocations, newSteps, maxSteps);
+            }
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_with_random_scenario_must_rebalance_shards_with_max_5_regions_5_shards()
+        {
+            TestRebalance(strategyWithoutLimits, maxRegions: 5, maxShardsPerRegion: 5, expectedMaxSteps: 2);
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_with_random_scenario_must_rebalance_shards_with_max_5_regions_100_shards()
+        {
+            TestRebalance(strategyWithoutLimits, maxRegions: 5, maxShardsPerRegion: 100, expectedMaxSteps: 2);
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_with_random_scenario_must_rebalance_shards_with_max_20_regions_5_shards()
+        {
+            TestRebalance(strategyWithoutLimits, maxRegions: 20, maxShardsPerRegion: 5, expectedMaxSteps: 2);
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_with_random_scenario_must_rebalance_shards_with_max_20_regions__20_shards()
+        {
+            TestRebalance(strategyWithoutLimits, maxRegions: 20, maxShardsPerRegion: 20, expectedMaxSteps: 2);
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_with_random_scenario_must_rebalance_shards_with_max_20_regions_200_shards()
+        {
+            TestRebalance(strategyWithoutLimits, maxRegions: 20, maxShardsPerRegion: 200, expectedMaxSteps: 5);
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_with_random_scenario_must_rebalance_shards_with_max_100_regions_100_shards()
+        {
+            TestRebalance(strategyWithoutLimits, maxRegions: 100, maxShardsPerRegion: 100, expectedMaxSteps: 5);
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_with_random_scenario_must_rebalance_shards_with_max_100_regions_1000_shards()
+        {
+            TestRebalance(strategyWithoutLimits, maxRegions: 100, maxShardsPerRegion: 1000, expectedMaxSteps: 5);
+        }
+
+        [Fact]
+        public void LeastShardAllocationStrategy_with_random_scenario_must_rebalance_shards_with_max_20_regions_20_shards_and_limits()
+        {
+            var absoluteLimit = 3 + rnd.Next(7) + 3;
+            var relativeLimit = 0.05 + (rnd.NextDouble() * 0.95);
+
+            var strategy = ShardAllocationStrategy.LeastShardAllocationStrategy(absoluteLimit, relativeLimit);
+            TestRebalance(strategy, maxRegions: 20, maxShardsPerRegion: 20, expectedMaxSteps: 20);
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
@@ -1352,7 +1352,7 @@ namespace Akka.Cluster.Sharding
 
         private void Acked(IActorRef shardRegion)
         {
-            _remaining.Remove(Sender);
+            _remaining.Remove(shardRegion);
             if (_remaining.Count == 0)
             {
                 Log.Debug("All shard regions acked, handing off shard [{0}].", _shard);

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
@@ -177,7 +177,7 @@ namespace Akka.Cluster.Sharding
                     {
                         if (Equals(Context.Child(coordinatorSingletonManagerName), ActorRefs.Nobody))
                         {
-                            var minBackoff = settings.TunningParameters.CoordinatorFailureBackoff;
+                            var minBackoff = settings.TuningParameters.CoordinatorFailureBackoff;
                             var maxBackoff = new TimeSpan(minBackoff.Ticks * 5);
                             var coordinatorProps = settings.StateStoreMode == StateStoreMode.Persistence
                                 ? PersistentShardCoordinator.Props(start.TypeName, settings, start.AllocationStrategy)

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingSettings.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingSettings.cs
@@ -169,6 +169,9 @@ namespace Akka.Cluster.Sharding
     [Serializable]
     public sealed class ClusterShardingSettings : INoSerializationVerificationNeeded
     {
+        public const string StateStoreModePersistence = "Persistence";
+        public const string StateStoreModeDData = "DData";
+
         /// <summary>
         /// Specifies that this entity type requires cluster nodes with a specific role.
         /// If the role is not specified all nodes in the cluster are used.

--- a/src/contrib/cluster/Akka.Cluster.Sharding/DDataShard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/DDataShard.cs
@@ -100,11 +100,11 @@ namespace Akka.Cluster.Sharding
             Replicator = replicator;
             MajorityCap = majorityCap;
 
-            RememberedEntitiesRecoveryStrategy = Settings.TunningParameters.EntityRecoveryStrategy == "constant"
+            RememberedEntitiesRecoveryStrategy = Settings.TuningParameters.EntityRecoveryStrategy == "constant"
                 ? EntityRecoveryStrategy.ConstantStrategy(
                     Context.System,
-                    Settings.TunningParameters.EntityRecoveryConstantRateStrategyFrequency,
-                    Settings.TunningParameters.EntityRecoveryConstantRateStrategyNumberOfEntities)
+                    Settings.TuningParameters.EntityRecoveryConstantRateStrategyFrequency,
+                    Settings.TuningParameters.EntityRecoveryConstantRateStrategyNumberOfEntities)
                 : EntityRecoveryStrategy.AllStrategy;
 
             var idleInterval = TimeSpan.FromTicks(Settings.PassivateIdleEntityAfter.Ticks / 2);
@@ -112,8 +112,8 @@ namespace Akka.Cluster.Sharding
                 ? Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(idleInterval, idleInterval, Self, Shard.PassivateIdleTick.Instance, Self)
                 : null;
 
-            _readConsistency = new ReadMajority(settings.TunningParameters.WaitingForStateTimeout, majorityCap);
-            _writeConsistency = new WriteMajority(settings.TunningParameters.UpdatingStateTimeout, majorityCap);
+            _readConsistency = new ReadMajority(settings.TuningParameters.WaitingForStateTimeout, majorityCap);
+            _writeConsistency = new WriteMajority(settings.TuningParameters.UpdatingStateTimeout, majorityCap);
             _stateKeys = Enumerable.Range(0, NrOfKeys).Select(i => new ORSetKey<EntryId>($"shard-{typeName}-{shardId}-{i}")).ToImmutableArray();
 
             if (settings.LeaseSettings != null)
@@ -211,7 +211,7 @@ namespace Akka.Cluster.Sharding
                     ReceiveOne(i);
                     break;
                 case GetFailure failure:
-                    Log.Error("The DDataShard was unable to get an initial state within 'waiting-for-state-timeout': {0}", Settings.TunningParameters.WaitingForStateTimeout);
+                    Log.Error("The DDataShard was unable to get an initial state within 'waiting-for-state-timeout': {0}", Settings.TuningParameters.WaitingForStateTimeout);
                     Context.Stop(Self);
                     break;
                 case NotFound notFound:
@@ -277,13 +277,13 @@ namespace Akka.Cluster.Sharding
                     {
                         // parent ShardRegion supervisor will notice that it terminated and will start it again, after backoff
                         Log.Error("The DDataShard was unable to update state after {0} attempts, within 'updating-state-timeout'={1}, event={2}. " +
-                            "Shard will be restarted after backoff.", MaxUpdateAttempts, Settings.TunningParameters.UpdatingStateTimeout, e);
+                            "Shard will be restarted after backoff.", MaxUpdateAttempts, Settings.TuningParameters.UpdatingStateTimeout, e);
                         Context.Stop(Self);
                     }
                     else
                     {
                         Log.Error("The DDataShard was unable to update state, attempt {0} of {1}, within 'updating-state-timeout'={2}, event={3}",
-                            retryCount, MaxUpdateAttempts, Settings.TunningParameters.UpdatingStateTimeout, e);
+                            retryCount, MaxUpdateAttempts, Settings.TuningParameters.UpdatingStateTimeout, e);
                         SendUpdate(e, retryCount + 1);
                     }
                     break;

--- a/src/contrib/cluster/Akka.Cluster.Sharding/DDataShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/DDataShardCoordinator.cs
@@ -31,6 +31,7 @@ namespace Akka.Cluster.Sharding
         public ILoggingAdapter Log { get; }
         public ImmutableDictionary<string, ICancelable> UnAckedHostShards { get; set; } = ImmutableDictionary<string, ICancelable>.Empty;
         public ImmutableDictionary<string, ImmutableHashSet<IActorRef>> RebalanceInProgress { get; set; } = ImmutableDictionary<string, ImmutableHashSet<IActorRef>>.Empty;
+        public ImmutableHashSet<IActorRef> RebalanceWorkers { get; set; } = ImmutableHashSet<IActorRef>.Empty;
         public ImmutableHashSet<IActorRef> GracefullShutdownInProgress { get; set; } = ImmutableHashSet<IActorRef>.Empty;
         public ImmutableHashSet<IActorRef> AliveRegions { get; set; } = ImmutableHashSet<IActorRef>.Empty;
         public ImmutableHashSet<IActorRef> RegionTerminationInProgress { get; set; } = ImmutableHashSet<IActorRef>.Empty;

--- a/src/contrib/cluster/Akka.Cluster.Sharding/DDataShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/DDataShardCoordinator.cs
@@ -27,6 +27,7 @@ namespace Akka.Cluster.Sharding
         IActorContext IShardCoordinator.Context => Context;
         IActorRef IShardCoordinator.Self => Self;
         IActorRef IShardCoordinator.Sender => Sender;
+        IActorRef IShardCoordinator.IgnoreRef => Context.System.IgnoreRef;
         public ILoggingAdapter Log { get; }
         public ImmutableDictionary<string, ICancelable> UnAckedHostShards { get; set; } = ImmutableDictionary<string, ICancelable>.Empty;
         public ImmutableDictionary<string, ImmutableHashSet<IActorRef>> RebalanceInProgress { get; set; } = ImmutableDictionary<string, ImmutableHashSet<IActorRef>>.Empty;

--- a/src/contrib/cluster/Akka.Cluster.Sharding/DDataShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/DDataShardCoordinator.cs
@@ -62,10 +62,10 @@ namespace Akka.Cluster.Sharding
             MinMembers = string.IsNullOrEmpty(settings.Role)
                 ? Cluster.Settings.MinNrOfMembers
                 : Cluster.Settings.MinNrOfMembersOfRole.GetValueOrDefault(settings.Role, 1);
-            RebalanceTask = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(Settings.TunningParameters.RebalanceInterval, Settings.TunningParameters.RebalanceInterval, Self, RebalanceTick.Instance, Self);
+            RebalanceTask = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(Settings.TuningParameters.RebalanceInterval, Settings.TuningParameters.RebalanceInterval, Self, RebalanceTick.Instance, Self);
 
-            _readConsistency = new ReadMajority(settings.TunningParameters.WaitingForStateTimeout, majorityMinCap);
-            _writeConsistency = new WriteMajority(settings.TunningParameters.UpdatingStateTimeout, majorityMinCap);
+            _readConsistency = new ReadMajority(settings.TuningParameters.WaitingForStateTimeout, majorityMinCap);
+            _writeConsistency = new WriteMajority(settings.TuningParameters.UpdatingStateTimeout, majorityMinCap);
             _coordinatorStateKey = new LWWRegisterKey<PersistentShardCoordinator.State>(typeName + "CoordinatorState");
             _allShardsKey = new GSetKey<string>($"shard-{typeName}-all");
             _allKeys = rememberEntities

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Internal/AbstractLeastShardAllocationStrategy.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Internal/AbstractLeastShardAllocationStrategy.cs
@@ -104,9 +104,10 @@ namespace Akka.Cluster.Sharding.Internal
         {
             // Avoid rebalance when rolling update is in progress
             // (This will ignore versions on members with no shard regions, because of sharding role or not yet completed joining)
-            var version = regionEntries.First().Member.AppVersion;
-            var allNodesSameVersion = regionEntries.All(r => r.Member.AppVersion == version);
-
+            var region = regionEntries.FirstOrDefault();
+            if (region == null)
+                return false; // empty list of regions, probably not a good time to rebalance...
+            var allNodesSameVersion = regionEntries.All(r => r.Member.AppVersion == region.Member.AppVersion);
             // Rebalance requires ack from regions and proxies - no need to rebalance if it cannot be completed
             // FIXME #29589, we currently only look at same dc but proxies in other dcs may delay complete as well right now
             var neededMembersReachable = !ClusterState.Members.Any(m => ClusterState.Unreachable.Contains(m));

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Internal/AbstractLeastShardAllocationStrategy.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Internal/AbstractLeastShardAllocationStrategy.cs
@@ -1,0 +1,146 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AbstractLeastShardAllocationStrategy.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Akka.Actor;
+
+namespace Akka.Cluster.Sharding.Internal
+{
+    using static Akka.Cluster.ClusterEvent;
+    using ShardId = String;
+
+    /// <summary>
+    /// Common logic for the least shard allocation strategy implementations
+    /// </summary>
+    public abstract class AbstractLeastShardAllocationStrategy : IActorSystemDependentAllocationStrategy
+    {
+        private static ImmutableHashSet<MemberStatus> JoiningCluster = ImmutableHashSet.Create(MemberStatus.Joining, MemberStatus.WeaklyUp);
+        private static ImmutableHashSet<MemberStatus> LeavingClusterStatuses = ImmutableHashSet.Create(MemberStatus.Leaving, MemberStatus.Exiting, MemberStatus.Down);
+
+        public sealed class RegionEntry
+        {
+            public RegionEntry(IActorRef region, Member member, IImmutableList<ShardId> shardIds)
+            {
+                Region = region;
+                Member = member;
+                ShardIds = shardIds;
+            }
+
+            public IActorRef Region { get; }
+            public Member Member { get; }
+            public IImmutableList<string> ShardIds { get; }
+        }
+
+        internal class ShardSuitabilityOrdering : IComparer<RegionEntry>
+        {
+            public static readonly ShardSuitabilityOrdering Instance = new ShardSuitabilityOrdering();
+
+            private ShardSuitabilityOrdering()
+            {
+
+            }
+
+            public int Compare(RegionEntry x, RegionEntry y)
+            {
+                if (x.Member.Status != y.Member.Status)
+                {
+                    // prefer allocating to nodes that are not on their way out of the cluster
+                    var xIsLeaving = LeavingClusterStatuses.Contains(x.Member.Status);
+                    var yIsLeaving = LeavingClusterStatuses.Contains(y.Member.Status);
+                    return xIsLeaving.CompareTo(yIsLeaving);
+                }
+                else if (x.Member.AppVersion != y.Member.AppVersion)
+                {
+                    // prefer nodes with the highest rolling update app version
+                    return y.Member.AppVersion.CompareTo(x.Member.AppVersion);
+                }
+                else
+                {
+                    // prefer the node with the least allocated shards
+                    return x.ShardIds.Count.CompareTo(y.ShardIds.Count);
+                }
+            }
+        }
+
+        private ActorSystem system;
+        private Cluster cluster;
+
+        // protected for testability
+        protected virtual CurrentClusterState ClusterState => cluster.State;
+        protected virtual Member SelfMember => cluster.SelfMember;
+
+        public void Start(ActorSystem system)
+        {
+            this.system = system;
+            cluster = Cluster.Get(system);
+        }
+
+        public async Task<IActorRef> AllocateShard(IActorRef requester, string shardId, IImmutableDictionary<IActorRef, IImmutableList<string>> currentShardAllocations)
+        {
+            var regionEntries = RegionEntriesFor(currentShardAllocations);
+            if (regionEntries.IsEmpty)
+            {
+                // very unlikely to ever happen but possible because of cluster state view not yet updated when collecting
+                // region entries, view should be updated after a very short time
+                await Task.Delay(50);
+                return await AllocateShard(requester, shardId, currentShardAllocations);
+            }
+            else
+            {
+                var suitable = MostSuitableRegion(regionEntries);
+                return suitable.Region;
+            }
+        }
+
+        protected bool IsAGoodTimeToRebalance(IEnumerable<RegionEntry> regionEntries)
+        {
+            // Avoid rebalance when rolling update is in progress
+            // (This will ignore versions on members with no shard regions, because of sharding role or not yet completed joining)
+            var version = regionEntries.First().Member.AppVersion;
+            var allNodesSameVersion = regionEntries.All(r => r.Member.AppVersion == version);
+
+            // Rebalance requires ack from regions and proxies - no need to rebalance if it cannot be completed
+            // FIXME #29589, we currently only look at same dc but proxies in other dcs may delay complete as well right now
+            var neededMembersReachable = !ClusterState.Members.Any(m => ClusterState.Unreachable.Contains(m));
+            // No members in same dc joining, we want that to complete before rebalance, such nodes should reach Up soon
+            var membersInProgressOfJoining =
+                ClusterState.Members.Any(m => JoiningCluster.Contains(m.Status));
+
+            return allNodesSameVersion && neededMembersReachable && !membersInProgressOfJoining;
+        }
+
+        protected (IActorRef Region, IImmutableList<ShardId> Shards) MostSuitableRegion(
+            IEnumerable<RegionEntry> regionEntries)
+        {
+            var mostSuitableEntry = regionEntries.Min(ShardSuitabilityOrdering.Instance);
+            return (mostSuitableEntry.Region, mostSuitableEntry.ShardIds);
+        }
+
+        protected ImmutableList<RegionEntry> RegionEntriesFor(IImmutableDictionary<IActorRef, IImmutableList<string>> currentShardAllocations)
+        {
+            var addressToMember = ClusterState.Members.ToImmutableDictionary(m => m.Address, m => m);
+
+            return currentShardAllocations.Select(i =>
+            {
+                var regionAddress = i.Key.Path.Address.HasLocalScope ? SelfMember.Address : i.Key.Path.Address;
+
+                var memberForRegion = addressToMember.GetValueOrDefault(regionAddress);
+                // if the member is unknown (very unlikely but not impossible) because of view not updated yet
+                // that node is ignored for this invocation
+                if (memberForRegion != null)
+                    return new RegionEntry(i.Key, memberForRegion, i.Value);
+                return null;
+            }).Where(i => i != null).ToImmutableList();
+        }
+
+        public abstract Task<IImmutableSet<string>> Rebalance(IImmutableDictionary<IActorRef, IImmutableList<string>> currentShardAllocations, IImmutableSet<string> rebalanceInProgress);
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Internal/AbstractLeastShardAllocationStrategy.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Internal/AbstractLeastShardAllocationStrategy.cs
@@ -22,8 +22,8 @@ namespace Akka.Cluster.Sharding.Internal
     /// </summary>
     public abstract class AbstractLeastShardAllocationStrategy : IActorSystemDependentAllocationStrategy
     {
-        private static ImmutableHashSet<MemberStatus> JoiningCluster = ImmutableHashSet.Create(MemberStatus.Joining, MemberStatus.WeaklyUp);
-        private static ImmutableHashSet<MemberStatus> LeavingClusterStatuses = ImmutableHashSet.Create(MemberStatus.Leaving, MemberStatus.Exiting, MemberStatus.Down);
+        private static readonly ImmutableHashSet<MemberStatus> JoiningCluster = ImmutableHashSet.Create(MemberStatus.Joining, MemberStatus.WeaklyUp);
+        private static readonly ImmutableHashSet<MemberStatus> LeavingClusterStatuses = ImmutableHashSet.Create(MemberStatus.Leaving, MemberStatus.Exiting, MemberStatus.Down);
 
         public sealed class RegionEntry
         {

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Internal/LeastShardAllocationStrategy.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Internal/LeastShardAllocationStrategy.cs
@@ -1,0 +1,165 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="LeastShardAllocationStrategy.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Akka.Actor;
+
+namespace Akka.Cluster.Sharding.Internal
+{
+    using ShardId = String;
+
+    /// <summary>
+    /// INTERNAL API: Use <see cref="ShardAllocationStrategy.LeastShardAllocationStrategy(int, double)"/> factory method.
+    ///
+    /// <see cref="IShardAllocationStrategy"/> that  allocates new shards to the <see cref="ShardRegion"/> (node) with least
+    /// number of previously allocated shards.
+    ///
+    /// When a node is added to the cluster the shards on the existing nodes will be rebalanced to the new node.
+    /// The <see cref="LeastShardAllocationStrategy"/> picks shards for rebalancing from the <see cref="ShardRegion"/>s with most number
+    /// of previously allocated shards. They will then be allocated to the <see cref="ShardRegion"/> with least number of
+    /// previously allocated shards, i.e. new members in the cluster. The amount of shards to rebalance in each
+    /// round can be limited to make it progress slower since rebalancing too many shards at the same time could
+    /// result in additional load on the system. For example, causing many Event Sourced entites to be started
+    /// at the same time.
+    ///
+    /// It will not rebalance when there is already an ongoing rebalance in progress.
+    /// </summary>
+    [Serializable]
+    internal sealed class LeastShardAllocationStrategy : IShardAllocationStrategy
+    {
+        private static readonly Task<IImmutableSet<ShardId>> emptyRebalanceResult = Task.FromResult<IImmutableSet<ShardId>>(ImmutableHashSet<ShardId>.Empty);
+
+        private readonly int _absoluteLimit;
+        private readonly double _relativeLimit;
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="absoluteLimit">The maximum number of shards that will be rebalanced in one rebalance round</param>
+        /// <param name="relativeLimit">Fraction (&lt; 1.0) of total number of (known) shards that will be rebalanced in one rebalance round</param>
+        public LeastShardAllocationStrategy(int absoluteLimit, double relativeLimit)
+        {
+            _absoluteLimit = absoluteLimit;
+            _relativeLimit = relativeLimit;
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="requester">TBD</param>
+        /// <param name="shardId">TBD</param>
+        /// <param name="currentShardAllocations">TBD</param>
+        /// <returns>TBD</returns>
+        public Task<IActorRef> AllocateShard(IActorRef requester, string shardId, IImmutableDictionary<IActorRef, IImmutableList<ShardId>> currentShardAllocations)
+        {
+            var min = currentShardAllocations.OrderBy(i => i.Value.Count).FirstOrDefault();
+            return Task.FromResult(min.Key);
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="currentShardAllocations">TBD</param>
+        /// <param name="rebalanceInProgress">TBD</param>
+        /// <returns>TBD</returns>
+        public Task<IImmutableSet<ShardId>> Rebalance(IImmutableDictionary<IActorRef, IImmutableList<ShardId>> currentShardAllocations, IImmutableSet<ShardId> rebalanceInProgress)
+        {
+            int Limit(int numberOfShards)
+            {
+                return Math.Max(1, Math.Min((int)(_relativeLimit * numberOfShards), _absoluteLimit));
+            }
+
+            IImmutableSet<ShardId> RebalancePhase1(
+                int numberOfShards,
+                int optimalPerRegion,
+                ImmutableList<IImmutableList<ShardId>> sortedAllocations
+                )
+            {
+                var selected = ImmutableList.CreateBuilder<ShardId>();
+
+                foreach (var shards in sortedAllocations)
+                {
+                    if (shards.Count > optimalPerRegion)
+                    {
+                        selected.AddRange(shards.Take(shards.Count - optimalPerRegion));
+                    }
+                }
+                var result = selected.ToImmutable();
+                return result.Take(Limit(numberOfShards)).ToImmutableHashSet();
+            }
+
+            Task<IImmutableSet<ShardId>> RebalancePhase2(
+                int numberOfShards,
+                int optimalPerRegion,
+                ImmutableList<IImmutableList<ShardId>> sortedAllocations)
+            {
+                // In the first phase the optimalPerRegion is rounded up, and depending on number of shards per region and number
+                // of regions that might not be the exact optimal.
+                // In second phase we look for diff of >= 2 below optimalPerRegion and rebalance that number of shards.
+                var countBelowOptimal =
+                  sortedAllocations.Select(shards => Math.Max(0, (optimalPerRegion - 1) - shards.Count)).Sum();
+                if (countBelowOptimal == 0)
+                {
+                    return emptyRebalanceResult;
+                }
+                else
+                {
+                    var selected = ImmutableList.CreateBuilder<ShardId>();
+                    foreach (var shards in sortedAllocations)
+                    {
+                        if (shards.Count >= optimalPerRegion)
+                        {
+                            selected.Add(shards.First());
+                        }
+                    }
+                    var result = selected.ToImmutable().Take(Math.Min(countBelowOptimal, Limit(numberOfShards))).ToImmutableHashSet();
+                    return Task.FromResult<IImmutableSet<ShardId>>(result);
+                }
+            }
+
+            if (rebalanceInProgress.Count > 0)
+            {
+                // one rebalance at a time
+                return emptyRebalanceResult;
+            }
+            else
+            {
+                var numberOfShards = currentShardAllocations.Values.Sum(i => i.Count);
+                var numberOfRegions = currentShardAllocations.Count;
+                if (numberOfRegions == 0 || numberOfShards == 0)
+                {
+                    return emptyRebalanceResult;
+                }
+                else
+                {
+                    var sortedAllocations = currentShardAllocations.Values.OrderBy(i => i.Count).ToImmutableList();//.toVector.sortBy(_.size);
+                    var optimalPerRegion = numberOfShards / numberOfRegions + ((numberOfShards % numberOfRegions == 0) ? 0 : 1);
+
+                    var result1 = RebalancePhase1(numberOfShards, optimalPerRegion, sortedAllocations);
+
+                    if (result1.Count > 0)
+                    {
+                        return Task.FromResult<IImmutableSet<ShardId>>(result1);
+                    }
+                    else
+                    {
+                        return RebalancePhase2(numberOfShards, optimalPerRegion, sortedAllocations);
+                    }
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return $"LeastShardAllocationStrategy({_absoluteLimit},{_relativeLimit})";
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShard.cs
@@ -75,11 +75,11 @@ namespace Akka.Cluster.Sharding
             PersistenceId = "/sharding/" + TypeName + "Shard/" + ShardId;
             JournalPluginId = settings.JournalPluginId;
             SnapshotPluginId = settings.SnapshotPluginId;
-            RememberedEntitiesRecoveryStrategy = Settings.TunningParameters.EntityRecoveryStrategy == "constant"
+            RememberedEntitiesRecoveryStrategy = Settings.TuningParameters.EntityRecoveryStrategy == "constant"
                 ? EntityRecoveryStrategy.ConstantStrategy(
                     Context.System,
-                    Settings.TunningParameters.EntityRecoveryConstantRateStrategyFrequency,
-                    Settings.TunningParameters.EntityRecoveryConstantRateStrategyNumberOfEntities)
+                    Settings.TuningParameters.EntityRecoveryConstantRateStrategyFrequency,
+                    Settings.TuningParameters.EntityRecoveryConstantRateStrategyNumberOfEntities)
                 : EntityRecoveryStrategy.AllStrategy;
 
             var idleInterval = TimeSpan.FromTicks(Settings.PassivateIdleEntityAfter.Ticks / 2);
@@ -113,14 +113,14 @@ namespace Akka.Cluster.Sharding
             {
                 case SaveSnapshotSuccess m:
                     Log.Debug("PersistentShard snapshot saved successfully");
-                    InternalDeleteMessagesBeforeSnapshot(m, Settings.TunningParameters.KeepNrOfBatches, Settings.TunningParameters.SnapshotAfter);
+                    InternalDeleteMessagesBeforeSnapshot(m, Settings.TuningParameters.KeepNrOfBatches, Settings.TuningParameters.SnapshotAfter);
                     break;
                 case SaveSnapshotFailure m:
                     Log.Warning("PersistentShard snapshot failure: [{0}]", m.Cause.Message);
                     break;
                 case DeleteMessagesSuccess m:
                     var deleteTo = m.ToSequenceNr - 1;
-                    var deleteFrom = Math.Max(0, deleteTo - Settings.TunningParameters.KeepNrOfBatches * Settings.TunningParameters.SnapshotAfter);
+                    var deleteFrom = Math.Max(0, deleteTo - Settings.TuningParameters.KeepNrOfBatches * Settings.TuningParameters.SnapshotAfter);
                     Log.Debug("PersistentShard messages to [{0}] deleted successfully. Deleting snapshots from [{1}] to [{2}]", m.ToSequenceNr, deleteFrom, deleteTo);
                     DeleteSnapshots(new SnapshotSelectionCriteria(deleteTo, DateTime.MaxValue, deleteFrom));
                     break;
@@ -177,7 +177,7 @@ namespace Akka.Cluster.Sharding
 
         public void SaveSnapshotWhenNeeded()
         {
-            if (LastSequenceNr % Settings.TunningParameters.SnapshotAfter == 0 && LastSequenceNr != 0)
+            if (LastSequenceNr % Settings.TuningParameters.SnapshotAfter == 0 && LastSequenceNr != 0)
             {
                 Log.Debug("Saving snapshot, sequence number [{0}]", SnapshotSequenceNr);
                 SaveSnapshot(State);
@@ -212,7 +212,7 @@ namespace Akka.Cluster.Sharding
                 if (!Passivating.Contains(tref))
                 {
                     Log.Debug("Entity [{0}] stopped without passivating, will restart after backoff", id);
-                    Context.System.Scheduler.ScheduleTellOnce(Settings.TunningParameters.EntityRestartBackoff, Self, new Shard.RestartEntity(id), ActorRefs.NoSender);
+                    Context.System.Scheduler.ScheduleTellOnce(Settings.TuningParameters.EntityRestartBackoff, Self, new Shard.RestartEntity(id), ActorRefs.NoSender);
                 }
                 else
                     ProcessChange(new Shard.EntityStopped(id), this.PassivateCompleted);

--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
@@ -1258,6 +1258,7 @@ namespace Akka.Cluster.Sharding
         public ILoggingAdapter Log { get; }
         public ImmutableDictionary<string, ICancelable> UnAckedHostShards { get; set; } = ImmutableDictionary<string, ICancelable>.Empty;
         public ImmutableDictionary<string, ImmutableHashSet<IActorRef>> RebalanceInProgress { get; set; } = ImmutableDictionary<string, ImmutableHashSet<IActorRef>>.Empty;
+        public ImmutableHashSet<IActorRef> RebalanceWorkers { get; set; } = ImmutableHashSet<IActorRef>.Empty;
         // regions that have requested handoff, for graceful shutdown
         public ImmutableHashSet<IActorRef> GracefullShutdownInProgress { get; set; } = ImmutableHashSet<IActorRef>.Empty;
         public ImmutableHashSet<IActorRef> AliveRegions { get; set; } = ImmutableHashSet<IActorRef>.Empty;

--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
@@ -1270,6 +1270,7 @@ namespace Akka.Cluster.Sharding
         IActorRef IShardCoordinator.Self => Self;
         IActorRef IShardCoordinator.Sender => Sender;
         IActorContext IShardCoordinator.Context => Context;
+        IActorRef IShardCoordinator.IgnoreRef => Context.System.IgnoreRef;
 
         /// <summary>
         /// TBD

--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
@@ -1310,6 +1310,19 @@ namespace Akka.Cluster.Sharding
         /// </summary>
         public override String PersistenceId { get; }
 
+        protected override void PreStart()
+        {
+            switch (AllocationStrategy)
+            {
+                case IStartableAllocationStrategy strategy:
+                    strategy.Start();
+                    break;
+                case IActorSystemDependentAllocationStrategy strategy:
+                    strategy.Start(Context.System);
+                    break;
+            }
+        }
+
         protected override void PostStop()
         {
             base.PostStop();

--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
@@ -1297,7 +1297,7 @@ namespace Akka.Cluster.Sharding
             JournalPluginId = Settings.JournalPluginId;
             SnapshotPluginId = Settings.SnapshotPluginId;
 
-            RebalanceTask = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(Settings.TunningParameters.RebalanceInterval, Settings.TunningParameters.RebalanceInterval, Self, RebalanceTick.Instance, Self);
+            RebalanceTask = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(Settings.TuningParameters.RebalanceInterval, Settings.TuningParameters.RebalanceInterval, Self, RebalanceTick.Instance, Self);
 
             Cluster.Subscribe(Self, ClusterEvent.SubscriptionInitialStateMode.InitialStateAsEvents, new[] { typeof(ClusterEvent.ClusterShuttingDown) });
         }
@@ -1420,7 +1420,7 @@ namespace Akka.Cluster.Sharding
             {
                 case SaveSnapshotSuccess m:
                     Log.Debug("Persistent snapshot saved successfully");
-                    InternalDeleteMessagesBeforeSnapshot(m, Settings.TunningParameters.KeepNrOfBatches, Settings.TunningParameters.SnapshotAfter);
+                    InternalDeleteMessagesBeforeSnapshot(m, Settings.TuningParameters.KeepNrOfBatches, Settings.TuningParameters.SnapshotAfter);
                     break;
 
                 case SaveSnapshotFailure m:
@@ -1463,7 +1463,7 @@ namespace Akka.Cluster.Sharding
 
         private void SaveSnapshotWhenNeeded()
         {
-            if (LastSequenceNr % Settings.TunningParameters.SnapshotAfter == 0 && LastSequenceNr != 0)
+            if (LastSequenceNr % Settings.TuningParameters.SnapshotAfter == 0 && LastSequenceNr != 0)
             {
                 Log.Debug("Saving snapshot, sequence number [{0}]", SnapshotSequenceNr);
                 SaveSnapshot(CurrentState);

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
@@ -446,11 +446,11 @@ namespace Akka.Cluster.Sharding
             ExtractEntityId = extractEntityId;
             ExtractShardId = extractShardId;
             HandOffStopMessage = handOffStopMessage;
-            RememberedEntitiesRecoveryStrategy = Settings.TunningParameters.EntityRecoveryStrategy == "constant"
+            RememberedEntitiesRecoveryStrategy = Settings.TuningParameters.EntityRecoveryStrategy == "constant"
                 ? EntityRecoveryStrategy.ConstantStrategy(
                     Context.System,
-                    Settings.TunningParameters.EntityRecoveryConstantRateStrategyFrequency,
-                    Settings.TunningParameters.EntityRecoveryConstantRateStrategyNumberOfEntities)
+                    Settings.TuningParameters.EntityRecoveryConstantRateStrategyFrequency,
+                    Settings.TuningParameters.EntityRecoveryConstantRateStrategyNumberOfEntities)
                 : EntityRecoveryStrategy.AllStrategy;
 
             var idleInterval = TimeSpan.FromTicks(Settings.PassivateIdleEntityAfter.Ticks / 2);
@@ -766,7 +766,7 @@ namespace Akka.Cluster.Sharding
 
                 if (!shard.IdByRef.IsEmpty)
                 {
-                    var entityHandOffTimeout = (shard.Settings.TunningParameters.HandOffTimeout - TimeSpan.FromSeconds(5));
+                    var entityHandOffTimeout = (shard.Settings.TuningParameters.HandOffTimeout - TimeSpan.FromSeconds(5));
                     if (entityHandOffTimeout < TimeSpan.FromSeconds(1))
                         entityHandOffTimeout = TimeSpan.FromSeconds(1);
                     shard.Log.Debug("Starting HandOffStopper for shard [{0}] to terminate [{1}] entities.",
@@ -896,7 +896,7 @@ namespace Akka.Cluster.Sharding
                 {
                     if (shard.MessageBuffers.TryGetValue(id, out var buffer))
                     {
-                        if (shard.TotalBufferSize() >= shard.Settings.TunningParameters.BufferSize)
+                        if (shard.TotalBufferSize() >= shard.Settings.TuningParameters.BufferSize)
                         {
                             shard.Log.Warning("Buffer is full, dropping message for entity [{0}]", id);
                             shard.Context.System.DeadLetters.Tell(message);
@@ -1035,7 +1035,7 @@ namespace Akka.Cluster.Sharding
 
             SendStart(ids);
 
-            var resendInterval = settings.TunningParameters.RetryInterval;
+            var resendInterval = settings.TuningParameters.RetryInterval;
             _tickTask = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(resendInterval, resendInterval, Self, Tick.Instance, ActorRefs.NoSender);
         }
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
@@ -772,7 +772,7 @@ namespace Akka.Cluster.Sharding
                     shard.Log.Debug("Starting HandOffStopper for shard [{0}] to terminate [{1}] entities.",
                         shard.ShardId, shard.IdByRef.Keys.Count());
                     shard.HandOffStopper = shard.Context.Watch(shard.Context.ActorOf(
-                        ShardRegion.HandOffStopper.Props(shard.ShardId, replyTo, shard.IdByRef.Keys, shard.HandOffStopMessage, entityHandOffTimeout)));
+                        ShardRegion.HandOffStopper.Props(shard.TypeName, shard.ShardId, replyTo, shard.IdByRef.Keys, shard.HandOffStopMessage, entityHandOffTimeout)));
 
                     //During hand off we only care about watching for termination of the hand off stopper
                     shard.Context.Become(message =>

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardCoordinator.cs
@@ -134,7 +134,7 @@ namespace Akka.Cluster.Sharding
         {
             region.Tell(new PersistentShardCoordinator.HostShard(shard));
             var cancel = coordinator.Context.System.Scheduler.ScheduleTellOnceCancelable(
-                coordinator.Settings.TunningParameters.ShardStartTimeout,
+                coordinator.Settings.TuningParameters.ShardStartTimeout,
                 coordinator.Self,
                 new ResendShardHost(shard, region),
                 coordinator.Self);
@@ -235,7 +235,7 @@ namespace Akka.Cluster.Sharding
             if (ok)
                 coordinator.Log.Debug("Rebalance shard [{0}] completed successfully", shard);
             else
-                coordinator.Log.Warning("Rebalance shard [{0}] didn't complete within [{1}]", shard, coordinator.Settings.TunningParameters.HandOffTimeout);
+                coordinator.Log.Warning("Rebalance shard [{0}] didn't complete within [{1}]", shard, coordinator.Settings.TuningParameters.HandOffTimeout);
 
             // The shard could have been removed by ShardRegionTerminated
             if (coordinator.CurrentState.Shards.TryGetValue(shard, out var region))
@@ -483,7 +483,7 @@ namespace Akka.Cluster.Sharding
                         coordinator.Log.Debug("Rebalance shard [{0}] from [{1}]", shard, rebalanceFromRegion);
 
                         var regions = coordinator.CurrentState.Regions.Keys.Union(coordinator.CurrentState.RegionProxies);
-                        coordinator.Context.ActorOf(RebalanceWorker.Props(shard, rebalanceFromRegion, coordinator.Settings.TunningParameters.HandOffTimeout, regions)
+                        coordinator.Context.ActorOf(RebalanceWorker.Props(shard, rebalanceFromRegion, coordinator.Settings.TuningParameters.HandOffTimeout, regions)
                             .WithDispatcher(coordinator.Context.Props.Dispatcher));
                     }
                     else

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
@@ -378,7 +378,7 @@ namespace Akka.Cluster.Sharding
             _replicator = replicator;
             _majorityMinCap = majorityMinCap;
 
-            _retryTask = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(Settings.TunningParameters.RetryInterval, Settings.TunningParameters.RetryInterval, Self, Retry.Instance, Self);
+            _retryTask = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(Settings.TuningParameters.RetryInterval, Settings.TuningParameters.RetryInterval, Self, Retry.Instance, Self);
             SetupCoordinatedShutdown();
         }
 
@@ -681,7 +681,7 @@ namespace Akka.Cluster.Sharding
         private void BufferMessage(ShardId shardId, Msg message, IActorRef sender)
         {
             var totalBufferSize = TotalBufferSize;
-            if (totalBufferSize >= Settings.TunningParameters.BufferSize)
+            if (totalBufferSize >= Settings.TuningParameters.BufferSize)
             {
                 if (_loggedFullBufferWarning)
                     Log.Debug("{0}: Buffer is full, dropping message for shard [{1}]", TypeName, shardId);
@@ -701,7 +701,7 @@ namespace Akka.Cluster.Sharding
 
                 // log some insight to how buffers are filled up every 10% of the buffer capacity
                 var total = totalBufferSize + 1;
-                var bufferSize = Settings.TunningParameters.BufferSize;
+                var bufferSize = Settings.TuningParameters.BufferSize;
                 if (total % (bufferSize / 10) == 0)
                 {
                     const string logMsg = "{0}: ShardRegion is using [{1} %] of its buffer capacity.";
@@ -1090,7 +1090,7 @@ namespace Akka.Cluster.Sharding
                     // if persist fails it will stop
                     Log.Debug("{0}: Shard [{1}] terminated while not being handed off", TypeName, shard);
                     if (Settings.RememberEntities)
-                        Context.System.Scheduler.ScheduleTellOnce(Settings.TunningParameters.ShardFailureBackoff, Self, new RestartShard(shard), Self);
+                        Context.System.Scheduler.ScheduleTellOnce(Settings.TuningParameters.ShardFailureBackoff, Self, new RestartShard(shard), Self);
                 }
 
                 TryCompleteGracefulShutdown();

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardedDaemonProcess.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardedDaemonProcess.cs
@@ -154,7 +154,7 @@ namespace Akka.Cluster.Sharding
                 "",
                 TimeSpan.Zero, // passivation disabled
                 StateStoreMode.DData,
-                shardingBaseSettings.TunningParameters,
+                shardingBaseSettings.TuningParameters,
                 shardingBaseSettings.CoordinatorSingletonSettings);
 
             if (string.IsNullOrEmpty(shardingSettings.Role) || Cluster.Get(_system).SelfRoles.Contains(shardingSettings.Role))

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardingMessages.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardingMessages.cs
@@ -85,6 +85,20 @@ namespace Akka.Cluster.Sharding
         }
     }
 
+    [Serializable]
+    internal sealed class GracefulShutdownTimeout : IShardRegionCommand
+    {
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public static readonly GracefulShutdownTimeout Instance = new GracefulShutdownTimeout();
+
+        private GracefulShutdownTimeout()
+        {
+        }
+    }
+
+
     /// <summary>
     /// We must be sure that a shard is initialized before to start send messages to it.
     /// Shard could be terminated during initialization.

--- a/src/contrib/cluster/Akka.Cluster.Sharding/reference.conf
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/reference.conf
@@ -90,8 +90,28 @@ akka.cluster.sharding {
   # Default value of 2 leaves last maximum 2*`snapshot-after` messages and 3 snapshots (2 old ones + fresh snapshot)
   keep-nr-of-batches = 2
 
-  # Setting for the default shard allocation strategy
+  # Settings for LeastShardAllocationStrategy.
+  #
+  # A new rebalance algorithm was included in Akka.Net 1.4.11. It can reach optimal balance in
+  # less rebalance rounds (typically 1 or 2 rounds). The amount of shards to rebalance in each
+  # round can still be limited to make it progress slower. For backwards compatibility
+  # the new algorithm is not enabled by default. Enable the new algorithm by setting
+  # `rebalance-absolute-limit` > 0, for example:
+  # akka.cluster.sharding.least-shard-allocation-strategy.rebalance-absolute-limit=20
+  # The new algorithm is recommended and will become the default in future versions of Akka.
   least-shard-allocation-strategy {
+    # Maximum number of shards that will be rebalanced in one rebalance round.
+    # The lower of this and `rebalance-relative-limit` will be used.
+    rebalance-absolute-limit = 0
+
+    # Maximum number of shards that will be rebalanced in one rebalance round.
+    # Fraction of total number of (known) shards.
+    # The lower of this and `rebalance-absolute-limit` will be used.
+    rebalance-relative-limit = 0.1
+
+    # Deprecated: Use rebalance-absolute-limit and rebalance-relative-limit instead. This property is not used
+    # when rebalance-absolute-limit > 0.
+    #
     # Threshold of how large the difference between most and least number of
     # allocated shards must be to begin the rebalancing.
     # The difference between number of shards in the region with most shards and
@@ -104,6 +124,9 @@ akka.cluster.sharding {
     # on different nodes before rebalance will occur.
     rebalance-threshold = 1
 
+    # Deprecated: Use rebalance-absolute-limit and rebalance-relative-limit instead. This property is not used
+    # when rebalance-absolute-limit > 0.
+    #
     # The number of ongoing rebalancing processes is limited to this number.
     max-simultaneous-rebalance = 3
   }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveClusterSharding.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveClusterSharding.approved.txt
@@ -169,7 +169,7 @@ namespace Akka.Cluster.Sharding
         public override int GetHashCode() { }
         public override string ToString() { }
     }
-    public class ShardRegion : Akka.Actor.ActorBase
+    public class ShardRegion : Akka.Actor.ActorBase, Akka.Actor.IWithTimers
     {
         public readonly Akka.Cluster.Cluster Cluster;
         public readonly string CoordinatorPath;
@@ -191,6 +191,7 @@ namespace Akka.Cluster.Sharding
         public bool GracefulShutdownInProgress { get; }
         public Akka.Event.ILoggingAdapter Log { get; }
         protected object RegistrationMessage { get; }
+        public Akka.Actor.ITimerScheduler Timers { get; set; }
         public int TotalBufferSize { get; }
         protected bool MatchingRole(Akka.Cluster.Member member) { }
         protected override void PostStop() { }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveClusterSharding.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveClusterSharding.approved.txt
@@ -51,9 +51,11 @@ namespace Akka.Cluster.Sharding
         public readonly string Role;
         public readonly string SnapshotPluginId;
         public readonly Akka.Cluster.Sharding.StateStoreMode StateStoreMode;
-        public readonly Akka.Cluster.Sharding.TunningParameters TunningParameters;
-        public ClusterShardingSettings(string role, bool rememberEntities, string journalPluginId, string snapshotPluginId, System.TimeSpan passivateIdleEntityAfter, Akka.Cluster.Sharding.StateStoreMode stateStoreMode, Akka.Cluster.Sharding.TunningParameters tunningParameters, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings coordinatorSingletonSettings) { }
-        public ClusterShardingSettings(string role, bool rememberEntities, string journalPluginId, string snapshotPluginId, System.TimeSpan passivateIdleEntityAfter, Akka.Cluster.Sharding.StateStoreMode stateStoreMode, Akka.Cluster.Sharding.TunningParameters tunningParameters, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings coordinatorSingletonSettings, Akka.Coordination.LeaseUsageSettings leaseSettings) { }
+        public const string StateStoreModeDData = "DData";
+        public const string StateStoreModePersistence = "Persistence";
+        public readonly Akka.Cluster.Sharding.TuningParameters TuningParameters;
+        public ClusterShardingSettings(string role, bool rememberEntities, string journalPluginId, string snapshotPluginId, System.TimeSpan passivateIdleEntityAfter, Akka.Cluster.Sharding.StateStoreMode stateStoreMode, Akka.Cluster.Sharding.TuningParameters tuningParameters, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings coordinatorSingletonSettings) { }
+        public ClusterShardingSettings(string role, bool rememberEntities, string journalPluginId, string snapshotPluginId, System.TimeSpan passivateIdleEntityAfter, Akka.Cluster.Sharding.StateStoreMode stateStoreMode, Akka.Cluster.Sharding.TuningParameters tuningParameters, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings coordinatorSingletonSettings, Akka.Coordination.LeaseUsageSettings leaseSettings) { }
         public static Akka.Cluster.Sharding.ClusterShardingSettings Create(Akka.Actor.ActorSystem system) { }
         public static Akka.Cluster.Sharding.ClusterShardingSettings Create(Akka.Configuration.Config config, Akka.Configuration.Config singletonConfig) { }
         public Akka.Cluster.Sharding.ClusterShardingSettings WithCoordinatorSingletonSettings(Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings coordinatorSingletonSettings) { }
@@ -64,7 +66,7 @@ namespace Akka.Cluster.Sharding
         public Akka.Cluster.Sharding.ClusterShardingSettings WithRole(string role) { }
         public Akka.Cluster.Sharding.ClusterShardingSettings WithSnapshotPluginId(string snapshotPluginId) { }
         public Akka.Cluster.Sharding.ClusterShardingSettings WithStateStoreMode(Akka.Cluster.Sharding.StateStoreMode mode) { }
-        public Akka.Cluster.Sharding.ClusterShardingSettings WithTuningParameters(Akka.Cluster.Sharding.TunningParameters tunningParameters) { }
+        public Akka.Cluster.Sharding.ClusterShardingSettings WithTuningParameters(Akka.Cluster.Sharding.TuningParameters tuningParameters) { }
     }
     public sealed class ClusterShardingStats : Akka.Cluster.Sharding.IClusterShardingSerializable, System.IEquatable<Akka.Cluster.Sharding.ClusterShardingStats>
     {
@@ -122,6 +124,10 @@ namespace Akka.Cluster.Sharding
         public virtual object EntityMessage(object message) { }
         public virtual string ShardId(object message) { }
     }
+    public interface IActorSystemDependentAllocationStrategy : Akka.Actor.INoSerializationVerificationNeeded, Akka.Cluster.Sharding.IShardAllocationStrategy
+    {
+        void Start(Akka.Actor.ActorSystem system);
+    }
     public interface IClusterShardingSerializable { }
     public interface IMessageExtractor
     {
@@ -136,16 +142,23 @@ namespace Akka.Cluster.Sharding
     }
     public interface IShardRegionCommand { }
     public interface IShardRegionQuery { }
-    public class LeastShardAllocationStrategy : Akka.Actor.INoSerializationVerificationNeeded, Akka.Cluster.Sharding.IShardAllocationStrategy
+    public interface IStartableAllocationStrategy : Akka.Actor.INoSerializationVerificationNeeded, Akka.Cluster.Sharding.IShardAllocationStrategy
+    {
+        void Start();
+    }
+    public class LeastShardAllocationStrategy : Akka.Cluster.Sharding.Internal.AbstractLeastShardAllocationStrategy
     {
         public LeastShardAllocationStrategy(int rebalanceThreshold, int maxSimultaneousRebalance) { }
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> AllocateShard(Akka.Actor.IActorRef requester, string shardId, System.Collections.Immutable.IImmutableDictionary<Akka.Actor.IActorRef, System.Collections.Immutable.IImmutableList<string>> currentShardAllocations) { }
-        public System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableSet<string>> Rebalance(System.Collections.Immutable.IImmutableDictionary<Akka.Actor.IActorRef, System.Collections.Immutable.IImmutableList<string>> currentShardAllocations, System.Collections.Immutable.IImmutableSet<string> rebalanceInProgress) { }
+        public override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableSet<string>> Rebalance(System.Collections.Immutable.IImmutableDictionary<Akka.Actor.IActorRef, System.Collections.Immutable.IImmutableList<string>> currentShardAllocations, System.Collections.Immutable.IImmutableSet<string> rebalanceInProgress) { }
     }
     public sealed class Passivate : Akka.Cluster.Sharding.IShardRegionCommand
     {
         public Passivate(object stopMessage) { }
         public object StopMessage { get; }
+    }
+    public class static ShardAllocationStrategy
+    {
+        public static Akka.Cluster.Sharding.IShardAllocationStrategy LeastShardAllocationStrategy(int absoluteLimit, double relativeLimit) { }
     }
     public sealed class ShardInitialized : System.IEquatable<Akka.Cluster.Sharding.ShardInitialized>
     {
@@ -249,7 +262,7 @@ namespace Akka.Cluster.Sharding
         Persistence = 0,
         DData = 1,
     }
-    public class TunningParameters
+    public class TuningParameters
     {
         public readonly int BufferSize;
         public readonly System.TimeSpan CoordinatorFailureBackoff;
@@ -259,8 +272,10 @@ namespace Akka.Cluster.Sharding
         public readonly System.TimeSpan EntityRestartBackoff;
         public readonly System.TimeSpan HandOffTimeout;
         public readonly int KeepNrOfBatches;
+        public readonly int LeastShardAllocationAbsoluteLimit;
         public readonly int LeastShardAllocationMaxSimultaneousRebalance;
         public readonly int LeastShardAllocationRebalanceThreshold;
+        public readonly double LeastShardAllocationRelativeLimit;
         public readonly System.TimeSpan RebalanceInterval;
         public readonly System.TimeSpan RetryInterval;
         public readonly System.TimeSpan ShardFailureBackoff;
@@ -268,7 +283,7 @@ namespace Akka.Cluster.Sharding
         public readonly int SnapshotAfter;
         public readonly System.TimeSpan UpdatingStateTimeout;
         public readonly System.TimeSpan WaitingForStateTimeout;
-        public TunningParameters(
+        public TuningParameters(
                     System.TimeSpan coordinatorFailureBackoff, 
                     System.TimeSpan retryInterval, 
                     int bufferSize, 
@@ -285,7 +300,34 @@ namespace Akka.Cluster.Sharding
                     System.TimeSpan updatingStateTimeout, 
                     string entityRecoveryStrategy, 
                     System.TimeSpan entityRecoveryConstantRateStrategyFrequency, 
-                    int entityRecoveryConstantRateStrategyNumberOfEntities) { }
+                    int entityRecoveryConstantRateStrategyNumberOfEntities, 
+                    int leastShardAllocationAbsoluteLimit, 
+                    double leastShardAllocationRelativeLimit) { }
+    }
+}
+namespace Akka.Cluster.Sharding.Internal
+{
+    public abstract class AbstractLeastShardAllocationStrategy : Akka.Actor.INoSerializationVerificationNeeded, Akka.Cluster.Sharding.IActorSystemDependentAllocationStrategy, Akka.Cluster.Sharding.IShardAllocationStrategy
+    {
+        protected AbstractLeastShardAllocationStrategy() { }
+        protected virtual Akka.Cluster.ClusterEvent.CurrentClusterState ClusterState { get; }
+        protected virtual Akka.Cluster.Member SelfMember { get; }
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> AllocateShard(Akka.Actor.IActorRef requester, string shardId, System.Collections.Immutable.IImmutableDictionary<Akka.Actor.IActorRef, System.Collections.Immutable.IImmutableList<string>> currentShardAllocations) { }
+        protected bool IsAGoodTimeToRebalance(System.Collections.Generic.IEnumerable<Akka.Cluster.Sharding.Internal.AbstractLeastShardAllocationStrategy.RegionEntry> regionEntries) { }
+        [return: System.Runtime.CompilerServices.TupleElementNamesAttribute(new string[] {
+                "Region",
+                "Shards"})]
+        protected System.ValueTuple<Akka.Actor.IActorRef, System.Collections.Immutable.IImmutableList<string>> MostSuitableRegion(System.Collections.Generic.IEnumerable<Akka.Cluster.Sharding.Internal.AbstractLeastShardAllocationStrategy.RegionEntry> regionEntries) { }
+        public abstract System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableSet<string>> Rebalance(System.Collections.Immutable.IImmutableDictionary<Akka.Actor.IActorRef, System.Collections.Immutable.IImmutableList<string>> currentShardAllocations, System.Collections.Immutable.IImmutableSet<string> rebalanceInProgress);
+        protected System.Collections.Immutable.ImmutableList<Akka.Cluster.Sharding.Internal.AbstractLeastShardAllocationStrategy.RegionEntry> RegionEntriesFor(System.Collections.Immutable.IImmutableDictionary<Akka.Actor.IActorRef, System.Collections.Immutable.IImmutableList<string>> currentShardAllocations) { }
+        public void Start(Akka.Actor.ActorSystem system) { }
+        public sealed class RegionEntry
+        {
+            public RegionEntry(Akka.Actor.IActorRef region, Akka.Cluster.Member member, System.Collections.Immutable.IImmutableList<string> shardIds) { }
+            public Akka.Cluster.Member Member { get; }
+            public Akka.Actor.IActorRef Region { get; }
+            public System.Collections.Immutable.IImmutableList<string> ShardIds { get; }
+        }
     }
 }
 namespace Akka.Cluster.Sharding.Serialization

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -340,6 +340,7 @@ namespace Akka.Actor
         public abstract Akka.Actor.IActorRef DeadLetters { get; }
         public abstract Akka.Dispatch.Dispatchers Dispatchers { get; }
         public abstract Akka.Event.EventStream EventStream { get; }
+        public abstract Akka.Actor.IActorRef IgnoreRef { get; }
         public abstract Akka.Event.ILoggingAdapter Log { get; }
         public abstract Akka.Dispatch.Mailboxes Mailboxes { get; }
         public abstract string Name { get; }
@@ -938,6 +939,7 @@ namespace Akka.Actor
         Akka.Actor.Address DefaultAddress { get; }
         Akka.Actor.Deployer Deployer { get; }
         Akka.Actor.LocalActorRef Guardian { get; }
+        Akka.Actor.IActorRef IgnoreRef { get; }
         Akka.Actor.IInternalActorRef RootGuardian { get; }
         Akka.Actor.ActorPath RootPath { get; }
         [Akka.Annotations.InternalApiAttribute()]
@@ -1233,6 +1235,7 @@ namespace Akka.Actor
         public Akka.Actor.Deployer Deployer { get; }
         public Akka.Event.EventStream EventStream { get; }
         public Akka.Actor.LocalActorRef Guardian { get; }
+        public Akka.Actor.IActorRef IgnoreRef { get; }
         public Akka.Event.ILoggingAdapter Log { get; }
         public Akka.Actor.IInternalActorRef RootGuardian { get; }
         public Akka.Actor.ActorPath RootPath { get; }
@@ -1849,6 +1852,7 @@ namespace Akka.Actor.Internal
         public override Akka.Event.EventStream EventStream { get; }
         public override Akka.Actor.IInternalActorRef Guardian { get; }
         public Akka.Util.Option<Akka.Actor.Props> GuardianProps { get; }
+        public override Akka.Actor.IActorRef IgnoreRef { get; }
         public override Akka.Event.ILoggingAdapter Log { get; }
         public override Akka.Actor.IInternalActorRef LookupRoot { get; }
         public override Akka.Dispatch.Mailboxes Mailboxes { get; }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveRemote.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveRemote.approved.txt
@@ -186,6 +186,7 @@ namespace Akka.Remote
         public Akka.Actor.Address DefaultAddress { get; }
         public Akka.Actor.Deployer Deployer { get; set; }
         public Akka.Actor.LocalActorRef Guardian { get; }
+        public Akka.Actor.IActorRef IgnoreRef { get; }
         public Akka.Actor.IInternalActorRef RemoteDaemon { get; }
         public Akka.Remote.RemoteSettings RemoteSettings { get; }
         public Akka.Actor.IActorRef RemoteWatcher { get; }

--- a/src/core/Akka.Cluster.Tests/ActorRefIgnoreSerializationSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ActorRefIgnoreSerializationSpec.cs
@@ -1,0 +1,85 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ClusterSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.TestKit;
+using Akka.Util.Internal;
+using Xunit;
+using FluentAssertions;
+using Xunit.Abstractions;
+using Akka.Util;
+
+namespace Akka.Cluster.Tests
+{
+    public class ActorRefIgnoreSerializationSpec : AkkaSpec
+    {
+        const string Config = @"
+            akka {
+                loglevel = debug
+                actor.provider = cluster
+            }
+            akka.remote.log-remote-lifecycle-events = off
+            akka.remote.dot-netty.tcp.port = 0";
+
+        private ActorSystem system1;
+        private ActorSystem system2;
+
+
+        public ActorRefIgnoreSerializationSpec(ITestOutputHelper output)
+            : base(Config, output)
+        {
+            system1 = ActorSystem.Create("sys1", Config);
+            system2 = ActorSystem.Create("sys2", Config);
+        }
+
+
+        protected override void AfterAll()
+        {
+            base.AfterAll();
+            system1.Terminate();
+            system2.Terminate();
+        }
+
+        [Fact]
+        public void ActorSystem_IgnoreRef_should_return_a_serializable_ActorRef_that_can_be_sent_between_two_ActorSystems_using_remote()
+        {
+            var ignoreRef = system1.IgnoreRef;
+            var remoteRefStr = ignoreRef.Path.ToSerializationFormatWithAddress(system1.AsInstanceOf<ExtendedActorSystem>().Provider.DefaultAddress);
+
+            remoteRefStr.Should().Be(IgnoreActorRef.StaticPath.ToString(), "check ActorRef path stays untouched, ie: /local/ignore");
+
+            var providerSys2 = system2.AsInstanceOf<ExtendedActorSystem>().Provider;
+            var deserRef = providerSys2.ResolveActorRef(remoteRefStr);
+            deserRef.Path.Should().Be(IgnoreActorRef.StaticPath, "check ActorRef path stays untouched when deserialized by another actor system");
+            deserRef.Should().BeSameAs(system2.IgnoreRef, "check ActorRef path stays untouched when deserialized by another actor system");
+
+            var surrogate = ignoreRef.ToSurrogate(system1);
+            var fromSurrogate1 = surrogate.FromSurrogate(system1);
+            fromSurrogate1.Should().BeOfType<IgnoreActorRef>();
+            ((IgnoreActorRef)fromSurrogate1).Path.Should().Be(system1.IgnoreRef.Path);
+        }
+
+        [Fact]
+        public void ActorSystem_IgnoreRef_should_return_same_instance_when_deserializing_it_twice_IgnoreActorRef_is_cached()
+        {
+            var ignoreRef = system1.IgnoreRef;
+            var remoteRefStr = ignoreRef.Path.ToSerializationFormat();
+            var providerSys1 = system1.AsInstanceOf<ExtendedActorSystem>().Provider;
+
+            var deserRef1 = providerSys1.ResolveActorRef(remoteRefStr);
+            var deserRef2 = providerSys1.ResolveActorRef(remoteRefStr);
+            deserRef1.Should().BeSameAs(deserRef2);
+        }
+    }
+}
+

--- a/src/core/Akka.Cluster/ClusterEvent.cs
+++ b/src/core/Akka.Cluster/ClusterEvent.cs
@@ -185,6 +185,9 @@ namespace Akka.Cluster
                 }
             }
 
+            internal bool IsMemberUp(Address address) =>
+                Members.Any(m => m.Address.Equals(address) && m.Status == MemberStatus.Up);
+
             /// <summary>
             /// Creates a deep copy of the <see cref="CurrentClusterState"/> and optionally allows you
             /// to specify different values for the outgoing objects

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -66,7 +66,7 @@ namespace Akka.Remote
 
         /// <summary>
         /// INTERNAL API.
-        /// 
+        ///
         /// Called in deserialization of incoming remote messages where the correct local address is known.
         /// </summary>
         /// <param name="path">TBD</param>
@@ -182,6 +182,8 @@ namespace Akka.Remote
 
         /// <inheritdoc/>
         public IActorRef DeadLetters { get { return _local.DeadLetters; } }
+
+        public IActorRef IgnoreRef => _local.IgnoreRef;
 
         /// <inheritdoc/>
         public Deployer Deployer { get; protected set; }
@@ -474,7 +476,7 @@ namespace Akka.Remote
 
         /// <summary>
         /// INTERNAL API.
-        /// 
+        ///
         /// Called in deserialization of incoming remote messages where the correct local address is known.
         /// </summary>
         /// <param name="path">TBD</param>
@@ -499,7 +501,7 @@ namespace Akka.Remote
             return InternalDeadLetters;
         }
 
-        
+
         /// <summary>
         /// Used to create <see cref="RemoteActorRef"/> instances upon deserialiation inside the Akka.Remote pipeline.
         /// </summary>
@@ -518,6 +520,9 @@ namespace Akka.Remote
         /// <returns>A local <see cref="IActorRef"/> if it exists, <see cref="ActorRefs.Nobody"/> otherwise.</returns>
         public IActorRef ResolveActorRef(string path)
         {
+            if (IgnoreActorRef.IsIgnoreRefPath(path))
+                return IgnoreRef;
+
             // using thread local LRU cache, which will call InternalResolveActorRef
             // if the value is not cached
             if (_actorRefResolveThreadLocalCache == null)

--- a/src/core/Akka.Tests/Actor/ActorRefIgnoreSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorRefIgnoreSpec.cs
@@ -1,0 +1,132 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ActorRefIgnoreSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using Akka.Actor;
+using Akka.Actor.Internal;
+using Akka.Serialization;
+using Akka.TestKit;
+using Akka.TestKit.TestActors;
+using Xunit;
+using Akka.Util.Internal;
+using FluentAssertions;
+
+namespace Akka.Tests.Actor
+{
+    public class ActorRefIgnoreSpec : AkkaSpec, INoImplicitSender
+    {
+        [Fact]
+        public void IgnoreActorRef_should_ignore_all_incoming_messages()
+        {
+            var askMeRef = Sys.ActorOf(Props.Create(() => new AskMeActor()));
+
+            var probe = CreateTestProbe("response-probe");
+            askMeRef.Tell(new Request(probe.Ref));
+            probe.ExpectMsg(1);
+
+            // this is more a compile-time proof
+            // since the reply is ignored, we can't check that a message was sent to it
+            askMeRef.Tell(new Request(Sys.IgnoreRef));
+
+            probe.ExpectNoMsg();
+
+            // but we do check that the counter has increased when we used the ActorRef.ignore
+            askMeRef.Tell(new Request(probe.Ref));
+            probe.ExpectMsg(3);
+        }
+
+        [Fact]
+        public void IgnoreActorRef_should_make_a_Future_timeout_when_used_in_a_ask()
+        {
+            // this is kind of obvious, the Future won't complete because the ignoreRef is used
+
+            var timeout = TimeSpan.FromMilliseconds(500);
+            var askMeRef = Sys.ActorOf(Props.Create(() => new AskMeActor()));
+
+            Assert.Throws<AskTimeoutException>(() =>
+            {
+                _ = askMeRef.Ask(new Request(Sys.IgnoreRef), timeout).GetAwaiter().GetResult();
+            });
+        }
+
+        [Fact]
+        public void IgnoreActorRef_should_be_watchable_from_another_actor_without_throwing_an_exception()
+        {
+            var probe = CreateTestProbe("probe-response");
+            var forwardMessageRef = Sys.ActorOf(Props.Create(() => new ForwardMessageWatchActor(probe)));
+
+            // this proves that the actor started and is operational and 'watch' didn't impact it
+            forwardMessageRef.Tell("abc");
+            probe.ExpectMsg("abc");
+        }
+
+        [Fact]
+        public void IgnoreActorRef_should_be_a_singleton()
+        {
+            Sys.IgnoreRef.Should().BeSameAs(Sys.IgnoreRef);
+        }
+
+        /// <summary>
+        /// this Actor behavior receives simple request and answers back total number of
+        /// messages it received so far
+        /// </summary>
+        internal class AskMeActor : ActorBase
+        {
+            private int counter;
+
+            public AskMeActor()
+            {
+            }
+
+            protected override bool Receive(object message)
+            {
+                switch (message)
+                {
+                    case Request r:
+                        counter++;
+                        r.ReplyTo.Tell(counter);
+                        return true;
+                }
+                return false;
+            }
+        }
+
+        internal class Request
+        {
+            public Request(IActorRef replyTo)
+            {
+                ReplyTo = replyTo;
+            }
+
+            public IActorRef ReplyTo { get; }
+        }
+
+        internal class ForwardMessageWatchActor : ActorBase
+        {
+            private readonly IActorRef probe;
+
+            public ForwardMessageWatchActor(IActorRef probe)
+            {
+                Context.Watch(Context.System.IgnoreRef);
+                this.probe = probe;
+            }
+
+            protected override bool Receive(object message)
+            {
+                switch (message)
+                {
+                    case string str:
+                        probe.Tell(str);
+                        return true;
+                }
+                return false;
+            }
+        }
+    }
+}
+

--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -102,15 +102,15 @@ namespace Akka.Actor
 
             #endregion
         }
-        
+
         /// <summary>
         /// INTERNAL API
         /// </summary>
         internal static readonly char[] ValidSymbols = @"""-_.*$+:@&=,!~';""()".ToCharArray();
 
-        /// <summary> 
+        /// <summary>
         /// Method that checks if actor name conforms to RFC 2396, http://www.ietf.org/rfc/rfc2396.txt
-        /// Note that AKKA JVM does not allow parenthesis ( ) but, according to RFC 2396 those are allowed, and 
+        /// Note that AKKA JVM does not allow parenthesis ( ) but, according to RFC 2396 those are allowed, and
         /// since we use URL Encode to create valid actor names, we must allow them.
         /// </summary>
         /// <param name="s">TBD</param>
@@ -192,10 +192,10 @@ namespace Akka.Actor
 
         /// <summary>
         /// INTERNAL API.
-        /// 
+        ///
         /// Used in Akka.Remote - when resolving deserialized local actor references
         /// we need to be able to include the UID at the tail end of the elements.
-        /// 
+        ///
         /// It's implemented in this class because we don't have an ActorPathExtractor equivalent.
         /// </summary>
         internal IReadOnlyList<string> ElementsWithUid
@@ -243,7 +243,7 @@ namespace Akka.Actor
 
             ActorPath a = this;
             ActorPath b = other;
-            for (;;)
+            for (; ; )
             {
                 if (ReferenceEquals(a, b))
                     return true;
@@ -378,8 +378,8 @@ namespace Akka.Actor
                     //port may not be specified for these types of paths
                     return false;
                 }
-                //System name is in the "host" position. According to rfc3986 host is case 
-                //insensitive, but should be produced as lowercase, so if we use uri.Host 
+                //System name is in the "host" position. According to rfc3986 host is case
+                //insensitive, but should be produced as lowercase, so if we use uri.Host
                 //we'll get it in lower case.
                 //So we'll extract it ourselves using the original path.
                 //We skip the protocol and "://"
@@ -445,7 +445,7 @@ namespace Akka.Actor
         /// <inheritdoc/>
         public override string ToString()
         {
-            return ToStringWithAddress();
+            return $"{Address}{Join()}";
         }
 
         /// <summary>
@@ -537,6 +537,11 @@ namespace Akka.Actor
         /// <returns>TBD</returns>
         public string ToSerializationFormatWithAddress(Address address)
         {
+            if (IgnoreActorRef.IsIgnoreRefPath(this))
+            {
+                // we never change address for IgnoreActorRef
+                return ToString();
+            }
             var withAddress = ToStringWithAddress(address);
             var result = AppendUidFragment(withAddress);
             return result;
@@ -559,6 +564,11 @@ namespace Akka.Actor
         /// <returns> System.String. </returns>
         public string ToStringWithAddress(Address address)
         {
+            if (IgnoreActorRef.IsIgnoreRefPath(this))
+            {
+                // we never change address for IgnoreActorRef
+                return ToString();
+            }
             if (Address.Host != null && Address.Port.HasValue)
                 return $"{Address}{Join()}";
 

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -25,10 +25,10 @@ namespace Akka.Actor
 
     /// <summary>
     /// INTERNAL API
-    /// 
+    ///
     /// All ActorRefs have a scope which describes where they live. Since it is often
     /// necessary to distinguish between local and non-local references, this is the only
-    /// method provided on the scope. 
+    /// method provided on the scope.
     /// </summary>
     [InternalApi]
     public interface IActorRefScope
@@ -41,19 +41,19 @@ namespace Akka.Actor
     }
 
     /// <summary>
-    /// Marker interface for Actors that are deployed within local scope, 
+    /// Marker interface for Actors that are deployed within local scope,
     /// i.e. <see cref="IActorRefScope.IsLocal"/> always returns <c>true</c>.
     /// </summary>
     internal interface ILocalRef : IActorRefScope { }
 
     /// <summary>
     /// INTERNAL API
-    /// 
+    ///
     /// RepointableActorRef (and potentially others) may change their locality at
     /// runtime, meaning that isLocal might not be stable. RepointableActorRef has
     /// the feature that it starts out "not fully started" (but you can send to it),
     /// which is why <see cref="IsStarted"/> features here; it is not improbable that cluster
-    /// actor refs will have the same behavior. 
+    /// actor refs will have the same behavior.
     /// </summary>
     public interface IRepointableRef : IActorRefScope
     {
@@ -65,7 +65,7 @@ namespace Akka.Actor
 
     /// <summary>
     /// INTERNAL API.
-    /// 
+    ///
     /// ActorRef implementation used for one-off tasks.
     /// </summary>
     public class FutureActorRef : MinimalActorRef
@@ -167,7 +167,7 @@ namespace Akka.Actor
     /// An actor reference. Acts as a handle to an actor. Used to send messages to an actor, whether an actor is local or remote.
     /// If you receive a reference to an actor, that actor is guaranteed to have existed at some point
     /// in the past. However, an actor can always be terminated in the future.
-    /// 
+    ///
     /// If you want to be notified about an actor terminating, call <see cref="ICanWatch.Watch(IActorRef)">IActorContext.Watch</see>
     /// on this actor and you'll receive a <see cref="Terminated"/> message when the actor dies or if it
     /// is already dead.
@@ -327,7 +327,7 @@ namespace Akka.Actor
         public int CompareTo(object obj)
         {
             if (obj is null) return 1;
-            if(!(obj is IActorRef other))
+            if (!(obj is IActorRef other))
                 throw new ArgumentException($"Object must be of type IActorRef, found {obj.GetType()} instead.", nameof(obj));
 
             return CompareTo(other);
@@ -338,9 +338,9 @@ namespace Akka.Actor
         /// </summary>
         /// <param name="other"></param>
         /// <returns>
-        /// <c>true</c> if this <see cref="IActorRef"/> instance have the same reference 
-        /// as the <paramref name="other"/> instance, if this <see cref="ActorPath"/> of 
-        /// this <see cref="IActorRef"/> instance is equal to the <paramref name="other"/> instance, 
+        /// <c>true</c> if this <see cref="IActorRef"/> instance have the same reference
+        /// as the <paramref name="other"/> instance, if this <see cref="ActorPath"/> of
+        /// this <see cref="IActorRef"/> instance is equal to the <paramref name="other"/> instance,
         /// and <paramref name="other"/> is not <c>null</c>; otherwise <c>false</c>.
         /// </returns>
         public bool Equals(IActorRef other)
@@ -376,7 +376,7 @@ namespace Akka.Actor
 
     /// <summary>
     /// INTERNAL API.
-    /// 
+    ///
     /// Used by built-in <see cref="IActorRef"/> implementations for handling
     /// internal operations that are not exposed directly to end-users.
     /// </summary>
@@ -400,9 +400,9 @@ namespace Akka.Actor
         bool IsTerminated { get; }
 
         /// <summary>
-        /// Obtain a child given the paths element to that actor, by possibly traversing the actor tree or 
-        /// looking it up at some provider-specific location. 
-        /// A path element of ".." signifies the parent, a trailing "" element must be disregarded. 
+        /// Obtain a child given the paths element to that actor, by possibly traversing the actor tree or
+        /// looking it up at some provider-specific location.
+        /// A path element of ".." signifies the parent, a trailing "" element must be disregarded.
         /// If the requested path does not exist, returns <see cref="Nobody"/>.
         /// </summary>
         /// <param name="name">The path elements.</param>
@@ -453,7 +453,7 @@ namespace Akka.Actor
 
     /// <summary>
     /// INTERNAL API.
-    /// 
+    ///
     /// Abstract implementation of <see cref="IInternalActorRef"/>.
     /// </summary>
     [InternalApi]
@@ -466,7 +466,7 @@ namespace Akka.Actor
         public abstract IActorRefProvider Provider { get; }
 
         /// <inheritdoc cref="IInternalActorRef"/>
-        public abstract IActorRef GetChild(IEnumerable<string> name);    //TODO: Refactor this to use an IEnumerator instead as this will be faster instead of enumerating multiple times over name, as the implementations currently do.		
+        public abstract IActorRef GetChild(IEnumerable<string> name);    //TODO: Refactor this to use an IEnumerator instead as this will be faster instead of enumerating multiple times over name, as the implementations currently do.
 
         /// <inheritdoc cref="IInternalActorRef"/>
         public abstract void Resume(Exception causedByFailure = null);
@@ -502,7 +502,7 @@ namespace Akka.Actor
 
     /// <summary>
     /// INTERNAL API.
-    /// 
+    ///
     /// Barebones <see cref="IActorRef"/> with no backing actor or <see cref="ActorCell"/>.
     /// </summary>
     [InternalApi]
@@ -569,6 +569,68 @@ namespace Akka.Actor
         public override bool IsTerminated { get { return false; } }
     }
 
+
+    /// <summary>
+    /// An ActorRef that ignores any incoming messages.
+    /// </summary>
+    internal sealed class IgnoreActorRef : MinimalActorRef
+    {
+        /// <summary>
+        /// A surrogate for serializing <see cref="IgnoreActorRef"/>.
+        /// </summary>
+        public class IgnoreActorRefSurrogate : ISurrogate
+        {
+            /// <summary>
+            /// Converts the <see cref="ISurrogate"/> into a <see cref="IActorRef"/>.
+            /// </summary>
+            /// <param name="system">The actor system.</param>
+            /// <returns>TBD</returns>
+            public ISurrogated FromSurrogate(ActorSystem system)
+            {
+                return new IgnoreActorRef(system.AsInstanceOf<ExtendedActorSystem>().Provider);
+            }
+        }
+
+        private static readonly IgnoreActorRefSurrogate SurrogateInstance = new IgnoreActorRefSurrogate();
+
+        private const string fakeSystemName = "local";
+
+        private static readonly ActorPath path = new RootActorPath(new Address("akka", fakeSystemName)) / "ignore";
+        private static readonly string pathString = path.ToString();
+
+        public static ActorPath StaticPath => path;
+
+        public IgnoreActorRef(IActorRefProvider provider)
+        {
+            Provider = provider;
+        }
+
+        public override ActorPath Path => path;
+
+        public override IActorRefProvider Provider { get; }
+
+        /// <summary>
+        /// Check if the passed `otherPath` is the same as IgnoreActorRef.path
+        /// </summary>
+        /// <param name="otherPath"></param>
+        /// <returns></returns>
+        public static bool IsIgnoreRefPath(string otherPath) =>
+            pathString.Equals(otherPath);
+
+        /// <summary>
+        /// Check if the passed `otherPath` is the same as IgnoreActorRef.path
+        /// </summary>
+        /// <param name="otherPath"></param>
+        /// <returns></returns>
+        public static bool IsIgnoreRefPath(ActorPath otherPath) =>
+            path.Equals(otherPath);
+
+        public override ISurrogate ToSurrogate(ActorSystem system)
+        {
+            return SurrogateInstance;
+        }
+    }
+
     /// <summary> This is an internal look-up failure token, not useful for anything else.</summary>
     public sealed class Nobody : MinimalActorRef
     {
@@ -623,7 +685,7 @@ namespace Akka.Actor
 
     /// <summary>
     /// INTERNAL API
-    /// 
+    ///
     /// Used to power actors that use an <see cref="ActorCell"/>, which is the majority of them.
     /// </summary>
     [InternalApi]
@@ -798,7 +860,7 @@ override def getChild(name: Iterator[String]): InternalActorRef = {
         }
 
         /// <summary>
-        /// Returns <c>true</c> if the <see cref="VirtualPathContainer"/> contains any children, 
+        /// Returns <c>true</c> if the <see cref="VirtualPathContainer"/> contains any children,
         /// <c>false</c> otherwise.
         /// </summary>
         public bool HasChildren
@@ -848,7 +910,7 @@ override def getChild(name: Iterator[String]): InternalActorRef = {
 
     /// <summary>
     /// INTERNAL API
-    /// 
+    ///
     /// This kind of ActorRef passes all received messages to the given function for
     /// performing a non-blocking side-effect. The intended use is to transform the
     /// message before sending to the real target actor. Such references can be created
@@ -857,7 +919,7 @@ override def getChild(name: Iterator[String]): InternalActorRef = {
     /// towards the live children of an actor, they do not receive the Terminate command
     /// and do not prevent the parent from terminating. FunctionRef is properly
     /// registered for remote lookup and ActorSelection.
-    /// 
+    ///
     /// When using the <see cref="ICanWatch.Watch"/> feature you must ensure that upon reception of the
     /// Terminated message the watched actorRef is <see cref="ICanWatch.Unwatch"/>ed.
     /// </summary>
@@ -885,7 +947,7 @@ override def getChild(name: Iterator[String]): InternalActorRef = {
         /// Have this FunctionRef watch the given Actor. This method must not be
         /// called concurrently from different threads, it should only be called by
         /// its parent Actor.
-        /// 
+        ///
         /// Upon receiving the Terminated message, <see cref="Unwatch"/> must be called from a
         /// safe context (i.e. normally from the parent Actor).
         /// </summary>

--- a/src/core/Akka/Actor/ActorRefProvider.cs
+++ b/src/core/Akka/Actor/ActorRefProvider.cs
@@ -53,6 +53,8 @@ namespace Akka.Actor
         /// <summary>Gets the dead letters.</summary>
         IActorRef DeadLetters { get; }
 
+        IActorRef IgnoreRef { get; }
+
         /// <summary>
         /// Gets the root path for all actors within this actor system, not including any remote address information.
         /// </summary>
@@ -199,6 +201,8 @@ namespace Akka.Actor
             if (deadLettersFactory == null)
                 deadLettersFactory = p => new DeadLetterActorRef(this, p, _eventStream);
             _deadLetters = deadLettersFactory(_rootPath / "deadLetters");
+            IgnoreRef = new IgnoreActorRef(this);
+
             _tempNumber = new AtomicCounterLong(1);
             _tempNode = _rootPath / "temp";
 
@@ -210,6 +214,8 @@ namespace Akka.Actor
         /// TBD
         /// </summary>
         public IActorRef DeadLetters { get { return _deadLetters; } }
+
+        public IActorRef IgnoreRef { get; }
 
         /// <summary>
         /// TBD
@@ -333,9 +339,9 @@ namespace Akka.Actor
             var userGuardian = new LocalActorRef(
                 _system,
                 _system.GuardianProps.GetOrElse(Props.Create<GuardianActor>(UserGuardianSupervisorStrategy)),
-                dispatcher, 
-                _defaultMailbox, 
-                rootGuardian, 
+                dispatcher,
+                _defaultMailbox,
+                rootGuardian,
                 RootPath / name);
 
             cell.InitChild(userGuardian);
@@ -435,7 +441,7 @@ namespace Akka.Actor
             //{
             //    if(actorPath.Elements.Head() == "temp")
             //    {
-            //        //skip ""/"temp", 
+            //        //skip ""/"temp",
             //        string[] parts = actorPath.Elements.Drop(1).ToArray();
             //        return _tempContainer.GetChild(parts);
             //    }

--- a/src/core/Akka/Actor/ActorSystem.cs
+++ b/src/core/Akka/Actor/ActorSystem.cs
@@ -97,15 +97,15 @@ namespace Akka.Actor
     /// </summary>
     public sealed class BootstrapSetup : Setup.Setup
     {
-        internal BootstrapSetup() 
+        internal BootstrapSetup()
             : this(
-                Option<Config>.None, 
+                Option<Config>.None,
                 Option<ProviderSelection>.None)
         {
         }
 
         internal BootstrapSetup(
-            Option<Config> config, 
+            Option<Config> config,
             Option<ProviderSelection> actorRefProvider)
         {
             Config = config;
@@ -185,6 +185,8 @@ namespace Akka.Actor
         /// </summary>
         /// <value>The dead letters.</value>
         public abstract IActorRef DeadLetters { get; }
+
+        public abstract IActorRef IgnoreRef { get; }
 
         /// <summary>Gets the dispatchers.</summary>
         /// <value>The dispatchers.</value>
@@ -339,7 +341,7 @@ namespace Akka.Actor
         /// <para>
         /// If `akka.coordinated-shutdown.run-by-actor-system-terminate` is configured to `off`
         /// it will not run `CoordinatedShutdown`, but the `ActorSystem` and its actors
-        /// will still be terminated.        
+        /// will still be terminated.
         /// </para>
         /// <para>
         /// Terminates this actor system. This will stop the guardian actor, which in turn will recursively stop

--- a/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
@@ -55,9 +55,9 @@ namespace Akka.Actor.Internal
         /// <param name="name">The name given to the actor system.</param>
         public ActorSystemImpl(string name)
             : this(
-                name, 
-                ConfigurationFactory.Default(), 
-                ActorSystemSetup.Empty, 
+                name,
+                ConfigurationFactory.Default(),
+                ActorSystemSetup.Empty,
                 Option<Props>.None)
         {
         }
@@ -74,9 +74,9 @@ namespace Akka.Actor.Internal
         /// </exception>
         /// <exception cref="ArgumentNullException">This exception is thrown if the given <paramref name="config"/> is undefined.</exception>
         public ActorSystemImpl(
-            string name, 
-            Config config, 
-            ActorSystemSetup setup, 
+            string name,
+            Config config,
+            ActorSystemSetup setup,
             Option<Props>? guardianProps = null)
         {
             if(!Regex.Match(name, "^[a-zA-Z0-9][a-zA-Z0-9-]*$").Success)
@@ -120,6 +120,9 @@ namespace Akka.Actor.Internal
 
         /// <inheritdoc cref="ActorSystem"/>
         public override IActorRef DeadLetters { get { return Provider.DeadLetters; } }
+
+        /// <inheritdoc cref="ActorSystem"/>
+        public override IActorRef IgnoreRef { get { return Provider.IgnoreRef; } }
 
         /// <inheritdoc cref="ActorSystem"/>
         public override Dispatchers Dispatchers { get { return _dispatchers; } }
@@ -190,7 +193,7 @@ namespace Akka.Actor.Internal
 
         /// <summary>
         /// Shuts down the <see cref="ActorSystem"/> without all of the usual guarantees,
-        /// i.e. we may not guarantee that remotely deployed actors are properly shut down 
+        /// i.e. we may not guarantee that remotely deployed actors are properly shut down
         /// when we abort.
         /// </summary>
         public override void Abort()
@@ -465,11 +468,11 @@ namespace Akka.Actor.Internal
         private void ConfigureDispatchers()
         {
             _dispatchers = new Dispatchers(
-                this, 
+                this,
                 new DefaultDispatcherPrerequisites(
-                    EventStream, 
-                    Scheduler, 
-                    Settings, 
+                    EventStream,
+                    Scheduler,
+                    Settings,
                     Mailboxes),
                 _log);
         }
@@ -533,7 +536,7 @@ namespace Akka.Actor.Internal
         internal override void FinalTerminate()
         {
             Log.Debug("System shutdown initiated");
-            if (!Settings.LogDeadLettersDuringShutdown && _logDeadLetterListener != null) 
+            if (!Settings.LogDeadLettersDuringShutdown && _logDeadLetterListener != null)
                 Stop(_logDeadLetterListener);
             _provider.Guardian.Stop();
         }

--- a/src/core/Akka/Util/AppVersion.cs
+++ b/src/core/Akka/Util/AppVersion.cs
@@ -27,7 +27,7 @@ namespace Akka.Util
     ///
     ///  It has support for https://github.com/dwijnand/sbt-dynver format with `+` or
     ///  `-` separator. The number of commits from the tag is handled as a numeric part.
-    ///  For example `1.0.0+3-73475dce26` is less than `1.0.10+10-ed316bd024` (3 < 10).
+    ///  For example `1.0.0+3-73475dce26` is less than `1.0.10+10-ed316bd024` (3 &lt; 10).
     /// </summary>
     public class AppVersion : IComparable<AppVersion>, IEquatable<AppVersion>
     {


### PR DESCRIPTION
Mostly Sharding allocation / rebalancing changes making use of the newly introduced AppVersion.
Let me know if you want to split it into smaller parts.

* Holistic shard allocation strategy,  (migrated from https://github.com/akka/akka/pull/29555)

  *  The rebalance in the LeastShardAllocationStrategy is only comparing the region
  with most shards with the one with least shards. Makes the rebalance rather
  slow. By default it's only rebalancing 1 shard at a time.
  * This new strategy looks at all current allocations to find the optimal
  number of shards per region and tries to adjust towards that value.
  Picking from all regions with more shards than the optimal.
  * Absolute and relative limit on how many shards that can be rebalanced
  in one round.
  * It's also not starting a new rebalance round until the previous has
  completed.
  * unit tests
  * second phase for fine grained rebalance, due to rounding it will not be perfect in the first phase
  * randomized unit test
  * configuration settings
  * docs

* Cluster aware shard allocation and rolling updates (migrated from https://github.com/akka/akka/pull/29548)
  * Adds some level of cluster awareness to both the LeastShardAllocationStrategy implementations:
  * prefer shard allocations on new nodes during rolling updates
  * don't rebalance during rolling update
  * don't rebalance when there are joining nodes
  * don't allocate to leaving, downed, exiting and unreachable nodes
  * When allocating when there are joining, unreachable, are leaving are de-prioritized to decrease the risk that a shard is allocated just to directly need to be re-allocated on a different node.

* Handle when there are no known regions yet (migrated from https://github.com/akka/akka/pull/29712)

* ShardRegion ignores HostShard when shutting down (migrated from https://github.com/akka/akka/pull/29707)

* Adds ActorRef.Ignore (Migrated from https://github.com/akka/akka/pull/28630)

* Allocate rebalanced shards immediately (migrated from https://github.com/akka/akka/pull/29551)
  * Otherwise it will continue to deallocate when there is no traffic
  that triggers allocations

* Forward terminated from ShardCoordinator to RebalanceWorker (migrated from https://github.com/akka/akka/pull/29463)
  * Avoiding the need for rebalance workers to watch shard regions which is
expensive as there is one rebalance worker per shard
  * fix race in rebalance worker (partially migrated from https://github.com/akka/akka/pull/29502)

* ClusterSharding: increasing retry interval for registration call (migrated from https://github.com/akka/akka/pull/26756)

* Make a distinction between hand-offs for rebalance and region shutdown (migrated from https://github.com/akka/akka/pull/29579)

* improve logging of shard region shutdown timeout (migrated from https://github.com/akka/akka/pull/29747)

