### PR TITLE
Consistent Markdown Styling

### DIFF
--- a/docs/articles/actors/routers.md
+++ b/docs/articles/actors/routers.md
@@ -569,7 +569,7 @@ Most messages sent to router will be forwarded according to router's routing log
 
 ### Broadcast Messages
 
-A `Broadcast` message can be used to send message to __all__ routees of a router. When a router receives `Broadcast` message, it will broadcast that message's __payload__ to all routees, no matter how that router normally handles its messages.
+A `Broadcast` message can be used to send message to **all** routees of a router. When a router receives `Broadcast` message, it will broadcast that message's **payload** to all routees, no matter how that router normally handles its messages.
 
 Here is an example of how to send a message to every routee of a router.
 
@@ -596,7 +596,7 @@ In this example, the router received the `Broadcast` message, extracted its payl
 
 When an actor received `PoisonPill` message, that actor will be stopped. (see [PoisonPill](xref:receive-actor-api#poisonpill) for details).
 
-For a router, which normally passes on messages to routees, the `PoisonPill` messages are processed __by the router only__. `PoisonPill` messages sent to a router will __not__ be sent on to its routees.
+For a router, which normally passes on messages to routees, the `PoisonPill` messages are processed **by the router only**. `PoisonPill` messages sent to a router will **not** be sent on to its routees.
 
 However, a `PoisonPill` message sent to a router may still affect its routees, as it will stop the router which in turns stop children the router has created. Each child will process its current message and then stop. This could lead to some messages being unprocessed.
 

--- a/docs/articles/clustering/cluster-sharding.md
+++ b/docs/articles/clustering/cluster-sharding.md
@@ -176,7 +176,7 @@ For supporting remembered entities in an environment without disk storage but wi
 
 One complication that  `akka.cluster.sharding.remember-entities = true` introduces is that your sharded entity actors can no longer be terminated through the normal Akka.NET channels, i.e. `Context.Stop(Self)`, `PoisonPill.Instance`, and the like. This is because as part of the `remember-entities` contract - the sharding system is going to insist on keeping all remembered entities alive until explicitly told to stop.
 
-To terminate a remembered entity, the sharded entity actor needs to send a [`Passivate` command](xref:Akka.Cluster.Sharding.Passivate) _to its parent actor_ in order to signal to the sharding system that we no longer need to remember this particular entity.
+To terminate a remembered entity, the sharded entity actor needs to send a [`Passivate` command](xref:Akka.Cluster.Sharding.Passivate) *to its parent actor* in order to signal to the sharding system that we no longer need to remember this particular entity.
 
 ```csharp
 protected override bool ReceiveCommand(object message)
@@ -256,7 +256,7 @@ In the normal operation of an Akka.NET cluster, the sharding system automaticall
 
 However, in the event that an `ActorSystem` is aborted as a result of a process / hardware failure it's possible that when using `akka.cluster.sharding.state-store-mode=persistence` leftover sharding data can still be present inside the Akka.Persistence journal and snapshot store - which will prevent the Akka.Cluster.Sharding system from recovering and starting up correctly the next time it's launched.
 
-This is a _rare_, but not impossible occurrence. In the event that this happens you'll need to purge the old Akka.Cluster.Sharding data before restarting the sharding system. You can purge this data automatically by [using the Akka.Cluster.Sharding.RepairTool](https://github.com/petabridge/Akka.Cluster.Sharding.RepairTool) produced by [Petabridge](https://petabridge.com/).
+This is a *rare*, but not impossible occurrence. In the event that this happens you'll need to purge the old Akka.Cluster.Sharding data before restarting the sharding system. You can purge this data automatically by [using the Akka.Cluster.Sharding.RepairTool](https://github.com/petabridge/Akka.Cluster.Sharding.RepairTool) produced by [Petabridge](https://petabridge.com/).
 
 ## Tutorial
 

--- a/docs/articles/clustering/split-brain-resolver.md
+++ b/docs/articles/clustering/split-brain-resolver.md
@@ -54,7 +54,7 @@ akka.cluster {
 This will cause the [`Akka.Cluster.SBR.SplitBrainResolverProvider`](xref:Akka.Cluster.SBR.SplitBrainResolverProvider) to be loaded by Akka.Cluster at startup and it will automatically begin executing your configured `active-strategy` on each member node that joins the cluster.
 
 > [!IMPORTANT]
-> _The cluster leader_ on either side of the partition is the only one who actually downs unreachable nodes in the event of a split brain - so it is _essential_ that every node in the cluster be configured using the same split brain resolver settings. Otherwise there's no way to guarantee predictable behavior when network partitions occur.
+> *The cluster leader* on either side of the partition is the only one who actually downs unreachable nodes in the event of a split brain - so it is *essential* that every node in the cluster be configured using the same split brain resolver settings. Otherwise there's no way to guarantee predictable behavior when network partitions occur.
 
 The following strategies are supported:
 
@@ -105,7 +105,7 @@ There is no simple way to decide the value of `stable-after`, as:
 > [!NOTE]
 > The rule of thumb for this setting is to set `stable-after` to `log10(maxExpectedNumberOfNodes) * 10`.
 
-The `down-all-when-unstable` option, which is _enabled by default_, will terminate the entire cluster in the event that cluster instability lasts for longer than the `stable-after` + 3/4 of the `stable-after` value in seconds - so by default, 35 seconds.
+The `down-all-when-unstable` option, which is *enabled by default*, will terminate the entire cluster in the event that cluster instability lasts for longer than the `stable-after` + 3/4 of the `stable-after` value in seconds - so by default, 35 seconds.
 
 > [!IMPORTANT]
 > If you are running in an environment where processes are not automatically restarted in the event of an unplanned termination (i.e. Kubernetes), we strongly recommend that you disable this setting by setting `akka.cluster.split-brain-resolver.down-all-when-unstable = off`.

--- a/docs/articles/intro/getting-started/tutorial-3.md
+++ b/docs/articles/intro/getting-started/tutorial-3.md
@@ -146,8 +146,8 @@ we will need a way to remove those from the `Dictionary<string, IActorRef>`. We 
 is simply stopped. We need some way for the parent to be notified when one of the device actors are stopped. Unfortunately,
 supervision will not help because it is used for error scenarios, not graceful stopping.
 
-There is a feature in Akka.NET that is exactly what we need here. It is possible for an actor to _watch_ another actor
-and be notified if the other actor is stopped. This feature is called _Death Watch_ and it is an important tool for
+There is a feature in Akka.NET that is exactly what we need here. It is possible for an actor to *watch* another actor
+and be notified if the other actor is stopped. This feature is called *Death Watch* and it is an important tool for
 any Akka.NET application. Unlike supervision, watching is not limited to parent-child relationships, any actor can watch
 any other actor given its `IActorRef`. After a watched actor stops, the watcher receives a `Terminated(ref)` message
 which also contains the reference to the watched actor. The watcher can either handle this message explicitly or, if
@@ -176,7 +176,7 @@ We almost have everything to test the removal of devices. What is missing is:
 
 * Stopping a device actor from our test case, from the outside: any actor can be stopped by simply sending a special
    built-in message, `PoisonPill`, which instructs the actor to stop.
-* Be notified once the device actor is stopped: we can use the _Death Watch_ facility for this purpose, too. Thankfully
+* Be notified once the device actor is stopped: we can use the *Death Watch* facility for this purpose, too. Thankfully
    the `TestProbe` has two messages that we can easily use, `Watch()` to watch a specific actor, and `ExpectTerminated`
    to assert that the watched actor has been terminated.
 

--- a/docs/articles/persistence/custom-persistence-provider.md
+++ b/docs/articles/persistence/custom-persistence-provider.md
@@ -40,7 +40,7 @@ Task ReplayMessagesAsync(
 * **`max`**: Maximum number of messages to be replayed
 * **`recoveryCallback`**: Called to replay a message, may be called from any thread.
 
-This call is __NOT__ protected with a circuit-breaker.
+This call is **NOT** protected with a circuit-breaker.
 
 This method should asynchronously replay persistent messages:
 
@@ -438,7 +438,7 @@ In order to do this, you will need to extend two things, `IExtension` and `Exten
 
 There are two conventions that needs to be implemented when you extend `IExtension`:
 
-* Any class extending this interface is __required__ to provide a single constructor that takes a single `ExtendedActorSystem` as its argument.
+* Any class extending this interface is **required** to provide a single constructor that takes a single `ExtendedActorSystem` as its argument.
 
 [!code-csharp[Constructor](../../../src/examples/Akka.Persistence.Custom/SqlitePersistence.cs?name=Constructor "Extension constructor")]
 

--- a/docs/articles/streams/basics.md
+++ b/docs/articles/streams/basics.md
@@ -8,7 +8,7 @@ title: Basics and working with Flows
 ## Core Concepts
 
 Akka Streams is a library to process and transfer a sequence of elements using bounded buffer space.
-This latter property is what we refer to as _boundedness_ and it is the defining feature of Akka Streams.
+This latter property is what we refer to as *boundedness* and it is the defining feature of Akka Streams.
 Translated to everyday terms it is possible to express a chain (or as we see later, graphs)
 of processing entities, each executing independently (and possibly concurrently) from the others while only buffering a limited number of elements at any given time.
 This property of bounded buffers is one of the differences from the actor model, where each actor usually has an unbounded, or a bounded, but dropping mailbox.
@@ -25,7 +25,7 @@ Buffer sizes are always expressed as number of elements independently from the a
   
 **Back-pressure**  
 A means of flow-control, a way for consumers of data to notify a producer about their current availability, effectively slowing down the upstream producer to match their consumption speeds.
-In the context of Akka Streams back-pressure is always understood as _non-blocking_ and _asynchronous_.
+In the context of Akka Streams back-pressure is always understood as *non-blocking* and *asynchronous*.
   
 **Non-Blocking**  
 Means that a certain operation does not hinder the progress of the calling thread,
@@ -39,7 +39,7 @@ The common name for all building blocks that build up a `Graph`.
 Examples of a processing stage would be operations like `Select()`, `Where()`, custom `GraphStage's` and graph junctions like `Merge` or `Broadcast`.
 For the full list of built-in processing stages see [stages overview](xref:streams-builtin-stages)
   
-When we talk about _asynchronous, non-blocking backpressure_ we mean that the processing stages available in Akka Streams
+When we talk about *asynchronous, non-blocking backpressure* we mean that the processing stages available in Akka Streams
 will not use blocking calls but asynchronous message passing to exchange messages between each other,
 and they will use asynchronous means to slow down a fast producer, without blocking its thread.
 This is a thread-pool friendly design, since entities that need to wait (a fast producer waiting on a slow consumer)
@@ -50,13 +50,13 @@ will not block the thread but can hand it back for further use to an underlying 
 Linear processing pipelines can be expressed in Akka Streams using the following core abstractions:  
   
 **Source**  
-A processing stage with _exactly one output_, emitting data elements whenever downstream processing stages are ready to receive them.
+A processing stage with *exactly one output*, emitting data elements whenever downstream processing stages are ready to receive them.
   
 **Sink**  
-A processing stage with _exactly one input_, requesting and accepting data elements possibly slowing down the upstream producer of elements
+A processing stage with *exactly one input*, requesting and accepting data elements possibly slowing down the upstream producer of elements
   
 **Flow**  
-A processing stage which has _exactly one input and output_, which connects its up- and downstreams by transforming the data elements flowing through it.
+A processing stage which has *exactly one input and output*, which connects its up- and downstreams by transforming the data elements flowing through it.
   
 **RunnableGraph**  
 A Flow that has both ends "attached" to a `Source` and `Sink` respectively, and is ready to be `run()`.

--- a/docs/articles/streams/builtinstages.md
+++ b/docs/articles/streams/builtinstages.md
@@ -709,7 +709,7 @@ This stage can recover the failure signal, but not the skipped elements, which w
 
 ### SelectError
 
-While similar to `Recover` this stage can be used to transform an error signal to a different one *without* logging
+While similar to `Recover` this stage can be used to transform an error signal to a different one _without_ logging
 it as an error in the process. So in that sense it is NOT exactly equivalent to ``Recover(e -> throw e2)`` since recover
 would log the `e2` error.
 

--- a/docs/community/contributing/debugging.md
+++ b/docs/community/contributing/debugging.md
@@ -30,7 +30,7 @@ How do we fix this? Two possible ways.
 
 [!code-csharp[FixedMsgOrdering](../../../src/core/Akka.Docs.Tests/Debugging/RacySpecs.cs?name=FixedMsgOrdering)]
 
-The simplest way in this case is to just change the assertion to an `ExpectMsgAllOf` call, which expects an array of messages back _but doesn't care about the order in which they arrive_. This approach may not work in all cases, so the second approach we recommend to fixing these types of buggy tests will usually do the trick.
+The simplest way in this case is to just change the assertion to an `ExpectMsgAllOf` call, which expects an array of messages back *but doesn't care about the order in which they arrive*. This approach may not work in all cases, so the second approach we recommend to fixing these types of buggy tests will usually do the trick.
 
 [!code-csharp[SplitMsgOrdering](../../../src/core/Akka.Docs.Tests/Debugging/RacySpecs.cs?name=SplitMsgOrdering)]
 

--- a/docs/community/whats-new/akkadotnet-v1.4-upgrade-advisories.md
+++ b/docs/community/whats-new/akkadotnet-v1.4-upgrade-advisories.md
@@ -54,7 +54,7 @@ If you are running a mixed .NET Core and .NET Framework cluster, see the process
 
 ### Deploying v1.4.26 Into Mixed .NET Core and .NET Framework Environments
 
-*However*, if you are attempting to run a mixed-mode cluster - i.e. some services running on .NET Framework and some running on .NET Core, you will eventually want to turn this setting to `off` in order to facilitate smooth operation between both platforms.
+_However_, if you are attempting to run a mixed-mode cluster - i.e. some services running on .NET Framework and some running on .NET Core, you will eventually want to turn this setting to `off` in order to facilitate smooth operation between both platforms.
 
 #### Already Deployed v1.4.20 or Later
 


### PR DESCRIPTION
## Changes

- [x] `router.md` => replaced underscore (__) with asterisk (**) [67d4cf6](https://github.com/akkadotnet/akka.net/pull/5582/commits/67d4cf6a5f1f9a4360a78e6c6bd7beae8f7e7578)
- [x] `cluster-sharding.md` => replaced underscore (_) with asterisk (*) [92ac7f5](https://github.com/akkadotnet/akka.net/pull/5582/commits/92ac7f56db9840baa0a9732d240f174f9635b185)
- [x] `split-brain-resolver.md` => replaced underscore (_) with asterisk (*) [1897a6e](https://github.com/akkadotnet/akka.net/pull/5582/commits/1897a6e1259ea73346725453402a32537b3094f9)
- [x] `tutorial-3.md` => replaced underscore (_) with asterisk (*) [c675728](https://github.com/akkadotnet/akka.net/pull/5582/commits/c675728f6d4fb72db01e3b8c3a16d21eb5b3d660)
- [x] `custom-persistence-provider` => replaced underscore (__) with asterisk (**) [0ee1944](https://github.com/akkadotnet/akka.net/pull/5582/commits/0ee1944115995e3393f43a7625003ef9a2d4a025)
- [x] `Streams.basics.md` => replaced underscore (_) with asterisk (*) [928ec4f](https://github.com/akkadotnet/akka.net/pull/5582/commits/928ec4fd7f338b1250f65f37e217f0b44800c203)