### PR TITLE
Resolve Akka.Cluster startup

### DIFF
--- a/src/core/Akka.Cluster.Tests.MultiNode/TransitionSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/TransitionSpec.cs
@@ -122,12 +122,12 @@ namespace Akka.Cluster.Tests.MultiNode
 
         private void LeaderActions()
         {
-            Cluster.TellCoreSafe(InternalClusterAction.LeaderActionsTick.Instance);
+            Cluster.ClusterCore.Tell(InternalClusterAction.LeaderActionsTick.Instance);
         }
 
         private void ReapUnreachable()
         {
-            Cluster.TellCoreSafe(InternalClusterAction.ReapUnreachableTick.Instance);
+            Cluster.ClusterCore.Tell(InternalClusterAction.ReapUnreachableTick.Instance);
         }
 
         private int _gossipBarrierCounter = 0;
@@ -148,7 +148,7 @@ namespace Akka.Cluster.Tests.MultiNode
             {
                 EnterBarrier("before-gossip-" + _gossipBarrierCounter);
                 // send gossip
-                Cluster.TellCoreSafe(new InternalClusterAction.SendGossipTo(GetAddress(toRole)));
+                Cluster.ClusterCore.Tell(new InternalClusterAction.SendGossipTo(GetAddress(toRole)));
                 // gossip chat will synchronize the views
                 AwaitCondition(() => ImmutableHashSet.Create(fromRole, toRole).Except(SeenLatestGossip()).IsEmpty);
                 EnterBarrier("after-gossip-" + _gossipBarrierCounter);
@@ -286,7 +286,7 @@ namespace Akka.Cluster.Tests.MultiNode
             RunOn(() =>
             {
                 // send gossip
-                Cluster.TellCoreSafe(new InternalClusterAction.SendGossipTo(GetAddress(other2)));
+                Cluster.ClusterCore.Tell(new InternalClusterAction.SendGossipTo(GetAddress(other2)));
             }, other1);
 
             RunOn(() =>

--- a/src/core/Akka.Cluster.Tests/ClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterSpec.cs
@@ -61,7 +61,7 @@ namespace Akka.Cluster.Tests
 
         internal void LeaderActions()
         {
-            _cluster.TellCoreSafe(InternalClusterAction.LeaderActionsTick.Instance);
+            _cluster.ClusterCore.Tell(InternalClusterAction.LeaderActionsTick.Instance);
         }
 
         [Fact]


### PR DESCRIPTION
I think some of the race conditions that began to appear as a result of .NET 6's threadpool changes hid some of the faults exposed by this PR and some of the other Akka.Cluster ones. We need to carefully and quickly restore this functionality since https://github.com/akkadotnet/akka.net/issues/5435 is a critical issue.