### PR TITLE
Feature: Payload Message

### DIFF
--- a/src/core/Akka.Streams/Serialization/StreamRefSerializer.cs
+++ b/src/core/Akka.Streams/Serialization/StreamRefSerializer.cs
@@ -172,7 +172,7 @@ namespace Akka.Streams.Serialization
             var serializer = _serialization.FindSerializerFor(payload);
             var manifest = Akka.Serialization.Serialization.ManifestFor(serializer, payload);
 
-            var p = new Payload
+            var p = new Proto.Msg.Payload
             {
                 EnclosedMessage = ByteString.CopyFrom(serializer.ToBinary(payload)),
                 SerializerId = serializer.Identifier

--- a/src/core/Akka.Tests/Actor/PayloadSpec.cs
+++ b/src/core/Akka.Tests/Actor/PayloadSpec.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Tests.Actor
+{
+    public class PayloadSpec : AkkaSpec
+    {
+        sealed class Echo
+        {
+            public readonly Payload Payload;
+
+            public Echo(Payload payload)
+            {
+                Payload = payload;
+            }
+
+            public Echo(object content)
+            {
+                Payload = new Payload(content);
+            }
+        }
+
+        sealed class EchoActor : UntypedActor
+        {
+            protected override void OnReceive(object message)
+            {
+                switch(message)
+                {
+                    case Echo msg:
+                        Sender.Tell(msg.Payload);
+                        break;
+                }
+            }
+        }
+
+        sealed class SomeMessgage
+        {
+            public object Value { get; }
+
+            public SomeMessgage(object value)
+            {
+                Value = value;
+            }
+        }
+
+        [Fact]
+        public void payload_should_equal_when_serialized()
+        {
+            var p1 = new Payload("Hello world", Sys);
+
+            var p2 = new Payload("Hello" + " " + "world", Sys);
+
+            p1.Serialize(Sys);
+
+            p2.Serialize(Sys);
+
+            p1.ShouldBe(p2);
+        }
+
+        [Fact]
+        public void payload_should_equal_when_deserialized()
+        {
+            var p1 = new Payload("Hello world", Sys);
+
+            var p2 = new Payload("Hello" + " " + "world", Sys);
+
+            p1.ShouldBe(p2);
+        }
+
+        [Fact]
+        public void payload_should_not_equal_when_serialized_and_deserialized()
+        {
+            var p1 = new Payload("Hello world", Sys);
+
+            var p2 = new Payload("Hello" + " " + "world", Sys);
+
+            p1.Serialize(Sys);
+
+            p1.ShouldNotBe(p2);
+        }
+
+        [Fact]
+        public void payload_should_received_deserialized()
+        {
+            var actor = Sys.ActorOf<EchoActor>();
+
+            actor.Tell(new Echo(new SomeMessgage("Something")));
+
+            ExpectMsg<SomeMessgage>(m => ((string)m.Value) == "Something");
+        }
+    }
+
+    
+}

--- a/src/core/Akka/Actor/ActorBase.cs
+++ b/src/core/Akka/Actor/ActorBase.cs
@@ -191,7 +191,17 @@ namespace Akka.Actor
                 }
             }
 
