### PR TITLE
Port `Akka.Tests.Routing` tests to `async/await` - `RandomSpec`

### DIFF
--- a/src/core/Akka.Tests/Routing/RandomSpec.cs
+++ b/src/core/Akka.Tests/Routing/RandomSpec.cs
@@ -133,13 +133,13 @@ namespace Akka.Tests.Routing
             }
         }
 
-        private int RouteeSize(IActorRef router)
+        private async Task<int> RouteeSize(IActorRef router)
         {
-            return router.Ask<Routees>(new GetRoutees()).Result.Members.Count();
+            return (await router.Ask<Routees>(new GetRoutees())).Members.Count();
         }
 
         [Fact]
-        public void Random_pool_must_be_able_to_shut_down_its_instance()
+        public async Task Random_pool_must_be_able_to_shut_down_its_instance()
         {
             const int routeeCount = 7;
             var testLatch = new TestLatch(routeeCount);
@@ -153,10 +153,10 @@ namespace Akka.Tests.Routing
             actor.Tell("hello");
             actor.Tell("hello");
 
-            Within(TimeSpan.FromSeconds(2), () => {
+            await WithinAsync(TimeSpan.FromSeconds(2), async() => {
                 for (int i = 1; i <= 5; i++)
                 {
-                    ExpectMsg("world");
+                    await ExpectMsgAsync("world");
                 }
             });
 
@@ -218,22 +218,22 @@ namespace Akka.Tests.Routing
         }
 
         [Fact]
-        public void Random_pool_must_be_controlled_with_management_messages()
+        public async Task Random_pool_must_be_controlled_with_management_messages()
         {
             IActorRef actor = Sys.ActorOf(new RandomPool(3)
                 .Props(Props.Create<EmptyBehaviorActor>()), "random-managed");
 
-            RouteeSize(actor).Should().Be(3);
+            (await RouteeSize(actor)).Should().Be(3);
             actor.Tell(new AdjustPoolSize(4));
-            RouteeSize(actor).Should().Be(7);
+            (await RouteeSize(actor)).Should().Be(7);
             actor.Tell(new AdjustPoolSize(-2));
-            RouteeSize(actor).Should().Be(5);
+            (await RouteeSize(actor)).Should().Be(5);
 
             var other = new ActorSelectionRoutee(Sys.ActorSelection("/user/other"));
             actor.Tell(new AddRoutee(other));
-            RouteeSize(actor).Should().Be(6);
+            (await RouteeSize(actor)).Should().Be(6);
             actor.Tell(new RemoveRoutee(other));
-            RouteeSize(actor).Should().Be(5);
+            (await RouteeSize(actor)).Should().Be(5);
         }
 
         [Fact]
@@ -302,7 +302,7 @@ namespace Akka.Tests.Routing
 
             Watch(actor);
             actor.Tell(new Broadcast("end"));
-            ExpectTerminated(actor);
+            await ExpectTerminatedAsync(actor);
 
             replies.Values.ForEach(c => c.Should().BeGreaterThan(0));
             replies.Values.Any(c => c != iterationCount).ShouldBeTrue();


### PR DESCRIPTION
## Changes

### RandomSpec
- Changed `Random_pool_must_be_controlled_with_management_messages` to `async/await`
- Changed `Random_pool_must_be_able_to_shut_down_its_instance` to `async/await`