### PR TITLE
Akka.Cluster.Sharding performance benchmarks

### DIFF
--- a/src/Akka.sln
+++ b/src/Akka.sln
@@ -246,6 +246,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SerializationBenchmarks", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DDataStressTest", "examples\Cluster\DData\DDataStressTest\DDataStressTest.csproj", "{44B3DDD6-6103-4E8F-8AC2-0F4BA3CF6B50}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Cluster.Benchmarks", "benchmark\Akka.Cluster.Benchmarks\Akka.Cluster.Benchmarks.csproj", "{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1137,6 +1139,18 @@ Global
 		{44B3DDD6-6103-4E8F-8AC2-0F4BA3CF6B50}.Release|x64.Build.0 = Release|Any CPU
 		{44B3DDD6-6103-4E8F-8AC2-0F4BA3CF6B50}.Release|x86.ActiveCfg = Release|Any CPU
 		{44B3DDD6-6103-4E8F-8AC2-0F4BA3CF6B50}.Release|x86.Build.0 = Release|Any CPU
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}.Debug|x64.Build.0 = Debug|Any CPU
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}.Debug|x86.Build.0 = Debug|Any CPU
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}.Release|x64.ActiveCfg = Release|Any CPU
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}.Release|x64.Build.0 = Release|Any CPU
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}.Release|x86.ActiveCfg = Release|Any CPU
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1245,6 +1259,7 @@ Global
 		{D62F4AD6-318F-4ECC-B875-83FA9933A81B} = {162F5991-EA57-4221-9B70-F9B6FEC18036}
 		{2E4B9584-42CC-4D17-B719-9F462B16C94D} = {73108242-625A-4D7B-AA09-63375DBAE464}
 		{44B3DDD6-6103-4E8F-8AC2-0F4BA3CF6B50} = {C50E1A9E-820C-4E75-AE39-6F96A99AC4A7}
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B} = {73108242-625A-4D7B-AA09-63375DBAE464}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {03AD8E21-7507-4E68-A4E9-F4A7E7273164}

--- a/src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj
+++ b/src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
     <!-- FluentAssertions is used in some benchmarks to validate internal behaviors -->
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>

--- a/src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj
+++ b/src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj
@@ -8,8 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <!-- FluentAssertions is used in some benchmarks to validate internal behaviors -->
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>

--- a/src/benchmark/Akka.Cluster.Benchmarks/Akka.Cluster.Benchmarks.csproj
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Akka.Cluster.Benchmarks.csproj
@@ -5,4 +5,19 @@
         <TargetFramework>$(NetCoreTestVersion)</TargetFramework>
     </PropertyGroup>
 
+    <ItemGroup>
+        <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\contrib\cluster\Akka.Cluster.Sharding\Akka.Cluster.Sharding.csproj" />
+      <ProjectReference Include="..\..\contrib\persistence\Akka.Persistence.Sqlite\Akka.Persistence.Sqlite.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Compile Include="..\Akka.Benchmarks\Configurations\Configs.cs">
+        <Link>Configs.cs</Link>
+      </Compile>
+    </ItemGroup>
+
 </Project>

--- a/src/benchmark/Akka.Cluster.Benchmarks/Akka.Cluster.Benchmarks.csproj
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Akka.Cluster.Benchmarks.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <Import Project="..\..\common.props" />
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>$(NetCoreTestVersion)</TargetFramework>
+    </PropertyGroup>
+
+</Project>

--- a/src/benchmark/Akka.Cluster.Benchmarks/Program.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Akka.Cluster.Benchmarks
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/src/benchmark/Akka.Cluster.Benchmarks/Program.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Program.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Reflection;
+using BenchmarkDotNet.Running;
 
 namespace Akka.Cluster.Benchmarks
 {
@@ -6,7 +8,7 @@ namespace Akka.Cluster.Benchmarks
     {
         static void Main(string[] args)
         {
-            Console.WriteLine("Hello World!");
+            BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args);
         }
     }
 }

--- a/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardMessageRoutingBenchmarks.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardMessageRoutingBenchmarks.cs
@@ -110,6 +110,26 @@ namespace Akka.Cluster.Benchmarks.Sharding
             _batchActor.Tell(new BulkSendActor.BeginSend(_messageToSys1, _shardRegion1, BatchSize));
             await _batchComplete;
         }
