### PR TITLE
improve child lookup performance

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Actor/GetChildBenchmark.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/GetChildBenchmark.cs
@@ -96,7 +96,7 @@ namespace Akka.Benchmarks.Actor
         private ActorWithChild.Get _getMessage = new ActorWithChild.Get("food");
         private ActorWithChild.Create _createMessage = new ActorWithChild.Create("food");
 
-        private ActorCell _cell;
+        private IActorContext _cell;
         private RepointableActorRef _repointableActorRef;
         private LocalActorRef _localActorRef;
 
@@ -118,7 +118,7 @@ namespace Akka.Benchmarks.Actor
         [Benchmark]
         public void ResolveChild()
         {
-            _cell.TryGetSingleChild(_getMessage.Name, out var child);
+            _cell.Child(_getMessage.Name);
         }
         
         [Benchmark]

--- a/src/core/Akka/Actor/ActorCell.Children.cs
+++ b/src/core/Akka/Actor/ActorCell.Children.cs
@@ -265,8 +265,7 @@ namespace Akka.Actor
         {
             get
             {
-                var terminating = ChildrenContainer as TerminatingChildrenContainer;
-                return terminating != null && terminating.Reason is SuspendReason.IWaitingForChildren;
+                return ChildrenContainer is TerminatingChildrenContainer terminating && terminating.Reason is SuspendReason.IWaitingForChildren;
             }
         }
 
@@ -325,8 +324,7 @@ namespace Akka.Actor
         /// </summary>
         private bool TryGetChildRestartStatsByName(string name, out ChildRestartStats child)
         {
-            IChildStats stats;
-            if (ChildrenContainer.TryGetByName(name, out stats))
+            if (ChildrenContainer.TryGetByName(name, out var stats))
             {
                 child = stats as ChildRestartStats;
                 if (child != null)
@@ -361,6 +359,8 @@ namespace Akka.Actor
             IInternalActorRef child;
             return TryGetSingleChild(name, out child) ? child : ActorRefs.Nobody;
         }
+
+        
 
         /// <summary>
         /// TBD

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -241,7 +241,10 @@ namespace Akka.Actor
 
         IActorRef IActorContext.Child(string name)
         {
-            return TryGetSingleChild(name, out var child) ? child : ActorRefs.Nobody;
+            if (TryGetChildStatsByName(name, out var child) && child is ChildRestartStats s)
+                return s.Child;
+            
+            return ActorRefs.Nobody;
         }
 
         /// <summary>


### PR DESCRIPTION
Baseline performance from https://github.com/akkadotnet/akka.net/pull/5239

Done, expanded the benchmark to include some more scenarios.

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19041.1165 (2004/May2020Update/20H1)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=5.0.302
  [Host]     : .NET Core 3.1.17 (CoreCLR 4.700.21.31506, CoreFX 4.700.21.31502), X64 RyuJIT
  DefaultJob : .NET Core 3.1.17 (CoreCLR 4.700.21.31506, CoreFX 4.700.21.31502), X64 RyuJIT


```
|                               Method |      Mean |    Error |   StdDev |  Gen 0 | Allocated |
|------------------------------------- |----------:|---------:|---------:|-------:|----------:|
|                         ResolveChild |  64.69 ns | 0.145 ns | 0.129 ns |      - |         - |
| Resolve3DeepChildRepointableActorRef | 652.15 ns | 9.237 ns | 8.641 ns | 0.0839 |     352 B |
|       Resolve3DeepChildLocalActorRef | 311.74 ns | 4.924 ns | 4.605 ns | 0.0629 |     264 B |
