### PR TITLE
akka.PublishSubscribe - new setting and small fixes

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubMediatorSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubMediatorSpec.cs
@@ -284,7 +284,7 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.PublishSubscribe
             AwaitAssert(() =>
             {
                 Mediator.Tell(Count.Instance);
-                Assert.Equal(expected, ExpectMsg<int>());
+                ExpectMsg<int>().Should().Be(expected);
             });
         }
 
@@ -293,7 +293,7 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.PublishSubscribe
             AwaitAssert(() =>
             {
                 Mediator.Tell(new CountSubscribers(topic));
-                Assert.Equal(expected, ExpectMsg<int>());
+                ExpectMsg<int>().Should().Be(expected);
             });
         }
 
@@ -637,16 +637,16 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.PublishSubscribe
                     var u12 = CreateChatUser("u12");
                     u12.Tell(new JoinGroup("topic2", "group2"));
                     var message1 = ExpectMsg<SubscribeAck>();
-                    message1.Subscribe.Topic.ShouldBe("topic2");
-                    message1.Subscribe.Group.ShouldBe("group2");
-                    message1.Subscribe.Ref.ShouldBe(u12);
+                    message1.Subscribe.Topic.Should().Be("topic2");
+                    message1.Subscribe.Group.Should().Be("group2");
+                    message1.Subscribe.Ref.Should().Be(u12);
 
                     var u13 = CreateChatUser("u13");
                     u13.Tell(new JoinGroup("topic2", "group2"));
                     var message2 = ExpectMsg<SubscribeAck>();
-                    message2.Subscribe.Topic.ShouldBe("topic2");
-                    message2.Subscribe.Group.ShouldBe("group2");
-                    message2.Subscribe.Ref.ShouldBe(u13);
+                    message2.Subscribe.Topic.Should().Be("topic2");
+                    message2.Subscribe.Group.Should().Be("group2");
+                    message2.Subscribe.Ref.Should().Be(u13);
                 }, _second);
 
                 AwaitCount(19);
@@ -678,16 +678,16 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.PublishSubscribe
                     var u12 = ChatUser("u12");
                     u12.Tell(new ExitGroup("topic2", "group2"));
                     var message1 = ExpectMsg<UnsubscribeAck>();
-                    message1.Unsubscribe.Topic.ShouldBe("topic2");
-                    message1.Unsubscribe.Group.ShouldBe("group2");
-                    message1.Unsubscribe.Ref.ShouldBe(u12);
+                    message1.Unsubscribe.Topic.Should().Be("topic2");
+                    message1.Unsubscribe.Group.Should().Be("group2");
+                    message1.Unsubscribe.Ref.Should().Be(u12);
 
                     var u13 = ChatUser("u13");
                     u13.Tell(new ExitGroup("topic2", "group2"));
                     var message2 = ExpectMsg<UnsubscribeAck>();
-                    message2.Unsubscribe.Topic.ShouldBe("topic2");
-                    message2.Unsubscribe.Group.ShouldBe("group2");
-                    message2.Unsubscribe.Ref.ShouldBe(u13);
+                    message2.Unsubscribe.Topic.Should().Be("topic2");
+                    message2.Unsubscribe.Group.Should().Be("group2");
+                    message2.Unsubscribe.Ref.Should().Be(u13);
                 }, _second);
                 EnterBarrier("after-12");
             });
@@ -703,10 +703,10 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.PublishSubscribe
             {
                 Mediator.Tell(new Tools.PublishSubscribe.Internal.Status(ImmutableDictionary<Address, long>.Empty, isReplyToStatus: false));
                 var deltaBuckets = ExpectMsg<Delta>().Buckets;
-                deltaBuckets.Count.ShouldBe(3);
-                deltaBuckets.First(x => x.Owner == firstAddress).Content.Count.ShouldBe(10);
-                deltaBuckets.First(x => x.Owner == secondAddress).Content.Count.ShouldBe(9);
-                deltaBuckets.First(x => x.Owner == thirdAddress).Content.Count.ShouldBe(2);
+                deltaBuckets.Count.Should().Be(3);
+                deltaBuckets.First(x => x.Owner == firstAddress).Content.Count.Should().Be(10);
+                deltaBuckets.First(x => x.Owner == secondAddress).Content.Count.Should().Be(9);
+                deltaBuckets.First(x => x.Owner == thirdAddress).Content.Count.Should().Be(2);
             }, _first);
             EnterBarrier("verified-initial-delta");
 
@@ -721,15 +721,16 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.PublishSubscribe
 
                 Mediator.Tell(new Tools.PublishSubscribe.Internal.Status(ImmutableDictionary<Address, long>.Empty, isReplyToStatus: false));
                 var deltaBuckets1 = ExpectMsg<Delta>().Buckets;
-                deltaBuckets1.Sum(x => x.Content.Count).ShouldBe(500);
+                deltaBuckets1.Sum(x => x.Content.Count).Should().Be(500);
+                var versions1 = deltaBuckets1.ToImmutableDictionary(b => b.Owner, b => b.Version);
 
