### PR TITLE
Prevent loggers to throw FormatException and show a friendly message instead.

### DIFF
--- a/src/contrib/testkits/Akka.TestKit.Xunit2/Internals/Loggers.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit2/Internals/Loggers.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using Akka.Actor;
 using Akka.Event;
 using Xunit.Abstractions;
@@ -16,20 +17,44 @@ namespace Akka.TestKit.Xunit2.Internals
     /// </summary>
     public class TestOutputLogger : ReceiveActor
     {
+        private readonly ITestOutputHelper _output;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TestOutputLogger"/> class.
         /// </summary>
         /// <param name="output">The provider used to write test output.</param>
         public TestOutputLogger(ITestOutputHelper output)
         {
-            Receive<Debug>(e => output.WriteLine(e.ToString()));
-            Receive<Info>(e => output.WriteLine(e.ToString()));
-            Receive<Warning>(e => output.WriteLine(e.ToString()));
-            Receive<Error>(e => output.WriteLine(e.ToString()));
+            _output = output;
+
+            Receive<Debug>(HandleLogEvent);
+            Receive<Info>(HandleLogEvent);
+            Receive<Warning>(HandleLogEvent);
+            Receive<Error>(HandleLogEvent);
             Receive<InitializeLogger>(e =>
             {
                 e.LoggingBus.Subscribe(Self, typeof (LogEvent));
             });
+        }
+
+        private void HandleLogEvent(LogEvent e)
+        {
+            try
+            {
+                _output.WriteLine(e.ToString());
+            }
+            catch (FormatException ex)
+            {
+                if (e.Message is LogMessage msg)
+                {
+                    var message =
+                        $"Received a malformed formatted message. Log level: [{e.LogLevel()}], Template: [{msg.Format}], args: [{string.Join(",", msg.Args)}]";
+                    if(e.Cause != null)
+                        throw new AggregateException(message, ex, e.Cause);
+                    throw new FormatException(message, ex);
+                }
+                throw;
+            }
         }
     }
 }

--- a/src/core/Akka.TestKit/Internal/InternalTestActor.cs
+++ b/src/core/Akka.TestKit/Internal/InternalTestActor.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Collections.Concurrent;
 using Akka.Actor;
 using Akka.Event;
