### PR TITLE
Reorder Source/FlowWithContext type parameters

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.approved.txt
@@ -1324,7 +1324,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> AggregateAsync<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, TOut2 zero, System.Func<TOut2, TOut1, System.Threading.Tasks.Task<TOut2>> fold) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> AlsoTo<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat> that) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat3> AlsoToMaterialized<TIn, TOut, TMat, TMat2, TMat3>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> that, System.Func<TMat, TMat2, TMat3> materializerFunction) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TCtxIn, TIn, TCtxOut, TOut, TMat> AsFlowWithContext<TCtxIn, TIn, TCtxOut, TOut, TMat, TIn2>(this Akka.Streams.Dsl.Flow<TIn2, TOut, TMat> flow, System.Func<TIn, TCtxIn, TIn2> collapseContext, System.Func<TOut, TCtxOut> extractContext) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtxIn, TOut, TCtxOut, TMat> AsFlowWithContext<TIn, TCtxIn, TOut, TCtxOut, TMat, TIn2>(this Akka.Streams.Dsl.Flow<TIn2, TOut, TMat> flow, System.Func<TIn, TCtxIn, TIn2> collapseContext, System.Func<TOut, TCtxOut> extractContext) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> BackpressureTimeout<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> Batch<TIn, TOut, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, long max, System.Func<TOut, TOut2> seed, System.Func<TOut2, TOut, TOut2> aggregate) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> BatchWeighted<TIn, TOut, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, long max, System.Func<TOut, long> costFunction, System.Func<TOut, TOut2> seed, System.Func<TOut2, TOut, TOut2> aggregate) { }
@@ -1416,28 +1416,29 @@ namespace Akka.Streams.Dsl
     }
     public class static FlowWithContext
     {
-        public static Akka.Streams.Dsl.FlowWithContext<TCtx, TIn, TCtx, TIn, Akka.NotUsed> Create<TCtx, TIn>() { }
-        public static Akka.Streams.Dsl.FlowWithContext<TCtxIn, TIn, TCtxOut, TOut, TMat> From<TCtxIn, TIn, TCtxOut, TOut, TMat>(Akka.Streams.Dsl.Flow<System.ValueTuple<TIn, TCtxIn>, System.ValueTuple<TOut, TCtxOut>, TMat> flow) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TIn, TCtx, Akka.NotUsed> Create<TIn, TCtx>() { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtxIn, TOut, TCtxOut, TMat> From<TIn, TCtxIn, TOut, TCtxOut, TMat>(Akka.Streams.Dsl.Flow<System.ValueTuple<TIn, TCtxIn>, System.ValueTuple<TOut, TCtxOut>, TMat> flow) { }
     }
     public class static FlowWithContextOperations
     {
-        public static Akka.Streams.Dsl.FlowWithContext<TCtx, TIn, TCtx, TOut2, TMat> Collect<TCtx, TIn, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TCtx flow, System.Func<TOut, TOut2> fn)
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Collect<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<TOut, TOut2> fn)
             where TOut2 :  class { }
-        public static Akka.Streams.Dsl.FlowWithContext<TCtx, TIn, System.Collections.Generic.IReadOnlyList<TCtx>, System.Collections.Generic.IReadOnlyList<TOut>, TMat> Grouped<TCtx, TIn, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TCtx flow, int n) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TCtx, TIn, TCtx, TOut2, TMat> Select<TCtx, TIn, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TCtx flow, System.Func<TOut, TOut2> fn) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TCtx, TIn, TCtx, TOut2, TMat> SelectAsync<TCtx, TIn, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TCtx flow, int parallelism, System.Func<TOut, System.Threading.Tasks.Task<TOut2>> fn) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TCtx, TIn, TCtx, TOut2, TMat> SelectConcat<TCtx, TIn, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TCtx flow, System.Func<TOut, System.Collections.Generic.IEnumerable<TOut2>> fn) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TCtx, TIn, TCtx2, TOut, TMat> SelectContext<TCtx, TIn, TCtx2, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TCtx flow, System.Func<TCtx, TCtx2> mapContext) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TCtx, TIn, System.Collections.Generic.IReadOnlyList<TCtx>, System.Collections.Generic.IReadOnlyList<TOut>, TMat> Sliding<TCtx, TIn, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TCtx flow, int n, int step = 1) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TCtx, TIn, TCtx, TOut2, TMat> StatefulSelectConcat<TCtx, TIn, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TCtx flow, System.Func<System.Func<TOut, System.Collections.Generic.IEnumerable<TOut2>>> fn) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TCtx, TIn, TCtx, TOut, TMat> Where<TCtx, TIn, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TCtx flow, System.Func<TOut, bool> predicate) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TCtx, TIn, TCtx, TOut, TMat> WhereNot<TCtx, TIn, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TCtx flow, System.Func<TOut, bool> predicate) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, System.Collections.Generic.IReadOnlyList<TOut>, System.Collections.Generic.IReadOnlyList<TCtx>, TMat> Grouped<TIn, TCtx, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, int n) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Select<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<TOut, TOut2> fn) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> SelectAsync<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, int parallelism, System.Func<TOut, System.Threading.Tasks.Task<TOut2>> fn) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> SelectConcat<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<TOut, System.Collections.Generic.IEnumerable<TOut2>> fn) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx2, TMat> SelectContext<TIn, TCtx, TOut, TCtx2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<TCtx, TCtx2> mapContext) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, System.Collections.Generic.IReadOnlyList<TOut>, System.Collections.Generic.IReadOnlyList<TCtx>, TMat> Sliding<TIn, TCtx, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, int n, int step = 1) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> StatefulSelectConcat<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<System.Func<TOut, System.Collections.Generic.IEnumerable<TOut2>>> fn) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> Where<TIn, TCtx, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<TOut, bool> predicate) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> WhereNot<TIn, TCtx, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<TOut, bool> predicate) { }
     }
