### PR TITLE
supress `InvalidOperationException` in xUnit OutputLogger

### DIFF
--- a/src/contrib/testkits/Akka.TestKit.Xunit2/Internals/Loggers.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit2/Internals/Loggers.cs
@@ -49,11 +49,16 @@ namespace Akka.TestKit.Xunit2.Internals
                 {
                     var message =
                         $"Received a malformed formatted message. Log level: [{e.LogLevel()}], Template: [{msg.Format}], args: [{string.Join(",", msg.Args)}]";
-                    if(e.Cause != null)
+                    if (e.Cause != null)
                         throw new AggregateException(message, ex, e.Cause);
                     throw new FormatException(message, ex);
                 }
+
                 throw;
+            }
+            catch (InvalidOperationException ie)
+            {
+                Console.WriteLine($"Received InvalidOperationException: {ie} - probably because the test had completed executing.");
             }
         }
     }


### PR DESCRIPTION
Whenever I have a test run long and the `ActorSystem` has to shutdown behind the scenes, my logs are filled with thousands of `InvalidOperationException: no active test" as a result of calling `_output.WriteLine` once the XUnit test has been terminated. Each time this actor crashes and restarts it generates another one of those logs.

## Changes

Added `InvalidOperationException` to the `catch` list and we just write out to `Console` now when this occurs, as xUnit test `IOutputHelper` is no longer available.