### PR TITLE
Added v1.4.16 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
-#### 1.4.16 January 20 2021 ####
-**Placeholder for nightlies**
+#### 1.4.16 January 22 2021 ####
+**Maintenance Release for Akka.NET 1.4**
+
+This is a tiny release of Akka.NET, aimed at solving a transient dependency issue with Akka.DependencyInjection:
+
+* [Akka.DependencyInjection: Allow different versions of MS Abstractions nuget package for Akka.DependencyInjection](https://github.com/akkadotnet/akka.net/pull/4739) - rolls back to Microsoft.Extensions.DependencyInjection.Abstractions 3.1 instead of 5.0
 
 #### 1.4.15 January 19 2021 ####
 **Maintenance Release for Akka.NET 1.4**


### PR DESCRIPTION
#### 1.4.16 January 22 2021 ####
**Maintenance Release for Akka.NET 1.4**

This is a tiny release of Akka.NET, aimed at solving a transient dependency issue with Akka.DependencyInjection:

* [Akka.DependencyInjection: Allow different versions of MS Abstractions nuget package for Akka.DependencyInjection](https://github.com/akkadotnet/akka.net/pull/4739) - rolls back to Microsoft.Extensions.DependencyInjection.Abstractions 3.1 instead of 5.0