### PR TITLE
Consolidate intercept

### DIFF
--- a/src/core/Akka.Remote.Tests/Transport/AkkaProtocolSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaProtocolSpec.cs
@@ -423,11 +423,7 @@ namespace Akka.Remote.Tests.Transport
 
             Watch(stateActor);
 
-            // inner exception will be a TimeoutException
-            Intercept<AggregateException>(() =>
-            {
-                statusPromise.Task.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
-            });
+            Intercept<TimeoutException>(() => statusPromise.Task.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue());
             ExpectTerminated(stateActor);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowAskSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowAskSpec.cs
@@ -266,13 +266,11 @@ namespace Akka.Streams.Tests.Dsl
                 .Ask<Reply>(r, _timeout, 4)
                 .RunWith(Sink.Ignore<Reply>(), _materializer);
 
-            Intercept<AggregateException>(() =>
+            Intercept<WatchedActorTerminatedException>(() =>
             {
                 r.Tell(PoisonPill.Instance);
                 done.Wait(RemainingOrDefault);
-            })
-            .Flatten()
-            .InnerException.Should().BeOfType<WatchedActorTerminatedException>();
+            });
 
         }, _materializer);
 

--- a/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
@@ -154,37 +154,6 @@ namespace Akka.TestKit
             }
             throw new ThrowsException(typeof(Exception));
         }
-        
-        protected async Task InterceptAsync(Func<Task> asyncActionThatThrows)
-        {
-            try
-            {
-                await asyncActionThatThrows();
-            }
-            catch(Exception)
-            {
-                return;
-            }
-            throw new ThrowsException(typeof(Exception));
-        }
-
-        [Obsolete("Use Intercept instead. This member will be removed.")]
-        protected void intercept<T>(Action actionThatThrows) where T : Exception
-        {
-            Assert.Throws<T>(() => actionThatThrows());
-        }
-
-        [Obsolete("Use ExpectMsgPf instead. This member will be removed.")]
-        protected T expectMsgPF<T>(string hint, Func<object, T> pf)
-        {
-            return ExpectMsgPf<T>(hint, pf);
-        }
-
-        [Obsolete("Use ExpectMsgPf instead. This member will be removed.")]
-        protected T expectMsgPF<T>(TimeSpan duration, string hint, Func<object, T> pf)
-        {
-            return ExpectMsgPf<T>(duration, hint, pf);
-        }
 
         protected void MuteDeadLetters(params Type[] messageClasses)
         {

--- a/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
@@ -212,7 +212,7 @@ namespace Akka.TestKit
             throw new ThrowsException(typeof(T));
         }
 
-        [Obsolete("User AssertThrows instead.")]
+        [Obsolete("Use AssertThrows instead.")]
         protected void Intercept(Action actionThatThrows)
         {
             try

--- a/src/core/Akka.Tests/Actor/CoordinatedShutdownSpec.cs
+++ b/src/core/Akka.Tests/Actor/CoordinatedShutdownSpec.cs
@@ -337,18 +337,7 @@ namespace Akka.Tests.Actor
 
             var result = co.Run(CoordinatedShutdown.UnknownReason.Instance);
             ExpectMsg("B");
-            Intercept<AggregateException>(() =>
-            {
-                if (result.Wait(RemainingOrDefault))
-                {
-                    result.Exception?.Flatten().InnerException.Should().BeOfType<TimeoutException>();
-                }
-                else
-                {
-                    throw new Exception("CoordinatedShutdown task did not complete");
-                }
-            });
-
+            Intercept<TimeoutException>(() => result.Wait(RemainingOrDefault));
             ExpectNoMsg(TimeSpan.FromMilliseconds(200)); // C not run
         }
 


### PR DESCRIPTION
Currently there are a few `Intercept` methods included in `AkkaSpec`, but they lack cohesion in their implementations. This PR aims at solving this by consolidating all of them under a single one that also overcome their biggest limitation: not unwrapping `AggregateExceptions`, which force users to deal with these inside the tests themselves. 

This PR also brings along the `AssertThrows` method (a proper implementation of the `Intercept` that returns `void` instead), which should be the preferred  between the two when no further inspection of the caught exception is needed.

Hopefully this will make it porting unit tests more straight forward and better aligned with the JVM.