-                Mediator.Tell(new Tools.PublishSubscribe.Internal.Status(deltaBuckets1.ToImmutableDictionary(b => b.Owner, b => b.Version), isReplyToStatus: false));
+                Mediator.Tell(new Tools.PublishSubscribe.Internal.Status(versions1, isReplyToStatus: false));
                 var deltaBuckets2 = ExpectMsg<Delta>().Buckets;
-                deltaBuckets2.Sum(x => x.Content.Count).ShouldBe(500);
+                deltaBuckets2.Sum(x => x.Content.Count).Should().Be(500);
 
-                Mediator.Tell(new Tools.PublishSubscribe.Internal.Status(deltaBuckets2.ToImmutableDictionary(b => b.Owner, b => b.Version), isReplyToStatus: false));
+                Mediator.Tell(new Tools.PublishSubscribe.Internal.Status(versions1.SetItems(deltaBuckets2.ToImmutableDictionary(b => b.Owner, b => b.Version)), isReplyToStatus: false));
                 var deltaBuckets3 = ExpectMsg<Delta>().Buckets;
-                deltaBuckets3.Sum(x => x.Content.Count).ShouldBe(10 + 9 + 2 + many - 500 - 500);
+                deltaBuckets3.Sum(x => x.Content.Count).Should().Be(10 + 9 + 2 + many - 500 - 500);
             }, _first);
             EnterBarrier("verified-delta-with-many");
 
@@ -825,8 +826,8 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.PublishSubscribe
                         Mediator.Tell(GetTopics.Instance);
                         var topics = ExpectMsg<CurrentTopics>().Topics;
 
-                        topics.Contains("topic_a1").ShouldBeTrue();
-                        topics.Contains("topic_a2").ShouldBeTrue();
+                        topics.Contains("topic_a1").Should().BeTrue();
+                        topics.Contains("topic_a2").Should().BeTrue();
                     });
                 }, _second);
                 EnterBarrier("after-get-topics");

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubMediatorSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubMediatorSpec.cs
@@ -19,6 +19,7 @@ using Akka.Remote.TestKit;
 using Akka.TestKit;
 using Xunit;
 using FluentAssertions;
+using System.Collections.Immutable;
 
 namespace Akka.Cluster.Tools.Tests.MultiNode.PublishSubscribe
 {
@@ -48,7 +49,7 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.PublishSubscribe
 
     public class DistributedPubSubMediatorSpec : MultiNodeClusterSpec
     {
-        #region setup 
+        #region setup
 
         [Serializable]
         public sealed class Whisper
@@ -700,9 +701,9 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.PublishSubscribe
 
             RunOn(() =>
             {
-                Mediator.Tell(new Tools.PublishSubscribe.Internal.Status(new Dictionary<Address, long>(), isReplyToStatus: false));
+                Mediator.Tell(new Tools.PublishSubscribe.Internal.Status(ImmutableDictionary<Address, long>.Empty, isReplyToStatus: false));
                 var deltaBuckets = ExpectMsg<Delta>().Buckets;
-                deltaBuckets.Length.ShouldBe(3);
+                deltaBuckets.Count.ShouldBe(3);
                 deltaBuckets.First(x => x.Owner == firstAddress).Content.Count.ShouldBe(10);
                 deltaBuckets.First(x => x.Owner == secondAddress).Content.Count.ShouldBe(9);
                 deltaBuckets.First(x => x.Owner == thirdAddress).Content.Count.ShouldBe(2);
@@ -718,15 +719,15 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.PublishSubscribe
                     Mediator.Tell(new Put(CreateChatUser("u" + (1000 + i))));
                 }
 
-                Mediator.Tell(new Tools.PublishSubscribe.Internal.Status(new Dictionary<Address, long>(), isReplyToStatus: false));
+                Mediator.Tell(new Tools.PublishSubscribe.Internal.Status(ImmutableDictionary<Address, long>.Empty, isReplyToStatus: false));
                 var deltaBuckets1 = ExpectMsg<Delta>().Buckets;
                 deltaBuckets1.Sum(x => x.Content.Count).ShouldBe(500);
 
-                Mediator.Tell(new Tools.PublishSubscribe.Internal.Status(deltaBuckets1.ToDictionary(b => b.Owner, b => b.Version), isReplyToStatus: false));
+                Mediator.Tell(new Tools.PublishSubscribe.Internal.Status(deltaBuckets1.ToImmutableDictionary(b => b.Owner, b => b.Version), isReplyToStatus: false));
                 var deltaBuckets2 = ExpectMsg<Delta>().Buckets;
                 deltaBuckets2.Sum(x => x.Content.Count).ShouldBe(500);
 
-                Mediator.Tell(new Tools.PublishSubscribe.Internal.Status(deltaBuckets2.ToDictionary(b => b.Owner, b => b.Version), isReplyToStatus: false));
+                Mediator.Tell(new Tools.PublishSubscribe.Internal.Status(deltaBuckets2.ToImmutableDictionary(b => b.Owner, b => b.Version), isReplyToStatus: false));
                 var deltaBuckets3 = ExpectMsg<Delta>().Buckets;
                 deltaBuckets3.Sum(x => x.Content.Count).ShouldBe(10 + 9 + 2 + many - 500 - 500);
             }, _first);

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubMessageSerializerSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubMessageSerializerSpec.cs
@@ -37,7 +37,7 @@ namespace Akka.Cluster.Tools.Tests.PublishSubscribe
                 {address1, 3},
                 {address2, 17},
                 {address3, 5}
-            }, true);
+            }.ToImmutableDictionary(), true);
 
             AssertEqual(message);
         }
