### PR TITLE
set the metadata for the Akka.DependencyInjection package to point at specific page on Akka.NET website

### DIFF
--- a/src/contrib/dependencyinjection/Akka.DependencyInjection/Akka.DependencyInjection.csproj
+++ b/src/contrib/dependencyinjection/Akka.DependencyInjection/Akka.DependencyInjection.csproj
@@ -8,6 +8,7 @@
         <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
         <PackageTags>$(AkkaPackageTags);dependency injection</PackageTags>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <PackageProjectUrl>https://getakka.net/articles/actors/dependency-injection.html</PackageProjectUrl>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
set the metadata for the Akka.DependencyInjection package to point at https://getakka.net/articles/actors/dependency-injection.html