+        
+        [Benchmark]
+        public async Task SingleRequestResponseToRemoteEntity()
+        {
+            for (var i = 0; i < MsgCount; i++)
+                await _shardRegion1.Ask<ShardedMessage>(_messageToSys2);
+        }
+        
+        [Benchmark]
+        public async Task StreamingToRemoteEntity()
+        {
+            _batchActor.Tell(new BulkSendActor.BeginSend(_messageToSys2, _shardRegion1, BatchSize));
+            await _batchComplete;
+        }
+
+        [IterationCleanup]
+        public void IterationCleanup()
+        {
+            _sys1.Stop(_batchActor);
+        }
 
         [GlobalCleanup]
         public async Task Cleanup()

--- a/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardMessageRoutingBenchmarks.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardMessageRoutingBenchmarks.cs
@@ -9,12 +9,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Xml.Serialization;
 using Akka.Actor;
 using Akka.Benchmarks.Configurations;
-using Akka.Configuration;
 using Akka.Cluster.Sharding;
-using Akka.Configuration;
 using BenchmarkDotNet.Attributes;
 using static Akka.Cluster.Benchmarks.Sharding.ShardingHelper;
 
@@ -45,8 +42,6 @@ namespace Akka.Cluster.Benchmarks.Sharding
 
         private IActorRef _batchActor;
         private Task _batchComplete;
-        
-        
 
         [GlobalSetup]
         public async Task Setup()

--- a/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardMessageRoutingBenchmarks.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardMessageRoutingBenchmarks.cs
@@ -1,0 +1,124 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ShardMessageRoutingBenchmarks.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using Akka.Configuration;
+using Akka.Cluster.Sharding;
+using Akka.Configuration;
+using BenchmarkDotNet.Attributes;
+using static Akka.Cluster.Benchmarks.Sharding.ShardingHelper;
+
+namespace Akka.Cluster.Benchmarks.Sharding
+{
+    [Config(typeof(MonitoringConfig))]
+    public class ShardMessageRoutingBenchmarks
+    {
+        [Params(StateStoreMode.Persistence, StateStoreMode.DData)]
+        public StateStoreMode StateMode;
+
+        [Params(10000)]
+        public int MsgCount;
+
+        public int BatchSize = 20;
+
+        private ActorSystem _sys1;
+        private ActorSystem _sys2;
+
+        private IActorRef _shardRegion1;
+        private IActorRef _shardRegion2;
+
+        private string _entityOnSys1;
+        private string _entityOnSys2;
+
+        private ShardedMessage _messageToSys1;
+        private ShardedMessage _messageToSys2;
+
+        private IActorRef _batchActor;
+        private Task _batchComplete;
+        
+        
+
+        [GlobalSetup]
+        public async Task Setup()
+        {
+            var config = StateMode switch
+            {
+                StateStoreMode.Persistence => CreatePersistenceConfig(),
+                StateStoreMode.DData => CreateDDataConfig(),
+                _ => null
+            };
+
+            _sys1 = ActorSystem.Create("BenchSys", config);
+            _sys2 = ActorSystem.Create("BenchSys", config);
+
+            var c1 = Cluster.Get(_sys1);
+            var c2 = Cluster.Get(_sys2);
+
+            await c1.JoinAsync(c1.SelfAddress);
+            await c2.JoinAsync(c1.SelfAddress);
+
+            _shardRegion1 = StartShardRegion(_sys1);
+            _shardRegion2 = StartShardRegion(_sys2);
+
+            var s1Asks = new List<Task<ActorIdentity>>(20);
+            var s2Asks = new List<Task<ActorIdentity>>(20);
+
+            foreach (var i in Enumerable.Range(0, 20))
+            {
+                s1Asks.Add(_shardRegion1.Ask<ActorIdentity>(new Identify(i), TimeSpan.FromSeconds(3)));
+                s2Asks.Add(_shardRegion2.Ask<ActorIdentity>(new Identify(i), TimeSpan.FromSeconds(3)));
+            }
+
+            // wait for all Ask operations to complete
+            await Task.WhenAll(s1Asks.Concat(s2Asks));
+
+            _entityOnSys1 = s1Asks.First(x => x.Result.Subject.Path.Address.Equals(c1.SelfAddress)).Result.Subject.Path
+                .Name;
+            _entityOnSys2 = s2Asks.First(x => x.Result.Subject.Path.Address.Equals(c2.SelfAddress)).Result.Subject.Path
+                .Name;
+
+            _messageToSys1 = new ShardedMessage(_entityOnSys1, 10);
+            _messageToSys2 = new ShardedMessage(_entityOnSys2, 10);
+        }
+
+        [IterationSetup]
+        public void PerIteration()
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            _batchComplete = tcs.Task;
+            _batchActor = _sys1.ActorOf(Props.Create(() => new BulkSendActor(tcs, MsgCount)));
+        }
+
+        [Benchmark]
+        public async Task SingleRequestResponseToLocalEntity()
+        {
+            for (var i = 0; i < MsgCount; i++)
+                await _shardRegion1.Ask<ShardedMessage>(_messageToSys1);
+        }
+        
+        [Benchmark]
+        public async Task StreamingToLocalEntity()
+        {
+            _batchActor.Tell(new BulkSendActor.BeginSend(_messageToSys1, _shardRegion1, BatchSize));
+            await _batchComplete;
+        }
+
+        [GlobalCleanup]
+        public async Task Cleanup()
+        {
+            var t1 = _sys1.Terminate();
+            var t2 = _sys2.Terminate();
+            await Task.WhenAll(t1, t2);
+        }
+    }
+}

