### PR TITLE
Decouple MultiNodeFact from Xunit

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 1.4.26 September 08 2021 ####
+**Placeholder for nightlies**
+
 #### 1.4.25 September 08 2021 ####
 **Maintenance Release for Akka.NET 1.4**
 Akka.NET v1.4.25 includes some _significant_ performance improvements for Akka.Remote and a number of important bug fixes and improvements.

--- a/src/core/Akka.Remote.TestKit/MultiNodeFact.cs
+++ b/src/core/Akka.Remote.TestKit/MultiNodeFact.cs
@@ -49,6 +49,14 @@ namespace Akka.Remote.TestKit
         /// null, which will cause the fully qualified test name to be used.
         /// </summary>
         public virtual string DisplayName { get; set; }
+
+        /// <summary>
+        /// Marks the test as having a timeout, and gets or sets the timeout (in milliseconds).
+        /// WARNING: Using this with parallelization turned on will result in undefined behavior.
+        /// Timeout is only supported when parallelization is disabled, either globally or with
+        /// a parallelization-disabled test collection.
+        /// </summary>
+        public virtual int Timeout { get; set; }
     }
 }
 

--- a/src/core/Akka.Remote.TestKit/MultiNodeFact.cs
+++ b/src/core/Akka.Remote.TestKit/MultiNodeFact.cs
@@ -10,7 +10,8 @@ using Xunit;
 
 namespace Akka.Remote.TestKit
 {
-    public class MultiNodeFactAttribute : FactAttribute
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class MultiNodeFactAttribute : Attribute
     {
         /// <summary>
         /// Set by MultiNodeTestRunner when running multi-node tests
@@ -28,16 +29,26 @@ namespace Akka.Remote.TestKit
                     || Environment.GetEnvironmentVariable(MultiNodeTestEnvironmentName) != null;
             });
 
-        public override string Skip
+        private string _skip;
+        /// <summary>
+        /// Marks the test so that it will not be run, and gets or sets the skip reason
+        /// </summary>
+        public virtual string Skip
         {
             get
             {
                 return ExecutedByMultiNodeRunner.Value
-                    ? base.Skip
+                    ? _skip
                     : "Must be executed by multi-node test runner";
             }
-            set { base.Skip = value; }
+            set { _skip = value; }
         }
+        
+        /// <summary>
+        /// Gets the name of the test to be used when the test is skipped. Defaults to
+        /// null, which will cause the fully qualified test name to be used.
+        /// </summary>
+        public virtual string DisplayName { get; set; }
     }
 }
 


### PR DESCRIPTION
This is needed by the new MultiNodeTestRunner so that it can run independently from Xunit