### PR TITLE
Prevent EndpointDisassociatedException from being thrown from EndpointReader

### DIFF
--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -1961,6 +1961,10 @@ namespace Akka.Remote
                             {
                                 LogTransientSerializationError(ackAndMessage.MessageOption, e);
                             }
+                            catch (InvalidCastException e)
+                            {
+                                LogTransientSerializationError(ackAndMessage.MessageOption, e);
+                            }
                             catch (Exception e)
                             {
                                 throw;


### PR DESCRIPTION
Hyperion can throw an InvalidCastException when deserializing a message that came from a system that uses a different sorting order compared to the receiving system. This exception should be treated like a SerializationException and should not cause the EndpointReader to fail.