### PR TITLE
Fix TestKitBase and Option<T>

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
@@ -1292,7 +1292,9 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> Batch<TIn, TOut, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, long max, System.Func<TOut, TOut2> seed, System.Func<TOut2, TOut, TOut2> aggregate) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> BatchWeighted<TIn, TOut, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, long max, System.Func<TOut, long> costFunction, System.Func<TOut, TOut2> seed, System.Func<TOut2, TOut, TOut2> aggregate) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Buffer<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int size, Akka.Streams.OverflowStrategy strategy) { }
+        [System.ObsoleteAttribute("Deprecated. Please use Collect(isDefined, collector) instead")]
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> Collect<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, System.Func<TOut1, TOut2> collector) { }
+        public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> Collect<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, System.Func<TOut1, bool> isDefined, System.Func<TOut1, TOut2> collector) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> CompletionTimeout<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Concat<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> ConcatMany<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, System.Func<TOut1, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat>> flatten) { }
@@ -1908,7 +1910,9 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Source<TOut2, TMat> Batch<TOut, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, long max, System.Func<TOut, TOut2> seed, System.Func<TOut2, TOut, TOut2> aggregate) { }
         public static Akka.Streams.Dsl.Source<TOut2, TMat> BatchWeighted<TOut, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, long max, System.Func<TOut, long> costFunction, System.Func<TOut, TOut2> seed, System.Func<TOut2, TOut, TOut2> aggregate) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> Buffer<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, int size, Akka.Streams.OverflowStrategy strategy) { }
+        [System.ObsoleteAttribute("Deprecated. Please use Collect(isDefined, collector) instead")]
         public static Akka.Streams.Dsl.Source<TOut2, TMat> Collect<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, System.Func<TOut1, TOut2> collector) { }
+        public static Akka.Streams.Dsl.Source<TOut2, TMat> Collect<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, System.Func<TOut1, bool> isDefined, System.Func<TOut1, TOut2> collector) { }
         public static Akka.Streams.Dsl.Source<TOut2, TMatOut> CombineMaterialized<T, TOut2, TMat1, TMat2, TMatOut>(this Akka.Streams.Dsl.Source<T, TMat1> flow, Akka.Streams.Dsl.Source<T, TMat2> other, System.Func<int, Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<T, TOut2>, Akka.NotUsed>> strategy, System.Func<TMat1, TMat2, TMatOut> combineMaterializers) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> CompletionTimeout<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> Concat<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other) { }
@@ -3821,7 +3825,9 @@ namespace Akka.Streams.Implementation.Fusing
     [Akka.Annotations.InternalApiAttribute()]
     public sealed class Collect<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
+        [System.ObsoleteAttribute("Deprecated. Please use the .ctor(Func, Func) constructor")]
         public Collect(System.Func<TIn, TOut> func) { }
+        public Collect(System.Func<TIn, bool> isDefined, System.Func<TIn, TOut> collector) { }
         public Akka.Streams.Inlet<TIn> In { get; }
         protected override Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<TOut> Out { get; }

--- a/src/core/Akka.Streams.Tests/Actor/ActorPublisherSpec.cs
+++ b/src/core/Akka.Streams.Tests/Actor/ActorPublisherSpec.cs
@@ -282,7 +282,7 @@ my-dispatcher1 {
         }
 
         [Fact]
