### PR TITLE
API - added overload for IScheduler that accepts IRunnable

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -888,11 +888,13 @@ namespace Akka.Actor
         protected override System.DateTimeOffset TimeNow { get; }
         public void Dispose() { }
         protected override void InternalScheduleOnce(System.TimeSpan delay, System.Action action, Akka.Actor.ICancelable cancelable) { }
+        protected override void InternalScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable) { }
         protected override void InternalScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action, Akka.Actor.ICancelable cancelable) { }
+        protected override void InternalScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable) { }
         protected override void InternalScheduleTellOnce(System.TimeSpan delay, Akka.Actor.ICanTell receiver, object message, Akka.Actor.IActorRef sender, Akka.Actor.ICancelable cancelable) { }
         protected override void InternalScheduleTellRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Actor.ICanTell receiver, object message, Akka.Actor.IActorRef sender, Akka.Actor.ICancelable cancelable) { }
     }
-    public interface IActionScheduler
+    public interface IActionScheduler : Akka.Actor.IRunnableScheduler
     {
         void ScheduleOnce(System.TimeSpan delay, System.Action action, Akka.Actor.ICancelable cancelable);
         void ScheduleOnce(System.TimeSpan delay, System.Action action);
@@ -967,7 +969,7 @@ namespace Akka.Actor
     {
         Akka.Actor.IStash Stash { get; set; }
     }
-    public interface IAdvancedScheduler : Akka.Actor.IActionScheduler { }
+    public interface IAdvancedScheduler : Akka.Actor.IActionScheduler, Akka.Actor.IRunnableScheduler { }
     public interface IAutoReceivedMessage { }
     public interface ICanTell
     {
@@ -1084,6 +1086,13 @@ namespace Akka.Actor
     public interface IRepointableRef : Akka.Actor.IActorRefScope
     {
         bool IsStarted { get; }
+    }
+    public interface IRunnableScheduler
+    {
+        void ScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable);
+        void ScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action);
+        void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable);
+        void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action);
     }
     public interface IScheduler : Akka.Actor.ITellScheduler, Akka.Actor.ITimeProvider
     {
@@ -1534,7 +1543,7 @@ namespace Akka.Actor
         public override void Stop() { }
         protected override void TellInternal(object message, Akka.Actor.IActorRef sender) { }
     }
-    public abstract class SchedulerBase : Akka.Actor.IActionScheduler, Akka.Actor.IAdvancedScheduler, Akka.Actor.IScheduler, Akka.Actor.ITellScheduler, Akka.Actor.ITimeProvider
+    public abstract class SchedulerBase : Akka.Actor.IActionScheduler, Akka.Actor.IAdvancedScheduler, Akka.Actor.IRunnableScheduler, Akka.Actor.IScheduler, Akka.Actor.ITellScheduler, Akka.Actor.ITimeProvider
     {
         protected readonly Akka.Event.ILoggingAdapter Log;
         protected readonly Akka.Configuration.Config SchedulerConfig;
@@ -1543,9 +1552,15 @@ namespace Akka.Actor
         public abstract System.TimeSpan MonotonicClock { get; }
         protected abstract System.DateTimeOffset TimeNow { get; }
         protected abstract void InternalScheduleOnce(System.TimeSpan delay, System.Action action, Akka.Actor.ICancelable cancelable);
+        protected abstract void InternalScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable);
         protected abstract void InternalScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action, Akka.Actor.ICancelable cancelable);
+        protected abstract void InternalScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable);
         protected abstract void InternalScheduleTellOnce(System.TimeSpan delay, Akka.Actor.ICanTell receiver, object message, Akka.Actor.IActorRef sender, Akka.Actor.ICancelable cancelable);
         protected abstract void InternalScheduleTellRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Actor.ICanTell receiver, object message, Akka.Actor.IActorRef sender, Akka.Actor.ICancelable cancelable);
+        public void ScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable) { }
+        public void ScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action) { }
+        public void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable) { }
+        public void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action) { }
         protected static void ValidateDelay(System.TimeSpan delay, string parameterName) { }
         protected static void ValidateInterval(System.TimeSpan interval, string parameterName) { }
     }

--- a/src/core/Akka.TestKit/TestScheduler.cs
+++ b/src/core/Akka.TestKit/TestScheduler.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Akka.Actor;
 using Akka.Configuration;
+using Akka.Dispatch;
 using Akka.Event;
 
 namespace Akka.TestKit
@@ -310,5 +311,26 @@ namespace Akka.TestKit
                 DeliveryCount = 0;
             }
         }
