### PR TITLE
Perf optimize `ActorSelection`

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Actor/ActorSelectionBenchmark.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/ActorSelectionBenchmark.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.NetworkInformation;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+
+namespace Akka.Benchmarks.Actor
+{
+    [Config(typeof(MicroBenchmarkConfig))] // need memory diagnosis
+    public class ActorSelectionBenchmark
+    {
+        public const int Operations = 1_000_000;
+        private TimeSpan _timeout;
+        private ActorSystem _system;
+        private IActorRef _echo;
+
+        // cached selection for measuring .Tell / .Ask performance
+        private ActorSelection _actorSelection;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _timeout = TimeSpan.FromMinutes(1);
+            _system = ActorSystem.Create("system");
+            _echo = _system.ActorOf(Props.Create(() => new EchoActor()), "echo");
+            _actorSelection = _system.ActorSelection("/user/echo");
+        }
+
+        [Benchmark]
+        public async Task RequestResponseActorSelection()
+        {
+            await _actorSelection.Ask("foo", _timeout);
+        }
+
+        [Benchmark]
+        public void CreateActorSelection()
+        {
+            _system.ActorSelection("/user/echo");
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+          _system.Terminate().Wait();
+        }
+
+        public class EchoActor : UntypedActor
+        {
+            protected override void OnReceive(object message)
+            {
+                Sender.Tell(message);
+            }
+        }
+    }
+}

