### PR TITLE
Change the location of core Akka configuration page 

### DIFF
--- a/docs/articles/configuration/akka.html
+++ b/docs/articles/configuration/akka.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+   <head>
+      <title>Akka Configuration</title>
+      <meta http-equiv = "refresh" content="1;url=../configuration/modules/akka.html" />
+   </head>
+   <body>
+      <p>This page has been moved to <a href="../configuration/modules/akka.html">Akka Configuration</a>.</p>
+   </body>
+</html>

--- a/docs/articles/configuration/modules/akka.md
+++ b/docs/articles/configuration/modules/akka.md
@@ -7,4 +7,4 @@ title: Akka Configuration
 
 Below is the default HOCON configuration for the base `Akka` package.
 
-[!code[Akka.dll HOCON Configuration](../../../src/core/Akka/Configuration/Pigeon.conf)]
+[!code[Akka.dll HOCON Configuration](../../../../src/core/Akka/Configuration/Pigeon.conf)]

--- a/docs/articles/configuration/modules/toc.yml
+++ b/docs/articles/configuration/modules/toc.yml
@@ -1,3 +1,5 @@
+- name: Akka
+  href: akka.md
 - name: Akka.Cluster
   href: akka.cluster.md
 - name: Akka.Remote

--- a/docs/articles/configuration/toc.yml
+++ b/docs/articles/configuration/toc.yml
@@ -2,7 +2,5 @@
   href: config.md
 - name: HOCON Syntax and Practices in Akka.NET
   href: hocon.md
-- name: Akka
-  href: akka.md
 - name: Modules
   href: modules/toc.yml


### PR DESCRIPTION
## Changes

Moved the `akka core` configuration page into `modules`
