### PR TITLE
Upgraded DocFx to 2.58.9, dropped `TargetFramework`

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -33,7 +33,7 @@ $FakeVersion = "4.63.0"
 $NugetVersion = "5.8.0";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/v$NugetVersion/nuget.exe"
 $ProtobufVersion = "3.13.0"
-$DocfxVersion = "2.48.1"
+$DocfxVersion = "2.58.9"
 
 $IncrementalistVersion = "0.6.0";
 

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -17,9 +17,6 @@
         }],
         "dest": "api",
         "filter": "filterConfig.yml",
-        "properties": {
-            "TargetFramework": "net45"
-        }
     }],
     "build": {
         "content": [{


### PR DESCRIPTION
close https://github.com/akkadotnet/akka.net/issues/5406