### PR TITLE
Removed comment that no longer applies.

### DIFF
--- a/src/core/Akka.TestKit/TestKitBase_Receive.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Receive.cs
@@ -62,7 +62,6 @@ namespace Akka.TestKit
         ///
         /// Ignores all messages except for a message of type <typeparamref name="T"/>.
         /// Asserts that all messages are not of the of type <typeparamref name="T"/>.
-        /// Note that when comparing types, inheritance is ignored, in other words, only perfectly matching types are asserted.
         /// </summary>
         /// <typeparam name="T">The type that the message is not supposed to be.</typeparam>
         /// <param name="max">Optional. The maximum wait duration. Defaults to <see cref="RemainingOrDefault"/> when unset.</param>


### PR DESCRIPTION
When I wrote this comment originally, it applied. Since then, the implementation of the method has changed. Now, the comment no longer applies. Therefore, I removed the comment. 
