### PR TITLE
Change ReceiveWhile Test Methods to Sync over Async

### DIFF
--- a/src/core/Akka.TestKit.Tests/TestKitBaseTests/ReceiveTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestKitBaseTests/ReceiveTests.cs
@@ -115,7 +115,7 @@ namespace Akka.Testkit.Tests.TestKitBaseTests
         {
             var probe = CreateTestProbe("probe");
             probe.Ref.Tell(3, TestActor);
-            Func<Task> func = () => probe.FishUntilMessageAsync<int>(max: TimeSpan.FromMilliseconds(10)).AsTask();
+            Func<Task> func = () => probe.FishUntilMessageAsync<int>(max: TimeSpan.FromMilliseconds(10));
             await func.Should().ThrowAsync<Exception>();
         }
 

--- a/src/core/Akka.TestKit.Tests/TestKitBaseTests/ReceiveTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestKitBaseTests/ReceiveTests.cs
@@ -115,7 +115,7 @@ namespace Akka.Testkit.Tests.TestKitBaseTests
         {
             var probe = CreateTestProbe("probe");
             probe.Ref.Tell(3, TestActor);
-            Func<Task> func = () => probe.FishUntilMessageAsync<int>(max: TimeSpan.FromMilliseconds(10));
+            Func<Task> func = () => probe.FishUntilMessageAsync<int>(max: TimeSpan.FromMilliseconds(10)).AsTask();
             await func.Should().ThrowAsync<Exception>();
         }
 

--- a/src/core/Akka.TestKit/Akka.TestKit.csproj
+++ b/src/core/Akka.TestKit/Akka.TestKit.csproj
@@ -28,8 +28,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
     <PackageReference Include="Nito.AsyncEx.Context" Version="5.1.2" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/core/Akka.TestKit/TestKitBase_Expect.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Expect.cs
@@ -9,9 +9,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit.Internal;
 using Akka.Util;
+using Nito.AsyncEx.Synchronous;
 
 namespace Akka.TestKit
 {
@@ -369,18 +371,28 @@ namespace Akka.TestKit
             return InternalExpectMsgAllOf(dilated, messages);
         }
 
-        private IReadOnlyCollection<T> InternalExpectMsgAllOf<T>(TimeSpan max, IReadOnlyCollection<T> messages, Func<T, T, bool> areEqual = null, bool shouldLog=false)
+        private IReadOnlyCollection<T> InternalExpectMsgAllOf<T>(TimeSpan max, IReadOnlyCollection<T> messages, Func<T, T, bool> areEqual = null, bool shouldLog=false, CancellationToken cancellationToken = default)
+        {
+            var task = InternalExpectMsgAllOfAsync(max, messages, areEqual, shouldLog, cancellationToken);
+            task.WaitAndUnwrapException(cancellationToken);
+            return task.Result;
+        }
+
+        private async Task<IReadOnlyCollection<T>> InternalExpectMsgAllOfAsync<T>(TimeSpan max,
+            IReadOnlyCollection<T> messages, Func<T, T, bool> areEqual = null, bool shouldLog = false,
+            CancellationToken cancellationToken = default)
         {
             ConditionalLog(shouldLog, "Expecting {0} messages during {1}", messages.Count, max);
             areEqual = areEqual ?? ((x, y) => Equals(x, y));
             var start = Now;
-            var receivedMessages = InternalReceiveN(messages.Count, max, shouldLog).ToList();
-            var missing = messages.Where(m => !receivedMessages.Any(r => r is T && areEqual((T)r, m))).ToList();
-            var unexpected = receivedMessages.Where(r => !messages.Any(m => r is T && areEqual((T)r, m))).ToList();
+            
+            var receivedMessages = await InternalReceiveNAsync(messages.Count, max, shouldLog, cancellationToken).ToListAsync(cancellationToken);
+
+            var missing = messages.Where(m => !receivedMessages.Any(r => r is T obj && areEqual(obj, m))).ToList();
+            var unexpected = receivedMessages.Where(r => !messages.Any(m => r is T obj && areEqual(obj, m))).ToList();
             CheckMissingAndUnexpected(missing, unexpected, "not found", "found unexpected", shouldLog, string.Format("Expected {0} messages during {1}. Failed after {2}. ", messages.Count, max, Now-start));
             return receivedMessages.Cast<T>().ToList();
         }
