### PR TITLE
cleaned up internal ActorCell and TestKit methods

### DIFF
--- a/src/core/Akka.TestKit/CallingThreadDispatcher.cs
+++ b/src/core/Akka.TestKit/CallingThreadDispatcher.cs
@@ -12,7 +12,7 @@ using Akka.Dispatch;
 namespace Akka.TestKit
 {
     /// <summary>
-    /// TBD
+    /// INTERNAL API
     /// </summary>
     public class CallingThreadDispatcherConfigurator : MessageDispatcherConfigurator
     {
@@ -36,7 +36,9 @@ namespace Akka.TestKit
     }
 
     /// <summary>
-    /// TBD
+    /// INTERNAL API
+    ///
+    /// Used to run an actor on the foreground thread.
     /// </summary>
     public class CallingThreadDispatcher : MessageDispatcher
     {

--- a/src/core/Akka.TestKit/Internal/InternalTestActorRef.cs
+++ b/src/core/Akka.TestKit/Internal/InternalTestActorRef.cs
@@ -172,21 +172,18 @@ namespace Akka.TestKit.Internal
 
             var dispatcher = system.Dispatchers.Lookup(props.Deploy.Dispatcher);
 
-            var supervisorLocal = supervisor as LocalActorRef;
-            if (supervisorLocal != null)
+            if (supervisor is LocalActorRef supervisorLocal)
             {
                 supervisorLocal.Cell.ReserveChild(name);
             }
             else
             {
-                var supervisorRep = supervisor as RepointableActorRef;
-                if (supervisorRep != null)
+                if (supervisor is RepointableActorRef supervisorRep)
                 {
                     var repUnderlying = supervisorRep.Underlying;
                     if (repUnderlying is UnstartedCell)
                         throw new IllegalStateException("Cannot attach a TestActor to an unstarted top-level actor, ensure that it is started by sending a message and observing the reply");
-                    var cellUnderlying = repUnderlying as ActorCell;
-                    if (cellUnderlying != null)
+                    if (repUnderlying is ActorCell cellUnderlying)
                     {
                         cellUnderlying.ReserveChild(name);
                     }
@@ -197,7 +194,7 @@ namespace Akka.TestKit.Internal
                 }
             }
 
-            MailboxType mailbox = system.Mailboxes.GetMailboxType(props, dispatcher.Configurator.Config);
+            var mailbox = system.Mailboxes.GetMailboxType(props, dispatcher.Configurator.Config);
             var testActorRef = new InternalTestActorRef((ActorSystemImpl)system, props, dispatcher, mailbox, (IInternalActorRef)supervisor, supervisor.Path / name);
 
             // we need to start ourselves since the creation of an actor has been split into initialization and starting

--- a/src/core/Akka.TestKit/TestKitBase.cs
+++ b/src/core/Akka.TestKit/TestKitBase.cs
@@ -170,8 +170,7 @@ namespace Akka.TestKit
             // Calling sync version here, since .Wait() causes deadlock
             AwaitCondition(() =>
             {
-                var repRef = testActor as IRepointableRef;
-                return repRef == null || repRef.IsStarted;
+                return !(testActor is IRepointableRef repRef) || repRef.IsStarted;
             }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(10));
 
             if (!(this is INoImplicitSender))

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -315,7 +315,7 @@ namespace Akka.Actor
             BecomeStacked(m => { receive(m); return true; });
         }
 
-        private long NewUid()
+        private static long NewUid()
         {
             // Note that this uid is also used as hashCode in ActorRef, so be careful
             // to not break hashing if you change the way uid is generated

--- a/src/core/Akka/Dispatch/Dispatchers.cs
+++ b/src/core/Akka/Dispatch/Dispatchers.cs
@@ -507,13 +507,13 @@ namespace Akka.Dispatch
             var simpleName = id.Substring(id.LastIndexOf('.') + 1);
             return IdConfig(id)
                 .WithFallback(appConfig)
-                .WithFallback(ConfigurationFactory.ParseString(string.Format("name: {0}", simpleName)))
+                .WithFallback(ConfigurationFactory.ParseString($"name: {simpleName}"))
                 .WithFallback(DefaultDispatcherConfig);
         }
 
-        private Config IdConfig(string id)
+        private static Config IdConfig(string id)
         {
-            return ConfigurationFactory.ParseString(string.Format("id: {0}", id));
+            return ConfigurationFactory.ParseString($"id: {id}");
         }
 
 


### PR DESCRIPTION
Found some methods that could be made static on `ActorCell`, which should help with total actor memory footprint.