### PR TITLE
added .YML and .YAML mime types to IIS

### DIFF
--- a/docs/web.config
+++ b/docs/web.config
@@ -3,6 +3,8 @@
     <system.webServer>
         <staticContent>
             <mimeMap fileExtension=".json" mimeType="application/json" />
+            <mimeMap fileExtension=".yml" mimeType="text/yaml" />
+            <mimeMap fileExtension=".yaml" mimeType="text/yaml" />
         </staticContent>
         <rewrite>
             <rules>


### PR DESCRIPTION
Need this so other applications that build on top of Akka.NET can reference Akka.NET's `xrefmap` via DocFx remote references: https://dotnet.github.io/docfx/tutorial/links_and_cross_references.html#advanced-more-options-for-cross-reference