-    public sealed class FlowWithContext<TCtxIn, TIn, TCtxOut, TOut, TMat> : Akka.Streams.GraphDelegate<Akka.Streams.FlowShape<System.ValueTuple<TIn, TCtxIn>, System.ValueTuple<TOut, TCtxOut>>, TMat>
+    [Akka.Annotations.ApiMayChangeAttribute()]
+    public sealed class FlowWithContext<TIn, TCtxIn, TOut, TCtxOut, TMat> : Akka.Streams.GraphDelegate<Akka.Streams.FlowShape<System.ValueTuple<TIn, TCtxIn>, System.ValueTuple<TOut, TCtxOut>>, TMat>
     {
         public Akka.Streams.Dsl.Flow<System.ValueTuple<TIn, TCtxIn>, System.ValueTuple<TOut, TCtxOut>, TMat> AsFlow() { }
-        public Akka.Streams.Dsl.FlowWithContext<TCtxIn, TIn, TCtx2, TOut2, TMat> Via<TCtx2, TOut2, TMat2>(Akka.Streams.IGraph<Akka.Streams.FlowShape<System.ValueTuple<TOut, TCtxOut>, System.ValueTuple<TOut2, TCtx2>>, TMat2> viaFlow) { }
-        public Akka.Streams.Dsl.FlowWithContext<TCtxIn, TIn, TCtx2, TOut2, TMat3> ViaMaterialized<TCtx2, TOut2, TMat2, TMat3>(Akka.Streams.IGraph<Akka.Streams.FlowShape<System.ValueTuple<TOut, TCtxOut>, System.ValueTuple<TOut2, TCtx2>>, TMat2> viaFlow, System.Func<TMat, TMat2, TMat3> combine) { }
+        public Akka.Streams.Dsl.FlowWithContext<TIn, TCtxIn, TOut2, TCtx2, TMat> Via<TOut2, TCtx2, TMat2>(Akka.Streams.IGraph<Akka.Streams.FlowShape<System.ValueTuple<TOut, TCtxOut>, System.ValueTuple<TOut2, TCtx2>>, TMat2> viaFlow) { }
+        public Akka.Streams.Dsl.FlowWithContext<TIn, TCtxIn, TOut2, TCtx2, TMat3> ViaMaterialized<TOut2, TCtx2, TMat2, TMat3>(Akka.Streams.IGraph<Akka.Streams.FlowShape<System.ValueTuple<TOut, TCtxOut>, System.ValueTuple<TOut2, TCtx2>>, TMat2> viaFlow, System.Func<TMat, TMat2, TMat3> combine) { }
     }
     public sealed class Flow<TIn, TOut, TMat> : Akka.Streams.Dsl.IFlow<TOut, TMat>, Akka.Streams.IGraph<Akka.Streams.FlowShape<TIn, TOut>>, Akka.Streams.IGraph<Akka.Streams.FlowShape<TIn, TOut>, TMat>
     {
@@ -1996,7 +1997,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Source<TOut2, TMat> AggregateAsync<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, TOut2 zero, System.Func<TOut2, TOut1, System.Threading.Tasks.Task<TOut2>> fold) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> AlsoTo<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat> that) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat3> AlsoToMaterialized<TOut, TMat, TMat2, TMat3>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> that, System.Func<TMat, TMat2, TMat3> materializerFunction) { }
-        public static Akka.Streams.Dsl.SourceWithContext<TCtx, TOut, TMat> AsSourceWithContext<TCtx, TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Func<TOut, TCtx> fn) { }
+        public static Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> AsSourceWithContext<TOut, TCtx, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Func<TOut, TCtx> fn) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> BackpressureTimeout<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.Source<TOut2, TMat> Batch<TOut, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, long max, System.Func<TOut, TOut2> seed, System.Func<TOut2, TOut, TOut2> aggregate) { }
         public static Akka.Streams.Dsl.Source<TOut2, TMat> BatchWeighted<TOut, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, long max, System.Func<TOut, long> costFunction, System.Func<TOut, TOut2> seed, System.Func<TOut2, TOut, TOut2> aggregate) { }
@@ -2088,24 +2089,26 @@ namespace Akka.Streams.Dsl
     }
     public class static SourceWithContextOperations
     {
-        public static Akka.Streams.Dsl.SourceWithContext<TCtx, TOut2, TMat> Collect<TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TCtx, TOut, TMat> flow, System.Func<TOut, TOut2> fn)
+        public static Akka.Streams.Dsl.SourceWithContext<TOut2, TCtx, TMat> Collect<TOut, TCtx, TOut2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, System.Func<TOut, TOut2> fn)
             where TOut2 :  class { }
-        public static Akka.Streams.Dsl.SourceWithContext<System.Collections.Generic.IReadOnlyList<TCtx>, System.Collections.Generic.IReadOnlyList<TOut>, TMat> Grouped<TCtx, TOut, TMat>(this Akka.Streams.Dsl.SourceWithContext<TCtx, TOut, TMat> flow, int n) { }
-        public static Akka.Streams.Dsl.SourceWithContext<TCtx, TOut2, TMat> Select<TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TCtx, TOut, TMat> flow, System.Func<TOut, TOut2> fn) { }
-        public static Akka.Streams.Dsl.SourceWithContext<TCtx, TOut2, TMat> SelectAsync<TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TCtx, TOut, TMat> flow, int parallelism, System.Func<TOut, System.Threading.Tasks.Task<TOut2>> fn) { }
-        public static Akka.Streams.Dsl.SourceWithContext<TCtx, TOut2, TMat> SelectConcat<TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TCtx, TOut, TMat> flow, System.Func<TOut, System.Collections.Generic.IEnumerable<TOut2>> fn) { }
-        public static Akka.Streams.Dsl.SourceWithContext<TCtx2, TOut, TMat> SelectContext<TCtx, TCtx2, TOut, TMat>(this Akka.Streams.Dsl.SourceWithContext<TCtx, TOut, TMat> flow, System.Func<TCtx, TCtx2> mapContext) { }
-        public static Akka.Streams.Dsl.SourceWithContext<System.Collections.Generic.IReadOnlyList<TCtx>, System.Collections.Generic.IReadOnlyList<TOut>, TMat> Sliding<TCtx, TOut, TMat>(this Akka.Streams.Dsl.SourceWithContext<TCtx, TOut, TMat> flow, int n, int step = 1) { }
-        public static Akka.Streams.Dsl.SourceWithContext<TCtx, TOut2, TMat> StatefulSelectConcat<TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TCtx, TOut, TMat> flow, System.Func<System.Func<TOut, System.Collections.Generic.IEnumerable<TOut2>>> fn) { }
-        public static Akka.Streams.Dsl.SourceWithContext<TCtx, TOut, TMat> Where<TCtx, TOut, TMat>(this Akka.Streams.Dsl.SourceWithContext<TCtx, TOut, TMat> flow, System.Func<TOut, bool> predicate) { }
-        public static Akka.Streams.Dsl.SourceWithContext<TCtx, TOut, TMat> WhereNot<TCtx, TOut, TMat>(this Akka.Streams.Dsl.SourceWithContext<TCtx, TOut, TMat> flow, System.Func<TOut, bool> predicate) { }
+        public static Akka.Streams.Dsl.SourceWithContext<System.Collections.Generic.IReadOnlyList<TOut>, System.Collections.Generic.IReadOnlyList<TCtx>, TMat> Grouped<TOut, TCtx, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, int n) { }
+        public static Akka.Streams.Dsl.SourceWithContext<TOut2, TCtx, TMat> Select<TOut, TCtx, TOut2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, System.Func<TOut, TOut2> fn) { }
+        public static Akka.Streams.Dsl.SourceWithContext<TOut2, TCtx, TMat> SelectAsync<TOut, TCtx, TOut2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, int parallelism, System.Func<TOut, System.Threading.Tasks.Task<TOut2>> fn) { }
+        public static Akka.Streams.Dsl.SourceWithContext<TOut2, TCtx, TMat> SelectConcat<TOut, TCtx, TOut2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, System.Func<TOut, System.Collections.Generic.IEnumerable<TOut2>> fn) { }
+        public static Akka.Streams.Dsl.SourceWithContext<TOut, TCtx2, TMat> SelectContext<TOut, TCtx, TCtx2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, System.Func<TCtx, TCtx2> mapContext) { }
+        public static Akka.Streams.Dsl.SourceWithContext<System.Collections.Generic.IReadOnlyList<TOut>, System.Collections.Generic.IReadOnlyList<TCtx>, TMat> Sliding<TOut, TCtx, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, int n, int step = 1) { }
+        public static Akka.Streams.Dsl.SourceWithContext<TOut2, TCtx, TMat> StatefulSelectConcat<TOut, TCtx, TOut2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, System.Func<System.Func<TOut, System.Collections.Generic.IEnumerable<TOut2>>> fn) { }
+        public static Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> Where<TOut, TCtx, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, System.Func<TOut, bool> predicate) { }
+        public static Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> WhereNot<TOut, TCtx, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, System.Func<TOut, bool> predicate) { }
     }
