### PR TITLE
Added Source.Never

### DIFF
--- a/docs/articles/streams/builtinstages.md
+++ b/docs/articles/streams/builtinstages.md
@@ -26,6 +26,14 @@ Stream the values of an ``IEnumerable<T>``.
 
 **completes** when the last element of the enumerable has been emitted
 
+#### Never
+
+A source which never emits any elements, never completes and never fails. Useful for tests.
+
+**emits** never
+
+**completes** never
+
 #### Single
 
 Stream a single object

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
@@ -1948,6 +1948,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> FromTask<T>(System.Threading.Tasks.Task<T> task) { }
         public static Akka.Streams.Dsl.Source<TOut, System.Threading.Tasks.Task<TMat>> Lazily<TOut, TMat>(System.Func<Akka.Streams.Dsl.Source<TOut, TMat>> create) { }
         public static Akka.Streams.Dsl.Source<T, System.Threading.Tasks.TaskCompletionSource<T>> Maybe<T>() { }
+        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> Never<T>() { }
         public static Akka.Streams.Dsl.Source<T, Akka.Streams.ISourceQueueWithComplete<T>> Queue<T>(int bufferSize, Akka.Streams.OverflowStrategy overflowStrategy) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> Repeat<T>(T element) { }
         public static Akka.Streams.SourceShape<T> Shape<T>(string name) { }
@@ -4456,6 +4457,7 @@ namespace Akka.Streams.Implementation.Stages
         public static readonly Akka.Streams.Attributes MaybeSource;
         public static readonly Akka.Streams.Attributes Merge;
         public static readonly Akka.Streams.Attributes MergePreferred;
+        public static readonly Akka.Streams.Attributes NeverSource;
         public static readonly Akka.Streams.Attributes OrElse;
         public static readonly Akka.Streams.Attributes OutputStreamSink;
         public static readonly Akka.Streams.Attributes OutputStreamSource;

--- a/src/core/Akka.Streams.Tests/Dsl/NeverSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/NeverSourceSpec.cs
@@ -1,0 +1,43 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="NeverSourceSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Streams.Dsl;
+using Akka.Streams.TestKit;
+using Akka.Streams.TestKit.Tests;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Streams.Tests.Dsl
+{
+    public class NeverSourceSpec : AkkaSpec
+    {
+        private readonly IMaterializer materializer;
+
+        public NeverSourceSpec() => materializer = ActorMaterializer.Create(Sys);
+
+        [Fact]
+        public void NeverSource_must_never_completes()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var neverSource = Source.Never<int>();
+                var pubSink = Sink.AsPublisher<int>(false);
+
+                var neverPub = neverSource.ToMaterialized(pubSink, Keep.Right).Run(materializer);
+
+                var c = this.CreateManualSubscriberProbe<int>();
+                neverPub.Subscribe(c);
+                var subs = c.ExpectSubscription();
+                subs.Request(1);
+                c.ExpectNoMsg(TimeSpan.FromMilliseconds(300));
+
+                subs.Cancel();
+            }, materializer);
+        }
+    }
+}

--- a/src/core/Akka.Streams/Dsl/Source.cs
+++ b/src/core/Akka.Streams/Dsl/Source.cs
@@ -526,7 +526,15 @@ namespace Akka.Streams.Dsl
         /// <typeparam name="T">TBD</typeparam>
         /// <param name="task">TBD</param>
         /// <returns>TBD</returns>
-        public static Source<T, NotUsed> FromTask<T>(Task<T> task) => FromGraph(new TaskSource<T>(task));
+        public static Source<T, NotUsed> FromTask<T>(Task<T> task) => FromGraph(new TaskSource<T>(task));        
+
+        /// <summary>
+        /// Never emits any elements, never completes and never fails.
+        /// This stream could be useful in tests.
+        /// </summary>
+        /// <typeparam name="T">TBD</typeparam>
+        /// <returns>TBD</returns>
+        public static Source<T, NotUsed> Never<T>() => FromTask(new TaskCompletionSource<T>().Task).WithAttributes(DefaultAttributes.NeverSource);
 
         /// <summary>
         /// Elements are emitted periodically with the specified interval.

--- a/src/core/Akka.Streams/Implementation/Stages/Stages.cs
+++ b/src/core/Akka.Streams/Implementation/Stages/Stages.cs
@@ -318,6 +318,10 @@ namespace Akka.Streams.Implementation.Stages
         /// <summary>
         /// TBD
         /// </summary>
+        public static readonly Attributes NeverSource = Attributes.CreateName("neverSource");
+        /// <summary>
+        /// TBD
+        /// </summary>
         public static readonly Attributes FailedSource = Attributes.CreateName("failedSource");
         /// <summary>
         /// TBD


### PR DESCRIPTION
A `Source` which never emits any elements, never completes and never fails. Useful for tests.