### PR TITLE
Added `SendToDeadLettersWhenNoSubscribers` to `DistributedPubSubConfigSpec`

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubConfigSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubConfigSpec.cs
@@ -38,6 +38,7 @@ namespace Akka.Cluster.Tools.Tests.PublishSubscribe
             distributedPubSubSettings.RoutingLogic.GetType().ShouldBe(typeof(RandomLogic));
             distributedPubSubSettings.GossipInterval.TotalSeconds.ShouldBe(1);
             distributedPubSubSettings.RemovedTimeToLive.TotalSeconds.ShouldBe(120);
+            distributedPubSubSettings.SendToDeadLettersWhenNoSubscribers.ShouldBe(true);
             distributedPubSubSettings.MaxDeltaElements.ShouldBe(3000);
 
             var config = Sys.Settings.Config.GetConfig("akka.cluster.pub-sub");


### PR DESCRIPTION
Fixes #5557

## Changes

Assert `true` to be the default value for `SendToDeadLettersWhenNoSubscribers`