### PR TITLE
added timestamp to node failures in MNTR

### DIFF
--- a/src/core/Akka.MultiNodeTestRunner.Shared.Tests/ParsingSpec.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared.Tests/ParsingSpec.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Reflection;
 using Akka.Actor;
 using Akka.Configuration;
@@ -115,11 +116,23 @@ namespace Akka.MultiNodeTestRunner.Shared.Tests
             //format the string as it would appear when reported by multinode test runner
             var nodeMessageFragment = "[NODE1:super_role_1]      Only part of a message!";
             var runnerMessageStr = foundMessage.ToString();
+            try
+            {
+                throw new ApplicationException("test");
+            }
+            catch (Exception ex)
+            {
+                specFail.FailureExceptionTypes.Add(ex.GetType().ToString());
+                specFail.FailureMessages.Add(ex.Message);
+                specFail.FailureStackTraces.Add(ex.StackTrace);
+            }
             
+            var specFailMsg = specFail.ToString();
+
             MessageSink.DetermineMessageType(runnerMessageStr).ShouldBe(MessageSink.MultiNodeTestRunnerMessageType.RunnerLogMessage);
             MessageSink.DetermineMessageType(specPass.ToString()).ShouldBe(MessageSink.MultiNodeTestRunnerMessageType.NodePassMessage);
-            MessageSink.DetermineMessageType(specFail.ToString()).ShouldBe(MessageSink.MultiNodeTestRunnerMessageType.NodeFailMessage);
-            MessageSink.DetermineMessageType("[Node2][FAIL-EXCEPTION] Type: Xunit.Sdk.TrueException").ShouldBe(MessageSink.MultiNodeTestRunnerMessageType.NodeFailureException);
+            MessageSink.DetermineMessageType(specFailMsg).ShouldBe(MessageSink.MultiNodeTestRunnerMessageType.NodeFailMessage);
+            MessageSink.DetermineMessageType($"[Node2][{DateTime.UtcNow}][FAIL-EXCEPTION] Type: Xunit.Sdk.TrueException").ShouldBe(MessageSink.MultiNodeTestRunnerMessageType.NodeFailureException);
             MessageSink.DetermineMessageType(nodeMessageFragment).ShouldBe(MessageSink.MultiNodeTestRunnerMessageType.NodeLogFragment);
             MessageSink.DetermineMessageType("foo!").ShouldBe(MessageSink.MultiNodeTestRunnerMessageType.Unknown);
         }

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/MessageSink.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/MessageSink.cs
@@ -89,7 +89,7 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
         };
 
         private const string NodePassStatusRegexString =
-            @"\[(\w){4}(?<node>[0-9]{1,2})(?<role>:\w+)?\]\[(?<status>(PASS|FAIL))\]{1}\s(?<test>.*)";
+            @"\[(\w){4}(?<node>[0-9]{1,2})(?<role>:\w+)?\]\[(?<time>\d{1,4}[- /.]\d{1,4}[- /.]\d{1,4}\s\d{1,2}:\d{1,2}:\d{1,2}(\s(AM|PM)){0,1})\]\[(?<status>(PASS|FAIL))\]{1}\s(?<test>.*)";
         protected static readonly Regex NodePassStatusRegex = new Regex(NodePassStatusRegexString);
 
         private const string NodePassed = "PASS";
@@ -97,7 +97,7 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
         private const string NodeFailed = "FAIL";
 
         private const string NodeFailureReasonRegexString =
-            @"\[(\w){4}(?<node>[0-9]{1,2})(?<role>:\w+)?\]\[(?<status>(FAIL-EXCEPTION))\]{1}\s(?<message>.*)";
+            @"\[(\w){4}(?<node>[0-9]{1,2})(?<role>:\w+)?\]\[(?<time>\d{1,4}[- /.]\d{1,4}[- /.]\d{1,4}\s\d{1,2}:\d{1,2}:\d{1,2}(\s(AM|PM)){0,1})\]\[(?<status>(FAIL-EXCEPTION))\]{1}\s(?<message>.*)";
         protected static readonly Regex NodeFailureReasonRegex = new Regex(NodeFailureReasonRegexString);
 
         /*

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/Spec.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/Spec.cs
@@ -28,6 +28,7 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
             TestDisplayName = testDisplayName;
             NodeIndex = nodeIndex;
             NodeRole = nodeRole;
+            Timestamp = DateTime.UtcNow;
         }
 
         public int NodeIndex { get; private set; }
@@ -35,9 +36,11 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
 
         public string TestDisplayName { get; private set; }
 
+        public DateTime Timestamp { get; }
+
         public override string ToString()
         {
-            return string.Format("[Node{0}:{1}][PASS] {2}", NodeIndex, NodeRole, TestDisplayName);
+            return $"[Node{NodeIndex}:{NodeRole}][{Timestamp}][PASS] {TestDisplayName}";
         }
     }
 

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/Spec.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/Spec.cs
@@ -56,29 +56,32 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
             FailureMessages = new List<string>();
             FailureStackTraces = new List<string>();
             FailureExceptionTypes = new List<string>();
+            Timestamp = DateTime.UtcNow;
         }
 
         public IList<string> FailureMessages { get; private set; }
         public IList<string> FailureStackTraces { get; private set; }
         public IList<string> FailureExceptionTypes { get; private set; }
 
+        public DateTime Timestamp { get; }
+
         public override string ToString()
         {
             var sb = new StringBuilder();
-            sb.AppendLine(string.Format("[Node{0}:{1}][FAIL] {2}", NodeIndex, NodeRole, TestDisplayName));
+            sb.AppendLine($"[Node{NodeIndex}:{NodeRole}][{Timestamp}][FAIL] {TestDisplayName}");
             foreach (var exception in FailureExceptionTypes)
             {
-                sb.AppendFormat("[Node{0}:{1}][FAIL-EXCEPTION] Type: {2}", NodeIndex, NodeRole, exception);
+                sb.Append($"[Node{NodeIndex}:{NodeRole}][{Timestamp}][FAIL-EXCEPTION] Type: {exception}");
                 sb.AppendLine();
             }
             foreach (var exception in FailureMessages)
             {
-                sb.AppendFormat("--> [Node{0}:{1}][FAIL-EXCEPTION] Message: {2}", NodeIndex, NodeRole, exception);
+                sb.Append($"--> [Node{NodeIndex}:{NodeRole}][{Timestamp}][FAIL-EXCEPTION] Message: {exception}");
                 sb.AppendLine();
             }
             foreach (var exception in FailureStackTraces)
             {
-                sb.AppendFormat("--> [Node{0}:{1}][FAIL-EXCEPTION] StackTrace: {2}", NodeIndex, NodeRole, exception);
+                sb.Append($"--> [Node{NodeIndex}:{NodeRole}][{Timestamp}][FAIL-EXCEPTION] StackTrace: {exception}");
                 sb.AppendLine();
             }
             return sb.ToString();


### PR DESCRIPTION
Small change designed to make it easier to correlate the failure that triggered a node death in the MNTR with the other captured logs.