### PR TITLE
Docs: Fix unresolved base documentaion WARNINGS in `EventSequences.cs`

### DIFF
--- a/src/core/Akka.Persistence/Journal/EventSequences.cs
+++ b/src/core/Akka.Persistence/Journal/EventSequences.cs
@@ -45,13 +45,13 @@ namespace Akka.Persistence.Journal
         /// </summary>
         public IEnumerable<object> Events => Enumerable.Empty<object>();
 
-        /// <inheritdoc/>
+       
         public bool Equals(IEventSequence other)
         {
             return other is EmptyEventSequence;
         }
 
-        /// <inheritdoc/>
+       
         public override bool Equals(object obj)
         {
             return Equals(obj as IEventSequence);
@@ -80,13 +80,13 @@ namespace Akka.Persistence.Journal
         /// </summary>
         public IEnumerable<object> Events => _events;
 
-        /// <inheritdoc/>
+        
         public bool Equals(IEventSequence other)
         {
             return other != null && _events.SequenceEqual(other.Events);
         }
 
-        /// <inheritdoc/>
+        
         public override bool Equals(object obj)
         {
             return Equals(obj as IEventSequence);
@@ -114,7 +114,7 @@ namespace Akka.Persistence.Journal
         /// </summary>
         public IEnumerable<object> Events => _events;
 
-        /// <inheritdoc/>
+        
         public bool Equals(IEventSequence other)
         {
             if (other == null) return false;
@@ -122,7 +122,7 @@ namespace Akka.Persistence.Journal
             return e != null && e.Equals(_events[0]) && other.Events.Count() == 1;
         }
 
-        /// <inheritdoc/>
+        
         public override bool Equals(object obj)
         {
             return Equals(obj as IEventSequence);


### PR DESCRIPTION
Part fix for #5542

## Changes

Remove 'inheritdoc` from overriden members that can not be resolved by DocFx