### PR TITLE
harden HubSpec

### DIFF
--- a/src/core/Akka.Streams.TestKit.Tests/Utils.cs
+++ b/src/core/Akka.Streams.TestKit.Tests/Utils.cs
@@ -77,7 +77,7 @@ namespace Akka.Streams.TestKit.Tests
 
         public static T AwaitResult<T>(this Task<T> task, TimeSpan? timeout = null)
         {
-            task.Wait(timeout??TimeSpan.FromSeconds(3)).ShouldBeTrue();
+            task.Wait(timeout??TimeSpan.FromSeconds(3)).ShouldBeTrue("Task timed out while awaiting");
             return task.Result;
         }
     }

--- a/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
@@ -183,15 +183,19 @@ namespace Akka.Streams.Tests.Dsl
         {
             this.AssertAllStagesStopped(() =>
             {
-                var t = MergeHub.Source<int>(1).Take(20000).ToMaterialized(Sink.Seq<int>(), Keep.Both)
-                    .Run(Materializer);
-                var sink = t.Item1;
-                var result = t.Item2;
+                Within(TimeSpan.FromSeconds(10), () =>
+                {
+                    var t = MergeHub.Source<int>(1).Take(20000).ToMaterialized(Sink.Seq<int>(), Keep.Both)
+                        .Run(Materializer);
+                    var sink = t.Item1;
+                    var result = t.Item2;
 
-                Source.From(Enumerable.Range(1, 10000)).RunWith(sink, Materializer);
-                Source.From(Enumerable.Range(10001, 10000)).RunWith(sink, Materializer);
+                    Source.From(Enumerable.Range(1, 10000)).RunWith(sink, Materializer);
+                    Source.From(Enumerable.Range(10001, 10000)).RunWith(sink, Materializer);
 
-                result.AwaitResult().OrderBy(x => x).Should().BeEquivalentTo(Enumerable.Range(1, 20000));
+                    result.AwaitResult(RemainingOrDefault).OrderBy(x => x).Should().BeEquivalentTo(Enumerable.Range(1, 20000));
+                });
+                
             }, Materializer);
         }
 


### PR DESCRIPTION
`MergeHub_must_work_with_long_streams_when_buffer_size_is_1` needs a longer time interval to await potentially, given that it's working with a large stream and a tiny input buffer.