### PR TITLE
Auto-tuning DotNetty batching + removing scheduler from batching system

### DIFF
--- a/src/common.props
+++ b/src/common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2020 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.4.13</VersionPrefix>
+    <VersionPrefix>1.4.14</VersionPrefix>
     <PackageIconUrl>https://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>
@@ -28,33 +28,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Maintenance Release for Akka.NET 1.4**
-Akka.NET v1.4.13 includes a number of bug fixes and enhancements:
-`AppVersion` now uses Assembly Version by Default**
-The new `AppVersion` setting, which is used to communicate application version numbers throughout Akka.Cluster and is used in scenarios such as Akka.Cluster.Sharding to help determine which nodes receive new shard allocations and which ones do not, now uses the following default HOCON setting:
-```
-akka.cluster.app-version = assembly-version
-```
-By default now the `AppVersion` communicated inside Akka.Cluster `Member` events uses the `Major.Minor.BuildNumber` from the `Assembly.GetEntryssembly()` or `Assembly.GetExecutingAssembly()` (in case the `EntryAssembly` is `null`). That way any updates made to your executable's (i.e. the .dll that hosts `Program.cs`) version number will be automatically reflected in the cluster now without Akka.NET developers having to set an additional configuration value during deployments.
-Other bug fixes and improvements:
-[Akka.IO: UdpExt.Manager: OverflowException when sending UDP packets to terminated clients](https://github.com/akkadotnet/akka.net/issues/4641)
-[Akka.Configuration / Akka.Streams: Memory Leak when using many short lived instances of ActorMaterializer](https://github.com/akkadotnet/akka.net/issues/4659)
-[Akka: Deprecate `PatternMatch`](https://github.com/akkadotnet/akka.net/issues/4658)
-[Akka: FSM: exception in LogTermination changes stopEvent.Reason to Shutdown](https://github.com/akkadotnet/akka.net/issues/3723)
-[Akka.Cluster.Tools: ClusterSingleton - Ignore possible state change in start](https://github.com/akkadotnet/akka.net/pull/4646)
-[Akka.Cluster.Tools: DistributedPubSub - new setting and small fixes](https://github.com/akkadotnet/akka.net/pull/4649)
-[Akka.DistributedData: `KeyNotFoundException` thrown periodically](https://github.com/akkadotnet/akka.net/issues/4639)
-To see the [full set of fixes in Akka.NET v1.4.13, please see the milestone on Github](https://github.com/akkadotnet/akka.net/milestone/44).
-| COMMITS | LOC+ | LOC- | AUTHOR |
-| --- | --- | --- | --- |
-| 5 | 316 | 29 | Aaron Stannard |
-| 2 | 53 | 8 | Gregorius Soedharmo |
-| 2 | 223 | 197 | zbynek001 |
-| 2 | 2 | 2 | dependabot-preview[bot] |
-| 2 | 11 | 3 | Ebere Abanonu |
-| 1 | 37 | 27 | Razvan Goga |
-| 1 | 217 | 11 | motmot80 |
-| 1 | 2 | 0 | Ismael Hamed |</PackageReleaseNotes>
+    <PackageReleaseNotes>Placeholder for nightlies**</PackageReleaseNotes>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>

--- a/src/core/Akka.Remote.Tests/RemoteConfigSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteConfigSpec.cs
@@ -174,9 +174,7 @@ namespace Akka.Remote.Tests
             var s = DotNettyTransportSettings.Create(c);
 
             s.BatchWriterSettings.EnableBatching.Should().BeTrue();
-            s.BatchWriterSettings.FlushInterval.Should().Be(BatchWriterSettings.DefaultFlushInterval);
-            s.BatchWriterSettings.MaxPendingBytes.Should().Be(BatchWriterSettings.DefaultMaxPendingBytes);
-            s.BatchWriterSettings.MaxPendingWrites.Should().Be(BatchWriterSettings.DefaultMaxPendingWrites);
+            s.BatchWriterSettings.MaxExplicitFlushes.Should().Be(BatchWriterSettings.DefaultMaxPendingWrites);
         }
    }
 }

--- a/src/core/Akka.Remote.Tests/Transport/DotNettyBatchWriterSpecs.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettyBatchWriterSpecs.cs
@@ -66,17 +66,13 @@ namespace Akka.Remote.Tests.Transport
                     batching{
                         enabled = false
                         max-pending-writes = 50
-                        max-pending-bytes = 32k
-                        flush-interval = 10ms
                     }
                 }
             ";
             var s = DotNettyTransportSettings.Create(c.GetConfig("akka.remote.dot-netty.tcp"));
 
             s.BatchWriterSettings.EnableBatching.Should().BeFalse();
-            s.BatchWriterSettings.FlushInterval.Should().NotBe(BatchWriterSettings.DefaultFlushInterval);
-            s.BatchWriterSettings.MaxPendingBytes.Should().NotBe(BatchWriterSettings.DefaultMaxPendingBytes);
-            s.BatchWriterSettings.MaxPendingWrites.Should().NotBe(BatchWriterSettings.DefaultMaxPendingWrites);
+            s.BatchWriterSettings.MaxExplicitFlushes.Should().NotBe(BatchWriterSettings.DefaultMaxPendingWrites);
         }
 
         /// <summary>
@@ -85,7 +81,7 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task BatchWriter_should_succeed_with_timer()
         {
-            var writer = new BatchWriter(new BatchWriterSettings(), Sys.Scheduler);
+            var writer = new FlushConsolidationHandler();
             var ch = new EmbeddedChannel(Flush, writer);
 
             await Flush.Activated;
@@ -98,14 +94,13 @@ namespace Akka.Remote.Tests.Transport
                 var ints = Enumerable.Range(0, 4).ToArray();
                 foreach (var i in ints)
                 {
-                    _ = ch.WriteAsync(Unpooled.Buffer(1).WriteInt(i));
+                    _ = ch.WriteAndFlushAsync(Unpooled.Buffer(1).WriteInt(i));
                 }
 
                 // force write tasks to run
                 ch.RunPendingTasks();
 
-                ch.Unsafe.OutboundBuffer.TotalPendingWriteBytes().Should().Be(ints.Length * 4);
-                ch.OutboundMessages.Count.Should().Be(0);
+                ch.OutboundMessages.Count.Should().Be(ints.Length);
 
                 await AwaitAssertAsync(() =>
                 {
@@ -124,7 +119,7 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task BatchWriter_should_flush_messages_during_shutdown()
         {
-            var writer = new BatchWriter(new BatchWriterSettings(), Sys.Scheduler);
+            var writer = new FlushConsolidationHandler();
             var ch = new EmbeddedChannel(Flush, writer);
 
             await Flush.Activated;
@@ -136,14 +131,13 @@ namespace Akka.Remote.Tests.Transport
             var ints = Enumerable.Range(0, 10).ToArray();
             foreach (var i in ints)
             {
-                _ = ch.WriteAsync(Unpooled.Buffer(1).WriteInt(i));
+                _ = ch.WriteAndFlushAsync(Unpooled.Buffer(1).WriteInt(i));
             }
 
             // force write tasks to run
             ch.RunPendingTasks();
 
-            ch.Unsafe.OutboundBuffer.TotalPendingWriteBytes().Should().Be(ints.Length * 4);
-            ch.OutboundMessages.Count.Should().Be(0);
+            ch.OutboundMessages.Count.Should().Be(ints.Length);
 
             // close channels
             _ = ch.CloseAsync();

--- a/src/core/Akka.Remote/Configuration/Remote.conf
+++ b/src/core/Akka.Remote/Configuration/Remote.conf
@@ -444,28 +444,9 @@ akka {
         # fast (< 40ms) acknowledgement for all periodic messages.
         enabled = true
 
-        # The max write threshold based on the number of logical messages regardless of their size. 
-        # This is a safe default value - decrease it if you have a small number of remote actors
-        # who engage in frequent request->response communication which requires low latency (< 40ms).
+        # The maximum number of explicit flushes that will be allowed before being batched.
+        # Batching normally happens when the channel switches from writes to reads and self-tunes automatically.
         max-pending-writes = 30
-
-        # The max write threshold based on the byte size of all buffered messages. If there are 4 messages
-        # waiting to be written (with batching.max-pending-writes = 30) but their total size is greater than
-        # batching.max-pending-bytes, a flush will be triggered immediately.
-        #
-        # Increase this value is you have larger message sizes and watch to take advantage of batching, but
-        # otherwise leave it as-is.
-        #
-        # NOTE: this value should always be smaller than dot-netty.tcp.maximum-frame-size.
-        max-pending-bytes = 16k
-
-        # In the event that neither the batching.max-pending-writes or batching.max-pending-bytes
-        # is hit we guarantee that all pending writes will be flushed within this interval.
-        #
-        # This setting, realistically, can't be enforced any lower than the OS' clock resolution (~20ms).
-        # If you have a very low-traffic system, either disable pooling altogether or lower the batching.max-pending-writes
-        # threshold to maximize throughput. Otherwise, leave this setting as-is.
-        flush-interval = 40ms
       }
 
       # If set to "<id.of.dispatcher>" then the specified dispatcher

--- a/src/core/Akka.Remote/Transport/DotNetty/BatchWriter.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/BatchWriter.cs
@@ -15,6 +15,11 @@ using Akka.Configuration;
 
 namespace Akka.Remote.Transport.DotNetty
 {
+    internal class FlushConsolidationHandler : ChannelDuplexHandler
+    {
+
+    }
+
     /// <summary>
     /// INTERNAL API.
     ///

--- a/src/core/Akka.Remote/Transport/DotNetty/BatchWriter.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/BatchWriter.cs
@@ -22,12 +22,11 @@ namespace Akka.Remote.Transport.DotNetty
         /// The default number of flushes after which a flush will be forwarded to downstream handlers (whether while in a
         /// read loop, or while batching outside of a read loop).
         /// </summary>
-        public const int DEFAULT_EXPLICIT_FLUSH_AFTER_FLUSHES = 256;
+        public const int DefaultExplicitFlushAfterFlushes = 256;
 
         public int ExplicitFlushAfterFlushes { get; }
         public bool ConsolidateWhenNoReadInProgress { get; }
 
-        public readonly IScheduler Scheduler;
         private int _flushPendingCount;
         private bool _readInProgress;
         private IChannelHandlerContext _context;
@@ -56,7 +55,7 @@ namespace Akka.Remote.Transport.DotNetty
             }
         }
 
-        public FlushConsolidationHandler() : this(DEFAULT_EXPLICIT_FLUSH_AFTER_FLUSHES, true){}
+        public FlushConsolidationHandler() : this(DefaultExplicitFlushAfterFlushes, true){}
 
         public FlushConsolidationHandler(int explicitFlushAfterFlushes, bool consolidateWhenNoReadInProgress)
         {

--- a/src/core/Akka.Remote/Transport/DotNetty/BatchWriter.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/BatchWriter.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using DotNetty.Buffers;
@@ -17,7 +18,186 @@ namespace Akka.Remote.Transport.DotNetty
 {
     internal class FlushConsolidationHandler : ChannelDuplexHandler
     {
+        /// <summary>
+        /// The default number of flushes after which a flush will be forwarded to downstream handlers (whether while in a
+        /// read loop, or while batching outside of a read loop).
+        /// </summary>
+        public const int DEFAULT_EXPLICIT_FLUSH_AFTER_FLUSHES = 256;
 
+        public int ExplicitFlushAfterFlushes { get; }
+        public bool ConsolidateWhenNoReadInProgress { get; }
+
+        public readonly IScheduler Scheduler;
+        private int _flushPendingCount;
+        private bool _readInProgress;
+        private IChannelHandlerContext _context;
+        private CancellationTokenSource _nextScheduledFlush;
+        private FlushTask _flushTask;
+        private Func<bool> _flushFunc;
+
+        private class FlushTask : IRunnable
+        {
+            private readonly FlushConsolidationHandler _handler;
+
+            public FlushTask(FlushConsolidationHandler handler)
+            {
+                _handler = handler;
+            }
+
+            public void Run()
+            {
+                if (_handler._flushPendingCount > 0 && !_handler._readInProgress)
+                {
+                    _handler._flushPendingCount = 0;
+                    _handler._nextScheduledFlush?.Dispose();
+                    _handler._nextScheduledFlush = null;
+                    _handler._context.Flush();
+                } // else we'll flush when the read completes
+            }
+        }
+
+        public FlushConsolidationHandler() : this(DEFAULT_EXPLICIT_FLUSH_AFTER_FLUSHES, true){}
+
+        public FlushConsolidationHandler(int explicitFlushAfterFlushes, bool consolidateWhenNoReadInProgress)
+        {
+            ExplicitFlushAfterFlushes = explicitFlushAfterFlushes;
+            ConsolidateWhenNoReadInProgress = consolidateWhenNoReadInProgress;
+            if (consolidateWhenNoReadInProgress)
+            {
+                _flushTask = new FlushTask(this);
+                _flushFunc = () =>
+                {
+                    _flushTask?.Run();
+                    return true;
+                };
+            }
+        }
+
+        public override void HandlerAdded(IChannelHandlerContext context)
+        {
+            _context = context;
+        }
+
+        public override void Flush(IChannelHandlerContext context)
+        {
+            if (_readInProgress)
+            {
+                // If there is still a read in progress we are sure we will see a channelReadComplete(...) call. Thus
+                // we only need to flush if we reach the explicitFlushAfterFlushes limit.
+                if (++_flushPendingCount == ExplicitFlushAfterFlushes)
+                {
+                    FlushNow(context);
+                }
+            } else if (ConsolidateWhenNoReadInProgress)
+            {
+                // Flush immediately if we reach the threshold, otherwise schedule
+                if (++_flushPendingCount == ExplicitFlushAfterFlushes)
+                {
+                    FlushNow(context);
+                }
+                else
+                {
+                    ScheduleFlush(context);
+                }
+            }
+            else
+            {
+                // Always flush directly
+                FlushNow(context);
+            }
+        }
+
+        public override void ChannelReadComplete(IChannelHandlerContext context)
+        {
+            // This may be the last event in the read loop, so flush now!
+            ResetReadAndFlushIfNeeded(context);
+            context.FireChannelReadComplete();
+        }
+
+        public override void ChannelRead(IChannelHandlerContext context, object message)
+        {
+            _readInProgress = true;
+            context.FireChannelRead(message);
+        }
+
+        public override void ExceptionCaught(IChannelHandlerContext context, Exception exception)
+        {
+            // To ensure we not miss to flush anything, do it now.
+            ResetReadAndFlushIfNeeded(context);
+            context.FireExceptionCaught(exception);
+        }
+
+        public override Task DisconnectAsync(IChannelHandlerContext context)
+        {
+            // Try to flush one last time if flushes are pending before disconnect the channel.
+            ResetReadAndFlushIfNeeded(context);
+            return context.DisconnectAsync();
+        }
+
+        public override Task CloseAsync(IChannelHandlerContext context)
+        {
+            // Try to flush one last time if flushes are pending before disconnect the channel.
+            ResetReadAndFlushIfNeeded(context);
+            return context.CloseAsync();
+        }
+
+        public override void ChannelWritabilityChanged(IChannelHandlerContext context)
+        {
+            if (!context.Channel.IsWritable)
+            {
+                // The writability of the channel changed to false, so flush all consolidated flushes now to free up memory.
+                FlushIfNeeded(context);
+            }
+
+            context.FireChannelWritabilityChanged();
+        }
+
+        public override void HandlerRemoved(IChannelHandlerContext context)
+        {
+            FlushIfNeeded(context);
+            _flushFunc = null;
+            _flushTask = null;
+        }
+
+        private void ResetReadAndFlushIfNeeded(IChannelHandlerContext ctx)
+        {
+            _readInProgress = false;
+            FlushIfNeeded(ctx);
+        }
+
+        private void FlushIfNeeded(IChannelHandlerContext ctx)
+        {
+            if (_flushPendingCount > 0)
+            {
+                FlushNow(ctx);
+            }
+        }
+
+        private void FlushNow(IChannelHandlerContext ctx)
+        {
+            CancelScheduledFlush();
+            _flushPendingCount = 0;
+            ctx.Flush();
+        }
+
+        private void ScheduleFlush(IChannelHandlerContext ctx)
+        {
+            if (_nextScheduledFlush == null && ConsolidateWhenNoReadInProgress)
+            {
+                // Run as soon as possible, but still yield to give a chance for additional writes to enqueue.
+                _nextScheduledFlush = new CancellationTokenSource();
+                ctx.Channel.EventLoop.SubmitAsync(_flushFunc, _nextScheduledFlush.Token);
+            }
+        }
+
+        private void CancelScheduledFlush()
+        {
+            if (_nextScheduledFlush != null)
+            {
+                _nextScheduledFlush.Cancel(false);
+                _nextScheduledFlush = null;
+            }
+        }
     }
 
     /// <summary>

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
@@ -329,7 +329,7 @@ namespace Akka.Remote.Transport.DotNetty
             }
 
             if(Settings.BatchWriterSettings.EnableBatching)
-                pipeline.AddLast("BatchWriter", new FlushConsolidationHandler());
+                pipeline.AddLast("BatchWriter", new FlushConsolidationHandler(Settings.BatchWriterSettings.MaxExplicitFlushes));
         }
 
         private void SetClientPipeline(IChannel channel, Address remoteAddress)

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
@@ -329,7 +329,7 @@ namespace Akka.Remote.Transport.DotNetty
             }
 
             if(Settings.BatchWriterSettings.EnableBatching)
-                pipeline.AddLast("BatchWriter", new BatchWriter(Settings.BatchWriterSettings, System.Scheduler));
+                pipeline.AddLast("BatchWriter", new FlushConsolidationHandler());
         }
 
         private void SetClientPipeline(IChannel channel, Address remoteAddress)

--- a/src/core/Akka.Remote/Transport/DotNetty/TcpTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/TcpTransport.cs
@@ -35,14 +35,12 @@ namespace Akka.Remote.Transport.DotNetty
         
         protected override void RegisterListener(IChannel channel, IHandleEventListener listener, object msg, IPEndPoint remoteAddress)
         {
-            this._listener = listener;
+            _listener = listener;
         }
         
         protected override AssociationHandle CreateHandle(IChannel channel, Address localAddress, Address remoteAddress)
         {
-            if(Transport.Settings.BatchWriterSettings.EnableBatching)
-                return new BatchingTcpAssociationHandle(localAddress, remoteAddress, Transport, channel);
-            return new NonBatchingTcpAssociationHandle(localAddress, remoteAddress, Transport, channel);
+           return new TcpAssociationHandle(localAddress, remoteAddress, Transport, channel);
         }
         
         public override void ChannelInactive(IChannelHandlerContext context)
@@ -105,7 +103,7 @@ namespace Akka.Remote.Transport.DotNetty
         public TcpServerHandler(DotNettyTransport transport, ILoggingAdapter log, Task<IAssociationEventListener> associationEventListener) 
             : base(transport, log)
         {
-            this._associationEventListener = associationEventListener;
+            _associationEventListener = associationEventListener;
         }
         
         public override void ChannelActive(IChannelHandlerContext context)
@@ -126,8 +124,7 @@ namespace Akka.Remote.Transport.DotNetty
                     socketAddress: socketAddress, 
                     schemeIdentifier: Transport.SchemeIdentifier,
                     systemName: Transport.System.Name);
-                AssociationHandle handle;
-                Init(channel, socketAddress, remoteAddress, msg, out handle);
+                Init(channel, socketAddress, remoteAddress, msg, out var handle);
                 listener.Notify(new InboundAssociation(handle));
             }, TaskContinuationOptions.OnlyOnRanToCompletion);
         }
