### PR TITLE
Port `Akka.Tests.Actor` tests to `async/await` - `BugFix4376Spec`

### DIFF
--- a/src/core/Akka.Tests/Actor/BugFix4376Spec.cs
+++ b/src/core/Akka.Tests/Actor/BugFix4376Spec.cs
@@ -185,12 +185,12 @@ namespace Akka.Tests.Actor
             }
 
             poolActorRef.Tell(2);
-            ExpectMsg<int>();
-            ExpectMsg<int>();
-            ExpectMsg<int>();
-            ExpectMsg<int>();
-            ExpectMsg<int>();
-            ExpectNoMsg(TimeSpan.FromSeconds(1));
+            await ExpectMsgAsync<int>();
+            await ExpectMsgAsync<int>();
+            await ExpectMsgAsync<int>();
+            await ExpectMsgAsync<int>();
+            await ExpectMsgAsync<int>();
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
         }
 
         [Fact]


### PR DESCRIPTION
## Changes

### BugFix4376Spec
- Changed `Supervisor_with_Broadcast_Pool_router_should_handle_multiple_child_failure` to `async/await`
