### PR TITLE
Convert Xunit2.TestKit and AkkaSpec from IDisposable to IAsyncLifetime

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
@@ -96,10 +96,11 @@ namespace Akka.Cluster.Sharding.Tests
             });
         }
 
-        protected override void BeforeTermination()
+        protected override async Task AfterAllAsync()
         {
-            Shutdown(_sys1);
-            Shutdown(_sys2);
+            await base.AfterAllAsync();
+            await ShutdownAsync(_sys1);
+            await ShutdownAsync(_sys2);
         }
 
         /// <summary>

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonLeavingSpeedSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonLeavingSpeedSpec.cs
@@ -160,10 +160,11 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             }
         }
 
-        protected override void AfterTermination()
+        protected override async Task AfterAllAsync()
         {
+            await base.AfterAllAsync();
             foreach (var s in _systems)
-                Shutdown(s);
+                await ShutdownAsync(s);
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart2Spec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart2Spec.cs
@@ -125,13 +125,14 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             });
         }
 
-        protected override void AfterTermination()
+        protected override async Task AfterAllAsync()
         {
-            Shutdown(_sys1);
-            Shutdown(_sys2);
-            Shutdown(_sys3);
+            await base.AfterAllAsync();
+            await ShutdownAsync(_sys1);
+            await ShutdownAsync(_sys2);
+            await ShutdownAsync(_sys3);
             if (_sys4 != null)
-                Shutdown(_sys4);
+                await ShutdownAsync(_sys4);
         }
 
         public class Singleton : ReceiveActor

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestartSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestartSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Cluster.Tools.Singleton;
 using Akka.Configuration;
@@ -128,12 +129,13 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             });
         }
 
-        protected override void AfterTermination()
+        protected override async Task AfterAllAsync()
         {
-            Shutdown(_sys1);
-            Shutdown(_sys2);
+            await base.AfterAllAsync();
+            await ShutdownAsync(_sys1);
+            await ShutdownAsync(_sys2);
             if(_sys3 != null)
-                Shutdown(_sys3);
+                await ShutdownAsync(_sys3);
         }
 
         /// <summary>

--- a/src/contrib/cluster/Akka.DistributedData.Tests/ReplicatorSpecs.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/ReplicatorSpecs.cs
@@ -574,12 +574,12 @@ namespace Akka.DistributedData.Tests
             });
         }
 
-
-        protected override void BeforeTermination()
+        protected override async Task AfterAllAsync()
         {
-            Shutdown(_sys1);
-            Shutdown(_sys2);
-            Shutdown(_sys3);
+            await base.AfterAllAsync();
+            await ShutdownAsync(_sys1);
+            await ShutdownAsync(_sys2);
+            await ShutdownAsync(_sys3);
             GC.Collect();
         }
 

--- a/src/contrib/testkits/Akka.TestKit.Xunit2/TestKit.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit2/TestKit.cs
@@ -6,11 +6,13 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Setup;
 using Akka.Configuration;
 using Akka.Event;
 using Akka.TestKit.Xunit2.Internals;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Akka.TestKit.Xunit2
@@ -19,10 +21,8 @@ namespace Akka.TestKit.Xunit2
     /// This class represents an Akka.NET TestKit that uses <a href="https://xunit.github.io/">xUnit</a>
     /// as its testing framework.
     /// </summary>
-    public class TestKit : TestKitBase , IDisposable
+    public class TestKit : TestKitBase, IAsyncLifetime
     {
-        private bool _isDisposed; //Automatically initialized to false;
-
         /// <summary>
         /// The provider used to write test output.
         /// </summary>
@@ -104,14 +104,13 @@ namespace Akka.TestKit.Xunit2
         /// This method is called when a test ends.
         /// 
         /// <remarks>
-        /// If you override this, then make sure you either call base.AfterTest() or
-        /// <see cref="TestKitBase.Shutdown(System.Nullable{System.TimeSpan},bool)">TestKitBase.Shutdown</see>
+        /// If you override this, then make sure you either call base.AfterAllAsync()
         /// to shut down the system. Otherwise a memory leak will occur.
         /// </remarks>
         /// </summary>
-        protected virtual void AfterAll()
+        protected virtual async Task AfterAllAsync()
         {
-            Shutdown();
+            await ShutdownAsync();
         }
 
         /// <summary>
@@ -128,42 +127,14 @@ namespace Akka.TestKit.Xunit2
             }
         }
 
