### PR TITLE
UnfoldResourceSource closing twice on failure

### DIFF
--- a/src/core/Akka.Streams/Implementation/Sources.cs
+++ b/src/core/Akka.Streams/Implementation/Sources.cs
@@ -441,6 +441,7 @@ namespace Akka.Streams.Implementation
                         switch (directive)
                         {
                             case Directive.Stop:
+                                _open = false;
                                 _stage._close(_blockingStream);
                                 FailStage(ex);
                                 stop = true;
@@ -467,6 +468,7 @@ namespace Akka.Streams.Implementation
 
             private void RestartState()
             {
+                _open = false;
                 _stage._close(_blockingStream);
                 _blockingStream = _stage._create();
                 _open = true;


### PR DESCRIPTION
Ported fix for [#24924](https://github.com/akka/akka/issues/24924)