### PR TITLE
Add Serialization.WithTransport overload that takes TState

### DIFF
--- a/src/Akka.sln
+++ b/src/Akka.sln
@@ -242,6 +242,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AspNetCore", "AspNetCore", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.Akka.AspNetCore", "examples\AspNetCore\Samples.Akka.AspNetCore\Samples.Akka.AspNetCore.csproj", "{D62F4AD6-318F-4ECC-B875-83FA9933A81B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SerializationBenchmarks", "benchmark\SerializationBenchmarks\SerializationBenchmarks.csproj", "{2E4B9584-42CC-4D17-B719-9F462B16C94D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1109,6 +1111,18 @@ Global
 		{D62F4AD6-318F-4ECC-B875-83FA9933A81B}.Release|x64.Build.0 = Release|Any CPU
 		{D62F4AD6-318F-4ECC-B875-83FA9933A81B}.Release|x86.ActiveCfg = Release|Any CPU
 		{D62F4AD6-318F-4ECC-B875-83FA9933A81B}.Release|x86.Build.0 = Release|Any CPU
+		{2E4B9584-42CC-4D17-B719-9F462B16C94D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E4B9584-42CC-4D17-B719-9F462B16C94D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E4B9584-42CC-4D17-B719-9F462B16C94D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2E4B9584-42CC-4D17-B719-9F462B16C94D}.Debug|x64.Build.0 = Debug|Any CPU
+		{2E4B9584-42CC-4D17-B719-9F462B16C94D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2E4B9584-42CC-4D17-B719-9F462B16C94D}.Debug|x86.Build.0 = Debug|Any CPU
+		{2E4B9584-42CC-4D17-B719-9F462B16C94D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E4B9584-42CC-4D17-B719-9F462B16C94D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2E4B9584-42CC-4D17-B719-9F462B16C94D}.Release|x64.ActiveCfg = Release|Any CPU
+		{2E4B9584-42CC-4D17-B719-9F462B16C94D}.Release|x64.Build.0 = Release|Any CPU
+		{2E4B9584-42CC-4D17-B719-9F462B16C94D}.Release|x86.ActiveCfg = Release|Any CPU
+		{2E4B9584-42CC-4D17-B719-9F462B16C94D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1215,6 +1229,7 @@ Global
 		{38F5A7D9-081E-4896-8CB3-C92234CBA592} = {48845655-5E60-40AB-A798-F118CC1CF510}
 		{162F5991-EA57-4221-9B70-F9B6FEC18036} = {D3AF8295-AEB5-4324-AA82-FCC0014AC310}
 		{D62F4AD6-318F-4ECC-B875-83FA9933A81B} = {162F5991-EA57-4221-9B70-F9B6FEC18036}
+		{2E4B9584-42CC-4D17-B719-9F462B16C94D} = {73108242-625A-4D7B-AA09-63375DBAE464}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {03AD8E21-7507-4E68-A4E9-F4A7E7273164}

--- a/src/benchmark/SerializationBenchmarks/Program.cs
+++ b/src/benchmark/SerializationBenchmarks/Program.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Serialization;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+
+namespace SerializationBenchmarks
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            BenchmarkRunner.Run<SerializationTests>();
+        }
+    }
+
+    //[MemoryDiagnoser]
+    public class SerializationTests
+    {
+        private ActorSystem _sys;
+        private Serializer _ser;
+
+        public SerializationTests()
+        {
+            _sys = ActorSystem.Create("bench-serialization",ConfigurationFactory.ParseString(@"
+akka.actor {{
+                        serializers {{
+                            hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                        }}
+                        serialization-bindings {{
+                            ""System.Object"" = hyperion
+                        }}
+                    }}"));
+            _ser = _sys.Serialization.FindSerializerForType(typeof(MyType));
+        }
+        
+        public static MyType payload =>
+            new MyType() { SomeInt = 1, SomeStr = "lol" };
+        [Benchmark]
+        public void Serialization_WithTransport_NoState()
+        {
+            DoSer_NoState(payload);
+        }
+
+        //Noninlining here because we don't want
+        //Jitter to inline and possibly remove the capture of 2 variables
+        //we want to simulate in this benchmark
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void DoSer_NoState(MyType thisPayload)
+        {
+            var res = Akka.Serialization.Serialization.WithTransport(
+                _sys.Serialization.System,
+                () =>
+                {
+                    return _ser.ToBinary(thisPayload);
+                });
+        }
+
+        //Noinlining here to be fair, since we are noinling on other.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void DoSer_State(MyType thisPayload)
+        {
+            var res = Akka.Serialization.Serialization.WithTransport(
+                _sys.Serialization.System,(_ser,thisPayload),
+                (inp) =>
+                {
+                    var (serializer, myType) = inp;
+                    return serializer.ToBinary(myType);
+                });
+        }
+        
+        [Benchmark]
+        public void Serialization_WithTransport_State()
+        {
+            DoSer_State(payload);
+        }
+    }
+
+    public class MyType
+    {
+        public string SomeStr { get; set; }
+        public int SomeInt { get; set; }
+    }
+}

--- a/src/benchmark/SerializationBenchmarks/SerializationBenchmarks.csproj
+++ b/src/benchmark/SerializationBenchmarks/SerializationBenchmarks.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\contrib\serializers\Akka.Serialization.Hyperion\Akka.Serialization.Hyperion.csproj" />
+      <ProjectReference Include="..\..\core\Akka\Akka.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -4667,6 +4667,7 @@ namespace Akka.Serialization
         [System.ObsoleteAttribute("Obsolete. Use the SerializeWithTransport<T>(ExtendedActorSystem) method instead.")]
         public static T WithTransport<T>(Akka.Actor.ActorSystem system, Akka.Actor.Address address, System.Func<T> action) { }
         public static T WithTransport<T>(Akka.Actor.ExtendedActorSystem system, System.Func<T> action) { }
+        public static T WithTransport<TState, T>(Akka.Actor.ExtendedActorSystem system, TState state, System.Func<TState, T> action) { }
     }
     public sealed class SerializationSetup : Akka.Actor.Setup.Setup
     {


### PR DESCRIPTION
This PR adds the following method to Akka.Serialization.Serialization:

```
public static T WithTransport<TState, T>(ExtendedActorSystem system, TState state, Func<TState, T> action)
```

The purpose of this overload is to allow a TState value to be passed into the `action` when executed, allowing consumers to avoid allocations due to delegate captures if present.

It looks like remoting already does something similar to this internally since it has access to the right internals, but there are other aspects of Akka (specifically persistence) that could benefit from this overload.

This PR also contains a benchmark of both versions of `WithTransport`. It looks like we are a little bit faster:

|                              Method |     Mean |     Error |    StdDev |
|------------------------------------ |---------:|----------:|----------:|
| Serialization_WithTransport_NoState | 2.991 us | 0.0201 us | 0.0178 us |
|   Serialization_WithTransport_State | 2.864 us | 0.0482 us | 0.0427 us |

I'm not sure why it comes up slower with `[MemoryDiagnoser]`, but important thing is we save ~90 bytes here:

|                              Method |     Mean |     Error |    StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------------------------ |---------:|----------:|----------:|-------:|-------:|------:|----------:|
| Serialization_WithTransport_NoState | 2.849 us | 0.0366 us | 0.0324 us | 0.8087 | 0.0038 |     - |   3.72 KB |
|   Serialization_WithTransport_State | 2.893 us | 0.0518 us | 0.0485 us | 0.7858 | 0.0038 |     - |   3.63 KB |


That may not look like much but since this is called deep in pipelines I'm expecting at least some gains in Persistence benches. Working on looking at that in Sql.Common