### PR TITLE
[DO NOT MERGE] Fishing for racy test causes

### DIFF
--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -9,6 +9,10 @@ parameters:
   outputDirectory: ''
   timeoutInMinutes: 120
 
+variables:
+  -name: COMPlus_ThreadPool_UsePortableThreadPool
+   value: 0
+
 jobs:
   - job: ${{ parameters.name }}
     displayName: ${{ parameters.displayName }}

--- a/src/core/Akka/Done.cs
+++ b/src/core/Akka/Done.cs
@@ -23,3 +23,4 @@ namespace Akka
         private Done() { }
     }
 }
+

--- a/src/core/Akka/PatternMatch.cs
+++ b/src/core/Akka/PatternMatch.cs
@@ -232,7 +232,4 @@ namespace Akka
             return _result;
         }
     }
-
-
 }
-


### PR DESCRIPTION
Fishing for racy test caused by recent PR merges. Removing one variable by disabling .NET 6 new managed thread pool implementation.