### PR TITLE
Convert Akka.TestKit.Tests.TestKitBaseTests.AwaitAssertTests to async

### DIFF
--- a/src/core/Akka.TestKit.Tests/TestKitBaseTests/AwaitAssertTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestKitBaseTests/AwaitAssertTests.cs
@@ -6,10 +6,13 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 using Xunit.Sdk;
+using static FluentAssertions.FluentActions;
 
-namespace Akka.TestKit.Tests.Xunit2.TestKitBaseTests
+namespace Akka.TestKit.Tests.TestKitBaseTests
 {
     public class AwaitAssertTests : TestKit.Xunit2.TestKit
     {
@@ -18,18 +21,43 @@ namespace Akka.TestKit.Tests.Xunit2.TestKitBaseTests
         }
 
         [Fact]
-        public void AwaitAssert_must_not_throw_any_exception_when_assertion_is_valid()
+        public async Task AwaitAssertAsync_must_not_throw_any_exception_when_assertion_is_valid()
         {
-            AwaitAssert(() => Assert.Equal("foo", "foo"));
+            await AwaitAssertAsync(() => Assert.Equal("foo", "foo"));
         }
 
         [Fact]
-        public void AwaitAssert_must_throw_exception_when_assertion_is_invalid()
+        public async Task AwaitAssertAsync_with_async_delegate_must_not_throw_any_exception_when_assertion_is_valid()
         {
-            Within(TimeSpan.FromMilliseconds(300), TimeSpan.FromSeconds(1), () =>
+            await AwaitAssertAsync(() =>
             {
-                Assert.Throws<EqualException>(() =>
-                    AwaitAssert(() => Assert.Equal("foo", "bar"), TimeSpan.FromMilliseconds(500), TimeSpan.FromMilliseconds(300)));
+                Assert.Equal("foo", "foo");
+                return Task.CompletedTask;
+            });
+        }
+
+        [Fact]
+        public async Task AwaitAssertAsync_must_throw_exception_when_assertion_is_invalid()
+        {
+            await WithinAsync(TimeSpan.FromMilliseconds(300), TimeSpan.FromSeconds(1), async () =>
+            {
+                await Awaiting(async () =>
+                        await AwaitAssertAsync(() => Assert.Equal("foo", "bar"), TimeSpan.FromMilliseconds(500), TimeSpan.FromMilliseconds(300)))
+                    .Should().ThrowAsync<EqualException>();
+            });
+        }
+        
+        [Fact]
+        public async Task AwaitAssertAsync_with_async_delegate_must_throw_exception_when_assertion_is_invalid()
+        {
+            await WithinAsync(TimeSpan.FromMilliseconds(300), TimeSpan.FromSeconds(1), async () =>
+            {
+                await Awaiting(async () => await AwaitAssertAsync(() =>
+                    {
+                        Assert.Equal("foo", "bar");
+                        return Task.CompletedTask;
+                    }, TimeSpan.FromMilliseconds(500), TimeSpan.FromMilliseconds(300)))
+                    .Should().ThrowAsync<EqualException>();
             });
         }
     }


### PR DESCRIPTION
Fixes #

## Changes

Please provide a brief description of the changes here.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
