### PR TITLE
Docs: Fix unresolved base documentaion WARNINGS in `EnumeratorEnumerable.cs`

### DIFF
--- a/src/core/Akka.Streams/Util/EnumeratorEnumerable.cs
+++ b/src/core/Akka.Streams/Util/EnumeratorEnumerable.cs
@@ -60,7 +60,9 @@ namespace Akka.Streams.Util
            
             public void Dispose() => _enumeratorFactory = null;
 
-            
+            /// <exception cref="ArgumentException">
+            /// This exception is thrown when the enumerator has passed the end of an enumerable.
+            /// </exception>
             public bool MoveNext()
             {
                 if (_current == null || !_current.MoveNext())

--- a/src/core/Akka.Streams/Util/EnumeratorEnumerable.cs
+++ b/src/core/Akka.Streams/Util/EnumeratorEnumerable.cs
@@ -60,10 +60,7 @@ namespace Akka.Streams.Util
            
             public void Dispose() => _enumeratorFactory = null;
 
-            /// <inheritdoc/>
-            /// <exception cref="ArgumentException">
-            /// This exception is thrown when the enumerator has passed the end of an enumerable.
-            /// </exception>
+            
             public bool MoveNext()
             {
                 if (_current == null || !_current.MoveNext())


### PR DESCRIPTION
Part fix for #5542

## Changes

Remove 'inheritdoc` from overriden members that can not be resolved by DocFx


