### PR TITLE
HeartbeatNodeRing performance

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj
+++ b/src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj
@@ -10,6 +10,8 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <!-- FluentAssertions is used in some benchmarks to validate internal behaviors -->
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/benchmark/Akka.Benchmarks/Cluster/HeartbeatNodeRingBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Cluster/HeartbeatNodeRingBenchmarks.cs
@@ -38,7 +38,7 @@ namespace Akka.Benchmarks.Cluster
         private static void MyReceivers(HeartbeatNodeRing ring)
         {
             var r = new HeartbeatNodeRing(ring.SelfAddress, ring.Nodes, ImmutableHashSet<UniqueAddress>.Empty, ring.MonitoredByNumberOfNodes);
-            r.MyReceivers.Value.IsEmpty.Should().BeFalse();
+            r.MyReceivers.Value.Count.Should().BeGreaterThan(0);
         }
 
         [Benchmark]

--- a/src/benchmark/Akka.Benchmarks/Cluster/HeartbeatNodeRingBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Cluster/HeartbeatNodeRingBenchmarks.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using Akka.Cluster;
+using BenchmarkDotNet.Attributes;
+using FluentAssertions;
+
+namespace Akka.Benchmarks.Cluster
+{
+    [Config(typeof(MicroBenchmarkConfig))]
+    public class HeartbeatNodeRingBenchmarks
+    {
+        [Params(10, 100, 250)]
+        public int NodesSize;
+
+
+        internal static HeartbeatNodeRing CreateHearbeatNodeRingOfSize(int size)
+        {
+            var nodes = Enumerable.Range(1, size)
+                .Select(x => new UniqueAddress(new Address("akka", "sys", "node-" + x, 2552), x))
+                .ToList();
+            var selfAddress = nodes[size / 2];
+            return new HeartbeatNodeRing(selfAddress, nodes.ToImmutableHashSet(), ImmutableHashSet<UniqueAddress>.Empty, 5);
+        }
+
+        private HeartbeatNodeRing _ring;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _ring = CreateHearbeatNodeRingOfSize(NodesSize);
+        }
+
+        private static void MyReceivers(HeartbeatNodeRing ring)
+        {
+            var r = new HeartbeatNodeRing(ring.SelfAddress, ring.Nodes, ImmutableHashSet<UniqueAddress>.Empty, ring.MonitoredByNumberOfNodes);
+            r.MyReceivers.Value.IsEmpty.Should().BeFalse();
+        }
+
+        [Benchmark]
+        [Arguments(1000)]
+        public void HeartbeatNodeRing_should_produce_MyReceivers(int iterations)
+        {
+            for(var i = 0; i < iterations; i++)
+                MyReceivers(_ring);
+        }
+    }
+}

