### PR TITLE
GSet elements needs to be sorted during serialization

### DIFF
--- a/src/contrib/cluster/Akka.DistributedData/Serialization/OtherMessageComparer.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Serialization/OtherMessageComparer.cs
@@ -7,6 +7,11 @@ namespace Akka.DistributedData.Serialization
 {
     internal class OtherMessageComparer : IComparer<OtherMessage>
     {
+        public static OtherMessageComparer Instance { get; } = new OtherMessageComparer();
+
+        private OtherMessageComparer()
+        {}
+
         public int Compare(OtherMessage a, OtherMessage b)
         {
             if (a == null || b == null)


### PR DESCRIPTION
Just like ORSet, GSet elements need to be sorted during serialization so that the digest of any same GSets with the same elements with different element positioning will always be the same.