### PR TITLE
Channel executor not injected

### DIFF
--- a/src/core/Akka.Tests/Dispatch/ChannelExecutorSpec.cs
+++ b/src/core/Akka.Tests/Dispatch/ChannelExecutorSpec.cs
@@ -1,0 +1,22 @@
+﻿
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Tests.Dispatch
+{
+    public class ChannelExecutorSpec : AkkaSpec
+    {
+        [Fact]
+        public void Should_Successfully_Create_Channel_Executor_ActorSystem()
+        {
+            var config = @"
+                          akka.actor.default-dispatcher = { 
+                              executor = channel-executor
+                              channel-executor.priority = normal
+                          }";
+            var actorSytem = ActorSystem.Create("ce", config);
+        }
+    }
+}

--- a/src/core/Akka.Tests/Dispatch/ChannelExecutorSpec.cs
+++ b/src/core/Akka.Tests/Dispatch/ChannelExecutorSpec.cs
@@ -14,7 +14,7 @@ namespace Akka.Tests.Dispatch
             var config = @"
                           akka.actor.default-dispatcher = { 
                               executor = channel-executor
-                              channel-executor.priority = normal
+                              # channel-executor.priority = normal
                           }";
             var actorSytem = ActorSystem.Create("ce", config);
         }

--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -268,16 +268,6 @@ akka {
         }
       }
     }
-
-    channel-scheduler {
-        parallelism-min = 4    #same as for ForkJoinDispatcher
-        parallelism-factor = 1 #same as for ForkJoinDispatcher
-        parallelism-max = 64   #same as for ForkJoinDispatcher
-        work-max = 10          #max executed work items in sequence until priority loop
-	    work-interval = 500    #time target of executed work items in ms
-	    work-step = 2          #target work item count in interval / burst
-    }
-
     #used for GUI applications
     synchronized-dispatcher {
         type = "SynchronizedDispatcher"
@@ -560,7 +550,14 @@ akka {
       }
     }
   }
-
+  channel-scheduler {
+        parallelism-min = 4    #same as for ForkJoinDispatcher
+        parallelism-factor = 1 #same as for ForkJoinDispatcher
+        parallelism-max = 64   #same as for ForkJoinDispatcher
+        work-max = 10          #max executed work items in sequence until priority loop
+	    work-interval = 500    #time target of executed work items in ms
+	    work-step = 2          #target work item count in interval / burst
+    }
   # Used to set the behavior of the scheduler.
   # Changing the default values may change the system behavior drastically so make
   # sure you know what you're doing! See the Scheduler section of the Akka

--- a/src/core/Akka/Dispatch/ChannelSchedulerExtension.cs
+++ b/src/core/Akka/Dispatch/ChannelSchedulerExtension.cs
@@ -60,7 +60,7 @@ namespace Akka.Dispatch
         public ChannelTaskScheduler(ExtendedActorSystem system)
         {
             //config channel-scheduler
-            var config = system.Settings.Config.GetConfig("akka.channel-scheduler");
+            var config = system.Settings.Config.GetConfig("akka.actor.channel-scheduler");
             _maximumConcurrencyLevel = ThreadPoolConfig.ScaledPoolSize(
                         config.GetInt("parallelism-min"),
                         config.GetDouble("parallelism-factor", 1.0D), // the scalar-based factor to scale the threadpool size to 

--- a/src/core/Akka/Dispatch/ChannelSchedulerExtension.cs
+++ b/src/core/Akka/Dispatch/ChannelSchedulerExtension.cs
@@ -60,7 +60,7 @@ namespace Akka.Dispatch
         public ChannelTaskScheduler(ExtendedActorSystem system)
         {
             //config channel-scheduler
-            var config = system.Settings.Config.GetConfig("akka.actor.channel-scheduler");
+            var config = system.Settings.Config.GetConfig("akka.channel-scheduler");
             _maximumConcurrencyLevel = ThreadPoolConfig.ScaledPoolSize(
                         config.GetInt("parallelism-min"),
                         config.GetDouble("parallelism-factor", 1.0D), // the scalar-based factor to scale the threadpool size to 


### PR DESCRIPTION
Fixes #5541

## Changes

From `var config = system.Settings.Config.GetConfig("akka.channel-scheduler");` to `var config = system.Settings.Config.GetConfig("akka.actor.channel-scheduler");`

* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #5541
