### PR TITLE
Fix AbstractSerializationTransportInformationSpec

### DIFF
--- a/src/core/Akka.Remote.Tests/Serialization/SerializationTransportInformationSpec.cs
+++ b/src/core/Akka.Remote.Tests/Serialization/SerializationTransportInformationSpec.cs
@@ -181,6 +181,7 @@ namespace Akka.Remote.Tests.Serialization
 
         protected override void AfterAll()
         {
+            base.AfterAll();
             Shutdown(System2, verifySystemShutdown: true);
         }
     }


### PR DESCRIPTION
## Changes

Call `base.AfterAll()` to kill TestKit ActorSystem. The unit test file overrides the `AfterAll()` method but failed to call the base class method. This causes the TestKit ActorSystem to leak and can freeze the test runner.
![image](https://user-images.githubusercontent.com/8293237/156855652-e0173b5b-2488-4221-883e-db22935c7ba7.png)
As can be seen from the screenshot, the "no currently active test" error got repeated over and over until the test runner can kill the process.