### PR TITLE
Port `Akka.Tests.Actor.Scheduler` tests to async/await

### DIFF
--- a/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_ActionScheduler_Cancellation_Tests.cs
+++ b/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_ActionScheduler_Cancellation_Tests.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
 using Akka.Util.Internal;
@@ -17,7 +18,7 @@ namespace Akka.Tests.Actor.Scheduler
     public class DefaultScheduler_ActionScheduler_Cancellation_Tests : AkkaSpec
     {
         [Fact]
-        public void When_ScheduleOnce_using_canceled_Cancelable_Then_their_actions_should_not_be_invoked()
+        public async Task When_ScheduleOnce_using_canceled_Cancelable_Then_their_actions_should_not_be_invoked()
         {
             // Prepare, set up actions to be fired
             IActionScheduler scheduler = new HashedWheelTimerScheduler(Sys.Settings.Config, Log);
@@ -28,7 +29,7 @@ namespace Akka.Tests.Actor.Scheduler
                 scheduler.ScheduleOnce(0, () => TestActor.Tell("Test"), canceled);
 
                 //Validate that no messages were sent
-                ExpectNoMsg(100);
+                await ExpectNoMsgAsync(100);
             }
             finally
             {
@@ -37,7 +38,7 @@ namespace Akka.Tests.Actor.Scheduler
         }
 
         [Fact]
-        public void When_ScheduleRepeatedly_using_canceled_Cancelable_Then_their_actions_should_not_be_invoked()
+        public async Task When_ScheduleRepeatedly_using_canceled_Cancelable_Then_their_actions_should_not_be_invoked()
         {
             // Prepare, set up actions to be fired
             IActionScheduler scheduler = new HashedWheelTimerScheduler(Sys.Settings.Config, Log);
@@ -49,7 +50,7 @@ namespace Akka.Tests.Actor.Scheduler
                 scheduler.ScheduleRepeatedly(50, 100, () => TestActor.Tell("Test2"), canceled);
 
                 //Validate that no messages were sent
-                ExpectNoMsg(150);
+                await ExpectNoMsgAsync(150);
             }
             finally
             {
@@ -58,7 +59,7 @@ namespace Akka.Tests.Actor.Scheduler
         }
 
         [Fact]
-        public void When_ScheduleOnce_and_then_canceling_before_they_occur_Then_their_actions_should_not_be_invoked()
+        public async Task When_ScheduleOnce_and_then_canceling_before_they_occur_Then_their_actions_should_not_be_invoked()
         {
             // Prepare, set up actions to be fired
             IActionScheduler scheduler = new HashedWheelTimerScheduler(Sys.Settings.Config, Log);
@@ -70,7 +71,7 @@ namespace Akka.Tests.Actor.Scheduler
                 cancelable.Cancel();
 
                 //Validate that no messages were sent
-                ExpectNoMsg(150);
+                await ExpectNoMsgAsync(150);
             }
             finally
             {
@@ -79,7 +80,7 @@ namespace Akka.Tests.Actor.Scheduler
         }
 
         [Fact]
-        public void When_ScheduleRepeatedly_and_then_canceling_before_they_occur_Then_their_actions_should_not_be_invoked()
+        public async Task When_ScheduleRepeatedly_and_then_canceling_before_they_occur_Then_their_actions_should_not_be_invoked()
         {
             // Prepare, set up actions to be fired
             IActionScheduler scheduler = new HashedWheelTimerScheduler(Sys.Settings.Config, Log);
@@ -91,7 +92,7 @@ namespace Akka.Tests.Actor.Scheduler
                 cancelable.Cancel();
 
                 //Validate that no messages were sent
-                ExpectNoMsg(150);
+                await ExpectNoMsgAsync(150);
             }
             finally
             {
@@ -100,7 +101,7 @@ namespace Akka.Tests.Actor.Scheduler
         }
 
         [Fact]
-        public void When_canceling_existing_running_repeaters_Then_their_future_actions_should_not_be_invoked()
+        public async Task When_canceling_existing_running_repeaters_Then_their_future_actions_should_not_be_invoked()
         {
             // Prepare, set up actions to be fired
             IActionScheduler scheduler = new HashedWheelTimerScheduler(Sys.Settings.Config, Log);
@@ -109,11 +110,11 @@ namespace Akka.Tests.Actor.Scheduler
             {
                 var cancelable = new Cancelable(scheduler);
                 scheduler.ScheduleRepeatedly(0, 150, () => TestActor.Tell("Test"), cancelable);
-                ExpectMsg("Test");
+                await ExpectMsgAsync("Test");
                 cancelable.Cancel();
 
                 //Validate that no more messages were sent
-                ExpectNoMsg(200);
+                await ExpectNoMsgAsync(200);
             }
             finally
             {
@@ -124,7 +125,7 @@ namespace Akka.Tests.Actor.Scheduler
         // Might be racy, failed at least once in Azure Pipelines.
         // Passed 500 consecutive local test runs with no fail with very heavy load without modification
         [Fact]
-        public void When_canceling_existing_running_repeaters_by_scheduling_the_cancellation_ahead_of_time_Then_their_future_actions_should_not_be_invoked()
+        public async Task When_canceling_existing_running_repeaters_by_scheduling_the_cancellation_ahead_of_time_Then_their_future_actions_should_not_be_invoked()
         {
             // Prepare, set up actions to be fired
             IActionScheduler scheduler = new HashedWheelTimerScheduler(Sys.Settings.Config, Log);
@@ -136,10 +137,10 @@ namespace Akka.Tests.Actor.Scheduler
                 cancelableOdd.CancelAfter(50);
 
                 //Expect one message
-                ExpectMsg("Test");
+                await ExpectMsgAsync("Test");
 
                 //Validate that no messages were sent
-                ExpectNoMsg(200);
+                await ExpectNoMsgAsync(200);
             }
             finally
             {

--- a/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_ActionScheduler_Schedule_Tests.cs
+++ b/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_ActionScheduler_Schedule_Tests.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
 using Akka.Util.Internal;
@@ -21,7 +22,7 @@ namespace Akka.Tests.Actor.Scheduler
     {
         [Theory]
         [InlineData(10, 1000)]
-        public void ScheduleRepeatedly_in_milliseconds_Tests_and_verify_the_interval(int initialDelay, int interval)
+        public async Task ScheduleRepeatedly_in_milliseconds_Tests_and_verify_the_interval(int initialDelay, int interval)
         {
             // Prepare, set up actions to be fired
             IActionScheduler scheduler = new HashedWheelTimerScheduler(Sys.Settings.Config, Log);
@@ -48,7 +49,7 @@ namespace Akka.Tests.Actor.Scheduler
                 scheduler.ScheduleRepeatedly(initialDelay, interval, () => receiver.Tell(""), cancelable);
 
                 //Expect to get a list from receiver after it has received three messages
-                var dateTimeOffsets = ExpectMsg<List<DateTimeOffset>>();
+                var dateTimeOffsets = await ExpectMsgAsync<List<DateTimeOffset>>();
                 dateTimeOffsets.ShouldHaveCount(3);
                 Action<int, int> validate = (a, b) =>
                 {
@@ -76,7 +77,7 @@ namespace Akka.Tests.Actor.Scheduler
         [Theory]
         [InlineData(50, 50)]
         [InlineData(00, 50)]
-        public void ScheduleRepeatedly_in_milliseconds_Tests(int initialDelay, int interval)
+        public async Task ScheduleRepeatedly_in_milliseconds_Tests(int initialDelay, int interval)
         {
             // Prepare, set up actions to be fired
             IActionScheduler testScheduler = new HashedWheelTimerScheduler(Sys.Settings.Config, Log);
@@ -86,9 +87,9 @@ namespace Akka.Tests.Actor.Scheduler
                 testScheduler.ScheduleRepeatedly(initialDelay, interval, () => TestActor.Tell("Test"));
 
                 //Just check that we receives more than one message
-                ExpectMsg("Test");
-                ExpectMsg("Test");
-                ExpectMsg("Test");
+                await ExpectMsgAsync("Test");
+                await ExpectMsgAsync("Test");
+                await ExpectMsgAsync("Test");
             }
             finally
             {
@@ -99,7 +100,7 @@ namespace Akka.Tests.Actor.Scheduler
         [Theory]
         [InlineData(50, 50)]
         [InlineData(00, 50)]
-        public void ScheduleRepeatedly_in_TimeSpan_Tests(int initialDelay, int interval)
+        public async Task ScheduleRepeatedly_in_TimeSpan_Tests(int initialDelay, int interval)
         {
             // Prepare, set up actions to be fired
             IActionScheduler testScheduler = new HashedWheelTimerScheduler(Sys.Settings.Config, Log);
@@ -110,9 +111,9 @@ namespace Akka.Tests.Actor.Scheduler
                     TimeSpan.FromMilliseconds(interval), () => TestActor.Tell("Test"));
 
                 //Just check that we receives more than one message
-                ExpectMsg("Test");
-                ExpectMsg("Test");
-                ExpectMsg("Test");
+                await ExpectMsgAsync("Test");
+                await ExpectMsgAsync("Test");
+                await ExpectMsgAsync("Test");
             }
             finally
             {
@@ -122,7 +123,7 @@ namespace Akka.Tests.Actor.Scheduler
 
 
         [Fact]
-        public void ScheduleOnceTests()
+        public async Task ScheduleOnceTests()
         {
             // Prepare, set up actions to be fired
             IActionScheduler testScheduler = new HashedWheelTimerScheduler(Sys.Settings.Config, Log);
@@ -132,10 +133,10 @@ namespace Akka.Tests.Actor.Scheduler
                 testScheduler.ScheduleOnce(50, () => TestActor.Tell("Test1"));
                 testScheduler.ScheduleOnce(100, () => TestActor.Tell("Test2"));
 
-                ExpectMsg("Test1");
-                ExpectMsg("Test2");
+                await ExpectMsgAsync("Test1");
+                await ExpectMsgAsync("Test2");
 
-                ExpectNoMsg(100);
+                await ExpectNoMsgAsync(100);
             }
             finally
             {
@@ -147,7 +148,7 @@ namespace Akka.Tests.Actor.Scheduler
 
         [Theory]
         [InlineData(new int[] { 1, 1, 50, 50, 100, 100 })]
-        public void When_ScheduleOnce_many_at_the_same_time_Then_all_fires(int[] times)
+        public async Task When_ScheduleOnce_many_at_the_same_time_Then_all_fires(int[] times)
         {
             // Prepare, set up actions to be fired
             IActionScheduler scheduler = new HashedWheelTimerScheduler(Sys.Settings.Config, Log);
@@ -161,13 +162,13 @@ namespace Akka.Tests.Actor.Scheduler
                 }
 
                 //Perform the test
-                ExpectMsg("Test1");
-                ExpectMsg("Test1");
-                ExpectMsg("Test50");
-                ExpectMsg("Test50");
-                ExpectMsg("Test100");
-                ExpectMsg("Test100");
-                ExpectNoMsg(50);
+                await ExpectMsgAsync("Test1");
+                await ExpectMsgAsync("Test1");
+                await ExpectMsgAsync("Test50");
+                await ExpectMsgAsync("Test50");
+                await ExpectMsgAsync("Test100");
+                await ExpectMsgAsync("Test100");
+                await ExpectNoMsgAsync(50);
             }
             finally
             {
@@ -273,7 +274,7 @@ namespace Akka.Tests.Actor.Scheduler
         }
 
         [Fact]
-        public void When_ScheduleRepeatedly_action_crashes_Then_no_more_calls_will_be_scheduled()
+        public async Task When_ScheduleRepeatedly_action_crashes_Then_no_more_calls_will_be_scheduled()
         {
             IActionScheduler testScheduler = new HashedWheelTimerScheduler(Sys.Settings.Config, Log);
 
@@ -285,8 +286,8 @@ namespace Akka.Tests.Actor.Scheduler
                     Interlocked.Increment(ref timesCalled);
                     throw new Exception("Crash");
                 });
-                AwaitCondition(() => timesCalled >= 1);
-                Thread.Sleep(200); //Allow any scheduled actions to be fired. 
+                await AwaitConditionAsync(() => timesCalled >= 1);
+                await Task.Delay(200); //Allow any scheduled actions to be fired. 
 
                 //We expect only one of the scheduled actions to actually fire
                 timesCalled.ShouldBe(1);

--- a/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_TellScheduler_Cancellation_Tests.cs
+++ b/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_TellScheduler_Cancellation_Tests.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
 using Akka.Util.Internal;
@@ -17,7 +18,7 @@ namespace Akka.Tests.Actor.Scheduler
     public class DefaultScheduler_TellScheduler_Cancellation_Tests : AkkaSpec
     {
         [Fact]
-        public void When_ScheduleTellOnce_using_canceled_Cancelable_Then_their_actions_should_not_be_invoked()
+        public async Task When_ScheduleTellOnce_using_canceled_Cancelable_Then_their_actions_should_not_be_invoked()
         {
             // Prepare, set up actions to be fired
             ITellScheduler scheduler = new HashedWheelTimerScheduler(Sys.Settings.Config, Log);
@@ -29,7 +30,7 @@ namespace Akka.Tests.Actor.Scheduler
                 scheduler.ScheduleTellOnce(1, TestActor, "Test", ActorRefs.NoSender, canceled);
 
                 //Validate that no messages were sent
-                ExpectNoMsg(100);
+                await ExpectNoMsgAsync(100);
             }
             finally
             {
@@ -38,7 +39,7 @@ namespace Akka.Tests.Actor.Scheduler
         }
 
         [Fact]
-        public void When_ScheduleTellRepeatedly_using_canceled_Cancelable_Then_their_actions_should_not_be_invoked()
+        public async Task When_ScheduleTellRepeatedly_using_canceled_Cancelable_Then_their_actions_should_not_be_invoked()
         {
             // Prepare, set up actions to be fired
             ITellScheduler scheduler = new HashedWheelTimerScheduler(Sys.Settings.Config, Log);
@@ -50,7 +51,7 @@ namespace Akka.Tests.Actor.Scheduler
                 scheduler.ScheduleTellRepeatedly(1, 2, TestActor, "Test", ActorRefs.NoSender, canceled);
 
                 //Validate that no messages were sent
-                ExpectNoMsg(100);
+                await ExpectNoMsgAsync(100);
             }
             finally
             {
@@ -59,7 +60,7 @@ namespace Akka.Tests.Actor.Scheduler
         }
 
         [Fact]
-        public void When_ScheduleTellOnce_and_then_canceling_before_they_occur_Then_their_actions_should_not_be_invoked()
+        public async Task When_ScheduleTellOnce_and_then_canceling_before_they_occur_Then_their_actions_should_not_be_invoked()
         {
             // Prepare, set up actions to be fired
             IScheduler scheduler = new HashedWheelTimerScheduler(Sys.Settings.Config, Log);
@@ -71,7 +72,7 @@ namespace Akka.Tests.Actor.Scheduler
                 cancelable.Cancel();
 
                 //Validate that no messages were sent
-                ExpectNoMsg(150);
+                await ExpectNoMsgAsync(150);
             }
             finally
             {
@@ -81,7 +82,7 @@ namespace Akka.Tests.Actor.Scheduler
 
 
         [Fact]
-        public void When_ScheduleTellRepeatedly_and_then_canceling_before_they_occur_Then_their_actions_should_not_be_invoked()
+        public async Task When_ScheduleTellRepeatedly_and_then_canceling_before_they_occur_Then_their_actions_should_not_be_invoked()
         {
             // Prepare, set up actions to be fired
             IScheduler scheduler = new HashedWheelTimerScheduler(Sys.Settings.Config, Log);
@@ -93,7 +94,7 @@ namespace Akka.Tests.Actor.Scheduler
                 cancelable.Cancel();
 
                 //Validate that no messages were sent
-                ExpectNoMsg(150);
+                await ExpectNoMsgAsync(150);
             }
             finally
             {
@@ -103,7 +104,7 @@ namespace Akka.Tests.Actor.Scheduler
 
 
         [Fact]
-        public void When_canceling_existing_running_repeaters_Then_their_future_actions_should_not_be_invoked()
+        public async Task When_canceling_existing_running_repeaters_Then_their_future_actions_should_not_be_invoked()
         {
             // Prepare, set up actions to be fired
             IScheduler scheduler = new HashedWheelTimerScheduler(Sys.Settings.Config, Log);
@@ -112,11 +113,11 @@ namespace Akka.Tests.Actor.Scheduler
             {
                 var cancelable = new Cancelable(scheduler);
                 scheduler.ScheduleTellRepeatedly(0, 150, TestActor, "Test", ActorRefs.NoSender, cancelable);
-                ExpectMsg("Test");
+                await ExpectMsgAsync("Test");
                 cancelable.Cancel();
 
                 //Validate that no more messages were sent
-                ExpectNoMsg(200);
+                await ExpectNoMsgAsync(200);
             }
             finally
             {
@@ -126,7 +127,7 @@ namespace Akka.Tests.Actor.Scheduler
         }
 
         [Fact]
-        public void When_canceling_existing_running_repeaters_by_scheduling_the_cancellation_ahead_of_time_Then_their_future_actions_should_not_be_invoked()
+        public async Task When_canceling_existing_running_repeaters_by_scheduling_the_cancellation_ahead_of_time_Then_their_future_actions_should_not_be_invoked()
         {
             // Prepare, set up actions to be fired
             IScheduler scheduler = new HashedWheelTimerScheduler(Sys.Settings.Config, Log);
@@ -138,10 +139,10 @@ namespace Akka.Tests.Actor.Scheduler
                 cancelableOdd.CancelAfter(50);
 
                 //Expect one message
-                ExpectMsg("Test");
+                await ExpectMsgAsync("Test");
 
                 //Validate that no messages were sent
-                ExpectNoMsg(200);
+                await ExpectNoMsgAsync(200);
             }
             finally
             {


### PR DESCRIPTION
## Changes

### DefaultScheduler_ActionScheduler_Cancellation_Tests
- Changed `When_ScheduleOnce_using_canceled_Cancelable_Then_their_actions_should_not_be_invoked` to `async/await`
- Changed `When_ScheduleRepeatedly_using_canceled_Cancelable_Then_their_actions_should_not_be_invoked` to `async/await`
- Changed `When_ScheduleOnce_and_then_canceling_before_they_occur_Then_their_actions_should_not_be_invoked` to `async/await`
- Changed `When_ScheduleRepeatedly_and_then_canceling_before_they_occur_Then_their_actions_should_not_be_invoked` to `async/await`
- Changed `When_canceling_existing_running_repeaters_Then_their_future_actions_should_not_be_invoked` to `async/await`
- Changed `When_canceling_existing_running_repeaters_by_scheduling_the_cancellation_ahead_of_time_Then_their_future_actions_should_not_be_invoked` to `async/await`

### DefaultScheduler_ActionScheduler_Schedule_Tests
- Changed `ScheduleRepeatedly_in_milliseconds_Tests_and_verify_the_interval` to `async/await`
- Changed `ScheduleRepeatedly_in_milliseconds_Tests` to `async/await`
- Changed `ScheduleRepeatedly_in_TimeSpan_Tests` to `async/await`
- Changed `ScheduleOnceTests` to `async/await`
- Changed `When_ScheduleOnce_many_at_the_same_time_Then_all_fires` to `async/await`
- Changed `When_ScheduleRepeatedly_action_crashes_Then_no_more_calls_will_be_scheduled` to `async/await`

### DefaultScheduler_TellScheduler_Cancellation_Tests
- Changed `When_ScheduleTellOnce_using_canceled_Cancelable_Then_their_actions_should_not_be_invoked` to `async/await`
- Changed `When_ScheduleTellRepeatedly_using_canceled_Cancelable_Then_their_actions_should_not_be_invoked` to `async/await`
- Changed `When_ScheduleTellOnce_and_then_canceling_before_they_occur_Then_their_actions_should_not_be_invoked` to `async/await`
- Changed `When_ScheduleTellRepeatedly_and_then_canceling_before_they_occur_Then_their_actions_should_not_be_invoked` to `async/await`
- Changed `When_canceling_existing_running_repeaters_Then_their_future_actions_should_not_be_invoked` to `async/await`
- Changed `When_canceling_existing_running_repeaters_by_scheduling_the_cancellation_ahead_of_time_Then_their_future_actions_should_not_be_invoked(` to `async/await`

### DefaultScheduler_TellScheduler_Schedule_Tests
- Changed `ScheduleTellRepeatedly_in_milliseconds_Tests` to `async/await`
- Changed `ScheduleTellRepeatedly_TimeSpan_Tests` to `async/await`
- Changed `ScheduleTellOnceTests` to `async/await`
- Changed `When_ScheduleTellOnce_many_at_the_same_time_Then_all_fires` to `async/await`
- Changed `When_ScheduleTellOnce_with_invalid_delay_Then_exception_is_thrown` to `async/await`
- Changed `When_ScheduleTellRepeatedly_with_invalid_delay_Then_exception_is_thrown` to `async/await`
- Changed `When_ScheduleTellRepeatedly_with_invalid_interval_Then_exception_is_thrown` to `async/await`
- Changed `When_ScheduleTellOnce_with_0_delay_Then_action_is_executed_immediately` to `async/await`
- Changed `When_ScheduleTellRepeatedly_with_0_delay_Then_action_is_executed_immediately` to `async/await`