### PR TITLE
Port `Akka.Tests.Actor` tests to `async/await` - `CoordinatedShutdownSpec`

### DIFF
--- a/src/core/Akka.Tests/Actor/CoordinatedShutdownSpec.cs
+++ b/src/core/Akka.Tests/Actor/CoordinatedShutdownSpec.cs
@@ -17,6 +17,7 @@ using Akka.Configuration;
 using FluentAssertions;
 using Xunit;
 using static Akka.Actor.CoordinatedShutdown;
+using Akka.Tests.Util;
 
 namespace Akka.Tests.Actor
 {
@@ -114,12 +115,12 @@ namespace Akka.Tests.Actor
         [Fact]
         public void CoordinatedShutdown_must_detect_cycles_in_phases_non_DAG()
         {
-            Intercept<ArgumentException>(() =>
+            Assert.Throws<ArgumentException>(() =>
             {
                 CoordinatedShutdown.TopologicalSort(new Dictionary<string, Phase>() { { "a", Phase("a") } });
             });
 
-            Intercept<ArgumentException>(() =>
+            Assert.Throws<ArgumentException>(() =>
             {
                 CoordinatedShutdown.TopologicalSort(new Dictionary<string, Phase>()
                 {
@@ -128,7 +129,7 @@ namespace Akka.Tests.Actor
                 });
             });
 
-            Intercept<ArgumentException>(() =>
+            Assert.Throws<ArgumentException>(() =>
             {
                 CoordinatedShutdown.TopologicalSort(new Dictionary<string, Phase>()
                 {
@@ -138,7 +139,7 @@ namespace Akka.Tests.Actor
                 });
             });
 
-            Intercept<ArgumentException>(() =>
+            Assert.Throws<ArgumentException>(() =>
             {
                 CoordinatedShutdown.TopologicalSort(new Dictionary<string, Phase>()
                 {
@@ -171,7 +172,7 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
-        public void CoordinatedShutdown_must_run_ordered_phases()
+        public async Task CoordinatedShutdown_must_run_ordered_phases()
         {
             var phases = new Dictionary<string, Phase>()
             {
@@ -207,12 +208,12 @@ namespace Akka.Tests.Actor
                 return TaskEx.Completed;
             });
 
-            co.Run(CoordinatedShutdown.UnknownReason.Instance).Wait(RemainingOrDefault);
-            ReceiveN(4).Should().Equal(new object[] { "A", "B", "B", "C" });
+            await co.Run(CoordinatedShutdown.UnknownReason.Instance).AwaitWithTimeout(RemainingOrDefault);
+            (await ReceiveNAsync(4, default).ToListAsync()).Should().Equal(new object[] { "A", "B", "B", "C" });
         }
 
         [Fact]
-        public void CoordinatedShutdown_must_run_from_given_phase()
+        public async Task CoordinatedShutdown_must_run_from_given_phase()
         {
             var phases = new Dictionary<string, Phase>()
             {
@@ -240,13 +241,13 @@ namespace Akka.Tests.Actor
                 return TaskEx.Completed;
             });
 
-            co.Run(customReason, "b").Wait(RemainingOrDefault);
-            ReceiveN(2).Should().Equal(new object[] { "B", "C" });
+            await co.Run(customReason, "b").AwaitWithTimeout(RemainingOrDefault);
+            (await ReceiveNAsync(2, default).ToListAsync()).Should().Equal(new object[] { "B", "C" });
             co.ShutdownReason.Should().BeEquivalentTo(customReason);
         }
 
         [Fact]
-        public void CoordinatedShutdown_must_only_run_once()
+        public async Task CoordinatedShutdown_must_only_run_once()
         {
             var phases = new Dictionary<string, Phase>()
             {
@@ -261,17 +262,17 @@ namespace Akka.Tests.Actor
             });
 
             co.ShutdownReason.Should().BeNull();
-            co.Run(customReason).Wait(RemainingOrDefault);
+            await co.Run(customReason).AwaitWithTimeout(RemainingOrDefault);
             co.ShutdownReason.Should().BeEquivalentTo(customReason);
-            ExpectMsg("A");
-            co.Run(CoordinatedShutdown.UnknownReason.Instance).Wait(RemainingOrDefault);
+            await ExpectMsgAsync("A");
+            await co.Run(CoordinatedShutdown.UnknownReason.Instance).AwaitWithTimeout(RemainingOrDefault);
             TestActor.Tell("done");
-            ExpectMsg("done"); // no additional A
+            await ExpectMsgAsync("done"); // no additional A
             co.ShutdownReason.Should().BeEquivalentTo(customReason);
         }
 
         [Fact]
-        public void CoordinatedShutdown_must_continue_after_timeout_or_failure()
+        public async Task CoordinatedShutdown_must_continue_after_timeout_or_failure()
         {
             var phases = new Dictionary<string, Phase>()
             {
@@ -306,15 +307,15 @@ namespace Akka.Tests.Actor
                 return TaskEx.Completed;
             });
 
-            co.Run(CoordinatedShutdown.UnknownReason.Instance).Wait(RemainingOrDefault);
-            ExpectMsg("A");
-            ExpectMsg("A");
-            ExpectMsg("B");
-            ExpectMsg("C");
+            await co.Run(CoordinatedShutdown.UnknownReason.Instance).AwaitWithTimeout(RemainingOrDefault);
+            await ExpectMsgAsync("A");
+            await ExpectMsgAsync("A");
+            await ExpectMsgAsync("B");
+            await ExpectMsgAsync("C");
         }
 
         [Fact]
-        public void CoordinatedShutdown_must_abort_if_recover_is_off()
+        public async Task CoordinatedShutdown_must_abort_if_recover_is_off()
         {
             var phases = new Dictionary<string, Phase>()
             {
@@ -335,14 +336,13 @@ namespace Akka.Tests.Actor
                 return TaskEx.Completed;
             });
 
-            var result = co.Run(CoordinatedShutdown.UnknownReason.Instance);
-            ExpectMsg("B");
-            Intercept<TimeoutException>(() => result.Wait(RemainingOrDefault));
-            ExpectNoMsg(TimeSpan.FromMilliseconds(200)); // C not run
+            await ExpectMsgAsync("B");
+            await Assert.ThrowsAsync<TimeoutException>(async() => await co.Run(CoordinatedShutdown.UnknownReason.Instance).AwaitWithTimeout(RemainingOrDefault));
+            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200)); // C not run
         }
 
         [Fact]
-        public void CoordinatedShutdown_must_be_possible_to_add_tasks_in_later_phase_from_earlier_phase()
+        public async Task CoordinatedShutdown_must_be_possible_to_add_tasks_in_later_phase_from_earlier_phase()
         {
             var phases = new Dictionary<string, Phase>()
             {
@@ -362,9 +362,9 @@ namespace Akka.Tests.Actor
                 return TaskEx.Completed;
             });
 
-            co.Run(CoordinatedShutdown.UnknownReason.Instance).Wait(RemainingOrDefault);
-            ExpectMsg("A");
-            ExpectMsg("B");
+            await co.Run(CoordinatedShutdown.UnknownReason.Instance).AwaitWithTimeout(RemainingOrDefault);
+            await ExpectMsgAsync("A");
+            await ExpectMsgAsync("B");
         }
 
         [Fact]
@@ -392,10 +392,10 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
-        public void CoordinatedShutdown_must_terminate_ActorSystem()
+        public async Task CoordinatedShutdown_must_terminate_ActorSystem()
         {
-            var shutdownSystem = CoordinatedShutdown.Get(Sys).Run(customReason);
-            shutdownSystem.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+            (await CoordinatedShutdown.Get(Sys).Run(customReason)
+                .AwaitWithTimeout(TimeSpan.FromSeconds(10))).Should().BeTrue();
 
             Sys.WhenTerminated.IsCompleted.Should().BeTrue();
             CoordinatedShutdown.Get(Sys).ShutdownReason.Should().BeEquivalentTo(customReason);

--- a/src/core/Akka.Tests/Util/TaskHelpers.cs
+++ b/src/core/Akka.Tests/Util/TaskHelpers.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Runtime.ExceptionServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Akka.Tests.Util
@@ -7,9 +9,26 @@ namespace Akka.Tests.Util
     {
         public static async Task<bool> AwaitWithTimeout(this Task parentTask, TimeSpan timeout)
         {
-            var delayed = Task.Delay(timeout);
-            await Task.WhenAny(delayed, parentTask);
-            return parentTask.IsCompleted;
+            using (var cts = new CancellationTokenSource())
+            {
+                try
+                {
+                    var delayed = Task.Delay(timeout, cts.Token);
+                    var returnedTask = await Task.WhenAny(delayed, parentTask);
+                    
+                    if(returnedTask == parentTask && returnedTask.Exception != null)
+                    {
+                        var flattened = returnedTask.Exception.Flatten();
+                        ExceptionDispatchInfo.Capture(flattened.InnerException).Throw();
+                    }
+                    
+                    return parentTask.IsCompleted;
+                }
+                finally
+                {
+                    cts.Cancel();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Changes

### CoordinatedShutdownSpec
- Changed `CoordinatedShutdown_must_detect_cycles_in_phases_non_DAG` to `Assert.Throws`
- Changed `CoordinatedShutdown_must_run_ordered_phases` to `async/await`
- Changed `CoordinatedShutdown_must_run_from_given_phase` to `async/await`
- Changed `CoordinatedShutdown_must_only_run_once` to `async/await`
- Changed `CoordinatedShutdown_must_continue_after_timeout_or_failure` to `async/await`
- Changed `CoordinatedShutdown_must_abort_if_recover_is_off` to `async/await` [failing @Arkatufus ]
- Changed `CoordinatedShutdown_must_be_possible_to_add_tasks_in_later_phase_from_earlier_phase` to `async/await`
- Changed `CoordinatedShutdown_must_terminate_ActorSystem` to `async/await`