### PR TITLE
Wait for radio silence

### DIFF
--- a/src/core/Akka.TestKit.Tests/TestKitBaseTests/ReceiveTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestKitBaseTests/ReceiveTests.cs
@@ -86,6 +86,26 @@ namespace Akka.Testkit.Tests.TestKitBaseTests
         }
 
         [Fact]
+        public async Task WaitForRadioSilenceAsync_should_succeed_with_good_input()
+        {
+            var probe = CreateTestProbe("probe");
+            await probe.WaitForRadioSilenceAsync(max: TimeSpan.FromMilliseconds(0));
+        }
+
+        [Fact]
+        public async Task WaitForRadioSilenceAsync_should_fail_with_bad_input()
+        {
+            var probe = CreateTestProbe("probe");
+            probe.Ref.Tell(3, TestActor);
+            try
+            {
+                await probe.WaitForRadioSilenceAsync(max: TimeSpan.FromMilliseconds(0), maxIterations: 0);
+                Assert.True(false, "we should never get here");
+            }
+            catch (XunitException) { }
+        }
+
+        [Fact]
         public void ReceiveWhile_Filter_should_on_a_timeout_return_no_messages()
         {
             ReceiveWhile<object>(_ => _, TimeSpan.FromMilliseconds(10)).Count.ShouldBe(0);

--- a/src/core/Akka.TestKit/TestKitBase_Receive.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Receive.cs
@@ -95,7 +95,7 @@ namespace Akka.TestKit
 
                 for (uint i = 0; ; i++)
                 {
-                    _assertions.AssertFalse(maxIterations.HasValue && i >= maxIterations.Value, $"{nameof(maxIterations)} violated (current iteration: {i}).");
+                    _assertions.AssertFalse(maxIterations.HasValue && i > maxIterations.Value, $"{nameof(maxIterations)} violated (current iteration: {i}).");
 
                     var currentMessages = ReceiveWhile<object>(shouldContinue: x => true, max: max);
 


### PR DESCRIPTION
Fixes: 
Nothing is fixed in this PR.

Changes: 
1. I added a new API method: WaitForRadioSilenceAsync
2. I added a bunch of tests for this new method

A brief description of the changes:
I have been using my own WaitForRadioSilenceAsync for a while now. 
And I find it very useful. So I thought to contribute it to the community. 
As its name suggests, it waits for radio silence. 
"radio silence": A period of time during which no messages are encountered by a probe.

Is it a significant change: 
No. 
