### PR TITLE
Updated Akka.DependencyInjection documentation

### DIFF
--- a/docs/articles/actors/dependency-injection.md
+++ b/docs/articles/actors/dependency-injection.md
@@ -5,6 +5,12 @@ title: Dependency injection
 # Dependency Injection
 As of Akka.NET v1.4.15 we recommend to Akka.NET users adopt the Akka.DependencyInjection library, which integrates directly with Microsoft.Extensions.DependencyInjection and deprecates the previous Akka.DI.Core and Akka.DI.* libraries.
 
+You can install Akka.DependenecyInjection via NuGet:
+
+```
+PS> Install-Package Akka.DependencyInjection
+```
+
 Akka.DependencyInjection allows users to pass in an [`IServiceProvider`](https://docs.microsoft.com/en-us/dotnet/api/system.iserviceprovider) into the `ActorSystem` before the latter is created, via [a new kind of programmatic configuration `Setup` that was introduced in Akka.NET v1.4](xref:configuration#programmatic-configuration-with-setup)
 
 ## Integrating with Microsoft.Extensions.DependencyInjection
@@ -32,7 +38,7 @@ From there, we want to call `ServiceProvider.Props` to create a set of `Props` f
 ### Managing Lifecycle Dependencies with Akka.DependencyInjection
 Akka.DependencyInjection allows Akka.NET developers to mix and match injected dependencies along with non-injected dependencies - for instance:
 
-[!code-csharp[NonDiActor](../../../src/contrib/dependencyinjection/Akka.DependencyInjection/ActorServiceProviderPropsWithScopesSpecs.cs?name=NonDiArgsActor)]
+[!code-csharp[NonDiActor](../../../src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/ActorServiceProviderPropsWithScopesSpecs.cs?name=NonDiArgsActor)]
 
 In this case, the actor accepts:
 
@@ -42,7 +48,7 @@ In this case, the actor accepts:
 
 Here's how Akka.DependencyInjection is used to instantiate this actor via `Props`:
 
-[!code-csharp[NonDiActor](../../../src/contrib/dependencyinjection/Akka.DependencyInjection/ActorServiceProviderPropsWithScopesSpecs.cs?name=CreateNonDiActor)]
+[!code-csharp[NonDiActor](../../../src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/ActorServiceProviderPropsWithScopesSpecs.cs?name=CreateNonDiActor)]
 
 The `ServiceProvider.Props` method will accept additional arguments that can be used to instantiate the actor in addition to the arguments that will be provided via your depedency injection container.
 
@@ -61,9 +67,13 @@ A best practice for working with Akka.NET actors and Microsoft.Extensions.Depend
 
 You can see an example of an actor that follows this pattern below:
 
-[!code-csharp[MixedActor](../../../src/contrib/dependencyinjection/Akka.DependencyInjection/ActorServiceProviderPropsWithScopesSpecs.cs?name=MixedActor)]
+[!code-csharp[MixedActor](../../../src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/ActorServiceProviderPropsWithScopesSpecs.cs?name=MixedActor)]
 
 ## Akka.DI - Deprecated Akka.NET DI Dupport
+
+> [!WARNING]
+> As of [Akka.NET v1.4.15](https://github.com/akkadotnet/akka.net/releases/tag/1.4.15), Akka.DI.Core and all of the libraries that implement it are deprecated. Going forward Akka.NET users are encouraged to use the [Akka.DependencyInjection library](xref:dependency-injection) instead, which uses the Microsoft.Extensions.DependencyInjection interfaces to integration DI directly into your Akka.NET actors.
+
 If your actor has a constructor that takes parameters then those need
 to be part of the `Props` as well, as described above. But there are cases when
 a factory method must be used, for example when the actual constructor arguments

--- a/docs/articles/actors/dependency-injection.md
+++ b/docs/articles/actors/dependency-injection.md
@@ -3,6 +3,67 @@ uid: dependency-injection
 title: Dependency injection
 ---
 # Dependency Injection
+As of Akka.NET v1.4.15 we recommend to Akka.NET users adopt the Akka.DependencyInjection library, which integrates directly with Microsoft.Extensions.DependencyInjection and deprecates the previous Akka.DI.Core and Akka.DI.* libraries.
+
+Akka.DependencyInjection allows users to pass in an [`IServiceProvider`](https://docs.microsoft.com/en-us/dotnet/api/system.iserviceprovider) into the `ActorSystem` before the latter is created, via [a new kind of programmatic configuration `Setup` that was introduced in Akka.NET v1.4](xref:configuration#programmatic-configuration-with-setup)
+
+## Integrating with Microsoft.Extensions.DependencyInjection
+Many .NET applications begin with a `Startup` class that uses the Microsoft.Extensions.DependencyInjection to build an `IServiceCollection` that contains 1 or more service bindings:
+
+[!code-csharp[Startup](../../../src/examples/AspNetCore/Samples.Akka.AspNetCore/Startup.cs?name=DiSetup)]
+
+In this instance, we're going to run Akka.NET behind the scenes as a [`Microsoft.Extensions.Hosting.IHostedService`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.ihostedservice) and in the process, we will pass the `IServiceProvider` that contains our DI bindings to it:
+
+[!code-csharp[AkkaServiceSetup](../../../src/examples/AspNetCore/Samples.Akka.AspNetCore/Actors/AkkaService.cs?name=AkkaServiceSetup)]
+
+To incorporate our `IServiceProvider` into our `ActorSystem`, we will use a `Akka.DependencyInjection.ServiceProviderSetup` class to combine the `IServiceProvider` with the HOCON configuration we're going to use.
+
+Once the `ActorSystem` is created, we can easily access the `IServiceProvider` by calling `ServiceProvider.For(ActorSystem)`:
+
+[!code-csharp[ServiceProviderFor](../../../src/examples/AspNetCore/Samples.Akka.AspNetCore/Actors/AkkaService.cs?name=ServiceProviderFor)]
+
+From there, we want to call `ServiceProvider.Props` to create a set of `Props` for our actor, whose arguments can be populated via the services registered with the `IServiceProvider`:
+
+[!code-csharp[HasherActor](../../../src/examples/AspNetCore/Samples.Akka.AspNetCore/Actors/HasherActor.cs?name=HasherActor)]
+
+> [!NOTE]
+> Akka.DependencyInjection is not going to manage the lifecycle of your dependencies for you. Keep reading.
+
+### Managing Lifecycle Dependencies with Akka.DependencyInjection
+Akka.DependencyInjection allows Akka.NET developers to mix and match injected dependencies along with non-injected dependencies - for instance:
+
+[!code-csharp[NonDiActor](../../../src/contrib/dependencyinjection/Akka.DependencyInjection/ActorServiceProviderPropsWithScopesSpecs.cs?name=NonDiArgsActor)]
+
+In this case, the actor accepts:
+
+1. A singleton scoped service, injected directly via the constructor;
+2. A `IServiceProvider` instance, which is also populated directly via the DI system; and
+3. Two `string` arguments that _are not_ provided via dependency injection.
+
+Here's how Akka.DependencyInjection is used to instantiate this actor via `Props`:
+
+[!code-csharp[NonDiActor](../../../src/contrib/dependencyinjection/Akka.DependencyInjection/ActorServiceProviderPropsWithScopesSpecs.cs?name=CreateNonDiActor)]
+
+The `ServiceProvider.Props` method will accept additional arguments that can be used to instantiate the actor in addition to the arguments that will be provided via your depedency injection container.
+
+Akka.DependencyInjection does not manage the lifecycle of your dependencies automatically - in fact, Akka.NET recommends that you follow [Microsoft's own dependency injection guidelines](https://docs.microsoft.com/en-us/dotnet/core/extensions/dependency-injection-guidelines):
+
+> Use the factory pattern to create an instance outside of the parent scope. In this situation, the app would generally have a Create method that calls the final type's constructor directly. If the final type has other dependencies, the factory can:
+> * Receive an `IServiceProvider` in its constructor.
+> * Use `ActivatorUtilities.CreateInstance` to instantiate the instance outside of the container, while using the container for its dependencies.
+
+A best practice for working with Akka.NET actors and Microsoft.Extensions.DependencyInjection:
+
+1. Always provide an `IServiceProvider` into the constructor of your actors, to use Microsoft's so-called "factory" pattern;
+2. Always use the `IServiceProvider` to create an `IServiceScope`;
+3. Use the `IServiceScope` to create your dependencies; and
+4. Dispose your `IServiceScope` inside the `PostStop` method of your actor to ensure orderly disposal of any transient or scoped dependencies your actor may have used.
+
+You can see an example of an actor that follows this pattern below:
+
+[!code-csharp[MixedActor](../../../src/contrib/dependencyinjection/Akka.DependencyInjection/ActorServiceProviderPropsWithScopesSpecs.cs?name=MixedActor)]
+
+## Akka.DI - Deprecated Akka.NET DI Dupport
 If your actor has a constructor that takes parameters then those need
 to be part of the `Props` as well, as described above. But there are cases when
 a factory method must be used, for example when the actual constructor arguments
@@ -29,7 +90,7 @@ var worker1Ref = system.ActorOf(system.DI().Props<TypedWorker>(), "Worker1");
 var worker2Ref = system.ActorOf(system.DI().Props<TypedWorker>(), "Worker2");
 ```
 
-## Creating Child Actors using DI
+### Creating Child Actors using DI
 When you want to create child actors from within your existing actors using
 Dependency Injection you can use the Actor Content extension just like in
 the following example.
@@ -48,7 +109,7 @@ protected override void PreStart()
 > [!NOTE]
 > There is currently still an extension method available for the actor Context. `Context.DI().ActorOf<>`. However this has been officially **deprecated** and will be removed in future versions.
 
-## Notes
+### Notes
 
 > [!WARNING]
 > You might be tempted at times to use an `IndirectActorProducer`
@@ -77,7 +138,7 @@ guideline.
 
 Currently the following Akka.NET Dependency Injection plugins are available:
 
-### AutoFac
+#### AutoFac
 
 In order to use this plugin, install the Nuget package with
 `Install-Package Akka.DI.AutoFac`, then follow the instructions:
@@ -94,7 +155,7 @@ var system = ActorSystem.Create("MySystem");
 system.UseAutofac(container);
 ```
 
-### CastleWindsor
+#### CastleWindsor
 
 In order to use this plugin, install the Nuget package with
 `Install-Package Akka.DI.CastleWindsor`, then follow the instructions:
@@ -110,7 +171,7 @@ var system = ActorSystem.Create("MySystem");
 var propsResolver = new WindsorDependencyResolver(container, system);
 ```
 
-### Ninject
+#### Ninject
 
 In order to use this plugin, install the Nuget package with
 `Install-Package Akka.DI.Ninject`, then follow the instructions:
@@ -126,7 +187,7 @@ var system = ActorSystem.Create("MySystem");
 var propsResolver = new NinjectDependencyResolver(container,system);
 ```
 
-### Other frameworks
+#### Other frameworks
 
 Support for additional dependency injection frameworks may be added in the
 future, but you can easily implement your own by implementing an

--- a/docs/articles/actors/di-core.md
+++ b/docs/articles/actors/di-core.md
@@ -5,6 +5,9 @@ title: DI Core
 
 # Akka.DI.Core
 
+> [!WARNING]
+> As of [Akka.NET v1.4.15](https://github.com/akkadotnet/akka.net/releases/tag/1.4.15), Akka.DI.Core and all of the libraries that implement it are deprecated. Going forward Akka.NET users are encouraged to use the [Akka.DependencyInjection library](xref:dependency-injection) instead, which uses the Microsoft.Extensions.DependencyInjection interfaces to integration DI directly into your Akka.NET actors.
+
 **Actor Producer Extension** library is used to create a Dependency Injection Container for the [Akka.NET](https://github.com/akkadotnet/akka.net) framework.
 
 # What is it?

--- a/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/ActorServiceProviderPropsWithScopesSpecs.cs
+++ b/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/ActorServiceProviderPropsWithScopesSpecs.cs
@@ -122,6 +122,7 @@ namespace Akka.DependencyInjection.Tests
             "DI: actors who receive a non-DI'd dependencies should be started correctly")]
         public void ActorsWithNonDiDependenciesShouldStart()
         {
+            // <CreateNonDiActor>
             var spExtension = ServiceProvider.For(Sys);
             var arg1 = "foo";
             var arg2 = "bar";
@@ -129,6 +130,7 @@ namespace Akka.DependencyInjection.Tests
 
             // create a scoped actor using the props from Akka.DependencyInjection
             var scoped1 = Sys.ActorOf(props, "scoped1");
+            // </CreateNonDiActor>
             scoped1.Tell(new FetchDependencies());
             var deps1 = ExpectMsg<CurrentDependencies>();
             deps1.Dependencies.All(x => x.Disposed).Should().BeFalse();
@@ -204,6 +206,7 @@ namespace Akka.DependencyInjection.Tests
             }
         }
 
+        // <MixedActor>
         public class MixedActor : ReceiveActor
         {
             private readonly AkkaDiFixture.ISingletonDependency _singleton;
@@ -235,7 +238,9 @@ namespace Akka.DependencyInjection.Tests
                 _scope.Dispose();
             }
         }
+        // </MixedActor>
 
+        // <NonDiArgsActor>
         public class NonDiArgsActor : ReceiveActor
         {
             private readonly AkkaDiFixture.ISingletonDependency _singleton;
@@ -277,7 +282,8 @@ namespace Akka.DependencyInjection.Tests
                 _scope.Dispose();
             }
         }
+        // </NonDiArgsActor>
     }
 
