### PR TITLE
fix `ActorSystemSetup.And`

### DIFF
--- a/src/core/Akka.Tests/Actor/Setup/ActorSystemSetupSpec.cs
+++ b/src/core/Akka.Tests/Actor/Setup/ActorSystemSetupSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using Akka.Actor;
 using Akka.Actor.Setup;
 using Akka.TestKit;
@@ -106,6 +107,37 @@ namespace Akka.Tests.Actor.Setup
             {
                 system?.Terminate().Wait(TimeSpan.FromSeconds(5));
             }
+        }
+
+        /// <summary>
+        /// Reproduction for https://github.com/akkadotnet/akka.net/issues/5728
+        /// </summary>
+        [Fact]
+        public void ActorSystemSetupBugFix5728Reproduction()
+        {
+            // arrange
+            var setups = new HashSet<Akka.Actor.Setup.Setup>();
+            setups.Add(new DummySetup("Blantons"));
+            setups.Add(new DummySetup2("Colonel E.H. Taylor"));
+            
+            var actorSystemSetup = ActorSystemSetup.Empty;
+
+            foreach (var s in setups)
+            {
+                actorSystemSetup = actorSystemSetup.And(s);
+            }
+
+            // act
+            var dummySetup = actorSystemSetup.Get<DummySetup>();
+            var dummySetup2 = actorSystemSetup.Get<DummySetup2>();
+            
+            // shouldn't exist
+            var dummySetup3 = actorSystemSetup.Get<DummySetup3>();
+
+            // assert
+            dummySetup.HasValue.Should().BeTrue();
+            dummySetup2.HasValue.Should().BeTrue();
+            dummySetup3.HasValue.Should().BeFalse();
         }
     }
 }

--- a/src/core/Akka/Actor/Setup/ActorSystemSetup.cs
+++ b/src/core/Akka/Actor/Setup/ActorSystemSetup.cs
@@ -72,7 +72,8 @@ namespace Akka.Actor.Setup
         /// <returns>A new, immutable <see cref="ActorSystemSetup"/> instance.</returns>
         public ActorSystemSetup WithSetup<T>(T setup) where T : Setup
         {
-            return new ActorSystemSetup(_setups.SetItem(typeof(T), setup));
+            var typeT = setup.GetType();
+            return new ActorSystemSetup(_setups.SetItem(typeT, setup));
         }
 
         /// <summary>


### PR DESCRIPTION
close #5728 

## Changes

Modified the `ActorSystemSetup.WithSetup` method to evaluate the type of the `Setup` object being passed in rather than the generic method argument type.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).