### PR TITLE
Port `Akka.Tests.Actor.Dispatch` tests to async/await

### DIFF
--- a/src/core/Akka.Tests/Actor/Dispatch/ActorModelSpec.cs
+++ b/src/core/Akka.Tests/Actor/Dispatch/ActorModelSpec.cs
@@ -492,7 +492,7 @@ namespace Akka.Tests.Actor.Dispatch
         }
 
         [Fact]
-        public void A_dispatcher_must_handle_queuing_from_multiple_threads()
+        public async Task A_dispatcher_must_handle_queuing_from_multiple_threads()
         {
             var dispatcher = InterceptedDispatcher();
             var counter = new CountdownEvent(200);
@@ -517,7 +517,7 @@ namespace Akka.Tests.Actor.Dispatch
             }
             finally
             {
-                var stats = a.Ask<InterceptorStats>(GetStats.Instance).Result;
+                var stats = await a.Ask<InterceptorStats>(GetStats.Instance);
                 _testOutputHelper.WriteLine("Observed stats: {0}", stats);
 
                 Sys.Stop(a);

--- a/src/core/Akka.Tests/Actor/Dispatch/Bug2640Spec.cs
+++ b/src/core/Akka.Tests/Actor/Dispatch/Bug2640Spec.cs
@@ -80,16 +80,17 @@ namespace Akka.Tests.Actor.Dispatch
             for (var i = 0; i < 100; i++)
                 actor.Tell(GetThread.Instance);
 
-            threads = ReceiveN(100).Cast<Thread>().GroupBy(x => x.ManagedThreadId)
+            var objs = await ReceiveNAsync(100, default).ToListAsync();
+            threads = objs.Cast<Thread>().GroupBy(x => x.ManagedThreadId)
                 .ToDictionary(x => x.Key, grouping => grouping.First());
 
             await Sys.Terminate();
-            AwaitAssert(() =>
+            await AwaitAssertAsync(() =>
                 threads.Values.All(x => x.IsAlive == false).Should().BeTrue("All threads should be stopped"));
         }
 
         [Fact(DisplayName = "ForkJoinExecutor should terminate all threads upon all attached actors shutting down")]
-        public void ForkJoinExecutorShouldShutdownUponAllActorsTerminating()
+        public async Task ForkJoinExecutorShouldShutdownUponAllActorsTerminating()
         {
             var actor = Sys.ActorOf(Props.Create(() => new ThreadReporterActor())
                 .WithDispatcher("myapp.my-fork-join-dispatcher").WithRouter(new RoundRobinPool(4)));
@@ -99,29 +100,31 @@ namespace Akka.Tests.Actor.Dispatch
             for (var i = 0; i < 100; i++)
                 actor.Tell(GetThread.Instance);
 
-            threads = ReceiveN(100).Cast<Thread>().GroupBy(x => x.ManagedThreadId)
+            var objs = await ReceiveNAsync(100, default).ToListAsync();
+
+            threads = objs.Cast<Thread>().GroupBy(x => x.ManagedThreadId)
                 .ToDictionary(x => x.Key, grouping => grouping.First());
 
             Sys.Stop(actor);
-            ExpectTerminated(actor);
-            AwaitAssert(() =>
+            await ExpectTerminatedAsync(actor);
+            await AwaitAssertAsync(() =>
                 threads.Values.All(x => x.IsAlive == false).Should().BeTrue("All threads should be stopped"));
         }
 
         [Fact(DisplayName = "PinnedDispatcher should terminate its thread upon actor shutdown")]
-        public void PinnedDispatcherShouldShutdownUponActorTermination()
+        public async Task PinnedDispatcherShouldShutdownUponActorTermination()
         {
             var actor = Sys.ActorOf(Props.Create(() => new ThreadReporterActor())
                 .WithDispatcher("myapp.my-pinned-dispatcher"));
 
             Watch(actor);
             actor.Tell(GetThread.Instance);
-            var thread = ExpectMsg<Thread>();
+            var thread = await ExpectMsgAsync<Thread>();
             thread.IsAlive.Should().BeTrue();
 
             Sys.Stop(actor);
-            ExpectTerminated(actor);
-            AwaitCondition(() => !thread.IsAlive); // wait for thread to terminate
+            await ExpectTerminatedAsync(actor);
+            await AwaitConditionAsync(() => !thread.IsAlive); // wait for thread to terminate
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/Dispatch/Bug2751Spec.cs
+++ b/src/core/Akka.Tests/Actor/Dispatch/Bug2751Spec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
 using Xunit;
@@ -40,14 +41,14 @@ namespace Akka.Tests.Actor.Dispatch
         }
 
         [Fact]
-        public void ShouldReceiveSysMsgBeforeUserMsg()
+        public async Task ShouldReceiveSysMsgBeforeUserMsg()
         {
             var stopper = Sys.ActorOf(Props.Create(() => new StopActor(TestActor)));
             stopper.Tell("stop");
-            ExpectNoMsg(TimeSpan.FromMilliseconds(250));
+            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(250));
             Watch(stopper);
-            ExpectTerminated(stopper);
-            ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+            await ExpectTerminatedAsync(stopper);
+            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
         }
     }
 

--- a/src/core/Akka.Tests/Actor/Dispatch/CurrentSynchronizationContextDispatcherSpecs.cs
+++ b/src/core/Akka.Tests/Actor/Dispatch/CurrentSynchronizationContextDispatcherSpecs.cs
@@ -34,11 +34,11 @@ namespace Akka.Tests.Actor.Dispatch
         public CurrentSynchronizationContextDispatcherSpecs() : base(_config) { }
 
         [Fact]
-        public void CurrentSynchronizationContextDispatcher_should_start_without_error_Fix2172()
+        public async Task CurrentSynchronizationContextDispatcher_should_start_without_error_Fix2172()
         {
             var uiActor = Sys.ActorOf(EchoActor.Props(this), "some-ui-actor");
             uiActor.Tell("ping");
-            ExpectMsg("ping");
+            await ExpectMsgAsync("ping");
         }
     }
 }


### PR DESCRIPTION
## Changes

### ActorModelSpec
- Chnaged `A_dispatcher_must_handle_queuing_from_multiple_threads` to `async/await`

### Bug2640Spec
- Changed `ForkJoinExecutorShouldShutdownUponActorSystemTermination` to `async/await`
- Changed `ForkJoinExecutorShouldShutdownUponAllActorsTerminating` to `async/await`
- Changed `PinnedDispatcherShouldShutdownUponActorTermination` to `async/await`

### Bug2751Spec
- Chnaged `ShouldReceiveSysMsgBeforeUserMsg` to `async/await`

### CurrentSynchronizationContextDispatcherSpecs
- Chnaged `CurrentSynchronizationContextDispatcher_should_start_without_error_Fix2172` to `async/await`