-
 
         private void CheckMissingAndUnexpected<TMissing, TUnexpected>(IReadOnlyCollection<TMissing> missing, IReadOnlyCollection<TUnexpected> unexpected, string missingMessage, string unexpectedMessage, bool shouldLog, string hint)
         {

--- a/src/core/Akka.TestKit/TestKitBase_Receive.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Receive.cs
@@ -32,6 +32,12 @@ namespace Akka.TestKit
         public object FishForMessage(Predicate<object> isMessage, TimeSpan? max = null, string hint = "")
         {
             return FishForMessage<object>(isMessage, max, hint);
+        } 
+
+        /// <inheritdoc cref="FishForMessage(Predicate{object}, TimeSpan?, string)"/>
+        public async ValueTask<object> FishForMessageAsync(Predicate<object> isMessage, TimeSpan? max = null, string hint = "")
+        {
+            return await FishForMessageAsync<object>(isMessage, max, hint);
         }
 
         /// <summary>
@@ -46,6 +52,12 @@ namespace Akka.TestKit
         public T FishForMessage<T>(Predicate<T> isMessage, TimeSpan? max = null, string hint = "")
         {
             return FishForMessage(isMessage: isMessage, max: max, hint: hint, allMessages: null);
+        }
+
+        /// <inheritdoc cref="FishForMessage(Predicate{object}, TimeSpan?, string)"/>
+        public async ValueTask<T> FishForMessageAsync<T>(Predicate<T> isMessage, TimeSpan? max = null, string hint = "")
+        {
+            return await FishForMessageAsync(isMessage: isMessage, max: max, hint: hint, allMessages: null);
         }
 
         /// <summary>

--- a/src/core/Akka.TestKit/TestKitBase_Receive.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Receive.cs
@@ -54,7 +54,7 @@ namespace Akka.TestKit
             return FishForMessage(isMessage: isMessage, max: max, hint: hint, allMessages: null);
         }
 
-        /// <inheritdoc cref="FishForMessage(Predicate{object}, TimeSpan?, string)"/>
+        /// <inheritdoc cref="FishForMessage{T}(Predicate{T}, TimeSpan?, string)"/>
         public async ValueTask<T> FishForMessageAsync<T>(Predicate<T> isMessage, TimeSpan? max = null, string hint = "")
         {
             return await FishForMessageAsync(isMessage: isMessage, max: max, hint: hint, allMessages: null);

--- a/src/core/Akka.TestKit/TestKitBase_Receive.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Receive.cs
@@ -499,7 +499,7 @@ namespace Akka.TestKit
         /// The max duration is scaled by <see cref="Dilated(TimeSpan)"/>
         /// </summary>
         /// <typeparam name="T">TBD</typeparam>
-        /// <param name="max"></param>
+        /// <param name="max">TBD</param>
         /// <param name="idle">TBD</param>
         /// <param name="filter">TBD</param>
         /// <param name="msgs">TBD</param>


### PR DESCRIPTION
Part fix for https://github.com/akkadotnet/akka.net/issues/5617

## Changes

- Changed `ReceiveWhile()` to sync over `async` that calls `ReceiveWhileAsync()`
- Created `ReceiveWhileAsync()`
- Changed `ReceiveN()` to sync over `async` that calls `ReceiveNAsync()`
- Created `ReceiveNAsync()`
- Changed `InternalReceiveN()` to sync over `async` that calls `InternalReceiveNAsync()`
- Created `InternalReceiveNAsync()`