### PR TITLE
make Akka.Discovery RTM, rather than beta status

### DIFF
--- a/src/core/Akka.Discovery/Akka.Discovery.csproj
+++ b/src/core/Akka.Discovery/Akka.Discovery.csproj
@@ -8,7 +8,6 @@
     <PackageTags>$(AkkaPackageTags)</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>8</LangVersion>
-    <VersionSuffix>beta</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Given how things are going with [Akka.Management](https://github.com/akkadotnet/Akka.Management), I think it would be worthwhile to take Akka.Discovery out of beta so we can also begin releasing Akka.Management RTM packages in the near future.