@@ -38,7 +39,19 @@ namespace Akka.TestKit.Internal
         /// <returns>TBD</returns>
         protected override bool Receive(object message)
         {
-            global::System.Diagnostics.Debug.WriteLine("TestActor received " + message);
+            try
+            {
+                global::System.Diagnostics.Debug.WriteLine("TestActor received " + message);
+            }
+            catch (FormatException)
+            {
+                if (message is LogEvent evt && evt.Message is LogMessage msg)
+                    global::System.Diagnostics.Debug.WriteLine(
+                        $"TestActor received a malformed formatted message. Template:[{msg.Format}], args:[{string.Join(",", msg.Args)}]");
+                else
+                    throw;
+            }
+
             var setIgnore = message as TestKit.TestActor.SetIgnore;
             if(setIgnore != null)
             {

--- a/src/core/Akka.Tests/Loggers/LoggerSpec.cs
+++ b/src/core/Akka.Tests/Loggers/LoggerSpec.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Threading;
 using Akka.Actor;
-using Akka.Actor.Setup;
 using Akka.Configuration;
 using Akka.Event;
 using Akka.TestKit;
@@ -29,10 +26,13 @@ akka.stdout-loglevel = DEBUG");
         [Fact]
         public void TestOutputLogger_WithBadFormattingMustNotThrow()
         {
+            // Need to wait until TestOutputLogger initializes
+            Thread.Sleep(200);
             Sys.EventStream.Subscribe(TestActor, typeof(LogEvent));
 
             Sys.Log.Error(new FakeException("BOOM"), Case.t, Case.p);
             ExpectMsg<Error>().Cause.Should().BeOfType<FakeException>();
+            ExpectMsg<Error>().Cause.Should().BeOfType<AggregateException>();
 
             Sys.Log.Warning(Case.t, Case.p);
             ExpectMsg<Warning>();

--- a/src/core/Akka.Tests/Loggers/LoggerSpec.cs
+++ b/src/core/Akka.Tests/Loggers/LoggerSpec.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Actor.Setup;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.TestKit;
+using Xunit;
+using Xunit.Abstractions;
+using FluentAssertions;
+
+namespace Akka.Tests.Loggers
+{
+    public class LoggerSpec : AkkaSpec
+    {
+        private static readonly Config Config = ConfigurationFactory.ParseString(@"
+akka.loglevel = DEBUG
+akka.stdout-loglevel = DEBUG");
+
+        public static readonly (string t, string[] p) Case =  
+            ("This is {0} a {1} janky formatting. {4}", new []{"also", "very", "not cool"});
+
+        public LoggerSpec(ITestOutputHelper output) : base(Config, output)
+        { }
+
+        [Fact]
+        public void TestOutputLogger_WithBadFormattingMustNotThrow()
+        {
+            Sys.EventStream.Subscribe(TestActor, typeof(LogEvent));
+
+            Sys.Log.Error(new FakeException("BOOM"), Case.t, Case.p);
+            ExpectMsg<Error>().Cause.Should().BeOfType<FakeException>();
+
+            Sys.Log.Warning(Case.t, Case.p);
+            ExpectMsg<Warning>();
+            ExpectMsg<Error>().Cause.Should().BeOfType<FormatException>();
+
+            Sys.Log.Info(Case.t, Case.p);
+            ExpectMsg<Info>();
+            ExpectMsg<Error>().Cause.Should().BeOfType<FormatException>();
+
+            Sys.Log.Debug(Case.t, Case.p);
+            ExpectMsg<Debug>();
+            ExpectMsg<Error>().Cause.Should().BeOfType<FormatException>();
+        }
+
+        [Fact]
+        public void DefaultLogger_WithBadFormattingMustNotThrow()
+        {
+            var config = ConfigurationFactory.ParseString("akka.loggers = [\"Akka.Event.DefaultLogger\"]");
+            var sys2 = ActorSystem.Create("DefaultLoggerTest", config.WithFallback(Sys.Settings.Config));
+            var probe = CreateTestProbe(sys2);
+
+            sys2.EventStream.Subscribe(probe, typeof(LogEvent));
+
+            sys2.Log.Error(new FakeException("BOOM"), Case.t, Case.p);
+            probe.ExpectMsg<Error>().Cause.Should().BeOfType<FakeException>();
+
+            sys2.Log.Warning(Case.t, Case.p);
+            probe.ExpectMsg<Warning>();
+
+            sys2.Log.Info(Case.t, Case.p);
+            probe.ExpectMsg<Info>();
+
+            sys2.Log.Debug(Case.t, Case.p);
+            probe.ExpectMsg<Debug>();
+
+            sys2.Terminate().Wait();
+        }
+
+        [Fact]
+        public void StandardOutLogger_WithBadFormattingMustNotThrow()
+        {
+            var config = ConfigurationFactory.ParseString("akka.loggers = [\"Akka.Event.StandardOutLogger\"]");
+            var sys2 = ActorSystem.Create("StandardOutLoggerTest", config.WithFallback(Sys.Settings.Config));
+            var probe = CreateTestProbe(sys2);
+
+            sys2.EventStream.Subscribe(probe, typeof(LogEvent));
+
+            sys2.Log.Error(new FakeException("BOOM"), Case.t, Case.p);
+            probe.ExpectMsg<Error>().Cause.Should().BeOfType<FakeException>();
+
+            sys2.Log.Warning(Case.t, Case.p);
+            probe.ExpectMsg<Warning>();
+
+            sys2.Log.Info(Case.t, Case.p);
+            probe.ExpectMsg<Info>();
+
+            sys2.Log.Debug(Case.t, Case.p);
+            probe.ExpectMsg<Debug>();
+
+            sys2.Terminate().Wait();
+        }
+
+        [Theory]
+        [MemberData(nameof(LogEventFactory))]
+        public void StandardOutLogger_PrintLogEvent_WithBadLogFormattingMustNotThrow(LogEvent @event)
+        {
+            var obj = new object();
+            obj.Invoking(o => StandardOutLogger.PrintLogEvent(@event)).Should().NotThrow();
+        }
+
+        public static IEnumerable<object[]> LogEventFactory()
+        {
+            var ex = new FakeException("BOOM");
+            var logSource = LogSource.Create(nameof(LoggerSpec));
+            var ls = logSource.Source;
+            var lc = logSource.Type;
+            var formatter = new DefaultLogMessageFormatter();
+
+            yield return new object[] { new Error(ex, ls, lc, new LogMessage(formatter, Case.t, Case.p)) }; 
+
+            yield return new object[] {new Warning(ex, ls, lc, new LogMessage(formatter, Case.t, Case.p))};
+
+            yield return new object[] {new Info(ex, ls, lc, new LogMessage(formatter, Case.t, Case.p))};
+
+            yield return new object[] {new Debug(ex, ls, lc, new LogMessage(formatter, Case.t, Case.p))};
+        }
+
+        private class FakeException : Exception
+        {
+            public FakeException(string message) : base(message)
+            { }
+        }
+    }
+}


### PR DESCRIPTION
Closes #4908