### PR TITLE
ddata exclude exiting members in Read/Write MajorityPlus (migrated from htt…

### DIFF
--- a/src/contrib/cluster/Akka.DistributedData/ReadAggregator.cs
+++ b/src/contrib/cluster/Akka.DistributedData/ReadAggregator.cs
@@ -234,7 +234,8 @@ namespace Akka.DistributedData
 
     /// <summary>
     /// <see cref="ReadMajority"/> but with the given number of <see cref="Additional"/> nodes added to the majority count. At most
-    /// all nodes.
+    /// all nodes. Exiting nodes are excluded using `ReadMajorityPlus` because those are typically
+    /// about to be removed and will not be able to respond.
     /// </summary>
     public sealed class ReadMajorityPlus : IReadConsistency, IEquatable<ReadMajorityPlus>
     {

--- a/src/contrib/cluster/Akka.DistributedData/WriteAggregator.cs
+++ b/src/contrib/cluster/Akka.DistributedData/WriteAggregator.cs
@@ -267,7 +267,8 @@ namespace Akka.DistributedData
 
     /// <summary>
     /// <see cref="WriteMajority"/> but with the given number of <see cref="Additional"/> nodes added to the majority count. At most
-    /// all nodes.
+    /// all nodes. Exiting nodes are excluded using `WriteMajorityPlus` because those are typically
+    /// about to be removed and will not be able to respond.
     /// </summary>
     public sealed class WriteMajorityPlus : IWriteConsistency, IEquatable<WriteMajorityPlus>
     {


### PR DESCRIPTION
Exclude exiting members in Read/Write MajorityPlus (migrated from https://github.com/akka/akka/pull/30328)

* this saves at least 2 seconds where the coordinator is not able to respond
  when the oldest node is shutdown