### PR TITLE
Make ddata replicator actor configurable to have backoff supervisor

### DIFF
--- a/src/contrib/cluster/Akka.DistributedData/DistributedData.cs
+++ b/src/contrib/cluster/Akka.DistributedData/DistributedData.cs
@@ -85,7 +85,9 @@ namespace Akka.DistributedData
             else
             {
                 var name = config.GetString("name", null);
-                Replicator = system.ActorOf(GetSupervisedReplicator(_settings, name), name+"Supervisor");
+                Replicator = _settings.RecreateOnFailure
+                    ? _system.ActorOf(GetSupervisedReplicator(_settings, name), name + "Supervisor")
+                    : _system.ActorOf(Akka.DistributedData.Replicator.Props(_settings), name);
             }
         }
 

--- a/src/contrib/cluster/Akka.DistributedData/ReplicatorSettings.cs
+++ b/src/contrib/cluster/Akka.DistributedData/ReplicatorSettings.cs
@@ -77,7 +77,8 @@ namespace Akka.DistributedData
                 durableStoreProps: durableStoreProps,
                 pruningMarkerTimeToLive: config.GetTimeSpan("pruning-marker-time-to-live", TimeSpan.FromHours(6)),
                 durablePruningMarkerTimeToLive: durableConfig.GetTimeSpan("pruning-marker-time-to-live", TimeSpan.FromDays(10)),
-                maxDeltaSize: config.GetInt("delta-crdt.max-delta-size", 50));
+                maxDeltaSize: config.GetInt("delta-crdt.max-delta-size", 50),
+                recreateOnFailure: config.GetBoolean("recreate-on-failure", false));
         }
 
         /// <summary>
@@ -150,6 +151,8 @@ namespace Akka.DistributedData
 
         public int MaxDeltaSize { get; }
 
+        public bool RecreateOnFailure { get; set; }
+        
         public ReplicatorSettings(string role,
                                   TimeSpan gossipInterval,
                                   TimeSpan notifySubscribersInterval,
@@ -161,7 +164,8 @@ namespace Akka.DistributedData
                                   Props durableStoreProps, 
                                   TimeSpan pruningMarkerTimeToLive, 
                                   TimeSpan durablePruningMarkerTimeToLive,
-                                  int maxDeltaSize)
+                                  int maxDeltaSize, 
+                                  bool recreateOnFailure)
         {
             Role = role;
             GossipInterval = gossipInterval;
@@ -175,7 +179,10 @@ namespace Akka.DistributedData
             PruningMarkerTimeToLive = pruningMarkerTimeToLive;
             DurablePruningMarkerTimeToLive = durablePruningMarkerTimeToLive;
             MaxDeltaSize = maxDeltaSize;
+            RecreateOnFailure = recreateOnFailure;
         }
+
+        
 
         private ReplicatorSettings Copy(string role = null,
             TimeSpan? gossipInterval = null,
@@ -188,7 +195,8 @@ namespace Akka.DistributedData
             Props durableStoreProps = null,
             TimeSpan? pruningMarkerTimeToLive = null,
             TimeSpan? durablePruningMarkerTimeToLive = null,
-            int? maxDeltaSize = null)
+            int? maxDeltaSize = null,
+            bool? recreateOnFailure = null)
         {
             return new ReplicatorSettings(
                 role: role ?? this.Role,
@@ -202,7 +210,8 @@ namespace Akka.DistributedData
                 durableStoreProps: durableStoreProps ?? this.DurableStoreProps,
                 pruningMarkerTimeToLive: pruningMarkerTimeToLive ?? this.PruningMarkerTimeToLive,
                 durablePruningMarkerTimeToLive: durablePruningMarkerTimeToLive ?? this.DurablePruningMarkerTimeToLive,
-                maxDeltaSize: maxDeltaSize ?? this.MaxDeltaSize);
+                maxDeltaSize: maxDeltaSize ?? this.MaxDeltaSize,
+                recreateOnFailure: recreateOnFailure ?? this.RecreateOnFailure);
         }
 
         public ReplicatorSettings WithRole(string role) => Copy(role: role);

--- a/src/contrib/cluster/Akka.DistributedData/reference.conf
+++ b/src/contrib/cluster/Akka.DistributedData/reference.conf
@@ -122,6 +122,12 @@ akka.cluster.distributed-data {
       write-behind-interval = off
     }
   }
+  
+  # Turning this on will enable a Backoff Supervisor, so any unexpected 
+  # errors that cause the replicator to stop, will be restarted. 
+  # Turning this on or off during an upgrade to an existing cluster will 
+  # disrupt replication momentarily
+  recreate-on-failure = off
 }
 #//#distributed-data
 


### PR DESCRIPTION
Make ddata replicator actor configurable to have backoff supervisor. Defaults to not (original implementation) 

The test maybe a little overkill, I just wanted to prove that the original implementation how users would have it today, behaved the same way, including the way it fails