### PR TITLE
added .NET 6 dual targeting to all assemblies

### DIFF
--- a/src/common.props
+++ b/src/common.props
@@ -22,6 +22,7 @@
     <NetTestVersion>net6.0</NetTestVersion>
     <NetFrameworkTestVersion>net471</NetFrameworkTestVersion>
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>
+    <NetLibVersion>net6.0</NetLibVersion>
     <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <FsCheckVersion>2.16.4</FsCheckVersion>

--- a/src/contrib/cluster/Akka.Cluster.Metrics/Akka.Cluster.Metrics.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Metrics/Akka.Cluster.Metrics.csproj
@@ -7,7 +7,7 @@
             The member nodes of the cluster can collect system health metrics and publish that to other cluster nodes
             and to the registered subscribers on the system event bus with the help of Cluster Metrics Extension.
         </Description>
-        <TargetFramework>$(NetStandardLibVersion)</TargetFramework>
+        <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
         <PackageTags>$(AkkaPackageTags);network;cluster;sharding</PackageTags>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>

--- a/src/contrib/cluster/Akka.Cluster.Metrics/Collectors/DefaultCollector.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics/Collectors/DefaultCollector.cs
@@ -85,7 +85,7 @@ namespace Akka.Cluster.Metrics.Collectors
             
             try
             {
-                TimeSpan measureStartTime;
+                TimeSpan measureStartTime = TimeSpan.Zero;
                 TimeSpan measureEndTime;
                 ImmutableDictionary<int, TimeSpan> currentCpuTimings;
                 

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Akka.Cluster.Sharding.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Akka.Cluster.Sharding.csproj
@@ -1,25 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\common.props" />
+    <Import Project="..\..\..\common.props"/>
 
-  <PropertyGroup>
-    <AssemblyTitle>Akka.Cluster.Sharding</AssemblyTitle>
-    <Description>Sharded actors with managed lifecycle for Akka.NET cluster</Description>
-    <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
-    <PackageTags>$(AkkaPackageTags);network;cluster;sharding</PackageTags>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <AssemblyTitle>Akka.Cluster.Sharding</AssemblyTitle>
+        <Description>Sharded actors with managed lifecycle for Akka.NET cluster</Description>
+        <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
+        <PackageTags>$(AkkaPackageTags);network;cluster;sharding</PackageTags>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="reference.conf" />
-    <ProjectReference Include="..\..\..\core\Akka.Coordination\Akka.Coordination.csproj" />
-    <ProjectReference Include="..\..\..\core\Akka.Persistence\Akka.Persistence.csproj" />
-    <ProjectReference Include="..\Akka.Cluster.Tools\Akka.Cluster.Tools.csproj" />
-    <ProjectReference Include="..\Akka.DistributedData.LightningDB\Akka.DistributedData.LightningDB.csproj" />
-    <ProjectReference Include="..\Akka.DistributedData\Akka.DistributedData.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="reference.conf"/>
+        <ProjectReference Include="..\..\..\core\Akka.Coordination\Akka.Coordination.csproj"/>
+        <ProjectReference Include="..\..\..\core\Akka.Persistence\Akka.Persistence.csproj"/>
+        <ProjectReference Include="..\Akka.Cluster.Tools\Akka.Cluster.Tools.csproj"/>
+        <ProjectReference Include="..\Akka.DistributedData.LightningDB\Akka.DistributedData.LightningDB.csproj"/>
+        <ProjectReference Include="..\Akka.DistributedData\Akka.DistributedData.csproj"/>
+    </ItemGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
-  </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+    </PropertyGroup>
 
 </Project>

--- a/src/contrib/cluster/Akka.Cluster.Tools/Akka.Cluster.Tools.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Akka.Cluster.Tools.csproj
@@ -1,22 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\common.props" />
+    <Import Project="..\..\..\common.props"/>
 
-  <PropertyGroup>
-    <AssemblyTitle>Akka.Cluster.Tools</AssemblyTitle>
-    <Description>Distributed publish/subscribe, client and singleton support for Akka.NET cluster</Description>
-    <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
-    <PackageTags>$(AkkaPackageTags);network;cluster</PackageTags>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <AssemblyTitle>Akka.Cluster.Tools</AssemblyTitle>
+        <Description>Distributed publish/subscribe, client and singleton support for Akka.NET cluster</Description>
+        <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
+        <PackageTags>$(AkkaPackageTags);network;cluster</PackageTags>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="Client\reference.conf;PublishSubscribe\reference.conf;Singleton\reference.conf" />
-    <ProjectReference Include="..\..\..\core\Akka.Cluster\Akka.Cluster.csproj" />
-    <ProjectReference Include="..\..\..\core\Akka.Coordination\Akka.Coordination.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="Client\reference.conf;PublishSubscribe\reference.conf;Singleton\reference.conf"/>
+        <ProjectReference Include="..\..\..\core\Akka.Cluster\Akka.Cluster.csproj"/>
+        <ProjectReference Include="..\..\..\core\Akka.Coordination\Akka.Coordination.csproj"/>
+    </ItemGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
-  </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+    </PropertyGroup>
 
 </Project>

--- a/src/contrib/cluster/Akka.DistributedData.LightningDB/Akka.DistributedData.LightningDB.csproj
+++ b/src/contrib/cluster/Akka.DistributedData.LightningDB/Akka.DistributedData.LightningDB.csproj
@@ -1,25 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\common.props" />
+    <Import Project="..\..\..\common.props"/>
 
-  <PropertyGroup>
-    <AssemblyTitle>Akka.DistributedData.LightningDB</AssemblyTitle>
-    <Description>Replicated data using CRDT structures</Description>
-    <TargetFramework>$(NetStandardLibVersion)</TargetFramework>
-    <PackageTags>$(AkkaPackageTags);network;cluster;crdt;replication;lightningdb;lmdb</PackageTags>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <AssemblyTitle>Akka.DistributedData.LightningDB</AssemblyTitle>
+        <Description>Replicated data using CRDT structures</Description>
+        <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
+        <PackageTags>$(AkkaPackageTags);network;cluster;crdt;replication;lightningdb;lmdb</PackageTags>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="reference.conf" />
-    <ProjectReference Include="..\Akka.DistributedData\Akka.DistributedData.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="reference.conf"/>
+        <ProjectReference Include="..\Akka.DistributedData\Akka.DistributedData.csproj"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="LightningDB" Version="0.14.0" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="LightningDB" Version="0.14.0"/>
+    </ItemGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
-  </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+    </PropertyGroup>
 
 </Project>

--- a/src/contrib/cluster/Akka.DistributedData/Akka.DistributedData.csproj
+++ b/src/contrib/cluster/Akka.DistributedData/Akka.DistributedData.csproj
@@ -1,25 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\common.props" />
+    <Import Project="..\..\..\common.props"/>
 
-  <PropertyGroup>
-    <AssemblyTitle>Akka.DistributedData</AssemblyTitle>
-    <Description>Replicated data using CRDT structures</Description>
-    <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
-    <PackageTags>$(AkkaPackageTags);network;cluster;crdt;replication</PackageTags>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <AssemblyTitle>Akka.DistributedData</AssemblyTitle>
+        <Description>Replicated data using CRDT structures</Description>
+        <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
+        <PackageTags>$(AkkaPackageTags);network;cluster;crdt;replication</PackageTags>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="reference.conf" />
-    <ProjectReference Include="..\..\..\core\Akka.Cluster\Akka.Cluster.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="reference.conf"/>
+        <ProjectReference Include="..\..\..\core\Akka.Cluster\Akka.Cluster.csproj"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Hyperion" Version="$(HyperionVersion)" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Hyperion" Version="$(HyperionVersion)"/>
+    </ItemGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
-  </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+    </PropertyGroup>
 
 </Project>

--- a/src/contrib/dependencyinjection/Akka.DependencyInjection/Akka.DependencyInjection.csproj
+++ b/src/contrib/dependencyinjection/Akka.DependencyInjection/Akka.DependencyInjection.csproj
@@ -5,7 +5,7 @@
     <PropertyGroup>
         <AssemblyTitle>Akka.DependencyInjection</AssemblyTitle>
         <Description>Dependency injection support for Akka.NET</Description>
-        <TargetFramework>$(NetStandardLibVersion)</TargetFramework>
+        <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
         <PackageTags>$(AkkaPackageTags);dependency injection</PackageTags>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageProjectUrl>https://getakka.net/articles/actors/dependency-injection.html</PackageProjectUrl>

--- a/src/contrib/persistence/Akka.Persistence.Query.Sql/Akka.Persistence.Query.Sql.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Query.Sql/Akka.Persistence.Query.Sql.csproj
@@ -1,23 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\common.props" />
+    <Import Project="..\..\..\common.props"/>
 
-  <PropertyGroup>
-    <AssemblyTitle>Akka.Persistence.Query.Sql</AssemblyTitle>
-    <Description>Akka.NET streams support for ADO.NET Persistence middleware.</Description>
-    <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
-    <PackageTags>$(AkkaPackageTags);persistence;eventsource;sql;reactive;streams</PackageTags>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <AssemblyTitle>Akka.Persistence.Query.Sql</AssemblyTitle>
+        <Description>Akka.NET streams support for ADO.NET Persistence middleware.</Description>
+        <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
+        <PackageTags>$(AkkaPackageTags);persistence;eventsource;sql;reactive;streams</PackageTags>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="reference.conf" />
-    <ProjectReference Include="..\..\..\core\Akka.Persistence\Akka.Persistence.csproj" />
-    <ProjectReference Include="..\..\..\core\Akka.Persistence.Query\Akka.Persistence.Query.csproj" />
-    <ProjectReference Include="..\Akka.Persistence.Sql.Common\Akka.Persistence.Sql.Common.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="reference.conf"/>
+        <ProjectReference Include="..\..\..\core\Akka.Persistence\Akka.Persistence.csproj"/>
+        <ProjectReference Include="..\..\..\core\Akka.Persistence.Query\Akka.Persistence.Query.csproj"/>
+        <ProjectReference Include="..\Akka.Persistence.Sql.Common\Akka.Persistence.Sql.Common.csproj"/>
+    </ItemGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
-  </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+    </PropertyGroup>
 
 </Project>

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj
@@ -1,28 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\common.props" />
+    <Import Project="..\..\..\common.props"/>
 
-  <PropertyGroup>
-    <AssemblyTitle>Akka.Persistence.Sql.Common</AssemblyTitle>
-    <Description>Akka.NET Persistence ADO.NET middleware</Description>
-    <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
-    <PackageTags>$(AkkaPackageTags);persistence;eventsource;sql</PackageTags>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <AssemblyTitle>Akka.Persistence.Sql.Common</AssemblyTitle>
+        <Description>Akka.NET Persistence ADO.NET middleware</Description>
+        <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
+        <PackageTags>$(AkkaPackageTags);persistence;eventsource;sql</PackageTags>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(ConfigurationManagerVersion)" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(ConfigurationManagerVersion)"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\core\Akka.Persistence\Akka.Persistence.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\core\Akka.Persistence\Akka.Persistence.csproj"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Data.Common" Version="4.3.0" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="System.Data.Common" Version="4.3.0"/>
+    </ItemGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
-  </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+    </PropertyGroup>
 
 </Project>

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Akka.Persistence.Sqlite.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Akka.Persistence.Sqlite.csproj
@@ -1,26 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\common.props" />
+    <Import Project="..\..\..\common.props"/>
 
-  <PropertyGroup>
-    <AssemblyTitle>Akka.Persistence.Sqlite</AssemblyTitle>
-    <Description>Akka.NET Persistence journal and snapshot store backed by SQLite.</Description>
-    <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
-    <PackageTags>$(AkkaPackageTags);persistence;eventsource;sql;sqlite</PackageTags>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <AssemblyTitle>Akka.Persistence.Sqlite</AssemblyTitle>
+        <Description>Akka.NET Persistence journal and snapshot store backed by SQLite.</Description>
+        <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
+        <PackageTags>$(AkkaPackageTags);persistence;eventsource;sql;sqlite</PackageTags>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="sqlite.conf" />
-    <ProjectReference Include="..\..\..\core\Akka.Persistence\Akka.Persistence.csproj" />
-    <ProjectReference Include="..\Akka.Persistence.Sql.Common\Akka.Persistence.Sql.Common.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="sqlite.conf"/>
+        <ProjectReference Include="..\..\..\core\Akka.Persistence\Akka.Persistence.csproj"/>
+        <ProjectReference Include="..\Akka.Persistence.Sql.Common\Akka.Persistence.Sql.Common.csproj"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SQLite" Version="6.0.4" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Data.SQLite" Version="6.0.4"/>
+    </ItemGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
-  </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+    </PropertyGroup>
 
 </Project>

--- a/src/contrib/serializers/Akka.Serialization.Hyperion/Akka.Serialization.Hyperion.csproj
+++ b/src/contrib/serializers/Akka.Serialization.Hyperion/Akka.Serialization.Hyperion.csproj
@@ -1,27 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\common.props" />
-  <PropertyGroup>
-    <AssemblyTitle>Akka.Serialization.Hyperion</AssemblyTitle>
-    <Description>Hyperion serializer for Akka.NET</Description>
-    <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
-    <PackageTags>$(AkkaPackageTags);hyperion;serializer;serialize</PackageTags>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="reference.conf" />
-    <PackageReference Include="Hyperion" Version="$(HyperionVersion)" />
-    <ProjectReference Include="..\..\..\core\Akka\Akka.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <PackageReference Include="System.Reflection" Version="4.3.0" />
-    <PackageReference Include="System.Runtime" Version="4.3.1" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkLibVersion)' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
+    <Import Project="..\..\..\common.props"/>
+    <PropertyGroup>
+        <AssemblyTitle>Akka.Serialization.Hyperion</AssemblyTitle>
+        <Description>Hyperion serializer for Akka.NET</Description>
+        <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
+        <PackageTags>$(AkkaPackageTags);hyperion;serializer;serialize</PackageTags>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="reference.conf"/>
+        <PackageReference Include="Hyperion" Version="$(HyperionVersion)"/>
+        <ProjectReference Include="..\..\..\core\Akka\Akka.csproj"/>
+    </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
+        <PackageReference Include="System.Reflection" Version="4.3.0"/>
+        <PackageReference Include="System.Runtime" Version="4.3.1"/>
+    </ItemGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
-  </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+    </PropertyGroup>
 </Project>

