### PR TITLE
Fix: no `DeadLetter`s when publishing to a `Topic` with no subscribers

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubMediatorSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubMediatorSpec.cs
@@ -79,9 +79,6 @@ namespace Akka.Cluster.Tools.Tests.PublishSubscribe
             _ = ExpectMsg<UnsubscribeAck>();
 
             // assert
-
-            // slightly racey, since the 0-subscriber topics are removed on a scheduled task that runs once per second
-            // hence why we use AwaitAssert to re-run the assertion
             await EventFilter.DeadLetter<object>().ExpectAsync(1,
                 () => { mediator.Tell(new Publish("pub-sub", $"hit")); });
         }

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubMediator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubMediator.cs
@@ -643,7 +643,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
 
         private IActorRef NewTopicActor(string encodedTopic)
         {
-            var t = Context.ActorOf(Actor.Props.Create(() => new Topic(_settings.RemovedTimeToLive, _settings.RoutingLogic)), encodedTopic);
+            var t = Context.ActorOf(Actor.Props.Create(() => new Topic(_settings.RemovedTimeToLive, _settings.RoutingLogic, _settings.SendToDeadLettersWhenNoSubscribers)), encodedTopic);
             HandleRegisterTopic(t);
             return t;
         }


### PR DESCRIPTION
The summary of the PubSub design is this, as it relates to #5352, if there are no subscribers, wait on the Deadline and if no new subscriber within that window terminate the Topic actor.

It is the `waiting on the Deadline` that is the actual issue.