### PR TITLE
Fixed actor cancellation message namespace for SourceRef

### DIFF
--- a/src/core/Akka.Streams/Implementation/IO/FilePublisher.cs
+++ b/src/core/Akka.Streams/Implementation/IO/FilePublisher.cs
@@ -130,7 +130,7 @@ namespace Akka.Streams.Implementation.IO
             => message.Match()
                 .With<Request>(() => ReadAndSignal(_maxBuffer))
                 .With<Continue>(() => ReadAndSignal(_maxBuffer))
-                .With<Cancel>(() => Context.Stop(Self))
+                .With<Actors.Cancel>(() => Context.Stop(Self))
                 .WasHandled;
 
         private void ReadAndSignal(int maxReadAhead)

--- a/src/core/Akka.Streams/Implementation/IO/InputStreamPublisher.cs
+++ b/src/core/Akka.Streams/Implementation/IO/InputStreamPublisher.cs
@@ -76,7 +76,7 @@ namespace Akka.Streams.Implementation.IO
             => message.Match()
                     .With<Request>(ReadAndSignal)
                     .With<Continue>(ReadAndSignal)
-                    .With<Cancel>(() => Context.Stop(Self))
+                    .With<Actors.Cancel>(() => Context.Stop(Self))
                     .WasHandled;
 
         /// <summary>


### PR DESCRIPTION
Close #4744

Making our code to match scala implementation:
```scala
def receive = {
    case ActorPublisherMessage.Request(elements) ⇒ readAndSignal()
    case Continue                                ⇒ readAndSignal()
    case ActorPublisherMessage.Cancel            ⇒ context.stop(self)
  }
```