-       
-        public void Dispose()
+        public virtual Task InitializeAsync()
         {
-            Dispose(true);
-            //Take this object off the finalization queue and prevent finalization code for this object
-            //from executing a second time.
-            GC.SuppressFinalize(this);
+            return Task.CompletedTask;
         }
 
-        /// <summary>
-        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
-        /// </summary>
-        /// <param name="disposing">
-        /// if set to <c>true</c> the method has been called directly or indirectly by a  user's code.
-        /// Managed and unmanaged resources will be disposed.<br /> if set to <c>false</c> the method
-        /// has been called by the runtime from inside the finalizer and only unmanaged resources can
-        ///  be disposed.
-        /// </param>
-        protected virtual void Dispose(bool disposing)
+        public virtual async Task DisposeAsync()
         {
-            // If disposing equals false, the method has been called by the
-            // runtime from inside the finalizer and you should not reference
-            // other objects. Only unmanaged resources can be disposed.
-
-            try
-            {
-                //Make sure Dispose does not get called more than once, by checking the disposed field
-                if(!_isDisposed && disposing)
-                {
-                    AfterAll();
-                }
-                _isDisposed = true;
-            }
-            finally
-            {
-            }
+            await AfterAllAsync();
         }
     }
 }

--- a/src/core/Akka.Cluster.Tests/ActorRefIgnoreSerializationSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ActorRefIgnoreSerializationSpec.cs
@@ -42,12 +42,11 @@ namespace Akka.Cluster.Tests
             system2 = ActorSystem.Create("sys2", Config);
         }
 
-
-        protected override void AfterAll()
+        protected override async Task AfterAllAsync()
         {
-            base.AfterAll();
-            system1.Terminate();
-            system2.Terminate();
+            await base.AfterAllAsync();
+            await ShutdownAsync(system1);
+            await ShutdownAsync(system2);
         }
 
         [Fact]

--- a/src/core/Akka.Cluster.Tests/ShutdownAfterJoinSeedNodesSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ShutdownAfterJoinSeedNodesSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
@@ -37,12 +38,12 @@ namespace Akka.Cluster.Tests
             _ordinary1 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
         }
 
-        protected override void AfterTermination()
+        protected override async Task AfterAllAsync()
         {
-            base.AfterTermination();
-            Shutdown(_seed1);
-            Shutdown(_seed2);
-            Shutdown(_ordinary1);
+            await base.AfterAllAsync();
+            await ShutdownAsync(_seed1);
+            await ShutdownAsync(_seed2);
+            await ShutdownAsync(_ordinary1);
         }
 
         [Fact]

--- a/src/core/Akka.Persistence.TCK/Query/CurrentEventsByPersistenceIdSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Query/CurrentEventsByPersistenceIdSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Persistence.Query;
@@ -203,10 +204,10 @@ namespace Akka.Persistence.TCK.Query
             return Sys.ActorOf(Query.TestActor.Props(persistenceId));
         }
 
-        protected override void Dispose(bool disposing)
+        public override Task DisposeAsync()
         {
             Materializer.Dispose();
-            base.Dispose(disposing);
+            return base.DisposeAsync();
         }
     }
 }

--- a/src/core/Akka.Persistence.TCK/Query/CurrentPersistenceIdsSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Query/CurrentPersistenceIdsSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Persistence.Query;
@@ -105,10 +106,10 @@ namespace Akka.Persistence.TCK.Query
             return pref;
         }
 
-        protected override void Dispose(bool disposing)
+        public override Task DisposeAsync()
         {
             Materializer.Dispose();
-            base.Dispose(disposing);
+            return base.DisposeAsync();
         }
     }
 }

--- a/src/core/Akka.Persistence.TCK/Query/EventsByPersistenceIdSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Query/EventsByPersistenceIdSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Persistence.Query;
@@ -126,10 +127,10 @@ namespace Akka.Persistence.TCK.Query
             return Sys.ActorOf(Query.TestActor.Props(persistenceId));
         }
 
-        protected override void Dispose(bool disposing)
+        public override Task DisposeAsync()
         {
             Materializer.Dispose();
-            base.Dispose(disposing);
+            return base.DisposeAsync();
         }
     }
 }

