### PR TITLE
Change Receive Test Methods to `Sync` over `Async`

### DIFF
--- a/src/core/Akka.TestKit/Internal/AsyncQueue.cs
+++ b/src/core/Akka.TestKit/Internal/AsyncQueue.cs
@@ -10,6 +10,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Nito.AsyncEx.Synchronous;
 
 namespace Akka.TestKit.Internal
 {
@@ -19,7 +20,7 @@ namespace Akka.TestKit.Internal
 
         public int Count => _collection.Count;
         
-        public void Enqueue(T item) => EnqueueAsync(item).AsTask().Wait();
+        public void Enqueue(T item) => EnqueueAsync(item).AsTask().WaitAndUnwrapException();
 
         public ValueTask EnqueueAsync(T item) => new ValueTask(_collection.AddAsync(item)); 
 

--- a/src/core/Akka.TestKit/TestKitBase_Receive.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Receive.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.TestKit.Internal;
+using Nito.AsyncEx.Synchronous;
 
 namespace Akka.TestKit
 {
@@ -60,7 +61,7 @@ namespace Akka.TestKit
         public T FishForMessage<T>(Predicate<T> isMessage, ArrayList allMessages, TimeSpan? max = null, string hint = "")
         {
             var task = FishForMessageAsync<T>(isMessage, allMessages, max, hint).AsTask();
-            task.Wait();
+            task.WaitAndUnwrapException();
             return task.Result; 
         }
 
@@ -147,7 +148,7 @@ namespace Akka.TestKit
         public object ReceiveOne(TimeSpan? max = null)
         {
             var task = ReceiveOneAsync(max).AsTask();
-            task.Wait();
+            task.WaitAndUnwrapException();
             var received = task.Result;
             return received;
         }
@@ -172,7 +173,7 @@ namespace Akka.TestKit
         public object ReceiveOne(CancellationToken cancellationToken)
         {
            var task = ReceiveOneAsync(cancellationToken).AsTask();
-           task.Wait();
+           task.WaitAndUnwrapException();
            var received = task.Result;
            return received;
         }
@@ -244,7 +245,7 @@ namespace Akka.TestKit
         private bool InternalTryReceiveOne(out MessageEnvelope envelope, TimeSpan? max, CancellationToken cancellationToken, bool shouldLog)
         {
             var task = InternalTryReceiveOneAsync(max, cancellationToken, shouldLog).AsTask();
-            task.Wait();
+            task.WaitAndUnwrapException();
             var received = task.Result;
             envelope = received.envelope;
             return received.success;
@@ -310,7 +311,7 @@ namespace Akka.TestKit
         public object PeekOne(TimeSpan? max = null)
         {
             var task = PeekOneAsync(max).AsTask();
-            task.Wait();
+            task.WaitAndUnwrapException();
             var peeked = task.Result;
             return peeked;
         } 
@@ -333,7 +334,7 @@ namespace Akka.TestKit
         public object PeekOne(CancellationToken cancellationToken)
         {
             var task = PeekOneAsync(cancellationToken).AsTask();
-            task.Wait();
+            task.WaitAndUnwrapException();
             var peeked = task.Result;
             return peeked;
         }
@@ -403,7 +404,7 @@ namespace Akka.TestKit
         private bool InternalTryPeekOne(out MessageEnvelope envelope, TimeSpan? max, CancellationToken cancellationToken, bool shouldLog)
         {
             var task = InternalTryPeekOneAsync(max, cancellationToken, shouldLog).AsTask();
-            task.Wait();
+            task.WaitAndUnwrapException();
             var received = task.Result;
             envelope = received.envelope;
             return received.success;

--- a/src/core/Akka.TestKit/TestKitBase_Receive.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Receive.cs
@@ -64,6 +64,7 @@ namespace Akka.TestKit
             return task.Result; 
         }
 
+        /// <inheritdoc cref="FishForMessage{T}(Predicate{T}, ArrayList, TimeSpan?, string)"/>
         public async ValueTask<T> FishForMessageAsync<T>(Predicate<T> isMessage, ArrayList allMessages, TimeSpan? max = null, string hint = "")
         {
             var maxValue = RemainingOrDilated(max);


### PR DESCRIPTION
Part fix for https://github.com/akkadotnet/akka.net/issues/5617

## Changes

- Change `ReceiveOne()` to sync over async that calls `ReceiveOneAsync()`
- Create `ReceiveOneAsync()` method
- Change `TryReceiveOne()` to sync over async that calls `TryReceiveOneAsync()`
- Create `TryReceiveOneAsync()`
- Change `PeekOne()` to sync over async that calls `PeekOneAsync()`
- Create `PeekOneAsync()` method
- Change `TryPeekOne()` to sync over async that calls `TryPeekOneAsync()`
- Create `TryPeekOneAsync()`
- Change `FishForMessage()` to sync over async that calls `FishForMessageAsync()`
- Create `FishForMessageAsync()`