### PR TITLE
`MessageContainerSerializer` reports on serializerId and manifest of failed payload

### DIFF
--- a/src/core/Akka.Remote.Tests/Serialization/BugFix5062Spec.cs
+++ b/src/core/Akka.Remote.Tests/Serialization/BugFix5062Spec.cs
@@ -51,7 +51,7 @@ namespace Akka.Remote.Tests.Serialization
             var o = new object();
             o.Invoking(s => MessageSerializer.Deserialize((ExtendedActorSystem)Sys, serialized)).Should()
                 .Throw<SerializationException>()
-                .WithMessage($"Failed to deserialize payload object when deserializing {nameof(ActorSelectionMessage)} addressed to [{childName}]")
+                .WithMessage($"Failed to deserialize payload object when deserializing {nameof(ActorSelectionMessage)} with payload [SerializerId=13, Manifest=SM] addressed to [{childName}]")
                 .WithInnerExceptionExactly<NotImplementedException>();
         }
 

--- a/src/core/Akka.Remote/Serialization/MessageContainerSerializer.cs
+++ b/src/core/Akka.Remote/Serialization/MessageContainerSerializer.cs
@@ -93,8 +93,14 @@ namespace Akka.Remote.Serialization
             }
             catch (Exception ex)
             {
+                var payload = selectionEnvelope.Payload;
+                
+                var manifest = !payload.MessageManifest.IsEmpty
+                    ? payload.MessageManifest.ToStringUtf8()
+                    : string.Empty;
+                
                 throw new SerializationException(
-                    $"Failed to deserialize payload object when deserializing {nameof(ActorSelectionMessage)} addressed to [{string.Join(",", elements.Select(e => e.ToString()))}]", ex);
+                    $"Failed to deserialize payload object when deserializing {nameof(ActorSelectionMessage)} with payload [SerializerId={payload.SerializerId}, Manifest={manifest}] addressed to [{string.Join(",", elements.Select(e => e.ToString()))}]", ex);
             }
 
             return new ActorSelectionMessage(message, elements);


### PR DESCRIPTION
close #5118 