### PR TITLE
Port `Akka.Tests.Actor` tests to `async/await`

### DIFF
--- a/src/core/Akka.Tests/Actor/ActorBecomeTests.cs
+++ b/src/core/Akka.Tests/Actor/ActorBecomeTests.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
 using Xunit;
@@ -16,7 +17,7 @@ namespace Akka.Tests.Actor
     {
 
         [Fact]
-        public void When_calling_become_Then_the_new_handler_is_used()
+        public async Task When_calling_become_Then_the_new_handler_is_used()
         {
 
             //Given
@@ -28,12 +29,12 @@ namespace Akka.Tests.Actor
             actor.Tell("hello", TestActor);
 
             //Then
-            ExpectMsg("2:hello");
+            await ExpectMsgAsync("2:hello");
         }
 
 
         [Fact]
-        public void Given_actor_that_has_called_default_Become_twice_When_calling_unbecome_Then_the_default_handler_is_used_and_not_the_last_handler()
+        public async Task Given_actor_that_has_called_default_Become_twice_When_calling_unbecome_Then_the_default_handler_is_used_and_not_the_last_handler()
         {
             //Calling Become() does not persist the current handler, it just overwrites it, so when we call Unbecome(),
             //no matter how many times, there is no persisted handler to revert to, so we'll end up with the default one
@@ -54,12 +55,12 @@ namespace Akka.Tests.Actor
             actor.Tell("hello", TestActor);
 
             //Then
-            ExpectMsg("1:hello");
+            await ExpectMsgAsync("1:hello");
         }
 
 
         [Fact]
-        public void Given_actor_that_has_called_default_Become_without_overwriting_previous_handler_When_calling_unbecome_Then_the_previous_handler_is_used()
+        public async Task Given_actor_that_has_called_default_Become_without_overwriting_previous_handler_When_calling_unbecome_Then_the_previous_handler_is_used()
         {
             //Calling Become() does not persist the current handler, it just overwrites it, so when we call Unbecome(),
             //no matter how many times, there is no persisted handler to revert to, so we'll end up with the default one
@@ -79,11 +80,11 @@ namespace Akka.Tests.Actor
             actor.Tell("hello", TestActor);
 
             //Then
-            ExpectMsg("2:hello");
+            await ExpectMsgAsync("2:hello");
         }
 
         [Fact]
-        public void Given_actor_that_calls_become_in_the_become_handler_only_first_become_receive_set_is_used() {
+        public async Task Given_actor_that_calls_become_in_the_become_handler_only_first_become_receive_set_is_used() {
             var system = ActorSystem.Create("test");
 
             //Given, this actor calls become(A) inside A() it calls Become(B);
@@ -97,10 +98,10 @@ namespace Akka.Tests.Actor
             //which means this message should never be handled, because only B() has a receive for this.
             actor.Tell(2, TestActor);
 
-            ExpectMsg("A says: hi");
-            ExpectMsg("A says: True");
+            await ExpectMsgAsync("A says: hi");
+            await ExpectMsgAsync("A says: True");
             //we dont expect any further messages
-            this.ExpectNoMsg();
+            await ExpectNoMsgAsync(default);
         }
 
         private class BecomeActor : UntypedActor


### PR DESCRIPTION
## Changes

### ActorBecomeTests
- Changed `When_calling_become_Then_the_new_handler_is_used` to `async/await`
- Changed `Given_actor_that_has_called_default_Become_twice_When_calling_unbecome_Then_the_default_handler_is_used_and_not_the_last_handler` to `async/await`
- Changed `Given_actor_that_has_called_default_Become_without_overwriting_previous_handler_When_calling_unbecome_Then_the_previous_handler_is_used` to `async/await`
- Changed `Given_actor_that_calls_become_in_the_become_handler_only_first_become_receive_set_is_used` to `async/await`