@@ -71,7 +71,7 @@ namespace Akka.Cluster.Tools.Tests.PublishSubscribe
                     {"/user/u4", new ValueHolder(4, u4)},
                     {"/user/u5", new ValueHolder(5, null)},
                 }.ToImmutableDictionary())
-            }.ToArray());
+            }.ToImmutableList());
 
             AssertEqual(message);
         }

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubMediator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubMediator.cs
@@ -131,13 +131,13 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         /// <summary>
         /// TBD
         /// </summary>
-        public IDictionary<Address, long> OwnVersions
+        public IImmutableDictionary<Address, long> OwnVersions
         {
             get
             {
                 return _registry
                     .Select(entry => new KeyValuePair<Address, long>(entry.Key, entry.Value.Version))
-                    .ToDictionary(kv => kv.Key, kv => kv.Value);
+                    .ToImmutableDictionary(kv => kv.Key, kv => kv.Value);
             }
         }
 
@@ -192,7 +192,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
                     new Router(_settings.RoutingLogic, routees.ToArray()).Route(
                         Internal.Utils.WrapIfNeeded(send.Message), Sender);
                 else
-                    SendToDeadLetters(send.Message);
+                    IgnoreOrSendToDeadLetters(send.Message);
             });
             Receive<SendToAll>(sendToAll =>
             {
@@ -290,8 +290,8 @@ namespace Akka.Cluster.Tools.PublishSubscribe
                 if (_nodes.Contains(Sender.Path.Address) || Sender.Path.Address.HasLocalScope)
                 {
                     // gossip chat starts with a Status message, containing the bucket versions of the other node
-                    var delta = CollectDelta(status.Versions).ToArray();
-                    if (delta.Length != 0)
+                    var delta = CollectDelta(status.Versions).ToImmutableList();
+                    if (delta.Count != 0)
                         Sender.Tell(new Delta(delta));
 
                     if (!status.IsReplyToStatus && OtherHasNewerVersions(status.Versions))
@@ -404,7 +404,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
             });
         }
 
-        private bool OtherHasNewerVersions(IDictionary<Address, long> versions)
+        private bool OtherHasNewerVersions(IImmutableDictionary<Address, long> versions)
         {
             return versions.Any(entry =>
             {
@@ -415,7 +415,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
             });
         }
 
-        private IEnumerable<Bucket> CollectDelta(IDictionary<Address, long> versions)
+        private IEnumerable<Bucket> CollectDelta(IImmutableDictionary<Address, long> versions)
         {
             // missing entries are represented by version 0
             var filledOtherVersions = OwnVersions.ToDictionary(c => c.Key, c => 0L);
@@ -496,9 +496,10 @@ namespace Akka.Cluster.Tools.PublishSubscribe
                 _registry[_cluster.SelfAddress] = new Bucket(bucket.Owner, v, bucket.Content.SetItem(key, new ValueHolder(v, value)));
         }
 
-        private void SendToDeadLetters(object message)
+        private void IgnoreOrSendToDeadLetters(object message)
         {
-            Context.System.DeadLetters.Tell(new DeadLetter(message, Sender, Context.Self));
+            if (_settings.SendToDeadLettersWhenNoSubscribers)
+                Context.System.DeadLetters.Tell(new DeadLetter(message, Sender, Context.Self));
         }
 
         private void PublishMessage(string path, object message, bool allButSelf = false)
@@ -526,7 +527,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
                 counter++;
             }
 
-            if (counter == 0) SendToDeadLetters(message);
+            if (counter == 0) IgnoreOrSendToDeadLetters(message);
         }
 
         private void PublishToEachGroup(string path, object message)
@@ -539,7 +540,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
 
             if (groups.Count == 0)
             {
-                SendToDeadLetters(message);
+                IgnoreOrSendToDeadLetters(message);
             }
             else
             {

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubMediator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubMediator.cs
@@ -437,8 +437,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
                 {
                     var deltaContent = bucket.Content
                         .Where(kv => kv.Value.Version > v)
-                        .Aggregate(ImmutableDictionary<string, ValueHolder>.Empty,
-                            (current, kv) => current.SetItem(kv.Key, kv.Value));
+                        .ToImmutableDictionary(i => i.Key, i => i.Value);
 
                     count += deltaContent.Count;
 
@@ -449,8 +448,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
                         // exceeded the maxDeltaElements, pick the elements with lowest versions
                         var sortedContent = deltaContent.OrderBy(x => x.Value.Version).ToArray();
                         var chunk = sortedContent.Take(_settings.MaxDeltaElements - (count - sortedContent.Length)).ToList();
-                        var content = chunk.Aggregate(ImmutableDictionary<string, ValueHolder>.Empty,
-                            (current, kv) => current.SetItem(kv.Key, kv.Value));
+                        var content = chunk.ToImmutableDictionary(i => i.Key, i => i.Value);
 
                         yield return new Bucket(bucket.Owner, chunk.Last().Value.Version, content);
                     }

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubSettings.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubSettings.cs
@@ -74,7 +74,8 @@ namespace Akka.Cluster.Tools.PublishSubscribe
                 routingLogic,
                 config.GetTimeSpan("gossip-interval"),
                 config.GetTimeSpan("removed-time-to-live"),
-                config.GetInt("max-delta-elements"));
+                config.GetInt("max-delta-elements"),
+                config.GetBoolean("send-to-dead-letters-when-no-subscribers"));
         }
 
         /// <summary>
