### PR TITLE
Updated specs that might be used in documentation to not use internal properties

### DIFF
--- a/src/core/Akka.Cluster.Tests.MultiNode/RestartFirstSeedNodeSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/RestartFirstSeedNodeSpec.cs
@@ -108,14 +108,14 @@ namespace Akka.Cluster.Tests.MultiNode
                     AwaitAssert(() =>
                     {
                         Cluster.Get(seed1System.Value)
-                            .ReadView.Members.Count
+                            .State.Members.Count
                             .Should()
                             .Be(3);
                     }, TimeSpan.FromSeconds(10));
                     AwaitAssert(() =>
                     {
                         Cluster.Get(seed1System.Value)
-                            .ReadView.Members.All(c => c.Status == MemberStatus.Up)
+                            .State.Members.All(c => c.Status == MemberStatus.Up)
                             .Should()
                             .BeTrue();
                     });
@@ -142,14 +142,14 @@ namespace Akka.Cluster.Tests.MultiNode
                         AwaitAssert(() =>
                         {
                             Cluster.Get(restartedSeed1System.Value)
-                                .ReadView.Members.Count
+                                .State.Members.Count
                                 .Should()
                                 .Be(3);
                         });
                         AwaitAssert(() =>
                         {
                             Cluster.Get(restartedSeed1System.Value)
-                                .ReadView.Members.All(c => c.Status == MemberStatus.Up)
+                                .State.Members.All(c => c.Status == MemberStatus.Up)
                                 .Should()
                                 .BeTrue();
                         });

--- a/src/core/Akka.Cluster.Tests.MultiNode/RestartNode2Spec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/RestartNode2Spec.cs
@@ -127,8 +127,8 @@ namespace Akka.Cluster.Tests.MultiNode
                 RunOn(() =>
                 {
                     Cluster.Get(seed1System.Value).JoinSeedNodes(SeedNodes);
-                    AwaitAssert(() => Cluster.Get(seed1System.Value).ReadView.Members.Count.Should().Be(2));
-                    AwaitAssert(() => Cluster.Get(seed1System.Value).ReadView.Members.All(x => x.Status == MemberStatus.Up).Should().BeTrue());
+                    AwaitAssert(() => Cluster.Get(seed1System.Value).State.Members.Count.Should().Be(2));
+                    AwaitAssert(() => Cluster.Get(seed1System.Value).State.Members.All(x => x.Status == MemberStatus.Up).Should().BeTrue());
                 }, _config.Seed1);
 
                 RunOn(() =>
@@ -150,8 +150,8 @@ namespace Akka.Cluster.Tests.MultiNode
                     Cluster.Get(restartedSeed1System.Value).JoinSeedNodes(SeedNodes);
                     Within(TimeSpan.FromSeconds(30), () =>
                     {
-                        AwaitAssert(() => Cluster.Get(restartedSeed1System.Value).ReadView.Members.Count.Should().Be(2));
-                        AwaitAssert(() => Cluster.Get(restartedSeed1System.Value).ReadView.Members.All(x => x.Status == MemberStatus.Up).Should().BeTrue());
+                        AwaitAssert(() => Cluster.Get(restartedSeed1System.Value).State.Members.Count.Should().Be(2));
+                        AwaitAssert(() => Cluster.Get(restartedSeed1System.Value).State.Members.All(x => x.Status == MemberStatus.Up).Should().BeTrue());
                     });
                 }, _config.Seed1);
 

--- a/src/core/Akka.Cluster.Tests.MultiNode/RestartNodeSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/RestartNodeSpec.cs
@@ -140,8 +140,8 @@ namespace Akka.Cluster.Tests.MultiNode
                 RunOn(() =>
                 {
                     Cluster.Get(_secondSystem.Value).JoinSeedNodes(SeedNodes);
-                    AwaitAssert(() => Assert.Equal(3, Cluster.Get(_secondSystem.Value).ReadView.Members.Count));
-                    AwaitAssert(() => Assert.True(Cluster.Get(_secondSystem.Value).ReadView.Members.Select(x => x.Status).All(s => s == MemberStatus.Up)));
+                    AwaitAssert(() => Assert.Equal(3, Cluster.Get(_secondSystem.Value).State.Members.Count));
+                    AwaitAssert(() => Assert.True(Cluster.Get(_secondSystem.Value).State.Members.Select(x => x.Status).All(s => s == MemberStatus.Up)));
                 }, _config.Second);
                 EnterBarrier("started");
 
