### PR TITLE
Akka.NET v1.4.25 Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 1.4.25 August 17 2021 ####
+**Placeholder for nightlies
+
 #### 1.4.24 August 17 2021 ####
 **Maintenance Release for Akka.NET 1.4**
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,5 @@
 #### 1.4.25 August 17 2021 ####
-**Placeholder for nightlies
+**Placeholder for nightlies**
 
 #### 1.4.24 August 17 2021 ####
 **Maintenance Release for Akka.NET 1.4**

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,75 @@
-#### 1.4.25 August 17 2021 ####
-**Placeholder for nightlies**
+#### 1.4.25 September 08 2021 ####
+**Maintenance Release for Akka.NET 1.4**
+Akka.NET v1.4.25 includes some _significant_ performance improvements for Akka.Remote and a number of important bug fixes and improvements.
+
+**Bug Fixes and Improvements**
+* [Akka.IO.Tcp: connecting to an unreachable DnsEndpoint never times out](https://github.com/akkadotnet/akka.net/issues/5154)
+* [Akka.Actor: need to enforce `stdout-loglevel = off` all the way through ActorSystem lifecycle](https://github.com/akkadotnet/akka.net/issues/5246)
+* [Akka.Actor: `Ask` should push unhandled answers into deadletter](https://github.com/akkadotnet/akka.net/pull/5259)
+* [Akka.Routing: Make Router.Route` virtual](https://github.com/akkadotnet/akka.net/pull/5238)
+* [Akka.Actor: Improve performance on `IActorRef.Child` API](https://github.com/akkadotnet/akka.net/pull/5242) - _signficantly_ improves performance of many Akka.NET functions, but includes a public API change on `IActorRef` that is source compatible but not necessarily binary-compatible. `IActorRef GetChild(System.Collections.Generic.IEnumerable<string> name)` is now `IActorRef GetChild(System.Collections.Generic.IReadOnlyList<string> name)`. This API is almost never called directly by user code (it's almost always called via the internals of the `ActorSystem` when resolving `ActorSelection`s or remote messages) so this change should be safe.
+* [Akka.Actor: `IsNobody` throws NRE](https://github.com/akkadotnet/akka.net/issues/5213)
+* [Akka.Cluster.Tools: singleton fix cleanup of overdue _removed members](https://github.com/akkadotnet/akka.net/pull/5229)
+* [Akka.DistributedData: ddata exclude `Exiting` members in Read/Write `MajorityPlus`](https://github.com/akkadotnet/akka.net/pull/5227)
+
+**Performance Improvements**
+Using our standard `RemotePingPong` benchmark, the difference between v1.4.24 and v1.4.24 is significant:
+
+_v1.4.24_
+
+```
+OSVersion:                         Microsoft Windows NT 6.2.9200.0 
+ProcessorCount:                    16                              
+ClockSpeed:                        0 MHZ                           
+Actor Count:                       32                              
+Messages sent/received per client: 200000  (2e5)                   
+Is Server GC:                      True                            
+Thread count:                      111                             
+                                                                   
+Num clients, Total [msg], Msgs/sec, Total [ms]                     
+         1,  200000,     96994,    2062.08                         
+         5, 1000000,    194818,    5133.93                         
+        10, 2000000,    198966,   10052.93                         
+        15, 3000000,    199455,   15041.56                         
+        20, 4000000,    198177,   20184.53                         
+        25, 5000000,    197613,   25302.80                         
+        30, 6000000,    197349,   30403.82                         
+```
+
+_v1.4.25_
+
+```
+OSVersion:                         Microsoft Windows NT 6.2.9200.0
+ProcessorCount:                    16
+ClockSpeed:                        0 MHZ
+Actor Count:                       32
+Messages sent/received per client: 200000  (2e5)
+Is Server GC:                      True
+Thread count:                      111
+
+Num clients, Total [msg], Msgs/sec, Total [ms]
+         1,  200000,    130634,    1531.54
+         5, 1000000,    246975,    4049.20
+        10, 2000000,    244499,    8180.16
+        15, 3000000,    244978,   12246.39
+        20, 4000000,    245159,   16316.37
+        25, 5000000,    243333,   20548.09
+        30, 6000000,    241644,   24830.55
+```
+
+This represents a 24% overall throughput improvement in Akka.Remote across the board. We have additional PRs staged that should get aggregate performance improvements above 40% for Akka.Remote over v1.4.24 but they didn't make it into the Akka.NET v1.4.25 release.
+
+You can [see the full set of changes introduced in Akka.NET v1.4.25 here](https://github.com/akkadotnet/akka.net/milestone/56?closed=1)
+
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 32 | 1301 | 400 | Aaron Stannard |
+| 4 | 358 | 184 | Andreas Dirnberger |
+| 3 | 414 | 149 | Gregorius Soedharmo |
+| 3 | 3 | 3 | dependabot[bot] |
+| 2 | 43 | 10 | zbynek001 |
+| 1 | 14 | 13 | tometchy |
+| 1 | 139 | 3 | carlcamilleri |
 
 #### 1.4.24 August 17 2021 ####
 **Maintenance Release for Akka.NET 1.4**

--- a/docs/articles/utilities/logging.md
+++ b/docs/articles/utilities/logging.md
@@ -25,6 +25,28 @@ Akka.NET comes with two built in loggers.
 * __StandardOutLogger__
 * __BusLogging__
 
+### StandardOutLogger
+`StandardOutLogger` is considered as a minimal logger and implements the `MinimalLogger` abstract
+class. Its job is simply to output all `LogEvent`s emitted by the `EventBus` onto the console. 
+Since it is not an actual actor, ie. it doesn't need the `ActorSystem` to operate, it is also 
+used to log other loggers activity at the very start and very end of the `ActorSystem` life cycle. 
+You can change the minimal logger start and end life cycle behaviour by changing the 
+`akka.stdout-loglevel` HOCON settings to `OFF` if you do not need these feature in your application.
+
+### Advanced MinimalLogger Setup
+You can also replace `StandardOutLogger` by making your own logger class with an empty constructor 
+that inherits/implements the `MinimalLogger` abstract class and passing the fully qualified class 
+name into the `akka.stdout-logger-class` HOCON settings. 
+
+> [!WARNING]
+> Be aware that `MinimalLogger` implementations are __NOT__ real actors and will __NOT__ have any 
+> access to the `ActorSystem` and all of its extensions. All logging done inside a `MinimalLogger` 
+> have to be done in as simple as possible manner since it is used to log how other loggers are 
+> behaving at the very start and very end of the `ActorSystem` life cycle.
+> 
+> Note that `MinimalLogger` are __NOT__ interchangeable with other Akka.NET loggers and there can 
+> only be one `MinimalLogger` registered with the `ActorSystem` in the HOCON settings.
+
 ## Contrib Loggers
 These loggers are also available as separate nuget packages
 

--- a/docs/articles/utilities/logging.md
+++ b/docs/articles/utilities/logging.md
@@ -64,17 +64,18 @@ akka {
 ```
 ## Example configuration
 ```hocon
-akka {  
-    stdout-loglevel = DEBUG
-    loglevel = DEBUG
-    log-config-on-start = on        
-    actor {                
-        debug {  
-              receive = on 
-              autoreceive = on
-              lifecycle = on
-              event-stream = on
-              unhandled = on
-        }
-    }  
+akka {
+  stdout-loglevel = DEBUG
+  loglevel = DEBUG
+  log-config-on-start = on
+  actor {
+    debug {
+      receive = on
+      autoreceive = on
+      lifecycle = on
+      event-stream = on
+      unhandled = on
+    }
+  }
+}
 ```

--- a/src/Akka.sln
+++ b/src/Akka.sln
@@ -246,6 +246,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SerializationBenchmarks", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DDataStressTest", "examples\Cluster\DData\DDataStressTest\DDataStressTest.csproj", "{44B3DDD6-6103-4E8F-8AC2-0F4BA3CF6B50}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Cluster.Benchmarks", "benchmark\Akka.Cluster.Benchmarks\Akka.Cluster.Benchmarks.csproj", "{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1137,6 +1139,18 @@ Global
 		{44B3DDD6-6103-4E8F-8AC2-0F4BA3CF6B50}.Release|x64.Build.0 = Release|Any CPU
 		{44B3DDD6-6103-4E8F-8AC2-0F4BA3CF6B50}.Release|x86.ActiveCfg = Release|Any CPU
 		{44B3DDD6-6103-4E8F-8AC2-0F4BA3CF6B50}.Release|x86.Build.0 = Release|Any CPU
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}.Debug|x64.Build.0 = Debug|Any CPU
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}.Debug|x86.Build.0 = Debug|Any CPU
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}.Release|x64.ActiveCfg = Release|Any CPU
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}.Release|x64.Build.0 = Release|Any CPU
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}.Release|x86.ActiveCfg = Release|Any CPU
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1245,6 +1259,7 @@ Global
 		{D62F4AD6-318F-4ECC-B875-83FA9933A81B} = {162F5991-EA57-4221-9B70-F9B6FEC18036}
 		{2E4B9584-42CC-4D17-B719-9F462B16C94D} = {73108242-625A-4D7B-AA09-63375DBAE464}
 		{44B3DDD6-6103-4E8F-8AC2-0F4BA3CF6B50} = {C50E1A9E-820C-4E75-AE39-6F96A99AC4A7}
+		{3CEBB0AE-6A88-4C32-A1D3-A8FB1E7E236B} = {73108242-625A-4D7B-AA09-63375DBAE464}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {03AD8E21-7507-4E68-A4E9-F4A7E7273164}

--- a/src/benchmark/Akka.Benchmarks/Actor/ActorRefBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/ActorRefBenchmarks.cs
@@ -1,0 +1,67 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="ActorRefBenchmarks.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Benchmarks.Actor
+{
+    [Config(typeof(MicroBenchmarkConfig))] // need memory diagnosis
+    public class ActorRefBenchmarks
+    {
+        [Params(10000)]
+        public int Iterations { get; set; }
+        private TimeSpan _timeout;
+        private ActorSystem _system;
+        private IActorRef _echo;
+        private IActorRef _echo2;
+        
+        [GlobalSetup]
+        public void Setup()
+        {
+            _timeout = TimeSpan.FromMinutes(1);
+            _system = ActorSystem.Create("system");
+            _echo = _system.ActorOf(Props.Create(() => new EchoActor()), "echo");
+            _echo2 = _system.ActorOf(Props.Create(() => new EchoActor()), "echo2");
+        }
+
+        [Benchmark]
+        public int ActorRefGetHashCode()
+        {
+            return _echo.GetHashCode();
+        }
+
+        [Benchmark]
+        public bool ActorRefEqualsSelf()
+        {
+            return _echo.Equals(_echo);
+        }
+        
+        [Benchmark]
+        public bool ActorRefEqualsSomeoneElse()
+        {
+            return _echo.Equals(_echo2);
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            _system.Terminate().Wait();
+        }
+
+        public class EchoActor : UntypedActor
+        {
+            protected override void OnReceive(object message)
+            {
+                Sender.Tell(message);
+            }
+        }
+    }
+}

--- a/src/benchmark/Akka.Benchmarks/Actor/GetChildBenchmark.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/GetChildBenchmark.cs
@@ -100,8 +100,8 @@ namespace Akka.Benchmarks.Actor
         private RepointableActorRef _repointableActorRef;
         private LocalActorRef _localActorRef;
 
-        private List<string> _rpChildQueryPath = new List<string>() { "food", "foo", "fo" };
-        private List<string> _lclChildQueryPath = new List<string>() { "foo", "fo", "f" };
+        private List<string> _rpChildQueryPath = new List<string>() { "food", "ood", "od" };
+        private List<string> _lclChildQueryPath = new List<string>() { "ood", "od", "d" };
         
         [GlobalSetup]
         public async Task Setup()

--- a/src/benchmark/Akka.Benchmarks/Actor/GetChildBenchmark.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/GetChildBenchmark.cs
@@ -99,9 +99,11 @@ namespace Akka.Benchmarks.Actor
         private ActorCell _cell;
         private RepointableActorRef _repointableActorRef;
         private LocalActorRef _localActorRef;
+        private VirtualPathContainer _virtualPathContainer;
 
         private List<string> _rpChildQueryPath = new List<string>() { "food", "ood", "od" };
         private List<string> _lclChildQueryPath = new List<string>() { "ood", "od", "d" };
+        private List<string> _virtualPathContainerQueryPath = new List<string>() { "foo" };
         
         [GlobalSetup]
         public async Task Setup()
@@ -113,6 +115,15 @@ namespace Akka.Benchmarks.Actor
             
             _cell = _parentActor.As<ActorRefWithCell>().Underlying.As<ActorCell>();
             _repointableActorRef = (RepointableActorRef)_parentActor;
+
+            var exp = _system.As<ExtendedActorSystem>();
+
+            var vPath = exp.Guardian.Path / "testTemp";
+            _virtualPathContainer =
+                new VirtualPathContainer(exp.Provider, vPath, exp.Guardian, exp.Log);
+
+            _virtualPathContainer.AddChild("foo",
+                new EmptyLocalActorRef(exp.Provider, vPath / "foo", exp.EventStream));
         }
 
         [Benchmark]
@@ -131,6 +142,12 @@ namespace Akka.Benchmarks.Actor
         public void Resolve3DeepChildLocalActorRef()
         {
             _localActorRef.GetChild(_lclChildQueryPath);
+        }
+        
+        [Benchmark]
+        public void ResolveVirtualPathContainer()
+        {
+            _virtualPathContainer.GetChild(_virtualPathContainerQueryPath);
         }
 
         [GlobalCleanup]

--- a/src/benchmark/Akka.Benchmarks/Actor/GetChildBenchmark.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/GetChildBenchmark.cs
@@ -96,7 +96,7 @@ namespace Akka.Benchmarks.Actor
         private ActorWithChild.Get _getMessage = new ActorWithChild.Get("food");
         private ActorWithChild.Create _createMessage = new ActorWithChild.Create("food");
 
-        private ActorCell _cell;
+        private IActorContext _cell;
         private RepointableActorRef _repointableActorRef;
         private LocalActorRef _localActorRef;
         private VirtualPathContainer _virtualPathContainer;
@@ -129,7 +129,7 @@ namespace Akka.Benchmarks.Actor
         [Benchmark]
         public void ResolveChild()
         {
-            _cell.TryGetSingleChild(_getMessage.Name, out var child);
+            _cell.Child(_getMessage.Name);
         }
         
         [Benchmark]

--- a/src/benchmark/Akka.Benchmarks/Actor/GetChildBenchmark.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/GetChildBenchmark.cs
@@ -1,0 +1,142 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="GetChildBenchmark.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using FluentAssertions;
+
+namespace Akka.Benchmarks.Actor
+{
+    /// <summary>
+    /// Used to measure how quickly an <see cref="IActorContext.Child"/> call can be executed in the wild.
+    /// </summary>
+    [Config(typeof(MicroBenchmarkConfig))]
+    public class GetChildBenchmark
+    {
+        #region classes
+        public sealed class Child : UntypedActor
+        {
+            protected override void OnReceive(object message)
+            {
+                
+            }
+
+            protected override void PreStart()
+            {
+                if (Self.Path.Name.Length > 1)
+                {
+                    // recursively create children using the previous name segments
+                    var nextName = new string(Self.Path.Name.Skip(1).ToArray());
+                    Context.ActorOf(Props.Create(() => new Child()), nextName);
+                }
+            }
+        }
+        
+        public sealed class ActorWithChild : UntypedActor
+        {
+            public sealed class Get
+            {
+                public Get(string name)
+                {
+                    Name = name;
+                }
+
+                public string Name { get; }
+            }
+
+            public sealed class Create
+            {
+                public Create(string name)
+                {
+                    Name = name;
+                }
+
+                public string Name { get; }
+            }
+
+            protected override void OnReceive(object message)
+            {
+                switch (message)
+                {
+                    case Get g:
+                    {
+                        var child = Context.Child(g.Name);
+                        Sender.Tell(child);
+                        break;
+                    }
+                    case Create c:
+                    {
+                        var child = Context.ActorOf(Props.Create(() => new Child()), c.Name);
+                        Sender.Tell(child);
+                        break;
+                    }
+                    default:
+                        Unhandled(message);
+                        break;
+                }
+            }
+        }
+        
+        #endregion
+        
+        private TimeSpan _timeout;
+        private ActorSystem _system;
+        private IActorRef _parentActor;
+
+        private ActorWithChild.Get _getMessage = new ActorWithChild.Get("food");
+        private ActorWithChild.Create _createMessage = new ActorWithChild.Create("food");
+
+        private ActorCell _cell;
+        private RepointableActorRef _repointableActorRef;
+        private LocalActorRef _localActorRef;
+
+        private List<string> _rpChildQueryPath = new List<string>() { "food", "foo", "fo" };
+        private List<string> _lclChildQueryPath = new List<string>() { "foo", "fo", "f" };
+        
+        [GlobalSetup]
+        public async Task Setup()
+        {
+            _timeout = TimeSpan.FromMinutes(1);
+            _system = ActorSystem.Create("system");
+            _parentActor = _system.ActorOf(Props.Create(() => new ActorWithChild()), "parent");
+            _localActorRef = (LocalActorRef)await _parentActor.Ask<IActorRef>(_createMessage, _timeout);
+            
+            _cell = _parentActor.As<ActorRefWithCell>().Underlying.As<ActorCell>();
+            _repointableActorRef = (RepointableActorRef)_parentActor;
+        }
+
+        [Benchmark]
+        public void ResolveChild()
+        {
+            _cell.TryGetSingleChild(_getMessage.Name, out var child);
+        }
+        
+        [Benchmark]
+        public void Resolve3DeepChildRepointableActorRef()
+        {
+            _repointableActorRef.GetChild(_rpChildQueryPath);
+        }
+        
+        [Benchmark]
+        public void Resolve3DeepChildLocalActorRef()
+        {
+            _localActorRef.GetChild(_lclChildQueryPath);
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            _system.Terminate().Wait();
+        }
+    }
+}

