### PR TITLE
Port `Akka.Tests.Actor` tests to `async/await` - `BugFix4823Spec`

### DIFF
--- a/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
@@ -35,6 +35,7 @@ namespace Akka.TestKit
             stdout-loglevel = WARNING
             serialize-messages = on
             actor {
+              ask-timeout = 20s
               #default-dispatcher {
               #  executor = fork-join-executor
               #  fork-join-executor {

--- a/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
@@ -35,7 +35,6 @@ namespace Akka.TestKit
             stdout-loglevel = WARNING
             serialize-messages = on
             actor {
-              ask-timeout = 20s
               #default-dispatcher {
               #  executor = fork-join-executor
               #  fork-join-executor {

--- a/src/core/Akka.Tests/Actor/BugFix4823Spec.cs
+++ b/src/core/Akka.Tests/Actor/BugFix4823Spec.cs
@@ -22,12 +22,12 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
-        public void Actor_should_not_loose_self_context_after_async_call()
+        public async Task Actor_should_not_loose_self_context_after_async_call()
         {
             var identity = ActorOfAsTestActorRef<MyActor>(Props.Create(() => new MyActor(TestActor)), TestActor);
             identity.Tell(NotUsed.Instance);
-            var selfBefore = ExpectMsg<IActorRef>();
-            var selfAfter = ExpectMsg<IActorRef>();
+            var selfBefore = await ExpectMsgAsync<IActorRef>();
+            var selfAfter = await ExpectMsgAsync<IActorRef>();
             selfAfter.Should().Be(selfBefore);
         }
 


### PR DESCRIPTION
## Changes

### BugFix4823Spec
- Changed `Actor_should_not_loose_self_context_after_async_call` to `async/await`