--- a/src/contrib/testkits/Akka.TestKit.Xunit/Akka.TestKit.Xunit.csproj
+++ b/src/contrib/testkits/Akka.TestKit.Xunit/Akka.TestKit.Xunit.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\common.props" />
+    <Import Project="..\..\..\common.props"/>
 
-  <PropertyGroup>
-    <AssemblyTitle>Akka.TestKit.Xunit</AssemblyTitle>
-    <Description>TestKit for writing tests for Akka.NET using xUnit.</Description>
-    <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
-    <PackageTags>$(AkkaPackageTags);testkit;xunit</PackageTags>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <AssemblyTitle>Akka.TestKit.Xunit</AssemblyTitle>
+        <Description>TestKit for writing tests for Akka.NET using xUnit.</Description>
+        <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
+        <PackageTags>$(AkkaPackageTags);testkit;xunit</PackageTags>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\core\Akka.TestKit\Akka.TestKit.csproj" />
-    <PackageReference Include="xunit" Version="$(XunitVersion)" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\core\Akka.TestKit\Akka.TestKit.csproj"/>
+        <PackageReference Include="xunit" Version="$(XunitVersion)"/>
+    </ItemGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- WORKAROUND: for some reason starting at Akka.NET 1.3.2 this package was determined as "unpackable" by default via DOTNET CLI -->
-    <IsPackable>true</IsPackable>
-  </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+    </PropertyGroup>
+    <PropertyGroup>
+        <!-- WORKAROUND: for some reason starting at Akka.NET 1.3.2 this package was determined as "unpackable" by default via DOTNET CLI -->
+        <IsPackable>true</IsPackable>
+    </PropertyGroup>
 </Project>

