### PR TITLE
fixed wrong comment

### DIFF
--- a/src/core/Akka.TestKit/TestKitBase_Receive.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Receive.cs
@@ -73,7 +73,7 @@ namespace Akka.TestKit
                 ReceiveWhile<object>(max: max, shouldContinue: x =>
                 {
                     _assertions.AssertFalse(x is T, "did not expect a message of type {0}", typeof(T));
-                    return true; // we are not returning anything
+                    return true; // please continue receiving, don't stop
                 });
             });
         }


### PR DESCRIPTION
The old comment that I previously wrote in ("we are not returning anything") was based on an old variable name that threw me off. 
Here is the old code with the old variable name: 
```C#
                probe.ReceiveWhile<object>(max: max, shouldIgnore: x =>
                {
                    x.Should().NotBeOfType<T>();
                    return false; // we are not returning anything
                });
```
When I looked into the code of the method ReceiveWhile(), I realized that "shouldIgnore" was a misleading variable name. 
So I changed it to "shouldContinue" which much better reflects the code and the docs around it. 

But I did not update the comment: "we are not returning anything". 

So now, it is time to update the comment as well.
The new comment is: "please continue receiving, don't stop". 
Which much better reflects the code and the variable name ("shouldContinue"). 