--- a/src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj
+++ b/src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(NetCoreTestVersion)</TargetFramework>
+    <TargetFrameworks>$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj
+++ b/src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj
@@ -7,9 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
     <!-- FluentAssertions is used in some benchmarks to validate internal behaviors -->
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>

--- a/src/benchmark/Akka.Benchmarks/Remoting/LruBoundedCacheBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Remoting/LruBoundedCacheBenchmarks.cs
@@ -18,6 +18,7 @@ using BenchmarkDotNet.Attributes;
 namespace Akka.Benchmarks.Remoting
 {
     [Config(typeof(MicroBenchmarkConfig))]
+    [SimpleJob( invocationCount: 10_000_000)]
     public class LruBoundedCacheBenchmarks
     {
         private ActorSystem _sys1;

--- a/src/benchmark/Akka.Benchmarks/Remoting/LruBoundedCacheBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Remoting/LruBoundedCacheBenchmarks.cs
@@ -1,0 +1,107 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="LruBoundedCacheBenchmarks.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Actor.Dsl;
+using Akka.Benchmarks.Configurations;
+using Akka.Configuration;
+using Akka.Remote.Serialization;
+using Akka.Util;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Benchmarks.Remoting
+{
+    [Config(typeof(MicroBenchmarkConfig))]
+    public class LruBoundedCacheBenchmarks
+    {
+        private ActorSystem _sys1;
+        private Config _config = @"akka.actor.provider = remote
+                                     akka.remote.dot-netty.tcp.port = 0";
+
+        private ActorRefResolveThreadLocalCache _resolveCache;
+        private ActorPathThreadLocalCache _pathCache;
+        private AddressThreadLocalCache _addressCache;
+
+        private string _cacheMissPath;
+        private IActorRef _cacheMissActorRef;
+
+        private string _cacheHitPath;
+        private int _cacheHitPathCount = 0;
+        private IActorRef _cacheHitActorRef;
+
+        private Address _addr1;
+        private string _addr1String;
+
+        [GlobalSetup]
+        public async Task Setup()
+        {
+            _sys1 = ActorSystem.Create("BenchSys", _config);
+            _resolveCache = ActorRefResolveThreadLocalCache.For(_sys1);
+            _pathCache = ActorPathThreadLocalCache.For(_sys1);
+            _addressCache = AddressThreadLocalCache.For(_sys1);
+
+            var es = (ExtendedActorSystem)_sys1;
+            _addr1 = es.Provider.DefaultAddress;
+            _addr1String = _addr1.ToString();
+
+            var name = "target" + ++_cacheHitPathCount;
+            _cacheHitActorRef = _sys1.ActorOf(act =>
+            {
+                act.ReceiveAny((o, context) => context.Sender.Tell(context.Sender));
+            }, name);
+
+            _cacheMissActorRef = await _cacheHitActorRef.Ask<IActorRef>("hit", CancellationToken.None);
+
+            _cacheHitPath = _cacheHitActorRef.Path.ToString();
+            _cacheMissPath = _cacheMissActorRef.Path.ToString();
+        }
+
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            _cacheMissPath = $"/user/f/{_cacheHitPathCount++}";
+        }
+
+        [Benchmark]
+        public void ActorRefResolveMissBenchmark()
+        {
+            _resolveCache.Cache.GetOrCompute("/user/ignore");
+        }
+        
+        [Benchmark]
+        public void ActorRefResolveHitBenchmark()
+        {
+            _resolveCache.Cache.GetOrCompute(_cacheHitPath);
+        }
+
+        [Benchmark]
+        public void AddressHitBenchmark()
+        {
+            _addressCache.Cache.GetOrCompute(_addr1String);
+        }
+        
+        [Benchmark]
+        public void ActorPathCacheHitBenchmark()
+        {
+            _pathCache.Cache.GetOrCompute(_cacheHitPath);
+        }
+        
+        [Benchmark]
+        public void ActorPathCacheMissBenchmark()
+        {
+            _pathCache.Cache.GetOrCompute(_cacheMissPath);
+        }
+        
+        [GlobalCleanup]
+        public async Task Cleanup()
+        {
+            await _sys1.Terminate();
+        }
+    }
+}

--- a/src/benchmark/Akka.Cluster.Benchmarks/Akka.Cluster.Benchmarks.csproj
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Akka.Cluster.Benchmarks.csproj
@@ -2,7 +2,7 @@
     <Import Project="..\..\common.props" />
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>$(NetCoreTestVersion)</TargetFramework>
+        <TargetFrameworks>$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/benchmark/Akka.Cluster.Benchmarks/Akka.Cluster.Benchmarks.csproj
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Akka.Cluster.Benchmarks.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <Import Project="..\..\common.props" />
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>$(NetCoreTestVersion)</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\contrib\cluster\Akka.Cluster.Sharding\Akka.Cluster.Sharding.csproj" />
+      <ProjectReference Include="..\..\contrib\persistence\Akka.Persistence.Sqlite\Akka.Persistence.Sqlite.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Compile Include="..\Akka.Benchmarks\Configurations\Configs.cs">
+        <Link>Configs.cs</Link>
+      </Compile>
+    </ItemGroup>
+
+</Project>

--- a/src/benchmark/Akka.Cluster.Benchmarks/Program.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 
 namespace Akka.Cluster.Benchmarks
@@ -8,7 +9,12 @@ namespace Akka.Cluster.Benchmarks
     {
         static void Main(string[] args)
         {
+#if (DEBUG)
+            BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args, new DebugInProcessConfig());
+#else
             BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args);
+#endif
+
         }
     }
 }

--- a/src/benchmark/Akka.Cluster.Benchmarks/Program.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Program.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Reflection;
+using BenchmarkDotNet.Running;
+
+namespace Akka.Cluster.Benchmarks
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args);
+        }
+    }
+}

--- a/src/benchmark/Akka.Cluster.Benchmarks/Sharding/HashCodeMessageExtractorBenchmarks.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Sharding/HashCodeMessageExtractorBenchmarks.cs
@@ -1,0 +1,37 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="HashCodeMessageExtractorBenchmarks.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Benchmarks.Configurations;
+using Akka.Cluster.Sharding;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Cluster.Benchmarks.Sharding
+{
+    [Config(typeof(MicroBenchmarkConfig))]
+    public class HashCodeMessageExtractorBenchmarks
+    {
+        private ShardingEnvelope _m1 = new ShardingEnvelope("foo", 1);
+        private ShardedMessage _m2 = new ShardedMessage("foo", 1);
+        private IMessageExtractor _extractor = new ShardMessageExtractor();
+
+        [Benchmark]
+        public void RouteShardEnvelope()
+        {
+            _extractor.EntityId(_m1);
+            _extractor.EntityMessage(_m1);
+            _extractor.ShardId(_m1);
+        }
+        
+        [Benchmark]
+        public void RouteTypedMessage()
+        {
+            _extractor.EntityId(_m2);
+            _extractor.EntityMessage(_m2);
+            _extractor.ShardId(_m2);
+        }
+    }
+}

--- a/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardMessageRoutingBenchmarks.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardMessageRoutingBenchmarks.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Benchmarks.Configurations;
 using Akka.Cluster.Sharding;
+using Akka.Routing;
 using BenchmarkDotNet.Attributes;
 using static Akka.Cluster.Benchmarks.Sharding.ShardingHelper;
 
@@ -33,6 +34,7 @@ namespace Akka.Cluster.Benchmarks.Sharding
 
         private IActorRef _shardRegion1;
         private IActorRef _shardRegion2;
+        private IActorRef _localRouter;
 
         private string _entityOnSys1;
         private string _entityOnSys2;
@@ -43,6 +45,50 @@ namespace Akka.Cluster.Benchmarks.Sharding
         private IActorRef _batchActor;
         private Task _batchComplete;
 
+#if (DEBUG)
+        [GlobalSetup]
+        public void Setup()
+        {
+            var config = StateMode switch
+            {
+                StateStoreMode.Persistence => CreatePersistenceConfig(),
+                StateStoreMode.DData => CreateDDataConfig(),
+                _ => null
+            };
+
+            _sys1 = ActorSystem.Create("BenchSys", config);
+            _sys2 = ActorSystem.Create("BenchSys", config);
+
+            var c1 = Cluster.Get(_sys1);
+            var c2 = Cluster.Get(_sys2);
+
+            c1.JoinAsync(c1.SelfAddress).Wait();
+            c2.JoinAsync(c1.SelfAddress).Wait();
+
+            _shardRegion1 = StartShardRegion(_sys1);
+            _shardRegion2 = StartShardRegion(_sys2);
+
+            _localRouter = _sys1.ActorOf(Props.Create<ShardedProxyEntityActor>(_shardRegion1).WithRouter(new RoundRobinPool(50)));
+
+            var s1Asks = new List<Task<ShardedEntityActor.ResolveResp>>(20);
+            var s2Asks = new List<Task<ShardedEntityActor.ResolveResp>>(20);
+
+            foreach (var i in Enumerable.Range(0, 20))
+            {
+                s1Asks.Add(_shardRegion1.Ask<ShardedEntityActor.ResolveResp>(new ShardingEnvelope(i.ToString(), ShardedEntityActor.Resolve.Instance), TimeSpan.FromSeconds(3)));
+                s2Asks.Add(_shardRegion2.Ask<ShardedEntityActor.ResolveResp>(new ShardingEnvelope(i.ToString(), ShardedEntityActor.Resolve.Instance), TimeSpan.FromSeconds(3)));
+            }
+
+            // wait for all Ask operations to complete
+            Task.WhenAll(s1Asks.Concat(s2Asks)).Wait();
+
+            _entityOnSys2 = s1Asks.First(x => x.Result.Addr.Equals(c2.SelfAddress)).Result.EntityId;
+            _entityOnSys1 = s2Asks.First(x => x.Result.Addr.Equals(c1.SelfAddress)).Result.EntityId;
+
+            _messageToSys1 = new ShardedMessage(_entityOnSys1, 10);
+            _messageToSys2 = new ShardedMessage(_entityOnSys2, 10);
+        }
+#else
         [GlobalSetup]
         public async Task Setup()
         {
@@ -65,6 +111,8 @@ namespace Akka.Cluster.Benchmarks.Sharding
             _shardRegion1 = StartShardRegion(_sys1);
             _shardRegion2 = StartShardRegion(_sys2);
 
+            _localRouter = _sys1.ActorOf(Props.Create<ShardedProxyEntityActor>(_shardRegion1).WithRouter(new RoundRobinPool(1000)));
+
             var s1Asks = new List<Task<ShardedEntityActor.ResolveResp>>(20);
             var s2Asks = new List<Task<ShardedEntityActor.ResolveResp>>(20);
 
@@ -83,6 +131,7 @@ namespace Akka.Cluster.Benchmarks.Sharding
             _messageToSys1 = new ShardedMessage(_entityOnSys1, 10);
             _messageToSys2 = new ShardedMessage(_entityOnSys2, 10);
         }
+#endif
 
         [IterationSetup]
         public void PerIteration()
@@ -98,21 +147,29 @@ namespace Akka.Cluster.Benchmarks.Sharding
             for (var i = 0; i < MsgCount; i++)
                 await _shardRegion1.Ask<ShardedMessage>(_messageToSys1);
         }
-        
+
         [Benchmark]
         public async Task StreamingToLocalEntity()
         {
             _batchActor.Tell(new BulkSendActor.BeginSend(_messageToSys1, _shardRegion1, BatchSize));
             await _batchComplete;
         }
-        
+
         [Benchmark]
         public async Task SingleRequestResponseToRemoteEntity()
         {
             for (var i = 0; i < MsgCount; i++)
                 await _shardRegion1.Ask<ShardedMessage>(_messageToSys2);
         }
-        
+
+
+        [Benchmark]
+        public async Task SingleRequestResponseToRemoteEntityWithLocalProxy()
+        {
+            for (var i = 0; i < MsgCount; i++)
+                await _localRouter.Ask<ShardedMessage>(new SendShardedMessage(_messageToSys2.EntityId, _messageToSys2));
+        }
+
         [Benchmark]
         public async Task StreamingToRemoteEntity()
         {

--- a/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardMessageRoutingBenchmarks.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardMessageRoutingBenchmarks.cs
@@ -1,0 +1,137 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ShardMessageRoutingBenchmarks.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using Akka.Cluster.Sharding;
+using BenchmarkDotNet.Attributes;
+using static Akka.Cluster.Benchmarks.Sharding.ShardingHelper;
+
+namespace Akka.Cluster.Benchmarks.Sharding
+{
+    [Config(typeof(MonitoringConfig))]
+    public class ShardMessageRoutingBenchmarks
+    {
+        [Params(StateStoreMode.Persistence, StateStoreMode.DData)]
+        public StateStoreMode StateMode;
+
+        [Params(10000)]
+        public int MsgCount;
+
+        public int BatchSize = 20;
+
+        private ActorSystem _sys1;
+        private ActorSystem _sys2;
+
+        private IActorRef _shardRegion1;
+        private IActorRef _shardRegion2;
+
+        private string _entityOnSys1;
+        private string _entityOnSys2;
+
+        private ShardedMessage _messageToSys1;
+        private ShardedMessage _messageToSys2;
+
+        private IActorRef _batchActor;
+        private Task _batchComplete;
+
+        [GlobalSetup]
+        public async Task Setup()
+        {
+            var config = StateMode switch
+            {
+                StateStoreMode.Persistence => CreatePersistenceConfig(),
+                StateStoreMode.DData => CreateDDataConfig(),
+                _ => null
+            };
+
+            _sys1 = ActorSystem.Create("BenchSys", config);
+            _sys2 = ActorSystem.Create("BenchSys", config);
+
+            var c1 = Cluster.Get(_sys1);
+            var c2 = Cluster.Get(_sys2);
+
+            await c1.JoinAsync(c1.SelfAddress);
+            await c2.JoinAsync(c1.SelfAddress);
+
+            _shardRegion1 = StartShardRegion(_sys1);
+            _shardRegion2 = StartShardRegion(_sys2);
+
+            var s1Asks = new List<Task<ShardedEntityActor.ResolveResp>>(20);
+            var s2Asks = new List<Task<ShardedEntityActor.ResolveResp>>(20);
+
+            foreach (var i in Enumerable.Range(0, 20))
+            {
+                s1Asks.Add(_shardRegion1.Ask<ShardedEntityActor.ResolveResp>(new ShardingEnvelope(i.ToString(), ShardedEntityActor.Resolve.Instance), TimeSpan.FromSeconds(3)));
+                s2Asks.Add(_shardRegion2.Ask<ShardedEntityActor.ResolveResp>(new ShardingEnvelope(i.ToString(), ShardedEntityActor.Resolve.Instance), TimeSpan.FromSeconds(3)));
+            }
+
+            // wait for all Ask operations to complete
+            await Task.WhenAll(s1Asks.Concat(s2Asks));
+
+            _entityOnSys2 = s1Asks.First(x => x.Result.Addr.Equals(c2.SelfAddress)).Result.EntityId;
+            _entityOnSys1 = s2Asks.First(x => x.Result.Addr.Equals(c1.SelfAddress)).Result.EntityId;
+
+            _messageToSys1 = new ShardedMessage(_entityOnSys1, 10);
+            _messageToSys2 = new ShardedMessage(_entityOnSys2, 10);
+        }
+
+        [IterationSetup]
+        public void PerIteration()
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            _batchComplete = tcs.Task;
+            _batchActor = _sys1.ActorOf(Props.Create(() => new BulkSendActor(tcs, MsgCount)));
+        }
+
+        [Benchmark]
+        public async Task SingleRequestResponseToLocalEntity()
+        {
+            for (var i = 0; i < MsgCount; i++)
+                await _shardRegion1.Ask<ShardedMessage>(_messageToSys1);
+        }
+        
+        [Benchmark]
+        public async Task StreamingToLocalEntity()
+        {
+            _batchActor.Tell(new BulkSendActor.BeginSend(_messageToSys1, _shardRegion1, BatchSize));
+            await _batchComplete;
+        }
+        
+        [Benchmark]
+        public async Task SingleRequestResponseToRemoteEntity()
+        {
+            for (var i = 0; i < MsgCount; i++)
+                await _shardRegion1.Ask<ShardedMessage>(_messageToSys2);
+        }
+        
+        [Benchmark]
+        public async Task StreamingToRemoteEntity()
+        {
+            _batchActor.Tell(new BulkSendActor.BeginSend(_messageToSys2, _shardRegion1, BatchSize));
+            await _batchComplete;
+        }
+
+        [IterationCleanup]
+        public void IterationCleanup()
+        {
+            _sys1.Stop(_batchActor);
+        }
+
+        [GlobalCleanup]
+        public async Task Cleanup()
+        {
+            var t1 = _sys1.Terminate();
+            var t2 = _sys2.Terminate();
+            await Task.WhenAll(t1, t2);
+        }
+    }
+}

