### PR TITLE
Fix approval specs to use Xunit2Reporter when v2 runner is used

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShard.cs
@@ -21,6 +21,10 @@ namespace Akka.Cluster.Sharding
     using EntryId = String;
     using Msg = Object;
 
+    
+    // break approval spec
+    public class Tmp { }
+    
     /// <summary>
     /// This actor creates children entity actors on demand that it is told to be
     /// responsible for. It is used when `rememberEntities` is enabled.

--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShard.cs
@@ -20,10 +20,6 @@ namespace Akka.Cluster.Sharding
     using ShardId = String;
     using EntryId = String;
     using Msg = Object;
-
-    
-    // break approval spec
-    public class Tmp { }
     
     /// <summary>
     /// This actor creates children entity actors on demand that it is told to be

--- a/src/core/Akka.API.Tests/Akka.API.Tests.csproj
+++ b/src/core/Akka.API.Tests/Akka.API.Tests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.API.Tests</AssemblyTitle>
-    <TargetFrameworks>$(NetFrameworkTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
     <UserSecretsId>93253ee8-0410-4483-9809-9bb2d32860fa</UserSecretsId>
   </PropertyGroup>
 
@@ -28,12 +28,9 @@
   <ItemGroup>
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.assert" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="ApiApprover" Version="9.3.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="App_Packages\" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/core/Akka.API.Tests/CoreAPISpec.cs
+++ b/src/core/Akka.API.Tests/CoreAPISpec.cs
@@ -31,6 +31,12 @@ namespace Akka.API.Tests
 {
     public class CoreAPISpec
     {
+        public CoreAPISpec()
+        {
+            // force xunit.assert to be loaded into context, to fix https://github.com/akkadotnet/akka.net/issues/4765
+            var ass = AppDomain.CurrentDomain.Load("xunit.assert");
+        }
+        
         [Fact]
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void ApproveCore()

--- a/src/core/Akka/Done.cs
+++ b/src/core/Akka/Done.cs
@@ -22,7 +22,4 @@ namespace Akka
 
         private Done() { }
     }
-    
-    // break approval spec
-    public class Tmp { }
 }

--- a/src/core/Akka/Done.cs
+++ b/src/core/Akka/Done.cs
@@ -22,4 +22,7 @@ namespace Akka
 
         private Done() { }
     }
+    
+    // break approval spec
+    public class Tmp { }
 }


### PR DESCRIPTION
Close #4765