### PR TITLE
Port `Akka.Tests.Actor` tests to `async/await` - `FunctionRefSpecs`

### DIFF
--- a/src/core/Akka.Tests/Actor/FunctionRefSpecs.cs
+++ b/src/core/Akka.Tests/Actor/FunctionRefSpecs.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
@@ -127,56 +128,56 @@ namespace Akka.Tests.Actor
         #region top level
 
         [Fact]
-        public void FunctionRef_created_by_top_level_actor_must_forward_messages()
+        public async Task FunctionRef_created_by_top_level_actor_must_forward_messages()
         {
             var s = SuperActor();
-            var forwarder = GetFunctionRef(s);
+            var forwarder = await GetFunctionRef(s);
 
             forwarder.Tell("hello");
-            ExpectMsg(new Forwarded("hello", TestActor));
+            await ExpectMsgAsync(new Forwarded("hello", TestActor));
         }
 
         [Fact]
-        public void FunctionRef_created_by_top_level_actor_must_be_watchable()
+        public async Task FunctionRef_created_by_top_level_actor_must_be_watchable()
         {
             var s = SuperActor();
             var forwarder = GetFunctionRef(s);
 
             s.Tell(new GetForwarder(TestActor));
-            var f = ExpectMsg<FunctionRef>();
+            var f = await ExpectMsgAsync<FunctionRef>();
             Watch(f);
             s.Tell(new DropForwarder(f));
-            ExpectTerminated(f);
+            await ExpectTerminatedAsync(f);
         }
 
         [Fact]
-        public void FunctionRef_created_by_top_level_actor_must_be_able_to_watch()
+        public async Task FunctionRef_created_by_top_level_actor_must_be_able_to_watch()
         {
             var s = SuperActor();
-            var forwarder = GetFunctionRef(s);
+            var forwarder = await GetFunctionRef(s);
 
             s.Tell(new GetForwarder(TestActor));
-            var f = ExpectMsg<FunctionRef>();
+            var f = await ExpectMsgAsync<FunctionRef>();
             forwarder.Watch(f);
             s.Tell(new DropForwarder(f));
-            ExpectMsg(new Forwarded(new Terminated(f, true, false), f));
+            await ExpectMsgAsync(new Forwarded(new Terminated(f, true, false), f));
         }
 
         [Fact]
-        public void FunctionRef_created_by_top_level_actor_must_terminate_when_their_parent_terminates()
+        public async Task FunctionRef_created_by_top_level_actor_must_terminate_when_their_parent_terminates()
         {
             var s = SuperActor();
-            var forwarder = GetFunctionRef(s);
+            var forwarder = await GetFunctionRef(s);
 
             Watch(forwarder);
             s.Tell(PoisonPill.Instance);
-            ExpectTerminated(forwarder);
+            await ExpectTerminatedAsync(forwarder);
         }
 
-        private FunctionRef GetFunctionRef(IActorRef s)
+        private async ValueTask<FunctionRef> GetFunctionRef(IActorRef s)
         {
             s.Tell(new GetForwarder(TestActor));
-            return ExpectMsg<FunctionRef>();
+            return await ExpectMsgAsync<FunctionRef>();
         }
 
         private IActorRef SuperActor() => Sys.ActorOf(Props.Create<Super>(), "super");
@@ -186,50 +187,50 @@ namespace Akka.Tests.Actor
         #region non-top level
 
         [Fact]
-        public void FunctionRef_created_by_non_top_level_actor_must_forward_messages()
+        public async Task FunctionRef_created_by_non_top_level_actor_must_forward_messages()
         {
             var s = SupSuperActor();
-            var forwarder = GetFunctionRef(s);
+            var forwarder = await GetFunctionRef(s);
 
             forwarder.Tell("hello");
-            ExpectMsg(new Forwarded("hello", TestActor));
+            await ExpectMsgAsync(new Forwarded("hello", TestActor));
         }
 
         [Fact]
