### PR TITLE
Fix `SpawnActor` benchmark

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Actor/SpawnActorBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/SpawnActorBenchmarks.cs
@@ -22,16 +22,16 @@ namespace Akka.Benchmarks.Actor
         public int ActorCount { get;set; }
         private ActorSystem system;
 
-        [GlobalSetup]
+        [IterationSetup]
         public void Setup()
         {
             system = ActorSystem.Create("system");
         }
 
-        [GlobalCleanup]
-        public async Task Cleanup()
+        [IterationCleanup]
+        public void Cleanup()
         {
-            await system.Terminate();
+           system.Terminate().Wait();
         }
 
         [Benchmark]

--- a/src/benchmark/Akka.Benchmarks/Actor/SpawnActorBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/SpawnActorBenchmarks.cs
@@ -15,38 +15,41 @@ using BenchmarkDotNet.Engines;
 namespace Akka.Benchmarks.Actor
 {
     [Config(typeof(MicroBenchmarkConfig))]
-    [SimpleJob(RunStrategy.Throughput, targetCount:10, warmupCount:5, invocationCount: ActorCount)]
+    [SimpleJob(RunStrategy.Throughput, targetCount:10, warmupCount:5)]
     public class SpawnActorBenchmarks
     {
-        public const int ActorCount = 100_000;
-        private TimeSpan timeout;
+        [Params(100_000)]
+        public int ActorCount { get;set; }
         private ActorSystem system;
 
         [GlobalSetup]
         public void Setup()
         {
-            timeout = TimeSpan.FromMinutes(1);
             system = ActorSystem.Create("system");
         }
 
         [GlobalCleanup]
-        public void Cleanup()
+        public async Task Cleanup()
         {
-            system.Dispose();
+            await system.Terminate();
         }
 
         [Benchmark]
-        public void Actor_spawn()
+        public async Task Actor_spawn()
         {
             var parent = system.ActorOf(Parent.Props);
+            await parent.Ask<TestDone>(new StartTest(ActorCount), TimeSpan.FromMinutes(2));
         }
 
         #region actors
 
         sealed class StartTest
         {
-            public static readonly StartTest Instance = new StartTest();
-            private StartTest() { }
+            public StartTest(int actorCount) {
+                ActorCount = actorCount;
+            }
+
+            public int ActorCount { get; }
         }
 
         sealed class ChildReady
@@ -64,12 +67,13 @@ namespace Akka.Benchmarks.Actor
         sealed class Parent : ReceiveActor
         {
             public static readonly Props Props = Props.Create<Parent>();
-            private int count = ActorCount - 1; // -1 because we also create the parent
+            private int count;
             private IActorRef replyTo;
             public Parent()
             {
                 Receive<StartTest>(_ =>
                 {
+                    count = _.ActorCount - 1; // -1 because we also create the parent
                     replyTo = Sender;
                     for (int i = 0; i < count; i++)
                     {


### PR DESCRIPTION
Now actually measures spawning of 100,000 actors.

Baseline performance:

 ``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.928 (2004/?/20H1)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=5.0.201
  [Host]     : .NET Core 3.1.13 (CoreCLR 4.700.21.11102, CoreFX 4.700.21.11602), X64 RyuJIT
  Job-USATMF : .NET Core 3.1.13 (CoreCLR 4.700.21.11102, CoreFX 4.700.21.11602), X64 RyuJIT

InvocationCount=1  IterationCount=10  RunStrategy=Throughput  
UnrollFactor=1  WarmupCount=5  

```
|      Method | ActorCount |    Mean |    Error |   StdDev |       Gen 0 |      Gen 1 |     Gen 2 | Allocated |
|------------ |----------- |--------:|---------:|---------:|------------:|-----------:|----------:|----------:|
| Actor_spawn |     100000 | 2.353 s | 0.1107 s | 0.0732 s | 111000.0000 | 31000.0000 | 4000.0000 | 637.99 MB |