### PR TITLE
harden Akka.DependencyInjection.Tests

### DIFF
--- a/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/ActorServiceProviderPropsWithScopesSpecs.cs
+++ b/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/ActorServiceProviderPropsWithScopesSpecs.cs
@@ -45,7 +45,11 @@ namespace Akka.DependencyInjection.Tests
             ExpectTerminated(scoped1);
 
             // all dependencies should be disposed
-            deps1.Dependencies.All(x => x.Disposed).Should().BeTrue();
+            AwaitAssert(() =>
+            {
+                deps1.Dependencies.All(x => x.Disposed).Should().BeTrue();
+            });
+            
 
             // reuse the same props
             var scoped2 = Sys.ActorOf(props, "scoped2");
@@ -76,7 +80,10 @@ namespace Akka.DependencyInjection.Tests
             });
 
             // all previous dependencies should be disposed
-            deps1.Dependencies.All(x => x.Disposed).Should().BeTrue();
+            AwaitAssert(() =>
+            {
+                deps1.Dependencies.All(x => x.Disposed).Should().BeTrue();
+            });
 
             // actor should restart with totally new dependencies
             scoped1.Tell(new FetchDependencies());
@@ -104,7 +111,10 @@ namespace Akka.DependencyInjection.Tests
             });
 
             // all previous SCOPED dependencies should be disposed
-            deps1.Dependencies.Where(x => !(x is AkkaDiFixture.ISingletonDependency)).All(x => x.Disposed).Should().BeTrue();
+            AwaitAssert(() =>
+            {
+                deps1.Dependencies.Where(x => !(x is AkkaDiFixture.ISingletonDependency)).All(x => x.Disposed).Should().BeTrue();
+            });
 
             // singletons should not be disposed
             deps1.Dependencies.Where(x => (x is AkkaDiFixture.ISingletonDependency)).All(x => x.Disposed).Should().BeFalse();


### PR DESCRIPTION
Added some `AwaitAssert` calls to check for disposed dependencies - these calls can be racy due to background actor thread calling `Dipose` after foreground test thread checks the `Disposed` property.