-    public sealed class SourceWithContext<TCtx, TOut, TMat> : Akka.Streams.GraphDelegate<Akka.Streams.SourceShape<System.ValueTuple<TOut, TCtx>>, TMat>
+    [Akka.Annotations.ApiMayChangeAttribute()]
+    public sealed class SourceWithContext<TOut, TCtx, TMat> : Akka.Streams.GraphDelegate<Akka.Streams.SourceShape<System.ValueTuple<TOut, TCtx>>, TMat>
     {
         public SourceWithContext(Akka.Streams.Dsl.Source<System.ValueTuple<TOut, TCtx>, TMat> source) { }
         public Akka.Streams.Dsl.Source<System.ValueTuple<TOut, TCtx>, TMat> AsSource() { }
-        public Akka.Streams.Dsl.SourceWithContext<TCtx2, TOut2, TMat> Via<TCtx2, TOut2, TMat2>(Akka.Streams.IGraph<Akka.Streams.FlowShape<System.ValueTuple<TOut, TCtx>, System.ValueTuple<TOut2, TCtx2>>, TMat2> viaFlow) { }
-        public Akka.Streams.Dsl.SourceWithContext<TCtx2, TOut2, TMat3> ViaMaterialized<TCtx2, TOut2, TMat2, TMat3>(Akka.Streams.IGraph<Akka.Streams.FlowShape<System.ValueTuple<TOut, TCtx>, System.ValueTuple<TOut2, TCtx2>>, TMat2> viaFlow, System.Func<TMat, TMat2, TMat3> combine) { }
+        public TMat2 RunWith<TMat2>(Akka.Streams.IGraph<Akka.Streams.SinkShape<System.ValueTuple<TOut, TCtx>>, TMat2> sink, Akka.Streams.IMaterializer materializer) { }
+        public Akka.Streams.Dsl.SourceWithContext<TOut2, TCtx2, TMat> Via<TOut2, TCtx2, TMat2>(Akka.Streams.IGraph<Akka.Streams.FlowShape<System.ValueTuple<TOut, TCtx>, System.ValueTuple<TOut2, TCtx2>>, TMat2> viaFlow) { }
+        public Akka.Streams.Dsl.SourceWithContext<TOut2, TCtx2, TMat3> ViaMaterialized<TOut2, TCtx2, TMat2, TMat3>(Akka.Streams.IGraph<Akka.Streams.FlowShape<System.ValueTuple<TOut, TCtx>, System.ValueTuple<TOut2, TCtx2>>, TMat2> viaFlow, System.Func<TMat, TMat2, TMat3> combine) { }
     }
     public sealed class Source<TOut, TMat> : Akka.Streams.Dsl.IFlow<TOut, TMat>, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>>, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat>
     {

--- a/src/core/Akka.Streams.Tests/Dsl/FlowWithContextSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowWithContextSpec.cs
@@ -1,0 +1,80 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="FlowWithContextSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using Akka.Streams.Dsl;
+using Akka.Streams.TestKit;
+using Akka.TestKit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Streams.Tests.Dsl
+{
+    public class FlowWithContextSpec : AkkaSpec
+    {
+        private ActorMaterializer Materializer { get; }
+
+        public FlowWithContextSpec(ITestOutputHelper helper) : base(helper)
+        {
+            var settings = ActorMaterializerSettings.Create(Sys);
+            Materializer = ActorMaterializer.Create(Sys, settings);
+        }
+
+        [Fact]
+        public void A_FlowWithContext_must_get_created_from_FlowAsFlowWithContext()
+        {
+            var flow = Flow.Create<Message>().Select(m => m.Copy(data: m.Data + "z"));
+            var flowWithContext = flow.AsFlowWithContext<Message, long, Message, long, NotUsed, Message>((m, o) => new Message(m.Data, o), m => m.Offset);
+
+            Source.From(new[] { new Message("a", 1L) })
+                .AsSourceWithContext(m => m.Offset)
+                .Via(flowWithContext)
+                .AsSource()
+                .RunWith(this.SinkProbe<(Message, long)>(), Materializer)
+                .Request(1)
+                .ExpectNext((new Message("az", 1L), 1L))
+                .ExpectComplete();
+        }
+    }
+
+    sealed class Message : IEquatable<Message>
+    {
+        public string Data { get; }
+        public long Offset { get; }
+
+        public Message(string data, long offset)
+        {
+            Data = data;
+            Offset = offset;
+        }
+
+        public Message Copy(string data = null, long? offset = null) => new Message(data ?? Data, offset ?? Offset);
+
+        public bool Equals(Message other)
+        {
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return string.Equals(Data, other.Data) && Offset == other.Offset;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            return obj is Message other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((Data != null ? Data.GetHashCode() : 0) * 397) ^ Offset.GetHashCode();
+            }
+        }
+    }
+}

