### PR TITLE
use `Failure` to programmatically cancel `Ask`

### DIFF
--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -146,6 +146,15 @@ namespace Akka.Actor
                 }
             }
         }
+        
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="message">TBD</param>
+        public override void SendSystemMessage(ISystemMessage message)
+        {
+            base.SendSystemMessage(message);
+        }
     }
 
 

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -134,6 +134,10 @@ namespace Akka.Actor
                     {
                         _result.TrySetResult(t);
                     }
+                    else if (message is Failure f)
+                    {
+                        _result.TrySetException(f.Exception ?? new TaskCanceledException("Task cancelled by actor via Failure message."));
+                    }
                     else
                     {
                         _result.TrySetException(new ArgumentException(
@@ -141,15 +145,6 @@ namespace Akka.Actor
                     }
                 }
             }
-        }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="message">TBD</param>
-        public override void SendSystemMessage(ISystemMessage message)
-        {
-            base.SendSystemMessage(message);
         }
     }
 


### PR DESCRIPTION
close #3091 - part of the `Ask` API that's never been fully implemented.