### PR TITLE
ClusterStressSpec and Cluster Failure Detector Cleanup

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -348,6 +348,7 @@ Target "MultiNodeTests" (fun _ ->
 
 Target "MultiNodeTestsNetCore" (fun _ ->
     if not skipBuild.Value then
+        setEnvironVar "akka.cluster.assert" "on" // needed to enable assert invariants for Akka.Cluster
         let multiNodeTestPath = findToolInSubPath "Akka.MultiNodeTestRunner.dll" (currentDirectory @@ "src" @@ "core" @@ "Akka.MultiNodeTestRunner" @@ "bin" @@ "Release" @@ testNetCoreVersion @@ "win10-x64" @@ "publish")
 
         let projects =
@@ -388,6 +389,7 @@ Target "MultiNodeTestsNetCore" (fun _ ->
 )
 Target "MultiNodeTestsNet" (fun _ ->
     if not skipBuild.Value then
+        setEnvironVar "akka.cluster.assert" "on" // needed to enable assert invariants for Akka.Cluster
         let multiNodeTestPath = findToolInSubPath "Akka.MultiNodeTestRunner.dll" (currentDirectory @@ "src" @@ "core" @@ "Akka.MultiNodeTestRunner" @@ "bin" @@ "Release" @@ testNetVersion @@ "win10-x64" @@ "publish")
 
         let projects =

--- a/src/common.props
+++ b/src/common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2021 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.4.18</VersionPrefix>
+    <VersionPrefix>1.4.19</VersionPrefix>
     <PackageIconUrl>https://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>
@@ -29,7 +29,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Placeholder for Nightlies**</PackageReleaseNotes>
+    <PackageReleaseNotes>Placeholder for nightlies**</PackageReleaseNotes>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>

--- a/src/core/Akka.Cluster.TestKit/MultiNodeClusterSpec.cs
+++ b/src/core/Akka.Cluster.TestKit/MultiNodeClusterSpec.cs
@@ -175,7 +175,7 @@ namespace Akka.Cluster.TestKit
 
         //TODO: ExpectedTestDuration?
 
-        void MuteLog(ActorSystem sys = null)
+        public virtual void MuteLog(ActorSystem sys = null)
         {
             if (sys == null) sys = Sys;
             if (!sys.Log.IsDebugEnabled)

--- a/src/core/Akka.Cluster.Tests.MultiNode/Akka.Cluster.Tests.MultiNode.csproj
+++ b/src/core/Akka.Cluster.Tests.MultiNode/Akka.Cluster.Tests.MultiNode.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <AssemblyTitle>Akka.Cluster.Tests.MultiNode</AssemblyTitle>
     <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/core/Akka.Cluster.Tests.MultiNode/Bugfix4353Specs.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/Bugfix4353Specs.cs
@@ -36,7 +36,7 @@ namespace Akka.Cluster.Tests.MultiNode
         }
 
         [MultiNodeFact]
-        public void Bugfix4353Spec_Cluster_of_3_must_reach_cnovergence()
+        public void Bugfix4353Spec_Cluster_of_3_must_reach_convergence()
         {
             AwaitClusterUp(First, Second, Third);
             EnterBarrier("after-1");

--- a/src/core/Akka.Cluster.Tests.MultiNode/StressSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/StressSpec.cs
@@ -684,8 +684,10 @@ namespace Akka.Cluster.Tests.MultiNode
         public int Step = 0;
         public int NbrUsedRoles = 0;
 
-        protected virtual void MuteLog(ActorSystem sys)
+        public override void MuteLog(ActorSystem sys = null)
         {
+            sys ??= Sys;
+            base.MuteLog(sys);
             Sys.EventStream.Publish(new Mute(new ErrorFilter(typeof(ApplicationException), new ContainsString("Simulated exception"))));
             MuteDeadLetters(sys, typeof(AggregatedClusterResult), typeof(StatsResult), typeof(PhiResult), typeof(RetryTick));
         }

--- a/src/core/Akka.Cluster.Tests.MultiNode/StressSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/StressSpec.cs
@@ -1,0 +1,1249 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using Akka.Actor;
+using Akka.Cluster.TestKit;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.Remote;
+using Akka.Remote.TestKit;
+using Akka.Remote.Transport;
+using Akka.TestKit;
+using Akka.TestKit.Internal;
+using Akka.TestKit.Internal.StringMatcher;
+using Akka.TestKit.TestEvent;
+using Akka.Util;
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+using Environment = System.Environment;
+
+namespace Akka.Cluster.Tests.MultiNode
+{
+    public class StressSpecConfig : MultiNodeConfig
+    {
+        public int TotalNumberOfNodes => Environment.GetEnvironmentVariable("MultiNode.Akka.Cluster.Stress.NrOfNodes") switch
+        {
+            string e when string.IsNullOrEmpty(e) => 13,
+            string val => int.Parse(val),
+            _ => 13
+        };
+
+        public StressSpecConfig()
+        {
+            foreach (var i in Enumerable.Range(1, TotalNumberOfNodes))
+                Role("node-" + i);
+
+            CommonConfig = ConfigurationFactory.ParseString(@"
+                akka.test.cluster-stress-spec {
+      infolog = off
+      # scale the nr-of-nodes* settings with this factor
+      nr-of-nodes-factor = 1
+      # not scaled
+      nr-of-seed-nodes = 3
+      nr-of-nodes-joining-to-seed-initially = 2
+      nr-of-nodes-joining-one-by-one-small = 2
+      nr-of-nodes-joining-one-by-one-large = 2
+      nr-of-nodes-joining-to-one = 2
+      nr-of-nodes-leaving-one-by-one-small = 1
+      nr-of-nodes-leaving-one-by-one-large = 1
+      nr-of-nodes-leaving = 2
+      nr-of-nodes-shutdown-one-by-one-small = 1
+      nr-of-nodes-shutdown-one-by-one-large = 1
+      nr-of-nodes-partition = 2
+      nr-of-nodes-shutdown = 2
+      nr-of-nodes-join-remove = 2
+      # not scaled
+      # scale the *-duration settings with this factor
+      duration-factor = 1
+      join-remove-duration = 90s
+      idle-gossip-duration = 10s
+      expected-test-duration = 600s
+      # scale convergence within timeouts with this factor
+      convergence-within-factor = 1.0
+    }
+    akka.actor.provider = cluster
+    akka.cluster {
+      failure-detector.acceptable-heartbeat-pause =  3s
+      downing-provider-class = ""Akka.Cluster.SBR.SplitBrainResolverProvider, Akka.Cluster""
+      split-brain-resolver {
+          active-strategy = keep-majority #TODO: remove this once it's been made default
+          stable-after = 10s
+      }
+      publish-stats-interval = 1s
+    }
+    akka.loggers = [""Akka.TestKit.TestEventListener, Akka.TestKit""]
+            akka.loglevel = INFO
+            akka.remote.log-remote-lifecycle-events = off
+            akka.actor.default-dispatcher.fork-join-executor {
+                parallelism - min = 8
+                parallelism - max = 8
+            }
+            ");
+
+            TestTransport = true;
+        }
+
+        public class Settings
+        {
+            private readonly Config _testConfig;
+
+            public Settings(Config config, int totalNumberOfNodes)
+            {
+                TotalNumberOfNodes = totalNumberOfNodes;
+                _testConfig = config.GetConfig("akka.test.cluster-stress-spec");
+                Infolog = _testConfig.GetBoolean("infolog");
+                NFactor = _testConfig.GetInt("nr-of-nodes-factor");
+                NumberOfSeedNodes = _testConfig.GetInt("nr-of-seed-nodes");
+                NumberOfNodesJoiningToSeedNodesInitially =
+                    _testConfig.GetInt("nr-of-nodes-joining-to-seed-initially") * NFactor;
+                NumberOfNodesJoiningOneByOneSmall = _testConfig.GetInt("nr-of-nodes-joining-one-by-one-small") * NFactor;
+                NumberOfNodesJoiningOneByOneLarge = _testConfig.GetInt("nr-of-nodes-joining-one-by-one-large") * NFactor;
+                NumberOfNodesJoiningToOneNode = _testConfig.GetInt("nr-of-nodes-joining-to-one") * NFactor;
+                // remaining will join to seed nodes
+                NumberOfNodesJoiningToSeedNodes = (totalNumberOfNodes - NumberOfSeedNodes -
+                                                   NumberOfNodesJoiningToSeedNodesInitially -
+                                                   NumberOfNodesJoiningOneByOneSmall -
+                                                   NumberOfNodesJoiningOneByOneLarge - NumberOfNodesJoiningToOneNode);
+                if (NumberOfNodesJoiningToSeedNodes < 0)
+                    throw new ArgumentOutOfRangeException("nr-of-nodes-joining-*",
+                        $"too many configured nr-of-nodes-joining-*, total should be <= {totalNumberOfNodes}");
+
+                NumberOfNodesLeavingOneByOneSmall = _testConfig.GetInt("nr-of-nodes-leaving-one-by-one-small") * NFactor;
+                NumberOfNodesLeavingOneByOneLarge = _testConfig.GetInt("nr-of-nodes-leaving-one-by-one-large") * NFactor;
+                NumberOfNodesLeaving = _testConfig.GetInt("nr-of-nodes-leaving") * NFactor;
+                NumberOfNodesShutdownOneByOneSmall = _testConfig.GetInt("nr-of-nodes-shutdown-one-by-one-small") * NFactor;
+                NumberOfNodesShutdownOneByOneLarge = _testConfig.GetInt("nr-of-nodes-shutdown-one-by-one-large") * NFactor;
+                NumberOfNodesShutdown = _testConfig.GetInt("nr-of-nodes-shutdown") * NFactor;
+                NumberOfNodesPartition = _testConfig.GetInt("nr-of-nodes-partition") * NFactor;
+                NumberOfNodesJoinRemove = _testConfig.GetInt("nr-of-nodes-join-remove"); // not scaled by nodes factor
+
+                DFactor = _testConfig.GetInt("duration-factor");
+                JoinRemoveDuration = TimeSpan.FromMilliseconds(_testConfig.GetTimeSpan("join-remove-duration").TotalMilliseconds * DFactor);
+                IdleGossipDuration = TimeSpan.FromMilliseconds(_testConfig.GetTimeSpan("idle-gossip-duration").TotalMilliseconds * DFactor);
+                ExpectedTestDuration = TimeSpan.FromMilliseconds(_testConfig.GetTimeSpan("expected-test-duration").TotalMilliseconds * DFactor);
+                ConvergenceWithinFactor = _testConfig.GetDouble("convergence-within-factor");
+
+                if (NumberOfSeedNodes + NumberOfNodesJoiningToSeedNodesInitially + NumberOfNodesJoiningOneByOneSmall +
+                    NumberOfNodesJoiningOneByOneLarge + NumberOfNodesJoiningToOneNode +
+                    NumberOfNodesJoiningToSeedNodes > totalNumberOfNodes)
+                {
+                    throw new ArgumentOutOfRangeException("nr-of-nodes-joining-*",
+                        $"specified number of joining nodes <= {totalNumberOfNodes}");
+                }
+
+                // don't shutdown the 3 nodes hosting the master actors
+                if (NumberOfNodesLeavingOneByOneSmall + NumberOfNodesLeavingOneByOneLarge + NumberOfNodesLeaving +
+                      NumberOfNodesShutdownOneByOneSmall + NumberOfNodesShutdownOneByOneLarge + NumberOfNodesShutdown >
+                      totalNumberOfNodes - 3)
+                {
+                    throw new ArgumentOutOfRangeException("nr-of-nodes-leaving-*",
+                        $"specified number of leaving/shutdown nodes <= {totalNumberOfNodes - 3}");
+                }
+
+                if (NumberOfNodesJoinRemove > totalNumberOfNodes)
+                {
+                    throw new ArgumentOutOfRangeException("nr-of-nodes-join-remove*",
+                        $"nr-of-nodes-join-remove should be <= {totalNumberOfNodes}");
+                }
+            }
+
+            public int TotalNumberOfNodes { get; }
+
+            public bool Infolog { get; }
+            public int NFactor { get; }
+
+            public int NumberOfSeedNodes { get; }
+
+            public int NumberOfNodesJoiningToSeedNodesInitially { get; }
+
+            public int NumberOfNodesJoiningOneByOneSmall { get; }
+
+            public int NumberOfNodesJoiningOneByOneLarge { get; }
+
+            public int NumberOfNodesJoiningToOneNode { get; }
+
+            public int NumberOfNodesJoiningToSeedNodes { get; }
+
+            public int NumberOfNodesLeavingOneByOneSmall { get; }
+
+            public int NumberOfNodesLeavingOneByOneLarge { get; }
+
+            public int NumberOfNodesLeaving { get; }
+
+            public int NumberOfNodesShutdownOneByOneSmall { get; }
+
+            public int NumberOfNodesShutdownOneByOneLarge { get; }
+
+            public int NumberOfNodesShutdown { get; }
+
+            public int NumberOfNodesPartition { get; }
+
+            public int NumberOfNodesJoinRemove { get; }
+
+            public int DFactor { get; }
+
+            public TimeSpan JoinRemoveDuration { get; }
+
+            public TimeSpan IdleGossipDuration { get; }
+
+            public TimeSpan ExpectedTestDuration { get; }
+
+            public double ConvergenceWithinFactor { get; }
+
+            public override string ToString()
+            {
+                return _testConfig.WithFallback($"nrOfNodes={TotalNumberOfNodes}").Root.ToString(2);
+            }
+        }
+    }
+
+    internal sealed class ClusterResult
+    {
+        public ClusterResult(Address address, TimeSpan duration, GossipStats clusterStats)
+        {
+            Address = address;
+            Duration = duration;
+            ClusterStats = clusterStats;
+        }
+
+        public Address Address { get; }
+        public TimeSpan Duration { get; }
+        public GossipStats ClusterStats { get; }
+    }
+
+    internal sealed class AggregatedClusterResult
+    {
+        public AggregatedClusterResult(string title, TimeSpan duration, GossipStats clusterStats)
+        {
+            Title = title;
+            Duration = duration;
+            ClusterStats = clusterStats;
+        }
+
+        public string Title { get; }
+
+        public TimeSpan Duration { get; }
+
+        public GossipStats ClusterStats { get; }
+    }
+
+    /// <summary>
+    /// Central aggregator of cluster statistics and metrics.
+    ///
+    /// Reports the result via log periodically and when all
+    /// expected results has been collected. It shuts down
+    /// itself when expected results has been collected.
+    /// </summary>
+    internal class ClusterResultAggregator : ReceiveActor
+    {
+        private readonly string _title;
+        private readonly int _expectedResults;
+        private readonly StressSpecConfig.Settings _settings;
+
+        private readonly ILoggingAdapter _log = Context.GetLogger();
+
+        private Option<IActorRef> _reportTo = Option<IActorRef>.None;
+        private ImmutableList<ClusterResult> _results = ImmutableList<ClusterResult>.Empty;
+        private ImmutableSortedDictionary<Address, ImmutableSortedSet<PhiValue>> _phiValuesObservedByNode =
+            ImmutableSortedDictionary<Address, ImmutableSortedSet<PhiValue>>.Empty.WithComparers(Member.AddressOrdering);
+        private ImmutableSortedDictionary<Address, ClusterEvent.CurrentInternalStats> _clusterStatsObservedByNode =
+            ImmutableSortedDictionary<Address, ClusterEvent.CurrentInternalStats>.Empty.WithComparers(Member.AddressOrdering);
+
+        public static readonly string FormatPhiHeader = "[Monitor]\t[Subject]\t[count]\t[count phi > 1.0]\t[max phi]";
+
+        public string FormatPhiLine(Address monitor, Address subject, PhiValue phi)
+        {
+            return $"{monitor}\t{subject}\t{phi.Count}\t{phi.CountAboveOne}\t{phi.Max:F2}";
+        }
+
+        public string FormatPhi()
+        {
+            if (_phiValuesObservedByNode.IsEmpty) return string.Empty;
+            else
+            {
+                //var lines = _phiValuesObservedByNode.Select(
+                //    x => x.Value.SelectMany(y => FormatPhiLine(x.Key, y.Address, y)));
+                var lines = (from mon in _phiValuesObservedByNode from phi in mon.Value select FormatPhiLine(mon.Key, phi.Address, phi));
+                return FormatPhiHeader + Environment.NewLine + string.Join(Environment.NewLine, lines);
+            }
+        }
+
+        public TimeSpan MaxDuration => _results.Max(x => x.Duration);
+
+        public GossipStats TotalGossipStats =>
+            _results.Aggregate(new GossipStats(), (stats, result) => stats += result.ClusterStats);
+
+        public string FormatStats()
+        {
+            string F(ClusterEvent.CurrentInternalStats stats)
+            {
+                return
+                    $"CurrentClusterStats({stats.GossipStats.ReceivedGossipCount}, {stats.GossipStats.MergeCount}, " +
+                    $"{stats.GossipStats.SameCount}, {stats.GossipStats.NewerCount}, {stats.GossipStats.OlderCount}," +
+                    $"{stats.SeenBy.VersionSize}, {stats.SeenBy.SeenLatest})";
+            }
+
+            return string.Join(Environment.NewLine, "ClusterStats(gossip, merge, same, newer, older, vclockSize, seenLatest)" +
+                                                    Environment.NewLine +
+                                                    _clusterStatsObservedByNode.Select(x => $"{x.Key}\t{F(x.Value)}"));
+        }
+
+        public ClusterResultAggregator(string title, int expectedResults, StressSpecConfig.Settings settings)
+        {
+            _title = title;
+            _expectedResults = expectedResults;
+            _settings = settings;
+
+            Receive<PhiResult>(phi =>
+            {
+                _phiValuesObservedByNode = _phiValuesObservedByNode.SetItem(phi.Address, phi.PhiValues);
+            });
+
+            Receive<StatsResult>(stats =>
+            {
+                _clusterStatsObservedByNode = _clusterStatsObservedByNode.SetItem(stats.Address, stats.Stats);
+            });
+
+            Receive<ReportTick>(_ =>
+            {
+                if (_settings.Infolog)
+                {
+                    _log.Info("[{0}] in progress" + Environment.NewLine + "{1}" + Environment.NewLine + "{2}", _title,
+                        FormatPhi(), FormatStats());
+                }
+            });
+
+            Receive<ClusterResult>(r =>
+            {
+                _results = _results.Add(r);
+                if (_results.Count == _expectedResults)
+                {
+                    var aggregated = new AggregatedClusterResult(_title, MaxDuration, TotalGossipStats);
+                    if (_settings.Infolog)
+                    {
+                        _log.Info("[{0}] completed in [{1}] ms" + Environment.NewLine + "{2}" +
+                                  Environment.NewLine + "{3}" + Environment.NewLine + "{4}", _title, aggregated.Duration.TotalMilliseconds,
+                        aggregated.ClusterStats, FormatPhi(), FormatStats());
+                    }
+                    _reportTo.OnSuccess(r => r.Tell(aggregated));
+                    Context.Stop(Self);
+                }
+            });
+
+            Receive<ClusterEvent.CurrentClusterState>(_ => { });
+            Receive<ReportTo>(re =>
+            {
+                _reportTo = re.Ref;
+            });
+        }
+    }
+
+    /// <summary>
+    /// Keeps cluster statistics and metrics reported by <see cref="ClusterResultAggregator"/>.
+    ///
+    /// Logs the list of historical results when a new <see cref="AggregatedClusterResult"/> is received.
+    /// </summary>
+    internal class ClusterResultHistory : ReceiveActor
+    {
+        private ILoggingAdapter _log = Context.GetLogger();
+        private ImmutableList<AggregatedClusterResult> _history = ImmutableList<AggregatedClusterResult>.Empty;
+
+        public ClusterResultHistory()
+        {
+            Receive<AggregatedClusterResult>(result =>
+            {
+                _history = _history.Add(result);
+            });
+        }
+
+        public static readonly string FormatHistoryHeader = "[Title]\t[Duration (ms)]\t[GossipStats(gossip, merge, same, newer, older)]";
+
+        public string FormatHistoryLine(AggregatedClusterResult result)
+        {
+            return $"{result.Title}\t{result.Duration.TotalMilliseconds}\t{result.ClusterStats}";
+        }
+
+        public string FormatHistory => FormatHistoryHeader + Environment.NewLine +
+                                       string.Join(Environment.NewLine, _history.Select(x => FormatHistoryLine(x)));
+    }
+
+    /// <summary>
+    /// Collect phi values of the failure detector and report to the central <see cref="ClusterResultAggregator"/>
+    /// </summary>
+    internal class PhiObserver : ReceiveActor
+    {
+        private readonly Cluster _cluster = Cluster.Get(Context.System);
+        private readonly ILoggingAdapter _log = Context.GetLogger();
+        private ImmutableDictionary<Address, PhiValue> _phiByNode = ImmutableDictionary<Address, PhiValue>.Empty;
+
+        private Option<IActorRef> _reportTo = Option<IActorRef>.None;
+        private HashSet<Address> _nodes = new HashSet<Address>();
+
+        private ICancelable _checkPhiTask = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(1), Context.Self, PhiTick.Instance, ActorRefs.NoSender);
+
+        private double Phi(Address address)
+        {
+            return _cluster.FailureDetector switch
+            {
+                DefaultFailureDetectorRegistry<Address> reg => (reg.GetFailureDetector(address)) switch
+                {
+                    PhiAccrualFailureDetector fd => fd.CurrentPhi,
+                    _ => 0.0d
+                },
+                _ => 0.0d
+            };
+        }
+
+        private PhiValue PhiByNodeDefault(Address address)
+        {
+            if (!_phiByNode.ContainsKey(address))
+            {
+                // populate default value
+                _phiByNode = _phiByNode.Add(address, new PhiValue(address, 0, 0, 0.0d));
+            }
+
+            return _phiByNode[address];
+        }
+
+        public PhiObserver()
+        {
+            Receive<PhiTick>(_ =>
+            {
+                foreach (var node in _nodes)
+                {
+                    var previous = PhiByNodeDefault(node);
+                    var p = Phi(node);
+                    if (p > 0 || _cluster.FailureDetector.IsMonitoring(node))
+                    {
+                        var aboveOne = !double.IsInfinity(p) && p > 1.0d ? 1 : 0;
+                        _phiByNode = _phiByNode.SetItem(node, new PhiValue(node,
+                            previous.CountAboveOne + aboveOne,
+                            previous.Count + 1,
+                            Math.Max(previous.Max, p)));
+                    }
+                }
+
+                var phiSet = _phiByNode.Values.ToImmutableSortedSet();
+                _reportTo.OnSuccess(r => r.Tell(new PhiResult(_cluster.SelfAddress, phiSet)));
+            });
+
+            Receive<ClusterEvent.CurrentClusterState>(state =>
+            {
+                _nodes = new HashSet<Address>(state.Members.Select(x => x.Address));
+            });
+
+            Receive<ClusterEvent.IMemberEvent>(m =>
+            {
+                _nodes.Add(m.Member.Address);
+            });
+
+            Receive<ReportTo>(r =>
+            {
+                _reportTo.OnSuccess(o => Context.Unwatch(o));
+                _reportTo = r.Ref;
+                _reportTo.OnSuccess(n => Context.Watch(n));
+            });
+
+            Receive<Terminated>(t =>
+            {
+                if (_reportTo.HasValue)
+                    _reportTo = Option<IActorRef>.None;
+            });
+
+            Receive<Reset>(_ =>
+            {
+                _phiByNode = ImmutableDictionary<Address, PhiValue>.Empty;
+                _nodes.Clear();
+                _cluster.Unsubscribe(Self);
+                _cluster.Subscribe(Self, typeof(ClusterEvent.IMemberEvent));
+            });
+        }
+
+        protected override void PreStart()
+        {
+            _cluster.Subscribe(Self, typeof(ClusterEvent.IMemberEvent));
+        }
+
+        protected override void PostStop()
+        {
+            _cluster.Unsubscribe(Self);
+            _checkPhiTask.Cancel();
+            base.PostStop();
+        }
+
+        public ITimerScheduler Timers { get; set; }
+    }
+
+    internal readonly struct PhiValue : IComparable<PhiValue>
+    {
+        public PhiValue(Address address, int countAboveOne, int count, double max)
+        {
+            Address = address;
+            CountAboveOne = countAboveOne;
+            Count = count;
+            Max = max;
+        }
+
+        public Address Address { get; }
+        public int CountAboveOne { get; }
+        public int Count { get; }
+        public double Max { get; }
+
+        public int CompareTo(PhiValue other)
+        {
+            return Member.AddressOrdering.Compare(Address, other.Address);
+        }
+    }
+
+    internal readonly struct PhiResult
+    {
+        public PhiResult(Address address, ImmutableSortedSet<PhiValue> phiValues)
+        {
+            Address = address;
+            PhiValues = phiValues;
+        }
+
+        public Address Address { get; }
+
+        public ImmutableSortedSet<PhiValue> PhiValues { get; }
+    }
+
+    internal class StatsObserver : ReceiveActor
+    {
+        private readonly Cluster _cluster = Cluster.Get(Context.System);
+        private Option<IActorRef> _reportTo = Option<IActorRef>.None;
+        private Option<GossipStats> _startStats = Option<GossipStats>.None;
+
+        protected override void PreStart()
+        {
+            _cluster.Subscribe(Self, typeof(ClusterEvent.CurrentInternalStats));
+        }
+
+        protected override void PostStop()
+        {
+            _cluster.Unsubscribe(Self);
+        }
+
+        public StatsObserver()
+        {
+            Receive<ClusterEvent.CurrentInternalStats>(stats =>
+            {
+                var gossipStats = stats.GossipStats;
+                var vclockStats = stats.SeenBy;
+
+                GossipStats MatchStats()
+                {
+                    if (!_startStats.HasValue)
+                    {
+                        _startStats = gossipStats;
+                        return gossipStats;
+                    }
+
+                    return _startStats.Value - gossipStats;
+                }
+
+                var diff = MatchStats();
+                var res = new StatsResult(_cluster.SelfAddress, new ClusterEvent.CurrentInternalStats(diff, vclockStats));
+                _reportTo.OnSuccess(a => a.Tell(res));
+            });
+
+            Receive<ReportTo>(r =>
+            {
+                _reportTo.OnSuccess(o => Context.Unwatch(o));
+                _reportTo = r.Ref;
+                _reportTo.OnSuccess(n => Context.Watch(n));
+            });
+
+            Receive<Terminated>(t =>
+            {
+                if (_reportTo.HasValue)
+                    _reportTo = Option<IActorRef>.None;
+            });
+
+            Receive<Reset>(_ =>
+            {
+                _startStats = Option<GossipStats>.None;
+            });
+
+            // nothing interesting here
+            Receive<ClusterEvent.CurrentClusterState>(_ => { });
+        }
+    }
+
+    /// <summary>
+    /// Used for remote death watch testing
+    /// </summary>
+    internal class Watchee : ActorBase
+    {
+        protected override bool Receive(object message)
+        {
+            return true;
+        }
+    }
+
+    internal sealed class Begin
+    {
+        public static readonly Begin Instance = new Begin();
+        private Begin() { }
+    }
+
+    internal sealed class End
+    {
+        public static readonly End Instance = new End();
+        private End() { }
+    }
+
+    internal sealed class RetryTick
+    {
+        public static readonly RetryTick Instance = new RetryTick();
+        private RetryTick() { }
+    }
+
+    internal sealed class ReportTick
+    {
+        public static readonly ReportTick Instance = new ReportTick();
+        private ReportTick() { }
+    }
+
+    internal sealed class PhiTick
+    {
+        public static readonly PhiTick Instance = new PhiTick();
+        private PhiTick() { }
+    }
+
+    internal sealed class ReportTo
+    {
+        public ReportTo(Option<IActorRef> @ref)
+        {
+            Ref = @ref;
+        }
+
+        public Option<IActorRef> Ref { get; }
+    }
+
+    internal sealed class StatsResult
+    {
+        public StatsResult(Address address, ClusterEvent.CurrentInternalStats stats)
+        {
+            Address = address;
+            Stats = stats;
+        }
+
+        public Address Address { get; }
+
+        public Akka.Cluster.ClusterEvent.CurrentInternalStats Stats { get; }
+    }
+
+    internal sealed class Reset
+    {
+        public static readonly Reset Instance = new Reset();
+        private Reset() { }
+    }
+
+    internal class MeasureDurationUntilDown : ReceiveActor
+    {
+        private readonly Cluster _cluster = Cluster.Get(Context.System);
+        private readonly long _startTime;
+        private readonly ILoggingAdapter _log = Context.GetLogger();
+        public MeasureDurationUntilDown()
+        {
+            _startTime = MonotonicClock.GetTicks();
+
+            Receive<ClusterEvent.MemberDowned>(d =>
+            {
+                var m = d.Member;
+                if (m.UniqueAddress == _cluster.SelfUniqueAddress)
+                {
+                    _log.Info("Downed [{0}] after [{1} ms]", _cluster.SelfAddress, TimeSpan.FromTicks(MonotonicClock.GetTicks() - _startTime).TotalMilliseconds);
+                }
+            });
+
+            Receive<ClusterEvent.CurrentClusterState>(_ => { });
+        }
+
+        protected override void PreStart()
+        {
+            _cluster.Subscribe(Self, ClusterEvent.SubscriptionInitialStateMode.InitialStateAsSnapshot, typeof(ClusterEvent.MemberDowned));
+        }
+    }
+
+    public class StressSpec : MultiNodeClusterSpec
+    {
+        public StressSpecConfig.Settings Settings { get; }
+        public TestProbe IdentifyProbe;
+
+        protected override TimeSpan ShutdownTimeout => Dilated(TimeSpan.FromSeconds(30));
+
+        public int Step = 0;
+        public int NbrUsedRoles = 0;
+
+        protected virtual void MuteLog(ActorSystem sys)
+        {
+            Sys.EventStream.Publish(new Mute(new ErrorFilter(typeof(ApplicationException), new ContainsString("Simulated exception"))));
+            MuteDeadLetters(sys, typeof(AggregatedClusterResult), typeof(StatsResult), typeof(PhiResult), typeof(RetryTick));
+        }
+
+        public StressSpec() : this(new StressSpecConfig()){ }
+
+        protected StressSpec(StressSpecConfig config) : base(config, typeof(StressSpec))
+        {
+            Settings = new StressSpecConfig.Settings(Sys.Settings.Config, config.TotalNumberOfNodes);
+            ClusterResultHistory = new Lazy<IActorRef>(() =>
+            {
+                if (Settings.Infolog)
+                    return Sys.ActorOf(Props.Create(() => new ClusterResultHistory()), "resultHistory");
+                return Sys.DeadLetters;
+            });
+
+            PhiObserver = new Lazy<IActorRef>(() =>
+            {
+                return Sys.ActorOf(Props.Create(() => new PhiObserver()), "phiObserver");
+            });
+
+            StatsObserver = new Lazy<IActorRef>(() =>
+            {
+                return Sys.ActorOf(Props.Create(() => new StatsObserver()), "statsObserver");
+            });
+        }
+
+        protected override void AtStartup()
+        {
+            IdentifyProbe = CreateTestProbe();
+            base.AtStartup();
+        }
+
+        public string ClrInfo()
+        {
+            var sb = new StringBuilder();
+            sb.Append("Operating System: ")
+                .Append(Environment.OSVersion.Platform)
+                .Append(", ")
+                .AppendLine(RuntimeInformation.ProcessArchitecture.ToString())
+                .Append(", ")
+                .Append(Environment.OSVersion.VersionString)
+                .AppendLine();
+
+            sb.Append("CLR: ")
+                .Append(RuntimeInformation.FrameworkDescription)
+                .AppendLine();
+
+            sb.Append("Processors: ").Append(Environment.ProcessorCount)
+                .AppendLine()
+                .Append("Load average: ").Append("can't be easily measured on .NET Core") // TODO: fix
+                .AppendLine()
+                .Append("Thread count: ")
+                .Append(Process.GetCurrentProcess().Threads.Count)
+                .AppendLine();
+
+            sb.Append("Memory: ")
+                .Append(Process.GetCurrentProcess().VirtualMemorySize64 / 1024 / 1024)
+                .Append("MB [allocated virtual memory]")
+                .AppendLine()
+                .Append(" (")
+                .Append(Process.GetCurrentProcess().WorkingSet64 / 1024 / 1024)
+                .Append(" - ")
+                .Append(Process.GetCurrentProcess().PeakWorkingSet64 / 1024 / 1024)
+                .Append(") MB [working set / peak working set]");
+
+            sb.AppendLine("Args: ").Append(string.Join(Environment.NewLine, Environment.GetCommandLineArgs()))
+                .AppendLine();
+
+            return sb.ToString();
+        }
+
+        public ImmutableList<RoleName> SeedNodes => Roles.Take(Settings.NumberOfSeedNodes).ToImmutableList();
+
+        internal GossipStats LatestGossipStats => Cluster.ReadView.LatestStats.GossipStats;
+
+        public Lazy<IActorRef> ClusterResultHistory { get; }
+
+        public Lazy<IActorRef> PhiObserver { get; }
+
+        public Lazy<IActorRef> StatsObserver { get; }
+
+        public Option<IActorRef> ClusterResultAggregator()
+        {
+            Sys.ActorSelection(new RootActorPath(GetAddress(Roles.First())) / "user" / ("result" + Step))
+                .Tell(new Identify(Step), IdentifyProbe.Ref);
+            return new Option<IActorRef>(IdentifyProbe.ExpectMsg<ActorIdentity>().Subject);
+        }
+
+        public void CreateResultAggregator(string title, int expectedResults, bool includeInHistory)
+        {
+            RunOn(() =>
+                {
+                    var aggregator = Sys.ActorOf(
+                        Props.Create(() => new ClusterResultAggregator(title, expectedResults, Settings))
+                            .WithDeploy(Deploy.Local), "result" + Step);
+
+                    if (includeInHistory && Settings.Infolog)
+                    {
+                        aggregator.Tell(new ReportTo(new Option<IActorRef>(ClusterResultHistory.Value)));
+                    }
+                    else
+                    {
+                        aggregator.Tell(new ReportTo(Option<IActorRef>.None));
+                    }
+                },
+                Roles.First());
+            EnterBarrier("result-aggregator-created-" + Step);
+
+            RunOn(() =>
+            {
+                var resultAggregator = ClusterResultAggregator();
+                PhiObserver.Value.Tell(new ReportTo(resultAggregator));
+                StatsObserver.Value.Tell(Reset.Instance);
+                StatsObserver.Value.Tell(new ReportTo(resultAggregator));
+            }, Roles.Take(NbrUsedRoles).ToArray());
+
+        }
+
+        public void AwaitClusterResult()
+        {
+            RunOn(() =>
+            {
+                ClusterResultAggregator().OnSuccess(r =>
+                {
+                    Watch(r);
+                    ExpectMsg<Terminated>(t => t.ActorRef.Path == r.Path);
+                });
+            }, Roles.First());
+            EnterBarrier("cluster-result-done-" + Step);
+        }
+
+        public void JoinOneByOne(int numberOfNodes)
+        {
+            foreach (var i in Enumerable.Range(0, numberOfNodes))
+            {
+                JoinOne();
+                NbrUsedRoles += 1;
+                Step += 1;
+            }
+        }
+
+        public TimeSpan ConvergenceWithin(TimeSpan baseDuration, int nodes)
+        {
+            return TimeSpan.FromMilliseconds(baseDuration.TotalMilliseconds * Settings.ConvergenceWithinFactor * nodes);
+        }
+
+        public void JoinOne()
+        {
+            Within(TimeSpan.FromSeconds(5) + ConvergenceWithin(TimeSpan.FromSeconds(2), NbrUsedRoles + 1), () =>
+            {
+                var currentRoles = Roles.Take(NbrUsedRoles + 1).ToArray();
+                var title = $"join one to {NbrUsedRoles} nodes cluster";
+                CreateResultAggregator(title, expectedResults: currentRoles.Length, includeInHistory: true);
+                RunOn(() =>
+                {
+                    ReportResult(() =>
+                    {
+                        RunOn(() =>
+                        {
+                            Cluster.Join(GetAddress(Roles.First()));
+                        }, currentRoles.Last());
+                        AwaitMembersUp(currentRoles.Length, timeout: RemainingOrDefault);
+                        return true;
+                    });
+                }, currentRoles);
+                AwaitClusterResult();
+                EnterBarrier("join-one-" + Step);
+            });
+        }
+
+        public void JoinSeveral(int numberOfNodes, bool toSeedNodes)
+        {
+            string FormatSeedJoin()
+            {
+                return toSeedNodes ? "seed nodes" : "one node";
+            }
+
+            Within(TimeSpan.FromSeconds(10) + ConvergenceWithin(TimeSpan.FromSeconds(3), NbrUsedRoles + numberOfNodes),
+                () =>
+                {
+                    var currentRoles = Roles.Take(NbrUsedRoles + numberOfNodes).ToArray();
+                    var joiningRoles = currentRoles.Skip(NbrUsedRoles).ToArray();
+                    var title = $"join {numberOfNodes} to {FormatSeedJoin()}, in {NbrUsedRoles} nodes cluster";
+                    CreateResultAggregator(title, expectedResults: currentRoles.Length, true);
+                    RunOn(() =>
+                    {
+                        ReportResult<bool>(() =>
+                        {
+                            RunOn(() =>
+                            {
+                                if (toSeedNodes)
+                                {
+                                    Cluster.JoinSeedNodes(SeedNodes.Select(x => GetAddress(x)));
+                                }
+                                else
+                                {
+                                    Cluster.Join(GetAddress(Roles.First()));
+                                }
+                            }, joiningRoles);
+                            AwaitMembersUp(currentRoles.Length, timeout: RemainingOrDefault);
+                            return true;
+                        });
+                    }, currentRoles);
+                    AwaitClusterResult();
+                    EnterBarrier("join-several-" + Step);
+                });
+        }
+
+        public void RemoveOneByOne(int numberOfNodes, bool shutdown)
+        {
+            foreach (var i in Enumerable.Range(0, numberOfNodes))
+            {
+                RemoveOne(shutdown);
+                NbrUsedRoles -= 1;
+                Step += 1;
+            }
+        }
+
+        public void RemoveOne(bool shutdown)
+        {
+            string FormatNodeLeave()
+            {
+                return shutdown ? "shutdown" : "remove";
+            }
+
+            Within(TimeSpan.FromSeconds(25) + ConvergenceWithin(TimeSpan.FromSeconds(3), NbrUsedRoles - 1), ()
+                =>
+            {
+                var currentRoles = Roles.Take(NbrUsedRoles - 1).ToArray();
+                var title = $"{FormatNodeLeave()} one from {NbrUsedRoles} nodes cluster";
+                CreateResultAggregator(title, expectedResults:currentRoles.Length, true);
+                var removeRole = Roles[NbrUsedRoles - 1];
+                var removeAddress = GetAddress(removeRole);
+
+                RunOn(() =>
+                {
+                    var watchee = Sys.ActorOf(Props.Create(() => new Watchee()), "watchee");
+                    if(!shutdown)
+                        Cluster.Leave(GetAddress(Myself));
+                }, removeRole);
+
+                EnterBarrier("watchee-created-" + Step);
+
+                RunOn(() =>
+                {
+                    Sys.ActorSelection(Node(removeRole) / "user" / "watchee").Tell(new Identify("watchee"), IdentifyProbe.Ref);
+                    var watchee = IdentifyProbe.ExpectMsg<ActorIdentity>().Subject;
+                    Watch(watchee);
+                }, Roles.First());
+                EnterBarrier("watchee-established-" + Step);
+
+                RunOn(() =>
+                {
+                    ReportResult(() =>
+                    {
+                        RunOn(() =>
+                        {
+                            if (shutdown)
+                            {
+                                if (Settings.Infolog)
+                                {
+                                    Log.Info("Shutting down [{0}]", removeAddress);
+                                }
+
+                                TestConductor.Exit(removeRole, 0).Wait(RemainingOrDefault);
+                            }
+                        }, Roles.First());
+
+                        AwaitMembersUp(currentRoles.Length, timeout: RemainingOrDefault);
+                        AwaitAllReachable();
+                        return true;
+                    });
+                }, currentRoles);
+
+                RunOn(() =>
+                {
+                    var expectedPath = new RootActorPath(removeAddress) / "user" / "watchee";
+                    ExpectMsg<Terminated>(t => t.ActorRef.Path == expectedPath);
+                }, Roles.First());
+
+                EnterBarrier("watch-verified-" + Step);
+
+                AwaitClusterResult();
+                EnterBarrier("remove-one-" + Step);
+            });
+        }
+
+        public void RemoveSeveral(int numberOfNodes, bool shutdown)
+        {
+            string FormatNodeLeave()
+            {
+                return shutdown ? "shutdown" : "remove";
+            }
+
+            Within(TimeSpan.FromSeconds(25) + ConvergenceWithin(TimeSpan.FromSeconds(5), NbrUsedRoles - numberOfNodes),
+                () =>
+                {
+                    var currentRoles = Roles.Take(NbrUsedRoles - numberOfNodes).ToArray();
+                    var removeRoles = Roles.Skip(currentRoles.Length).Take(numberOfNodes).ToArray();
+                    var title = $"{FormatNodeLeave()} {numberOfNodes} in {NbrUsedRoles} nodes cluster";
+                    CreateResultAggregator(title, expectedResults: currentRoles.Length, includeInHistory: true);
+
+                    RunOn(() =>
+                    {
+                        if (!shutdown)
+                        {
+                            Cluster.Leave(GetAddress(Myself));
+                        }
+                    }, removeRoles);
+
+                    RunOn(() =>
+                    {
+                        ReportResult<bool>(() =>
+                        {
+                            RunOn(() =>
+                            {
+                                if (shutdown)
+                                {
+                                    foreach (var role in removeRoles)
+                                    {
+                                        if (Settings.Infolog)
+                                            Log.Info("Shutting down [{0}]", GetAddress(role));
+                                        TestConductor.Exit(role, 0).Wait(RemainingOrDefault);
+                                    }
+                                }
+                            }, Roles.First());
+                            AwaitMembersUp(currentRoles.Length, timeout: RemainingOrDefault);
+                            AwaitAllReachable();
+                            return true;
+                        });
+                    }, currentRoles);
+
+                    AwaitClusterResult();
+                    EnterBarrier("remove-several-" + Step);
+                });
+        }
+
+        public void PartitionSeveral(int numberOfNodes)
+        {
+            Within(TimeSpan.FromSeconds(25) + ConvergenceWithin(TimeSpan.FromSeconds(5), NbrUsedRoles - numberOfNodes),
+                () =>
+                {
+                    var currentRoles = Roles.Take(NbrUsedRoles - numberOfNodes).ToArray();
+                    var removeRoles = Roles.Skip(currentRoles.Length).Take(numberOfNodes).ToArray();
+                    var title = $"partition {numberOfNodes} in {NbrUsedRoles} nodes cluster";
+                    CreateResultAggregator(title, expectedResults: currentRoles.Length, includeInHistory: true);
+
+                    RunOn(() =>
+                    {
+                        foreach (var x in currentRoles)
+                        {
+                            foreach (var y in removeRoles)
+                            {
+                                TestConductor.Blackhole(x, y, ThrottleTransportAdapter.Direction.Both);
+                            }
+                        }
+                    }, Roles.First());
+                    EnterBarrier("partition-several-blackhole");
+
+                    RunOn(() =>
+                    {
+                        ReportResult<bool>(() =>
+                        {
+                            var startTime = MonotonicClock.GetTicks();
+                            AwaitMembersUp(currentRoles.Length, timeout:RemainingOrDefault);
+                            Sys.Log.Info("Removed [{0}] members after [{0} ms]",
+                                removeRoles.Length, TimeSpan.FromTicks(MonotonicClock.GetTicks() - startTime).TotalMilliseconds);
+                            AwaitAllReachable();
+                            return true;
+                        });
+                    }, currentRoles);
+
+                    RunOn(() =>
+                    {
+                        Sys.ActorOf(Props.Create<MeasureDurationUntilDown>());
+                        AwaitAssert(() =>
+                        {
+                            Cluster.IsTerminated.Should().BeTrue();
+                        });
+                    }, removeRoles);
+                    AwaitClusterResult();
+                    EnterBarrier("partition-several-" + Step);
+                });
+        }
+
+        public T ReportResult<T>(Func<T> thunk)
+        {
+            var startTime = MonotonicClock.GetTicks();
+            var startStats = ClusterView.LatestStats.GossipStats;
+
+            var returnValue = thunk();
+
+            ClusterResultAggregator().OnSuccess(r =>
+            {
+                r.Tell(new ClusterResult(Cluster.SelfAddress, TimeSpan.FromTicks(MonotonicClock.GetTicks() - startTime), LatestGossipStats - startStats));
+            });
+
+            return returnValue;
+        }
+
+        public void ExerciseJoinRemove(string title, TimeSpan duration)
+        {
+            var activeRoles = Roles.Take(Settings.NumberOfNodesJoinRemove).ToArray();
+            var loopDuration = TimeSpan.FromSeconds(10) +
+                               ConvergenceWithin(TimeSpan.FromSeconds(4), NbrUsedRoles + activeRoles.Length);
+            var rounds = (int)Math.Max(1.0d, (duration - loopDuration).TotalMilliseconds / loopDuration.TotalMilliseconds);
+            var usedRoles = Roles.Take(NbrUsedRoles).ToArray();
+            var usedAddresses = usedRoles.Select(x => GetAddress(x)).ToImmutableHashSet();
+
+            Option<ActorSystem> Loop(int counter, Option<ActorSystem> previousAs,
+                ImmutableHashSet<Address> allPreviousAddresses)
+            {
+                if (counter > rounds) return previousAs;
+
+                var t = title + " round " + counter;
+                RunOn(() =>
+                {
+                    PhiObserver.Value.Tell(Reset.Instance);
+                    StatsObserver.Value.Tell(Reset.Instance);
+                }, usedRoles);
+                CreateResultAggregator(t, expectedResults:NbrUsedRoles, includeInHistory:true);
+
+                var nextAs = Option<ActorSystem>.None;
+                var nextAddresses = ImmutableHashSet<Address>.Empty;
+                Within(loopDuration, () =>
+                {
+                   var (nextAsy, nextAddr) = ReportResult(() =>
+                    {
+                        Option<ActorSystem> nextAs;
+
+                        if (activeRoles.Contains(Myself))
+                        {
+                            previousAs.OnSuccess(s =>
+                            {
+                                Shutdown(s);
+                            });
+
+                            var sys = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
+                            MuteLog(sys);
+                            Akka.Cluster.Cluster.Get(sys).JoinSeedNodes(SeedNodes.Select(x => GetAddress(x)));
+                            nextAs = new Option<ActorSystem>(sys);
+                        }
+                        else
+                        {
+                            nextAs = previousAs;
+                        }
+
+                        RunOn(() =>
+                        {
+                            AwaitMembersUp(NbrUsedRoles + activeRoles.Length, 
+                                canNotBePartOfMemberRing: allPreviousAddresses,
+                                timeout: RemainingOrDefault);
+                            AwaitAllReachable();
+                        }, usedRoles);
+
+                        nextAddresses = ClusterView.Members.Select(x => x.Address).ToImmutableHashSet()
+                            .Except(usedAddresses);
+
+                        RunOn(() =>
+                        {
+                            nextAddresses.Count.Should().Be(Settings.NumberOfNodesJoinRemove);
+                        }, usedRoles);
+
+                        return (nextAs, nextAddresses);
+                    });
+
+                   nextAs = nextAsy;
+                   nextAddresses = nextAddr;
+                });
+
+                AwaitClusterResult();
+                Step += 1;
+                return Loop(counter + 1, nextAs, nextAddresses);
+            }
+
+            Loop(1, Option<ActorSystem>.None, ImmutableHashSet<Address>.Empty).OnSuccess(aSys =>
+            {
+                Shutdown(aSys);
+            });
+
+            Within(loopDuration, () =>
+            {
+                RunOn(() =>
+                {
+                    AwaitMembersUp(NbrUsedRoles, timeout: RemainingOrDefault);
+                    AwaitAllReachable();
+                    PhiObserver.Value.Tell(Reset.Instance);
+                    StatsObserver.Value.Tell(Reset.Instance);
+                }, usedRoles);
+            });
+            EnterBarrier("join-remove-shutdown-" + Step);
+        }
+
+        public void IdleGossip(string title)
+        {
+            CreateResultAggregator(title, expectedResults: NbrUsedRoles, includeInHistory: true);
+            ReportResult(() =>
+            {
+                ClusterView.Members.Count.Should().Be(NbrUsedRoles);
+                Thread.Sleep(Settings.IdleGossipDuration);
+                ClusterView.Members.Count.Should().Be(NbrUsedRoles);
+                return true;
+            });
+            AwaitClusterResult();
+        }
+
+        public void IncrementStep()
+        {
+            Step += 1;
+        }
+
+        [MultiNodeFact]
+        public void Cluster_under_stress()
+        {
+            MustLogSettings();
+            IncrementStep();
+            MustJoinSeedNodes();
+            IncrementStep();
+        }
+
+        public void MustLogSettings()
+        {
+            if (Settings.Infolog)
+            {
+                Log.Info("StressSpec CLR:" + Environment.NewLine + ClrInfo());
+                RunOn(() =>
+                {
+                    Log.Info("StressSpec settings:" + Environment.NewLine + Settings);
+                });
+            }
+            EnterBarrier("after-" + Step);
+        }
+
+        public void MustJoinSeedNodes()
+        {
+            Within(TimeSpan.FromSeconds(30), () =>
+            {
+                var otherNodesJoiningSeedNodes = Roles.Skip(Settings.NumberOfSeedNodes)
+                    .Take(Settings.NumberOfNodesJoiningToSeedNodesInitially).ToArray();
+                var size = SeedNodes.Count + otherNodesJoiningSeedNodes.Length;
+
+                CreateResultAggregator("join seed nodes", expectedResults: size, includeInHistory: true);
+
+                RunOn(() =>
+                {
+                    ReportResult(() =>
+                    {
+                        Cluster.JoinSeedNodes(SeedNodes.Select(x => GetAddress(x)));
+                        AwaitMembersUp(size, timeout: RemainingOrDefault);
+                        return true;
+                    });
+                }, SeedNodes.AddRange(otherNodesJoiningSeedNodes).ToArray());
+
+                AwaitClusterResult();
+                NbrUsedRoles += size;
+                EnterBarrier("after-" + Step);
+            });
+        }
+    }
+}

--- a/src/core/Akka.Cluster/Cluster.cs
+++ b/src/core/Akka.Cluster/Cluster.cs
@@ -62,13 +62,29 @@ namespace Akka.Cluster
             return system.WithExtension<Cluster, ClusterExtension>();
         }
 
+        static Cluster()
+        {
+            bool GetAssertInvariants()
+            {
+                var isOn = Environment.GetEnvironmentVariable("akka.cluster.assert")?.ToLowerInvariant();
+                switch (isOn)
+                {
+                    case "on":
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+
+            IsAssertInvariantsEnabled = GetAssertInvariants();
+        }
+
         /// <summary>
         /// TBD
         /// </summary>
         internal static bool IsAssertInvariantsEnabled
         {
-            //TODO: Consequences of this?
-            get { return false; }
+            get;
         }
 
         /// <summary>

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -1964,8 +1964,11 @@ namespace Akka.Cluster
             // for all new joining nodes we remove them from the failure detector
             foreach (var node in _latestGossip.Members)
             {
-                if (node.Status == MemberStatus.Joining && !localGossip.Members.Contains(node))
+                if (!localGossip.Members.Contains(node))
+                {
                     _cluster.FailureDetector.Remove(node.Address);
+                }
+                    
             }
 
             _log.Debug("Cluster Node [{0}] - Receiving gossip from [{1}]", _cluster.SelfAddress, from);

--- a/src/core/Akka.Cluster/ClusterHeartbeat.cs
+++ b/src/core/Akka.Cluster/ClusterHeartbeat.cs
@@ -649,11 +649,12 @@ namespace Akka.Cluster
                 {
                     if (iter.MoveNext() == false || n == 0)
                     {
+                        iter.Dispose(); // dispose enumerator
                         return (n, acc);
                     }
                     else
                     {
-                        UniqueAddress next = iter.Current;
+                        var next = iter.Current;
                         var isUnreachable = Unreachable.Contains(next);
                         if (isUnreachable && acc.Count >= MonitoredByNumberOfNodes)
                         {
@@ -670,13 +671,11 @@ namespace Akka.Cluster
                     }
                 };
 
-                var tuple = take(MonitoredByNumberOfNodes, NodeRing().From(sender).Skip(1).GetEnumerator(), ImmutableSortedSet<UniqueAddress>.Empty);
-                var remaining = tuple.Item1;
-                var slice1 = tuple.Item2;
+                var (remaining, slice1) = take(MonitoredByNumberOfNodes, NodeRing().From(sender).Skip(1).GetEnumerator(), ImmutableSortedSet<UniqueAddress>.Empty);
 
                 IImmutableSet<UniqueAddress> slice = remaining == 0 
-                    ? slice1 
-                    : take(remaining, NodeRing().Until(sender).Where(c => !c.Equals(sender)).GetEnumerator(), slice1).Item2;
+                    ? slice1 // or, wrap0around
+                    : take(remaining, NodeRing().TakeWhile(x => x != sender).GetEnumerator(), slice1).Item2;
 
                 return slice.ToImmutableHashSet();
             }
@@ -729,7 +728,9 @@ namespace Akka.Cluster
 
         #region Comparer
         /// <summary>
-        /// TBD
+        /// Data structure for picking heartbeat receivers. The node ring is
+        /// shuffled by deterministic hashing to avoid picking physically co-located
+        /// neighbors.
         /// </summary>
         internal class RingComparer : IComparer<UniqueAddress>
         {
@@ -742,12 +743,10 @@ namespace Akka.Cluster
             /// <inheritdoc/>
             public int Compare(UniqueAddress x, UniqueAddress y)
             {
-                var result = Member.AddressOrdering.Compare(x.Address, y.Address);
-                if (result == 0)
-                    if (x.Uid < y.Uid) return -1;
-                    else if (x.Uid == y.Uid) return 0;
-                    else return 1;
-                return result;
+                var ha = x.GetHashCode();
+                var hb = y.GetHashCode();
+                var c = ha.CompareTo(hb);
+                return c == 0 ? Member.AddressOrdering.Compare(x.Address, y.Address) : c;
             }
         }
         #endregion

--- a/src/core/Akka.Cluster/ClusterHeartbeat.cs
+++ b/src/core/Akka.Cluster/ClusterHeartbeat.cs
@@ -510,7 +510,9 @@ namespace Akka.Cluster
             foreach (var r in removedReceivers)
             {
                 if (FailureDetector.IsAvailable(r.Address))
+                {
                     FailureDetector.Remove(r.Address);
+                }
                 else
                 {
                     adjustedOldReceiversNowUnreachable = adjustedOldReceiversNowUnreachable.Add(r);
@@ -674,7 +676,7 @@ namespace Akka.Cluster
                 var (remaining, slice1) = take(MonitoredByNumberOfNodes, NodeRing().From(sender).Skip(1).GetEnumerator(), ImmutableSortedSet<UniqueAddress>.Empty);
 
                 IImmutableSet<UniqueAddress> slice = remaining == 0 
-                    ? slice1 // or, wrap0around
+                    ? slice1 // or, wrap-around
                     : take(remaining, NodeRing().TakeWhile(x => x != sender).GetEnumerator(), slice1).Item2;
 
                 return slice.ToImmutableHashSet();
@@ -743,8 +745,8 @@ namespace Akka.Cluster
             /// <inheritdoc/>
             public int Compare(UniqueAddress x, UniqueAddress y)
             {
-                var ha = x.GetHashCode();
-                var hb = y.GetHashCode();
+                var ha = x.Uid;
+                var hb = y.Uid;
                 var c = ha.CompareTo(hb);
                 return c == 0 ? Member.AddressOrdering.Compare(x.Address, y.Address) : c;
             }

--- a/src/core/Akka.Cluster/Gossip.cs
+++ b/src/core/Akka.Cluster/Gossip.cs
@@ -516,9 +516,6 @@ namespace Akka.Cluster
     /// </summary>
     class GossipEnvelope : IClusterMessage
     {
-        //TODO: Serialization?
-        //TODO: ser stuff?
-
         readonly UniqueAddress _from;
         readonly UniqueAddress _to;
 

--- a/src/core/Akka.Cluster/Gossip.cs
+++ b/src/core/Akka.Cluster/Gossip.cs
@@ -156,25 +156,33 @@ namespace Akka.Cluster
 
         private void AssertInvariants()
         {
-            if (_members.Any(m => m.Status == MemberStatus.Removed))
+            void IfTrueThrow(bool func, string expected, string actual)
             {
-                var members = string.Join(", ", _members.Where(m => m.Status == MemberStatus.Removed).Select(m => m.ToString()));
-                throw new ArgumentException($"Live members must not have status [Removed], got {members}", nameof(_members));
+                if (func) throw new ArgumentException($"{expected}, but found [{actual}]");
             }
+
+
+            IfTrueThrow(_members.Any(m => m.Status == MemberStatus.Removed),
+                expected: "Live members must not have status [Removed]",
+                actual: string.Join(", ",
+                    _members.Where(m => m.Status == MemberStatus.Removed).Select(m => m.ToString())));
+
 
             var inReachabilityButNotMember = _overview.Reachability.AllObservers.Except(_members.Select(m => m.UniqueAddress));
-            if (!inReachabilityButNotMember.IsEmpty)
-            {
-                var inreachability = string.Join(", ", inReachabilityButNotMember.Select(a => a.ToString()));
-                throw new ArgumentException($"Nodes not part of cluster in reachability table, got {inreachability}", nameof(_overview));
-            }
+            IfTrueThrow(!inReachabilityButNotMember.IsEmpty,
+                expected: "Nodes not part of cluster in reachability table",
+                actual: string.Join(", ", inReachabilityButNotMember.Select(a => a.ToString())));
+
+            var inReachabilityVersionsButNotMember =
+                _overview.Reachability.Versions.Keys.Except(Members.Select(x => x.UniqueAddress)).ToImmutableHashSet();
+            IfTrueThrow(!inReachabilityVersionsButNotMember.IsEmpty,
+                expected: "Nodes not part of cluster in reachability versions table",
+                actual: string.Join(", ", inReachabilityVersionsButNotMember.Select(a => a.ToString())));
 
             var seenButNotMember = _overview.Seen.Except(_members.Select(m => m.UniqueAddress));
-            if (!seenButNotMember.IsEmpty)
-            {
-                var seen = string.Join(", ", seenButNotMember.Select(a => a.ToString()));
-                throw new ArgumentException($"Nodes not part of cluster have marked the Gossip as seen, got {seen}", nameof(_overview));
-            }
+            IfTrueThrow(!seenButNotMember.IsEmpty,
+                expected: "Nodes not part of cluster have marked the Gossip as seen",
+                actual: string.Join(", ", seenButNotMember.Select(a => a.ToString())));
         }
 
         //TODO: Serializer should ignore
@@ -274,7 +282,7 @@ namespace Akka.Cluster
             var mergedMembers = EmptyMembers.Union(Member.PickHighestPriority(this._members, that._members));
 
             // 3. merge reachability table by picking records with highest version
-            var mergedReachability = this._overview.Reachability.Merge(mergedMembers.Select(m => m.UniqueAddress),
+            var mergedReachability = _overview.Reachability.Merge(mergedMembers.Select(m => m.UniqueAddress),
                 that._overview.Reachability);
 
             // 4. Nobody can have seen this new gossip yet
@@ -448,7 +456,7 @@ namespace Akka.Cluster
     /// <summary>
     /// Represents the overview of the cluster, holds the cluster convergence table and set with unreachable nodes.
     /// </summary>
-    class GossipOverview
+    internal class GossipOverview
     {
         readonly ImmutableHashSet<UniqueAddress> _seen;
         readonly Reachability _reachability;

--- a/src/core/Akka.Cluster/Member.cs
+++ b/src/core/Akka.Cluster/Member.cs
@@ -507,7 +507,7 @@ namespace Akka.Cluster
         /// <inheritdoc cref="object.GetHashCode"/>
         public override int GetHashCode()
         {
-            return Uid;
+            return MurmurHash.ByteHash(BitConverter.GetBytes(Uid));
         }
 
         /// <summary>

--- a/src/core/Akka.Cluster/Member.cs
+++ b/src/core/Akka.Cluster/Member.cs
@@ -502,12 +502,12 @@ namespace Akka.Cluster
         }
 
         /// <inheritdoc cref="object.Equals(object)"/>
-        public override bool Equals(object obj) => obj is UniqueAddress && Equals((UniqueAddress)obj);
+        public override bool Equals(object obj) => obj is UniqueAddress address && Equals(address);
 
         /// <inheritdoc cref="object.GetHashCode"/>
         public override int GetHashCode()
         {
-            return MurmurHash.ByteHash(BitConverter.GetBytes(Uid));
+            return Uid;
         }
 
         /// <summary>

--- a/src/core/Akka.Cluster/Reachability.cs
+++ b/src/core/Akka.Cluster/Reachability.cs
@@ -15,218 +15,122 @@ using Akka.Util.Internal;
 namespace Akka.Cluster
 {
     /// <summary>
-    /// Immutable data structure that holds the reachability status of subject nodes as seen
-    /// from observer nodes. Failure detector for the subject nodes exist on the
-    /// observer nodes. Changes (reachable, unreachable, terminated) are only performed
-    /// by observer nodes to its own records. Each change bumps the version number of the
-    /// record, and thereby it is always possible to determine which record is newest 
-    /// merging two instances.
-    ///
-    /// Aggregated status of a subject node is defined as (in this order):
-    /// - Terminated if any observer node considers it as Terminated
-    /// - Unreachable if any observer node considers it as Unreachable
-    /// - Reachable otherwise, i.e. no observer node considers it as Unreachable
+    ///     Immutable data structure that holds the reachability status of subject nodes as seen
+    ///     from observer nodes. Failure detector for the subject nodes exist on the
+    ///     observer nodes. Changes (reachable, unreachable, terminated) are only performed
+    ///     by observer nodes to its own records. Each change bumps the version number of the
+    ///     record, and thereby it is always possible to determine which record is newest
+    ///     merging two instances.
+    ///     Aggregated status of a subject node is defined as (in this order):
+    ///     - Terminated if any observer node considers it as Terminated
+    ///     - Unreachable if any observer node considers it as Unreachable
+    ///     - Reachable otherwise, i.e. no observer node considers it as Unreachable
     /// </summary>
     internal class Reachability //TODO: ISerializable?
     {
         /// <summary>
-        /// TBD
+        ///     TBD
         /// </summary>
-        public static readonly Reachability Empty = 
-            new Reachability(ImmutableList.Create<Record>(), ImmutableDictionary.Create<UniqueAddress, long>());
+        public enum ReachabilityStatus
+        {
+            /// <summary>
+            ///     TBD
+            /// </summary>
+            Reachable,
+
+            /// <summary>
+            ///     TBD
+            /// </summary>
+            Unreachable,
+
+            /// <summary>
+            ///     TBD
+            /// </summary>
+            Terminated
+        }
 
         /// <summary>
-        /// TBD
+        ///     TBD
+        /// </summary>
+        public static readonly Reachability Empty =
+            new Reachability(ImmutableList.Create<Record>(), ImmutableDictionary.Create<UniqueAddress, long>());
+
+        //TODO: Serialization should ignore
+        private readonly Lazy<Cache> _cache;
+
+        /// <summary>
+        ///     TBD
         /// </summary>
         /// <param name="records">TBD</param>
         /// <param name="versions">TBD</param>
         public Reachability(ImmutableList<Record> records, ImmutableDictionary<UniqueAddress, long> versions)
         {
             _cache = new Lazy<Cache>(() => new Cache(records));
-            _versions = versions;
-            _records = records;
+            Versions = versions;
+            Records = records;
         }
 
         /// <summary>
-        /// TBD
+        ///     TBD
         /// </summary>
-        public sealed class Record
+        public ImmutableList<Record> Records { get; }
+
+        /// <summary>
+        ///     TBD
+        /// </summary>
+        public ImmutableDictionary<UniqueAddress, long> Versions { get; }
+
+        /*
+         *  def isReachable(observer: UniqueAddress, subject: UniqueAddress): Boolean =
+            status(observer, subject) == Reachable
+         */
+
+        /// <summary>
+        ///     TBD
+        /// </summary>
+        public bool IsAllReachable => Records.IsEmpty;
+
+        /// <summary>
+        ///     Doesn't include terminated
+        /// </summary>
+        public ImmutableHashSet<UniqueAddress> AllUnreachable => _cache.Value.AllUnreachable;
+
+        /// <summary>
+        ///     TBD
+        /// </summary>
+        public ImmutableHashSet<UniqueAddress> AllUnreachableOrTerminated => _cache.Value.AllUnreachableOrTerminated;
+
+        /// <summary>
+        ///     TBD
+        /// </summary>
+        public ImmutableDictionary<UniqueAddress, ImmutableHashSet<UniqueAddress>> ObserversGroupedByUnreachable
         {
-            readonly UniqueAddress _observer;
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public UniqueAddress Observer { get { return _observer; } }
-            readonly UniqueAddress _subject;
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public UniqueAddress Subject { get { return _subject; } }
-            readonly ReachabilityStatus _status;
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public ReachabilityStatus Status { get { return _status; } }
-            readonly long _version;
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public long Version { get { return _version; } }
-
-            /// <summary>
-            /// TBD
-            /// </summary>
-            /// <param name="observer">TBD</param>
-            /// <param name="subject">TBD</param>
-            /// <param name="status">TBD</param>
-            /// <param name="version">TBD</param>
-            public Record(UniqueAddress observer, UniqueAddress subject, ReachabilityStatus status, long version)
+            get
             {
-                _observer = observer;
-                _subject = subject;
-                _status = status;
-                _version = version;
-            }
+                var builder = new Dictionary<UniqueAddress, ImmutableHashSet<UniqueAddress>>();
 
-            /// <inheritdoc/>
-            public override bool Equals(object obj)
-            {
-                var other = obj as Record;
-                if (other == null) return false;
-                return _version.Equals(other._version) &&
-                       _status == other.Status &&
-                       _observer.Equals(other._observer) &&
-                       _subject.Equals(other._subject);
-            }
-
-            /// <inheritdoc/>
-            public override int GetHashCode()
-            {
-                unchecked
-                {
-                    var hashCode = (Observer != null ? Observer.GetHashCode() : 0);
-                    hashCode = (hashCode * 397) ^ Version.GetHashCode();
-                    hashCode = (hashCode * 397) ^ Status.GetHashCode();
-                    hashCode = (hashCode * 397) ^ (Subject != null ? Subject.GetHashCode() : 0);
-                    return hashCode;
-                }
+                var grouped = Records.GroupBy(p => p.Subject);
+                foreach (var records in grouped)
+                    if (records.Any(r => r.Status == ReachabilityStatus.Unreachable))
+                        builder.Add(records.Key, records.Where(r => r.Status == ReachabilityStatus.Unreachable)
+                            .Select(r => r.Observer).ToImmutableHashSet());
+                return builder.ToImmutableDictionary();
             }
         }
 
         /// <summary>
-        /// TBD
+        ///     TBD
         /// </summary>
-        public enum ReachabilityStatus
-        {
-            /// <summary>
-            /// TBD
-            /// </summary>
-            Reachable,
-            /// <summary>
-            /// TBD
-            /// </summary>
-            Unreachable,
-            /// <summary>
-            /// TBD
-            /// </summary>
-            Terminated
-        }
+        public ImmutableHashSet<UniqueAddress> AllObservers => Records.Select(i => i.Observer).ToImmutableHashSet();
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        public ImmutableList<Record> Records { get { return _records; } }
-        readonly ImmutableList<Record> _records;
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        public ImmutableDictionary<UniqueAddress, long> Versions { get { return _versions; } }
-        readonly ImmutableDictionary<UniqueAddress, long> _versions;
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        class Cache
-        {
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public ImmutableDictionary<UniqueAddress, ImmutableDictionary<UniqueAddress, Record>> ObserverRowMap { get { return _observerRowsMap; } }
-            readonly ImmutableDictionary<UniqueAddress, ImmutableDictionary<UniqueAddress, Record>> _observerRowsMap;
-
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public ImmutableHashSet<UniqueAddress> AllTerminated { get { return _allTerminated; } }
-            readonly ImmutableHashSet<UniqueAddress> _allTerminated;
-
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public ImmutableHashSet<UniqueAddress> AllUnreachable { get { return _allUnreachable; } }
-            readonly ImmutableHashSet<UniqueAddress> _allUnreachable;
-
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public ImmutableHashSet<UniqueAddress> AllUnreachableOrTerminated { get { return _allUnreachableOrTerminated; } }
-            readonly ImmutableHashSet<UniqueAddress> _allUnreachableOrTerminated;
-
-            /// <summary>
-            /// TBD
-            /// </summary>
-            /// <param name="records">TBD</param>
-            public Cache(ImmutableList<Record> records)
-            {
-                if (records.IsEmpty)
-                {
-                    _observerRowsMap = ImmutableDictionary.Create<UniqueAddress, ImmutableDictionary<UniqueAddress, Record>>();
-                    _allTerminated = ImmutableHashSet.Create<UniqueAddress>();
-                    _allUnreachable = ImmutableHashSet.Create<UniqueAddress>();
-                }
-                else
-                {
-                    var mapBuilder = new Dictionary<UniqueAddress, ImmutableDictionary<UniqueAddress, Record>>();
-                    var terminatedBuilder = ImmutableHashSet.CreateBuilder<UniqueAddress>();
-                    var unreachableBuilder = ImmutableHashSet.CreateBuilder<UniqueAddress>();
-
-                    foreach (var r in records)
-                    {
-                        ImmutableDictionary<UniqueAddress, Record> m = mapBuilder.TryGetValue(r.Observer, out m) 
-                            ? m.SetItem(r.Subject, r) 
-                            //TODO: Other collections take items for Create. Create unnecessary array here
-                            : ImmutableDictionary.CreateRange(new[] { new KeyValuePair<UniqueAddress, Record>(r.Subject, r) });
-                        
-
-                        mapBuilder.AddOrSet(r.Observer, m);
-
-                        if (r.Status == ReachabilityStatus.Unreachable) unreachableBuilder.Add(r.Subject);
-                        else if (r.Status == ReachabilityStatus.Terminated) terminatedBuilder.Add(r.Subject);
-                    }
-
-                    _observerRowsMap = ImmutableDictionary.CreateRange(mapBuilder);
-                    _allTerminated = terminatedBuilder.ToImmutable();
-                    _allUnreachable = unreachableBuilder.ToImmutable().Except(AllTerminated);
-                }
-
-                _allUnreachableOrTerminated = _allTerminated.IsEmpty
-                    ? AllUnreachable
-                    : AllUnreachable.Union(AllTerminated);
-            }
-        }
-
-        //TODO: Serialization should ignore
-        readonly Lazy<Cache> _cache;
-
-        ImmutableDictionary<UniqueAddress, Record> ObserverRows(UniqueAddress observer)
+        private ImmutableDictionary<UniqueAddress, Record> ObserverRows(UniqueAddress observer)
         {
             _cache.Value.ObserverRowMap.TryGetValue(observer, out var observerRows);
             return observerRows;
         }
 
         /// <summary>
-        /// TBD
+        ///     TBD
         /// </summary>
         /// <param name="observer">TBD</param>
         /// <param name="subject">TBD</param>
@@ -237,7 +141,7 @@ namespace Akka.Cluster
         }
 
         /// <summary>
-        /// TBD
+        ///     TBD
         /// </summary>
         /// <param name="observer">TBD</param>
         /// <param name="subject">TBD</param>
@@ -248,7 +152,7 @@ namespace Akka.Cluster
         }
 
         /// <summary>
-        /// TBD
+        ///     TBD
         /// </summary>
         /// <param name="observer">TBD</param>
         /// <param name="subject">TBD</param>
@@ -258,12 +162,12 @@ namespace Akka.Cluster
             return Change(observer, subject, ReachabilityStatus.Terminated);
         }
 
-        long CurrentVersion(UniqueAddress observer)
+        private long CurrentVersion(UniqueAddress observer)
         {
-            return _versions.TryGetValue(observer, out long version) ? version : 0;
+            return Versions.TryGetValue(observer, out var version) ? version : 0;
         }
 
-        long NextVersion(UniqueAddress observer)
+        private long NextVersion(UniqueAddress observer)
         {
             return CurrentVersion(observer) + 1;
         }
@@ -271,18 +175,18 @@ namespace Akka.Cluster
         private Reachability Change(UniqueAddress observer, UniqueAddress subject, ReachabilityStatus status)
         {
             var v = NextVersion(observer);
-            var newVersions = _versions.SetItem(observer, v);
+            var newVersions = Versions.SetItem(observer, v);
             var newRecord = new Record(observer, subject, status, v);
             var oldObserverRows = ObserverRows(observer);
             if (oldObserverRows == null && status == ReachabilityStatus.Reachable) return this;
-            if (oldObserverRows == null) return new Reachability(_records.Add(newRecord), newVersions);
+            if (oldObserverRows == null) return new Reachability(Records.Add(newRecord), newVersions);
 
-            if(!oldObserverRows.TryGetValue(subject, out var oldRecord))
+            if (!oldObserverRows.TryGetValue(subject, out var oldRecord))
             {
                 if (status == ReachabilityStatus.Reachable &&
                     oldObserverRows.Values.All(r => r.Status == ReachabilityStatus.Reachable))
-                    return new Reachability(_records.FindAll(r => !r.Observer.Equals(observer)), newVersions);
-                return new Reachability(_records.Add(newRecord), newVersions);
+                    return new Reachability(Records.FindAll(r => !r.Observer.Equals(observer)), newVersions);
+                return new Reachability(Records.Add(newRecord), newVersions);
             }
 
             if (oldRecord.Status == ReachabilityStatus.Terminated || oldRecord.Status == status)
@@ -290,14 +194,14 @@ namespace Akka.Cluster
 
             if (status == ReachabilityStatus.Reachable &&
                 oldObserverRows.Values.All(r => r.Status == ReachabilityStatus.Reachable || r.Subject.Equals(subject)))
-                return new Reachability(_records.FindAll(r => !r.Observer.Equals(observer)), newVersions);
+                return new Reachability(Records.FindAll(r => !r.Observer.Equals(observer)), newVersions);
 
-            var newRecords = _records.SetItem(_records.IndexOf(oldRecord), newRecord);
+            var newRecords = Records.SetItem(Records.IndexOf(oldRecord), newRecord);
             return new Reachability(newRecords, newVersions);
         }
 
         /// <summary>
-        /// TBD
+        ///     TBD
         /// </summary>
         /// <param name="allowed">TBD</param>
         /// <param name="other">TBD</param>
@@ -306,7 +210,7 @@ namespace Akka.Cluster
         {
             var recordBuilder = ImmutableList.CreateBuilder<Record>();
             //TODO: Size hint somehow?
-            var newVersions = _versions;
+            var newVersions = Versions;
             foreach (var observer in allowed)
             {
                 var observerVersion1 = CurrentVersion(observer);
@@ -318,21 +222,18 @@ namespace Akka.Cluster
                 if (rows1 != null && rows2 != null)
                 {
                     var rows = observerVersion1 > observerVersion2 ? rows1 : rows2;
-                    foreach(var record in rows.Values.Where(r => allowed.Contains(r.Subject)))
+                    foreach (var record in rows.Values.Where(r => allowed.Contains(r.Subject)))
                         recordBuilder.Add(record);
                 }
+
                 if (rows1 != null && rows2 == null)
-                {
-                    if(observerVersion1 > observerVersion2)
+                    if (observerVersion1 > observerVersion2)
                         foreach (var record in rows1.Values.Where(r => allowed.Contains(r.Subject)))
                             recordBuilder.Add(record);
-                }
                 if (rows1 == null && rows2 != null)
-                {
                     if (observerVersion2 > observerVersion1)
                         foreach (var record in rows2.Values.Where(r => allowed.Contains(r.Subject)))
-                           recordBuilder.Add(record);
-                }
+                            recordBuilder.Add(record);
 
                 if (observerVersion2 > observerVersion1)
                     newVersions = newVersions.SetItem(observer, observerVersion2);
@@ -344,20 +245,20 @@ namespace Akka.Cluster
         }
 
         /// <summary>
-        /// TBD
+        ///     TBD
         /// </summary>
         /// <param name="nodes">TBD</param>
         /// <returns>TBD</returns>
         public Reachability Remove(IEnumerable<UniqueAddress> nodes)
         {
             var nodesSet = nodes.ToImmutableHashSet();
-            var newRecords = _records.FindAll(r => !nodesSet.Contains(r.Observer) && !nodesSet.Contains(r.Subject));
-            var newVersions = _versions.RemoveRange(nodes);
+            var newRecords = Records.FindAll(r => !nodesSet.Contains(r.Observer) && !nodesSet.Contains(r.Subject));
+            var newVersions = Versions.RemoveRange(nodes);
             return new Reachability(newRecords, newVersions);
         }
 
         /// <summary>
-        /// TBD
+        ///     TBD
         /// </summary>
         /// <param name="nodes">TBD</param>
         /// <returns>TBD</returns>
@@ -367,12 +268,10 @@ namespace Akka.Cluster
             {
                 return this;
             }
-            else
-            {
-                var newRecords = _records.FindAll(r => !nodes.Contains(r.Observer));
-                var newVersions = _versions.RemoveRange(nodes);
-                return new Reachability(newRecords, newVersions);
-            }
+
+            var newRecords = Records.FindAll(r => !nodes.Contains(r.Observer));
+            var newVersions = Versions.RemoveRange(nodes);
+            return new Reachability(newRecords, newVersions);
         }
 
         public Reachability FilterRecords(Predicate<Record> f)
@@ -381,7 +280,7 @@ namespace Akka.Cluster
         }
 
         /// <summary>
-        /// TBD
+        ///     TBD
         /// </summary>
         /// <param name="observer">TBD</param>
         /// <param name="subject">TBD</param>
@@ -391,14 +290,14 @@ namespace Akka.Cluster
             var observerRows = ObserverRows(observer);
             if (observerRows == null) return ReachabilityStatus.Reachable;
 
-            if(!observerRows.TryGetValue(subject, out var record))
+            if (!observerRows.TryGetValue(subject, out var record))
                 return ReachabilityStatus.Reachable;
 
             return record.Status;
         }
 
         /// <summary>
-        /// TBD
+        ///     TBD
         /// </summary>
         /// <param name="node">TBD</param>
         /// <returns>TBD</returns>
@@ -410,7 +309,7 @@ namespace Akka.Cluster
         }
 
         /// <summary>
-        /// TBD
+        ///     TBD
         /// </summary>
         /// <param name="node">TBD</param>
         /// <returns>TBD</returns>
@@ -420,7 +319,7 @@ namespace Akka.Cluster
         }
 
         /// <summary>
-        /// TBD
+        ///     TBD
         /// </summary>
         /// <param name="observer">TBD</param>
         /// <param name="subject">TBD</param>
@@ -430,37 +329,8 @@ namespace Akka.Cluster
             return Status(observer, subject) == ReachabilityStatus.Reachable;
         }
 
-        /*
-         *  def isReachable(observer: UniqueAddress, subject: UniqueAddress): Boolean =
-            status(observer, subject) == Reachable
-         */
-
         /// <summary>
-        /// TBD
-        /// </summary>
-        public bool IsAllReachable
-        {
-            get { return _records.IsEmpty; } 
-        }
-
-        /// <summary>
-        /// Doesn't include terminated
-        /// </summary>
-        public ImmutableHashSet<UniqueAddress> AllUnreachable
-        {
-            get { return _cache.Value.AllUnreachable; }
-        }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        public ImmutableHashSet<UniqueAddress> AllUnreachableOrTerminated
-        {
-            get { return _cache.Value.AllUnreachableOrTerminated; }
-        }
-
-        /// <summary>
-        /// TBD
+        ///     TBD
         /// </summary>
         /// <param name="observer">TBD</param>
         /// <returns>TBD</returns>
@@ -474,40 +344,7 @@ namespace Akka.Cluster
         }
 
         /// <summary>
-        /// TBD
-        /// </summary>
-        public ImmutableDictionary<UniqueAddress, ImmutableHashSet<UniqueAddress>> ObserversGroupedByUnreachable
-        {
-            get
-            {
-                var builder = new Dictionary<UniqueAddress, ImmutableHashSet<UniqueAddress>>();
-
-                var grouped = _records.GroupBy(p => p.Subject);
-                foreach (var records in grouped)
-                {
-                    if (records.Any(r => r.Status == ReachabilityStatus.Unreachable))
-                    {
-                        builder.Add(records.Key, records.Where(r => r.Status == ReachabilityStatus.Unreachable)
-                            .Select(r => r.Observer).ToImmutableHashSet());
-                    }
-                }
-                return builder.ToImmutableDictionary();
-            }
-        }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        public ImmutableHashSet<UniqueAddress> AllObservers
-        {
-            get
-            {
-                return _records.Select(i => i.Observer).ToImmutableHashSet();
-        }
-        }
-
-        /// <summary>
-        /// TBD
+        ///     TBD
         /// </summary>
         /// <param name="observer">TBD</param>
         /// <returns>TBD</returns>
@@ -518,28 +355,28 @@ namespace Akka.Cluster
             return rows.Values.ToImmutableList();
         }
 
-        /// <inheritdoc/>
+        /// <inheritdoc />
         public override int GetHashCode()
         {
-            return _versions.GetHashCode();
+            return Versions.GetHashCode();
         }
 
-        /// <inheritdoc/>
+        /// <inheritdoc />
         public override bool Equals(object obj)
         {
             var other = obj as Reachability;
             if (other == null) return false;
-            return _records.Count == other._records.Count && 
-                _versions.Equals(other._versions) && 
-                _cache.Value.ObserverRowMap.Equals(other._cache.Value.ObserverRowMap);
+            return Records.Count == other.Records.Count &&
+                   Versions.Equals(other.Versions) &&
+                   _cache.Value.ObserverRowMap.Equals(other._cache.Value.ObserverRowMap);
         }
 
-        /// <inheritdoc/>
+        /// <inheritdoc />
         public override string ToString()
         {
             var builder = new StringBuilder("Reachability(");
 
-            foreach (var observer in _versions.Keys)
+            foreach (var observer in Versions.Keys)
             {
                 var rows = ObserverRows(observer);
                 if (rows == null) continue;
@@ -550,6 +387,146 @@ namespace Akka.Cluster
             }
 
             return builder.Append(')').ToString();
+        }
+
+        /// <summary>
+        ///     TBD
+        /// </summary>
+        public sealed class Record
+        {
+            /// <summary>
+            ///     TBD
+            /// </summary>
+            /// <param name="observer">TBD</param>
+            /// <param name="subject">TBD</param>
+            /// <param name="status">TBD</param>
+            /// <param name="version">TBD</param>
+            public Record(UniqueAddress observer, UniqueAddress subject, ReachabilityStatus status, long version)
+            {
+                Observer = observer;
+                Subject = subject;
+                Status = status;
+                Version = version;
+            }
+
+            /// <summary>
+            ///     TBD
+            /// </summary>
+            public UniqueAddress Observer { get; }
+
+            /// <summary>
+            ///     TBD
+            /// </summary>
+            public UniqueAddress Subject { get; }
+
+            /// <summary>
+            ///     TBD
+            /// </summary>
+            public ReachabilityStatus Status { get; }
+
+            /// <summary>
+            ///     TBD
+            /// </summary>
+            public long Version { get; }
+
+            /// <inheritdoc />
+            public override bool Equals(object obj)
+            {
+                var other = obj as Record;
+                if (other == null) return false;
+                return Version.Equals(other.Version) &&
+                       Status == other.Status &&
+                       Observer.Equals(other.Observer) &&
+                       Subject.Equals(other.Subject);
+            }
+
+            /// <inheritdoc />
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hashCode = Observer != null ? Observer.GetHashCode() : 0;
+                    hashCode = (hashCode * 397) ^ Version.GetHashCode();
+                    hashCode = (hashCode * 397) ^ Status.GetHashCode();
+                    hashCode = (hashCode * 397) ^ (Subject != null ? Subject.GetHashCode() : 0);
+                    return hashCode;
+                }
+            }
+        }
+
+        /// <summary>
+        ///     TBD
+        /// </summary>
+        private class Cache
+        {
+            /// <summary>
+            ///     TBD
+            /// </summary>
+            /// <param name="records">TBD</param>
+            public Cache(ImmutableList<Record> records)
+            {
+                if (records.IsEmpty)
+                {
+                    ObserverRowMap = ImmutableDictionary
+                        .Create<UniqueAddress, ImmutableDictionary<UniqueAddress, Record>>();
+                    AllTerminated = ImmutableHashSet.Create<UniqueAddress>();
+                    AllUnreachable = ImmutableHashSet.Create<UniqueAddress>();
+                }
+                else
+                {
+                    var mapBuilder = new Dictionary<UniqueAddress, ImmutableDictionary<UniqueAddress, Record>>();
+                    var terminatedBuilder = ImmutableHashSet.CreateBuilder<UniqueAddress>();
+                    var unreachableBuilder = ImmutableHashSet.CreateBuilder<UniqueAddress>();
+
+                    foreach (var r in records)
+                    {
+                        ImmutableDictionary<UniqueAddress, Record> m = mapBuilder.TryGetValue(r.Observer, out m)
+                            ? m.SetItem(r.Subject, r)
+                            //TODO: Other collections take items for Create. Create unnecessary array here
+                            : ImmutableDictionary.CreateRange(new[]
+                            {
+                                new KeyValuePair<UniqueAddress, Record>(r.Subject, r)
+                            });
+
+
+                        mapBuilder.AddOrSet(r.Observer, m);
+
+                        if (r.Status == ReachabilityStatus.Unreachable) unreachableBuilder.Add(r.Subject);
+                        else if (r.Status == ReachabilityStatus.Terminated) terminatedBuilder.Add(r.Subject);
+                    }
+
+                    ObserverRowMap = ImmutableDictionary.CreateRange(mapBuilder);
+                    AllTerminated = terminatedBuilder.ToImmutable();
+                    AllUnreachable = unreachableBuilder.ToImmutable().Except(AllTerminated);
+                }
+
+                AllUnreachableOrTerminated = AllTerminated.IsEmpty
+                    ? AllUnreachable
+                    : AllUnreachable.Union(AllTerminated);
+            }
+
+            /// <summary>
+            ///     TBD
+            /// </summary>
+            public ImmutableDictionary<UniqueAddress, ImmutableDictionary<UniqueAddress, Record>> ObserverRowMap
+            {
+                get;
+            }
+
+            /// <summary>
+            ///     TBD
+            /// </summary>
+            public ImmutableHashSet<UniqueAddress> AllTerminated { get; }
+
+            /// <summary>
+            ///     TBD
+            /// </summary>
+            public ImmutableHashSet<UniqueAddress> AllUnreachable { get; }
+
+            /// <summary>
+            ///     TBD
+            /// </summary>
+            public ImmutableHashSet<UniqueAddress> AllUnreachableOrTerminated { get; }
         }
     }
 }

