### PR TITLE
Akka.NET v1.4.13 Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 1.4.13 November 16 2020 ####
+**Placeholder for Nightlies**
+
 #### 1.4.12 November 16 2020 ####
 **Maintenance Release for Akka.NET 1.4**
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,39 @@
-#### 1.4.13 November 16 2020 ####
-**Placeholder for Nightlies**
+#### 1.4.13 December 16 2020 ####
+**Maintenance Release for Akka.NET 1.4**
+
+Akka.NET v1.4.13 includes a number of bug fixes and enhancements:
+
+**`AppVersion` now uses Assembly Version by Default**
+The new `AppVersion` setting, which is used to communicate application version numbers throughout Akka.Cluster and is used in scenarios such as Akka.Cluster.Sharding to help determine which nodes receive new shard allocations and which ones do not, now uses the following default HOCON setting:
+
+```
+akka.cluster.app-version = assembly-version
+```
+
+By default now the `AppVersion` communicated inside Akka.Cluster `Member` events uses the `Major.Minor.BuildNumber` from the `Assembly.GetEntryssembly()` or `Assembly.GetExecutingAssembly()` (in case the `EntryAssembly` is `null`). That way any updates made to your executable's (i.e. the .dll that hosts `Program.cs`) version number will be automatically reflected in the cluster now without Akka.NET developers having to set an additional configuration value during deployments.
+
+Other bug fixes and improvements:
+
+* [Akka.IO: UdpExt.Manager: OverflowException when sending UDP packets to terminated clients](https://github.com/akkadotnet/akka.net/issues/4641)
+* [Akka.Configuration / Akka.Streams: Memory Leak when using many short lived instances of ActorMaterializer](https://github.com/akkadotnet/akka.net/issues/4659)
+* [Akka: Deprecate `PatternMatch`](https://github.com/akkadotnet/akka.net/issues/4658)
+* [Akka: FSM: exception in LogTermination changes stopEvent.Reason to Shutdown](https://github.com/akkadotnet/akka.net/issues/3723)
+* [Akka.Cluster.Tools: ClusterSingleton - Ignore possible state change in start](https://github.com/akkadotnet/akka.net/pull/4646)
+* [Akka.Cluster.Tools: DistributedPubSub - new setting and small fixes](https://github.com/akkadotnet/akka.net/pull/4649)
+* [Akka.DistributedData: `KeyNotFoundException` thrown periodically](https://github.com/akkadotnet/akka.net/issues/4639)
+
+To see the [full set of fixes in Akka.NET v1.4.13, please see the milestone on Github](https://github.com/akkadotnet/akka.net/milestone/44).
+
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 5 | 316 | 29 | Aaron Stannard |
+| 2 | 53 | 8 | Gregorius Soedharmo |
+| 2 | 223 | 197 | zbynek001 |
+| 2 | 2 | 2 | dependabot-preview[bot] |
+| 2 | 11 | 3 | Ebere Abanonu |
+| 1 | 37 | 27 | Razvan Goga |
+| 1 | 217 | 11 | motmot80 |
+| 1 | 2 | 0 | Ismael Hamed |
 
 #### 1.4.12 November 16 2020 ####
 **Maintenance Release for Akka.NET 1.4**

--- a/docs/articles/concepts/configuration.md
+++ b/docs/articles/concepts/configuration.md
@@ -5,6 +5,34 @@ title: Configuration
 
 # Akka.NET Configuration
 
+Akka.NET relies on [HOCON](xref:hocon) configuration to configure its various knobs and dials. 
+
+However, as of Akka.NET v1.4 we now support the [`Setup` class](xref:Akka.Actor.Setup.Setup) and the [`BootstrapSetup` constructs](xref:Akka.Actor.BootstrapSetup), which allow developers to configure various parts of Akka.NET using programmatic configuration in addition to HOCON.
+
+This article will explain how to use both in the context of your Akka.NET applications.
+
+## Programmatic Configuration with `Setup`
+As part of the Akka.NET v1.4 release we introduced the [`Setup` class](xref:Akka.Actor.Setup.Setup), which is meant to be an extensible base class that can be used in concert with areas of Akka.NET that support programmatic configuration.
+
+For instance it is now possible to [configure custom serialization bindings in Akka.NET using the `SerializationSetup` class](xref:serialization#configuring-serialization-bindings-programmatically). Phobos, a propreitary add-on to Akka.NET for application performance monitoring, uses the [`PhobosSetup` class to pass in monitoring and tracing components to an `ActorSystem` at startup](https://phobos.petabridge.com/articles/setup/configuration.html).
+
+Other parts of Akka.NET in the future, such as its dependency injection system, will likely expand their use of the `Setup` class to allow a degree of programmatic configuration.
+
+### `BootstrapSetup` and `ActorSystemSetup`
+So what if we want to use some built-in `Setup` types in combination with an `ActorSystem`? How do we work with these new types?
+
+First, if we have HOCON that we need to pass into our `ActorSystem` still then we must use the [`BootstrapSetup` class]((xref:Akka.Actor.BootstrapSetup) to store our HOCON `Config`:
+
+[!code-csharp[SerializationSetup](../../../src/core/Akka.Docs.Tests/Configuration/SerializationSetupDocSpec.cs?name=MergedSetup)]
+
+In addition to our `BootstrapSetup`, we can also merge that class with one or more other `Setup`s and produce a merged `ActorSystemSetup` object - which is what our `ActorSystem` actually needs.
+
+From there, we can create our `ActorSystem`:
+
+[!code-csharp[SerializationSetup](../../../src/core/Akka.Docs.Tests/Configuration/SerializationSetupDocSpec.cs?name=Verification)]
+
+## HOCON 
+
 *Quoted from [Akka.NET Bootcamp: Unit 2, Lesson 1 - "Using HOCON Configuration to Configure Akka.NET"](https://github.com/petabridge/akka-bootcamp/tree/master/src/Unit-2/lesson1 "Using HOCON Configuration to Configure Akka.NET")*
 
 Akka.NET leverages a configuration format, called HOCON, to allow you to configure your Akka.NET applications with whatever level of granularity you want.

--- a/docs/articles/networking/serialization.md
+++ b/docs/articles/networking/serialization.md
@@ -61,6 +61,54 @@ subtype of the other, a warning will be issued.
 
 Akka.NET provides serializers for POCO's (Plain Old C# Objects) and for `Google.Protobuf.IMessage` by default, so you don't usually need to add configuration for that.
 
+### Configuring Serialization Bindings Programmatically
+As of Akka.NET v1.4 it is now possible to bind serializers to their target types programmatically using the [`SerializationSetup` class](xref:Akka.Serialization.SerializationSetup).
+
+First, we define a set of messages that all implement a common protocol and will be handled by the same serializer:
+
+[!code-csharp[SerializationProtocol](../../../src/core/Akka.Docs.Tests/Configuration/SerializationSetupDocSpec.cs?name=Protocol)]
+
+And then a custom [`SerializerWithStringManifest` implementation](xref:Akka.Serialization.SerializerWithStringManifest) to perform the serialization:
+
+[!code-csharp[CustomSerializer](../../../src/core/Akka.Docs.Tests/Configuration/SerializationSetupDocSpec.cs?name=Serializer)]
+
+With our application protocol and serializer defined we can now create some serialization bindings - these tell Akka.NET which serializer to use whenever we make any calls to serialize messages.
+
+This is where we can use the [`SerializationSetup` class](xref:Akka.Serialization.SerializationSetup) to create statically typed serialization bindings that can be checked by the compiler, rather than defining them through HOCON.
+
+[!code-csharp[SerializationSetup](../../../src/core/Akka.Docs.Tests/Configuration/SerializationSetupDocSpec.cs?name=SerializerSetup)]
+
+The `SerializationSetup` takes a function with the following signature:
+
+```csharp
+Func<ExtendedActorSystem, ImmutableHashSet<SerializerDetails>>
+```
+
+The `ExtendedActorSystem` passed into this method is the `ActorSystem` you're configuring, as all `Serializer` classes in Akka.NET require an `ExtendedActorSystem` as a construtor argument.
+
+For each serialization binding you wish to create, you need to create [a `SerializerDetails` object](xref:Akka.Serialization.SerializerDetails) using the `SerializerDetails.Create` method:
+
+```csharp
+public static SerializerDetails Create(string alias, Serializer serializer, ImmutableHashSet<Type> useFor)
+```
+
+The `string alias` is the same alias you'd configure in HOCON's `akka.actor.serializers` section - and the serializer configured via `SerializationSetup` can be consumed by other parts of Akka.NET by referencing this alias, so make sure you pick a unique name.
+
+The `ImmutableHashSet<Type> useFor` is where you define your serialization type bindings - in this case, we bound the serializer to the `IAppProtocol` interface: any type that implements this interface will be handled by the `AppProtocolSerializer`.
+
+Now that we've created our `SerializationSetup`, we need to actually pass this into our `ActorSystem` - to do this we will want to combine our `SerializationSetup` with a [`BootstrapSetup` instance that holds the rest of our HOCON configuration](xref:Akka.Actor.BootstrapSetup):
+
+[!code-csharp[SerializationSetup](../../../src/core/Akka.Docs.Tests/Configuration/SerializationSetupDocSpec.cs?name=MergedSetup)]
+
+And using the `ActorSystemSetup` produced by merged the `BootstrapSetup` and `SerializationSetup` together, we can create our `ActorSystem` and verify that the serialization bindings were configured correctly:
+
+[!code-csharp[SerializationSetup](../../../src/core/Akka.Docs.Tests/Configuration/SerializationSetupDocSpec.cs?name=Verification)]
+
+And that's how you can configure Akka.NET serialization programmatically.
+
+> [!NOTE]
+> There are other parts of Akka.NET that are possible to configure programmatically via `ActorSystemSetup`. [Read more about them here](xref:configuration).
+
 ### Verification
 Normally, messages sent between local actors (i.e. same CLR) do not undergo serialization.
 For testing, it may be desirable to force serialization on all messages, both remote and local. 
@@ -133,13 +181,13 @@ serializer.
 
 ### Serializer with String Manifest
 The `Serializer` illustrated above supports a class-based manifest (type hint). 
-For serialization of data that need to evolve over time, the `SerializerWithStringManifest` is recommended instead of `Serializer` because the manifest (type hint) is a `String` instead of a `Type`. 
+For serialization of data that need to evolve over time, the [`SerializerWithStringManifest`](xref:Akka.Serialization.SerializerWithStringManifest) is recommended instead of `Serializer` because the manifest (type hint) is a `String` instead of a `Type`. 
 This means that the class can be moved/removed and the serializer can still deserialize old data by matching on the String. 
 This is especially useful for `Persistence`.
 
 The manifest string can also encode a version number that can be used in `FromBinary` to deserialize in different ways to migrate old data to new domain objects.
 
-If the data was originally serialized with `Serializer`, and in a later version of the system you change to `SerializerWithStringManifest`, the manifest string will be the full class name if you used `IncludeManifest=true`, otherwise it will be the empty string.
+If the data was originally serialized with `Serializer`, and in a later version of the system you change to [`SerializerWithStringManifest`](xref:Akka.Serialization.SerializerWithStringManifest), the manifest string will be the full class name if you used `IncludeManifest=true`, otherwise it will be the empty string.
 
 This is how a `SerializerWithStringManifest` looks:
 [!code-csharp[Main](../../../src/core/Akka.Docs.Tests/Networking/Serialization/MyOwnSerializer2.cs?name=CustomSerialization)]

--- a/docs/web.config
+++ b/docs/web.config
@@ -3,6 +3,8 @@
     <system.webServer>
         <staticContent>
             <mimeMap fileExtension=".json" mimeType="application/json" />
+            <mimeMap fileExtension=".yml" mimeType="text/yaml" />
+            <mimeMap fileExtension=".yaml" mimeType="text/yaml" />
         </staticContent>
         <rewrite>
             <rules>

--- a/src/common.props
+++ b/src/common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2020 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.4.12</VersionPrefix>
+    <VersionPrefix>1.4.13</VersionPrefix>
     <PackageIconUrl>https://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>
@@ -28,7 +28,33 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Placeholder for nightlies**</PackageReleaseNotes>
+    <PackageReleaseNotes>Maintenance Release for Akka.NET 1.4**
+Akka.NET v1.4.13 includes a number of bug fixes and enhancements:
+`AppVersion` now uses Assembly Version by Default**
+The new `AppVersion` setting, which is used to communicate application version numbers throughout Akka.Cluster and is used in scenarios such as Akka.Cluster.Sharding to help determine which nodes receive new shard allocations and which ones do not, now uses the following default HOCON setting:
+```
+akka.cluster.app-version = assembly-version
+```
+By default now the `AppVersion` communicated inside Akka.Cluster `Member` events uses the `Major.Minor.BuildNumber` from the `Assembly.GetEntryssembly()` or `Assembly.GetExecutingAssembly()` (in case the `EntryAssembly` is `null`). That way any updates made to your executable's (i.e. the .dll that hosts `Program.cs`) version number will be automatically reflected in the cluster now without Akka.NET developers having to set an additional configuration value during deployments.
+Other bug fixes and improvements:
+[Akka.IO: UdpExt.Manager: OverflowException when sending UDP packets to terminated clients](https://github.com/akkadotnet/akka.net/issues/4641)
+[Akka.Configuration / Akka.Streams: Memory Leak when using many short lived instances of ActorMaterializer](https://github.com/akkadotnet/akka.net/issues/4659)
+[Akka: Deprecate `PatternMatch`](https://github.com/akkadotnet/akka.net/issues/4658)
+[Akka: FSM: exception in LogTermination changes stopEvent.Reason to Shutdown](https://github.com/akkadotnet/akka.net/issues/3723)
+[Akka.Cluster.Tools: ClusterSingleton - Ignore possible state change in start](https://github.com/akkadotnet/akka.net/pull/4646)
+[Akka.Cluster.Tools: DistributedPubSub - new setting and small fixes](https://github.com/akkadotnet/akka.net/pull/4649)
+[Akka.DistributedData: `KeyNotFoundException` thrown periodically](https://github.com/akkadotnet/akka.net/issues/4639)
+To see the [full set of fixes in Akka.NET v1.4.13, please see the milestone on Github](https://github.com/akkadotnet/akka.net/milestone/44).
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 5 | 316 | 29 | Aaron Stannard |
+| 2 | 53 | 8 | Gregorius Soedharmo |
+| 2 | 223 | 197 | zbynek001 |
+| 2 | 2 | 2 | dependabot-preview[bot] |
+| 2 | 11 | 3 | Ebere Abanonu |
+| 1 | 37 | 27 | Razvan Goga |
+| 1 | 217 | 11 | motmot80 |
+| 1 | 2 | 0 | Ismael Hamed |</PackageReleaseNotes>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>

--- a/src/common.props
+++ b/src/common.props
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <XunitVersion>2.4.1</XunitVersion>
-    <TestSdkVersion>16.8.0</TestSdkVersion>
+    <TestSdkVersion>16.8.3</TestSdkVersion>
     <HyperionVersion>0.9.16</HyperionVersion>
     <NewtonsoftJsonVersion>12.0.3</NewtonsoftJsonVersion>
     <NBenchVersion>2.0.1</NBenchVersion>

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubMessageSerializerSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubMessageSerializerSpec.cs
@@ -37,7 +37,7 @@ namespace Akka.Cluster.Tools.Tests.PublishSubscribe
                 {address1, 3},
                 {address2, 17},
                 {address3, 5}
-            }, true);
+            }.ToImmutableDictionary(), true);
 
             AssertEqual(message);
         }
@@ -71,7 +71,7 @@ namespace Akka.Cluster.Tools.Tests.PublishSubscribe
                     {"/user/u4", new ValueHolder(4, u4)},
                     {"/user/u5", new ValueHolder(5, null)},
                 }.ToImmutableDictionary())
-            }.ToArray());
+            }.ToImmutableList());
 
             AssertEqual(message);
         }

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubSettings.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubSettings.cs
@@ -112,13 +112,30 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         /// <summary>
         /// Creates a new instance of the <see cref="DistributedPubSubSettings" />.
         /// </summary>
-        /// <param name="role">TBD</param>
-        /// <param name="routingLogic">TBD</param>
-        /// <param name="gossipInterval">TBD</param>
-        /// <param name="removedTimeToLive">TBD</param>
-        /// <param name="maxDeltaElements">TBD</param>
+        /// <param name="role">The role that will host <see cref="DistributedPubSubMediator"/> instances.</param>
+        /// <param name="routingLogic">Optional. The routing logic used for distributing messages for topic groups.</param>
+        /// <param name="gossipInterval">The gossip interval for propagating topic/subscriber data to other mediators.</param>
+        /// <param name="removedTimeToLive">The amount of time it takes to prune a deactivated subscriber from the network.</param>
+        /// <param name="maxDeltaElements">The maximum number of delta elements that can be propagated in a single gossip tick.</param>
+        /// <exception cref="ArgumentException">Thrown if a user tries to use a <see cref="ConsistentHashingRoutingLogic"/> with routingLogic.</exception>
+        [Obsolete("Obsolete - please us the full constructor instead. This constructor only exists for backwards API compatibility.")]
+        public DistributedPubSubSettings(
+            string role,
+            RoutingLogic routingLogic,
+            TimeSpan gossipInterval,
+            TimeSpan removedTimeToLive,
+            int maxDeltaElements) : this(role, routingLogic, gossipInterval, removedTimeToLive, maxDeltaElements, true){ }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="DistributedPubSubSettings" />.
+        /// </summary>
+        /// <param name="role">The role that will host <see cref="DistributedPubSubMediator"/> instances.</param>
+        /// <param name="routingLogic">Optional. The routing logic used for distributing messages for topic groups.</param>
+        /// <param name="gossipInterval">The gossip interval for propagating topic/subscriber data to other mediators.</param>
+        /// <param name="removedTimeToLive">The amount of time it takes to prune a deactivated subscriber from the network.</param>
+        /// <param name="maxDeltaElements">The maximum number of delta elements that can be propagated in a single gossip tick.</param>
         /// <param name="sendToDeadLettersWhenNoSubscribers">When a message is published to a topic with no subscribers send it to the dead letters.</param>
-        /// <exception cref="ArgumentException">TBD</exception>
+        /// <exception cref="ArgumentException">Thrown if a user tries to use a <see cref="ConsistentHashingRoutingLogic"/> with routingLogic.</exception>
         public DistributedPubSubSettings(
             string role,
             RoutingLogic routingLogic,

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubSettings.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubSettings.cs
@@ -74,7 +74,8 @@ namespace Akka.Cluster.Tools.PublishSubscribe
                 routingLogic,
                 config.GetTimeSpan("gossip-interval"),
                 config.GetTimeSpan("removed-time-to-live"),
-                config.GetInt("max-delta-elements"));
+                config.GetInt("max-delta-elements"),
+                config.GetBoolean("send-to-dead-letters-when-no-subscribers"));
         }
 
         /// <summary>
@@ -98,10 +99,15 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public TimeSpan RemovedTimeToLive { get; }
 
         /// <summary>
-        /// Maximum number of elements to transfer in one message when synchronizing the registries. 
+        /// Maximum number of elements to transfer in one message when synchronizing the registries.
         /// Next chunk will be transferred in next round of gossip.
         /// </summary>
         public int MaxDeltaElements { get; }
+
+        /// <summary>
+        /// When a message is published to a topic with no subscribers send it to the dead letters.
+        /// </summary>
+        public bool SendToDeadLettersWhenNoSubscribers { get; }
 
         /// <summary>
         /// Creates a new instance of the <see cref="DistributedPubSubSettings" />.
@@ -111,8 +117,15 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         /// <param name="gossipInterval">TBD</param>
         /// <param name="removedTimeToLive">TBD</param>
         /// <param name="maxDeltaElements">TBD</param>
+        /// <param name="sendToDeadLettersWhenNoSubscribers">When a message is published to a topic with no subscribers send it to the dead letters.</param>
         /// <exception cref="ArgumentException">TBD</exception>
-        public DistributedPubSubSettings(string role, RoutingLogic routingLogic, TimeSpan gossipInterval, TimeSpan removedTimeToLive, int maxDeltaElements)
+        public DistributedPubSubSettings(
+            string role,
+            RoutingLogic routingLogic,
+            TimeSpan gossipInterval,
+            TimeSpan removedTimeToLive,
+            int maxDeltaElements,
+            bool sendToDeadLettersWhenNoSubscribers)
         {
             if (routingLogic is ConsistentHashingRoutingLogic)
             {
@@ -124,6 +137,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
             GossipInterval = gossipInterval;
             RemovedTimeToLive = removedTimeToLive;
             MaxDeltaElements = maxDeltaElements;
+            SendToDeadLettersWhenNoSubscribers = sendToDeadLettersWhenNoSubscribers;
         }
 
         /// <summary>
@@ -133,7 +147,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         /// <returns>TBD</returns>
         public DistributedPubSubSettings WithRole(string role)
         {
-            return new DistributedPubSubSettings(role, RoutingLogic, GossipInterval, RemovedTimeToLive, MaxDeltaElements);
+            return new DistributedPubSubSettings(role, RoutingLogic, GossipInterval, RemovedTimeToLive, MaxDeltaElements, SendToDeadLettersWhenNoSubscribers);
         }
 
         /// <summary>
@@ -143,7 +157,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         /// <returns>TBD</returns>
         public DistributedPubSubSettings WithRoutingLogic(RoutingLogic routingLogic)
         {
-            return new DistributedPubSubSettings(Role, routingLogic, GossipInterval, RemovedTimeToLive, MaxDeltaElements);
+            return new DistributedPubSubSettings(Role, routingLogic, GossipInterval, RemovedTimeToLive, MaxDeltaElements, SendToDeadLettersWhenNoSubscribers);
         }
 
         /// <summary>
@@ -153,7 +167,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         /// <returns>TBD</returns>
         public DistributedPubSubSettings WithGossipInterval(TimeSpan gossipInterval)
         {
-            return new DistributedPubSubSettings(Role, RoutingLogic, gossipInterval, RemovedTimeToLive, MaxDeltaElements);
+            return new DistributedPubSubSettings(Role, RoutingLogic, gossipInterval, RemovedTimeToLive, MaxDeltaElements, SendToDeadLettersWhenNoSubscribers);
         }
 
         /// <summary>
@@ -163,7 +177,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         /// <returns>TBD</returns>
         public DistributedPubSubSettings WithRemovedTimeToLive(TimeSpan removedTtl)
         {
-            return new DistributedPubSubSettings(Role, RoutingLogic, GossipInterval, removedTtl, MaxDeltaElements);
+            return new DistributedPubSubSettings(Role, RoutingLogic, GossipInterval, removedTtl, MaxDeltaElements, SendToDeadLettersWhenNoSubscribers);
         }
 
         /// <summary>
@@ -173,7 +187,17 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         /// <returns>TBD</returns>
         public DistributedPubSubSettings WithMaxDeltaElements(int maxDeltaElements)
         {
-            return new DistributedPubSubSettings(Role, RoutingLogic, GossipInterval, RemovedTimeToLive, maxDeltaElements);
+            return new DistributedPubSubSettings(Role, RoutingLogic, GossipInterval, RemovedTimeToLive, maxDeltaElements, SendToDeadLettersWhenNoSubscribers);
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="sendToDeadLetterWhenNoSubscribers">TBD</param>
+        /// <returns></returns>
+        public DistributedPubSubSettings WithSendToDeadLettersWhenNoSubscribers(bool sendToDeadLetterWhenNoSubscribers)
+        {
+            return new DistributedPubSubSettings(Role, RoutingLogic, GossipInterval, RemovedTimeToLive, MaxDeltaElements, sendToDeadLetterWhenNoSubscribers);
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Internal/TopicMessages.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Internal/TopicMessages.cs
@@ -199,16 +199,16 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
         /// </summary>
         /// <param name="versions">TBD</param>
         /// <param name="isReplyToStatus">TBD</param>
-        public Status(IDictionary<Address, long> versions, bool isReplyToStatus)
+        public Status(IImmutableDictionary<Address, long> versions, bool isReplyToStatus)
         {
-            Versions = versions ?? new Dictionary<Address, long>(0);
+            Versions = versions ?? ImmutableDictionary<Address, long>.Empty;
             IsReplyToStatus = isReplyToStatus;
         }
 
         /// <summary>
         /// TBD
         /// </summary>
-        public IDictionary<Address, long> Versions { get; }
+        public IImmutableDictionary<Address, long> Versions { get; }
 
         /// <summary>
         /// TBD
@@ -225,7 +225,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
             if (other == null)
                 return false;
 
-            return Versions.SequenceEqual(other.Versions) 
+            return Versions.SequenceEqual(other.Versions)
                 && IsReplyToStatus.Equals(other.IsReplyToStatus);
         }
 
@@ -256,15 +256,15 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
         /// <summary>
         /// TBD
         /// </summary>
-        public Bucket[] Buckets { get; }
+        public IImmutableList<Bucket> Buckets { get; }
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="buckets">TBD</param>
-        public Delta(Bucket[] buckets)
+        public Delta(IImmutableList<Bucket> buckets)
         {
-            Buckets = buckets ?? new Bucket[0];
+            Buckets = buckets ?? ImmutableList<Bucket>.Empty;
         }
 
         /// <inheritdoc/>

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Internal/Topics.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Internal/Topics.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Akka.Actor;
@@ -70,58 +71,53 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
         /// <returns>TBD</returns>
         protected bool DefaultReceive(object message)
         {
-            if (message is Subscribe)
+            switch (message)
             {
-                var subscribe = (Subscribe)message;
-
-                Context.Watch(subscribe.Ref);
-                Subscribers.Add(subscribe.Ref);
-                PruneDeadline = null;
-                Context.Parent.Tell(new Subscribed(new SubscribeAck(subscribe), Sender));
-            }
-            else if (message is Unsubscribe)
-            {
-                var unsubscribe = (Unsubscribe)message;
-
-                Context.Unwatch(unsubscribe.Ref);
-                Remove(unsubscribe.Ref);
-                Context.Parent.Tell(new Unsubscribed(new UnsubscribeAck(unsubscribe), Sender));
-            }
-            else if (message is Terminated)
-            {
-                var terminated = (Terminated)message;
-                Remove(terminated.ActorRef);
-            }
-            else if (message is Prune)
-            {
-                if (PruneDeadline != null && PruneDeadline.IsOverdue)
-                {
+                case Subscribe subscribe:
+                    Context.Watch(subscribe.Ref);
+                    Subscribers.Add(subscribe.Ref);
                     PruneDeadline = null;
-                    Context.Parent.Tell(NoMoreSubscribers.Instance);
-                }
-            }
-            else if (message is TerminateRequest)
-            {
-                if (Subscribers.Count == 0 && !Context.GetChildren().Any())
-                {
-                    Context.Stop(Self);
-                }
-                else
-                {
-                    Context.Parent.Tell(NewSubscriberArrived.Instance);
-                }
-            }
-            else if (message is Count)
-            {
-                Sender.Tell(Subscribers.Count);
-            }
-            else
-            {
-                foreach (var subscriber in Subscribers)
-                    subscriber.Forward(message);
-            }
+                    Context.Parent.Tell(new Subscribed(new SubscribeAck(subscribe), Sender));
+                    return true;
 
-            return true;
+                case Unsubscribe unsubscribe:
+                    Context.Unwatch(unsubscribe.Ref);
+                    Remove(unsubscribe.Ref);
+                    Context.Parent.Tell(new Unsubscribed(new UnsubscribeAck(unsubscribe), Sender));
+                    return true;
+
+                case Terminated terminated:
+                    Remove(terminated.ActorRef);
+                    return true;
+
+                case Prune _:
+                    if (PruneDeadline != null && PruneDeadline.IsOverdue)
+                    {
+                        PruneDeadline = null;
+                        Context.Parent.Tell(NoMoreSubscribers.Instance);
+                    }
+                    return true;
+
+                case TerminateRequest _:
+                    if (Subscribers.Count == 0 && !Context.GetChildren().Any())
+                    {
+                        Context.Stop(Self);
+                    }
+                    else
+                    {
+                        Context.Parent.Tell(NewSubscriberArrived.Instance);
+                    }
+                    return true;
+
+                case Count _:
+                    Sender.Tell(Subscribers.Count);
+                    return true;
+
+                default:
+                    foreach (var subscriber in Subscribers)
+                        subscriber.Forward(message);
+                    return true;
+            }
         }
 
         /// <summary>
@@ -178,69 +174,67 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
         /// <returns>TBD</returns>
         protected override bool Business(object message)
         {
-            Subscribe subscribe;
-            Unsubscribe unsubscribe;
-            if ((subscribe = message as Subscribe) != null && subscribe.Group != null)
+            switch (message)
             {
-                var encodedGroup = Utils.EncodeName(subscribe.Group);
-                _buffer.BufferOr(Utils.MakeKey(Self.Path / encodedGroup), subscribe, Sender, () =>
-                {
-                    var child = Context.Child(encodedGroup);
-                    if (!child.IsNobody())
+                case Subscribe subscribe when subscribe.Group != null:
+                    var encodedGroup = Utils.EncodeName(subscribe.Group);
+                    _buffer.BufferOr(Utils.MakeKey(Self.Path / encodedGroup), subscribe, Sender, () =>
                     {
-                        child.Forward(message);
-                    }
-                    else
+                        var child = Context.Child(encodedGroup);
+                        if (!child.IsNobody())
+                        {
+                            child.Forward(message);
+                        }
+                        else
+                        {
+                            NewGroupActor(encodedGroup).Forward(message);
+                        }
+                    });
+                    PruneDeadline = null;
+                    return true;
+
+                case Unsubscribe unsubscribe when unsubscribe.Group != null:
+                    encodedGroup = Utils.EncodeName(unsubscribe.Group);
+                    _buffer.BufferOr(Utils.MakeKey(Self.Path / encodedGroup), unsubscribe, Sender, () =>
                     {
-                        NewGroupActor(encodedGroup).Forward(message);
-                    }
-                });
-                PruneDeadline = null;
+                        var child = Context.Child(encodedGroup);
+                        if (!child.IsNobody())
+                        {
+                            child.Forward(message);
+                        }
+                        else
+                        {
+                            // no such group here
+                        }
+                    });
+                    return true;
+
+                case Subscribed _:
+                    Context.Parent.Forward(message);
+                    return true;
+
+                case Unsubscribed _:
+                    Context.Parent.Forward(message);
+                    return true;
+
+                case NoMoreSubscribers _:
+                    var key = Utils.MakeKey(Sender);
+                    _buffer.InitializeGrouping(key);
+                    Sender.Tell(TerminateRequest.Instance);
+                    return true;
+
+                case NewSubscriberArrived _:
+                    key = Utils.MakeKey(Sender);
+                    _buffer.ForwardMessages(key, Sender);
+                    return true;
+
+                case Terminated terminated:
+                    key = Utils.MakeKey(terminated.ActorRef);
+                    _buffer.RecreateAndForwardMessagesIfNeeded(key, () => NewGroupActor(terminated.ActorRef.Path.Name));
+                    Remove(terminated.ActorRef);
+                    return true;
             }
-            else if ((unsubscribe = message as Unsubscribe) != null && unsubscribe.Group != null)
-            {
-                var encodedGroup = Utils.EncodeName(unsubscribe.Group);
-                _buffer.BufferOr(Utils.MakeKey(Self.Path / encodedGroup), unsubscribe, Sender, () =>
-                {
-                    var child = Context.Child(encodedGroup);
-                    if (!child.IsNobody())
-                    {
-                        child.Forward(message);
-                    }
-                    else
-                    {
-                        // no such group here
-                    }
-                });
-            }
-            else if (message is Subscribed)
-            {
-                Context.Parent.Forward(message);
-            }
-            else if (message is Unsubscribed)
-            {
-                Context.Parent.Forward(message);
-            }
-            else if (message is NoMoreSubscribers)
-            {
-                var key = Utils.MakeKey(Sender);
-                _buffer.InitializeGrouping(key);
-                Sender.Tell(TerminateRequest.Instance);
-            }
-            else if (message is NewSubscriberArrived)
-            {
-                var key = Utils.MakeKey(Sender);
-                _buffer.ForwardMessages(key, Sender);
-            }
-            else if (message is Terminated)
-            {
-                var terminated = (Terminated)message;
-                var key = Utils.MakeKey(terminated.ActorRef);
-                _buffer.RecreateAndForwardMessagesIfNeeded(key, () => NewGroupActor(terminated.ActorRef.Path.Name));
-                Remove(terminated.ActorRef);
-            }
-            else return false;
-            return true;
+            return false;
         }
 
         private IActorRef NewGroupActor(string encodedGroup)
@@ -276,11 +270,10 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
         /// <returns>TBD</returns>
         protected override bool Business(object message)
         {
-            if (message is SendToOneSubscriber)
+            if (message is SendToOneSubscriber send)
             {
                 if (Subscribers.Count != 0)
                 {
-                    var send = (SendToOneSubscriber)message;
                     var routees = Subscribers.Select(sub => (Routee)new ActorRefRoutee(sub)).ToArray();
                     new Router(_routingLogic, routees).Route(Utils.WrapIfNeeded(send.Message), Sender);
                 }

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/PerGroupingBuffer.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/PerGroupingBuffer.cs
@@ -31,11 +31,11 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         {
             if (_buffers.TryGetValue(grouping, out var messages))
             {
-                _buffers[grouping].Add(new KeyValuePair<object, IActorRef>(message, originalSender));
+                messages.Add(new KeyValuePair<object, IActorRef>(message, originalSender));
                 _totalBufferSize += 1;
             }
-            
-            action();
+            else
+                action();
         }
 
         /// <summary>

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Serialization/DistributedPubSubMessageSerializer.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Serialization/DistributedPubSubMessageSerializer.cs
@@ -153,14 +153,14 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
         private Internal.Status StatusFrom(byte[] bytes)
         {
             var statusProto = Proto.Msg.Status.Parser.ParseFrom(bytes);
-            var versions = new Dictionary<Address, long>();
+            var versions = ImmutableDictionary.CreateBuilder<Address, long>();
 
             foreach (var protoVersion in statusProto.Versions)
             {
                 versions.Add(AddressFrom(protoVersion.Address), protoVersion.Timestamp);
             }
 
-            return new Internal.Status(versions, statusProto.ReplyToStatus);
+            return new Internal.Status(versions.ToImmutable(), statusProto.ReplyToStatus);
         }
 
         private static byte[] DeltaToProto(Delta delta)
@@ -189,7 +189,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
         private Delta DeltaFrom(byte[] bytes)
         {
             var deltaProto = Proto.Msg.Delta.Parser.ParseFrom(bytes);
-            var buckets = new List<Bucket>();
+            var buckets = ImmutableList.CreateBuilder<Bucket>();
             foreach (var protoBuckets in deltaProto.Buckets)
             {
                 var content = new Dictionary<string, ValueHolder>();
@@ -204,7 +204,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
                 buckets.Add(bucket);
             }
 
-            return new Delta(buckets.ToArray());
+            return new Delta(buckets.ToImmutable());
         }
 
         private byte[] SendToProto(Send send)

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/reference.conf
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/reference.conf
@@ -28,8 +28,11 @@ akka.cluster.pub-sub {
   # Maximum number of elements to transfer in one message when synchronizing the registries.
   # Next chunk will be transferred in next round of gossip.
   max-delta-elements = 3000
-  
-  # The id of the dispatcher to use for DistributedPubSubMediator actors. 
+
+  # When a message is published to a topic with no subscribers send it to the dead letters.
+  send-to-dead-letters-when-no-subscribers = on
+
+  # The id of the dispatcher to use for DistributedPubSubMediator actors.
   # If not specified, the internal dispatcher is used.
   # If specified you need to define the settings of the actual dispatcher.
   use-dispatcher = ""

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManager.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManager.cs
@@ -623,7 +623,7 @@ namespace Akka.Cluster.Tools.Singleton
         private bool _oldestChangedReceived = true;
         private bool _selfExited;
 
-        // started when when self member is Up
+        // started when self member is Up
         private IActorRef _oldestChangedBuffer;
         // keep track of previously removed members
         private ImmutableDictionary<UniqueAddress, Deadline> _removed = ImmutableDictionary<UniqueAddress, Deadline>.Empty;
@@ -744,7 +744,7 @@ namespace Akka.Cluster.Tools.Singleton
             if(_removed.TryGetValue(node, out _))
             {
                 _removed = _removed.SetItem(node, Deadline.Now + TimeSpan.FromMinutes(15.0));
-            } 
+            }
             else
             {
                 _removed = _removed.Add(node, Deadline.Now + TimeSpan.FromMinutes(15.0));
@@ -896,6 +896,9 @@ namespace Akka.Cluster.Tools.Singleton
                                 ? GoTo(ClusterSingletonState.BecomingOldest).Using(new BecomingOldestData(initialOldestState.Oldest.FindAll(u => !u.Equals(_selfUniqueAddress))))
                                 : GoTo(ClusterSingletonState.Younger).Using(new YoungerData(initialOldestState.Oldest.FindAll(u => !u.Equals(_selfUniqueAddress))));
                         }
+                    case HandOverToMe _:
+                        // nothing to hand over in start
+                        return Stay();
                     default:
                         return null;
                 }

--- a/src/contrib/cluster/Akka.DistributedData/Internal/Internal.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Internal/Internal.cs
@@ -558,7 +558,15 @@ namespace Akka.DistributedData.Internal
 
             foreach (var entry in Pruning)
             {
-                if (!Equals(entry.Value, other.Pruning[entry.Key])) return false;
+                //"it's possible that one node that begins pruning may"
+                //"have different data than another node that hasn't started"
+                if (other.Pruning.TryGetValue(entry.Key, out var state))
+                {
+                    if (!Equals(entry.Value, state))
+                        return false;
+                }
+                else
+                    return false;
             }
 
             return true;

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Performance/SqliteJournalPerfSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Performance/SqliteJournalPerfSpec.cs
@@ -10,7 +10,7 @@ using Akka.Persistence.TestKit.Performance;
 using Akka.Util.Internal;
 using Xunit.Abstractions;
 
-namespace Akka.Persistence.Redis.Tests.Performance
+namespace Akka.Persistence.Sqlite.Tests.Performance
 {
     public class SqliteJournalPerfSpec : JournalPerfSpec
     {

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Akka.Persistence.Sqlite.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Akka.Persistence.Sqlite.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SQLite" Version="3.1.9" />
+    <PackageReference Include="Microsoft.Data.SQLite" Version="5.0.1" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveClusterTools.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveClusterTools.approved.txt
@@ -197,19 +197,20 @@ namespace Akka.Cluster.Tools.PublishSubscribe
     {
         public DistributedPubSubMediator(Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings settings) { }
         public Akka.Event.ILoggingAdapter Log { get; }
-        public System.Collections.Generic.IDictionary<Akka.Actor.Address, long> OwnVersions { get; }
+        public System.Collections.Immutable.IImmutableDictionary<Akka.Actor.Address, long> OwnVersions { get; }
         protected override void PostStop() { }
         protected override void PreStart() { }
         public static Akka.Actor.Props Props(Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings settings) { }
     }
     public sealed class DistributedPubSubSettings : Akka.Actor.INoSerializationVerificationNeeded
     {
-        public DistributedPubSubSettings(string role, Akka.Routing.RoutingLogic routingLogic, System.TimeSpan gossipInterval, System.TimeSpan removedTimeToLive, int maxDeltaElements) { }
+        public DistributedPubSubSettings(string role, Akka.Routing.RoutingLogic routingLogic, System.TimeSpan gossipInterval, System.TimeSpan removedTimeToLive, int maxDeltaElements, bool sendToDeadLettersWhenNoSubscribers) { }
         public System.TimeSpan GossipInterval { get; }
         public int MaxDeltaElements { get; }
         public System.TimeSpan RemovedTimeToLive { get; }
         public string Role { get; }
         public Akka.Routing.RoutingLogic RoutingLogic { get; }
+        public bool SendToDeadLettersWhenNoSubscribers { get; }
         public static Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings Create(Akka.Actor.ActorSystem system) { }
         public static Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings Create(Akka.Configuration.Config config) { }
         public Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings WithGossipInterval(System.TimeSpan gossipInterval) { }
@@ -217,6 +218,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings WithRemovedTimeToLive(System.TimeSpan removedTtl) { }
         public Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings WithRole(string role) { }
         public Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings WithRoutingLogic(Akka.Routing.RoutingLogic routingLogic) { }
+        public Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings WithSendToDeadLettersWhenNoSubscribers(bool sendToDeadLetterWhenNoSubscribers) { }
     }
     public sealed class GetTopics
     {

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveClusterTools.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveClusterTools.approved.txt
@@ -204,6 +204,9 @@ namespace Akka.Cluster.Tools.PublishSubscribe
     }
     public sealed class DistributedPubSubSettings : Akka.Actor.INoSerializationVerificationNeeded
     {
+        [System.ObsoleteAttribute("Obsolete - please us the full constructor instead. This constructor only exists f" +
+            "or backwards API compatibility.")]
+        public DistributedPubSubSettings(string role, Akka.Routing.RoutingLogic routingLogic, System.TimeSpan gossipInterval, System.TimeSpan removedTimeToLive, int maxDeltaElements) { }
         public DistributedPubSubSettings(string role, Akka.Routing.RoutingLogic routingLogic, System.TimeSpan gossipInterval, System.TimeSpan removedTimeToLive, int maxDeltaElements, bool sendToDeadLettersWhenNoSubscribers) { }
         public System.TimeSpan GossipInterval { get; }
         public int MaxDeltaElements { get; }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -2111,6 +2111,7 @@ namespace Akka
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.ObsoleteAttribute("Use instead the pattern matching feature introduced in C# 7.0")]
     public class static PatternMatch
     {
         public static Akka.Case Match(this object target) { }

--- a/src/core/Akka.Cluster.Tests/ClusterConfigSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterConfigSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Immutable;
 using Akka.Actor;
+using Akka.Configuration;
 using Akka.Dispatch;
 using Akka.Remote;
 using Akka.TestKit;
@@ -46,7 +47,9 @@ namespace Akka.Cluster.Tests
             settings.MinNrOfMembers.Should().Be(1);
             settings.MinNrOfMembersOfRole.Should().Equal(ImmutableDictionary<string, int>.Empty);
             settings.Roles.Should().BeEquivalentTo(ImmutableHashSet<string>.Empty);
-            settings.AppVersion.Should().Be(AppVersion.Zero);
+
+            var appVersion = AppVersion.AppVersionFromAssemblyVersion();
+            settings.AppVersion.Should().Be(appVersion);
             settings.UseDispatcher.Should().Be(Dispatchers.InternalDispatcherId);
             settings.GossipDifferentViewProbability.Should().Be(0.8);
             settings.ReduceGossipDifferentViewProbability.Should().Be(400);
@@ -66,6 +69,17 @@ namespace Akka.Cluster.Tests
             settings.VerboseHeartbeatLogging.Should().BeFalse();
             settings.VerboseGossipReceivedLogging.Should().BeFalse();
             settings.RunCoordinatedShutdownWhenDown.Should().BeTrue();
+        }
+
+        /// <summary>
+        /// To verify that overriding AppVersion from HOCON works
+        /// </summary>
+        [Fact]
+        public void Clustering_should_parse_nondefault_AppVersion()
+        {
+            Config config = "akka.cluster.app-version = \"0.0.0\"";
+            var settings = new ClusterSettings(config.WithFallback(Sys.Settings.Config), Sys.Name);
+            settings.AppVersion.Should().Be(AppVersion.Zero);
         }
     }
 }

--- a/src/core/Akka.Cluster/ClusterSettings.cs
+++ b/src/core/Akka.Cluster/ClusterSettings.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Reflection;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Dispatch;
@@ -69,6 +70,7 @@ namespace Akka.Cluster
 
             Roles = clusterConfig.GetStringList("roles", new string[] { }).ToImmutableHashSet();
             AppVersion = Util.AppVersion.Create(clusterConfig.GetString("app-version"));
+
             MinNrOfMembers = clusterConfig.GetInt("min-nr-of-members", 0);
 
             _useDispatcher = clusterConfig.GetString("use-dispatcher", null);

--- a/src/core/Akka.Cluster/Configuration/Cluster.conf
+++ b/src/core/Akka.Cluster/Configuration/Cluster.conf
@@ -92,7 +92,16 @@ akka {
     # It has support for https://github.com/dwijnand/sbt-dynver format with `+` or
     # `-` separator. The number of commits from the tag is handled as a numeric part.
     # For example `1.0.0+3-73475dce26` is less than `1.0.10+10-ed316bd024` (3 < 10).
-    app-version = "0.0.0"
+    #
+    # DEFAULT: by default the app-version will default to the entry assembly's version,
+    # i.e. the assembly of the executable running `Program.cs`
+    # 
+    # Values can be "assembly-version" or a version string as defined above, i.e.
+    # app-version = "1.0.0"
+    # app-version = "1.1-beta1"
+    # app-version = "1"
+    # app-version = "1.1"
+    app-version = assembly-version 
 
 	# Run the coordinated shutdown from phase 'cluster-shutdown' when the cluster
     # is shutdown for other reasons than when leaving, e.g. when downing. This

--- a/src/core/Akka.Docs.Tests/Configuration/SerializationSetupDocSpec.cs
+++ b/src/core/Akka.Docs.Tests/Configuration/SerializationSetupDocSpec.cs
@@ -1,0 +1,129 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SerializationSetupDocSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Immutable;
+using Akka.Actor;
+using Akka.Actor.Setup;
+using Akka.Configuration;
+using Akka.Serialization;
+using Akka.TestKit.Configs;
+using FluentAssertions;
+using Xunit;
+
+namespace DocsExamples.Configuration
+{
+    // <Protocol>
+    public interface IAppProtocol{}
+
+    public sealed class Ack : IAppProtocol{ }
+
+    public sealed class Nack : IAppProtocol{ }
+    // </Protocol>
+
+    // <Serializer>
+    public sealed class AppProtocolSerializer : SerializerWithStringManifest
+    {
+        public AppProtocolSerializer(ExtendedActorSystem system) : base(system)
+        {
+        }
+
+        /// <summary>
+        /// Pick a custom value between 100-1000 - this gets included in the manifests
+        /// that are sent via Akka.Remote and Akka.Persistence, so it's important to pick
+        /// a unique and stable value for each custom serializer.
+        /// </summary>
+        public override int Identifier => 588;
+
+        public override byte[] ToBinary(object obj)
+        {
+            switch (obj)
+            {
+                // no dynamic content here - manifest is enough to tell us what message type is
+                // so no need to populate byte array
+                case Ack _:
+                    return Array.Empty<byte>();
+                case Nack _:
+                    return Array.Empty<byte>();
+                default:
+                    throw new NotImplementedException($"Unsupported serialization type [{obj.GetType()}]");
+            }
+        }
+
+        public override object FromBinary(byte[] bytes, string manifest)
+        {
+            switch (manifest)
+            {
+                case "A":
+                    return new Ack();
+                case "N":
+                    return new Nack();
+                default:
+                    throw new NotImplementedException($"Unsupported serialization manifest [{manifest}]");
+            }
+        }
+
+        public override string Manifest(object o)
+        {
+            switch (o)
+            {
+                case Ack _:
+                    return "A";
+                case Nack _:
+                    return "N";
+                default:
+                    throw new NotImplementedException($"Unsupported serialization type [{o.GetType()}]");
+            }
+        }
+    }
+    // </Serializer>
+
+    public class SerializationSetupDocSpec
+    {
+        // <SerializerSetup>
+        public static SerializationSetup SerializationSettings => 
+            SerializationSetup.Create(actorSystem => 
+                    ImmutableHashSet<SerializerDetails>.Empty.Add(
+                        SerializerDetails.Create("app-protocol", 
+                            new AppProtocolSerializer(actorSystem), 
+                            ImmutableHashSet<Type>.Empty.Add(typeof(IAppProtocol)))));
+        // </SerializerSetup>
+
+        // <MergedSetup>
+        public static readonly BootstrapSetup Bootstrap = BootstrapSetup.Create().WithConfig(
+            ConfigurationFactory.ParseString(@"
+            akka{
+                actor{
+                    serialize-messages = off
+                }
+            }
+        ").WithFallback(TestConfigs.DefaultConfig));
+
+        // Merges the SerializationSetup and BootstrapSetup together into a unified ActorSystemSetup class
+        public static readonly ActorSystemSetup ActorSystemSettings = ActorSystemSetup.Create(SerializationSettings, Bootstrap);
+        // </MergedSetup>
+
+        [Fact]
+        public void SerializationSetupShouldWorkAsExpected()
+        {
+            // <Verification>
+            // consume the ActorSystemSetup
+            using (var actorSystem = ActorSystem.Create("TestSerialization", ActorSystemSettings))
+            {
+                // implements IAppProtocol
+                var ack = new Ack();
+
+                // lookup the serializer configured by Akka.NET to manage Ack
+                var foundSerializer = actorSystem.Serialization.FindSerializerFor(ack);
+
+                // it's the custom serializer we specified in our SerializationSetup
+                foundSerializer.Should().BeOfType<AppProtocolSerializer>();
+            }
+            // </Verification>
+        }
+    }
+}

--- a/src/core/Akka.MultiNodeTestRunner/Program.cs
+++ b/src/core/Akka.MultiNodeTestRunner/Program.cs
@@ -24,9 +24,6 @@ using Akka.MultiNodeTestRunner.Shared.Persistence;
 using Akka.MultiNodeTestRunner.Shared.Reporting;
 using Akka.MultiNodeTestRunner.Shared.Sinks;
 using Akka.Remote.TestKit;
-using Akka.Util;
-using JetBrains.TeamCity.ServiceMessages.Write.Special;
-using JetBrains.TeamCity.ServiceMessages.Write.Special.Impl;
 using Xunit;
 #if CORECLR
 using System.Runtime.Loader;
@@ -125,7 +122,9 @@ namespace Akka.MultiNodeTestRunner
         {
             OutputDirectory = CommandLine.GetPropertyOrDefault("multinode.output-directory", string.Empty);
             FailedSpecsDirectory = CommandLine.GetPropertyOrDefault("multinode.failed-specs-directory", "FAILED_SPECS_LOGS");
-            TestRunSystem = ActorSystem.Create("TestRunnerLogging");
+            
+            string logLevel = CommandLine.GetPropertyOrDefault("multinode.loglevel", "WARNING");
+            TestRunSystem = ActorSystem.Create("TestRunnerLogging", $"akka.loglevel={logLevel}");
 
             var suiteName = Path.GetFileNameWithoutExtension(Path.GetFullPath(args[0].Trim('"')));
             var teamCityFormattingOn = CommandLine.GetPropertyOrDefault("multinode.teamcity", "false");
@@ -369,7 +368,7 @@ namespace Akka.MultiNodeTestRunner
                                     // Dump aggregated timeline to file for this test
                                     timelineCollector.Ask<Done>(new TimelineLogCollectorActor.DumpToFile(Path.Combine(testOutputDir, "aggregated.txt"))),
                                     // Print aggregated timeline into the console
-                                    timelineCollector.Ask<Done>(new TimelineLogCollectorActor.PrintToConsole())
+                                    timelineCollector.Ask<Done>(new TimelineLogCollectorActor.PrintToConsole(logLevel))
                                 };
 
                                 if (specFailed)

--- a/src/core/Akka.Persistence/Snapshot/SnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/SnapshotStore.cs
@@ -39,9 +39,9 @@ namespace Akka.Persistence.Snapshot
             var config = extension.ConfigFor(Self);
             _breaker = CircuitBreaker.Create(
                 Context.System.Scheduler,
-                config.GetInt("circuit-breaker.max-failures", 0),
-                config.GetTimeSpan("circuit-breaker.call-timeout", null),
-                config.GetTimeSpan("circuit-breaker.reset-timeout", null));
+                config.GetInt("circuit-breaker.max-failures", 10),
+                config.GetTimeSpan("circuit-breaker.call-timeout", TimeSpan.FromSeconds(10)),
+                config.GetTimeSpan("circuit-breaker.reset-timeout", TimeSpan.FromSeconds(30)));
         }
 
         /// <inheritdoc/>

--- a/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
+++ b/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
@@ -151,7 +151,7 @@ namespace Akka.Remote.TestKit
                         : ConfigurationFactory.Empty;
 
                 var builder = ImmutableList.CreateBuilder<Config>();
-                if (_nodeConf.TryGetValue(Myself, out var nodeConfig)) 
+                if (_nodeConf.TryGetValue(Myself, out var nodeConfig))
                     builder.Add(nodeConfig);
                 builder.Add(_commonConf);
                 builder.Add(transportConfig);
@@ -185,7 +185,7 @@ namespace Akka.Remote.TestKit
     /// </summary>
     public abstract class MultiNodeSpec : TestKitBase, IMultiNodeSpecCallbacks, IDisposable
     {
-        //TODO: Sort out references to Java classes in 
+        //TODO: Sort out references to Java classes in
 
         /// <summary>
         /// Marker used to indicate that <see cref="MaxNodes"/> has not been set yet.
@@ -216,9 +216,9 @@ namespace Akka.Remote.TestKit
         /// <summary>
         /// Name (or IP address; must be resolvable)
         /// of the host this node is running on
-        /// 
+        ///
         /// <code>-Dmultinode.host=host.example.com</code>
-        /// 
+        ///
         /// InetAddress.getLocalHost.getHostAddress is used if empty or "localhost"
         /// is defined as system property "multinode.host".
         /// </summary>
@@ -246,7 +246,7 @@ namespace Akka.Remote.TestKit
 
         /// <summary>
         /// Port number of this node. Defaults to 0 which means a random port.
-        /// 
+        ///
         /// <code>-Dmultinode.port=0</code>
         /// </summary>
         public static int SelfPort
@@ -268,7 +268,7 @@ namespace Akka.Remote.TestKit
         /// <summary>
         /// Name (or IP address; must be resolvable using InetAddress.getByName)
         /// of the host that the server node is running on.
-        /// 
+        ///
         /// <code>-Dmultinode.server-host=server.example.com</code>
         /// </summary>
         public static string ServerName
@@ -292,13 +292,13 @@ namespace Akka.Remote.TestKit
         /// <summary>
         /// Default value for <see cref="ServerPort"/>
         /// </summary>
-        private const int ServerPortDefault = 4711;
+        private const int ServerPortDefault = 47110;
 
         private static int _serverPort = ServerPortUnsetValue;
 
         /// <summary>
         /// Port number of the node that's running the server system. Defaults to 4711.
-        /// 
+        ///
         /// <code>-Dmultinode.server-port=4711</code>
         /// </summary>
         public static int ServerPort
@@ -366,7 +366,7 @@ namespace Akka.Remote.TestKit
                         coordinated-shutdown.terminate-actor-system = off
                         coordinated-shutdown.run-by-actor-system-terminate = off
                         coordinated-shutdown.run-by-clr-shutdown-hook = off
-                        log-dead-letters = off 
+                        log-dead-letters = off
                         log-dead-letters-during-shutdown = on
                         actor {
                           default-dispatcher {
@@ -479,7 +479,7 @@ namespace Akka.Remote.TestKit
 
         /// <summary>
         /// MUST BE DEFINED BY USER.
-        /// 
+        ///
         /// Defines the number of participants required for starting the test. This
         /// might not be equals to the number of nodes available to the test.
         /// </summary>
@@ -511,7 +511,7 @@ namespace Akka.Remote.TestKit
             if (nodes.Length == 0) throw new ArgumentException("No node given to run on.");
             if (IsNode(nodes)) thunk();
         }
-        
+
         /// <summary>
         /// Execute the given block of code only on the given nodes (names according
         /// to the `roleMap`).
@@ -542,12 +542,12 @@ namespace Akka.Remote.TestKit
         /// <summary>
         /// Query the controller for the transport address of the given node (by role name) and
         /// return that as an ActorPath for easy composition:
-        /// 
+        ///
         /// <code>var serviceA = Sys.ActorSelection(Node(new RoleName("master")) / "user" / "serviceA");</code>
         /// </summary>
         public ActorPath Node(RoleName role)
         {
-            //TODO: Async stuff here 
+            //TODO: Async stuff here
             return new RootActorPath(TestConductor.GetAddressFor(role).Result);
         }
 
@@ -677,9 +677,9 @@ namespace Akka.Remote.TestKit
 
 
         /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
-        /// <param name="disposing">if set to <c>true</c> the method has been called directly or indirectly by a 
+        /// <param name="disposing">if set to <c>true</c> the method has been called directly or indirectly by a
         /// user's code. Managed and unmanaged resources will be disposed.<br />
-        /// if set to <c>false</c> the method has been called by the runtime from inside the finalizer and only 
+        /// if set to <c>false</c> the method has been called by the runtime from inside the finalizer and only
         /// unmanaged resources can be disposed.</param>
         protected void Dispose(bool disposing)
         {

--- a/src/core/Akka.Streams/ActorMaterializer.cs
+++ b/src/core/Akka.Streams/ActorMaterializer.cs
@@ -74,7 +74,9 @@ namespace Akka.Streams
         {
             var haveShutDown = new AtomicBoolean();
             var system = ActorSystemOf(context);
+
             system.Settings.InjectTopLevelFallback(DefaultConfig());
+
             settings = settings ?? ActorMaterializerSettings.Create(system);
 
             return new ActorMaterializerImpl(

--- a/src/core/Akka.Tests/IO/TcpListenerSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpListenerSpec.cs
@@ -28,7 +28,7 @@ namespace Akka.Tests.IO
         { }
 
         [Fact]
-        public void A_TCP_Listner_must_let_the_bind_commander_know_when_binding_is_complete()
+        public void A_TCP_Listener_must_let_the_bind_commander_know_when_binding_is_complete()
         {
             new TestSetup(this, pullMode: false).Run(x =>
             {
@@ -37,7 +37,7 @@ namespace Akka.Tests.IO
         }
 
         [Fact]
-        public void A_TCP_Listner_must_continue_to_accept_connections_after_a_previous_accept()
+        public void A_TCP_Listener_must_continue_to_accept_connections_after_a_previous_accept()
         {
             new TestSetup(this, pullMode: false).Run(x =>
             {
@@ -49,17 +49,17 @@ namespace Akka.Tests.IO
         }
 
         [Fact]
-        public void A_TCP_Listner_must_react_to_unbind_commands_by_replying_with_unbound_and_stopping_itself()
+        public void A_TCP_Listener_must_react_to_unbind_commands_by_replying_with_unbound_and_stopping_itself()
         {
             new TestSetup(this, pullMode:false).Run(x =>
             {
                 x.BindListener();
 
                 var unbindCommander = CreateTestProbe();
-                unbindCommander.Send(x.Listner, Tcp.Unbind.Instance);
+                unbindCommander.Send(x.Listener, Tcp.Unbind.Instance);
 
                 unbindCommander.ExpectMsg(Tcp.Unbound.Instance);
-                x.Parent.ExpectTerminated(x.Listner);
+                x.Parent.ExpectTerminated(x.Listener);
             });    
         }
 
@@ -107,7 +107,7 @@ namespace Akka.Tests.IO
                 new Socket(_endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp).Connect(_endpoint);
             }
 
-            public IActorRef Listner { get { return _parentRef.UnderlyingActor.Listner; } }
+            public IActorRef Listener { get { return _parentRef.UnderlyingActor.Listener; } }
 
             public TestProbe SelectorRouter
             {
@@ -121,23 +121,23 @@ namespace Akka.Tests.IO
             {
                 private readonly TestSetup _test;
                 private readonly bool _pullMode;
-                private readonly IActorRef _listner;
+                private readonly IActorRef _listener;
 
                 public ListenerParent(TestSetup test, bool pullMode)
                 {
                     _test = test;
                     _pullMode = pullMode;
 
-                    _listner = Context.ActorOf(Props.Create(() =>
+                    _listener = Context.ActorOf(Props.Create(() =>
                         new TcpListener(
                             Tcp.Instance.Apply(Context.System),
                             test._bindCommander.Ref,
                             new Tcp.Bind(_test._handler.Ref, test._endpoint, 100, new Inet.SocketOption[]{}, pullMode)))
                                                               .WithDeploy(Deploy.Local));
-                    _test._parent.Watch(_listner);
+                    _test._parent.Watch(_listener);
                 }
 
-                internal IActorRef Listner { get { return _listner; } }
+                internal IActorRef Listener { get { return _listener; } }
 
                 protected override bool Receive(object message)
                 {

--- a/src/core/Akka.Tests/IO/UdpListenerSpec.cs
+++ b/src/core/Akka.Tests/IO/UdpListenerSpec.cs
@@ -1,0 +1,182 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="UdpListenerSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2020 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2020 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using Akka.Actor;
+using Akka.IO;
+using Akka.TestKit;
+using Xunit;
+using UdpListener = Akka.IO.UdpListener;
+
+namespace Akka.Tests.IO
+{
+    public class UdpListenerSpec : AkkaSpec
+    {
+        public UdpListenerSpec()
+            : base(@"akka.io.udp.max-channels = unlimited
+                    akka.io.udp.nr-of-selectors = 1
+                    akka.io.udp.direct-buffer-pool-limit = 100
+                    akka.io.udp.direct-buffer-size = 1024")
+        { }
+
+        [Fact]
+        public void A_UDP_Listener_must_let_the_bind_commander_know_when_binding_is_complete()
+        {
+            new TestSetup(this).Run(x =>
+            {
+                x.BindCommander.ExpectMsg<Udp.Bound>();
+            });           
+        }
+
+        [Fact]
+        public void A_UDP_Listener_must_forward_incoming_packets_to_handler_actor()
+        {
+            const string dgram = "Fly little packet!";
+            new TestSetup(this).Run(x =>
+            {
+                x.BindCommander.ExpectMsg<Udp.Bound>();
+                x.SendDataToLocal(Encoding.UTF8.GetBytes(dgram));
+                x.Handler.ExpectMsg<Udp.Received>(_ => Assert.Equal(dgram, Encoding.UTF8.GetString(_.Data.ToArray())));
+                x.SendDataToLocal(Encoding.UTF8.GetBytes(dgram));
+                x.Handler.ExpectMsg<Udp.Received>(_ => Assert.Equal(dgram, Encoding.UTF8.GetString(_.Data.ToArray())));
+            });           
+        }
+        
+        [Fact]
+        public void A_UDP_Listener_must_be_able_to_send_and_receive_when_server_goes_away()
+        {
+            new TestSetup(this).Run(x =>
+            {
+                x.BindCommander.ExpectMsg<Udp.Bound>();
+                
+                // Receive UDP messages from a sender
+                const string requestMessage = "This is my last request!";
+                var notExistingEndPoint = x.SendDataToLocal(Encoding.UTF8.GetBytes(requestMessage));
+                x.Handler.ExpectMsg<Udp.Received>(_ =>
+                {
+                    Assert.Equal(requestMessage, Encoding.UTF8.GetString(_.Data.ToArray()));
+                });
+
+                // Try to reply to this sender which DOES NOT EXIST any more
+                // Important: The UDP port of the reply must match the listing UDP port!
+                // This UDP port will also be used for ICMP error reporting.
+                // Hint: On Linux the listener port cannot be reused. We are using the udp actor to respond.
+                IActorRef localSender = x.Listener;
+                const string response = "Are you still alive?"; // he is not
+                localSender.Tell(Udp.Send.Create(ByteString.FromBytes(Encoding.UTF8.GetBytes(response)), notExistingEndPoint));
+
+                // Now an ICMP error message "port unreachable" (SocketError.ConnectionReset) is sent to our UDP server port
+                x.Handler.ExpectNoMsg(TimeSpan.FromSeconds(1));
+
+                const string followUpMessage = "Back online!";
+                x.SendDataToLocal(Encoding.UTF8.GetBytes(followUpMessage));
+                x.Handler.ExpectMsg<Udp.Received>(_ => Assert.Equal(followUpMessage, Encoding.UTF8.GetString(_.Data.ToArray())));
+            });         
+        }
+
+        class TestSetup
+        {
+            private readonly TestKitBase _kit;
+
+            private readonly TestProbe _handler;
+            private readonly TestProbe _bindCommander;
+            private readonly TestProbe _parent;
+            private readonly IPEndPoint _localEndpoint;
+            private readonly TestActorRef<ListenerParent> _parentRef;
+
+            public TestSetup(TestKitBase kit) :
+                this(kit, TestUtils.TemporaryServerAddress())
+            {
+
+            }
+
+            public TestSetup(TestKitBase kit, IPEndPoint localEndpoint)
+            {
+                _kit = kit;
+                _localEndpoint = localEndpoint;
+                _handler = kit.CreateTestProbe();
+                _bindCommander = kit.CreateTestProbe();
+                _parent = kit.CreateTestProbe();
+                _parentRef = new TestActorRef<ListenerParent>(kit.Sys, Props.Create(() => new ListenerParent(this)));
+            }
+
+            public void Run(Action<TestSetup> test)
+            {
+                test(this);
+            }
+
+            public void BindListener()
+            {
+                _bindCommander.ExpectMsg<Udp.Bound>();
+            }
+
+            public IPEndPoint SendDataToLocal(byte[] buffer)
+            {
+                return SendDataToEndpoint(buffer, _localEndpoint);
+            }
+
+            public IPEndPoint SendDataToEndpoint(byte[] buffer, IPEndPoint receiverEndpoint)
+            {
+                var tempEndpoint = TestUtils.TemporaryServerAddress();
+                return SendDataToEndpoint(buffer, receiverEndpoint, tempEndpoint);
+            }
+
+            public IPEndPoint SendDataToEndpoint(byte[] buffer, IPEndPoint receiverEndpoint, IPEndPoint senderEndpoint)
+            {
+                using (var udpClient = new UdpClient(senderEndpoint.Port))
+                {
+                    udpClient.Connect(receiverEndpoint);
+                    udpClient.Send(buffer, buffer.Length);
+                }
+                return senderEndpoint;
+            }
+            
+            public IActorRef Listener { get { return _parentRef.UnderlyingActor.Listener; } }
+            
+            public TestProbe BindCommander { get { return _bindCommander; } }
+
+            public TestProbe Handler { get { return _handler; } }
+            
+            public IPEndPoint LocalLocalEndPoint { get { return _localEndpoint; }  }
+
+            class ListenerParent : ActorBase
+            {
+                private readonly TestSetup _test;
+                private readonly IActorRef _listener;
+                public ListenerParent(TestSetup test)
+                {
+                    _test = test;
+
+                    _listener = Context.ActorOf(Props.Create(() =>
+                        new UdpListener(
+                            Udp.Instance.Apply(Context.System),
+                            test._bindCommander.Ref,
+                            new Udp.Bind(_test._handler.Ref, test._localEndpoint, new Inet.SocketOption[]{})))
+                                                              .WithDeploy(Deploy.Local));
+                    _test._parent.Watch(_listener);
+                }
+
+                internal IActorRef Listener { get { return _listener; } }
+
+                protected override bool Receive(object message)
+                {
+                    _test._parent.Forward(message);
+                    return true;
+                }
+
+                protected override SupervisorStrategy SupervisorStrategy()
+                {
+                    return Akka.Actor.SupervisorStrategy.StoppingStrategy;
+                }
+
+            }
+        }
+    }
+}

--- a/src/core/Akka/Actor/FSM.cs
+++ b/src/core/Akka/Actor/FSM.cs
@@ -1338,7 +1338,7 @@ namespace Akka.Actor
                 }
                 else
                 {
-                    _log.Error(failure.Cause.ToString());
+                    _log.Error(failure.Cause is null? "null": failure.Cause.ToString());
                 }
             }
         }

--- a/src/core/Akka/Actor/Settings.cs
+++ b/src/core/Akka/Actor/Settings.cs
@@ -44,6 +44,9 @@ namespace Akka.Actor
         /// <param name="config">TBD</param>
         public void InjectTopLevelFallback(Config config)
         {
+            if (Config.Contains(config)) 
+                return;
+
             _fallbackConfig = config.SafeWithFallback(_fallbackConfig);
             RebuildConfig();
         }

--- a/src/core/Akka/Configuration/Hocon/HoconValue.cs
+++ b/src/core/Akka/Configuration/Hocon/HoconValue.cs
@@ -169,7 +169,7 @@ namespace Akka.Configuration.Hocon
         /// <returns>The element at the given key.</returns>
         public HoconValue GetChildObject(string key)
         {
-            return GetObject().GetKey(key);
+            return GetObject()?.GetKey(key);
         }
 
         /// <summary>
@@ -343,9 +343,9 @@ namespace Akka.Configuration.Hocon
         /// <returns>A list of values represented by this <see cref="HoconValue"/>.</returns>
         public IList<HoconValue> GetArray()
         {
-            IEnumerable<HoconValue> x = from arr in Values
-                where arr.IsArray()
-                from e in arr.GetArray()
+            IEnumerable<HoconValue> x = from element in Values
+                where element.IsArray()
+                from e in element.GetArray()
                 select e;
 
             return x.ToList();
@@ -359,7 +359,7 @@ namespace Akka.Configuration.Hocon
         /// </returns>
         public bool IsArray()
         {
-            return GetArray() != null;
+            return GetArray().Count != 0;
         }
 
         /// <summary>

--- a/src/core/Akka/IO/UdpListener.cs
+++ b/src/core/Akka/IO/UdpListener.cs
@@ -118,7 +118,15 @@ namespace Akka.IO
         {
             try
             {
-                handler.Tell(new Received(ByteString.CopyFrom(e.Buffer, e.Offset, e.BytesTransferred), e.RemoteEndPoint));
+                if (!IsICMPError(e))
+                {
+                    if (e.SocketError != SocketError.Success)
+                        throw new SocketException((int)e.SocketError);
+
+                    handler.Tell(new Received(ByteString.CopyFrom(e.Buffer, e.Offset, e.BytesTransferred),
+                        e.RemoteEndPoint));
+                }
+
                 ReceiveAsync();
             }
             finally
@@ -127,6 +135,21 @@ namespace Akka.IO
                 Udp.SocketEventArgsPool.Release(e);
                 Udp.BufferPool.Release(buffer);
             }
+        }
+
+        /// <summary>
+        /// Checks if the socket event is an ICMP error message.
+        /// </summary>
+        /// <seealso href="https://tools.ietf.org/html/rfc1122#page-78"/>
+        private bool IsICMPError(SocketAsyncEventArgs e)
+        {
+            if (e.SocketError == SocketError.ConnectionReset)
+            {
+                Log.Debug("Ignoring client connection reset.");
+                return true;
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -151,6 +174,7 @@ namespace Akka.IO
         private void ReceiveAsync()
         {
             var e = Udp.SocketEventArgsPool.Acquire(Self);
+            
             var buffer = Udp.BufferPool.Rent();
             e.SetBuffer(buffer.Array, buffer.Offset, buffer.Count);
             e.RemoteEndPoint = Socket.LocalEndPoint;

--- a/src/core/Akka/PatternMatch.cs
+++ b/src/core/Akka/PatternMatch.cs
@@ -12,6 +12,7 @@ namespace Akka
     /// <summary>
     /// Class PatternMatch.
     /// </summary>
+    [Obsolete("Use instead the pattern matching feature introduced in C# 7.0")]
     public static class PatternMatch
     {
         


### PR DESCRIPTION
#### 1.4.13 December 16 2020 ####
**Maintenance Release for Akka.NET 1.4**

Akka.NET v1.4.13 includes a number of bug fixes and enhancements:

**`AppVersion` now uses Assembly Version by Default**
The new `AppVersion` setting, which is used to communicate application version numbers throughout Akka.Cluster and is used in scenarios such as Akka.Cluster.Sharding to help determine which nodes receive new shard allocations and which ones do not, now uses the following default HOCON setting:

```
akka.cluster.app-version = assembly-version
```

By default now the `AppVersion` communicated inside Akka.Cluster `Member` events uses the `Major.Minor.BuildNumber` from the `Assembly.GetEntryssembly()` or `Assembly.GetExecutingAssembly()` (in case the `EntryAssembly` is `null`). That way any updates made to your executable's (i.e. the .dll that hosts `Program.cs`) version number will be automatically reflected in the cluster now without Akka.NET developers having to set an additional configuration value during deployments.

Other bug fixes and improvements:

* [Akka.IO: UdpExt.Manager: OverflowException when sending UDP packets to terminated clients](https://github.com/akkadotnet/akka.net/issues/4641)
* [Akka.Configuration / Akka.Streams: Memory Leak when using many short lived instances of ActorMaterializer](https://github.com/akkadotnet/akka.net/issues/4659)
* [Akka: Deprecate `PatternMatch`](https://github.com/akkadotnet/akka.net/issues/4658)
* [Akka: FSM: exception in LogTermination changes stopEvent.Reason to Shutdown](https://github.com/akkadotnet/akka.net/issues/3723)
* [Akka.Cluster.Tools: ClusterSingleton - Ignore possible state change in start](https://github.com/akkadotnet/akka.net/pull/4646)
* [Akka.Cluster.Tools: DistributedPubSub - new setting and small fixes](https://github.com/akkadotnet/akka.net/pull/4649)
* [Akka.DistributedData: `KeyNotFoundException` thrown periodically](https://github.com/akkadotnet/akka.net/issues/4639)

To see the [full set of fixes in Akka.NET v1.4.13, please see the milestone on Github](https://github.com/akkadotnet/akka.net/milestone/44).

| COMMITS | LOC+ | LOC- | AUTHOR |
| --- | --- | --- | --- |
| 5 | 316 | 29 | Aaron Stannard |
| 2 | 53 | 8 | Gregorius Soedharmo |
| 2 | 223 | 197 | zbynek001 |
| 2 | 2 | 2 | dependabot-preview[bot] |
| 2 | 11 | 3 | Ebere Abanonu |
| 1 | 37 | 27 | Razvan Goga |
| 1 | 217 | 11 | motmot80 |
| 1 | 2 | 0 | Ismael Hamed |
