### PR TITLE
Cluster startup hard block

### DIFF
--- a/src/core/Akka.Cluster.Tests/StartupWithChannelExecutorSpec.cs
+++ b/src/core/Akka.Cluster.Tests/StartupWithChannelExecutorSpec.cs
@@ -1,0 +1,74 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="StartupWithOneThreadSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using Akka.Actor;
+using Akka.Actor.Dsl;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.TestKit;
+using Akka.Util;
+using Xunit;
+
+namespace Akka.Cluster.Tests
+{
+    public sealed class StartupWithChannelExecutorSpec : AkkaSpec
+    {
+        private static readonly Config Configuration = ConfigurationFactory.ParseString(@"
+            akka.actor.creation-timeout = 10s
+            akka.actor.provider = cluster
+            akka.actor.default-dispatcher.executor = channel-executor
+            akka.actor.internal-dispatcher.executor = channel-executor
+            akka.remote.default-remote-dispatcher.executor = channel-executor
+            akka.remote.backoff-remote-dispatcher.executor = channel-executor            
+        ").WithFallback(ConfigurationFactory.Default());
+
+        private long _startTime;
+
+        public StartupWithChannelExecutorSpec() : base(Configuration)
+        {
+            _startTime = MonotonicClock.GetTicks();
+        }
+
+        private Props TestProps
+        {
+            get
+            {
+                Action<IActorDsl> actor = (c =>
+                {
+                    c.ReceiveAny((o, context) => context.Sender.Tell(o));
+                    c.OnPreStart = context =>
+                    {
+                        var log = context.GetLogger();
+                        var cluster = Cluster.Get(context.System);
+                        log.Debug("Started {0} {1}", cluster.SelfAddress, Thread.CurrentThread.Name);
+                    };
+                });
+                return Props.Create(() => new Act(actor));
+            }
+        }
+
+        [Fact]
+        public void A_cluster_must_startup_with_channel_executor_dispatcher()
+        {
+            var totalStartupTime = TimeSpan.FromTicks(MonotonicClock.GetTicks() - _startTime).TotalMilliseconds;
+            Assert.True(totalStartupTime < (Sys.Settings.CreationTimeout - TimeSpan.FromSeconds(2)).TotalMilliseconds);
+            Sys.ActorOf(TestProps).Tell("hello");
+            Sys.ActorOf(TestProps).Tell("hello");
+            Sys.ActorOf(TestProps).Tell("hello");
+
+            var cluster = Cluster.Get(Sys);
+            totalStartupTime = TimeSpan.FromTicks(MonotonicClock.GetTicks() - _startTime).TotalMilliseconds;
+            Assert.True(totalStartupTime < (Sys.Settings.CreationTimeout - TimeSpan.FromSeconds(2)).TotalMilliseconds);
+
+            ExpectMsg("hello");
+            ExpectMsg("hello");
+            ExpectMsg("hello");
+        }
+    }
+}

--- a/src/core/Akka/Dispatch/ChannelSchedulerExtension.cs
+++ b/src/core/Akka/Dispatch/ChannelSchedulerExtension.cs
@@ -62,14 +62,17 @@ namespace Akka.Dispatch
             //config channel-scheduler
             var config = system.Settings.Config.GetConfig("akka.channel-scheduler");
             _maximumConcurrencyLevel = ThreadPoolConfig.ScaledPoolSize(
-                        config.GetInt("parallelism-min"),
-                        config.GetDouble("parallelism-factor", 1.0D), // the scalar-based factor to scale the threadpool size to 
-                        config.GetInt("parallelism-max"));
+                        config?.GetInt("parallelism-min", 4) ?? 4,
+                        config?.GetDouble("parallelism-factor", 1.0D) ?? 1.0D, // the scalar-based factor to scale the threadpool size to 
+                        config?.GetInt("parallelism-max", 64) ?? 64);
             _maximumConcurrencyLevel = Math.Max(_maximumConcurrencyLevel, 1);
-            _maxWork = Math.Max(config.GetInt("work-max", _maxWork), 3); //min 3 normal work in work-loop
-
-            _workInterval = config.GetInt("work-interval", _workInterval);
-            _workStep = config.GetInt("work-step", _workStep);
+            
+            if (config != null)
+            {
+                _maxWork = Math.Max(config.GetInt("work-max", _maxWork), 3); //min 3 normal work in work-loop
+                _workInterval = config.GetInt("work-interval", _workInterval);
+                _workStep = config.GetInt("work-step", _workStep);
+            }                
 
             //create task schedulers
             var channelOptions = new UnboundedChannelOptions()
@@ -276,7 +279,7 @@ namespace Akka.Dispatch
             //the work loop
             _threadPriority = TaskSchedulerPriority.Idle;
             try
-            {   
+            {
                 do
                 {
                     rounds++;


### PR DESCRIPTION
Fixes https://github.com/akkadotnet/akka.net/issues/5498
Fix startup with missing config for channel-executor

## Changes

The constructor thread of cluster startup got reused by the default TaskScheduler used by the ChannelExecutor.