--- a/src/core/Akka.Cluster/Reachability.cs
+++ b/src/core/Akka.Cluster/Reachability.cs
@@ -26,7 +26,7 @@ namespace Akka.Cluster
     ///     - Unreachable if any observer node considers it as Unreachable
     ///     - Reachable otherwise, i.e. no observer node considers it as Unreachable
     /// </summary>
-    internal class Reachability //TODO: ISerializable?
+    internal class Reachability
     {
         /// <summary>
         ///     TBD

--- a/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
+++ b/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
@@ -508,7 +508,6 @@ namespace Akka.Remote.TestKit
         /// </summary>
         public void RunOn(Action thunk, params RoleName[] nodes)
         {
-            if (nodes.Length == 0) throw new ArgumentException("No node given to run on.");
             if (IsNode(nodes)) thunk();
         }
 
@@ -518,7 +517,6 @@ namespace Akka.Remote.TestKit
         /// </summary>
         public async Task RunOnAsync(Func<Task> thunkAsync, params RoleName[] nodes)
         {
-            if (nodes.Length == 0) throw new ArgumentException("No node given to run on.");
             if (IsNode(nodes)) await thunkAsync();
         }
 

--- a/src/core/Akka.Remote/DefaultFailureDetectorRegistry.cs
+++ b/src/core/Akka.Remote/DefaultFailureDetectorRegistry.cs
@@ -122,6 +122,7 @@ namespace Akka.Remote
                 }
                 break;
             }
