### PR TITLE
Update PersistAsync to match docs.

### DIFF
--- a/src/core/Akka.Docs.Tests/Persistence/PersistentActor/PersistAsync.cs
+++ b/src/core/Akka.Docs.Tests/Persistence/PersistentActor/PersistAsync.cs
@@ -27,9 +27,8 @@ namespace DocsExamples.Persistence.PersistentActor
                 if (message is string c)
                 {
                     Sender.Tell(c);
-                    Persist($"evt-{c}-1", e => Sender.Tell(e));
-                    Persist($"evt-{c}-2", e => Sender.Tell(e));
-                    DeferAsync($"evt-{c}-3", e => Sender.Tell(e));
+                    PersistAsync($"evt-{c}-1", e => Sender.Tell(e));
+                    PersistAsync($"evt-{c}-2", e => Sender.Tell(e));
                 }
             }
         }


### PR DESCRIPTION
This is supposed to be the example for persistAsync, but persistAsync doesn't get used at all.

https://getakka.net/articles/persistence/event-sourcing.html#relaxed-local-consistency-requirements-and-high-throughput-use-cases

## Changes

I changed the code to match what is here:

https://doc.akka.io/docs/akka/current/persistence.html#relaxed-local-consistency-requirements-and-high-throughput-use-cases

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).