### PR TITLE
Docs: Fix unresolved base documentaion WARNINGS in `Akka.Coordination`

### DIFF
--- a/src/core/Akka.Coordination/LeaseSettings.cs
+++ b/src/core/Akka.Coordination/LeaseSettings.cs
@@ -75,7 +75,7 @@ namespace Akka.Coordination
             return new LeaseSettings(LeaseName, OwnerName, timeoutSettings, LeaseConfig);
         }
 
-        /// <inheritdoc/>
+        
         public override string ToString()
         {
             return $"LeaseSettings({ LeaseName }, { OwnerName }, { TimeoutSettings })";

--- a/src/core/Akka.Coordination/LeaseUsageSettings.cs
+++ b/src/core/Akka.Coordination/LeaseUsageSettings.cs
@@ -35,7 +35,7 @@ namespace Akka.Coordination
             LeaseRetryInterval = leaseRetryInterval;
         }
 
-        /// <inheritdoc/>
+       
         public override string ToString()
         {
             return $"LeaseUsageSettings({ LeaseImplementation }, { LeaseRetryInterval })";

--- a/src/core/Akka.Coordination/TimeoutSettings.cs
+++ b/src/core/Akka.Coordination/TimeoutSettings.cs
@@ -103,7 +103,7 @@ namespace Akka.Coordination
             return new TimeoutSettings(heartbeatInterval ?? HeartbeatInterval, heartbeatTimeout ?? HeartbeatTimeout, operationTimeout ?? OperationTimeout);
         }
 
-        /// <inheritdoc/>
+        
         public override string ToString()
         {
             return $"TimeoutSettings({ HeartbeatInterval }, { HeartbeatTimeout }, { OperationTimeout })";


### PR DESCRIPTION
Part fix for #5542

## Changes

Remove 'inheritdoc` from overriden members that can not be resolved by DocFx