### PR TITLE
Reworked `Ask<T>` to allocate fewer objects, `await` less

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/AsyncWriteProxyEx.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/AsyncWriteProxyEx.cs
@@ -436,7 +436,7 @@ namespace Akka.Cluster.Sharding.Tests
             //create a new tempcontainer path
             ActorPath path = provider.TempPath();
 
-            var future = new FutureActorRef(result, () => { }, path);
+            var future = new FutureActorRef<object>(result, () => { }, path);
             //The future actor needs to be registered in the temp container
             provider.RegisterTempActor(future, path);
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/AsyncWriteProxyEx.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/AsyncWriteProxyEx.cs
@@ -436,7 +436,7 @@ namespace Akka.Cluster.Sharding.Tests
             //create a new tempcontainer path
             ActorPath path = provider.TempPath();
 
-            var future = new FutureActorRef<object>(result, () => { }, path);
+            var future = new FutureActorRef<object>(result, t => { }, path);
             //The future actor needs to be registered in the temp container
             provider.RegisterTempActor(future, path);
 

--- a/src/contrib/serializers/Akka.Serialization.TestKit/AkkaSerializationSpec.cs
+++ b/src/contrib/serializers/Akka.Serialization.TestKit/AkkaSerializationSpec.cs
@@ -475,7 +475,7 @@ my-settings{
             Sys.EventStream.Subscribe(TestActor, typeof(object));
             var empty = Sys.ActorOf<EmptyActor>();
             empty.Ask("hello");
-            var f = ExpectMsg<FutureActorRef>();
+            var f = ExpectMsg<FutureActorRef<object>>();
 
 
             var message = new SomeMessage

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -866,7 +866,7 @@ namespace Akka.Actor
     }
     public class FutureActorRef<T> : Akka.Actor.MinimalActorRef
     {
-        public FutureActorRef(System.Threading.Tasks.TaskCompletionSource<T> result, System.Action unregister, Akka.Actor.ActorPath path) { }
+        public FutureActorRef(System.Threading.Tasks.TaskCompletionSource<T> result, System.Action<System.Threading.Tasks.Task> unregister, Akka.Actor.ActorPath path) { }
         public override Akka.Actor.ActorPath Path { get; }
         public override Akka.Actor.IActorRefProvider Provider { get; }
         public override void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message) { }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -864,9 +864,9 @@ namespace Akka.Actor
         public Failures() { }
         public System.Collections.Generic.List<Akka.Actor.Failure> Entries { get; }
     }
-    public class FutureActorRef : Akka.Actor.MinimalActorRef
+    public class FutureActorRef<T> : Akka.Actor.MinimalActorRef
     {
-        public FutureActorRef(System.Threading.Tasks.TaskCompletionSource<object> result, System.Action unregister, Akka.Actor.ActorPath path) { }
+        public FutureActorRef(System.Threading.Tasks.TaskCompletionSource<T> result, System.Action unregister, Akka.Actor.ActorPath path) { }
         public override Akka.Actor.ActorPath Path { get; }
         public override Akka.Actor.IActorRefProvider Provider { get; }
         public override void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message) { }

--- a/src/core/Akka.Remote.Tests/RemotingSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemotingSpec.cs
@@ -174,7 +174,7 @@ namespace Akka.Remote.Tests
             //so the token is cancelled before the delay completed.. 
             var (msg, actorRef) = await _here.Ask<(string, IActorRef)>("ping", DefaultTimeout);
             Assert.Equal("pong", msg);
-            Assert.IsType<FutureActorRef>(actorRef);
+            Assert.IsType<FutureActorRef<(string, IActorRef)>>(actorRef);
         }
 
         [Fact(Skip = "Racy")]

--- a/src/core/Akka.Tests/Actor/AskSpec.cs
+++ b/src/core/Akka.Tests/Actor/AskSpec.cs
@@ -178,7 +178,7 @@ namespace Akka.Tests.Actor
             var actor = Sys.ActorOf<SomeActor>();
 
             // expect int, but in fact string
-            await Assert.ThrowsAsync<InvalidCastException>(async () => await actor.Ask<int>("answer"));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await actor.Ask<int>("answer"));
         }
 
         [Fact]
@@ -187,7 +187,7 @@ namespace Akka.Tests.Actor
             AsyncContext.Run(() =>
             {
                 var actor = Sys.ActorOf<SomeActor>();
-                var res = actor.Ask<string>("answer").Result; // blocking on purpose
+                var res = actor.Ask<string>("answer", TimeSpan.FromSeconds(3)).Result; // blocking on purpose
                 res.ShouldBe("answer");
             });
         }

--- a/src/core/Akka.Tests/Serialization/SerializationSpec.cs
+++ b/src/core/Akka.Tests/Serialization/SerializationSpec.cs
@@ -521,7 +521,7 @@ namespace Akka.Tests.Serialization
             Sys.EventStream.Subscribe(TestActor, typeof(object));
             var empty = Sys.ActorOf<EmptyActor>();
             empty.Ask("hello");
