### PR TITLE
Fix/standardout logger format error

### DIFF
--- a/src/common.props
+++ b/src/common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2021 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.4.18</VersionPrefix>
+    <VersionPrefix>1.4.19</VersionPrefix>
     <PackageIconUrl>https://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>
@@ -29,7 +29,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Placeholder for Nightlies**</PackageReleaseNotes>
+    <PackageReleaseNotes>Placeholder for nightlies**</PackageReleaseNotes>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>

--- a/src/core/Akka.TestKit/EventFilter/TestEventListener.cs
+++ b/src/core/Akka.TestKit/EventFilter/TestEventListener.cs
@@ -30,57 +30,64 @@ namespace Akka.TestKit
         /// <returns>TBD</returns>
         protected override bool Receive(object message)
         {
-            if(message is InitializeLogger)
+            switch (message)
             {
-                var initLogger = (InitializeLogger)message;
-                var bus = initLogger.LoggingBus;
-                var self = Context.Self;
-                bus.Subscribe(self, typeof(Mute));
-                bus.Subscribe(self, typeof(Unmute));
-                bus.Subscribe(self, typeof(DeadLetter));
-                bus.Subscribe(self, typeof(UnhandledMessage));
-                Sender.Tell(new LoggerInitialized());
-            }
-            else if(message is Mute)
-            {
-                var mute = (Mute)message;
-                foreach(var filter in mute.Filters)
+                case InitializeLogger initLogger:
                 {
-                    AddFilter(filter);
+                    var bus = initLogger.LoggingBus;
+                    var self = Context.Self;
+                    bus.Subscribe(self, typeof(Mute));
+                    bus.Subscribe(self, typeof(Unmute));
+                    bus.Subscribe(self, typeof(DeadLetter));
+                    bus.Subscribe(self, typeof(UnhandledMessage));
+                    Sender.Tell(new LoggerInitialized());
+                    break;
                 }
-            }
-            else if(message is Unmute)
-            {
-                var unmute = (Unmute)message;
-                foreach(var filter in unmute.Filters)
+                case Mute mute:
                 {
-                    RemoveFilter(filter);
+                    foreach(var filter in mute.Filters)
+                    {
+                        AddFilter(filter);
+                    }
+
+                    break;
                 }
-            }
-            else if(message is LogEvent)
-            {
-                var logEvent = (LogEvent)message;
-                if(!ShouldFilter(logEvent))
+                case Unmute unmute:
                 {
-                    Print(logEvent);
+                    foreach(var filter in unmute.Filters)
+                    {
+                        RemoveFilter(filter);
+                    }
+
+                    break;
                 }
+                case LogEvent @event:
+                {
+                    var logEvent = @event;
+                    if(!ShouldFilter(logEvent))
+                    {
+                        Print(logEvent);
+                    }
+
+                    break;
+                }
+                case DeadLetter letter:
+                    HandleDeadLetter(letter);
+                    break;
+                case UnhandledMessage unhandledMessage:
+                {
+                    var un = unhandledMessage;
+                    var rcp = un.Recipient;
+                    var warning = new Warning(rcp.Path.ToString(), rcp.GetType(), "Unhandled message from " + un.Sender + ": " + un.Message);
+                    if(!ShouldFilter(warning))
+                        Print(warning);
+                    break;
+                }
+                default:
+                    Print(new Debug(Context.System.Name,GetType(),message));
+                    break;
             }
-            else if(message is DeadLetter)
-            {
-                HandleDeadLetter((DeadLetter)message);
-            }
-            else if(message is UnhandledMessage)
-            {
-                var un = (UnhandledMessage) message;
-                var rcp = un.Recipient;
-                var warning = new Warning(rcp.Path.ToString(), rcp.GetType(), "Unhandled message from " + un.Sender + ": " + un.Message);
-                if(!ShouldFilter(warning))
-                    Print(warning);
-            }
-            else
-            {
-                Print(new Debug(Context.System.Name,GetType(),message));
-            }
+
             return true;
         }
 

--- a/src/core/Akka/Event/StandardOutLogger.cs
+++ b/src/core/Akka/Event/StandardOutLogger.cs
@@ -138,15 +138,15 @@ namespace Akka.Event
             catch (FormatException)
             {
                 /*
-                 * If we've reached this point, the `logEvent` itself is informatted incorrectly. 
+                 * If we've reached this point, the `logEvent` itself is formatted incorrectly. 
                  * Therefore we have to treat the data inside the `logEvent` as suspicious and avoid throwing
                  * a second FormatException.
                  */
                 var sb = new StringBuilder();
                 sb.AppendFormat("[ERROR][{0}][Thread {1}][StandardOutLogger] ", logEvent.Timestamp, 0);
-                sb.AppendFormat("Encoutered System.FormatException while recording log: [" +
+                sb.AppendFormat("Encountered System.FormatException while recording log: [" +
                                 logEvent.LogLevel().PrettyNameFor() + "]")
-                    .AppendFormat("[" + logEvent.LogSource + "][" + logEvent.Message + "]");
+                    .Append("[" + logEvent.LogSource + "][" + logEvent.Message + "]");
 
                 string msg;
                 switch (logEvent.Message)


### PR DESCRIPTION
This `System.FormatException` can be thrown when a bad format string is passed into the `StandardOutLogger.PrintLog` method - ironically enough, it was our `catch` block for intercepting this same error that re-threw the exception.

**Issue is still not solved in this PR**

Pretty sure I found the bag log message that triggers this here:

https://github.com/akkadotnet/akka.net/blob/e7b3fb2956eafa867cfb9e2eb7ac5cc6a87e94e8/src/core/Akka.Cluster/SBR/SplitBrainResolver.cs#L179-L184

Missed the number 2 index on the format string.