--- a/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardSpawnBenchmarks.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardSpawnBenchmarks.cs
@@ -1,0 +1,79 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="ShardSpawnBenchmarks.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using Akka.Cluster.Sharding;
+using BenchmarkDotNet.Attributes;
+using static Akka.Cluster.Benchmarks.Sharding.ShardingHelper;
+
+namespace Akka.Cluster.Benchmarks.Sharding
+{
+    [Config(typeof(MonitoringConfig))]
+    public class ShardSpawnBenchmarks
+    {
+        [Params(StateStoreMode.Persistence, StateStoreMode.DData)]
+        public StateStoreMode StateMode;
+
+        [Params(1000)]
+        public int EntityCount;
+
+        [Params(true, false)]
+        public bool RememberEntities;
+
+        public int BatchSize = 20;
+
+        private ActorSystem _sys1;
+        private ActorSystem _sys2;
+
+        private IActorRef _shardRegion1;
+        private IActorRef _shardRegion2;
+        
+        
+        [GlobalSetup]
+        public async Task Setup()
+        {
+            var config = StateMode switch
+            {
+                StateStoreMode.Persistence => CreatePersistenceConfig(RememberEntities),
+                StateStoreMode.DData => CreateDDataConfig(RememberEntities),
+                _ => null
+            };
+
+            _sys1 = ActorSystem.Create("BenchSys", config);
+            _sys2 = ActorSystem.Create("BenchSys", config);
+
+            var c1 = Cluster.Get(_sys1);
+            var c2 = Cluster.Get(_sys2);
+
+            await c1.JoinAsync(c1.SelfAddress);
+            await c2.JoinAsync(c1.SelfAddress);
+
+            _shardRegion1 = StartShardRegion(_sys1);
+            _shardRegion2 = StartShardRegion(_sys2);
+        }
+
+        [Benchmark]
+        public async Task SpawnEntities()
+        {
+            for (var i = 0; i < EntityCount; i++)
+            {
+                var msg = new ShardedMessage(i.ToString(), i);
+                await _shardRegion1.Ask<ShardedMessage>(msg);
+            }
+        }
+        
+        [GlobalCleanup]
+        public async Task Cleanup()
+        {
+            var t1 = _sys1.Terminate();
+            var t2 = _sys2.Terminate();
+            await Task.WhenAll(t1, t2);
+        }
+    }
+}

--- a/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardSpawnBenchmarks.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardSpawnBenchmarks.cs
@@ -16,7 +16,7 @@ using static Akka.Cluster.Benchmarks.Sharding.ShardingHelper;
 namespace Akka.Cluster.Benchmarks.Sharding
 {
     [Config(typeof(MonitoringConfig))]
-    [SimpleJob(RunStrategy.ColdStart, targetCount:1, warmupCount:0)]
+    [SimpleJob(RunStrategy.ColdStart, targetCount:1, warmupCount:0, launchCount:5)]
     public class ShardSpawnBenchmarks
     {
         [Params(StateStoreMode.Persistence, StateStoreMode.DData)]
@@ -84,8 +84,9 @@ namespace Akka.Cluster.Benchmarks.Sharding
         [GlobalCleanup]
         public async Task Cleanup()
         {
-            var t1 = _sys1.Terminate();
-            var t2 = _sys2.Terminate();
+            var t2 = CoordinatedShutdown.Get(_sys2).Run(CoordinatedShutdown.ActorSystemTerminateReason.Instance);
+            var t1 = CoordinatedShutdown.Get(_sys1).Run(CoordinatedShutdown.ActorSystemTerminateReason.Instance);
+           
             await Task.WhenAll(t1, t2);
         }
     }

--- a/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardingInfrastructure.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardingInfrastructure.cs
@@ -183,11 +183,11 @@ namespace Akka.Cluster.Benchmarks.Sharding
             return config;
         }
 