--- a/src/benchmark/Akka.Benchmarks/Cluster/ReachabilityBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Cluster/ReachabilityBenchmarks.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Akka.Util;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using Akka.Cluster;
+using BenchmarkDotNet.Attributes;
+using FluentAssertions;
+
+namespace Akka.Benchmarks.Cluster
+{
+    [Config(typeof(MicroBenchmarkConfig))]
+    public class ReachabilityBenchmarks
+    {
+        [Params(10, 100, 250)]
+        public int NodesSize;
+
+        [Params(100)]
+        public int Iterations;
+
+        public Address Address = new Address("akka", "sys", "a", 2552);
+        public Address Node = new Address("akka", "sys", "a", 2552);
+
+        private Reachability CreateReachabilityOfSize(Reachability baseReachability, int size)
+        {
+            return Enumerable.Range(1, size).Aggregate(baseReachability, (r, i) =>
+            {
+                var obs = new UniqueAddress(Address.WithHost("node-" + i), i);
+                var j = i == size ? 1 : i + 1;
+                var subject = new UniqueAddress(Address.WithHost("node-" + j), j);
+                return r.Unreachable(obs, subject).Reachable(obs, subject);
+            });
+        }
+
+        private Reachability AddUnreachable(Reachability baseReachability, int count)
+        {
+            var observers = baseReachability.Versions.Keys.Take(count);
+            // the Keys HashSet<T> IEnumerator does not support Reset, hence why we have to convert it to a list
+            using var subjects = baseReachability.Versions.Keys.ToList().GetContinuousEnumerator();
+            return observers.Aggregate(baseReachability, (r, o) =>
+            {
+                return Enumerable.Range(1, 5).Aggregate(r, (r2, i) =>
+                {
+                    subjects.MoveNext();
+                    return r2.Unreachable(o, subjects.Current);
+                });
+            });
+        }
+
+        internal Reachability Reachability1;
+        internal Reachability Reachability2;
+        internal Reachability Reachability3;
+        internal HashSet<UniqueAddress> Allowed;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            Reachability1 = CreateReachabilityOfSize(Reachability.Empty, NodesSize);
+            Reachability2 = CreateReachabilityOfSize(Reachability1, NodesSize);
+            Reachability3 = AddUnreachable(Reachability1, NodesSize / 2);
+            Allowed =  Reachability1.Versions.Keys.ToHashSet();
+        }
+
+        private void CheckThunkFor(Reachability r1, Reachability r2, Action<Reachability, Reachability> thunk,
+            int times)
+        {
+            for (var i = 0; i < times; i++)
+                thunk(new Reachability(r1.Records, r1.Versions), new Reachability(r2.Records, r2.Versions));
+        }
+
+        private void CheckThunkFor(Reachability r1, Action<Reachability> thunk, int times)
+        {
+            for (var i = 0; i < times; i++)
+                thunk(new Reachability(r1.Records, r1.Versions));
+        }
+
+        private void Merge(Reachability r1, Reachability r2, int expectedRecords)
+        {
+            r1.Merge(Allowed, r2).Records.Count.Should().Be(expectedRecords);
+        }
+
+        private void CheckStatus(Reachability r1)
+        {
+            var record = r1.Records.First();
+            r1.Status(record.Observer, record.Subject).Should().Be(record.Status);
+        }
+
+        private void CheckAggregatedStatus(Reachability r1)
+        {
+            var record = r1.Records.First();
+            r1.Status(record.Subject).Should().Be(record.Status);
+        }
+
+        private void AllUnreachableOrTerminated(Reachability r1)
+        {
+            r1.AllUnreachableOrTerminated.IsEmpty.Should().BeFalse();
+        }
+
+        private void AllUnreachable(Reachability r1)
+        {
+            r1.AllUnreachable.IsEmpty.Should().BeFalse();
+        }
+
+        private void RecordsFrom(Reachability r1)
+        {
+            foreach (var o in r1.AllObservers)
+            {
+                r1.RecordsFrom(o).Should().NotBeNull();
+            }
+        }
+
+        [Benchmark]
+        public void Reachability_must_merge_with_same_versions()
+        {
+            CheckThunkFor(Reachability1, Reachability1, (r1, r2) => Merge(r1, r2, 0), Iterations);
+        }
+
+        [Benchmark]
+        public void Reachability_must_merge_with_all_older_versions()
+        {
+            CheckThunkFor(Reachability2, Reachability1, (r1, r2) => Merge(r1, r2, 0), Iterations);
+        }
+
+        [Benchmark]
+        public void Reachability_must_merge_with_all_newer_versions()
+        {
+            CheckThunkFor(Reachability1, Reachability2, (r1, r2) => Merge(r1, r2, 0), Iterations);
+        }
+
+        [Benchmark]
+        public void Reachability_must_merge_with_half_nodes_unreachable()
+        {
+            CheckThunkFor(Reachability1, Reachability3, (r1, r2) => Merge(r1, r2, 5* NodesSize/2), Iterations);
+        }
+
+        [Benchmark]
+        public void Reachability_must_merge_with_half_nodes_unreachable_opposite()
+        {
+            CheckThunkFor(Reachability3, Reachability1, (r1, r2) => Merge(r1, r2, 5 * NodesSize / 2), Iterations);
+        }
+
+        [Benchmark]
+        public void Reachability_must_check_status_with_half_nodes_unreachable()
+        {
+            CheckThunkFor(Reachability3,  CheckAggregatedStatus, Iterations);
+        }
+
+        [Benchmark]
+        public void Reachability_must_check_AllUnreachableOrTerminated_with_half_nodes_unreachable()
+        {
+            CheckThunkFor(Reachability3, AllUnreachableOrTerminated, Iterations);
+        }
+
+        [Benchmark]
+        public void Reachability_must_check_AllUnreachable_with_half_nodes_unreachable()
+        {
+            CheckThunkFor(Reachability3, AllUnreachable, Iterations);
+        }
+
+        [Benchmark]
+        public void Reachability_must_check_RecordsFrom_with_half_nodes_unreachable()
+        {
+            CheckThunkFor(Reachability3, RecordsFrom, Iterations);
+        }
+    }
+}

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCluster.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCluster.approved.txt
@@ -1,4 +1,5 @@
 ﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Benchmarks")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Metrics")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests")]

--- a/src/core/Akka.Cluster.Tests/ClusterHeartBeatSenderStateSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterHeartBeatSenderStateSpec.cs
@@ -97,14 +97,14 @@ namespace Akka.Cluster.Tests
         public void ClusterHeartbeatSenderState_must_return_empty_active_set_when_no_nodes()
         {
             _emptyState
-                .ActiveReceivers.IsEmpty.Should().BeTrue();
+                .ActiveReceivers.Count.Should().Be(0);
         }
 
         [Fact]
         public void ClusterHeartbeatSenderState_must_init_with_empty()
         {
             _emptyState.Init(ImmutableHashSet<UniqueAddress>.Empty, ImmutableHashSet<UniqueAddress>.Empty)
-                .ActiveReceivers.IsEmpty.Should().BeTrue();
+                .ActiveReceivers.Count.Should().Be(0);
         }
 
         [Fact]

--- a/src/core/Akka.Cluster/ClusterHeartbeat.cs
+++ b/src/core/Akka.Cluster/ClusterHeartbeat.cs
@@ -627,10 +627,10 @@ namespace Akka.Cluster
         public readonly Lazy<ImmutableHashSet<UniqueAddress>> MyReceivers;
 
         /// <summary>
