### PR TITLE
Docs: Fix unresolved base documentaion WARNINGS in `QueryApi.cs`

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryApi.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryApi.cs
@@ -268,17 +268,17 @@ namespace Akka.Persistence.Sql.Common.Journal
             return Equals(HighestSequenceNr, other.HighestSequenceNr);
         }
 
-        /// <inheritdoc/>
+        
         public override bool Equals(object obj)
         {
             if (!(obj is EventReplaySuccess evt)) return false;
             return Equals(evt);
         }
 
-        /// <inheritdoc/>
+        
         public override int GetHashCode() => HighestSequenceNr.GetHashCode();
 
-        /// <inheritdoc/>
+        
         public override string ToString() => $"EventReplaySuccess<highestSequenceNr: {HighestSequenceNr}>";
     }
 
@@ -302,17 +302,17 @@ namespace Akka.Persistence.Sql.Common.Journal
             return Equals(Cause, other.Cause);
         }
 
-        /// <inheritdoc/>
+        
         public override bool Equals(object obj)
         {
             if (!(obj is EventReplayFailure f)) return false;
             return Equals(f);
         }
 
-        /// <inheritdoc/>
+        
         public override int GetHashCode() => Cause.GetHashCode();
 
-        /// <inheritdoc/>
+        
         public override string ToString() => $"EventReplayFailure<cause: {Cause.Message}>";
     }
 


### PR DESCRIPTION
Part fix for #5542

## Changes

Remove 'inheritdoc` from overriden members that can not be resolved by DocFx