### PR TITLE
Benchmark to test SingleRequestResponseToRemoteEntity with a local proxy

### DIFF
--- a/src/benchmark/Akka.Cluster.Benchmarks/Program.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 
 namespace Akka.Cluster.Benchmarks
@@ -8,7 +9,12 @@ namespace Akka.Cluster.Benchmarks
     {
         static void Main(string[] args)
         {
+#if (DEBUG)
+            BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args, new DebugInProcessConfig());
+#else
             BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args);
+#endif
+
         }
     }
 }

--- a/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardMessageRoutingBenchmarks.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardMessageRoutingBenchmarks.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Benchmarks.Configurations;
 using Akka.Cluster.Sharding;
+using Akka.Routing;
 using BenchmarkDotNet.Attributes;
 using static Akka.Cluster.Benchmarks.Sharding.ShardingHelper;
 
@@ -33,6 +34,7 @@ namespace Akka.Cluster.Benchmarks.Sharding
 
         private IActorRef _shardRegion1;
         private IActorRef _shardRegion2;
+        private IActorRef _localRouter;
 
         private string _entityOnSys1;
         private string _entityOnSys2;
@@ -43,6 +45,50 @@ namespace Akka.Cluster.Benchmarks.Sharding
         private IActorRef _batchActor;
         private Task _batchComplete;
 
+#if (DEBUG)
+        [GlobalSetup]
+        public void Setup()
+        {
+            var config = StateMode switch
+            {
+                StateStoreMode.Persistence => CreatePersistenceConfig(),
+                StateStoreMode.DData => CreateDDataConfig(),
+                _ => null
+            };
+
+            _sys1 = ActorSystem.Create("BenchSys", config);
+            _sys2 = ActorSystem.Create("BenchSys", config);
+
+            var c1 = Cluster.Get(_sys1);
+            var c2 = Cluster.Get(_sys2);
+
+            c1.JoinAsync(c1.SelfAddress).Wait();
+            c2.JoinAsync(c1.SelfAddress).Wait();
+
+            _shardRegion1 = StartShardRegion(_sys1);
+            _shardRegion2 = StartShardRegion(_sys2);
+
+            _localRouter = _sys1.ActorOf(Props.Create<ShardedProxyEntityActor>(_shardRegion1).WithRouter(new RoundRobinPool(50)));
+
+            var s1Asks = new List<Task<ShardedEntityActor.ResolveResp>>(20);
+            var s2Asks = new List<Task<ShardedEntityActor.ResolveResp>>(20);
+
+            foreach (var i in Enumerable.Range(0, 20))
+            {
+                s1Asks.Add(_shardRegion1.Ask<ShardedEntityActor.ResolveResp>(new ShardingEnvelope(i.ToString(), ShardedEntityActor.Resolve.Instance), TimeSpan.FromSeconds(3)));
+                s2Asks.Add(_shardRegion2.Ask<ShardedEntityActor.ResolveResp>(new ShardingEnvelope(i.ToString(), ShardedEntityActor.Resolve.Instance), TimeSpan.FromSeconds(3)));
+            }
+
+            // wait for all Ask operations to complete
+            Task.WhenAll(s1Asks.Concat(s2Asks)).Wait();
+
+            _entityOnSys2 = s1Asks.First(x => x.Result.Addr.Equals(c2.SelfAddress)).Result.EntityId;
+            _entityOnSys1 = s2Asks.First(x => x.Result.Addr.Equals(c1.SelfAddress)).Result.EntityId;
+
+            _messageToSys1 = new ShardedMessage(_entityOnSys1, 10);
+            _messageToSys2 = new ShardedMessage(_entityOnSys2, 10);
+        }
+#else
         [GlobalSetup]
         public async Task Setup()
         {
@@ -65,6 +111,8 @@ namespace Akka.Cluster.Benchmarks.Sharding
             _shardRegion1 = StartShardRegion(_sys1);
             _shardRegion2 = StartShardRegion(_sys2);
 
+            _localRouter = _sys1.ActorOf(Props.Create<ShardedProxyEntityActor>(_shardRegion1).WithRouter(new RoundRobinPool(1000)));
+
             var s1Asks = new List<Task<ShardedEntityActor.ResolveResp>>(20);
             var s2Asks = new List<Task<ShardedEntityActor.ResolveResp>>(20);
 
@@ -83,6 +131,7 @@ namespace Akka.Cluster.Benchmarks.Sharding
             _messageToSys1 = new ShardedMessage(_entityOnSys1, 10);
             _messageToSys2 = new ShardedMessage(_entityOnSys2, 10);
         }
+#endif
 
         [IterationSetup]
         public void PerIteration()
@@ -92,7 +141,7 @@ namespace Akka.Cluster.Benchmarks.Sharding
             _batchActor = _sys1.ActorOf(Props.Create(() => new BulkSendActor(tcs, MsgCount)));
         }
 
-        [Benchmark]
+       // [Benchmark]
         public async Task SingleRequestResponseToLocalEntity()
         {
             for (var i = 0; i < MsgCount; i++)
@@ -112,7 +161,15 @@ namespace Akka.Cluster.Benchmarks.Sharding
             for (var i = 0; i < MsgCount; i++)
                 await _shardRegion1.Ask<ShardedMessage>(_messageToSys2);
         }
-        
+
+
+        [Benchmark]
+        public async Task SingleRequestResponseToRemoteEntityWithLocalProxy()
+        {
+            for (var i = 0; i < MsgCount; i++)
+                await _localRouter.Ask<ShardedMessage>(new SendShardedMessage(_messageToSys2.EntityId, _messageToSys2));
+        }
+
         [Benchmark]
         public async Task StreamingToRemoteEntity()
         {

--- a/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardMessageRoutingBenchmarks.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardMessageRoutingBenchmarks.cs
@@ -141,20 +141,20 @@ namespace Akka.Cluster.Benchmarks.Sharding
             _batchActor = _sys1.ActorOf(Props.Create(() => new BulkSendActor(tcs, MsgCount)));
         }
 
-       // [Benchmark]
+        [Benchmark]
         public async Task SingleRequestResponseToLocalEntity()
         {
             for (var i = 0; i < MsgCount; i++)
                 await _shardRegion1.Ask<ShardedMessage>(_messageToSys1);
         }
-        
+
         [Benchmark]
         public async Task StreamingToLocalEntity()
         {
             _batchActor.Tell(new BulkSendActor.BeginSend(_messageToSys1, _shardRegion1, BatchSize));
             await _batchComplete;
         }
-        
+
         [Benchmark]
         public async Task SingleRequestResponseToRemoteEntity()
         {


### PR DESCRIPTION
Adding benchmark to test performance of sending messages to a remote entity without relying on remote `ASK` as per the approach discussed at https://github.com/akkadotnet/akka.net/issues/5203#issuecomment-907587322 