--- a/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardSpawnBenchmarks.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardSpawnBenchmarks.cs
@@ -1,0 +1,93 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="ShardSpawnBenchmarks.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using Akka.Cluster.Sharding;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using static Akka.Cluster.Benchmarks.Sharding.ShardingHelper;
+
+namespace Akka.Cluster.Benchmarks.Sharding
+{
+    [Config(typeof(MonitoringConfig))]
+    [SimpleJob(RunStrategy.ColdStart, targetCount:1, warmupCount:0, launchCount:5)]
+    public class ShardSpawnBenchmarks
+    {
+        [Params(StateStoreMode.Persistence, StateStoreMode.DData)]
+        public StateStoreMode StateMode;
+
+        [Params(1000)]
+        public int EntityCount;
+
+        [Params(true, false)]
+        public bool RememberEntities;
+
+        public int BatchSize = 20;
+
+        private ActorSystem _sys1;
+        private ActorSystem _sys2;
+
+        private IActorRef _shardRegion1;
+        private IActorRef _shardRegion2;
+
+        public static int _shardRegionId = 0;
+        
+        
+        [GlobalSetup]
+        public async Task Setup()
+        {
+            var config = StateMode switch
+            {
+                StateStoreMode.Persistence => CreatePersistenceConfig(RememberEntities),
+                StateStoreMode.DData => CreateDDataConfig(RememberEntities),
+                _ => null
+            };
+
+            _sys1 = ActorSystem.Create("BenchSys", config);
+            _sys2 = ActorSystem.Create("BenchSys", config);
+
+            var c1 = Cluster.Get(_sys1);
+            var c2 = Cluster.Get(_sys2);
+
+            await c1.JoinAsync(c1.SelfAddress);
+            await c2.JoinAsync(c1.SelfAddress);
+        }
+
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            /*
+             * Create a new set of shard regions each time, so all of the shards are freshly allocated
+             * on each benchmark run. 
+             */
+            _shardRegion1 = StartShardRegion(_sys1, "entities" + _shardRegionId);
+            _shardRegion2 = StartShardRegion(_sys2, "entities" + _shardRegionId);
+            _shardRegionId++;
+        }
+
+        [Benchmark]
+        public async Task SpawnEntities()
+        {
+            for (var i = 0; i < EntityCount; i++)
+            {
+                var msg = new ShardedMessage(i.ToString(), i);
+                await _shardRegion1.Ask<ShardedMessage>(msg);
+            }
+        }
+        
+        [GlobalCleanup]
+        public async Task Cleanup()
+        {
+            var t2 = CoordinatedShutdown.Get(_sys2).Run(CoordinatedShutdown.ActorSystemTerminateReason.Instance);
+            var t1 = CoordinatedShutdown.Get(_sys1).Run(CoordinatedShutdown.ActorSystemTerminateReason.Instance);
+           
+            await Task.WhenAll(t1, t2);
+        }
+    }
+}

--- a/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardingInfrastructure.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardingInfrastructure.cs
@@ -1,0 +1,194 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="ShardingInfrastructure.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Cluster.Sharding;
+using Akka.Configuration;
+using Akka.Util.Internal;
+
+namespace Akka.Cluster.Benchmarks.Sharding
+{
+    public sealed class ShardedEntityActor : ReceiveActor
+    {
+        public sealed class Resolve
+        {
+            public static readonly Resolve Instance = new Resolve();
+            private Resolve(){}
+        }
+
+        public sealed class ResolveResp
+        {
+            public ResolveResp(string entityId, Address addr)
+            {
+                EntityId = entityId;
+                Addr = addr;
+            }
+
+            public string EntityId { get; }
+            
+            public Address Addr { get; }
+        }
+        
+        public ShardedEntityActor()
+        {
+            Receive<ShardingEnvelope>(e =>
+            {
+                Sender.Tell(new ResolveResp(e.EntityId, Cluster.Get(Context.System).SelfAddress));
+            });
+            
+            ReceiveAny(_ => Sender.Tell(_));
+        }
+    }
+
+    public sealed class BulkSendActor : ReceiveActor
+    {
+        public sealed class BeginSend
+        {
+            public BeginSend(ShardedMessage msg, IActorRef target, int batchSize)
+            {
+                Msg = msg;
+                Target = target;
+                BatchSize = batchSize;
+            }
+
+            public ShardedMessage Msg { get; }
+            
+            public IActorRef Target { get; }
+            
+            public int BatchSize { get; }
+        }
+        
+        private int _remaining;
+
+        private readonly TaskCompletionSource<bool> _tcs;
+
+        public BulkSendActor(TaskCompletionSource<bool> tcs, int remaining)
+        {
+            _tcs = tcs;
+            _remaining = remaining;
+
+            Receive<BeginSend>(b =>
+            {
+                for (var i = 0; i < b.BatchSize; i++)
+                {
+                    b.Target.Tell(b.Msg);
+                }
+            });
+
+            Receive<ShardedMessage>(s =>
+            {
+                if (--remaining > 0)
+                {
+                    Sender.Tell(s);
+                }
+                else
+                {
+                    Context.Stop(Self); // shut ourselves down
+                    _tcs.TrySetResult(true);
+                }
+            });
+        }
+    }
+    
+    public sealed class ShardedMessage
+    {
+        public ShardedMessage(string entityId, int message)
+        {
+            EntityId = entityId;
+            Message = message;
+        }
+
+        public string EntityId { get; }
+            
+        public int Message { get; }
+    }
+
+    /// <summary>
+    /// Use a default <see cref="IMessageExtractor"/> even though it takes extra work to setup the benchmark
+    /// </summary>
+    public sealed class ShardMessageExtractor : HashCodeMessageExtractor
+    {
+        /// <summary>
+        /// We only ever run with a maximum of two nodes, so ~10 shards per node
+        /// </summary>
+        public ShardMessageExtractor(int shardCount = 20) : base(shardCount)
+        {
+        }
+
+        public override string EntityId(object message)
+        {
+            if(message is ShardedMessage sharded)
+            {
+                return sharded.EntityId;
+            }
+
+            if (message is ShardingEnvelope e)
+            {
+                return e.EntityId;
+            }
+
+            return null;
+        }
+    }
+
+    public static class ShardingHelper
+    {
+        public static AtomicCounter DbId = new AtomicCounter(0);
+
+        internal static string BoolToToggle(bool val)
+        {
+            return val ? "on" : "off";
+        }
+        
+        public static Config CreatePersistenceConfig(bool rememberEntities = false)
+        {
+            var connectionString =
+                "Filename=file:memdb-journal-" + DbId.IncrementAndGet() + ".db;Mode=Memory;Cache=Shared";
+            var config = $@"
+                akka.actor.provider = cluster
+                akka.remote.dot-netty.tcp.port = 0
+                akka.cluster.sharding.state-store-mode=persistence
+                akka.cluster.sharding.remember-entities = {BoolToToggle(rememberEntities)}
+                akka.persistence.journal.plugin = ""akka.persistence.journal.sqlite""
+                akka.persistence.journal.sqlite {{
+                    class = ""Akka.Persistence.Sqlite.Journal.SqliteJournal, Akka.Persistence.Sqlite""
+                    auto-initialize = on
+                    connection-string = ""{connectionString}""
+                }}
+                akka.persistence.snapshot-store {{
+                    plugin = ""akka.persistence.snapshot-store.sqlite""
+                    sqlite {{
+                        class = ""Akka.Persistence.Sqlite.Snapshot.SqliteSnapshotStore, Akka.Persistence.Sqlite""
+                        auto-initialize = on
+                        connection-string = ""{connectionString}""
+                    }}
+                }}";
+
+            return config;
+        }
+
+        public static Config CreateDDataConfig(bool rememberEntities = false)
+        {
+            var config = $@"
+                akka.actor.provider = cluster
+                akka.remote.dot-netty.tcp.port = 0
+                akka.cluster.sharding.state-store-mode=ddata
+                akka.cluster.sharding.remember-entities = {BoolToToggle(rememberEntities)}";
+
+            return config;
+        }
+
+        public static IActorRef StartShardRegion(ActorSystem system, string entityName = "entities")
+        {
+            var props = Props.Create(() => new ShardedEntityActor());
+            var sharding = ClusterSharding.Get(system);
+            return sharding.Start(entityName, s => props, ClusterShardingSettings.Create(system),
+                new ShardMessageExtractor());
+        }
+    }
+}

--- a/src/common.props
+++ b/src/common.props
@@ -21,7 +21,7 @@
     <NetFrameworkTestVersion>net471</NetFrameworkTestVersion>
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>
     <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>
-    <FsCheckVersion>2.16.0</FsCheckVersion>
+    <FsCheckVersion>2.16.3</FsCheckVersion>
     <HoconVersion>2.0.3</HoconVersion>
     <ConfigurationManagerVersion>4.7.0</ConfigurationManagerVersion>
     <AkkaPackageTags>akka;actors;actor model;Akka;concurrency</AkkaPackageTags>

--- a/src/common.props
+++ b/src/common.props
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <XunitVersion>2.4.1</XunitVersion>
-    <TestSdkVersion>16.10.0</TestSdkVersion>
+    <TestSdkVersion>16.11.0</TestSdkVersion>
     <HyperionVersion>0.11.1</HyperionVersion>
     <NewtonsoftJsonVersion>[12.0.3,)</NewtonsoftJsonVersion>
     <NBenchVersion>2.0.1</NBenchVersion>

--- a/src/common.props
+++ b/src/common.props
@@ -21,7 +21,7 @@
     <NetFrameworkTestVersion>net471</NetFrameworkTestVersion>
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>
     <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>
-    <FsCheckVersion>2.15.3</FsCheckVersion>
+    <FsCheckVersion>2.16.0</FsCheckVersion>
     <HoconVersion>2.0.3</HoconVersion>
     <ConfigurationManagerVersion>4.7.0</ConfigurationManagerVersion>
     <AkkaPackageTags>akka;actors;actor model;Akka;concurrency</AkkaPackageTags>

--- a/src/common.props
+++ b/src/common.props
@@ -15,6 +15,7 @@
     <NewtonsoftJsonVersion>[12.0.3,)</NewtonsoftJsonVersion>
     <NBenchVersion>2.0.1</NBenchVersion>
     <ProtobufVersion>3.17.3</ProtobufVersion>
+    <BenchmarkDotNetVersion>0.13.1</BenchmarkDotNetVersion>
     <NetCoreTestVersion>netcoreapp3.1</NetCoreTestVersion>
     <NetTestVersion>net5.0</NetTestVersion>
     <NetFrameworkTestVersion>net471</NetFrameworkTestVersion>

