### PR TITLE
Docs: Fix unresolved base documentaion WARNINGS in `Cluster.Metrics`

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Metrics/Collectors/DefaultCollector.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics/Collectors/DefaultCollector.cs
@@ -44,7 +44,7 @@ namespace Akka.Cluster.Metrics.Collectors
         {
         }
 
-        /// <inheritdoc />
+        
         public void Dispose()
         {
             _cpuWatch.Stop();

--- a/src/contrib/cluster/Akka.Cluster.Metrics/Serialization/Metric.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics/Serialization/Metric.cs
@@ -170,7 +170,7 @@ namespace Akka.Cluster.Metrics.Serialization
                  */
 
 
-                /// <inheritdoc />
+                
                 public bool Equals(Metric other)
                 {
                     if (ReferenceEquals(null, other)) return false;
@@ -178,7 +178,7 @@ namespace Akka.Cluster.Metrics.Serialization
                     return Name == other.Name;
                 }
 
-                /// <inheritdoc />
+                
                 public override int GetHashCode()
                 {
                     return (Name != null ? Name.GetHashCode() : 0);

--- a/src/contrib/cluster/Akka.Cluster.Metrics/Serialization/NodeMetrics.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics/Serialization/NodeMetrics.cs
@@ -94,7 +94,7 @@ namespace Akka.Cluster.Metrics.Serialization
          */
 
 
-        /// <inheritdoc />
+        
         public bool Equals(NodeMetrics other)
         {
             if (ReferenceEquals(null, other)) return false;
@@ -102,7 +102,7 @@ namespace Akka.Cluster.Metrics.Serialization
             return Equals(Address, other.Address);
         }
 
-        /// <inheritdoc />
+        
         public override int GetHashCode()
         {
             return (Address != null ? Address.GetHashCode() : 0);


### PR DESCRIPTION
Part fix for #5542

## Changes

Remove 'inheritdoc` from overriden members that can not be resolved by DocFx

