### PR TITLE
Docs: Fix `Akka.Util` unresolved base documentaion

### DIFF
--- a/src/core/Akka/Util/Option.cs
+++ b/src/core/Akka/Util/Option.cs
@@ -84,7 +84,7 @@ namespace Akka.Util
         public bool Equals(Option<T> other)
             => HasValue == other.HasValue && EqualityComparer<T>.Default.Equals(Value, other.Value);
 
-        /// <inheritdoc/>
+       
         public override bool Equals(object obj)
         {
             if (obj is null)
@@ -92,7 +92,7 @@ namespace Akka.Util
             return obj is Option<T> opt && Equals(opt);
         }
         
-        /// <inheritdoc/>
+       
         public override int GetHashCode()
         {
             unchecked
@@ -101,7 +101,7 @@ namespace Akka.Util
             }
         }
 
-        /// <inheritdoc/>
+        
         public override string ToString() => HasValue ? $"Some<{Value}>" : "None";
 
         /// <summary>

--- a/src/core/Akka/Util/Result.cs
+++ b/src/core/Akka/Util/Result.cs
@@ -53,7 +53,7 @@ namespace Akka.Util
             Exception = exception;
         }
 
-        /// <inheritdoc/>
+        
         public bool Equals(Result<T> other)
         {
             if (IsSuccess ^ other.IsSuccess) return false;
@@ -62,14 +62,14 @@ namespace Akka.Util
                 : Equals(Exception, other.Exception);
         }
 
-        /// <inheritdoc/>
+        
         public override bool Equals(object obj)
         {
             if (obj is Result<T>) return Equals((Result<T>) obj);
             return false;
         }
 
-        /// <inheritdoc/>
+        
         public override int GetHashCode()
         {
             return IsSuccess


### PR DESCRIPTION
Part fix for #5542

## Changes

Remove 'inheritdoc` from overriden members that can not be resolved by DocFx
