### PR TITLE
Port `Akka.Tests.Actor` tests to `async/await` - `PipeToSupportSpec`

### DIFF
--- a/src/core/Akka.Tests/Actor/PatternSpec.cs
+++ b/src/core/Akka.Tests/Actor/PatternSpec.cs
@@ -78,7 +78,7 @@ namespace Akka.Tests.Actor
 
             //assert  
             Assert.True(stopped);
-            ExpectNoMsg(TimeSpan.Zero);
+            await ExpectNoMsgAsync(TimeSpan.Zero);
         }
 
         #region Actors

--- a/src/core/Akka.Tests/Actor/PatternSpec.cs
+++ b/src/core/Akka.Tests/Actor/PatternSpec.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
 using Akka.TestKit;
+using Akka.Tests.Util;
 using Xunit;
 
 namespace Akka.Tests.Actor
@@ -17,17 +18,17 @@ namespace Akka.Tests.Actor
     public class PatternSpec : AkkaSpec
     {
         [Fact]
-        public void GracefulStop_must_provide_Task_for_stopping_an_actor()
+        public async Task GracefulStop_must_provide_Task_for_stopping_an_actor()
         {
             //arrange
             var target = Sys.ActorOf<TargetActor>();
 
             //act
-            var result = target.GracefulStop(TimeSpan.FromSeconds(5));
-            result.Wait(TimeSpan.FromSeconds(6));
+            var result = await target.GracefulStop(TimeSpan.FromSeconds(5))
+                .AwaitWithTimeout(TimeSpan.FromSeconds(6));;
 
             //assert
-            Assert.True(result.Result);
+            Assert.True(result);
 
         }
 
@@ -46,7 +47,7 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
-        public void GracefulStop_must_complete_Task_with_TaskCanceledException_when_actor_not_terminated_within_timeout()
+        public async Task GracefulStop_must_complete_Task_with_TaskCanceledException_when_actor_not_terminated_within_timeout()
         {
             //arrange
             var target = Sys.ActorOf<TargetActor>();
@@ -56,11 +57,9 @@ namespace Akka.Tests.Actor
             target.Tell((latch, TimeSpan.FromSeconds(2)));
 
             //assert
-            XAssert.Throws<TaskCanceledException>(() =>
+            await Assert.ThrowsAsync<TaskCanceledException>(async () =>
             {
-                var task = target.GracefulStop(TimeSpan.FromMilliseconds(500));
-                task.Wait();
-                var result = task.Result;
+                await target.GracefulStop(TimeSpan.FromMilliseconds(50));
             });
             latch.Open();
 

--- a/src/core/Akka.Tests/Actor/PipeToSupportSpec.cs
+++ b/src/core/Akka.Tests/Actor/PipeToSupportSpec.cs
@@ -31,58 +31,58 @@ namespace Akka.Tests.Actor
         }
         
         [Fact]
-        public void Should_immediately_PipeTo_completed_Task()
+        public async Task Should_immediately_PipeTo_completed_Task()
         {
             var task = Task.FromResult("foo");
             task.PipeTo(TestActor);
-            ExpectMsg("foo");
+            await ExpectMsgAsync("foo");
         }
 
         [Fact]
-        public void Should_by_default_send_task_result_as_message()
+        public async Task Should_by_default_send_task_result_as_message()
         {
             _task.PipeTo(TestActor);
             _taskCompletionSource.SetResult("Hello");
-            ExpectMsg("Hello");
+            await ExpectMsgAsync("Hello");
         }
 
         [Fact]
-        public void Should_by_default_not_send_a_success_message_if_the_task_does_not_produce_a_result()
+        public async Task Should_by_default_not_send_a_success_message_if_the_task_does_not_produce_a_result()
         {
             _taskWithoutResult.PipeTo(TestActor);
             _taskCompletionSource.SetResult("Hello");
-            ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
         }
 
         [Fact]
-        public void Should_by_default_send_task_exception_as_status_failure_message()
+        public async Task Should_by_default_send_task_exception_as_status_failure_message()
         {
             _task.PipeTo(TestActor);
             _taskWithoutResult.PipeTo(TestActor);
             _taskCompletionSource.SetException(new Exception("Boom"));
-            ExpectMsg<Status.Failure>(x => x.Cause.Message == "Boom");
-            ExpectMsg<Status.Failure>(x => x.Cause.Message == "Boom");
+            await ExpectMsgAsync<Status.Failure>(x => x.Cause.Message == "Boom");
+            await ExpectMsgAsync<Status.Failure>(x => x.Cause.Message == "Boom");
         }
 
         [Fact]
-        public void Should_use_success_handling_to_transform_task_result()
+        public async Task Should_use_success_handling_to_transform_task_result()
         {
             _task.PipeTo(TestActor, success: x => "Hello " + x);
             _taskWithoutResult.PipeTo(TestActor, success: () => "Hello");
             _taskCompletionSource.SetResult("World");
-            var pipeTo = ReceiveN(2).Cast<string>().ToList();
+            var pipeTo = (await ReceiveNAsync(2, default).ToListAsync()).Cast<string>().ToList();
             pipeTo.Should().Contain("Hello");
             pipeTo.Should().Contain("Hello World");
         }
 
         [Fact]
-        public void Should_use_failure_handling_to_transform_task_exception()
+        public async Task Should_use_failure_handling_to_transform_task_exception()
         {
             _task.PipeTo(TestActor, failure: e => "Such a " + e.Message);
             _taskWithoutResult.PipeTo(TestActor, failure: e => "Such a " + e.Message);
             _taskCompletionSource.SetException(new Exception("failure..."));
-            ExpectMsg("Such a failure...");
-            ExpectMsg("Such a failure...");
+            await ExpectMsgAsync("Such a failure...");
+            await ExpectMsgAsync("Such a failure...");
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/PipeToSupportSpec.cs
+++ b/src/core/Akka.Tests/Actor/PipeToSupportSpec.cs
@@ -70,7 +70,7 @@ namespace Akka.Tests.Actor
             _task.PipeTo(TestActor, success: x => "Hello " + x);
             _taskWithoutResult.PipeTo(TestActor, success: () => "Hello");
             _taskCompletionSource.SetResult("World");
-            var pipeTo = (await ReceiveNAsync(2, default).ToListAsync()).Cast<string>().ToList();
+            var pipeTo = await ReceiveNAsync(2, default).Cast<string>().ToListAsync();
             pipeTo.Should().Contain("Hello");
             pipeTo.Should().Contain("Hello World");
         }


### PR DESCRIPTION
## Changes

### PipeToSupportSpec
- Changed `Should_immediately_PipeTo_completed_Task` to `async/await`
- Changed `Should_by_default_send_task_result_as_message` to `async/await`
- Changed `Should_by_default_not_send_a_success_message_if_the_task_does_not_produce_a_result` to `async/await`
- Changed `Should_by_default_send_task_exception_as_status_failure_message` to `async/await`
- Changed `Should_use_success_handling_to_transform_task_result` to `async/await`
- Changed `Should_use_failure_handling_to_transform_task_exception` to `async/await`