### PR TITLE
Restart(Source|Flow|Sink): Configurable stream restart deadline

### DIFF
--- a/docs/articles/streams/error-handling.md
+++ b/docs/articles/streams/error-handling.md
@@ -96,6 +96,16 @@ when a WebSocket connection fails due to the HTTP server it's running on going d
 By using an exponential backoff, we avoid going into a tight reconnect look, which both gives the HTTP server some time
 to recover, and it avoids using needless resources on the client side.
 
+The various restart shapes mentioned all expect an `Akka.Stream.RestartSettings` which configures the restart behavior.
+
+Configurable parameters are:
+
+* `minBackoff` is the initial duration until the underlying stream is restarted
+* `maxBackoff` caps the exponential backoff
+* `randomFactor` allows addition of a random delay following backoff calculation
+* `maxRestarts` caps the total number of restarts
+* `maxRestartsWithin` sets a timeframe during which restarts are counted towards the same total for `maxRestarts`
+
 The following snippet shows how to create a backoff supervisor using `Akka.Streams.Dsl.RestartSource` 
 which will supervise the given `Source`. The `Source` in this case is a 
 `HttpResponseMessage`, produced by `HttpCLient`. If the stream fails or completes at any point, the request will

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
@@ -859,6 +859,20 @@ namespace Akka.Streams
         public RemoteStreamRefActorTerminatedException(string message) { }
         protected RemoteStreamRefActorTerminatedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
+    public class RestartSettings
+    {
+        public System.TimeSpan MaxBackoff { get; }
+        public int MaxRestarts { get; }
+        public System.TimeSpan MaxRestartsWithin { get; }
+        public System.TimeSpan MinBackoff { get; }
+        public double RandomFactor { get; }
+        public static Akka.Streams.RestartSettings Create(System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        public override string ToString() { }
+        public Akka.Streams.RestartSettings WithMaxBackoff(System.TimeSpan value) { }
+        public Akka.Streams.RestartSettings WithMaxRestarts(int count, System.TimeSpan within) { }
+        public Akka.Streams.RestartSettings WithMinBackoff(System.TimeSpan value) { }
+        public Akka.Streams.RestartSettings WithRandomFactor(double value) { }
+    }
     public abstract class Shape : System.ICloneable
     {
         protected Shape() { }
@@ -1763,22 +1777,37 @@ namespace Akka.Streams.Dsl
     }
     public class static RestartFlow
     {
+        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
         public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> OnFailuresWithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
         public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> OnFailuresWithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> OnFailuresWithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, Akka.Streams.RestartSettings settings) { }
+        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
         public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> WithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
         public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> WithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> WithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, Akka.Streams.RestartSettings settings) { }
     }
     public class static RestartSink
     {
+        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
         public static Akka.Streams.Dsl.Sink<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Sink<T, TMat>> sinkFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
         public static Akka.Streams.Dsl.Sink<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Sink<T, TMat>> sinkFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
+        public static Akka.Streams.Dsl.Sink<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Sink<T, TMat>> sinkFactory, Akka.Streams.RestartSettings settings) { }
     }
     public class static RestartSource
     {
+        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> OnFailuresWithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> OnFailuresWithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
+        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> OnFailuresWithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, Akka.Streams.RestartSettings settings) { }
+        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
+        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, Akka.Streams.RestartSettings settings) { }
     }
     public class static Retry
     {

--- a/src/core/Akka.Streams/RestartSettings.cs
+++ b/src/core/Akka.Streams/RestartSettings.cs
@@ -1,0 +1,63 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RestartSettings.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+
+namespace Akka.Streams
+{
+    public class RestartSettings
+    {
+        public TimeSpan MinBackoff { get; }
+        public TimeSpan MaxBackoff { get; }
+        public double RandomFactor { get; }
+        public int MaxRestarts { get; }
+        public TimeSpan MaxRestartsWithin { get; }
+
+        private RestartSettings(TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor, int maxRestarts, TimeSpan maxRestartsWithin)
+        {
+            MinBackoff = minBackoff;
+            MaxBackoff = maxBackoff;
+            RandomFactor = randomFactor;
+            MaxRestarts = maxRestarts;
+            MaxRestartsWithin = maxRestartsWithin;
+        }
+
+        public static RestartSettings Create(TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor) =>
+            new RestartSettings(minBackoff, maxBackoff, randomFactor, int.MaxValue, minBackoff);
+
+        /// <summary>
+        /// Minimum (initial) duration until the child actor will started again, if it is terminated
+        /// </summary>
+        public RestartSettings WithMinBackoff(TimeSpan value) => Copy(minBackoff: value);
+
+        /// <summary>
+        /// The exponential back-off is capped to this duration
+        /// </summary>
+        public RestartSettings WithMaxBackoff(TimeSpan value) => Copy(maxBackoff: value);
+
+        /// <summary>
+        /// After calculation of the exponential back-off an additional random delay based on this factor is added
+        /// * e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`
+        /// </summary>
+        public RestartSettings WithRandomFactor(double value) => Copy(randomFactor: value);
+
+        /// <summary>
+        /// The amount of restarts is capped to `count` within a timeframe of `within`
+        /// </summary>
+        public RestartSettings WithMaxRestarts(int count, TimeSpan within) => Copy(maxRestarts: count, maxRestartsWithin: within);
+
+        public override string ToString() => $"RestartSettings(" +
+            $"minBackoff={MinBackoff}," +
+            $"maxBackoff={MaxBackoff}," +
+            $"randomFactor={RandomFactor}," +
+            $"maxRestarts={MaxRestarts}," +
+            $"maxRestartsWithin={MaxRestartsWithin})";
+
+        private RestartSettings Copy(TimeSpan? minBackoff = null, TimeSpan? maxBackoff = null, double? randomFactor = null, int? maxRestarts = null, TimeSpan? maxRestartsWithin = null) =>
+            new RestartSettings(minBackoff ?? MinBackoff, maxBackoff ?? MaxBackoff, randomFactor ?? RandomFactor, maxRestarts ?? MaxRestarts, maxRestartsWithin ?? MaxRestartsWithin);
+    }
+}


### PR DESCRIPTION
Port [#29591](https://github.com/akka/akka/pull/29591)

This PR also adds a few missing tests, and attempts to fix the racy ones.