### PR TITLE
[TEST] Fix and cleanup TestKit codes

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/PersistentShardSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/PersistentShardSpec.cs
@@ -84,7 +84,7 @@ namespace Akka.Cluster.Sharding.Tests
             secondIncarnation.Tell(Shard.GetShardStats.Instance);
             AwaitAssert(() =>
             {
-                ExpectMsgAllOf(new Shard.ShardStats("shard-1", 1));
+                ExpectMsgAllOf(new []{ new Shard.ShardStats("shard-1", 1) });
             });
         }
     }

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Bugfix4360Spec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Bugfix4360Spec.cs
@@ -22,30 +22,30 @@ namespace Akka.Persistence.Sqlite.Tests
     {
         public static Config TestConf = @"
 akka.persistence {
-journal {
-plugin = ""akka.persistence.journal.sqlite""
-sqlite {
-class = ""Akka.Persistence.Sqlite.Journal.SqliteJournal, Akka.Persistence.Sqlite""
-plugin-dispatcher = ""akka.actor.default-dispatcher""
-connection-string = ""DataSource=AkkaJournalfxR16.db""
-connection-timeout = 25s
-table-name = event_journal
-auto-initialize = on
-}
-}
-snapshot-store {
-plugin = ""akka.persistence.snapshot-store.sqlite""
-sqlite {
-class = ""Akka.Persistence.Sqlite.Snapshot.SqliteSnapshotStore, Akka.Persistence.Sqlite""
-plugin-dispatcher = ""akka.actor.default-dispatcher""
-connection-string = ""DataSource=AkkaSnapShotfxR16.db""
-connection-timeout = 25s
-table-name = snapshot_store
-auto-initialize = on
-}
-}
-#end persistence
-}}";
+  journal {
+    plugin = ""akka.persistence.journal.sqlite""
+    sqlite {
+      class = ""Akka.Persistence.Sqlite.Journal.SqliteJournal, Akka.Persistence.Sqlite""
+      plugin-dispatcher = ""akka.actor.default-dispatcher""
+      connection-string = ""DataSource=AkkaJournalfxR16.db""
+      connection-timeout = 25s
+      table-name = event_journal
+      auto-initialize = on
+    }
+  }
+  snapshot-store {
+    plugin = ""akka.persistence.snapshot-store.sqlite""
+    sqlite {
+      class = ""Akka.Persistence.Sqlite.Snapshot.SqliteSnapshotStore, Akka.Persistence.Sqlite""
+      plugin-dispatcher = ""akka.actor.default-dispatcher""
+      connection-string = ""DataSource=AkkaSnapShotfxR16.db""
+      connection-timeout = 25s
+      table-name = snapshot_store
+      auto-initialize = on
+    }
+  }
+  #end persistence
+}";
 
         private class RecoverActor : UntypedPersistentActor
         {
@@ -129,7 +129,7 @@ auto-initialize = on
             recoveryActor.Tell("foo");
             recoveryActor.Tell("bar");
             recoveryActor.Tell(RecoverActor.DoSnapshot.Instance);
-            ExpectMsgAllOf("foo", "bar");
+            ExpectMsgAllOf(new []{ "foo", "bar" });
             ExpectMsg<SaveSnapshotSuccess>();
 
             Watch(recoveryActor);

--- a/src/core/Akka.Docs.Tests/Debugging/RacySpecs.cs
+++ b/src/core/Akka.Docs.Tests/Debugging/RacySpecs.cs
@@ -102,7 +102,7 @@ namespace DocsExamples.Debugging
             // assert
 
             // no raciness - ExpectMsgAllOf doesn't care about order
-            ExpectMsgAllOf("hit1a1", "hit2a1");
+            ExpectMsgAllOf(new []{ "hit1a1", "hit2a1" });
         }
         // </FixedMsgOrdering>
         

--- a/src/core/Akka.Docs.Tests/Streams/HubsDocTests.cs
+++ b/src/core/Akka.Docs.Tests/Streams/HubsDocTests.cs
@@ -54,7 +54,7 @@ namespace DocsExamples.Streams
             Source.Single("Hub!").RunWith(toConsumer, Materializer);
             #endregion
 
-            ExpectMsgAllOf("Hello!", "Hub!");
+            ExpectMsgAllOf(new []{ "Hello!", "Hub!"});
         }
 
         [Fact]

--- a/src/core/Akka.Persistence.Tests/PersistentActorSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorSpec.cs
@@ -239,7 +239,7 @@ namespace Akka.Persistence.Tests
             {
                 foreach (var probe in probes)
                 {
-                    probe.ExpectMsgAllOf<string>();
+                    probe.ExpectMsgAllOf(new string[]{} );
                 }
             });
         }

