### PR TITLE
Backport of #5895: Fix typo in `akka.remote.dot-netty.ssl.certificate`

### DIFF
--- a/src/core/Akka.Remote/Configuration/Remote.conf
+++ b/src/core/Akka.Remote/Configuration/Remote.conf
@@ -555,13 +555,13 @@ akka {
 
 			# To use a Thumbprint instead of a file, set this to true
 			# And specify a thumprint and it's storage location below
-			use-thumprint-over-file = false
+			use-thumbprint-over-file = false
 
 			# Valid Thumprint required (if use-thumbprint-over-file is true)
 			# A typical thumbprint is a format similar to: "45df32e258c92a7abf6c112e54912ab15bbb9eb0"
 			# On Windows machines, The thumprint for an installed certificate can be located
 			# By using certlm.msc and opening the certificate under the 'Details' tab.
-			thumpbrint = ""
+			thumbprint = ""
 
 			# The Store name. Under windows The most common option is "My", which indicates the personal store.
 			# See System.Security.Cryptography.X509Certificates.StoreName for other common values.


### PR DESCRIPTION
(cherry picked from commit 51465599485dc1532039534ef71cd45cfb19d455)

Bakport #5895