### PR TITLE
Add random factor for CircuitBreaker

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.approved.txt
@@ -4023,6 +4023,7 @@ namespace Akka.Pattern
     {
         public CircuitBreaker(Akka.Actor.IScheduler scheduler, int maxFailures, System.TimeSpan callTimeout, System.TimeSpan resetTimeout) { }
         public CircuitBreaker(Akka.Actor.IScheduler scheduler, int maxFailures, System.TimeSpan callTimeout, System.TimeSpan resetTimeout, System.TimeSpan maxResetTimeout, double exponentialBackoffFactor) { }
+        public CircuitBreaker(Akka.Actor.IScheduler scheduler, int maxFailures, System.TimeSpan callTimeout, System.TimeSpan resetTimeout, System.TimeSpan maxResetTimeout, double exponentialBackoffFactor, double randomFactor) { }
         public System.TimeSpan CallTimeout { get; }
         public long CurrentFailureCount { get; }
         public double ExponentialBackoffFactor { get; }
@@ -4032,6 +4033,7 @@ namespace Akka.Pattern
         public System.Exception LastCaughtException { get; }
         public int MaxFailures { get; }
         public System.TimeSpan MaxResetTimeout { get; }
+        public double RandomFactor { get; }
         public System.TimeSpan ResetTimeout { get; }
         public Akka.Actor.IScheduler Scheduler { get; }
         public static Akka.Pattern.CircuitBreaker Create(Akka.Actor.IScheduler scheduler, int maxFailures, System.TimeSpan callTimeout, System.TimeSpan resetTimeout) { }
@@ -4043,6 +4045,7 @@ namespace Akka.Pattern
         public System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.Tasks.Task<T>> body) { }
         public System.Threading.Tasks.Task WithCircuitBreaker(System.Func<System.Threading.Tasks.Task> body) { }
         public Akka.Pattern.CircuitBreaker WithExponentialBackoff(System.TimeSpan maxResetTimeout) { }
+        public Akka.Pattern.CircuitBreaker WithRandomFactor(double randomFactor) { }
         public void WithSyncCircuitBreaker(System.Action body) { }
         public T WithSyncCircuitBreaker<T>(System.Func<T> body) { }
     }

--- a/src/core/Akka.Tests/Pattern/CircuitBreakerSpec.cs
+++ b/src/core/Akka.Tests/Pattern/CircuitBreakerSpec.cs
@@ -494,7 +494,7 @@ namespace Akka.Tests.Pattern
         
         public TestBreaker NonOneFactorCb()
         {
-            return new TestBreaker(new CircuitBreaker(Sys.Scheduler, 1, TimeSpan.FromMilliseconds(2000), TimeSpan.FromMilliseconds(1000), TimeSpan.FromDays(1), 5));
+            return new TestBreaker(new CircuitBreaker(Sys.Scheduler, 1, TimeSpan.FromMilliseconds(2000), TimeSpan.FromMilliseconds(1000), TimeSpan.FromDays(1), 5, 0));
         }
     }
 

--- a/src/core/Akka/Pattern/CircuitBreakerState.cs
+++ b/src/core/Akka/Pattern/CircuitBreakerState.cs
@@ -88,7 +88,8 @@ namespace Akka.Pattern
             GetAndSet(DateTime.UtcNow.Ticks);
             _breaker.Scheduler.Advanced.ScheduleOnce(_breaker.CurrentResetTimeout, () => _breaker.AttemptReset());
 
-            var nextResetTimeout = TimeSpan.FromTicks(_breaker.CurrentResetTimeout.Ticks * (long)_breaker.ExponentialBackoffFactor);
+            var rnd = 1.0 + ThreadLocalRandom.Current.NextDouble() * _breaker.RandomFactor;
+            var nextResetTimeout = TimeSpan.FromTicks(_breaker.CurrentResetTimeout.Ticks * (long)_breaker.ExponentialBackoffFactor * (long)rnd);
             if (nextResetTimeout < _breaker.MaxResetTimeout)
             {
                 _breaker.SwapStateResetTimeout(_breaker.CurrentResetTimeout, nextResetTimeout);


### PR DESCRIPTION
> So the motivation for this change is that when a heavily-used server (which is used by many clients that use a circuitbreaker) goes out, it will be ramped up more gracefully instead of 'hammered' when the reset timeout triggers for all circuitbreakers at once.

Original PR: [#29478](https://github.com/akka/akka/pull/29478)