+            Console.WriteLine("Removed heartbeats to {0}", resource);
         }
 
         /// <summary>

--- a/src/core/Akka.Remote/DefaultFailureDetectorRegistry.cs
+++ b/src/core/Akka.Remote/DefaultFailureDetectorRegistry.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Akka.Util;
 
 namespace Akka.Remote
@@ -30,11 +31,11 @@ namespace Akka.Remote
 
         private readonly Func<FailureDetector> _factory;
 
-        private AtomicReference<Dictionary<T, FailureDetector>> _resourceToFailureDetector = new AtomicReference<Dictionary<T, FailureDetector>>(new Dictionary<T, FailureDetector>());
+        private AtomicReference<ImmutableDictionary<T, FailureDetector>> _resourceToFailureDetector = new AtomicReference<ImmutableDictionary<T, FailureDetector>>(ImmutableDictionary<T, FailureDetector>.Empty);
 
         private readonly object _failureDetectorCreationLock = new object();
 
-        private Dictionary<T, FailureDetector> ResourceToFailureDetector
+        private ImmutableDictionary<T, FailureDetector> ResourceToFailureDetector
         {
             get { return _resourceToFailureDetector; }
             set { _resourceToFailureDetector = value; }
@@ -83,7 +84,7 @@ namespace Akka.Remote
                 {
                     // First check for non-existing key wa outside the lock, and a second thread might just have released the lock
                     // when this one acquired it, so the second check is needed (double-check locking pattern)
-                    var oldTable = new Dictionary<T, FailureDetector>(ResourceToFailureDetector);
+                    var oldTable = ResourceToFailureDetector;
                     if (oldTable.TryGetValue(resource, out failureDetector))
                         failureDetector.HeartBeat();
                     else
@@ -98,8 +99,8 @@ namespace Akka.Remote
                         }
 
                         newDetector.HeartBeat();
-                        oldTable.Add(resource, newDetector);
-                        ResourceToFailureDetector = oldTable;
+                        var newTable = oldTable.Add(resource, newDetector);
+                        ResourceToFailureDetector = newTable;
                     }
                 }
             }