-        public void ActorPublisher_should_work_together_with_Flow_and_ActorSubscriber()
+        public void ActorPublisher_should_work_together_with_Flow_and_ActorSubscriber_using_old_Collect_behaviour()
         {
             var materializer = Sys.Materializer();
             this.AssertAllStagesStopped(() =>
@@ -302,7 +302,7 @@ my-dispatcher1 {
 
                 for (var i = 1; i <= 3; i++)
                     snd.Tell(i);
-                probe.ExpectMsg("elem-2");
+                probe.ExpectMsg("elem-2", TimeSpan.FromMinutes(10));
 
                 for (var n = 4; n <= 500; n++)
                 {
@@ -320,6 +320,42 @@ my-dispatcher1 {
             }, materializer);
         }
 
+        [Fact]
+        public void ActorPublisher_should_work_together_with_Flow_and_ActorSubscriber()
+        {
+            var materializer = Sys.Materializer();
+            this.AssertAllStagesStopped(() =>
+            {
+                var probe = CreateTestProbe();
+                var source = Source.ActorPublisher<int>(Sender.Props);
+                var sink = Sink.ActorSubscriber<string>(Receiver.Props(probe.Ref));
+
+                var t = source.Collect(
+                    n => n % 2 == 0, 
+                    n => "elem-" + n)
+                    .ToMaterialized(sink, Keep.Both).Run(materializer);
+                var snd = t.Item1;
+                var rcv = t.Item2;
+
+                for (var i = 1; i <= 3; i++)
+                    snd.Tell(i);
+                probe.ExpectMsg("elem-2", TimeSpan.FromMinutes(10));
+
+                for (var n = 4; n <= 500; n++)
+                {
+                    if (n % 19 == 0)
+                        Thread.Sleep(50); // simulate bursts
+                    snd.Tell(n);
+                }
+
+                for (var n = 4; n <= 500; n += 2)
+                    probe.ExpectMsg("elem-" + n);
+
+                Watch(snd);
+                rcv.Tell(PoisonPill.Instance);
+                ExpectTerminated(snd);
+            }, materializer);
+        }
 
         [Fact]
         public void ActorPublisher_should_work_in_a_GraphDsl()

--- a/src/core/Akka.Streams.Tests/Dsl/FlowCollectSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowCollectSpec.cs
@@ -30,21 +30,38 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
+        public void An_old_behaviour_Collect_must_collect()
+        {
+            var random = new Random();
+            var script = Script.Create(RandomTestRange(Sys).Select(_ =>
+            {
+                var x = random.Next(0, 10000);
+                return ((ICollection<int>)new[] { x },
+                    (x & 1) == 0 ? (ICollection<string>)new[] { (x * x).ToString() } : (ICollection<string>)new string[] { });
+            }).ToArray());
+
+            RandomTestRange(Sys).ForEach(_ => RunScript(script, Materializer.Settings, flow => flow.Collect(x => x % 2 == 0 ? (x * x).ToString() : null)));
+        }
+
+        [Fact]
         public void A_Collect_must_collect()
         {
             var random = new Random();
-            Script<int,string> script = Script.Create(RandomTestRange(Sys).Select(_ =>
+            var script = Script.Create(RandomTestRange(Sys).Select(_ =>
             {
                 var x = random.Next(0, 10000);
                 return ((ICollection<int>)new[] { x },
                         (x & 1) == 0 ? (ICollection<string>)new[] { (x*x).ToString() } : (ICollection<string>)new string[] {});
             }).ToArray());
 
-            RandomTestRange(Sys).ForEach(_=>RunScript(script, Materializer.Settings,flow => flow.Collect(x => x%2 == 0 ? (x*x).ToString() : null)));
+            RandomTestRange(Sys).ForEach(_=>RunScript(
+                script, 
+                Materializer.Settings,
+                flow => flow.Collect(x => x % 2 == 0, x =>  (x*x).ToString())));
         }
 
         [Fact]
-        public void A_Collect_must_restart_when_Collect_throws()
+        public void An_old_behaviour_Collect_must_restart_when_Collect_throws()
         {
             Func<int, int> throwOnTwo = x =>
             {
@@ -56,6 +73,24 @@ namespace Akka.Streams.Tests.Dsl
             var probe =
                 Source.From(Enumerable.Range(1, 3))
                     .Collect(throwOnTwo)
+                    .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.RestartingDecider))
+                    .RunWith(this.SinkProbe<int>(), Materializer);
+            probe.Request(1);
+            probe.ExpectNext(1);
+            probe.Request(1);
+            probe.ExpectNext(3);
+            probe.Request(1);
+            probe.ExpectComplete();
+        }
+
+        [Fact]
+        public void A_Collect_must_restart_when_Collect_throws()
+        {
+            bool ThrowOnTwo(int x) => x == 2 ? throw new TestException("") : true;
+
+            var probe =
+                Source.From(Enumerable.Range(1, 3))
+                    .Collect(ThrowOnTwo, x => x)
                     .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.RestartingDecider))
                     .RunWith(this.SinkProbe<int>(), Materializer);
             probe.Request(1);

--- a/src/core/Akka.Streams/Dsl/FlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/FlowOperations.cs
@@ -470,9 +470,39 @@ namespace Akka.Streams.Dsl
         /// <param name="flow">TBD</param>
         /// <param name="collector">TBD</param>
         /// <returns>TBD</returns>
+        [Obsolete("Deprecated. Please use Collect(isDefined, collector) instead")]
         public static Flow<TIn, TOut2, TMat> Collect<TIn, TOut1, TOut2, TMat>(this Flow<TIn, TOut1, TMat> flow, Func<TOut1, TOut2> collector)
         {
             return (Flow<TIn, TOut2, TMat>)InternalFlowOperations.Collect(flow, collector);
+        }
+
+        /// <summary>
+        /// Transform this stream by applying the given function <paramref name="collector"/> to each of the elements
+        /// on which the function is defined (read: <paramref name="isDefined"/> returns true) as they pass through this processing step.
+        /// Non-matching elements are filtered out.
+        /// <para>
+        /// Emits when the provided function <paramref name="collector"/> is defined for the element
+        /// </para>
+        /// Backpressures when the function <paramref name="collector"/> is defined for the element and downstream backpressures
+        /// <para>
+        /// Completes when upstream completes
+        /// </para>
+        /// Cancels when downstream cancels
+        /// </summary>
+        /// <typeparam name="TIn">TBD</typeparam>
+        /// <typeparam name="TOut1">TBD</typeparam>
+        /// <typeparam name="TOut2">TBD</typeparam>
+        /// <typeparam name="TMat">TBD</typeparam>
+        /// <param name="flow">TBD</param>
+        /// <param name="isDefined">TBD</param>
+        /// <param name="collector">TBD</param>
+        /// <returns>TBD</returns>
+        public static Flow<TIn, TOut2, TMat> Collect<TIn, TOut1, TOut2, TMat>(
+            this Flow<TIn, TOut1, TMat> flow,
+            Func<TOut1, bool> isDefined,
+            Func<TOut1, TOut2> collector)
+        {
+            return (Flow<TIn, TOut2, TMat>)InternalFlowOperations.Collect(flow, isDefined, collector);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
@@ -472,9 +472,38 @@ namespace Akka.Streams.Dsl.Internal
         /// <param name="flow">TBD</param>
         /// <param name="collector">TBD</param>
         /// <returns>TBD</returns>
+        [Obsolete("Deprecated. Please use Collect(isDefined, collector) instead")]
         public static IFlow<TOut, TMat> Collect<TIn, TOut, TMat>(this IFlow<TIn, TMat> flow, Func<TIn, TOut> collector)
         {
             return flow.Via(new Fusing.Collect<TIn, TOut>(collector));
+        }
+
+        /// <summary>
+        /// Transform this stream by applying the given function <paramref name="collector"/> to each of the elements
+        /// on which the function is defined (read: <paramref name="isDefined"/> returns true) as they pass through this processing step.
+        /// Non-matching elements are filtered out.
+        /// <para>
+        /// Emits when the provided function <paramref name="collector"/> is defined for the element
+        /// </para>
+        /// Backpressures when the function <paramref name="collector"/> is defined for the element and downstream backpressures
+        /// <para>
+        /// Completes when upstream completes
+        /// </para>
+        /// Cancels when downstream cancels
+        /// </summary>
+        /// <typeparam name="TIn">TBD</typeparam>
+        /// <typeparam name="TOut">TBD</typeparam>
+        /// <typeparam name="TMat">TBD</typeparam>
+        /// <param name="flow">TBD</param>
+        /// <param name="isDefined">TBD</param>
+        /// <param name="collector">TBD</param>
+        /// <returns>TBD</returns>
+        public static IFlow<TOut, TMat> Collect<TIn, TOut, TMat>(
+            this IFlow<TIn, TMat> flow, 
+            Func<TIn, bool> isDefined, 
+            Func<TIn, TOut> collector)
+        {
+            return flow.Via(new Fusing.Collect<TIn, TOut>(isDefined, collector));
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/SourceOperations.cs
+++ b/src/core/Akka.Streams/Dsl/SourceOperations.cs
@@ -444,9 +444,38 @@ namespace Akka.Streams.Dsl
         /// <param name="flow">TBD</param>
         /// <param name="collector">TBD</param>
         /// <returns>TBD</returns>
+        [Obsolete("Deprecated. Please use Collect(isDefined, collector) instead")]
         public static Source<TOut2, TMat> Collect<TOut1, TOut2, TMat>(this Source<TOut1, TMat> flow, Func<TOut1, TOut2> collector)
         {
             return (Source<TOut2, TMat>)InternalFlowOperations.Collect(flow, collector);
+        }
+
+        /// <summary>
+        /// Transform this stream by applying the given function <paramref name="collector"/> to each of the elements
+        /// on which the function is defined (read: <paramref name="isDefined"/> returns true) as they pass through this processing step.
+        /// Non-matching elements are filtered out.
+        /// <para>
+        /// Emits when the provided function <paramref name="collector"/> is defined for the element
+        /// </para>
+        /// Backpressures when the function <paramref name="collector"/> is defined for the element and downstream backpressures
+        /// <para>
+        /// Completes when upstream completes
+        /// </para>
+        /// Cancels when downstream cancels
+        /// </summary>
+        /// <typeparam name="TOut1">TBD</typeparam>
+        /// <typeparam name="TOut2">TBD</typeparam>
+        /// <typeparam name="TMat">TBD</typeparam>
+        /// <param name="flow">TBD</param>
+        /// <param name="isDefined">TBD</param>
+        /// <param name="collector">TBD</param>
+        /// <returns>TBD</returns>
+        public static Source<TOut2, TMat> Collect<TOut1, TOut2, TMat>(
+            this Source<TOut1, TMat> flow, 
+            Func<TOut1, bool> isDefined,
+            Func<TOut1, TOut2> collector)
+        {
+            return (Source<TOut2, TMat>)InternalFlowOperations.Collect(flow, isDefined, collector);
         }
 
         /// <summary>

--- a/src/core/Akka.TestKit/TestKitBase.cs
+++ b/src/core/Akka.TestKit/TestKitBase.cs
@@ -131,16 +131,19 @@ namespace Akka.TestKit
 
             if (system == null)
             {
-                var boostrap = config.Get<BootstrapSetup>();
-                var configWithDefaultFallback = boostrap.HasValue
-                    ? boostrap.Value.Config.Select(c => c == _defaultConfig ? c : c.WithFallback(_defaultConfig))
+                var bootstrap = config.Get<BootstrapSetup>();
+                var configWithDefaultFallback = bootstrap.HasValue
+                    ? bootstrap.Value.Config.Select(c => c == _defaultConfig ? c : c.WithFallback(_defaultConfig))
                     : _defaultConfig;
 
-                var newBootstrap = BootstrapSetup.Create().WithConfig(configWithDefaultFallback.Value);
-                if (boostrap.FlatSelect(x => x.ActorRefProvider).HasValue)
+                var newBootstrap = BootstrapSetup.Create().WithConfig(
+                    configWithDefaultFallback.HasValue 
+                        ? configWithDefaultFallback.Value 
+                        : _defaultConfig);
+                if (bootstrap.FlatSelect(x => x.ActorRefProvider).HasValue)
                 {
                     newBootstrap =
-                        newBootstrap.WithActorRefProvider(boostrap.FlatSelect(x => x.ActorRefProvider).Value);
+                        newBootstrap.WithActorRefProvider(bootstrap.FlatSelect(x => x.ActorRefProvider).Value);
                 }
                 system = ActorSystem.Create(actorSystemName ?? "test", config.WithSetup(newBootstrap));
             }

--- a/src/core/Akka/Util/Option.cs
+++ b/src/core/Akka/Util/Option.cs
@@ -16,7 +16,7 @@ namespace Akka.Util
     /// Useful where distinguishing between null (or zero, or false) and uninitialized is significant.
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
-    public struct Option<T>
+    public readonly struct Option<T>
     {
         /// <summary>
         /// None.
@@ -30,7 +30,7 @@ namespace Akka.Util
         public Option(T value)
         {
             Value = value;
-            HasValue = true;
+            HasValue = value != null;
         }
 
         /// <summary>
@@ -81,16 +81,15 @@ namespace Akka.Util
             return mapper(Value);
         }
 
-        /// <inheritdoc/>
         public bool Equals(Option<T> other)
             => HasValue == other.HasValue && EqualityComparer<T>.Default.Equals(Value, other.Value);
 
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj))
+            if (obj is null)
                 return false;
-            return obj is Option<T> && Equals((Option<T>)obj);
+            return obj is Option<T> opt && Equals(opt);
         }
         
         /// <inheritdoc/>


### PR DESCRIPTION
Closes #4496.

Original problem was that 
- `Option<T>` failed to report that it has no value when passed a null value.
- `TestKitBase` did not check for `Option<Config>.None` 