+
+         // don't need these methods - not used during testing
+         public void ScheduleOnce(TimeSpan delay, IRunnable action, ICancelable cancelable)
+         {
+             throw new NotImplementedException();
+         }
+
+         public void ScheduleOnce(TimeSpan delay, IRunnable action)
+         {
+             throw new NotImplementedException();
+         }
+
+         public void ScheduleRepeatedly(TimeSpan initialDelay, TimeSpan interval, IRunnable action, ICancelable cancelable)
+         {
+             throw new NotImplementedException();
+         }
+
+         public void ScheduleRepeatedly(TimeSpan initialDelay, TimeSpan interval, IRunnable action)
+         {
+             throw new NotImplementedException();
+         }
     }
 }

--- a/src/core/Akka.Tests/Actor/Scheduler/SchedulerShutdownSpec.cs
+++ b/src/core/Akka.Tests/Actor/Scheduler/SchedulerShutdownSpec.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
+using Akka.Dispatch;
 using Akka.Event;
 using Akka.TestKit;
 using Akka.Util.Internal;
@@ -53,9 +54,19 @@ namespace Akka.Tests.Actor.Scheduler
                 action();
             }
 
+            protected override void InternalScheduleOnce(TimeSpan delay, IRunnable action, ICancelable cancelable)
+            {
+                action.Run();
+            }
+
             protected override void InternalScheduleRepeatedly(TimeSpan initialDelay, TimeSpan interval, Action action, ICancelable cancelable)
             {
                 action();
+            }
+
+            protected override void InternalScheduleRepeatedly(TimeSpan initialDelay, TimeSpan interval, IRunnable action, ICancelable cancelable)
+            {
+                action.Run();
             }
 
             public void Dispose()

--- a/src/core/Akka/Actor/Scheduler/HashedWheelTimerScheduler.cs
+++ b/src/core/Akka/Actor/Scheduler/HashedWheelTimerScheduler.cs
@@ -326,7 +326,12 @@ namespace Akka.Actor
         /// <param name="cancelable">TBD</param>
         protected override void InternalScheduleOnce(TimeSpan delay, Action action, ICancelable cancelable)
         {
-            InternalSchedule(delay, TimeSpan.Zero, new ActionRunnable(action), cancelable);
+            InternalScheduleOnce(delay, new ActionRunnable(action), cancelable);
+        }
+
+        protected override void InternalScheduleOnce(TimeSpan delay, IRunnable action, ICancelable cancelable)
+        {
+            InternalSchedule(delay, TimeSpan.Zero, action, cancelable);
         }
 
         /// <summary>
@@ -339,6 +344,11 @@ namespace Akka.Actor
         protected override void InternalScheduleRepeatedly(TimeSpan initialDelay, TimeSpan interval, Action action, ICancelable cancelable)
         {
             InternalSchedule(initialDelay, interval, new ActionRunnable(action), cancelable);
+        }
+
+        protected override void InternalScheduleRepeatedly(TimeSpan initialDelay, TimeSpan interval, IRunnable action, ICancelable cancelable)
+        {
+            InternalSchedule(initialDelay, interval, action, cancelable);
         }
 
         private AtomicReference<TaskCompletionSource<IEnumerable<SchedulerRegistration>>> _stopped = new AtomicReference<TaskCompletionSource<IEnumerable<SchedulerRegistration>>>();

--- a/src/core/Akka/Actor/Scheduler/IActionScheduler.cs
+++ b/src/core/Akka/Actor/Scheduler/IActionScheduler.cs
@@ -6,13 +6,14 @@
 //-----------------------------------------------------------------------
 
 using System;
