### PR TITLE
changed API doc root link back to `index.md`

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -3,7 +3,7 @@
   homepage: articles/intro/what-is-akka.md
 - name: API Reference
   href: api/
-  homepage: api/Akka.Actor.yml
+  homepage: api/index.md
 - name: Community
   href: community/
   homepage: community/building-akka-net.md


### PR DESCRIPTION
Now that https://github.com/akkadotnet/akka.net/issues/5406 is fixed we can roll this back