### PR TITLE
added `FastHash` benchmark

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Remoting/FastHashBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Remoting/FastHashBenchmarks.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Akka.Benchmarks.Configurations;
+using Akka.Remote.Serialization;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Benchmarks.Remoting
+{
+    [Config(typeof(MicroBenchmarkConfig))]
+    public class FastHashBenchmarks
+    {
+        public const string HashKey1 = "hash1";
+
+        [Benchmark]
+        public int FastHash_OfString()
+        {
+            return FastHash.OfString(HashKey1);
+        }
+
+        [Benchmark]
+        public int FastHash_OfStringUnsafe()
+        {
+            return FastHash.OfStringFast(HashKey1);
+        }
+    }
+}

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveRemote.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveRemote.approved.txt
@@ -1,4 +1,5 @@
 ﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Benchmarks")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Metrics")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding")]

--- a/src/core/Akka.Remote/Properties/AssemblyInfo.cs
+++ b/src/core/Akka.Remote/Properties/AssemblyInfo.cs
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("Akka.Cluster.Tools")]
 [assembly: InternalsVisibleTo("Akka.Cluster.Sharding")]
 [assembly: InternalsVisibleTo("Akka.Cluster.Metrics")]
+[assembly: InternalsVisibleTo("Akka.Benchmarks")]


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19041.985 (2004/May2020Update/20H1)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=5.0.203
  [Host]     : .NET Core 3.1.15 (CoreCLR 4.700.21.21202, CoreFX 4.700.21.21402), X64 RyuJIT
  DefaultJob : .NET Core 3.1.15 (CoreCLR 4.700.21.21202, CoreFX 4.700.21.21402), X64 RyuJIT


```
|                  Method |      Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------ |----------:|----------:|----------:|-------:|------:|------:|----------:|
|       FastHash_OfString | 20.598 ns | 0.2125 ns | 0.1884 ns | 0.0095 |     - |     - |      40 B |
| FastHash_OfStringUnsafe |  6.172 ns | 0.0379 ns | 0.0336 ns |      - |     - |     - |         - |
