### PR TITLE
Persistence fixes

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
@@ -113,7 +113,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
-    public sealed class DeleteMessagesFailure : System.IEquatable<Akka.Persistence.DeleteMessagesFailure>
+    public sealed class DeleteMessagesFailure : Akka.Actor.INoSerializationVerificationNeeded, System.IEquatable<Akka.Persistence.DeleteMessagesFailure>
     {
         public DeleteMessagesFailure(System.Exception cause, long toSequenceNr) { }
         public System.Exception Cause { get; }

--- a/src/core/Akka.Persistence.Tests/PersistentActorDeleteFailureSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorDeleteFailureSpec.cs
@@ -115,7 +115,7 @@ namespace Akka.Persistence.Tests
         {
             var pref = Sys.ActorOf(Props.Create(() => new DoesNotHandleDeleteFailureActor(Name)));
             Sys.EventStream.Subscribe(TestActor, typeof (Warning));
-            pref.Tell(new DeleteTo(100));
+            pref.Tell(new DeleteTo(long.MaxValue));
             var message = ExpectMsg<Warning>().Message.ToString();
             message.Contains("Failed to DeleteMessages").ShouldBeTrue();
             message.Contains("Boom! Unable to delete events!").ShouldBeTrue();
@@ -126,8 +126,8 @@ namespace Akka.Persistence.Tests
         {
             var pref = Sys.ActorOf(Props.Create(() => new HandlesDeleteFailureActor(Name, TestActor)));
             Sys.EventStream.Subscribe(TestActor, typeof (Warning));
-            pref.Tell(new DeleteTo(100));
-            ExpectMsg<DeleteMessagesFailure>(m => m.ToSequenceNr == 100);
+            pref.Tell(new DeleteTo(long.MaxValue));
+            ExpectMsg<DeleteMessagesFailure>();
             ExpectNoMsg(TimeSpan.FromMilliseconds(100));
         }
     }

--- a/src/core/Akka.Persistence.Tests/PersistentActorSpec.Actors.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorSpec.Actors.cs
@@ -39,6 +39,13 @@ namespace Akka.Persistence.Tests
                     throw new ArgumentNullException("Received DeleteMessagesSuccess without anyone asking for delete!");
                 AskedForDelete.Tell(message);
             }
+            else if (message is DeleteMessagesFailure)
+            {
+                if (AskedForDelete == null)
+                    throw new ArgumentNullException("Received DeleteMessagesSuccess without anyone asking for delete!");
+                AskedForDelete.Tell(message);
+            }
+
             else return false;
             return true;
         }
@@ -144,7 +151,7 @@ namespace Akka.Persistence.Tests
                 if (message is Evt)
                     Events = Events.AddFirst((message as Evt).Data);
                 else if (message is IActorRef)
-                    AskedForDelete = (IActorRef) message;
+                    AskedForDelete = (IActorRef)message;
                 else
                     return false;
                 return true;
