### PR TITLE
Add new test to AkkaSerializationSpec. Failed for HyperionSerializer.

### DIFF
--- a/src/contrib/serializers/Akka.Serialization.TestKit/AkkaSerializationSpec.cs
+++ b/src/contrib/serializers/Akka.Serialization.TestKit/AkkaSerializationSpec.cs
@@ -384,6 +384,25 @@ my-settings{
         }
 
         [Fact]
+        public void CanSerializeActorPathCollection()
+        {
+            var collection = new []
+            {
+                ActorPath.Parse("akka.tcp://sys@localhost:9100/user1/actor"),
+                ActorPath.Parse("akka.tcp://sys@localhost:9100/user2/actor"),
+                ActorPath.Parse("akka.tcp://sys@localhost:9100/user1/actor")
+            };
+            var serializer = Sys.Serialization.FindSerializerFor(collection);
+            var serialized = serializer.ToBinary(collection);
+            var deserialized = (ActorPath[])serializer.FromBinary(serialized, typeof(ActorPath[]));
+
+            Assert.Equal(collection.Length, deserialized.Length);
+            Assert.Equal(collection[0], deserialized[0]);
+            Assert.Equal(collection[1], deserialized[1]);
+            Assert.Equal(collection[2], deserialized[2]);
+        }
+
+        [Fact]
         public void CanSerializeSingletonMessages()
         {
             var message = PoisonPill.Instance;


### PR DESCRIPTION
An error occurred while serializing the `ActorPath` collection with duplicate paths. For the last `ActorPath`, `Hyperion.ValueSerializers.ObjectSerializer` is used instead of `Hyperion.ValueSerializers.FromSurrogateSerializer`. This causes the error `System.InvalidCastException: Unable to cast object of type 'Surrogate' to type 'Akka.Actor.ActorPath'`. For the `Poco` (`ISurrogated`) collection of objects no error occurs regardless of the stored values.

In the test I gave an example with a simple array of elements, but in a real task the following class `State` is used.

```c#
public class Scheduled
{
    public Scheduled(string scheduleId, ActorPath executor)
    {
        ScheduleId = scheduleId;
        Executor = executor;
    }

    public string ScheduleId { get; }
    public ActorPath Executor { get; }
}

public sealed class State
{
    private readonly ImmutableDictionary<string, Scheduled> _entries;

    public State()
    {
        _entries = ImmutableDictionary<string, ScheduledTest>.Empty;
    }

    public State(IEnumerable<Scheduled> entries)
    {
        _entries = ImmutableDictionary.CreateRange(entries.Select(e => new KeyValuePair<string, Scheduled>(e.ScheduleId, e)));
    }

    public IEnumerable<Scheduled> Entries => _entries.Values;
}
```