### PR TITLE
re-enabled Akka.FSharp.Tests on .NET Core 3.1, .NET 5.0

### DIFF
--- a/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
+++ b/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.FSharp.Tests</AssemblyTitle>
-    <TargetFrameworks>$(NetFrameworkTestVersion);netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <NoWarn></NoWarn> 
   </PropertyGroup>
@@ -31,6 +31,10 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
+
+    <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' OR '$(TargetFramework)' == '$(NetTestVersion)'">
+        <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
+    </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>

--- a/src/core/Akka.FSharp.Tests/ApiTests.fs
+++ b/src/core/Akka.FSharp.Tests/ApiTests.fs
@@ -12,7 +12,7 @@ open Akka.Actor
 open System
 open Xunit
 
-
+#if !CORECLR // not supported on .NET Core / .NET 5
 [<Fact>]
 let ``configuration loader should load data from app.config`` () =
     let config = Configuration.load()
@@ -20,6 +20,7 @@ let ``configuration loader should load data from app.config`` () =
     |> equals true
     config.GetInt "akka.test.value"
     |> equals 10
+#endif
 
 [<Fact>]
 let ``can serialize expression decider`` () =


### PR DESCRIPTION
close #5194 