### PR TITLE
remove .NET install scripts from build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -46,38 +46,6 @@ if [ ! -d "$TOOLS_DIR" ]; then
 fi
 
 ###########################################################################
-# INSTALL .NET 5 SDK
-###########################################################################
-
-echo "Installing .NET 5 SDK..."
-if [ ! -d "$SCRIPT_DIR/.dotnet" ]; then
-  mkdir "$SCRIPT_DIR/.dotnet"
-fi
-curl -Lsfo "$SCRIPT_DIR/.dotnet/dotnet-install.sh" $DOTNET_INSTALLER_URL
-bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version $DOTNET_VERSION --channel $DOTNET_CHANNEL --install-dir .dotnet --no-path
-export PATH="$SCRIPT_DIR/.dotnet":$PATH
-export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-export DOTNET_CLI_TELEMETRY_OPTOUT=1
-chmod -R 0755 ".dotnet"
-"$SCRIPT_DIR/.dotnet/dotnet" --info
-
-###########################################################################
-# INSTALL .NET CORE CLI
-###########################################################################
-
-echo "Installing .NET CLI..."
-if [ ! -d "$SCRIPT_DIR/.dotnet" ]; then
-  mkdir "$SCRIPT_DIR/.dotnet"
-fi
-curl -Lsfo "$SCRIPT_DIR/.dotnet/dotnet-install.sh" $DOTNET_INSTALLER_URL
-bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version $DOTNETCORE_VERSION --channel $DOTNET_CHANNEL --install-dir .dotnet --no-path
-export PATH="$SCRIPT_DIR/.dotnet":$PATH
-export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-export DOTNET_CLI_TELEMETRY_OPTOUT=1
-chmod -R 0755 ".dotnet"
-"$SCRIPT_DIR/.dotnet/dotnet" --info
-
-###########################################################################
 # INSTALL NUGET
 ###########################################################################
 
@@ -136,7 +104,7 @@ fi
 # INSTALL Incrementalist
 ###########################################################################
 if [ ! -f "$INCREMENTALIST_EXE" ]; then
-    "$SCRIPT_DIR/.dotnet/dotnet" tool install Incrementalist.Cmd --version $INCREMENTALIST_VERSION --tool-path "$INCREMENTALIST_DIR"
+    dotnet tool install Incrementalist.Cmd --version $INCREMENTALIST_VERSION --tool-path "$INCREMENTALIST_DIR"
     if [ $? -ne 0 ]; then
         echo "Incrementalist already installed."
     fi

--- a/src/core/Akka/ActorState.cs
+++ b/src/core/Akka/ActorState.cs
@@ -11,7 +11,7 @@ using Akka.Util;
 namespace Akka.Actor
 {
     /// <summary>
-    /// This interface represents the parts of the internal actor state; the behavior stack, watched by, watching and termination queue
+    /// This interface represents the parts of the internal actor state; the behavior stack, watched by, watching and termination queue.
     /// </summary>
     internal interface IActorState 
     {


### PR DESCRIPTION
Standardize the build system to pull all of its .NET / .NET Core dependencies from Azure DevOps, not from `build.ps1` or `build.sh`