### PR TITLE
Port `Akka.Tests.Actor` tests to `async/await` - `ActorLookup`

### DIFF
--- a/src/core/Akka.Tests/Actor/ActorLookupSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorLookupSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Internal;
 using Akka.TestKit;
@@ -134,16 +135,16 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
-        public void ActorSystem_must_take_actor_incarnation_into_account_when_comparing_actor_references()
+        public async Task ActorSystem_must_take_actor_incarnation_into_account_when_comparing_actor_references()
         {
             var name = "abcdefg";
             var a1 = Sys.ActorOf(P, name);
             Watch(a1);
             a1.Tell(PoisonPill.Instance);
-            ExpectTerminated(a1);
+            await ExpectTerminatedAsync(a1);
 
             // let it be completely removed from the user guardian
-            ExpectNoMsg(1.Seconds());
+            await ExpectNoMsgAsync(1.Seconds());
 
             // not equal, because it's terminated
             Provider.ResolveActorRef(a1.Path.ToString()).Should().NotBe(a1);
@@ -156,11 +157,11 @@ namespace Akka.Tests.Actor
 
             Watch(a2);
             a2.Tell(PoisonPill.Instance);
-            ExpectTerminated(a2);
+            await ExpectTerminatedAsync(a2);
         }
 
         [Fact]
-        public void ActorSystem_must_find_temporary_actors()
+        public async Task ActorSystem_must_find_temporary_actors()
         {
             var f = c1.Ask(new GetSender(TestActor));
             var a = ExpectMsg<IInternalActorRef>();
@@ -171,8 +172,8 @@ namespace Akka.Tests.Actor
             f.IsCompleted.Should().Be(false);
             a.IsTerminated.Should().Be(false);
             a.Tell(42);
-            AwaitAssert(() => f.IsCompleted.Should().Be(true));
-            AwaitAssert(() => f.Result.Should().Be(42));
+            await AwaitAssertAsync(() => f.IsCompleted.Should().Be(true));
+            await AwaitAssertAsync(() => f.Result.Should().Be(42));
         }
 
         /*


### PR DESCRIPTION
## Changes

### ActorLookupSpec
- Changed `ActorSystem_must_find_temporary_actors` to `async/await`
- Changed `ActorSystem_must_take_actor_incarnation_into_account_when_comparing_actor_references` to `async/await`