### PR TITLE
[Perf] `ActorPath`: tried caching `Join()` output

### DIFF
--- a/src/common.props
+++ b/src/common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2021 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.4.19</VersionPrefix>
+    <VersionPrefix>1.4.21</VersionPrefix>
     <PackageIconUrl>https://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>

--- a/src/core/Akka/Actor/ActorPath.cs
+++ b/src/core/Akka/Actor/ActorPath.cs
@@ -496,6 +496,7 @@ namespace Akka.Actor
             return false;
         }
 
+        private string _join = null;
 
         /// <summary>
         /// Joins this instance.
@@ -506,30 +507,36 @@ namespace Akka.Actor
             if (this is RootActorPath)
                 return "/";
 
-            // Resolve length of final string
-            var totalLength = 0;
-            var p = this;
-            while (!(p is RootActorPath))
+            if (string.IsNullOrEmpty(_join))
             {
-                totalLength += p.Name.Length + 1;
-                p = p.Parent;
+                // Resolve length of final string
+                var totalLength = 0;
+                var p = this;
+                while (!(p is RootActorPath))
+                {
+                    totalLength += p.Name.Length + 1;
+                    p = p.Parent;
+                }
+
+                // Concatenate segments (in reverse order) into buffer with '/' prefixes
+                char[] buffer = new char[totalLength];
+                int offset = buffer.Length;
+                p = this;
+                while (!(p is RootActorPath))
+                {
+                    offset -= p.Name.Length + 1;
+                    buffer[offset] = '/';
+
+                    p.Name.CopyTo(0, buffer, offset + 1, p.Name.Length);
+
+                    p = p.Parent;
+                }
+
+                _join = new string(buffer);
             }
 
-            // Concatenate segments (in reverse order) into buffer with '/' prefixes
-            char[] buffer = new char[totalLength];
-            int offset = buffer.Length;
-            p = this;
-            while (!(p is RootActorPath))
-            {
-                offset -= p.Name.Length + 1;
-                buffer[offset] = '/';
+            return _join;
 
-                p.Name.CopyTo(0, buffer, offset + 1, p.Name.Length);
-
-                p = p.Parent;
-            }
-
-            return new string(buffer);
         }
 
         /// <summary>


### PR DESCRIPTION
Alternative to https://github.com/akkadotnet/akka.net/pull/5046

Ultimately, didn't seem to move the needle much - plus the memory footprint tradeoffs don't seem worth it to me for systems that have a very large number of actors.

```ini
BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19041.985 (2004/May2020Update/20H1)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=5.0.203
  [Host]     : .NET Core 3.1.15 (CoreCLR 4.700.21.21202, CoreFX 4.700.21.21402), X64 RyuJIT
  DefaultJob : .NET Core 3.1.15 (CoreCLR 4.700.21.21202, CoreFX 4.700.21.21402), X64 RyuJIT
```

|                                     Method |      Mean |     Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------------------------- |----------:|----------:|---------:|-------:|------:|------:|----------:|
|                            ActorPath_Parse | 565.45 ns | 10.378 ns | 9.707 ns | 0.1469 |     - |     - |     616 B |
|                           ActorPath_Concat |  57.81 ns |  1.216 ns | 2.065 ns | 0.0305 |     - |     - |     128 B |
|                           ActorPath_Equals |  20.21 ns |  0.322 ns | 0.285 ns |      - |     - |     - |         - |
|                         ActorPath_ToString | 129.42 ns |  1.091 ns | 1.021 ns | 0.0267 |     - |     - |     112 B |
|            ActorPath_ToSerializationFormat | 156.49 ns |  2.290 ns | 2.030 ns | 0.0267 |     - |     - |     112 B |
| ActorPath_ToSerializationFormatWithAddress | 175.53 ns |  1.431 ns | 1.338 ns | 0.0267 |     - |     - |     112 B |