### PR TITLE
Change the failure log inside `AllEventPublisher` from Debug to Error

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Query.Sql/AllEventsPublisher.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.Sql/AllEventsPublisher.cs
@@ -127,7 +127,7 @@ namespace Akka.Persistence.Query.Sql
                     ReceiveRecoverySuccess(success.HighestSequenceNr);
                     return true;
                 case EventReplayFailure failure:
-                    Log.Debug("event replay failed, due to [{0}]", failure.Cause.Message);
+                    Log.Error(failure.Cause, "event replay failed, due to [{0}]", failure.Cause.Message);
                     Buffer.DeliverBuffer(TotalDemand);
                     OnErrorThenStop(failure.Cause);
                     return true;


### PR DESCRIPTION
Closes #5834

This doesn't really fix a bug. We're just making sure that an error is logged even when nothing is catching the stream failure exception.