### PR TITLE
v1.4.37 Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,17 @@
+#### 1.4.37 April 14 2022 ####
+Akka.NET v1.4.37 is a minor release that contains some minor bug fixes.
+
+* [Persistence.Query: Change AllEvents query failure log severity from Debug to Error](https://github.com/akkadotnet/akka.net/pull/5835)
+* [Coordination: Harden LeaseProvider instance Activator exception handling](https://github.com/akkadotnet/akka.net/pull/5838)
+* [Akka: Make ActorSystemImpl.Abort skip the CoordinatedShutdown check](https://github.com/akkadotnet/akka.net/pull/5839)
+
+If you want to see the [full set of changes made in Akka.NET v1.4.37, click here](https://github.com/akkadotnet/akka.net/milestone/68?closed=1).
+
+| COMMITS | LOC+ | LOC- | AUTHOR              |
+|---------|------|------|---------------------|
+| 3       | 15   | 4    | Gregorius Soedharmo |
+| 1       | 2    | 2    | dependabot[bot]     |
+
 #### 1.4.36 April 4 2022 ####
 Akka.NET v1.4.36 is a minor release that contains some bug fixes. Most of the changes have been aimed at improving our web documentation and code cleanup to modernize some of our code.
 

--- a/src/contrib/persistence/Akka.Persistence.Query.Sql/AllEventsPublisher.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.Sql/AllEventsPublisher.cs
@@ -127,7 +127,7 @@ namespace Akka.Persistence.Query.Sql
                     ReceiveRecoverySuccess(success.HighestSequenceNr);
                     return true;
                 case EventReplayFailure failure:
-                    Log.Debug("event replay failed, due to [{0}]", failure.Cause.Message);
+                    Log.Error(failure.Cause, "event replay failed, due to [{0}]", failure.Cause.Message);
                     Buffer.DeliverBuffer(TotalDemand);
                     OnErrorThenStop(failure.Cause);
                     return true;

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Akka.Persistence.Sqlite.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Akka.Persistence.Sqlite.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SQLite" Version="5.0.11" />
+    <PackageReference Include="Microsoft.Data.SQLite" Version="6.0.4" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/core/Akka.Coordination/LeaseProvider.cs
+++ b/src/core/Akka.Coordination/LeaseProvider.cs
@@ -141,12 +141,12 @@ namespace Akka.Coordination
                     {
                         return (Lease)Activator.CreateInstance(leaseType, settings, _system);
                     }
-                    catch
+                    catch(MissingMethodException)
                     {
                         return (Lease)Activator.CreateInstance(leaseType, settings);
                     }
                 }
-                catch (Exception ex)
+                catch (MissingMethodException ex)
                 {
                     Log.Error(
                       ex,
@@ -156,6 +156,17 @@ namespace Akka.Coordination
                       settings.LeaseName,
                       configPath,
                       leaseType);
+
+                    throw;
+                }
+                catch(Exception ex)
+                {
+                    Log.Error(
+                        ex,
+                        "Failed to instantiate lease class [{2}] for leaseName [{0}], configPath [{1}].",
+                        settings.LeaseName,
+                        configPath,
+                        leaseType);
 
                     throw;
                 }

--- a/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
@@ -199,7 +199,7 @@ namespace Akka.Actor.Internal
         public override void Abort()
         {
             Aborting = true;
-            Terminate();
+            FinalTerminate(); // Skip CoordinatedShutdown check and aggressively shutdown the ActorSystem
         }
 
         /// <summary>Starts this system</summary>

--- a/src/examples/Akka.Persistence.Custom/Akka.Persistence.Custom.csproj
+++ b/src/examples/Akka.Persistence.Custom/Akka.Persistence.Custom.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Data.SQLite" Version="5.0.11" />
+        <PackageReference Include="Microsoft.Data.SQLite" Version="6.0.4" />
     </ItemGroup>
     
     <ItemGroup>


### PR DESCRIPTION
#### 1.4.37 April 14 2022 ####
Akka.NET v1.4.37 is a minor release that contains some minor bug fixes.

* [Persistence.Query: Change AllEvents query failure log severity from Debug to Error](https://github.com/akkadotnet/akka.net/pull/5835)
* [Coordination: Harden LeaseProvider instance Activator exception handling](https://github.com/akkadotnet/akka.net/pull/5838)
* [Akka: Make ActorSystemImpl.Abort skip the CoordinatedShutdown check](https://github.com/akkadotnet/akka.net/pull/5839)

If you want to see the [full set of changes made in Akka.NET v1.4.37, click here](https://github.com/akkadotnet/akka.net/milestone/68?closed=1).

| COMMITS | LOC+ | LOC- | AUTHOR              |
|---------|------|------|---------------------|
| 3       | 15   | 4    | Gregorius Soedharmo |
| 1       | 2    | 2    | dependabot[bot]     |
