### PR TITLE
cached ShardIds generated by HashCodeMessageExtractor

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
@@ -60,6 +60,8 @@ namespace Akka.Cluster.Sharding
         /// </summary>
         public readonly int MaxNumberOfShards;
 
+        private readonly Dictionary<int, string> _cachedIds;
+
         /// <summary>
         /// TBD
         /// </summary>
@@ -67,6 +69,11 @@ namespace Akka.Cluster.Sharding
         protected HashCodeMessageExtractor(int maxNumberOfShards)
         {
             MaxNumberOfShards = maxNumberOfShards;
+            _cachedIds = new Dictionary<int, string>(MaxNumberOfShards);
+            foreach (var c in Enumerable.Range(0, maxNumberOfShards))
+            {
+                _cachedIds[c] = c.ToString();
+            }
         }
 
         /// <summary>
@@ -98,8 +105,8 @@ namespace Akka.Cluster.Sharding
                 id = se.EntityId;
             else
                 id = EntityId(message);
-
-            return (Math.Abs(MurmurHash.StringHash(id)) % MaxNumberOfShards).ToString();
+            
+            return _cachedIds[(Math.Abs(MurmurHash.StringHash(id)) % MaxNumberOfShards)];
         }
     }
 


### PR DESCRIPTION
Since the number of possible shards is bounded at startup, we can avoid allocating a string each time we route a message by pre-calculating them in the constructor of the `HashCodeMessageExtractor`.

This improvement reduces all allocations and reduces latency by 50%.

## Before

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19041.1165 (2004/May2020Update/20H1)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=5.0.302
  [Host]     : .NET Core 3.1.17 (CoreCLR 4.700.21.31506, CoreFX 4.700.21.31502), X64 RyuJIT
  DefaultJob : .NET Core 3.1.17 (CoreCLR 4.700.21.31506, CoreFX 4.700.21.31502), X64 RyuJIT


```
|             Method |     Mean |    Error |   StdDev |   Median |  Gen 0 | Allocated |
|------------------- |---------:|---------:|---------:|---------:|-------:|----------:|
| RouteShardEnvelope | 49.05 ns | 0.397 ns | 0.372 ns | 49.02 ns | 0.0076 |      32 B |
|  RouteTypedMessage | 45.76 ns | 0.952 ns | 1.425 ns | 44.86 ns | 0.0076 |      32 B |


## After

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19041.1165 (2004/May2020Update/20H1)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=5.0.302
  [Host] : .NET Core 3.1.17 (CoreCLR 4.700.21.31506, CoreFX 4.700.21.31502), X64 RyuJIT

Toolchain=InProcessEmitToolchain  

```
|             Method |     Mean |    Error |   StdDev | Allocated |
|------------------- |---------:|---------:|---------:|----------:|
| RouteShardEnvelope | 24.05 ns | 0.096 ns | 0.080 ns |         - |
|  RouteTypedMessage | 28.55 ns | 0.171 ns | 0.160 ns |         - |
