### PR TITLE
Docs: Fix unresolved base documentaion WARNINGS in `TestProbe.cs`

### DIFF
--- a/src/core/Akka.TestKit/TestProbe.cs
+++ b/src/core/Akka.TestKit/TestProbe.cs
@@ -241,25 +241,25 @@ namespace Akka.TestKit
             ((IInternalActorRef)TestActor).SendSystemMessage(message);
         }
 
-        /// <inheritdoc/>
+   
         public int CompareTo(object obj)
         {
             return TestActor.CompareTo(obj);
         }
 
-        /// <inheritdoc/>
+       
         public override bool Equals(object obj)
         {
             return TestActor.Equals(obj);
         }
 
-        /// <inheritdoc/>
+       
         public override int GetHashCode()
         {
             return TestActor.GetHashCode();
         }
 
-        /// <inheritdoc/>
+       
         public override string ToString()
         {
             return $"TestProbe({TestActor})";


### PR DESCRIPTION
Part fix for #5542

## Changes

Remove 'inheritdoc` from overriden members that can not be resolved by DocFx


