### PR TITLE
Performance optimize `VectorClock`

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Cluster/VectorClockBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Cluster/VectorClockBenchmarks.cs
@@ -14,7 +14,7 @@ namespace Akka.Benchmarks.Cluster
     [Config(typeof(MicroBenchmarkConfig))]
     public class VectorClockBenchmarks
     {
-        [Params(100, 500, 1000)]
+        [Params(100)]
         public int ClockSize;
 
         [Params(1000)]

--- a/src/core/Akka.Cluster/VectorClock.cs
+++ b/src/core/Akka.Cluster/VectorClock.cs
@@ -120,25 +120,25 @@ namespace Akka.Cluster
                 return new Node(hash);
             }
             
-            // TODO: replace with Murmur3 or SHA512, some other consistent hash algorithm for FIPS complaince and no collisions in Akka.NET v1.5 or 2.0
-            [ThreadStatic] // underlying algorithm isn't thread-safe. Has to be made `ThreadStatic` in order to guarantee safety.
-            private static readonly System.Security.Cryptography.MD5 HashAlgo = System.Security.Cryptography.MD5.Create();
+            
 
             private static Node Hash(string name)
             {
-                
-                var inputBytes = Encoding.UTF8.GetBytes(name);
-                var hash = HashAlgo.ComputeHash(inputBytes);
+                // TODO: replace with Murmur3 or SHA512, some other consistent hash algorithm for FIPS complaince and no collisions in Akka.NET v1.5 or 2.0
+                using(var md5 = System.Security.Cryptography.MD5.Create()){
+                    var inputBytes = Encoding.UTF8.GetBytes(name);
+                    var hash = md5.ComputeHash(inputBytes);
 
 
-                var sb = new StringBuilder();
+                    var sb = new StringBuilder();
 
-                foreach (var t in hash)
-                {
-                    sb.Append(t.ToString("X2"));
-                }
+                    foreach (var t in hash)
+                    {
+                        sb.Append(t.ToString("X2"));
+                    }
 
-                return new Node(sb.ToString());
+                    return new Node(sb.ToString());
+                }               
             }
 
             /// <inheritdoc/>

--- a/src/core/Akka.Cluster/VectorClock.cs
+++ b/src/core/Akka.Cluster/VectorClock.cs
@@ -40,7 +40,7 @@ namespace Akka.Cluster
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
-            return obj is VectorClock && Equals((VectorClock) obj);
+            return obj is VectorClock vc && Equals(vc);
         }
 
         public override int GetHashCode()
@@ -368,7 +368,7 @@ namespace Akka.Cluster
         /// <returns>The true ordering based on the contents of the vectorclock.</returns>
         internal Ordering CompareOnlyTo(VectorClock that, Ordering order)
         {
-            if (ReferenceEquals(this, that) || Versions.Equals(that.Versions)) return Ordering.Same;
+            if (ReferenceEquals(this, that) || ReferenceEquals(this.Versions, that.Versions)) return Ordering.Same;
 
             return Compare(_versions.GetEnumerator(), that._versions.GetEnumerator(), order == Ordering.Concurrent ? Ordering.FullOrder : order);
         }

--- a/src/core/Akka.Cluster/VectorClock.cs
+++ b/src/core/Akka.Cluster/VectorClock.cs
@@ -171,7 +171,7 @@ namespace Akka.Cluster
         /// <summary>
         /// Timestamp used by the <see cref="VectorClock"/>.
         /// </summary>
-        internal class Timestamp
+        internal static class Timestamp
         {
             /// <summary>
             /// TBD
@@ -342,7 +342,7 @@ namespace Akka.Cluster
             return left.IsConcurrentWith(right);
         }
 
-        private static readonly KeyValuePair<Node, long> CmpEndMarker = new KeyValuePair<Node, long>(Node.Create("endmarker"), long.MinValue);
+        private static readonly KeyValuePair<Node, long> CmpEndMarker = new KeyValuePair<Node, long>(Node.Create("endmarker"), Timestamp.EndMarker);
 
         /// <summary>
         /// <para>

--- a/src/core/Akka.Cluster/VectorClock.cs
+++ b/src/core/Akka.Cluster/VectorClock.cs
@@ -419,6 +419,8 @@ namespace Akka.Cluster
                     return compareNext(nt1, NextOrElse(i2, CmpEndMarker), Ordering.Before);
                 };
 
+            using(i1)
+            using(i2)
             return compareNext(NextOrElse(i1, CmpEndMarker), NextOrElse(i2, CmpEndMarker), Ordering.Same);
         }
 

--- a/src/core/Akka.Cluster/VectorClock.cs
+++ b/src/core/Akka.Cluster/VectorClock.cs
@@ -119,12 +119,16 @@ namespace Akka.Cluster
             {
                 return new Node(hash);
             }
+            
+            // TODO: replace with Murmur3 or SHA512, some other consistent hash algorithm for FIPS complaince and no collisions in Akka.NET v1.5 or 2.0
+            [ThreadStatic] // underlying algorithm isn't thread-safe. Has to be made `ThreadStatic` in order to guarantee safety.
+            private static readonly System.Security.Cryptography.MD5 HashAlgo = System.Security.Cryptography.MD5.Create();
 
             private static Node Hash(string name)
             {
-                var md5 = System.Security.Cryptography.MD5.Create();
+                
                 var inputBytes = Encoding.UTF8.GetBytes(name);
-                var hash = md5.ComputeHash(inputBytes);
+                var hash = HashAlgo.ComputeHash(inputBytes);
 
 
                 var sb = new StringBuilder();


### PR DESCRIPTION
Starting a thread for optimizing the `VectorClock` class, which is heavily used in all `Gossip` and decision-making inside the cluster.

part of #4849