### PR TITLE
Fix SonarQube's "IEnumerable LINQs should be simplified" / Code Smell

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/TestLease.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/TestLease.cs
@@ -167,7 +167,7 @@ namespace Akka.Cluster.Tools.Tests.MultiNode
                     return true;
 
                 case ActionRequest ar:
-                    var r = requests.Where(i => i.Item2.Equals(ar.Request)).FirstOrDefault();
+                    var r = requests.FirstOrDefault(i => i.Item2.Equals(ar.Request));
                     if (r.Item1 != null)
                     {
                         _log.Info("Actioning request {0} to {1}", r.Item2, ar.Result);


### PR DESCRIPTION
Hello,

This pull request is _very simple_ and aims to reduce the technical debt. It specifically targets the "IEnumerable LINQs should be simplified" [rule](https://rules.sonarsource.com/csharp/RSPEC-2971)  in SonarQube.

Let me know if you are interested in similar contributions.

Best,
Martin