### PR TITLE
removed InternalApi attribute from ActorSystemSetup

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -2045,7 +2045,6 @@ namespace Akka.Actor.Internal
 }
 namespace Akka.Actor.Setup
 {
-    [Akka.Annotations.InternalApiAttribute()]
     public sealed class ActorSystemSetup
     {
         public static readonly Akka.Actor.Setup.ActorSystemSetup Empty;

--- a/src/core/Akka/Actor/Setup/ActorSystemSetup.cs
+++ b/src/core/Akka/Actor/Setup/ActorSystemSetup.cs
@@ -41,7 +41,6 @@ namespace Akka.Actor.Setup
     /// The constructor is internal. Use <see cref="ActorSystemSetup.Create"/> or <see cref="ActorSystemSetup.WithSetup{T}"/>
     /// to create instances.
     /// </remarks>
-    [InternalApi]
     public sealed class ActorSystemSetup
     {
         public static readonly ActorSystemSetup Empty = new ActorSystemSetup(ImmutableDictionary<Type, Setup>.Empty);


### PR DESCRIPTION
ActorSystemSetup is part of the public API and is used in the creation of `ActorSystem`s. It should not be marked as `InternalApi`.