@@ -98,10 +99,15 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public TimeSpan RemovedTimeToLive { get; }
 
         /// <summary>
-        /// Maximum number of elements to transfer in one message when synchronizing the registries. 
+        /// Maximum number of elements to transfer in one message when synchronizing the registries.
         /// Next chunk will be transferred in next round of gossip.
         /// </summary>
         public int MaxDeltaElements { get; }
+
+        /// <summary>
+        /// When a message is published to a topic with no subscribers send it to the dead letters.
+        /// </summary>
+        public bool SendToDeadLettersWhenNoSubscribers { get; }
 
         /// <summary>
         /// Creates a new instance of the <see cref="DistributedPubSubSettings" />.
@@ -111,8 +117,15 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         /// <param name="gossipInterval">TBD</param>
         /// <param name="removedTimeToLive">TBD</param>
         /// <param name="maxDeltaElements">TBD</param>
+        /// <param name="sendToDeadLettersWhenNoSubscribers">When a message is published to a topic with no subscribers send it to the dead letters.</param>
         /// <exception cref="ArgumentException">TBD</exception>
-        public DistributedPubSubSettings(string role, RoutingLogic routingLogic, TimeSpan gossipInterval, TimeSpan removedTimeToLive, int maxDeltaElements)
+        public DistributedPubSubSettings(
+            string role,
+            RoutingLogic routingLogic,
+            TimeSpan gossipInterval,
+            TimeSpan removedTimeToLive,
+            int maxDeltaElements,
+            bool sendToDeadLettersWhenNoSubscribers)
         {
             if (routingLogic is ConsistentHashingRoutingLogic)
             {
@@ -124,6 +137,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
             GossipInterval = gossipInterval;
             RemovedTimeToLive = removedTimeToLive;
             MaxDeltaElements = maxDeltaElements;
+            SendToDeadLettersWhenNoSubscribers = sendToDeadLettersWhenNoSubscribers;
         }
 
         /// <summary>
@@ -133,7 +147,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         /// <returns>TBD</returns>
         public DistributedPubSubSettings WithRole(string role)
         {
-            return new DistributedPubSubSettings(role, RoutingLogic, GossipInterval, RemovedTimeToLive, MaxDeltaElements);
+            return new DistributedPubSubSettings(role, RoutingLogic, GossipInterval, RemovedTimeToLive, MaxDeltaElements, SendToDeadLettersWhenNoSubscribers);
         }
 
         /// <summary>
@@ -143,7 +157,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         /// <returns>TBD</returns>
         public DistributedPubSubSettings WithRoutingLogic(RoutingLogic routingLogic)
         {
-            return new DistributedPubSubSettings(Role, routingLogic, GossipInterval, RemovedTimeToLive, MaxDeltaElements);
+            return new DistributedPubSubSettings(Role, routingLogic, GossipInterval, RemovedTimeToLive, MaxDeltaElements, SendToDeadLettersWhenNoSubscribers);
         }
 
         /// <summary>
@@ -153,7 +167,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         /// <returns>TBD</returns>
         public DistributedPubSubSettings WithGossipInterval(TimeSpan gossipInterval)
         {
-            return new DistributedPubSubSettings(Role, RoutingLogic, gossipInterval, RemovedTimeToLive, MaxDeltaElements);
+            return new DistributedPubSubSettings(Role, RoutingLogic, gossipInterval, RemovedTimeToLive, MaxDeltaElements, SendToDeadLettersWhenNoSubscribers);
         }
 
         /// <summary>
@@ -163,7 +177,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         /// <returns>TBD</returns>
         public DistributedPubSubSettings WithRemovedTimeToLive(TimeSpan removedTtl)
         {
-            return new DistributedPubSubSettings(Role, RoutingLogic, GossipInterval, removedTtl, MaxDeltaElements);
+            return new DistributedPubSubSettings(Role, RoutingLogic, GossipInterval, removedTtl, MaxDeltaElements, SendToDeadLettersWhenNoSubscribers);
         }
 
         /// <summary>
@@ -173,7 +187,17 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         /// <returns>TBD</returns>
         public DistributedPubSubSettings WithMaxDeltaElements(int maxDeltaElements)
         {
-            return new DistributedPubSubSettings(Role, RoutingLogic, GossipInterval, RemovedTimeToLive, maxDeltaElements);
+            return new DistributedPubSubSettings(Role, RoutingLogic, GossipInterval, RemovedTimeToLive, maxDeltaElements, SendToDeadLettersWhenNoSubscribers);
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="sendToDeadLetterWhenNoSubscribers">TBD</param>
+        /// <returns></returns>
+        public DistributedPubSubSettings WithSendToDeadLettersWhenNoSubscribers(bool sendToDeadLetterWhenNoSubscribers)
+        {
+            return new DistributedPubSubSettings(Role, RoutingLogic, GossipInterval, RemovedTimeToLive, MaxDeltaElements, sendToDeadLetterWhenNoSubscribers);
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Internal/TopicMessages.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Internal/TopicMessages.cs
@@ -199,16 +199,16 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
         /// </summary>
         /// <param name="versions">TBD</param>
         /// <param name="isReplyToStatus">TBD</param>
-        public Status(IDictionary<Address, long> versions, bool isReplyToStatus)
+        public Status(IImmutableDictionary<Address, long> versions, bool isReplyToStatus)
         {
-            Versions = versions ?? new Dictionary<Address, long>(0);
+            Versions = versions ?? ImmutableDictionary<Address, long>.Empty;
             IsReplyToStatus = isReplyToStatus;
         }
 
         /// <summary>
         /// TBD
         /// </summary>
-        public IDictionary<Address, long> Versions { get; }
+        public IImmutableDictionary<Address, long> Versions { get; }
 
         /// <summary>
         /// TBD
@@ -225,7 +225,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
             if (other == null)
                 return false;
 
-            return Versions.SequenceEqual(other.Versions) 
+            return Versions.SequenceEqual(other.Versions)
                 && IsReplyToStatus.Equals(other.IsReplyToStatus);
         }
 
@@ -256,15 +256,15 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
         /// <summary>
         /// TBD
         /// </summary>
-        public Bucket[] Buckets { get; }
+        public IImmutableList<Bucket> Buckets { get; }
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="buckets">TBD</param>
-        public Delta(Bucket[] buckets)
+        public Delta(IImmutableList<Bucket> buckets)
         {
-            Buckets = buckets ?? new Bucket[0];
+            Buckets = buckets ?? ImmutableList<Bucket>.Empty;
         }
 
         /// <inheritdoc/>

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Internal/Topics.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Internal/Topics.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Akka.Actor;
@@ -70,58 +71,53 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
         /// <returns>TBD</returns>
         protected bool DefaultReceive(object message)
         {
-            if (message is Subscribe)
+            switch (message)
             {
-                var subscribe = (Subscribe)message;
-
-                Context.Watch(subscribe.Ref);
-                Subscribers.Add(subscribe.Ref);
-                PruneDeadline = null;
-                Context.Parent.Tell(new Subscribed(new SubscribeAck(subscribe), Sender));
-            }
-            else if (message is Unsubscribe)
-            {
-                var unsubscribe = (Unsubscribe)message;
-
-                Context.Unwatch(unsubscribe.Ref);
-                Remove(unsubscribe.Ref);
-                Context.Parent.Tell(new Unsubscribed(new UnsubscribeAck(unsubscribe), Sender));
-            }
-            else if (message is Terminated)
-            {
-                var terminated = (Terminated)message;
-                Remove(terminated.ActorRef);
-            }
-            else if (message is Prune)
-            {
-                if (PruneDeadline != null && PruneDeadline.IsOverdue)
-                {
+                case Subscribe subscribe:
+                    Context.Watch(subscribe.Ref);
+                    Subscribers.Add(subscribe.Ref);
                     PruneDeadline = null;
-                    Context.Parent.Tell(NoMoreSubscribers.Instance);
-                }
-            }
-            else if (message is TerminateRequest)
-            {
-                if (Subscribers.Count == 0 && !Context.GetChildren().Any())
-                {
-                    Context.Stop(Self);
-                }
-                else
-                {
-                    Context.Parent.Tell(NewSubscriberArrived.Instance);
-                }
-            }
-            else if (message is Count)
-            {
-                Sender.Tell(Subscribers.Count);
-            }
-            else
-            {
-                foreach (var subscriber in Subscribers)
-                    subscriber.Forward(message);
-            }
+                    Context.Parent.Tell(new Subscribed(new SubscribeAck(subscribe), Sender));
+                    return true;
 
-            return true;
+                case Unsubscribe unsubscribe:
+                    Context.Unwatch(unsubscribe.Ref);
+                    Remove(unsubscribe.Ref);
+                    Context.Parent.Tell(new Unsubscribed(new UnsubscribeAck(unsubscribe), Sender));
+                    return true;
+
+                case Terminated terminated:
+                    Remove(terminated.ActorRef);
+                    return true;
+
+                case Prune _:
+                    if (PruneDeadline != null && PruneDeadline.IsOverdue)
+                    {
+                        PruneDeadline = null;
+                        Context.Parent.Tell(NoMoreSubscribers.Instance);
+                    }
+                    return true;
+
+                case TerminateRequest _:
+                    if (Subscribers.Count == 0 && !Context.GetChildren().Any())
+                    {
+                        Context.Stop(Self);
+                    }
+                    else
+                    {
+                        Context.Parent.Tell(NewSubscriberArrived.Instance);
+                    }
+                    return true;
+
+                case Count _:
+                    Sender.Tell(Subscribers.Count);
+                    return true;
+
+                default:
+                    foreach (var subscriber in Subscribers)
+                        subscriber.Forward(message);
+                    return true;
+            }
         }
 
         /// <summary>
@@ -178,69 +174,67 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
         /// <returns>TBD</returns>
         protected override bool Business(object message)
         {
-            Subscribe subscribe;
-            Unsubscribe unsubscribe;
-            if ((subscribe = message as Subscribe) != null && subscribe.Group != null)
+            switch (message)
             {
-                var encodedGroup = Utils.EncodeName(subscribe.Group);
-                _buffer.BufferOr(Utils.MakeKey(Self.Path / encodedGroup), subscribe, Sender, () =>
-                {
-                    var child = Context.Child(encodedGroup);
-                    if (!child.IsNobody())
+                case Subscribe subscribe when subscribe.Group != null:
+                    var encodedGroup = Utils.EncodeName(subscribe.Group);
+                    _buffer.BufferOr(Utils.MakeKey(Self.Path / encodedGroup), subscribe, Sender, () =>
                     {
-                        child.Forward(message);
-                    }
-                    else
+                        var child = Context.Child(encodedGroup);
+                        if (!child.IsNobody())
+                        {
+                            child.Forward(message);
+                        }
+                        else
+                        {
+                            NewGroupActor(encodedGroup).Forward(message);
+                        }
+                    });
+                    PruneDeadline = null;
+                    return true;
+
+                case Unsubscribe unsubscribe when unsubscribe.Group != null:
+                    encodedGroup = Utils.EncodeName(unsubscribe.Group);
+                    _buffer.BufferOr(Utils.MakeKey(Self.Path / encodedGroup), unsubscribe, Sender, () =>
                     {
-                        NewGroupActor(encodedGroup).Forward(message);
-                    }
-                });
-                PruneDeadline = null;
+                        var child = Context.Child(encodedGroup);
+                        if (!child.IsNobody())
+                        {
+                            child.Forward(message);
+                        }
+                        else
+                        {
+                            // no such group here
+                        }
+                    });
+                    return true;
+
+                case Subscribed _:
+                    Context.Parent.Forward(message);
+                    return true;
+
+                case Unsubscribed _:
+                    Context.Parent.Forward(message);
+                    return true;
+
+                case NoMoreSubscribers _:
+                    var key = Utils.MakeKey(Sender);
+                    _buffer.InitializeGrouping(key);
+                    Sender.Tell(TerminateRequest.Instance);
+                    return true;
+
+                case NewSubscriberArrived _:
+                    key = Utils.MakeKey(Sender);
+                    _buffer.ForwardMessages(key, Sender);
+                    return true;
+
+                case Terminated terminated:
+                    key = Utils.MakeKey(terminated.ActorRef);
+                    _buffer.RecreateAndForwardMessagesIfNeeded(key, () => NewGroupActor(terminated.ActorRef.Path.Name));
+                    Remove(terminated.ActorRef);
+                    return true;
             }
