### PR TITLE
Added support for copying .HTML files in DocFx

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -27,7 +27,9 @@
         }, {
             "files": [
                 "articles/**.md",
+                "articles/**.html",
                 "articles/**/toc.yml",
+                "community/**.html",
                 "community/**.md",
                 "community/**/toc.yml",
                 "toc.yml",


### PR DESCRIPTION
Needed to add this to support our manual approach for creating redirects for old content https://getakka.net/community/contributing/documentation-guidelines.html#moving-documentation-pages