### PR TITLE
Docs: Fix unresolved base documentaion WARNINGS in `Snapshot.cs`

### DIFF
--- a/src/core/Akka.Persistence/Serialization/Snapshot.cs
+++ b/src/core/Akka.Persistence/Serialization/Snapshot.cs
@@ -33,13 +33,13 @@ namespace Akka.Persistence.Serialization
         /// </summary>
         public object Data { get; private set; }
 
-        /// <inheritdoc/>
+       
         private bool Equals(Snapshot other)
         {
             return Equals(Data, other.Data);
         }
 
-        /// <inheritdoc/>
+       
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(null, obj)) return false;
@@ -47,7 +47,7 @@ namespace Akka.Persistence.Serialization
             return obj is Snapshot && Equals((Snapshot)obj);
         }
 
-        /// <inheritdoc/>
+       
         public override int GetHashCode()
         {
             return (Data != null ? Data.GetHashCode() : 0);


### PR DESCRIPTION
Part fix for #5542

## Changes

Remove 'inheritdoc` from overriden members that can not be resolved by DocFx
