### PR TITLE
upgraded test target for .NET framework to .NET 4.7.2

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -53,7 +53,7 @@ let runIncrementally = hasBuildParam "incremental"
 let incrementalistReport = output @@ "incrementalist.txt"
 
 // Configuration values for tests
-let testNetFrameworkVersion = "net461"
+let testNetFrameworkVersion = "net471"
 let testNetCoreVersion = "netcoreapp3.1"
 let testNetVersion = "net5.0"
 

--- a/src/common.props
+++ b/src/common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2020 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.4.14</VersionPrefix>
+    <VersionPrefix>1.4.15</VersionPrefix>
     <PackageIconUrl>https://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>
@@ -17,7 +17,7 @@
     <ProtobufVersion>3.14.0</ProtobufVersion>
     <NetCoreTestVersion>netcoreapp3.1</NetCoreTestVersion>
     <NetTestVersion>net5.0</NetTestVersion>
-    <NetFrameworkTestVersion>net461</NetFrameworkTestVersion>
+    <NetFrameworkTestVersion>net471</NetFrameworkTestVersion>
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>
     <FluentAssertionsVersion>4.14.0</FluentAssertionsVersion>
     <FsCheckVersion>2.14.3</FsCheckVersion>
@@ -42,6 +42,6 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
     <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat> 
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 </Project>

--- a/src/core/Akka.MultiNodeTestRunner/Akka.MultiNodeTestRunner.nuspec.template
+++ b/src/core/Akka.MultiNodeTestRunner/Akka.MultiNodeTestRunner.nuspec.template
@@ -15,7 +15,7 @@
     <tags>akka actors actor model Akka concurrency</tags>
   </metadata>
   <files>
-    <file src="bin\Release\net461\win10-x64\publish\*.*" target="lib\net461\" />
+    <file src="bin\Release\net471\win10-x64\publish\*.*" target="lib\net471\" />
     <file src="bin\Release\netcoreapp3.1\win10-x64\publish\*.*" target="lib\netcoreapp3.1\" />
     <file src="bin\Release\net5.0\win10-x64\publish\*.*" target="lib\net5.0\" />
   </files>


### PR DESCRIPTION
Added this to solve build problems related to https://github.com/akkadotnet/akka.net/pull/4713 - which comes from the .NET 4.6.1 target referencing the .NET 4.5 version of FluentAssertions 5.10, which in turn depends on the System.ValueTuple NuGet package - which causes a build conflict on Linux.

Moving off of .NET 4.6.1 and onto 4.7.1 forces the system to resolve that dependency as .NET Standard 2.0 instead.