### PR TITLE
Add Flow.LazyInitAsync, and fix materialized value of Sink.LazyInit

### DIFF
--- a/docs/articles/streams/builtinstages.md
+++ b/docs/articles/streams/builtinstages.md
@@ -449,6 +449,18 @@ are emitted from the source
 The ``Stream`` will no longer be writable when the ``Source`` has been canceled from its downstream, and
 closing the ``Stream`` will complete the ``Source``.
 
+### LazyInitAsync
+
+Creates a real ``Sink`` upon receiving the first element. Internal sink will not be created if there are no elements, because of completion or error.
+
+* If upstream completes before an element was received then the ``Task`` is completed with ``None``.
+* If upstream fails before an element was received, ``sinkFactory`` throws an exception, or materialization of the internal sink fails then the ``Task`` is completed with the exception.
+* Otherwise the ``Task`` is completed with the materialized value of the internal sink.
+
+**cancels** never
+
+**backpressures** when initialized and when created sink backpressures
+
 ## File IO Sinks and Sources
 
 Sources and sinks for reading and writing files can be found on ``FileIO``.
@@ -756,6 +768,22 @@ If the wire-tap ``Sink`` backpressures, elements that would've been sent to it w
 **completes** when upstream completes
 
 **cancels** when downstream cancels