@@ -116,13 +117,11 @@ namespace Akka.Remote
                 var oldTable = ResourceToFailureDetector;
                 if (oldTable.ContainsKey(resource))
                 {
-                    var newTable = new Dictionary<T, FailureDetector>(oldTable);
-                    newTable.Remove(resource); //if we won the race then update else try again
-                    if (_resourceToFailureDetector.CompareAndSet(oldTable, newTable)) continue;
+                    var newTable = oldTable.Remove(resource); //if we won the race then update else try again
+                    if (!_resourceToFailureDetector.CompareAndSet(oldTable, newTable)) continue;
                 }
                 break;
             }
-            Console.WriteLine("Removed heartbeats to {0}", resource);
         }
 
         /// <summary>
@@ -134,7 +133,7 @@ namespace Akka.Remote
             {
                 var oldTable = ResourceToFailureDetector;
                 // if we won the race then update else try again
-                if (_resourceToFailureDetector.CompareAndSet(oldTable, new Dictionary<T, FailureDetector>())) continue;
+                if (!_resourceToFailureDetector.CompareAndSet(oldTable, ImmutableDictionary<T, FailureDetector>.Empty)) continue;
                 break;
             }
         }

--- a/src/core/Akka.Remote/PhiAccrualFailureDetector.cs
+++ b/src/core/Akka.Remote/PhiAccrualFailureDetector.cs
@@ -154,7 +154,7 @@ namespace Akka.Remote
 
         private AtomicReference<State> _state;
 
