### PR TITLE
Added InverseFishForMessage and nuget package fluent-assertions

### DIFF
--- a/src/core/Akka.TestKit/Akka.TestKit.csproj
+++ b/src/core/Akka.TestKit/Akka.TestKit.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Configs\TestScheduler.conf;Internal\Reference.conf" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <ProjectReference Include="..\Akka\Akka.csproj" />
   </ItemGroup>
 

--- a/src/core/Akka.TestKit/TestKitBase_Receive.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Receive.cs
@@ -9,7 +9,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.TestKit.Internal;
+using FluentAssertions;
 
 namespace Akka.TestKit
 {
@@ -56,6 +58,23 @@ namespace Akka.TestKit
             }
         }
 
+        /// <summary>
+        /// Receives messages until <paramref name="max"/>. Ignores all messages except for a message of type <typeparamref name="T"/>. Asserts that all messages are not of the of type <typeparamref name="T"/>. Note that when comparing types, inheritance is ignored, in other words, only perfectly matching types are asserted.
+        /// </summary>
+        /// <typeparam name="T">The type that the message is not supposed to be.</typeparam>
+        /// <param name="probe"></param>
+        /// <param name="max"></param>
+        public async static Task InverseFishForMessage<T>(TestProbe probe, TimeSpan? max = null)
+        {
+            await Task.Run(() =>
+            {
+                probe.ReceiveWhile<object>(max: max, shouldIgnore: x =>
+                {
+                    x.Should().NotBeOfType<T>();
+                    return false; // we are not returning anything
+                });
+            });
+        }
 
         /// <summary>
         /// Receive one message from the internal queue of the TestActor.


### PR DESCRIPTION
This pull request is based on a thread I had with @Aaronontheweb on Gitter: https://gitter.im/akkadotnet/akka.net?at=61ae5b0acd3f06175df32eda. 