--- a/src/contrib/testkits/Akka.TestKit.Xunit2/Akka.TestKit.Xunit2.csproj
+++ b/src/contrib/testkits/Akka.TestKit.Xunit2/Akka.TestKit.Xunit2.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\common.props" />
+    <Import Project="..\..\..\common.props"/>
 
-  <PropertyGroup>
-    <AssemblyTitle>Akka.TestKit.Xunit2</AssemblyTitle>
-    <Description>TestKit for writing tests for Akka.NET using xUnit.</Description>
-    <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
-    <PackageTags>$(AkkaPackageTags);testkit;xunit</PackageTags>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <AssemblyTitle>Akka.TestKit.Xunit2</AssemblyTitle>
+        <Description>TestKit for writing tests for Akka.NET using xUnit.</Description>
+        <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
+        <PackageTags>$(AkkaPackageTags);testkit;xunit</PackageTags>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\core\Akka.TestKit\Akka.TestKit.csproj" />
-    <PackageReference Include="xunit" Version="$(XunitVersion)" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\core\Akka.TestKit\Akka.TestKit.csproj"/>
+        <PackageReference Include="xunit" Version="$(XunitVersion)"/>
+    </ItemGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- WORKAROUND: for some reason starting at Akka.NET 1.3.2 this package was determined as "unpackable" by default via DOTNET CLI -->
-    <IsPackable>true</IsPackable>
-  </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+    </PropertyGroup>
+    <PropertyGroup>
+        <!-- WORKAROUND: for some reason starting at Akka.NET 1.3.2 this package was determined as "unpackable" by default via DOTNET CLI -->
+        <IsPackable>true</IsPackable>
+    </PropertyGroup>
 </Project>