--- a/src/core/Akka.Persistence.Tests/PersistentActorSpecAsyncAwait.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorSpecAsyncAwait.cs
@@ -238,7 +238,7 @@ namespace Akka.Persistence.Tests
             {
                 foreach (var probe in probes)
                 {
-                    probe.ExpectMsgAllOf<string>();
+                    probe.ExpectMsgAllOf(new string[]{ });
                 }
             });
         }

--- a/src/core/Akka.Persistence.Tests/SnapshotSpec.cs
+++ b/src/core/Akka.Persistence.Tests/SnapshotSpec.cs
@@ -212,7 +212,7 @@ namespace Akka.Persistence.Tests
             pref.Tell(TakeSnapshot.Instance);
             pref.Tell("e");
             pref.Tell("f");
-            ExpectMsgAllOf(1L, 2L, 4L);
+            ExpectMsgAllOf(new []{ 1L, 2L, 4L });
         }
 
         [Fact]

--- a/src/core/Akka.Remote.Tests.MultiNode/RemoteReDeploymentSpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/RemoteReDeploymentSpec.cs
@@ -142,7 +142,7 @@ namespace Akka.Remote.Tests.MultiNode
                     }
                     else
                     {
-                        ExpectMsgAllOf("PostStop", "PreStart");
+                        ExpectMsgAllOf(new []{ "PostStop", "PreStart" });
                     }
                 });
             }, _config.First);

--- a/src/core/Akka.Remote.Tests/Serialization/SerializationTransportInformationSpec.cs
+++ b/src/core/Akka.Remote.Tests/Serialization/SerializationTransportInformationSpec.cs
@@ -181,6 +181,7 @@ namespace Akka.Remote.Tests.Serialization
 
         protected override void AfterAll()
         {
+            base.AfterAll();
             Shutdown(System2, verifySystemShutdown: true);
         }
     }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncUnorderedSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncUnorderedSpec.cs
@@ -97,7 +97,7 @@ namespace Akka.Streams.Tests.Dsl
             probe.ExpectNoMsg(TimeSpan.Zero);
             sub.Request(1);
             var got = new List<int> {c.ExpectNext()};
-            probe.ExpectMsgAllOf(1, 2, 3, 4, 5);
+            probe.ExpectMsgAllOf(new []{ 1, 2, 3, 4, 5 });
             probe.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
             sub.Request(25);
             probe.ExpectMsgAllOf(Enumerable.Range(6, 15).ToArray());

--- a/src/core/Akka.Streams.Tests/Dsl/QueueSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/QueueSourceSpec.cs
@@ -173,7 +173,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 sub.Cancel();
 
-                ExpectMsgAllOf<object>(QueueClosed.Instance, "done");
+                ExpectMsgAllOf(new object[]{ QueueClosed.Instance, "done" });
             }, _materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/SinkForeachParallelSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SinkForeachParallelSpec.cs
@@ -78,7 +78,7 @@ namespace Akka.Streams.Tests.Dsl
                     latch[n].Ready(TimeSpan.FromSeconds(5));
                 }), Materializer);
 
-                probe.ExpectMsgAllOf(1, 2, 3, 4);
+                probe.ExpectMsgAllOf(new []{ 1, 2, 3, 4 });
                 probe.ExpectNoMsg(TimeSpan.FromMilliseconds(200));
 
                 p.IsCompleted.Should().BeFalse();
@@ -112,7 +112,7 @@ namespace Akka.Streams.Tests.Dsl
                 }).WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider)), Materializer);
 
                 latch.CountDown();
-                probe.ExpectMsgAllOf(1, 2, 4, 5);
+                probe.ExpectMsgAllOf(new []{ 1, 2, 4, 5 });
 
                 p.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
             }, Materializer);
@@ -138,7 +138,7 @@ namespace Akka.Streams.Tests.Dsl
                 // make sure the stream is up and running, otherwise the latch is maybe ready before the third message arrives
                 Thread.Sleep(500);
                 latch.CountDown();
-                probe.ExpectMsgAllOf(1, 2);
+                probe.ExpectMsgAllOf(new []{ 1, 2 });
 
                 var ex = p.Invoking(t => t.Wait(TimeSpan.FromSeconds(1))).Should().Throw<AggregateException>().Which;
                 ex.Flatten().InnerException.Should().BeOfType<TestException>();

--- a/src/core/Akka.Streams.Tests/IO/InputStreamSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/InputStreamSinkSpec.cs
@@ -60,7 +60,7 @@ namespace Akka.Streams.Tests.IO
                 var inputStream = Source.From(new[] { _byteString, byteString2, null })
                     .RunWith(TestSink(sinkProbe), _materializer);
 
