### PR TITLE
`Span<char>`-ifying `ActorPath` and `Address` parsing

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Actor/ActorPathBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/ActorPathBenchmarks.cs
@@ -16,12 +16,16 @@ namespace Akka.Benchmarks.Actor
     {
         private ActorPath x;
         private ActorPath y;
+        private ActorPath _childPath;
+        private Address _sysAdr = new Address("akka.tcp", "system", "127.0.0.1", 1337);
+        private Address _otherAdr = new Address("akka.tcp", "system", "127.0.0.1", 1338);
 
         [GlobalSetup]
         public void Setup()
         {
-            x = new RootActorPath(new Address("akka.tcp", "system", "127.0.0.1", 1337), "user");
-            y = new RootActorPath(new Address("akka.tcp", "system", "127.0.0.1", 1337), "system");
+            x = new RootActorPath(_sysAdr, "user");
+            y = new RootActorPath(_sysAdr, "system");
+            _childPath = x / "parent" / "child";
         }
 
         [Benchmark]
@@ -45,7 +49,19 @@ namespace Akka.Benchmarks.Actor
         [Benchmark]
         public string ActorPath_ToString()
         {
-            return x.ToString();
+            return _childPath.ToString();
+        }
+
+        [Benchmark]
+        public string ActorPath_ToSerializationFormat()
+        {
+            return _childPath.ToSerializationFormat();
+        }
+
+        [Benchmark]
+        public string ActorPath_ToSerializationFormatWithAddress()
+        {
+            return _childPath.ToSerializationFormatWithAddress(_otherAdr);
         }
     }
 }

--- a/src/benchmark/Akka.Benchmarks/Actor/NameAndUidBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/NameAndUidBenchmarks.cs
@@ -20,9 +20,9 @@ namespace Akka.Benchmarks.Actor
         public const string ActorPath = "foo#11241311";
 
         [Benchmark]
-        public void ActorCell_SplitNameAndUid()
+        public NameAndUid ActorCell_SplitNameAndUid()
         {
-            ActorCell.SplitNameAndUid(ActorPath);
+            return ActorCell.SplitNameAndUid(ActorPath);
         }
     }
 }

--- a/src/benchmark/Akka.Benchmarks/Actor/NameAndUidBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/NameAndUidBenchmarks.cs
@@ -20,9 +20,9 @@ namespace Akka.Benchmarks.Actor
         public const string ActorPath = "foo#11241311";
 
         [Benchmark]
-        public NameAndUid ActorCell_SplitNameAndUid()
+        public void ActorCell_SplitNameAndUid()
         {
-            return ActorCell.SplitNameAndUid(ActorPath);
+            ActorCell.SplitNameAndUid(ActorPath);
         }
     }
 }

--- a/src/benchmark/Akka.Benchmarks/Actor/NameAndUidBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/NameAndUidBenchmarks.cs
@@ -1,0 +1,28 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="NameAndUidBenchmarks.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Benchmarks.Actor
+{
+    [Config(typeof(MicroBenchmarkConfig))]
+    public class NameAndUidBenchmarks
+    {
+        public const string ActorPath = "foo#11241311";
+
+        [Benchmark]
+        public NameAndUid ActorCell_SplitNameAndUid()
+        {
+            return ActorCell.SplitNameAndUid(ActorPath);
+        }
+    }
+}

--- a/src/benchmark/Akka.Benchmarks/Actor/NameAndUidBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/NameAndUidBenchmarks.cs
@@ -24,5 +24,11 @@ namespace Akka.Benchmarks.Actor
         {
             return ActorCell.SplitNameAndUid(ActorPath);
         }
+
+        [Benchmark]
+        public (string name, int uid) ActorCell_GetNameAndUid()
+        {
+            return ActorCell.GetNameAndUid(ActorPath);
+        }
     }
 }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -115,6 +115,7 @@ namespace Akka.Actor
         protected bool SetChildrenTerminationReason(Akka.Actor.Internal.SuspendReason reason) { }
         public void SetReceiveTimeout(System.Nullable<System.TimeSpan> timeout = null) { }
         protected void SetTerminated() { }
+        public static Akka.Actor.NameAndUid SplitNameAndUid(string name) { }
         public virtual void Start() { }
         protected void Stash(Akka.Dispatch.SysMsg.SystemMessage msg) { }
         public void Stop(Akka.Actor.IActorRef child) { }
