### PR TITLE
Reduced allocations around `ActorCell` and `Task` handling

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -110,7 +110,7 @@ namespace Akka.Actor
         public void Resume(System.Exception causedByFailure) { }
         public virtual void SendMessage(Akka.Actor.Envelope message) { }
         public virtual void SendMessage(Akka.Actor.IActorRef sender, object message) { }
-        public void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage systemMessage) { }
+        public virtual void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage systemMessage) { }
         protected void SetActorFields(Akka.Actor.ActorBase actor) { }
         protected bool SetChildrenTerminationReason(Akka.Actor.Internal.SuspendReason reason) { }
         public void SetReceiveTimeout(System.Nullable<System.TimeSpan> timeout = null) { }

--- a/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
+++ b/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
@@ -401,7 +401,7 @@ namespace Akka.Actor
             }
         }
 
-        private void HandleSupervise(IActorRef child, bool async)
+        private static void HandleSupervise(IActorRef child, bool async)
         {
             if (async && child is RepointableActorRef @ref)
             {
@@ -506,11 +506,11 @@ namespace Akka.Actor
         }
 
         /// <summary>
-        /// TBD
+        /// Handles a <see cref="ISystemMessage"/>
         /// </summary>
         /// <remarks>➡➡➡ NEVER SEND THE SAME SYSTEM MESSAGE OBJECT TO TWO ACTORS ⬅⬅⬅</remarks>
-        /// <param name="systemMessage">TBD</param>
-        public void SendSystemMessage(ISystemMessage systemMessage)
+        /// <param name="systemMessage">The system message to process.</param>
+        public virtual void SendSystemMessage(ISystemMessage systemMessage)
         {
             try
             {
@@ -522,7 +522,7 @@ namespace Akka.Actor
             }
         }
 
-        private void Kill()
+        private static void Kill()
         {
             throw new ActorKilledException("Kill");
         }

--- a/src/core/Akka/Actor/ReceiveActor.cs
+++ b/src/core/Akka/Actor/ReceiveActor.cs
@@ -111,7 +111,7 @@ namespace Akka.Actor
             return newHandler;
         }
 
-        private Action<T> WrapAsyncHandler<T>(Func<T, Task> asyncHandler)
+        private static Action<T> WrapAsyncHandler<T>(Func<T, Task> asyncHandler)
         {
             return m =>
             {

--- a/src/core/Akka/Dispatch/ActorTaskScheduler.cs
+++ b/src/core/Akka/Dispatch/ActorTaskScheduler.cs
@@ -116,7 +116,7 @@ namespace Akka.Dispatch
             RunTask(() =>
             {
                 action();
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             });
         }
 


### PR DESCRIPTION
* Made `ActorCell.SendSystemMessage` `virtual` so it can be subclassed
* Made a number of `ActorCell` methods `static` to reduce object memory footprint
* Reduced number of possible `Task` allocations where they weren't needed