### PR TITLE
Fix PersistenceId Query and Sqlite unit tests

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/SqlJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/SqlJournal.cs
@@ -106,7 +106,7 @@ namespace Akka.Persistence.Sql.Common.Journal
                     return true;
                 case SelectCurrentPersistenceIds request:
                     SelectAllPersistenceIdsAsync(request.Offset)
-                        .PipeTo(request.ReplyTo, success: result => new CurrentPersistenceIds(result.Ids, request.Offset));
+                        .PipeTo(request.ReplyTo, success: result => new CurrentPersistenceIds(result.Ids, result.LastOrdering));
                     return true;
                 case SubscribeTag subscribe:
                     AddTagSubscriber(Sender, subscribe.Tag);

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/BatchingSqliteAllEventsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/BatchingSqliteAllEventsSpec.cs
@@ -22,6 +22,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
         public static Config Config => ConfigurationFactory.ParseString($@"
             akka.loglevel = INFO
             akka.persistence.journal.plugin = ""akka.persistence.journal.sqlite""
+            akka.persistence.query.journal.sql.refresh-interval = 1s
             akka.persistence.journal.sqlite {{
                 class = ""Akka.Persistence.Sqlite.Journal.BatchingSqliteJournal, Akka.Persistence.Sqlite""
                 plugin-dispatcher = ""akka.actor.default-dispatcher""
@@ -29,7 +30,6 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                 metadata-table-name = journal_metadata
                 auto-initialize = on
                 connection-string = ""Filename=file:memdb-journal-eventsbytag-{Guid.NewGuid()}.db;Mode=Memory;Cache=Shared""
-                refresh-interval = 1s
             }}
             akka.test.single-expect-default = 10s")
             .WithFallback(SqlReadJournal.DefaultConfiguration());

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/BatchingSqliteCurrentAllEventsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/BatchingSqliteCurrentAllEventsSpec.cs
@@ -24,6 +24,7 @@ namespace Akka.Persistence.Sqlite.Tests.Batching
         public static Config Config(int id) => ConfigurationFactory.ParseString($@"
             akka.loglevel = INFO
             akka.persistence.journal.plugin = ""akka.persistence.journal.sqlite""
+            akka.persistence.query.journal.sql.refresh-interval = 1s
             akka.persistence.journal.sqlite {{
                 class = ""Akka.Persistence.Sqlite.Journal.BatchingSqliteJournal, Akka.Persistence.Sqlite""
                 plugin-dispatcher = ""akka.actor.default-dispatcher""
@@ -31,7 +32,6 @@ namespace Akka.Persistence.Sqlite.Tests.Batching
                 metadata-table-name = journal_metadata
                 auto-initialize = on
                 connection-string = ""Filename=file:memdb-journal-eventsbytag-{id}.db;Mode=Memory;Cache=Shared""
-                refresh-interval = 1s
             }}
             akka.test.single-expect-default = 10s")
             .WithFallback(SqlReadJournal.DefaultConfiguration());

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/BatchingSqliteCurrentEventsByPersistenceIdSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/BatchingSqliteCurrentEventsByPersistenceIdSpec.cs
@@ -20,6 +20,7 @@ namespace Akka.Persistence.Sqlite.Tests.Batching
         public static Config Config(int id) => ConfigurationFactory.ParseString($@"
             akka.loglevel = INFO
             akka.persistence.journal.plugin = ""akka.persistence.journal.sqlite""
+            akka.persistence.query.journal.sql.refresh-interval = 1s
             akka.persistence.journal.sqlite {{
                 class = ""Akka.Persistence.Sqlite.Journal.BatchingSqliteJournal, Akka.Persistence.Sqlite""
                 plugin-dispatcher = ""akka.actor.default-dispatcher""
@@ -27,7 +28,6 @@ namespace Akka.Persistence.Sqlite.Tests.Batching
                 metadata-table-name = journal_metadata
                 auto-initialize = on
                 connection-string = ""Datasource=memdb-journal-batch-currenteventsbypersistenceid-{id}.db;Mode=Memory;Cache=Shared""
-                refresh-interval = 1s
             }}
             akka.test.single-expect-default = 10s")
             .WithFallback(SqlReadJournal.DefaultConfiguration());

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/BatchingSqliteCurrentEventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/BatchingSqliteCurrentEventsByTagSpec.cs
@@ -21,6 +21,7 @@ namespace Akka.Persistence.Sqlite.Tests.Batching
         public static Config Config(int id) => ConfigurationFactory.ParseString($@"
             akka.loglevel = INFO
             akka.persistence.journal.plugin = ""akka.persistence.journal.sqlite""
+            akka.persistence.query.journal.sql.refresh-interval = 1s
             akka.persistence.journal.sqlite {{
                 event-adapters {{
                   color-tagger  = ""Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK""
@@ -34,7 +35,6 @@ namespace Akka.Persistence.Sqlite.Tests.Batching
                 metadata-table-name = journal_metadata
                 auto-initialize = on
                 connection-string = ""Datasource=memdb-journal-batch-currenteventsbytag-{id}.db;Mode=Memory;Cache=Shared""
-                refresh-interval = 1s
             }}
             akka.test.single-expect-default = 10s")
             .WithFallback(SqlReadJournal.DefaultConfiguration());

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/BatchingSqliteCurrentPersistenceIdsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/BatchingSqliteCurrentPersistenceIdsSpec.cs
@@ -21,6 +21,7 @@ namespace Akka.Persistence.Sqlite.Tests.Batching
         public static Config Config(int id) => ConfigurationFactory.ParseString($@"
             akka.loglevel = INFO
             akka.persistence.journal.plugin = ""akka.persistence.journal.sqlite""
+            akka.persistence.query.journal.sql.refresh-interval = 1s
             akka.persistence.journal.sqlite {{
                 class = ""Akka.Persistence.Sqlite.Journal.BatchingSqliteJournal, Akka.Persistence.Sqlite""
                 plugin-dispatcher = ""akka.actor.default-dispatcher""
@@ -28,7 +29,6 @@ namespace Akka.Persistence.Sqlite.Tests.Batching
                 metadata-table-name = journal_metadata
                 auto-initialize = on
                 connection-string = ""Datasource=memdb-journal-batch-currentpersistenceids-{id}.db;Mode=Memory;Cache=Shared""
-                refresh-interval = 1s
             }}
             akka.test.single-expect-default = 10s")
             .WithFallback(SqlReadJournal.DefaultConfiguration());

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/BatchingSqliteEventsByPersistenceIdSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/BatchingSqliteEventsByPersistenceIdSpec.cs
@@ -20,6 +20,7 @@ namespace Akka.Persistence.Sqlite.Tests.Batching
         public static Config Config(int id) => ConfigurationFactory.ParseString($@"
             akka.loglevel = INFO
             akka.persistence.journal.plugin = ""akka.persistence.journal.sqlite""
+            akka.persistence.query.journal.sql.refresh-interval = 1s
             akka.persistence.journal.sqlite {{
                 class = ""Akka.Persistence.Sqlite.Journal.BatchingSqliteJournal, Akka.Persistence.Sqlite""
                 plugin-dispatcher = ""akka.actor.default-dispatcher""
@@ -27,7 +28,6 @@ namespace Akka.Persistence.Sqlite.Tests.Batching
                 metadata-table-name = journal_metadata
                 auto-initialize = on
                 connection-string = ""Datasource=memdb-journal-batch-eventsbypersistenceid-{id}.db;Mode=Memory;Cache=Shared""
-                refresh-interval = 1s
             }}
             akka.test.single-expect-default = 10s")
             .WithFallback(SqlReadJournal.DefaultConfiguration());

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/BatchingSqliteEventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/BatchingSqliteEventsByTagSpec.cs
@@ -20,6 +20,7 @@ namespace Akka.Persistence.Sqlite.Tests.Batching
         public static Config Config(int id) => ConfigurationFactory.ParseString($@"
             akka.loglevel = INFO
             akka.persistence.journal.plugin = ""akka.persistence.journal.sqlite""
+            akka.persistence.query.journal.sql.refresh-interval = 1s
             akka.persistence.journal.sqlite {{
                 event-adapters {{
                   color-tagger  = ""Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK""
@@ -33,7 +34,6 @@ namespace Akka.Persistence.Sqlite.Tests.Batching
                 metadata-table-name = journal_metadata
                 auto-initialize = on
                 connection-string = ""Datasource=memdb-journal-batch-eventsbytag-{id}.db;Mode=Memory;Cache=Shared""
-                refresh-interval = 1s
             }}
             akka.test.single-expect-default = 10s")
             .WithFallback(SqlReadJournal.DefaultConfiguration());

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/BatchingSqlitePersistenceIdSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Batching/BatchingSqlitePersistenceIdSpec.cs
@@ -31,6 +31,7 @@ namespace Akka.Persistence.Sqlite.Tests.Batching
             }}
             akka.persistence {{
                 publish-plugin-commands = on
+                query.journal.sql.refresh-interval = 200ms
                 journal {{
                     plugin = ""akka.persistence.journal.sqlite""
                     sqlite = {{
@@ -40,7 +41,6 @@ namespace Akka.Persistence.Sqlite.Tests.Batching
                         metadata-table-name = journal_metadata
                         auto-initialize = on
                         connection-string = ""{ConnectionString("journal")}""
-                        refresh-interval = 200ms
                     }}
                 }}
                 snapshot-store {{

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteAllEventsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteAllEventsSpec.cs
@@ -22,6 +22,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
         public static Config Config => ConfigurationFactory.ParseString($@"
             akka.loglevel = INFO
             akka.persistence.journal.plugin = ""akka.persistence.journal.sqlite""
+            akka.persistence.query.journal.sql.refresh-interval = 1s
             akka.persistence.journal.sqlite {{
                 class = ""Akka.Persistence.Sqlite.Journal.SqliteJournal, Akka.Persistence.Sqlite""
                 plugin-dispatcher = ""akka.actor.default-dispatcher""
@@ -29,7 +30,6 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                 metadata-table-name = journal_metadata
                 auto-initialize = on
                 connection-string = ""Filename=file:memdb-journal-eventsbytag-{Guid.NewGuid()}.db;Mode=Memory;Cache=Shared""
-                refresh-interval = 1s
             }}
             akka.test.single-expect-default = 10s")
             .WithFallback(SqlReadJournal.DefaultConfiguration());

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteCurrentAllEventsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteCurrentAllEventsSpec.cs
@@ -24,6 +24,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
         public static Config Config(int id) => ConfigurationFactory.ParseString($@"
             akka.loglevel = INFO
             akka.persistence.journal.plugin = ""akka.persistence.journal.sqlite""
+            akka.persistence.query.journal.sql.refresh-interval = 1s
             akka.persistence.journal.sqlite {{
                 class = ""Akka.Persistence.Sqlite.Journal.SqliteJournal, Akka.Persistence.Sqlite""
                 plugin-dispatcher = ""akka.actor.default-dispatcher""
@@ -31,7 +32,6 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                 metadata-table-name = journal_metadata
                 auto-initialize = on
                 connection-string = ""Filename=file:memdb-journal-allevents-{id}.db;Mode=Memory;Cache=Shared""
-                refresh-interval = 1s
             }}
             akka.test.single-expect-default = 10s")
             .WithFallback(SqlReadJournal.DefaultConfiguration());

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteCurrentEventsByPersistenceIdSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteCurrentEventsByPersistenceIdSpec.cs
@@ -20,6 +20,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
         public static Config Config(int id) => ConfigurationFactory.ParseString($@"
             akka.loglevel = INFO
             akka.persistence.journal.plugin = ""akka.persistence.journal.sqlite""
+            akka.persistence.query.journal.sql.refresh-interval = 1s
             akka.persistence.journal.sqlite {{
                 class = ""Akka.Persistence.Sqlite.Journal.SqliteJournal, Akka.Persistence.Sqlite""
                 plugin-dispatcher = ""akka.actor.default-dispatcher""
@@ -27,7 +28,6 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                 metadata-table-name = journal_metadata
                 auto-initialize = on
                 connection-string = ""Filename=file:memdb-journal-currenteventsbypersistenceid-{id}.db;Mode=Memory;Cache=Shared""
-                refresh-interval = 1s
             }}
             akka.test.single-expect-default = 10s")
             .WithFallback(SqlReadJournal.DefaultConfiguration());

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteCurrentEventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteCurrentEventsByTagSpec.cs
@@ -22,6 +22,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
         public static Config Config(int id) => ConfigurationFactory.ParseString($@"
             akka.loglevel = INFO
             akka.persistence.journal.plugin = ""akka.persistence.journal.sqlite""
+            akka.persistence.query.journal.sql.refresh-interval = 1s
             akka.persistence.journal.sqlite {{
                 event-adapters {{
                   color-tagger  = ""Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK""
@@ -35,7 +36,6 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                 metadata-table-name = journal_metadata
                 auto-initialize = on
                 connection-string = ""Filename=file:memdb-journal-currenteventsbytag-{id}.db;Mode=Memory;Cache=Shared""
-                refresh-interval = 1s
             }}
             akka.test.single-expect-default = 10s")
             .WithFallback(SqlReadJournal.DefaultConfiguration());

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteCurrentPersistenceIdsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteCurrentPersistenceIdsSpec.cs
@@ -22,6 +22,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
         public static Config Config(int id) => ConfigurationFactory.ParseString($@"
             akka.loglevel = INFO
             akka.persistence.journal.plugin = ""akka.persistence.journal.sqlite""
+            akka.persistence.query.journal.sql.refresh-interval = 1s
             akka.persistence.journal.sqlite {{
                 class = ""Akka.Persistence.Sqlite.Journal.SqliteJournal, Akka.Persistence.Sqlite""
                 plugin-dispatcher = ""akka.actor.default-dispatcher""
@@ -29,7 +30,6 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                 metadata-table-name = journal_metadata
                 auto-initialize = on
                 connection-string = ""Filename=file:memdb-journal-currentpersistenceids-{id}.db;Mode=Memory;Cache=Shared""
-                refresh-interval = 1s
             }}
             akka.test.single-expect-default = 10s")
             .WithFallback(SqlReadJournal.DefaultConfiguration());

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteEventsByPersistenceIdSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteEventsByPersistenceIdSpec.cs
@@ -20,6 +20,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
         public static Config Config(int id) => ConfigurationFactory.ParseString($@"
             akka.loglevel = INFO
             akka.persistence.journal.plugin = ""akka.persistence.journal.sqlite""
+            akka.persistence.query.journal.sql.refresh-interval = 1s
             akka.persistence.journal.sqlite {{
                 class = ""Akka.Persistence.Sqlite.Journal.SqliteJournal, Akka.Persistence.Sqlite""
                 plugin-dispatcher = ""akka.actor.default-dispatcher""
@@ -27,7 +28,6 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                 metadata-table-name = journal_metadata
                 auto-initialize = on
                 connection-string = ""Filename=file:memdb-journal-eventsbypersistenceid-{id}.db;Mode=Memory;Cache=Shared""
-                refresh-interval = 1s
             }}
             akka.test.single-expect-default = 10s")
             .WithFallback(SqlReadJournal.DefaultConfiguration());

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteEventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteEventsByTagSpec.cs
@@ -21,6 +21,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
 
         public static Config Config(int id) => ConfigurationFactory.ParseString($@"
             akka.loglevel = INFO
+            akka.persistence.query.journal.sql.refresh-interval = 1s
             akka.persistence.journal.plugin = ""akka.persistence.journal.sqlite""
             akka.persistence.journal.sqlite {{
                 event-adapters {{
@@ -35,7 +36,6 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                 metadata-table-name = journal_metadata
                 auto-initialize = on
                 connection-string = ""Filename=file:memdb-journal-eventsbytag-{id}.db;Mode=Memory;Cache=Shared""
-                refresh-interval = 1s
             }}
             akka.test.single-expect-default = 10s")
             .WithFallback(SqlReadJournal.DefaultConfiguration());

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqlitePersistenceIdsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqlitePersistenceIdsSpec.cs
@@ -6,12 +6,15 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Persistence.Query;
 using Akka.Persistence.Query.Sql;
 using Akka.Persistence.TCK.Query;
+using Akka.Streams.TestKit;
 using Akka.Util.Internal;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Akka.Persistence.Sqlite.Tests.Query
@@ -32,6 +35,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
             }}
             akka.persistence {{
                 publish-plugin-commands = on
+                query.journal.sql.refresh-interval = 200ms
                 journal {{
                     plugin = ""akka.persistence.journal.sqlite""
                     sqlite = {{
@@ -41,7 +45,6 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                         metadata-table-name = journal_metadata
                         auto-initialize = on
                         connection-string = ""{ConnectionString("journal")}""
-                        refresh-interval = 200ms
                     }}
                 }}
                 snapshot-store {{

--- a/src/core/Akka.Persistence.TCK/Query/PersistenceIdsSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Query/PersistenceIdsSpec.cs
@@ -17,6 +17,7 @@ using Akka.Streams;
 using Akka.Streams.TestKit;
 using Akka.TestKit;
 using Akka.Util.Internal;
+using FluentAssertions;
 using Reactive.Streams;
 using Xunit;
 using Xunit.Abstractions;
@@ -80,7 +81,7 @@ namespace Akka.Persistence.TCK.Query
             var expected = new List<string> { "h", "i", "j" };
             probe.Within(TimeSpan.FromSeconds(10), () =>
             {
-                expected.Remove(probe.Request(1).ExpectNext());
+                expected.Remove(probe.Request(1).ExpectNext()).Should().BeTrue();
                 return probe.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
             });
 

--- a/src/core/Akka.Persistence.TCK/Query/PersistenceIdsSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Query/PersistenceIdsSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
@@ -76,18 +77,23 @@ namespace Akka.Persistence.TCK.Query
             var source = queries.PersistenceIds();
             var probe = source.RunWith(this.SinkProbe<string>(), Materializer);
 
+            var expected = new List<string> { "h", "i", "j" };
             probe.Within(TimeSpan.FromSeconds(10), () =>
             {
-                probe.Request(1).ExpectNext();
-                return probe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+                expected.Remove(probe.Request(1).ExpectNext());
+                return probe.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
             });
 
             Setup("j", 1);
-            probe.Within(TimeSpan.FromSeconds(10), () =>
-            {
-                probe.Request(5).ExpectNext();
-                return probe.ExpectNext();
-            });
+            probe.Within(TimeSpan.FromSeconds(10), () => probe.Request(5).ExpectNextUnordered(expected[0], expected[1]));
+            
+            Setup("a1", 1);
+            Thread.Sleep(TimeSpan.FromSeconds(2));
+            probe.ExpectNext(TimeSpan.FromSeconds(10));
+
+            Thread.Sleep(TimeSpan.FromSeconds(2));
+            Setup("a2", 1);
+            probe.ExpectNext(TimeSpan.FromSeconds(10));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #5714

## Changes
* `SelectCurrentPersistentIds` command returns the wrong `HighestOrderingNumber`
* Fix `AllPersistenceIdsPublisher` receive state
* Fix all Akka.Persistence.Sqlite unit test `refresh-interval` settings