--- a/src/core/Akka.Persistence.TCK/Query/PersistenceIdsSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Query/PersistenceIdsSpec.cs
@@ -247,11 +247,10 @@ namespace Akka.Persistence.TCK.Query
             return pref;
         }
 
-
-        protected override void Dispose(bool disposing)
+        public override Task DisposeAsync()
         {
             Materializer.Dispose();
-            base.Dispose(disposing);
+            return base.DisposeAsync();
         }
     }
 }

--- a/src/core/Akka.Persistence.Tests/PersistenceSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistenceSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Configuration;
 using Akka.TestKit;
 using Akka.Util.Internal;
@@ -61,9 +62,9 @@ namespace Akka.Persistence.Tests
         public string NamePrefix { get { return Sys.Name; } }
         public string Name { get { return _name; } }
 
-        protected override void AfterAll()
+        protected override async Task AfterAllAsync()
         {
-            base.AfterAll();
+            await base.AfterAllAsync();
             Clean.Dispose();
         }
 

--- a/src/core/Akka.Persistence.Tests/Serialization/MessageSerializerRemotingSpec.cs
+++ b/src/core/Akka.Persistence.Tests/Serialization/MessageSerializerRemotingSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
@@ -176,10 +177,10 @@ akka {
             return ((ExtendedActorSystem) system).Provider.DefaultAddress;
         }
 
-        protected override void AfterTermination()
+        protected override async Task AfterAllAsync()
         {
-            _remoteSystem.Terminate().Wait(TimeSpan.FromSeconds(2));
-            base.AfterTermination();
+            await base.AfterAllAsync();
+            await ShutdownAsync(_remoteSystem);
         }
 
         [Fact]

--- a/src/core/Akka.Persistence.Tests/SnapshotDirectoryFailureSpec.cs
+++ b/src/core/Akka.Persistence.Tests/SnapshotDirectoryFailureSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System.IO;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Xunit;
 
@@ -66,10 +67,10 @@ namespace Akka.Persistence.Tests
             using (_file.Create()) {}
         }
 
-        protected override void AfterTermination()
+        protected override async Task AfterTerminationAsync()
         {
             _file.Delete();
-            base.AfterTermination();
+            await base.AfterTerminationAsync();
         }
 
         [Fact]

--- a/src/core/Akka.Remote.Tests/RemoteMetricsSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteMetricsSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Event;
@@ -50,10 +51,9 @@ namespace Akka.Remote.Tests
             Sys.EventStream.Subscribe(listener, typeof (Info));
         }
 
-
-        protected override void AfterTermination()
+        protected override async Task AfterTerminationAsync()
         {
-            Shutdown(_client);
+            await ShutdownAsync(_client);
         }
 
 

--- a/src/core/Akka.Remote.Tests/RemoteRouterSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteRouterSpec.cs
@@ -132,9 +132,9 @@ namespace Akka.Remote.Tests
                 .Replace("${port}", port.ToString()));
         }
 
-        protected override void AfterTermination()
+        protected override async Task AfterTerminationAsync()
         {
-            Shutdown(masterSystem);
+            await ShutdownAsync(masterSystem);
         }
 
         private IEnumerable<ActorPath> CollectRouteePaths(TestProbe probe, IActorRef router, int n)

--- a/src/core/Akka.Remote.Tests/RemoteWatcherSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteWatcherSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
 using Akka.Util.Internal;
@@ -185,11 +186,12 @@ namespace Akka.Remote.Tests
             _heartbeatRspB = new RemoteWatcher.HeartbeatRsp(remoteAddressUid);
         }
 
-        protected override void AfterAll()
+        protected override async Task AfterAllAsync()
         {
-            Shutdown(_remoteSystem);
-            base.AfterAll();
+            await ShutdownAsync(_remoteSystem);
+            await base.AfterAllAsync();
         }
+
         readonly ActorSystem _remoteSystem;
         readonly Address _remoteAddress;
         readonly RemoteWatcher.HeartbeatRsp _heartbeatRspB;

--- a/src/core/Akka.Remote.Tests/RemotingSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemotingSpec.cs
@@ -148,12 +148,11 @@ namespace Akka.Remote.Tests
 
         private TimeSpan DefaultTimeout => Dilated(TestKitSettings.DefaultTimeout);
 
-
-        protected override void AfterAll()
+        protected override async Task AfterAllAsync()
         {
-            Shutdown(_remoteSystem, RemainingOrDefault);
+            await ShutdownAsync(_remoteSystem);
             AssociationRegistry.Clear();
-            base.AfterAll();
+            await base.AfterAllAsync();
         }
 
 