--- a/src/core/Akka.Cluster/Akka.Cluster.csproj
+++ b/src/core/Akka.Cluster/Akka.Cluster.csproj
@@ -1,22 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\common.props" />
+    <Import Project="..\..\common.props"/>
 
-  <PropertyGroup>
-    <AssemblyTitle>Akka.Cluster</AssemblyTitle>
-    <Description>Cluster support for Akka.NET</Description>
-    <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
-    <PackageTags>$(AkkaPackageTags);network;cluster</PackageTags>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <AssemblyTitle>Akka.Cluster</AssemblyTitle>
+        <Description>Cluster support for Akka.NET</Description>
+        <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
+        <PackageTags>$(AkkaPackageTags);network;cluster</PackageTags>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="Configuration\Cluster.conf" />
-    <ProjectReference Include="..\Akka.Coordination\Akka.Coordination.csproj" />
-    <ProjectReference Include="..\Akka.Remote\Akka.Remote.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="Configuration\Cluster.conf"/>
+        <ProjectReference Include="..\Akka.Coordination\Akka.Coordination.csproj"/>
+        <ProjectReference Include="..\Akka.Remote\Akka.Remote.csproj"/>
+    </ItemGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
-  </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+    </PropertyGroup>
 
 </Project>

--- a/src/core/Akka.Coordination/Akka.Coordination.csproj
+++ b/src/core/Akka.Coordination/Akka.Coordination.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\common.props" />
+    <Import Project="..\..\common.props"/>
 