-        public static IActorRef StartShardRegion(ActorSystem system)
+        public static IActorRef StartShardRegion(ActorSystem system, string entityName = "entities")
         {
             var props = Props.Create(() => new ShardedEntityActor());
             var sharding = ClusterSharding.Get(system);
-            return sharding.Start("entities", s => props, ClusterShardingSettings.Create(system),
+            return sharding.Start(entityName, s => props, ClusterShardingSettings.Create(system),
                 new ShardMessageExtractor());
         }
     }

--- a/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardingInfrastructure.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardingInfrastructure.cs
@@ -1,0 +1,163 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="ShardingInfrastructure.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Cluster.Sharding;
+using Akka.Configuration;
+using Akka.Util.Internal;
+
+namespace Akka.Cluster.Benchmarks.Sharding
+{
+    public sealed class ShardedEntityActor : ReceiveActor
+    {
+        public ShardedEntityActor()
+        {
+            ReceiveAny(_ => Sender.Tell(_));
+        }
+    }
+
+    public sealed class BulkSendActor : ReceiveActor
+    {
+        public sealed class BeginSend
+        {
+            public BeginSend(ShardedMessage msg, IActorRef target, int batchSize)
+            {
+                Msg = msg;
+                Target = target;
+                BatchSize = batchSize;
+            }
+
+            public ShardedMessage Msg { get; }
+            
+            public IActorRef Target { get; }
+            
+            public int BatchSize { get; }
+        }
+        
+        private int _remaining;
+
+        private readonly TaskCompletionSource<bool> _tcs;
+
+        public BulkSendActor(TaskCompletionSource<bool> tcs, int remaining)
+        {
+            _tcs = tcs;
+            _remaining = remaining;
+
+            Receive<BeginSend>(b =>
+            {
+                for (var i = 0; i < b.BatchSize; i++)
+                {
+                    b.Target.Tell(b.Msg);
+                }
+            });
+
+            Receive<ShardedMessage>(s =>
+            {
+                if (--remaining > 0)
+                {
+                    Sender.Tell(s);
+                }
+                else
+                {
+                    Context.Stop(Self); // shut ourselves down
+                    _tcs.TrySetResult(true);
+                }
+            });
+        }
+    }
+    
+    public sealed class ShardedMessage
+    {
+        public ShardedMessage(string entityId, int message)
+        {
+            EntityId = entityId;
+            Message = message;
+        }
+
+        public string EntityId { get; }
+            
+        public int Message { get; }
+    }
+
+    /// <summary>
+    /// Use a default <see cref="IMessageExtractor"/> even though it takes extra work to setup the benchmark
+    /// </summary>
+    public sealed class ShardMessageExtractor : HashCodeMessageExtractor
+    {
+        /// <summary>
+        /// We only ever run with a maximum of two nodes, so ~10 shards per node
+        /// </summary>
+        public ShardMessageExtractor(int shardCount = 20) : base(shardCount)
+        {
+        }
+
+        public override string EntityId(object message)
+        {
+            if(message is ShardedMessage sharded)
+            {
+                return sharded.EntityId;
+            }
+
+            return null;
+        }
+    }
+
+    public static class ShardingHelper
+    {
+        public static AtomicCounter DbId = new AtomicCounter(0);
+
+        internal static string BoolToToggle(bool val)
+        {
+            return val ? "on" : "off";
+        }
+        
+        public static Config CreatePersistenceConfig(bool rememberEntities = false)
+        {
+            var connectionString =
+                "Filename=file:memdb-journal-" + DbId.IncrementAndGet() + ".db;Mode=Memory;Cache=Shared";
+            var config = $@"
+                akka.actor.provider = cluster
+                akka.remote.dot-netty.tcp.port = 0
+                akka.cluster.sharding.state-store-mode=persistence
+                akka.cluster.sharding.remember-entities = {BoolToToggle(rememberEntities)}
+                akka.persistence.journal.plugin = ""akka.persistence.journal.sqlite""
+                akka.persistence.journal.sqlite {{
+                    class = ""Akka.Persistence.Sqlite.Journal.SqliteJournal, Akka.Persistence.Sqlite""
+                    connection-string = ""{connectionString}""
+                }}
+                akka.persistence.snapshot-store {{
+                    plugin = ""akka.persistence.snapshot-store.sqlite""
+                    sqlite {{
+                        class = ""Akka.Persistence.Sqlite.Snapshot.SqliteSnapshotStore, Akka.Persistence.Sqlite""
+                        connection-string = ""{connectionString}""
+                    }}
+                }}";
+
+            return config;
+        }
+
+        public static Config CreateDDataConfig(bool rememberEntities = false)
+        {
+            var config = $@"
+                akka.actor.provider = cluster
+                akka.remote.dot-netty.tcp.port = 0
+                akka.cluster.sharding.state-store-mode=ddata
+                akka.cluster.sharding.remember-entities = {BoolToToggle(rememberEntities)}";
+
+            return config;
+        }
+
+        public static IActorRef StartShardRegion(ActorSystem system)
+        {
+            var props = Props.Create(() => new ShardedEntityActor());
+            var sharding = ClusterSharding.Get(system);
+            return sharding.Start("entities", s => props, ClusterShardingSettings.Create(system),
+                new ShardMessageExtractor());
+        }
+    }
+}

