### PR TITLE
fixed `GetChild` benchmark

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Actor/GetChildBenchmark.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/GetChildBenchmark.cs
@@ -100,8 +100,8 @@ namespace Akka.Benchmarks.Actor
         private RepointableActorRef _repointableActorRef;
         private LocalActorRef _localActorRef;
 
-        private List<string> _rpChildQueryPath = new List<string>() { "food", "foo", "fo" };
-        private List<string> _lclChildQueryPath = new List<string>() { "foo", "fo", "f" };
+        private List<string> _rpChildQueryPath = new List<string>() { "food", "ood", "od" };
+        private List<string> _lclChildQueryPath = new List<string>() { "ood", "od", "d" };
         
         [GlobalSetup]
         public async Task Setup()


### PR DESCRIPTION
turns out my original benchmark was wrong - as it ran headfirst into a bad resolve for `GetChild`.

This benchmark results in a good resolve.