### PR TITLE
made `GraphStageLogic.LogSource` virtual and change default `StageLogic` `LogSource`

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
@@ -4639,7 +4639,7 @@ namespace Akka.Streams.Stage
         protected GraphStageLogic(Akka.Streams.Shape shape) { }
         public virtual bool KeepGoingAfterAllPortsClosed { get; }
         public Akka.Event.ILoggingAdapter Log { get; }
-        protected object LogSource { get; }
+        protected virtual object LogSource { get; }
         protected Akka.Streams.IMaterializer Materializer { get; }
         public Akka.Streams.Stage.StageActor StageActor { get; }
         [Akka.Annotations.ApiMayChangeAttribute()]

--- a/src/core/Akka.Streams/Stage/GraphStage.cs
+++ b/src/core/Akka.Streams/Stage/GraphStage.cs
@@ -839,6 +839,7 @@ namespace Akka.Streams.Stage
         /// <param name="shape">TBD</param>
         protected GraphStageLogic(Shape shape) : this(shape.Inlets.Count(), shape.Outlets.Count())
         {
+            LogSource = Akka.Event.LogSource.Create(shape.ToString());
         }
 
         /// <summary>
@@ -879,7 +880,7 @@ namespace Akka.Streams.Stage
         /// <summary>
         /// Override to customise reported log source 
         /// </summary>
-        protected object LogSource => this;
+        protected virtual object LogSource { get; }
 
         public ILoggingAdapter Log
         {

--- a/src/core/Akka.Streams/Stage/GraphStage.cs
+++ b/src/core/Akka.Streams/Stage/GraphStage.cs
@@ -839,7 +839,7 @@ namespace Akka.Streams.Stage
         /// <param name="shape">TBD</param>
         protected GraphStageLogic(Shape shape) : this(shape.Inlets.Count(), shape.Outlets.Count())
         {
-            LogSource = Akka.Event.LogSource.Create(shape.ToString());
+            LogSource = Akka.Event.LogSource.Create(shape);
         }
 
         /// <summary>


### PR DESCRIPTION
Also, changed the default `LogSource` to be the output of the `Stage.ToString()` method. Right now all `GraphStageLogic` log sources default to just "Logic (akka://{ActorSystemName})"