-            else if ((unsubscribe = message as Unsubscribe) != null && unsubscribe.Group != null)
-            {
-                var encodedGroup = Utils.EncodeName(unsubscribe.Group);
-                _buffer.BufferOr(Utils.MakeKey(Self.Path / encodedGroup), unsubscribe, Sender, () =>
-                {
-                    var child = Context.Child(encodedGroup);
-                    if (!child.IsNobody())
-                    {
-                        child.Forward(message);
-                    }
-                    else
-                    {
-                        // no such group here
-                    }
-                });
-            }
-            else if (message is Subscribed)
-            {
-                Context.Parent.Forward(message);
-            }
-            else if (message is Unsubscribed)
-            {
-                Context.Parent.Forward(message);
-            }
-            else if (message is NoMoreSubscribers)
-            {
-                var key = Utils.MakeKey(Sender);
-                _buffer.InitializeGrouping(key);
-                Sender.Tell(TerminateRequest.Instance);
-            }
-            else if (message is NewSubscriberArrived)
-            {
-                var key = Utils.MakeKey(Sender);
-                _buffer.ForwardMessages(key, Sender);
-            }
-            else if (message is Terminated)
-            {
-                var terminated = (Terminated)message;
-                var key = Utils.MakeKey(terminated.ActorRef);
-                _buffer.RecreateAndForwardMessagesIfNeeded(key, () => NewGroupActor(terminated.ActorRef.Path.Name));
-                Remove(terminated.ActorRef);
-            }
-            else return false;
-            return true;
+            return false;
         }
 
         private IActorRef NewGroupActor(string encodedGroup)
