### PR TITLE
Port `Akka.Tests.Pattern` tests to `async/await` - `BackoffSupervisorSpec`

### DIFF
--- a/src/core/Akka.Tests/Pattern/BackoffSupervisorSpec.cs
+++ b/src/core/Akka.Tests/Pattern/BackoffSupervisorSpec.cs
@@ -378,6 +378,7 @@ namespace Akka.Tests.Pattern
             supervisor.Tell(BackoffSupervisor.GetRestartCount.Instance);
             (await ExpectMsgAsync<BackoffSupervisor.RestartCount>()).Count.Should().Be(1);
 
+            // This code looks suspicious, this might be the cause of the raciness
             var c2 = await WaitForChild();
             await AwaitAssertAsync(() => c2.ShouldNotBe(c1));
             Watch(c2);
@@ -429,6 +430,7 @@ namespace Akka.Tests.Pattern
                 supervisor.Tell(BackoffSupervisor.GetRestartCount.Instance);
                 (await ExpectMsgAsync<BackoffSupervisor.RestartCount>()).Count.Should().Be(1);
 
+                // This code looks suspicious, this might be the cause of the raciness
                 var c2 = await WaitForChild();
                 await AwaitAssertAsync(() => c2.ShouldNotBe(c1));
                 Watch(c2);


### PR DESCRIPTION
## Changes

### BackoffSupervisorSpec
- Changed `BackoffSupervisor_must_start_child_again_when_it_stops_when_using_Backoff_OnStop` to `async/await`
- Changed `BackoffSupervisor_must_forward_messages_to_the_child` to `async/await`
- Changed `BackoffSupervisor_must_support_custom_supervision_strategy` to `async/await`
- Changed `BackoffSupervisor_must_support_default_stopping_strategy_when_using_Backoff_OnStop` to `async/await`
- Changed `BackoffSupervisor_must_support_manual_reset` to `async/await`
- Changed `BackoffSupervisor_must_reply_to_sender_if_replyWhileStopped_is_specified` to `async/await`
- Changed `BackoffSupervisor_must_not_reply_to_sender_if_replyWhileStopped_is_not_specified` to `async/await`
- Changed `BackoffSupervisor_must_stop_restarting_the_child_after_reaching_maxNrOfRetries_limit_using_BackOff_OnStop` to `async/await`
- Changed `BackoffSupervisor_must_stop_restarting_the_child_after_reaching_maxNrOfRetries_limit_using_BackOff_OnFailure` to `async/await`
- Changed `BackoffSupervisor_must_stop_restarting_the_child_if_final_stop_message_received_using_BackOff_OnStop` to `async/await`
- Changed `BackoffSupervisor_must_not_stop_when_final_stop_message_has_not_been_received` to `async/await`