### PR TITLE
Renamed FishUntilMessage to FishUntilMessageAsync

### DIFF
--- a/src/core/Akka.TestKit.Tests/TestKitBaseTests/ReceiveTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestKitBaseTests/ReceiveTests.cs
@@ -68,20 +68,20 @@ namespace Akka.Testkit.Tests.TestKitBaseTests
         }
 
         [Fact]
-        public async Task FishUntilMessage_should_succeed_with_good_input()
+        public async Task FishUntilMessageAsync_should_succeed_with_good_input()
         {
             var probe = CreateTestProbe("probe");
             probe.Ref.Tell(1d, TestActor);
-            await probe.FishUntilMessage<int>(max: TimeSpan.FromMilliseconds(10));
+            await probe.FishUntilMessageAsync<int>(max: TimeSpan.FromMilliseconds(10));
         }
 
 
         [Fact]
-        public async Task FishUntilMessage_should_fail_with_bad_input()
+        public async Task FishUntilMessageAsync_should_fail_with_bad_input()
         {
             var probe = CreateTestProbe("probe");
             probe.Ref.Tell(3, TestActor);
-            Func<Task> func = () => probe.FishUntilMessage<int>(max: TimeSpan.FromMilliseconds(10));
+            Func<Task> func = () => probe.FishUntilMessageAsync<int>(max: TimeSpan.FromMilliseconds(10));
             await func.Should().ThrowAsync<Exception>();
         }
 

--- a/src/core/Akka.TestKit/TestKitBase_Receive.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Receive.cs
@@ -65,7 +65,7 @@ namespace Akka.TestKit
         /// </summary>
         /// <typeparam name="T">The type that the message is not supposed to be.</typeparam>
         /// <param name="max">Optional. The maximum wait duration. Defaults to <see cref="RemainingOrDefault"/> when unset.</param>
-        public async Task FishUntilMessage<T>(TimeSpan? max = null)
+        public async Task FishUntilMessageAsync<T>(TimeSpan? max = null)
         {
             await Task.Run(() =>
             {


### PR DESCRIPTION
This PR renaming breaks backwards compatibility. 
But since the original fixed code is very young - I think it is worth it. 