+using Akka.Dispatch;
 
 namespace Akka.Actor
 {
     /// <summary>
     /// This interface defines a scheduler that is able to execute actions on a set schedule.
     /// </summary>
-    public interface IActionScheduler
+    public interface IActionScheduler : IRunnableScheduler
     {
         /// <summary>
         /// Schedules an action to be invoked after a delay. The action is wrapped so that it
@@ -55,6 +56,56 @@ namespace Akka.Actor
         /// <param name="interval">The time period that has to pass between each invocation of the action.</param>
         /// <param name="action">The action that is being scheduled.</param>
         void ScheduleRepeatedly(TimeSpan initialDelay, TimeSpan interval, Action action);
+    }
+
+    /// <summary>
+    /// INTERNAL API
+    ///
+    /// Convenience API for working with <see cref="IRunnable"/>
+    /// </summary>
+    public interface IRunnableScheduler
+    {
+        /// <summary>
+        /// Schedules an action to be invoked after a delay. The action is wrapped so that it
+        /// completes inside the currently active actor if it is called from within an actor.
+        /// <remarks>Note! It's considered bad practice to use concurrency inside actors, and very easy to get wrong so usage is discouraged.</remarks>
+        /// </summary>
+        /// <param name="delay">The time period that has to pass before the action is invoked.</param>
+        /// <param name="action">The action that is being scheduled.</param>
+        /// <param name="cancelable">A cancelable used to cancel the action from being executed.</param>
+        void ScheduleOnce(TimeSpan delay, IRunnable action, ICancelable cancelable);
+
+        /// <summary>
+        /// Schedules an action to be invoked after a delay. The action is wrapped so that it
+        /// completes inside the currently active actor if it is called from within an actor.
+        /// <remarks>Note! It's considered bad practice to use concurrency inside actors, and very easy to get wrong so usage is discouraged.</remarks>
+        /// </summary>
+        /// <param name="delay">The time period that has to pass before the action is invoked.</param>
+        /// <param name="action">The action that is being scheduled.</param>
+        void ScheduleOnce(TimeSpan delay, IRunnable action);
+
+        /// <summary>
+        /// Schedules an action to be invoked after an initial delay and then repeatedly.
+        /// The action is wrapped so that it completes inside the currently active actor
+        /// if it is called from within an actor.
+        /// <remarks>Note! It's considered bad practice to use concurrency inside actors, and very easy to get wrong so usage is discouraged.</remarks>
+        /// </summary>
+        /// <param name="initialDelay">The time period that has to pass before first invocation of the action.</param>
+        /// <param name="interval">The time period that has to pass between each invocation of the action.</param>
+        /// <param name="action">The action that is being scheduled.</param>
+        /// <param name="cancelable">A cancelable used to cancel the action from being executed.</param>
+        void ScheduleRepeatedly(TimeSpan initialDelay, TimeSpan interval, IRunnable action, ICancelable cancelable);
+
+        /// <summary>
+        /// Schedules an action to be invoked after an initial delay and then repeatedly.
+        /// The action is wrapped so that it completes inside the currently active actor
+        /// if it is called from within an actor.
+        /// <remarks>Note! It's considered bad practice to use concurrency inside actors, and very easy to get wrong so usage is discouraged.</remarks>
+        /// </summary>
+        /// <param name="initialDelay">The time period that has to pass before first invocation of the action.</param>
+        /// <param name="interval">The time period that has to pass between each invocation of the action.</param>
+        /// <param name="action">The action that is being scheduled.</param>
+        void ScheduleRepeatedly(TimeSpan initialDelay, TimeSpan interval, IRunnable action);
     }
 }
 

--- a/src/core/Akka/Actor/Scheduler/SchedulerBase.cs
+++ b/src/core/Akka/Actor/Scheduler/SchedulerBase.cs
@@ -6,7 +6,9 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using Akka.Configuration;
+using Akka.Dispatch;
 using Akka.Event;
 
 namespace Akka.Actor
@@ -145,6 +147,15 @@ namespace Akka.Actor
         /// <param name="action">TBD</param>
         /// <param name="cancelable">TBD</param>
         protected abstract void InternalScheduleOnce(TimeSpan delay, Action action, ICancelable cancelable);
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="delay">TBD</param>
+        /// <param name="action">TBD</param>
+        /// <param name="cancelable">TBD</param>
+        protected abstract void InternalScheduleOnce(TimeSpan delay, IRunnable action, ICancelable cancelable);
+
         /// <summary>
         /// TBD
         /// </summary>
@@ -153,6 +164,8 @@ namespace Akka.Actor
         /// <param name="action">TBD</param>
         /// <param name="cancelable">TBD</param>
         protected abstract void InternalScheduleRepeatedly(TimeSpan initialDelay, TimeSpan interval, Action action, ICancelable cancelable);
+
+        protected abstract void InternalScheduleRepeatedly(TimeSpan initialDelay, TimeSpan interval, IRunnable action, ICancelable cancelable);
 
         /// <summary>
         /// TBD
@@ -176,6 +189,26 @@ namespace Akka.Actor
         {
             if(delay < TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(parameterName), $"Delay must be >=0. It was {delay}");
+        }
+
+        public void ScheduleOnce(TimeSpan delay, IRunnable action, ICancelable cancelable)
+        {
+            InternalScheduleOnce(delay, action, cancelable);
+        }
+
+        public void ScheduleOnce(TimeSpan delay, IRunnable action)
+        {
+           ScheduleOnce(delay, action, null);
+        }
+
+        public void ScheduleRepeatedly(TimeSpan initialDelay, TimeSpan interval, IRunnable action, ICancelable cancelable)
+        {
+            InternalScheduleRepeatedly(initialDelay, interval, action, cancelable);
+        }
+
+        public void ScheduleRepeatedly(TimeSpan initialDelay, TimeSpan interval, IRunnable action)
+        {
+            InternalScheduleRepeatedly(initialDelay, interval, action, null);
         }
     }
 }


### PR DESCRIPTION
Purpose of this change is to make it possible to take Akka.Dispatch.IRunnable, the abstraction we use inside Dispatchers for processing mailboxes among other things, and pass it directly to the IScheduler for execution without having to wrap it.

This is largely a performance optimization and I don't expect this API to be used outside of Akka.NET's dispatching system.