### PR TITLE
remove `ActorPath.ToString` call from `ResolveActorRefWithLocalAddress`

### DIFF
--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -489,7 +489,6 @@ namespace Akka.Remote
                 //the actor's local address was already included in the ActorPath
                 if (HasAddress(actorPath.Address))
                 {
-                    // HACK: needed to make ActorSelections work
                     if (actorPath is RootActorPath)
                         return RootGuardian;
                     return _local.ResolveActorRef(RootGuardian, actorPath.ElementsWithUid);

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -490,7 +490,7 @@ namespace Akka.Remote
                 if (HasAddress(actorPath.Address))
                 {
                     // HACK: needed to make ActorSelections work
-                    if (actorPath.ToStringWithoutAddress().Equals("/"))
+                    if (actorPath is RootActorPath)
                         return RootGuardian;
                     return _local.ResolveActorRef(RootGuardian, actorPath.ElementsWithUid);
                 }


### PR DESCRIPTION
Provided that this works, should eliminate an entire source of allocations from the Akka.Remote deserialization pipeline.