### PR TITLE
code cleanup on Akka.Persistence

### DIFF
--- a/src/core/Akka.Persistence/Eventsourced.Lifecycle.cs
+++ b/src/core/Akka.Persistence/Eventsourced.Lifecycle.cs
@@ -63,10 +63,21 @@ namespace Akka.Persistence
             finally
             {
                 object inner;
-                if (message is WriteMessageSuccess) inner = (message as WriteMessageSuccess).Persistent;
-                else if (message is LoopMessageSuccess) inner = (message as LoopMessageSuccess).Message;
-                else if (message is ReplayedMessage) inner = (message as ReplayedMessage).Persistent;
-                else inner = message;
+                switch (message)
+                {
+                    case WriteMessageSuccess success:
+                        inner = success.Persistent;
+                        break;
+                    case LoopMessageSuccess success:
+                        inner = success.Message;
+                        break;
+                    case ReplayedMessage replayedMessage:
+                        inner = replayedMessage.Persistent;
+                        break;
+                    default:
+                        inner = message;
+                        break;
+                }
 
                 FlushJournalBatch();
                 base.AroundPreRestart(cause, inner);
@@ -97,31 +108,36 @@ namespace Akka.Persistence
         /// <inheritdoc/>
         protected override void Unhandled(object message)
         {
-            if (message is RecoveryCompleted) return; // ignore
-            if (message is SaveSnapshotFailure)
+            switch (message)
             {
-                var m = (SaveSnapshotFailure) message;
-                if (Log.IsWarningEnabled)
-                    Log.Warning("Failed to SaveSnapshot given metadata [{0}] due to: [{1}: {2}]", m.Metadata, m.Cause, m.Cause.Message);
+                case RecoveryCompleted _:
+                    return; // ignore
+                case SaveSnapshotFailure failure:
+                {
+                    if (Log.IsWarningEnabled)
+                        Log.Warning("Failed to SaveSnapshot given metadata [{0}] due to: [{1}: {2}]", failure.Metadata, failure.Cause, failure.Cause.Message);
+                    break;
+                }
+                case DeleteSnapshotFailure failure:
+                {
+                    if (Log.IsWarningEnabled)
+                        Log.Warning("Failed to DeleteSnapshot given metadata [{0}] due to: [{1}: {2}]", failure.Metadata, failure.Cause, failure.Cause.Message);
+                    break;
+                }
+                case DeleteSnapshotsFailure failure:
+                {
+                    if (Log.IsWarningEnabled)
+                        Log.Warning("Failed to DeleteSnapshots given criteria [{0}] due to: [{1}: {2}]", failure.Criteria, failure.Cause, failure.Cause.Message);
+                    break;
+                }
+                case DeleteMessagesFailure failure:
+                {
+                    if (Log.IsWarningEnabled)
+                        Log.Warning("Failed to DeleteMessages ToSequenceNr [{0}] for PersistenceId [{1}] due to: [{2}: {3}]", failure.ToSequenceNr, PersistenceId, failure.Cause, failure.Cause.Message);
+                    break;
+                }
             }
-            if (message is DeleteSnapshotFailure)
-            {
-                var m = (DeleteSnapshotFailure) message;
-                if (Log.IsWarningEnabled)
-                    Log.Warning("Failed to DeleteSnapshot given metadata [{0}] due to: [{1}: {2}]", m.Metadata, m.Cause, m.Cause.Message);
-            }
-            if (message is DeleteSnapshotsFailure)
-            {
-                var m = (DeleteSnapshotsFailure) message;
-                if (Log.IsWarningEnabled)
-                    Log.Warning("Failed to DeleteSnapshots given criteria [{0}] due to: [{1}: {2}]", m.Criteria, m.Cause, m.Cause.Message);
-            }
-            if (message is DeleteMessagesFailure)
-            {
-                var m = (DeleteMessagesFailure) message;
-                if (Log.IsWarningEnabled)
-                    Log.Warning("Failed to DeleteMessages ToSequenceNr [{0}] for PersistenceId [{1}] due to: [{2}: {3}]", m.ToSequenceNr, PersistenceId, m.Cause, m.Cause.Message);
-            }
+
             base.Unhandled(message);
         }
     }

--- a/src/core/Akka.Persistence/Eventsourced.cs
+++ b/src/core/Akka.Persistence/Eventsourced.cs
@@ -628,9 +628,9 @@ namespace Akka.Persistence
                     var sender = Sender;
                     Context.System.DeadLetters.Tell(new DeadLetter(currentMessage, sender, Self), Sender);
                 }
-                else if (strategy is ReplyToStrategy)
+                else if (strategy is ReplyToStrategy toStrategy)
                 {
-                    Sender.Tell(((ReplyToStrategy)strategy).Response);
+                    Sender.Tell(toStrategy.Response);
                 }
                 else if (strategy is ThrowOverflowExceptionStrategy)
                 {


### PR DESCRIPTION
## Changes

Cleaning up some of the `Eventsourced` and `AsyncWriteJournal` code to use newer C# features - should help improve with compiler optimization in some small areas, but mostly serves to help improve readability.