+
+### LazyInitAsync
+
+Creates a real ``Flow`` upon receiving the first element by calling relevant flowFactory given as an argument. Internal flow will not be created if there are no elements, because of completion or error. The materialized value of the ``Flow`` will be the materialized value of the created internal flow.
+
+The materialized value of the Flow is a ``Task<Option<TMat>>`` that is completed with ```TMat``` when the internal flow gets materialized or with ``None`` when there where no elements. If the flow materialization (including the call of the ``flowFactory``) fails then the future is completed with a failure.
+
+Adheres to the ``ActorAttributes.SupervisionStrategy`` attribute.
+
+**emits** when the internal flow is successfully created and it emits
+
+**backpressures** when the internal flow is successfully created and it backpressures
+
+**completes** when upstream completes and all elements have been emitted from the internal flow
+
+**completes** when upstream completes and all futures have been completed and all elements have been emitted
 
 ## Asynchronous Processing Stages
 

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
@@ -1316,6 +1316,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> FromSinkAndSource<TIn, TOut, TMat1, TMat2, TMat>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TIn>, TMat1> sink, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat2> source, System.Func<TMat1, TMat2, TMat> combine) { }
         public static Akka.Streams.Dsl.Flow<T, T, Akka.NotUsed> Identity<T>() { }
         public static Akka.Streams.Dsl.Flow<T, T, TMat> Identity<T, TMat>() { }
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, System.Threading.Tasks.Task<Akka.Util.Option<TMat>>> LazyInitAsync<TIn, TOut, TMat>(System.Func<System.Threading.Tasks.Task<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>>> flowFactory) { }
     }
     public class static FlowOperations
     {
@@ -1910,6 +1911,10 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task> Ignore<TIn>() { }
         public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task<TIn>> Last<TIn>() { }
         public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task<TIn>> LastOrDefault<TIn>() { }
+        public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task<Akka.Util.Option<TMat>>> LazyInitAsync<TIn, TMat>(System.Func<System.Threading.Tasks.Task<Akka.Streams.Dsl.Sink<TIn, TMat>>> sinkFactory) { }
+        [System.ObsoleteAttribute("Use LazyInitAsync instead. LazyInitAsync no more needs a fallback function and th" +
+            "e materialized value more clearly indicates if the internal sink was materialize" +
+            "d or not.")]
         public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task<TMat>> LazySink<TIn, TMat>(System.Func<TIn, System.Threading.Tasks.Task<Akka.Streams.Dsl.Sink<TIn, TMat>>> sinkFactory, System.Func<TMat> fallback) { }
         public static Akka.Streams.Dsl.Sink<TIn, Akka.NotUsed> OnComplete<TIn>(System.Action success, System.Action<System.Exception> failure) { }
         public static Akka.Streams.Dsl.Sink<TIn, Reactive.Streams.IPublisher<TIn>> Publisher<TIn>() { }
@@ -4188,6 +4193,17 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     [Akka.Annotations.InternalApiAttribute()]
+    public sealed class LazyFlow<TIn, TOut, TMat> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.FlowShape<TIn, TOut>, System.Threading.Tasks.Task<Akka.Util.Option<TMat>>>
+    {
+        public LazyFlow(System.Func<TIn, System.Threading.Tasks.Task<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>>> flowFactory) { }
+        public Akka.Streams.Inlet<TIn> In { get; }
+        protected override Akka.Streams.Attributes InitialAttributes { get; }
+        public Akka.Streams.Outlet<TOut> Out { get; }
+        public override Akka.Streams.FlowShape<TIn, TOut> Shape { get; }
+        public override Akka.Streams.Stage.ILogicAndMaterializedValue<System.Threading.Tasks.Task<Akka.Util.Option<TMat>>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
+        public override string ToString() { }
+    }
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class LimitWeighted<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public LimitWeighted(long max, System.Func<T, long> costFunc) { }
@@ -4501,6 +4517,7 @@ namespace Akka.Streams.Implementation.Stages
         public static readonly Akka.Streams.Attributes InputStreamSource;
         public static readonly Akka.Streams.Attributes LastOrDefaultSink;
         public static readonly Akka.Streams.Attributes LastSink;
+        public static readonly Akka.Streams.Attributes LazyFlow;
         public static readonly Akka.Streams.Attributes LazySink;
         public static readonly Akka.Streams.Attributes LazySource;
         public static readonly Akka.Streams.Attributes Limit;

--- a/src/core/Akka.Streams.Tests/Dsl/LazyFlowSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/LazyFlowSpec.cs
@@ -1,0 +1,227 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="LazyFlowSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Akka.Streams.Dsl;
+using Akka.Streams.TestKit;
+using Akka.Streams.TestKit.Tests;
+using Akka.TestKit;
+using Akka.Util.Internal;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Streams.Tests.Dsl
+{
+    public class LazyFlowSpec : AkkaSpec
+    {
+        public LazyFlowSpec(ITestOutputHelper helper)
+            : base(helper)
+        {
+            var settings = ActorMaterializerSettings.Create(Sys).WithInputBuffer(1, 1);
+            Materializer = Sys.Materializer(settings);
+        }
+
+        private ActorMaterializer Materializer { get; }
+
+        private static readonly Func<NotUsed> Fallback = () => NotUsed.Instance;
+
+        private static readonly Exception Ex = new TestException("");
+
+        private static readonly Task<Flow<int, int, NotUsed>> FlowF = Task.FromResult(Flow.Create<int>());
+
+        [Fact]
+        public void A_LazyFlow_must_work_in_happy_case()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                Func<Task<Flow<int, string, NotUsed>>> MapF(int e) => () =>
+                    Task.FromResult(Flow.FromFunction<int, string>(i => (i * e).ToString()));
+
+                var probe = Source.From(Enumerable.Range(2, 10))
+                    .Via(Flow.LazyInitAsync(MapF(2)))
+                    .RunWith(this.SinkProbe<string>(), Materializer);
+                probe.Request(100);
+                Enumerable.Range(2, 10).Select(i => (i * 2).ToString()).ForEach(i => probe.ExpectNext(i));
+            }, Materializer);
+        }
+
+        [Fact]
+        public void A_LazyFlow_must_work_with_slow_flow_init()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var p = new TaskCompletionSource<Flow<int, int, NotUsed>>();
+                var sourceProbe = this.CreateManualPublisherProbe<int>();
+                var flowProbe = Source.FromPublisher(sourceProbe)
+                    .Via(Flow.LazyInitAsync(() => p.Task))
+                    .RunWith(this.SinkProbe<int>(), Materializer);
+
+                var sourceSub = sourceProbe.ExpectSubscription();
+                flowProbe.Request(1);
+                sourceSub.ExpectRequest(1);
+                sourceSub.SendNext(0);
+                sourceSub.ExpectRequest(1);
+                sourceProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(200));
+
+                p.SetResult(Flow.Create<int>());
+                flowProbe.Request(99);
+                flowProbe.ExpectNext(0);
+                Enumerable.Range(1, 10).ForEach(i =>
+                 {
+                     sourceSub.SendNext(i);
+                     flowProbe.ExpectNext(i);
+                 });
+                sourceSub.SendComplete();
+            }, Materializer);
+        }
+
+        [Fact]
+        public void A_LazyFlow_must_complete_when_there_was_no_elements_in_stream()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var probe = Source.Empty<int>()
+                    .Via(Flow.LazyInitAsync(() => FlowF))
+                    .RunWith(this.SinkProbe<int>(), Materializer);
+                probe.Request(1).ExpectComplete();
+            }, Materializer);
+        }
+
+        [Fact]
+        public void A_LazyFlow_must_complete_normally_when_upstream_completes_BEFORE_the_stage_has_switched_to_the_inner_flow()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var promise = new TaskCompletionSource<Flow<int, int, NotUsed>>();
+                var (pub, sub) = this.SourceProbe<int>()
+                    .ViaMaterialized(Flow.LazyInitAsync(() => promise.Task), Keep.Left)
+                    .ToMaterialized(this.SinkProbe<int>(), Keep.Both)
+                    .Run(Materializer);
+
+                sub.Request(1);
+                pub.SendNext(1).SendComplete();
+                promise.SetResult(Flow.Create<int>());
+                sub.ExpectNext(1).ExpectComplete();
+            }, Materializer);
+        }
+
+        [Fact]
+        public void A_LazyFlow_must_complete_normally_when_upstream_completes_AFTER_the_stage_has_switched_to_the_inner_flow()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var (pub, sub) = this.SourceProbe<int>()
+                    .ViaMaterialized(Flow.LazyInitAsync(() => Task.FromResult(Flow.Create<int>())), Keep.Left)
+                    .ToMaterialized(this.SinkProbe<int>(), Keep.Both)
+                    .Run(Materializer);
+
+                sub.Request(1);
+                pub.SendNext(1);
+                sub.ExpectNext(1);
+                pub.SendComplete();
+                sub.ExpectComplete();
+            }, Materializer);
+        }
+
+        [Fact]
+        public void A_LazyFlow_must_fail_gracefully_when_flow_factory_method_failed()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var sourceProbe = this.CreateManualPublisherProbe<int>();
+                var probe = Source.FromPublisher(sourceProbe)
+                    .Via(Flow.LazyInitAsync<int, int, NotUsed>(() => throw Ex))
+                    .RunWith(this.SinkProbe<int>(), Materializer);
+
+                var sourceSub = sourceProbe.ExpectSubscription();
+                probe.Request(1);
+                sourceSub.ExpectRequest(1);
+                sourceSub.SendNext(0);
+                sourceSub.ExpectCancellation();
+                probe.ExpectError().Should().Be(Ex);
+            }, Materializer);
+        }
+
+        [Fact]
+        public void A_LazyFlow_must_fail_gracefully_when_upstream_failed()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var sourceProbe = this.CreateManualPublisherProbe<int>();
+                var probe = Source.FromPublisher(sourceProbe)
+                    .Via(Flow.LazyInitAsync(() => FlowF))
+                    .RunWith(this.SinkProbe<int>(), Materializer);
+
+                var sourceSub = sourceProbe.ExpectSubscription();
+                sourceSub.ExpectRequest(1);
+                sourceSub.SendNext(0);
+                probe.Request(1).ExpectNext(0);
+                sourceSub.SendError(Ex);
+                probe.ExpectError().Should().Be(Ex);
+            }, Materializer);
+        }
+
+        [Fact]
+        public void A_LazyFlow_must_fail_gracefully_when_factory_task_failed()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var sourceProbe = this.CreateManualPublisherProbe<int>();
+                var flowprobe = Source.FromPublisher(sourceProbe)
+                    .Via(Flow.LazyInitAsync(() => Task.FromException<Flow<int, int, NotUsed>>(Ex)))
+                    .RunWith(this.SinkProbe<int>(), Materializer);
+
+                var sourceSub = sourceProbe.ExpectSubscription();
+                sourceSub.ExpectRequest(1);
+                sourceSub.SendNext(0);
+                var error = flowprobe.Request(1).ExpectError().As<AggregateException>();
+                error.Flatten().InnerException.Should().Be(Ex);
+            }, Materializer);
+        }
+
+        [Fact]
+        public void A_LazyFlow_must_cancel_upstream_when_the_downstream_is_cancelled()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var sourceProbe = this.CreateManualPublisherProbe<int>();
+                var probe = Source.FromPublisher(sourceProbe)
+                    .Via(Flow.LazyInitAsync(() => FlowF))
+                    .RunWith(this.SinkProbe<int>(), Materializer);
+
+                var sourceSub = sourceProbe.ExpectSubscription();
+                probe.Request(1);
+                sourceSub.ExpectRequest(1);
+                sourceSub.SendNext(0);
+                sourceSub.ExpectRequest(1);
+                probe.ExpectNext(0);
+                probe.Cancel();
+                sourceSub.ExpectCancellation();
+            }, Materializer);
+        }
+
+        [Fact]
+        public void A_LazyFlow_must_fail_correctly_when_factory_throw_error()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                const string msg = "fail!";
+                var matFail = new TestException(msg);
+
+                var result = Source.Single("whatever")
+                    .ViaMaterialized(Flow.LazyInitAsync<string, string, Exception>(() => throw matFail), Keep.Right)
+                    .ToMaterialized(Sink.Ignore<string>(), Keep.Left)
+                    .Invoking(source => source.Run(Materializer));
+
+                result.Should().Throw<TestException>().WithMessage(msg);
+            }, Materializer);
+        }
+    }
+}