--- a/src/core/Akka.Remote.Tests/Serialization/SerializationTransportInformationSpec.cs
+++ b/src/core/Akka.Remote.Tests/Serialization/SerializationTransportInformationSpec.cs
@@ -179,10 +179,10 @@ namespace Akka.Remote.Tests.Serialization
             ExpectMsg(echo);
         }
 
-        protected override void AfterAll()
+        protected override async Task AfterAllAsync()
         {
-            base.AfterAll();
-            Shutdown(System2, verifySystemShutdown: true);
+            await ShutdownAsync(System2, verifySystemShutdown: true);
+            await base.AfterAllAsync();
         }
     }
 

--- a/src/core/Akka.Remote.Tests/TransientSerializationErrorSpec.cs
+++ b/src/core/Akka.Remote.Tests/TransientSerializationErrorSpec.cs
@@ -12,6 +12,7 @@ using Akka.TestKit;
 using Xunit;
 using Akka.Serialization;
 using System.Runtime.Serialization;
+using System.Threading.Tasks;
 
 namespace Akka.Remote.Tests
 {
@@ -167,9 +168,9 @@ namespace Akka.Remote.Tests
             ";
         }
 
-        protected override void AfterTermination()
+        protected override async Task AfterTerminationAsync()
         {
-            Shutdown(system2);
+            await ShutdownAsync(system2);
         }
 
 

--- a/src/core/Akka.Remote.Tests/Transport/AkkaProtocolStressTest.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaProtocolStressTest.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Remote.Transport;
@@ -209,20 +210,21 @@ namespace Akka.Remote.Tests.Transport
 
         #region Cleanup
 
-        protected override void BeforeTermination()
+        protected override async Task BeforeTerminationAsync()
         {
             EventFilter.Warning(start: "received dead letter").Mute();
             EventFilter.Warning(new Regex("received dead letter.*(InboundPayload|Disassociate)")).Mute();
             systemB.EventStream.Publish(new Mute(new WarningFilter(new RegexMatcher(new Regex("received dead letter.*(InboundPayload|Disassociate)"))),
                 new ErrorFilter(typeof(EndpointException)),
                 new ErrorFilter(new StartsWithString("AssociationError"))));
-            base.BeforeTermination();
+
+            await base.BeforeTerminationAsync();
         }
 
-        protected override void AfterTermination()
+        protected override async Task AfterTerminationAsync()
         {
-            Shutdown(systemB);
-            base.AfterTermination();
+            await ShutdownAsync(systemB);
+            await base.AfterTerminationAsync();
         }
 
         #endregion

--- a/src/core/Akka.Remote.Tests/Transport/DotNettySslSupportSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettySslSupportSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
@@ -180,15 +181,10 @@ namespace Akka.Remote.Tests.Transport
 
         #region helper classes / methods
 
-
-        protected override void Dispose(bool disposing)
+        protected override async Task AfterAllAsync()
         {
-            base.Dispose(disposing);
-            if (disposing)
-            {
-                Shutdown(sys2, TimeSpan.FromSeconds(3));
-            }
-
+            await ShutdownAsync(sys2, TimeSpan.FromSeconds(3));
+            await base.AfterAllAsync();
         }
 
         private void InstallCert()

--- a/src/core/Akka.Remote.Tests/Transport/ThrottlerTransportAdapterSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/ThrottlerTransportAdapterSpec.cs
@@ -261,20 +261,20 @@ namespace Akka.Remote.Tests.Transport
 
         #region Cleanup 
 
-        protected override void BeforeTermination()
+        protected override async Task BeforeTerminationAsync()
         {
             EventFilter.Warning(start: "received dead letter").Mute();
             EventFilter.Warning(new Regex("received dead letter.*(InboundPayload|Disassociate)")).Mute();
             _systemB.EventStream.Publish(new Mute(new WarningFilter(new RegexMatcher(new Regex("received dead letter.*(InboundPayload|Disassociate)"))), 
                 new ErrorFilter(typeof(EndpointException)),
                 new ErrorFilter(new StartsWithString("AssociationError"))));
-            base.BeforeTermination();
+            await base.BeforeTerminationAsync();
         }
 
