### PR TITLE
harden RestartFirstSeedNodeSpec

### DIFF
--- a/src/core/Akka.Cluster.Tests.MultiNode/RestartFirstSeedNodeSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/RestartFirstSeedNodeSpec.cs
@@ -104,7 +104,9 @@ namespace Akka.Cluster.Tests.MultiNode
                 // now we can join seed1System, seed2, seed3 together
                 RunOn(() =>
                 {
-                    Cluster.Get(seed1System.Value).JoinSeedNodes(GetSeedNodes());
+                    var seeds = GetSeedNodes();
+                    seeds.Count.Should().Be(4); // validate that we have complete seed node list
+                    Cluster.Get(seed1System.Value).JoinSeedNodes(seeds);
                     AwaitAssert(() =>
                     {
                         Cluster.Get(seed1System.Value)
@@ -122,7 +124,9 @@ namespace Akka.Cluster.Tests.MultiNode
                 }, _config.Seed1);
                 RunOn(() =>
                 {
-                    Cluster.JoinSeedNodes(GetSeedNodes());
+                    var seeds = GetSeedNodes();
+                    seeds.Count.Should().Be(4); // validate that we have complete seed node list
+                    Cluster.JoinSeedNodes(seeds);
                     AwaitMembersUp(3);
                 }, _config.Seed2, _config.Seed3);
                 EnterBarrier("started");

--- a/src/core/Akka.Cluster.Tests.MultiNode/RestartFirstSeedNodeSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/RestartFirstSeedNodeSpec.cs
@@ -43,7 +43,7 @@ namespace Akka.Cluster.Tests.MultiNode
     {
         private readonly RestartFirstSeedNodeSpecConfig _config;
         private Address _missedSeed;
-        private static Address _seedNode1Address;
+        private static volatile Address _seedNode1Address;
 
         private Lazy<ActorSystem> seed1System;
         private Lazy<ActorSystem> restartedSeed1System;


### PR DESCRIPTION
Found a race condition inside `RestartFirstSeedNodeSpec`:

```
[Node #2(seed2)][WARNING][4/19/2021 8:33:24 PM][Thread 0021][akka.tcp://RestartFirstSeedNodeSpec@localhost:52468/system/cluster/core/daemon/joinSeedNodeProcess-1] Couldn't join seed nodes after [2] attempts, will try again. seed-nodes=[akka.tcp://RestartFirstSeedNodeSpec@localhost:52473,akka.tcp://RestartFirstSeedNodeSpec@localhost:52467,akka.tcp://RestartFirstSeedNodeSpec@localhost:61313]
[Node #3(seed3)][WARNING][4/19/2021 8:33:24 PM][Thread 0022][akka.tcp://RestartFirstSeedNodeSpec@localhost:52467/system/cluster/core/daemon/joinSeedNodeProcess-1] Couldn't join seed nodes after [2] attempts, will try again. seed-nodes=[akka.tcp://RestartFirstSeedNodeSpec@localhost:52473,akka.tcp://RestartFirstSeedNodeSpec@localhost:52468,akka.tcp://RestartFirstSeedNodeSpec@localhost:61313]
```

Neither nodes 2 or 3 received node 1's address - I think it's because we're using an actor to set this value in shared memory.