### PR TITLE
Docs: Fix `Routing` unresolved base documentaion

### DIFF
--- a/src/core/Akka/Routing/Resizer.cs
+++ b/src/core/Akka/Routing/Resizer.cs
@@ -344,7 +344,7 @@ namespace Akka.Routing
         /// </summary>
         public int MessagesPerResize { get; private set; }
 
-        /// <inheritdoc/>
+        
         public bool Equals(DefaultResizer other)
         {
             if (ReferenceEquals(null, other)) return false;
@@ -352,7 +352,7 @@ namespace Akka.Routing
             return MessagesPerResize == other.MessagesPerResize && BackoffRate.Equals(other.BackoffRate) && RampupRate.Equals(other.RampupRate) && BackoffThreshold.Equals(other.BackoffThreshold) && UpperBound == other.UpperBound && PressureThreshold == other.PressureThreshold && LowerBound == other.LowerBound;
         }
 
-        /// <inheritdoc/>
+       
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(null, obj)) return false;
@@ -361,7 +361,7 @@ namespace Akka.Routing
             return Equals((DefaultResizer)obj);
         }
 
-        /// <inheritdoc/>
+        
         public override int GetHashCode()
         {
             unchecked

--- a/src/core/Akka/Routing/Router.cs
+++ b/src/core/Akka/Routing/Router.cs
@@ -106,7 +106,7 @@ namespace Akka.Routing
             return Actor.Ask(message, timeout);
         }
 
-        /// <inheritdoc/>
+       
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(null, obj)) return false;
@@ -118,7 +118,7 @@ namespace Akka.Routing
         /// <inheritdoc/>
         protected bool Equals(ActorRefRoutee other) => Equals(Actor, other.Actor);
 
-        /// <inheritdoc/>
+        
         public override int GetHashCode() => Actor?.GetHashCode() ?? 0;
     }
 
@@ -150,7 +150,7 @@ namespace Akka.Routing
             return Selection.Ask(message, timeout);
         }
 
-        /// <inheritdoc/>
+       
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(null, obj)) return false;
@@ -162,7 +162,7 @@ namespace Akka.Routing
         /// <inheritdoc/>
         protected bool Equals(ActorSelectionRoutee other) => Equals(Selection, other.Selection);
 
-        /// <inheritdoc/>
+        
         public override int GetHashCode() => Selection?.GetHashCode() ?? 0;
     }
 

--- a/src/core/Akka/Routing/RouterConfig.cs
+++ b/src/core/Akka/Routing/RouterConfig.cs
@@ -124,7 +124,7 @@ namespace Akka.Routing
         /// <returns>The surrogate representation of the current router.</returns>
         public abstract ISurrogate ToSurrogate(ActorSystem system);
 
-        /// <inheritdoc/>
+        
         public bool Equals(RouterConfig other)
         {
             if (ReferenceEquals(null, other)) return false;
@@ -133,7 +133,7 @@ namespace Akka.Routing
             return GetType() == other.GetType() && (GetType() == typeof(NoRouter) || string.Equals(RouterDispatcher, other.RouterDispatcher));
         }
 
-        /// <inheritdoc/>
+        
         public override bool Equals(object obj) => Equals(obj as RouterConfig);
     }
 
@@ -203,7 +203,7 @@ namespace Akka.Routing
             return new RouterActor();
         }
 
-        /// <inheritdoc/>
+       
         public bool Equals(Group other)
         {
             if (ReferenceEquals(null, other)) return false;
@@ -211,7 +211,7 @@ namespace Akka.Routing
             return InternalPaths.SequenceEqual(other.InternalPaths);
         }
 
-        /// <inheritdoc/>
+        
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(null, obj)) return false;
@@ -220,7 +220,7 @@ namespace Akka.Routing
             return Equals((Group)obj);
         }
 
-        /// <inheritdoc/>
+        
         public override int GetHashCode() => InternalPaths?.GetHashCode() ?? 0;
     }
 
@@ -362,7 +362,7 @@ namespace Akka.Routing
             }
         }
 
-        /// <inheritdoc/>
+        
         public bool Equals(Pool other)
         {
             if (ReferenceEquals(null, other)) return false;
@@ -371,7 +371,7 @@ namespace Akka.Routing
                    NrOfInstances == other.NrOfInstances;
         }
 
-        /// <inheritdoc/>
+        
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(null, obj)) return false;
@@ -380,7 +380,7 @@ namespace Akka.Routing
             return Equals((Pool)obj);
         }
 
-        /// <inheritdoc/>
+        
         public override int GetHashCode()
         {
             unchecked
@@ -414,7 +414,7 @@ namespace Akka.Routing
         {
         }
 
-        /// <inheritdoc cref="RouterConfig.CreateRouterActor"/>
+        
         public override ActorBase CreateRouterActor()
         {
             return new RouterActor();


### PR DESCRIPTION
Part fix for #5542

## Changes

Remove 'inheritdoc` from overriden members that can not be resolved by DocFx