-        protected override void AfterTermination()
+        protected override async Task AfterTerminationAsync()
         {
-            Shutdown(_systemB);
-            base.AfterTermination();
+            await ShutdownAsync(_systemB);
+            await base.AfterTerminationAsync();
         }
 
         #endregion

--- a/src/core/Akka.Remote.Tests/UntrustedSpec.cs
+++ b/src/core/Akka.Remote.Tests/UntrustedSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Event;
@@ -71,9 +72,9 @@ namespace Akka.Remote.Tests
         }
 
 
-        protected override void AfterTermination()
+        protected override async Task AfterTerminationAsync()
         {
-            Shutdown(_client);
+            await ShutdownAsync(_client);
         }
 
 

--- a/src/core/Akka.Streams.Tests/Dsl/StreamRefsSerializerSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/StreamRefsSerializerSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Internal;
 using Akka.Configuration;
@@ -169,11 +170,16 @@ namespace Akka.Streams.Tests
         private readonly TestProbe _probe;
         private readonly IActorRef _remoteActor;
 
-        protected override void BeforeTermination()
+        protected override async Task BeforeTerminationAsync()
         {
-            base.BeforeTermination();
-            RemoteSystem.Dispose();
+            await base.BeforeTerminationAsync();
             Materializer.Dispose();
+        }
+
+        protected override async Task AfterAllAsync()
+        {
+            await base.AfterAllAsync();
+            await ShutdownAsync(RemoteSystem);
         }
 
         [Fact]

--- a/src/core/Akka.Streams.Tests/Dsl/StreamRefsSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/StreamRefsSpec.cs
@@ -16,6 +16,7 @@ using FluentAssertions;
 using System;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Abstractions;
@@ -222,11 +223,16 @@ namespace Akka.Streams.Tests
         private readonly TestProbe _probe;
         private readonly IActorRef _remoteActor;
 
-        protected override void BeforeTermination()
+        protected override async Task BeforeTerminationAsync()
         {
-            base.BeforeTermination();
-            RemoteSystem.Dispose();
+            await base.BeforeTerminationAsync();
             Materializer.Dispose();
+        }
+
+        protected override async Task AfterAllAsync()
+        {
+            await base.AfterAllAsync();
+            await ShutdownAsync(RemoteSystem);
         }
 
         [Fact]

--- a/src/core/Akka.Streams.Tests/Dsl/UnfoldResourceSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/UnfoldResourceSourceSpec.cs
@@ -9,6 +9,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.IO;
 using Akka.Streams.Dsl;
@@ -308,9 +309,9 @@ namespace Akka.Streams.Tests.Dsl
             closedCounter.Current.Should().Be(1);
         }
 
-        protected override void AfterAll()
+        protected override async Task AfterAllAsync()
         {
-            base.AfterAll();
+            await base.AfterAllAsync();
             _manyLinesFile.Delete();
         }
     }

--- a/src/core/Akka.Streams.Tests/IO/FileSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/FileSourceSpec.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.IO;
 using Akka.Streams.Dsl;
@@ -364,14 +365,15 @@ namespace Akka.Streams.Tests.IO
             return f;
         }
 
-        protected override void AfterAll()
+        protected override async Task AfterAllAsync()
         {
-            base.AfterAll();
-
+            await base.AfterAllAsync();
+            
             //give the system enough time to shutdown and release the file handle
-            Thread.Sleep(500);
+            await Task.Delay(500);
             _manyLinesPath?.Delete();
             _testFilePath?.Delete();
         }
+
     }
 }

--- a/src/core/Akka.TestKit.Tests/TestActorRefTests/ReplyActor.cs
+++ b/src/core/Akka.TestKit.Tests/TestActorRefTests/ReplyActor.cs
@@ -5,7 +5,9 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Threading;
 using Akka.Actor;
