### PR TITLE
fixed - InternalExpectAsync does not await actionAsync() - causing ac…

### DIFF
--- a/src/core/Akka.TestKit/EventFilter/Internal/EventFilterApplier.cs
+++ b/src/core/Akka.TestKit/EventFilter/Internal/EventFilterApplier.cs
@@ -456,7 +456,7 @@ namespace Akka.TestKit.Internal
         /// </summary>
         private async Task InternalExpectAsync(Func<Task> actionAsync, ActorSystem actorSystem, int expectedCount, TimeSpan? timeout = null)
         {
-            await InterceptAsync<object>(() => { actionAsync(); return Task.FromResult<object>(null); }, actorSystem, timeout, expectedCount);
+            await InterceptAsync<object>(async () => { await actionAsync(); return Task.FromResult<object>(null); }, actorSystem, timeout, expectedCount);
         }
         
         /// <summary>


### PR DESCRIPTION
…tionAsync to run as a detached task #5537

Fixes #
InternalExpectAsync does not await actionAsync() - causing actionAsync to run as a detached task #5537

## Changes
1. added a test ExpectAsync_should_await_actionAsync that reproduced the issue by failing and stopped failing when fix was applied. 
2. the actual fix: added async and await. 

Please provide a brief description of the changes here.
1. the issue was that a test that should have failed, was not failing. 
2. so I created test that reproduces this issue - a test that fails - when a failed assertion was not failing (a false positive).
3. once I created the test (RED), I fixed the issue (GREEN). 
4. done


Include data from before / after this change here.

Before: 
```c#
﻿ Akka.TestKit.Tests.Xunit2.TestEventListenerTests.CustomEventFilterWarningTests.ExpectAsync_should_await_actionAsync
   Source: AllTestForEventFilterBase.cs line 180
   Duration: 3.6 sec

  Message: 
Assert.Throws() Failure
Expected: typeof(Akka.TestKit.Xunit2.Internals.AkkaEqualException)
Actual:   (No exception was thrown)

  Stack Trace: 
AllTestForEventFilterBase`1.ExpectAsync_should_await_actionAsync() line 183
--- End of stack trace from previous location ---

```

After: 

```c#
﻿ Akka.TestKit.Tests.Xunit2.TestEventListenerTests.CustomEventFilterWarningTests.ExpectAsync_should_await_actionAsync
   Source: AllTestForEventFilterBase.cs line 180
   Duration: 450 ms

```