### PR TITLE
harden Bugfix4360Spec.Should_recover_persistentactor_sqlite

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Bugfix4360Spec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Bugfix4360Spec.cs
@@ -129,10 +129,14 @@ auto-initialize = on
             ExpectTerminated(recoveryActor);
 
             // recreate the actor and recover
-            var recoveryActor2 = Sys.ActorOf(Props.Create(() => new RecoverActor(TestActor)), recoveryActor.Path.Name);
 
-            var r2 = ExpectMsg<IEnumerable<string>>();
-            r2.Should().Contain(new[] { "foo", "bar" });
+            AwaitAssert(() =>
+            {
+                var recoveryActor2 = Sys.ActorOf(Props.Create(() => new RecoverActor(TestActor)), recoveryActor.Path.Name);
+
+                var r2 = ExpectMsg<IEnumerable<string>>(TimeSpan.FromMilliseconds(100));
+                r2.Should().Contain(new[] { "foo", "bar" });
+            }, interval:TimeSpan.FromMilliseconds(150));
         }
 
         [Fact]


### PR DESCRIPTION
resolves minor race condition in unit test where Terminated message can be delivered before UserGuardian has updated its ChildContainer collection.