### PR TITLE
marking Akka.Persistence.Sql.Common as `beta` for v1.4.20

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj
@@ -7,6 +7,7 @@
     <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
     <PackageTags>$(AkkaPackageTags);persistence;eventsource;sql</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <VersionSuffix>beta</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Due to https://github.com/akkadotnet/akka.net/pull/4953 - we decided to mark `Akka.Persistence.Sql.Common` as a beta package until we can validate that the changes to the `BatchingSqlJournal` didn't totally destroy performance / functionality for actual end-users.