### PR TITLE
v1.4.20 Production Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,26 @@
-#### 1.4.20 April 28 2021 ####
-**Placeholder for nightlies**
+#### 1.4.20 May 12 2021 ####
+**Maintenance Release for Akka.NET 1.4**
 
+Akka.NET v1.4.20 is a minor release that includes some bug fixes and improvements to Akka.NET.
+
+* [Akka: Fixed some `internal-dispatcher` usages ](https://github.com/akkadotnet/akka.net/pull/4995)
+* [Akka: Remove restrictions required by netstandard 1.x but available in 2.0 ](https://github.com/akkadotnet/akka.net/pull/3790)
+* [Akka: Prevent loggers to throw `FormatException` and show a friendly message instead. ](https://github.com/akkadotnet/akka.net/pull/4998)
+* [Akka.Persistence.Sql.Common: Some persistent actors are stuck with `RecoveryTimedOutException` after circuit breaker opens](https://github.com/akkadotnet/akka.net/issues/4265)
+* [Akka.Persistence.Sql.Common: marking Akka.Persistence.Sql.Common as `beta` for v1.4.20](https://github.com/akkadotnet/akka.net/pull/5006)
+* [Akka.Remote: `Akka.Remote.Serialization.PrimitiveSerializers` needs cross platform compatibility](https://github.com/akkadotnet/akka.net/issues/4986)
+* [Akka.Streams: Fixed `QueueSource.PostStop` and added a missing test case](https://github.com/akkadotnet/akka.net/pull/4991)
+* [Akka.Cluster.Sharding: Reduce sharding warnings when there are no buffered messages](https://github.com/akkadotnet/akka.net/pull/5003)
+
+To see the [full set of fixes in Akka.NET v1.4.20, please see the milestone on Github](https://github.com/akkadotnet/akka.net/milestone/50).
+
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 4 | 677 | 316 | Gregorius Soedharmo |
+| 3 | 3 | 3 | dependabot[bot] |
+| 3 | 101 | 44 | Ismael Hamed |
+| 2 | 5 | 0 | Aaron Stannard |
+| 1 | 625 | 675 | Matthew Heaton |
 
 #### 1.4.19 April 28 2021 ####
 **Maintenance Release for Akka.NET 1.4**

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 1.4.20 April 28 2021 ####
+**Placeholder for nightlies**
+
+
 #### 1.4.19 April 28 2021 ####
 **Maintenance Release for Akka.NET 1.4**
 

--- a/src/common.props
+++ b/src/common.props
@@ -14,7 +14,7 @@
     <HyperionVersion>0.10.1</HyperionVersion>
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <NBenchVersion>2.0.1</NBenchVersion>
-    <ProtobufVersion>3.15.8</ProtobufVersion>
+    <ProtobufVersion>3.16.0</ProtobufVersion>
     <NetCoreTestVersion>netcoreapp3.1</NetCoreTestVersion>
     <NetTestVersion>net5.0</NetTestVersion>
     <NetFrameworkTestVersion>net471</NetFrameworkTestVersion>

--- a/src/common.props
+++ b/src/common.props
@@ -20,7 +20,7 @@
     <NetFrameworkTestVersion>net471</NetFrameworkTestVersion>
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>
     <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>
-    <FsCheckVersion>2.15.2</FsCheckVersion>
+    <FsCheckVersion>2.15.3</FsCheckVersion>
     <HoconVersion>2.0.3</HoconVersion>
     <ConfigurationManagerVersion>4.7.0</ConfigurationManagerVersion>
     <AkkaPackageTags>akka;actors;actor model;Akka;concurrency</AkkaPackageTags>

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/Akka.Cluster.Sharding.Tests.MultiNode.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/Akka.Cluster.Sharding.Tests.MultiNode.csproj
@@ -25,14 +25,6 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
-    <DefineConstants>$(DefineConstants);</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/AsyncWriteProxyEx.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/AsyncWriteProxyEx.cs
@@ -43,7 +43,6 @@ namespace Akka.Cluster.Sharding.Tests
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncReplayTimeoutException"/> class.
         /// </summary>
@@ -53,7 +52,6 @@ namespace Akka.Cluster.Sharding.Tests
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Akka.Cluster.Sharding.Tests.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Akka.Cluster.Sharding.Tests.csproj
@@ -27,14 +27,6 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZABLE</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Akka.Cluster.Sharding.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Akka.Cluster.Sharding.csproj
@@ -18,10 +18,6 @@
     <ProjectReference Include="..\Akka.DistributedData\Akka.DistributedData.csproj" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
@@ -664,11 +664,25 @@ namespace Akka.Cluster.Sharding
                         ? $"Coordinator [{MembersByAge.First()}] is unreachable."
                         : $"Coordinator [{MembersByAge.First()}] is reachable.";
 
-                    Log.Warning("{0}: Trying to register to coordinator at [{1}], but no acknowledgement. Total [{2}] buffered messages. [{3}]",
-                        TypeName,
-                        string.Join(", ", actorSelections.Select(i => i.PathString)),
-                        TotalBufferSize,
-                        coordinatorMessage);
+                    var bufferSize = ShardBuffers.Count;
+                    if (bufferSize > 0)
+                    {
+                        if (Log.IsWarningEnabled)
+                        {
+                            Log.Warning("{0}: Trying to register to coordinator at [{1}], but no acknowledgement. Total [{2}] buffered messages. [{3}]",
+                                TypeName,
+                                string.Join(", ", actorSelections.Select(i => i.PathString)),
+                                TotalBufferSize,
+                                coordinatorMessage);
+                        }
+                    }
+                    else if (Log.IsDebugEnabled)
+                    {
+                        Log.Debug("{0}: Trying to register to coordinator at [{1}], but no acknowledgement. No buffered messages yet. [{2}]",
+                            TypeName,
+                            string.Join(", ", actorSelections.Select(i => i.PathString)),
+                            coordinatorMessage);
+                    }
                 }
                 else
                 {
@@ -678,8 +692,17 @@ namespace Akka.Cluster.Sharding
                         ? "Has Cluster Sharding been started on every node and nodes been configured with the correct role(s)?"
                         : "Probably, no seed-nodes configured and manual cluster join not performed?";
 
-                    Log.Warning("{0}: No coordinator found to register. {1} Total [{2}] buffered messages.",
-                        TypeName, possibleReason, TotalBufferSize);
+                    var bufferSize = ShardBuffers.Count;
+                    if (bufferSize > 0)
+                    {
+                        Log.Warning("{0}: No coordinator found to register. {1} Total [{2}] buffered messages.",
+                            TypeName, possibleReason, TotalBufferSize);
+                    }
+                    else
+                    {
+                        Log.Debug("{0}: No coordinator found to register. {1} No buffered messages yet.",
+                            TypeName, possibleReason);
+                    }
                 }
             }
         }

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Akka.Cluster.Tools.Tests.MultiNode.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Akka.Cluster.Tools.Tests.MultiNode.csproj
@@ -19,10 +19,6 @@
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Akka.Cluster.Tools.Tests.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Akka.Cluster.Tools.Tests.csproj
@@ -19,14 +19,6 @@
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZABLE</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonLeaseSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonLeaseSpec.cs
@@ -117,7 +117,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
 
         private ClusterSingletonManagerSettings NextSettings() => ClusterSingletonManagerSettings.Create(Sys).WithSingletonName(NextName());
 
-        private string LeaseNameFor(ClusterSingletonManagerSettings settings) => $"AkkaSpec-singleton-akka://AkkaSpec/user/{settings.SingletonName}";
+        private string LeaseNameFor(ClusterSingletonManagerSettings settings) => $"{Sys.Name}-singleton-akka://{Sys.Name}/user/{settings.SingletonName}";
 
         [Fact]
         public void ClusterSingleton_with_lease_should_not_start_until_lease_is_available()

--- a/src/contrib/cluster/Akka.Cluster.Tools/Akka.Cluster.Tools.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Akka.Cluster.Tools.csproj
@@ -15,10 +15,6 @@
     <ProjectReference Include="..\..\..\core\Akka.Coordination\Akka.Coordination.csproj" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManager.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManager.cs
@@ -525,7 +525,6 @@ namespace Akka.Cluster.Tools.Singleton
         /// <param name="message">The message that describes the error.</param>
         public ClusterSingletonManagerIsStuckException(string message) : base(message) { }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="ClusterSingletonManagerIsStuckException"/> class.
         /// </summary>
@@ -534,7 +533,6 @@ namespace Akka.Cluster.Tools.Singleton
         public ClusterSingletonManagerIsStuckException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>

--- a/src/contrib/cluster/Akka.DistributedData.Tests.MultiNode/Akka.DistributedData.Tests.MultiNode.csproj
+++ b/src/contrib/cluster/Akka.DistributedData.Tests.MultiNode/Akka.DistributedData.Tests.MultiNode.csproj
@@ -24,10 +24,6 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/contrib/cluster/Akka.DistributedData.Tests/Akka.DistributedData.Tests.csproj
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/Akka.DistributedData.Tests.csproj
@@ -20,10 +20,6 @@
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZABLE</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/contrib/cluster/Akka.DistributedData/Akka.DistributedData.csproj
+++ b/src/contrib/cluster/Akka.DistributedData/Akka.DistributedData.csproj
@@ -14,9 +14,9 @@
     <ProjectReference Include="..\..\..\core\Akka.Cluster\Akka.Cluster.csproj" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Hyperion" Version="$(HyperionVersion)" />
+  </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>

--- a/src/contrib/cluster/Akka.DistributedData/Durable/Messages.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Durable/Messages.cs
@@ -91,11 +91,9 @@ namespace Akka.DistributedData.Durable
         {
         }
 
-#if SERIALIZATION
         public LoadFailedException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 
     public sealed class DurableDataEnvelope : IReplicatorMessage, IEquatable<DurableDataEnvelope>

--- a/src/contrib/cluster/Akka.DistributedData/Replicator.Messages.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Replicator.Messages.cs
@@ -997,6 +997,7 @@ namespace Akka.DistributedData
     /// <summary>
     /// TBD
     /// </summary>
+    [Serializable]
     public class DataDeletedException : Exception
     {
         /// <summary>
@@ -1006,6 +1007,13 @@ namespace Akka.DistributedData
         public DataDeletedException(string message) : base(message)
         {
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DataDeletedException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
+        protected DataDeletedException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 
     public interface IReplicatorMessage { }

--- a/src/contrib/dependencyinjection/Akka.DI.Core/Akka.DI.Core.csproj
+++ b/src/contrib/dependencyinjection/Akka.DI.Core/Akka.DI.Core.csproj
@@ -13,15 +13,11 @@
     <ProjectReference Include="..\..\..\core\Akka\Akka.csproj" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/contrib/dependencyinjection/Akka.DI.Core/Extensions.cs
+++ b/src/contrib/dependencyinjection/Akka.DI.Core/Extensions.cs
@@ -11,9 +11,6 @@ using System.Linq;
 using System.Reflection;
 using Akka.Actor;
 
-#if CORECLR 
-using Microsoft.Extensions.DependencyModel;
-#endif
 namespace Akka.DI.Core
 {
     /// <summary>
@@ -78,28 +75,7 @@ namespace Akka.DI.Core
         /// <returns>The list of loaded assemblies</returns>
         private static IEnumerable<Assembly> GetLoadedAssemblies()
         {
-#if APPDOMAIN
             return AppDomain.CurrentDomain.GetAssemblies();
-#elif CORECLR 
-            var assemblies = new List<Assembly>();
-            var dependencies = DependencyContext.Default.RuntimeLibraries;
-            foreach (var library in dependencies)
-            {
-                try
-                {
-                    var assembly = Assembly.Load(new AssemblyName(library.Name));
-                    assemblies.Add(assembly);
-                }
-                catch
-                {
-                    //do nothing can't if can't load assembly
-                }
-            }
-            return assemblies;
-#else
-#warning Method not implemented
-            throw new NotImplementedException();
-#endif
         }
     }
 }

--- a/src/contrib/dependencyinjection/Akka.DI.TestKit/Akka.DI.TestKit.csproj
+++ b/src/contrib/dependencyinjection/Akka.DI.TestKit/Akka.DI.TestKit.csproj
@@ -14,14 +14,6 @@
     <ProjectReference Include="..\..\testkits\Akka.TestKit.Xunit2\Akka.TestKit.Xunit2.csproj" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <DefineConstants>$(DefineConstants);APPDOMAIN</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/contrib/persistence/Akka.Persistence.Query.Sql/Akka.Persistence.Query.Sql.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Query.Sql/Akka.Persistence.Query.Sql.csproj
@@ -16,10 +16,6 @@
     <ProjectReference Include="..\Akka.Persistence.Sql.Common\Akka.Persistence.Sql.Common.csproj" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj
@@ -17,13 +17,9 @@
     <ProjectReference Include="..\..\..\core\Akka.Persistence\Akka.Persistence.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
+  <ItemGroup>
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR;CONFIGURATION</DefineConstants>
-  </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj
@@ -7,6 +7,7 @@
     <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
     <PackageTags>$(AkkaPackageTags);persistence;eventsource;sql</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <VersionSuffix>beta</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/BatchingSqlJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/BatchingSqlJournal.cs
@@ -22,6 +22,7 @@ using Akka.Pattern;
 using Akka.Persistence.Journal;
 using Akka.Serialization;
 using Akka.Util;
+using Akka.Util.Internal;
 
 namespace Akka.Persistence.Sql.Common.Journal
 {
@@ -360,11 +361,13 @@ namespace Akka.Persistence.Sql.Common.Journal
         {
             public Exception Cause { get; }
             public IJournalRequest[] Requests { get; }
+            public int ChunkId { get; }
 
-            public ChunkExecutionFailure(Exception cause, IJournalRequest[] requests)
+            public ChunkExecutionFailure(Exception cause, IJournalRequest[] requests, int chunkId)
             {
                 Cause = cause;
                 Requests = requests;
+                ChunkId = chunkId;
             }
         }
 
@@ -373,14 +376,12 @@ namespace Akka.Persistence.Sql.Common.Journal
             public readonly int ChunkId;
             public readonly int OperationCount;
             public readonly TimeSpan TimeSpent;
-            public readonly Exception Cause;
 
-            public BatchComplete(int chunkId, int operationCount, TimeSpan timeSpent, Exception cause = null)
+            public BatchComplete(int chunkId, int operationCount, TimeSpan timeSpent)
             {
                 ChunkId = chunkId;
                 TimeSpent = timeSpent;
                 OperationCount = operationCount;
-                Cause = cause;
             }
         }
 
@@ -532,11 +533,19 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// </summary>
         protected readonly ILoggingAdapter Log;
 
+        private readonly Queue<(IJournalRequest request, long id)>[] _buffers;
+
         /// <summary>
-        /// Buffer for requests that are waiting to be served when next DB connection will be released.
-        /// This object access is NOT thread safe.
+        /// Buffer for write requests that are waiting to be served when next DB connection will be released.
         /// </summary>
-        protected readonly Queue<IJournalRequest> Buffer;
+        private Queue<(IJournalRequest request, long id)> WriteBuffer => _buffers[0];
+
+        /// <summary>
+        /// Buffer for read requests that are waiting to be served when next DB connection will be released.
+        /// </summary>
+        private Queue<(IJournalRequest request, long id)> ReadBuffer => _buffers[1];
+
+        private readonly AtomicCounterLong _bufferIdCounter;
 
         private readonly Dictionary<string, HashSet<IActorRef>> _persistenceIdSubscribers;
         private readonly Dictionary<string, HashSet<IActorRef>> _tagSubscribers;
@@ -560,7 +569,13 @@ namespace Akka.Persistence.Sql.Common.Journal
             _newEventSubscriber = new HashSet<IActorRef>();
 
             _remainingOperations = Setup.MaxConcurrentOperations;
-            Buffer = new Queue<IJournalRequest>(Setup.MaxBatchSize);
+            _buffers = new[]
+            {
+                new Queue<(IJournalRequest, long)>(Setup.MaxBatchSize),
+                new Queue<(IJournalRequest, long)>(Setup.MaxBatchSize)
+            };
+            _bufferIdCounter = new AtomicCounterLong(0);
+
             _serialization = Context.System.Serialization;
             Log = Context.GetLogger();
             _circuitBreaker = CircuitBreaker.Create(
@@ -733,31 +748,65 @@ namespace Akka.Persistence.Sql.Common.Journal
 
         private void FailChunkExecution(ChunkExecutionFailure message)
         {
+            _remainingOperations++;
             var cause = message.Cause;
-            Log.Error(cause, "Failed to execute chunk for {0} requests", message.Requests.Length);
-
-            foreach (var req in message.Requests)
+            Log.Error(cause, "An error occurred during event batch processing. ChunkId: [{0}], batched requests: [{1}]", message.ChunkId, message.Requests.Length);
+            
+            foreach (var request in message.Requests)
             {
-                switch (req)
+                switch (request)
                 {
-                    case WriteMessages write:
-                        var atomicWriteCount = write.Messages.OfType<AtomicWrite>().Count();
-                        write.PersistentActor.Tell(new WriteMessagesFailed(cause, atomicWriteCount));
+                    case WriteMessages req:
+                    {
+                        var atomicWriteCount = req.Messages.OfType<AtomicWrite>().Count();
+                        var actorInstanceId = req.ActorInstanceId;
+                        var aRef = req.PersistentActor;
+
+                        aRef.Tell(new WriteMessagesFailed(cause, atomicWriteCount));
+                        foreach (var envelope in req.Messages)
+                        {
+                            if (!(envelope is AtomicWrite write)) 
+                                continue;
+
+                            var writes = (IImmutableList<IPersistentRepresentation>)write.Payload;
+                            foreach (var unadapted in writes)
+                            {
+                                if (cause is DbException)
+                                {
+                                    // database-related exceptions should result in failure                                
+                                    aRef.Tell(new WriteMessageFailure(unadapted, cause, actorInstanceId), unadapted.Sender);
+                                }
+                                else
+                                {
+                                    aRef.Tell(new WriteMessageRejected(unadapted, cause, actorInstanceId), unadapted.Sender);
+                                }
+                            }
+                        }
                         break;
+                    }
+
+                    case DeleteMessagesTo delete:
+                        delete.PersistentActor.Tell(new DeleteMessagesFailure(cause, delete.ToSequenceNr), ActorRefs.NoSender);
+                        break;
+
                     case ReplayMessages replay:
                         replay.PersistentActor.Tell(new ReplayMessagesFailure(cause));
                         break;
-                    case DeleteMessagesTo delete:
-                        delete.PersistentActor.Tell(new DeleteMessagesFailure(cause, delete.ToSequenceNr));
-                        break;
+
                     case ReplayTaggedMessages replayTagged:
                         replayTagged.ReplyTo.Tell(new ReplayMessagesFailure(cause));
                         break;
+
                     case ReplayAllEvents replayAll:
                         replayAll.ReplyTo.Tell(new EventReplayFailure(cause));
                         break;
+
+                    default:
+                        throw new Exception($"Unknown persistence journal request type [{request.GetType()}]");
                 }
             }
+
+            TryProcess();
         }
 
         #region subscriptions
@@ -829,10 +878,20 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// <param name="message">TBD</param>
         protected void BatchRequest(IJournalRequest message)
         {
-            if (Buffer.Count > Setup.MaxBufferSize)
+            if (WriteBuffer.Count + ReadBuffer.Count > Setup.MaxBufferSize)
+            {
                 OnBufferOverflow(message);
+            }
             else
-                Buffer.Enqueue(message);
+            {
+                var id = _bufferIdCounter.GetAndIncrement();
+                // Enqueue writes and delete operation requests into the write queue,
+                // else if they are query operations, enqueue them into the read queue
+                if (message is WriteMessages || message is DeleteMessagesTo)
+                    WriteBuffer.Enqueue((message, id));
+                else
+                    ReadBuffer.Enqueue((message, id));
+            }
 
             TryProcess();
         }
@@ -870,25 +929,28 @@ namespace Akka.Persistence.Sql.Common.Journal
 
         private void TryProcess()
         {
-            if (_remainingOperations > 0 && Buffer.Count > 0)
+            if (_remainingOperations > 0 && (WriteBuffer.Count > 0 || ReadBuffer.Count > 0))
             {
                 _remainingOperations--;
 
                 var chunk = DequeueChunk(_remainingOperations);
                 var context = Context;
                 _circuitBreaker.WithCircuitBreaker(() => ExecuteChunk(chunk, context))
-                    .PipeTo(Self, failure: ex => new ChunkExecutionFailure(ex, chunk.Requests));
+                    .PipeTo(Self, failure: ex => new ChunkExecutionFailure(ex, chunk.Requests, chunk.ChunkId));
             }
         }
 
         private async Task<BatchComplete> ExecuteChunk(RequestChunk chunk, IActorContext context)
         {
-            Exception cause = null;
+            var writeResults = new Queue<WriteMessagesResult>();
+            var isWriteOperation = false;
             var stopwatch = new Stopwatch();
             using (var connection = CreateConnection(Setup.ConnectionString))
             {
                 await connection.OpenAsync();
 
+                // In the grand scheme of thing, using a transaction in an all read batch operation
+                // should not hurt performance by much, because it is done only once at the start.
                 using (var tx = connection.BeginTransaction(Setup.IsolationLevel))
                 using (var command = (TCommand)connection.CreateCommand())
                 {
@@ -897,20 +959,22 @@ namespace Akka.Persistence.Sql.Common.Journal
                     try
                     {
                         stopwatch.Start();
-                        for (int i = 0; i < chunk.Requests.Length; i++)
+                        // This looks dangerous at a glance, but we have separated read and write operations
+                        // in the DequeueChunk method. 
+                        foreach (var req in chunk.Requests)
                         {
-                            var req = chunk.Requests[i];
-
                             switch (req)
                             {
                                 case WriteMessages msg:
-                                    await HandleWriteMessages(msg, command);
+                                    isWriteOperation = true;
+                                    writeResults.Enqueue(await HandleWriteMessages(msg, command)); 
+                                    break;
+                                case DeleteMessagesTo msg:
+                                    isWriteOperation = true;
+                                    await HandleDeleteMessagesTo(msg, command);
                                     break;
                                 case ReplayMessages msg:
                                     await HandleReplayMessages(msg, command, context);
-                                    break;
-                                case DeleteMessagesTo msg:
-                                    await HandleDeleteMessagesTo(msg, command);
                                     break;
                                 case ReplayTaggedMessages msg:
                                     await HandleReplayTaggedMessages(msg, command);
@@ -926,21 +990,19 @@ namespace Akka.Persistence.Sql.Common.Journal
                                     break;
                             }
                         }
-
                         tx.Commit();
-
-                        if (CanPublish)
-                        {
-                            for (int i = 0; i < chunk.Requests.Length; i++)
-                            {
-                                context.System.EventStream.Publish(chunk.Requests[i]);
-                            }
-                        }
                     }
-                    catch (Exception e)
+                    catch (Exception e1)
                     {
-                        cause = e;
-                        tx.Rollback();
+                        try
+                        {
+                            tx.Rollback();
+                        }
+                        catch (Exception e2)
+                        {
+                            throw new AggregateException(e2, e1);
+                        }
+                        throw;
                     }
                     finally
                     {
@@ -949,7 +1011,33 @@ namespace Akka.Persistence.Sql.Common.Journal
                 }
             }
 
-            return new BatchComplete(chunk.ChunkId, chunk.Requests.Length, stopwatch.Elapsed, cause);
+            if (CanPublish)
+            {
+                foreach (var request in chunk.Requests)
+                {
+                    context.System.EventStream.Publish(request);
+                }
+            }
+
+            if (isWriteOperation)
+            {
+                foreach (var request in chunk.Requests)
+                {
+                    switch (request)
+                    {
+                        case WriteMessages _:
+                            writeResults.Dequeue().FinalizeSuccess(this);
+                            break;
+                        case DeleteMessagesTo req:
+                            req.PersistentActor.Tell(new DeleteMessagesSuccess(req.ToSequenceNr));
+                            break;
+                        default:
+                            throw new Exception($"Unknown database write operation {request.GetType()}");
+                    }
+                }
+            }
+
+            return new BatchComplete(chunk.ChunkId, chunk.Requests.Length, stopwatch.Elapsed);
         }
 
         protected virtual async Task HandleDeleteMessagesTo(DeleteMessagesTo req, TCommand command)
@@ -957,35 +1045,24 @@ namespace Akka.Persistence.Sql.Common.Journal
             var toSequenceNr = req.ToSequenceNr;
             var persistenceId = req.PersistenceId;
 
-            try
-            {
-                var highestSequenceNr = await ReadHighestSequenceNr(persistenceId, command);
+            var highestSequenceNr = await ReadHighestSequenceNr(persistenceId, command);
 
-                command.CommandText = DeleteBatchSql;
+            command.CommandText = DeleteBatchSql;
+            command.Parameters.Clear();
+            AddParameter(command, "@PersistenceId", DbType.String, persistenceId);
+            AddParameter(command, "@ToSequenceNr", DbType.Int64, toSequenceNr);
+
+            await command.ExecuteNonQueryAsync();
+
+            if (highestSequenceNr <= toSequenceNr)
+            {
+                command.CommandText = UpdateSequenceNrSql;
                 command.Parameters.Clear();
+
                 AddParameter(command, "@PersistenceId", DbType.String, persistenceId);
-                AddParameter(command, "@ToSequenceNr", DbType.Int64, toSequenceNr);
+                AddParameter(command, "@SequenceNr", DbType.Int64, highestSequenceNr);
 
                 await command.ExecuteNonQueryAsync();
-
-                if (highestSequenceNr <= toSequenceNr)
-                {
-                    command.CommandText = UpdateSequenceNrSql;
-                    command.Parameters.Clear();
-
-                    AddParameter(command, "@PersistenceId", DbType.String, persistenceId);
-                    AddParameter(command, "@SequenceNr", DbType.Int64, highestSequenceNr);
-
-                    await command.ExecuteNonQueryAsync();
-                }
-
-                var response = new DeleteMessagesSuccess(toSequenceNr);
-                req.PersistentActor.Tell(response);
-            }
-            catch (Exception cause)
-            {
-                var response = new DeleteMessagesFailure(cause, toSequenceNr);
-                req.PersistentActor.Tell(response, ActorRefs.NoSender); 
             }
         }
 
@@ -1168,116 +1245,47 @@ namespace Akka.Persistence.Sql.Common.Journal
             }
         }
 
-        private async Task HandleWriteMessages(WriteMessages req, TCommand command)
+        private async Task<WriteMessagesResult> HandleWriteMessages(WriteMessages req, TCommand command)
         {
-            IJournalResponse summary = null;
-            var responses = new List<(IJournalResponse, IActorRef)>();
             var tags = new HashSet<string>();
             var persistenceIds = new HashSet<string>();
-            var actorInstanceId = req.ActorInstanceId;
-            var atomicWriteCount = req.Messages.OfType<AtomicWrite>().Count();
 
-            try
+            command.CommandText = InsertEventSql;
+
+            var tagBuilder = new StringBuilder(16); // magic number                
+
+            foreach (var envelope in req.Messages.OfType<AtomicWrite>())
             {
-                command.CommandText = InsertEventSql;
-
-                var tagBuilder = new StringBuilder(16); // magic number                
-
-                foreach (var envelope in req.Messages)
+                var writes = (IImmutableList<IPersistentRepresentation>)envelope.Payload;
+                foreach (var unadapted in writes)
                 {
-                    if (envelope is AtomicWrite write)
+                    command.Parameters.Clear();
+                    tagBuilder.Clear();
+
+                    var persistent = AdaptToJournal(unadapted);
+                    if (persistent.Payload is Tagged tagged)
                     {
-                        var writes = (IImmutableList<IPersistentRepresentation>)write.Payload;
-                        foreach (var unadapted in writes)
+                        if (tagged.Tags.Count != 0)
                         {
-                            try
+                            tagBuilder.Append(';');
+                            foreach (var tag in tagged.Tags)
                             {
-                                command.Parameters.Clear();
-                                tagBuilder.Clear();
-
-                                var persistent = AdaptToJournal(unadapted);
-                                if (persistent.Payload is Tagged tagged)
-                                {
-                                    if (tagged.Tags.Count != 0)
-                                    {
-                                        tagBuilder.Append(';');
-                                        foreach (var tag in tagged.Tags)
-                                        {
-                                            tags.Add(tag);
-                                            tagBuilder.Append(tag).Append(';');
-                                        }
-                                    }
-                                    persistent = persistent.WithPayload(tagged.Payload);
-                                }
-
-                                WriteEvent(command, persistent.WithTimestamp(DateTime.UtcNow.Ticks), tagBuilder.ToString());
-
-                                await command.ExecuteNonQueryAsync();
-
-                                var response = (new WriteMessageSuccess(unadapted, actorInstanceId), unadapted.Sender);
-                                responses.Add(response);
-                                persistenceIds.Add(persistent.PersistenceId);
-                            }
-                            catch (DbException cause)
-                            {
-                                // database-related exceptions should result in failure                                
-                                summary = new WriteMessagesFailed(cause, atomicWriteCount);
-                                var response = (new WriteMessageFailure(unadapted, cause, actorInstanceId), unadapted.Sender);
-                                responses.Add(response);
-                            }
-                            catch (Exception cause)
-                            {
-                                //TODO: this scope wraps atomic write. Atomic writes have all-or-nothing commits.
-                                // so we should revert transaction here. But we need to check how this affect performance.
-
-                                var response = (new WriteMessageRejected(unadapted, cause, actorInstanceId), unadapted.Sender);
-                                responses.Add(response);
+                                tags.Add(tag);
+                                tagBuilder.Append(tag).Append(';');
                             }
                         }
+                        persistent = persistent.WithPayload(tagged.Payload);
                     }
-                    else
-                    {
-                        //TODO: other cases?
-                        var response = (new LoopMessageSuccess(envelope.Payload, actorInstanceId), envelope.Sender);
-                        responses.Add(response);
-                    }
-                }
 
-                if (HasTagSubscribers && tags.Count != 0)
-                {
-                    foreach (var tag in tags)
-                    {
-                        NotifyTagChanged(tag);
-                    }
-                }
+                    WriteEvent(command, persistent.WithTimestamp(DateTime.UtcNow.Ticks), tagBuilder.ToString());
 
-                if (HasPersistenceIdSubscribers)
-                {
-                    foreach (var persistenceId in persistenceIds)
-                    {
-                        NotifyPersistenceIdChanged(persistenceId);
-                    }
-                }
+                    await command.ExecuteNonQueryAsync();
 
-                if (HasNewEventsSubscribers)
-                {
-                    NotifyNewEventAppended();
+                    persistenceIds.Add(persistent.PersistenceId);
                 }
-
-                summary = summary ?? WriteMessagesSuccessful.Instance;
-            }
-            catch (Exception cause)
-            {
-                summary = new WriteMessagesFailed(cause, atomicWriteCount);
             }
 
-            var aref = req.PersistentActor;
-
-            aref.Tell(summary);
-            foreach (var r in responses)
-            {
-                aref.Tell(r.Item1, r.Item2);
-            }
+            return new WriteMessagesResult(req, tags, persistenceIds);
         }
 
         /// <summary>
@@ -1388,29 +1396,111 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// <param name="param">Parameter to customize</param>
         protected virtual void PreAddParameterToCommand(TCommand command, DbParameter param) { }
         
+        /// <summary>
+        /// Select the buffer that has the smallest id on its first item, retrieve a maximum Setup.MaxBatchSize
+        /// items from it, and return it as a chunk that needs to be batched
+        /// </summary>
         private RequestChunk DequeueChunk(int chunkId)
         {
-            var operationsCount = Math.Min(Buffer.Count, Setup.MaxBatchSize);
-            var array = new IJournalRequest[operationsCount];
-            for (int i = 0; i < operationsCount; i++)
-            {
-                var req = Buffer.Dequeue();
-                array[i] = req;
-            }
+            var currentBuffer = _buffers
+                .Where(q => q.Count > 0)
+                .OrderBy(q => q.Peek().id).First();
 
-            return new RequestChunk(chunkId, array);
+            var operations = new List<IJournalRequest>();
+            if (ReferenceEquals(currentBuffer, WriteBuffer))
+            {
+                // Stop dequeuing when we encounter another type of write operation request
+                // We don't batch delete and writes in the same batch, reason being a database
+                // can be deadlocked if write and delete happens in the same transaction
+                var writeType = currentBuffer.Peek().request.GetType();
+                while(currentBuffer.Count > 0 && currentBuffer.Peek().request.GetType() == writeType)
+                {
+                    operations.Add(currentBuffer.Dequeue().request);
+                    if (operations.Count == Setup.MaxBatchSize)
+                        break;
+                }
+            }
+            else
+            {
+                while(currentBuffer.Count > 0)
+                {
+                    operations.Add(currentBuffer.Dequeue().request);
+                    if (operations.Count == Setup.MaxBatchSize)
+                        break;
+                }
+            }
+            
+            return new RequestChunk(chunkId, operations.ToArray());
         }
 
         private void CompleteBatch(BatchComplete msg)
         {
             _remainingOperations++;
-            if (msg.Cause != null)
-            {
-                Log.Error(msg.Cause, "An error occurred during event batch processing (chunkId: {0})", msg.ChunkId);
-            }
-            else Log.Debug("Completed batch (chunkId: {0}) of {1} operations in {2} milliseconds", msg.ChunkId, msg.OperationCount, msg.TimeSpent.TotalMilliseconds);
+            Log.Debug("Completed batch (chunkId: {0}) of {1} operations in {2} milliseconds", msg.ChunkId, msg.OperationCount, msg.TimeSpent.TotalMilliseconds);
 
             TryProcess();
+        }
+
+        private class WriteMessagesResult
+        {
+            private readonly WriteMessages _request;
+
+            private readonly ImmutableHashSet<string> _tags;
+            private readonly ImmutableHashSet<string> _persistenceIds;
+
+            public WriteMessagesResult(
+                WriteMessages request,
+                IEnumerable<string> tags, 
+                IEnumerable<string> persistenceIds)
+            {
+                _request = request;
+                _tags = tags.ToImmutableHashSet();
+                _persistenceIds = persistenceIds.ToImmutableHashSet();
+            }
+
+            public void FinalizeSuccess(BatchingSqlJournal<TConnection, TCommand> journal)
+            {
+                var actorInstanceId = _request.ActorInstanceId;
+                var aRef = _request.PersistentActor;
+                aRef.Tell(WriteMessagesSuccessful.Instance);
+
+                foreach (var envelope in _request.Messages)
+                {
+                    if (!(envelope is AtomicWrite write))
+                    {
+                        aRef.Tell(new LoopMessageSuccess(envelope.Payload, actorInstanceId), envelope.Sender);
+                        continue;
+                    }
+
+                    var writes = (IImmutableList<IPersistentRepresentation>)write.Payload;
+                    foreach (var unadapted in writes)
+                    {
+                        aRef.Tell(new WriteMessageSuccess(unadapted, actorInstanceId), unadapted.Sender);
+                    }
+                }
+
+                if (journal.HasTagSubscribers && _tags.Count != 0)
+                {
+                    foreach (var tag in _tags)
+                    {
+                        journal.NotifyTagChanged(tag);
+                    }
+                }
+
+                if (journal.HasPersistenceIdSubscribers)
+                {
+                    foreach (var persistenceId in _persistenceIds)
+                    {
+                        journal.NotifyPersistenceIdChanged(persistenceId);
+                    }
+                }
+
+                if (journal.HasNewEventsSubscribers)
+                {
+                    journal.NotifyNewEventAppended();
+                }
+
+            }
         }
     }
 

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/BatchingSqlJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/BatchingSqlJournal.cs
@@ -13,6 +13,7 @@ using System.Data.Common;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
 using Akka.Actor;
@@ -257,14 +258,12 @@ namespace Akka.Persistence.Sql.Common.Journal
                 throw ConfigurationException.NullOrEmptyConfig<BatchingSqlJournalSetup>();
 
             var connectionString = config.GetString("connection-string", null);
-#if CONFIGURATION
             if (string.IsNullOrWhiteSpace(connectionString))
             {
                 connectionString = System.Configuration.ConfigurationManager
                     .ConnectionStrings[config.GetString("connection-string-name", "DefaultConnection")]?
                     .ConnectionString;
             }
-#endif
 
             if (string.IsNullOrWhiteSpace(connectionString))
                 throw new ConfigurationException("No connection string for Sql Event Journal was specified");
@@ -1522,6 +1521,16 @@ namespace Akka.Persistence.Sql.Common.Journal
             + "requests incoming faster than the underlying database is able to fulfill them. You may modify "
             + "`max-buffer-size`, `max-batch-size` and `max-concurrent-operations` HOCON settings in order to "
             + " change it.")
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JournalBufferOverflowException" /> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
+        protected JournalBufferOverflowException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/SqlJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/SqlJournal.cs
@@ -506,12 +506,10 @@ namespace Akka.Persistence.Sql.Common.Journal
         {
             var connectionString = _settings.ConnectionString;
 
-#if CONFIGURATION
             if (string.IsNullOrEmpty(connectionString))
             {
                 connectionString = System.Configuration.ConfigurationManager.ConnectionStrings[_settings.ConnectionStringName].ConnectionString;
             }
-#endif
 
             return connectionString;
         }

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Snapshot/SqlSnapshotStore.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Snapshot/SqlSnapshotStore.cs
@@ -149,12 +149,10 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         {
             var connectionString = _settings.ConnectionString;
 
-#if CONFIGURATION
             if (string.IsNullOrEmpty(connectionString))
             {
                 connectionString = System.Configuration.ConfigurationManager.ConnectionStrings[_settings.ConnectionStringName].ConnectionString;
             }
-#endif
 
             return connectionString;
         }

--- a/src/contrib/persistence/Akka.Persistence.Sql.TestKit/Akka.Persistence.Sql.TestKit.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sql.TestKit/Akka.Persistence.Sql.TestKit.csproj
@@ -16,10 +16,6 @@
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Akka.Persistence.Sqlite.Tests.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Akka.Persistence.Sqlite.Tests.csproj
@@ -27,10 +27,6 @@
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZABLE</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Akka.Persistence.Sqlite.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Akka.Persistence.Sqlite.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SQLite" Version="5.0.5" />
+    <PackageReference Include="Microsoft.Data.SQLite" Version="5.0.6" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/contrib/serializers/Akka.Serialization.Hyperion/Akka.Serialization.Hyperion.csproj
+++ b/src/contrib/serializers/Akka.Serialization.Hyperion/Akka.Serialization.Hyperion.csproj
@@ -12,6 +12,14 @@
     <PackageReference Include="Hyperion" Version="$(HyperionVersion)" />
     <ProjectReference Include="..\..\..\core\Akka\Akka.csproj" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
+    <PackageReference Include="System.Reflection" Version="4.3.0" />
+    <PackageReference Include="System.Runtime" Version="4.3.1" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkLibVersion)' ">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>

--- a/src/contrib/serializers/Akka.Serialization.TestKit/Akka.Serialization.TestKit.csproj
+++ b/src/contrib/serializers/Akka.Serialization.TestKit/Akka.Serialization.TestKit.csproj
@@ -13,4 +13,9 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj" />
   </ItemGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+  </PropertyGroup>
+
 </Project>

--- a/src/contrib/testkits/Akka.TestKit.Xunit/Internals/AkkaEqualException.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit/Internals/AkkaEqualException.cs
@@ -33,7 +33,6 @@ namespace Akka.TestKit.Xunit.Internals
             _args = args;
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="AkkaEqualException"/> class.
         /// </summary>
@@ -43,7 +42,7 @@ namespace Akka.TestKit.Xunit.Internals
             : base(info, context)
         {
         }
-#endif
+
         /// <summary>
         /// The message that describes the error.
         /// </summary>

--- a/src/contrib/testkits/Akka.TestKit.Xunit2/Internals/AkkaEqualException.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit2/Internals/AkkaEqualException.cs
@@ -33,7 +33,6 @@ namespace Akka.TestKit.Xunit2.Internals
             _args = args;
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="AkkaEqualException"/> class.
         /// </summary>
@@ -43,7 +42,7 @@ namespace Akka.TestKit.Xunit2.Internals
             : base(info, context)
         {
         }
-#endif
+
         /// <summary>
         /// The message that describes the error.
         /// </summary>

--- a/src/contrib/testkits/Akka.TestKit.Xunit2/Internals/Loggers.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit2/Internals/Loggers.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using Akka.Actor;
 using Akka.Event;
 using Xunit.Abstractions;
@@ -16,20 +17,44 @@ namespace Akka.TestKit.Xunit2.Internals
     /// </summary>
     public class TestOutputLogger : ReceiveActor
     {
+        private readonly ITestOutputHelper _output;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TestOutputLogger"/> class.
         /// </summary>
         /// <param name="output">The provider used to write test output.</param>
         public TestOutputLogger(ITestOutputHelper output)
         {
-            Receive<Debug>(e => output.WriteLine(e.ToString()));
-            Receive<Info>(e => output.WriteLine(e.ToString()));
-            Receive<Warning>(e => output.WriteLine(e.ToString()));
-            Receive<Error>(e => output.WriteLine(e.ToString()));
+            _output = output;
+
+            Receive<Debug>(HandleLogEvent);
+            Receive<Info>(HandleLogEvent);
+            Receive<Warning>(HandleLogEvent);
+            Receive<Error>(HandleLogEvent);
             Receive<InitializeLogger>(e =>
             {
                 e.LoggingBus.Subscribe(Self, typeof (LogEvent));
             });
+        }
+
+        private void HandleLogEvent(LogEvent e)
+        {
+            try
+            {
+                _output.WriteLine(e.ToString());
+            }
+            catch (FormatException ex)
+            {
+                if (e.Message is LogMessage msg)
+                {
+                    var message =
+                        $"Received a malformed formatted message. Log level: [{e.LogLevel()}], Template: [{msg.Format}], args: [{string.Join(",", msg.Args)}]";
+                    if(e.Cause != null)
+                        throw new AggregateException(message, ex, e.Cause);
+                    throw new FormatException(message, ex);
+                }
+                throw;
+            }
         }
     }
 }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCluster.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCluster.approved.txt
@@ -176,6 +176,7 @@ namespace Akka.Cluster
     public class ClusterJoinFailedException : Akka.Actor.AkkaException
     {
         public ClusterJoinFailedException(string message) { }
+        protected ClusterJoinFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class ClusterScope : Akka.Actor.Scope
     {

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveClusterTools.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveClusterTools.approved.txt
@@ -345,6 +345,7 @@ namespace Akka.Cluster.Tools.Singleton
     public sealed class ClusterSingletonManagerIsStuckException : Akka.Actor.AkkaException
     {
         public ClusterSingletonManagerIsStuckException(string message) { }
+        public ClusterSingletonManagerIsStuckException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public sealed class ClusterSingletonManagerSettings : Akka.Actor.INoSerializationVerificationNeeded
     {

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCoordination.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCoordination.approved.txt
@@ -15,6 +15,7 @@ namespace Akka.Coordination
     {
         public LeaseException(string message) { }
         public LeaseException(string message, System.Exception innerEx) { }
+        protected LeaseException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class LeaseProvider : Akka.Actor.IExtension
     {
@@ -43,6 +44,7 @@ namespace Akka.Coordination
     {
         public LeaseTimeoutException(string message) { }
         public LeaseTimeoutException(string message, System.Exception innerEx) { }
+        protected LeaseTimeoutException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public sealed class LeaseUsageSettings
     {

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -151,21 +151,26 @@ namespace Akka.Actor
         public ActorInitializationException(string message) { }
         public ActorInitializationException(string message, System.Exception cause) { }
         public ActorInitializationException(Akka.Actor.IActorRef actor, string message, System.Exception cause = null) { }
+        protected ActorInitializationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public Akka.Actor.IActorRef Actor { get; set; }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public override string ToString() { }
     }
     public class ActorInterruptedException : Akka.Actor.AkkaException
     {
         public ActorInterruptedException(string message = null, System.Exception cause = null) { }
+        protected ActorInterruptedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class ActorKilledException : Akka.Actor.AkkaException
     {
         public ActorKilledException() { }
         public ActorKilledException(string message) { }
+        protected ActorKilledException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class ActorNotFoundException : Akka.Actor.AkkaException
     {
         public ActorNotFoundException() { }
+        protected ActorNotFoundException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public ActorNotFoundException(string message, System.Exception innerException = null) { }
     }
     public abstract class ActorPath : Akka.Util.ISurrogated, System.IComparable<Akka.Actor.ActorPath>, System.IEquatable<Akka.Actor.ActorPath>
@@ -384,7 +389,7 @@ namespace Akka.Actor
             where T :  class, Akka.Actor.IExtension
             where TI : Akka.Actor.IExtensionId { }
     }
-    public sealed class Address : Akka.Util.ISurrogated, System.IComparable, System.IComparable<Akka.Actor.Address>, System.IEquatable<Akka.Actor.Address>
+    public sealed class Address : Akka.Util.ISurrogated, System.ICloneable, System.IComparable, System.IComparable<Akka.Actor.Address>, System.IEquatable<Akka.Actor.Address>
     {
         public static readonly Akka.Actor.Address AllSystems;
         public static readonly System.Collections.Generic.IComparer<Akka.Actor.Address> Comparer;
@@ -424,6 +429,7 @@ namespace Akka.Actor
     {
         protected AkkaException() { }
         protected AkkaException(string message, System.Exception cause = null) { }
+        protected AkkaException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         protected System.Exception Cause { get; }
     }
     public class AllForOneStrategy : Akka.Actor.SupervisorStrategy, System.IEquatable<Akka.Actor.AllForOneStrategy>
@@ -458,6 +464,7 @@ namespace Akka.Actor
     public class AskTimeoutException : Akka.Actor.AkkaException
     {
         public AskTimeoutException(string message) { }
+        protected AskTimeoutException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public sealed class BootstrapSetup : Akka.Actor.Setup.Setup
     {
@@ -577,7 +584,9 @@ namespace Akka.Actor
     public class DeathPactException : Akka.Actor.AkkaException
     {
         public DeathPactException(Akka.Actor.IActorRef deadActor) { }
+        protected DeathPactException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public Akka.Actor.IActorRef DeadActor { get; }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class static Decider
     {
@@ -1160,10 +1169,12 @@ namespace Akka.Actor
     public class IllegalActorNameException : Akka.Actor.AkkaException
     {
         public IllegalActorNameException(string message) { }
+        protected IllegalActorNameException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class IllegalActorStateException : Akka.Actor.AkkaException
     {
         public IllegalActorStateException(string message) { }
+        protected IllegalActorStateException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class Inbox : Akka.Actor.ICanWatch, Akka.Actor.IInboxable, System.IDisposable
     {
@@ -1204,11 +1215,13 @@ namespace Akka.Actor
     {
         public InvalidActorNameException(string message) { }
         public InvalidActorNameException(string message, System.Exception innerException) { }
+        protected InvalidActorNameException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class InvalidMessageException : Akka.Actor.AkkaException
     {
         public InvalidMessageException() { }
         public InvalidMessageException(string message) { }
+        protected InvalidMessageException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public sealed class Kill : Akka.Actor.IAutoReceivedMessage
     {
@@ -1293,6 +1306,7 @@ namespace Akka.Actor
         public LoggerInitializationException() { }
         public LoggerInitializationException(string message) { }
         public LoggerInitializationException(string message, System.Exception cause = null) { }
+        protected LoggerInitializationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     [Akka.Annotations.InternalApiAttribute()]
     public abstract class MinimalActorRef : Akka.Actor.InternalActorRefBase, Akka.Actor.IActorRefScope
@@ -1374,11 +1388,17 @@ namespace Akka.Actor
     public class PostRestartException : Akka.Actor.ActorInitializationException
     {
         public PostRestartException(Akka.Actor.IActorRef actor, System.Exception cause, System.Exception originalCause) { }
+        protected PostRestartException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public System.Exception OriginalCause { get; }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
-    public class PreRestartException : Akka.Actor.AkkaException
+    public class PreRestartException : Akka.Actor.ActorInitializationException
     {
         public PreRestartException(Akka.Actor.IActorRef actor, System.Exception restartException, System.Exception cause, object optionalMessage) { }
+        protected PreRestartException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public object OptionalMessage { get; }
+        public System.Exception RestartException { get; }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class Props : Akka.Util.ISurrogated, System.IEquatable<Akka.Actor.Props>
     {
@@ -1577,6 +1597,7 @@ namespace Akka.Actor
     public sealed class SchedulerException : Akka.Actor.AkkaException
     {
         public SchedulerException(string message) { }
+        protected SchedulerException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class static SchedulerExtensions
     {
@@ -1692,6 +1713,7 @@ namespace Akka.Actor
     public class StashOverflowException : Akka.Actor.AkkaException
     {
         public StashOverflowException(string message, System.Exception cause = null) { }
+        protected StashOverflowException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public abstract class Status
     {
@@ -2206,6 +2228,7 @@ namespace Akka.Configuration
     {
         public ConfigurationException(string message) { }
         public ConfigurationException(string message, System.Exception exception) { }
+        protected ConfigurationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public static Akka.Configuration.ConfigurationException NullOrEmptyConfig<T>(string path = null) { }
     }
     public class ConfigurationFactory
@@ -2642,6 +2665,7 @@ namespace Akka.Dispatch
     public class RejectedExecutionException : Akka.Actor.AkkaException
     {
         public RejectedExecutionException(string message = null, System.Exception inner = null) { }
+        protected RejectedExecutionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class ThreadPoolConfig
     {
@@ -3192,6 +3216,7 @@ namespace Akka.IO.Buffers
     public class BufferPoolAllocationException : Akka.Actor.AkkaException
     {
         public BufferPoolAllocationException(string message) { }
+        protected BufferPoolAllocationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public interface IBufferPool
     {
@@ -3973,6 +3998,7 @@ namespace Akka.Pattern
     {
         public IllegalStateException(string message) { }
         public IllegalStateException(string message, System.Exception innerEx) { }
+        protected IllegalStateException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class OpenCircuitException : Akka.Actor.AkkaException
     {
@@ -3983,7 +4009,9 @@ namespace Akka.Pattern
         public OpenCircuitException(string message, System.Exception cause, System.TimeSpan remainingDuration) { }
         public OpenCircuitException(System.Exception cause) { }
         public OpenCircuitException(System.Exception cause, System.TimeSpan remainingDuration) { }
+        protected OpenCircuitException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public System.TimeSpan RemainingDuration { get; }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class static RetrySupport
     {
@@ -3995,6 +4023,7 @@ namespace Akka.Pattern
     public class UserCalledFailException : Akka.Actor.AkkaException
     {
         public UserCalledFailException() { }
+        protected UserCalledFailException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
 }
 namespace Akka.Routing

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveDistributedData.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveDistributedData.approved.txt
@@ -42,6 +42,7 @@ namespace Akka.DistributedData
     public class DataDeletedException : System.Exception
     {
         public DataDeletedException(string message) { }
+        protected DataDeletedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public sealed class Delete : Akka.Actor.INoSerializationVerificationNeeded, System.IEquatable<Akka.DistributedData.Delete>
     {
@@ -981,6 +982,7 @@ namespace Akka.DistributedData.Durable
     {
         public LoadFailedException(string message) { }
         public LoadFailedException(string message, System.Exception cause) { }
+        public LoadFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public sealed class Store
     {

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistence.approved.txt
@@ -362,6 +362,7 @@ namespace Akka.Persistence
         public MaxUnconfirmedMessagesExceededException() { }
         public MaxUnconfirmedMessagesExceededException(string message) { }
         public MaxUnconfirmedMessagesExceededException(string message, System.Exception innerException) { }
+        protected MaxUnconfirmedMessagesExceededException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class Persistence : Akka.Actor.ExtensionIdProvider<Akka.Persistence.PersistenceExtension>
     {
@@ -505,6 +506,7 @@ namespace Akka.Persistence
     {
         public RecoveryTimedOutException() { }
         public RecoveryTimedOutException(string message, System.Exception cause = null) { }
+        public RecoveryTimedOutException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public sealed class ReplayMessages : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalRequest, Akka.Persistence.IPersistenceMessage, System.IEquatable<Akka.Persistence.ReplayMessages>
     {
@@ -827,6 +829,7 @@ namespace Akka.Persistence.Journal
     {
         public AsyncReplayTimeoutException() { }
         public AsyncReplayTimeoutException(string message) { }
+        protected AsyncReplayTimeoutException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public abstract class AsyncWriteJournal : Akka.Persistence.Journal.WriteJournalBase, Akka.Persistence.Journal.IAsyncRecovery
     {
@@ -1109,6 +1112,7 @@ namespace Akka.Persistence.Snapshot
             public NoSnapshotStoreException() { }
             public NoSnapshotStoreException(string message) { }
             public NoSnapshotStoreException(string message, System.Exception innerException) { }
+            protected NoSnapshotStoreException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         }
     }
     public class SnapshotEntry

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistenceSqlCommon.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistenceSqlCommon.approved.txt
@@ -187,6 +187,7 @@ namespace Akka.Persistence.Sql.Common.Journal
     {
         public static readonly Akka.Persistence.Sql.Common.Journal.JournalBufferOverflowException Instance;
         public JournalBufferOverflowException() { }
+        protected JournalBufferOverflowException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public sealed class JournalEntry
     {

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistenceSqlCommon.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistenceSqlCommon.approved.txt
@@ -74,7 +74,6 @@ namespace Akka.Persistence.Sql.Common.Journal
         where TConnection : System.Data.Common.DbConnection
         where TCommand : System.Data.Common.DbCommand
     {
-        protected readonly System.Collections.Generic.Queue<Akka.Persistence.IJournalRequest> Buffer;
         protected readonly bool CanPublish;
         protected const int IsDeletedIndex = 3;
         protected readonly Akka.Event.ILoggingAdapter Log;

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveRemote.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveRemote.approved.txt
@@ -434,11 +434,11 @@ namespace Akka.Remote.Serialization
         public override string Manifest(object obj) { }
         public override byte[] ToBinary(object obj) { }
     }
-    public sealed class PrimitiveSerializers : Akka.Serialization.Serializer
+    public sealed class PrimitiveSerializers : Akka.Serialization.SerializerWithStringManifest
     {
         public PrimitiveSerializers(Akka.Actor.ExtendedActorSystem system) { }
-        public override bool IncludeManifest { get; }
-        public override object FromBinary(byte[] bytes, System.Type type) { }
+        public override object FromBinary(byte[] bytes, string manifest) { }
+        public override string Manifest(object obj) { }
         public override byte[] ToBinary(object obj) { }
     }
     public class ProtobufSerializer : Akka.Serialization.Serializer

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveRemote.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveRemote.approved.txt
@@ -284,6 +284,7 @@ namespace Akka.Remote
     public class RemoteTransportException : Akka.Actor.AkkaException
     {
         public RemoteTransportException(string message, System.Exception cause = null) { }
+        protected RemoteTransportException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class RemoteWatcher : Akka.Actor.UntypedActor, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedMessageQueueSemantics>
     {
@@ -502,6 +503,7 @@ namespace Akka.Remote.Transport
     public class AkkaProtocolException : Akka.Actor.AkkaException
     {
         public AkkaProtocolException(string message, System.Exception cause = null) { }
+        protected AkkaProtocolException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public sealed class AssociateAttempt : Akka.Remote.Transport.Activity
     {
@@ -602,6 +604,7 @@ namespace Akka.Remote.Transport
     public class InvalidAssociationException : Akka.Actor.AkkaException
     {
         public InvalidAssociationException(string message, System.Exception cause = null) { }
+        protected InvalidAssociationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public sealed class ListenAttempt : Akka.Remote.Transport.Activity
     {

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
@@ -890,6 +890,10 @@ namespace Akka.Streams
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
     }
+    public class StreamDetachedException : System.Exception
+    {
+        public static readonly Akka.Streams.StreamDetachedException Instance;
+    }
     public class StreamLimitReachedException : System.Exception
     {
         public StreamLimitReachedException(long max) { }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
@@ -12,11 +12,13 @@ namespace Akka.Streams
     public sealed class AbruptStageTerminationException : System.Exception
     {
         public AbruptStageTerminationException(Akka.Streams.Stage.GraphStageLogic logic) { }
+        protected AbruptStageTerminationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class AbruptTerminationException : System.Exception
     {
         public readonly Akka.Actor.IActorRef Actor;
         public AbruptTerminationException(Akka.Actor.IActorRef actor) { }
+        protected AbruptTerminationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class static ActorAttributes
     {
@@ -280,11 +282,13 @@ namespace Akka.Streams
     public class BindFailedException : Akka.Streams.StreamTcpException
     {
         public static readonly Akka.Streams.BindFailedException Instance;
+        protected BindFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class BufferOverflowException : System.Exception
     {
         public BufferOverflowException(string message) { }
         public BufferOverflowException(string message, System.Exception innerException) { }
+        protected BufferOverflowException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class ClosedShape : Akka.Streams.Shape
     {
@@ -298,6 +302,7 @@ namespace Akka.Streams
     {
         public ConnectionException(string message) { }
         public ConnectionException(string message, System.Exception innerException) { }
+        protected ConnectionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class static Construct
     {
@@ -757,12 +762,14 @@ namespace Akka.Streams
     public sealed class InvalidPartnerActorException : Akka.Pattern.IllegalStateException
     {
         public InvalidPartnerActorException(Akka.Actor.IActorRef expectedRef, Akka.Actor.IActorRef gotRef, string message) { }
+        protected InvalidPartnerActorException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public Akka.Actor.IActorRef ExpectedRef { get; }
         public Akka.Actor.IActorRef GotRef { get; }
     }
     public sealed class InvalidSequenceNumberException : Akka.Pattern.IllegalStateException
     {
         public InvalidSequenceNumberException(long expectedSeqNr, long gotSeqNr, string message) { }
+        protected InvalidSequenceNumberException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public long ExpectedSeqNr { get; }
         public long GotSeqNr { get; }
     }
@@ -783,6 +790,7 @@ namespace Akka.Streams
     public class MaterializationException : System.Exception
     {
         public MaterializationException(string message, System.Exception innerException) { }
+        protected MaterializationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public sealed class NoMaterializer : Akka.Streams.IMaterializer
     {
@@ -797,6 +805,7 @@ namespace Akka.Streams
     public class NoSuchElementException : System.Exception
     {
         public NoSuchElementException(string message) { }
+        protected NoSuchElementException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public abstract class OutPort
     {
@@ -848,8 +857,9 @@ namespace Akka.Streams
     public sealed class RemoteStreamRefActorTerminatedException : System.Exception
     {
         public RemoteStreamRefActorTerminatedException(string message) { }
+        protected RemoteStreamRefActorTerminatedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
-    public abstract class Shape
+    public abstract class Shape : System.ICloneable
     {
         protected Shape() { }
         public abstract System.Collections.Immutable.ImmutableArray<Akka.Streams.Inlet> Inlets { get; }
@@ -897,6 +907,7 @@ namespace Akka.Streams
     public class StreamLimitReachedException : System.Exception
     {
         public StreamLimitReachedException(long max) { }
+        protected StreamLimitReachedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class static StreamRefAttributes
     {
@@ -945,6 +956,7 @@ namespace Akka.Streams
     public sealed class StreamRefSubscriptionTimeoutException : Akka.Pattern.IllegalStateException
     {
         public StreamRefSubscriptionTimeoutException(string message) { }
+        protected StreamRefSubscriptionTimeoutException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public sealed class StreamSubscriptionTimeoutSettings : System.IEquatable<Akka.Streams.StreamSubscriptionTimeoutSettings>
     {
@@ -967,6 +979,7 @@ namespace Akka.Streams
     {
         public StreamTcpException(string message) { }
         public StreamTcpException(string message, System.Exception innerException) { }
+        protected StreamTcpException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public enum SubstreamCancelStrategy
     {
@@ -976,6 +989,7 @@ namespace Akka.Streams
     public sealed class TargetRefNotInitializedYetException : Akka.Pattern.IllegalStateException
     {
         public TargetRefNotInitializedYetException() { }
+        protected TargetRefNotInitializedYetException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public enum ThrottleMode
     {
@@ -1021,6 +1035,7 @@ namespace Akka.Streams
     public class WatchedActorTerminatedException : Akka.Actor.AkkaException
     {
         public WatchedActorTerminatedException(string stageName, Akka.Actor.IActorRef actorRef) { }
+        protected WatchedActorTerminatedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
 }
 namespace Akka.Streams.Actors
@@ -1458,6 +1473,7 @@ namespace Akka.Streams.Dsl
         public class FramingException : System.Exception
         {
             public FramingException(string message) { }
+            protected FramingException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         }
     }
     public class static GraphDsl
@@ -1692,6 +1708,7 @@ namespace Akka.Streams.Dsl
     public class OutputTruncationException : System.Exception
     {
         public OutputTruncationException() { }
+        protected OutputTruncationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class static PagedSource
     {
@@ -1722,6 +1739,7 @@ namespace Akka.Streams.Dsl
     public sealed class PartitionOutOfBoundsException : System.Exception
     {
         public PartitionOutOfBoundsException(string message) { }
+        protected PartitionOutOfBoundsException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class PartitionWith<TIn, TOut0, TOut1> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanOutShape<TIn, TOut0, TOut1>>
     {
@@ -2209,6 +2227,7 @@ namespace Akka.Streams.Dsl
     public sealed class TcpIdleTimeoutException : System.TimeoutException
     {
         public TcpIdleTimeoutException(string message, System.TimeSpan duration) { }
+        protected TcpIdleTimeoutException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public System.TimeSpan Duration { get; }
     }
     public class static TcpStreamExtensions
@@ -2223,6 +2242,7 @@ namespace Akka.Streams.Dsl
     public class UnexpectedOutputException : System.Exception
     {
         public UnexpectedOutputException(object element) { }
+        protected UnexpectedOutputException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class UnzipWith
     {
@@ -3164,6 +3184,7 @@ namespace Akka.Streams.Implementation
         public class MaterializationPanicException : System.Exception
         {
             public MaterializationPanicException(System.Exception innerException) { }
+            protected MaterializationPanicException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         }
     }
     [Akka.Annotations.InternalApiAttribute()]
@@ -3222,10 +3243,12 @@ namespace Akka.Streams.Implementation
     public class NormalShutdownException : Akka.Pattern.IllegalStateException
     {
         public NormalShutdownException(string message) { }
+        protected NormalShutdownException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class NothingToReadException : System.Exception
     {
         public static readonly Akka.Streams.Implementation.NothingToReadException Instance;
+        protected NothingToReadException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class OutputBunch<T>
     {
@@ -3386,6 +3409,7 @@ namespace Akka.Streams.Implementation
     public class SignalThrewException : Akka.Pattern.IllegalStateException, Akka.Streams.Implementation.ISpecViolation
     {
         public SignalThrewException(string message, System.Exception cause) { }
+        protected SignalThrewException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class SimpleOutputs
     {
@@ -3584,6 +3608,7 @@ namespace Akka.Streams.Implementation
     {
         public SubscriptionTimeoutException(string message) { }
         public SubscriptionTimeoutException(string message, System.Exception innerException) { }
+        protected SubscriptionTimeoutException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     [Akka.Annotations.InternalApiAttribute()]
     public class Throttle<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
@@ -4842,6 +4867,7 @@ namespace Akka.Streams.Stage
     public class StageActorRefNotInitializedException : System.Exception
     {
         public static readonly Akka.Streams.Stage.StageActorRefNotInitializedException Instance;
+        protected StageActorRefNotInitializedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public abstract class StageState<TIn, TOut>
     {

--- a/src/core/Akka.Cluster.TestKit/Akka.Cluster.TestKit.csproj
+++ b/src/core/Akka.Cluster.TestKit/Akka.Cluster.TestKit.csproj
@@ -14,10 +14,6 @@
     <ProjectReference Include="..\Akka.Cluster\Akka.Cluster.csproj" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Cluster.Tests.MultiNode/Akka.Cluster.Tests.MultiNode.csproj
+++ b/src/core/Akka.Cluster.Tests.MultiNode/Akka.Cluster.Tests.MultiNode.csproj
@@ -23,10 +23,6 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' OR '$(TargetFramework)' == '$(NetTestVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
+++ b/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
@@ -22,14 +22,6 @@
     <PackageReference Include="Fsharp.Core" Version="5.0.1" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZABLE;</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' OR '$(TargetFramework)' == '$(NetTestVersion)'">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Cluster/Akka.Cluster.csproj
+++ b/src/core/Akka.Cluster/Akka.Cluster.csproj
@@ -15,10 +15,6 @@
     <ProjectReference Include="..\Akka.Remote\Akka.Remote.csproj" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Cluster/Cluster.cs
+++ b/src/core/Akka.Cluster/Cluster.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
@@ -713,6 +714,16 @@ namespace Akka.Cluster
     public class ClusterJoinFailedException : AkkaException
     {
         public ClusterJoinFailedException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClusterJoinFailedException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        protected ClusterJoinFailedException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/core/Akka.Cluster/ClusterRemoteWatcher.cs
+++ b/src/core/Akka.Cluster/ClusterRemoteWatcher.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Akka.Actor;
+using Akka.Dispatch;
 using Akka.Remote;
 
 namespace Akka.Cluster
@@ -31,19 +32,21 @@ namespace Akka.Cluster
         /// <param name="heartbeatInterval">TBD</param>
         /// <param name="unreachableReaperInterval">TBD</param>
         /// <param name="heartbeatExpectedResponseAfter">TBD</param>
-        public static Props Props(
+        public new static Props Props(
             IFailureDetectorRegistry<Address> failureDetector,
             TimeSpan heartbeatInterval,
             TimeSpan unreachableReaperInterval,
             TimeSpan heartbeatExpectedResponseAfter)
         {
             return new Props(typeof(ClusterRemoteWatcher), new object[]
-            {
-                failureDetector, 
-                heartbeatInterval, 
-                unreachableReaperInterval, 
-                heartbeatExpectedResponseAfter
-            }).WithDeploy(Deploy.Local);
+                {
+                    failureDetector, 
+                    heartbeatInterval, 
+                    unreachableReaperInterval, 
+                    heartbeatExpectedResponseAfter
+                })
+                .WithDispatcher(Dispatchers.InternalDispatcherId)
+                .WithDeploy(Deploy.Local);
         }
 
         private readonly Cluster _cluster;

--- a/src/core/Akka.Coordination.Tests/Akka.Coordination.Tests.csproj
+++ b/src/core/Akka.Coordination.Tests/Akka.Coordination.Tests.csproj
@@ -20,14 +20,6 @@
     <PackageReference Include="FsCheck.Xunit" Version="$(FsCheckVersion)" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZABLE;</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' OR '$(TargetFramework)' == '$(NetTestVersion)'">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Coordination/Akka.Coordination.csproj
+++ b/src/core/Akka.Coordination/Akka.Coordination.csproj
@@ -9,10 +9,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Coordination/LeaseException.cs
+++ b/src/core/Akka.Coordination/LeaseException.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Akka.Coordination
 {
@@ -32,12 +33,10 @@ namespace Akka.Coordination
         {
         }
 
-#if SERIALIZATION
         protected LeaseException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
 
         }
-#endif
     }
 }

--- a/src/core/Akka.Coordination/LeaseTimeoutException.cs
+++ b/src/core/Akka.Coordination/LeaseTimeoutException.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Akka.Coordination
 {
@@ -32,12 +33,10 @@ namespace Akka.Coordination
         {
         }
 
-#if SERIALIZATION
         protected LeaseTimeoutException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
 
         }
-#endif
     }
 }

--- a/src/core/Akka.Discovery/Akka.Discovery.csproj
+++ b/src/core/Akka.Discovery/Akka.Discovery.csproj
@@ -23,10 +23,6 @@
     <ProjectReference Include="..\Akka\Akka.csproj" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.MultiNodeTestRunner.Shared.Tests/Akka.MultiNodeTestRunner.Shared.Tests.csproj
+++ b/src/core/Akka.MultiNodeTestRunner.Shared.Tests/Akka.MultiNodeTestRunner.Shared.Tests.csproj
@@ -27,10 +27,6 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' OR '$(TargetFramework)' == '$(NetTestVersion)'">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Akka.MultiNodeTestRunner.Shared.csproj
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Akka.MultiNodeTestRunner.Shared.csproj
@@ -33,10 +33,6 @@
     </Content>
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.MultiNodeTestRunner.Shared/CompilerErrorCollection.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/CompilerErrorCollection.cs
@@ -9,7 +9,6 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 
-#if CORECLR
 namespace System.CodeDom.Compiler
 {
     public class CompilerErrorCollection : List<CompilerError>
@@ -22,4 +21,3 @@ namespace System.CodeDom.Compiler
         public bool IsWarning { get; set; }
     }
 }
-#endif

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Extensions/DateTimeExtension.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Extensions/DateTimeExtension.cs
@@ -12,7 +12,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-#if CORECLR
 namespace Akka.MultiNodeTestRunner.Shared.Extensions
 {
     internal static class DateTimeExtension
@@ -23,4 +22,3 @@ namespace Akka.MultiNodeTestRunner.Shared.Extensions
         }
     }
 }
-#endif

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Extensions/TypeExtension.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Extensions/TypeExtension.cs
@@ -12,7 +12,6 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
-#if CORECLR
 namespace Akka.MultiNodeTestRunner.Shared.Extensions
 {
     internal static class TypeExtension
@@ -23,4 +22,3 @@ namespace Akka.MultiNodeTestRunner.Shared.Extensions
         }
     }
 }
-#endif

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Persistence/VisualizerRuntimeTemplate.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Persistence/VisualizerRuntimeTemplate.cs
@@ -15,10 +15,6 @@
 // </auto-generated>
 // ------------------------------------------------------------------------------
 
-#if CORECLR
-using Akka.MultiNodeTestRunner.Shared.Extensions;
-#endif
-
 namespace Akka.MultiNodeTestRunner.Shared.Persistence
 {
     using System.Linq;

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/ConsoleMessageSinkActor.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/ConsoleMessageSinkActor.cs
@@ -9,9 +9,6 @@ using System;
 using System.Linq;
 using Akka.Actor;
 using Akka.Event;
-#if CORECLR
-using Akka.MultiNodeTestRunner.Shared.Extensions;
-#endif
 using Akka.MultiNodeTestRunner.Shared.Reporting;
 
 namespace Akka.MultiNodeTestRunner.Shared.Sinks

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/SinkCoordinator.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/SinkCoordinator.cs
@@ -187,11 +187,7 @@ namespace Akka.MultiNodeTestRunner.Shared.Sinks
         {
             foreach (var sink in Sinks)
             {
-#if CORECLR
-                sink.LogRunnerMessage(message.Message, Assembly.GetEntryAssembly().GetName().Name, LogLevel.InfoLevel);
-#else
                 sink.LogRunnerMessage(message.Message, Assembly.GetExecutingAssembly().GetName().Name, LogLevel.InfoLevel);
-#endif
             }
         }
 

--- a/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/TeamCityMessageSinkActor.cs
+++ b/src/core/Akka.MultiNodeTestRunner.Shared/Sinks/TeamCityMessageSinkActor.cs
@@ -13,9 +13,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
-#if CORECLR
-using Akka.MultiNodeTestRunner.Shared.Extensions;
-#endif
 using Akka.MultiNodeTestRunner.Shared.Reporting;
 using JetBrains.TeamCity.ServiceMessages;
 using JetBrains.TeamCity.ServiceMessages.Write.Special;

--- a/src/core/Akka.MultiNodeTestRunner/Discovery.cs
+++ b/src/core/Akka.MultiNodeTestRunner/Discovery.cs
@@ -20,11 +20,7 @@ using Xunit.Sdk;
 
 namespace Akka.MultiNodeTestRunner
 {
-#if CORECLR
-    public class Discovery : IMessageSink, IDisposable
-#else
     public class Discovery : MarshalByRefObject, IMessageSink, IDisposable
-#endif
     {
         public Dictionary<string, List<NodeTest>> Tests { get; set; }
         public List<ErrorMessage> Errors { get; } = new List<ErrorMessage>();
@@ -75,12 +71,8 @@ namespace Akka.MultiNodeTestRunner
         {
             try
             {
-#if CORECLR
-                var specType = testCaseDiscoveryMessage.TestAssembly.Assembly.GetType(testClass.Name).ToRuntimeType();
-#else
                 var testAssembly = Assembly.LoadFrom(testCaseDiscoveryMessage.TestAssembly.Assembly.AssemblyPath);
                 var specType = testAssembly.GetType(testClass.Name);
-#endif
                 var roles = RoleNames(specType);
 
                 var details = roles.Select((r, i) => new NodeTest
@@ -118,20 +110,11 @@ namespace Akka.MultiNodeTestRunner
             var current = configUser;
             while (current != null)
             {
-
-#if CORECLR
-                var ctorWithConfig = current
-                    .GetConstructors(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
-                    .FirstOrDefault(c => null != c.GetParameters().FirstOrDefault(p => p.ParameterType.GetTypeInfo().IsSubclassOf(baseConfigType)));
-            
-                current = current.GetTypeInfo().BaseType;
-#else
                 var ctorWithConfig = current
                     .GetConstructors(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
                     .FirstOrDefault(c => null != c.GetParameters().FirstOrDefault(p => p.ParameterType.IsSubclassOf(baseConfigType)));
 
                 current = current.BaseType;
-#endif
                 if (ctorWithConfig != null) return ctorWithConfig;
             }
 
@@ -143,15 +126,9 @@ namespace Akka.MultiNodeTestRunner
             var ctors = configType.GetConstructors(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
             var empty = ctors.FirstOrDefault(c => !c.GetParameters().Any());
 
-#if CORECLR
-            return empty != null
-                ? new object[0]
-                : ctors.First().GetParameters().Select(p => p.ParameterType.GetTypeInfo().IsValueType ? Activator.CreateInstance(p.ParameterType) : null).ToArray();
-#else
             return empty != null
                 ? new object[0]
                 : ctors.First().GetParameters().Select(p => p.ParameterType.IsValueType ? Activator.CreateInstance(p.ParameterType) : null).ToArray();
-#endif
         }
 
         /// <inheritdoc/>

--- a/src/core/Akka.Persistence.Query.Tests/Akka.Persistence.Query.Tests.csproj
+++ b/src/core/Akka.Persistence.Query.Tests/Akka.Persistence.Query.Tests.csproj
@@ -23,14 +23,6 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZABLE</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' OR '$(TargetFramework)' == '$(NetTestVersion)'">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Persistence.TCK.Tests/Akka.Persistence.TCK.Tests.csproj
+++ b/src/core/Akka.Persistence.TCK.Tests/Akka.Persistence.TCK.Tests.csproj
@@ -18,14 +18,6 @@
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZABLE</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' OR '$(TargetFramework)' == '$(NetTestVersion)'">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Persistence.TCK/Akka.Persistence.TCK.csproj
+++ b/src/core/Akka.Persistence.TCK/Akka.Persistence.TCK.csproj
@@ -20,14 +20,6 @@
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Persistence.TestKit.Tests/Akka.Persistence.TestKit.Tests.csproj
+++ b/src/core/Akka.Persistence.TestKit.Tests/Akka.Persistence.TestKit.Tests.csproj
@@ -23,10 +23,6 @@
     <ProjectReference Include="..\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' OR '$(TargetFramework)' == '$(NetTestVersion)'">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Persistence.Tests/Akka.Persistence.Tests.csproj
+++ b/src/core/Akka.Persistence.Tests/Akka.Persistence.Tests.csproj
@@ -25,14 +25,6 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZABLE</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' OR '$(TargetFramework)' == '$(NetTestVersion)'">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Persistence/Akka.Persistence.csproj
+++ b/src/core/Akka.Persistence/Akka.Persistence.csproj
@@ -14,9 +14,6 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
   </ItemGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Persistence/AtLeastOnceDeliverySemantic.cs
+++ b/src/core/Akka.Persistence/AtLeastOnceDeliverySemantic.cs
@@ -225,7 +225,6 @@ namespace Akka.Persistence
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="MaxUnconfirmedMessagesExceededException"/> class.
         /// </summary>
@@ -234,7 +233,6 @@ namespace Akka.Persistence
         protected MaxUnconfirmedMessagesExceededException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 
     #endregion

--- a/src/core/Akka.Persistence/Journal/AsyncWriteProxy.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteProxy.cs
@@ -37,7 +37,6 @@ namespace Akka.Persistence.Journal
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncReplayTimeoutException"/> class.
         /// </summary>
@@ -47,7 +46,6 @@ namespace Akka.Persistence.Journal
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>

--- a/src/core/Akka.Persistence/PersistentActor.cs
+++ b/src/core/Akka.Persistence/PersistentActor.cs
@@ -136,7 +136,6 @@ namespace Akka.Persistence
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="RecoveryTimedOutException"/> class.
         /// </summary>
@@ -145,7 +144,6 @@ namespace Akka.Persistence
         public RecoveryTimedOutException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>

--- a/src/core/Akka.Persistence/Snapshot/NoSnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/NoSnapshotStore.cs
@@ -49,7 +49,6 @@ namespace Akka.Persistence.Snapshot
             {
             }
 
-#if SERIALIZATION
             /// <summary>
             /// Initializes a new instance of the <see cref="NoSnapshotStoreException"/> class.
             /// </summary>
@@ -58,7 +57,6 @@ namespace Akka.Persistence.Snapshot
             protected NoSnapshotStoreException(SerializationInfo info, StreamingContext context) : base(info, context)
             {
             }
-#endif
         }
 
         /// <summary>

--- a/src/core/Akka.Remote.TestKit.Tests/Akka.Remote.TestKit.Tests.csproj
+++ b/src/core/Akka.Remote.TestKit.Tests/Akka.Remote.TestKit.Tests.csproj
@@ -23,14 +23,6 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZABLE</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' OR '$(TargetFramework)' == '$(NetTestVersion)'">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Remote.TestKit/Akka.Remote.TestKit.csproj
+++ b/src/core/Akka.Remote.TestKit/Akka.Remote.TestKit.csproj
@@ -22,11 +22,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
+  
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Remote.TestKit/Controller.cs
+++ b/src/core/Akka.Remote.TestKit/Controller.cs
@@ -98,7 +98,6 @@ namespace Akka.Remote.TestKit
             /// <param name="message">The message that describes the error.</param>
             public ClientDisconnectedException(string message) : base(message){}
 
-#if SERIALIZATION
             /// <summary>
             /// Initializes a new instance of the <see cref="ClientDisconnectedException"/> class.
             /// </summary>
@@ -107,7 +106,6 @@ namespace Akka.Remote.TestKit
             protected ClientDisconnectedException(SerializationInfo info, StreamingContext context) : base(info, context)
             {
             }
-#endif
         }
 
         public class GetNodes

--- a/src/core/Akka.Remote.TestKit/Internals/TestConductorConfigFactory.cs
+++ b/src/core/Akka.Remote.TestKit/Internals/TestConductorConfigFactory.cs
@@ -36,11 +36,7 @@ namespace Akka.Remote.TestKit.Internals
         /// <returns>The configuration defined in the current executing assembly.</returns>
         internal static Config FromResource(string resourceName)
         {
-#if CORECLR
-            var assembly = typeof(TestConductorConfigFactory).GetTypeInfo().Assembly;
-#else
             var assembly = typeof(TestConductorConfigFactory).Assembly;
-#endif
 
             using (var stream = assembly.GetManifestResourceStream(resourceName))
             {

--- a/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
+++ b/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
@@ -408,13 +408,7 @@ namespace Akka.Remote.TestKit
             _roles = roles;
             _deployments = deployments;
 
-#if CORECLR
-            var dnsTask = Dns.GetHostAddressesAsync(ServerName);
-            dnsTask.Wait();
-            var node = new IPEndPoint(dnsTask.Result[0], ServerPort);
-#else
             var node = new IPEndPoint(Dns.GetHostAddresses(ServerName)[0], ServerPort);
-#endif
             _controllerAddr = node;
 
             AttachConductor(new TestConductor(system));

--- a/src/core/Akka.Remote.Tests.MultiNode/Akka.Remote.Tests.MultiNode.csproj
+++ b/src/core/Akka.Remote.Tests.MultiNode/Akka.Remote.Tests.MultiNode.csproj
@@ -27,10 +27,6 @@
     <DefineConstants>$(DefineConstants);</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' OR '$(TargetFramework)' == '$(NetTestVersion)'">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Remote.Tests/ExceptionSupportSpec.cs
+++ b/src/core/Akka.Remote.Tests/ExceptionSupportSpec.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Dispatch;
+using Akka.IO.Buffers;
+using Akka.Pattern;
+using Akka.Remote.Serialization;
+using Akka.Remote.Transport;
+using Akka.Serialization;
+using Akka.TestKit;
+using Xunit;
+using Xunit.Abstractions;
+using FluentAssertions;
+
+namespace Akka.Remote.Tests
+{
+    public class ExceptionSupportSpec : AkkaSpec
+    {
+        private readonly ExceptionSupport _serializer;
+        private readonly Exception _innerException = new Exception("inner message");
+        private readonly Exception _innerException2 = new Exception("inner message 2");
+
+        public ExceptionSupportSpec(ITestOutputHelper output) : base(output)
+        {
+            _serializer = new ExceptionSupport((ExtendedActorSystem)Sys);
+        }
+
+        [Theory]
+        [InlineData(new object[]{typeof(ActorInterruptedException)})]
+        [InlineData(new object[]{typeof(ActorNotFoundException)})]
+        [InlineData(new object[]{typeof(InvalidActorNameException)})]
+        [InlineData(new object[]{typeof(LoggerInitializationException)})]
+        [InlineData(new object[]{typeof(StashOverflowException)})]
+        [InlineData(new object[]{typeof(ConfigurationException)})]
+        [InlineData(new object[]{typeof(RejectedExecutionException)})]
+        [InlineData(new object[]{typeof(IllegalStateException)})]
+        [InlineData(new object[]{typeof(RemoteTransportException)})]
+        [InlineData(new object[]{typeof(AkkaProtocolException)})]
+        [InlineData(new object[]{typeof(InvalidAssociationException)})]
+        public void ExceptionSupport_should_serialize_exceptions_with_inner_exception(Type type)
+        {
+            var instance = (Exception) Activator.CreateInstance(type, "TestMessage", _innerException);
+            AssertDefaultsEquals(instance);
+        }
+
+        [Theory]
+        [InlineData(new object[]{typeof(ActorKilledException)})]
+        [InlineData(new object[]{typeof(AskTimeoutException)})]
+        [InlineData(new object[]{typeof(IllegalActorNameException)})]
+        [InlineData(new object[]{typeof(IllegalActorStateException)})]
+        [InlineData(new object[]{typeof(InvalidMessageException)})]
+        [InlineData(new object[]{typeof(SchedulerException)})]
+        [InlineData(new object[]{typeof(BufferPoolAllocationException)})]
+        public void ExceptionSupport_should_serialize_exceptions_with_message(Type type)
+        {
+            var instance = (Exception) Activator.CreateInstance(type, "TestMessage");
+            AssertDefaultsEquals(instance);
+        }
+
+        [Theory]
+        [InlineData(new object[]{typeof(UserCalledFailException)})]
+        public void ExceptionSupport_should_serialize_exceptions(Type type)
+        {
+            var instance = (Exception) Activator.CreateInstance(type, new object[]{});
+            AssertDefaultsEquals(instance);
+        }
+
+        [Fact]
+        public void ExceptionSupport_should_serialize_ActorInitializationException()
+        {
+            var probe = CreateTestProbe();
+            var exception = AssertDefaultsEquals(new ActorInitializationException(probe.Ref, "TestMessage", _innerException));
+
+            exception.Actor.Should().NotBeNull();
+            exception.Actor.Equals(probe).Should().BeTrue();
+        }
+
+        [Fact]
+        public void ExceptionSupport_should_serialize_DeathPactException()
+        {
+            var probe = CreateTestProbe();
+            var exception = AssertDefaultsEquals(new DeathPactException(probe.Ref));
+
+            exception.DeadActor.Should().NotBeNull();
+            exception.DeadActor.Equals(probe).Should().BeTrue();
+        }
+
+        [Fact]
+        public void ExceptionSupport_should_serialize_PostRestartException()
+        {
+            var probe = CreateTestProbe();
+            var exception = AssertDefaultsEquals(new PostRestartException(probe.Ref, _innerException, _innerException2));
+
+            exception.Actor.Should().NotBeNull();
+            exception.Actor.Equals(probe).Should().BeTrue();
+            AssertExceptionEquals(_innerException2, exception.OriginalCause);
+        }
+
+        [Fact]
+        public void ExceptionSupport_should_serialize_PreRestartException()
+        {
+            var probe = CreateTestProbe();
+            var testMessage = new
+            {
+                value = 1
+            };
+            var exception = AssertDefaultsEquals(new PreRestartException(probe.Ref, _innerException2, _innerException, testMessage));
+
+            exception.Actor.Should().NotBeNull();
+            exception.Actor.Equals(probe).Should().BeTrue();
+            AssertExceptionEquals(_innerException2, exception.RestartException);
+            exception.OptionalMessage.Should().BeEquivalentTo(testMessage);
+        }
+
+        [Fact]
+        public void ExceptionSupport_should_serialize_OpenCircuitException()
+        {
+            var remaining = new TimeSpan(1234567);
+            var exception = AssertDefaultsEquals(new OpenCircuitException("TestMessage", _innerException, remaining));
+
+            exception.RemainingDuration.Should().Be(remaining);
+        }
+
+        private T AssertDefaultsEquals<T>(T expected) where T: Exception
+        {
+            var serialized = _serializer.ExceptionToProto(expected);
+            var deserialized = (T)_serializer.ExceptionFromProto(serialized);
+
+            AssertExceptionEquals(expected, deserialized);
+
+            return deserialized;
+        }
+
+        private void AssertExceptionEquals(Exception expected, Exception actual)
+        {
+            actual.Message.Should().Be(expected.Message);
+            // HResult is not serialized
+            // actual.HResult.Should().Be(expected.HResult);
+            actual.Source.Should().Be(expected.Source);
+            actual.StackTrace.Should().Be(expected.StackTrace);
+            actual.TargetSite.Should().BeEquivalentTo(expected.TargetSite);
+            if (actual.InnerException != null)
+            {
+                AssertExceptionEquals(actual.InnerException, expected.InnerException);
+            }
+        }
+    }
+}

--- a/src/core/Akka.Remote/AckedDelivery.cs
+++ b/src/core/Akka.Remote/AckedDelivery.cs
@@ -341,7 +341,6 @@ namespace Akka.Remote
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="ResendBufferCapacityReachedException"/> class.
         /// </summary>
@@ -351,7 +350,6 @@ namespace Akka.Remote
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>
@@ -365,6 +363,17 @@ namespace Akka.Remote
         public ResendUnfulfillableException()
             : base("Unable to fulfill resend request since negatively acknowledged payload is no longer in buffer. " +
                 "The resend states between two systems are compromised and cannot be recovered") { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResendUnfulfillableException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        protected ResendUnfulfillableException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+
     }
 
 #endregion

--- a/src/core/Akka.Remote/Akka.Remote.csproj
+++ b/src/core/Akka.Remote/Akka.Remote.csproj
@@ -15,9 +15,6 @@
     <PackageReference Include="DotNetty.Handlers" Version="0.6.0" />
     <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
   </ItemGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -191,7 +191,6 @@ namespace Akka.Remote
         /// <param name="cause">The exception that is the cause of the current exception.</param>
         public EndpointException(string message, Exception cause = null) : base(message, cause) { }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="EndpointException"/> class.
         /// </summary>
@@ -201,7 +200,6 @@ namespace Akka.Remote
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>
@@ -325,6 +323,16 @@ namespace Akka.Remote
             : base(message)
         {
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EndpointDisassociatedException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        protected EndpointDisassociatedException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
     }
 
     /// <summary>
@@ -347,6 +355,16 @@ namespace Akka.Remote
         /// <param name="message">The message that describes the error.</param>
         /// <param name="innerException">The exception that is the cause of the current exception.</param>
         public EndpointAssociationException(string message, Exception innerException) : base(message, innerException) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EndpointAssociationException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        protected EndpointAssociationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
     }
 
     /// <summary>
@@ -360,6 +378,16 @@ namespace Akka.Remote
         /// <param name="message">The message that describes the error.</param>
         public OversizedPayloadException(string message)
             : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OversizedPayloadException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        protected OversizedPayloadException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/core/Akka.Remote/RemoteTransport.cs
+++ b/src/core/Akka.Remote/RemoteTransport.cs
@@ -132,7 +132,6 @@ namespace Akka.Remote
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="RemoteTransportException"/> class.
         /// </summary>
@@ -142,7 +141,6 @@ namespace Akka.Remote
             : base(info, context)
         {
         }
-#endif
     }
 }
 

--- a/src/core/Akka.Remote/RemoteWatcher.cs
+++ b/src/core/Akka.Remote/RemoteWatcher.cs
@@ -54,6 +54,7 @@ namespace Akka.Remote
             TimeSpan heartbeatExpectedResponseAfter)
         {
             return Actor.Props.Create(() => new RemoteWatcher(failureDetector, heartbeatInterval, unreachableReaperInterval, heartbeatExpectedResponseAfter))
+                .WithDispatcher(Dispatchers.InternalDispatcherId)
                 .WithDeploy(Deploy.Local);
         }
 

--- a/src/core/Akka.Remote/Serialization/PrimitiveSerializers.cs
+++ b/src/core/Akka.Remote/Serialization/PrimitiveSerializers.cs
@@ -13,8 +13,22 @@ using Akka.Util;
 
 namespace Akka.Remote.Serialization
 {
-    public sealed class PrimitiveSerializers : Serializer
+    public sealed class PrimitiveSerializers : SerializerWithStringManifest
     {
+        internal const string StringManifest = "S";
+        internal const string Int32Manifest = "I";
+        internal const string Int64Manifest = "L";
+
+        // .Net Core manifests
+        internal const string StringManifestNetCore = "System.String, System.Private.CoreLib";
+        internal const string Int32ManifestNetCore = "System.Int32, System.Private.CoreLib";
+        internal const string Int64ManifestNetCore = "System.Int64, System.Private.CoreLib";
+
+        // .Net Framework manifests
+        internal const string StringManifestNetFx = "System.String, mscorlib";
+        internal const string Int32ManifestNetFx = "System.Int32, mscorlib";
+        internal const string Int64ManifestNetFx = "System.Int64, mscorlib";
+
         /// <summary>
         /// Initializes a new instance of the <see cref="PrimitiveSerializers" /> class.
         /// </summary>
@@ -24,27 +38,57 @@ namespace Akka.Remote.Serialization
         }
 
         /// <inheritdoc />
-        public override bool IncludeManifest { get; } = true;
-
-        /// <inheritdoc />
         public override byte[] ToBinary(object obj)
         {
-            var str = obj as string;
-            if (str != null) return Encoding.UTF8.GetBytes(str);
-            if (obj is int) return BitConverter.GetBytes((int)obj);
-            if (obj is long) return BitConverter.GetBytes((long)obj);
-
-            throw new ArgumentException($"Cannot serialize object of type [{obj.GetType().TypeQualifiedName()}]");
+            switch (obj)
+            {
+                case string s:
+                    return Encoding.UTF8.GetBytes(s);
+                case int i:
+                    return BitConverter.GetBytes(i);
+                case long l:
+                    return BitConverter.GetBytes(l);
+                default:
+                    throw new ArgumentException($"Cannot serialize object of type [{obj.GetType()}]");
+            }
         }
 
         /// <inheritdoc />
-        public override object FromBinary(byte[] bytes, Type type)
+        public override object FromBinary(byte[] bytes, string manifest)
         {
-            if (type == typeof(string)) return Encoding.UTF8.GetString(bytes);
-            if (type == typeof(int)) return BitConverter.ToInt32(bytes, 0);
-            if (type == typeof(long)) return BitConverter.ToInt64(bytes, 0);
+            switch (manifest)
+            {
+                case StringManifest:
+                case StringManifestNetCore:
+                case StringManifestNetFx:
+                    return Encoding.UTF8.GetString(bytes);
+                case Int32Manifest:
+                case Int32ManifestNetCore:
+                case Int32ManifestNetFx:
+                    return BitConverter.ToInt32(bytes, 0);
+                case Int64Manifest:
+                case Int64ManifestNetCore:
+                case Int64ManifestNetFx:
+                    return BitConverter.ToInt64(bytes, 0);
+                default:
+                    throw new ArgumentException($"Unimplemented deserialization of message with manifest [{manifest}] in [${GetType()}]");
+            }
+        }
 
-            throw new ArgumentException($"Unimplemented deserialization of message with manifest [{type.TypeQualifiedName()}] in [${nameof(PrimitiveSerializers)}]");
+        /// <inheritdoc />
+        public override string Manifest(object obj)
+        {
+            switch (obj)
+            {
+                case string _:
+                    return StringManifest;
+                case int _:
+                    return Int32Manifest;
+                case long _:
+                    return Int64Manifest;
+                default:
+                    throw new ArgumentException($"Cannot serialize object of type [{obj.GetType()}] in [{GetType()}]");
+            }
         }
     }
 }

--- a/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
+++ b/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
@@ -28,7 +28,6 @@ namespace Akka.Remote.Transport
         /// <param name="cause">The exception that is the cause of the current exception.</param>
         public PduCodecException(string message, Exception cause = null) : base(message, cause) { }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="PduCodecException"/> class.
         /// </summary>
@@ -38,7 +37,6 @@ namespace Akka.Remote.Transport
             : base(info, context)
         {
         }
-#endif
     }
 
     /*

--- a/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
+++ b/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
@@ -63,7 +63,6 @@ namespace Akka.Remote.Transport
         /// <param name="cause">The exception that is the cause of the current exception.</param>
         public AkkaProtocolException(string message, Exception cause = null) : base(message, cause) { }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="AkkaProtocolException"/> class.
         /// </summary>
@@ -73,7 +72,6 @@ namespace Akka.Remote.Transport
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
@@ -104,7 +104,6 @@ namespace Akka.Remote.Transport.DotNetty
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="DotNettyTransportException"/> class.
         /// </summary>
@@ -113,7 +112,6 @@ namespace Akka.Remote.Transport.DotNetty
         protected DotNettyTransportException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 
     internal abstract class DotNettyTransport : Transport

--- a/src/core/Akka.Remote/Transport/FailureInjectorTransportAdapter.cs
+++ b/src/core/Akka.Remote/Transport/FailureInjectorTransportAdapter.cs
@@ -48,7 +48,6 @@ namespace Akka.Remote.Transport
             Msg = msg;
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="FailureInjectorException"/> class.
         /// </summary>
@@ -58,7 +57,6 @@ namespace Akka.Remote.Transport
             : base(info, context)
         {
         }
-#endif
 
         /// <summary>
         /// Retrieves the message of the simulated failure.

--- a/src/core/Akka.Remote/Transport/Transport.cs
+++ b/src/core/Akka.Remote/Transport/Transport.cs
@@ -99,7 +99,6 @@ namespace Akka.Remote.Transport
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="InvalidAssociationException"/> class.
         /// </summary>
@@ -109,7 +108,6 @@ namespace Akka.Remote.Transport
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>

--- a/src/core/Akka.Streams.TestKit.Tests/Akka.Streams.TestKit.Tests.csproj
+++ b/src/core/Akka.Streams.TestKit.Tests/Akka.Streams.TestKit.Tests.csproj
@@ -25,14 +25,6 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION;AKKAIO</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' OR '$(TargetFramework)' == '$(NetTestVersion)'">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Streams.TestKit.Tests/ScriptedTest.cs
+++ b/src/core/Akka.Streams.TestKit.Tests/ScriptedTest.cs
@@ -27,10 +27,7 @@ namespace Akka.Streams.TestKit.Tests
         public ScriptException() { }
         public ScriptException(string message) : base(message) { }
         public ScriptException(string message, Exception inner) : base(message, inner) { }
-
-#if SERIALIZATION
         protected ScriptException(SerializationInfo info, StreamingContext context) : base(info, context) { }
-#endif
     }
 
     public abstract class ScriptedTest : AkkaSpec

--- a/src/core/Akka.Streams.TestKit/Akka.Streams.TestKit.csproj
+++ b/src/core/Akka.Streams.TestKit/Akka.Streams.TestKit.csproj
@@ -14,10 +14,6 @@
     <ProjectReference Include="..\Akka.TestKit\Akka.TestKit.csproj" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Streams.TestKit/TestSubscriber.cs
+++ b/src/core/Akka.Streams.TestKit/TestSubscriber.cs
@@ -34,7 +34,7 @@ namespace Akka.Streams.TestKit
             public override string ToString() => $"TestSubscriber.OnSubscribe({Subscription})";
         }
 
-        public struct OnNext<T> : ISubscriberEvent
+        public struct OnNext<T> : ISubscriberEvent, IEquatable<OnNext<T>>
         {
             public readonly T Element;
 
@@ -44,6 +44,21 @@ namespace Akka.Streams.TestKit
             }
 
             public override string ToString() => $"TestSubscriber.OnNext({Element})";
+
+            public bool Equals(OnNext<T> other)
+            {
+                return EqualityComparer<T>.Default.Equals(Element, other.Element);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is OnNext<T> other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                return EqualityComparer<T>.Default.GetHashCode(Element);
+            }
         }
 
         public sealed class OnComplete: ISubscriberEvent

--- a/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
+++ b/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
@@ -35,14 +35,6 @@
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION;CONFIGURATION;AKKAIO</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' OR '$(TargetFramework)' == '$(NetTestVersion)'">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Streams.Tests/Dsl/QueueSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/QueueSinkSpec.cs
@@ -153,7 +153,7 @@ namespace Akka.Streams.Tests.Dsl
             }, _materializer);
         }
 
-        [Fact(Skip = "Racy, see https://github.com/akkadotnet/akka.net/pull/4424#issuecomment-632284459")]
+        [Fact]
         public void QueueSink_should_fail_pull_future_when_stream_is_completed()
         {
             this.AssertAllStagesStopped(() =>
@@ -170,10 +170,8 @@ namespace Akka.Streams.Tests.Dsl
                 var result = queue.PullAsync().Result;
                 result.Should().Be(Option<int>.None);
 
-                ((Task)queue.PullAsync()).ContinueWith(t =>
-                {
-                    t.Exception.InnerException.Should().BeOfType<IllegalStateException>();
-                }, TaskContinuationOptions.OnlyOnFaulted).Wait();
+                var exception = Record.ExceptionAsync(async () => await queue.PullAsync()).Result;
+                exception.Should().BeOfType<StreamDetachedException>();
             }, _materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/QueueSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/QueueSourceSpec.cs
@@ -262,6 +262,22 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
+        public void QueueSource_should_complete_watching_future_with_failure_if_materializer_shut_down()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var tempMap = ActorMaterializer.Create(Sys);
+                var s = this.CreateManualSubscriberProbe<int>();
+                var queue = Source.Queue<int>(1, OverflowStrategy.Fail)
+                    .To(Sink.FromSubscriber(s))
+                    .Run(tempMap);
+                queue.WatchCompletionAsync().PipeTo(TestActor);
+                tempMap.Shutdown();
+                ExpectMsg<Status.Failure>();
+            }, _materializer);
+        }
+
+        [Fact]
         public void QueueSource_should_return_false_when_element_was_not_added_to_buffer()
         {
             this.AssertAllStagesStopped(() =>
@@ -322,11 +338,12 @@ namespace Akka.Streams.Tests.Dsl
                         .Run(_materializer);
                 var sub = s.ExpectSubscription();
 
-                queue.WatchCompletionAsync().ContinueWith(t => "done").PipeTo(TestActor);
+                queue.WatchCompletionAsync().ContinueWith(t => Done.Instance).PipeTo(TestActor);
                 sub.Cancel();
-                ExpectMsg("done");
+                ExpectMsg(Done.Instance);
 
-                queue.OfferAsync(1).ContinueWith(t => t.Exception.Should().BeOfType<IllegalStateException>());
+                var exception = Record.ExceptionAsync(async () => await queue.OfferAsync(1)).Result;
+                exception.Should().BeOfType<StreamDetachedException>();
             }, _materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/StageActorRefSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/StageActorRefSpec.cs
@@ -178,7 +178,7 @@ namespace Akka.Streams.Tests.Dsl
             warn.Message.ToString()
                 .Should()
                 .MatchRegex(
-                    "<PoisonPill> message sent to StageActor\\(akka\\://AkkaSpec/user/StreamSupervisor-[0-9]+/\\$\\$[a-z]+\\) will be ignored, since it is not a real Actor. Use a custom message type to communicate with it instead.");
+                    $"<PoisonPill> message sent to StageActor\\(akka\\://{Sys.Name}/user/StreamSupervisor-[0-9]+/\\$\\$[a-z]+\\) will be ignored, since it is not a real Actor. Use a custom message type to communicate with it instead.");
 
             stageRef.Tell(Kill.Instance);
             warn = ExpectMsg<Warning>(TimeSpan.FromSeconds(1));
@@ -186,7 +186,7 @@ namespace Akka.Streams.Tests.Dsl
             warn.Message.ToString()
                            .Should()
                            .MatchRegex(
-                               "<Kill> message sent to StageActor\\(akka\\://AkkaSpec/user/StreamSupervisor-[0-9]+/\\$\\$[a-z]+\\) will be ignored, since it is not a real Actor. Use a custom message type to communicate with it instead.");
+                               $"<Kill> message sent to StageActor\\(akka\\://{Sys.Name}/user/StreamSupervisor-[0-9]+/\\$\\$[a-z]+\\) will be ignored, since it is not a real Actor. Use a custom message type to communicate with it instead.");
 
             source.SetResult(2);
 

--- a/src/core/Akka.Streams.Tests/Implementation/StreamLayoutSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/StreamLayoutSpec.cs
@@ -240,7 +240,6 @@ namespace Akka.Streams.Tests.Implementation
             CheckMaterialized(runnable);
         }
 
-#if !CORECLR
         [Fact(Skip = "We can't catch a StackOverflowException")]
         public void StreamLayout_should_fail_fusing_when_value_computation_is_too_complex()
         {
@@ -250,7 +249,6 @@ namespace Akka.Streams.Tests.Implementation
                     (flow, i) => flow.MapMaterializedValue(x => x + i));
             g.Invoking(flow => Streams.Fusing.Aggressive(flow)).Should().Throw<StackOverflowException>();
         }
-#endif
 
         [Fact]
         public void StreamLayout_should_not_fail_materialization_when_building_a_large_graph_with_simple_computation_when_starting_from_a_Source()

--- a/src/core/Akka.Streams/ActorMaterializer.cs
+++ b/src/core/Akka.Streams/ActorMaterializer.cs
@@ -242,7 +242,6 @@ namespace Akka.Streams
             Actor = actor;
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="AbruptTerminationException" /> class.
         /// </summary>
@@ -252,7 +251,6 @@ namespace Akka.Streams
         {
             Actor = (IActorRef)info.GetValue("Actor", typeof(IActorRef));
         }
-#endif
     }
 
     /// <summary>
@@ -267,14 +265,12 @@ namespace Akka.Streams
         /// <param name="innerException">The exception that is the cause of the current exception.</param>
         public MaterializationException(string message, Exception innerException) : base(message, innerException) { }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="MaterializationException"/> class.
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
         protected MaterializationException(SerializationInfo info, StreamingContext context) : base(info, context) { }
-#endif
     }
 
     /// <summary>
@@ -289,6 +285,13 @@ namespace Akka.Streams
         {
 
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AbruptStageTerminationException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
+        protected AbruptStageTerminationException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 
 

--- a/src/core/Akka.Streams/Akka.Streams.csproj
+++ b/src/core/Akka.Streams/Akka.Streams.csproj
@@ -65,9 +65,6 @@
     <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
     <PackageReference Include="Reactive.Streams" Version="1.0.2" />
   </ItemGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Streams/Dsl/Framing.cs
+++ b/src/core/Akka.Streams/Dsl/Framing.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using Akka.IO;
 using Akka.Streams.Implementation.Fusing;
 using Akka.Streams.Implementation.Stages;
@@ -122,6 +123,13 @@ namespace Akka.Streams.Dsl
             public FramingException(string message) : base(message)
             {
             }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="FramingException"/> class.
+            /// </summary>
+            /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
+            /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
+            protected FramingException(SerializationInfo info, StreamingContext context) : base(info, context) { }
         }
 
         private static readonly Func<IEnumerator<byte>, int, int> BigEndianDecoder = (enumerator, length) =>

--- a/src/core/Akka.Streams/Dsl/Graph.cs
+++ b/src/core/Akka.Streams/Dsl/Graph.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.Serialization;
 using Akka.Streams.Implementation;
 using Akka.Streams.Implementation.Fusing;
 using Akka.Streams.Implementation.Stages;
@@ -1211,6 +1212,13 @@ namespace Akka.Streams.Dsl
         {
 
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PartitionOutOfBoundsException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
+        protected PartitionOutOfBoundsException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 
     /// <summary>

--- a/src/core/Akka.Streams/Dsl/Keep.cs
+++ b/src/core/Akka.Streams/Dsl/Keep.cs
@@ -56,11 +56,7 @@ namespace Akka.Streams.Dsl
         /// <returns>TBD</returns>
         public static NotUsed None<TLeft, TRight>(TLeft left, TRight right) => NotUsed.Instance;
 
-#if !CORECLR
         private static readonly RuntimeMethodHandle KeepRightMethodhandle = typeof(Keep).GetMethod(nameof(Right)).MethodHandle;
-#else
-        private static readonly MethodInfo KeepRightMethodInfo = typeof(Keep).GetMethod(nameof(Right));
-#endif
 
         /// <summary>
         /// TBD
@@ -72,18 +68,10 @@ namespace Akka.Streams.Dsl
         /// <returns>TBD</returns>
         public static bool IsRight<T1, T2, T3>(Func<T1, T2, T3> fn)
         {
-#if !CORECLR
             return fn.GetMethodInfo().IsGenericMethod && fn.GetMethodInfo().GetGenericMethodDefinition().MethodHandle.Value == KeepRightMethodhandle.Value;
-#else
-            return fn.GetMethodInfo().IsGenericMethod && fn.GetMethodInfo().GetGenericMethodDefinition().Equals(KeepRightMethodInfo);
-#endif
         }
 
-#if !CORECLR
         private static readonly RuntimeMethodHandle KeepLeftMethodhandle = typeof(Keep).GetMethod(nameof(Left)).MethodHandle;
-#else
-        private static readonly MethodInfo KeepLeftMethodInfo = typeof(Keep).GetMethod(nameof(Left));
-#endif
 
         /// <summary>
         /// TBD
@@ -95,11 +83,7 @@ namespace Akka.Streams.Dsl
         /// <returns>TBD</returns>
         public static bool IsLeft<T1, T2, T3>(Func<T1, T2, T3> fn)
         {
-#if !CORECLR
             return fn.GetMethodInfo().IsGenericMethod && fn.GetMethodInfo().GetGenericMethodDefinition().MethodHandle.Value == KeepLeftMethodhandle.Value;
-#else
-            return fn.GetMethodInfo().IsGenericMethod && fn.GetMethodInfo().GetGenericMethodDefinition().Equals(KeepLeftMethodInfo);
-#endif
         }
     }
 }

--- a/src/core/Akka.Streams/Dsl/One2OneBidiFlow.cs
+++ b/src/core/Akka.Streams/Dsl/One2OneBidiFlow.cs
@@ -6,6 +6,8 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Runtime.Serialization;
+using Akka.Pattern;
 using Akka.Streams.Stage;
 
 namespace Akka.Streams.Dsl
@@ -41,6 +43,13 @@ namespace Akka.Streams.Dsl
         {
 
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnexpectedOutputException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
+        protected UnexpectedOutputException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 
     /// <summary>
@@ -48,7 +57,14 @@ namespace Akka.Streams.Dsl
     /// </summary>
     public class OutputTruncationException : Exception
     {
+        public OutputTruncationException() { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserCalledFailException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
+        protected OutputTruncationException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 
     /// <summary>

--- a/src/core/Akka.Streams/Dsl/Tcp.cs
+++ b/src/core/Akka.Streams/Dsl/Tcp.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Net;
+using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Annotations;
@@ -302,6 +303,13 @@ namespace Akka.Streams.Dsl
         {
             Duration = duration;
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TcpIdleTimeoutException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
+        protected TcpIdleTimeoutException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 
         public TimeSpan Duration { get; }
     }

--- a/src/core/Akka.Streams/Implementation/ActorPublisher.cs
+++ b/src/core/Akka.Streams/Implementation/ActorPublisher.cs
@@ -114,14 +114,12 @@ namespace Akka.Streams.Implementation
         /// <param name="message">The message that describes the error.</param>
         public NormalShutdownException(string message) : base(message) { }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="NormalShutdownException"/> class.
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
         protected NormalShutdownException(SerializationInfo info, StreamingContext context) : base(info, context) { }
-#endif
     }
 
     /// <summary>

--- a/src/core/Akka.Streams/Implementation/ReactiveStreamsCompliance.cs
+++ b/src/core/Akka.Streams/Implementation/ReactiveStreamsCompliance.cs
@@ -30,14 +30,12 @@ namespace Akka.Streams.Implementation
         /// <param name="cause">The exception that is the cause of the current exception.</param>
         public SignalThrewException(string message, Exception cause) : base(message, cause) { }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="SignalThrewException"/> class.
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
         protected SignalThrewException(SerializationInfo info, StreamingContext context) : base(info, context) { }
-#endif
     }
 
     /// <summary>

--- a/src/core/Akka.Streams/Implementation/ResizableMultiReaderRingBuffer.cs
+++ b/src/core/Akka.Streams/Implementation/ResizableMultiReaderRingBuffer.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using Akka.Annotations;
 using Akka.Streams.Util;
 
@@ -28,7 +29,6 @@ namespace Akka.Streams.Implementation
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="NothingToReadException"/> class.
         /// </summary>
@@ -38,7 +38,6 @@ namespace Akka.Streams.Implementation
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>

--- a/src/core/Akka.Streams/Implementation/Sinks.cs
+++ b/src/core/Akka.Streams/Implementation/Sinks.cs
@@ -624,10 +624,10 @@ namespace Akka.Streams.Implementation
 
             public override void PostStop()
             {
-                if(!_completionSignalled)
+                if (!_completionSignalled)
                     _promise.TrySetException(new AbruptStageTerminationException(this));
             }
-            
+
             public override void PreStart() => Pull(_stage.In);
         }
 
@@ -805,12 +805,8 @@ namespace Akka.Streams.Implementation
                 Pull(_stage.In);
             }
 
-            public override void PostStop()
-            {
-                StopCallback(
-                    promise =>
-                            promise.SetException(new IllegalStateException("Stream is terminated. QueueSink is detached")));
-            }
+            public override void PostStop() => 
+                StopCallback(promise => promise.SetException(StreamDetachedException.Instance));
 
             private Action<TaskCompletionSource<Option<T>>> Callback()
             {
@@ -1024,7 +1020,8 @@ namespace Akka.Streams.Implementation
             {
                 var sourceOut = new SubSource(this, firstElement);
 
-                try {
+                try
+                {
                     var matVal = Source.FromGraph(sourceOut.Source)
                         .RunWith(sink, Interpreter.SubFusingMaterializer);
                     _completion.TrySetResult(matVal);
@@ -1034,7 +1031,7 @@ namespace Akka.Streams.Implementation
                     _completion.TrySetException(ex);
                     FailStage(ex);
                 }
-                
+
             }
 
             #region SubSource
@@ -1176,7 +1173,7 @@ namespace Akka.Streams.Implementation
                 }
             }
         }
-        
+
         private sealed class ObservableLogic : GraphStageLogic, IObservable<T>
         {
             private readonly ObservableSinkStage<T> _stage;
@@ -1216,12 +1213,12 @@ namespace Akka.Streams.Implementation
                 ImmutableInterlocked.TryRemove(ref _observers, observer, out var _);
             }
 
-            public IDisposable Subscribe(IObserver<T> observer) => 
+            public IDisposable Subscribe(IObserver<T> observer) =>
                 ImmutableInterlocked.GetOrAdd(ref _observers, observer, new ObserverDisposable(this, observer));
         }
 
         #endregion
-        
+
 
         public ObservableSinkStage()
         {

--- a/src/core/Akka.Streams/Implementation/Sources.cs
+++ b/src/core/Akka.Streams/Implementation/Sources.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Akka.Annotations;
 using Akka.Pattern;
@@ -15,7 +14,6 @@ using Akka.Streams.Dsl;
 using Akka.Streams.Implementation.Stages;
 using Akka.Streams.Stage;
 using Akka.Streams.Supervision;
-using Akka.Streams.Util;
 using Akka.Util;
 using Akka.Util.Internal;
 
@@ -170,14 +168,13 @@ namespace Akka.Streams.Implementation
 
             public override void PostStop()
             {
+                var exception = StreamDetachedException.Instance;
+                _completion.TrySetException(exception);
                 StopCallback(input =>
                 {
-                    var offer = input as Offer<TOut>;
-                    if (offer != null)
-                    {
-                        var promise = offer.CompletionSource;
-                        promise.NonBlockingTrySetException(new IllegalStateException("Stream is terminated. SourceQueue is detached."));
-                    }
+                    if (!(input is Offer<TOut> offer)) return;
+                    var promise = offer.CompletionSource;
+                    promise.NonBlockingTrySetException(exception);
                 });
             }
 

--- a/src/core/Akka.Streams/Implementation/StreamLayout.cs
+++ b/src/core/Akka.Streams/Implementation/StreamLayout.cs
@@ -2142,7 +2142,6 @@ namespace Akka.Streams.Implementation
             {
             }
 
-#if SERIALIZATION
             /// <summary>
             /// Initializes a new instance of the <see cref="MaterializationPanicException" /> class.
             /// </summary>
@@ -2152,7 +2151,6 @@ namespace Akka.Streams.Implementation
                 : base(info, context)
             {
             }
-#endif
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Implementation/StreamSubscriptionTimeout.cs
+++ b/src/core/Akka.Streams/Implementation/StreamSubscriptionTimeout.cs
@@ -36,7 +36,6 @@ namespace Akka.Streams.Implementation
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="SubscriptionTimeoutException"/> class.
         /// </summary>
@@ -45,7 +44,6 @@ namespace Akka.Streams.Implementation
         protected SubscriptionTimeoutException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>

--- a/src/core/Akka.Streams/OverflowStrategy.cs
+++ b/src/core/Akka.Streams/OverflowStrategy.cs
@@ -110,7 +110,6 @@ namespace Akka.Streams
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="BufferOverflowException"/> class.
         /// </summary>
@@ -119,6 +118,5 @@ namespace Akka.Streams
         protected BufferOverflowException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 }

--- a/src/core/Akka.Streams/Shape.cs
+++ b/src/core/Akka.Streams/Shape.cs
@@ -173,10 +173,7 @@ namespace Akka.Streams
     /// matters from the outside are the connections that can be made with it,
     /// otherwise it is just a black box.
     /// </summary>
-    public abstract class Shape
-#if CLONEABLE
-     : ICloneable
-#endif
+    public abstract class Shape : ICloneable
     {
         /// <summary>
         /// Gets list of all input ports.

--- a/src/core/Akka.Streams/Stage/GraphStage.cs
+++ b/src/core/Akka.Streams/Stage/GraphStage.cs
@@ -2191,14 +2191,12 @@ namespace Akka.Streams.Stage
         public static readonly StageActorRefNotInitializedException Instance = new StageActorRefNotInitializedException();
         private StageActorRefNotInitializedException() : base("You must first call GetStageActorRef(StageActorRef.Receive), to initialize the actor's behavior") { }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="StageActorRefNotInitializedException"/> class.
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
         protected StageActorRefNotInitializedException(SerializationInfo info, StreamingContext context) : base(info, context) { }
-#endif
     }
 
     /// <summary>

--- a/src/core/Akka.Streams/StageException.cs
+++ b/src/core/Akka.Streams/StageException.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Akka.Streams
 {
@@ -21,6 +22,16 @@ namespace Akka.Streams
         public NoSuchElementException(string message) : base(message)
         {
 
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NoSuchElementException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        protected NoSuchElementException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
         }
     }
 }

--- a/src/core/Akka.Streams/StreamLimitReachedException.cs
+++ b/src/core/Akka.Streams/StreamLimitReachedException.cs
@@ -23,7 +23,6 @@ namespace Akka.Streams
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="StreamLimitReachedException"/> class.
         /// </summary>
@@ -32,6 +31,5 @@ namespace Akka.Streams
         protected StreamLimitReachedException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 }

--- a/src/core/Akka.Streams/StreamRefs.cs
+++ b/src/core/Akka.Streams/StreamRefs.cs
@@ -6,12 +6,14 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Runtime.Serialization;
 using Akka.Actor;
 using Akka.Pattern;
 using Akka.Streams.Dsl;
 using Akka.Streams.Implementation;
 using Akka.Util;
 
+#pragma warning disable 628
 namespace Akka.Streams
 {
     /// <summary>
@@ -58,11 +60,31 @@ namespace Akka.Streams
             "This should not happen due to proper flow-control, please open a ticket on the issue tracker: https://github.com/akkadotnet/akka.net")
         {
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TargetRefNotInitializedYetException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        protected TargetRefNotInitializedYetException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
     }
 
     public sealed class StreamRefSubscriptionTimeoutException : IllegalStateException
     {
         public StreamRefSubscriptionTimeoutException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamRefSubscriptionTimeoutException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        protected StreamRefSubscriptionTimeoutException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }
@@ -73,6 +95,16 @@ namespace Akka.Streams
             new RemoteStreamRefActorTerminatedException("Remote target receiver of data terminated. Local stream terminating, message loss (on remote side) may have happened.");
 
         public RemoteStreamRefActorTerminatedException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RemoteStreamRefActorTerminatedException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        protected RemoteStreamRefActorTerminatedException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }
@@ -87,6 +119,16 @@ namespace Akka.Streams
         {
             ExpectedSeqNr = expectedSeqNr;
             GotSeqNr = gotSeqNr;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidSequenceNumberException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        protected InvalidSequenceNumberException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
         }
     }
 
@@ -110,6 +152,16 @@ namespace Akka.Streams
             "This may happen due to 'double-materialization' on the other side of this stream ref. " +
             "Do note that stream refs are one-shot references and have to be paired up in 1:1 pairs. " +
             "Multi-cast such as broadcast etc can be implemented by sharing multiple new stream references. ")
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidPartnerActorException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        protected InvalidPartnerActorException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/core/Akka.Streams/StreamTcpException.cs
+++ b/src/core/Akka.Streams/StreamTcpException.cs
@@ -45,6 +45,22 @@ namespace Akka.Streams
     }
 
     /// <summary>
+    /// This exception signals that materialized value is already detached from stream. This usually happens
+    /// when stream is completed and an ActorSystem is shut down while materialized object is still available.
+    /// </summary>
+    public class StreamDetachedException : Exception
+    {
+        /// <summary>
+        /// Initializes a single instance of the <see cref="StreamDetachedException"/> class.
+        /// </summary>
+        public static readonly StreamDetachedException Instance = new StreamDetachedException();
+
+        private StreamDetachedException() : base("Stream is terminated. Materialized value is detached.")
+        {
+        }
+    }
+
+    /// <summary>
     /// TBD
     /// </summary>
     public class BindFailedException : StreamTcpException

--- a/src/core/Akka.Streams/StreamTcpException.cs
+++ b/src/core/Akka.Streams/StreamTcpException.cs
@@ -32,7 +32,6 @@ namespace Akka.Streams
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="StreamTcpException"/> class.
         /// </summary>
@@ -41,7 +40,6 @@ namespace Akka.Streams
         protected StreamTcpException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>
@@ -74,7 +72,6 @@ namespace Akka.Streams
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="BindFailedException"/> class.
         /// </summary>
@@ -83,7 +80,6 @@ namespace Akka.Streams
         protected BindFailedException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>
@@ -108,7 +104,6 @@ namespace Akka.Streams
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="ConnectionException"/> class.
         /// </summary>
@@ -117,6 +112,5 @@ namespace Akka.Streams
         protected ConnectionException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 }

--- a/src/core/Akka.Streams/WatchedActorTerminatedException.cs
+++ b/src/core/Akka.Streams/WatchedActorTerminatedException.cs
@@ -24,7 +24,6 @@ namespace Akka.Streams
             : base($"Actor watched by [{stageName}] has terminated! Was: {actorRef}")
         { }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="AkkaException"/> class.
         /// </summary>
@@ -34,6 +33,5 @@ namespace Akka.Streams
             : base(info, context)
         {
         }
-#endif
     }
 }

--- a/src/core/Akka.TestKit.Tests/Akka.TestKit.Tests.csproj
+++ b/src/core/Akka.TestKit.Tests/Akka.TestKit.Tests.csproj
@@ -20,12 +20,6 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' OR '$(TargetFramework)' == '$(NetTestVersion)'">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.TestKit.Tests/TestEventListenerTests/ExceptionEventFilterTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestEventListenerTests/ExceptionEventFilterTests.cs
@@ -6,125 +6,170 @@
 //-----------------------------------------------------------------------
 
 using System;
+using Akka.Actor;
 using Akka.Event;
 using Akka.TestKit;
+using Akka.TestKit.Tests.Xunit2.TestEventListenerTests;
 using Xunit;
 using Xunit.Sdk;
 
 namespace Akka.Testkit.Tests.TestEventListenerTests
 {
-    //public class ExceptionEventFilterTests : EventFilterTestBase
-    //{
-    //    public ExceptionEventFilterTests()
-    //        : base("akka.logLevel=ERROR")
-    //    {
-    //    }
-    //    public class TestFinished : Exception { }
-    //    public class SomeException : Exception { }
+    public class ExceptionEventFilterTests : EventFilterTestBase
+    {
+        public ExceptionEventFilterTests()
+            : base("akka.logLevel=ERROR")
+        {
+        }
+        public class SomeException : Exception { }
 
-    //    protected override void SendInitLoggerMessage(InitLoggerMessage message)
-    //    {
-    //        throw new NotImplementedException();
-    //    }
+        protected override void SendRawLogEventMessage(object message)
+        {
+            Sys.EventStream.Publish(new Error(null, nameof(ExceptionEventFilterTests), GetType(), message));
+        }
 
-    //    protected override void AfterTest()
-    //    {
-    //        //After every test we make sure no uncatched messages have been logged
-    //        EnsureNoMoreLoggedMessages();
-    //        base.AfterTest();
-    //    }
+        [Fact]
+        public void SingleExceptionIsIntercepted()
+        {
+            EventFilter.Exception<SomeException>()
+                .ExpectOne(() => Log.Error(new SomeException(), "whatever"));
+            ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+        }
 
-    //    private void EnsureNoMoreLoggedMessages()
-    //    {
-    //        //We log a TestFinished exception. When it arrives to TestActor we know no other message has been logged7
-    //        //If we receive something else it means another message was logged, and ExpectMsg will fail
-    //        Log.Error(new TestFinished(), "Finished");
-    //        ExpectMsg<Error>(err => err.Cause is TestFinished,"cause to be <TestFinished>");
-    //    }
+        [Fact]
+        public void CanInterceptMessagesWhenStartIsSpecified()
+        {
+            EventFilter.Exception<SomeException>(start: "what")
+                .ExpectOne(() => Log.Error(new SomeException(), "whatever"));
+            ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+        }
 
-    //    [Fact]
-    //    public void SingleExceptionIsIntercepted()
-    //    {
-    //        EventFilter.Exception<SomeException>().Intercept(() => Log.Error(new SomeException(), "whatever"));
-    //    }
+        [Fact]
+        public void DoNotInterceptMessagesWhenStartDoesNotMatch()
+        {
+            EventFilter.Exception<SomeException>(start: "this is clearly not in message");
+            Log.Error(new SomeException(), "whatever");
+            ExpectMsg<Error>(err => (string)err.Message == "whatever");
+        }
 
-    //    [Fact]
-    //    public void CanInterceptMessagesWhenStartIsSpecified()
-    //    {
-    //        EventFilter.Exception<SomeException>(start: "what").Intercept(() => Log.Error(new SomeException(), "whatever"));
-    //    }
+        [Fact]
+        public void CanInterceptMessagesWhenMessageIsSpecified()
+        {
+            EventFilter.Exception<SomeException>(message: "whatever")
+                .ExpectOne(() => Log.Error(new SomeException(), "whatever"));
+            ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+        }
 
-    //    [Fact]
-    //    public void DoNotInterceptMessagesWhenStartDoesNotMatch()
-    //    {
-    //        EventFilter.Exception<SomeException>(start: "this is clearly not in message").Intercept(() => Log.Error(new SomeException(), "whatever"));
-    //        ExpectMsg<Error>(err => (string)err.Message == "whatever");
-    //    }
+        [Fact]
+        public void DoNotInterceptMessagesWhenMessageDoesNotMatch()
+        {
+            EventFilter.Exception<SomeException>(message: "this is clearly not the message");
+            Log.Error(new SomeException(), "whatever");
+            ExpectMsg<Error>(err => (string)err.Message == "whatever");
+        }
 
-    //    [Fact]
-    //    public void CanInterceptMessagesWhenMessageIsSpecified()
-    //    {
-    //        EventFilter.Exception<SomeException>(message: "whatever").Intercept(() => Log.Error(new SomeException(), "whatever"));
-    //    }
+        [Fact]
+        public void CanInterceptMessagesWhenContainsIsSpecified()
+        {
+            EventFilter.Exception<SomeException>(contains: "ate")
+                .ExpectOne(() => Log.Error(new SomeException(), "whatever"));
+            ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+        }
 
-    //    [Fact]
-    //    public void DoNotInterceptMessagesWhenMessageDoesNotMatch()
-    //    {
-    //        EventFilter.Exception<SomeException>(message: "this is clearly not the message").Intercept(() => Log.Error(new SomeException(), "whatever"));
-    //        ExpectMsg<Error>(err => (string)err.Message == "whatever");
-    //    }
-
-    //    [Fact]
-    //    public void CanInterceptMessagesWhenContainsIsSpecified()
-    //    {
-    //        EventFilter.Exception<SomeException>(contains: "ate").Intercept(() => Log.Error(new SomeException(), "whatever"));
-    //    }
-
-    //    [Fact]
-    //    public void DoNotInterceptMessagesWhenContainsDoesNotMatch()
-    //    {
-    //        EventFilter.Exception<SomeException>(contains: "this is clearly not in the message").Intercept(() => Log.Error(new SomeException(), "whatever"));
-    //        ExpectMsg<Error>(err => (string)err.Message == "whatever");
-    //    }
+        [Fact]
+        public void DoNotInterceptMessagesWhenContainsDoesNotMatch()
+        {
+            EventFilter.Exception<SomeException>(contains: "this is clearly not in the message");
+            Log.Error(new SomeException(), "whatever");
+            ExpectMsg<Error>(err => (string)err.Message == "whatever");
+        }
 
 
-    //    [Fact]
-    //    public void CanInterceptMessagesWhenSourceIsSpecified()
-    //    {
-    //        EventFilter.Exception<SomeException>(source: GetType().FullName).Intercept(() => Log.Error(new SomeException(), "whatever"));
-    //    }
+        [Fact]
+        public void CanInterceptMessagesWhenSourceIsSpecified()
+        {
+            EventFilter.Exception<SomeException>(source: LogSource.Create(this, Sys).Source)
+                .ExpectOne(() =>
+            {
+                Log.Error(new SomeException(), "whatever");
+            });
+            ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+        }
 
-    //    [Fact]
-    //    public void DoNotInterceptMessagesWhenSourceDoesNotMatch()
-    //    {
-    //        EventFilter.Exception<SomeException>(source: "this is clearly not the source").Intercept(() => Log.Error(new SomeException(), "whatever"));
-    //        ExpectMsg<Error>(err => (string)err.Message == "whatever");
-    //    }
+        [Fact]
+        public void DoNotInterceptMessagesWhenSourceDoesNotMatch()
+        {
+            EventFilter.Exception<SomeException>(source: "this is clearly not the source");
+            Log.Error(new SomeException(), "whatever");
+            ExpectMsg<Error>(err => (string)err.Message == "whatever");
+        }
 
 
-    //    [Fact]
-    //    public void SpecifiedNumbersOfExceptionsCanBeIntercepted()
-    //    {
-    //        EventFilter.Exception<SomeException>(occurrences: 2).Intercept(() =>
-    //        {
-    //            Log.Error(new SomeException(), "whatever");
-    //            Log.Error(new SomeException(), "whatever");
-    //        });
-    //    }
+        [Fact]
+        public void SpecifiedNumbersOfExceptionsCanBeIntercepted()
+        {
+            EventFilter.Exception<SomeException>()
+                .Expect(2, () =>
+                {
+                    Log.Error(new SomeException(), "whatever");
+                    Log.Error(new SomeException(), "whatever");
+                });
+            ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+        }
 
-    //    [Fact]
-    //    public void ShouldFailIfMoreExceptionsThenSpecifiedAreLogged()
-    //    {
-    //        var exception = XAssert.Throws<AssertException>(() =>
-    //            EventFilter.Exception<SomeException>(occurrences: 2).Intercept(() =>
-    //            {
-    //                Log.Error(new SomeException(), "whatever");
-    //                Log.Error(new SomeException(), "whatever");
-    //                Log.Error(new SomeException(), "whatever");
-    //            }));
-    //        Assert.Contains("1 messages too many", exception.Message, StringComparison.OrdinalIgnoreCase);
-    //    }
+        [Fact]
+        public void ShouldFailIfMoreExceptionsThenSpecifiedAreLogged()
+        {
+            var exception = XAssert.Throws<TrueException>(() =>
+                EventFilter.Exception<SomeException>().Expect(2, () =>
+                {
+                    Log.Error(new SomeException(), "whatever");
+                    Log.Error(new SomeException(), "whatever");
+                    Log.Error(new SomeException(), "whatever");
+                }));
+            Assert.Contains("1 message too many", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
 
-    //}
+        [Fact]
+        public void ShouldReportCorrectMessageCount()
+        {
+            var toSend = "Eric Cartman";
+            var actor = ActorOf( ExceptionTestActor.Props() );
+
+            EventFilter
+                .Exception<InvalidOperationException>(source: actor.Path.ToString())
+                // expecting 2 because the same exception is logged in PostRestart
+                .Expect(2, () => actor.Tell( toSend ));
+        }
+
+        internal sealed class ExceptionTestActor : UntypedActor
+        {
+            private ILoggingAdapter Log { get; } = Context.GetLogger();
+
+            protected override void PostRestart(Exception reason)
+            {
+                Log.Error(reason, "[PostRestart]");
+                base.PostRestart(reason);
+            }
+
+            protected override void OnReceive( object message )
+            {
+                switch (message)
+                {
+                    case string msg:
+                        throw new InvalidOperationException( "I'm sailing away. Set an open course" );
+
+                    default:
+                        Unhandled( message );
+                        break;
+                }
+            }
+
+            public static Props Props()
+            {
+                return Actor.Props.Create( () => new ExceptionTestActor() );
+            }
+        }
+    }
 }
 

--- a/src/core/Akka.TestKit/Akka.TestKit.csproj
+++ b/src/core/Akka.TestKit/Akka.TestKit.csproj
@@ -26,10 +26,6 @@
     </Compile>
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.TestKit/Internal/InternalTestActor.cs
+++ b/src/core/Akka.TestKit/Internal/InternalTestActor.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Collections.Concurrent;
 using Akka.Actor;
 using Akka.Event;
@@ -38,7 +39,19 @@ namespace Akka.TestKit.Internal
         /// <returns>TBD</returns>
         protected override bool Receive(object message)
         {
-            global::System.Diagnostics.Debug.WriteLine("TestActor received " + message);
+            try
+            {
+                global::System.Diagnostics.Debug.WriteLine("TestActor received " + message);
+            }
+            catch (FormatException)
+            {
+                if (message is LogEvent evt && evt.Message is LogMessage msg)
+                    global::System.Diagnostics.Debug.WriteLine(
+                        $"TestActor received a malformed formatted message. Template:[{msg.Format}], args:[{string.Join(",", msg.Args)}]");
+                else
+                    throw;
+            }
+
             var setIgnore = message as TestKit.TestActor.SetIgnore;
             if(setIgnore != null)
             {

--- a/src/core/Akka.Tests.Shared.Internals/Akka.Tests.Shared.Internals.csproj
+++ b/src/core/Akka.Tests.Shared.Internals/Akka.Tests.Shared.Internals.csproj
@@ -17,10 +17,6 @@
     <PackageReference Include="Fsharp.Core" Version="5.0.1" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
@@ -100,10 +100,6 @@ namespace Akka.TestKit
 
         private static string GetCallerName()
         {
-#if CORECLR
-            // TODO: CORECLR FIX IT
-            var name = "AkkaSpec";
-#else
             var systemNumber = Interlocked.Increment(ref _systemNumber);
             var stackTrace = new StackTrace(0);
             var name = stackTrace.GetFrames().
@@ -112,7 +108,7 @@ namespace Akka.TestKit
                 SkipWhile(m => m.DeclaringType.Name == "AkkaSpec").
                 Select(m => _nameReplaceRegex.Replace(m.DeclaringType.Name + "-" + systemNumber, "-")).
                 FirstOrDefault() ?? "test";
-#endif
+
             return name;
         }
 

--- a/src/core/Akka.Tests/Actor/Dispatch/Bug2640Spec.cs
+++ b/src/core/Akka.Tests/Actor/Dispatch/Bug2640Spec.cs
@@ -46,6 +46,12 @@ namespace Akka.Tests.Actor.Dispatch
         {
             public ThreadReporterActor()
             {
+                // Improve reliability of ForkJoinExecutorShouldShutdownUponAllActorsTerminating
+                // test which intermittently can fail because all messages are actually serviced 
+                // by a single thread from the pool. Happens under load, presumably when the processor
+                // finds it more efficient to keep thread locality of the execution.
+                Thread.Sleep(1);
+
                 Receive<GetThread>(_ => Sender.Tell(Thread.CurrentThread));
             }
         }
@@ -90,11 +96,10 @@ namespace Akka.Tests.Actor.Dispatch
 
             Dictionary<int, Thread> threads = null;
             Watch(actor);
-            var msgCount = 100;
-            for (var i = 0; i < msgCount; i++)
+            for (var i = 0; i < 100; i++)
                 actor.Tell(GetThread.Instance);
 
-            threads = ReceiveN(msgCount).Cast<Thread>().GroupBy(x => x.ManagedThreadId)
+            threads = ReceiveN(100).Cast<Thread>().GroupBy(x => x.ManagedThreadId)
                 .ToDictionary(x => x.Key, grouping => grouping.First());
 
             Sys.Stop(actor);

--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -21,20 +21,10 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="FsCheck.Xunit" Version="$(FsCheckVersion)" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
-    <Reference Include="System.Configuration" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' OR '$(TargetFramework)' == '$(NetTestVersion)'">
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION;CONFIGURATION</DefineConstants>
-  </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' OR '$(TargetFramework)' == '$(NetTestVersion)'">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>

--- a/src/core/Akka.Tests/IO/TcpIntegrationSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpIntegrationSpec.cs
@@ -21,9 +21,7 @@ using Akka.Util.Internal;
 using Xunit;
 using Xunit.Abstractions;
 using FluentAssertions;
-#if CORECLR
 using System.Runtime.InteropServices;
-#endif
 
 namespace Akka.Tests.IO
 {
@@ -174,14 +172,10 @@ namespace Akka.Tests.IO
         public void The_TCP_transport_implementation_should_properly_support_connecting_to_DNS_endpoints(AddressFamily family)
         {
             // Aaronontheweb, 9/2/2017 - POSIX-based OSES are still having trouble with IPV6 DNS resolution
-#if CORECLR
-            if(!System.Runtime.InteropServices.RuntimeInformation
+            if(!RuntimeInformation
                 .IsOSPlatform(OSPlatform.Windows) && family == AddressFamily.InterNetworkV6)
-            return;
-#else
-            if (RuntimeDetector.IsMono && family == AddressFamily.InterNetworkV6) // same as above
                 return;
-#endif
+
             var serverHandler = CreateTestProbe();
             var bindCommander = CreateTestProbe();
             bindCommander.Send(Sys.Tcp(), new Tcp.Bind(serverHandler.Ref, new IPEndPoint(family == AddressFamily.InterNetwork ? IPAddress.Loopback 

--- a/src/core/Akka.Tests/Loggers/LoggerSpec.cs
+++ b/src/core/Akka.Tests/Loggers/LoggerSpec.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.TestKit;
+using Xunit;
+using Xunit.Abstractions;
+using FluentAssertions;
+
+namespace Akka.Tests.Loggers
+{
+    public class LoggerSpec : AkkaSpec
+    {
+        private static readonly Config Config = ConfigurationFactory.ParseString(@"
+akka.loglevel = DEBUG
+akka.stdout-loglevel = DEBUG");
+
+        public static readonly (string t, string[] p) Case =  
+            ("This is {0} a {1} janky formatting. {4}", new []{"also", "very", "not cool"});
+
+        public LoggerSpec(ITestOutputHelper output) : base(Config, output)
+        { }
+
+        [Fact]
+        public void TestOutputLogger_WithBadFormattingMustNotThrow()
+        {
+            // Need to wait until TestOutputLogger initializes
+            Thread.Sleep(200);
+            Sys.EventStream.Subscribe(TestActor, typeof(LogEvent));
+
+            Sys.Log.Error(new FakeException("BOOM"), Case.t, Case.p);
+            ExpectMsg<Error>().Cause.Should().BeOfType<FakeException>();
+            ExpectMsg<Error>().Cause.Should().BeOfType<AggregateException>();
+
+            Sys.Log.Warning(Case.t, Case.p);
+            ExpectMsg<Warning>();
+            ExpectMsg<Error>().Cause.Should().BeOfType<FormatException>();
+
+            Sys.Log.Info(Case.t, Case.p);
+            ExpectMsg<Info>();
+            ExpectMsg<Error>().Cause.Should().BeOfType<FormatException>();
+
+            Sys.Log.Debug(Case.t, Case.p);
+            ExpectMsg<Debug>();
+            ExpectMsg<Error>().Cause.Should().BeOfType<FormatException>();
+        }
+
+        [Fact]
+        public void DefaultLogger_WithBadFormattingMustNotThrow()
+        {
+            var config = ConfigurationFactory.ParseString("akka.loggers = [\"Akka.Event.DefaultLogger\"]");
+            var sys2 = ActorSystem.Create("DefaultLoggerTest", config.WithFallback(Sys.Settings.Config));
+            var probe = CreateTestProbe(sys2);
+
+            sys2.EventStream.Subscribe(probe, typeof(LogEvent));
+
+            sys2.Log.Error(new FakeException("BOOM"), Case.t, Case.p);
+            probe.ExpectMsg<Error>().Cause.Should().BeOfType<FakeException>();
+
+            sys2.Log.Warning(Case.t, Case.p);
+            probe.ExpectMsg<Warning>();
+
+            sys2.Log.Info(Case.t, Case.p);
+            probe.ExpectMsg<Info>();
+
+            sys2.Log.Debug(Case.t, Case.p);
+            probe.ExpectMsg<Debug>();
+
+            sys2.Terminate().Wait();
+        }
+
+        [Fact]
+        public void StandardOutLogger_WithBadFormattingMustNotThrow()
+        {
+            var config = ConfigurationFactory.ParseString("akka.loggers = [\"Akka.Event.StandardOutLogger\"]");
+            var sys2 = ActorSystem.Create("StandardOutLoggerTest", config.WithFallback(Sys.Settings.Config));
+            var probe = CreateTestProbe(sys2);
+
+            sys2.EventStream.Subscribe(probe, typeof(LogEvent));
+
+            sys2.Log.Error(new FakeException("BOOM"), Case.t, Case.p);
+            probe.ExpectMsg<Error>().Cause.Should().BeOfType<FakeException>();
+
+            sys2.Log.Warning(Case.t, Case.p);
+            probe.ExpectMsg<Warning>();
+
+            sys2.Log.Info(Case.t, Case.p);
+            probe.ExpectMsg<Info>();
+
+            sys2.Log.Debug(Case.t, Case.p);
+            probe.ExpectMsg<Debug>();
+
+            sys2.Terminate().Wait();
+        }
+
+        [Theory]
+        [MemberData(nameof(LogEventFactory))]
+        public void StandardOutLogger_PrintLogEvent_WithBadLogFormattingMustNotThrow(LogEvent @event)
+        {
+            var obj = new object();
+            obj.Invoking(o => StandardOutLogger.PrintLogEvent(@event)).Should().NotThrow();
+        }
+
+        public static IEnumerable<object[]> LogEventFactory()
+        {
+            var ex = new FakeException("BOOM");
+            var logSource = LogSource.Create(nameof(LoggerSpec));
+            var ls = logSource.Source;
+            var lc = logSource.Type;
+            var formatter = new DefaultLogMessageFormatter();
+
+            yield return new object[] { new Error(ex, ls, lc, new LogMessage(formatter, Case.t, Case.p)) }; 
+
+            yield return new object[] {new Warning(ex, ls, lc, new LogMessage(formatter, Case.t, Case.p))};
+
+            yield return new object[] {new Info(ex, ls, lc, new LogMessage(formatter, Case.t, Case.p))};
+
+            yield return new object[] {new Debug(ex, ls, lc, new LogMessage(formatter, Case.t, Case.p))};
+        }
+
+        private class FakeException : Exception
+        {
+            public FakeException(string message) : base(message)
+            { }
+        }
+    }
+}

--- a/src/core/Akka.Tests/Pattern/CircuitBreakerSpec.cs
+++ b/src/core/Akka.Tests/Pattern/CircuitBreakerSpec.cs
@@ -515,12 +515,10 @@ namespace Akka.Tests.Pattern
         {
         }
 
-#if SERIALIZATION
         protected TestException( SerializationInfo info, StreamingContext context )
             : base( info, context )
         {
         }
-#endif
     }
 
 }

--- a/src/core/Akka/Actor/Address.cs
+++ b/src/core/Akka/Actor/Address.cs
@@ -23,10 +23,7 @@ namespace Akka.Actor
     /// for example a remote transport would want to associate additional
     /// information with an address, then this must be done externally.
     /// </summary>
-    public sealed class Address : IEquatable<Address>, IComparable<Address>, IComparable, ISurrogated
-#if CLONEABLE
-        , ICloneable
-#endif
+    public sealed class Address : IEquatable<Address>, IComparable<Address>, IComparable, ISurrogated, ICloneable
     {
         #region comparer
 

--- a/src/core/Akka/Actor/Props.cs
+++ b/src/core/Akka/Actor/Props.cs
@@ -768,12 +768,7 @@ namespace Akka.Actor
         protected override Props Copy()
         {
             var initialCopy = base.Copy();
-#if CLONEABLE
             var invokerCopy = (Func<TActor>)invoker.Clone();
-#else
-            // TODO: CORECLR FIX IT
-            var invokerCopy = invoker;
-#endif
             return new DynamicProps<TActor>(initialCopy, invokerCopy);
         }
 

--- a/src/core/Akka/Actor/Scheduler/SchedulerException.cs
+++ b/src/core/Akka/Actor/Scheduler/SchedulerException.cs
@@ -5,6 +5,8 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Runtime.Serialization;
+
 namespace Akka.Actor
 {
     /// <summary>
@@ -18,6 +20,16 @@ namespace Akka.Actor
         /// </summary>
         /// <param name="message">The message that describes the error.</param>
         public SchedulerException(string message) : base(message) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SchedulerException" /> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
+        protected SchedulerException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
     }
 }
 

--- a/src/core/Akka/Actor/Stash/StashOverflowException.cs
+++ b/src/core/Akka/Actor/Stash/StashOverflowException.cs
@@ -22,7 +22,6 @@ namespace Akka.Actor
         /// <param name="cause">The exception that is the cause of the current exception.</param>
         public StashOverflowException(string message, Exception cause = null) : base(message, cause) { }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="StashOverflowException"/> class.
         /// </summary>
@@ -32,6 +31,5 @@ namespace Akka.Actor
             : base(info, context)
         {
         }
-#endif
     }
 }

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -16,6 +16,8 @@
 
   <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
       <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
   </ItemGroup>
 
@@ -36,10 +38,6 @@
       <DependentUpon>PartialHandlerArgumentsCapture.tt</DependentUpon>
     </Compile>
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants);CORECLR;CONFIGURATION;</DefineConstants>
-  </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>

--- a/src/core/Akka/Configuration/ConfigurationException.cs
+++ b/src/core/Akka/Configuration/ConfigurationException.cs
@@ -40,7 +40,6 @@ namespace Akka.Configuration
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfigurationException"/> class.
         /// </summary>
@@ -50,7 +49,6 @@ namespace Akka.Configuration
             : base(info, context)
         {
         }
-#endif
     }
 }
 

--- a/src/core/Akka/Configuration/ConfigurationFactory.cs
+++ b/src/core/Akka/Configuration/ConfigurationFactory.cs
@@ -61,12 +61,8 @@ namespace Akka.Configuration
         /// <returns>The configuration defined in the configuration file.</returns>
         public static Config Load()
         {
-#if CONFIGURATION
             var section = (AkkaConfigurationSection)System.Configuration.ConfigurationManager.GetSection("akka") ?? new AkkaConfigurationSection();
             return section.AkkaConfig;
-#else
-            return ConfigurationFactory.Empty;
-#endif
         }
 
         /// <summary>

--- a/src/core/Akka/Configuration/Hocon/AkkaConfigurationSection.cs
+++ b/src/core/Akka/Configuration/Hocon/AkkaConfigurationSection.cs
@@ -5,7 +5,6 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-#if CONFIGURATION
 using System.Configuration;
 
 namespace Akka.Configuration.Hocon
@@ -67,4 +66,3 @@ namespace Akka.Configuration.Hocon
         }
     }
 }
-#endif

--- a/src/core/Akka/Configuration/Hocon/CDataConfigurationElement.cs
+++ b/src/core/Akka/Configuration/Hocon/CDataConfigurationElement.cs
@@ -5,7 +5,6 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-#if CONFIGURATION
 using System.Configuration;
 using System.Xml;
 
@@ -64,4 +63,3 @@ namespace Akka.Configuration.Hocon
         }
     }
 }
-#endif

--- a/src/core/Akka/Configuration/Hocon/HoconConfigurationElement.cs
+++ b/src/core/Akka/Configuration/Hocon/HoconConfigurationElement.cs
@@ -5,7 +5,6 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-#if CONFIGURATION
 using System.Configuration;
 
 namespace Akka.Configuration.Hocon
@@ -42,4 +41,3 @@ namespace Akka.Configuration.Hocon
         }
     }
 }
-#endif

--- a/src/core/Akka/Dispatch/ExecutorService.cs
+++ b/src/core/Akka/Dispatch/ExecutorService.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Runtime.Serialization;
 using Akka.Actor;
 using Akka.Annotations;
 
@@ -70,6 +71,13 @@ namespace Akka.Dispatch
         /// <param name="message">TBD</param>
         /// <param name="inner">TBD</param>
         public RejectedExecutionException(string message = null, Exception inner = null) : base(message, inner) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RejectedExecutionException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
+        protected RejectedExecutionException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }
 

--- a/src/core/Akka/Event/EventBusUnsubscriber.cs
+++ b/src/core/Akka/Event/EventBusUnsubscriber.cs
@@ -8,6 +8,7 @@
 using Akka.Actor;
 using Akka.Actor.Internal;
 using Akka.Annotations;
+using Akka.Dispatch;
 using Akka.Util.Internal;
 
 namespace Akka.Event
@@ -176,7 +177,7 @@ namespace Akka.Event
         /// <param name="debug">TBD</param>
         public void Start(ActorSystemImpl system, EventStream eventStream, bool debug)
         {
-            system.SystemActorOf(Props.Create<EventStreamUnsubscriber>(eventStream, system, debug),
+            system.SystemActorOf(Props.Create<EventStreamUnsubscriber>(eventStream, system, debug).WithDispatcher(Dispatchers.InternalDispatcherId),
                 string.Format("EventStreamUnsubscriber-{0}", _unsubscribersCounter.IncrementAndGet()));
         }
     }

--- a/src/core/Akka/IO/Buffers/DirectBufferPool.cs
+++ b/src/core/Akka/IO/Buffers/DirectBufferPool.cs
@@ -21,6 +21,16 @@ namespace Akka.IO.Buffers
         public BufferPoolAllocationException(string message) : base(message)
         {
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BufferPoolAllocationException" /> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
+        protected BufferPoolAllocationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
     }
 
     /// <summary>

--- a/src/core/Akka/Pattern/IllegalStateException.cs
+++ b/src/core/Akka/Pattern/IllegalStateException.cs
@@ -33,7 +33,6 @@ namespace Akka.Pattern
         {
         }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="IllegalStateException"/> class.
         /// </summary>
@@ -43,6 +42,5 @@ namespace Akka.Pattern
             : base(info, context)
         {
         }
-#endif
     }
 }

--- a/src/core/Akka/Pattern/OpenCircuitException.cs
+++ b/src/core/Akka/Pattern/OpenCircuitException.cs
@@ -82,7 +82,6 @@ namespace Akka.Pattern
             : this("Circuit Breaker is open; calls are failing fast", cause, remainingDuration)
         { }
 
-#if SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="OpenCircuitException"/> class.
         /// </summary>
@@ -91,7 +90,15 @@ namespace Akka.Pattern
         protected OpenCircuitException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
+            var duration = (string)info.GetValue("RemainingDuration", typeof(string));
+            RemainingDuration = TimeSpan.Parse(duration);
         }
-#endif
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null) throw new ArgumentNullException(nameof(info));
+            info.AddValue("RemainingDuration", RemainingDuration);
+            base.GetObjectData(info, context);
+        }
     }
 }

--- a/src/core/Akka/Pattern/UserCalledFailException.cs
+++ b/src/core/Akka/Pattern/UserCalledFailException.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using System.Text;
 using Akka.Actor;
 
@@ -16,5 +17,12 @@ namespace Akka.Pattern
     {
         public UserCalledFailException() : base($"User code caused [{nameof(CircuitBreaker)}] to fail because it calls the [{nameof(CircuitBreaker.Fail)}()] method.")
         { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserCalledFailException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
+        protected UserCalledFailException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/core/Akka/Routing/TailChopping.cs
+++ b/src/core/Akka/Routing/TailChopping.cs
@@ -122,7 +122,14 @@ namespace Akka.Routing
                     try
                     {
 
-                        completion.TrySetResult(await (_routees[currentIndex].Ask(message, _within)).ConfigureAwait(false));
+                        completion.TrySetResult(
+                            await (_routees[currentIndex].Ask(message, _within)).ConfigureAwait(false));
+                    }
+                    catch (AskTimeoutException)
+                    {
+                        completion.TrySetResult(
+                            new Status.Failure(
+                                new AskTimeoutException($"Ask timed out on {sender} after {_within}")));
                     }
                     catch (TaskCanceledException)
                     {

--- a/src/core/Akka/Util/MatchHandler/CachedMatchCompiler.cs
+++ b/src/core/Akka/Util/MatchHandler/CachedMatchCompiler.cs
@@ -71,27 +71,6 @@ namespace Akka.Tools.MatchHandler
             delegateArguments = result.Arguments;
             return compiledLambda;
         }
-
-#if !CORECLR
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="handlers">TBD</param>
-        /// <param name="capturedArguments">TBD</param>
-        /// <param name="signature">TBD</param>
-        /// <param name="typeBuilder">TBD</param>
-        /// <param name="methodName">TBD</param>
-        /// <param name="methodAttributes">TBD</param>
-        /// <returns>TBD</returns>
-        public void CompileToMethod(IReadOnlyList<TypeHandler> handlers, IReadOnlyList<Argument> capturedArguments, MatchBuilderSignature signature, TypeBuilder typeBuilder, string methodName, MethodAttributes methodAttributes = MethodAttributes.Public | MethodAttributes.Static)
-        {
-            var result = _expressionBuilder.BuildLambdaExpression(handlers);
-            var lambdaExpression = result.LambdaExpression;
-            var parameterTypes = lambdaExpression.Parameters.Select(p => p.Type).ToArray();
-            var method = typeBuilder.DefineMethod(methodName, methodAttributes, typeof(bool), parameterTypes);
-            _expressionCompiler.CompileToMethod(lambdaExpression, method);
-        }
-#endif
     }
 }
 

--- a/src/core/Akka/Util/MatchHandler/ILambdaExpressionCompiler.cs
+++ b/src/core/Akka/Util/MatchHandler/ILambdaExpressionCompiler.cs
@@ -22,15 +22,6 @@ namespace Akka.Tools.MatchHandler
         /// <param name="expression">The expression to compile</param>
         /// <returns>A delegate containing the compiled version of the lambda.</returns>
         Delegate Compile(LambdaExpression expression);
-
-#if !CORECLR
-        /// <summary>
-        /// Compiles the lambda into a method definition.
-        /// </summary>
-        /// <param name="expression">The expression to compile</param>
-        /// <param name="method">A <see cref="MethodBuilder"/> which will be used to hold the lambda's IL.</param>
-        void CompileToMethod(LambdaExpression expression, MethodBuilder method);
-#endif
     }
 }
 

--- a/src/core/Akka/Util/MatchHandler/IMatchCompiler.cs
+++ b/src/core/Akka/Util/MatchHandler/IMatchCompiler.cs
@@ -25,20 +25,6 @@ namespace Akka.Tools.MatchHandler
         /// <param name="signature">TBD</param>
         /// <returns>TBD</returns>
         PartialAction<T> Compile(IReadOnlyList<TypeHandler> handlers, IReadOnlyList<Argument> capturedArguments, MatchBuilderSignature signature);
-
-#if !CORECLR
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="handlers">TBD</param>
-        /// <param name="capturedArguments">TBD</param>
-        /// <param name="signature">TBD</param>
-        /// <param name="typeBuilder">TBD</param>
-        /// <param name="methodName">TBD</param>
-        /// <param name="methodAttributes">TBD</param>
-        /// <returns>TBD</returns>
-        void CompileToMethod(IReadOnlyList<TypeHandler> handlers, IReadOnlyList<Argument> capturedArguments, MatchBuilderSignature signature, TypeBuilder typeBuilder, string methodName, MethodAttributes methodAttributes = MethodAttributes.Public | MethodAttributes.Static);
-#endif
     }
 }
 

--- a/src/core/Akka/Util/MatchHandler/LambdaExpressionCompiler.cs
+++ b/src/core/Akka/Util/MatchHandler/LambdaExpressionCompiler.cs
@@ -25,19 +25,6 @@ namespace Akka.Tools.MatchHandler
         {
             return expression.Compile();
         }
-
-#if !CORECLR
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="expression">TBD</param>
-        /// <param name="method"></param>
-        /// <returns>TBD</returns>
-        public void CompileToMethod(LambdaExpression expression, MethodBuilder method)
-        {
-            expression.CompileToMethod(method);
-        }
-#endif
     }
 }
 

--- a/src/core/Akka/Util/MatchHandler/MatchBuilder.cs
+++ b/src/core/Akka/Util/MatchHandler/MatchBuilder.cs
@@ -171,21 +171,6 @@ namespace Akka.Tools.MatchHandler
             return partialAction;
         }
 
-#if !CORECLR
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="typeBuilder">TBD</param>
-        /// <param name="methodName">TBD</param>
-        /// <param name="attributes">TBD</param>
-        /// <returns>TBD</returns>
-        public void BuildToMethod(TypeBuilder typeBuilder, string methodName, MethodAttributes attributes = MethodAttributes.Public | MethodAttributes.Static)
-        {
-            _compiler.CompileToMethod(_typeHandlers, _arguments, new MatchBuilderSignature(_signature), typeBuilder, methodName, methodAttributes: attributes);
-            _state = State.Built;
-        }
-#endif
-
         private static void EnsureCanHandleType(Type handlesType)
         {
             if(!_itemType.IsAssignableFrom(handlesType))

--- a/src/core/Akka/Util/RuntimeDetector.cs
+++ b/src/core/Akka/Util/RuntimeDetector.cs
@@ -37,12 +37,7 @@ namespace Akka.Util
         /// <returns><c>true</c> if the current runtime is Windows</returns>
         private static bool _IsWindows()
         {
-#if CORECLR
-            return System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-#else
-            return System.Environment.OSVersion.Platform != PlatformID.MacOSX &&
-                   System.Environment.OSVersion.Platform != PlatformID.Unix;
-#endif
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         }
     }
 }


### PR DESCRIPTION
#### 1.4.20 May 12 2021 ####
**Maintenance Release for Akka.NET 1.4**

Akka.NET v1.4.20 is a minor release that includes some bug fixes and improvements to Akka.NET.

* [Akka: Fixed some `internal-dispatcher` usages ](https://github.com/akkadotnet/akka.net/pull/4995)
* [Akka: Remove restrictions required by netstandard 1.x but available in 2.0 ](https://github.com/akkadotnet/akka.net/pull/3790)
* [Akka: Prevent loggers to throw `FormatException` and show a friendly message instead. ](https://github.com/akkadotnet/akka.net/pull/4998)
* [Akka.Persistence.Sql.Common: Some persistent actors are stuck with `RecoveryTimedOutException` after circuit breaker opens](https://github.com/akkadotnet/akka.net/issues/4265)
* [Akka.Persistence.Sql.Common: marking Akka.Persistence.Sql.Common as `beta` for v1.4.20](https://github.com/akkadotnet/akka.net/pull/5006)
* [Akka.Remote: `Akka.Remote.Serialization.PrimitiveSerializers` needs cross platform compatibility](https://github.com/akkadotnet/akka.net/issues/4986)
* [Akka.Streams: Fixed `QueueSource.PostStop` and added a missing test case](https://github.com/akkadotnet/akka.net/pull/4991)
* [Akka.Cluster.Sharding: Reduce sharding warnings when there are no buffered messages](https://github.com/akkadotnet/akka.net/pull/5003)

To see the [full set of fixes in Akka.NET v1.4.20, please see the milestone on Github](https://github.com/akkadotnet/akka.net/milestone/50).

| COMMITS | LOC+ | LOC- | AUTHOR |
| --- | --- | --- | --- |
| 4 | 677 | 316 | Gregorius Soedharmo |
| 3 | 3 | 3 | dependabot[bot] |
| 3 | 101 | 44 | Ismael Hamed |
| 2 | 5 | 0 | Aaron Stannard |
| 1 | 625 | 675 | Matthew Heaton |