--- a/src/core/Akka.Streams.Tests/IO/FileSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/FileSinkSpec.cs
@@ -12,7 +12,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
-using Akka.Dispatch;
 using Akka.IO;
 using Akka.Streams.Dsl;
 using Akka.Streams.Implementation;
@@ -20,7 +19,6 @@ using Akka.Streams.Implementation.IO;
 using Akka.Streams.IO;
 using Akka.Streams.TestKit.Tests;
 using Akka.TestKit;
-using Akka.Tests.Shared.Internals;
 using Akka.Util.Internal;
 using FluentAssertions;
 using Xunit;
@@ -312,12 +310,12 @@ namespace Akka.Streams.Tests.IO
         {
             Within(_expectTimeout, () =>
             {
+                // LazySink must wait for result of initialization even if got UpstreamComplete
                 TargetFile(f => 
                 {
-                    var lazySink = Sink.LazySink(
-                            (ByteString _) => Task.FromResult(FileIO.ToFile(f)),
-                            () => Task.FromResult(IOResult.Success(0)))
-                        .MapMaterializedValue(t => t.AwaitResult());
+                    var lazySink = Sink.LazyInitAsync(() => Task.FromResult(FileIO.ToFile(f)))
+                        // map a Task<Option<Task<IOResult>>> into a Task<IOResult>
+                        .MapMaterializedValue(t => t.Result.GetOrElse(Task.FromResult(IOResult.Success(0))));
 
                     var completion = Source.From(new []{_testByteStrings.Head()})
                         .RunWith(lazySink, _materializer);

--- a/src/core/Akka.Streams/Implementation/Sinks.cs
+++ b/src/core/Akka.Streams/Implementation/Sinks.cs
@@ -931,179 +931,167 @@ namespace Akka.Streams.Implementation
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
     /// <typeparam name="TMat">TBD</typeparam>
-    internal sealed class LazySink<TIn, TMat> : GraphStageWithMaterializedValue<SinkShape<TIn>, Task<TMat>>
+    internal sealed class LazySink<TIn, TMat> : GraphStageWithMaterializedValue<SinkShape<TIn>, Task<Option<TMat>>>
     {
         #region Logic
 
         private sealed class Logic : InGraphStageLogic
         {
             private readonly LazySink<TIn, TMat> _stage;
-            private readonly TaskCompletionSource<TMat> _completion;
-            private readonly Lazy<Decider> _decider;
+            private readonly TaskCompletionSource<Option<TMat>> _completion;
+            private bool _switching;
 
-            private bool _completed;
-
-            public Logic(LazySink<TIn, TMat> stage, Attributes inheritedAttributes,
-                TaskCompletionSource<TMat> completion) : base(stage.Shape)
+            public Logic(LazySink<TIn, TMat> stage, Attributes inheritedAttributes, TaskCompletionSource<Option<TMat>> completion) 
+                : base(stage.Shape)
             {
                 _stage = stage;
                 _completion = completion;
-                _decider = new Lazy<Decider>(() =>
-                {
-                    var attr = inheritedAttributes.GetAttribute<ActorAttributes.SupervisionStrategy>(null);
-                    return attr != null ? attr.Decider : Deciders.StoppingDecider;
-                });
 
                 SetHandler(stage.In, this);
             }
 
-            public override void OnPush()
-            {
-                try
-                {
-                    var element = Grab(_stage.In);
-                    var callback = GetAsyncCallback<Result<Sink<TIn, TMat>>>(result =>
-                    {
-                        if (result.IsSuccess)
-                            InitInternalSource(result.Value, element);
-                        else
-                            Failure(result.Exception);
-                    });
-                    _stage._sinkFactory(element)
-                        .ContinueWith(t => callback(Result.FromTask(t)),
-                            TaskContinuationOptions.ExecuteSynchronously);
-                    SetHandler(_stage.In, new LambdaInHandler(
-                            onPush: () => { },
-                            onUpstreamFinish: GotCompletionEvent,
-                            onUpstreamFailure: Failure
-                        ));
-                }
-                catch (Exception ex)
-                {
-                    if (_decider.Value(ex) == Directive.Stop)
-                        Failure(ex);
-                    else
-                        Pull(_stage.In);
-                }
-            }
-
-            public override void OnUpstreamFinish()
-            {
-                CompleteStage();
-                try
-                {
-                    _completion.TrySetResult(_stage._zeroMaterialised());
-                }
-                catch (Exception ex)
-                {
-                    _completion.SetException(ex);
-                }
-            }
-
-            public override void OnUpstreamFailure(Exception e) => Failure(e);
-
-            private void GotCompletionEvent()
-            {
-                SetKeepGoing(true);
-                _completed = true;
-            }
-
             public override void PreStart() => Pull(_stage.In);
 
-            private void Failure(Exception ex)
+            public override void OnPush()
             {
-                FailStage(ex);
-                _completion.SetException(ex);
-            }
+                var element = Grab(_stage.In);
+                _switching = true;
 
-            private void InitInternalSource(Sink<TIn, TMat> sink, TIn firstElement)
-            {
-                var sourceOut = new SubSource(this, firstElement);
+                var callback = GetAsyncCallback<Result<Sink<TIn, TMat>>>(result =>
+                {
+                    if (result.IsSuccess)
+                    {
+                        // check if the stage is still in need for the lazy sink
+                        // (there could have been an OnUpstreamFailure in the meantime that has completed the promise)
+                        if (!_completion.Task.IsCompleted)
+                        {
+                            try
+                            {
+                                var mat = SwitchTo(result.Value, element);
+                                _completion.TrySetResult(mat);
+                                SetKeepGoing(true);
+                            }
+                            catch (Exception ex)
+                            {
+                                _completion.TrySetException(ex);
+                                FailStage(ex);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        _completion.TrySetException(result.Exception);
+                        FailStage(result.Exception);
+                    }
+                });
 
                 try
                 {
-                    var matVal = Source.FromGraph(sourceOut.Source)
-                        .RunWith(sink, Interpreter.SubFusingMaterializer);
-                    _completion.TrySetResult(matVal);
+                    _stage._sinkFactory(element)
+                        .ContinueWith(t => callback(Result.FromTask(t)), TaskContinuationOptions.ExecuteSynchronously);
                 }
                 catch (Exception ex)
                 {
                     _completion.TrySetException(ex);
                     FailStage(ex);
                 }
-
             }
 
-            #region SubSource
-
-            private sealed class SubSource : SubSourceOutlet<TIn>
+            public override void OnUpstreamFinish()
             {
-                private readonly Logic _logic;
-                private readonly LazySink<TIn, TMat> _stage;
-
-                public SubSource(Logic logic, TIn firstElement) : base(logic, "LazySink")
+                // ignore OnUpstreamFinish while the stage is switching but SetKeepGoing
+                if (_switching)
                 {
-                    _logic = logic;
-                    _stage = logic._stage;
-
-                    SetHandler(new LambdaOutHandler(onPull: () =>
-                    {
-                        Push(firstElement);
-                        if (_logic._completed)
-                            SourceComplete();
-                        else
-                            SwitchToFinalHandler();
-                    }, onDownstreamFinish: SourceComplete));
-
-                    logic.SetHandler(_stage.In, new LambdaInHandler(
-                        onPush: () => Push(logic.Grab(_stage.In)),
-                        onUpstreamFinish: logic.GotCompletionEvent,
-                        onUpstreamFailure: SourceFailure));
-                }
-
-                private void SourceFailure(Exception ex)
+                    // there is a cached element -> the stage must not be shut down automatically because IsClosed(In) is satisfied
+                    SetKeepGoing(true);
+                }                
+                else
                 {
-                    Fail(ex);
-                    _logic.FailStage(ex);
-                }
-
-                private void SwitchToFinalHandler()
-                {
-                    SetHandler(new LambdaOutHandler(
-                        onPull: () => _logic.Pull(_stage.In),
-                        onDownstreamFinish: SourceComplete));
-
-                    _logic.SetHandler(_stage.In, new LambdaInHandler(
-                        onPush: () => Push(_logic.Grab(_stage.In)),
-                        onUpstreamFinish: SourceComplete,
-                        onUpstreamFailure: SourceFailure));
-                }
-
-                private void SourceComplete()
-                {
-                    Complete();
-                    _logic.CompleteStage();
+                    _completion.TrySetResult(Option<TMat>.None);
+                    base.OnUpstreamFinish();
                 }
             }
 
-            #endregion
+            public override void OnUpstreamFailure(Exception ex)
+            {
+                _completion.TrySetException(ex);
+                base.OnUpstreamFailure(ex);
+            }
+
+            private TMat SwitchTo(Sink<TIn, TMat> sink, TIn firstElement)
+            {
+                var firstElementPushed = false;
+
+                var subOutlet = new SubSourceOutlet<TIn>(this, "LazySink");
+
+                var matVal = Source.FromGraph(subOutlet.Source).RunWith(sink, Interpreter.SubFusingMaterializer);
+
+                void MaybeCompleteStage()
+                {
+                    if (IsClosed(_stage.In) && subOutlet.IsClosed)
+                        CompleteStage();
+                }
+
+                // The stage must not be shut down automatically; it is completed when MaybeCompleteStage decides
+                SetKeepGoing(true);
+
+                SetHandler(_stage.In, new LambdaInHandler(
+                    () => subOutlet.Push(Grab(_stage.In)),
+                    () =>
+                    {
+                        if (firstElementPushed)
+                        {
+                            subOutlet.Complete();
+                            MaybeCompleteStage();
+                        }
+                    },
+                    ex =>
+                    {
+                        // propagate exception irrespective if the cached element has been pushed or not
+                        subOutlet.Fail(ex);
+                        MaybeCompleteStage();
+                    }));
+
+                subOutlet.SetHandler(new LambdaOutHandler(
+                    () =>
+                    {
+                        if (firstElementPushed)
+                            Pull(_stage.In);
+                        else
+                        {
+                            // the demand can be satisfied right away by the cached element
+                            firstElementPushed = true;
+                            subOutlet.Push(firstElement);
+                            // In.OnUpstreamFinished was not propagated if it arrived before the cached element was pushed
+                            // -> check if the completion must be propagated now
+                            if (IsClosed(_stage.In))
+                            {
+                                subOutlet.Complete();
+                                MaybeCompleteStage();
+                            }
+                        }
+                    },
+                    () =>
+                    {
+                        if (!IsClosed(_stage.In)) Cancel(_stage.In);
+                        MaybeCompleteStage();
+                    }));
+
+                return matVal;
+            }
         }
 
         #endregion
 
         private readonly Func<TIn, Task<Sink<TIn, TMat>>> _sinkFactory;
-        private readonly Func<TMat> _zeroMaterialised;
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="sinkFactory">TBD</param>
-        /// <param name="zeroMaterialised">TBD</param>
-        public LazySink(Func<TIn, Task<Sink<TIn, TMat>>> sinkFactory, Func<TMat> zeroMaterialised)
+        public LazySink(Func<TIn, Task<Sink<TIn, TMat>>> sinkFactory)
         {
             _sinkFactory = sinkFactory;
-            _zeroMaterialised = zeroMaterialised;
-
             Shape = new SinkShape<TIn>(In);
         }
 
@@ -1127,11 +1115,11 @@ namespace Akka.Streams.Implementation
         /// </summary>
         /// <param name="inheritedAttributes">TBD</param>
         /// <returns>TBD</returns>
-        public override ILogicAndMaterializedValue<Task<TMat>> CreateLogicAndMaterializedValue(Attributes inheritedAttributes)
+        public override ILogicAndMaterializedValue<Task<Option<TMat>>> CreateLogicAndMaterializedValue(Attributes inheritedAttributes)
         {
-            var completion = new TaskCompletionSource<TMat>();
+            var completion = new TaskCompletionSource<Option<TMat>>();
             var stageLogic = new Logic(this, inheritedAttributes, completion);
-            return new LogicAndMaterializedValue<Task<TMat>>(stageLogic, completion.Task);
+            return new LogicAndMaterializedValue<Task<Option<TMat>>>(stageLogic, completion.Task);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Implementation/Stages/Stages.cs
+++ b/src/core/Akka.Streams/Implementation/Stages/Stages.cs
@@ -423,6 +423,10 @@ namespace Akka.Streams.Implementation.Stages
         /// <summary>
         /// TBD
         /// </summary>
+        public static readonly Attributes LazyFlow = Attributes.CreateName("lazyFlow");
+        /// <summary>
+        /// TBD
+        /// </summary>
         public static readonly Attributes LazySource = Attributes.CreateName("lazySource");
         /// <summary>
         /// TBD


### PR DESCRIPTION
Currently, we have `LazySource` and `LazySink`. This PR adds the missing `LazyFlow` and the `Flow.LazyInitAsync` stage that builds on top of it. 

## Changes

Also, `Sink.LazyInit` materialized value is a now wrapped in a `Task` to clearly indicate whether the internal sink was materialized or not. It is marked deprecated in favor of the new `Sink.LazyInitAsync`, aligned with `Flow.LazyInitAsync`.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [X] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [X] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [X] Changes in public API reviewed, if any.
* [X] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

Don't apply.

### This PR's Benchmarks

Don't apply.