### PR TITLE
remove ISSUE_TEMPLATE.md

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,6 +1,0 @@
-When creating a new issue, please make sure the following information is part of your issue description. (if applicable). Thank You!
-
-- Which Akka.Net version you are using
-- On which platform you are using Akka.Net
-- A list of steps to reproduce the issue. Or an gist or github repo which can be easily used to reproduce your case.
-


### PR DESCRIPTION
We now get issue templates from the Akka.NET organization itself https://github.com/akkadotnet/.github