-  <PropertyGroup>
-    <AssemblyTitle>Akka.Coordination</AssemblyTitle>
-    <Description>Distributed coordination support for Akka.NET</Description>
-    <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
-    <PackageTags>$(AkkaPackageTags)</PackageTags>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <AssemblyTitle>Akka.Coordination</AssemblyTitle>
+        <Description>Distributed coordination support for Akka.NET</Description>
+        <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
+        <PackageTags>$(AkkaPackageTags)</PackageTags>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
-  </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="reference.conf" />
-  </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="reference.conf"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Akka\Akka.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Akka\Akka.csproj"/>
+    </ItemGroup>
 
 </Project>

--- a/src/core/Akka.Discovery/Akka.Discovery.csproj
+++ b/src/core/Akka.Discovery/Akka.Discovery.csproj
@@ -1,29 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\common.props" />
+    <Import Project="..\..\common.props"/>
 
-  <PropertyGroup>
-    <AssemblyTitle>Akka.Discovery</AssemblyTitle>
-    <Description>Service Discovery for Akka.NET</Description>
-    <TargetFramework>$(NetStandardLibVersion)</TargetFramework>
-    <PackageTags>$(AkkaPackageTags)</PackageTags>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>8</LangVersion>
-  </PropertyGroup>
+    <PropertyGroup>
+        <AssemblyTitle>Akka.Discovery</AssemblyTitle>
+        <Description>Service Discovery for Akka.NET</Description>
+        <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
+        <PackageTags>$(AkkaPackageTags)</PackageTags>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <LangVersion>8</LangVersion>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <None Remove="Resources\reference.conf" />
-  </ItemGroup>
+    <ItemGroup>
+        <None Remove="Resources\reference.conf"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="Resources\reference.conf" />
-  </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="Resources\reference.conf"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Akka\Akka.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Akka\Akka.csproj"/>
+    </ItemGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
-  </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+    </PropertyGroup>
 
 </Project>

--- a/src/core/Akka.FSharp/Akka.FSharp.fsproj
+++ b/src/core/Akka.FSharp/Akka.FSharp.fsproj
@@ -1,33 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\common.props" />
+    <Import Project="..\..\common.props"/>
 
-  <PropertyGroup>
-    <AssemblyTitle>Akka.FSharp</AssemblyTitle>
-    <Description>F# API support for Akka.NET</Description>
-    <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
-    <PackageTags>$(AkkaPackageTags);F#;fsharp</PackageTags>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
-    <NoWarn></NoWarn>    
-  </PropertyGroup>
+    <PropertyGroup>
+        <AssemblyTitle>Akka.FSharp</AssemblyTitle>
+        <Description>F# API support for Akka.NET</Description>
+        <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
+        <PackageTags>$(AkkaPackageTags);F#;fsharp</PackageTags>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="FsApi.fs" />
-    <Compile Include="Schedulers.fs" />
-  </ItemGroup>
+    <ItemGroup>
+        <Compile Include="FsApi.fs"/>
+        <Compile Include="Schedulers.fs"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Akka\Akka.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Akka\Akka.csproj"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FSharp.Quotations.Evaluator" Version="2.1.0" />
-    <PackageReference Include="FsPickler" Version="5.3.2" />
-    <PackageReference Include="FSharp.Core" Version="6.0.1" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="FSharp.Quotations.Evaluator" Version="2.1.0"/>
+        <PackageReference Include="FsPickler" Version="5.3.2"/>
+        <PackageReference Include="FSharp.Core" Version="6.0.1"/>
+    </ItemGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
-  </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+    </PropertyGroup>
 
 </Project>