--- a/src/contrib/cluster/Akka.Cluster.Metrics/Routing/ClusterMetricsRouting.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics/Routing/ClusterMetricsRouting.cs
@@ -22,12 +22,17 @@ using Akka.Configuration;
 
 namespace Akka.Cluster.Metrics
 {
+    public interface IClusterMetricsRoutingLogic
+    {
+        void MetricsChanged(ClusterMetricsChanged @event);
+    }
+    
     /// <summary>
     /// Load balancing of messages to cluster nodes based on cluster metric data.
     ///
     /// It uses random selection of routees based on probabilities derived from the remaining capacity of corresponding node.
     /// </summary>
-    public sealed class AdaptiveLoadBalancingRoutingLogic : RoutingLogic
+    public sealed class AdaptiveLoadBalancingRoutingLogic : RoutingLogic, IClusterMetricsRoutingLogic
     {
         private readonly ActorSystem _system;
         private readonly IMetricsSelector _metricsSelector;
@@ -176,7 +181,7 @@ namespace Akka.Cluster.Metrics
         /// <inheritdoc />
         public override Props RoutingLogicController(RoutingLogic routingLogic)
         {
-            return Actor.Props.Create(() => new AdaptiveLoadBalancingMetricsListener(routingLogic as AdaptiveLoadBalancingRoutingLogic));
+            return Actor.Props.Create(() => new AdaptiveLoadBalancingMetricsListener((IClusterMetricsRoutingLogic)routingLogic));
         }
         
         /// <inheritdoc />
@@ -328,7 +333,7 @@ namespace Akka.Cluster.Metrics
         /// <inheritdoc />
         public override Props RoutingLogicController(RoutingLogic routingLogic)
         {
-            return Actor.Props.Create(() => new AdaptiveLoadBalancingMetricsListener(routingLogic as AdaptiveLoadBalancingRoutingLogic));
+            return Actor.Props.Create(() => new AdaptiveLoadBalancingMetricsListener((IClusterMetricsRoutingLogic)routingLogic));
         }
 
         /// <inheritdoc />
@@ -392,10 +397,10 @@ namespace Akka.Cluster.Metrics
     [InternalApi]
     public class AdaptiveLoadBalancingMetricsListener : ActorBase
     {
-        private readonly AdaptiveLoadBalancingRoutingLogic _routingLogic;
+        private readonly IClusterMetricsRoutingLogic _routingLogic;
         private readonly ClusterMetrics _extension = ClusterMetrics.Get(Context.System);
 
-        public AdaptiveLoadBalancingMetricsListener(AdaptiveLoadBalancingRoutingLogic routingLogic)
+        public AdaptiveLoadBalancingMetricsListener(IClusterMetricsRoutingLogic routingLogic)
         {
             _routingLogic = routingLogic;
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/AsyncWriteProxyEx.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/AsyncWriteProxyEx.cs
@@ -161,7 +161,7 @@ namespace Akka.Cluster.Sharding.Tests
             if (_store == null)
                 return StoreNotInitialized<IImmutableList<Exception>>();
 
-            return _store.AskEx<object>(sender => new WriteMessages(messages, sender, 1), Timeout)
+            return _store.Ask<object>(sender => new WriteMessages(messages, sender, 1), Timeout, CancellationToken.None)
                 .ContinueWith(r =>
                 {
                     if (r.IsCanceled)
@@ -197,7 +197,7 @@ namespace Akka.Cluster.Sharding.Tests
 
             var result = new TaskCompletionSource<object>();
 
-            _store.AskEx(sender => new DeleteMessagesTo(persistenceId, toSequenceNr, sender), Timeout).ContinueWith(r =>
+            _store.Ask<object>(sender => new DeleteMessagesTo(persistenceId, toSequenceNr, sender), Timeout, CancellationToken.None).ContinueWith(r =>
             {
                 if (r.IsFaulted)
                     result.TrySetException(r.Exception);
@@ -252,7 +252,7 @@ namespace Akka.Cluster.Sharding.Tests
 
             var result = new TaskCompletionSource<long>();
 
-            _store.AskEx<object>(sender => new ReplayMessages(0, 0, 0, persistenceId, sender), Timeout)
+            _store.Ask<object>(sender => new ReplayMessages(0, 0, 0, persistenceId, sender), Timeout, CancellationToken.None)
                 .ContinueWith(t =>
                 {
                     if (t.IsFaulted)
@@ -356,112 +356,6 @@ namespace Akka.Cluster.Sharding.Tests
                     return true;
             }
             return false;
-        }
-    }
-
-    internal static class FuturesEx
-    {
-        public static Task<object> AskEx(this ICanTell self, Func<IActorRef, object> messageFactory, TimeSpan? timeout = null)
-        {
-            return self.AskEx<object>(messageFactory, timeout, CancellationToken.None);
-        }
-
-        public static Task<object> AskEx(this ICanTell self, Func<IActorRef, object> messageFactory, CancellationToken cancellationToken)
-        {
-            return self.AskEx<object>(messageFactory, null, cancellationToken);
-        }
-
-        public static Task<object> AskEx(this ICanTell self, Func<IActorRef, object> messageFactory, TimeSpan? timeout, CancellationToken cancellationToken)
-        {
-            return self.AskEx<object>(messageFactory, timeout, cancellationToken);
-        }
-
-        public static Task<T> AskEx<T>(this ICanTell self, Func<IActorRef, object> messageFactory, TimeSpan? timeout = null)
-        {
-            return self.AskEx<T>(messageFactory, timeout, CancellationToken.None);
-        }
-
-        public static Task<T> AskEx<T>(this ICanTell self, Func<IActorRef, object> messageFactory, CancellationToken cancellationToken)
-        {
-            return self.AskEx<T>(messageFactory, null, cancellationToken);
-        }
-
-        public static async Task<T> AskEx<T>(this ICanTell self, Func<IActorRef, object> messageFactory, TimeSpan? timeout, CancellationToken cancellationToken)
-        {
-            IActorRefProvider provider = ResolveProvider(self);
-            if (provider == null)
-                throw new ArgumentException("Unable to resolve the target Provider", nameof(self));
-
-            return (T)await AskEx(self, messageFactory, provider, timeout, cancellationToken);
-        }
-        internal static IActorRefProvider ResolveProvider(ICanTell self)
-        {
-            if (InternalCurrentActorCellKeeper.Current != null)
-                return InternalCurrentActorCellKeeper.Current.SystemImpl.Provider;
-
-            if (self is IInternalActorRef iar)
-                return iar.Provider;
-
-            if (self is ActorSelection asel)
-                return ResolveProvider(asel.Anchor);
-
-            return null;
-        }
-
-        private static async Task<object> AskEx(ICanTell self, Func<IActorRef, object> messageFactory, IActorRefProvider provider, TimeSpan? timeout, CancellationToken cancellationToken)
-        {
-            var result = new TaskCompletionSource<object>();
-
-            CancellationTokenSource timeoutCancellation = null;
-            timeout = timeout ?? provider.Settings.AskTimeout;
-            var ctrList = new List<CancellationTokenRegistration>(2);
-
-            if (timeout != Timeout.InfiniteTimeSpan && timeout.Value > default(TimeSpan))
-            {
-                timeoutCancellation = new CancellationTokenSource();
-
-                ctrList.Add(timeoutCancellation.Token.Register(() =>
-                {
-                    result.TrySetException(new AskTimeoutException($"Timeout after {timeout} seconds"));
-                }));
-
-                timeoutCancellation.CancelAfter(timeout.Value);
-            }
-
-            if (cancellationToken.CanBeCanceled)
-            {
-                ctrList.Add(cancellationToken.Register(() => result.TrySetCanceled()));
-            }
-
-            //create a new tempcontainer path
-            ActorPath path = provider.TempPath();
-
-            var future = new FutureActorRef<object>(result, t => { }, path);
-            //The future actor needs to be registered in the temp container
-            provider.RegisterTempActor(future, path);
-
-            self.Tell(messageFactory(future), future);
-
-            try
-            {
-                return await result.Task;
-            }
-            finally
-            {
-                //callback to unregister from tempcontainer
-
-                provider.UnregisterTempActor(path);
-
-                for (var i = 0; i < ctrList.Count; i++)
-                {
-                    ctrList[i].Dispose();
-                }
-
-                if (timeoutCancellation != null)
-                {
-                    timeoutCancellation.Dispose();
-                }
-            }
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
@@ -60,6 +60,8 @@ namespace Akka.Cluster.Sharding
         /// </summary>
         public readonly int MaxNumberOfShards;
 
+        private readonly Dictionary<int, string> _cachedIds;
+
         /// <summary>
         /// TBD
         /// </summary>
@@ -67,6 +69,11 @@ namespace Akka.Cluster.Sharding
         protected HashCodeMessageExtractor(int maxNumberOfShards)
         {
             MaxNumberOfShards = maxNumberOfShards;
+            _cachedIds = new Dictionary<int, string>(MaxNumberOfShards);
+            foreach (var c in Enumerable.Range(0, maxNumberOfShards))
+            {
+                _cachedIds[c] = c.ToString();
+            }
         }
 
         /// <summary>
@@ -98,8 +105,8 @@ namespace Akka.Cluster.Sharding
                 id = se.EntityId;
             else
                 id = EntityId(message);
-
-            return (Math.Abs(MurmurHash.StringHash(id)) % MaxNumberOfShards).ToString();
+            
+            return _cachedIds[(Math.Abs(MurmurHash.StringHash(id)) % MaxNumberOfShards)];
         }
     }
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
@@ -974,7 +974,7 @@ namespace Akka.Cluster.Sharding
             if (GracefulShutdownInProgress)
             {
                 var actorSelections = CoordinatorSelection;
-                Log.Debug("Sending graceful shutdown to {0}", actorSelections);
+                Log.Debug("Sending graceful shutdown to {0}", string.Join(",", actorSelections.Select(c => c.ToString())));
                 actorSelections.ForEach(c => c.Tell(new PersistentShardCoordinator.GracefulShutdownRequest(Self)));
             }
         }

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManager.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManager.cs
@@ -751,7 +751,7 @@ namespace Akka.Cluster.Tools.Singleton
 
         private void CleanupOverdueNotMemberAnyMore()
         {
-            _removed = _removed.Where(kv => kv.Value.IsOverdue).ToImmutableDictionary();
+            _removed = _removed.Where(kv => !kv.Value.IsOverdue).ToImmutableDictionary();
         }
 
         private ActorSelection Peer(Address at)

--- a/src/contrib/cluster/Akka.DistributedData/ReadAggregator.cs
+++ b/src/contrib/cluster/Akka.DistributedData/ReadAggregator.cs
@@ -234,7 +234,8 @@ namespace Akka.DistributedData
 
     /// <summary>
     /// <see cref="ReadMajority"/> but with the given number of <see cref="Additional"/> nodes added to the majority count. At most
-    /// all nodes.
+    /// all nodes. Exiting nodes are excluded using `ReadMajorityPlus` because those are typically
+    /// about to be removed and will not be able to respond.
     /// </summary>
     public sealed class ReadMajorityPlus : IReadConsistency, IEquatable<ReadMajorityPlus>
     {

--- a/src/contrib/cluster/Akka.DistributedData/WriteAggregator.cs
+++ b/src/contrib/cluster/Akka.DistributedData/WriteAggregator.cs
@@ -267,7 +267,8 @@ namespace Akka.DistributedData
 
     /// <summary>
     /// <see cref="WriteMajority"/> but with the given number of <see cref="Additional"/> nodes added to the majority count. At most
-    /// all nodes.
+    /// all nodes. Exiting nodes are excluded using `WriteMajorityPlus` because those are typically
+    /// about to be removed and will not be able to respond.
     /// </summary>
     public sealed class WriteMajorityPlus : IWriteConsistency, IEquatable<WriteMajorityPlus>
     {

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj
@@ -7,7 +7,6 @@
     <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
     <PackageTags>$(AkkaPackageTags);persistence;eventsource;sql</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionSuffix>beta</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Bugfix4360Spec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Bugfix4360Spec.cs
@@ -57,9 +57,9 @@ auto-initialize = on
                 private DoSnapshot() { }
             }
 
-            public RecoverActor(IActorRef reply)
+            public RecoverActor(IActorRef reply, string persistenceId)
             {
-                PersistenceId = Self.Path.Name;
+                PersistenceId = persistenceId;
                 Reply = reply;
             }
 
@@ -120,7 +120,8 @@ auto-initialize = on
         [Fact]
         public void Should_recover_persistentactor_sqlite()
         {
-            var recoveryActor = Sys.ActorOf(Props.Create(() => new RecoverActor(TestActor)), ThreadLocalRandom.Current.Next(0, 100000).ToString());
+            var id = ThreadLocalRandom.Current.Next(0, 100000).ToString();
+            var recoveryActor = Sys.ActorOf(Props.Create(() => new RecoverActor(TestActor, id)));
 
             var r1 = ExpectMsg<IEnumerable<string>>();
             r1.Count().Should().Be(0); // empty recovery
@@ -136,7 +137,7 @@ auto-initialize = on
             ExpectTerminated(recoveryActor);
 
             // recreate the actor and recover
-            var recoveryActor2 = Sys.ActorOf(Props.Create(() => new RecoverActor(TestActor)), recoveryActor.Path.Name);
+            var recoveryActor2 = Sys.ActorOf(Props.Create(() => new RecoverActor(TestActor, id)));
 
             var r2 = ExpectMsg<IEnumerable<string>>();
             r2.Should().Contain(new[] { "foo", "bar" });

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Bugfix4360Spec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Bugfix4360Spec.cs
@@ -136,14 +136,10 @@ auto-initialize = on
             ExpectTerminated(recoveryActor);
 
             // recreate the actor and recover
+            var recoveryActor2 = Sys.ActorOf(Props.Create(() => new RecoverActor(TestActor)), recoveryActor.Path.Name);
 
-            AwaitAssert(() =>
-            {
-                var recoveryActor2 = Sys.ActorOf(Props.Create(() => new RecoverActor(TestActor)), recoveryActor.Path.Name);
-
-                var r2 = ExpectMsg<IEnumerable<string>>(TimeSpan.FromMilliseconds(100));
-                r2.Should().Contain(new[] { "foo", "bar" });
-            }, interval:TimeSpan.FromMilliseconds(150));
+            var r2 = ExpectMsg<IEnumerable<string>>();
+            r2.Should().Contain(new[] { "foo", "bar" });
         }
 
         [Fact]

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteCurrentAllEventsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteCurrentAllEventsSpec.cs
@@ -30,7 +30,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                 table-name = event_journal
                 metadata-table-name = journal_metadata
                 auto-initialize = on
-                connection-string = ""Filename=file:memdb-journal-eventsbytag-{id}.db;Mode=Memory;Cache=Shared""
+                connection-string = ""Filename=file:memdb-journal-allevents-{id}.db;Mode=Memory;Cache=Shared""
                 refresh-interval = 1s
             }}
             akka.test.single-expect-default = 10s")

--- a/src/contrib/testkits/Akka.TestKit.Xunit/Internals/Loggers.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit/Internals/Loggers.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using Akka.Actor;
 using Akka.Event;
 using Xunit.Abstractions;
@@ -16,20 +17,44 @@ namespace Akka.TestKit.Xunit.Internals
     /// </summary>
     public class TestOutputLogger : ReceiveActor
     {
+        private readonly ITestOutputHelper _output;
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="TestOutputLogger"/> class.
         /// </summary>
         /// <param name="output">The provider used to write test output.</param>
         public TestOutputLogger(ITestOutputHelper output)
         {
-            Receive<Debug>(e => output.WriteLine(e.ToString()));
-            Receive<Info>(e => output.WriteLine(e.ToString()));
-            Receive<Warning>(e => output.WriteLine(e.ToString()));
-            Receive<Error>(e => output.WriteLine(e.ToString()));
+            _output = output;
+            
+            Receive<Debug>(Write);
+            Receive<Info>(Write);
+            Receive<Warning>(Write);
+            Receive<Error>(Write);
             Receive<InitializeLogger>(e =>
             {
                 e.LoggingBus.Subscribe(Self, typeof (LogEvent));
             });
+        }
+
+        private void Write(LogEvent e)
+        {
+            try
+            {
+                _output.WriteLine(e.ToString());
+            }
+            catch (FormatException ex)
+            {
+                if (e.Message is LogMessage msg)
+                {
+                    var message =
+                        $"Received a malformed formatted message. Log level: [{e.LogLevel()}], Template: [{msg.Format}], args: [{string.Join(",", msg.Args)}]";
+                    if(e.Cause != null)
+                        throw new AggregateException(message, ex, e.Cause);
+                    throw new FormatException(message, ex);
+                }
+                throw;
+            }
         }
     }
 }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveClusterMetrics.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveClusterMetrics.approved.txt
@@ -23,7 +23,7 @@ namespace Akka.Cluster.Metrics
     [Akka.Annotations.InternalApiAttribute()]
     public class AdaptiveLoadBalancingMetricsListener : Akka.Actor.ActorBase
     {
-        public AdaptiveLoadBalancingMetricsListener(Akka.Cluster.Metrics.AdaptiveLoadBalancingRoutingLogic routingLogic) { }
+        public AdaptiveLoadBalancingMetricsListener(Akka.Cluster.Metrics.IClusterMetricsRoutingLogic routingLogic) { }
         protected override void PostStop() { }
         protected override void PreStart() { }
         protected override bool Receive(object message) { }
@@ -52,7 +52,7 @@ namespace Akka.Cluster.Metrics
             public Akka.Util.ISurrogated FromSurrogate(Akka.Actor.ActorSystem system) { }
         }
     }
-    public sealed class AdaptiveLoadBalancingRoutingLogic : Akka.Routing.RoutingLogic
+    public sealed class AdaptiveLoadBalancingRoutingLogic : Akka.Routing.RoutingLogic, Akka.Cluster.Metrics.IClusterMetricsRoutingLogic
     {
         public AdaptiveLoadBalancingRoutingLogic(Akka.Actor.ActorSystem system, Akka.Cluster.Metrics.IMetricsSelector metricsSelector = null) { }
         public void MetricsChanged(Akka.Cluster.Metrics.Events.ClusterMetricsChanged @event) { }
@@ -119,6 +119,10 @@ namespace Akka.Cluster.Metrics
         public static readonly Akka.Cluster.Metrics.CpuMetricsSelector Instance;
         public CpuMetricsSelector() { }
         public override System.Collections.Immutable.IImmutableDictionary<Akka.Actor.Address, double> Capacity(System.Collections.Immutable.IImmutableSet<Akka.Cluster.Metrics.Serialization.NodeMetrics> nodeMetrics) { }
+    }
+    public interface IClusterMetricsRoutingLogic
+    {
+        void MetricsChanged(Akka.Cluster.Metrics.Events.ClusterMetricsChanged @event);
     }
     public interface IMetricsCollector : System.IDisposable
     {

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -862,11 +862,12 @@ namespace Akka.Actor
         public Failures() { }
         public System.Collections.Generic.List<Akka.Actor.Failure> Entries { get; }
     }
-    public sealed class FutureActorRef<T> : Akka.Actor.MinimalActorRef
+    public class FutureActorRef<T> : Akka.Actor.MinimalActorRef
     {
-        public FutureActorRef(System.Threading.Tasks.TaskCompletionSource<T> result, Akka.Actor.ActorPath path, Akka.Actor.IActorRefProvider provider) { }
+        public FutureActorRef(System.Threading.Tasks.TaskCompletionSource<T> result, System.Action<System.Threading.Tasks.Task> unregister, Akka.Actor.ActorPath path) { }
         public override Akka.Actor.ActorPath Path { get; }
         public override Akka.Actor.IActorRefProvider Provider { get; }
+        public override void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message) { }
         protected override void TellInternal(object message, Akka.Actor.IActorRef sender) { }
     }
     public class static Futures

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -1696,6 +1696,7 @@ namespace Akka.Actor
         public bool SerializeAllMessages { get; }
         public Akka.Actor.Setup.ActorSystemSetup Setup { get; }
         public string StdoutLogLevel { get; }
+        public Akka.Event.MinimalLogger StdoutLogger { get; }
         public string SupervisorStrategyClass { get; }
         public Akka.Actor.ActorSystem System { get; }
         public System.TimeSpan UnstartedPushTimeout { get; }
@@ -3089,7 +3090,7 @@ namespace Akka.Event
         public static string FromType(System.Type t, Akka.Actor.ActorSystem system) { }
         public static System.Type SourceType(object o) { }
     }
-    public class LoggerInitialized : Akka.Actor.INoSerializationVerificationNeeded
+    public class LoggerInitialized : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
     {
         public LoggerInitialized() { }
     }
@@ -3099,7 +3100,6 @@ namespace Akka.Event
     }
     public class static Logging
     {
-        public static readonly Akka.Event.StandardOutLogger StandardOutLogger;
         public static System.Type ClassFor(this Akka.Event.LogLevel logLevel) { }
         public static Akka.Event.ILoggingAdapter GetLogger(this Akka.Actor.IActorContext context, Akka.Event.ILogMessageFormatter logMessageFormatter = null) { }
         public static Akka.Event.ILoggingAdapter GetLogger(Akka.Actor.ActorSystem system, object logSourceObj, Akka.Event.ILogMessageFormatter logMessageFormatter = null) { }
@@ -3152,6 +3152,14 @@ namespace Akka.Event
         public void SetLogLevel(Akka.Event.LogLevel logLevel) { }
         public void StartStdoutLogger(Akka.Actor.Settings config) { }
     }
+    public abstract class MinimalLogger : Akka.Actor.MinimalActorRef
+    {
+        protected MinimalLogger() { }
+        public virtual Akka.Actor.ActorPath Path { get; }
+        public virtual Akka.Actor.IActorRefProvider Provider { get; }
+        protected abstract void Log(object message);
+        protected virtual void TellInternal(object message, Akka.Actor.IActorRef sender) { }
+    }
     public sealed class NoLogger : Akka.Event.ILoggingAdapter
     {
         public static readonly Akka.Event.ILoggingAdapter Instance;
@@ -3172,18 +3180,15 @@ namespace Akka.Event
         public void Warning(string format, params object[] args) { }
         public void Warning(System.Exception cause, string format, params object[] args) { }
     }
-    public class StandardOutLogger : Akka.Actor.MinimalActorRef
+    public class StandardOutLogger : Akka.Event.MinimalLogger
     {
         public StandardOutLogger() { }
         public static System.ConsoleColor DebugColor { get; set; }
         public static System.ConsoleColor ErrorColor { get; set; }
         public static System.ConsoleColor InfoColor { get; set; }
-        public override Akka.Actor.ActorPath Path { get; }
-        public override Akka.Actor.IActorRefProvider Provider { get; }
         public static bool UseColors { get; set; }
         public static System.ConsoleColor WarningColor { get; set; }
-        public static void PrintLogEvent(Akka.Event.LogEvent logEvent) { }
-        protected override void TellInternal(object message, Akka.Actor.IActorRef sender) { }
+        protected override void Log(object message) { }
     }
     public class Subscription<TSubscriber, TClassifier>
     {

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -851,12 +851,14 @@ namespace Akka.Actor
         }
         public delegate void TransitionHandler<TState, TData>(TState initialState, TState nextState);
     }
+    [System.ObsoleteAttribute("Use Akka.Actor.Status.Failure")]
     public class Failure
     {
         public Failure() { }
         public System.Exception Exception { get; set; }
         public System.DateTime Timestamp { get; set; }
     }
+    [System.ObsoleteAttribute("Use List of Akka.Actor.Status.Failure")]
     public class Failures
     {
         public Failures() { }
@@ -1718,16 +1720,20 @@ namespace Akka.Actor
     public abstract class Status
     {
         protected Status() { }
-        public class Failure : Akka.Actor.Status
+        public sealed class Failure : Akka.Actor.Status
         {
             public readonly System.Exception Cause;
+            public readonly object State;
             public Failure(System.Exception cause) { }
+            public Failure(System.Exception cause, object state) { }
             public override string ToString() { }
         }
-        public class Success : Akka.Actor.Status
+        public sealed class Success : Akka.Actor.Status
         {
+            public static readonly Akka.Actor.Status.Success Instance;
             public readonly object Status;
             public Success(object status) { }
+            public override string ToString() { }
         }
     }
     public class StoppingSupervisorStrategy : Akka.Actor.SupervisorStrategyConfigurator

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -862,12 +862,11 @@ namespace Akka.Actor
         public Failures() { }
         public System.Collections.Generic.List<Akka.Actor.Failure> Entries { get; }
     }
