### PR TITLE
Port `Akka.Tests.Routing` tests to `async/await` - `ScatterGatherFirstCompletedSpec`

### DIFF
--- a/src/core/Akka.Tests/Routing/ScatterGatherFirstCompletedSpec.cs
+++ b/src/core/Akka.Tests/Routing/ScatterGatherFirstCompletedSpec.cs
@@ -68,10 +68,10 @@ namespace Akka.Tests.Routing
                 {
 
                 });
-
-                ReceiveAny(x =>
+                
+                ReceiveAnyAsync(async x =>
                 {
-                    Thread.Sleep(100 * _id);
+                    await Task.Delay(100 * _id);
                     Sender.Tell(_id);
                 });
             }
@@ -122,19 +122,19 @@ namespace Akka.Tests.Routing
         }
 
         [Fact]
-        public void Scatter_gather_pool_must_without_routees_should_reply_immediately()
+        public async Task Scatter_gather_pool_must_without_routees_should_reply_immediately()
         {
             var probe = CreateTestProbe();
             var routedActor = Sys.ActorOf(new ScatterGatherFirstCompletedPool(0, TimeSpan.FromSeconds(5)).Props(Props.Empty));
             routedActor.Tell("hello", probe.Ref);
-            var message = probe.ExpectMsg<Status.Failure>(2.Seconds());
+            var message = await probe.ExpectMsgAsync<Status.Failure>(2.Seconds());
             message.Should().NotBeNull();
             message.Cause.Should().BeOfType<AskTimeoutException>();
         }
 
         // Resolved https://github.com/akkadotnet/akka.net/issues/1718
         [Fact]
-        public void Scatter_gather_group_must_only_return_one_response()
+        public async Task Scatter_gather_group_must_only_return_one_response()
         {
             var actor1 = Sys.ActorOf(Props.Create(() => new StopActor(1, null)));
             var actor2 = Sys.ActorOf(Props.Create(() => new StopActor(14, null)));
@@ -144,8 +144,8 @@ namespace Akka.Tests.Routing
 
             routedActor.Tell(0);
 
-            ExpectMsg<int>();
-            ExpectNoMsg();
+            await ExpectMsgAsync<int>();
+            await ExpectNoMsgAsync();
         }
 
         // Resolved https://github.com/akkadotnet/akka.net/issues/1718


### PR DESCRIPTION
## Changes

### ScatterGatherFirstCompletedSpec
- Changed `Scatter_gather_pool_must_without_routees_should_reply_immediately` to `async/await`
- Changed `Scatter_gather_group_must_only_return_one_response` to `async/await`