### PR TITLE
harden ManyRecoveriesSpec

### DIFF
--- a/src/core/Akka.Persistence.Tests/ManyRecoveriesSpec.cs
+++ b/src/core/Akka.Persistence.Tests/ManyRecoveriesSpec.cs
@@ -60,7 +60,7 @@ namespace Akka.Persistence.Tests
         public ManyRecoveriesSpec() : base(ConfigurationFactory.ParseString(@"
             akka.actor.default-dispatcher.Type = ForkJoinDispatcher
             akka.actor.default-dispatcher.dedicated-thread-pool.thread-count = 5
-            akka.persistence.max-concurrent-recoveries = 3
+            akka.persistence.max-concurrent-recoveries = 1
             akka.persistence.journal.plugin = ""akka.persistence.journal.inmem""
 
             # snapshot store plugin is NOT defined, things should still work


### PR DESCRIPTION
This spec can fail because on a low CPU count machine, such as the type that can be used by Azure DevOps, 3 blocked threads can also mean 3 blocked CPUs. I believe most Azure DevOps machines run using ~2 vCPU.

It's possible there could be a deeper underlying issue with the `DedicatedThreadPool` that could cause this problem, but instead I tried to constrain the `max-concurrent-recoveries=1` to limit the number of blocked CPUs to less than 1.