--- a/src/common.props
+++ b/src/common.props
@@ -15,6 +15,7 @@
     <NewtonsoftJsonVersion>[12.0.3,)</NewtonsoftJsonVersion>
     <NBenchVersion>2.0.1</NBenchVersion>
     <ProtobufVersion>3.17.3</ProtobufVersion>
+    <BenchmarkDotNetVersion>0.13.1</BenchmarkDotNetVersion>
     <NetCoreTestVersion>netcoreapp3.1</NetCoreTestVersion>
     <NetTestVersion>net5.0</NetTestVersion>
     <NetFrameworkTestVersion>net471</NetFrameworkTestVersion>


### PR DESCRIPTION
close #3083

Initial numbers:

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19041.1165 (2004/May2020Update/20H1)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=5.0.302
  [Host]     : .NET Core 3.1.17 (CoreCLR 4.700.21.31506, CoreFX 4.700.21.31502), X64 RyuJIT
  Job-HXSFLM : .NET Core 3.1.17 (CoreCLR 4.700.21.31506, CoreFX 4.700.21.31502), X64 RyuJIT

InvocationCount=1  UnrollFactor=1  

```
|                              Method |   StateMode | MsgCount |         Mean |      Error |      StdDev |       Median |
|------------------------------------ |------------ |--------- |-------------:|-----------:|------------:|-------------:|
|  **SingleRequestResponseToLocalEntity** | **Persistence** |    **10000** |   **110.158 ms** |  **2.1994 ms** |   **3.0832 ms** |   **109.456 ms** |
|              StreamingToLocalEntity | Persistence |    10000 |     5.156 ms |  0.3821 ms |   1.0964 ms |     4.934 ms |
| SingleRequestResponseToRemoteEntity | Persistence |    10000 | 4,157.097 ms | 82.5627 ms | 199.3982 ms | 4,069.618 ms |
|             StreamingToRemoteEntity | Persistence |    10000 |           NA |         NA |          NA |           NA |
|  **SingleRequestResponseToLocalEntity** |       **DData** |    **10000** |   **111.700 ms** |  **2.2282 ms** |   **6.0620 ms** |   **110.184 ms** |
|              StreamingToLocalEntity |       DData |    10000 |     4.897 ms |  0.3378 ms |   0.9360 ms |     4.858 ms |
| SingleRequestResponseToRemoteEntity |       DData |    10000 | 4,157.913 ms | 82.7139 ms | 165.1886 ms | 4,152.249 ms |
|             StreamingToRemoteEntity |       DData |    10000 |   506.119 ms | 10.1116 ms |  10.3839 ms |   504.516 ms |

Benchmarks with issues:
  ShardMessageRoutingBenchmarks.StreamingToRemoteEntity: Job-HXSFLM(InvocationCount=1, UnrollFactor=1) [StateMode=Persistence, MsgCount=10000]

Confirms https://github.com/akkadotnet/akka.net/issues/5203