### PR TITLE
experimenting with RemoteActorRefProvider address resolution performance

### DIFF
--- a/src/common.props
+++ b/src/common.props
@@ -21,7 +21,7 @@
     <NetFrameworkTestVersion>net471</NetFrameworkTestVersion>
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>
     <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>
-    <FsCheckVersion>2.15.3</FsCheckVersion>
+    <FsCheckVersion>2.16.0</FsCheckVersion>
     <HoconVersion>2.0.3</HoconVersion>
     <ConfigurationManagerVersion>4.7.0</ConfigurationManagerVersion>
     <AkkaPackageTags>akka;actors;actor model;Akka;concurrency</AkkaPackageTags>

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -435,7 +435,7 @@ namespace Akka.Remote
 
         public bool HasAddress(Address address)
         {
-            return address.Equals(_local.RootPath.Address) || address.Equals(RootPath.Address) || Transport.Addresses.Any(a => a.Equals(address));
+            return address.Equals(_local.RootPath.Address) || address.Equals(RootPath.Address) || Transport.Addresses.Contains(address);
         }
 
         /// <summary>

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -435,7 +435,7 @@ namespace Akka.Remote
 
         public bool HasAddress(Address address)
         {
-            return address == _local.RootPath.Address || address == RootPath.Address || Transport.Addresses.Any(a => a == address);
+            return address.Equals(_local.RootPath.Address) || address.Equals(RootPath.Address) || Transport.Addresses.Any(a => a.Equals(address));
         }
 
         /// <summary>

--- a/src/core/Akka/Actor/Address.cs
+++ b/src/core/Akka/Actor/Address.cs
@@ -154,7 +154,7 @@ namespace Akka.Actor
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => obj is Address && Equals((Address)obj);
+        public override bool Equals(object obj) => obj is Address address && Equals(address);
 
         /// <inheritdoc/>
         public override int GetHashCode()

--- a/src/core/Akka/Actor/Address.cs
+++ b/src/core/Akka/Actor/Address.cs
@@ -245,7 +245,8 @@ namespace Akka.Actor
         /// <returns><c>true</c> if both addresses are equal; otherwise <c>false</c></returns>
         public static bool operator ==(Address left, Address right)
         {
-            return Equals(left, right);
+            Debug.Assert(!ReferenceEquals(left, null));
+            return left.Equals(right);
         }
 
         /// <summary>
@@ -256,7 +257,8 @@ namespace Akka.Actor
         /// <returns><c>true</c> if both addresses are not equal; otherwise <c>false</c></returns>
         public static bool operator !=(Address left, Address right)
         {
-            return !Equals(left, right);
+            Debug.Assert(!ReferenceEquals(left, null));
+            return !left.Equals(right);
         }
 
         /// <summary>

--- a/src/core/Akka/Actor/Address.cs
+++ b/src/core/Akka/Actor/Address.cs
@@ -246,10 +246,7 @@ namespace Akka.Actor
         /// <returns><c>true</c> if both addresses are equal; otherwise <c>false</c></returns>
         public static bool operator ==(Address left, Address right)
         {
-            if (left != null) {
-                return left.Equals(right);
-            }
-            return right == null;
+            return left?.Equals(right) ?? ReferenceEquals(right, null);
         }
 
         /// <summary>

--- a/src/core/Akka/Actor/Address.cs
+++ b/src/core/Akka/Actor/Address.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using System.Xml.Xsl;
 using Akka.Util;
 
 namespace Akka.Actor
@@ -245,8 +246,8 @@ namespace Akka.Actor
         /// <returns><c>true</c> if both addresses are equal; otherwise <c>false</c></returns>
         public static bool operator ==(Address left, Address right)
         {
-            Debug.Assert(!ReferenceEquals(left, null));
-            return left.Equals(right);
+            return ReferenceEquals(left, right)
+                ||(left?.Equals(right) ?? false); // left is null, right is not
         }
 
         /// <summary>
@@ -257,8 +258,8 @@ namespace Akka.Actor
         /// <returns><c>true</c> if both addresses are not equal; otherwise <c>false</c></returns>
         public static bool operator !=(Address left, Address right)
         {
-            Debug.Assert(!ReferenceEquals(left, null));
-            return !left.Equals(right);
+            return !ReferenceEquals(left, right) &&
+                   (left?.Equals(right) ?? true);
         }
 
         /// <summary>

--- a/src/core/Akka/Actor/Address.cs
+++ b/src/core/Akka/Actor/Address.cs
@@ -155,7 +155,7 @@ namespace Akka.Actor
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => obj is Address address && Equals(address);
+        public override bool Equals(object obj) => Equals(obj as Address);
 
         /// <inheritdoc/>
         public override int GetHashCode()
@@ -246,8 +246,7 @@ namespace Akka.Actor
         /// <returns><c>true</c> if both addresses are equal; otherwise <c>false</c></returns>
         public static bool operator ==(Address left, Address right)
         {
-            return ReferenceEquals(left, right)
-                ||(left?.Equals(right) ?? false); // left is null, right is not
+            return EqualityComparer<Address>.Default.Equals(left, right);
         }
 
         /// <summary>
@@ -258,8 +257,7 @@ namespace Akka.Actor
         /// <returns><c>true</c> if both addresses are not equal; otherwise <c>false</c></returns>
         public static bool operator !=(Address left, Address right)
         {
-            return !ReferenceEquals(left, right) &&
-                   (left?.Equals(right) ?? true);
+            return !(left == right);
         }
 
         /// <summary>

