### PR TITLE
Port `Akka.Tests.Actor` tests to `async/await` - RefIgnoreSpec

### DIFF
--- a/src/core/Akka.TestKit/TestKitBase_Expect.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Expect.cs
@@ -373,7 +373,7 @@ namespace Akka.TestKit
             Action<T> msgAssert,
             Action<IActorRef> senderAssert,
             string hint,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken = default)
         {
             return InternalExpectMsgAsync(timeout, msgAssert, senderAssert, hint, cancellationToken)
                 .ConfigureAwait(false).GetAwaiter().GetResult();
@@ -475,7 +475,7 @@ namespace Akka.TestKit
         }
         
         /// <inheritdoc cref="ExpectNoMsg(CancellationToken)"/>
-        public async ValueTask ExpectNoMsgAsync(CancellationToken cancellationToken = default)
+        public async ValueTask ExpectNoMsgAsync(CancellationToken cancellationToken)
         {
             await InternalExpectNoMsgAsync(RemainingOrDefault, cancellationToken)
                 .ConfigureAwait(false);
@@ -596,7 +596,7 @@ namespace Akka.TestKit
 
         public async IAsyncEnumerable<T> ExpectMsgAllOfAsync<T>(
             IReadOnlyCollection<T> messages,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default)
         {
             var enumerable = InternalExpectMsgAllOfAsync(RemainingOrDefault, messages, cancellationToken: cancellationToken)
                 .ConfigureAwait(false).WithCancellation(cancellationToken);

--- a/src/core/Akka.TestKit/TestKitBase_Expect.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Expect.cs
@@ -373,7 +373,7 @@ namespace Akka.TestKit
             Action<T> msgAssert,
             Action<IActorRef> senderAssert,
             string hint,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken)
         {
             return InternalExpectMsgAsync(timeout, msgAssert, senderAssert, hint, cancellationToken)
                 .ConfigureAwait(false).GetAwaiter().GetResult();
@@ -475,7 +475,7 @@ namespace Akka.TestKit
         }
         
         /// <inheritdoc cref="ExpectNoMsg(CancellationToken)"/>
-        public async ValueTask ExpectNoMsgAsync(CancellationToken cancellationToken)
+        public async ValueTask ExpectNoMsgAsync(CancellationToken cancellationToken = default)
         {
             await InternalExpectNoMsgAsync(RemainingOrDefault, cancellationToken)
                 .ConfigureAwait(false);
@@ -596,7 +596,7 @@ namespace Akka.TestKit
 
         public async IAsyncEnumerable<T> ExpectMsgAllOfAsync<T>(
             IReadOnlyCollection<T> messages,
-            CancellationToken cancellationToken = default)
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             var enumerable = InternalExpectMsgAllOfAsync(RemainingOrDefault, messages, cancellationToken: cancellationToken)
                 .ConfigureAwait(false).WithCancellation(cancellationToken);

--- a/src/core/Akka.Tests/Actor/ActorRefIgnoreSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorRefIgnoreSpec.cs
@@ -34,7 +34,7 @@ namespace Akka.Tests.Actor
             // since the reply is ignored, we can't check that a message was sent to it
             askMeRef.Tell(new Request(Sys.IgnoreRef));
 
-            await probe.ExpectNoMsgAsync(default);
+            await probe.ExpectNoMsgAsync();
 
             // but we do check that the counter has increased when we used the ActorRef.ignore
             askMeRef.Tell(new Request(probe.Ref));

--- a/src/core/Akka.Tests/Actor/ActorRefIgnoreSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorRefIgnoreSpec.cs
@@ -15,29 +15,30 @@ using Akka.TestKit.TestActors;
 using Xunit;
 using Akka.Util.Internal;
 using FluentAssertions;
+using System.Threading.Tasks;
 
 namespace Akka.Tests.Actor
 {
     public class ActorRefIgnoreSpec : AkkaSpec, INoImplicitSender
     {
         [Fact]
-        public void IgnoreActorRef_should_ignore_all_incoming_messages()
+        public async Task IgnoreActorRef_should_ignore_all_incoming_messages()
         {
             var askMeRef = Sys.ActorOf(Props.Create(() => new AskMeActor()));
 
             var probe = CreateTestProbe("response-probe");
             askMeRef.Tell(new Request(probe.Ref));
-            probe.ExpectMsg(1);
+            await probe.ExpectMsgAsync(1);
 
             // this is more a compile-time proof
             // since the reply is ignored, we can't check that a message was sent to it
             askMeRef.Tell(new Request(Sys.IgnoreRef));
 
-            probe.ExpectNoMsg();
+            await probe.ExpectNoMsgAsync(default);
 
             // but we do check that the counter has increased when we used the ActorRef.ignore
             askMeRef.Tell(new Request(probe.Ref));
-            probe.ExpectMsg(3);
+            await probe.ExpectMsgAsync(3);
         }
 
         [Fact]
@@ -55,14 +56,14 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
-        public void IgnoreActorRef_should_be_watchable_from_another_actor_without_throwing_an_exception()
+        public async Task IgnoreActorRef_should_be_watchable_from_another_actor_without_throwing_an_exception()
         {
             var probe = CreateTestProbe("probe-response");
             var forwardMessageRef = Sys.ActorOf(Props.Create(() => new ForwardMessageWatchActor(probe)));
 
             // this proves that the actor started and is operational and 'watch' didn't impact it
             forwardMessageRef.Tell("abc");
-            probe.ExpectMsg("abc");
+            await probe.ExpectMsgAsync("abc");
         }
 
         [Fact]

--- a/src/core/Akka.Tests/Actor/ActorRefIgnoreSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorRefIgnoreSpec.cs
@@ -34,7 +34,7 @@ namespace Akka.Tests.Actor
             // since the reply is ignored, we can't check that a message was sent to it
             askMeRef.Tell(new Request(Sys.IgnoreRef));
 
-            await probe.ExpectNoMsgAsync();
+            await probe.ExpectNoMsgAsync(default);
 
             // but we do check that the counter has increased when we used the ActorRef.ignore
             askMeRef.Tell(new Request(probe.Ref));


### PR DESCRIPTION
## Changes

### ActorRefIgnoreSpec
- Changed `IgnoreActorRef_should_ignore_all_incoming_messages` to `async/await`
- Changed `IgnoreActorRef_should_make_a_Future_timeout_when_used_in_a_ask` to `async/await`
- Changed `IgnoreActorRef_should_be_watchable_from_another_actor_without_throwing_an_exception` to `async/await`