+using Akka.Util;
 
 namespace Akka.TestKit.Tests.TestActorRefTests
 {
@@ -15,16 +17,15 @@ namespace Akka.TestKit.Tests.TestActorRefTests
 
         protected override bool ReceiveMessage(object message)
         {
-            var strMessage = message as string;
-            switch(strMessage)
+            switch((string)message)
             {
                 case "complexRequest":
                     _replyTo = Sender;
-                    var worker = new TestActorRef<WorkerActor>(System, Props.Create<WorkerActor>());
+                    var worker = new TestActorRef<WorkerActor>(System, Props.Create(() => new WorkerActor(ParentThread, OtherThread)));
                     worker.Tell("work");
                     return true;
                 case "complexRequest2":
-                    var worker2 = new TestActorRef<WorkerActor>(System, Props.Create<WorkerActor>());
+                    var worker2 = new TestActorRef<WorkerActor>(System, Props.Create(() => new WorkerActor(ParentThread, OtherThread)));
                     worker2.Tell(Sender, Self);
                     return true;
                 case "workDone":
@@ -35,6 +36,10 @@ namespace Akka.TestKit.Tests.TestActorRefTests
                     return true;
             }
             return false;
+        }
+
+        public ReplyActor(Thread parentThread, AtomicReference<Thread> otherThread) : base(parentThread, otherThread)
+        {
         }
     }
 }

--- a/src/core/Akka.TestKit.Tests/TestActorRefTests/SenderActor.cs
+++ b/src/core/Akka.TestKit.Tests/TestActorRefTests/SenderActor.cs
@@ -5,17 +5,22 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Threading;
 using Akka.Actor;
