### PR TITLE
simplified the environment variable name for StressSpec

### DIFF
--- a/src/core/Akka.Cluster.Tests.MultiNode/StressSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/StressSpec.cs
@@ -33,7 +33,7 @@ namespace Akka.Cluster.Tests.MultiNode
 {
     public class StressSpecConfig : MultiNodeConfig
     {
-        public int TotalNumberOfNodes => Environment.GetEnvironmentVariable("MultiNode.Akka.Cluster.Stress.NrOfNodes") switch
+        public int TotalNumberOfNodes => Environment.GetEnvironmentVariable("MNTR_STRESSSPEC_NODECOUNT") switch
         {
             string e when string.IsNullOrEmpty(e) => 13,
             string val => int.Parse(val),


### PR DESCRIPTION
Did this to make it easier to set the maximum node count in PowerShell,

i.e. `$env:MNTR_STRESSSPEC_NODECOUNT="50"`