--- a/src/core/Akka/Actor/Address.cs
+++ b/src/core/Akka/Actor/Address.cs
@@ -246,7 +246,10 @@ namespace Akka.Actor
         /// <returns><c>true</c> if both addresses are equal; otherwise <c>false</c></returns>
         public static bool operator ==(Address left, Address right)
         {
-            return EqualityComparer<Address>.Default.Equals(left, right);
+            if (left != null) {
+                return left.Equals(right);
+            }
+            return right == null;
         }
 
         /// <summary>


### PR DESCRIPTION
Per @to11mtm 's reporting in our Gitter chat room...

## RemotePingPong

### Before

```
OSVersion:                         Microsoft Windows NT 6.2.9200.0
ProcessorCount:                    16
ClockSpeed:                        0 MHZ
Actor Count:                       32
Messages sent/received per client: 200000  (2e5)
Is Server GC:                      True
Thread count:                      111

Num clients, Total [msg], Msgs/sec, Total [ms]
         1,  200000,     96154,    2080.77
         5, 1000000,    187442,    5335.46
        10, 2000000,    188307,   10621.24
        15, 3000000,    190767,   15726.12
        20, 4000000,    189988,   21054.78
        25, 5000000,    188694,   26498.56
        30, 6000000,    188543,   31823.73
```

### After

```
OSVersion:                         Microsoft Windows NT 6.2.9200.0
ProcessorCount:                    16                             
ClockSpeed:                        0 MHZ                          
Actor Count:                       32                             
Messages sent/received per client: 200000  (2e5)                  
Is Server GC:                      True                           
Thread count:                      111                            
                                                                  
Num clients, Total [msg], Msgs/sec, Total [ms]                    
         1,  200000,    117717,    1699.19                        
         5, 1000000,    197278,    5069.24                        
        10, 2000000,    196677,   10169.66                        
        15, 3000000,    194075,   15458.38                        
        20, 4000000,    194657,   20549.84                        
        25, 5000000,    193641,   25821.94                        
        30, 6000000,    191712,   31297.06                        
```

## Sharding Performance

### Before

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19041.1165 (2004/May2020Update/20H1)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=5.0.302
  [Host]     : .NET Core 3.1.17 (CoreCLR 4.700.21.31506, CoreFX 4.700.21.31502), X64 RyuJIT
  Job-RAVSYY : .NET Core 3.1.17 (CoreCLR 4.700.21.31506, CoreFX 4.700.21.31502), X64 RyuJIT

InvocationCount=1  UnrollFactor=1  

```
|                              Method |   StateMode | MsgCount |         Mean |      Error |     StdDev |
|------------------------------------ |------------ |--------- |-------------:|-----------:|-----------:|
|  **SingleRequestResponseToLocalEntity** | **Persistence** |    **10000** |   **114.761 ms** |  **2.2856 ms** |  **4.2364 ms** |
|              StreamingToLocalEntity | Persistence |    10000 |     5.394 ms |  0.4011 ms |  1.1574 ms |
| SingleRequestResponseToRemoteEntity | Persistence |    10000 | 4,348.561 ms | 22.9590 ms | 21.4758 ms |
|             StreamingToRemoteEntity | Persistence |    10000 |   505.702 ms |  9.7041 ms | 11.9176 ms |
|  **SingleRequestResponseToLocalEntity** |       **DData** |    **10000** |   **112.387 ms** |  **2.2285 ms** |  **3.0504 ms** |
|              StreamingToLocalEntity |       DData |    10000 |     5.114 ms |  0.2683 ms |  0.7436 ms |
| SingleRequestResponseToRemoteEntity |       DData |    10000 | 4,396.789 ms | 18.9920 ms | 17.7651 ms |
|             StreamingToRemoteEntity |       DData |    10000 |   512.592 ms | 10.1481 ms | 10.4213 ms |


### After

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19041.1165 (2004/May2020Update/20H1)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=5.0.302
  [Host]     : .NET Core 3.1.17 (CoreCLR 4.700.21.31506, CoreFX 4.700.21.31502), X64 RyuJIT
  Job-HYNWDT : .NET Core 3.1.17 (CoreCLR 4.700.21.31506, CoreFX 4.700.21.31502), X64 RyuJIT

InvocationCount=1  UnrollFactor=1  

```
|                              Method |   StateMode | MsgCount |         Mean |      Error |    StdDev |
|------------------------------------ |------------ |--------- |-------------:|-----------:|----------:|
|  **SingleRequestResponseToLocalEntity** | **Persistence** |    **10000** |   **129.718 ms** |  **3.2318 ms** |  **9.427 ms** |
|              StreamingToLocalEntity | Persistence |    10000 |     6.162 ms |  0.5868 ms |  1.721 ms |
| SingleRequestResponseToRemoteEntity | Persistence |    10000 | 4,305.384 ms | 34.0898 ms | 31.888 ms |
|             StreamingToRemoteEntity | Persistence |    10000 |   511.976 ms | 10.0823 ms | 12.382 ms |
|  **SingleRequestResponseToLocalEntity** |       **DData** |    **10000** |   **117.223 ms** |  **2.3304 ms** |  **5.628 ms** |
|              StreamingToLocalEntity |       DData |    10000 |     5.616 ms |  0.4011 ms |  1.164 ms |
| SingleRequestResponseToRemoteEntity |       DData |    10000 | 4,519.704 ms | 81.3376 ms | 76.083 ms |
|             StreamingToRemoteEntity |       DData |    10000 |   506.318 ms |  5.9951 ms |  5.608 ms |
