### PR TITLE
Fixing Racy ClusterLogVerboseEnabledSpec

### DIFF
--- a/src/core/Akka.Cluster.Tests/ClusterLogSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterLogSpec.cs
@@ -123,7 +123,7 @@ namespace Akka.Cluster.Tests
             _cluster.Settings.LogInfoVerbose.ShouldBeFalse();
             await JoinAsync("is the new leader");
             AwaitUp();
-            Down("is no longer leader");
+            await DownAsync("is no longer leader");
         }
     }
 


### PR DESCRIPTION
## Changes

* [Exp.] Increase `TimeOut` to 1 mins from default 3s
* Converted test to `async/await`
* Added `JoinAsync` and `DownAsync`

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
