### PR TITLE
Allow different versions of MS Abstractions nuget package for Akka.DependencyInjection

### DIFF
--- a/src/contrib/dependencyinjection/Akka.DependencyInjection/Akka.DependencyInjection.csproj
+++ b/src/contrib/dependencyinjection/Akka.DependencyInjection/Akka.DependencyInjection.csproj
@@ -5,14 +5,14 @@
     <PropertyGroup>
         <AssemblyTitle>Akka.DependencyInjection</AssemblyTitle>
         <Description>Dependency injection support for Akka.NET</Description>
-        <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
+        <TargetFramework>$(NetStandardLibVersion)</TargetFramework>
         <PackageTags>$(AkkaPackageTags);dependency injection</PackageTags>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageProjectUrl>https://getakka.net/articles/actors/dependency-injection.html</PackageProjectUrl>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version=">=3.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/contrib/dependencyinjection/Akka.DependencyInjection/Akka.DependencyInjection.csproj
+++ b/src/contrib/dependencyinjection/Akka.DependencyInjection/Akka.DependencyInjection.csproj
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version=">=3.1.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.0,)" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Instead of multi-targeting, we can just allow lower versions of MS nuget package to be used, since all we need is `ActivatorUtilities` which exists in a wide version range of that package.