### PR TITLE
Ask should push unhandled answers into deadletter

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -866,7 +866,7 @@ namespace Akka.Actor
     }
     public class FutureActorRef<T> : Akka.Actor.MinimalActorRef
     {
-        public FutureActorRef(System.Threading.Tasks.TaskCompletionSource<T> result, System.Action<System.Threading.Tasks.Task> unregister, Akka.Actor.ActorPath path) { }
+        public FutureActorRef(System.Threading.Tasks.TaskCompletionSource<T> result, Akka.Actor.ActorPath path, Akka.Actor.IActorRefProvider provider) { }
         public override Akka.Actor.ActorPath Path { get; }
         public override Akka.Actor.IActorRefProvider Provider { get; }
         public override void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message) { }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -864,7 +864,7 @@ namespace Akka.Actor
         public Failures() { }
         public System.Collections.Generic.List<Akka.Actor.Failure> Entries { get; }
     }
-    public class FutureActorRef<T> : Akka.Actor.MinimalActorRef
+    public sealed class FutureActorRef<T> : Akka.Actor.MinimalActorRef
     {
         public FutureActorRef(System.Threading.Tasks.TaskCompletionSource<T> result, Akka.Actor.ActorPath path, Akka.Actor.IActorRefProvider provider) { }
         public override Akka.Actor.ActorPath Path { get; }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -869,7 +869,6 @@ namespace Akka.Actor
         public FutureActorRef(System.Threading.Tasks.TaskCompletionSource<T> result, Akka.Actor.ActorPath path, Akka.Actor.IActorRefProvider provider) { }
         public override Akka.Actor.ActorPath Path { get; }
         public override Akka.Actor.IActorRefProvider Provider { get; }
-        public override void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message) { }
         protected override void TellInternal(object message, Akka.Actor.IActorRef sender) { }
     }
     public class static Futures

--- a/src/core/Akka.Tests/Actor/AskSpec.cs
+++ b/src/core/Akka.Tests/Actor/AskSpec.cs
@@ -162,8 +162,8 @@ namespace Akka.Tests.Actor
 
             await EventFilter.DeadLetter<object>().ExpectAsync(0, async () =>
             {
-                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3)))
-                    await Assert.ThrowsAsync<TaskCanceledException>(async () => await actor.Ask<string>("timeout", Timeout.InfiniteTimeSpan, cts.Token));
+                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1)))
+                    await Assert.ThrowsAsync<TaskCanceledException>(async () => await actor.Ask<string>("delay", Timeout.InfiniteTimeSpan, cts.Token));
             });
         }
 

--- a/src/core/Akka.Tests/Actor/AskSpec.cs
+++ b/src/core/Akka.Tests/Actor/AskSpec.cs
@@ -35,6 +35,24 @@ namespace Akka.Tests.Actor
                 {
                     Sender.Tell("answer");
                 }
+
+                if (message.Equals("delay"))
+                {
+                    Thread.Sleep(3000);
+                    Sender.Tell("answer");
+                }
+
+                if (message.Equals("many"))
+                {
+                    Sender.Tell("answer1");
+                    Sender.Tell("answer2");
+                    Sender.Tell("answer2");
+                }
+
+                if (message.Equals("invalid"))
+                {
+                    Sender.Tell(123);
+                }
             }
         }
 
@@ -110,6 +128,52 @@ namespace Akka.Tests.Actor
         {
             var actor = Sys.ActorOf<SomeActor>();
             await Assert.ThrowsAsync<AskTimeoutException>(async () => await actor.Ask<string>("timeout", TimeSpan.FromSeconds(3)));
+        }
+
+        [Fact]
+        public async Task Ask_should_put_timeout_answer_into_deadletter()
+        {
+            var actor = Sys.ActorOf<SomeActor>();            
+            
+            await EventFilter.DeadLetter<object>().ExpectOneAsync(TimeSpan.FromSeconds(5), async () => 
+            {
+                await Assert.ThrowsAsync<AskTimeoutException>(async () => await actor.Ask<string>("delay", TimeSpan.FromSeconds(1)));
+            });
+        }
+
+        [Fact]
+        public async Task Ask_should_put_too_many_answers_into_deadletter()
+        {
+            var actor = Sys.ActorOf<SomeActor>();
+
+            await EventFilter.DeadLetter<object>().ExpectAsync(2, async () =>
+            {
+                var result = await actor.Ask<string>("many", TimeSpan.FromSeconds(1));
+                result.ShouldBe("answer1");
+            });
+        }
+
+        [Fact]
+        public async Task Ask_should_not_put_canceled_answer_into_deadletter()
+        {
+            var actor = Sys.ActorOf<SomeActor>();
+
+            await EventFilter.DeadLetter<object>().ExpectAsync(0, async () =>
+            {
+                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3)))
+                    await Assert.ThrowsAsync<TaskCanceledException>(async () => await actor.Ask<string>("timeout", Timeout.InfiniteTimeSpan, cts.Token));
+            });
+        }
+
+        [Fact]
+        public async Task Ask_should_put_invalid_answer_into_deadletter()
+        {
+            var actor = Sys.ActorOf<SomeActor>();
+
+            await EventFilter.DeadLetter<object>().ExpectOne(async () =>
+            {
+                await Assert.ThrowsAsync<ArgumentException>(async () => await actor.Ask<string>("invalid", TimeSpan.FromSeconds(1)));
+            });
         }
 
         [Fact]

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -97,11 +97,6 @@ namespace Akka.Actor
         /// </summary>
         public override IActorRefProvider Provider => _provider;
 
