### PR TITLE
Add version range support for nuget packages

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj
+++ b/src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <!-- FluentAssertions is used in some benchmarks to validate internal behaviors -->
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>

--- a/src/common.props
+++ b/src/common.props
@@ -14,7 +14,7 @@
     <HyperionVersion>0.11.0</HyperionVersion>
     <NewtonsoftJsonVersion>[12.0.3,)</NewtonsoftJsonVersion>
     <NBenchVersion>2.0.1</NBenchVersion>
-    <ProtobufVersion>[3.12.1,)</ProtobufVersion>
+    <ProtobufVersion>[3.13.0,)</ProtobufVersion>
     <ImmutableVersion>[1.7.1,)</ImmutableVersion>
     
     <NetCoreTestVersion>netcoreapp3.1</NetCoreTestVersion>

--- a/src/common.props
+++ b/src/common.props
@@ -14,7 +14,9 @@
     <HyperionVersion>0.11.0</HyperionVersion>
     <NewtonsoftJsonVersion>[12.0.3,)</NewtonsoftJsonVersion>
     <NBenchVersion>2.0.1</NBenchVersion>
-    <ProtobufVersion>3.17.3</ProtobufVersion>
+    <ProtobufVersion>[3.12.1,)</ProtobufVersion>
+    <ImmutableVersion>[1.7.1,)</ImmutableVersion>
+    
     <NetCoreTestVersion>netcoreapp3.1</NetCoreTestVersion>
     <NetTestVersion>net5.0</NetTestVersion>
     <NetFrameworkTestVersion>net471</NetFrameworkTestVersion>

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -15,10 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="System.Collections.Immutable" Version="$(ImmutableVersion)" />
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
-      <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetStandardLibVersion)'">


### PR DESCRIPTION
Nuget package reference should use version range to support backward compatibility on other packages that relies on the Akka.NET package.