-            var f = ExpectMsg<FutureActorRef>();
+            var f = ExpectMsg<FutureActorRef<object>>();
 
 
             var message = new SomeMessage

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -71,7 +71,6 @@ namespace Akka.Actor
     public class FutureActorRef<T> : MinimalActorRef
     {
         private readonly TaskCompletionSource<T> _result;
-        private readonly Action _unregister;
         private readonly ActorPath _path;
 
         /// <summary>
@@ -80,16 +79,16 @@ namespace Akka.Actor
         /// <param name="result">TBD</param>
         /// <param name="unregister">TBD</param>
         /// <param name="path">TBD</param>
-        public FutureActorRef(TaskCompletionSource<T> result, Action unregister, ActorPath path)
+        public FutureActorRef(TaskCompletionSource<T> result, Action<Task> unregister, ActorPath path)
         {
             if (ActorCell.Current != null)
             {
                 _actorAwaitingResultSender = ActorCell.Current.Sender;
             }
             _result = result;
-            _unregister = unregister;
             _path = path;
-            _result.Task.ContinueWith(_ => _unregister());
+
+            _result.Task.ContinueWith(unregister);
         }
 
         /// <summary>

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -68,9 +68,9 @@ namespace Akka.Actor
     ///
     /// ActorRef implementation used for one-off tasks.
     /// </summary>
-    public class FutureActorRef : MinimalActorRef
+    public class FutureActorRef<T> : MinimalActorRef
     {
-        private readonly TaskCompletionSource<object> _result;
+        private readonly TaskCompletionSource<T> _result;
         private readonly Action _unregister;
         private readonly ActorPath _path;
 
@@ -80,7 +80,7 @@ namespace Akka.Actor
         /// <param name="result">TBD</param>
         /// <param name="unregister">TBD</param>
         /// <param name="path">TBD</param>
-        public FutureActorRef(TaskCompletionSource<object> result, Action unregister, ActorPath path)
+        public FutureActorRef(TaskCompletionSource<T> result, Action unregister, ActorPath path)
         {
             if (ActorCell.Current != null)
             {
@@ -131,7 +131,15 @@ namespace Akka.Actor
             {
                 if (Interlocked.Exchange(ref status, COMPLETED) == INITIATED)
                 {
-                    _result.TrySetResult(message);
+                    if (message is T t)
+                    {
+                        _result.TrySetResult(t);
+                    }
+                    else
+                    {
+                        _result.TrySetException(new ArgumentException(
+                            $"Received message of type [{message.GetType()}] - Ask expected message of type [{typeof(T)}]"));
+                    }
                 }
             }
         }

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -119,7 +119,7 @@ namespace Akka.Actor
         /// <returns>TBD</returns>
         public static async Task<T> Ask<T>(this ICanTell self, Func<IActorRef, object> messageFactory, TimeSpan? timeout, CancellationToken cancellationToken)
         {
-            await SynchronizationContextManager.RemoveContext;
+            //await SynchronizationContextManager.RemoveContext;
 
             IActorRefProvider provider = ResolveProvider(self);
             if (provider == null)
@@ -159,15 +159,18 @@ namespace Akka.Actor
             provider.RegisterTempActor(future, path);
             var message = messageFactory(future);
             self.Tell(message, future);
+            var prevContext = SynchronizationContext.Current;
 
+  
             try
             {
+                SynchronizationContext.SetSynchronizationContext(null);
                 return await result.Task;
             }
             finally
             {
                 //callback to unregister from tempcontainer
-
+                SynchronizationContext.SetSynchronizationContext(prevContext);
                 provider.UnregisterTempActor(path);
 
                 ctr1?.Dispose();

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -117,7 +117,7 @@ namespace Akka.Actor
         /// This exception is thrown if the system can't resolve the target provider.
         /// </exception>
         /// <returns>TBD</returns>
-        public static async Task<T> Ask<T>(this ICanTell self, Func<IActorRef,object> messageFactory, TimeSpan? timeout, CancellationToken cancellationToken)
+        public static async Task<T> Ask<T>(this ICanTell self, Func<IActorRef, object> messageFactory, TimeSpan? timeout, CancellationToken cancellationToken)
         {
             await SynchronizationContextManager.RemoveContext;
 
@@ -125,58 +125,36 @@ namespace Akka.Actor
             if (provider == null)
                 throw new ArgumentException("Unable to resolve the target Provider", nameof(self));
 
-            return (T)await Ask(self, messageFactory, provider, timeout, cancellationToken);
-        }
-
-        /// <summary>
-        /// Resolves <see cref="IActorRefProvider"/> for Ask pattern
-        /// </summary>
-        /// <param name="self">Reference to someone we are sending Ask request to</param>
-        /// <returns>Provider used for Ask pattern implementation</returns>
-        internal static IActorRefProvider ResolveProvider(ICanTell self)
-        {
-            if (self is ActorSelection)
-                return ResolveProvider(self.AsInstanceOf<ActorSelection>().Anchor);
-
-            if (self is IInternalActorRef)
-                return self.AsInstanceOf<IInternalActorRef>().Provider;
-            
-            if (ActorCell.Current != null)
-                return InternalCurrentActorCellKeeper.Current.SystemImpl.Provider;
-
-            return null;
-        }
-        
-        private static async Task<object> Ask(ICanTell self, Func<IActorRef, object> messageFactory, IActorRefProvider provider,
-            TimeSpan? timeout, CancellationToken cancellationToken)
-        {
-            TaskCompletionSource<object> result = TaskEx.NonBlockingTaskCompletionSource<object>();
+            var result = TaskEx.NonBlockingTaskCompletionSource<T>();
 
             CancellationTokenSource timeoutCancellation = null;
             timeout = timeout ?? provider.Settings.AskTimeout;
-            var ctrList = new List<CancellationTokenRegistration>(2);
+
+            CancellationTokenRegistration? ctr1 = null;
+            CancellationTokenRegistration? ctr2 = null;
+
 
             if (timeout != Timeout.InfiniteTimeSpan && timeout.Value > default(TimeSpan))
             {
                 timeoutCancellation = new CancellationTokenSource();
 
-                ctrList.Add(timeoutCancellation.Token.Register(() =>
+                ctr1 = timeoutCancellation.Token.Register(() =>
                 {
                     result.TrySetException(new AskTimeoutException($"Timeout after {timeout} seconds"));
-                }));
+                });
 
                 timeoutCancellation.CancelAfter(timeout.Value);
             }
 
             if (cancellationToken.CanBeCanceled)
             {
-                ctrList.Add(cancellationToken.Register(() => result.TrySetCanceled()));
+                ctr2 = cancellationToken.Register(() => result.TrySetCanceled());
             }
 
             //create a new tempcontainer path
             ActorPath path = provider.TempPath();
 
-            var future = new FutureActorRef(result, () => { }, path);
+            var future = new FutureActorRef<T>(result, () => { }, path);
             //The future actor needs to be registered in the temp container
             provider.RegisterTempActor(future, path);
             var message = messageFactory(future);
@@ -192,16 +170,29 @@ namespace Akka.Actor
 
                 provider.UnregisterTempActor(path);
 
-                for (var i = 0; i < ctrList.Count; i++)
-                {
-                    ctrList[i].Dispose();
-                }
-
-                if (timeoutCancellation != null)
-                {
-                    timeoutCancellation.Dispose();
-                }
+                ctr1?.Dispose();
+                ctr2?.Dispose();
+                timeoutCancellation?.Dispose();
             }
+        }
+
+        /// <summary>
+        /// Resolves <see cref="IActorRefProvider"/> for Ask pattern
+        /// </summary>
+        /// <param name="self">Reference to someone we are sending Ask request to</param>
+        /// <returns>Provider used for Ask pattern implementation</returns>
+        internal static IActorRefProvider ResolveProvider(ICanTell self)
+        {
+            if (self is ActorSelection)
+                return ResolveProvider(self.AsInstanceOf<ActorSelection>().Anchor);
+
+            if (self is IInternalActorRef)
+                return self.AsInstanceOf<IInternalActorRef>().Provider;
+
+            if (ActorCell.Current != null)
+                return InternalCurrentActorCellKeeper.Current.SystemImpl.Provider;
+
+            return null;
         }
     }
 


### PR DESCRIPTION
Re-working the internals of `Ask<T>` to be more type safe, to `await` less internally, and to allocate fewer objects.

## Before
``` ini

BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19041.1052 (2004/May2020Update/20H1)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=5.0.203
  [Host]     : .NET Core 3.1.15 (CoreCLR 4.700.21.21202, CoreFX 4.700.21.21402), X64 RyuJIT
  DefaultJob : .NET Core 3.1.15 (CoreCLR 4.700.21.21202, CoreFX 4.700.21.21402), X64 RyuJIT


```
|                        Method | Iterations |      Mean |     Error |    StdDev |     Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------------ |----------- |----------:|----------:|----------:|----------:|------:|------:|----------:|
| RequestResponseActorSelection |      10000 | 83.313 ms | 0.7553 ms | 0.7065 ms | 4666.6667 |     - |     - |     19 MB |
|          CreateActorSelection |      10000 |  5.572 ms | 0.1066 ms | 0.1140 ms |  953.1250 |     - |     - |      4 MB |


## After (so far)
``` ini

BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19041.1052 (2004/May2020Update/20H1)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=5.0.203
  [Host]     : .NET Core 3.1.15 (CoreCLR 4.700.21.21202, CoreFX 4.700.21.21402), X64 RyuJIT
  DefaultJob : .NET Core 3.1.15 (CoreCLR 4.700.21.21202, CoreFX 4.700.21.21402), X64 RyuJIT


```
|                        Method | Iterations |      Mean |     Error |    StdDev |     Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------------ |----------- |----------:|----------:|----------:|----------:|------:|------:|----------:|
| RequestResponseActorSelection |      10000 | 71.216 ms | 0.9885 ms | 0.9246 ms | 4285.7143 |     - |     - |     17 MB |
|          CreateActorSelection |      10000 |  5.462 ms | 0.0495 ms | 0.0439 ms |  953.1250 |     - |     - |      4 MB |