--- a/src/core/Akka.Persistence.FSharp/Akka.Persistence.FSharp.fsproj
+++ b/src/core/Akka.Persistence.FSharp/Akka.Persistence.FSharp.fsproj
@@ -1,25 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\common.props" />
+    <Import Project="..\..\common.props"/>
 
-  <PropertyGroup>
-    <AssemblyTitle>Akka.Persistence.FSharp</AssemblyTitle>
-    <Description>F# API for persistence actors in Akka.NET</Description>
-    <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
-    <PackageTags>akka;actors;actor model;Akka;concurrency;F#;Fsharp;persistence;eventsource</PackageTags>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
-  </PropertyGroup>
+    <PropertyGroup>
+        <AssemblyTitle>Akka.Persistence.FSharp</AssemblyTitle>
+        <Description>F# API for persistence actors in Akka.NET</Description>
+        <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
+        <PackageTags>akka;actors;actor model;Akka;concurrency;F#;Fsharp;persistence;eventsource</PackageTags>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="FsApi.fs" />
-  </ItemGroup>
+    <ItemGroup>
+        <Compile Include="FsApi.fs"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Akka.FSharp\Akka.FSharp.fsproj" />
-    <ProjectReference Include="..\Akka.Persistence\Akka.Persistence.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Akka.FSharp\Akka.FSharp.fsproj"/>
+        <ProjectReference Include="..\Akka.Persistence\Akka.Persistence.csproj"/>
+    </ItemGroup>
 
-   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
-  </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+    </PropertyGroup>
 </Project>

--- a/src/core/Akka.Persistence.Query/Akka.Persistence.Query.csproj
+++ b/src/core/Akka.Persistence.Query/Akka.Persistence.Query.csproj
@@ -1,25 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\common.props" />
+    <Import Project="..\..\common.props"/>
 
-  <PropertyGroup>
-    <AssemblyTitle>Akka.Persistence.Query</AssemblyTitle>
-    <Description>Stream based query interface for persistence journal plugins for Akka.NET</Description>
-    <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
-    <PackageTags>$(AkkaPackageTags);persistence;eventsource;query;stream</PackageTags>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <AssemblyTitle>Akka.Persistence.Query</AssemblyTitle>
+        <Description>Stream based query interface for persistence journal plugins for Akka.NET</Description>
+        <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
+        <PackageTags>$(AkkaPackageTags);persistence;eventsource;query;stream</PackageTags>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Akka.Persistence\Akka.Persistence.csproj" />
-    <ProjectReference Include="..\Akka.Streams\Akka.Streams.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Akka.Persistence\Akka.Persistence.csproj"/>
+        <ProjectReference Include="..\Akka.Streams\Akka.Streams.csproj"/>
+    </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <DefineConstants>$(DefineConstants)</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
-  </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+    </PropertyGroup>
 
 </Project>

--- a/src/core/Akka.Persistence.TCK/Akka.Persistence.TCK.csproj
+++ b/src/core/Akka.Persistence.TCK/Akka.Persistence.TCK.csproj
@@ -1,27 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\common.props" />
+    <Import Project="..\..\common.props"/>
 
-  <PropertyGroup>
-    <AssemblyTitle>Akka.Persistence.TCK</AssemblyTitle>
-    <Description>Testkit for Persistence actor support for Akka.NET</Description>
-    <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
-    <PackageTags>$(AkkaPackageTags);persistence;eventsource;tck</PackageTags>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <AssemblyTitle>Akka.Persistence.TCK</AssemblyTitle>
+        <Description>Testkit for Persistence actor support for Akka.NET</Description>
+        <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
+        <PackageTags>$(AkkaPackageTags);persistence;eventsource;tck</PackageTags>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Akka.Persistence.Query\Akka.Persistence.Query.csproj" />
-    <ProjectReference Include="..\Akka.Persistence\Akka.Persistence.csproj" />
-    <ProjectReference Include="..\..\contrib\testkits\Akka.TestKit.Xunit2\Akka.TestKit.Xunit2.csproj" />
-    <ProjectReference Include="..\Akka.Streams.TestKit\Akka.Streams.TestKit.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Akka.Persistence.Query\Akka.Persistence.Query.csproj"/>
+        <ProjectReference Include="..\Akka.Persistence\Akka.Persistence.csproj"/>
+        <ProjectReference Include="..\..\contrib\testkits\Akka.TestKit.Xunit2\Akka.TestKit.Xunit2.csproj"/>
+        <ProjectReference Include="..\Akka.Streams.TestKit\Akka.Streams.TestKit.csproj"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)"/>
+    </ItemGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
-  </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+    </PropertyGroup>
 
 </Project>

