### PR TITLE
Cancel DBCommand after finish reading events by PersistenceId

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryExecutor.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryExecutor.cs
@@ -543,6 +543,7 @@ namespace Akka.Persistence.Sql.Common.Journal
                         var persistent = ReadEvent(reader);
                         callback(persistent);
                     }
+                    command.Cancel();
                 }
             }
         }


### PR DESCRIPTION
When loading events by PersistenceId the DbCommand will continue reading data until all events from the query is loaded even after max is reached. This can be prevented by calling `Cancel()` on the command before the reader is disposed.