### PR TITLE
added `LruBoundedCache` benchmarks

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Remoting/LruBoundedCacheBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Remoting/LruBoundedCacheBenchmarks.cs
@@ -1,0 +1,107 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="LruBoundedCacheBenchmarks.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Actor.Dsl;
+using Akka.Benchmarks.Configurations;
+using Akka.Configuration;
+using Akka.Remote.Serialization;
+using Akka.Util;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Benchmarks.Remoting
+{
+    [Config(typeof(MicroBenchmarkConfig))]
+    public class LruBoundedCacheBenchmarks
+    {
+        private ActorSystem _sys1;
+        private Config _config = @"akka.actor.provider = remote
+                                     akka.remote.dot-netty.tcp.port = 0";
+
+        private ActorRefResolveThreadLocalCache _resolveCache;
+        private ActorPathThreadLocalCache _pathCache;
+        private AddressThreadLocalCache _addressCache;
+
+        private string _cacheMissPath;
+        private IActorRef _cacheMissActorRef;
+
+        private string _cacheHitPath;
+        private int _cacheHitPathCount = 0;
+        private IActorRef _cacheHitActorRef;
+
+        private Address _addr1;
+        private string _addr1String;
+
+        [GlobalSetup]
+        public async Task Setup()
+        {
+            _sys1 = ActorSystem.Create("BenchSys", _config);
+            _resolveCache = ActorRefResolveThreadLocalCache.For(_sys1);
+            _pathCache = ActorPathThreadLocalCache.For(_sys1);
+            _addressCache = AddressThreadLocalCache.For(_sys1);
+
+            var es = (ExtendedActorSystem)_sys1;
+            _addr1 = es.Provider.DefaultAddress;
+            _addr1String = _addr1.ToString();
+
+            var name = "target" + ++_cacheHitPathCount;
+            _cacheHitActorRef = _sys1.ActorOf(act =>
+            {
+                act.ReceiveAny((o, context) => context.Sender.Tell(context.Sender));
+            }, name);
+
+            _cacheMissActorRef = await _cacheHitActorRef.Ask<IActorRef>("hit", CancellationToken.None);
+
+            _cacheHitPath = _cacheHitActorRef.Path.ToString();
+            _cacheMissPath = _cacheMissActorRef.Path.ToString();
+        }
+
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            _cacheMissPath = $"/user/f/{_cacheHitPathCount++}";
+        }
+
+        [Benchmark]
+        public void ActorRefResolveMissBenchmark()
+        {
+            _resolveCache.Cache.GetOrCompute("/user/ignore");
+        }
+        
+        [Benchmark]
+        public void ActorRefResolveHitBenchmark()
+        {
+            _resolveCache.Cache.GetOrCompute(_cacheHitPath);
+        }
+
+        [Benchmark]
+        public void AddressHitBenchmark()
+        {
+            _addressCache.Cache.GetOrCompute(_addr1String);
+        }
+        
+        [Benchmark]
+        public void ActorPathCacheHitBenchmark()
+        {
+            _pathCache.Cache.GetOrCompute(_cacheHitPath);
+        }
+        
+        [Benchmark]
+        public void ActorPathCacheMissBenchmark()
+        {
+            _pathCache.Cache.GetOrCompute(_cacheMissPath);
+        }
+        
+        [GlobalCleanup]
+        public async Task Cleanup()
+        {
+            await _sys1.Terminate();
+        }
+    }
+}


### PR DESCRIPTION
Initial performance benchmarks:

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19041.1165 (2004/May2020Update/20H1)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=5.0.302
  [Host]     : .NET Core 3.1.17 (CoreCLR 4.700.21.31506, CoreFX 4.700.21.31502), X64 RyuJIT
  Job-ALMZBX : .NET Core 3.1.17 (CoreCLR 4.700.21.31506, CoreFX 4.700.21.31502), X64 RyuJIT

InvocationCount=1  UnrollFactor=1  

```
|                       Method |      Mean |     Error |    StdDev |    Median | Allocated |
|----------------------------- |----------:|----------:|----------:|----------:|----------:|
| ActorRefResolveMissBenchmark | 13.042 μs | 2.5188 μs | 6.7666 μs | 12.250 μs |     136 B |
|  ActorRefResolveHitBenchmark |  1.952 μs | 0.3344 μs | 0.8926 μs |  1.700 μs |         - |
|          AddressHitBenchmark |  2.004 μs | 0.4800 μs | 1.2811 μs |  1.600 μs |         - |
|   ActorPathCacheHitBenchmark |  1.892 μs | 0.3220 μs | 0.8594 μs |  1.800 μs |         - |
|  ActorPathCacheMissBenchmark |  3.167 μs | 0.5848 μs | 1.5507 μs |  2.700 μs |         - |