-   
+
 }

--- a/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/AkkaDiFixture.cs
+++ b/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/AkkaDiFixture.cs
@@ -96,10 +96,12 @@ namespace Akka.DependencyInjection.Tests
         {
             Services = new ServiceCollection();
 
+            // <DiFixture>
             // register some default services
             Services.AddSingleton<ISingletonDependency, Singleton>()
                 .AddScoped<IScopedDependency, Scoped>()
                 .AddTransient<ITransientDependency, Transient>();
+            // </DiFixture>
             Provider = Services.BuildServiceProvider();
         }
 

--- a/src/examples/AspNetCore/Samples.Akka.AspNetCore/Actors/AkkaService.cs
+++ b/src/examples/AspNetCore/Samples.Akka.AspNetCore/Actors/AkkaService.cs
@@ -25,6 +25,7 @@ namespace Samples.Akka.AspNetCore.Actors
     /// <summary>
     /// Implements <see cref="IPublicHashingService"/>, which is the public interface used by ASP.NET Core.
     /// </summary>
+    // <AkkaServiceSetup>
     public class AkkaService : IPublicHashingService, IHostedService
     {
         private ActorSystem _actorSystem;
@@ -43,10 +44,13 @@ namespace Samples.Akka.AspNetCore.Actors
             var di = ServiceProviderSetup.Create(_sp);
             var actorSystemSetup = bootstrap.And(di);
             _actorSystem = ActorSystem.Create("AspNetDemo", actorSystemSetup);
+            // </AkkaServiceSetup>
 
+            // <ServiceProviderFor>
             // props created via IServiceProvider dependency injection
             var hasherProps = ServiceProvider.For(_actorSystem).Props<HasherActor>();
             RouterActor = _actorSystem.ActorOf(hasherProps.WithRouter(FromConfig.Instance), "hasher");
+            // </ServiceProviderFor>
 
             await Task.CompletedTask;
         }

