### PR TITLE
Increase timeout value to avoid timeout failure

### DIFF
--- a/src/core/Akka.Streams.Tests/Dsl/KeepAliveConcatSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/KeepAliveConcatSpec.cs
@@ -13,11 +13,16 @@ using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
 using FluentAssertions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Akka.Streams.Tests.Dsl
 {
     public class KeepAliveConcatSpec : Akka.TestKit.Xunit2.TestKit
     {
+        public KeepAliveConcatSpec(ITestOutputHelper output)
+            : base(output: output)
+        { }
+
         private readonly Source<IEnumerable<int>, NotUsed> _sampleSource = Source.From(Enumerable.Range(1, 10).Grouped(3));
 
         private IEnumerable<IEnumerable<int>> Expand(IEnumerable<int> lst)
@@ -52,7 +57,7 @@ namespace Akka.Streams.Tests.Dsl
                 .Grouped(1000)
                 .RunWith(Sink.First<IEnumerable<IEnumerable<int>>>(), Sys.Materializer());
 
-            t.AwaitResult()
+            t.AwaitResult(TimeSpan.FromSeconds(6))
                 .SelectMany(x => x)
                 .Should().BeEquivalentTo(Enumerable.Range(1, 10), o => o.WithStrictOrdering());
         }


### PR DESCRIPTION
With a 2 second initial delay, the spec is squeazing it too close to the default default timeout of 3 seconds, increased the timeout to avoid sporadic spec fail.