### PR TITLE
Lock markdownlint-cli version to 0.31.0 and markdownlint-rule-titlecase to 0.1.0

### DIFF
--- a/build-system/pr-validation.yaml
+++ b/build-system/pr-validation.yaml
@@ -48,7 +48,7 @@ jobs:
       - task: Npm@1
         inputs:
           command: "custom"
-          customCommand: "install -g markdownlint-cli markdownlint-rule-titlecase"
+          customCommand: "install -g markdownlint-cli@0.31.0 markdownlint-rule-titlecase@0.1.0"
       - task: CmdLine@2
         inputs:
           script: 'markdownlint "docs/**/*.md" --rules "markdownlint-rule-titlecase"'


### PR DESCRIPTION
Fixes #5583

## Changes

Lock build script dependency versions, markdownlint-cli version to 0.31.0 and markdownlint-rule-titlecase to 0.1.0