### PR TITLE
[WIP] Perf/`ChildContainer` Optimization

### DIFF
--- a/src/common.props
+++ b/src/common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2021 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.4.19</VersionPrefix>
+    <VersionPrefix>1.4.21</VersionPrefix>
     <PackageIconUrl>https://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>

--- a/src/core/Akka/Actor/ActorCell.Children.cs
+++ b/src/core/Akka/Actor/ActorCell.Children.cs
@@ -266,8 +266,7 @@ namespace Akka.Actor
         {
             get
             {
-                var terminating = ChildrenContainer as TerminatingChildrenContainer;
-                return terminating != null && terminating.Reason is SuspendReason.IWaitingForChildren;
+                return ChildrenContainer is TerminatingChildrenContainer terminating && terminating.Reason is SuspendReason.IWaitingForChildren;
             }
         }
 

--- a/src/core/Akka/Actor/ActorCell.Children.cs
+++ b/src/core/Akka/Actor/ActorCell.Children.cs
@@ -22,7 +22,7 @@ namespace Akka.Actor
 {
     public partial class ActorCell
     {
-        private volatile IChildrenContainer _childrenContainerDoNotCallMeDirectly = EmptyChildrenContainer.Instance;
+        private volatile IChildrenContainer _childrenContainerDoNotCallMeDirectly;
         private long _nextRandomNameDoNotCallMeDirectly = -1; // Interlocked.Increment automatically adds 1 to this value. Allows us to start from 0.
         private ImmutableDictionary<string, FunctionRef> _functionRefsDoNotCallMeDirectly = ImmutableDictionary<string, FunctionRef>.Empty;
 

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -82,6 +82,14 @@ namespace Akka.Actor
             Parent = parent;
             Dispatcher = dispatcher;
 
+            if (parent is RootGuardianActorRef || self is RootGuardianActorRef)
+            {
+                _childrenContainerDoNotCallMeDirectly = EmptyChildrenContainer.Instance;
+            }
+            else
+            {
+                _childrenContainerDoNotCallMeDirectly = EmptyNonRootChildrenContainer.Instance;
+            }
         }
 
         /// <summary>

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainerBase.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainerBase.cs
@@ -13,47 +13,47 @@ using System.Text;
 
 namespace Akka.Actor.Internal
 {
+    internal class LazyReadOnlyCollection<T> : IReadOnlyCollection<T>
+    {
+        private readonly IEnumerable<T> _enumerable;
+        private int _lazyCount;
+
+        public int Count
+        {
+            get
+            {
+                int count = _lazyCount;
+
+                if (count == -1)
+                    _lazyCount = count = _enumerable.Count();
+
+                return count;
+            }
+        }
+
+        public LazyReadOnlyCollection(IEnumerable<T> enumerable)
+        {
+            _enumerable = enumerable;
+            _lazyCount = -1;
+        }
+
+        /// <inheritdoc/>
+        public IEnumerator<T> GetEnumerator()
+        {
+            return _enumerable.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+
     /// <summary>
     /// TBD
     /// </summary>
     public abstract class ChildrenContainerBase : IChildrenContainer
     {
-        private class LazyReadOnlyCollection<T> : IReadOnlyCollection<T>
-        {
-            private readonly IEnumerable<T> _enumerable;
-            private int _lazyCount;
-
-            public int Count
-            {
-                get
-                {
-                    int count = _lazyCount;
-
-                    if (count == -1)
-                        _lazyCount = count = _enumerable.Count();
-
-                    return count;
-                }
-            }
-
-            public LazyReadOnlyCollection(IEnumerable<T> enumerable)
-            {
-                _enumerable = enumerable;
-                _lazyCount = -1;
-            }
-
-            /// <inheritdoc/>
-            public IEnumerator<T> GetEnumerator()
-            {
-                return _enumerable.GetEnumerator();
-            }
-
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return GetEnumerator();
-            }
-        }
-
         private readonly IImmutableDictionary<string, IChildStats> _children;
 
         /// <summary>

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/NonRootNormalChildrenContainer.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/NonRootNormalChildrenContainer.cs
@@ -6,6 +6,7 @@
 // //-----------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 
 namespace Akka.Actor.Internal
@@ -81,24 +82,167 @@ namespace Akka.Actor.Internal
         }
         public IChildrenContainer ShallDie(IActorRef actor)
         {
-            throw new System.NotImplementedException();
+            return new TerminatingChildrenContainer(_actorStats.ToImmutableDictionary(), actor, SuspendReason.UserRequest.Instance);
         }
 
         public IChildrenContainer Reserve(string name)
         {
-            throw new System.NotImplementedException();
+            if (_actorStats.ContainsKey(name))
+                throw new InvalidActorNameException($@"Actor name ""{name}"" is not unique!");
+            _actorStats[name] = ChildNameReserved.Instance;
+            return this;
         }
 
         public IChildrenContainer Unreserve(string name)
         {
-            throw new System.NotImplementedException();
+            if (_actorStats.TryGetValue(name, out var stats) && (stats is ChildNameReserved))
+            {
+                _actorStats.Remove(name);
+            }
+            return this;
         }
 
-        public bool IsTerminating { get; }
-        public bool IsNormal { get; }
+        public bool IsTerminating => false;
+        public bool IsNormal => true;
         public bool Contains(IActorRef actor)
         {
-            throw new System.NotImplementedException();
+            return TryGetByRef(actor, out _);
         }
+    }
+
+    /// <summary>
+    /// This is the empty container, shared among all leaf actors.
+    /// </summary>
+    public class EmptyNonRootChildrenContainer : IChildrenContainer
+    {
+        private static readonly ImmutableDictionary<string, IChildStats> _emptyStats = ImmutableDictionary<string, IChildStats>.Empty;
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        protected EmptyNonRootChildrenContainer()
+        {
+            //Intentionally left blank
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public static IChildrenContainer Instance { get; } = new EmptyNonRootChildrenContainer();
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="name">TBD</param>
+        /// <param name="stats">TBD</param>
+        /// <returns>TBD</returns>
+        public virtual IChildrenContainer Add(string name, ChildRestartStats stats)
+        {
+            var newMap = _emptyStats.Add(name, stats);
+            return NormalChildrenContainer.Create(newMap);
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="child">TBD</param>
+        /// <returns>TBD</returns>
+        public IChildrenContainer Remove(IActorRef child)
+        {
+            return this;
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="name">TBD</param>
+        /// <param name="stats">TBD</param>
+        /// <returns>TBD</returns>
+        public bool TryGetByName(string name, out IChildStats stats)
+        {
+            stats = null;
+            return false;
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="actor">TBD</param>
+        /// <param name="childRestartStats">TBD</param>
+        /// <returns>TBD</returns>
+        public bool TryGetByRef(IActorRef actor, out ChildRestartStats childRestartStats)
+        {
+            childRestartStats = null;
+            return false;
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="actor">TBD</param>
+        /// <returns>TBD</returns>
+        public bool Contains(IActorRef actor)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public IReadOnlyCollection<IInternalActorRef> Children { get { return ImmutableList<IInternalActorRef>.Empty; } }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public IReadOnlyCollection<ChildRestartStats> Stats { get { return ImmutableList<ChildRestartStats>.Empty; } }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="actor">TBD</param>
+        /// <returns>TBD</returns>
+        public IChildrenContainer ShallDie(IActorRef actor)
+        {
+            return this;
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="name">TBD</param>
+        /// <returns>TBD</returns>
+        public virtual IChildrenContainer Reserve(string name)
+        {
+            var dictionary = new Dictionary<string, IChildStats> { [name] = ChildNameReserved.Instance };
+            return new NonRootNormalChildrenContainer(dictionary);
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="name">TBD</param>
+        /// <returns>TBD</returns>
+        public IChildrenContainer Unreserve(string name)
+        {
+            return this;
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <returns>TBD</returns>
+        public override string ToString()
+        {
+            return "No children";
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public virtual bool IsTerminating { get { return false; } }
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public virtual bool IsNormal { get { return true; } }
     }
 }

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/NonRootNormalChildrenContainer.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/NonRootNormalChildrenContainer.cs
@@ -1,0 +1,104 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="NonRootNormalChildrenContainer.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Akka.Actor.Internal
+{
+    /// <summary>
+    /// MUTABLE
+    /// </summary>
+    public class NonRootNormalChildrenContainer : IChildrenContainer
+    {
+        private readonly IDictionary<string, IChildStats> _actorStats;
+
+        public NonRootNormalChildrenContainer(IDictionary<string, IChildStats> actorStats)
+        {
+            _actorStats = actorStats;
+        }
+
+        public IChildrenContainer Add(string name, ChildRestartStats stats)
+        {
+            _actorStats[name] = stats;
+            return this;
+        }
+
+        public IChildrenContainer Remove(IActorRef child)
+        {
+            _actorStats.Remove(child.Path.Name);
+            return this;
+        }
+
+        public bool TryGetByName(string name, out IChildStats stats)
+        {
+            return _actorStats.TryGetValue(name, out stats);
+        }
+
+        public bool TryGetByRef(IActorRef actor, out ChildRestartStats childRestartStats)
+        {
+            if (_actorStats.TryGetValue(actor.Path.Name, out var stats))
+            {
+                //Since the actor exists, ChildRestartStats is the only valid ChildStats.
+                if (stats is ChildRestartStats crStats && actor.Equals(crStats.Child))
+                {
+                    childRestartStats = crStats;
+                    return true;
+                }
+            }
+            childRestartStats = null;
+            return false;
+        }
+
+        public IReadOnlyCollection<IInternalActorRef> Children
+        {
+            get
+            {
+                var children = _actorStats.Values
+                    .OfType<ChildRestartStats>()
+                    .Select(item => item.Child);
+
+                // The children collection must stay lazy evaluated
+                return new LazyReadOnlyCollection<IInternalActorRef>(children);
+            }
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public IReadOnlyCollection<ChildRestartStats> Stats
+        {
+            get
+            {
+                var children = _actorStats.Values.OfType<ChildRestartStats>();
+
+                return new LazyReadOnlyCollection<ChildRestartStats>(children);
+            }
+        }
+        public IChildrenContainer ShallDie(IActorRef actor)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public IChildrenContainer Reserve(string name)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public IChildrenContainer Unreserve(string name)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool IsTerminating { get; }
+        public bool IsNormal { get; }
+        public bool Contains(IActorRef actor)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
Before

``` ini

BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19041.985 (2004/May2020Update/20H1)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=5.0.203
  [Host]     : .NET Core 3.1.15 (CoreCLR 4.700.21.21202, CoreFX 4.700.21.21402), X64 RyuJIT
  Job-KAXPBW : .NET Core 3.1.15 (CoreCLR 4.700.21.21202, CoreFX 4.700.21.21402), X64 RyuJIT

InvocationCount=1  IterationCount=10  RunStrategy=Throughput  
UnrollFactor=1  WarmupCount=5  

```
|      Method | ActorCount |    Mean |    Error |   StdDev |       Gen 0 |      Gen 1 |     Gen 2 | Allocated |
|------------ |----------- |--------:|---------:|---------:|------------:|-----------:|----------:|----------:|
| Actor_spawn |     100000 | 2.491 s | 0.1060 s | 0.0555 s | 111000.0000 | 31000.0000 | 4000.0000 |    638 MB |