### PR TITLE
Convert AwaitCondition in TestKitBase initializer, can not use `.Wait()` in ctor

### DIFF
--- a/src/core/Akka.TestKit/TestKitBase.cs
+++ b/src/core/Akka.TestKit/TestKitBase.cs
@@ -6,6 +6,8 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
@@ -166,12 +168,9 @@ namespace Akka.TestKit
                 testActorName = "testActor" + _testActorId.IncrementAndGet();
 
             var testActor = CreateTestActor(system, testActorName);
-            //Wait for the testactor to start
-            // Calling sync version here, since .Wait() causes deadlock
-            AwaitCondition(() =>
-            {
-                return !(testActor is IRepointableRef repRef) || repRef.IsStarted;
-            }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(10));
+
+            // Wait for the testactor to start
+            WaitUntilTestActorIsReady(testActor);
 
             if (!(this is INoImplicitSender))
             {
@@ -189,6 +188,30 @@ namespace Akka.TestKit
             _testState.TestActor = testActor;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void WaitUntilTestActorIsReady(IActorRef testActor)
+        {
+            var deadline = TimeSpan.FromSeconds(5);
+            var stopwatch = Stopwatch.StartNew();
+            var ready = false;
+            try
+            {
+                while (stopwatch.Elapsed < deadline)
+                {
+                    ready = !(testActor is IRepointableRef repRef) || repRef.IsStarted;
+                    if (ready) break;
+                    Thread.Sleep(10);
+                }
+            }
+            finally
+            {
+                stopwatch.Stop();
+            }
+
+            if (!ready)
+                throw new Exception("Timeout waiting for test actor to be ready");
+        }
+        
         /// <summary>
         /// Initializes the <see cref="TestState"/> for a new spec.
         /// </summary>


### PR DESCRIPTION
Using sync over async in constructors can cause deadlocks