### PR TITLE
fix `RemoteActorRefProvider.CreateRemoteRef` signature to return `IInternalActorRef`

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveRemote.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveRemote.approved.txt
@@ -204,7 +204,7 @@ namespace Akka.Remote
         public Akka.Actor.IInternalActorRef ActorOf(Akka.Actor.Internal.ActorSystemImpl system, Akka.Actor.Props props, Akka.Actor.IInternalActorRef supervisor, Akka.Actor.ActorPath path, bool systemService, Akka.Actor.Deploy deploy, bool lookupDeploy, bool async) { }
         protected virtual Akka.Actor.IActorRef CreateRemoteDeploymentWatcher(Akka.Actor.Internal.ActorSystemImpl system) { }
         protected virtual Akka.Actor.IInternalActorRef CreateRemoteRef(Akka.Actor.ActorPath actorPath, Akka.Actor.Address localAddress) { }
-        protected virtual Akka.Remote.RemoteActorRef CreateRemoteRef(Akka.Actor.Props props, Akka.Actor.IInternalActorRef supervisor, Akka.Actor.Address localAddress, Akka.Actor.ActorPath rpath, Akka.Actor.Deploy deployment) { }
+        protected virtual Akka.Actor.IInternalActorRef CreateRemoteRef(Akka.Actor.Props props, Akka.Actor.IInternalActorRef supervisor, Akka.Actor.Address localAddress, Akka.Actor.ActorPath rpath, Akka.Actor.Deploy deployment) { }
         protected virtual Akka.Actor.IActorRef CreateRemoteWatcher(Akka.Actor.Internal.ActorSystemImpl system) { }
         protected Akka.Remote.DefaultFailureDetectorRegistry<Akka.Actor.Address> CreateRemoteWatcherFailureDetector(Akka.Actor.ActorSystem system) { }
         public Akka.Actor.Address GetExternalAddressFor(Akka.Actor.Address address) { }

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -520,7 +520,7 @@ namespace Akka.Remote
         /// <param name="rpath">The remote actor path.</param>
         /// <param name="deployment">The deployment included in this Props.</param>
         /// <returns>An <see cref="IInternalActorRef"/> instance.</returns>
-        protected virtual RemoteActorRef CreateRemoteRef(Props props, IInternalActorRef supervisor, Address localAddress, ActorPath rpath, Deploy deployment)
+        protected virtual IInternalActorRef CreateRemoteRef(Props props, IInternalActorRef supervisor, Address localAddress, ActorPath rpath, Deploy deployment)
         {
             return new RemoteActorRef(Transport, localAddress, rpath, supervisor, props, deployment);
         }


### PR DESCRIPTION
Technically could be considered a breaking change, but this method was only just introduced in v1.4.22 and it's part of the RARP internals, so not likely.

Changed this because it needs to be consistent with the other overload of the same name - a detail that myself and the team missed during https://github.com/akkadotnet/akka.net/pull/5161