### PR TITLE
Turn on MiscMessageSerializer LocalScope message serialization.

### DIFF
--- a/src/core/Akka.Remote.Tests/Serialization/MiscMessageSerializerSpec.cs
+++ b/src/core/Akka.Remote.Tests/Serialization/MiscMessageSerializerSpec.cs
@@ -142,7 +142,7 @@ namespace Akka.Remote.Tests.Serialization
             AssertEqual(poisonPill);
         }
 
-        [Fact(Skip = "Not implemented yet")]
+        [Fact]
         public void Can_serialize_LocalScope()
         {
             var localScope = LocalScope.Instance;

--- a/src/core/Akka.Remote/Configuration/Remote.conf
+++ b/src/core/Akka.Remote/Configuration/Remote.conf
@@ -33,7 +33,7 @@ akka {
       "Akka.Actor.PoisonPill, Akka" = akka-misc
       "Akka.Actor.Kill, Akka" = akka-misc
       "Akka.Actor.PoisonPill, Akka" = akka-misc
-      #"Akka.Actor.LocalScope, Akka" = akka-misc
+      "Akka.Actor.LocalScope, Akka" = akka-misc
       "Akka.Actor.RemoteScope, Akka" = akka-misc
       "Akka.Routing.FromConfig, Akka" = akka-misc
       "Akka.Routing.DefaultResizer, Akka" = akka-misc


### PR DESCRIPTION
`LocalScope` was supposed to be serialized using `MiscMessageSerializer`. The code is there but it is not turned on on the `Akka.Remote` configurations file.
Is there a reason why we're not using it?