--- a/src/benchmark/Akka.Benchmarks/Actor/ActorSelectionBenchmark.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/ActorSelectionBenchmark.cs
@@ -13,7 +13,8 @@ namespace Akka.Benchmarks.Actor
     [Config(typeof(MicroBenchmarkConfig))] // need memory diagnosis
     public class ActorSelectionBenchmark
     {
-        public const int Operations = 1_000_000;
+        [Params(10000)]
+        public int Iterations { get; set; }
         private TimeSpan _timeout;
         private ActorSystem _system;
         private IActorRef _echo;
@@ -33,13 +34,15 @@ namespace Akka.Benchmarks.Actor
         [Benchmark]
         public async Task RequestResponseActorSelection()
         {
-            await _actorSelection.Ask("foo", _timeout);
+            for(var i = 0; i < Iterations; i++)
+                await _actorSelection.Ask("foo", _timeout);
         }
 
         [Benchmark]
         public void CreateActorSelection()
         {
-            _system.ActorSelection("/user/echo");
+            for (var i = 0; i < Iterations; i++)
+                _system.ActorSelection("/user/echo");
         }
 
         [GlobalCleanup]

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -1621,6 +1621,7 @@ namespace Akka.Actor
     }
     public class SelectChildRecursive : Akka.Actor.SelectionPathElement
     {
+        public static readonly Akka.Actor.SelectChildRecursive Instance;
         public SelectChildRecursive() { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
@@ -1628,6 +1629,7 @@ namespace Akka.Actor
     }
     public class SelectParent : Akka.Actor.SelectionPathElement
     {
+        public static readonly Akka.Actor.SelectParent Instance;
         public SelectParent() { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }

--- a/src/core/Akka.Cluster.Tests.MultiNode/StressSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/StressSpec.cs
@@ -319,7 +319,7 @@ namespace Akka.Cluster.Tests.MultiNode
             {
                 if (_settings.Infolog)
                 {
-                    _log.Info("[{0}] in progress" + Environment.NewLine + "{1}" + Environment.NewLine + "{2}", _title,
+                    _log.Info("BEGIN CLUSTER OPERATION: [{0}] in progress" + Environment.NewLine + "{1}" + Environment.NewLine + "{2}", _title,
                         FormatPhi(), FormatStats());
                 }
             });
@@ -332,7 +332,7 @@ namespace Akka.Cluster.Tests.MultiNode
                     var aggregated = new AggregatedClusterResult(_title, MaxDuration, TotalGossipStats);
                     if (_settings.Infolog)
                     {
-                        _log.Info("[{0}] completed in [{1}] ms" + Environment.NewLine + "{2}" +
+                        _log.Info("END CLUSTER OPERATION: [{0}] completed in [{1}] ms" + Environment.NewLine + "{2}" +
                                   Environment.NewLine + "{3}" + Environment.NewLine + "{4}", _title, aggregated.Duration.TotalMilliseconds,
                         aggregated.ClusterStats, FormatPhi(), FormatStats());
                     }

--- a/src/core/Akka.Tests.Performance/Actor/ActorSelectionSpecs.cs
+++ b/src/core/Akka.Tests.Performance/Actor/ActorSelectionSpecs.cs
@@ -66,6 +66,7 @@ namespace Akka.Tests.Performance.Actor
         [PerfBenchmark(Description = "Tests the message delivery throughput of NEW ActorSelections to NEW actors", 
             NumberOfIterations = 13, RunMode = RunMode.Throughput, RunTimeMilliseconds = 1000, TestMode = TestMode.Measurement)]
         [CounterMeasurement(ActorSelectionCounterName)]
+        [MemoryMeasurement(MemoryMetric.TotalBytesAllocated)]
         public void New_ActorSelection_on_new_actor_throughput(BenchmarkContext context)
         {
             var actorRef = System.ActorOf(_oneMessageBenchmarkProps); // create a new actor every time
@@ -77,6 +78,7 @@ namespace Akka.Tests.Performance.Actor
         [PerfBenchmark(Description = "Tests the message delivery throughput of REUSABLE ActorSelections to PRE-EXISTING actors",
             NumberOfIterations = 13, RunMode = RunMode.Iterations, TestMode = TestMode.Measurement)]
         [CounterMeasurement(ActorSelectionCounterName)]
+        [MemoryMeasurement(MemoryMetric.TotalBytesAllocated)]
         public void Reused_ActorSelection_on_pre_existing_actor_throughput(BenchmarkContext context)
         {
             var actorSelection = System.ActorSelection(_receiverActorPath);
@@ -91,6 +93,7 @@ namespace Akka.Tests.Performance.Actor
         [PerfBenchmark(Description = "Tests the message delivery throughput of NEW ActorSelections to PRE-EXISTING actors. This is really a stress test.",
             NumberOfIterations = 13, RunMode = RunMode.Iterations, TestMode = TestMode.Measurement)]
         [CounterMeasurement(ActorSelectionCounterName)]
+        [MemoryMeasurement(MemoryMetric.TotalBytesAllocated)]
         public void New_ActorSelection_on_pre_existing_actor_throughput(BenchmarkContext context)
         {
             for (var i = 0; i < NumberOfMessages;)
@@ -104,6 +107,7 @@ namespace Akka.Tests.Performance.Actor
         [PerfBenchmark(Description = "Tests the throughput of resolving an ActorSelection on a pre-existing actor via ResolveOne",
             NumberOfIterations = 13, RunMode = RunMode.Throughput, RunTimeMilliseconds = 1000, TestMode = TestMode.Measurement)]
         [CounterMeasurement(ActorSelectionCounterName)]
+        [MemoryMeasurement(MemoryMetric.TotalBytesAllocated)]
         public void ActorSelection_ResolveOne_throughput(BenchmarkContext context)
         {
             var actorRef= System.ActorSelection(_receiverActorPath).ResolveOne(TimeSpan.FromSeconds(2)).Result; // send that actor a message via selection
@@ -113,6 +117,7 @@ namespace Akka.Tests.Performance.Actor
         [PerfBenchmark(Description = "Continuously creates actors and attempts to resolve them immediately. Used to surface race conditions.",
             NumberOfIterations = 13, RunMode = RunMode.Throughput, RunTimeMilliseconds = 1000, TestMode = TestMode.Measurement)]
         [CounterMeasurement(ActorSelectionCounterName)]
+        [MemoryMeasurement(MemoryMetric.TotalBytesAllocated)]
         public void ActorSelection_ResolveOne_stress_test(BenchmarkContext context)
         {
             var actorRef = System.ActorOf(_oneMessageBenchmarkProps); // create a new actor every time

--- a/src/core/Akka.Tests/Actor/ActorSelectionSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorSelectionSpec.cs
@@ -486,6 +486,9 @@ namespace Akka.Tests.Actor
             // nothing under /user/a/b2/c1/d
             Sys.ActorSelection("/user/a/b2/c1/d/**").Tell(new Identify(3), probe.Ref);
             probe.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
+
+            Action illegalDoubleWildCard = () => Sys.ActorSelection("/user/a/**/d").Tell(new Identify(4), probe.Ref);
+            illegalDoubleWildCard.Should().Throw<IllegalActorNameException>();
         }
 
         [Fact]

--- a/src/core/Akka/Actor/ActorSelection.cs
+++ b/src/core/Akka/Actor/ActorSelection.cs
@@ -197,10 +197,12 @@ namespace Akka.Actor
                 {
                     if (actorRef is ActorRefWithCell refWithCell)
                     {
-                        var emptyRef = new EmptyLocalActorRef(
-                            provider: refWithCell.Provider,
-                            path: anchor.Path / sel.Elements.Select(el => el.ToString()),
-                            eventStream: refWithCell.Underlying.System.EventStream);
+                        EmptyLocalActorRef EmptyRef(){
+                            return new EmptyLocalActorRef(
+                                provider: refWithCell.Provider,
+                                path: anchor.Path / sel.Elements.Select(el => el.ToString()),
+                                eventStream: refWithCell.Underlying.System.EventStream);
+                        }
 
                         switch (iter.Next())
                         {
@@ -220,7 +222,7 @@ namespace Akka.Actor
                                 {
                                     // don't send to emptyRef after wildcard fan-out
                                     if (!sel.WildCardFanOut)
-                                        emptyRef.Tell(sel, sender);
+                                        EmptyRef().Tell(sel, sender);
                                 }
                                 else if (iter.IsEmpty())
                                 {
@@ -253,7 +255,7 @@ namespace Akka.Actor
                                 if (iter.IsEmpty())
                                 {
                                     if (matchingChildren.Count == 0 && !sel.WildCardFanOut)
-                                        emptyRef.Tell(sel, sender);
+                                        EmptyRef().Tell(sel, sender);
                                     else
                                     {
                                         for (var i = 0; i < matchingChildren.Count; i++)
@@ -264,7 +266,7 @@ namespace Akka.Actor
                                 {
                                     // don't send to emptyRef after wildcard fan-out
                                     if (matchingChildren.Count == 0 && !sel.WildCardFanOut)
-                                        emptyRef.Tell(sel, sender);
+                                        EmptyRef().Tell(sel, sender);
                                     else
                                     {
                                         var message = new ActorSelectionMessage(

--- a/src/core/Akka/Actor/ActorSelection.cs
+++ b/src/core/Akka/Actor/ActorSelection.cs
@@ -77,31 +77,34 @@ namespace Akka.Actor
             Anchor = anchor;
 
             var list = new List<SelectionPathElement>();
-            var iter = elements.Iterator();
-            while (!iter.IsEmpty())
+            var count = elements.Count(); // shouldn't have a multiple enumeration issue\
+            var i = 0;
+            foreach (var s in elements)
             {
-                var s = iter.Next();
                 switch (s)
                 {
                     case null:
                     case "":
                         break;
                     case "**":
-                        if (!iter.IsEmpty())
+                        if (i < count-1)
                             throw new IllegalActorNameException("Double wildcard can only appear at the last path entry");
-                        list.Add(new SelectChildRecursive());
+                        list.Add(SelectChildRecursive.Instance);
                         break;
                     case string e when e.Contains("?") || e.Contains("*"):
                         list.Add(new SelectChildPattern(e));
                         break;
                     case string e when e == "..":
-                        list.Add(new SelectParent());
+                        list.Add(SelectParent.Instance);
                         break;
                     default:
                         list.Add(new SelectChildName(s));
                         break;
                 }
+
+                i++;
             }
+
             Path = list.ToArray();
         }
 
@@ -474,6 +477,11 @@ namespace Akka.Actor
             return true;
         }
 
+        /// <summary>
+        ///  Use this instead of calling the default constructor
+        /// </summary>
+        public static readonly SelectChildRecursive Instance = new SelectChildRecursive();
+
         /// <inheritdoc/>
         public override int GetHashCode() => "**".GetHashCode();
 
@@ -487,6 +495,11 @@ namespace Akka.Actor
     /// </summary>
     public class SelectParent : SelectionPathElement
     {
+        /// <summary>
+        ///  Use this instead of calling the default constructor
+        /// </summary>
+        public static readonly SelectParent Instance = new SelectParent();
+
         /// <inheritdoc/>
         public override bool Equals(object obj) => !ReferenceEquals(obj, null) && obj is SelectParent;
 

--- a/src/core/Akka/Actor/ActorSelection.cs
+++ b/src/core/Akka/Actor/ActorSelection.cs
@@ -237,7 +237,7 @@ namespace Akka.Actor
                                 if (allChildren.Count == 0)
                                     return;
 
-                                var msg = new ActorSelectionMessage(sel.Message, new[] { new SelectChildRecursive() }, true);
+                                var msg = new ActorSelectionMessage(sel.Message, new SelectionPathElement[] { SelectChildRecursive.Instance }, true);
                                 foreach (var c in allChildren)
                                 {
                                     c.Tell(sel.Message, sender);

--- a/src/core/Akka/Util/Internal/Collections/Iterator.cs
+++ b/src/core/Akka/Util/Internal/Collections/Iterator.cs
@@ -10,13 +10,14 @@ using System.Linq;
 
 namespace Akka.Util.Internal.Collections
 {
-    internal sealed class Iterator<T>
+    internal struct Iterator<T>
     {
         private readonly IList<T> _enumerator;
         private int _index;
 
         public Iterator(IEnumerable<T> enumerator)
         {
+            _index = 0;
             _enumerator = enumerator.ToList();
         }
 


### PR DESCRIPTION
Saw some of the same inefficient / allocate-y patterns from `VectorClock` and elsewhere show up in this class and wanted to clean it up.