--- a/src/core/Akka.Persistence/Akka.Persistence.csproj
+++ b/src/core/Akka.Persistence/Akka.Persistence.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyTitle>Akka.Persistence</AssemblyTitle>
     <Description>Persistence actor support for Akka.NET</Description>
-    <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
     <PackageTags>$(AkkaPackageTags);persistence;eventsource</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/core/Akka.Remote/Akka.Remote.csproj
+++ b/src/core/Akka.Remote/Akka.Remote.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\common.props" />
-  <PropertyGroup>
-    <AssemblyTitle>Akka.Remote</AssemblyTitle>
-    <Description>Remote actor support for Akka.NET</Description>
-    <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
-    <PackageTags>$(AkkaPackageTags);network</PackageTags>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Configuration\Remote.conf" />
-    <ProjectReference Include="..\Akka\Akka.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="DotNetty.Handlers" Version="0.6.0" />
-    <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
-  </ItemGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-  </PropertyGroup>
+    <Import Project="..\..\common.props"/>
+    <PropertyGroup>
+        <AssemblyTitle>Akka.Remote</AssemblyTitle>
+        <Description>Remote actor support for Akka.NET</Description>
+        <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
+        <PackageTags>$(AkkaPackageTags);network</PackageTags>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="Configuration\Remote.conf"/>
+        <ProjectReference Include="..\Akka\Akka.csproj"/>
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="DotNetty.Handlers" Version="0.6.0"/>
+        <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)"/>
+    </ItemGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+    </PropertyGroup>
+    <PropertyGroup>
+        <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    </PropertyGroup>
 </Project>

--- a/src/core/Akka.Streams/Akka.Streams.csproj
+++ b/src/core/Akka.Streams/Akka.Streams.csproj
@@ -1,72 +1,72 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\common.props" />
-  <PropertyGroup>
-    <AssemblyTitle>Akka.Streams</AssemblyTitle>
-    <Description>Reactive stream support for Akka.NET</Description>
-    <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
-    <PackageTags>$(AkkaPackageTags);reactive;stream</PackageTags>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="reference.conf" />
-    <ProjectReference Include="..\Akka\Akka.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="CodeGen\Dsl\GraphApply.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-      <LastGenOutput>GraphApply.cs</LastGenOutput>
-    </None>
-    <Compile Update="CodeGen\Dsl\GraphApply.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>GraphApply.tt</DependentUpon>
-    </Compile>
-    <None Update="CodeGen\Dsl\UnzipWith.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-      <LastGenOutput>UnzipWith.cs</LastGenOutput>
-    </None>
-    <Compile Update="CodeGen\Dsl\UnzipWith.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>UnzipWith.tt</DependentUpon>
-    </Compile>
-    <None Update="CodeGen\Dsl\ZipWith.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-      <LastGenOutput>ZipWith.cs</LastGenOutput>
-    </None>
-    <Compile Update="CodeGen\Dsl\ZipWith.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>ZipWith.tt</DependentUpon>
-    </Compile>
-    <None Update="CodeGen\FanInShape.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-      <LastGenOutput>FanInShape.cs</LastGenOutput>
-    </None>
-    <Compile Update="CodeGen\FanInShape.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>FanInShape.tt</DependentUpon>
-    </Compile>
-    <None Update="CodeGen\FanOutShape.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-      <LastGenOutput>FanOutShape.cs</LastGenOutput>
-    </None>
-    <Compile Update="CodeGen\FanOutShape.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>FanOutShape.tt</DependentUpon>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
-    <PackageReference Include="Reactive.Streams" Version="1.0.2" />
-  </ItemGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
-  </PropertyGroup>
+    <Import Project="..\..\common.props"/>
+    <PropertyGroup>
+        <AssemblyTitle>Akka.Streams</AssemblyTitle>
+        <Description>Reactive stream support for Akka.NET</Description>
+        <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
+        <PackageTags>$(AkkaPackageTags);reactive;stream</PackageTags>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="reference.conf"/>
+        <ProjectReference Include="..\Akka\Akka.csproj"/>
+    </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
+        <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0"/>
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0"/>
+    </ItemGroup>
+    <ItemGroup>
+        <None Update="CodeGen\Dsl\GraphApply.tt">
+            <Generator>TextTemplatingFileGenerator</Generator>
+            <LastGenOutput>GraphApply.cs</LastGenOutput>
+        </None>
+        <Compile Update="CodeGen\Dsl\GraphApply.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>GraphApply.tt</DependentUpon>
+        </Compile>
+        <None Update="CodeGen\Dsl\UnzipWith.tt">
+            <Generator>TextTemplatingFileGenerator</Generator>
+            <LastGenOutput>UnzipWith.cs</LastGenOutput>
+        </None>
+        <Compile Update="CodeGen\Dsl\UnzipWith.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>UnzipWith.tt</DependentUpon>
+        </Compile>
+        <None Update="CodeGen\Dsl\ZipWith.tt">
+            <Generator>TextTemplatingFileGenerator</Generator>
+            <LastGenOutput>ZipWith.cs</LastGenOutput>
+        </None>
+        <Compile Update="CodeGen\Dsl\ZipWith.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>ZipWith.tt</DependentUpon>
+        </Compile>
+        <None Update="CodeGen\FanInShape.tt">
+            <Generator>TextTemplatingFileGenerator</Generator>
+            <LastGenOutput>FanInShape.cs</LastGenOutput>
+        </None>
+        <Compile Update="CodeGen\FanInShape.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>FanInShape.tt</DependentUpon>
+        </Compile>
+        <None Update="CodeGen\FanOutShape.tt">
+            <Generator>TextTemplatingFileGenerator</Generator>
+            <LastGenOutput>FanOutShape.cs</LastGenOutput>
+        </None>
+        <Compile Update="CodeGen\FanOutShape.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>FanOutShape.tt</DependentUpon>
+        </Compile>
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)"/>
+        <PackageReference Include="Reactive.Streams" Version="1.0.2"/>
+    </ItemGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+    </PropertyGroup>
 </Project>