-    public class FutureActorRef<T> : Akka.Actor.MinimalActorRef
+    public sealed class FutureActorRef<T> : Akka.Actor.MinimalActorRef
     {
-        public FutureActorRef(System.Threading.Tasks.TaskCompletionSource<T> result, System.Action<System.Threading.Tasks.Task> unregister, Akka.Actor.ActorPath path) { }
+        public FutureActorRef(System.Threading.Tasks.TaskCompletionSource<T> result, Akka.Actor.ActorPath path, Akka.Actor.IActorRefProvider provider) { }
         public override Akka.Actor.ActorPath Path { get; }
         public override Akka.Actor.IActorRefProvider Provider { get; }
-        public override void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message) { }
         protected override void TellInternal(object message, Akka.Actor.IActorRef sender) { }
     }
     public class static Futures

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -3294,10 +3294,13 @@ namespace Akka.IO
         }
         public class Resolved : Akka.IO.Dns.Command
         {
+            public Resolved(string name, System.Exception ex) { }
             public Resolved(string name, System.Collections.Generic.IEnumerable<System.Net.IPAddress> ipv4, System.Collections.Generic.IEnumerable<System.Net.IPAddress> ipv6) { }
             public System.Net.IPAddress Addr { get; }
+            public System.Exception Exception { get; }
             public System.Collections.Generic.IEnumerable<System.Net.IPAddress> Ipv4 { get; }
             public System.Collections.Generic.IEnumerable<System.Net.IPAddress> Ipv6 { get; }
+            public bool IsSuccess { get; }
             public string Name { get; }
             public static Akka.IO.Dns.Resolved Create(string name, System.Collections.Generic.IEnumerable<System.Net.IPAddress> addresses) { }
         }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -93,7 +93,6 @@ namespace Akka.Actor
         public System.Collections.Generic.IEnumerable<Akka.Actor.IInternalActorRef> GetChildren() { }
         public static Akka.Actor.IActorRef GetCurrentSelfOrNoSender() { }
         public static Akka.Actor.IActorRef GetCurrentSenderOrNoSender() { }
-        [System.ObsoleteAttribute("Use TryGetSingleChild [0.7.1]")]
         public Akka.Actor.IInternalActorRef GetSingleChild(string name) { }
         public void Init(bool sendSupervise, Akka.Dispatch.MailboxType mailboxType) { }
         public Akka.Actor.Internal.ChildRestartStats InitChild(Akka.Actor.IInternalActorRef actor) { }
@@ -127,7 +126,6 @@ namespace Akka.Actor
         public void TerminatedQueuedFor(Akka.Actor.IActorRef subject, Akka.Util.Option<object> customMessage) { }
         public bool TryGetChildStatsByName(string name, out Akka.Actor.Internal.IChildStats child) { }
         protected bool TryGetChildStatsByRef(Akka.Actor.IActorRef actor, out Akka.Actor.Internal.ChildRestartStats child) { }
-        public bool TryGetSingleChild(string name, out Akka.Actor.IInternalActorRef child) { }
         public void UnbecomeStacked() { }
         protected void UnreserveChild(string name) { }
         public Akka.Actor.IActorRef Unwatch(Akka.Actor.IActorRef subject) { }
@@ -1081,7 +1079,7 @@ namespace Akka.Actor
         bool IsTerminated { get; }
         Akka.Actor.IInternalActorRef Parent { get; }
         Akka.Actor.IActorRefProvider Provider { get; }
-        Akka.Actor.IActorRef GetChild(System.Collections.Generic.IEnumerable<string> name);
+        Akka.Actor.IActorRef GetChild(System.Collections.Generic.IReadOnlyList<string> name);
         void Restart(System.Exception cause);
         void Resume(System.Exception causedByFailure = null);
         [System.ObsoleteAttribute("Use SendSystemMessage(message) [1.1.0]")]
@@ -1202,7 +1200,7 @@ namespace Akka.Actor
         public abstract bool IsTerminated { get; }
         public abstract Akka.Actor.IInternalActorRef Parent { get; }
         public abstract Akka.Actor.IActorRefProvider Provider { get; }
-        public abstract Akka.Actor.IActorRef GetChild(System.Collections.Generic.IEnumerable<string> name);
+        public abstract Akka.Actor.IActorRef GetChild(System.Collections.Generic.IReadOnlyList<string> name);
         public abstract void Restart(System.Exception cause);
         public abstract void Resume(System.Exception causedByFailure = null);
         [System.ObsoleteAttribute("Use SendSystemMessage(message) instead [1.1.0]")]
@@ -1245,7 +1243,7 @@ namespace Akka.Actor
         protected Akka.Actor.IInternalActorRef Supervisor { get; }
         protected Akka.Actor.ActorSystem System { get; }
         public override Akka.Actor.ICell Underlying { get; }
-        public override Akka.Actor.IActorRef GetChild(System.Collections.Generic.IEnumerable<string> name) { }
+        public override Akka.Actor.IActorRef GetChild(System.Collections.Generic.IReadOnlyList<string> name) { }
         public override Akka.Actor.IInternalActorRef GetSingleChild(string name) { }
         protected virtual Akka.Actor.ActorCell NewActorCell(Akka.Actor.Internal.ActorSystemImpl system, Akka.Actor.IInternalActorRef self, Akka.Actor.Props props, Akka.Dispatch.MessageDispatcher dispatcher, Akka.Actor.IInternalActorRef supervisor) { }
         public override void Restart(System.Exception cause) { }
@@ -1317,7 +1315,7 @@ namespace Akka.Actor
         [System.ObsoleteAttribute("Use Context.Watch and Receive<Terminated> [1.1.0]")]
         public override bool IsTerminated { get; }
         public override Akka.Actor.IInternalActorRef Parent { get; }
-        public override Akka.Actor.IActorRef GetChild(System.Collections.Generic.IEnumerable<string> name) { }
+        public override Akka.Actor.IActorRef GetChild(System.Collections.Generic.IReadOnlyList<string> name) { }
         public override void Restart(System.Exception cause) { }
         public override void Resume(System.Exception causedByFailure = null) { }
         public override void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message) { }
@@ -1533,7 +1531,7 @@ namespace Akka.Actor
         public override Akka.Actor.ActorPath Path { get; }
         public override Akka.Actor.IActorRefProvider Provider { get; }
         public override Akka.Actor.ICell Underlying { get; }
-        public override Akka.Actor.IActorRef GetChild(System.Collections.Generic.IEnumerable<string> name) { }
+        public override Akka.Actor.IActorRef GetChild(System.Collections.Generic.IReadOnlyList<string> name) { }
         public override Akka.Actor.IInternalActorRef GetSingleChild(string name) { }
         public Akka.Actor.RepointableActorRef Initialize(bool async) { }
         protected virtual Akka.Actor.ActorCell NewCell() { }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -4480,7 +4480,7 @@ namespace Akka.Routing
         public virtual Akka.Routing.Router RemoveRoutee(Akka.Routing.Routee routee) { }
         public Akka.Routing.Router RemoveRoutee(Akka.Actor.IActorRef routee) { }
         public Akka.Routing.Router RemoveRoutee(Akka.Actor.ActorSelection routee) { }
-        public void Route(object message, Akka.Actor.IActorRef sender) { }
+        public virtual void Route(object message, Akka.Actor.IActorRef sender) { }
         protected virtual void Send(Akka.Routing.Routee routee, object message, Akka.Actor.IActorRef sender) { }
         protected object UnWrap(object message) { }
         public virtual Akka.Routing.Router WithRoutees(params Akka.Routing.Routee[] routees) { }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveRemote.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveRemote.approved.txt
@@ -171,7 +171,7 @@ namespace Akka.Remote
         public override Akka.Actor.IInternalActorRef Parent { get; }
         public override Akka.Actor.ActorPath Path { get; }
         public override Akka.Actor.IActorRefProvider Provider { get; }
-        public override Akka.Actor.IActorRef GetChild(System.Collections.Generic.IEnumerable<string> name) { }
+        public override Akka.Actor.IActorRef GetChild(System.Collections.Generic.IReadOnlyList<string> name) { }
         public bool IsWatchIntercepted(Akka.Actor.IActorRef watchee, Akka.Actor.IActorRef watcher) { }
         public override void Restart(System.Exception cause) { }
         public override void Resume(System.Exception causedByFailure = null) { }

--- a/src/core/Akka.Persistence.TCK/Query/PersistenceIdsSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Query/PersistenceIdsSpec.cs
@@ -177,7 +177,7 @@ namespace Akka.Persistence.TCK.Query
             });
         }
 
-        [Fact]
+        [Fact(Skip = "Not a good test - tightly couples to private implementation details")]
         public virtual async Task ReadJournal_should_deallocate_AllPersistenceIds_publisher_when_the_last_subscriber_left()
         {
             if (AllocatesAllPersistenceIDsPublisher)

--- a/src/core/Akka.Persistence.Tests/ManyRecoveriesSpec.cs
+++ b/src/core/Akka.Persistence.Tests/ManyRecoveriesSpec.cs
@@ -60,7 +60,7 @@ namespace Akka.Persistence.Tests
         public ManyRecoveriesSpec() : base(ConfigurationFactory.ParseString(@"
             akka.actor.default-dispatcher.Type = ForkJoinDispatcher
             akka.actor.default-dispatcher.dedicated-thread-pool.thread-count = 5
-            akka.persistence.max-concurrent-recoveries = 3
+            akka.persistence.max-concurrent-recoveries = 1
             akka.persistence.journal.plugin = ""akka.persistence.journal.inmem""
 
             # snapshot store plugin is NOT defined, things should still work

--- a/src/core/Akka.Persistence.Tests/ReceivePersistentActorAsyncAwaitSpec.cs
+++ b/src/core/Akka.Persistence.Tests/ReceivePersistentActorAsyncAwaitSpec.cs
@@ -621,7 +621,7 @@ namespace Akka.Persistence.Tests
             ExpectNoMsg(1000);
         }
 
-        [Fact]
+        [Fact(Skip = "Racy - both Tasks run inside the same scheduler with max concurrency == 1")]
         public void Actor_PipeTo_should_not_be_delayed_by_async_receive()
         {
             var actor = Sys.ActorOf(Props.Create(() => new AsyncPipeToDelayActor("pid")));

--- a/src/core/Akka.Remote/RemoteActorRef.cs
+++ b/src/core/Akka.Remote/RemoteActorRef.cs
@@ -12,6 +12,7 @@ using Akka.Actor;
 using Akka.Annotations;
 using Akka.Dispatch.SysMsg;
 using Akka.Event;
+using Akka.Util.Internal.Collections;
 
 namespace Akka.Remote
 {
@@ -106,17 +107,16 @@ namespace Akka.Remote
         /// <param name="name">The name.</param>
         /// <returns>ActorRef.</returns>
         /// <exception cref="System.NotImplementedException">TBD</exception>
-        public override IActorRef GetChild(IEnumerable<string> name)
+        public override IActorRef GetChild(IReadOnlyList<string> name)
         {
-            var items = name.ToList();
-            switch (items.FirstOrDefault())
+            switch (name.FirstOrDefault())
             {
                 case null:
                     return this;
                 case "..":
-                    return Parent.GetChild(items.Skip(1));
+                    return Parent.GetChild(name.NoCopySlice(1));
                 default:
-                    return new RemoteActorRef(Remote, LocalAddressToUse, Path / items, ActorRefs.Nobody, Props.None, Deploy.None);
+                    return new RemoteActorRef(Remote, LocalAddressToUse, Path / name, ActorRefs.Nobody, Props.None, Deploy.None);
             }
         }
 

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -435,7 +435,7 @@ namespace Akka.Remote
 
         public bool HasAddress(Address address)
         {
-            return address == _local.RootPath.Address || address == RootPath.Address || Transport.Addresses.Any(a => a == address);
+            return address.Equals(_local.RootPath.Address) || address.Equals(RootPath.Address) || Transport.Addresses.Contains(address);
         }
 
         /// <summary>

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -490,7 +490,7 @@ namespace Akka.Remote
                 {
                     if (actorPath is RootActorPath)
                         return RootGuardian;
-                    return _local.ResolveActorRef(RootGuardian, actorPath.ElementsWithUid);
+                    return (IInternalActorRef)ResolveActorRef(path); // so we can use caching
                 }
 
                 return CreateRemoteRef(new RootActorPath(actorPath.Address) / actorPath.ElementsWithUid, localAddress);

--- a/src/core/Akka.Remote/RemoteSystemDaemon.cs
+++ b/src/core/Akka.Remote/RemoteSystemDaemon.cs
@@ -156,11 +156,9 @@ namespace Akka.Remote
                     }
                 }
 
-                var t = Rec(ImmutableList<string>.Empty);
-                var concatenatedChildNames = t.Item1;
-                var m = t.Item2;
+                var (concatenatedChildNames, m) = Rec(ImmutableList<string>.Empty);
 
-                var child = GetChild(concatenatedChildNames);
+                var child = GetChild(concatenatedChildNames.ToList());
                 if (child.IsNobody())
                 {
                     var emptyRef = new EmptyLocalActorRef(_system.Provider,
@@ -302,7 +300,7 @@ namespace Akka.Remote
         /// </summary>
         /// <param name="name">The name.</param>
         /// <returns>ActorRef.</returns>
-        public override IActorRef GetChild(IEnumerable<string> name)
+        public override IActorRef GetChild(IReadOnlyList<string> name)
         {
             var path = name.Join("/");
             var n = 0;
@@ -313,7 +311,7 @@ namespace Akka.Remote
                 {
                     if (uid != ActorCell.UndefinedUid && uid != child.Path.Uid)
                         return Nobody.Instance;
-                    return n == 0 ? child : child.GetChild(name.TakeRight(n));
+                    return n == 0 ? child : child.GetChild(name.TakeRight(n).ToList());
                 }
 
                 var last = path.LastIndexOf("/", StringComparison.Ordinal);

--- a/src/core/Akka.Remote/Serialization/ActorRefResolveCache.cs
+++ b/src/core/Akka.Remote/Serialization/ActorRefResolveCache.cs
@@ -65,7 +65,8 @@ namespace Akka.Remote.Serialization
 
         protected override bool IsCacheable(IActorRef v)
         {
-            return !(v is EmptyLocalActorRef);
+            // don't cache any FutureActorRefs, et al
+            return !(v is MinimalActorRef && !(v is FunctionRef));
         }
     }
 }

--- a/src/core/Akka.Streams.Tests/Dsl/GraphStageTimersSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphStageTimersSpec.cs
@@ -81,8 +81,8 @@ namespace Akka.Streams.Tests.Dsl
         {
             var driver = SetupIsolatedStage();
             driver.Tell(TestCancelTimer.Instance);
-            Within(TimeSpan.FromMilliseconds(500), () => ExpectMsg<TestCancelTimerAck>());
-            Within(TimeSpan.FromMilliseconds(300), TimeSpan.FromSeconds(1), () => ExpectMsg(new Tick(1)));
+            Within(TimeSpan.FromMilliseconds(5000), () => ExpectMsg<TestCancelTimerAck>());
+            Within(TimeSpan.FromMilliseconds(200), TimeSpan.FromSeconds(3000), () => ExpectMsg(new Tick(1)));
             ExpectNoMsg(TimeSpan.FromSeconds(1));
             driver.StopStage();
         }

--- a/src/core/Akka.Streams.Tests/Dsl/SubstreamSubscriptionTimeoutSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SubstreamSubscriptionTimeoutSpec.cs
@@ -39,7 +39,7 @@ namespace Akka.Streams.Tests.Dsl
             Materializer = ActorMaterializer.Create(Sys, settings);
         }
 
-        [Fact]
+        [Fact(Skip = "Racy")]
         public void GroupBy_and_SplitWhen_must_timeout_and_cancel_substream_publisher_when_no_one_subscribes_to_them_after_some_time()
         {
             this.AssertAllStagesStopped(() =>
@@ -57,6 +57,13 @@ namespace Akka.Streams.Tests.Dsl
                 publisherProbe.SendNext(1);
                 publisherProbe.SendNext(2);
                 publisherProbe.SendNext(3);
+                
+                /*
+                 * Why this spec is skipped: in the event that subscriber.ExpectSubscription() or (subscriber.ExpectNext()
+                 * + s1SubscriberProbe.ExpectSubscription()) exceeds 300ms, the next call to subscriber.ExpectNext will
+                 * fail. This test is too tightly fitted to the timeout duration to be reliable, although somewhat ironically
+                 * it does validate that the underlying cancellation does work! 
+                 */
 
                 var s1 = subscriber.ExpectNext().Item2;
                 // should not break normal usage

--- a/src/core/Akka.Streams.Tests/Dsl/UnfoldFlowSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/UnfoldFlowSpec.cs
@@ -134,7 +134,7 @@ namespace Akka.Streams.Tests.Dsl
                 snk.ExpectError().Should().Be(kill);
             }
 
-            [Fact(Skip ="Racy")]
+            [Fact]
             public void UnfoldFlow_should_increment_integers_and_handle_KillSwitch_and_fail_after_timeout_when_aborted()
             {
                 var t = _source.ToMaterialized(this.SinkProbe<int>(), Keep.Both).Run(Sys.Materializer());
@@ -147,7 +147,6 @@ namespace Akka.Streams.Tests.Dsl
                 pub.EnsureSubscription();
                 snk.EnsureSubscription();
                 sub.Cancel();
-                snk.ExpectNoMsg(_timeout.DivideBy(2));
                 snk.ExpectError();
             }
 
@@ -165,7 +164,6 @@ namespace Akka.Streams.Tests.Dsl
                 snk.EnsureSubscription();
                 sub.Cancel();
                 snk.Request(1);
-                snk.ExpectNoMsg(_timeout.DivideBy(2));
                 snk.ExpectError();
             }
 

--- a/src/core/Akka.Streams.Tests/Dsl/UnfoldFlowSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/UnfoldFlowSpec.cs
@@ -442,7 +442,6 @@ namespace Akka.Streams.Tests.Dsl
                 pub.EnsureSubscription();
                 snk.EnsureSubscription();
                 sub.Cancel();
-                snk.ExpectNoMsg(_timeout.DivideBy(2));
                 pub.SendComplete();
                 snk.ExpectComplete();
             }

--- a/src/core/Akka.Streams.Tests/Dsl/UnfoldFlowSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/UnfoldFlowSpec.cs
@@ -362,7 +362,6 @@ namespace Akka.Streams.Tests.Dsl
                 snk.EnsureSubscription();
                 sub.Cancel();
                 snk.Request(1);
-                snk.ExpectNoMsg(_timeout.DivideBy(2));
                 snk.ExpectError();
             }
 