-        private State state
+        internal State state
         {
             get { return _state; }
             set { _state = value; }
@@ -209,6 +209,8 @@ namespace Akka.Remote
             }
 
             var newState = new State(newHistory, timestamp);
+            Console.WriteLine("Replacing state with timestamp [{0}] with timestamp [{1}] for node {2}", oldState.TimeStamp, newState.TimeStamp, Address);
+            
             //if we won the race then update else try again
             if(!_state.CompareAndSet(oldState, newState)) HeartBeat();
         }
@@ -248,6 +250,8 @@ namespace Akka.Remote
                     var history = oldState.History;
                     var mean = history.Mean;
                     var stdDeviation = EnsureValidStdDeviation(history.StdDeviation);
+                    if(timeDiff > (mean * 2))
+                        Console.WriteLine("About to process very large timeDiff: {0} vs mean: {1} for node {2}", timeDiff, mean, Address);
                     return Phi(timeDiff, mean + AcceptableHeartbeatPauseMillis, stdDeviation);
                 }
             }
@@ -304,7 +308,6 @@ namespace Akka.Remote
     internal readonly struct HeartbeatHistory
     {
         private readonly int _maxSampleSize;
-        private readonly ImmutableList<long> _intervals;
         private readonly long _intervalSum;
         private readonly long _squaredIntervalSum;
 
@@ -326,7 +329,7 @@ namespace Akka.Remote
         public HeartbeatHistory(int maxSampleSize, ImmutableList<long> intervals, long intervalSum, long squaredIntervalSum)
         {
             _maxSampleSize = maxSampleSize;
-            _intervals = intervals;
+            Intervals = intervals;
             _intervalSum = intervalSum;
             _squaredIntervalSum = squaredIntervalSum;
 
@@ -338,11 +341,13 @@ namespace Akka.Remote
                 throw new ArgumentOutOfRangeException(nameof(squaredIntervalSum), $"squaredIntervalSum must be >= 0, got {squaredIntervalSum}");
         }
 
-        public double Mean => ((double)_intervalSum / _intervals.Count);
+        public double Mean => ((double)_intervalSum / Intervals.Count);
 
-        public double Variance => ((double)_squaredIntervalSum / _intervals.Count) - (Mean * Mean);
+        public double Variance => ((double)_squaredIntervalSum / Intervals.Count) - (Mean * Mean);
 
         public double StdDeviation => Math.Sqrt(Variance);
+
+        public ImmutableList<long> Intervals { get; }
 
         /// <summary>
         /// Increments the <see cref="HeartbeatHistory"/>.
@@ -352,9 +357,9 @@ namespace Akka.Remote
         /// <returns>A new heartbeat history instance with the added interval.</returns>
         public static HeartbeatHistory operator +(HeartbeatHistory history, long interval)
         {
-            if (history._intervals.Count < history._maxSampleSize)
+            if (history.Intervals.Count < history._maxSampleSize)
             {
-                return new HeartbeatHistory(history._maxSampleSize, history._intervals.Add(interval),
+                return new HeartbeatHistory(history._maxSampleSize, history.Intervals.Add(interval),
                     history._intervalSum + interval, history._squaredIntervalSum + Pow2(interval));
             }
             else
@@ -365,8 +370,8 @@ namespace Akka.Remote
 
         private static HeartbeatHistory DropOldest(HeartbeatHistory history)
         {
-            return new HeartbeatHistory(history._maxSampleSize, history._intervals.RemoveAt(0), history._intervalSum - history._intervals.First(), 
-                history._squaredIntervalSum - Pow2(history._intervals.First()));
+            return new HeartbeatHistory(history._maxSampleSize, history.Intervals.RemoveAt(0), history._intervalSum - history.Intervals.First(), 
+                history._squaredIntervalSum - Pow2(history.Intervals.First()));
         }
 
         private static long Pow2(long x)

--- a/src/core/Akka.Remote/PhiAccrualFailureDetector.cs
+++ b/src/core/Akka.Remote/PhiAccrualFailureDetector.cs
@@ -209,8 +209,7 @@ namespace Akka.Remote
             }
 
             var newState = new State(newHistory, timestamp);
-            Console.WriteLine("Replacing state with timestamp [{0}] with timestamp [{1}] for node {2}", oldState.TimeStamp, newState.TimeStamp, Address);
-            
+
             //if we won the race then update else try again
             if(!_state.CompareAndSet(oldState, newState)) HeartBeat();
         }
@@ -250,8 +249,6 @@ namespace Akka.Remote
                     var history = oldState.History;
                     var mean = history.Mean;
                     var stdDeviation = EnsureValidStdDeviation(history.StdDeviation);
-                    if(timeDiff > (mean * 2))
-                        Console.WriteLine("About to process very large timeDiff: {0} vs mean: {1} for node {2}", timeDiff, mean, Address);
                     return Phi(timeDiff, mean + AcceptableHeartbeatPauseMillis, stdDeviation);
                 }
             }


### PR DESCRIPTION
close #4849 

Fixes Akka.Cluster failure detector removal for new nodes that appear in the gossip regardless of what their current membership status is - useful for scenarios where:

1. Node A heartbeats Node B;
2. Network split occurs - Node B gets downed, Node A stays up and maintains heartbeat record for Node A;
3. Node A restarts - rejoins unstable cluster and quickly gets promoted to `WeaklyUp`;
4. Network split heals - Node A has massive PhiAccrual value for Node B and immediately marks it as UNREACHABLE due to old data that occurred in previous split.

This resolves that issue by making it so when Node A appears as a new member in Node B's gossip (due to its different UID) the failure detector records get reset anyway, even if Node A appears as `WeaklyUp` initially and not `Joining`.