@@ -162,17 +162,17 @@ namespace Akka.Cluster.Tests.MultiNode
                 RunOn(() =>
                 {
                     Cluster.Get(_secondRestartedSystem.Value).JoinSeedNodes(SeedNodes);
-                    AwaitAssert(() => Assert.Equal(3, Cluster.Get(_secondRestartedSystem.Value).ReadView.Members.Count));
-                    AwaitAssert(() => Assert.True(Cluster.Get(_secondRestartedSystem.Value).ReadView.Members.Select(x => x.Status).All(s => s == MemberStatus.Up)));
+                    AwaitAssert(() => Assert.Equal(3, Cluster.Get(_secondRestartedSystem.Value).State.Members.Count));
+                    AwaitAssert(() => Assert.True(Cluster.Get(_secondRestartedSystem.Value).State.Members.Select(x => x.Status).All(s => s == MemberStatus.Up)));
                 }, _config.Second);
 
                 RunOn(() =>
                 {
                     AwaitAssert(() =>
                     {
-                        Assert.Equal(3, Cluster.Get(Sys).ReadView.Members.Count);
+                        Assert.Equal(3, Cluster.Get(Sys).State.Members.Count);
                         Assert.Contains(
-                            Cluster.Get(Sys).ReadView.Members,
+                            Cluster.Get(Sys).State.Members,
                             m => m.Address.Equals(SecondUniqueAddress.Address) && m.UniqueAddress.Uid != SecondUniqueAddress.Uid);
                     });
                 }, _config.First, _config.Third);

--- a/src/core/Akka.Cluster.Tests.MultiNode/TransitionSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/TransitionSpec.cs
@@ -91,7 +91,7 @@ namespace Akka.Cluster.Tests.MultiNode
 
         private ImmutableHashSet<RoleName> SeenLatestGossip()
         {
-            return ClusterView.SeenBy.Select(RoleName).ToImmutableHashSet();
+            return ClusterView.State.SeenBy.Select(RoleName).ToImmutableHashSet();
         }
 
         private void AwaitSeen(params Address[] addresses)

--- a/src/core/Akka.Cluster.Tests.MultiNode/UnreachableNodeJoinsAgainSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/UnreachableNodeJoinsAgainSpec.cs
@@ -219,9 +219,9 @@ namespace Akka.Cluster.Tests.MultiNode
                     Cluster.Get(freshSystem).Join(masterAddress);
                     Within(TimeSpan.FromSeconds(15), () =>
                     {
-                        AwaitAssert(() => Assert.Contains(victimAddress, Cluster.Get(freshSystem).ReadView.Members.Select(x => x.Address)));
-                        AwaitAssert(() => Assert.Equal(expectedNumberOfMembers,Cluster.Get(freshSystem).ReadView.Members.Count));
-                        AwaitAssert(() => Assert.True(Cluster.Get(freshSystem).ReadView.Members.All(y => y.Status == MemberStatus.Up)));
+                        AwaitAssert(() => Assert.Contains(victimAddress, Cluster.Get(freshSystem).State.Members.Select(x => x.Address)));
+                        AwaitAssert(() => Assert.Equal(expectedNumberOfMembers,Cluster.Get(freshSystem).State.Members.Count));
+                        AwaitAssert(() => Assert.True(Cluster.Get(freshSystem).State.Members.All(y => y.Status == MemberStatus.Up)));
                     });
 
                     // signal to master node that victim is done


### PR DESCRIPTION
Close #4772

Actually, initially I was going to remove `InternalsVisibleTo` attribute from `Akka.Cluster` assembly for test assemblies, so that we were using only public API in our own tests - but turned out that sometimes we really need this internals to be visible for assertions, and replacing them with public-only properties would be complicated (and would lead to code duplication). Users still do not need those internals.

So I have just did what I can - basically, replaced only those internals which were referenced in documentation. The specs where other internal properties were used are unlikely to be referenced in documentation since they are assertion our "internal stuff".