--- a/src/core/Akka.TestKit/TestActorRefBase.cs
+++ b/src/core/Akka.TestKit/TestActorRefBase.cs
@@ -258,7 +258,7 @@ namespace Akka.TestKit
 
         bool IInternalActorRef.IsTerminated { get { return _internalRef.IsTerminated; } }
 
-        IActorRef IInternalActorRef.GetChild(IEnumerable<string> name)
+        IActorRef IInternalActorRef.GetChild(IReadOnlyList<string> name)
         {
             return _internalRef.GetChild(name);
         }

--- a/src/core/Akka.TestKit/TestProbe.cs
+++ b/src/core/Akka.TestKit/TestProbe.cs
@@ -124,7 +124,7 @@ namespace Akka.TestKit
 
         bool IInternalActorRef.IsTerminated { get { return ((IInternalActorRef)TestActor).IsTerminated; } }
 
-        IActorRef IInternalActorRef.GetChild(IEnumerable<string> name)
+        IActorRef IInternalActorRef.GetChild(IReadOnlyList<string> name)
         {
             return ((IInternalActorRef)TestActor).GetChild(name);
         }

--- a/src/core/Akka.Tests/Actor/ActorRefSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorRefSpec.cs
@@ -12,6 +12,7 @@ using Akka.Actor.Internal;
 using Akka.Serialization;
 using Akka.TestKit;
 using Akka.TestKit.TestActors;
+using Akka.Util;
 using Xunit;
 
 namespace Akka.Tests.Actor
@@ -290,11 +291,52 @@ namespace Akka.Tests.Actor
             ExpectNoMsg();
         }
 
+        [Fact]
+        public void An_ActorRef_Mock_should_be_like_Nobody()
+        {
+            var mock = new ActorRefMock();
+
+            mock.Tell("dummy");
+
+            mock.IsNobody().ShouldBeTrue();
+        }
+
         private void VerifyActorTermination(IActorRef actorRef)
         {
             var watcher = CreateTestProbe();
             watcher.Watch(actorRef);
             watcher.ExpectTerminated(actorRef, TimeSpan.FromSeconds(20));
+        }
+
+        private sealed class ActorRefMock : IActorRef
+        {
+            public ActorRefMock() { }
+
+            ActorPath IActorRef.Path => null;
+
+            int IComparable<IActorRef>.CompareTo(IActorRef other)
+            {
+                throw new NotSupportedException();
+            }
+
+            int IComparable.CompareTo(object obj)
+            {
+                throw new NotSupportedException();
+            }
+
+            bool IEquatable<IActorRef>.Equals(IActorRef other)
+            {
+                throw new NotSupportedException();
+            }
+
+            void ICanTell.Tell(object message, IActorRef sender)
+            {
+            }
+
+            ISurrogate ISurrogated.ToSurrogate(ActorSystem system)
+            {
+                throw new NotSupportedException();
+            }
         }
 
         private class NestingActor : ActorBase

--- a/src/core/Akka.Tests/Actor/AskSpec.cs
+++ b/src/core/Akka.Tests/Actor/AskSpec.cs
@@ -37,24 +37,6 @@ namespace Akka.Tests.Actor
                 {
                     Sender.Tell("answer");
                 }
-
-                if (message.Equals("delay"))
-                {
-                    Thread.Sleep(3000);
-                    Sender.Tell("answer");
-                }
-
-                if (message.Equals("many"))
-                {
-                    Sender.Tell("answer1");
-                    Sender.Tell("answer2");
-                    Sender.Tell("answer2");
-                }
-
-                if (message.Equals("invalid"))
-                {
-                    Sender.Tell(123);
-                }
             }
         }
 
@@ -130,52 +112,6 @@ namespace Akka.Tests.Actor
         {
             var actor = Sys.ActorOf<SomeActor>();
             await Assert.ThrowsAsync<AskTimeoutException>(async () => await actor.Ask<string>("timeout", TimeSpan.FromSeconds(3)));
-        }
-
-        [Fact]
-        public async Task Ask_should_put_timeout_answer_into_deadletter()
-        {
-            var actor = Sys.ActorOf<SomeActor>();            
-            
-            await EventFilter.DeadLetter<object>().ExpectOneAsync(TimeSpan.FromSeconds(5), async () => 
-            {
-                await Assert.ThrowsAsync<AskTimeoutException>(async () => await actor.Ask<string>("delay", TimeSpan.FromSeconds(1)));
-            });
-        }
-
-        [Fact]
-        public async Task Ask_should_put_too_many_answers_into_deadletter()
-        {
-            var actor = Sys.ActorOf<SomeActor>();
-
-            await EventFilter.DeadLetter<object>().ExpectAsync(2, async () =>
-            {
-                var result = await actor.Ask<string>("many", TimeSpan.FromSeconds(1));
-                result.ShouldBe("answer1");
-            });
-        }
-
-        [Fact]
-        public async Task Ask_should_not_put_canceled_answer_into_deadletter()
-        {
-            var actor = Sys.ActorOf<SomeActor>();
-
-            await EventFilter.DeadLetter<object>().ExpectAsync(0, async () =>
-            {
-                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1)))
-                    await Assert.ThrowsAsync<TaskCanceledException>(async () => await actor.Ask<string>("delay", Timeout.InfiniteTimeSpan, cts.Token));
-            });
-        }
-
-        [Fact]
-        public async Task Ask_should_put_invalid_answer_into_deadletter()
-        {
-            var actor = Sys.ActorOf<SomeActor>();
-
-            await EventFilter.DeadLetter<object>().ExpectOne(async () =>
-            {
-                await Assert.ThrowsAsync<ArgumentException>(async () => await actor.Ask<string>("invalid", TimeSpan.FromSeconds(1)));
-            });
         }
 
         [Fact]

--- a/src/core/Akka.Tests/Actor/AskSpec.cs
+++ b/src/core/Akka.Tests/Actor/AskSpec.cs
@@ -37,6 +37,24 @@ namespace Akka.Tests.Actor
                 {
                     Sender.Tell("answer");
                 }
+
+                if (message.Equals("delay"))
+                {
+                    Thread.Sleep(3000);
+                    Sender.Tell("answer");
+                }
+
+                if (message.Equals("many"))
+                {
+                    Sender.Tell("answer1");
+                    Sender.Tell("answer2");
+                    Sender.Tell("answer2");
+                }
+
+                if (message.Equals("invalid"))
+                {
+                    Sender.Tell(123);
+                }
             }
         }
 
@@ -112,6 +130,52 @@ namespace Akka.Tests.Actor
         {
             var actor = Sys.ActorOf<SomeActor>();
             await Assert.ThrowsAsync<AskTimeoutException>(async () => await actor.Ask<string>("timeout", TimeSpan.FromSeconds(3)));
+        }
+
+        [Fact]
+        public async Task Ask_should_put_timeout_answer_into_deadletter()
+        {
+            var actor = Sys.ActorOf<SomeActor>();            
+            
+            await EventFilter.DeadLetter<object>().ExpectOneAsync(TimeSpan.FromSeconds(5), async () => 
+            {
+                await Assert.ThrowsAsync<AskTimeoutException>(async () => await actor.Ask<string>("delay", TimeSpan.FromSeconds(1)));
+            });
+        }
+
+        [Fact]
+        public async Task Ask_should_put_too_many_answers_into_deadletter()
+        {
+            var actor = Sys.ActorOf<SomeActor>();
+
+            await EventFilter.DeadLetter<object>().ExpectAsync(2, async () =>
+            {
+                var result = await actor.Ask<string>("many", TimeSpan.FromSeconds(1));
+                result.ShouldBe("answer1");
+            });
+        }
+
+        [Fact]
+        public async Task Ask_should_not_put_canceled_answer_into_deadletter()
+        {
+            var actor = Sys.ActorOf<SomeActor>();
+
+            await EventFilter.DeadLetter<object>().ExpectAsync(0, async () =>
+            {
+                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1)))
+                    await Assert.ThrowsAsync<TaskCanceledException>(async () => await actor.Ask<string>("delay", Timeout.InfiniteTimeSpan, cts.Token));
+            });
+        }
+
+        [Fact]
+        public async Task Ask_should_put_invalid_answer_into_deadletter()
+        {
+            var actor = Sys.ActorOf<SomeActor>();
+
+            await EventFilter.DeadLetter<object>().ExpectOne(async () =>
+            {
+                await Assert.ThrowsAsync<ArgumentException>(async () => await actor.Ask<string>("invalid", TimeSpan.FromSeconds(1)));
+            });
         }
 
         [Fact]

--- a/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
+++ b/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
@@ -42,6 +42,8 @@ namespace Akka.Tests.Configuration
             settings.LoggerStartTimeout.Seconds.ShouldBe(5);
             settings.LogLevel.ShouldBe("INFO");
             settings.StdoutLogLevel.ShouldBe("WARNING");
+            settings.StdoutLogger.Should().NotBeNull();
+            settings.StdoutLogger.Should().BeOfType<StandardOutLogger>();
             settings.LogConfigOnStart.ShouldBeFalse();
             settings.LogDeadLetters.ShouldBe(10);
             settings.LogDeadLettersDuringShutdown.ShouldBeFalse();

--- a/src/core/Akka.Tests/Loggers/LoggerSpec.cs
+++ b/src/core/Akka.Tests/Loggers/LoggerSpec.cs
@@ -2,7 +2,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Actor.Internal;
+using Akka.Actor.Setup;
 using Akka.Configuration;
 using Akka.Event;
 using Akka.TestKit;
@@ -142,5 +145,26 @@ akka.stdout-loglevel = DEBUG");
             public FakeException(string message) : base(message)
             { }
         }
+        
+        [Fact]
+        public async Task ShouldBeAbleToReplaceStandardOutLoggerWithCustomMinimalLogger()
+        {
+            var config = ConfigurationFactory
+                .ParseString("akka.stdout-logger-class = \"Akka.Tests.Loggers.LoggerSpec+CustomLogger, Akka.Tests\"")
+                .WithFallback(ConfigurationFactory.Default()); 
+            
+            var system = ActorSystem.Create("MinimalLoggerTest", config);
+            system.Settings.StdoutLogger.Should().BeOfType<CustomLogger>();
+            await system.Terminate();
+        }
+        
+        public class CustomLogger : MinimalLogger
+        {
+            protected override void Log(object message)
+            {
+                Console.WriteLine(message);
+            }
+        }
+        
     }
 }