-        public void FunctionRef_created_by_non_top_level_actor_must_be_watchable()
+        public async Task FunctionRef_created_by_non_top_level_actor_must_be_watchable()
         {
             var s = SupSuperActor();
-            var forwarder = GetFunctionRef(s);
+            var forwarder = await GetFunctionRef(s);
 
             s.Tell(new GetForwarder(TestActor));
-            var f = ExpectMsg<FunctionRef>();
+            var f = await ExpectMsgAsync<FunctionRef>();
             Watch(f);
             s.Tell(new DropForwarder(f));
-            ExpectTerminated(f);
+            await ExpectTerminatedAsync(f);
         }
 
         [Fact]
-        public void FunctionRef_created_by_non_top_level_actor_must_be_able_to_watch()
+        public async Task FunctionRef_created_by_non_top_level_actor_must_be_able_to_watch()
         {
             var s = SupSuperActor();
-            var forwarder = GetFunctionRef(s);
+            var forwarder = await GetFunctionRef(s);
 
             s.Tell(new GetForwarder(TestActor));
-            var f = ExpectMsg<FunctionRef>();
+            var f = await ExpectMsgAsync<FunctionRef>();
             forwarder.Watch(f);
             s.Tell(new DropForwarder(f));
-            ExpectMsg(new Forwarded(new Terminated(f, true, false), f));
+            await ExpectMsgAsync(new Forwarded(new Terminated(f, true, false), f));
         }
 
         [Fact]
-        public void FunctionRef_created_by_non_top_level_actor_must_terminate_when_their_parent_terminates()
+        public async Task FunctionRef_created_by_non_top_level_actor_must_terminate_when_their_parent_terminates()
         {
             var s = SupSuperActor();
-            var forwarder = GetFunctionRef(s);
+            var forwarder = await GetFunctionRef(s);
 
             Watch(forwarder);
             s.Tell(PoisonPill.Instance);
-            ExpectTerminated(forwarder);
+            await ExpectTerminatedAsync(forwarder);
         }
 
         private IActorRef SupSuperActor() => Sys.ActorOf(Props.Create<SupSuper>(), "supsuper");
@@ -237,16 +238,16 @@ namespace Akka.Tests.Actor
         #endregion
 
         [Fact(Skip = "FIXME")]
-        public void FunctionRef_when_not_registered_must_not_be_found()
+        public async Task FunctionRef_when_not_registered_must_not_be_found()
         {
             var provider = ((ExtendedActorSystem)Sys).Provider;
             var fref = new FunctionRef(TestActor.Path / "blabla", provider, Sys.EventStream, (x, y) => { });
-            EventFilter.Exception<InvalidOperationException>().ExpectOne(() =>
+            await EventFilter.Exception<InvalidOperationException>().ExpectOneAsync(async() =>
             {
                 // needs to be something that fails when the deserialized form is not a FunctionRef
                 // this relies upon serialize-messages during tests
                 TestActor.Tell(new DropForwarder(fref));
-                ExpectNoMsg(TimeSpan.FromSeconds(1));
+                await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
             });
         }
     }


### PR DESCRIPTION
## Changes

### FunctionRefSpecs
- Changed `FunctionRef_created_by_top_level_actor_must_forward_messages` to `async/await`
- Changed `FunctionRef_created_by_top_level_actor_must_be_watchable` to `async/await`
- Changed `FunctionRef_created_by_top_level_actor_must_be_able_to_watch` to `async/await`
- Changed `FunctionRef_created_by_top_level_actor_must_terminate_when_their_parent_terminates` to `async/await`
- Changed `FunctionRef_created_by_non_top_level_actor_must_forward_messages` to `async/await`
- Changed `FunctionRef_created_by_non_top_level_actor_must_be_watchable` to `async/await`
- Changed `FunctionRef_created_by_non_top_level_actor_must_be_able_to_watch` to `async/await`
- Changed `FunctionRef_created_by_non_top_level_actor_must_terminate_when_their_parent_terminates` to `async/await`