### PR TITLE
Brings back StreamTcpException static field Instance

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
@@ -916,6 +916,7 @@ namespace Akka.Streams
     }
     public class StreamDetachedException : System.Exception
     {
+        public static readonly Akka.Streams.StreamDetachedException Instance;
         public StreamDetachedException() { }
         public StreamDetachedException(string message) { }
     }

--- a/src/core/Akka.Streams/StreamTcpException.cs
+++ b/src/core/Akka.Streams/StreamTcpException.cs
@@ -48,6 +48,11 @@ namespace Akka.Streams
     /// </summary>
     public class StreamDetachedException : Exception
     {
+        /// <summary>
+        /// Initializes a single instance of the <see cref="StreamDetachedException"/> class.
+        /// </summary>
+        public static readonly StreamDetachedException Instance = new StreamDetachedException();
+
         public StreamDetachedException()
             : this("Stream is terminated. Materialized value is detached.")
         {


### PR DESCRIPTION
Reverts some of the changes made to the StreamTcpException's API in #5338