### PR TITLE
Removed `StringBuilder` allocation from `Base64Encoding`

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -4810,6 +4810,8 @@ namespace Akka.Util
     {
         public const string Base64Chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+~";
         public static string Base64Encode(this long value) { }
+        public static string Base64Encode(this long value, string prefix) { }
+        [System.ObsoleteAttribute("Do not use. Pass in prefix as a string instead.")]
         public static System.Text.StringBuilder Base64Encode(this long value, System.Text.StringBuilder sb) { }
         public static string Base64Encode(this string s) { }
     }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -4810,7 +4810,6 @@ namespace Akka.Util
     {
         public const string Base64Chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+~";
         public static string Base64Encode(this long value) { }
-        public static string Base64Encode(this long value, string prefix) { }
         [System.ObsoleteAttribute("Do not use. Pass in prefix as a string instead.")]
         public static System.Text.StringBuilder Base64Encode(this long value, System.Text.StringBuilder sb) { }
         public static string Base64Encode(this string s) { }

--- a/src/core/Akka/Actor/ActorCell.Children.cs
+++ b/src/core/Akka/Actor/ActorCell.Children.cs
@@ -135,8 +135,7 @@ namespace Akka.Actor
         private string GetRandomActorName(string prefix = "$")
         {
             var id = Interlocked.Increment(ref _nextRandomNameDoNotCallMeDirectly);
-            var sb = new StringBuilder(prefix);
-            return id.Base64Encode(sb).ToString();
+            return id.Base64Encode(prefix);
         }
 
         /// <summary>

--- a/src/core/Akka/Util/Base64Encoding.cs
+++ b/src/core/Akka/Util/Base64Encoding.cs
@@ -32,6 +32,8 @@ namespace Akka.Util
 
         public static string Base64Encode(this long value, string prefix)
         {
+            // 11 is the number of characters it takes to represent long.MaxValue
+            // so we will never need a larger size for encoding longs
             Span<char> sb = stackalloc char[11 + prefix?.Length ?? 0];
             var spanIndex = 0;
             if (!string.IsNullOrEmpty(prefix) && prefix.Length > 0)

--- a/src/core/Akka/Util/Base64Encoding.cs
+++ b/src/core/Akka/Util/Base64Encoding.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Text;
 
 namespace Akka.Util
@@ -24,7 +25,30 @@ namespace Akka.Util
         /// </summary>
         /// <param name="value">TBD</param>
         /// <returns>TBD</returns>
-        public static string Base64Encode(this long value) => Base64Encode(value, new StringBuilder()).ToString();
+        public static string Base64Encode(this long value)
+        {
+            return Base64Encode(value, "");
+        }
+
+        public static string Base64Encode(this long value, string prefix)
+        {
+            Span<char> sb = stackalloc char[11 + prefix?.Length ?? 0];
+            var spanIndex = 0;
+            if (!string.IsNullOrEmpty(prefix) && prefix.Length > 0)
+            {
+                prefix.AsSpan().CopyTo(sb);
+                spanIndex = prefix.Length;
+            }
+
+            var next = value;
+            do
+            {
+                var index = (int)(next & 63);
+                sb[spanIndex++] = Base64Chars[index];
+                next = next >> 6;
+            } while (next != 0);
+            return sb.Slice(0, spanIndex).ToString();
+        }
 
         /// <summary>
         /// TBD
@@ -32,6 +56,7 @@ namespace Akka.Util
         /// <param name="value">TBD</param>
         /// <param name="sb">TBD</param>
         /// <returns>TBD</returns>
+        [Obsolete("Do not use. Pass in prefix as a string instead.")]
         public static StringBuilder Base64Encode(this long value, StringBuilder sb)
         {
             var next = value;

--- a/src/core/Akka/Util/Base64Encoding.cs
+++ b/src/core/Akka/Util/Base64Encoding.cs
@@ -30,13 +30,13 @@ namespace Akka.Util
             return Base64Encode(value, "");
         }
 
-        public static string Base64Encode(this long value, string prefix)
+        internal static string Base64Encode(this long value, string prefix)
         {
             // 11 is the number of characters it takes to represent long.MaxValue
             // so we will never need a larger size for encoding longs
             Span<char> sb = stackalloc char[11 + prefix?.Length ?? 0];
             var spanIndex = 0;
-            if (!string.IsNullOrEmpty(prefix) && prefix.Length > 0)
+            if (!string.IsNullOrWhiteSpace(prefix) && prefix.Length > 0)
             {
                 prefix.AsSpan().CopyTo(sb);
                 spanIndex = prefix.Length;


### PR DESCRIPTION
## Before (ActorSelection + Ask)

``` ini

BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19041.985 (2004/May2020Update/20H1)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=5.0.203
  [Host]     : .NET Core 3.1.15 (CoreCLR 4.700.21.21202, CoreFX 4.700.21.21402), X64 RyuJIT
  DefaultJob : .NET Core 3.1.15 (CoreCLR 4.700.21.21202, CoreFX 4.700.21.21402), X64 RyuJIT


```
|                        Method | Iterations |       Mean |     Error |    StdDev |     Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------------ |----------- |-----------:|----------:|----------:|----------:|------:|------:|----------:|
| RequestResponseActorSelection |      10000 | 100.723 ms | 2.0080 ms | 5.6308 ms | 5000.0000 |     - |     - |     20 MB |
|          CreateActorSelection |      10000 |   7.564 ms | 0.2305 ms | 0.6795 ms |  953.1250 |     - |     - |      4 MB |


## After (ActorSelection + Ask)

``` ini

BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19041.985 (2004/May2020Update/20H1)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=5.0.203
  [Host]     : .NET Core 3.1.15 (CoreCLR 4.700.21.21202, CoreFX 4.700.21.21402), X64 RyuJIT
  DefaultJob : .NET Core 3.1.15 (CoreCLR 4.700.21.21202, CoreFX 4.700.21.21402), X64 RyuJIT


```
|                        Method | Iterations |      Mean |     Error |    StdDev |     Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------------ |----------- |----------:|----------:|----------:|----------:|------:|------:|----------:|
| RequestResponseActorSelection |      10000 | 89.490 ms | 1.2584 ms | 0.9824 ms | 4666.6667 |     - |     - |     19 MB |
|          CreateActorSelection |      10000 |  5.445 ms | 0.0385 ms | 0.0342 ms |  953.1250 |     - |     - |      4 MB |