--- a/src/core/Akka.Tests/Loggers/ShutdownLoggerSpec.cs
+++ b/src/core/Akka.Tests/Loggers/ShutdownLoggerSpec.cs
@@ -1,0 +1,84 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="ShutdownLoggerSpec.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.TestKit;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Tests.Loggers
+{
+    public class ShutdownLoggerSpec: AkkaSpec
+    {
+        private static readonly Config Config = ConfigurationFactory.ParseString(@"
+akka.loglevel = OFF
+akka.stdout-loglevel = OFF
+akka.stdout-logger-class = ""Akka.Tests.Loggers.ThrowingLogger, Akka.Tests""");
+
+        public ShutdownLoggerSpec(ITestOutputHelper output) : base(Config, output)
+        {
+        }
+
+        [Fact(DisplayName = "StandardOutLogger should not be called on shutdown when stdout-loglevel is set to OFF")]
+        public async Task StandardOutLoggerShouldNotBeCalled()
+        {
+            Sys.Settings.StdoutLogger.Should().BeOfType<ThrowingLogger>();
+            
+            var probeRef = Sys.ActorOf(Props.Create(() => new LogProbe()));
+            probeRef.Tell(new InitializeLogger(Sys.EventStream));
+            var probe = await probeRef.Ask<LogProbe>("hey");
+            
+            await Sys.Terminate();
+
+            await Task.Delay(RemainingOrDefault);
+            if (probe.Events.Any(o => o is Error err && err.Cause is ShutdownLogException))
+                throw new Exception("Test failed, log should not be called after shutdown.");
+        }
+    }
+
+    internal class LogProbe : ReceiveActor
+    {
+        public List<LogEvent> Events { get; } = new List<LogEvent>();
+
+        public LogProbe()
+        {
+            Receive<string>(msg => Sender.Tell(this));
+            Receive<LogEvent>(Events.Add);
+            Receive<InitializeLogger>(e =>
+            {
+                e.LoggingBus.Subscribe(Self, typeof (LogEvent));
+                Sender.Tell(new LoggerInitialized());
+            });
+
+        }
+    }
+
+    internal class ShutdownLogException : Exception
+    {
+        public ShutdownLogException()
+        { }
+        
+        public ShutdownLogException(string msg) : base(msg)
+        { }
+    }
+
+    internal class ThrowingLogger : MinimalLogger
+    {
+        protected override void Log(object message)
+        {
+            throw new ShutdownLogException("This logger should never be called.");
+        }
+    }
+}

--- a/src/core/Akka/Actor/ActorBase.cs
+++ b/src/core/Akka/Actor/ActorBase.cs
@@ -20,8 +20,10 @@ namespace Akka.Actor
         /// <summary>
         /// Indicates the success of some operation which has been performed
         /// </summary>
-        public class Success : Status
+        public sealed class Success : Status
         {
+            public static readonly Success Instance = new Success(null);
+
             /// <summary>
             /// TBD
             /// </summary>
@@ -35,18 +37,26 @@ namespace Akka.Actor
             {
                 Status = status;
             }
+
+            public override string ToString() => Status is null ? "Success" : $"Success: {Status}";
         }
 
         /// <summary>
         /// Indicates the failure of some operation that was requested and includes an
         /// <see cref="Exception"/> describing the underlying cause of the problem.
         /// </summary>
-        public class Failure : Status
+        public sealed class Failure : Status
         {
             /// <summary>
             /// The cause of the failure
             /// </summary>
             public readonly Exception Cause;
+
+            /// <summary>
+            /// The source state of the failure
+            /// It can be used to send the command message back
+            /// </summary>
+            public readonly object State;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="Failure"/> class.
@@ -55,13 +65,23 @@ namespace Akka.Actor
             public Failure(Exception cause)
             {
                 Cause = cause;
+                State = null;
+            }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="Failure"/> class.
+            /// </summary>
+            /// <param name="cause">The cause of the failure</param>
+            /// <param name="state">The source state of the failure</param>
+            public Failure(Exception cause, object state)
+            {
+                Cause = cause;
+                State = state;
             }
 
             /// <inheritdoc/>
             public override string ToString()
-            {
-                return $"Failure: {Cause}";
-            }
+                => State is null ? $"Failure: {Cause}" : $"Failure[{State}]: {Cause}";
         }
     }
 

--- a/src/core/Akka/Actor/ActorCell.Children.cs
+++ b/src/core/Akka/Actor/ActorCell.Children.cs
@@ -353,58 +353,37 @@ namespace Akka.Actor
         /// </summary>
         /// <param name="name">N/A</param>
         /// <returns>N/A</returns>
-        [Obsolete("Use TryGetSingleChild [0.7.1]")]
         public IInternalActorRef GetSingleChild(string name)
-        {
-            IInternalActorRef child;
-            return TryGetSingleChild(name, out child) ? child : ActorRefs.Nobody;
-        }
-
-        
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="name">TBD</param>
-        /// <param name="child">TBD</param>
-        /// <returns>TBD</returns>
-        public bool TryGetSingleChild(string name, out IInternalActorRef child)
         {
             if (name.IndexOf('#') < 0)
             {
                 // optimization for the non-uid case
-                if (TryGetChildRestartStatsByName(name, out var stats))
+                if (ChildrenContainer.TryGetByName(name, out var stats) && stats is ChildRestartStats r)
                 {
-                    child = stats.Child;
-                    return true;
+                    return r.Child;
                 }
-                else if (TryGetFunctionRef(name, out var functionRef))
+
+                if (TryGetFunctionRef(name, out var functionRef))
                 {
-                    child = functionRef;
-                    return true;
+                    return functionRef;
                 }
             }
             else
             {
                 var (s, uid) = GetNameAndUid(name);
-                if (TryGetChildRestartStatsByName(s, out var stats))
+                if (TryGetChildRestartStatsByName(s, out var stats) && (uid == ActorCell.UndefinedUid || uid == stats.Uid))
                 {
-                    if (uid == ActorCell.UndefinedUid || uid == stats.Uid)
-                    {
-                        child = stats.Child;
-                        return true;
-                    }
+                    return stats.Child;
                 }
-                else if (TryGetFunctionRef(s, uid, out var functionRef))
+
+                if (TryGetFunctionRef(s, uid, out var functionRef))
                 {
-                    child = functionRef;
-                    return true;
+                    return functionRef;
                 }
             }
-            child = ActorRefs.Nobody;
-            return false;
+            return ActorRefs.Nobody;
         }
-
+        
         /// <summary>
         /// TBD
         /// </summary>

--- a/src/core/Akka/Actor/ActorCell.Children.cs
+++ b/src/core/Akka/Actor/ActorCell.Children.cs
@@ -265,8 +265,7 @@ namespace Akka.Actor
         {
             get
             {
-                var terminating = ChildrenContainer as TerminatingChildrenContainer;
-                return terminating != null && terminating.Reason is SuspendReason.IWaitingForChildren;
+                return ChildrenContainer is TerminatingChildrenContainer terminating && terminating.Reason is SuspendReason.IWaitingForChildren;
             }
         }
 
@@ -325,8 +324,7 @@ namespace Akka.Actor
         /// </summary>
         private bool TryGetChildRestartStatsByName(string name, out ChildRestartStats child)
         {
-            IChildStats stats;
-            if (ChildrenContainer.TryGetByName(name, out stats))
+            if (ChildrenContainer.TryGetByName(name, out var stats))
             {
                 child = stats as ChildRestartStats;
                 if (child != null)
@@ -361,6 +359,8 @@ namespace Akka.Actor
             IInternalActorRef child;
             return TryGetSingleChild(name, out child) ? child : ActorRefs.Nobody;
         }
+
+        
 
         /// <summary>
         /// TBD

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -236,7 +236,7 @@ namespace Akka.Actor
         [Obsolete("Use TryGetChildStatsByName [0.7.1]", true)]
         public IInternalActorRef GetChildByName(string name)   //TODO: Should return  Option[ChildStats]
         {
-            return TryGetSingleChild(name, out var child) ? child : ActorRefs.Nobody;
+            return GetSingleChild(name);
         }
 
         IActorRef IActorContext.Child(string name)

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -241,7 +241,10 @@ namespace Akka.Actor
 
         IActorRef IActorContext.Child(string name)
         {
-            return TryGetSingleChild(name, out var child) ? child : ActorRefs.Nobody;
+            if (TryGetChildStatsByName(name, out var child) && child is ChildRestartStats s)
+                return s.Child;
+            
+            return ActorRefs.Nobody;
         }
 
         /// <summary>

--- a/src/core/Akka/Actor/ActorRef.Extensions.cs
+++ b/src/core/Akka/Actor/ActorRef.Extensions.cs
@@ -23,7 +23,8 @@ namespace Akka.Actor
         /// <returns><c>true</c> if the <paramref name="actorRef"/> is valid; otherwise <c>false</c>.</returns>
         public static bool IsNobody(this IActorRef actorRef)
         {
-            return actorRef == null || actorRef is Nobody || actorRef is DeadLetterActorRef || (actorRef.Path.Uid == 0 && actorRef.Path.Name == "deadLetters");
+            return actorRef is null || actorRef is Nobody || actorRef is DeadLetterActorRef 
+                || actorRef.Path is null || (actorRef.Path.Uid == 0 && actorRef.Path.Name == "deadLetters");
         }
 
         /// <summary>

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -69,51 +69,34 @@ namespace Akka.Actor
     ///
     /// ActorRef implementation used for one-off tasks.
     /// </summary>
-    public class FutureActorRef<T> : MinimalActorRef
+    public sealed class FutureActorRef<T> : MinimalActorRef
     {
         private readonly TaskCompletionSource<T> _result;
         private readonly ActorPath _path;
+        private readonly IActorRefProvider _provider;
 
         /// <summary>
         /// INTERNAL API
         /// </summary>
         /// <param name="result">TBD</param>
-        /// <param name="unregister">TBD</param>
         /// <param name="path">TBD</param>
-        public FutureActorRef(TaskCompletionSource<T> result, Action<Task> unregister, ActorPath path)
+        /// <param name="provider">TBD</param>
+        public FutureActorRef(TaskCompletionSource<T> result, ActorPath path, IActorRefProvider provider)
         {
-            if (ActorCell.Current != null)
-            {
-                _actorAwaitingResultSender = ActorCell.Current.Sender;
-            }
             _result = result;
             _path = path;
-
-            _result.Task.ContinueWith(unregister);
+            _provider = provider;
         }
 
         /// <summary>
         /// TBD
         /// </summary>
-        public override ActorPath Path
-        {
-            get { return _path; }
-        }
+        public override ActorPath Path => _path;
 
         /// <summary>
         /// TBD
         /// </summary>
-        /// <exception cref="System.NotImplementedException">TBD</exception>
-        public override IActorRefProvider Provider
-        {
-            get { throw new NotImplementedException(); }
-        }
-
-
-        private const int INITIATED = 0;
-        private const int COMPLETED = 1;
-        private int status = INITIATED;
-        private readonly IActorRef _actorAwaitingResultSender;
+        public override IActorRefProvider Provider => _provider;
 
         /// <summary>
         /// TBD
@@ -122,43 +105,36 @@ namespace Akka.Actor
         /// <param name="sender">TBD</param>
         protected override void TellInternal(object message, IActorRef sender)
         {
+            var handled = false;
 
-            if (message is ISystemMessage sysM) //we have special handling for system messages
+            switch (message)
             {
-                SendSystemMessage(sysM);
+                case ISystemMessage msg:
+                    handled = _result.TrySetException(new InvalidOperationException($"system message of type '{msg.GetType().Name}' is invalid for {nameof(FutureActorRef<T>)}"));
+                    break;
+                case T t:
+                    handled = _result.TrySetResult(t);
+                    break;
+                case null:
+                    handled = _result.TrySetResult(default);
+                    break;
+                case Status.Failure f:
+                    handled = _result.TrySetException(f.Cause
+                        ?? new TaskCanceledException("Task cancelled by actor via Failure message."));
+                    break;
+                case Failure f:
+                    handled = _result.TrySetException(f.Exception
+                        ?? new TaskCanceledException("Task cancelled by actor via Failure message."));
+                    break;
+                default:
+                    _ = _result.TrySetException(new ArgumentException(
+                        $"Received message of type [{message.GetType()}] - Ask expected message of type [{typeof(T)}]"));
+                    break;
             }
-            else
-            {
-                if (Interlocked.Exchange(ref status, COMPLETED) == INITIATED)
-                {
-                    if (message is T t)
-                    {
-                        _result.TrySetResult(t);
-                    }
-                    else if (message == null) //special case: https://github.com/akkadotnet/akka.net/issues/5204
-                    {
-                        _result.TrySetResult(default);
-                    }
-                    else if (message is Failure f)
-                    {
-                        _result.TrySetException(f.Exception ?? new TaskCanceledException("Task cancelled by actor via Failure message."));
-                    }
-                    else
-                    {
-                        _result.TrySetException(new ArgumentException(
-                            $"Received message of type [{message.GetType()}] - Ask expected message of type [{typeof(T)}]"));
-                    }
-                }
-            }
-        }
-        
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="message">TBD</param>
-        public override void SendSystemMessage(ISystemMessage message)
-        {
-            base.SendSystemMessage(message);
+
+            //ignore canceled ask and put unhandled answers into deadletter
+            if (!handled && !_result.Task.IsCanceled)
+                _provider.DeadLetters.Tell(message ?? default(T), this);            
         }
     }
 
@@ -727,16 +703,16 @@ namespace Akka.Actor
         private IEnumerable<IActorRef> SelfAndChildren()
         {
             yield return this;
-            foreach(var child in Children.SelectMany(x =>
-            {
-                switch(x)
-                {
-                    case ActorRefWithCell cell:
-                        return cell.SelfAndChildren();
-                    default:
-                        return new[] { x };
-                }
-            }))
+            foreach (var child in Children.SelectMany(x =>
+             {
+                 switch (x)
+                 {
+                     case ActorRefWithCell cell:
+                         return cell.SelfAndChildren();
+                     default:
+                         return new[] { x };
+                 }
+             }))
             {
                 yield return child;
             }

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -69,34 +69,51 @@ namespace Akka.Actor
     ///
     /// ActorRef implementation used for one-off tasks.
     /// </summary>
-    public sealed class FutureActorRef<T> : MinimalActorRef
+    public class FutureActorRef<T> : MinimalActorRef
     {
         private readonly TaskCompletionSource<T> _result;
         private readonly ActorPath _path;
-        private readonly IActorRefProvider _provider;
 
         /// <summary>
         /// INTERNAL API
         /// </summary>
         /// <param name="result">TBD</param>
+        /// <param name="unregister">TBD</param>
         /// <param name="path">TBD</param>
-        /// <param name="provider">TBD</param>
-        public FutureActorRef(TaskCompletionSource<T> result, ActorPath path, IActorRefProvider provider)
+        public FutureActorRef(TaskCompletionSource<T> result, Action<Task> unregister, ActorPath path)
         {
+            if (ActorCell.Current != null)
+            {
+                _actorAwaitingResultSender = ActorCell.Current.Sender;
+            }
             _result = result;
             _path = path;
-            _provider = provider;
+
+            _result.Task.ContinueWith(unregister);
         }
 
         /// <summary>
         /// TBD
         /// </summary>
-        public override ActorPath Path => _path;
+        public override ActorPath Path
+        {
+            get { return _path; }
+        }
 
         /// <summary>
         /// TBD
         /// </summary>
-        public override IActorRefProvider Provider => _provider;
+        /// <exception cref="System.NotImplementedException">TBD</exception>
+        public override IActorRefProvider Provider
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+
+        private const int INITIATED = 0;
+        private const int COMPLETED = 1;
+        private int status = INITIATED;
+        private readonly IActorRef _actorAwaitingResultSender;
 
         /// <summary>
         /// TBD
@@ -105,37 +122,43 @@ namespace Akka.Actor
         /// <param name="sender">TBD</param>
         protected override void TellInternal(object message, IActorRef sender)
         {
-            var handled = false;
 
-            switch (message)
+            if (message is ISystemMessage sysM) //we have special handling for system messages
             {
-                case ISystemMessage sysM:
-                    SendSystemMessage(sysM); //we have special handling for system messages
-                    handled = true;
-                    break;
-                case T t:
-                    handled = _result.TrySetResult(t);
-                    break;
-                case null:
-                    handled = _result.TrySetResult(default);
-                    break;
-                case Status.Failure f:
-                    handled = _result.TrySetException(f.Cause
-                        ?? new TaskCanceledException("Task cancelled by actor via Failure message."));
-                    break;
-                case Failure f:
-                    handled = _result.TrySetException(f.Exception
-                        ?? new TaskCanceledException("Task cancelled by actor via Failure message."));
-                    break;
-                default:
-                    _ = _result.TrySetException(new ArgumentException(
-                        $"Received message of type [{message.GetType()}] - Ask expected message of type [{typeof(T)}]"));
-                    break;
+                SendSystemMessage(sysM);
             }
-
-            //ignore canceled ask and put unhandled answers into deadletter
-            if (!handled && !_result.Task.IsCanceled)
-                _provider.DeadLetters.Tell(message ?? default(T), this);            
+            else
+            {
+                if (Interlocked.Exchange(ref status, COMPLETED) == INITIATED)
+                {
+                    if (message is T t)
+                    {
+                        _result.TrySetResult(t);
+                    }
+                    else if (message == null) //special case: https://github.com/akkadotnet/akka.net/issues/5204
+                    {
+                        _result.TrySetResult(default);
+                    }
+                    else if (message is Failure f)
+                    {
+                        _result.TrySetException(f.Exception ?? new TaskCanceledException("Task cancelled by actor via Failure message."));
+                    }
+                    else
+                    {
+                        _result.TrySetException(new ArgumentException(
+                            $"Received message of type [{message.GetType()}] - Ask expected message of type [{typeof(T)}]"));
+                    }
+                }
+            }
+        }
+        
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="message">TBD</param>
+        public override void SendSystemMessage(ISystemMessage message)
+        {
+            base.SendSystemMessage(message);
         }
     }
 
@@ -704,16 +727,16 @@ namespace Akka.Actor
         private IEnumerable<IActorRef> SelfAndChildren()
         {
             yield return this;
-            foreach (var child in Children.SelectMany(x =>
-             {
-                 switch (x)
-                 {
-                     case ActorRefWithCell cell:
-                         return cell.SelfAndChildren();
-                     default:
-                         return new[] { x };
-                 }
-             }))
+            foreach(var child in Children.SelectMany(x =>
+            {
+                switch(x)
+                {
+                    case ActorRefWithCell cell:
+                        return cell.SelfAndChildren();
+                    default:
+                        return new[] { x };
+                }
+            }))
             {
                 yield return child;
             }

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -69,51 +69,34 @@ namespace Akka.Actor
     ///
     /// ActorRef implementation used for one-off tasks.
     /// </summary>
-    public class FutureActorRef<T> : MinimalActorRef
+    public sealed class FutureActorRef<T> : MinimalActorRef
     {
         private readonly TaskCompletionSource<T> _result;
         private readonly ActorPath _path;
+        private readonly IActorRefProvider _provider;
 
         /// <summary>
         /// INTERNAL API
         /// </summary>
         /// <param name="result">TBD</param>
-        /// <param name="unregister">TBD</param>
         /// <param name="path">TBD</param>
-        public FutureActorRef(TaskCompletionSource<T> result, Action<Task> unregister, ActorPath path)
+        /// <param name="provider">TBD</param>
+        public FutureActorRef(TaskCompletionSource<T> result, ActorPath path, IActorRefProvider provider)
         {
-            if (ActorCell.Current != null)
-            {
-                _actorAwaitingResultSender = ActorCell.Current.Sender;
-            }
             _result = result;
             _path = path;
-
-            _result.Task.ContinueWith(unregister);
+            _provider = provider;
         }
 
         /// <summary>
         /// TBD
         /// </summary>
-        public override ActorPath Path
-        {
-            get { return _path; }
-        }
+        public override ActorPath Path => _path;
 
         /// <summary>
         /// TBD
         /// </summary>
-        /// <exception cref="System.NotImplementedException">TBD</exception>
-        public override IActorRefProvider Provider
-        {
-            get { throw new NotImplementedException(); }
-        }
-
-
-        private const int INITIATED = 0;
-        private const int COMPLETED = 1;
-        private int status = INITIATED;
-        private readonly IActorRef _actorAwaitingResultSender;
+        public override IActorRefProvider Provider => _provider;
 
         /// <summary>
         /// TBD
@@ -122,43 +105,37 @@ namespace Akka.Actor
         /// <param name="sender">TBD</param>
         protected override void TellInternal(object message, IActorRef sender)
         {
+            var handled = false;
 
-            if (message is ISystemMessage sysM) //we have special handling for system messages
+            switch (message)
             {
-                SendSystemMessage(sysM);
+                case ISystemMessage sysM:
+                    SendSystemMessage(sysM); //we have special handling for system messages
+                    handled = true;
+                    break;
+                case T t:
+                    handled = _result.TrySetResult(t);
+                    break;
+                case null:
+                    handled = _result.TrySetResult(default);
+                    break;
+                case Status.Failure f:
+                    handled = _result.TrySetException(f.Cause
+                        ?? new TaskCanceledException("Task cancelled by actor via Failure message."));
+                    break;
+                case Failure f:
+                    handled = _result.TrySetException(f.Exception
+                        ?? new TaskCanceledException("Task cancelled by actor via Failure message."));
+                    break;
+                default:
+                    _ = _result.TrySetException(new ArgumentException(
+                        $"Received message of type [{message.GetType()}] - Ask expected message of type [{typeof(T)}]"));
+                    break;
             }
-            else
-            {
-                if (Interlocked.Exchange(ref status, COMPLETED) == INITIATED)
-                {
-                    if (message is T t)
-                    {
-                        _result.TrySetResult(t);
-                    }
-                    else if (message == null) //special case: https://github.com/akkadotnet/akka.net/issues/5204
-                    {
-                        _result.TrySetResult(default);
-                    }
-                    else if (message is Failure f)
-                    {
-                        _result.TrySetException(f.Exception ?? new TaskCanceledException("Task cancelled by actor via Failure message."));
-                    }
-                    else
-                    {
-                        _result.TrySetException(new ArgumentException(
-                            $"Received message of type [{message.GetType()}] - Ask expected message of type [{typeof(T)}]"));
-                    }
-                }
-            }
-        }
-        
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="message">TBD</param>
-        public override void SendSystemMessage(ISystemMessage message)
-        {
-            base.SendSystemMessage(message);
+
+            //ignore canceled ask and put unhandled answers into deadletter
+            if (!handled && !_result.Task.IsCanceled)
+                _provider.DeadLetters.Tell(message ?? default(T), this);            
         }
     }
 
@@ -727,16 +704,16 @@ namespace Akka.Actor
         private IEnumerable<IActorRef> SelfAndChildren()
         {
             yield return this;
-            foreach(var child in Children.SelectMany(x =>
-            {
-                switch(x)
-                {
-                    case ActorRefWithCell cell:
-                        return cell.SelfAndChildren();
-                    default:
-                        return new[] { x };
-                }
-            }))
+            foreach (var child in Children.SelectMany(x =>
+             {
+                 switch (x)
+                 {
+                     case ActorRefWithCell cell:
+                         return cell.SelfAndChildren();
+                     default:
+                         return new[] { x };
+                 }
+             }))
             {
                 yield return child;
             }

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -19,6 +19,7 @@ using Akka.Dispatch.SysMsg;
 using Akka.Event;
 using Akka.Util;
 using Akka.Util.Internal;
+using Akka.Util.Internal.Collections;
 
 namespace Akka.Actor
 {
@@ -422,7 +423,7 @@ namespace Akka.Actor
         /// </summary>
         /// <param name="name">The path elements.</param>
         /// <returns>The <see cref="IActorRef"/>, or if the requested path does not exist, returns <see cref="Nobody"/>.</returns>
-        IActorRef GetChild(IEnumerable<string> name);
+        IActorRef GetChild(IReadOnlyList<string> name);
 
         /// <summary>
         /// Resumes an actor if it has been suspended.
@@ -481,7 +482,7 @@ namespace Akka.Actor
         public abstract IActorRefProvider Provider { get; }
 
         /// <inheritdoc cref="IInternalActorRef"/>
-        public abstract IActorRef GetChild(IEnumerable<string> name);    //TODO: Refactor this to use an IEnumerator instead as this will be faster instead of enumerating multiple times over name, as the implementations currently do.
+        public abstract IActorRef GetChild(IReadOnlyList<string> name);    //TODO: Refactor this to use an IEnumerator instead as this will be faster instead of enumerating multiple times over name, as the implementations currently do.
 
         /// <inheritdoc cref="IInternalActorRef"/>
         public abstract void Resume(Exception causedByFailure = null);
@@ -530,9 +531,9 @@ namespace Akka.Actor
         }
 
         /// <inheritdoc cref="InternalActorRefBase"/>
-        public override IActorRef GetChild(IEnumerable<string> name)
+        public override IActorRef GetChild(IReadOnlyList<string> name)
         {
-            if (name.All(string.IsNullOrEmpty))
+            if (name.All(x => string.IsNullOrEmpty(x)))
                 return this;
             return ActorRefs.Nobody;
         }
@@ -874,20 +875,17 @@ override def getChild(name: Iterator[String]): InternalActorRef = {
         /// </summary>
         /// <param name="name">TBD</param>
         /// <returns>TBD</returns>
-        public override IActorRef GetChild(IEnumerable<string> name)
+        public override IActorRef GetChild(IReadOnlyList<string> name)
         {
             //Using enumerator to avoid multiple enumerations of name.
-            var enumerator = name.GetEnumerator();
-            if (!enumerator.MoveNext())
-            {
-                //name was empty
+            if (name.Count == 0)
                 return this;
-            }
-            var firstName = enumerator.Current;
+  
+            var firstName = name[0];
             if (string.IsNullOrEmpty(firstName))
                 return this;
             if (_children.TryGetValue(firstName, out var child))
-                return child.GetChild(new Enumerable<string>(enumerator));
+                return child.GetChild(name.NoCopySlice(1));
             return ActorRefs.Nobody;
         }
 

--- a/src/core/Akka/Actor/ActorRefProvider.cs
+++ b/src/core/Akka/Actor/ActorRefProvider.cs
@@ -462,7 +462,7 @@ namespace Akka.Actor
         /// <param name="actorRef">TBD</param>
         /// <param name="pathElements">TBD</param>
         /// <returns>TBD</returns>
-        internal IInternalActorRef ResolveActorRef(IInternalActorRef actorRef, IReadOnlyCollection<string> pathElements)
+        internal IInternalActorRef ResolveActorRef(IInternalActorRef actorRef, IReadOnlyList<string> pathElements)
         {
             if (pathElements.Count == 0)
             {

--- a/src/core/Akka/Actor/Address.cs
+++ b/src/core/Akka/Actor/Address.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using System.Xml.Xsl;
 using Akka.Util;
 
 namespace Akka.Actor
@@ -154,7 +155,7 @@ namespace Akka.Actor
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => obj is Address && Equals((Address)obj);
+        public override bool Equals(object obj) => Equals(obj as Address);
 
         /// <inheritdoc/>
         public override int GetHashCode()
@@ -245,7 +246,7 @@ namespace Akka.Actor
         /// <returns><c>true</c> if both addresses are equal; otherwise <c>false</c></returns>
         public static bool operator ==(Address left, Address right)
         {
-            return Equals(left, right);
+            return left?.Equals(right) ?? ReferenceEquals(right, null);
         }
 
         /// <summary>
@@ -256,7 +257,7 @@ namespace Akka.Actor
         /// <returns><c>true</c> if both addresses are not equal; otherwise <c>false</c></returns>
         public static bool operator !=(Address left, Address right)
         {
-            return !Equals(left, right);
+            return !(left == right);
         }
 
         /// <summary>

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -149,19 +149,16 @@ namespace Akka.Actor
             }
 
             //create a new tempcontainer path
-            var path = provider.TempPath();
+            ActorPath path = provider.TempPath();
 
-            var future = new FutureActorRef<T>(result, path, provider);
-
-            //The future actor needs to be unregistered in the temp container
-            _ = result.Task.ContinueWith(t =>
+            var future = new FutureActorRef<T>(result, t =>
             {
                 provider.UnregisterTempActor(path);
 
                 ctr1?.Dispose();
                 ctr2?.Dispose();
                 timeoutCancellation?.Dispose();
-            }, TaskContinuationOptions.ExecuteSynchronously);
+            }, path);
 
             //The future actor needs to be registered in the temp container
             provider.RegisterTempActor(future, path);

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -149,16 +149,19 @@ namespace Akka.Actor
             }
 
             //create a new tempcontainer path
-            ActorPath path = provider.TempPath();
+            var path = provider.TempPath();
 
-            var future = new FutureActorRef<T>(result, t =>
+            var future = new FutureActorRef<T>(result, path, provider);
+
+            //The future actor needs to be unregistered in the temp container
+            _ = result.Task.ContinueWith(t =>
             {
                 provider.UnregisterTempActor(path);
 
                 ctr1?.Dispose();
                 ctr2?.Dispose();
                 timeoutCancellation?.Dispose();
-            }, path);
+            }, TaskContinuationOptions.ExecuteSynchronously);
 
             //The future actor needs to be registered in the temp container
             provider.RegisterTempActor(future, path);

--- a/src/core/Akka/Actor/RepointableActorRef.cs
+++ b/src/core/Akka/Actor/RepointableActorRef.cs
@@ -15,6 +15,7 @@ using Akka.Dispatch;
 using Akka.Dispatch.SysMsg;
 using Akka.Event;
 using Akka.Pattern;
+using Akka.Util.Internal.Collections;
 
 namespace Akka.Actor
 {
@@ -278,17 +279,16 @@ namespace Akka.Actor
         /// </summary>
         /// <param name="name">TBD</param>
         /// <returns>TBD</returns>
-        public override IActorRef GetChild(IEnumerable<string> name)
+        public override IActorRef GetChild(IReadOnlyList<string> name)
         {
-            var current = (IActorRef)this;
-            if (!name.Any()) return current;
+            if (name.Count == 0) return this;
 
-            var next = name.FirstOrDefault() ?? "";
+            var next = name[0];
 
             switch (next)
             {
                 case "..":
-                    return Parent.GetChild(name.Skip(1));
+                    return Parent.GetChild(name.NoCopySlice(1));
                 case "":
                     return ActorRefs.Nobody;
                 default:
@@ -297,8 +297,8 @@ namespace Akka.Actor
                     {
                         if (stats is ChildRestartStats crs && (uid == ActorCell.UndefinedUid || uid == crs.Uid))
                         {
-                            if (name.Skip(1).Any())
-                                return crs.Child.GetChild(name.Skip(1));
+                            if (name.Count > 1)
+                                return crs.Child.GetChild(name.NoCopySlice(1));
                             else
                                 return crs.Child;
                         }

--- a/src/core/Akka/Actor/SupervisorStrategy.cs
+++ b/src/core/Akka/Actor/SupervisorStrategy.cs
@@ -750,6 +750,7 @@ namespace Akka.Actor
     /// <summary>
     /// Collection of failures, used to keep track of how many times a given actor has failed.
     /// </summary>
+    [Obsolete("Use List of Akka.Actor.Status.Failure")]
     public class Failures
     {
         /// <summary>
@@ -769,6 +770,7 @@ namespace Akka.Actor
     /// <summary>
     ///     Represents a single failure.
     /// </summary>
+    [Obsolete("Use Akka.Actor.Status.Failure")]
     public class Failure
     {
         /// <summary>

--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -42,6 +42,10 @@ akka {
   # Log level for the very basic logger activated during AkkaApplication startup
   # Options: OFF, ERROR, WARNING, INFO, DEBUG
   stdout-loglevel = "WARNING"
+  
+  # Fully qualified class name (FQCN) of the very basic logger used on startup and shutdown.
+  # You can substitute the logger by supplying an FQCN to a custom class that implements Akka.Event.MinimumLogger
+  stdout-logger-class = "Akka.Event.StandardOutLogger"
 
   # Log the complete configuration at INFO level when the actor system is started.
   # This is useful when you are uncertain of what configuration is used.

--- a/src/core/Akka/Event/LoggerInitialized.cs
+++ b/src/core/Akka/Event/LoggerInitialized.cs
@@ -12,7 +12,7 @@ namespace Akka.Event
     /// <summary>
     /// This class represents a message used to notify subscribers that a logger has been initialized.
     /// </summary>
-    public class LoggerInitialized : INoSerializationVerificationNeeded
+    public class LoggerInitialized : INoSerializationVerificationNeeded, IDeadLetterSuppression
     {
     }
 }

--- a/src/core/Akka/Event/LoggerMailbox.cs
+++ b/src/core/Akka/Event/LoggerMailbox.cs
@@ -82,15 +82,15 @@ namespace Akka.Event
         {
             if (HasMessages)
             {
-                Envelope envelope;
-
+                var logger = _system.Settings.StdoutLogger;
+                
                 // Drain all remaining messages to the StandardOutLogger.
                 // CleanUp is called after switching out the mailbox, which is why
                 // this kind of look works without a limit.
-                while (TryDequeue(out envelope))
+                while (TryDequeue(out var envelope))
                 {
                     // Logging.StandardOutLogger is a MinimalActorRef, i.e. not a "real" actor
-                    Logging.StandardOutLogger.Tell(envelope.Message, envelope.Sender);
+                    logger.Tell(envelope.Message, envelope.Sender);
                 }
             }
             MessageQueue.CleanUp(owner, deadletters);

--- a/src/core/Akka/Event/Logging.cs
+++ b/src/core/Akka/Event/Logging.cs
@@ -148,11 +148,6 @@ namespace Akka.Event
         private const LogLevel OffLogLevel = (LogLevel) int.MaxValue;
 
         /// <summary>
-        /// Returns a singleton instance of the standard out logger.
-        /// </summary>
-        public static readonly StandardOutLogger StandardOutLogger = new StandardOutLogger();
-
-        /// <summary>
         /// Retrieves the log event class associated with the specified log level.
         /// </summary>
         /// <param name="logLevel">The log level used to lookup the associated class.</param>

--- a/src/core/Akka/Routing/Router.cs
+++ b/src/core/Akka/Routing/Router.cs
@@ -327,7 +327,7 @@ namespace Akka.Routing
         /// </summary>
         /// <param name="message">The message to send.</param>
         /// <param name="sender">The sender of this message - which will be propagated to the routee.</param>
-        public void Route(object message, IActorRef sender)
+        public virtual void Route(object message, IActorRef sender)
         {
             if (message is Broadcast)
             {

--- a/src/core/Akka/Util/Internal/Collections/ListSlice.cs
+++ b/src/core/Akka/Util/Internal/Collections/ListSlice.cs
@@ -1,0 +1,182 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="ListSlice.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Akka.Util.Internal.Collections
+{
+    internal static class SliceExtensions
+    {
+        public static IReadOnlyList<T> NoCopySlice<T>(this IReadOnlyList<T> list, int offset)
+        {
+            switch (list)
+            {
+                // slice of a slice
+                case ListSlice<T> slice:
+                {
+                    return new ListSlice<T>(slice.Array, slice.Offset + offset, slice.Array.Count - slice.Offset - offset);
+                }
+                default:
+                {
+                    return new ListSlice<T>(list, offset, list.Count - offset);
+                }
+            }
+        }
+    }
+    
+    /// <summary>
+    /// <see cref="ArraySegment{T}"/> but for <see cref="IReadOnlyList{T}"/>
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal struct ListSlice<T> : IList<T>, IReadOnlyList<T>
+    {
+        private sealed class SliceEnumerator : IEnumerator<T>
+        {
+            private readonly IReadOnlyList<T> _array;
+            private readonly int _start;
+            private readonly int _end;
+            private int _current;
+
+            public SliceEnumerator(ListSlice<T> array)
+            {
+                _array = array._array;
+                _start = array.Offset;
+                _end = _start + array.Count;
+                _current = _start - 1;
+            }
+
+            public bool MoveNext()
+            {
+                if (_current < _end)
+                {
+                    _current++;
+                    return (_current < _end);
+                }
+                return false;
+            }
+
+            public void Reset()
+            {
+                _current = _start - 1;
+            }
+
+            public T Current
+            {
+                get
+                {
+                    if (_current < _start) throw new InvalidOperationException("Enumeration not started.");
+                    if (_current >= _end) throw new InvalidOperationException("Enumeration ended.");
+                    return _array[_current];
+                }
+            }
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose()
+            {
+                
+            }
+        }
+        
+        private readonly IReadOnlyList<T> _array;
+
+        public ListSlice(IReadOnlyList<T> array)
+        {
+           
+            if (array == null)
+                throw new ArgumentNullException(nameof(array));
+
+            _array = array;
+            Offset = 0;
+            Count = array.Count;
+        }
+        
+        public ListSlice(IReadOnlyList<T> array, int offset, int count)
+        {
+            if (array == null)
+                throw new ArgumentNullException(nameof(array));
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException(nameof(offset), "Cannot be below zero.");
+            if (count < 0)
+                throw new ArgumentOutOfRangeException(nameof(count), "Cannot be below zero.");
+            
+            _array = array;
+            Offset = offset;
+            Count = count;
+        }
+
+        public int Offset { get; }
+
+        public IReadOnlyList<T> Array => _array;
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return new SliceEnumerator(this);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public void Add(T item)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void Clear()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool Contains(T item)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            var n = 0;
+            foreach (var i in _array.Skip(Offset).Take(Count))
+            {
+                array[arrayIndex + n++] = i;
+            }
+        }
+
+        public bool Remove(T item)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public int Count { get; }
+
+        public bool IsReadOnly => true;
+        public int IndexOf(T item)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void Insert(int index, T item)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public T this[int index]
+        {
+            get => _array[Offset + index];
+            set => throw new System.NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
#### 1.4.25 September 08 2021 ####
**Maintenance Release for Akka.NET 1.4**
Akka.NET v1.4.25 includes some _significant_ performance improvements for Akka.Remote and a number of important bug fixes and improvements.

**Bug Fixes and Improvements**
* [Akka.IO.Tcp: connecting to an unreachable DnsEndpoint never times out](https://github.com/akkadotnet/akka.net/issues/5154)
* [Akka.Actor: need to enforce `stdout-loglevel = off` all the way through ActorSystem lifecycle](https://github.com/akkadotnet/akka.net/issues/5246)
* [Akka.Actor: `Ask` should push unhandled answers into deadletter](https://github.com/akkadotnet/akka.net/pull/5259)
* [Akka.Routing: Make Router.Route` virtual](https://github.com/akkadotnet/akka.net/pull/5238)
* [Akka.Actor: Improve performance on `IActorRef.Child` API](https://github.com/akkadotnet/akka.net/pull/5242) - _signficantly_ improves performance of many Akka.NET functions, but includes a public API change on `IActorRef` that is source compatible but not necessarily binary-compatible. `IActorRef GetChild(System.Collections.Generic.IEnumerable<string> name)` is now `IActorRef GetChild(System.Collections.Generic.IReadOnlyList<string> name)`. This API is almost never called directly by user code (it's almost always called via the internals of the `ActorSystem` when resolving `ActorSelection`s or remote messages) so this change should be safe.
* [Akka.Actor: `IsNobody` throws NRE](https://github.com/akkadotnet/akka.net/issues/5213)
* [Akka.Cluster.Tools: singleton fix cleanup of overdue _removed members](https://github.com/akkadotnet/akka.net/pull/5229)
* [Akka.DistributedData: ddata exclude `Exiting` members in Read/Write `MajorityPlus`](https://github.com/akkadotnet/akka.net/pull/5227)

**Performance Improvements**
Using our standard `RemotePingPong` benchmark, the difference between v1.4.24 and v1.4.24 is significant:

_v1.4.24_

```
OSVersion:                         Microsoft Windows NT 6.2.9200.0 
ProcessorCount:                    16                              
ClockSpeed:                        0 MHZ                           
Actor Count:                       32                              
Messages sent/received per client: 200000  (2e5)                   
Is Server GC:                      True                            
Thread count:                      111                             
                                                                   
Num clients, Total [msg], Msgs/sec, Total [ms]                     
         1,  200000,     96994,    2062.08                         
         5, 1000000,    194818,    5133.93                         
        10, 2000000,    198966,   10052.93                         
        15, 3000000,    199455,   15041.56                         
        20, 4000000,    198177,   20184.53                         
        25, 5000000,    197613,   25302.80                         
        30, 6000000,    197349,   30403.82                         
```

_v1.4.25_

```
OSVersion:                         Microsoft Windows NT 6.2.9200.0
ProcessorCount:                    16
ClockSpeed:                        0 MHZ
Actor Count:                       32
Messages sent/received per client: 200000  (2e5)
Is Server GC:                      True
Thread count:                      111

Num clients, Total [msg], Msgs/sec, Total [ms]
         1,  200000,    130634,    1531.54
         5, 1000000,    246975,    4049.20
        10, 2000000,    244499,    8180.16
        15, 3000000,    244978,   12246.39
        20, 4000000,    245159,   16316.37
        25, 5000000,    243333,   20548.09
        30, 6000000,    241644,   24830.55
```

This represents a 24% overall throughput improvement in Akka.Remote across the board. We have additional PRs staged that should get aggregate performance improvements above 40% for Akka.Remote over v1.4.24 but they didn't make it into the Akka.NET v1.4.25 release.

You can [see the full set of changes introduced in Akka.NET v1.4.25 here](https://github.com/akkadotnet/akka.net/milestone/56?closed=1)

| COMMITS | LOC+ | LOC- | AUTHOR |
| --- | --- | --- | --- |
| 32 | 1301 | 400 | Aaron Stannard |
| 4 | 358 | 184 | Andreas Dirnberger |
| 3 | 414 | 149 | Gregorius Soedharmo |
| 3 | 3 | 3 | dependabot[bot] |
| 2 | 43 | 10 | zbynek001 |
| 1 | 14 | 13 | tometchy |
| 1 | 139 | 3 | carlcamilleri |