-            var wasHandled = receive(message);
+            bool wasHandled;
+            switch(message)
+            {
+                case IPayload payload when payload.TryGetContent(Context.System, out var content):
+                    wasHandled = receive(content);
+                    break;
+                default:
+                    wasHandled = receive(message);
+                    break;
+            }
+
             if (!wasHandled)
             {
                 Unhandled(message);

--- a/src/core/Akka/Actor/Payload.cs
+++ b/src/core/Akka/Actor/Payload.cs
@@ -1,0 +1,299 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+using Akka.Routing;
+using Akka.Serialization;
+using Akka.Util;
+using Newtonsoft.Json;
+
+namespace Akka.Actor
+{
+    public interface IPayload
+    {
+        int SerializerId { get; }
+
+        string Manifest { get; }
+
+        byte[] Data { get; }
+
+        byte[] HashKey { get; }
+
+        bool IsSerialized { get; }
+
+        bool TryGetContent(ActorSystem system, out object content);
+    }
+
+    /// <summary>
+    /// Container for implicit serialization, but deserialiazion is explicit 
+    /// </summary>
+    public sealed class Payload : IPayload, ISurrogated, IConsistentHashable, IEquatable<Payload>
+    {
+        readonly static JsonSerializerSettings FallbackJsonSettings = new JsonSerializerSettings
+        {
+            DefaultValueHandling = DefaultValueHandling.Ignore
+        };
+
+        public const int NotSerializedId = -1;
+        public const int FallbackJsonSerializerId = -2;
+
+        readonly ActorSystem _system;
+        object _content;
+
+        public int SerializerId { get; private set; } = NotSerializedId;
+
+        public string Manifest { get; private set; }
+
+        public byte[] Data { get; private set; }
+
+        public byte[] HashKey { get; private set; }
+
+        [JsonIgnore]
+        public bool IsSerialized => SerializerId != NotSerializedId;
+
+        object IConsistentHashable.ConsistentHashKey => HashKey ?? Data
+            ?? GetConsistentHashKey(_content)
+            ?? _content;
+
+        public Payload(object content, ActorSystem system = null)
+        {
+            switch (content)
+            {
+                case Payload other:
+                    _content = other._content;
+                    _system = system ?? other._system;
+                    SerializerId = other.SerializerId;
+                    Manifest = other.Manifest;
+                    Data = other.Data;
+                    HashKey = other.HashKey;
+                    break;
+                case Surrogate surrogate:
+                    _system = system;
+                    SerializerId = surrogate.SerializerId;
+                    Manifest = surrogate.Manifest;
+                    Data = surrogate.Data;
+                    HashKey = surrogate.HashKey;
+                    break;
+                default:
+                    _content = content;
+                    _system = system;
+                    break;
+            }
+        }
+
+        [JsonConstructor]
+        public Payload(int serializerId, string manifest, byte[] data, byte[] hashKey)
+        {
+            SerializerId = serializerId;
+            Manifest = manifest;
+            Data = data;
+            HashKey = hashKey;
+        }
+
+        private Payload(Surrogate surrogate, ActorSystem system)
+        {
+            _system = system;
+            SerializerId = surrogate.SerializerId;
+            Manifest = surrogate.Manifest;
+            Data = surrogate.Data;
+            HashKey = surrogate.HashKey;
+        }
+
+        public bool TryGetContent(ActorSystem system, out object content)
+        {
+            try
+            {
+                //content = (_content ??= Deserialize(system));
+                if (_content is null)
+                    _content = Deserialize(system);
+                content = _content;
+                return true;
+            }
+            catch (SerializationException ex)
+            {
+                if (IsSerialized)
+                    system?.Log.Debug("Deserializing of content[{manifest}] failed: {error}",
+                        Manifest, ex);
+
+                content = null;
+                return false;
+            }
+        }
+
+        public Payload WithSystem(ActorSystem system)
+        {
+            return _system == system ? this : new Payload(this, system);
+        }
+
+        [OnSerializing]
+        internal void OnSerializing(StreamingContext context)
+        {
+            Serialize(_system);
+        }
+
+        //[OnDeserialized]
+        //internal void OnDeserialized(StreamingContext context)
+        //{
+        //}
+
+        public void Serialize(ActorSystem system)
+        {
+            if (IsSerialized)
+                return;
+
+            if (_system is null && system is null)
+            {
+                //fallback serializer json
+                SerializerId = FallbackJsonSerializerId;
+                if (_content is null)
+                {
+                    Manifest = string.Empty;
+                    Data = Array.Empty<byte>();
+                }
+                else
+                {
+                    Manifest = _content.GetType().TypeQualifiedName();
+                    var json = FallbackToJsonString(_content);
+                    Data = Encoding.UTF8.GetBytes(json);
+                }
+                HashKey = GetConsistentHashKey(_content);
+                return;
+            }
+
+            switch ((system ?? _system).Serialization.FindSerializerFor(_content))
+            {
+                case SerializerWithStringManifest serial:
+                    SerializerId = serial.Identifier;
+                    Manifest = serial.Manifest(_content);
+                    Data = serial.ToBinary(_content);
+                    HashKey = GetConsistentHashKey(_content);
+                    break;
+                case Serializer serial when serial.IncludeManifest:
+                    SerializerId = serial.Identifier;
+                    Manifest = _content.GetType().TypeQualifiedName();
+                    Data = serial.ToBinary(_content);
+                    HashKey = GetConsistentHashKey(_content);
+                    break;
+                case null:
+                    //fallback serializer
+                    //var json = PNetConvert.ToJsonString(_content);
+                    //SerializerId = -1;
+                    //Data = Encoding.UTF8.GetBytes(json);
+                    throw new InvalidOperationException("serializer required");
+                case var serial:
+                    SerializerId = serial.Identifier;
+                    Manifest = string.Empty;
+                    Data = serial.ToBinary(_content);
+                    HashKey = GetConsistentHashKey(_content);
+                    break;
+            }
+        }
+
+        private object Deserialize(ActorSystem system)
+        {
+            switch (SerializerId)
+            {
+                case NotSerializedId:
+                    return _content;
+                case FallbackJsonSerializerId:
+                    if (Data != null && Data.Length > 0)
+                    {
+                        var json = Encoding.UTF8.GetString(Data);
+                        var type = !string.IsNullOrEmpty(Manifest)
+                                ? Type.GetType(Manifest) : typeof(object);
+                        return FallbackFromJsonString(json, type);
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                default:
+                    return (system ?? _system).Serialization.Deserialize(Data, SerializerId, Manifest);
+            }
+        }
+
+        ISurrogate ISurrogated.ToSurrogate(ActorSystem system)
+        {
+            Serialize(system);
+
+            return new Surrogate(Data, SerializerId, Manifest, HashKey);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as Payload);
+        }
+
+        public bool Equals(Payload other)
+        {
+            if (other is null) return false;
+
+            if (!IsSerialized && !other.IsSerialized)
+                return EqualityComparer<object>.Default.Equals(_content, other._content);
+
+            return SerializerId == other.SerializerId &&
+                   Manifest == other.Manifest &&
+                   HashKey.AsSpan().SequenceEqual(other.HashKey) &&
+                   Data.AsSpan().SequenceEqual(other.Data);
+        }
+
+        public override int GetHashCode()
+        {
+            //return HashCode.Combine(HashKey);
+            return ConsistentHash.HashFor(HashKey);
+        }
+
+        static byte[] GetConsistentHashKey(object obj)
+        {
+            if (ConsistentHash.ToBytesOrObject(obj) is byte[] bytes)
+                return bytes;
+
+            //todo system default hash mapping insteed of empty
+            var mappedKey = ConsistentHashingRouter.EmptyConsistentHashMapping(obj);
+            if (mappedKey != null)
+                return ConsistentHash.ToBytesOrObject(mappedKey) as byte[];
+            if (obj is IConsistentHashable hashable)
+                return ConsistentHash.ToBytesOrObject(hashable.ConsistentHashKey) as byte[];
+
+            return null;
+        }
+
+        static object FallbackFromJsonString(string json, Type type)
+        {
+            return !string.IsNullOrEmpty(json)
+                   ? JsonConvert.DeserializeObject(json, type, FallbackJsonSettings)
+                   : null;
+        }
+
+        static string FallbackToJsonString<T>(T value)
+        {
+            return value != null
+                ? JsonConvert.SerializeObject(value, FallbackJsonSettings)
+                : string.Empty;
+        }
+
+        internal sealed class Surrogate : ISurrogate
+        {
+            public readonly int SerializerId;
+
+            public readonly string Manifest;
+
+            public readonly byte[] Data;
+
+            public readonly byte[] HashKey;
+
+            public Surrogate(byte[] data, int serializerId, string manifest, byte[] hashKey)
+            {
+                SerializerId = serializerId;
+                Manifest = manifest;
+                Data = data;
+                HashKey = hashKey;
+            }
+
+            ISurrogated ISurrogate.FromSurrogate(ActorSystem system)
+            {
+                return new Payload(this, system);
+            }
+        }
+    }
+}

--- a/src/core/Akka/Routing/ConsistentHash.cs
+++ b/src/core/Akka/Routing/ConsistentHash.cs
@@ -202,6 +202,8 @@ namespace Akka.Routing
     /// </summary>
     public static class ConsistentHash
     {
+        static readonly byte[] NullHashKey = new byte[] { 0 };
+
         /// <summary>
         /// Factory method to create a <see cref="ConsistentHash{T}"/> instance.
         /// </summary>
@@ -292,7 +294,7 @@ namespace Akka.Routing
             switch (obj)
             {
                 case null:
-                    return new byte[] { 0 };
+                    return NullHashKey;
                 case byte[] bytes:
                     return bytes;
                 case int @int:


### PR DESCRIPTION
This PR introduces a new native type `Akka.Actor.IPayload` and `Akka.Actor.Payload`
A Payload can be a replacement for an object type in a message field or as a message itself.

Payload can be viewed as a union type. 
It will store a single value or both, the serialized data and/or the deserialized content.
The consistent HashKey is stored beside the serialized data 
to provide it to consistent hash router without the need to deserialize the content.

Payload will implicitly serialize, but only deserialize with an explicit call to `payload.TryGetContent(sys, out var content)`. 

The ActorBase needs to have native support for IPayload, 
because else every Actor would need to derive from a custom Base type.

This makes it possible to relay **unknown message types** over a node without **re-serializing** the message.

An example would be a persistent ScheduleJobService living on a remote node.
It does not no know every command message type it needs to schedule and can just 
send from the requestor specified payload back.

```csharp
myJobScheduler.Tell(new AddJob("MyJob1", "*/6 * * * *", new UnknownCommand("pulse")), Self);
```

Other use cases would be to capture messages with serializing errors,
Instead of a "fatal error" and a persistent unassociated node,
this could be an unhandled message warning.
One case would be for an unknown exception type of a remote node.

I am using the code already view years myself,
the native support is required for improvements in exception/error signaling.

Ideas and Inputs are welcome.
