### PR TITLE
Akka.Cluster.Sharding should not use Hyperion serializer

### DIFF
--- a/src/common.props
+++ b/src/common.props
@@ -11,7 +11,7 @@
   <PropertyGroup>
     <XunitVersion>2.4.1</XunitVersion>
     <TestSdkVersion>16.10.0</TestSdkVersion>
-    <HyperionVersion>0.10.2</HyperionVersion>
+    <HyperionVersion>0.11.0</HyperionVersion>
     <NewtonsoftJsonVersion>[12.0.3,)</NewtonsoftJsonVersion>
     <NBenchVersion>2.0.1</NBenchVersion>
     <ProtobufVersion>3.17.2</ProtobufVersion>

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingCustomShardAllocationSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingCustomShardAllocationSpec.cs
@@ -31,7 +31,7 @@ namespace Akka.Cluster.Sharding.Tests
                 .WithFallback(ConfigurationFactory.ParseString(@"
                     akka.actor {
                         serializers {
-                            hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                            hyperion = ""Akka.Cluster.Sharding.Tests.MultiNode.HyperionSerializerWrapper, Akka.Cluster.Sharding.Tests.MultiNode""
                         }
                         serialization-bindings {
                             ""System.Object"" = hyperion

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingFailureSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingFailureSpec.cs
@@ -37,7 +37,7 @@ namespace Akka.Cluster.Sharding.Tests
                 .WithFallback(ConfigurationFactory.ParseString($@"
                     akka.actor {{
                         serializers {{
-                            hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                            hyperion = ""Akka.Cluster.Sharding.Tests.MultiNode.HyperionSerializerWrapper, Akka.Cluster.Sharding.Tests.MultiNode""
                         }}
                         serialization-bindings {{
                             ""System.Object"" = hyperion

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStateSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStateSpec.cs
@@ -33,7 +33,7 @@ namespace Akka.Cluster.Sharding.Tests
                 .WithFallback(ConfigurationFactory.ParseString(@"
                     akka.actor {
                         serializers {
-                            hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                            hyperion = ""Akka.Cluster.Sharding.Tests.MultiNode.HyperionSerializerWrapper, Akka.Cluster.Sharding.Tests.MultiNode""
                         }
                         serialization-bindings {
                             ""System.Object"" = hyperion

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStatsSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStatsSpec.cs
@@ -34,7 +34,7 @@ namespace Akka.Cluster.Sharding.Tests
                 .WithFallback(ConfigurationFactory.ParseString(@"
                     akka.actor {
                         serializers {
-                            hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                            hyperion = ""Akka.Cluster.Sharding.Tests.MultiNode.HyperionSerializerWrapper, Akka.Cluster.Sharding.Tests.MultiNode""
                         }
                         serialization-bindings {
                             ""System.Object"" = hyperion

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGracefulShutdownSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGracefulShutdownSpec.cs
@@ -35,7 +35,7 @@ namespace Akka.Cluster.Sharding.Tests
                 .WithFallback(ConfigurationFactory.ParseString($@"
                     akka.actor {{
                         serializers {{
-                            hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                            hyperion = ""Akka.Cluster.Sharding.Tests.MultiNode.HyperionSerializerWrapper, Akka.Cluster.Sharding.Tests.MultiNode""
                         }}
                         serialization-bindings {{
                             ""System.Object"" = hyperion

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingLeavingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingLeavingSpec.cs
@@ -39,7 +39,7 @@ namespace Akka.Cluster.Sharding.Tests
                 .WithFallback(ConfigurationFactory.ParseString($@"
                     akka.actor {{
                         serializers {{
-                            hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                            hyperion = ""Akka.Cluster.Sharding.Tests.MultiNode.HyperionSerializerWrapper, Akka.Cluster.Sharding.Tests.MultiNode""
                         }}
                         serialization-bindings {{
                             ""System.Object"" = hyperion

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingMinMembersSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingMinMembersSpec.cs
@@ -36,7 +36,7 @@ namespace Akka.Cluster.Sharding.Tests
                 .WithFallback(ConfigurationFactory.ParseString($@"
                     akka.actor {{
                         serializers {{
-                            hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                            hyperion = ""Akka.Cluster.Sharding.Tests.MultiNode.HyperionSerializerWrapper, Akka.Cluster.Sharding.Tests.MultiNode""
                         }}
                         serialization-bindings {{
                             ""System.Object"" = hyperion

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRegistrationCoordinatedShutdownSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRegistrationCoordinatedShutdownSpec.cs
@@ -38,7 +38,7 @@ namespace Akka.Cluster.Sharding.Tests
                 .WithFallback(ConfigurationFactory.ParseString($@"
                     akka.actor {{
                         serializers {{
-                            hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                            hyperion = ""Akka.Cluster.Sharding.Tests.MultiNode.HyperionSerializerWrapper, Akka.Cluster.Sharding.Tests.MultiNode""
                         }}
                         serialization-bindings {{
                             ""System.Object"" = hyperion

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesNewExtractorSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesNewExtractorSpec.cs
@@ -36,7 +36,7 @@ namespace Akka.Cluster.Sharding.Tests
                 .WithFallback(ConfigurationFactory.ParseString($@"
                     akka.actor {{
                         serializers {{
-                            hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                            hyperion = ""Akka.Cluster.Sharding.Tests.MultiNode.HyperionSerializerWrapper, Akka.Cluster.Sharding.Tests.MultiNode""
                         }}
                         serialization-bindings {{
                             ""System.Object"" = hyperion

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesSpec.cs
@@ -39,7 +39,7 @@ namespace Akka.Cluster.Sharding.Tests
                 .WithFallback(ConfigurationFactory.ParseString($@"
                     akka.actor {{
                         serializers {{
-                            hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                            hyperion = ""Akka.Cluster.Sharding.Tests.MultiNode.HyperionSerializerWrapper, Akka.Cluster.Sharding.Tests.MultiNode""
                         }}
                         serialization-bindings {{
                             ""System.Object"" = hyperion

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
@@ -53,7 +53,7 @@ namespace Akka.Cluster.Sharding.Tests
                 .WithFallback(ConfigurationFactory.ParseString($@"
                     akka.actor {{
                         serializers {{
-                            hyperion = ""Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion""
+                            hyperion = ""Akka.Cluster.Sharding.Tests.MultiNode.HyperionSerializerWrapper, Akka.Cluster.Sharding.Tests.MultiNode""
                         }}
                         serialization-bindings {{
                             ""System.Object"" = hyperion

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/HyperionSerializerWrapper.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/HyperionSerializerWrapper.cs
@@ -39,28 +39,32 @@ namespace Akka.Cluster.Sharding.Tests.MultiNode
         {
             if (obj is IClusterShardingSerializable)
                 throw new Exception($"THIS ISN'T SUPPOSED TO BE SERIALIZED. Type: {obj.GetType().FullName}");
-            var typeName = obj.GetType().AssemblyQualifiedName;
-            if(typeName.StartsWith("Akka.Cluster.Sharding") && !typeName.Contains("Tests"))
-                throw new Exception($"THIS ISN'T SUPPOSED TO BE SERIALIZED. Type: {typeName}");
+            
+            // IShardRegionCommand isn't serialized using cluster sharding serializer
+            if (!(obj is IShardRegionCommand))
+            {
+                var typeName = obj.GetType().AssemblyQualifiedName;
+                if(typeName.StartsWith("Akka.Cluster.Sharding") && !typeName.Contains("Tests"))
+                    throw new Exception($"THIS ISN'T SUPPOSED TO BE SERIALIZED. Type: {typeName}");
+            }
 
             return _serializer.ToBinary(obj);
         }
 
         public override object FromBinary(byte[] bytes, Type type)
         {
-            if (type != null)
-            {
-                var name = type.AssemblyQualifiedName;
-                if(name.StartsWith("Akka.Cluster.Sharding") && !name.Contains("Tests"))
-                    throw new Exception($"THIS ISN'T SUPPOSED TO BE SERIALIZED. Type: {name}");
-            }
-            
             var obj = _serializer.FromBinary(bytes, type);
+            
             if (obj is IClusterShardingSerializable)
                 throw new Exception($"THIS ISN'T SUPPOSED TO BE SERIALIZED. Type: {obj.GetType().FullName}");
-            var typeName = obj.GetType().AssemblyQualifiedName;
-            if(typeName.StartsWith("Akka.Cluster.Sharding") && !typeName.Contains("Tests"))
-                throw new Exception($"THIS ISN'T SUPPOSED TO BE SERIALIZED. Type: {typeName}");
+            
+            // IShardRegionCommand isn't serialized using cluster sharding serializer
+            if (!(obj is IShardRegionCommand))
+            {
+                var typeName = obj.GetType().AssemblyQualifiedName;
+                if(typeName.StartsWith("Akka.Cluster.Sharding") && !typeName.Contains("Tests"))
+                    throw new Exception($"THIS ISN'T SUPPOSED TO BE SERIALIZED. Type: {typeName}");
+            }
             return obj;
         }
     }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/HyperionSerializerWrapper.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/HyperionSerializerWrapper.cs
@@ -1,0 +1,67 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="HyperionSerializerWrapper.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Serialization;
+
+namespace Akka.Cluster.Sharding.Tests.MultiNode
+{
+    public class HyperionSerializerWrapper : Serializer
+    {
+        private readonly HyperionSerializer _serializer;
+        
+        public HyperionSerializerWrapper(ExtendedActorSystem system) : base(system)
+        {
+            _serializer = new HyperionSerializer(system);
+        }
+
+        public HyperionSerializerWrapper(ExtendedActorSystem system, Config config) : base(system)
+        {
+            _serializer = new HyperionSerializer(system, config);
+        }
+        
+        public HyperionSerializerWrapper(ExtendedActorSystem system, HyperionSerializerSettings settings) : base(system)
+        {
+            _serializer = new HyperionSerializer(system, settings);
+        }
+
+        public override int Identifier => -6;
+        
+        public override bool IncludeManifest => false;
+        
+        public override byte[] ToBinary(object obj)
+        {
+            if (obj is IClusterShardingSerializable)
+                throw new Exception($"THIS ISN'T SUPPOSED TO BE SERIALIZED. Type: {obj.GetType().FullName}");
+            var typeName = obj.GetType().AssemblyQualifiedName;
+            if(typeName.StartsWith("Akka.Cluster.Sharding") && !typeName.Contains("Tests"))
+                throw new Exception($"THIS ISN'T SUPPOSED TO BE SERIALIZED. Type: {typeName}");
+
+            return _serializer.ToBinary(obj);
+        }
+
+        public override object FromBinary(byte[] bytes, Type type)
+        {
+            if (type != null)
+            {
+                var name = type.AssemblyQualifiedName;
+                if(name.StartsWith("Akka.Cluster.Sharding") && !name.Contains("Tests"))
+                    throw new Exception($"THIS ISN'T SUPPOSED TO BE SERIALIZED. Type: {name}");
+            }
+            
+            var obj = _serializer.FromBinary(bytes, type);
+            if (obj is IClusterShardingSerializable)
+                throw new Exception($"THIS ISN'T SUPPOSED TO BE SERIALIZED. Type: {obj.GetType().FullName}");
+            var typeName = obj.GetType().AssemblyQualifiedName;
+            if(typeName.StartsWith("Akka.Cluster.Sharding") && !typeName.Contains("Tests"))
+                throw new Exception($"THIS ISN'T SUPPOSED TO BE SERIALIZED. Type: {typeName}");
+            return obj;
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Serialization/Proto/ClusterShardingMessages.g.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Serialization/Proto/ClusterShardingMessages.g.cs
@@ -52,7 +52,10 @@ namespace Akka.Cluster.Sharding.Serialization.Proto.Msg {
             "dGVyLlNoYXJkaW5nLlNlcmlhbGl6YXRpb24uUHJvdG8uTXNnLlNoYXJkUmVn",
             "aW9uU3RhdHMiUwoOQ3VycmVudFJlZ2lvbnMSQQoHcmVnaW9ucxgBIAMoCzIw",
             "LkFra2EuUmVtb3RlLlNlcmlhbGl6YXRpb24uUHJvdG8uTXNnLkFkZHJlc3NE",
-            "YXRhYgZwcm90bzM="));
+            "YXRhIjAKClNoYXJkU3RhdGUSDwoHc2hhcmRJZBgBIAEoCRIRCgllbnRpdHlJ",
+            "ZHMYAiADKAkiZAoXQ3VycmVudFNoYXJkUmVnaW9uU3RhdGUSSQoGc2hhcmRz",
+            "GAEgAygLMjkuQWtrYS5DbHVzdGVyLlNoYXJkaW5nLlNlcmlhbGl6YXRpb24u",
+            "UHJvdG8uTXNnLlNoYXJkU3RhdGViBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Protobuf.WellKnownTypes.DurationReflection.Descriptor, global::Akka.Remote.Serialization.Proto.Msg.ContainerFormatsReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
@@ -71,7 +74,9 @@ namespace Akka.Cluster.Sharding.Serialization.Proto.Msg {
             new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.GetClusterShardingStats), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.GetClusterShardingStats.Parser, new[]{ "Timeout" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ClusterShardingStats), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ClusterShardingStats.Parser, new[]{ "Regions" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ShardRegionWithAddress), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ShardRegionWithAddress.Parser, new[]{ "NodeAddress", "Stats" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.CurrentRegions), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.CurrentRegions.Parser, new[]{ "Regions" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.CurrentRegions), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.CurrentRegions.Parser, new[]{ "Regions" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ShardState), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ShardState.Parser, new[]{ "ShardId", "EntityIds" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.CurrentShardRegionState), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.CurrentShardRegionState.Parser, new[]{ "Shards" }, null, null, null)
           }));
     }
     #endregion
@@ -2272,6 +2277,252 @@ namespace Akka.Cluster.Sharding.Serialization.Proto.Msg {
             break;
           case 10: {
             regions_.AddEntriesFrom(input, _repeated_regions_codec);
+            break;
+          }
+        }
+      }
+    }
+
+  }
+
+  internal sealed partial class ShardState : pb::IMessage<ShardState> {
+    private static readonly pb::MessageParser<ShardState> _parser = new pb::MessageParser<ShardState>(() => new ShardState());
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pb::MessageParser<ShardState> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ClusterShardingMessagesReflection.Descriptor.MessageTypes[16]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public ShardState() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public ShardState(ShardState other) : this() {
+      shardId_ = other.shardId_;
+      entityIds_ = other.entityIds_.Clone();
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public ShardState Clone() {
+      return new ShardState(this);
+    }
+
+    /// <summary>Field number for the "shardId" field.</summary>
+    public const int ShardIdFieldNumber = 1;
+    private string shardId_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string ShardId {
+      get { return shardId_; }
+      set {
+        shardId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "entityIds" field.</summary>
+    public const int EntityIdsFieldNumber = 2;
+    private static readonly pb::FieldCodec<string> _repeated_entityIds_codec
+        = pb::FieldCodec.ForString(18);
+    private readonly pbc::RepeatedField<string> entityIds_ = new pbc::RepeatedField<string>();
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public pbc::RepeatedField<string> EntityIds {
+      get { return entityIds_; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override bool Equals(object other) {
+      return Equals(other as ShardState);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool Equals(ShardState other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (ShardId != other.ShardId) return false;
+      if(!entityIds_.Equals(other.entityIds_)) return false;
+      return true;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (ShardId.Length != 0) hash ^= ShardId.GetHashCode();
+      hash ^= entityIds_.GetHashCode();
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void WriteTo(pb::CodedOutputStream output) {
+      if (ShardId.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(ShardId);
+      }
+      entityIds_.WriteTo(output, _repeated_entityIds_codec);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int CalculateSize() {
+      int size = 0;
+      if (ShardId.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(ShardId);
+      }
+      size += entityIds_.CalculateSize(_repeated_entityIds_codec);
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(ShardState other) {
+      if (other == null) {
+        return;
+      }
+      if (other.ShardId.Length != 0) {
+        ShardId = other.ShardId;
+      }
+      entityIds_.Add(other.entityIds_);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(pb::CodedInputStream input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            input.SkipLastField();
+            break;
+          case 10: {
+            ShardId = input.ReadString();
+            break;
+          }
+          case 18: {
+            entityIds_.AddEntriesFrom(input, _repeated_entityIds_codec);
+            break;
+          }
+        }
+      }
+    }
+
+  }
+
+  internal sealed partial class CurrentShardRegionState : pb::IMessage<CurrentShardRegionState> {
+    private static readonly pb::MessageParser<CurrentShardRegionState> _parser = new pb::MessageParser<CurrentShardRegionState>(() => new CurrentShardRegionState());
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pb::MessageParser<CurrentShardRegionState> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ClusterShardingMessagesReflection.Descriptor.MessageTypes[17]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public CurrentShardRegionState() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public CurrentShardRegionState(CurrentShardRegionState other) : this() {
+      shards_ = other.shards_.Clone();
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public CurrentShardRegionState Clone() {
+      return new CurrentShardRegionState(this);
+    }
+
+    /// <summary>Field number for the "shards" field.</summary>
+    public const int ShardsFieldNumber = 1;
+    private static readonly pb::FieldCodec<global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ShardState> _repeated_shards_codec
+        = pb::FieldCodec.ForMessage(10, global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ShardState.Parser);
+    private readonly pbc::RepeatedField<global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ShardState> shards_ = new pbc::RepeatedField<global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ShardState>();
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public pbc::RepeatedField<global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ShardState> Shards {
+      get { return shards_; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override bool Equals(object other) {
+      return Equals(other as CurrentShardRegionState);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool Equals(CurrentShardRegionState other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if(!shards_.Equals(other.shards_)) return false;
+      return true;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override int GetHashCode() {
+      int hash = 1;
+      hash ^= shards_.GetHashCode();
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void WriteTo(pb::CodedOutputStream output) {
+      shards_.WriteTo(output, _repeated_shards_codec);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int CalculateSize() {
+      int size = 0;
+      size += shards_.CalculateSize(_repeated_shards_codec);
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(CurrentShardRegionState other) {
+      if (other == null) {
+        return;
+      }
+      shards_.Add(other.shards_);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(pb::CodedInputStream input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            input.SkipLastField();
+            break;
+          case 10: {
+            shards_.AddEntriesFrom(input, _repeated_shards_codec);
             break;
           }
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Serialization/Proto/ClusterShardingMessages.g.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Serialization/Proto/ClusterShardingMessages.g.cs
@@ -50,7 +50,9 @@ namespace Akka.Cluster.Sharding.Serialization.Proto.Msg {
             "QWRkcmVzcxgBIAEoCzIwLkFra2EuUmVtb3RlLlNlcmlhbGl6YXRpb24uUHJv",
             "dG8uTXNnLkFkZHJlc3NEYXRhEk4KBXN0YXRzGAIgASgLMj8uQWtrYS5DbHVz",
             "dGVyLlNoYXJkaW5nLlNlcmlhbGl6YXRpb24uUHJvdG8uTXNnLlNoYXJkUmVn",
-            "aW9uU3RhdHNiBnByb3RvMw=="));
+            "aW9uU3RhdHMiUwoOQ3VycmVudFJlZ2lvbnMSQQoHcmVnaW9ucxgBIAMoCzIw",
+            "LkFra2EuUmVtb3RlLlNlcmlhbGl6YXRpb24uUHJvdG8uTXNnLkFkZHJlc3NE",
+            "YXRhYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Protobuf.WellKnownTypes.DurationReflection.Descriptor, global::Akka.Remote.Serialization.Proto.Msg.ContainerFormatsReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
@@ -68,7 +70,8 @@ namespace Akka.Cluster.Sharding.Serialization.Proto.Msg {
             new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.StartEntityAck), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.StartEntityAck.Parser, new[]{ "EntityId", "ShardId" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.GetClusterShardingStats), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.GetClusterShardingStats.Parser, new[]{ "Timeout" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ClusterShardingStats), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ClusterShardingStats.Parser, new[]{ "Regions" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ShardRegionWithAddress), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ShardRegionWithAddress.Parser, new[]{ "NodeAddress", "Stats" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ShardRegionWithAddress), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ShardRegionWithAddress.Parser, new[]{ "NodeAddress", "Stats" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Akka.Cluster.Sharding.Serialization.Proto.Msg.CurrentRegions), global::Akka.Cluster.Sharding.Serialization.Proto.Msg.CurrentRegions.Parser, new[]{ "Regions" }, null, null, null)
           }));
     }
     #endregion
@@ -2160,6 +2163,115 @@ namespace Akka.Cluster.Sharding.Serialization.Proto.Msg {
               stats_ = new global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ShardRegionStats();
             }
             input.ReadMessage(stats_);
+            break;
+          }
+        }
+      }
+    }
+
+  }
+
+  internal sealed partial class CurrentRegions : pb::IMessage<CurrentRegions> {
+    private static readonly pb::MessageParser<CurrentRegions> _parser = new pb::MessageParser<CurrentRegions>(() => new CurrentRegions());
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pb::MessageParser<CurrentRegions> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Akka.Cluster.Sharding.Serialization.Proto.Msg.ClusterShardingMessagesReflection.Descriptor.MessageTypes[15]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public CurrentRegions() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public CurrentRegions(CurrentRegions other) : this() {
+      regions_ = other.regions_.Clone();
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public CurrentRegions Clone() {
+      return new CurrentRegions(this);
+    }
+
+    /// <summary>Field number for the "regions" field.</summary>
+    public const int RegionsFieldNumber = 1;
+    private static readonly pb::FieldCodec<global::Akka.Remote.Serialization.Proto.Msg.AddressData> _repeated_regions_codec
+        = pb::FieldCodec.ForMessage(10, global::Akka.Remote.Serialization.Proto.Msg.AddressData.Parser);
+    private readonly pbc::RepeatedField<global::Akka.Remote.Serialization.Proto.Msg.AddressData> regions_ = new pbc::RepeatedField<global::Akka.Remote.Serialization.Proto.Msg.AddressData>();
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public pbc::RepeatedField<global::Akka.Remote.Serialization.Proto.Msg.AddressData> Regions {
+      get { return regions_; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override bool Equals(object other) {
+      return Equals(other as CurrentRegions);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool Equals(CurrentRegions other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if(!regions_.Equals(other.regions_)) return false;
+      return true;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override int GetHashCode() {
+      int hash = 1;
+      hash ^= regions_.GetHashCode();
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void WriteTo(pb::CodedOutputStream output) {
+      regions_.WriteTo(output, _repeated_regions_codec);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int CalculateSize() {
+      int size = 0;
+      size += regions_.CalculateSize(_repeated_regions_codec);
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(CurrentRegions other) {
+      if (other == null) {
+        return;
+      }
+      regions_.Add(other.regions_);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(pb::CodedInputStream input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            input.SkipLastField();
+            break;
+          case 10: {
+            regions_.AddEntriesFrom(input, _repeated_regions_codec);
             break;
           }
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardingMessages.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardingMessages.cs
@@ -355,7 +355,7 @@ namespace Akka.Cluster.Sharding
     /// TBD
     /// </summary>
     [Serializable]
-    public sealed class ShardState
+    public sealed class ShardState : IClusterShardingSerializable
     {
         /// <summary>
         /// TBD

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardingMessages.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardingMessages.cs
@@ -141,7 +141,7 @@ namespace Akka.Cluster.Sharding
     /// Intended for testing purpose to see when cluster sharding is "ready".
     /// </summary>
     [Serializable]
-    public sealed class GetCurrentRegions : IShardRegionQuery
+    public sealed class GetCurrentRegions : IShardRegionQuery, IClusterShardingSerializable
     {
         /// <summary>
         /// TBD
@@ -157,7 +157,7 @@ namespace Akka.Cluster.Sharding
     /// Reply to <see cref="GetCurrentRegions"/>.
     /// </summary>
     [Serializable]
-    public sealed class CurrentRegions
+    public sealed class CurrentRegions : IClusterShardingSerializable
     {
         /// <summary>
         /// TBD

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardingMessages.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardingMessages.cs
@@ -281,7 +281,7 @@ namespace Akka.Cluster.Sharding
     /// and what entities are running on each of those shards.
     /// </summary>
     [Serializable]
-    public sealed class GetShardRegionState : IShardRegionQuery
+    public sealed class GetShardRegionState : IShardRegionQuery, IClusterShardingSerializable
     {
         /// <summary>
         /// TBD
@@ -297,7 +297,7 @@ namespace Akka.Cluster.Sharding
     /// Reply to <see cref="GetShardRegionState"/> If gathering the shard information times out the set of shards will be empty.
     /// </summary>
     [Serializable]
-    public sealed class CurrentShardRegionState
+    public sealed class CurrentShardRegionState : IClusterShardingSerializable
     {
         /// <summary>
         /// TBD

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveClusterSharding.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveClusterSharding.approved.txt
@@ -77,12 +77,12 @@ namespace Akka.Cluster.Sharding
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
     }
-    public sealed class CurrentRegions
+    public sealed class CurrentRegions : Akka.Cluster.Sharding.IClusterShardingSerializable
     {
         public readonly System.Collections.Immutable.IImmutableSet<Akka.Actor.Address> Regions;
         public CurrentRegions(System.Collections.Immutable.IImmutableSet<Akka.Actor.Address> regions) { }
     }
-    public sealed class CurrentShardRegionState
+    public sealed class CurrentShardRegionState : Akka.Cluster.Sharding.IClusterShardingSerializable
     {
         public readonly System.Collections.Immutable.IImmutableSet<Akka.Cluster.Sharding.ShardState> Shards;
         public CurrentShardRegionState(System.Collections.Immutable.IImmutableSet<Akka.Cluster.Sharding.ShardState> shards) { }
@@ -101,11 +101,11 @@ namespace Akka.Cluster.Sharding
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
     }
-    public sealed class GetCurrentRegions : Akka.Cluster.Sharding.IShardRegionQuery
+    public sealed class GetCurrentRegions : Akka.Cluster.Sharding.IClusterShardingSerializable, Akka.Cluster.Sharding.IShardRegionQuery
     {
         public static readonly Akka.Cluster.Sharding.GetCurrentRegions Instance;
     }
-    public sealed class GetShardRegionState : Akka.Cluster.Sharding.IShardRegionQuery
+    public sealed class GetShardRegionState : Akka.Cluster.Sharding.IClusterShardingSerializable, Akka.Cluster.Sharding.IShardRegionQuery
     {
         public static readonly Akka.Cluster.Sharding.GetShardRegionState Instance;
     }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveClusterSharding.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveClusterSharding.approved.txt
@@ -222,7 +222,7 @@ namespace Akka.Cluster.Sharding
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
     }
-    public sealed class ShardState
+    public sealed class ShardState : Akka.Cluster.Sharding.IClusterShardingSerializable
     {
         public readonly System.Collections.Immutable.IImmutableSet<string> EntityIds;
         public readonly string ShardId;

--- a/src/protobuf/ClusterShardingMessages.proto
+++ b/src/protobuf/ClusterShardingMessages.proto
@@ -84,3 +84,12 @@ message ShardRegionWithAddress{
 message CurrentRegions {
   repeated Akka.Remote.Serialization.Proto.Msg.AddressData regions = 1;
 }
+
+message ShardState {
+  string shardId = 1;
+  repeated string entityIds = 2;
+}
+
+message CurrentShardRegionState {
+  repeated ShardState shards = 1;
+}

--- a/src/protobuf/ClusterShardingMessages.proto
+++ b/src/protobuf/ClusterShardingMessages.proto
@@ -80,3 +80,7 @@ message ShardRegionWithAddress{
     Akka.Remote.Serialization.Proto.Msg.AddressData nodeAddress = 1;
     ShardRegionStats stats = 2;
 }
+
+message CurrentRegions {
+  repeated Akka.Remote.Serialization.Proto.Msg.AddressData regions = 1;
+}


### PR DESCRIPTION
Fishing for possible serializer problem with Akka.Cluster.Sharding. It should never use the default object serializer for any of its message types.