--- a/src/core/Akka.Streams.Tests/Dsl/SourceWithContextSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SourceWithContextSpec.cs
@@ -126,17 +126,14 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void SourceWithContext_must_pass_through_context_using_FlowWithContext()
         {
-            var flowWithContext = FlowWithContext.Create<long, string>();
-
-            var msg = new Message("a", 1);
+            var flowWithContext = FlowWithContext.Create<string, long>();
 
             var sink = this.CreateSubscriberProbe<(string, long)>();
 
-            Source.From(new[] { msg })
+            Source.From(new[] { new Message("a", 1L) })
                 .AsSourceWithContext(x => x.Offset)
                 .Select(x => x.Data)
                 .Via(flowWithContext.Select(s => s + "b"))
-                .AsSource()
                 .RunWith(Sink.FromSubscriber(sink), Materializer);
 
             var sub = sink.ExpectSubscription();

--- a/src/core/Akka.Streams.Tests/Dsl/WithContextUsageSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/WithContextUsageSpec.cs
@@ -214,7 +214,7 @@ namespace Akka.Streams.Tests.Dsl
                     new CommittableMessage<Record>(new Record(GenKey(i), GenValue(i)), new CommittableOffsetImpl(i)))
                 .ToArray();
 
-        private static SourceWithContext<Offset, Record, NotUsed> CreateSourceWithContext(
+        private static SourceWithContext<Record, Offset, NotUsed> CreateSourceWithContext(
             params CommittableMessage<Record>[] messages) =>
             CommittableConsumer.CommittableSource(messages)
                 .AsSourceWithContext(m => new Offset(m.Offset.Offset))

--- a/src/core/Akka.Streams/Dsl/FlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/FlowOperations.cs
@@ -2399,7 +2399,7 @@ namespace Akka.Streams.Dsl
         /// <typeparam name="TCtxOut">Resulting context type</typeparam>
         /// <typeparam name="TMat">Materialized value type</typeparam>
         /// <typeparam name="TIn2">Type of passed flow elements</typeparam>
-        public static FlowWithContext<TCtxIn, TIn, TCtxOut, TOut, TMat> AsFlowWithContext<TCtxIn, TIn, TCtxOut, TOut, TMat, TIn2>(
+        public static FlowWithContext<TIn, TCtxIn, TOut, TCtxOut, TMat> AsFlowWithContext<TIn, TCtxIn, TOut, TCtxOut, TMat, TIn2>(
             this Flow<TIn2, TOut, TMat> flow,
             Func<TIn, TCtxIn, TIn2> collapseContext,
             Func<TOut, TCtxOut> extractContext)

--- a/src/core/Akka.Streams/Dsl/FlowWithContext.cs
+++ b/src/core/Akka.Streams/Dsl/FlowWithContext.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Akka.Annotations;
 
 namespace Akka.Streams.Dsl
 {
@@ -17,17 +18,16 @@ namespace Akka.Streams.Dsl
     /// operations.
     /// 
     /// An "empty" flow can be created by calling <see cref="FlowWithContext.Create{TCtx,TIn}"/>.
-    /// 
-    /// API MAY CHANGE
-    ///</summary> 
-    public sealed class FlowWithContext<TCtxIn, TIn, TCtxOut, TOut, TMat>
+    ///</summary>
+    [ApiMayChange]
+    public sealed class FlowWithContext<TIn, TCtxIn, TOut, TCtxOut, TMat>
         : GraphDelegate<FlowShape<(TIn, TCtxIn), (TOut, TCtxOut)>, TMat>
     {
-        internal FlowWithContext(Flow<(TIn, TCtxIn), (TOut, TCtxOut), TMat> flow) 
+        internal FlowWithContext(Flow<(TIn, TCtxIn), (TOut, TCtxOut), TMat> flow)
             : base(flow)
         {
         }
-        
+
         ///<summary>
         /// Transform this flow by the regular flow. The given flow must support manual context propagation by
         /// taking and producing tuples of (data, context).
@@ -35,10 +35,10 @@ namespace Akka.Streams.Dsl
         /// This can be used as an escape hatch for operations that are not (yet) provided with automatic
         /// context propagation here.
         ///</summary>
-        public FlowWithContext<TCtxIn, TIn, TCtx2, TOut2, TMat> Via<TCtx2, TOut2, TMat2>(
+        public FlowWithContext<TIn, TCtxIn, TOut2, TCtx2, TMat> Via<TOut2, TCtx2, TMat2>(
             IGraph<FlowShape<(TOut, TCtxOut), (TOut2, TCtx2)>, TMat2> viaFlow) =>
             FlowWithContext.From(Flow.FromGraph(Inner).Via(viaFlow));
-        
+
         ///<summary>
         /// Transform this flow by the regular flow. The given flow must support manual context propagation by
         /// taking and producing tuples of (data, context).
@@ -49,7 +49,7 @@ namespace Akka.Streams.Dsl
         /// The <paramref name="combine"/> function is used to compose the materialized values of this flow and that
         /// flow into the materialized value of the resulting Flow.
         ///</summary>
-        public FlowWithContext<TCtxIn, TIn, TCtx2, TOut2, TMat3> ViaMaterialized<TCtx2, TOut2, TMat2, TMat3>(
+        public FlowWithContext<TIn, TCtxIn, TOut2, TCtx2, TMat3> ViaMaterialized<TOut2, TCtx2, TMat2, TMat3>(
             IGraph<FlowShape<(TOut, TCtxOut), (TOut2, TCtx2)>, TMat2> viaFlow, Func<TMat, TMat2, TMat3> combine) =>
             FlowWithContext.From(Flow.FromGraph(Inner).ViaMaterialized(viaFlow, combine));
 
@@ -60,17 +60,17 @@ namespace Akka.Streams.Dsl
     public static class FlowWithContext
     {
         /// <summary>
-        /// Creates an "empty" <see cref="FlowWithContext{TCtxIn,TIn,TCtxOut,TOut,TMat}"/> that passes elements through with their context unchanged.
+        /// Creates an "empty" <see cref="FlowWithContext{TIn,TCtxIn,TOut,TCtxOut,TMat}"/> that passes elements through with their context unchanged.
         /// </summary>
-        /// <typeparam name="TCtx"></typeparam>
         /// <typeparam name="TIn"></typeparam>
+        /// <typeparam name="TCtx"></typeparam>
         /// <returns></returns>
-        public static FlowWithContext<TCtx, TIn, TCtx, TIn, NotUsed> Create<TCtx, TIn>()
+        public static FlowWithContext<TIn, TCtx, TIn, TCtx, NotUsed> Create<TIn, TCtx>()
         {
             var under = Flow.Create<(TIn, TCtx), NotUsed>();
-            return new FlowWithContext<TCtx, TIn, TCtx, TIn, NotUsed>(under);
+            return new FlowWithContext<TIn, TCtx, TIn, TCtx, NotUsed>(under);
         }
-        
+
         /// <summary>
         /// Creates a FlowWithContext from a regular flow that operates on a pair of `(data, context)` elements.
         /// </summary>
@@ -81,8 +81,8 @@ namespace Akka.Streams.Dsl
         /// <typeparam name="TOut"></typeparam>
         /// <typeparam name="TMat"></typeparam>
         /// <returns></returns>
-        public static FlowWithContext<TCtxIn, TIn, TCtxOut, TOut, TMat> From<TCtxIn, TIn, TCtxOut, TOut, TMat>(
-            Flow<(TIn, TCtxIn), (TOut, TCtxOut), TMat> flow) => 
-            new FlowWithContext<TCtxIn, TIn, TCtxOut, TOut, TMat>(flow);
+        public static FlowWithContext<TIn, TCtxIn, TOut, TCtxOut, TMat> From<TIn, TCtxIn, TOut, TCtxOut, TMat>(
+            Flow<(TIn, TCtxIn), (TOut, TCtxOut), TMat> flow) =>
+            new FlowWithContext<TIn, TCtxIn, TOut, TCtxOut, TMat>(flow);
     }
 }

--- a/src/core/Akka.Streams/Dsl/FlowWithContextOperations.cs
+++ b/src/core/Akka.Streams/Dsl/FlowWithContextOperations.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Akka.Streams.Implementation.Fusing;
 
@@ -17,20 +16,20 @@ namespace Akka.Streams.Dsl
     public static class FlowWithContextOperations
     {
         /// <summary>
-        /// Context-preserving variant of <see cref="FlowOperations.Select{T,TIn,TOut,TMat}"/>
+        /// Context-preserving variant of <see cref="FlowOperations.Select{TIn,T,TOut,TMat}"/>
         /// </summary>
-        public static FlowWithContext<TCtx, TIn, TCtx, TOut2, TMat> Select<TCtx, TIn, TOut, TOut2, TMat>(
-            this FlowWithContext<TCtx, TIn, TCtx, TOut, TMat> flow, Func<TOut, TOut2> fn)
+        public static FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Select<TIn, TCtx, TOut, TOut2, TMat>(
+            this FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, Func<TOut, TOut2> fn)
         {
             var stage = new Select<(TOut, TCtx), (TOut2, TCtx)>(x => (fn(x.Item1), x.Item2));
             return flow.Via(Flow.FromGraph(stage));
         }
 
         /// <summary>
-        /// Context-preserving variant of <see cref="FlowOperations.SelectAsync{T,TIn,TOut,TMat}"/>
+        /// Context-preserving variant of <see cref="FlowOperations.SelectAsync{TIn,T,TOut,TMat}"/>
         /// </summary>
-        public static FlowWithContext<TCtx, TIn, TCtx, TOut2, TMat> SelectAsync<TCtx, TIn, TOut, TOut2, TMat>(
-            this FlowWithContext<TCtx, TIn, TCtx, TOut, TMat> flow, int parallelism, Func<TOut, Task<TOut2>> fn)
+        public static FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> SelectAsync<TIn, TCtx, TOut, TOut2, TMat>(
+            this FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, int parallelism, Func<TOut, Task<TOut2>> fn)
         {
             var stage = new SelectAsync<(TOut, TCtx), (TOut2, TCtx)>(parallelism,
                 async x => (await fn(x.Item1), x.Item2));
@@ -38,10 +37,10 @@ namespace Akka.Streams.Dsl
         }
 
         /// <summary>
-        /// Context-preserving variant of <see cref="FlowOperations.Collect{T,TIn,TOut,TMat}"/>
+        /// Context-preserving variant of <see cref="FlowOperations.Collect{TIn,T,TOut,TMat}"/>
         /// </summary>
-        public static FlowWithContext<TCtx, TIn, TCtx, TOut2, TMat> Collect<TCtx, TIn, TOut, TOut2, TMat>(
-            this FlowWithContext<TCtx, TIn, TCtx, TOut, TMat> flow, Func<TOut, TOut2> fn) where TOut2 : class
+        public static FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Collect<TIn, TCtx, TOut, TOut2, TMat>(
+            this FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, Func<TOut, TOut2> fn) where TOut2 : class
         {
             var stage = new Collect<(TOut, TCtx), (TOut2, TCtx)>(func: x =>
             {
@@ -54,8 +53,8 @@ namespace Akka.Streams.Dsl
         /// <summary>
         /// Context-preserving variant of <see cref="FlowOperations.Where{TIn,TOut,TMat}"/>
         /// </summary>
-        public static FlowWithContext<TCtx, TIn, TCtx, TOut, TMat> Where<TCtx, TIn, TOut, TMat>(
-            this FlowWithContext<TCtx, TIn, TCtx, TOut, TMat> flow, Func<TOut, bool> predicate)
+        public static FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> Where<TIn, TCtx, TOut, TMat>(
+            this FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, Func<TOut, bool> predicate)
         {
             var stage = new Where<(TOut, TCtx)>(x => predicate(x.Item1));
             return flow.Via(Flow.FromGraph(stage));
@@ -64,8 +63,8 @@ namespace Akka.Streams.Dsl
         /// <summary>
         /// Context-preserving variant of <see cref="FlowOperations.Grouped{TIn,TOut,TMat}"/>
         /// </summary>
-        public static FlowWithContext<TCtx, TIn, TCtx, TOut, TMat> WhereNot<TCtx, TIn, TOut, TMat>(
-            this FlowWithContext<TCtx, TIn, TCtx, TOut, TMat> flow, Func<TOut, bool> predicate)
+        public static FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> WhereNot<TIn, TCtx, TOut, TMat>(
+            this FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, Func<TOut, bool> predicate)
         {
             var stage = new Where<(TOut, TCtx)>(x => !predicate(x.Item1));
             return flow.Via(Flow.FromGraph(stage));
@@ -75,9 +74,8 @@ namespace Akka.Streams.Dsl
         /// Context-preserving variant of <see cref="FlowOperations.Grouped{TIn,TOut,TMat}"/>
         /// Each output group will be associated with a `Seq` of corresponding context elements.
         /// </summary>
-        public static FlowWithContext<TCtx, TIn, IReadOnlyList<TCtx>, IReadOnlyList<TOut>, TMat> Grouped<TCtx, TIn,
-            TOut, TMat>(
-            this FlowWithContext<TCtx, TIn, TCtx, TOut, TMat> flow, int n)
+        public static FlowWithContext<TIn, TCtx, IReadOnlyList<TOut>, IReadOnlyList<TCtx>, TMat> Grouped<TIn, TCtx, TOut, TMat>(
+            this FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, int n)
         {
             var stage = new Grouped<(TOut, TCtx)>(n);
             return flow.Via(Flow.FromGraph(stage).Select(itemsWithContexts =>
@@ -99,9 +97,8 @@ namespace Akka.Streams.Dsl
         /// Context-preserving variant of <see cref="FlowOperations.Sliding{TIn,TOut,TMat}"/>
         /// Each output group will be associated with a `Seq` of corresponding context elements.
         /// </summary>
-        public static FlowWithContext<TCtx, TIn, IReadOnlyList<TCtx>, IReadOnlyList<TOut>, TMat> Sliding<TCtx, TIn,
-            TOut, TMat>(
-            this FlowWithContext<TCtx, TIn, TCtx, TOut, TMat> flow, int n, int step = 1)
+        public static FlowWithContext<TIn, TCtx, IReadOnlyList<TOut>, IReadOnlyList<TCtx>, TMat> Sliding<TIn, TCtx, TOut, TMat>(
+            this FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, int n, int step = 1)
         {
             var stage = new Sliding<(TOut, TCtx)>(n, step);
             return flow.Via(Flow.FromGraph(stage).Select(itemsWithContexts =>
@@ -120,19 +117,19 @@ namespace Akka.Streams.Dsl
         }
 
         /// <summary>
-        /// Context-preserving variant of <see cref="FlowOperations.SelectMany{T,TIn,TOut,TMat}"/>.
+        /// Context-preserving variant of <see cref="FlowOperations.SelectMany{TIn,T,TOut,TMat}"/>.
         /// The context of the input element will be associated with each of the output elements calculated from
         /// this input element.
         /// </summary>
-        public static FlowWithContext<TCtx, TIn, TCtx, TOut2, TMat> SelectConcat<TCtx, TIn, TOut, TOut2, TMat>(
-            this FlowWithContext<TCtx, TIn, TCtx, TOut, TMat> flow, Func<TOut, IEnumerable<TOut2>> fn) =>
+        public static FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> SelectConcat<TIn, TCtx, TOut, TOut2, TMat>(
+            this FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, Func<TOut, IEnumerable<TOut2>> fn) =>
             StatefulSelectConcat(flow, () => fn);
 
         /// <summary>
-        /// Context-preserving variant of <see cref="FlowOperations.StatefulSelectMany{T,TIn,TOut,TMat}"/>.
+        /// Context-preserving variant of <see cref="FlowOperations.StatefulSelectMany{TIn,T,TOut,TMat}"/>.
         /// </summary>
-        public static FlowWithContext<TCtx, TIn, TCtx, TOut2, TMat> StatefulSelectConcat<TCtx, TIn, TOut, TOut2, TMat>(
-            this FlowWithContext<TCtx, TIn, TCtx, TOut, TMat> flow, Func<Func<TOut, IEnumerable<TOut2>>> fn)
+        public static FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> StatefulSelectConcat<TIn, TCtx, TOut, TOut2, TMat>(
+            this FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, Func<Func<TOut, IEnumerable<TOut2>>> fn)
         {
             var stage = new StatefulSelectMany<(TOut, TCtx), (TOut2, TCtx)>(() =>
             {
@@ -149,33 +146,32 @@ namespace Akka.Streams.Dsl
         /// <summary>
         /// Apply the given function to each context element (leaving the data elements unchanged).
         /// </summary>
-        public static FlowWithContext<TCtx, TIn, TCtx2, TOut, TMat> SelectContext<TCtx, TIn, TCtx2, TOut, TMat>(
-            this FlowWithContext<TCtx, TIn, TCtx, TOut, TMat> flow, Func<TCtx, TCtx2> mapContext)
+        public static FlowWithContext<TIn, TCtx, TOut, TCtx2, TMat> SelectContext<TIn, TCtx, TOut, TCtx2, TMat>(
+            this FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, Func<TCtx, TCtx2> mapContext)
         {
             var stage = new Select<(TOut, TCtx), (TOut, TCtx2)>(x =>
                 (x.Item1, mapContext(x.Item2)));
             return flow.Via(Flow.FromGraph(stage));
         }
     }
-    
-    
+
     public static class SourceWithContextOperations
     {
         /// <summary>
-        /// Context-preserving variant of <see cref="SourceOperations.Select{T,TOut,TMat}"/>
+        /// Context-preserving variant of <see cref="SourceOperations.Select{TOut,T,TMat}"/>
         /// </summary>
-        public static SourceWithContext<TCtx, TOut2, TMat> Select<TCtx, TOut, TOut2, TMat>(
-            this SourceWithContext<TCtx, TOut, TMat> flow, Func<TOut, TOut2> fn)
+        public static SourceWithContext<TOut2, TCtx, TMat> Select<TOut, TCtx, TOut2, TMat>(
+            this SourceWithContext<TOut, TCtx, TMat> flow, Func<TOut, TOut2> fn)
         {
             var stage = new Select<(TOut, TCtx), (TOut2, TCtx)>(x => (fn(x.Item1), x.Item2));
             return flow.Via(Flow.FromGraph(stage));
         }
 
         /// <summary>
-        /// Context-preserving variant of <see cref="SourceOperations.SelectAsync{T,TOut,TMat}"/>
+        /// Context-preserving variant of <see cref="SourceOperations.SelectAsync{TOut,T,TMat}"/>
         /// </summary>
-        public static SourceWithContext<TCtx, TOut2, TMat> SelectAsync<TCtx, TOut, TOut2, TMat>(
-            this SourceWithContext<TCtx, TOut, TMat> flow, int parallelism, Func<TOut, Task<TOut2>> fn)
+        public static SourceWithContext<TOut2, TCtx, TMat> SelectAsync<TOut, TCtx, TOut2, TMat>(
+            this SourceWithContext<TOut, TCtx, TMat> flow, int parallelism, Func<TOut, Task<TOut2>> fn)
         {
             var stage = new SelectAsync<(TOut, TCtx), (TOut2, TCtx)>(parallelism,
                 async x => (await fn(x.Item1), x.Item2));
@@ -185,8 +181,8 @@ namespace Akka.Streams.Dsl
         /// <summary>
         /// Context-preserving variant of <see cref="SourceOperations.Collect{T,TOut,TMat}"/>
         /// </summary>
-        public static SourceWithContext<TCtx, TOut2, TMat> Collect<TCtx, TOut, TOut2, TMat>(
-            this SourceWithContext<TCtx, TOut, TMat> flow, Func<TOut, TOut2> fn) where TOut2 : class
+        public static SourceWithContext<TOut2, TCtx, TMat> Collect<TOut, TCtx, TOut2, TMat>(
+            this SourceWithContext<TOut, TCtx, TMat> flow, Func<TOut, TOut2> fn) where TOut2 : class
         {
             var stage = new Collect<(TOut, TCtx), (TOut2, TCtx)>(func: x =>
             {
@@ -199,8 +195,8 @@ namespace Akka.Streams.Dsl
         /// <summary>
         /// Context-preserving variant of <see cref="SourceOperations.Where{TOut,TMat}"/>
         /// </summary>
-        public static SourceWithContext<TCtx, TOut, TMat> Where<TCtx, TOut, TMat>(
-            this SourceWithContext<TCtx, TOut, TMat> flow, Func<TOut, bool> predicate)
+        public static SourceWithContext<TOut, TCtx, TMat> Where<TOut, TCtx, TMat>(
+            this SourceWithContext<TOut, TCtx, TMat> flow, Func<TOut, bool> predicate)
         {
             var stage = new Where<(TOut, TCtx)>(x => predicate(x.Item1));
             return flow.Via(Flow.FromGraph(stage));
@@ -209,8 +205,8 @@ namespace Akka.Streams.Dsl
         /// <summary>
         /// Context-preserving variant of <see cref="SourceOperations.Grouped{TOut,TMat}"/>
         /// </summary>
-        public static SourceWithContext<TCtx, TOut, TMat> WhereNot<TCtx, TOut, TMat>(
-            this SourceWithContext<TCtx, TOut, TMat> flow, Func<TOut, bool> predicate)
+        public static SourceWithContext<TOut, TCtx, TMat> WhereNot<TOut, TCtx, TMat>(
+            this SourceWithContext<TOut, TCtx, TMat> flow, Func<TOut, bool> predicate)
         {
             var stage = new Where<(TOut, TCtx)>(x => !predicate(x.Item1));
             return flow.Via(Flow.FromGraph(stage));
@@ -220,8 +216,8 @@ namespace Akka.Streams.Dsl
         /// Context-preserving variant of <see cref="SourceOperations.Grouped{TOut,TMat}"/>
         /// Each output group will be associated with a `Seq` of corresponding context elements.
         /// </summary>
-        public static SourceWithContext<IReadOnlyList<TCtx>, IReadOnlyList<TOut>, TMat> Grouped<TCtx, TOut, TMat>(
-            this SourceWithContext<TCtx, TOut, TMat> flow, int n)
+        public static SourceWithContext<IReadOnlyList<TOut>, IReadOnlyList<TCtx>, TMat> Grouped<TOut, TCtx, TMat>(
+            this SourceWithContext<TOut, TCtx, TMat> flow, int n)
         {
             var stage = new Grouped<(TOut, TCtx)>(n);
             return flow.Via(Flow.FromGraph(stage).Select(itemsWithContexts =>
@@ -243,8 +239,8 @@ namespace Akka.Streams.Dsl
         /// Context-preserving variant of <see cref="SourceOperations.Sliding{TOut,TMat}"/>
         /// Each output group will be associated with a `Seq` of corresponding context elements.
         /// </summary>
-        public static SourceWithContext<IReadOnlyList<TCtx>, IReadOnlyList<TOut>, TMat> Sliding<TCtx, TOut, TMat>(
-            this SourceWithContext<TCtx, TOut, TMat> flow, int n, int step = 1)
+        public static SourceWithContext<IReadOnlyList<TOut>, IReadOnlyList<TCtx>, TMat> Sliding<TOut, TCtx, TMat>(
+            this SourceWithContext<TOut, TCtx, TMat> flow, int n, int step = 1)
         {
             var stage = new Sliding<(TOut, TCtx)>(n, step);
             return flow.Via(Flow.FromGraph(stage).Select(itemsWithContexts =>
@@ -267,15 +263,15 @@ namespace Akka.Streams.Dsl
         /// The context of the input element will be associated with each of the output elements calculated from
         /// this input element.
         /// </summary>
-        public static SourceWithContext<TCtx, TOut2, TMat> SelectConcat<TCtx, TOut, TOut2, TMat>(
-            this SourceWithContext<TCtx, TOut, TMat> flow, Func<TOut, IEnumerable<TOut2>> fn) =>
+        public static SourceWithContext<TOut2, TCtx, TMat> SelectConcat<TOut, TCtx, TOut2, TMat>(
+            this SourceWithContext<TOut, TCtx, TMat> flow, Func<TOut, IEnumerable<TOut2>> fn) =>
             StatefulSelectConcat(flow, () => fn);
 
         /// <summary>
         /// Context-preserving variant of <see cref="SourceOperations.StatefulSelectMany{T,TOut,TMat}"/>.
         /// </summary>
-        public static SourceWithContext<TCtx, TOut2, TMat> StatefulSelectConcat<TCtx, TOut, TOut2, TMat>(
-            this SourceWithContext<TCtx, TOut, TMat> flow, Func<Func<TOut, IEnumerable<TOut2>>> fn)
+        public static SourceWithContext<TOut2, TCtx, TMat> StatefulSelectConcat<TOut, TCtx, TOut2, TMat>(
+            this SourceWithContext<TOut, TCtx, TMat> flow, Func<Func<TOut, IEnumerable<TOut2>>> fn)
         {
             var stage = new StatefulSelectMany<(TOut, TCtx), (TOut2, TCtx)>(() =>
             {
@@ -292,8 +288,8 @@ namespace Akka.Streams.Dsl
         /// <summary>
         /// Apply the given function to each context element (leaving the data elements unchanged).
         /// </summary>
-        public static SourceWithContext<TCtx2, TOut, TMat> SelectContext<TCtx, TCtx2, TOut, TMat>(
-            this SourceWithContext<TCtx, TOut, TMat> flow, Func<TCtx, TCtx2> mapContext)
+        public static SourceWithContext<TOut, TCtx2, TMat> SelectContext<TOut, TCtx, TCtx2, TMat>(
+            this SourceWithContext<TOut, TCtx, TMat> flow, Func<TCtx, TCtx2> mapContext)
         {
             var stage = new Select<(TOut, TCtx), (TOut, TCtx2)>(x =>
                 (x.Item1, mapContext(x.Item2)));

--- a/src/core/Akka.Streams/Dsl/SourceOperations.cs
+++ b/src/core/Akka.Streams/Dsl/SourceOperations.cs
@@ -2275,10 +2275,9 @@ namespace Akka.Streams.Dsl
         /// <typeparam name="TOut">Type of produced events.</typeparam>
         /// <typeparam name="TMat">Type of materialized value.</typeparam>
         /// <returns></returns>
-        public static SourceWithContext<TCtx, TOut, TMat> AsSourceWithContext<TCtx, TOut, TMat>(
-            this Source<TOut, TMat> flow, Func<TOut, TCtx> fn) =>
-            new SourceWithContext<TCtx, TOut, TMat>(flow.Select(x => (x, fn(x))));
-
+        public static SourceWithContext<TOut, TCtx, TMat> AsSourceWithContext<TOut, TCtx, TMat>(this Source<TOut, TMat> flow, Func<TOut, TCtx> fn) =>
+            new SourceWithContext<TOut, TCtx, TMat>(flow.Select(x => (x, fn(x))));
+      
         /// <summary>
         /// The operator fails with an <see cref="WatchedActorTerminatedException"/> if the target actor is terminated.
         /// 

--- a/src/core/Akka.Streams/Dsl/SourceWithContext.cs
+++ b/src/core/Akka.Streams/Dsl/SourceWithContext.cs
@@ -6,7 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
-using Akka.Streams.Implementation;
+using Akka.Annotations;
 
 namespace Akka.Streams.Dsl
 {
@@ -15,17 +15,15 @@ namespace Akka.Streams.Dsl
     /// Only a subset of common operations from [[FlowOps]] is supported. As an escape hatch you can
     /// use [[FlowWithContextOps.via]] to manually provide the context propagation for otherwise unsupported
     /// operations.
-    /// 
-    /// API MAY CHANGE
     /// </summary>
-    public sealed class SourceWithContext<TCtx, TOut, TMat> : GraphDelegate<SourceShape<(TOut, TCtx)>, TMat>
+    [ApiMayChange]
+    public sealed class SourceWithContext<TOut, TCtx, TMat> : GraphDelegate<SourceShape<(TOut, TCtx)>, TMat>
     {
         public SourceWithContext(Source<(TOut, TCtx), TMat> source)
-        : base(source)
+            : base(source)
         {
         }
-        
-        
+
         ///<summary>
         /// Transform this flow by the regular flow. The given flow must support manual context propagation by
         /// taking and producing tuples of (data, context).
@@ -33,10 +31,9 @@ namespace Akka.Streams.Dsl
         /// This can be used as an escape hatch for operations that are not (yet) provided with automatic
         /// context propagation here.
         ///</summary>
-        public SourceWithContext<TCtx2, TOut2, TMat> Via<TCtx2, TOut2, TMat2>(
-            IGraph<FlowShape<(TOut, TCtx), (TOut2, TCtx2)>, TMat2> viaFlow) =>
-            new SourceWithContext<TCtx2, TOut2, TMat>(Source.FromGraph(Inner).Via(viaFlow));
-        
+        public SourceWithContext<TOut2, TCtx2, TMat> Via<TOut2, TCtx2, TMat2>(IGraph<FlowShape<(TOut, TCtx), (TOut2, TCtx2)>, TMat2> viaFlow) =>
+            new SourceWithContext<TOut2, TCtx2, TMat>(Source.FromGraph(Inner).Via(viaFlow));
+
         ///<summary>
         /// Transform this flow by the regular flow. The given flow must support manual context propagation by
         /// taking and producing tuples of (data, context).
@@ -47,16 +44,25 @@ namespace Akka.Streams.Dsl
         /// The <paramref name="combine"/> function is used to compose the materialized values of this flow and that
         /// flow into the materialized value of the resulting Flow.
         ///</summary>
-        public SourceWithContext<TCtx2, TOut2, TMat3> ViaMaterialized<TCtx2, TOut2, TMat2, TMat3>(
+        public SourceWithContext<TOut2, TCtx2, TMat3> ViaMaterialized<TOut2, TCtx2, TMat2, TMat3>(
             IGraph<FlowShape<(TOut, TCtx), (TOut2, TCtx2)>, TMat2> viaFlow, Func<TMat, TMat2, TMat3> combine) =>
-            new SourceWithContext<TCtx2, TOut2, TMat3>(Source.FromGraph(Inner).ViaMaterialized(viaFlow, combine));
+            new SourceWithContext<TOut2, TCtx2, TMat3>(Source.FromGraph(Inner).ViaMaterialized(viaFlow, combine));
 
-        
+        /// <summary>
+        /// Connect this <see cref="SourceWithContext{TOut,TCtx,TMat}"/> to a Sink and run it. The returned value is the materialized value of the Sink.
+        /// Note that the ActorSystem can be used as the implicit materializer parameter to use the SystemMaterializer for running the stream.
+        /// </summary>
+        /// <typeparam name="TMat2"></typeparam>
+        /// <param name="sink"></param>
+        /// <param name="materializer"></param>
+        /// <returns></returns>
+        public TMat2 RunWith<TMat2>(IGraph<SinkShape<(TOut, TCtx)>, TMat2> sink, IMaterializer materializer)
+            => Source.FromGraph(Inner).RunWith(sink, materializer);
+
         ///<summary>
         ///Stops automatic context propagation from here and converts this to a regular
         ///stream of a pair of (data, context).
         ///</summary>
-        public Source<(TOut, TCtx), TMat> AsSource() => 
-            Inner is Source<(TOut, TCtx), TMat>  source ? source : Source.FromGraph(Inner);
+        public Source<(TOut, TCtx), TMat> AsSource() => Inner is Source<(TOut, TCtx), TMat> source ? source : Source.FromGraph(Inner);
     }
 }


### PR DESCRIPTION
Fixes `FlowWithContext` parameters order to follow actual shape of elements

## Changes

Reorder Source/FlowWithContext type parameters

## Checklist

* [X] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [X] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [X] Changes in public API reviewed, if any.