@@ -292,7 +299,7 @@ namespace Akka.Persistence.Tests
             protected override bool ReceiveCommand(object message)
             {
                 if (CommonBehavior(message)) return true;
-                
+
                 if (message is Cmd)
                 {
                     var cmd = message as Cmd;
@@ -324,7 +331,7 @@ namespace Akka.Persistence.Tests
             protected override bool ReceiveCommand(object message)
             {
                 if (CommonBehavior(message)) return true;
-                
+
                 if (message is Cmd)
                 {
                     var cmd = message as Cmd;
@@ -607,7 +614,7 @@ namespace Akka.Persistence.Tests
         internal class AsyncPersistAndPersistMixedSyncAsyncActor : ExamplePersistentActor
         {
             private int _counter = 0;
-            
+
             public AsyncPersistAndPersistMixedSyncAsyncActor(string name)
                 : base(name)
             {
@@ -883,7 +890,7 @@ namespace Akka.Persistence.Tests
             {
                 if (message is string)
                 {
-                    var s = (string) message;
+                    var s = (string)message;
                     _probe.Tell(s);
                     Persist(s + "-outer-1", outer =>
                     {
@@ -915,7 +922,7 @@ namespace Akka.Persistence.Tests
             {
                 if (message is string)
                 {
-                    var s = (string) message;
+                    var s = (string)message;
                     _probe.Tell(s);
                     PersistAsync(s + "-outer-1", outer =>
                     {
@@ -947,7 +954,7 @@ namespace Akka.Persistence.Tests
             {
                 if (message is string)
                 {
-                    var s = (string) message;
+                    var s = (string)message;
                     _probe.Tell(s);
                     Persist(s + "-outer-1", outer =>
                     {
@@ -979,7 +986,7 @@ namespace Akka.Persistence.Tests
             {
                 if (message is string)
                 {
-                    var s = (string) message;
+                    var s = (string)message;
                     _probe.Tell(s);
                     PersistAsync(s + "-outer-async-1", outer =>
                     {
@@ -1011,7 +1018,7 @@ namespace Akka.Persistence.Tests
             {
                 if (message is string)
                 {
-                    var s = (string) message;
+                    var s = (string)message;
                     _probe.Tell(s);
                     PersistAsync(s + "-outer-async", outer =>
                     {
@@ -1069,7 +1076,7 @@ namespace Akka.Persistence.Tests
             {
                 if (message is string)
                 {
-                    var s = (string) message;
+                    var s = (string)message;
                     _probe.Tell(s);
                     Persist(s + "-1", WeMustGoDeeper);
                     return true;
@@ -1113,7 +1120,7 @@ namespace Akka.Persistence.Tests
             {
                 if (message is string)
                 {
-                    var s = (string) message;
+                    var s = (string)message;
                     _probe.Tell(s);
                     PersistAsync(s + "-1", WeMustGoDeeper);
                     return true;

--- a/src/core/Akka.Persistence.Tests/PersistentActorSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorSpec.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Threading;
 using Akka.Actor;
 using Akka.TestKit;
+using FluentAssertions;
 using Xunit;
 
 namespace Akka.Persistence.Tests
@@ -528,14 +529,14 @@ namespace Akka.Persistence.Tests
             var got = ReceiveN(nestedPersistAsyncs).Select(m => m.ToString()).OrderBy(m => m).ToArray();
             got.ShouldOnlyContainInOrder(Enumerable.Range(1, nestedPersistAsyncs).Select(i => "a-" + i).ToArray());
 
-                
+
             pref.Tell("b");
             pref.Tell("c");
-            got = ReceiveN(nestedPersistAsyncs*2 + 2).Select(m => m.ToString()).OrderBy(m => m).ToArray();
+            got = ReceiveN(nestedPersistAsyncs * 2 + 2).Select(m => m.ToString()).OrderBy(m => m).ToArray();
             got.ShouldOnlyContainInOrder(
-                new [] {"b"}
+                new[] { "b" }
                 .Union(Enumerable.Range(1, nestedPersistAsyncs).Select(i => "b-" + i))
-                .Union(new [] {"c"})
+                .Union(new[] { "c" })
                 .Union(Enumerable.Range(1, nestedPersistAsyncs).Select(i => "c-" + i))
                 .ToArray());
         }
@@ -605,6 +606,20 @@ namespace Akka.Persistence.Tests
         }
 
         [Fact]
+        public void PersistentActor_should_not_be_able_to_delete_higher_seqnr_than_current()
+        {
+            var pref = ActorOf(Props.Create(() => new BehaviorOneActor(Name)));
+            pref.Tell(new Cmd("b"));
+            pref.Tell(GetState.Instance);
+            ExpectMsgInOrder("a-1", "a-2", "b-1", "b-2");
+            pref.Tell(new Delete(5)); // > current 4
+            pref.Tell("boom"); // restart, recover
+            ExpectMsg<DeleteMessagesFailure>(m => m.Cause.Message.Should().Contain("less than or equal to LastSequenceNr"));
+            pref.Tell(GetState.Instance);
+            ExpectMsgInOrder("a-1", "a-2", "b-1", "b-2");
+        }
+
+        [Fact]
         public void PersistentActor_should_brecover_the_message_which_caused_the_restart()
         {
             var persistentActor = ActorOf(Props.Create(() => new RecoverMessageCausedRestart(Name)));
@@ -617,7 +632,7 @@ namespace Akka.Persistence.Tests
         {
             var persistentActor = ActorOf(Props.Create(() => new PersistInRecovery(Name)));
             persistentActor.Tell(GetState.Instance);
-            ExpectAnyMsgInOrder(new[]{"a-1", "a-2", "rc-1", "rc-2" }, new[] { "a-1", "a-2", "rc-1", "rc-2", "rc-3" });
+            ExpectAnyMsgInOrder(new[] { "a-1", "a-2", "rc-1", "rc-2" }, new[] { "a-1", "a-2", "rc-1", "rc-2", "rc-3" });
             persistentActor.Tell(new Cmd("invalid"));
             persistentActor.Tell(GetState.Instance);
             ExpectMsgInOrder("a-1", "a-2", "rc-1", "rc-2", "rc-3", "invalid");

--- a/src/core/Akka.Persistence/Eventsourced.Recovery.cs
+++ b/src/core/Akka.Persistence/Eventsourced.Recovery.cs
@@ -255,6 +255,9 @@ namespace Akka.Persistence
                                 eventSeenInInterval = false;
                             }
                             break;
+                        case RecoveryTick tick when tick.Snapshot:
+                            // snapshot tick, ignore
+                            break;
                         default:
                             StashInternally(message);
                             break;

--- a/src/core/Akka.Persistence/Eventsourced.Recovery.cs
+++ b/src/core/Akka.Persistence/Eventsourced.Recovery.cs
@@ -208,8 +208,9 @@ namespace Akka.Persistence
                         case RecoverySuccess success:
                             timeoutCancelable.Cancel();
                             OnReplaySuccess();
-                            _sequenceNr = success.HighestSequenceNr;
-                            LastSequenceNr = success.HighestSequenceNr;
+                            var highestSeqNr = Math.Max(success.HighestSequenceNr, LastSequenceNr);
+                            _sequenceNr = highestSeqNr;
+                            LastSequenceNr = highestSeqNr;
                             recoveryRunning = false;
                             try
                             {

--- a/src/core/Akka.Persistence/JournalProtocol.cs
+++ b/src/core/Akka.Persistence/JournalProtocol.cs
@@ -70,7 +70,7 @@ namespace Akka.Persistence
     /// Reply message to failed <see cref="Eventsourced.DeleteMessages"/> request.
     /// </summary>
     [Serializable]
-    public sealed class DeleteMessagesFailure : IEquatable<DeleteMessagesFailure>
+    public sealed class DeleteMessagesFailure : IEquatable<DeleteMessagesFailure>, INoSerializationVerificationNeeded //serialization verification temporary disabled because of Cause serialization issues
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DeleteMessagesFailure"/> class.
@@ -134,7 +134,7 @@ namespace Akka.Persistence
         /// Initializes a new instance of the <see cref="DeleteMessagesTo"/> class.
         /// </summary>
         /// <param name="persistenceId">Requesting persistent actor id.</param>
-        /// <param name="toSequenceNr">Sequence number where replay should end (inclusive).</param>
+        /// <param name="toSequenceNr">Sequence number where replay should end (inclusive). <see cref="long.MaxValue"/> may be used to delete all persistent messages.</param>
         /// <param name="persistentActor">Requesting persistent actor.</param>
         /// <exception cref="ArgumentNullException">
         /// This exception is thrown when the specified <paramref name="persistenceId"/> is undefined.


### PR DESCRIPTION
some small persistence fixes:

* Enforce valid seqnr for deletes, migrated from https://github.com/akka/akka/pull/25488

* lastSequenceNr should reflect the snapshot sequence and not start with 0 when journal is empty. Migrated from https://github.com/akka/akka/pull/27496

* snapshot RecoveryTick ignored, part of https://github.com/akka/akka/pull/20753
