### PR TITLE
Fix support for `serialization-identifier` identifier override

### DIFF
--- a/src/core/Akka/Serialization/Serialization.cs
+++ b/src/core/Akka/Serialization/Serialization.cs
@@ -337,8 +337,8 @@ namespace Akka.Serialization
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void AddSerializer(string name, Serializer serializer)
         {
-            _serializersById.Add(serializer.Identifier, serializer);
-            _serializersByName.Add(name, serializer);
+            _serializersById[serializer.Identifier] = serializer;
+            _serializersByName[name] = serializer;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #5569

## Changes

Change the serialization initializer from using `Dictionary.Add()` to the index property, `Dictionary.Add()` does not like it when a key is inserted multiple times.