-
-        private const int INITIATED = 0;
-        private const int COMPLETED = 1;
-        private int status = INITIATED;
-
         /// <summary>
         /// TBD
         /// </summary>
@@ -113,7 +108,7 @@ namespace Akka.Actor
             {
                 SendSystemMessage(sysM);
             }
-            else if (Interlocked.Exchange(ref status, COMPLETED) == INITIATED)
+            else 
             {
                 var handled = false;
 
@@ -138,11 +133,6 @@ namespace Akka.Actor
                 //ignore canceled ask and put unhandled answers into deadletter
                 if (!handled && !_result.Task.IsCanceled)
                     _provider.DeadLetters.Tell(message ?? default(T), this);
-            }
-            else
-            {
-                //put too many answers into deadletter
-                _provider.DeadLetters.Tell(message ?? default(T), this);
             }
         }
 

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -118,6 +118,10 @@ namespace Akka.Actor
                 case null:
                     handled = _result.TrySetResult(default);
                     break;
+                case Status.Failure f:
+                    handled = _result.TrySetException(f.Cause
+                        ?? new TaskCanceledException("Task cancelled by actor via Failure message."));
+                    break;
                 case Failure f:
                     handled = _result.TrySetException(f.Exception
                         ?? new TaskCanceledException("Task cancelled by actor via Failure message."));

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -115,7 +115,7 @@ namespace Akka.Actor
             }
             else if (Interlocked.Exchange(ref status, COMPLETED) == INITIATED)
             {
-                bool handled;
+                var handled = false;
 
                 switch (message)
                 {
@@ -130,7 +130,7 @@ namespace Akka.Actor
                             ?? new TaskCanceledException("Task cancelled by actor via Failure message."));
                         break;
                     default:
-                        handled = _result.TrySetException(new ArgumentException(
+                        _ = _result.TrySetException(new ArgumentException(
                             $"Received message of type [{message.GetType()}] - Ask expected message of type [{typeof(T)}]"));
                         break;
                 }

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -161,8 +161,6 @@ namespace Akka.Actor
                 ctr1?.Dispose();
                 ctr2?.Dispose();
                 timeoutCancellation?.Dispose();
-
-                return t;
             }, TaskContinuationOptions.ExecuteSynchronously);
 
             //The future actor needs to be registered in the temp container

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -149,16 +149,21 @@ namespace Akka.Actor
             }
 
             //create a new tempcontainer path
-            ActorPath path = provider.TempPath();
+            var path = provider.TempPath();
 
-            var future = new FutureActorRef<T>(result, t =>
+            var future = new FutureActorRef<T>(result, path, provider);
+
+            //The future actor needs to be unregistered in the temp container
+            _ = result.Task.ContinueWith(t =>
             {
                 provider.UnregisterTempActor(path);
 
                 ctr1?.Dispose();
                 ctr2?.Dispose();
                 timeoutCancellation?.Dispose();
-            }, path);
+
+                return t;
+            }, TaskContinuationOptions.ExecuteSynchronously);
 
             //The future actor needs to be registered in the temp container
             provider.RegisterTempActor(future, path);


### PR DESCRIPTION
Currently invalid or timed out answers of Ask getting invisibly ignored by FutureActorRef<T>
This PR will push all invalid answers into deadletter.
Invalid answers are timeout-answer, too many answers, answer in a bad state of FutureActorRef<T>.

The only exception is a canceled Ask, this answer will still be ignored.