@@ -1323,6 +1324,13 @@ namespace Akka.Actor
         public override void Stop() { }
         public override void Suspend() { }
         protected override void TellInternal(object message, Akka.Actor.IActorRef sender) { }
+    }
+    public class NameAndUid
+    {
+        public NameAndUid(string name, int uid) { }
+        public string Name { get; }
+        public int Uid { get; }
+        public override string ToString() { }
     }
     public sealed class Nobody : Akka.Actor.MinimalActorRef
     {

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -115,6 +115,7 @@ namespace Akka.Actor
         protected bool SetChildrenTerminationReason(Akka.Actor.Internal.SuspendReason reason) { }
         public void SetReceiveTimeout(System.Nullable<System.TimeSpan> timeout = null) { }
         protected void SetTerminated() { }
+        [System.ObsoleteAttribute("Not used. Will be removed in Akka.NET v1.5.")]
         public static Akka.Actor.NameAndUid SplitNameAndUid(string name) { }
         public virtual void Start() { }
         protected void Stash(Akka.Dispatch.SysMsg.SystemMessage msg) { }
@@ -1325,6 +1326,7 @@ namespace Akka.Actor
         public override void Suspend() { }
         protected override void TellInternal(object message, Akka.Actor.IActorRef sender) { }
     }
+    [System.ObsoleteAttribute("Not used. Will be removed in Akka.NET v1.5.")]
     public class NameAndUid
     {
         public NameAndUid(string name, int uid) { }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -115,7 +115,6 @@ namespace Akka.Actor
         protected bool SetChildrenTerminationReason(Akka.Actor.Internal.SuspendReason reason) { }
         public void SetReceiveTimeout(System.Nullable<System.TimeSpan> timeout = null) { }
         protected void SetTerminated() { }
-        public static Akka.Actor.NameAndUid SplitNameAndUid(string name) { }
         public virtual void Start() { }
         protected void Stash(Akka.Dispatch.SysMsg.SystemMessage msg) { }
         public void Stop(Akka.Actor.IActorRef child) { }
@@ -1324,13 +1323,6 @@ namespace Akka.Actor
         public override void Stop() { }
         public override void Suspend() { }
         protected override void TellInternal(object message, Akka.Actor.IActorRef sender) { }
-    }
-    public class NameAndUid
-    {
-        public NameAndUid(string name, int uid) { }
-        public string Name { get; }
-        public int Uid { get; }
-        public override string ToString() { }
     }
     public sealed class Nobody : Akka.Actor.MinimalActorRef
     {

--- a/src/core/Akka.Remote/RemoteSystemDaemon.cs
+++ b/src/core/Akka.Remote/RemoteSystemDaemon.cs
@@ -308,10 +308,10 @@ namespace Akka.Remote
             var n = 0;
             while (true)
             {
-                var nameAndUid = ActorCell.SplitNameAndUid(path);
-                if (TryGetChild(nameAndUid.Name, out var child))
+                var (s, uid) = ActorCell.GetNameAndUid(path);
+                if (TryGetChild(s, out var child))
                 {
-                    if (nameAndUid.Uid != ActorCell.UndefinedUid && nameAndUid.Uid != child.Path.Uid)
+                    if (uid != ActorCell.UndefinedUid && uid != child.Path.Uid)
                         return Nobody.Instance;
                     return n == 0 ? child : child.GetChild(name.TakeRight(n));
                 }

--- a/src/core/Akka.Remote/Serialization/LruBoundedCache.cs
+++ b/src/core/Akka.Remote/Serialization/LruBoundedCache.cs
@@ -25,7 +25,7 @@ namespace Akka.Remote.Serialization
         /// <returns>A 32-bit pseudo-random hash value.</returns>
         public static int OfString(string s)
         {
-            var chars = s.ToCharArray();
+            var chars = s.AsSpan();
             var s0 = 391408L; // seed value 1, DON'T CHANGE
             var s1 = 601258L; // seed value 2, DON'T CHANGE
             unchecked

--- a/src/core/Akka.Tests/Actor/ActorSelectionSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorSelectionSpec.cs
@@ -76,12 +76,10 @@ namespace Akka.Tests.Actor
         {
             var result = node.Ask(query).Result;
 
-            var actorRef = result as IActorRef;
-            if (actorRef != null)
+            if (result is IActorRef actorRef)
                 return actorRef;
 
-            var selection = result as ActorSelection;
-            return selection != null ? Identify(selection) : null;
+            return result is ActorSelection selection ? Identify(selection) : null;
         }
 
         [Fact]

--- a/src/core/Akka/Actor/ActorCell.Children.cs
+++ b/src/core/Akka/Actor/ActorCell.Children.cs
@@ -387,17 +387,16 @@ namespace Akka.Actor
             }
             else
             {
-                var nameAndUid = SplitNameAndUid(name);
-                if (TryGetChildRestartStatsByName(nameAndUid.Name, out var stats))
+                var (s, uid) = GetNameAndUid(name);
+                if (TryGetChildRestartStatsByName(s, out var stats))
                 {
-                    var uid = nameAndUid.Uid;
                     if (uid == ActorCell.UndefinedUid || uid == stats.Uid)
                     {
                         child = stats.Child;
                         return true;
                     }
                 }
-                else if (TryGetFunctionRef(nameAndUid.Name, nameAndUid.Uid, out var functionRef))
+                else if (TryGetFunctionRef(s, uid, out var functionRef))
                 {
                     child = functionRef;
                     return true;

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -483,7 +483,7 @@ namespace Akka.Actor
         /// </summary>
         /// <param name="name">TBD</param>
         /// <returns>TBD</returns>
-        internal static NameAndUid SplitNameAndUid(string name)
+        public static NameAndUid SplitNameAndUid(string name)
         {
             var i = name.IndexOf('#');
             return i < 0

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -502,7 +502,7 @@ namespace Akka.Actor
             var i = name.IndexOf('#');
             return i < 0
                 ? (name, UndefinedUid)
-                : (name.Substring(0, i), Int32.Parse(name.Substring(i + 1)));
+                : (name.Substring(0, i), SpanHacks.Parse(name.AsSpan(i + 1)));
         }
 
         /// <summary>

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -483,7 +483,7 @@ namespace Akka.Actor
         /// </summary>
         /// <param name="name">TBD</param>
         /// <returns>TBD</returns>
-        public static NameAndUid SplitNameAndUid(string name)
+        internal static NameAndUid SplitNameAndUid(string name)
         {
             var i = name.IndexOf('#');
             return i < 0

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -479,16 +479,30 @@ namespace Akka.Actor
             actor?.Unclear();
         }
         /// <summary>
-        /// TBD
+        /// INTERNAL API
         /// </summary>
         /// <param name="name">TBD</param>
         /// <returns>TBD</returns>
+        [Obsolete("Not used. Will be removed in Akka.NET v1.5.")]
         public static NameAndUid SplitNameAndUid(string name)
         {
             var i = name.IndexOf('#');
             return i < 0
                 ? new NameAndUid(name, UndefinedUid)
                 : new NameAndUid(name.Substring(0, i), Int32.Parse(name.Substring(i + 1)));
+        }
+
+        /// <summary>
+        /// INTERNAL API
+        /// </summary>
+        /// <param name="name">The full name of the actor, including the UID if known</param>
+        /// <returns>A new (string name, int uid) instance.</returns>
+        internal static (string name, int uid) GetNameAndUid(string name)
+        {
+            var i = name.IndexOf('#');
+            return i < 0
+                ? (name, UndefinedUid)
+                : (name.Substring(0, i), Int32.Parse(name.Substring(i + 1)));
         }
 
         /// <summary>

--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -276,8 +276,8 @@ namespace Akka.Actor
         /// <returns>A newly created <see cref="ChildActorPath"/></returns>
         public static ActorPath operator /(ActorPath path, string name)
         {
-            var nameAndUid = ActorCell.SplitNameAndUid(name);
-            return new ChildActorPath(path, nameAndUid.Name, nameAndUid.Uid);
+            var (s, uid) = ActorCell.GetNameAndUid(name);
+            return new ChildActorPath(path, s, uid);
         }
 
         /// <summary>

--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -327,23 +327,22 @@ namespace Akka.Actor
         {
             actorPath = null;
 
-            Address address;
-            Uri uri;
-            if (!TryParseAddress(path, out address, out uri)) return false;
+            if (!TryParseAddress(path, out var address, out var uri)) return false;
             var spanified = uri.AbsolutePath.AsSpan();
-            var pathElements = new List<string>();
             var nextSlash = 0;
             var firstSlash = spanified.IndexOf('/');
             if (firstSlash == 0)
                 spanified = spanified.Slice(1); // skip
+
+            actorPath = new RootActorPath(address);
+
             while ((nextSlash = spanified.IndexOf('/')) > 0)
             {
-                pathElements.Add(spanified.Slice(0, nextSlash).ToString());
+                actorPath /= spanified.Slice(0, nextSlash).ToString();
                 spanified = spanified.Slice(nextSlash + 1, spanified.Length - nextSlash - 1);
             }
-            pathElements.Add(spanified.ToString()); // final element
+            actorPath /= spanified.ToString(); // final path element
 
-            actorPath = new RootActorPath(address) / pathElements;
             if (uri.Fragment.StartsWith("#"))
             {
                 var uid = int.Parse(uri.Fragment.Substring(1));

--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -330,37 +330,24 @@ namespace Akka.Actor
             if (!TryParseAddress(path, out var address, out var uri)) return false;
             var spanified = uri.AbsolutePath.AsSpan();
             var nextSlash = 0;
-            var firstSlash = spanified.IndexOf('/');
-            if (firstSlash == 0)
-                spanified = spanified.Slice(1); // skip
 
             actorPath = new RootActorPath(address);
 
-            while ((nextSlash = spanified.IndexOf('/')) > 0)
+            do
             {
-                actorPath /= spanified.Slice(0, nextSlash).ToString();
-                spanified = spanified.Slice(nextSlash + 1, spanified.Length - nextSlash - 1);
-            }
-
-            // have a final path element - and we need to make sure it's not a trailing slash
-            if (spanified.Length > 0)
-            {
-                // edge case - leading slash
-                if (spanified.IndexOf('/') == 0)
+                nextSlash = spanified.IndexOf('/');
+                if (nextSlash > 0)
                 {
-                    spanified = spanified.Slice(1); // skip it
-                    // edge case edge case - leading slash as was also trailing
-                    if (spanified.Length > 0) 
-                    {
-                        actorPath /= spanified.ToString();
-                    }
+                    actorPath /= spanified.Slice(0, nextSlash).ToString();
                 }
-                else
+                else if (nextSlash < 0 && spanified.Length > 0)
                 {
                     actorPath /= spanified.ToString();
                 }
-            }
-           
+
+                spanified = spanified.Slice(nextSlash + 1);
+            } while (nextSlash >= 0);
+
 
             if (uri.Fragment.StartsWith("#"))
             {

--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -332,15 +332,18 @@ namespace Akka.Actor
             if (!TryParseAddress(path, out address, out uri)) return false;
             var spanified = uri.AbsolutePath.AsSpan();
             var pathElements = new List<string>();
-            var curLen = 0;
             var nextSlash = 0;
+            var firstSlash = spanified.IndexOf('/');
+            if (firstSlash == 0)
+                spanified = spanified.Slice(1); // skip
             while ((nextSlash = spanified.IndexOf('/')) > 0)
             {
-                pathElements.Add(spanified.Slice(curLen, nextSlash).ToString());
-                curLen = nextSlash + 1;
+                pathElements.Add(spanified.Slice(0, nextSlash).ToString());
+                spanified = spanified.Slice(nextSlash + 1, spanified.Length - nextSlash - 1);
             }
+            pathElements.Add(spanified.ToString()); // final element
 
-            actorPath = new RootActorPath(address) / pathElements.Skip(1);
+            actorPath = new RootActorPath(address) / pathElements;
             if (uri.Fragment.StartsWith("#"))
             {
                 var uid = int.Parse(uri.Fragment.Substring(1));

--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -351,7 +351,7 @@ namespace Akka.Actor
 
             if (uri.Fragment.StartsWith("#"))
             {
-                var uid = int.Parse(uri.Fragment.Substring(1));
+                var uid = SpanHacks.Parse(uri.Fragment.AsSpan(1));
                 actorPath = actorPath.WithUid(uid);
             }
             return true;

--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -341,7 +341,26 @@ namespace Akka.Actor
                 actorPath /= spanified.Slice(0, nextSlash).ToString();
                 spanified = spanified.Slice(nextSlash + 1, spanified.Length - nextSlash - 1);
             }
-            actorPath /= spanified.ToString(); // final path element
+
+            // have a final path element - and we need to make sure it's not a trailing slash
+            if (spanified.Length > 0)
+            {
+                // edge case - leading slash
+                if (spanified.IndexOf('/') == 0)
+                {
+                    spanified = spanified.Slice(1); // skip it
+                    // edge case edge case - leading slash as was also trailing
+                    if (spanified.Length > 0) 
+                    {
+                        actorPath /= spanified.ToString();
+                    }
+                }
+                else
+                {
+                    actorPath /= spanified.ToString();
+                }
+            }
+           
 
             if (uri.Fragment.StartsWith("#"))
             {

--- a/src/core/Akka/Actor/NameAndUid.cs
+++ b/src/core/Akka/Actor/NameAndUid.cs
@@ -5,11 +5,14 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
+
 namespace Akka.Actor
 {
     /// <summary>
-    /// TBD
+    /// INTERNAL API
     /// </summary>
+    [Obsolete("Not used. Will be removed in Akka.NET v1.5.")]
     public class NameAndUid
     {
         private readonly string _name;

--- a/src/core/Akka/Actor/NameAndUid.cs
+++ b/src/core/Akka/Actor/NameAndUid.cs
@@ -8,9 +8,9 @@
 namespace Akka.Actor
 {
     /// <summary>
-    /// INTERNAL API
+    /// TBD
     /// </summary>
-    internal readonly struct NameAndUid
+    public class NameAndUid
     {
         private readonly string _name;
         private readonly int _uid;

--- a/src/core/Akka/Actor/NameAndUid.cs
+++ b/src/core/Akka/Actor/NameAndUid.cs
@@ -8,9 +8,9 @@
 namespace Akka.Actor
 {
     /// <summary>
-    /// TBD
+    /// INTERNAL API
     /// </summary>
-    public class NameAndUid
+    internal readonly struct NameAndUid
     {
         private readonly string _name;
         private readonly int _uid;

--- a/src/core/Akka/Actor/RepointableActorRef.cs
+++ b/src/core/Akka/Actor/RepointableActorRef.cs
@@ -292,12 +292,10 @@ namespace Akka.Actor
                 case "":
                     return ActorRefs.Nobody;
                 default:
-                    var nameAndUid = ActorCell.SplitNameAndUid(next);
-                    if (Lookup.TryGetChildStatsByName(nameAndUid.Name, out var stats))
+                    var (s, uid) = ActorCell.GetNameAndUid(next);
+                    if (Lookup.TryGetChildStatsByName(s, out var stats))
                     {
-                        var crs = stats as ChildRestartStats;
-                        var uid = nameAndUid.Uid;
-                        if (crs != null && (uid == ActorCell.UndefinedUid || uid == crs.Uid))
+                        if (stats is ChildRestartStats crs && (uid == ActorCell.UndefinedUid || uid == crs.Uid))
                         {
                             if (name.Skip(1).Any())
                                 return crs.Child.GetChild(name.Skip(1));
@@ -305,7 +303,7 @@ namespace Akka.Actor
                                 return crs.Child;
                         }
                     }
-                    else if (Lookup is ActorCell cell && cell.TryGetFunctionRef(nameAndUid.Name, nameAndUid.Uid, out var functionRef))
+                    else if (Lookup is ActorCell cell && cell.TryGetFunctionRef(s, uid, out var functionRef))
                     {
                         return functionRef;
                     }

--- a/src/core/Akka/Util/SpanHacks.cs
+++ b/src/core/Akka/Util/SpanHacks.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Akka.Util
+{
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// <see cref="Span{T}"/> polyfills that should be deleted once we drop .NET Standard 2.0 support.
+    /// </summary>
+    internal static class SpanHacks
+    {
+        /// <summary>
+        /// Parses an integer from a string.
+        /// </summary>
+        /// <remarks>
+        /// PERFORMS NO INPUT VALIDATION.
+        /// </remarks>
+        /// <param name="str">The span of input characters.</param>
+        /// <returns>An <see cref="int"/>.</returns>
+        public static int Parse(ReadOnlySpan<char> str)
+        {
+            var pos = 0;
+            var returnValue = 0;
+            var sign = 1;
+            if (str[0] == '-')
+            {
+                sign = -1;
+                pos++;
+            }
+
+            bool IsNumeric(char x)
+            {
+                return (x >= '0' && x <= '9');
+            }
+
+            for (; pos < str.Length; pos++)
+            {
+                if (!IsNumeric(str[pos]))
+                    throw new FormatException($"[{str.ToString()}] is now a valid numeric format");
+                returnValue = returnValue * 10 + str[pos] - '0';
+            }
+
+            return sign * returnValue;
+        }
+    }
+}


### PR DESCRIPTION
Inspired by @Arkatufus's excellent work on https://github.com/akkadotnet/akka.net/pull/5028 thus far, I decided to take a stab at performance optimizing some of the primitives in Akka.Actor that get used heavily in the hot path of the Akka.Remote deserialization pipeline.