--- a/src/core/Akka.TestKit/Akka.TestKit.csproj
+++ b/src/core/Akka.TestKit/Akka.TestKit.csproj
@@ -1,33 +1,33 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\common.props" />
+    <Import Project="..\..\common.props"/>
 
-  <PropertyGroup>
-    <AssemblyTitle>Akka.TestKit</AssemblyTitle>
-    <Description>You need a Akka.TestKit.* package! Add the one appropriate for the test framework you use instead. For example: Akka.TestKit.Xunit or Akka.TestKit.VsTest. This package only contains base functionality for writing tests for the Akka.NET framework.</Description>
-    <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
-    <PackageTags>$(AkkaPackageTags)</PackageTags>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <AssemblyTitle>Akka.TestKit</AssemblyTitle>
+        <Description>You need a Akka.TestKit.* package! Add the one appropriate for the test framework you use instead. For example: Akka.TestKit.Xunit or Akka.TestKit.VsTest. This package only contains base functionality for writing tests for the Akka.NET framework.</Description>
+        <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
+        <PackageTags>$(AkkaPackageTags)</PackageTags>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="Configs\TestScheduler.conf;Internal\Reference.conf" />
-    <ProjectReference Include="..\Akka\Akka.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="Configs\TestScheduler.conf;Internal\Reference.conf"/>
+        <ProjectReference Include="..\Akka\Akka.csproj"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <None Update="EventFilter\EventFilterFactory_Generated.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-      <LastGenOutput>EventFilterFactory_Generated.cs</LastGenOutput>
-    </None>
-    <Compile Update="EventFilter\EventFilterFactory_Generated.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>EventFilterFactory_Generated.tt</DependentUpon>
-    </Compile>
-  </ItemGroup>
+    <ItemGroup>
+        <None Update="EventFilter\EventFilterFactory_Generated.tt">
+            <Generator>TextTemplatingFileGenerator</Generator>
+            <LastGenOutput>EventFilterFactory_Generated.cs</LastGenOutput>
+        </None>
+        <Compile Update="EventFilter\EventFilterFactory_Generated.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>EventFilterFactory_Generated.tt</DependentUpon>
+        </Compile>
+    </ItemGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
-  </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+    </PropertyGroup>
 
 </Project>

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyTitle>Akka</AssemblyTitle>
     <Description>Akka.NET is a port of the popular Java/Scala framework Akka to .NET</Description>
-    <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
     <PackageTags>$(AkkaPackageTags)</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>7.2</LangVersion>
@@ -17,13 +17,20 @@
   <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="5.0.5" />
       <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
       <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
-      <PackageReference Include="System.Threading.Channels" Version="5.0.0" />
+      <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
+      <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+     
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetStandardLibVersion)'">
+      <PackageReference Include="System.Configuration.ConfigurationManager">
+          <Version>4.7.0</Version>
+      </PackageReference>
+       <PackageReference Include="System.Threading.Channels" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == '$(NetLibVersion)'">
       <PackageReference Include="System.Configuration.ConfigurationManager">
           <Version>4.7.0</Version>
       </PackageReference>


### PR DESCRIPTION
## Changes

Adds .NET 6 dual targeting to all binaries. .NET Standard 2.0 is still supported.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).