### PR TITLE
Investigate flaky unit test specs

### DIFF
--- a/src/core/Akka.Persistence.TestKit.Tests/Actors/CounterActor.cs
+++ b/src/core/Akka.Persistence.TestKit.Tests/Actors/CounterActor.cs
@@ -67,7 +67,7 @@ namespace Akka.Persistence.TestKit.Tests
 
     public class CounterActorTests : PersistenceTestKit
     {
-        [Fact]
+        [Fact(Skip = "Flaky: Timeout 00:00:03 while waiting for a message of type [X].")]
         public async Task CounterActor_internal_state_will_be_lost_if_underlying_persistence_store_is_not_available()
         {
             await WithJournalWrite(write => write.Fail(), async () => 
@@ -77,13 +77,13 @@ namespace Akka.Persistence.TestKit.Tests
                 
                 Watch(actor);
                 actor.Tell("inc", TestActor);
-                ExpectMsg<Terminated>(TimeSpan.FromSeconds(3));
+                ExpectMsg<Terminated>(TimeSpan.FromSeconds(3)); // FLAKY: Timeout happened here
 
                 // need to restart actor
                 actor = ActorOf(counterProps, "counter1");
                 actor.Tell("read", TestActor);
 
-                var value = ExpectMsg<int>(TimeSpan.FromSeconds(3));
+                var value = ExpectMsg<int>(TimeSpan.FromSeconds(3)); // FLAKY: Timeout happened here
                 value.ShouldBe(0);
             });
         }

--- a/src/core/Akka.Streams.Tests/Dsl/SubstreamSubscriptionTimeoutSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SubstreamSubscriptionTimeoutSpec.cs
@@ -39,7 +39,7 @@ namespace Akka.Streams.Tests.Dsl
             Materializer = ActorMaterializer.Create(Sys, settings);
         }
 
-        [Fact]
+        [Fact(Skip = "Flaky. Expected OnNext, found TestSubscriber.OnError(Substream Source has not been materialized in 00:00:00.3000000)")]
         public void GroupBy_and_SplitWhen_must_timeout_and_cancel_substream_publisher_when_no_one_subscribes_to_them_after_some_time()
         {
             this.AssertAllStagesStopped(() =>
@@ -72,7 +72,7 @@ namespace Akka.Streams.Tests.Dsl
                 s2.RunWith(Sink.FromSubscriber(s2SubscriberProbe), Materializer);
                 var s2Subscription = s2SubscriberProbe.ExpectSubscription();
                 s2Subscription.Request(100);
-                s2SubscriberProbe.ExpectNext().Should().Be(2);
+                s2SubscriberProbe.ExpectNext().Should().Be(2); // FLAKY: Materialization timeout here
 
                 var s3 = subscriber.ExpectNext().Item2;
 

--- a/src/core/Akka.TestKit/TestKitSettings.cs
+++ b/src/core/Akka.TestKit/TestKitSettings.cs
@@ -34,10 +34,10 @@ namespace Akka.TestKit
             if (config.IsNullOrEmpty())
                 throw ConfigurationException.NullOrEmptyConfig<TestKitSettings>();
 
-            _defaultTimeout = config.GetTimeSpan("akka.test.default-timeout", null, allowInfinite:false);
-            _singleExpectDefault = config.GetTimeSpan("akka.test.single-expect-default", null, allowInfinite: false);
-            _testEventFilterLeeway = config.GetTimeSpan("akka.test.filter-leeway", null, allowInfinite: false);
-            _timefactor = config.GetDouble("akka.test.timefactor", 0);
+            _defaultTimeout = config.GetTimeSpan("akka.test.default-timeout", TimeSpan.FromSeconds(5), allowInfinite:false);
+            _singleExpectDefault = config.GetTimeSpan("akka.test.single-expect-default", TimeSpan.FromSeconds(3), allowInfinite: false);
+            _testEventFilterLeeway = config.GetTimeSpan("akka.test.filter-leeway", TimeSpan.FromSeconds(3), allowInfinite: false);
+            _timefactor = config.GetDouble("akka.test.timefactor", 1.0);
             _logTestKitCalls = config.GetBoolean("akka.test.testkit.debug", false);
 
             if(_timefactor <= 0)


### PR DESCRIPTION
- Base cause are timeout of some sort of another
- Most common are related to the `ExpectMsg` assertions and its derivative.
- Problem with the test state mailbox?