--- a/src/examples/AspNetCore/Samples.Akka.AspNetCore/Actors/HasherActor.cs
+++ b/src/examples/AspNetCore/Samples.Akka.AspNetCore/Actors/HasherActor.cs
@@ -14,6 +14,7 @@ using Samples.Akka.AspNetCore.Services;
 
 namespace Samples.Akka.AspNetCore.Actors
 {
+    // <HasherActor>
     public class HasherActor : ReceiveActor
     {
         private readonly ILoggingAdapter _log = Context.GetLogger();
@@ -40,4 +41,5 @@ namespace Samples.Akka.AspNetCore.Actors
             _log.Info("Terminating. Is ScopedService disposed? {0}", _hashService.IsDisposed);
         }
     }
+    // </HasherActor>
 }

--- a/src/examples/AspNetCore/Samples.Akka.AspNetCore/Startup.cs
+++ b/src/examples/AspNetCore/Samples.Akka.AspNetCore/Startup.cs
@@ -24,18 +24,20 @@ namespace Samples.Akka.AspNetCore
     {
         // This method gets called by the runtime. Use this method to add services to the container.
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+        // <DiSetup>
         public void ConfigureServices(IServiceCollection services)
         {
             // set up a simple service we're going to hash
             services.AddScoped<IHashService, HashServiceImpl>();
 
             // creates instance of IPublicHashingService that can be accessed by ASP.NET
-            services.AddSingleton<IPublicHashingService, AkkaService>(); 
+            services.AddSingleton<IPublicHashingService, AkkaService>();
 
             // starts the IHostedService, which creates the ActorSystem and actors
             services.AddHostedService<AkkaService>(sp => (AkkaService)sp.GetRequiredService<IPublicHashingService>());
-            
+
         }
+        // </DiSetup>
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)


### PR DESCRIPTION
Rewrote the DI documentation to explain how to use the new Akka.DependencyInjection library, as part of the 1.4.15 release.