### PR TITLE
Improve status messages

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -853,12 +853,14 @@ namespace Akka.Actor
         }
         public delegate void TransitionHandler<TState, TData>(TState initialState, TState nextState);
     }
+    [System.ObsoleteAttribute("Use Akka.Actor.Status.Failure")]
     public class Failure
     {
         public Failure() { }
         public System.Exception Exception { get; set; }
         public System.DateTime Timestamp { get; set; }
     }
+    [System.ObsoleteAttribute("Use List of Akka.Actor.Status.Failure")]
     public class Failures
     {
         public Failures() { }
@@ -1720,16 +1722,20 @@ namespace Akka.Actor
     public abstract class Status
     {
         protected Status() { }
-        public class Failure : Akka.Actor.Status
+        public sealed class Failure : Akka.Actor.Status
         {
             public readonly System.Exception Cause;
+            public readonly object State;
             public Failure(System.Exception cause) { }
+            public Failure(System.Exception cause, object state) { }
             public override string ToString() { }
         }
-        public class Success : Akka.Actor.Status
+        public sealed class Success : Akka.Actor.Status
         {
+            public static readonly Akka.Actor.Status.Success Instance;
             public readonly object Status;
             public Success(object status) { }
+            public override string ToString() { }
         }
     }
     public class StoppingSupervisorStrategy : Akka.Actor.SupervisorStrategyConfigurator

--- a/src/core/Akka/Actor/ActorBase.cs
+++ b/src/core/Akka/Actor/ActorBase.cs
@@ -20,8 +20,10 @@ namespace Akka.Actor
         /// <summary>
         /// Indicates the success of some operation which has been performed
         /// </summary>
-        public class Success : Status
+        public sealed class Success : Status
         {
+            public static readonly Success Instance = new Success(null);
+
             /// <summary>
             /// TBD
             /// </summary>
@@ -35,18 +37,26 @@ namespace Akka.Actor
             {
                 Status = status;
             }
+
+            public override string ToString() => Status is null ? "Success" : $"Success: {Status}";
         }
 
         /// <summary>
         /// Indicates the failure of some operation that was requested and includes an
         /// <see cref="Exception"/> describing the underlying cause of the problem.
         /// </summary>
-        public class Failure : Status
+        public sealed class Failure : Status
         {
             /// <summary>
             /// The cause of the failure
             /// </summary>
             public readonly Exception Cause;
+
+            /// <summary>
+            /// The source state of the failure
+            /// It can be used to send the command message back
+            /// </summary>
+            public readonly object State;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="Failure"/> class.
@@ -55,13 +65,23 @@ namespace Akka.Actor
             public Failure(Exception cause)
             {
                 Cause = cause;
+                State = null;
+            }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="Failure"/> class.
+            /// </summary>
+            /// <param name="cause">The cause of the failure</param>
+            /// <param name="state">The source state of the failure</param>
+            public Failure(Exception cause, object state)
+            {
+                Cause = cause;
+                State = state;
             }
 
             /// <inheritdoc/>
             public override string ToString()
-            {
-                return $"Failure: {Cause}";
-            }
+                => State is null ? $"Failure: {Cause}" : $"Failure[{State}]: {Cause}";
         }
     }
 

--- a/src/core/Akka/Actor/SupervisorStrategy.cs
+++ b/src/core/Akka/Actor/SupervisorStrategy.cs
@@ -750,6 +750,7 @@ namespace Akka.Actor
     /// <summary>
     /// Collection of failures, used to keep track of how many times a given actor has failed.
     /// </summary>
+    [Obsolete("Use List of Akka.Actor.Status.Failure")]
     public class Failures
     {
         /// <summary>
@@ -769,6 +770,7 @@ namespace Akka.Actor
     /// <summary>
     ///     Represents a single failure.
     /// </summary>
+    [Obsolete("Use Akka.Actor.Status.Failure")]
     public class Failure
     {
         /// <summary>


### PR DESCRIPTION
`Akka.Actor.Failure` and `Akka.Actor.Failures` are unused and got obsoleted.

`Akka.Actor.Status.Success` and `Akka.Actor.Status.Failure` got sealed to improve pattern matching perf.
Failure got a new Field 'State' that the receiver can send the command or a correlation-id to the sender back.