-        /// TBD
+        /// The set of Akka.Cluster nodes designated for receiving heartbeats from this node.
         /// </summary>
-        /// <param name="sender">TBD</param>
-        /// <returns>TBD</returns>
+        /// <param name="sender">The node sending heartbeats.</param>
+        /// <returns>An organized ring of unique nodes.</returns>
         public ImmutableHashSet<UniqueAddress> Receivers(UniqueAddress sender)
         {
             if (_useAllAsReceivers)

--- a/src/core/Akka.Cluster/ClusterHeartbeat.cs
+++ b/src/core/Akka.Cluster/ClusterHeartbeat.cs
@@ -429,7 +429,7 @@ namespace Akka.Cluster
         /// <summary>
         /// TBD
         /// </summary>
-        public readonly ImmutableHashSet<UniqueAddress> ActiveReceivers;
+        public readonly IImmutableSet<UniqueAddress> ActiveReceivers;
 
         /// <summary>
         /// TBD
@@ -569,7 +569,7 @@ namespace Akka.Cluster
     internal sealed class HeartbeatNodeRing
     {
         private readonly bool _useAllAsReceivers;
-        private Option<ImmutableHashSet<UniqueAddress>> _myReceivers;
+        private Option<IImmutableSet<UniqueAddress>> _myReceivers;
 
         /// <summary>
         /// TBD
@@ -597,7 +597,7 @@ namespace Akka.Cluster
                 throw new ArgumentException($"Nodes [${string.Join(", ", nodes)}] must contain selfAddress [{selfAddress}]");
 
             _useAllAsReceivers = MonitoredByNumberOfNodes >= (NodeRing.Count - 1);
-            _myReceivers = Option<ImmutableHashSet<UniqueAddress>>.None;
+            _myReceivers = Option<IImmutableSet<UniqueAddress>>.None;
         }
 
         /// <summary>
@@ -625,13 +625,13 @@ namespace Akka.Cluster
         /// <summary>
         /// Receivers for <see cref="SelfAddress"/>. Cached for subsequent access.
         /// </summary>
-        public Option<ImmutableHashSet<UniqueAddress>> MyReceivers
+        public Option<IImmutableSet<UniqueAddress>> MyReceivers
         {
             get
             {
                 if (_myReceivers.IsEmpty)
                 {
-                    _myReceivers = Receivers(SelfAddress);
+                    _myReceivers = new Option<IImmutableSet<UniqueAddress>>(Receivers(SelfAddress));
                 }
 
                 return _myReceivers;
@@ -643,11 +643,11 @@ namespace Akka.Cluster
         /// </summary>
         /// <param name="sender">The node sending heartbeats.</param>
         /// <returns>An organized ring of unique nodes.</returns>
-        public ImmutableHashSet<UniqueAddress> Receivers(UniqueAddress sender)
+        public IImmutableSet<UniqueAddress> Receivers(UniqueAddress sender)
         {
             if (_useAllAsReceivers)
             {
-                return NodeRing.Remove(sender).ToImmutableHashSet();
+                return NodeRing.Remove(sender);
             }
             else
             {
@@ -688,7 +688,7 @@ namespace Akka.Cluster
                     ? slice1 // or, wrap-around
                     : Take(remaining, NodeRing.TakeWhile(x => x != sender).GetEnumerator(), slice1).Item2;
 
-                return slice.ToImmutableHashSet();
+                return slice;
             }
         }
 

--- a/src/core/Akka.Cluster/Properties/AssemblyInfo.cs
+++ b/src/core/Akka.Cluster/Properties/AssemblyInfo.cs
@@ -23,6 +23,7 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("Akka.Cluster.Sharding.Tests.MultiNode")]
 [assembly: InternalsVisibleTo("Akka.Cluster.Metrics")]
 [assembly: InternalsVisibleTo("Akka.DistributedData")]
+[assembly: InternalsVisibleTo("Akka.Benchmarks")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/src/core/Akka/Util/Internal/ArrayExtensions.cs
+++ b/src/core/Akka/Util/Internal/ArrayExtensions.cs
@@ -103,12 +103,7 @@ namespace Akka.Util.Internal
         /// <returns>TBD</returns>
         internal static IEnumerable<T> From<T>(this IEnumerable<T> items, T startingItem)
         {
-            var itemsAsList = items.ToList();
-            var indexOf = itemsAsList.IndexOf(startingItem);
-            if (indexOf == -1) return new List<T>();
-            if (indexOf == 0) return itemsAsList;
-            var itemCount = (itemsAsList.Count - indexOf);
-            return itemsAsList.Slice(indexOf, itemCount);
+            return items.SkipWhile(x => !x.Equals(startingItem));
         }
 
         /// <summary>


### PR DESCRIPTION
per https://github.com/akkadotnet/akka.net/issues/4849

Investigating some potential performance issues with the data structures used by the heartbeat system, since we have never really looked at their performance as a possible cause for heartbeat issues inside rapidly changing clusters (i.e. large K8s deployments) or clusters with large node counts.