+using Akka.Util;
+using Akka.Util.Internal;
 
 namespace Akka.TestKit.Tests.TestActorRefTests
 {
     public class SenderActor : TActorBase
     {
+        private readonly AtomicCounter _counter;
         private readonly IActorRef _replyActor;
 
-        public SenderActor(IActorRef replyActor)
+        public SenderActor(IActorRef replyActor, AtomicCounter counter, Thread parentThread, AtomicReference<Thread> otherThread) : base(parentThread, otherThread)
         {
             _replyActor = replyActor;
+            _counter = counter;
         }
 
         protected override bool ReceiveMessage(object message)
@@ -33,10 +38,10 @@ namespace Akka.TestKit.Tests.TestActorRefTests
                     _replyActor.Tell("simpleRequest", Self);
                     return true;
                 case "complexReply":
-                    TestActorRefSpec.Counter--;
+                    _counter.Decrement();
                     return true;
                 case "simpleReply":
-                    TestActorRefSpec.Counter--;
+                    _counter.Decrement();
                     return true;
             }
             return false;

--- a/src/core/Akka.TestKit.Tests/TestActorRefTests/TActorBase.cs
+++ b/src/core/Akka.TestKit.Tests/TestActorRefTests/TActorBase.cs
@@ -7,17 +7,27 @@
 
 using System.Threading;
 using Akka.Actor;
+using Akka.Util;
 
 namespace Akka.TestKit.Tests.TestActorRefTests
 {
     // ReSharper disable once InconsistentNaming
     public abstract class TActorBase : ActorBase
     {
+        protected readonly Thread ParentThread;
+        protected readonly AtomicReference<Thread> OtherThread;
+
+        protected TActorBase(Thread parentThread, AtomicReference<Thread> otherThread)
+        {
+            ParentThread = parentThread;
+            OtherThread = otherThread;
+        }
+
         protected sealed override bool Receive(object message)
         {
             var currentThread = Thread.CurrentThread;
-            if(currentThread != TestActorRefSpec.Thread)
-                TestActorRefSpec.OtherThread = currentThread;
+            if (currentThread != ParentThread)
+                OtherThread.GetAndSet(currentThread);
             return ReceiveMessage(message);
         }
 

--- a/src/core/Akka.TestKit.Tests/TestActorRefTests/WorkerActor.cs
+++ b/src/core/Akka.TestKit.Tests/TestActorRefTests/WorkerActor.cs
@@ -5,12 +5,18 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Threading;
 using Akka.Actor;
+using Akka.Util;
 
 namespace Akka.TestKit.Tests.TestActorRefTests
 {
     public class WorkerActor : TActorBase
     {
+        public WorkerActor(Thread parentThread, AtomicReference<Thread> otherThread) : base(parentThread, otherThread)
+        {
+        }
+        
         protected override bool ReceiveMessage(object message)
         {
             if((message as string) == "work")

--- a/src/core/Akka.TestKit.Tests/TestEventListenerTests/EventFilterTestBase.cs
+++ b/src/core/Akka.TestKit.Tests/TestEventListenerTests/EventFilterTestBase.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Threading.Tasks;
 using Akka.Event;
 using Akka.Testkit.Tests.TestEventListenerTests;
 
@@ -31,14 +32,14 @@ namespace Akka.TestKit.Tests.Xunit2.TestEventListenerTests
 
         protected abstract void SendRawLogEventMessage(object message);
 
-        protected override void AfterAll()
+        protected override Task AfterAllAsync()
         {
             //After every test we make sure no uncatched messages have been logged
             if(TestSuccessful)
             {
                 EnsureNoMoreLoggedMessages();
             }
-            base.AfterAll();
+            return base.AfterAllAsync();
         }
 
         private void EnsureNoMoreLoggedMessages()

--- a/src/core/Akka.TestKit/TestKitBase.cs
+++ b/src/core/Akka.TestKit/TestKitBase.cs
@@ -496,6 +496,22 @@ namespace Akka.TestKit
                 .ConfigureAwait(false).GetAwaiter().GetResult();
 
         /// <summary>
+        /// Shuts down this system.
+        /// On failure debug output will be logged about the remaining actors in the system.
+        /// If verifySystemShutdown is true, then an exception will be thrown on failure.
+        /// </summary>
+        /// <param name="duration">Optional. The duration to wait for shutdown. Default is 5 seconds multiplied with the config value "akka.test.timefactor".</param>
+        /// <param name="verifySystemShutdown">if set to <c>true</c> an exception will be thrown on failure.</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> to cancel the operation</param>
+        /// <exception cref="TimeoutException">TBD</exception>
+        public virtual async Task ShutdownAsync(
+            TimeSpan? duration = null,
+            bool verifySystemShutdown = false,
+            CancellationToken cancellationToken = default)
+            => await ShutdownAsync(_testState.System, duration, verifySystemShutdown, cancellationToken)
+                .ConfigureAwait(false);
+
+        /// <summary>
         /// Shuts down the specified system.
         /// On failure debug output will be logged about the remaining actors in the system.
         /// If verifySystemShutdown is true, then an exception will be thrown on failure.
@@ -538,8 +554,8 @@ namespace Akka.TestKit
             {
                 const string msg = "Failed to stop [{0}] within [{1}] \n{2}";
                 if(verifySystemShutdown)
-                    throw new TimeoutException(string.Format(msg, system.Name, durationValue, ""));
-                system.Log.Warning(msg, system.Name, durationValue, ""); //TODO: replace "" with system.PrintTree()
+                    throw new TimeoutException(string.Format(msg, system.Name, durationValue, ((ExtendedActorSystem) system).PrintTree()));
+                system.Log.Warning(msg, system.Name, durationValue, ((ExtendedActorSystem) system).PrintTree());
             }
         }
 

--- a/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
@@ -86,29 +86,35 @@ namespace Akka.TestKit
             AtStartup();
         }
 
-        protected override void AfterAll()
+        protected override async Task AfterAllAsync()
         {
-            BeforeTermination();
-            base.AfterAll();
-            AfterTermination();
+            await BeforeTerminationAsync();
+            await base.AfterAllAsync();
+            await AfterTerminationAsync();
         }
 
         protected virtual void AtStartup() { }
 
-        protected virtual void BeforeTermination() { }
+        protected virtual Task BeforeTerminationAsync()
+        {
+            return Task.CompletedTask;
+        }
 
-        protected virtual void AfterTermination() { }
+        protected virtual Task AfterTerminationAsync()
+        {
+            return Task.CompletedTask;
+        }
 
         private static string GetCallerName()
         {
             var systemNumber = Interlocked.Increment(ref _systemNumber);
             var stackTrace = new StackTrace(0);
-            var name = stackTrace.GetFrames().
-                Select(f => f.GetMethod()).
-                Where(m => m.DeclaringType != null).
-                SkipWhile(m => m.DeclaringType.Name == "AkkaSpec").
-                Select(m => _nameReplaceRegex.Replace(m.DeclaringType.Name + "-" + systemNumber, "-")).
-                FirstOrDefault() ?? "test";
+            var name = stackTrace.GetFrames()?
+                .Select(f => f.GetMethod())
+                .Where(m => m.DeclaringType != null)
+                .SkipWhile(m => m.DeclaringType.Name == "AkkaSpec")
+                .Select(m => _nameReplaceRegex.Replace(m.DeclaringType.Name + "-" + systemNumber, "-"))
+                .FirstOrDefault() ?? "test";
 
             return name;
         }


### PR DESCRIPTION
Convert IDisposable to IAsyncLifetime to allow for async method calls in test initialization/dispose