### PR TITLE
General Akka.TestKit fixes that are found while porting tests to async

### DIFF
--- a/src/core/Akka.TestKit/TestKitBase_Expect.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Expect.cs
@@ -373,7 +373,7 @@ namespace Akka.TestKit
             Action<T> msgAssert,
             Action<IActorRef> senderAssert,
             string hint,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken)
         {
             return InternalExpectMsgAsync(timeout, msgAssert, senderAssert, hint, cancellationToken)
                 .ConfigureAwait(false).GetAwaiter().GetResult();
@@ -475,7 +475,7 @@ namespace Akka.TestKit
         }
         
         /// <inheritdoc cref="ExpectNoMsg(CancellationToken)"/>
-        public async ValueTask ExpectNoMsgAsync(CancellationToken cancellationToken)
+        public async ValueTask ExpectNoMsgAsync(CancellationToken cancellationToken = default)
         {
             await InternalExpectNoMsgAsync(RemainingOrDefault, cancellationToken)
                 .ConfigureAwait(false);
@@ -596,7 +596,7 @@ namespace Akka.TestKit
 
         public async IAsyncEnumerable<T> ExpectMsgAllOfAsync<T>(
             IReadOnlyCollection<T> messages,
-            CancellationToken cancellationToken = default)
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             var enumerable = InternalExpectMsgAllOfAsync(RemainingOrDefault, messages, cancellationToken: cancellationToken)
                 .ConfigureAwait(false).WithCancellation(cancellationToken);

--- a/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
@@ -35,6 +35,7 @@ namespace Akka.TestKit
             stdout-loglevel = WARNING
             serialize-messages = on
             actor {
+              ask-timeout = 20s
               #default-dispatcher {
               #  executor = fork-join-executor
               #  fork-join-executor {


### PR DESCRIPTION
- General API and global ask timeout setting fix