@@ -155,52 +152,16 @@ namespace Akka.Remote.Transport.DotNetty
 
         private void InitOutbound(IChannel channel, IPEndPoint socketAddress, object msg)
         {
-            AssociationHandle handle;
-            Init(channel, socketAddress, _remoteAddress, msg, out handle);
+            Init(channel, socketAddress, _remoteAddress, msg, out var handle);
             _statusPromise.TrySetResult(handle);
         }
     }
 
-    internal sealed class BatchingTcpAssociationHandle : AssociationHandle
+    internal sealed class TcpAssociationHandle : AssociationHandle
     {
         private readonly IChannel _channel;
 
-        public BatchingTcpAssociationHandle(Address localAddress, Address remoteAddress, DotNettyTransport transport, IChannel channel)
-            : base(localAddress, remoteAddress)
-        {
-            _channel = channel;
-        }
-
-        public override bool Write(ByteString payload)
-        {
-            if (_channel.Open)
-            {
-                var data = ToByteBuffer(_channel, payload);
-                _channel.WriteAndFlushAsync(data);
-                return true;
-            }
-            return false;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static IByteBuffer ToByteBuffer(IChannel channel, ByteString payload)
-        {
-            var buffer = Unpooled.WrappedBuffer(payload.ToByteArray());
-            return buffer;
-        }
-
-        public override void Disassociate()
-        {
-            _channel.Flush(); // flush before we close
-            _channel.CloseAsync();
-        }
-    }
-
-    internal sealed class NonBatchingTcpAssociationHandle : AssociationHandle
-    {
-        private readonly IChannel _channel;
-
-        public NonBatchingTcpAssociationHandle(Address localAddress, Address remoteAddress, DotNettyTransport transport, IChannel channel)
+        public TcpAssociationHandle(Address localAddress, Address remoteAddress, DotNettyTransport transport, IChannel channel)
             : base(localAddress, remoteAddress)
         {
             _channel = channel;
@@ -251,19 +212,16 @@ namespace Akka.Remote.Transport.DotNetty
             {
                 throw HandleConnectException(remoteAddress, c, null);
             }
-            catch (AggregateException e) when (e.InnerException is ConnectException)
+            catch (AggregateException e) when (e.InnerException is ConnectException cause)
             {
-                var cause = (ConnectException)e.InnerException;
                 throw HandleConnectException(remoteAddress, cause, e);
             }
             catch (ConnectTimeoutException t)
             {
                 throw new InvalidAssociationException(t.Message);
             }
-            catch (AggregateException e) when (e.InnerException is ConnectTimeoutException)
+            catch (AggregateException e) when (e.InnerException is ConnectTimeoutException cause)
             {
-                var cause = (ConnectTimeoutException)e.InnerException;
-
                 throw new InvalidAssociationException(cause.Message);
             }
         }

--- a/src/core/Akka.Remote/Transport/DotNetty/TcpTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/TcpTransport.cs
@@ -176,7 +176,7 @@ namespace Akka.Remote.Transport.DotNetty
             if (_channel.Open)
             {
                 var data = ToByteBuffer(_channel, payload);
-                _channel.WriteAsync(data);
+                _channel.WriteAndFlushAsync(data);
                 return true;
             }
             return false;


### PR DESCRIPTION
Ported the `FlushConsolidationHandler` from Netty and used it to auto-tune batching inside Akka.Remote without having to set explicit thresholds and without having to rely on the `IScheduler`.

This accomplishes:

1. Lower Idle CPU consumption than even https://github.com/akkadotnet/akka.net/pull/4678
2. Significantly lower latencies on systems that don't write heavily
3. No need for users to manually tune their threshold settings in `akka.remote.dot-netty.tcp.batching` - this is now handled automatically by the `FlushConsolidationHandler`.

close https://github.com/akkadotnet/akka.net/issues/4636
close https://github.com/akkadotnet/akka.net/issues/4563

We still have some more work to do optimizing the `DedicatedThreadPool` to scale down automatically, but this eliminates most of the CPU noise coming from DotNetty.