### PR TITLE
Pipe of Canceled Tasks

### DIFF
--- a/src/core/Akka/Actor/PipeToSupport.cs
+++ b/src/core/Akka/Actor/PipeToSupport.cs
@@ -33,10 +33,17 @@ namespace Akka.Actor
             sender = sender ?? ActorRefs.NoSender;
             return taskToPipe.ContinueWith(tresult =>
             {
-                if (tresult.IsCanceled || tresult.IsFaulted)
+                if (tresult.IsFaulted)
                     recipient.Tell(failure != null
                         ? failure(tresult.Exception)
                         : new Status.Failure(tresult.Exception), sender);
+                else if (tresult.IsCanceled)
+                {
+                    var ex = tresult.Exception ?? new AggregateException(new TaskCanceledException());
+                    recipient.Tell(failure != null
+                        ? failure(ex)
+                        : new Status.Failure(ex), sender);
+                }
                 else if (tresult.IsCompleted)
                     recipient.Tell(success != null
                         ? success(tresult.Result)
@@ -59,10 +66,17 @@ namespace Akka.Actor
             sender = sender ?? ActorRefs.NoSender;
             return taskToPipe.ContinueWith(tresult =>
             {
-                if (tresult.IsCanceled || tresult.IsFaulted)
+                if (tresult.IsFaulted)
                     recipient.Tell(failure != null
                         ? failure(tresult.Exception)
                         : new Status.Failure(tresult.Exception), sender);
+                else if (tresult.IsCanceled)
+                {
+                    var ex = tresult.Exception ?? new AggregateException(new TaskCanceledException());
+                    recipient.Tell(failure != null
+                        ? failure(ex)
+                        : new Status.Failure(ex), sender);
+                }
                 else if (tresult.IsCompleted && success != null)
                     recipient.Tell(success(), sender);
             }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);


### PR DESCRIPTION
Canceled Task will have null as tresult.Exception.
The error handler need have a TaskCanceledException instance to indicate the cancellation.