### PR TITLE
Akka.Discovery Release Cleanup

### DIFF
--- a/docs/articles/discovery/index.md
+++ b/docs/articles/discovery/index.md
@@ -1,10 +1,10 @@
 # Discovery
 
 > [!WARNING]
->This module is currently marked as @ref:[may change](../common/may-change.md)
->This means that API or semantics can change without warning or deprecation period.
+>This module is currently marked as **may change**.
+>This means that API or semantics can change without warning or deprecation period. It's in a beta state.
 
-Akka Discovery provides an interface around various ways of locating services. The built in methods are:
+Akka.NET Discovery provides an interface around various ways of locating services. The built in methods are:
 
 * Configuration
 * DNS
@@ -113,4 +113,5 @@ targets for the given service name then `config` is queried which i configured w
 
 ## Discovery Method: DNS
 
-TODO
+> [!NOTE]
+> Akka.Discovery DNS implementation has not been added yet, but is a work in progress.

--- a/docs/articles/discovery/index.md
+++ b/docs/articles/discovery/index.md
@@ -1,4 +1,4 @@
-# Discovery
+# Discovery Overview
 
 > [!WARNING]
 >This module is currently marked as **may change**.

--- a/docs/articles/discovery/toc.yml
+++ b/docs/articles/discovery/toc.yml
@@ -1,0 +1,2 @@
+- name: Service Discovery
+  href: index.md

--- a/docs/articles/discovery/toc.yml
+++ b/docs/articles/discovery/toc.yml
@@ -1,2 +1,2 @@
-- name: Service Discovery
+- name: Service Discovery Overview
   href: index.md

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -186,6 +186,8 @@
   items:
   - name: Multi-Node Testing Distributed Akka.NET Applications
     href: testing/multi-node-testing.md
+- name: Service Discovery
+  href: discovery/toc.yml
 - name: Utilities
   items:
   - name: Event Bus

--- a/src/core/Akka.Discovery/Akka.Discovery.csproj
+++ b/src/core/Akka.Discovery/Akka.Discovery.csproj
@@ -3,11 +3,12 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.Discovery</AssemblyTitle>
-    <Description>Discovery support for Akka.NET</Description>
+    <Description>Service Discovery for Akka.NET</Description>
     <TargetFramework>$(NetStandardLibVersion)</TargetFramework>
     <PackageTags>$(AkkaPackageTags)</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>8</LangVersion>
+    <VersionSuffix>beta</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Cleaned up documentation and linked it from the table of contents
Changed Akka.Discovery to release under `beta` version prefix