### PR TITLE
Fixed System.ArgumentNullException in Interspase operation on empty stream finish.

### DIFF
--- a/src/core/Akka.Streams.Tests/Dsl/FlowIntersperseSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowIntersperseSpec.cs
@@ -102,6 +102,32 @@ namespace Akka.Streams.Tests.Dsl
             probe.ExpectSubscription();
             probe.ToStrict(TimeSpan.FromSeconds(1)).Aggregate((s, s1) => s + s1).Should().Be("[1]");
         }
+        
+        [Fact]
+        public void A_Intersperse_must_not_surround_empty_stream_with_null_start_and_stop()
+        {
+            var probe =
+                Source.From(new int[0])
+                    .Select(x => x.ToString())
+                    .Intersperse(",")
+                    .RunWith(this.SinkProbe<string>(), Materializer);
+
+            probe.ExpectSubscription();
+            probe.ToStrict(TimeSpan.FromSeconds(1)).Count().Should().Be(0);
+        }
+        
+        [Fact]
+        public void A_Intersperse_must_not_surround_single_element_stream_with_null_start_and_stop()
+        {
+            var probe =
+                Source.From(new int[]{1})
+                    .Select(x => x.ToString())
+                    .Intersperse(",")
+                    .RunWith(this.SinkProbe<string>(), Materializer);
+
+            probe.ExpectSubscription();
+            probe.ToStrict(TimeSpan.FromSeconds(1)).Aggregate((s, s1) => s + s1).Should().Be("1");
+        }
 
         [Fact]
         public void A_Intersperse_must__complete_the_stage_when_the_Source_has_been_completed()

--- a/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
@@ -1518,7 +1518,7 @@ namespace Akka.Streams.Implementation.Fusing
 
             public override void OnUpstreamFinish()
             {
-                _logic.EmitMultiple(_stage.Outlet, new[] { _stage._start, _stage._end });
+                if (_stage.InjectStartEnd) _logic.EmitMultiple(_stage.Outlet, new[] { _stage._start, _stage._end });
                 _logic.CompleteStage();
             }
         }


### PR DESCRIPTION
System.ArgumentNullException
Element must not be null, rule 2.13
Имя параметра: element
   в Akka.Streams.Implementation.ReactiveStreamsCompliance.RequireNonNullElement(Object element) в D:\GitHubDesktop\akka.net\src\core\Akka.Streams\Implementation\ReactiveStreamsCompliance.cs:строка 361
   в Akka.Streams.Stage.GraphStageLogic.Push[T](Outlet`1 outlet, T element) в D:\GitHubDesktop\akka.net\src\core\Akka.Streams\Stage\GraphStage.cs:строка 1214
   в Akka.Streams.Stage.GraphStageLogic.EmitMultiple[T](Outlet`1 outlet, IEnumerator`1 enumerator, Action andThen) в D:\GitHubDesktop\akka.net\src\core\Akka.Streams\Stage\GraphStage.cs:строка 1462
   в Akka.Streams.Stage.GraphStageLogic.EmitMultiple[T](Outlet`1 outlet, IEnumerable`1 elements, Action andThen) в D:\GitHubDesktop\akka.net\src\core\Akka.Streams\Stage\GraphStage.cs:строка 1431
   в Akka.Streams.Stage.GraphStageLogic.EmitMultiple[T](Outlet`1 outlet, IEnumerable`1 elements) в D:\GitHubDesktop\akka.net\src\core\Akka.Streams\Stage\GraphStage.cs:строка 1443
   в Akka.Streams.Implementation.Fusing.Intersperse`1.StartInHandler.OnUpstreamFinish() в D:\GitHubDesktop\akka.net\src\core\Akka.Streams\Implementation\Fusing\Ops.cs:строка 1521
   в Akka.Streams.Implementation.Fusing.GraphInterpreter.ProcessEvent(Connection connection) в D:\GitHubDesktop\akka.net\src\core\Akka.Streams\Implementation\Fusing\GraphInterpreter.cs:строка 862
   в Akka.Streams.Implementation.Fusing.GraphInterpreter.Execute(Int32 eventLimit) в D:\GitHubDesktop\akka.net\src\core\Akka.Streams\Implementation\Fusing\GraphInterpreter.cs:строка 669