@@ -276,11 +270,10 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
         /// <returns>TBD</returns>
         protected override bool Business(object message)
         {
-            if (message is SendToOneSubscriber)
+            if (message is SendToOneSubscriber send)
             {
                 if (Subscribers.Count != 0)
                 {
-                    var send = (SendToOneSubscriber)message;
                     var routees = Subscribers.Select(sub => (Routee)new ActorRefRoutee(sub)).ToArray();
                     new Router(_routingLogic, routees).Route(Utils.WrapIfNeeded(send.Message), Sender);
                 }

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/PerGroupingBuffer.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/PerGroupingBuffer.cs
@@ -31,11 +31,11 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         {
             if (_buffers.TryGetValue(grouping, out var messages))
             {
-                _buffers[grouping].Add(new KeyValuePair<object, IActorRef>(message, originalSender));
+                messages.Add(new KeyValuePair<object, IActorRef>(message, originalSender));
                 _totalBufferSize += 1;
             }
-            
-            action();
+            else
+                action();
         }
 
         /// <summary>

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Serialization/DistributedPubSubMessageSerializer.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Serialization/DistributedPubSubMessageSerializer.cs
@@ -153,14 +153,14 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
         private Internal.Status StatusFrom(byte[] bytes)
         {
             var statusProto = Proto.Msg.Status.Parser.ParseFrom(bytes);
-            var versions = new Dictionary<Address, long>();
+            var versions = ImmutableDictionary.CreateBuilder<Address, long>();
 
             foreach (var protoVersion in statusProto.Versions)
             {
                 versions.Add(AddressFrom(protoVersion.Address), protoVersion.Timestamp);
             }
 
-            return new Internal.Status(versions, statusProto.ReplyToStatus);
+            return new Internal.Status(versions.ToImmutable(), statusProto.ReplyToStatus);
         }
 
         private static byte[] DeltaToProto(Delta delta)
@@ -189,7 +189,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
         private Delta DeltaFrom(byte[] bytes)
         {
             var deltaProto = Proto.Msg.Delta.Parser.ParseFrom(bytes);
-            var buckets = new List<Bucket>();
+            var buckets = ImmutableList.CreateBuilder<Bucket>();
             foreach (var protoBuckets in deltaProto.Buckets)
             {
                 var content = new Dictionary<string, ValueHolder>();
@@ -204,7 +204,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
                 buckets.Add(bucket);
             }
 
-            return new Delta(buckets.ToArray());
+            return new Delta(buckets.ToImmutable());
         }
 
         private byte[] SendToProto(Send send)

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/reference.conf
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/reference.conf
@@ -28,8 +28,11 @@ akka.cluster.pub-sub {
   # Maximum number of elements to transfer in one message when synchronizing the registries.
   # Next chunk will be transferred in next round of gossip.
   max-delta-elements = 3000
-  
-  # The id of the dispatcher to use for DistributedPubSubMediator actors. 
+
+  # When a message is published to a topic with no subscribers send it to the dead letters.
+  send-to-dead-letters-when-no-subscribers = on
+
+  # The id of the dispatcher to use for DistributedPubSubMediator actors.
   # If not specified, the internal dispatcher is used.
   # If specified you need to define the settings of the actual dispatcher.
   use-dispatcher = ""

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveClusterTools.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveClusterTools.approved.txt
@@ -197,19 +197,20 @@ namespace Akka.Cluster.Tools.PublishSubscribe
     {
         public DistributedPubSubMediator(Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings settings) { }
         public Akka.Event.ILoggingAdapter Log { get; }
-        public System.Collections.Generic.IDictionary<Akka.Actor.Address, long> OwnVersions { get; }
+        public System.Collections.Immutable.IImmutableDictionary<Akka.Actor.Address, long> OwnVersions { get; }
         protected override void PostStop() { }
         protected override void PreStart() { }
         public static Akka.Actor.Props Props(Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings settings) { }
     }
     public sealed class DistributedPubSubSettings : Akka.Actor.INoSerializationVerificationNeeded
     {
-        public DistributedPubSubSettings(string role, Akka.Routing.RoutingLogic routingLogic, System.TimeSpan gossipInterval, System.TimeSpan removedTimeToLive, int maxDeltaElements) { }
+        public DistributedPubSubSettings(string role, Akka.Routing.RoutingLogic routingLogic, System.TimeSpan gossipInterval, System.TimeSpan removedTimeToLive, int maxDeltaElements, bool sendToDeadLettersWhenNoSubscribers) { }
         public System.TimeSpan GossipInterval { get; }
         public int MaxDeltaElements { get; }
         public System.TimeSpan RemovedTimeToLive { get; }
         public string Role { get; }
         public Akka.Routing.RoutingLogic RoutingLogic { get; }
+        public bool SendToDeadLettersWhenNoSubscribers { get; }
         public static Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings Create(Akka.Actor.ActorSystem system) { }
         public static Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings Create(Akka.Configuration.Config config) { }
         public Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings WithGossipInterval(System.TimeSpan gossipInterval) { }
@@ -217,6 +218,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings WithRemovedTimeToLive(System.TimeSpan removedTtl) { }
         public Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings WithRole(string role) { }
         public Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings WithRoutingLogic(Akka.Routing.RoutingLogic routingLogic) { }
+        public Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings WithSendToDeadLettersWhenNoSubscribers(bool sendToDeadLetterWhenNoSubscribers) { }
     }
     public sealed class GetTopics
     {

--- a/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
+++ b/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
@@ -151,7 +151,7 @@ namespace Akka.Remote.TestKit
                         : ConfigurationFactory.Empty;
 
                 var builder = ImmutableList.CreateBuilder<Config>();
-                if (_nodeConf.TryGetValue(Myself, out var nodeConfig)) 
+                if (_nodeConf.TryGetValue(Myself, out var nodeConfig))
                     builder.Add(nodeConfig);
                 builder.Add(_commonConf);
                 builder.Add(transportConfig);
@@ -185,7 +185,7 @@ namespace Akka.Remote.TestKit
     /// </summary>
     public abstract class MultiNodeSpec : TestKitBase, IMultiNodeSpecCallbacks, IDisposable
     {
-        //TODO: Sort out references to Java classes in 
+        //TODO: Sort out references to Java classes in
 
         /// <summary>
         /// Marker used to indicate that <see cref="MaxNodes"/> has not been set yet.
@@ -216,9 +216,9 @@ namespace Akka.Remote.TestKit
         /// <summary>
         /// Name (or IP address; must be resolvable)
         /// of the host this node is running on
-        /// 
+        ///
         /// <code>-Dmultinode.host=host.example.com</code>
-        /// 
+        ///
         /// InetAddress.getLocalHost.getHostAddress is used if empty or "localhost"
         /// is defined as system property "multinode.host".
         /// </summary>
@@ -246,7 +246,7 @@ namespace Akka.Remote.TestKit
 
         /// <summary>
         /// Port number of this node. Defaults to 0 which means a random port.
-        /// 
+        ///
         /// <code>-Dmultinode.port=0</code>
         /// </summary>
         public static int SelfPort
@@ -268,7 +268,7 @@ namespace Akka.Remote.TestKit
         /// <summary>
         /// Name (or IP address; must be resolvable using InetAddress.getByName)
         /// of the host that the server node is running on.
-        /// 
+        ///
         /// <code>-Dmultinode.server-host=server.example.com</code>
         /// </summary>
         public static string ServerName
@@ -292,13 +292,13 @@ namespace Akka.Remote.TestKit
         /// <summary>
         /// Default value for <see cref="ServerPort"/>
         /// </summary>
-        private const int ServerPortDefault = 4711;
+        private const int ServerPortDefault = 47110;
 
         private static int _serverPort = ServerPortUnsetValue;
 
         /// <summary>
         /// Port number of the node that's running the server system. Defaults to 4711.
-        /// 
+        ///
         /// <code>-Dmultinode.server-port=4711</code>
         /// </summary>
         public static int ServerPort
@@ -366,7 +366,7 @@ namespace Akka.Remote.TestKit
                         coordinated-shutdown.terminate-actor-system = off
                         coordinated-shutdown.run-by-actor-system-terminate = off
                         coordinated-shutdown.run-by-clr-shutdown-hook = off
-                        log-dead-letters = off 
+                        log-dead-letters = off
                         log-dead-letters-during-shutdown = on
                         actor {
                           default-dispatcher {
@@ -479,7 +479,7 @@ namespace Akka.Remote.TestKit
 
         /// <summary>
         /// MUST BE DEFINED BY USER.
-        /// 
+        ///
         /// Defines the number of participants required for starting the test. This
         /// might not be equals to the number of nodes available to the test.
         /// </summary>
@@ -511,7 +511,7 @@ namespace Akka.Remote.TestKit
             if (nodes.Length == 0) throw new ArgumentException("No node given to run on.");
             if (IsNode(nodes)) thunk();
         }
-        
+
         /// <summary>
         /// Execute the given block of code only on the given nodes (names according
         /// to the `roleMap`).
@@ -542,12 +542,12 @@ namespace Akka.Remote.TestKit
         /// <summary>
         /// Query the controller for the transport address of the given node (by role name) and
         /// return that as an ActorPath for easy composition:
-        /// 
+        ///
         /// <code>var serviceA = Sys.ActorSelection(Node(new RoleName("master")) / "user" / "serviceA");</code>
         /// </summary>
         public ActorPath Node(RoleName role)
         {
-            //TODO: Async stuff here 
+            //TODO: Async stuff here
             return new RootActorPath(TestConductor.GetAddressFor(role).Result);
         }
 
@@ -677,9 +677,9 @@ namespace Akka.Remote.TestKit
 
 
         /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
-        /// <param name="disposing">if set to <c>true</c> the method has been called directly or indirectly by a 
+        /// <param name="disposing">if set to <c>true</c> the method has been called directly or indirectly by a
         /// user's code. Managed and unmanaged resources will be disposed.<br />
-        /// if set to <c>false</c> the method has been called by the runtime from inside the finalizer and only 
+        /// if set to <c>false</c> the method has been called by the runtime from inside the finalizer and only
         /// unmanaged resources can be disposed.</param>
         protected void Dispose(bool disposing)
         {


### PR DESCRIPTION
new setting `send-to-dead-letters-when-no-subscribers`, some collections in messages switched to immutable, bugfix in PerGroupingBuffer