-                sinkProbe.ExpectMsgAllOf(GraphStageMessages.Push.Instance, GraphStageMessages.Push.Instance);
+                sinkProbe.ExpectMsgAllOf(new []{ GraphStageMessages.Push.Instance, GraphStageMessages.Push.Instance });
 
                 var result = ReadN(inputStream, 2);
                 result.Item1.Should().Be(2);
@@ -236,7 +236,7 @@ namespace Akka.Streams.Tests.IO
                 var inputStream = Source.From(new[] { bytes1, bytes2, null }).RunWith(TestSink(sinkProbe), _materializer);
 
                 //need to wait while both elements arrive to sink
-                sinkProbe.ExpectMsgAllOf(GraphStageMessages.Push.Instance, GraphStageMessages.Push.Instance);
+                sinkProbe.ExpectMsgAllOf(new []{ GraphStageMessages.Push.Instance, GraphStageMessages.Push.Instance });
 
                 var r1 = ReadN(inputStream, 15);
                 r1.Item1.Should().Be(15);

--- a/src/core/Akka.TestKit.Tests/TestKitBaseTests/DilatedTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestKitBaseTests/DilatedTests.cs
@@ -54,7 +54,7 @@ namespace Akka.Testkit.Tests.TestKitBaseTests
         public void ExpectMsgAllOf_should_dilate_timeout()
         {
             var stopwatch = Stopwatch.StartNew();
-            AssertThrows<TrueException>(() => ExpectMsgAllOf(TimeSpan.FromMilliseconds(Timeout), "1", "2"));
+            AssertThrows<TrueException>(() => ExpectMsgAllOf(TimeSpan.FromMilliseconds(Timeout), new []{ "1", "2" }));
             stopwatch.Stop();
             AssertDilated(stopwatch.ElapsedMilliseconds, $"Expected the timeout to be {ExpectedTimeout} but in fact it was {stopwatch.ElapsedMilliseconds}.");
         }

--- a/src/core/Akka.TestKit.Tests/TestKitBaseTests/ExpectTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestKitBaseTests/ExpectTests.cs
@@ -8,7 +8,10 @@
 using System;
 using Akka.Actor;
 using Akka.TestKit;
+using FluentAssertions;
 using Xunit;
+using Xunit.Sdk;
+using static FluentAssertions.FluentActions;
 
 namespace Akka.Testkit.Tests.TestKitBaseTests
 {
@@ -21,7 +24,7 @@ namespace Akka.Testkit.Tests.TestKitBaseTests
             TestActor.Tell("2");
             TestActor.Tell("3");
             TestActor.Tell("4");
-            ExpectMsgAllOf("3", "1", "4", "2").ShouldOnlyContainInOrder("1", "2", "3", "4");
+            ExpectMsgAllOf(new []{ "3", "1", "4", "2"}).ShouldOnlyContainInOrder("1", "2", "3", "4");
         }
 
         [Fact]
@@ -31,13 +34,15 @@ namespace Akka.Testkit.Tests.TestKitBaseTests
             TestActor.Tell("2");
             TestActor.Tell("Totally unexpected");
             TestActor.Tell("3");
-            Intercept(() => ExpectMsgAllOf("3", "1", "2"));
+            Invoking(() => ExpectMsgAllOf(new[] { "3", "1", "2" })).Should()
+                .Throw<XunitException>();
         }
 
         [Fact]
         public void ExpectMsgAllOf_should_timeout_when_not_receiving_any_messages()
         {
-            Intercept(() => ExpectMsgAllOf(TimeSpan.FromMilliseconds(100), "3", "1", "2"));
+            Invoking(() => ExpectMsgAllOf(TimeSpan.FromMilliseconds(100), new[] { "3", "1", "2" })).Should()
+                .Throw<XunitException>();
         }
 
         [Fact]
@@ -45,7 +50,8 @@ namespace Akka.Testkit.Tests.TestKitBaseTests
         {
             TestActor.Tell("1");
             TestActor.Tell("2");
-            Intercept(() => ExpectMsgAllOf(TimeSpan.FromMilliseconds(100), "3", "1", "2"));
+            Invoking(() => ExpectMsgAllOf(TimeSpan.FromMilliseconds(100), new[] { "3", "1", "2" })).Should()
+                .Throw<XunitException>();
         }
 
     }


### PR DESCRIPTION
* Convert all async methods that returns an `IReadOnlyCollection` to `IAsyncEnumerable`
* Clean sync over async codes to always call `.ConfigureAwait(false)`
* Clean async await codes to always call  `.ConfigureAwait(false)`
* Fix erroneous HOCON strings
* Add missing `base.AfterAll()` in `AbstractSerializationTransportInformationSpec`, leaving a leaked ActorSystem living in the background.