### PR TITLE
Fix Dns.Resolve issue by using GetHostEntry instead of GetHostEntryAsync

### DIFF
--- a/src/core/Akka.Tests/IO/TcpIntegrationSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpIntegrationSpec.cs
@@ -22,6 +22,8 @@ using Xunit;
 using Xunit.Abstractions;
 using FluentAssertions;
 using System.Runtime.InteropServices;
+using System.Threading;
+using Akka.Event;
 
 namespace Akka.Tests.IO
 {
@@ -468,6 +470,19 @@ namespace Akka.Tests.IO
             // expecting CommandFailed or no reply (within timeout)
             var replies = connectCommander.ReceiveWhile(TimeSpan.FromSeconds(1), x => x as Tcp.Connected);
             replies.Count.ShouldBe(0);
+        }
+
+        [Fact]
+        public void Should_report_Error_only_once_when_connecting_to_unreachable_DnsEndpoint()
+        {
+            var probe = CreateTestProbe();
+            // a "random" endpoint hopefully unavailable since it's in the test-net IP range
+            var endpoint = new DnsEndPoint("fake", 1000);
+            Sys.Tcp().Tell(new Tcp.Connect(endpoint), probe.Ref);
+            
+            // expecting CommandFailed or no reply (within timeout)
+            var replies = probe.ReceiveWhile(TimeSpan.FromSeconds(5), x => x as Tcp.CommandFailed);
+            replies.Count.ShouldBe(1);
         }
 
         [Fact]

--- a/src/core/Akka/IO/InetAddressDnsResolver.cs
+++ b/src/core/Akka/IO/InetAddressDnsResolver.cs
@@ -52,7 +52,7 @@ namespace Akka.IO
                     try
                     {
                         //TODO: IP6
-                        answer = Dns.Resolved.Create(resolve.Name, System.Net.Dns.GetHostEntryAsync(resolve.Name).Result.AddressList.Where(x => 
+                        answer = Dns.Resolved.Create(resolve.Name, System.Net.Dns.GetHostEntry(resolve.Name).AddressList.Where(x => 
                                 x.AddressFamily == AddressFamily.InterNetwork 
                                 || _useIpv6 && x.AddressFamily == AddressFamily.InterNetworkV6));
                         _cache.Put(answer, _positiveTtl);


### PR DESCRIPTION
Closes #5154
Fix option to #5260 (pick one)