### PR TITLE
Fix ChannelExecutor configuration backward compatibility problem

### DIFF
--- a/src/core/Akka.Tests/Dispatch/ChannelExecutorConfigurationSpec.cs
+++ b/src/core/Akka.Tests/Dispatch/ChannelExecutorConfigurationSpec.cs
@@ -1,0 +1,67 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="ChannelExecutorConfigurationSpec.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Dispatch;
+using Akka.TestKit;
+using Xunit;
+using FluentAssertions;
+
+namespace Akka.Tests.Dispatch
+{
+    public class ChannelExecutorConfigurationSpec : AkkaSpec
+    {
+        [Fact]
+        public void ChannelExecutor_config_should_be_injected_when_it_doesnt_exist()
+        {
+            var config = ConfigurationFactory.ParseString(@"executor = channel-executor");
+            var configurator = new ChannelExecutorConfigurator(config, Sys.Dispatchers.Prerequisites);
+            configurator.Priority.Should().Be(TaskSchedulerPriority.Normal);
+        }
+
+        [Fact]
+        public void ChannelExecutor_default_should_be_overriden_by_config()
+        {
+            var config = ConfigurationFactory.ParseString(@"
+executor = channel-executor
+channel-executor.priority = high");
+            var configurator = new ChannelExecutorConfigurator(config, Sys.Dispatchers.Prerequisites);
+            configurator.Priority.Should().Be(TaskSchedulerPriority.High);
+        }
+
+        [Fact]
+        public void ChannelExecutorConfigurator_should_use_default_when_config_is_null()
+        {
+            var configurator = new ChannelExecutorConfigurator(null, Sys.Dispatchers.Prerequisites);
+            configurator.Priority.Should().Be(TaskSchedulerPriority.Normal);
+        }
+
+        // backward compatibility test
+        [Fact]
+        public async Task ChannelExecutor_instantiation_should_not_throw_when_config_doesnt_exist()
+        {
+            var config = ConfigurationFactory.ParseString(@"
+akka.actor.default-dispatcher = { 
+    executor = channel-executor
+}");
+            
+            // Throws NRE in 1.4.29-32
+            var sys = ActorSystem.Create("test", config);
+            
+            // Check that all settings are correct
+            var dispatcher = sys.Dispatchers.Lookup("akka.actor.default-dispatcher");
+            dispatcher.Configurator.Config.GetString("executor").Should().Be("channel-executor");
+            
+            var configurator = new ChannelExecutorConfigurator(dispatcher.Configurator.Config, Sys.Dispatchers.Prerequisites);
+            configurator.Priority.Should().Be(TaskSchedulerPriority.Normal);
+
+            await sys.Terminate();
+        }
+    }
+}

--- a/src/core/Akka/Dispatch/AbstractDispatcher.cs
+++ b/src/core/Akka/Dispatch/AbstractDispatcher.cs
@@ -118,10 +118,16 @@ namespace Akka.Dispatch
 
     internal sealed class ChannelExecutorConfigurator : ExecutorServiceConfigurator
     {
+        private static readonly Config PriorityDefault = ConfigurationFactory.ParseString(@"
+executor = channel-executor 
+channel-executor.priority = normal");
+        
         public ChannelExecutorConfigurator(Config config, IDispatcherPrerequisites prerequisites) : base(config, prerequisites)
         {
-            var cfg = config.GetConfig("channel-executor");
-            Priority = (TaskSchedulerPriority)Enum.Parse(typeof(TaskSchedulerPriority), cfg.GetString("priority", "normal"), true);
+            config = config == null ? PriorityDefault : config.WithFallback(PriorityDefault);
+            
+            var priority = config.GetString("channel-executor.priority", "normal");
+            Priority = (TaskSchedulerPriority)Enum.Parse(typeof(TaskSchedulerPriority), priority, true);
         }
 
         public TaskSchedulerPriority Priority { get; }

--- a/src/core/Akka/Dispatch/ChannelSchedulerExtension.cs
+++ b/src/core/Akka/Dispatch/ChannelSchedulerExtension.cs
@@ -60,7 +60,7 @@ namespace Akka.Dispatch
         public ChannelTaskScheduler(ExtendedActorSystem system)
         {
             //config channel-scheduler
-            var config = system.Settings.Config.GetConfig("akka.channel-scheduler");
+            var config = system.Settings.Config.GetConfig("akka.actor.channel-scheduler");
             _maximumConcurrencyLevel = ThreadPoolConfig.ScaledPoolSize(
                         config.GetInt("parallelism-min"),
                         config.GetDouble("parallelism-factor", 1.0D), // the scalar-based factor to scale the threadpool size to 
@@ -349,7 +349,7 @@ namespace Akka.Dispatch
         /// and to help execute queued works internaly. 
         /// It supports task-inlining only for task equal or above the own priority
         /// </summary>
-        sealed class PriorityTaskScheduler : TaskScheduler, IDisposable
+        internal sealed class PriorityTaskScheduler : TaskScheduler, IDisposable
         {
             readonly Channel<Task> _channel;
 


### PR DESCRIPTION
Fixes #5541

## Changes

Make sure that `channel-executor` configuration is injected properly when it is missing